### PR TITLE
Add telemetry logging with opt-out option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ derive_more = { version = "1.0.0", features = ["full"] }
 dirs = "6"
 dupe = "0.9.1"
 env_logger = "0.11"
+pretty_env_logger = "0.5"
 indicatif = "0.17.8"
 inquire = "0.7"
 itertools = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ pcb-ui = { path = "crates/pcb-ui" }
 pcb-kicad = { path = "crates/pcb-kicad" }
 pcb-sexpr = { path = "crates/pcb-sexpr" }
 pcb-starlark-lsp = { path = "crates/pcb-starlark-lsp" }
+pcb-telem = { path = "crates/pcb-telem" }
 
 anyhow = "1.0"
 ariadne = { version = "0.5", features = ["auto-color"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3", features = ["console"] }
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
 flate2 = "1.0.34"
+gethostname = "0.5"
+machine-uid = "0.5"
+posthog-rs = "0.2"
+sentry = { version = "0.32", features = ["anyhow", "log", "backtrace"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When telemetry is enabled, we collect:
 - Command invocations (e.g., `pcb build`, `pcb layout`)
 - Error messages and stack traces (to help fix bugs)
 - Basic system info (OS type, tool version)
-- Anonymous usage ID (random UUID)
+- Anonymous machine ID (hashed for privacy)
 
 We **never** collect:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Zener is a next-generation PCB design toolchain that brings modern software engi
 ## Table of Contents
 
 - [Installation](#installation)
+- [Privacy & Telemetry](#privacy--telemetry)
 - [Quick Start](#quick-start)
 - [Core Concepts](#core-concepts)
 - [Command Reference](#command-reference)
@@ -52,6 +53,46 @@ cd pcb
 
 - Rust 2024 edition or later
 - KiCad (for generating and editing layouts)
+
+## Privacy & Telemetry
+
+Zener includes optional telemetry to help improve the tool. The telemetry is:
+
+- **Only active in release builds** - Debug builds have no telemetry
+- **Anonymous** - No personally identifiable information is collected
+- **Opt-out** - You can disable telemetry at any time
+- **Minimal** - Only basic usage statistics and error reports are sent
+
+### Disabling Telemetry
+
+To opt out of telemetry, set the `PCB_TELEMETRY` environment variable to `off`:
+
+```bash
+# Disable telemetry for current session
+export PCB_TELEMETRY=off
+
+# Or disable for a single command
+PCB_TELEMETRY=off pcb build my-design.star
+
+# To permanently disable, add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+echo 'export PCB_TELEMETRY=off' >> ~/.bashrc
+```
+
+### What is Collected?
+
+When telemetry is enabled, we collect:
+
+- Command invocations (e.g., `pcb build`, `pcb layout`)
+- Error messages and stack traces (to help fix bugs)
+- Basic system info (OS type, tool version)
+- Anonymous usage ID (random UUID, no personal data)
+
+We **never** collect:
+
+- Your PCB designs or source code
+- File names or directory paths with personal information
+- Network information or IP addresses
+- Any credentials or authentication data
 
 ## Quick Start
 
@@ -407,6 +448,7 @@ Zener is built as a modular Rust workspace with specialized crates:
 - **`pcb-sexpr`** - S-expression parser for KiCad file formats
 - **`pcb-ui`** - Terminal UI components including spinners, progress bars, and styled output
 - **`pcb-command-runner`** - Utility for running external commands with proper output capture
+- **`pcb-telem`** - Telemetry support with Sentry error reporting and PostHog analytics (release builds only)
 
 ### Key Design Principles
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When telemetry is enabled, we collect:
 - Command invocations (e.g., `pcb build`, `pcb layout`)
 - Error messages and stack traces (to help fix bugs)
 - Basic system info (OS type, tool version)
-- Anonymous usage ID (random UUID, no personal data)
+- Anonymous usage ID (random UUID)
 
 We **never** collect:
 

--- a/crates/pcb-telem/Cargo.toml
+++ b/crates/pcb-telem/Cargo.toml
@@ -14,6 +14,7 @@ once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+pretty_env_logger = { workspace = true }
 
 # Telemetry dependencies - always included but only used in release builds
 sentry = { version = "0.32", features = ["anyhow", "log", "backtrace"], optional = true }

--- a/crates/pcb-telem/Cargo.toml
+++ b/crates/pcb-telem/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pcb-telem"
+version = "0.2.0-dev"
+edition = "2021"
+repository = "https://github.com/diodeinc/pcb"
+description = "Telemetry support for PCB tools with Sentry and PostHog integration"
+homepage = "https://github.com/diodeinc/pcb"
+authors = ["Diode Computers, Inc. <founders@diode.computer>"]
+
+[dependencies]
+anyhow = { workspace = true }
+log = { workspace = true }
+once_cell = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Telemetry dependencies - only included in release builds
+[target.'cfg(not(debug_assertions))'.dependencies]
+sentry = { version = "0.32", features = ["anyhow", "log", "backtrace"] }
+posthog-rs = "0.2"
+gethostname = "0.5"
+
+[features]
+default = []

--- a/crates/pcb-telem/Cargo.toml
+++ b/crates/pcb-telem/Cargo.toml
@@ -17,10 +17,10 @@ uuid = { workspace = true }
 pretty_env_logger = { workspace = true }
 
 # Telemetry dependencies - always included but only used in release builds
-sentry = { version = "0.32", features = ["anyhow", "log", "backtrace"], optional = true }
-posthog-rs = { version = "0.2", optional = true }
-gethostname = { version = "0.5", optional = true }
-machine-uid = { version = "0.5", optional = true }
+sentry = { workspace = true, optional = true }
+posthog-rs = { workspace = true, optional = true }
+gethostname = { workspace = true, optional = true }
+machine-uid = { workspace = true, optional = true }
 
 [features]
 default = ["telemetry"]

--- a/crates/pcb-telem/Cargo.toml
+++ b/crates/pcb-telem/Cargo.toml
@@ -13,12 +13,13 @@ log = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uuid = { workspace = true }
 
-# Telemetry dependencies - only included in release builds
-[target.'cfg(not(debug_assertions))'.dependencies]
-sentry = { version = "0.32", features = ["anyhow", "log", "backtrace"] }
-posthog-rs = "0.2"
-gethostname = "0.5"
+# Telemetry dependencies - always included but only used in release builds
+sentry = { version = "0.32", features = ["anyhow", "log", "backtrace"], optional = true }
+posthog-rs = { version = "0.2", optional = true }
+gethostname = { version = "0.5", optional = true }
 
 [features]
-default = []
+default = ["telemetry"]
+telemetry = ["sentry", "posthog-rs", "gethostname"]

--- a/crates/pcb-telem/Cargo.toml
+++ b/crates/pcb-telem/Cargo.toml
@@ -19,7 +19,8 @@ uuid = { workspace = true }
 sentry = { version = "0.32", features = ["anyhow", "log", "backtrace"], optional = true }
 posthog-rs = { version = "0.2", optional = true }
 gethostname = { version = "0.5", optional = true }
+machine-uid = { version = "0.5", optional = true }
 
 [features]
 default = ["telemetry"]
-telemetry = ["sentry", "posthog-rs", "gethostname"]
+telemetry = ["sentry", "posthog-rs", "gethostname", "machine-uid"]

--- a/crates/pcb-telem/README.md
+++ b/crates/pcb-telem/README.md
@@ -46,13 +46,14 @@ When telemetry is enabled, we collect:
 - Command invocations
 - Error messages and stack traces
 - Basic system info (OS type, tool version)
-- Anonymous usage ID
+- Anonymous machine ID (hashed for privacy)
 
 We never collect:
 - Source code or design files
 - Personal file paths
 - Network information
 - Credentials
+- Raw machine identifiers
 
 ## Implementation Details
 
@@ -60,3 +61,5 @@ We never collect:
 - All telemetry functions are no-ops when disabled
 - Sentry is used for error reporting
 - PostHog is used for usage analytics
+- Machine UIDs are hashed for privacy using `machine-uid` crate
+- Anonymous IDs are cached per session for consistency

--- a/crates/pcb-telem/README.md
+++ b/crates/pcb-telem/README.md
@@ -1,0 +1,66 @@
+# pcb-telem
+
+Telemetry support for PCB tools with Sentry and PostHog integration.
+
+## Features
+
+- **Error Reporting**: Automatic error reporting to Sentry in release builds
+- **Analytics**: Usage analytics via PostHog
+- **Privacy First**: Opt-out telemetry with environment variable control
+- **Debug/Release Separation**: Telemetry only active in release builds
+
+## Usage
+
+```rust
+use pcb_telem::{init_telemetry, setup_logger, capture_error, AuthData};
+
+fn main() -> Result<()> {
+    // Setup logger with Sentry integration
+    setup_logger()?;
+    
+    // Initialize telemetry (optional auth data)
+    let auth = AuthData {
+        local_id: "user-id".to_string(),
+        email: Some("user@example.com".to_string()),
+    };
+    init_telemetry(Some(auth))?;
+    
+    // Your application code here
+    if let Err(e) = run_app() {
+        // Capture errors to Sentry
+        capture_error(&e);
+        return Err(e);
+    }
+    
+    Ok(())
+}
+```
+
+## Opting Out
+
+Users can disable telemetry by setting the `PCB_TELEMETRY` environment variable:
+
+```bash
+export PCB_TELEMETRY=off
+```
+
+## Privacy
+
+When telemetry is enabled, we collect:
+- Command invocations
+- Error messages and stack traces
+- Basic system info (OS type, tool version)
+- Anonymous usage ID
+
+We never collect:
+- Source code or design files
+- Personal file paths
+- Network information
+- Credentials
+
+## Implementation Details
+
+- Telemetry is compiled out in debug builds using `cfg(not(debug_assertions))`
+- All telemetry functions are no-ops when disabled
+- Sentry is used for error reporting
+- PostHog is used for usage analytics

--- a/crates/pcb-telem/README.md
+++ b/crates/pcb-telem/README.md
@@ -12,18 +12,14 @@ Telemetry support for PCB tools with Sentry and PostHog integration.
 ## Usage
 
 ```rust
-use pcb_telem::{init_telemetry, setup_logger, capture_error, AuthData};
+use pcb_telem::{init_telemetry, setup_logger, capture_error};
 
 fn main() -> Result<()> {
     // Setup logger with Sentry integration
     setup_logger()?;
     
-    // Initialize telemetry (optional auth data)
-    let auth = AuthData {
-        local_id: "user-id".to_string(),
-        email: Some("user@example.com".to_string()),
-    };
-    init_telemetry(Some(auth))?;
+    // Initialize telemetry
+    init_telemetry()?;
     
     // Your application code here
     if let Err(e) = run_app() {

--- a/crates/pcb-telem/src/lib.rs
+++ b/crates/pcb-telem/src/lib.rs
@@ -1,0 +1,263 @@
+//! Telemetry support for PCB tools with Sentry and PostHog integration
+//!
+//! This crate provides telemetry functionality that is only active in release builds.
+//! Users can opt-out of telemetry by setting the PCB_TELEMETRY environment variable to "off".
+
+use anyhow::{Context, Result};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+#[cfg(all(feature = "telemetry", not(debug_assertions)))]
+use gethostname::gethostname;
+
+#[cfg(all(feature = "telemetry", not(debug_assertions)))]
+use posthog_rs::Event;
+
+#[cfg(all(feature = "telemetry", not(debug_assertions)))]
+use sentry::ClientInitGuard;
+
+/// Sentry DSN for error reporting
+#[cfg(all(feature = "telemetry", not(debug_assertions)))]
+const SENTRY_DSN: &str = "https://5d5c576f68c44baca59fc5352d3e40b5@o4508175627059200.ingest.us.sentry.io/4508175629352960";
+
+/// PostHog API key for analytics
+#[cfg(all(feature = "telemetry", not(debug_assertions)))]
+const POSTHOG_KEY: &str = "phc_h5EuYy42Vt2Qm5aOxx7ajD8inYEtj88v0KY8rwmcXhC";
+
+/// Checks if telemetry is enabled based on environment variable
+pub fn is_telemetry_enabled() -> bool {
+    std::env::var("PCB_TELEMETRY")
+        .map(|val| val.to_lowercase() != "off")
+        .unwrap_or(true)
+}
+
+/// User authentication data structure
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AuthData {
+    pub local_id: String,
+    pub email: Option<String>,
+}
+
+impl Default for AuthData {
+    fn default() -> Self {
+        Self {
+            local_id: uuid::Uuid::new_v4().to_string(),
+            email: None,
+        }
+    }
+}
+
+/// Global telemetry state
+static TELEMETRY_STATE: Lazy<Mutex<TelemetryState>> = Lazy::new(|| {
+    Mutex::new(TelemetryState {
+        #[cfg(all(feature = "telemetry", not(debug_assertions)))]
+        _guard: None,
+        initialized: false,
+    })
+});
+
+struct TelemetryState {
+    #[cfg(all(feature = "telemetry", not(debug_assertions)))]
+    _guard: Option<ClientInitGuard>,
+    initialized: bool,
+}
+
+/// Initializes telemetry with the given authentication data
+///
+/// This function should be called once at the start of the application.
+/// In debug builds, this is a no-op. In release builds, it initializes
+/// Sentry and sends an initial PostHog event.
+pub fn init_telemetry(auth_data: Option<AuthData>) -> Result<()> {
+    if !is_telemetry_enabled() {
+        log::debug!("Telemetry is disabled via PCB_TELEMETRY environment variable");
+        return Ok(());
+    }
+
+    let mut state = TELEMETRY_STATE.lock().unwrap();
+    if state.initialized {
+        log::debug!("Telemetry already initialized");
+        return Ok(());
+    }
+
+    #[cfg(all(feature = "telemetry", not(debug_assertions)))]
+    {
+        let auth_data = auth_data.unwrap_or_default();
+        
+        // Initialize Sentry
+        let guard = sentry::init((
+            SENTRY_DSN,
+            sentry::ClientOptions {
+                release: sentry::release_name!(),
+                ..Default::default()
+            },
+        ));
+        
+        // Configure Sentry scope with user info
+        configure_sentry(&auth_data)?;
+        
+        // Send initial PostHog event
+        track_invocation(&auth_data)?;
+        
+        state._guard = Some(guard);
+    }
+    
+    state.initialized = true;
+    Ok(())
+}
+
+/// Configures Sentry scope with user and command information
+#[cfg(all(feature = "telemetry", not(debug_assertions)))]
+fn configure_sentry(auth: &AuthData) -> Result<()> {
+    sentry::configure_scope(|scope| {
+        scope.set_tag(
+            "command",
+            format!("{:?}", std::env::args().collect::<Vec<String>>().join(" ")),
+        );
+        scope.set_tag("path", std::env::current_dir().unwrap().to_string_lossy());
+        scope.set_tag("email", auth.email.as_deref().unwrap_or("(none)"));
+        scope.set_user(Some(sentry::User {
+            id: Some(auth.local_id.clone()),
+            email: auth.email.clone(),
+            ..Default::default()
+        }));
+    });
+    Ok(())
+}
+
+/// Tracks a command invocation in PostHog
+#[cfg(all(feature = "telemetry", not(debug_assertions)))]
+fn track_invocation(auth: &AuthData) -> Result<()> {
+    let client = posthog_rs::client(POSTHOG_KEY);
+    let mut event = Event::new("invocation", &auth.local_id);
+    
+    event.insert_prop("email", auth.email.as_deref().unwrap_or("(none)"))?;
+    event.insert_prop(
+        "command",
+        std::env::args().collect::<Vec<String>>().join(" "),
+    )?;
+    event.insert_prop("path", std::env::current_dir().unwrap().to_string_lossy())?;
+    event.insert_prop("hostname", format!("{:?}", gethostname()))?;
+    event.insert_prop("version", env!("CARGO_PKG_VERSION"))?;
+    
+    client.capture(event)?;
+    Ok(())
+}
+
+/// Sets up the logger with Sentry integration
+///
+/// This creates a logger that sends errors to Sentry and other log levels
+/// as breadcrumbs. The actual log level is controlled by the RUST_LOG
+/// environment variable, defaulting to "warn".
+pub fn setup_logger() -> Result<()> {
+    // Build env logger with default level set to warn
+    let mut log_builder = env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("warn")
+    );
+    
+    #[cfg(all(feature = "telemetry", not(debug_assertions)))]
+    if is_telemetry_enabled() {
+        let sentry_logger = sentry::integrations::log::SentryLogger::with_dest(log_builder.build())
+            .filter(|md| match md.level() {
+                log::Level::Error => sentry::integrations::log::LogFilter::Event,
+                _ => sentry::integrations::log::LogFilter::Breadcrumb,
+            });
+        
+        // Set the global logger
+        log::set_boxed_logger(Box::new(sentry_logger))?;
+        log::set_max_level(log::LevelFilter::Debug);
+    } else {
+        log_builder.init();
+    }
+    
+    #[cfg(debug_assertions)]
+    log_builder.init();
+    
+    Ok(())
+}
+
+/// Captures an error and sends it to Sentry (in release builds)
+///
+/// This is a convenience function for capturing errors. In debug builds,
+/// this is a no-op.
+pub fn capture_error(error: &anyhow::Error) {
+    #[cfg(all(feature = "telemetry", not(debug_assertions)))]
+    if is_telemetry_enabled() {
+        sentry::integrations::anyhow::capture_anyhow(error);
+    }
+}
+
+/// Tracks a custom event in PostHog
+///
+/// This allows tracking custom events beyond the initial invocation.
+/// In debug builds, this is a no-op.
+#[cfg(all(feature = "telemetry", not(debug_assertions)))]
+pub fn track_event(event_name: &str, properties: Option<serde_json::Value>) -> Result<()> {
+    if !is_telemetry_enabled() {
+        return Ok(());
+    }
+    
+    let auth_data = AuthData::default(); // You might want to load this from storage
+    let client = posthog_rs::client(POSTHOG_KEY);
+    let mut event = Event::new(event_name, &auth_data.local_id);
+    
+    if let Some(props) = properties {
+        if let Some(obj) = props.as_object() {
+            for (key, value) in obj {
+                event.insert_prop(key, value)?;
+            }
+        }
+    }
+    
+    client.capture(event)?;
+    Ok(())
+}
+
+#[cfg(debug_assertions)]
+pub fn track_event(_event_name: &str, _properties: Option<serde_json::Value>) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_telemetry_enabled_by_default() {
+        // Save current env var
+        let original = std::env::var("PCB_TELEMETRY").ok();
+        
+        // Remove env var
+        std::env::remove_var("PCB_TELEMETRY");
+        assert!(is_telemetry_enabled());
+        
+        // Restore original
+        if let Some(val) = original {
+            std::env::set_var("PCB_TELEMETRY", val);
+        }
+    }
+
+    #[test]
+    fn test_telemetry_can_be_disabled() {
+        // Save current env var
+        let original = std::env::var("PCB_TELEMETRY").ok();
+        
+        // Set to off
+        std::env::set_var("PCB_TELEMETRY", "off");
+        assert!(!is_telemetry_enabled());
+        
+        // Set to OFF (uppercase)
+        std::env::set_var("PCB_TELEMETRY", "OFF");
+        assert!(!is_telemetry_enabled());
+        
+        // Set to something else
+        std::env::set_var("PCB_TELEMETRY", "on");
+        assert!(is_telemetry_enabled());
+        
+        // Restore original
+        if let Some(val) = original {
+            std::env::set_var("PCB_TELEMETRY", val);
+        } else {
+            std::env::remove_var("PCB_TELEMETRY");
+        }
+    }
+}

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -30,4 +30,5 @@ colored = { workspace = true }
 pcb-kicad = { workspace = true }
 open = { workspace = true }
 inquire = { workspace = true }
-pcb-ui = { workspace = true } 
+pcb-ui = { workspace = true }
+pcb-telem = { workspace = true } 

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -37,21 +37,7 @@ enum Commands {
     External(Vec<OsString>),
 }
 
-fn main() {
-    // Run the actual main function and capture any errors
-    if let Err(e) = run() {
-        // Log error to stderr
-        eprintln!("Error: {:?}", e);
-        
-        // Send error to telemetry (only in release builds)
-        pcb_telem::capture_error(&e);
-        
-        // Exit with error code
-        std::process::exit(1);
-    }
-}
-
-fn run() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     // Initialize logger with telemetry support
     pcb_telem::setup_logger()?;
     
@@ -62,7 +48,7 @@ fn run() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
-    match cli.command {
+    let result = match cli.command {
         Commands::Build(args) => build::execute(args),
         Commands::Layout(args) => layout::execute(args),
         Commands::Lsp(args) => lsp::execute(args),
@@ -106,5 +92,12 @@ fn run() -> anyhow::Result<()> {
                 }
             }
         }
+    };
+    
+    // Capture any errors to telemetry before returning
+    if let Err(e) = &result {
+        pcb_telem::capture_error(e);
     }
+    
+    result
 }

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -37,9 +37,29 @@ enum Commands {
     External(Vec<OsString>),
 }
 
-fn main() -> anyhow::Result<()> {
-    // Initialize logger
-    env_logger::init();
+fn main() {
+    // Run the actual main function and capture any errors
+    if let Err(e) = run() {
+        // Log error to stderr
+        eprintln!("Error: {:?}", e);
+        
+        // Send error to telemetry (only in release builds)
+        pcb_telem::capture_error(&e);
+        
+        // Exit with error code
+        std::process::exit(1);
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    // Initialize logger with telemetry support
+    pcb_telem::setup_logger()?;
+    
+    // Initialize telemetry (only active in release builds)
+    // For now we use default auth data - in the future this could be loaded from a config file
+    if let Err(e) = pcb_telem::init_telemetry(None) {
+        log::debug!("Failed to initialize telemetry: {}", e);
+    }
 
     let cli = Cli::parse();
 

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -56,8 +56,7 @@ fn run() -> anyhow::Result<()> {
     pcb_telem::setup_logger()?;
     
     // Initialize telemetry (only active in release builds)
-    // For now we use default auth data - in the future this could be loaded from a config file
-    if let Err(e) = pcb_telem::init_telemetry(None) {
+    if let Err(e) = pcb_telem::init_telemetry() {
         log::debug!("Failed to initialize telemetry: {}", e);
     }
 


### PR DESCRIPTION
Add `pcb-telem` crate to enable anonymous, opt-out telemetry for usage analytics and error reporting.

This PR introduces a new `pcb-telem` crate to centralize and manage telemetry. It integrates Sentry for error reporting and PostHog for usage analytics. The telemetry is designed with privacy in mind: it's only active in release builds, uses hashed machine IDs for anonymous tracking (with a fallback to random UUIDs), and provides a clear opt-out mechanism via the `PCB_TELEMETRY=off` environment variable. All related dependencies are now managed at the workspace level for consistency.