### PR TITLE
Update symbol handling

### DIFF
--- a/crates/pcb-eda/src/kicad/mod.rs
+++ b/crates/pcb-eda/src/kicad/mod.rs
@@ -1,1 +1,2 @@
 pub mod symbol;
+pub mod symbol_library;

--- a/crates/pcb-eda/src/kicad/symbol.rs
+++ b/crates/pcb-eda/src/kicad/symbol.rs
@@ -20,6 +20,12 @@ pub struct KicadSymbol {
     properties: HashMap<String, String>,
 }
 
+impl KicadSymbol {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 #[derive(Debug, Default)]
 struct KicadPin {
     name: String,
@@ -84,7 +90,7 @@ impl KicadSymbol {
     }
 }
 
-fn parse_symbol(symbol_data: &[Sexp]) -> Result<KicadSymbol> {
+pub(super) fn parse_symbol(symbol_data: &[Sexp]) -> Result<KicadSymbol> {
     // Extract the symbol name
     let name = symbol_data
         .get(1)

--- a/crates/pcb-eda/src/kicad/symbol_library.rs
+++ b/crates/pcb-eda/src/kicad/symbol_library.rs
@@ -1,0 +1,104 @@
+use crate::Symbol;
+use anyhow::Result;
+use sexp::{parse, Atom, Sexp};
+use std::fs;
+use std::path::Path;
+
+use super::symbol::{parse_symbol, KicadSymbol};
+
+/// A KiCad symbol library that can contain multiple symbols
+pub struct KicadSymbolLibrary {
+    symbols: Vec<KicadSymbol>,
+}
+
+impl KicadSymbolLibrary {
+    /// Parse a KiCad symbol library from a string
+    pub fn from_string(content: &str) -> Result<Self> {
+        let sexp = parse(content)?;
+        let mut symbols = Vec::new();
+
+        match sexp {
+            Sexp::List(kicad_symbol_lib) => {
+                // Iterate through all items in the library
+                for item in kicad_symbol_lib {
+                    if let Sexp::List(ref symbol_list) = item {
+                        if let Some(Sexp::Atom(Atom::S(ref sym))) = symbol_list.first() {
+                            if sym == "symbol" {
+                                // Parse this symbol
+                                match parse_symbol(symbol_list) {
+                                    Ok(symbol) => symbols.push(symbol),
+                                    Err(e) => {
+                                        // Log error but continue parsing other symbols
+                                        eprintln!("Warning: Failed to parse symbol: {e}");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => return Err(anyhow::anyhow!("Invalid KiCad symbol library format")),
+        }
+
+        Ok(KicadSymbolLibrary { symbols })
+    }
+
+    /// Parse a KiCad symbol library from a file
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path)?;
+        Self::from_string(&content)
+    }
+
+    /// Get all symbols in the library
+    pub fn symbols(&self) -> &[KicadSymbol] {
+        &self.symbols
+    }
+
+    /// Get a symbol by name
+    pub fn get_symbol(&self, name: &str) -> Option<&KicadSymbol> {
+        self.symbols.iter().find(|s| s.name() == name)
+    }
+
+    /// Get the names of all symbols in the library
+    pub fn symbol_names(&self) -> Vec<&str> {
+        self.symbols.iter().map(|s| s.name()).collect()
+    }
+
+    /// Convert all symbols to the generic Symbol type
+    pub fn into_symbols(self) -> Vec<Symbol> {
+        self.symbols.into_iter().map(|s| s.into()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_multi_symbol_library() {
+        let content = r#"(kicad_symbol_lib
+            (symbol "Symbol1"
+                (property "Reference" "U" (at 0 0 0))
+                (symbol "Symbol1_0_1"
+                    (pin input line (at 0 0 0) (length 2.54)
+                        (name "A" (effects (font (size 1.27 1.27))))
+                        (number "1" (effects (font (size 1.27 1.27))))
+                    )
+                )
+            )
+            (symbol "Symbol2"
+                (property "Reference" "U" (at 0 0 0))
+                (symbol "Symbol2_0_1"
+                    (pin input line (at 0 0 0) (length 2.54)
+                        (name "B" (effects (font (size 1.27 1.27))))
+                        (number "2" (effects (font (size 1.27 1.27))))
+                    )
+                )
+            )
+        )"#;
+
+        let lib = KicadSymbolLibrary::from_string(content).unwrap();
+        assert_eq!(lib.symbols.len(), 2);
+        assert_eq!(lib.symbol_names(), vec!["Symbol1", "Symbol2"]);
+    }
+}

--- a/crates/pcb-eda/src/lib.rs
+++ b/crates/pcb-eda/src/lib.rs
@@ -2,13 +2,14 @@ pub mod kicad;
 
 use anyhow::Result;
 use kicad::symbol::KicadSymbol;
+use kicad::symbol_library::KicadSymbolLibrary;
 
 use std::collections::HashMap;
 use std::io;
 use std::path::Path;
 use std::str::FromStr;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Symbol {
     pub name: String,
     pub footprint: String,
@@ -22,13 +23,13 @@ pub struct Symbol {
     pub properties: HashMap<String, String>,
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct Part {
     pub part_number: String,
     pub url: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pin {
     pub name: String,
     pub number: String,
@@ -49,5 +50,60 @@ impl Symbol {
             "kicad_sym" => Ok(KicadSymbol::from_str(contents)?.into()),
             _ => Err(anyhow::anyhow!("Unsupported file type: {}", file_type)),
         }
+    }
+}
+
+/// A symbol library that can contain multiple symbols
+pub struct SymbolLibrary {
+    symbols: Vec<Symbol>,
+}
+
+impl SymbolLibrary {
+    /// Parse a symbol library from a file
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let extension = path.extension().unwrap_or("".as_ref()).to_str();
+        let error = io::Error::other("Unsupported file type");
+        match extension {
+            Some("kicad_sym") => {
+                let lib = KicadSymbolLibrary::from_file(path)?;
+                Ok(SymbolLibrary {
+                    symbols: lib.into_symbols(),
+                })
+            }
+            _ => Err(anyhow::anyhow!(error)),
+        }
+    }
+
+    /// Parse a symbol library from a string
+    pub fn from_string(contents: &str, file_type: &str) -> Result<Self> {
+        match file_type {
+            "kicad_sym" => {
+                let lib = KicadSymbolLibrary::from_string(contents)?;
+                Ok(SymbolLibrary {
+                    symbols: lib.into_symbols(),
+                })
+            }
+            _ => Err(anyhow::anyhow!("Unsupported file type: {}", file_type)),
+        }
+    }
+
+    /// Get all symbols in the library
+    pub fn symbols(&self) -> &[Symbol] {
+        &self.symbols
+    }
+
+    /// Get a symbol by name
+    pub fn get_symbol(&self, name: &str) -> Option<&Symbol> {
+        self.symbols.iter().find(|s| s.name == name)
+    }
+
+    /// Get the names of all symbols in the library
+    pub fn symbol_names(&self) -> Vec<&str> {
+        self.symbols.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    /// Get the first symbol in the library (for backwards compatibility)
+    pub fn first_symbol(&self) -> Option<&Symbol> {
+        self.symbols.first()
     }
 }

--- a/crates/pcb-sexpr/src/lib.rs
+++ b/crates/pcb-sexpr/src/lib.rs
@@ -260,8 +260,8 @@ impl<'a> Parser<'a> {
     }
 
     fn advance(&mut self) {
-        if let Some((pos, _)) = self.chars.next() {
-            self.current_pos = pos + 1; // pos is the start of the char, we want the position after it
+        if let Some((pos, ch)) = self.chars.next() {
+            self.current_pos = pos + ch.len_utf8(); // pos is the start of the char, we want the position after it
         }
     }
 
@@ -596,6 +596,23 @@ mod tests {
             let formatted = format_sexpr(&parsed, 0);
             let reparsed = parse(&formatted).unwrap();
             assert_eq!(parsed, reparsed, "Roundtrip failed for: {input}");
+        }
+    }
+
+    #[test]
+    fn test_utf8_handling() {
+        // Test with multi-byte UTF-8 characters
+        let input = r#"(symbol "résistance" "日本語" "🔥")"#;
+        let parsed = parse(input).unwrap();
+        
+        if let Sexpr::List(items) = parsed {
+            assert_eq!(items.len(), 4);
+            assert_eq!(items[0], Sexpr::Symbol("symbol".to_string()));
+            assert_eq!(items[1], Sexpr::String("résistance".to_string()));
+            assert_eq!(items[2], Sexpr::String("日本語".to_string()));
+            assert_eq!(items[3], Sexpr::String("🔥".to_string()));
+        } else {
+            panic!("Expected a list");
         }
     }
 }

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::needless_lifetimes)]
 
+use std::path::Path;
+
 use allocative::Allocative;
 use starlark::{
     any::ProvidesStaticType,
@@ -8,7 +10,7 @@ use starlark::{
     eval::{Arguments, Evaluator, ParametersSpec, ParametersSpecParam},
     starlark_complex_value, starlark_module, starlark_simple_value,
     values::{
-        dict::DictRef, starlark_value, Coerce, Freeze, FreezeResult, Heap, NoSerialize,
+        dict::DictRef, list::ListRef, starlark_value, tuple::TupleRef, Coerce, Freeze, FreezeResult, Heap, NoSerialize,
         StarlarkValue, Trace, Value, ValueLike,
     },
 };
@@ -18,7 +20,7 @@ use crate::lang::evaluator_ext::EvaluatorExt;
 use super::net::NetType;
 
 use anyhow::anyhow;
-use pcb_eda::Symbol as EdaSymbol;
+use pcb_eda::{Symbol as EdaSymbol, SymbolLibrary};
 
 #[derive(Clone, Coerce, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
 #[repr(C)]
@@ -32,6 +34,7 @@ pub struct ComponentValueGen<V> {
     connections: SmallMap<String, V>,
     properties: SmallMap<String, V>,
     source_path: String,
+    symbol: V,  // The Symbol value if one was provided (None if not)
 }
 
 impl<V: std::fmt::Debug> std::fmt::Debug for ComponentValueGen<V> {
@@ -75,6 +78,9 @@ impl<V: std::fmt::Debug> std::fmt::Debug for ComponentValueGen<V> {
                 props.into_iter().map(|(k, v)| (k.as_str(), v)).collect();
             debug.field("properties", &props_map);
         }
+        
+        // Show symbol field
+        debug.field("symbol", &self.symbol);
 
         debug.finish()
     }
@@ -159,6 +165,10 @@ impl<'v, V: ValueLike<'v>> ComponentValueGen<V> {
     pub fn source_path(&self) -> &str {
         &self.source_path
     }
+    
+    pub fn symbol(&self) -> &V {
+        &self.symbol
+    }
 }
 
 /// ComponentFactory is a value that represents a factory for a component.
@@ -168,7 +178,7 @@ pub struct ComponentType;
 
 starlark_simple_value!(ComponentType);
 
-#[starlark_value(type = "ComponentFactory")]
+#[starlark_value(type = "Component")]
 impl<'v> StarlarkValue<'v> for ComponentType
 where
     Self: ProvidesStaticType<'v>,
@@ -184,7 +194,7 @@ where
             [
                 ("name", ParametersSpecParam::<Value<'_>>::Required),
                 ("footprint", ParametersSpecParam::<Value<'_>>::Required),
-                ("pin_defs", ParametersSpecParam::<Value<'_>>::Required),
+                ("pin_defs", ParametersSpecParam::<Value<'_>>::Optional),
                 ("pins", ParametersSpecParam::<Value<'_>>::Required),
                 (
                     "prefix",
@@ -206,7 +216,6 @@ where
                 .ok_or_else(|| starlark::Error::new_other(anyhow!("`name` must be a string")))?
                 .to_owned();
 
-            // --- Footprint -------------------------------------------------
             let footprint_val: Value = param_parser.next()?;
             let mut footprint = footprint_val
                 .unpack_str()
@@ -232,27 +241,11 @@ where
                 }
             }
 
-            // --- Pins ------------------------------------------------------
-            let pin_defs_val: Value = param_parser.next()?;
-            let dict_ref = DictRef::from_value(pin_defs_val).ok_or_else(|| {
-                starlark::Error::new_other(anyhow!("`pin_defs` must be a dict of name -> pad"))
-            })?;
+            let pin_defs_val: Option<Value> = param_parser.next_opt()?;
+            
+            // We'll determine pins_str_map later, after we check for symbol
             let mut pins_str_map: SmallMap<String, String> = SmallMap::new();
-            for (k_val, v_val) in dict_ref.iter() {
-                let name = k_val
-                    .unpack_str()
-                    .ok_or_else(|| {
-                        starlark::Error::new_other(anyhow!("pin name must be a string"))
-                    })?
-                    .to_owned();
-                let pad = v_val
-                    .unpack_str()
-                    .ok_or_else(|| starlark::Error::new_other(anyhow!("pad must be a string")))?
-                    .to_owned();
-                pins_str_map.insert(name, pad);
-            }
 
-            // --- Connections ---------------------------------------------
             let pins_val: Value = param_parser.next()?;
             let conn_dict = DictRef::from_value(pins_val).ok_or_else(|| {
                 starlark::Error::new_other(anyhow!(
@@ -260,6 +253,66 @@ where
                 ))
             })?;
 
+            let prefix_val: Value = param_parser.next()?;
+            let prefix = prefix_val
+                .unpack_str()
+                .ok_or_else(|| starlark::Error::new_other(anyhow!("`prefix` must be a string")))?
+                .to_owned();
+
+            // Optional fields
+            let symbol_val: Option<Value> = param_parser.next_opt()?;
+            let mpn: Option<Value> = param_parser.next_opt()?;
+            let ctype: Option<Value> = param_parser.next_opt()?;
+            let properties_val: Value = param_parser.next_opt()?.unwrap_or_default();
+            
+            // Now determine pins_str_map based on either pin_defs or symbol
+            if let Some(pin_defs) = pin_defs_val {
+                // Old way: pin_defs provided as a dict
+                let dict_ref = DictRef::from_value(pin_defs).ok_or_else(|| {
+                    starlark::Error::new_other(anyhow!("`pin_defs` must be a dict of name -> pad"))
+                })?;
+                for (k_val, v_val) in dict_ref.iter() {
+                    let name = k_val
+                        .unpack_str()
+                        .ok_or_else(|| {
+                            starlark::Error::new_other(anyhow!("pin name must be a string"))
+                        })?
+                        .to_owned();
+                    let pad = v_val
+                        .unpack_str()
+                        .ok_or_else(|| starlark::Error::new_other(anyhow!("pad must be a string")))?
+                        .to_owned();
+                    pins_str_map.insert(name, pad);
+                }
+            } else if let Some(symbol) = &symbol_val {
+                // New way: symbol provided as a Symbol value
+                if symbol.get_type() == "Symbol" {
+                    // Extract pins from the Symbol value
+                    let symbol_value = symbol.downcast_ref::<SymbolValue>().ok_or_else(|| {
+                        starlark::Error::new_other(anyhow!("Failed to downcast Symbol value"))
+                    })?;
+                    
+                    // Convert Symbol pins (pad -> signal) to Component pins (signal -> pad)
+                    for (pad, signal_val) in symbol_value.pins() {
+                        if let Some(signal) = signal_val.unpack_str() {
+                            pins_str_map.insert(signal.to_owned(), pad.clone());
+                        }
+                    }
+                } else {
+                    // Old way: symbol is a string path (for backwards compatibility)
+                    // In this case, pin_defs is required
+                    return Err(starlark::Error::new_other(anyhow!(
+                        "When `symbol` is a string path, `pin_defs` must be provided"
+                    )));
+                }
+            } else {
+                // Neither pin_defs nor symbol provided
+                return Err(starlark::Error::new_other(anyhow!(
+                    "Either `pin_defs` or a Symbol value for `symbol` must be provided"
+                )));
+            }
+
+            // Now handle connections after we have pins_str_map
             let mut connections: SmallMap<String, Value<'v>> = SmallMap::new();
             for (k_val, v_val) in conn_dict.iter() {
                 let pin_name = k_val
@@ -300,18 +353,6 @@ where
                 ))));
             }
 
-            let prefix_val: Value = param_parser.next()?;
-            let prefix = prefix_val
-                .unpack_str()
-                .ok_or_else(|| starlark::Error::new_other(anyhow!("`prefix` must be a string")))?
-                .to_owned();
-
-            // Optional fields
-            let symbol_val: Option<Value> = param_parser.next_opt()?;
-            let mpn: Option<Value> = param_parser.next_opt()?;
-            let ctype: Option<Value> = param_parser.next_opt()?;
-            let properties_val: Value = param_parser.next_opt()?.unwrap_or_default();
-
             // Properties map
             let mut properties_map: SmallMap<String, Value<'v>> = SmallMap::new();
             if !properties_val.is_none() {
@@ -330,12 +371,17 @@ where
                 }
             }
 
-            properties_map.insert(
-                "symbol_path".to_string(),
-                symbol_val.map(|v| v.to_value()).unwrap_or_default(),
-            );
+            // Store the symbol path in properties if the symbol has one
+            if let Some(symbol) = &symbol_val {
+                if symbol.get_type() == "Symbol" {
+                    if let Some(symbol_value) = symbol.downcast_ref::<SymbolValue>() {
+                        if let Some(path) = symbol_value.source_path() {
+                            properties_map.insert("symbol_path".to_string(), eval_ctx.heap().alloc_str(path).to_value());
+                        }
+                    }
+                }
+            }
 
-            // ------------------- Build pins SmallMap<String, Value> -----------
             let mut pins_val_map: SmallMap<String, Value<'v>> = SmallMap::new();
             for (name, pad) in pins_str_map.iter() {
                 pins_val_map.insert(name.clone(), eval_ctx.heap().alloc_str(pad).to_value());
@@ -351,6 +397,7 @@ where
                 connections,
                 properties: properties_map,
                 source_path: eval_ctx.source_path().unwrap_or_default(),
+                symbol: symbol_val.unwrap_or_else(Value::new_none),
             });
 
             Ok(component)
@@ -373,6 +420,293 @@ impl std::fmt::Display for ComponentType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "<Component>")
     }
+}
+
+/// Symbol represents a schematic symbol definition with pins
+#[derive(Clone, Coerce, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
+#[repr(C)]
+pub struct SymbolValueGen<V> {
+    name: String,
+    pins: SmallMap<String, V>,  // pad name -> signal name
+    source_path: Option<String>,  // Absolute path to the symbol library (if loaded from file)
+}
+
+impl<V: std::fmt::Debug> std::fmt::Debug for SymbolValueGen<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Symbol");
+        debug.field("name", &self.name);
+        
+        // Sort pins for deterministic output
+        if !self.pins.is_empty() {
+            let mut pins: Vec<_> = self.pins.iter().collect();
+            pins.sort_by_key(|(k, _)| k.as_str());
+            let pins_map: std::collections::BTreeMap<_, _> =
+                pins.into_iter().map(|(k, v)| (k.as_str(), v)).collect();
+            debug.field("pins", &pins_map);
+        }
+        
+        debug.finish()
+    }
+}
+
+starlark_complex_value!(pub SymbolValue);
+
+#[starlark_value(type = "Symbol")]
+impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for SymbolValueGen<V>
+where
+    Self: ProvidesStaticType<'v>,
+{
+}
+
+impl<'v, V: ValueLike<'v>> std::fmt::Display for SymbolValueGen<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Symbol({})", self.name)?;
+        
+        let mut pins: Vec<_> = self.pins.iter().collect();
+        pins.sort_by(|(a, _), (b, _)| a.cmp(b));
+        
+        for (pad_name, signal_value) in pins {
+            let signal_str = signal_value.to_value().unpack_str().unwrap_or("<signal>");
+            writeln!(f, "  {pad_name} -> {signal_str}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<'v, V: ValueLike<'v>> SymbolValueGen<V> {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    
+    pub fn pins(&self) -> &SmallMap<String, V> {
+        &self.pins
+    }
+    
+    pub fn source_path(&self) -> Option<&str> {
+        self.source_path.as_deref()
+    }
+}
+
+/// SymbolType is a factory for creating Symbol values
+#[derive(Debug, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
+#[repr(C)]
+pub struct SymbolType;
+
+starlark_simple_value!(SymbolType);
+
+#[starlark_value(type = "Symbol")]
+impl<'v> StarlarkValue<'v> for SymbolType
+where
+    Self: ProvidesStaticType<'v>,
+{
+    fn invoke(
+        &self,
+        _me: Value<'v>,
+        args: &Arguments<'v, '_>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> starlark::Result<Value<'v>> {
+        let param_spec = ParametersSpec::new_named_only(
+            "Symbol",
+            [
+                ("name", ParametersSpecParam::<Value<'_>>::Optional),
+                ("definition", ParametersSpecParam::<Value<'_>>::Optional),
+                ("library", ParametersSpecParam::<Value<'_>>::Optional),
+            ],
+        );
+
+        let symbol_val = param_spec.parser(args, eval, |param_parser, eval_ctx| {
+            let name_val: Option<Value> = param_parser.next_opt()?;
+            let definition_val: Option<Value> = param_parser.next_opt()?;
+            let library_val: Option<Value> = param_parser.next_opt()?;
+            
+            // Case 1: Explicit definition provided
+            if let Some(def_val) = definition_val {
+                let name = name_val
+                    .and_then(|v| v.unpack_str())
+                    .map(|s| s.to_owned())
+                    .unwrap_or_else(|| "Symbol".to_owned());
+                
+                let def_list = ListRef::from_value(def_val).ok_or_else(|| {
+                    starlark::Error::new_other(anyhow!(
+                        "`definition` must be a list of (signal_name, [pad_names]) tuples"
+                    ))
+                })?;
+                
+                let mut pins: SmallMap<String, Value<'v>> = SmallMap::new();
+                
+                for item in def_list.iter() {
+                    let tuple = TupleRef::from_value(item).ok_or_else(|| {
+                        starlark::Error::new_other(anyhow!(
+                            "Each definition item must be a tuple of (signal_name, [pad_names])"
+                        ))
+                    })?;
+                    
+                    let tuple_items: Vec<_> = tuple.iter().collect();
+                    if tuple_items.len() != 2 {
+                        return Err(starlark::Error::new_other(anyhow!(
+                            "Each definition tuple must have exactly 2 elements: (signal_name, [pad_names])"
+                        )));
+                    }
+                    
+                    let signal_name = tuple_items[0].unpack_str().ok_or_else(|| {
+                        starlark::Error::new_other(anyhow!("Signal name must be a string"))
+                    })?;
+                    
+                    let pad_list = ListRef::from_value(tuple_items[1]).ok_or_else(|| {
+                        starlark::Error::new_other(anyhow!("Pad names must be a list"))
+                    })?;
+                    
+                    if pad_list.is_empty() {
+                        return Err(starlark::Error::new_other(anyhow!(
+                            "Pad list for signal '{}' cannot be empty", signal_name
+                        )));
+                    }
+                    
+                    // For each pad in the list, create a mapping from pad to signal
+                    for pad_val in pad_list.iter() {
+                        let pad_name = pad_val.unpack_str().ok_or_else(|| {
+                            starlark::Error::new_other(anyhow!("Pad name must be a string"))
+                        })?;
+                        
+                        // Check for duplicate pad assignments
+                        if pins.contains_key(pad_name) {
+                            return Err(starlark::Error::new_other(anyhow!(
+                                "Pad '{}' is already assigned to signal '{}'", 
+                                pad_name,
+                                pins.get(pad_name).unwrap().to_value().unpack_str().unwrap_or("<unknown>")
+                            )));
+                        }
+                        
+                        // Map: pad_name -> signal_name (note: this is inverted from the comment in the struct)
+                        pins.insert(pad_name.to_owned(), eval_ctx.heap().alloc_str(signal_name).to_value());
+                    }
+                }
+                
+                let symbol = eval_ctx.heap().alloc_complex(SymbolValue {
+                    name,
+                    pins,
+                    source_path: None,  // No source path for manually defined symbols
+                });
+                
+                Ok(symbol)
+            }
+            // Case 2: Load from library
+            else if let Some(lib_val) = library_val {
+                let library_path = lib_val
+                    .unpack_str()
+                    .ok_or_else(|| starlark::Error::new_other(anyhow!("`library` must be a string path")))?;
+                
+                
+                let load_resolver = eval_ctx
+                    .load_resolver()
+                    .ok_or_else(|| starlark::Error::new_other(anyhow!("No load resolver available")))?;
+                
+                let current_file = eval_ctx
+                    .source_path()
+                    .ok_or_else(|| starlark::Error::new_other(anyhow!("No source path available")))?;
+                
+                let resolved_path = load_resolver
+                    .resolve_path(eval_ctx.file_provider().unwrap().as_ref(), library_path, Path::new(&current_file))
+                    .map_err(|e| starlark::Error::new_other(anyhow!("Failed to resolve library path: {}", e)))?;
+                
+                let file_provider = eval_ctx
+                    .file_provider()
+                    .ok_or_else(|| starlark::Error::new_other(anyhow!("No file provider available")))?;
+                
+                // Read and parse the symbol library
+                let contents = file_provider.read_file(&resolved_path).map_err(|e| {
+                    starlark::Error::new_other(anyhow!(
+                        "Failed to read symbol library '{}': {}", 
+                        resolved_path.display(), 
+                        e
+                    ))
+                })?;
+                
+                // Parse all symbols from the library
+                let symbols = parse_all_symbols_from_library(&contents)?;
+                
+                // Determine which symbol to use
+                let selected_symbol = if symbols.len() == 1 {
+                    // Only one symbol, use it
+                    &symbols[0]
+                } else if symbols.is_empty() {
+                    return Err(starlark::Error::new_other(anyhow!(
+                        "No symbols found in library '{}'", 
+                        resolved_path.display()
+                    )));
+                } else {
+                    // Multiple symbols, need name parameter
+                    let symbol_name = name_val
+                        .and_then(|v| v.unpack_str())
+                        .ok_or_else(|| {
+                            starlark::Error::new_other(anyhow!(
+                                "Library '{}' contains {} symbols. Please specify which one with the 'name' parameter. Available symbols: {}",
+                                resolved_path.display(),
+                                symbols.len(),
+                                symbols.iter().map(|s| s.name.as_str()).collect::<Vec<_>>().join(", ")
+                            ))
+                        })?;
+                    
+                    symbols.iter()
+                        .find(|s| s.name == symbol_name)
+                        .ok_or_else(|| {
+                            starlark::Error::new_other(anyhow!(
+                                "Symbol '{}' not found in library '{}'. Available symbols: {}",
+                                symbol_name,
+                                resolved_path.display(),
+                                symbols.iter().map(|s| s.name.as_str()).collect::<Vec<_>>().join(", ")
+                            ))
+                        })?
+                };
+                
+                // Convert EdaSymbol pins to our Symbol format
+                // Map pad number -> signal name (which is the pin name from the symbol)
+                let mut pins: SmallMap<String, Value<'v>> = SmallMap::new();
+                for pin in &selected_symbol.pins {
+                    pins.insert(pin.number.clone(), eval_ctx.heap().alloc_str(&pin.name).to_value());
+                }
+                
+                // Get the absolute path using file provider
+                let absolute_path = file_provider.canonicalize(&resolved_path)
+                    .unwrap_or(resolved_path.clone())
+                    .to_string_lossy()
+                    .into_owned();
+                
+                let symbol = eval_ctx.heap().alloc_complex(SymbolValue {
+                    name: selected_symbol.name.clone(),
+                    pins,
+                    source_path: Some(absolute_path),
+                });
+                
+                Ok(symbol)
+            }
+            else {
+                Err(starlark::Error::new_other(anyhow!(
+                    "Symbol requires either 'definition' or 'library' parameter"
+                )))
+            }
+        })?;
+
+        Ok(symbol_val)
+    }
+
+    fn eval_type(&self) -> Option<starlark::typing::Ty> {
+        Some(<SymbolType as StarlarkValue>::get_type_starlark_repr())
+    }
+}
+
+impl std::fmt::Display for SymbolType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<Symbol>")
+    }
+}
+
+/// Parse all symbols from a KiCad symbol library
+fn parse_all_symbols_from_library(content: &str) -> starlark::Result<Vec<EdaSymbol>> {
+    let library = SymbolLibrary::from_string(content, "kicad_sym")
+        .map_err(|e| starlark::Error::new_other(anyhow!("Failed to parse symbol library: {}", e)))?;
+    
+    Ok(library.symbols().to_vec())
 }
 
 #[derive(Clone, Debug, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
@@ -443,7 +777,7 @@ impl std::fmt::Display for ComponentFactoryValue {
     }
 }
 
-#[starlark_value(type = "ComponentFactoryValue")]
+#[starlark_value(type = "Component")]
 impl<'v> StarlarkValue<'v> for ComponentFactoryValue
 where
     Self: ProvidesStaticType<'v>,
@@ -625,6 +959,7 @@ where
                 connections,
                 properties: properties_map,
                 source_path: eval_ctx.source_path().unwrap_or_default(),
+                symbol: Value::new_none(),  // ComponentFactory doesn't have a symbol
             });
 
             Ok(component)
@@ -719,6 +1054,7 @@ pub(crate) fn build_component_factory_from_symbol(
 pub fn component_globals(builder: &mut GlobalsBuilder) {
     const Component: ComponentType = ComponentType;
     const Net: NetType = NetType;
+    const Symbol: SymbolType = SymbolType;
 
     fn load_component<'v>(
         #[starlark(require = pos)] symbol_path: String,

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -460,15 +460,21 @@ where
 
 impl<'v, V: ValueLike<'v>> std::fmt::Display for SymbolValueGen<V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Symbol({})", self.name)?;
+        write!(f, "Symbol {{ name: \"{}\", pins: {{", self.name)?;
         
         let mut pins: Vec<_> = self.pins.iter().collect();
         pins.sort_by(|(a, _), (b, _)| a.cmp(b));
         
+        let mut first = true;
         for (pad_name, signal_value) in pins {
+            if !first {
+                write!(f, ",")?;
+            }
+            first = false;
             let signal_str = signal_value.to_value().unpack_str().unwrap_or("<signal>");
-            writeln!(f, "  {pad_name} -> {signal_str}")?;
+            write!(f, " \"{pad_name}\": \"{signal_str}\"")?;
         }
+        write!(f, " }} }}")?;
         Ok(())
     }
 }

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -20,6 +20,7 @@ use starlark::{
         dict::{AllocDict, DictRef},
         Heap, Value, ValueLike,
     },
+    PrintHandler,
 };
 
 use crate::lang::component::{build_component_factory_from_symbol, component_globals};
@@ -45,6 +46,31 @@ use super::{
     interface::interface_globals,
     module::{module_globals, FrozenModuleValue, ModuleLoader},
 };
+
+/// A PrintHandler that collects all print output into a vector
+struct CollectingPrintHandler {
+    output: RefCell<Vec<String>>,
+}
+
+impl CollectingPrintHandler {
+    fn new() -> Self {
+        Self {
+            output: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn take_output(&self) -> Vec<String> {
+        self.output.borrow_mut().drain(..).collect()
+    }
+}
+
+impl PrintHandler for CollectingPrintHandler {
+    fn println(&self, text: &str) -> starlark::Result<()> {
+        eprintln!("{text}");
+        self.output.borrow_mut().push(text.to_string());
+        Ok(())
+    }
+}
 
 pub(crate) trait DeepCopyToHeap {
     fn deep_copy_to<'dst>(&self, dst: &'dst Heap) -> anyhow::Result<Value<'dst>>;
@@ -97,6 +123,8 @@ pub struct EvalOutput {
     pub sch_module: FrozenModuleValue,
     /// Map of parameter names to their full parameter information
     pub signature: HashMap<String, crate::lang::type_info::ParameterInfo>,
+    /// Print output collected during evaluation
+    pub print_output: Vec<String>,
 }
 
 #[derive(Debug, Default)]
@@ -836,10 +864,14 @@ impl EvalContext {
         };
 
         eval_res.flat_map(|ast| {
+            // Create a print handler to collect output
+            let print_handler = CollectingPrintHandler::new();
+
             let eval_result = {
                 let mut eval = Evaluator::new(&self.module);
                 eval.enable_static_typechecking(true);
                 eval.set_loader(&self);
+                eval.set_print_handler(&print_handler);
 
                 // Attach a `ContextValue` so user code can access evaluation context.
                 self.module
@@ -873,6 +905,9 @@ impl EvalContext {
                 // value of the final expression, so map the result to `()`.
                 eval.eval_module(ast.clone(), &globals).map(|_| ())
             };
+
+            // Collect print output after evaluation
+            let print_output = print_handler.take_output();
 
             let result = match eval_result {
                 Ok(_) => {
@@ -915,6 +950,7 @@ impl EvalContext {
                             star_module: frozen_module,
                             sch_module: extra.module.clone(),
                             signature,
+                            print_output,
                         },
                         diagnostics,
                     )

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -236,7 +236,7 @@ pub struct EvalContext {
     pub(crate) file_provider: Option<Arc<dyn crate::FileProvider>>,
 
     /// Load resolver for resolving load() paths
-    load_resolver: Option<Arc<dyn crate::LoadResolver>>,
+    pub(crate) load_resolver: Option<Arc<dyn crate::LoadResolver>>,
 }
 
 impl Default for EvalContext {

--- a/crates/pcb-zen-core/src/lang/evaluator_ext.rs
+++ b/crates/pcb-zen-core/src/lang/evaluator_ext.rs
@@ -50,6 +50,9 @@ pub(crate) trait EvaluatorExt<'v> {
 
     /// Return the FileProvider from the EvalContext if available.
     fn file_provider(&self) -> Option<Arc<dyn crate::FileProvider>>;
+
+    /// Return the LoadResolver from the EvalContext if available.
+    fn load_resolver(&self) -> Option<Arc<dyn crate::LoadResolver>>;
 }
 
 impl<'v> EvaluatorExt<'v> for Evaluator<'v, '_, '_> {
@@ -117,5 +120,10 @@ impl<'v> EvaluatorExt<'v> for Evaluator<'v, '_, '_> {
     fn file_provider(&self) -> Option<Arc<dyn crate::FileProvider>> {
         self.eval_context()
             .and_then(|ctx| ctx.file_provider.clone())
+    }
+
+    fn load_resolver(&self) -> Option<Arc<dyn crate::LoadResolver>> {
+        self.eval_context()
+            .and_then(|ctx| ctx.load_resolver.clone())
     }
 }

--- a/crates/pcb-zen-core/tests/common/mod.rs
+++ b/crates/pcb-zen-core/tests/common/mod.rs
@@ -235,7 +235,19 @@ macro_rules! snapshot_eval {
                     let mut sorted_signature: Vec<_> = eval_output.signature.into_iter().collect();
                     sorted_signature.sort_by(|a, b| a.0.cmp(&b.0));
 
-                    format!("{:#?}\n{:#?}\n", eval_output.sch_module, sorted_signature)
+                    let mut output_parts = vec![];
+
+                    // Include print output if there was any
+                    if !eval_output.print_output.is_empty() {
+                        for line in eval_output.print_output {
+                            output_parts.push(line);
+                        }
+                    }
+
+                    output_parts.push(format!("{:#?}", eval_output.sch_module));
+                    output_parts.push(format!("{:#?}", sorted_signature));
+
+                    output_parts.join("\n") + "\n"
                 } else {
                     String::new()
                 }

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -42,3 +42,31 @@ snapshot_eval!(interface_net_incompatible, {
         )
     "#
 });
+
+snapshot_eval!(component_with_symbol, {
+    "test.zen" => r#"
+        # Create a symbol
+        i2c_symbol = Symbol(
+            name="I2C",
+            definition=[
+                ("SCL", ["1"]),
+                ("SDA", ["2"]),
+                ("VDD", ["3"]),
+                ("GND", ["4"])
+            ]
+        )
+        
+        # Create a component using the symbol
+        Component(
+            name = "I2C_Device",
+            footprint = "SOIC-8",
+            symbol = i2c_symbol,  # Use Symbol instead of pin_defs
+            pins = {
+                "SCL": Net("SCL"),
+                "SDA": Net("SDA"),
+                "VDD": Net("VDD"),
+                "GND": Net("GND"),
+            }
+        )
+    "#
+});

--- a/crates/pcb-zen-core/tests/snapshots/component__component_properties.snap
+++ b/crates/pcb-zen-core/tests/snapshots/component__component_properties.snap
@@ -114,6 +114,9 @@ Module {
                         "/C146731.kicad_sym",
                     ),
                 },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
     ],

--- a/crates/pcb-zen-core/tests/snapshots/component__component_with_symbol.snap
+++ b/crates/pcb-zen-core/tests/snapshots/component__component_with_symbol.snap
@@ -1,0 +1,77 @@
+---
+source: crates/pcb-zen-core/tests/component.rs
+expression: output
+---
+Module {
+    name: "<root>",
+    source: "test.zen",
+    children: [
+        FrozenValue(
+            Component {
+                name: "I2C_Device",
+                footprint: "SOIC-8",
+                prefix: "U",
+                pins: {
+                    "GND": FrozenValue(
+                        "4",
+                    ),
+                    "SCL": FrozenValue(
+                        "1",
+                    ),
+                    "SDA": FrozenValue(
+                        "2",
+                    ),
+                    "VDD": FrozenValue(
+                        "3",
+                    ),
+                },
+                connections: {
+                    "GND": FrozenValue(
+                        Net {
+                            name: "GND",
+                            id: "<ID>",
+                        },
+                    ),
+                    "SCL": FrozenValue(
+                        Net {
+                            name: "SCL",
+                            id: "<ID>",
+                        },
+                    ),
+                    "SDA": FrozenValue(
+                        Net {
+                            name: "SDA",
+                            id: "<ID>",
+                        },
+                    ),
+                    "VDD": FrozenValue(
+                        Net {
+                            name: "VDD",
+                            id: "<ID>",
+                        },
+                    ),
+                },
+                symbol: FrozenValue(
+                    Symbol {
+                        name: "I2C",
+                        pins: {
+                            "1": FrozenValue(
+                                "SCL",
+                            ),
+                            "2": FrozenValue(
+                                "SDA",
+                            ),
+                            "3": FrozenValue(
+                                "VDD",
+                            ),
+                            "4": FrozenValue(
+                                "GND",
+                            ),
+                        },
+                    },
+                ),
+            },
+        ),
+    ],
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/file__file_resolves_relative_path.snap
+++ b/crates/pcb-zen-core/tests/snapshots/file__file_resolves_relative_path.snap
@@ -2,6 +2,7 @@
 source: crates/pcb-zen-core/tests/file.rs
 expression: output
 ---
+Resolved path: /subdir/data.txt
 Module {
     name: "<root>",
     source: "test.zen",

--- a/crates/pcb-zen-core/tests/snapshots/input__config_str.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_str.snap
@@ -34,13 +34,13 @@ Module {
                     ),
                 },
                 properties: {
-                    "symbol_path": FrozenValue(
-                        NoneType,
-                    ),
                     "value": FrozenValue(
                         "",
                     ),
                 },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
     ],

--- a/crates/pcb-zen-core/tests/snapshots/input__config_types.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_types.snap
@@ -25,11 +25,9 @@ Module {
                         },
                     ),
                 },
-                properties: {
-                    "symbol_path": FrozenValue(
-                        NoneType,
-                    ),
-                },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
     ],

