### PR TITLE
fix: exclude aarch64-unknown-linux-gnu and add VSCode extension to cargo-dist

### DIFF
--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -1,0 +1,4 @@
+- name: Setup Node.js
+  uses: actions/setup-node@v4
+  with:
+    node-version: '20'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "Setup Node.js"
+        uses: "actions/setup-node@v4"
+        with:
+          "node-version": "20"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ installers = ["shell", "powershell", "npm", "homebrew", "msi"]
 # A GitHub repo to push Homebrew formulas to
 tap = "diodeinc/homebrew-pcb"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # A namespace to use when publishing this package to the npm registry
 npm-scope = "@diode"
 # Path that installers should place binaries in
@@ -23,3 +23,10 @@ publish-jobs = ["homebrew"]
 install-updater = true
 # Which actions to run on pull requests
 pr-run-mode = "skip"
+# GitHub build setup for Node.js
+github-build-setup = "build-setup.yml"
+
+# Extra artifacts to build and include
+[[dist.extra-artifacts]]
+artifacts = ["zener-vscode-extension.vsix"]
+build = ["bash", "-c", "cd vscode && npm install && cd client && npm install && cd ../preview && npm install && cd .. && npm run compile && npx --yes vsce package && mv zener-*.vsix ../zener-vscode-extension.vsix"]


### PR DESCRIPTION
## Summary
- Remove aarch64-unknown-linux-gnu target from cargo-dist to fix build failures
- Add VSCode extension as an extra artifact in releases
- Configure Node.js setup in GitHub Actions for building the extension

## Details
The aarch64-unknown-linux-gnu target was causing build failures in our release workflow. This PR removes it from the build matrix.

Additionally, this PR adds the VSCode extension to our release artifacts. The extension will now be automatically built and included as `zener-vscode-extension.vsix` in each release.

## Test plan
- [x] Verified cargo-dist plan locally shows correct targets
- [x] Confirmed VSCode extension is included in artifacts list
- [ ] Release workflow should complete successfully after merging

🤖 Generated with [Claude Code](https://claude.ai/code)