### PR TITLE
add nix flake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pcb"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-buildifier"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-command-runner"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "log",
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-eda"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-kicad"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-layout"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-sch"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-sexpr"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "log",
  "serde",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-starlark-lsp"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "derivative",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-ui"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-zen"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "allocative",
  "anyhow",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-zen-core"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "allocative",
  "anyhow",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-zen-wasm"
-version = "0.2.0-prerelease.1"
+version = "0.2.0-prerelease.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/pcb-buildifier/build.rs
+++ b/crates/pcb-buildifier/build.rs
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
     println!("cargo::rustc-check-cfg=cfg(external_buildifier)");
     if env::var("BUILDIFIER_BIN").is_ok() {
         println!("cargo:rustc-cfg=external_buildifier");
-        return Ok(())
+        return Ok(());
     }
 
     // Determine the target platform

--- a/crates/pcb-buildifier/build.rs
+++ b/crates/pcb-buildifier/build.rs
@@ -36,6 +36,12 @@ const CHECKSUMS: &[(&str, &str)] = &[
 ];
 
 fn main() -> Result<()> {
+    println!("cargo::rustc-check-cfg=cfg(external_buildifier)");
+    if env::var("BUILDIFIER_BIN").is_ok() {
+        println!("cargo:rustc-cfg=external_buildifier");
+        return Ok(())
+    }
+
     // Determine the target platform
     let target = env::var("TARGET").unwrap();
     let (platform, arch, extension) = match target.as_str() {

--- a/crates/pcb-buildifier/src/lib.rs
+++ b/crates/pcb-buildifier/src/lib.rs
@@ -11,24 +11,26 @@
 //! The buildtools project can be found at: https://github.com/bazelbuild/buildtools
 
 use anyhow::{Context, Result};
-use once_cell::sync::OnceCell;
-use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
-use std::sync::Mutex;
-
-// Include the buildifier binary at compile time
-const BUILDIFIER_BINARY: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/buildifier"));
-
-// Version of buildifier bundled in this crate (used for cache invalidation)
-const BUILDIFIER_VERSION: &str = "7.3.1";
-
-// Global cache for the buildifier binary path
-static CACHED_BINARY_PATH: OnceCell<Mutex<Option<PathBuf>>> = OnceCell::new();
 
 /// Get or create the cached buildifier binary path
+#[cfg(not(external_buildifier))]
 fn get_cached_binary_path() -> Result<PathBuf> {
+    use once_cell::sync::OnceCell;
+    use std::fs;
+    use std::io::Write;
+    use std::sync::Mutex;
+
+    // Include the buildifier binary at compile time
+    const BUILDIFIER_BINARY: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/buildifier"));
+
+    // Version of buildifier bundled in this crate (used for cache invalidation)
+    const BUILDIFIER_VERSION: &str = "7.3.1";
+
+    // Global cache for the buildifier binary path
+    static CACHED_BINARY_PATH: OnceCell<Mutex<Option<PathBuf>>> = OnceCell::new();
+
     let mutex = CACHED_BINARY_PATH.get_or_init(|| Mutex::new(None));
     let mut cache = mutex.lock().unwrap();
 
@@ -95,8 +97,16 @@ pub struct Buildifier {
 impl Buildifier {
     /// Create a new Buildifier instance using the cached binary
     pub fn new() -> Result<Self> {
-        let binary_path = get_cached_binary_path()?;
-        Ok(Self { binary_path })
+        #[cfg(external_buildifier)]
+        {
+            Ok(Self { binary_path: PathBuf::from(env!("BUILDIFIER_BIN")) })
+        }
+
+        #[cfg(not(external_buildifier))]
+        {
+            let binary_path = crate::get_cached_binary_path()?;
+            Ok(Self { binary_path })
+        }
     }
 
     /// Get the path to the buildifier binary

--- a/crates/pcb-buildifier/src/lib.rs
+++ b/crates/pcb-buildifier/src/lib.rs
@@ -99,7 +99,9 @@ impl Buildifier {
     pub fn new() -> Result<Self> {
         #[cfg(external_buildifier)]
         {
-            Ok(Self { binary_path: PathBuf::from(env!("BUILDIFIER_BIN")) })
+            Ok(Self {
+                binary_path: PathBuf::from(env!("BUILDIFIER_BIN")),
+            })
         }
 
         #[cfg(not(external_buildifier))]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1753316655,
+        "narHash": "sha256-tzWa2kmTEN69OEMhxFy+J2oWSvZP5QhEgXp3TROOzl0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "f35a3372d070c9e9ccb63ba7ce347f0634ddf3d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753432016,
+        "narHash": "sha256-cnL5WWn/xkZoyH/03NNUS7QgW5vI7D1i74g48qplCvg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6027c30c8e9810896b92429f0092f624f7b1aace",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        inherit (pkgs) lib;
+
+        craneLib = crane.mkLib pkgs;
+        src = craneLib.cleanCargoSource ./.;
+
+        commonArgs = {
+          inherit src;
+          strictDeps = true;
+          doCheck = false;
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+        pcb = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
+            pname = "pcb";
+            inherit (craneLib.crateNameFromCargoToml { inherit src; }) version;
+
+            prePatch = ''
+              substituteInPlace crates/pcb-layout/src/lib.rs \
+                --replace-fail "scripts/update_layout_file.py" ${crates/pcb-layout/src/scripts/update_layout_file.py}
+            '';
+
+            doCheck = false;
+          }
+        );
+      in
+      {
+        packages = {
+          default = pcb;
+        };
+
+        apps = {
+          default = flake-utils.lib.mkApp {
+            drv = pcb;
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,18 @@
           inherit src;
           strictDeps = true;
           doCheck = false;
+
+          nativeBuildInputs = [
+            pkgs.pkg-config
+            pkgs.openssl.dev
+          ];
+
+          buildInputs = [
+            pkgs.pkg-config
+            pkgs.openssl
+          ];
+
+          BUILDIFIER_BIN = "${pkgs.bazel-buildtools}/bin/buildifier";
         };
 
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;


### PR DESCRIPTION
```
nix profile install github:diodeinc/pcb
```

or to test

```
nix run github:0xcaff/pcb/martin/nix -- --help
```

kicad isn't packaged here yet but can deal with that later

used crane as there is a bug in nixpkgs rust https://discourse.nixos.org/t/rust-with-git-deps-symbolic-link-error-to-cargo-vendor-dep/28841 and naserk had some issue as well. crane isn't ideal because it doesn't cache properly but now it one click installs so whatever. i will go make the rust builds less stupid in nix with dynamic derivations soon and come back and fix this then