--- a/crates/pcb-zen-core/tests/snapshots/input__implicit_enum_conversion.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__implicit_enum_conversion.snap
@@ -29,11 +29,9 @@ Module {
                                     },
                                 ),
                             },
-                            properties: {
-                                "symbol_path": FrozenValue(
-                                    NoneType,
-                                ),
-                            },
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
                         },
                     ),
                 ],

--- a/crates/pcb-zen-core/tests/snapshots/input__interface_mixed_templates_and_types.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__interface_mixed_templates_and_types.snap
@@ -61,11 +61,9 @@ Module {
                         },
                     ),
                 },
-                properties: {
-                    "symbol_path": FrozenValue(
-                        NoneType,
-                    ),
-                },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
     ],

--- a/crates/pcb-zen-core/tests/snapshots/input__interface_multiple_net_templates.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__interface_multiple_net_templates.snap
@@ -43,11 +43,9 @@ Module {
                         },
                     ),
                 },
-                properties: {
-                    "symbol_path": FrozenValue(
-                        NoneType,
-                    ),
-                },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
         FrozenValue(
@@ -87,11 +85,9 @@ Module {
                         },
                     ),
                 },
-                properties: {
-                    "symbol_path": FrozenValue(
-                        NoneType,
-                    ),
-                },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
     ],

--- a/crates/pcb-zen-core/tests/snapshots/input__interface_nested_template.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__interface_nested_template.snap
@@ -52,11 +52,9 @@ Module {
                         },
                     ),
                 },
-                properties: {
-                    "symbol_path": FrozenValue(
-                        NoneType,
-                    ),
-                },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
     ],

--- a/crates/pcb-zen-core/tests/snapshots/input__interface_net_template_basic.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__interface_net_template_basic.snap
@@ -34,11 +34,9 @@ Module {
                         },
                     ),
                 },
-                properties: {
-                    "symbol_path": FrozenValue(
-                        NoneType,
-                    ),
-                },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
     ],

--- a/crates/pcb-zen-core/tests/snapshots/input__io_config.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__io_config.snap
@@ -29,11 +29,9 @@ Module {
                                     },
                                 ),
                             },
-                            properties: {
-                                "symbol_path": FrozenValue(
-                                    NoneType,
-                                ),
-                            },
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
                         },
                     ),
                 ],

--- a/crates/pcb-zen-core/tests/snapshots/input__optional_io_config.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__optional_io_config.snap
@@ -29,11 +29,9 @@ Module {
                                     },
                                 ),
                             },
-                            properties: {
-                                "symbol_path": FrozenValue(
-                                    NoneType,
-                                ),
-                            },
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
                         },
                     ),
                 ],

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_duplicate_pad_error.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_duplicate_pad_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Error: test.zen:3:7-8:2 Pad 'A1' is already assigned to signal 'SCL'

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_empty_pad_list.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_empty_pad_list.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Error: test.zen:3:7-7:2 Pad list for signal 'SCL' cannot be empty

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_missing_name.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_missing_name.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Error: test.zen:3:7-47 Library '/multi_symbol.kicad_sym' contains 2 symbols. Please specify which one with the 'name' parameter. Available symbols: Symbol1, Symbol2

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_single.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_single.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_single.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_single.snap
@@ -2,6 +2,7 @@
 source: crates/pcb-zen-core/tests/symbol.rs
 expression: output
 ---
+Symbol { name: "NB3N551DG", pins: { "1": "ICLK", "2": "Q1", "3": "Q2", "4": "Q3", "5": "Q4", "6": "GND", "7": "VDD", "8": "OE" } }
 Module {
     name: "<root>",
     source: "test.zen",

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_with_name.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_with_name.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_with_name.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_from_library_with_name.snap
@@ -2,6 +2,7 @@
 source: crates/pcb-zen-core/tests/symbol.rs
 expression: output
 ---
+Symbol { name: "Symbol2", pins: { "2": "B" } }
 Module {
     name: "<root>",
     source: "test.zen",

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_invalid_definition_format.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_invalid_definition_format.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Error: test.zen:3:7-7:2 Pad names must be a list

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_requires_parameter.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_requires_parameter.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Error: test.zen:3:7-15 Symbol requires either 'definition' or 'library' parameter

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_tilde_pin_name.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_tilde_pin_name.snap
@@ -1,0 +1,10 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Symbol { name: "TildePinTest", pins: { "1": "1", "2": "OUT", "3": "3" } }
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_with_definition.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_with_definition.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pcb-zen-core/tests/symbol.rs
+expression: output
+---
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/symbol__symbol_with_definition.snap
+++ b/crates/pcb-zen-core/tests/snapshots/symbol__symbol_with_definition.snap
@@ -2,6 +2,7 @@
 source: crates/pcb-zen-core/tests/symbol.rs
 expression: output
 ---
+Symbol { name: "MySymbol", pins: { "A1": "SCL", "A2": "SCL", "B1": "SDA", "C1": "VDD", "C2": "VDD", "C3": "VDD", "D1": "GND" } }
 Module {
     name: "<root>",
     source: "test.zen",

--- a/crates/pcb-zen-core/tests/snapshots/test__load_component_factory.snap
+++ b/crates/pcb-zen-core/tests/snapshots/test__load_component_factory.snap
@@ -111,6 +111,9 @@ Module {
                         "/C146731.kicad_sym",
                     ),
                 },
+                symbol: FrozenValue(
+                    NoneType,
+                ),
             },
         ),
     ],

--- a/crates/pcb-zen-core/tests/snapshots/test__nested_components.snap
+++ b/crates/pcb-zen-core/tests/snapshots/test__nested_components.snap
@@ -43,11 +43,9 @@ Module {
                                                 },
                                             ),
                                         },
-                                        properties: {
-                                            "symbol_path": FrozenValue(
-                                                NoneType,
-                                            ),
-                                        },
+                                        symbol: FrozenValue(
+                                            NoneType,
+                                        ),
                                     },
                                 ),
                             ],

--- a/crates/pcb-zen-core/tests/snapshots/test__net_name_deduplication.snap
+++ b/crates/pcb-zen-core/tests/snapshots/test__net_name_deduplication.snap
@@ -29,11 +29,9 @@ Module {
                                     },
                                 ),
                             },
-                            properties: {
-                                "symbol_path": FrozenValue(
-                                    NoneType,
-                                ),
-                            },
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
                         },
                     ),
                 ],
@@ -62,11 +60,9 @@ Module {
                                     },
                                 ),
                             },
-                            properties: {
-                                "symbol_path": FrozenValue(
-                                    NoneType,
-                                ),
-                            },
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
                         },
                     ),
                 ],
@@ -95,11 +91,9 @@ Module {
                                     },
                                 ),
                             },
-                            properties: {
-                                "symbol_path": FrozenValue(
-                                    NoneType,
-                                ),
-                            },
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
                         },
                     ),
                 ],

--- a/crates/pcb-zen-core/tests/snapshots/test__net_passing.snap
+++ b/crates/pcb-zen-core/tests/snapshots/test__net_passing.snap
@@ -44,11 +44,9 @@ Module {
                                                 },
                                             ),
                                         },
-                                        properties: {
-                                            "symbol_path": FrozenValue(
-                                                NoneType,
-                                            ),
-                                        },
+                                        symbol: FrozenValue(
+                                            NoneType,
+                                        ),
                                     },
                                 ),
                             ],

--- a/crates/pcb-zen-core/tests/snapshots/test__unknown_pin_should_error.snap
+++ b/crates/pcb-zen-core/tests/snapshots/test__unknown_pin_should_error.snap
@@ -2,4 +2,4 @@
 source: crates/pcb-zen-core/tests/test.rs
 expression: output
 ---
-Error: test_unknown.zen:5:1-19:2 Unknown pin name 'INVALID'
+Error: test_unknown.zen:5:1-19:2 Unknown pin name 'INVALID' (expected one of: ICLK, Q1, Q2, Q3, OE, VDD, GND, Q4)

--- a/crates/pcb-zen-core/tests/symbol.rs
+++ b/crates/pcb-zen-core/tests/symbol.rs
@@ -132,4 +132,34 @@ snapshot_eval!(symbol_from_library_with_name, {
     "#
 });
 
+snapshot_eval!(symbol_tilde_pin_name, {
+    "tilde_pins.kicad_sym" => r#"(kicad_symbol_lib
+        (symbol "TildePinTest"
+            (property "Reference" "U" (at 0 0 0))
+            (symbol "TildePinTest_0_1"
+                (pin input line (at 0 0 0) (length 2.54)
+                    (name "~" (effects (font (size 1.27 1.27))))
+                    (number "1" (effects (font (size 1.27 1.27))))
+                )
+                (pin output line (at 0 0 0) (length 2.54)
+                    (name "OUT" (effects (font (size 1.27 1.27))))
+                    (number "2" (effects (font (size 1.27 1.27))))
+                )
+                (pin power_in line (at 0 0 0) (length 2.54)
+                    (name "~" (effects (font (size 1.27 1.27))))
+                    (number "3" (effects (font (size 1.27 1.27))))
+                )
+            )
+        )
+    )"#,
+    "test.zen" => r#"
+        # Test that pins with ~ as name use the pin number instead
+        sym = Symbol(library="tilde_pins.kicad_sym")
+        
+        # Print the symbol to see the pin mapping
+        # Pins with ~ name should show their number as the signal name
+        print(sym)
+    "#
+});
+
 // TODO: Add tests for loading from library once we have test symbol files

--- a/crates/pcb-zen-core/tests/symbol.rs
+++ b/crates/pcb-zen-core/tests/symbol.rs
@@ -1,0 +1,135 @@
+#[macro_use]
+mod common;
+
+snapshot_eval!(symbol_with_definition, {
+    "test.zen" => r#"
+        # Test creating a symbol with explicit definition
+        sym = Symbol(
+            name="MySymbol",
+            definition=[
+                ("SCL", ["A1", "A2"]),
+                ("SDA", ["B1"]),
+                ("VDD", ["C1", "C2", "C3"]),
+                ("GND", ["D1"])
+            ]
+        )
+
+        # Print the symbol for snapshot
+        print(sym)
+    "#
+});
+
+snapshot_eval!(symbol_duplicate_pad_error, {
+    "test.zen" => r#"
+        # Test that duplicate pad assignments are caught
+        sym = Symbol(
+            definition=[
+                ("SCL", ["A1"]),
+                ("SDA", ["A1"])  # This should error - A1 already assigned
+            ]
+        )
+    "#
+});
+
+snapshot_eval!(symbol_invalid_definition_format, {
+    "test.zen" => r#"
+        # Test various invalid definition formats
+        sym = Symbol(
+            definition=[
+                ("SCL", "A1")  # Should be a list, not a string
+            ]
+        )
+    "#
+});
+
+snapshot_eval!(symbol_empty_pad_list, {
+    "test.zen" => r#"
+        # Test that empty pad lists are rejected
+        sym = Symbol(
+            definition=[
+                ("SCL", [])  # Empty pad list
+            ]
+        )
+    "#
+});
+
+snapshot_eval!(symbol_requires_parameter, {
+    "test.zen" => r#"
+        # Test that Symbol requires either definition or library parameter
+        sym = Symbol()
+    "#
+});
+
+snapshot_eval!(symbol_from_library_single, {
+    "C146731.kicad_sym" => include_str!("resources/C146731.kicad_sym"),
+    "test.zen" => r#"
+        # Test loading a symbol from a library with a single symbol
+        sym = Symbol(library="C146731.kicad_sym")
+        
+        # Verify we can access the pins using attribute access
+        # Note: KiCad symbol pins map pad number -> signal name
+        # So sym.1 would give us "ICLK" (the signal name for pad 1)
+        # But we can't use numeric attributes, so we'll just print the symbol
+        
+        print(sym)
+    "#
+});
+
+snapshot_eval!(symbol_from_library_missing_name, {
+    "multi_symbol.kicad_sym" => r#"(kicad_symbol_lib
+        (symbol "Symbol1"
+            (property "Reference" "U" (at 0 0 0))
+            (symbol "Symbol1_0_1"
+                (pin input line (at 0 0 0) (length 2.54)
+                    (name "A" (effects (font (size 1.27 1.27))))
+                    (number "1" (effects (font (size 1.27 1.27))))
+                )
+            )
+        )
+        (symbol "Symbol2"
+            (property "Reference" "U" (at 0 0 0))
+            (symbol "Symbol2_0_1"
+                (pin input line (at 0 0 0) (length 2.54)
+                    (name "B" (effects (font (size 1.27 1.27))))
+                    (number "2" (effects (font (size 1.27 1.27))))
+                )
+            )
+        )
+    )"#,
+    "test.zen" => r#"
+        # Test that multi-symbol libraries require a name parameter
+        sym = Symbol(library="multi_symbol.kicad_sym")
+    "#
+});
+
+snapshot_eval!(symbol_from_library_with_name, {
+    "multi_symbol.kicad_sym" => r#"(kicad_symbol_lib
+        (symbol "Symbol1"
+            (property "Reference" "U" (at 0 0 0))
+            (symbol "Symbol1_0_1"
+                (pin input line (at 0 0 0) (length 2.54)
+                    (name "A" (effects (font (size 1.27 1.27))))
+                    (number "1" (effects (font (size 1.27 1.27))))
+                )
+            )
+        )
+        (symbol "Symbol2"
+            (property "Reference" "U" (at 0 0 0))
+            (symbol "Symbol2_0_1"
+                (pin input line (at 0 0 0) (length 2.54)
+                    (name "B" (effects (font (size 1.27 1.27))))
+                    (number "2" (effects (font (size 1.27 1.27))))
+                )
+            )
+        )
+    )"#,
+    "test.zen" => r#"
+        # Test loading a specific symbol from a multi-symbol library
+        sym = Symbol(library="multi_symbol.kicad_sym", name="Symbol2")
+        
+        # Print the symbol to verify it's Symbol2
+        print(sym)
+    "#
+});
+
+// TODO: Add tests for loading from library once we have test symbol files

--- a/crates/pcb-zen/tests/snapshots/assert__snapshot_check_true_should_pass.snap
+++ b/crates/pcb-zen/tests/snapshots/assert__snapshot_check_true_should_pass.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/assert.rs
+source: crates/pcb-zen/tests/assert.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "comp0") (tstamps "4398fe89-a23f-5645-8878-bb2e739a72f1"))
       (tstamps "4398fe89-a23f-5645-8878-bb2e739a72f1")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/enum_conversion__snapshot_enum_config_conversion.snap
+++ b/crates/pcb-zen/tests/snapshots/enum_conversion__snapshot_enum_config_conversion.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/enum_conversion.rs
+source: crates/pcb-zen/tests/enum_conversion.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "child.comp0") (tstamps "1210f117-19c9-578c-bf69-b70ae9bad0e5"))
       (tstamps "1210f117-19c9-578c-bf69-b70ae9bad0e5")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/enum_conversion__snapshot_enum_io_conversion.snap
+++ b/crates/pcb-zen/tests/snapshots/enum_conversion__snapshot_enum_io_conversion.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/enum_conversion.rs
+source: crates/pcb-zen/tests/enum_conversion.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "child.comp0") (tstamps "1210f117-19c9-578c-bf69-b70ae9bad0e5"))
       (tstamps "1210f117-19c9-578c-bf69-b70ae9bad0e5")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/input__correct_usage_with_explicit_net_access.snap
+++ b/crates/pcb-zen/tests/snapshots/input__correct_usage_with_explicit_net_access.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/input.rs
+source: crates/pcb-zen/tests/input.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "test_comp") (tstamps "12cb098b-bab7-5f52-8c70-58c8f9863fe7"))
       (tstamps "12cb098b-bab7-5f52-8c70-58c8f9863fe7")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_io_and_config_with_values.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_io_and_config_with_values.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/input.rs
+source: crates/pcb-zen/tests/input.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "sub.comp0") (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5"))
       (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_optional_inputs_return_none.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_optional_inputs_return_none.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/input.rs
+source: crates/pcb-zen/tests/input.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "sub.comp0") (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5"))
       (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_mixed_templates_and_types.snap
+++ b/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_mixed_templates_and_types.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/interface_templates_snapshot.rs
+source: crates/pcb-zen/tests/interface_templates_snapshot.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "IC1") (tstamps "86322d06-d6e3-5efb-8630-3ca232293349"))
       (tstamps "86322d06-d6e3-5efb-8630-3ca232293349")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_multiple_net_templates.snap
+++ b/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_multiple_net_templates.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/interface_templates_snapshot.rs
+source: crates/pcb-zen/tests/interface_templates_snapshot.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "U1") (tstamps "bb9170a7-68d4-539c-bed9-f036cbc8d7db"))
       (tstamps "bb9170a7-68d4-539c-bed9-f036cbc8d7db")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
     (comp (ref "U2")
       (value "sensor")
@@ -24,7 +23,6 @@ expression: netlist
       (sheetpath (names "U2") (tstamps "36c85f89-8191-5cff-96a2-01503cd7115a"))
       (tstamps "36c85f89-8191-5cff-96a2-01503cd7115a")
       (property (name "Reference") (value "U2"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_nested_template.snap
+++ b/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_nested_template.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/interface_templates_snapshot.rs
+source: crates/pcb-zen/tests/interface_templates_snapshot.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "J1") (tstamps "b41f0e40-6e2d-5762-aae6-ebde6de0375a"))
       (tstamps "b41f0e40-6e2d-5762-aae6-ebde6de0375a")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_net_template_basic.snap
+++ b/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_net_template_basic.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/interface_templates_snapshot.rs
+source: crates/pcb-zen/tests/interface_templates_snapshot.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "R1") (tstamps "993684ed-29bc-53ba-bc0d-39d7d84da9bd"))
       (tstamps "993684ed-29bc-53ba-bc0d-39d7d84da9bd")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_template_property_inheritance.snap
+++ b/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_template_property_inheritance.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/interface_templates_snapshot.rs
+source: crates/pcb-zen/tests/interface_templates_snapshot.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "CPU") (tstamps "5e0c7041-4196-5aa4-8e84-bc97699f0f38"))
       (tstamps "5e0c7041-4196-5aa4-8e84-bc97699f0f38")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
     (comp (ref "U2")
       (value "memory")
@@ -24,7 +23,6 @@ expression: netlist
       (sheetpath (names "MEM") (tstamps "55dd74bc-6fd0-5d18-9878-1dd593abf8dd"))
       (tstamps "55dd74bc-6fd0-5d18-9878-1dd593abf8dd")
       (property (name "Reference") (value "U2"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/module_loading_remote__snapshot_load_remote_module_and_component.snap
+++ b/crates/pcb-zen/tests/snapshots/module_loading_remote__snapshot_load_remote_module_and_component.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/module_loading_remote.rs
+source: crates/pcb-zen/tests/module_loading_remote.rs
 expression: netlist
 ---
 (export (version "E")
@@ -16,7 +16,6 @@ expression: netlist
       (tstamps "1ef4a3b7-81ec-5a47-8b7f-9f08c2fe108b")
       (property (name "Reference") (value "U1"))
       (property (name "package") (value "Package(\"0402\")"))
-      (property (name "symbol_path") (value "None"))
       (property (name "value") (value "0.00001"))
     )
   )

--- a/crates/pcb-zen/tests/snapshots/placeholder__snapshot_io_and_config_placeholders.snap
+++ b/crates/pcb-zen/tests/snapshots/placeholder__snapshot_io_and_config_placeholders.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/placeholder.rs
+source: crates/pcb-zen/tests/placeholder.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "sub.comp0") (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5"))
       (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/placeholder__snapshot_undefined_placeholder.snap
+++ b/crates/pcb-zen/tests/snapshots/placeholder__snapshot_undefined_placeholder.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/placeholder.rs
+source: crates/pcb-zen/tests/placeholder.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "sub.comp0") (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5"))
       (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/test__nested_components.snap
+++ b/crates/pcb-zen/tests/snapshots/test__nested_components.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/test.rs
+source: crates/pcb-zen/tests/test.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "MyModule.MyComponent.Component") (tstamps "88868ff1-5bd1-55c8-8857-a9182b7af4bf"))
       (tstamps "88868ff1-5bd1-55c8-8857-a9182b7af4bf")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/test__net_name_deduplication.snap
+++ b/crates/pcb-zen/tests/snapshots/test__net_name_deduplication.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/test.rs
+source: crates/pcb-zen/tests/test.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "MyModule1.Component") (tstamps "634986a9-509e-5464-b539-8450f6429931"))
       (tstamps "634986a9-509e-5464-b539-8450f6429931")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
     (comp (ref "U2")
       (value "?")
@@ -24,7 +23,6 @@ expression: netlist
       (sheetpath (names "MyModule2.Component") (tstamps "49d7b781-9d5f-5d3f-9170-df886b275b2f"))
       (tstamps "49d7b781-9d5f-5d3f-9170-df886b275b2f")
       (property (name "Reference") (value "U2"))
-      (property (name "symbol_path") (value "None"))
     )
     (comp (ref "U3")
       (value "?")
@@ -33,7 +31,6 @@ expression: netlist
       (sheetpath (names "MyModule3.Component") (tstamps "38812e2a-4ee1-57b0-9eb7-e9d1dcd3bf43"))
       (tstamps "38812e2a-4ee1-57b0-9eb7-e9d1dcd3bf43")
       (property (name "Reference") (value "U3"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb-zen/tests/snapshots/test__net_passing.snap
+++ b/crates/pcb-zen/tests/snapshots/test__net_passing.snap
@@ -1,5 +1,5 @@
 ---
-source: projects/cli/crates/diode_star/tests/test.rs
+source: crates/pcb-zen/tests/test.rs
 expression: netlist
 ---
 (export (version "E")
@@ -15,7 +15,6 @@ expression: netlist
       (sheetpath (names "Test.MyComponent.capacitor") (tstamps "71dc92e1-05f7-5aa9-9ffa-4b281f38f62d"))
       (tstamps "71dc92e1-05f7-5aa9-9ffa-4b281f38f62d")
       (property (name "Reference") (value "U1"))
-      (property (name "symbol_path") (value "None"))
     )
   )
   (libparts

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4,7 +4,7 @@
 
 Zener is a domain-specific language built on top of
 [Starlark](https://github.com/bazelbuild/starlark/blob/master/spec.md) for
-describing PCB schematics. It provides primitives for defining components, nets,
+describing PCB schematics. It provides primitives for defining components, symbols, nets,
 interfaces, and modules in a type-safe, composable manner.
 
 This specification describes the language extensions and primitives added on top
@@ -45,13 +45,13 @@ The `load()` and `Module()` statements support multiple resolution strategies:
 
 ```starlark
 # Local file (relative to current file)
-load("./utils.star", "helper")
+load("./utils.zen", "helper")
 
 # Package reference
-load("@stdlib:1.2.3/math.star", "calculate")
+load("@stdlib:1.2.3/math.zen", "calculate")
 
 # GitHub repository
-load("@github/user/repo:branch/path.star", "function")
+load("@github/user/repo:branch/path.zen", "function")
 ```
 
 ## Core Types
@@ -71,37 +71,81 @@ net2 = Net("VCC")
 
 - `name` (optional): String identifier for the net
 
+### Symbol
+
+A `Symbol` represents a schematic symbol definition with its pins. Symbols can be created manually or loaded from KiCad symbol libraries.
+
+```starlark
+# Create a symbol from explicit definition
+my_symbol = Symbol(
+    name = "MyDevice",
+    definition = [
+        ("VCC", ["1", "8"]),    # VCC on pins 1 and 8
+        ("GND", ["4"]),         # GND on pin 4
+        ("IN", ["2"]),          # IN on pin 2
+        ("OUT", ["7"])          # OUT on pin 7
+    ]
+)
+
+# Load from a KiCad symbol library
+op_amp = Symbol(library = "./symbols/LM358.kicad_sym")
+
+# For multi-symbol libraries, specify which symbol
+mcu = Symbol(library = "./symbols/microcontrollers.kicad_sym", name = "STM32F103")
+```
+
+**Type**: `Symbol`  
+**Constructor**: `Symbol(name=None, definition=None, library=None)`
+
+- `name`: Symbol name (required when loading from multi-symbol library)
+- `definition`: List of (signal_name, [pad_numbers]) tuples
+- `library`: Path to KiCad symbol library file
+
 ### Component
 
 Components represent physical electronic parts with pins and properties.
 
 ```starlark
+# Using a Symbol for pin definitions
+my_symbol = Symbol(
+    definition = [
+        ("VCC", ["1"]),
+        ("GND", ["4"]),
+        ("OUT", ["8"])
+    ]
+)
+
 Component(
     name = "U1",                   # Required: instance name
     footprint = "SOIC-8",          # Required: PCB footprint
-    pin_defs = {                   # Required: pin name to number mapping
-        "VCC": "1",
-        "GND": "4",
-        "OUT": "8"
-    },
+    symbol = my_symbol,            # Symbol defines the pins
     pins = {                       # Required: pin connections
         "VCC": vcc_net,
         "GND": gnd_net,
         "OUT": output_net
     },
     prefix = "U",                  # Optional: reference designator prefix (default: "U")
-    symbol = "path/to/symbol",     # Optional: schematic symbol path
     mpn = "LM358",                 # Optional: manufacturer part number
     type = "op-amp",               # Optional: component type
     properties = {                 # Optional: additional properties
         "voltage": "5V"
-    },
-    ...
+    }
 )
 ```
 
 **Type**: `Component`  
 **Constructor**: `Component(**kwargs)`
+
+Key parameters:
+
+- `name`: Instance name (required)
+- `footprint`: PCB footprint (required)
+- `symbol`: Symbol object defining pins (required)
+- `pins`: Pin connections to nets (required)
+- `prefix`: Reference designator prefix (default: "U")
+- `mpn`: Manufacturer part number
+- `type`: Component type
+- `properties`: Additional properties dict
 
 ### Interface
 
@@ -148,7 +192,7 @@ Modules represent hierarchical subcircuits that can be instantiated multiple tim
 
 ```starlark
 # Load a module from a file
-SubCircuit = Module("./subcircuit.star")
+SubCircuit = Module("./subcircuit.zen")
 
 # Instantiate the module
 SubCircuit(
@@ -212,24 +256,6 @@ debug = config("debug", bool, optional=True)
 - `convert`: Optional conversion function
 - `optional`: If True, returns None when not provided (unless default is specified)
 
-### load_component(symbol_path, footprint=None)
-
-Loads a component factory from an EDA symbol file.
-
-```starlark
-# Load from KiCad symbol file
-OpAmp = load_component("./symbols/LM358.kicad_sym")
-
-# Override footprint
-OpAmp = load_component("./symbols/LM358.kicad_sym", footprint="SOIC-8")
-
-# Instantiate
-OpAmp(
-    name = "U1",
-    pins = { ... }
-)
-```
-
 ### File(path)
 
 Resolves a file or directory path using the load resolver.
@@ -273,10 +299,10 @@ add_property("critical", True)
 
 ### Module Definition
 
-A module is defined by a `.star` file that declares its inputs and creates components:
+A module is defined by a `.zen` file that declares its inputs and creates components:
 
 ```starlark
-# voltage_divider.star
+# voltage_divider.zen
 
 # Declare inputs
 vin = io("vin", Net)
@@ -286,12 +312,20 @@ gnd = io("gnd", Net)
 r1_value = config("r1", str, default="10k")
 r2_value = config("r2", str, default="10k")
 
+# Define a resistor symbol (could also load from library)
+resistor_symbol = Symbol(
+    definition = [
+        ("1", ["1"]),
+        ("2", ["2"])
+    ]
+)
+
 # Create components
 Component(
     name = "R1",
     type = "resistor",
     footprint = "0402",
-    pin_defs = {"1": "1", "2": "2"},
+    symbol = resistor_symbol,
     pins = {"1": vin, "2": vout},
     properties = {"value": r1_value}
 )
@@ -300,7 +334,7 @@ Component(
     name = "R2",
     type = "resistor",
     footprint = "0402",
-    pin_defs = {"1": "1", "2": "2"},
+    symbol = resistor_symbol,
     pins = {"1": vout, "2": gnd},
     properties = {"value": r2_value}
 )
@@ -310,7 +344,7 @@ Component(
 
 ```starlark
 # Load the module
-VDivider = Module("./voltage_divider.star")
+VDivider = Module("./voltage_divider.zen")
 
 # Create instances
 VDivider(

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -53,8 +53,11 @@ load("@stdlib:1.2.3/math.zen", "calculate")
 # GitHub repository
 load("@github/user/repo:branch/path.zen", "function")
 
-# GitLab repository
+# GitLab repository (simple)
 load("@gitlab/user/repo:branch/path.zen", "function")
+
+# GitLab repository (nested groups)
+load("@gitlab/kicad/libraries/kicad-symbols:v7.0.0/Device.kicad_sym", "Resistor")
 ```
 
 ## Core Types

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -52,6 +52,9 @@ load("@stdlib:1.2.3/math.zen", "calculate")
 
 # GitHub repository
 load("@github/user/repo:branch/path.zen", "function")
+
+# GitLab repository
+load("@gitlab/user/repo:branch/path.zen", "function")
 ```
 
 ## Core Types


### PR DESCRIPTION
Introduce a new `Symbol` type for representing EDA symbols. You can use it in two ways:

```
Symbol(
    name = "SOIC-8",
    definition = [
        ("GND", ["1", "5", "6", "7", "8"]),
        ("VDD", ["2"]),
        ("SCL", ["3"]),
        ("SDA", ["4"])
    ]
)
```

```
Symbol(
    name = "R",
    library  = "@gitlab/kicad/libraries/kicad-symbols:9.0.0/Device.kicad_sym"
)
````

You can then pass this to the `Component` constructor to attach the symbol to the component instance.

Also added support for `@gitlab` remote packages.