### PR TITLE
[DIO-301] Add `pcb vendor`, `pcb build --offline`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,6 @@ jobs:
           # Test simple workspace (no pcb.toml)
           cargo run -- bom test-workspaces/simple/boards/TestBoard.zen
           cargo run -- release test-workspaces/simple/boards/TestBoard.zen
-          cargo run -- vendor test-workspaces/simple
 
           # Test workspace with pcb.toml and workspace-relative loads
           cargo run -- bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,10 +119,12 @@ jobs:
           # Test simple workspace (no pcb.toml)
           cargo run -- bom test-workspaces/simple/boards/TestBoard.zen
           cargo run -- release test-workspaces/simple/boards/TestBoard.zen
+          cargo run -- vendor test-workspaces/simple
 
           # Test workspace with pcb.toml and workspace-relative loads
           cargo run -- bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
           cargo run -- release test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
+          cargo run -- vendor test-workspaces/with-pcb-toml
 
       - name: Test stdlib builds
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,7 @@ jobs:
           cargo run -- bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
           cargo run -- release test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
           cargo run -- vendor test-workspaces/with-pcb-toml
+          cargo run -- build test-workspaces/with-pcb-toml/boards --offline
 
       - name: Test stdlib builds
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dir-diff"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ad16bf5f84253b50d6557681c58c3ab67c47c77d39fed9aeb56e947290bd10"
+dependencies = [
+ "walkdir",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,7 +2371,9 @@ dependencies = [
  "clap",
  "colored",
  "comfy-table",
+ "dir-diff",
  "env_logger",
+ "ignore",
  "inquire",
  "insta",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
 dependencies = [
- "dupe_derive 0.9.1",
+ "dupe_derive 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -933,7 +933,7 @@ name = "dupe"
 version = "0.9.1"
 source = "git+https://github.com/LK/starlark-rust?rev=5d994c5c#5d994c5c83c6b08640079adf39d3bf8e8a2454dc"
 dependencies = [
- "dupe_derive 0.9.1",
+ "dupe_derive 0.9.1 (git+https://github.com/LK/starlark-rust?rev=5d994c5c)",
 ]
 
 [[package]]
@@ -2487,7 +2487,7 @@ dependencies = [
  "anyhow",
  "derivative",
  "derive_more",
- "dupe 0.9.1",
+ "dupe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.13.0",
  "lsp-server",
  "lsp-types",
@@ -2526,8 +2526,8 @@ dependencies = [
  "debugserver-types",
  "derive_more",
  "dirs 6.0.0",
- "display_container 0.9.0",
- "dupe 0.9.1",
+ "display_container 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dupe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "either",
  "flate2",
  "globset",
@@ -2576,7 +2576,7 @@ dependencies = [
  "debugserver-types",
  "derive_more",
  "dirs 6.0.0",
- "dupe 0.9.1",
+ "dupe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "either",
  "flate2",
  "getrandom 0.2.16",
@@ -3592,8 +3592,8 @@ dependencies = [
  "debugserver-types",
  "derivative",
  "derive_more",
- "display_container 0.9.0",
- "dupe 0.9.1",
+ "display_container 0.9.0 (git+https://github.com/LK/starlark-rust?rev=5d994c5c)",
+ "dupe 0.9.1 (git+https://github.com/LK/starlark-rust?rev=5d994c5c)",
  "either",
  "erased-serde",
  "hashbrown 0.14.5",
@@ -3624,7 +3624,7 @@ name = "starlark_derive"
 version = "0.13.0"
 source = "git+https://github.com/LK/starlark-rust?rev=5d994c5c#5d994c5c83c6b08640079adf39d3bf8e8a2454dc"
 dependencies = [
- "dupe 0.9.1",
+ "dupe 0.9.1 (git+https://github.com/LK/starlark-rust?rev=5d994c5c)",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3636,7 +3636,7 @@ version = "0.13.0"
 source = "git+https://github.com/LK/starlark-rust?rev=5d994c5c#5d994c5c83c6b08640079adf39d3bf8e8a2454dc"
 dependencies = [
  "allocative",
- "dupe 0.9.1",
+ "dupe 0.9.1 (git+https://github.com/LK/starlark-rust?rev=5d994c5c)",
  "equivalent",
  "fxhash",
  "hashbrown 0.14.5",
@@ -3654,7 +3654,7 @@ dependencies = [
  "anyhow",
  "derivative",
  "derive_more",
- "dupe 0.9.1",
+ "dupe 0.9.1 (git+https://github.com/LK/starlark-rust?rev=5d994c5c)",
  "lalrpop",
  "lalrpop-util",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,8 @@ openssl = { version = "0.10", features = ["vendored"] }
 wasm-bindgen-futures = "0.4"
 rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
 comfy-table = "7.1"
+dir-diff = "0.3"
+ignore = "0.4"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/pcb-layout/tests/layout_generation.rs
+++ b/crates/pcb-layout/tests/layout_generation.rs
@@ -23,7 +23,7 @@ macro_rules! layout_test {
                 assert!(zen_file.exists(), "{}.zen should exist", $board_name);
 
                 // Evaluate the Zen file to generate a schematic
-                let eval_result = pcb_zen::run(&zen_file);
+                let eval_result = pcb_zen::run(&zen_file, false);
 
                 // Check for errors in evaluation
                 if !eval_result.diagnostics.is_empty() {

--- a/crates/pcb-zen-core/src/load_spec.rs
+++ b/crates/pcb-zen-core/src/load_spec.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Default tag that is assumed when the caller does not specify one in a
 /// package spec, e.g. `@mypkg/utils.zen`.
@@ -229,14 +229,12 @@ impl LoadSpec {
     ///
     /// # Arguments
     /// * `spec` - The LoadSpec to resolve
-    /// * `workspace_root` - Optional workspace root path for alias lookup
     /// * `workspace_aliases` - Optional workspace-specific aliases (overrides defaults)
     ///
     /// # Returns
     /// A resolved LoadSpec, which may be the same as the input or a new spec based on alias resolution.
     pub fn resolve(
         &self,
-        _workspace_root: Option<&Path>,
         workspace_aliases: Option<&HashMap<String, String>>,
     ) -> Result<LoadSpec, anyhow::Error> {
         match self {
@@ -851,7 +849,7 @@ mod tests {
                 path: PathBuf::from("math.zen"),
             };
 
-            let resolved = spec.resolve(None, None).unwrap();
+            let resolved = spec.resolve(None).unwrap();
             assert_eq!(resolved, spec); // Should return unchanged
         }
 
@@ -863,7 +861,7 @@ mod tests {
                 path: PathBuf::from("math.zen"),
             };
 
-            let resolved = spec.resolve(None, None).unwrap();
+            let resolved = spec.resolve(None).unwrap();
 
             // Should resolve to GitHub spec based on default alias
             assert_eq!(
@@ -885,7 +883,7 @@ mod tests {
                 path: PathBuf::from("math.zen"),
             };
 
-            let resolved = spec.resolve(None, None).unwrap();
+            let resolved = spec.resolve(None).unwrap();
 
             // Should resolve to GitHub spec with custom tag overriding default
             assert_eq!(
@@ -913,7 +911,7 @@ mod tests {
                 "@github/myorg/custom-lib:main".to_string(),
             );
 
-            let resolved = spec.resolve(None, Some(&workspace_aliases)).unwrap();
+            let resolved = spec.resolve(Some(&workspace_aliases)).unwrap();
 
             assert_eq!(
                 resolved,
@@ -940,7 +938,7 @@ mod tests {
                 "@github/myorg/my-stdlib:v2.0.0".to_string(),
             );
 
-            let resolved = spec.resolve(None, Some(&workspace_aliases)).unwrap();
+            let resolved = spec.resolve(Some(&workspace_aliases)).unwrap();
 
             // Workspace alias should override default
             assert_eq!(
@@ -962,7 +960,7 @@ mod tests {
                 path: PathBuf::from("Device.kicad_sym"),
             };
 
-            let resolved = spec.resolve(None, None).unwrap();
+            let resolved = spec.resolve(None).unwrap();
 
             // Should resolve to GitLab spec based on default alias
             assert_eq!(
@@ -986,7 +984,7 @@ mod tests {
             let mut workspace_aliases = HashMap::new();
             workspace_aliases.insert("local-lib".to_string(), "./local/lib".to_string());
 
-            let resolved = spec.resolve(None, Some(&workspace_aliases)).unwrap();
+            let resolved = spec.resolve(Some(&workspace_aliases)).unwrap();
 
             assert_eq!(
                 resolved,
@@ -1010,7 +1008,7 @@ mod tests {
                 "//libs/workspace-lib".to_string(),
             );
 
-            let resolved = spec.resolve(None, Some(&workspace_aliases)).unwrap();
+            let resolved = spec.resolve(Some(&workspace_aliases)).unwrap();
 
             assert_eq!(
                 resolved,
@@ -1028,7 +1026,7 @@ mod tests {
                 path: PathBuf::new(),
             };
 
-            let resolved = spec.resolve(None, None).unwrap();
+            let resolved = spec.resolve(None).unwrap();
 
             // Should resolve without adding path
             assert_eq!(
@@ -1056,7 +1054,7 @@ mod tests {
                 "./local/lib".to_string(), // Path-based alias
             );
 
-            let result = spec.resolve(None, Some(&workspace_aliases));
+            let result = spec.resolve(Some(&workspace_aliases));
 
             // Should error because we can't apply tags to path-based aliases
             assert!(result.is_err());
@@ -1077,7 +1075,7 @@ mod tests {
                 "@".to_string(), // Invalid load spec - just @ with nothing after
             );
 
-            let result = spec.resolve(None, Some(&workspace_aliases));
+            let result = spec.resolve(Some(&workspace_aliases));
 
             // Should error because alias target is invalid
             assert!(result.is_err());
@@ -1110,7 +1108,7 @@ mod tests {
             ];
 
             for spec in specs {
-                let resolved = spec.resolve(None, None).unwrap();
+                let resolved = spec.resolve(None).unwrap();
                 assert_eq!(resolved, spec); // Should return unchanged
             }
         }

--- a/crates/pcb-zen-core/tests/common/mod.rs
+++ b/crates/pcb-zen-core/tests/common/mod.rs
@@ -217,7 +217,8 @@ macro_rules! snapshot_eval {
             let load_resolver = Arc::new(CoreLoadResolver::new(
                 file_provider.clone(),
                 Arc::new(NoopRemoteFetcher::default()),
-                Some(std::path::PathBuf::from("/")),
+                std::path::PathBuf::from("/"),
+                true,
             ));
 
 

--- a/crates/pcb-zen-core/tests/core_load_resolver.rs
+++ b/crates/pcb-zen-core/tests/core_load_resolver.rs
@@ -152,12 +152,12 @@ impl RemoteFetcher for MockRemoteFetcher {
     fn fetch_remote(
         &self,
         spec: &LoadSpec,
-        workspace_root: Option<&Path>,
+        workspace_root: &Path,
     ) -> Result<PathBuf, anyhow::Error> {
         self.fetch_calls
             .lock()
             .unwrap()
-            .push((spec.clone(), workspace_root.map(|p| p.to_path_buf())));
+            .push((spec.clone(), Some(workspace_root.to_path_buf())));
 
         let spec_str = spec.to_load_string();
         self.fetch_results
@@ -189,7 +189,8 @@ fn test_resolve_github_spec() {
     let resolver = CoreLoadResolver::new(
         file_provider.clone(),
         remote_fetcher.clone(),
-        Some(PathBuf::from("/workspace")),
+        PathBuf::from("/workspace"),
+        true,
     );
 
     let spec = LoadSpec::Github {
@@ -234,7 +235,8 @@ fn test_resolve_relative_from_github_spec() {
     let resolver = CoreLoadResolver::new(
         file_provider.clone(),
         remote_fetcher.clone(),
-        Some(PathBuf::from("/workspace")),
+        PathBuf::from("/workspace"),
+        true,
     );
 
     // First, let's test resolving a relative path from the cached Resistor.zen
@@ -277,7 +279,8 @@ fn test_resolve_workspace_path_from_remote() {
     let _resolver = CoreLoadResolver::new(
         file_provider.clone(),
         remote_fetcher.clone(),
-        Some(PathBuf::from("/workspace")),
+        PathBuf::from("/workspace"),
+        true,
     );
 
     // When resolving a workspace path from a remote file, it should be
@@ -320,7 +323,8 @@ stdlib = "@github/diodeinc/stdlib"
     let resolver = CoreLoadResolver::new(
         file_provider.clone(),
         remote_fetcher.clone(),
-        Some(workspace_root.clone()),
+        workspace_root.clone(),
+        true,
     );
 
     // Test resolving a package alias
@@ -380,7 +384,8 @@ fn test_resolve_relative_from_remote_with_mapping() {
     let resolver = CoreLoadResolver::new(
         file_provider.clone(),
         remote_fetcher.clone(),
-        Some(PathBuf::from("/workspace")),
+        PathBuf::from("/workspace"),
+        true,
     );
 
     // First resolve the GitHub spec for Resistor.zen
@@ -464,7 +469,8 @@ fn test_resolve_workspace_path_from_remote_with_mapping() {
     let resolver = CoreLoadResolver::new(
         file_provider.clone(),
         remote_fetcher.clone(),
-        Some(PathBuf::from("/workspace")),
+        PathBuf::from("/workspace"),
+        true,
     );
 
     // Resolve the initial file

--- a/crates/pcb-zen-wasm/src/lib.rs
+++ b/crates/pcb-zen-wasm/src/lib.rs
@@ -47,7 +47,7 @@ impl pcb_zen_core::RemoteFetcher for WasmRemoteFetcher {
     fn fetch_remote(
         &self,
         spec: &pcb_zen_core::LoadSpec,
-        _workspace_root: Option<&Path>,
+        _workspace_root: &Path,
     ) -> Result<PathBuf, anyhow::Error> {
         debug!("WasmRemoteFetcher::fetch_remote - Fetching spec: {spec:?}");
 
@@ -384,14 +384,14 @@ impl Module {
         let remote_fetcher = Arc::new(WasmRemoteFetcher::new(inner_provider));
 
         // Determine workspace root using pcb.toml discovery
-        let workspace_root = find_workspace_root(file_provider.as_ref(), &path)
-            .unwrap_or_else(|| path.parent().unwrap_or(&path).to_path_buf());
+        let workspace_root = find_workspace_root(file_provider.as_ref(), &path);
 
         // Create load resolver
         let load_resolver = Arc::new(pcb_zen_core::CoreLoadResolver::new(
             file_provider.clone(),
             remote_fetcher.clone(),
-            Some(workspace_root),
+            workspace_root,
+            true,
         ));
 
         Ok(Module {
@@ -427,14 +427,14 @@ impl Module {
 
         // Determine workspace root using pcb.toml discovery
         let main_path = PathBuf::from(main_file);
-        let workspace_root = find_workspace_root(file_provider.as_ref(), &main_path)
-            .unwrap_or_else(|| main_path.parent().unwrap_or(&main_path).to_path_buf());
+        let workspace_root = find_workspace_root(file_provider.as_ref(), &main_path);
 
         // Create load resolver
         let load_resolver = Arc::new(pcb_zen_core::CoreLoadResolver::new(
             file_provider.clone(),
             remote_fetcher.clone(),
-            Some(workspace_root),
+            workspace_root,
+            true,
         ));
 
         Ok(Module {

--- a/crates/pcb-zen/src/bundle.rs
+++ b/crates/pcb-zen/src/bundle.rs
@@ -230,8 +230,7 @@ pub fn create_bundle(input_path: &Path, output_path: &Path) -> Result<()> {
     let file_provider = Arc::new(DefaultFileProvider);
 
     // Find the workspace root by looking for pcb.toml, fall back to source dir if not found
-    let workspace_root = find_workspace_root(file_provider.as_ref(), &canonical_input)
-        .unwrap_or_else(|| source_dir.clone());
+    let workspace_root = find_workspace_root(file_provider.as_ref(), &canonical_input);
 
     // Create a temporary directory for the bundle
     let temp_dir = tempfile::tempdir()?;
@@ -256,7 +255,8 @@ pub fn create_bundle(input_path: &Path, output_path: &Path) -> Result<()> {
     let base_resolver = Arc::new(CoreLoadResolver::new(
         file_provider.clone(),
         remote_fetcher,
-        Some(workspace_root),
+        workspace_root,
+        true,
     ));
 
     // Create a tracking resolver that wraps the base resolver

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -36,16 +36,14 @@ fn create_standard_load_resolver(
     file_provider: Arc<dyn FileProvider>,
     file_path: &Path,
 ) -> Arc<CoreLoadResolver> {
-    let workspace_root = file_path
-        .parent()
-        .and_then(|parent| find_workspace_root(file_provider.as_ref(), parent))
-        .unwrap_or_else(|| file_path.parent().unwrap_or(file_path).to_path_buf());
+    let workspace_root = find_workspace_root(file_provider.as_ref(), file_path);
 
     let remote_fetcher = Arc::new(DefaultRemoteFetcher);
     Arc::new(CoreLoadResolver::new(
         file_provider,
         remote_fetcher,
-        Some(workspace_root.to_path_buf()),
+        workspace_root.to_path_buf(),
+        true,
     ))
 }
 

--- a/crates/pcb-zen/tests/common/mod.rs
+++ b/crates/pcb-zen/tests/common/mod.rs
@@ -79,7 +79,7 @@ impl TestProject {
     /// when a test already has a full path (e.g. returned from [`Self::add_file`]).
     pub fn eval_netlist_from_absolute(&self, top_path: &Path) -> WithDiagnostics<String> {
         use pcb_sch::kicad_netlist::to_kicad_netlist;
-        pcb_zen::run(top_path).map(|s| to_kicad_netlist(&s))
+        pcb_zen::run(top_path, false).map(|s| to_kicad_netlist(&s))
     }
 
     /// Parse a single text blob that contains multiple files and write them into

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -41,6 +41,9 @@ serde_json = { workspace = true }
 walkdir = { workspace = true }
 zip = { workspace = true }
 chrono = { workspace = true }
+dir-diff = { workspace = true }
+tempfile = { workspace = true }
+ignore = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/pcb/src/bom.rs
+++ b/crates/pcb/src/bom.rs
@@ -54,7 +54,7 @@ pub fn execute(args: BomArgs) -> Result<()> {
     let spinner = Spinner::builder(format!("{file_name}: Generating BOM")).start();
 
     // Evaluate the design
-    let (eval_result, has_errors) = evaluate_zen_file(&args.file);
+    let (eval_result, has_errors) = evaluate_zen_file(&args.file, false);
 
     if has_errors {
         spinner.error(format!("{file_name}: Build failed"));

--- a/crates/pcb/src/build.rs
+++ b/crates/pcb/src/build.rs
@@ -23,15 +23,22 @@ pub struct BuildArgs {
     /// Recursively traverse directories to find .zen/.star files
     #[arg(short = 'r', long = "recursive", default_value_t = false)]
     pub recursive: bool,
+
+    /// Disable network access (offline mode) - only use vendored dependencies
+    #[arg(long = "offline")]
+    pub offline: bool,
 }
 
 /// Evaluate a single Starlark file and print any diagnostics
 /// Returns the evaluation result and whether there were any errors
-pub fn evaluate_zen_file(path: &Path) -> (pcb_zen::WithDiagnostics<pcb_sch::Schematic>, bool) {
+pub fn evaluate_zen_file(
+    path: &Path,
+    offline: bool,
+) -> (pcb_zen::WithDiagnostics<pcb_sch::Schematic>, bool) {
     debug!("Compiling Zener file: {}", path.display());
 
     // Evaluate the design
-    let eval_result = pcb_zen::run(path);
+    let eval_result = pcb_zen::run(path, offline);
     let mut has_errors = false;
 
     // Print diagnostics
@@ -73,7 +80,7 @@ pub fn execute(args: BuildArgs) -> Result<()> {
         let spinner = Spinner::builder(format!("{file_name}: Building")).start();
 
         // Evaluate the design
-        let eval_result = pcb_zen::run(&zen_path);
+        let eval_result = pcb_zen::run(&zen_path, args.offline);
 
         // Check if we have diagnostics to print
         if !eval_result.diagnostics.is_empty() {

--- a/crates/pcb/src/clean.rs
+++ b/crates/pcb/src/clean.rs
@@ -21,7 +21,7 @@ pub fn execute(args: CleanArgs) -> Result<()> {
     // Find the workspace root starting from current directory
     let current_dir = std::env::current_dir()?;
     let file_provider = DefaultFileProvider;
-    let project_root = find_workspace_root(&file_provider, &current_dir).unwrap_or(current_dir);
+    let project_root = find_workspace_root(&file_provider, &current_dir);
 
     // Define the temp directories to clean
     let temp_dirs = vec![project_root.join(".pcb")];

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -28,6 +28,10 @@ pub struct LayoutArgs {
     /// Recursively traverse directories to find .zen/.star files
     #[arg(short = 'r', long = "recursive", default_value_t = false)]
     pub recursive: bool,
+
+    /// Disable network access (offline mode) - only use vendored dependencies
+    #[arg(long = "offline")]
+    pub offline: bool,
 }
 
 pub fn execute(args: LayoutArgs) -> Result<()> {
@@ -57,7 +61,7 @@ pub fn execute(args: LayoutArgs) -> Result<()> {
         let mut spinner = Spinner::builder(format!("{file_name}: Building")).start();
 
         // Evaluate the design
-        let eval_result = pcb_zen::run(&zen_path);
+        let eval_result = pcb_zen::run(&zen_path, args.offline);
 
         // Check if we have diagnostics to print
         if !eval_result.diagnostics.is_empty() {

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -58,7 +58,6 @@ enum Commands {
     Release(release::ReleaseArgs),
 
     /// Vendor external dependencies
-    #[command(alias = "v")]
     Vendor(vendor::VendorArgs),
 
     /// External subcommands are forwarded to pcb-<command>

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -12,6 +12,8 @@ mod open;
 mod release;
 mod tracking_resolver;
 mod upgrade;
+mod vendor;
+mod workspace;
 
 #[derive(Parser)]
 #[command(name = "pcb")]
@@ -55,6 +57,10 @@ enum Commands {
     #[command(alias = "r")]
     Release(release::ReleaseArgs),
 
+    /// Vendor external dependencies
+    #[command(alias = "v")]
+    Vendor(vendor::VendorArgs),
+
     /// External subcommands are forwarded to pcb-<command>
     #[command(external_subcommand)]
     External(Vec<OsString>),
@@ -76,6 +82,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Lsp(args) => lsp::execute(args),
         Commands::Open(args) => open::execute(args),
         Commands::Release(args) => release::execute(args),
+        Commands::Vendor(args) => vendor::execute(args),
         Commands::External(args) => {
             if args.is_empty() {
                 anyhow::bail!("No external command specified");

--- a/crates/pcb/src/open.rs
+++ b/crates/pcb/src/open.rs
@@ -58,7 +58,7 @@ fn open_layout(zen_paths: Vec<PathBuf>) -> Result<()> {
         let file_name = zen_path.file_name().unwrap().to_string_lossy();
 
         // Evaluate the zen file
-        let (eval_result, has_errors) = evaluate_zen_file(&zen_path);
+        let (eval_result, has_errors) = evaluate_zen_file(&zen_path, false);
 
         if has_errors {
             eprintln!("Skipping {file_name} due to build errors");

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -283,6 +283,24 @@ fn extract_layout_path(zen_path: &Path, eval: &WithDiagnostics<EvalOutput>) -> R
 fn copy_sources(info: &ReleaseInfo) -> Result<()> {
     let mut vendor_files = HashSet::new();
 
+    // Copy pcb.toml from workspace root if it exists
+    let pcb_toml_path = info.workspace.workspace_root.join("pcb.toml");
+    if pcb_toml_path.exists() {
+        let dest_path = info.staging_dir.join("src").join("pcb.toml");
+        if let Some(parent) = dest_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create parent directory: {}", parent.display())
+            })?;
+        }
+        fs::copy(&pcb_toml_path, &dest_path).with_context(|| {
+            format!(
+                "Failed to copy pcb.toml: {} -> {}",
+                pcb_toml_path.display(),
+                dest_path.display()
+            )
+        })?;
+    }
+
     for path in info.workspace.tracker.files() {
         match classify_file(
             &info.workspace.workspace_root,

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -2,15 +2,10 @@ use anyhow::{Context, Result};
 use clap::Args;
 
 use log::{debug, info, warn};
-use pcb_ui::{Colorize, Spinner, Style, StyledText};
-use pcb_zen::load::{cache_dir, DefaultRemoteFetcher};
-
 use pcb_sch::generate_bom as generate_bom_entries;
+use pcb_ui::{Colorize, Spinner, Style, StyledText};
 use pcb_zen_core::convert::ToSchematic;
-use pcb_zen_core::{
-    CoreLoadResolver, DefaultFileProvider, EvalContext, EvalOutput, InputMap, LoadSpec,
-    WithDiagnostics,
-};
+use pcb_zen_core::{EvalOutput, WithDiagnostics};
 
 use std::collections::HashSet;
 use std::fs;
@@ -18,10 +13,13 @@ use std::fs;
 use chrono::Utc;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Arc;
+
 use zip::{write::FileOptions, ZipWriter};
 
-use crate::tracking_resolver::TrackingLoadResolver;
+use crate::workspace::{
+    classify_file, gather_workspace_info, loadspec_to_vendor_path, FileClassification,
+    WorkspaceInfo,
+};
 
 #[derive(Args)]
 pub struct ReleaseArgs {
@@ -31,18 +29,14 @@ pub struct ReleaseArgs {
 
 /// All information gathered during the release preparation phase
 pub struct ReleaseInfo {
-    /// Canonical path to the .zen file being released
-    pub zen_path: PathBuf,
-    /// Root directory of the workspace
-    pub workspace_root: PathBuf,
+    /// Common workspace information
+    pub workspace: WorkspaceInfo,
     /// Release version (from git or fallback)
     pub version: String,
     /// Path to the staging directory where release will be assembled
     pub staging_dir: PathBuf,
     /// Path to the layout directory containing KiCad files
     pub layout_path: PathBuf,
-    /// Dependency tracker for finding all referenced files
-    pub tracker: Arc<TrackingLoadResolver>,
     /// Evaluated schematic from the zen file
     pub schematic: pcb_sch::Schematic,
 }
@@ -101,40 +95,25 @@ pub fn execute(args: ReleaseArgs) -> Result<()> {
 fn gather_release_info(zen_path: PathBuf) -> Result<ReleaseInfo> {
     debug!("Starting release information gathering");
 
-    // Canonicalize the zen path
-    let zen_path = zen_path
-        .canonicalize()
-        .with_context(|| format!("Failed to canonicalize zen path: {}", zen_path.display()))?;
-
-    // Try to find workspace root by walking up for pcb.toml
-    let initial_workspace_root = find_workspace_root(&zen_path)?;
-
-    // Evaluate the zen file and track dependencies
-    let (tracker, eval) = eval_zen_entrypoint(&zen_path, &initial_workspace_root)?;
-
-    // Refine workspace root based on tracked files if no pcb.toml was found
-    let workspace_root = if initial_workspace_root.join("pcb.toml").exists() {
-        initial_workspace_root
-    } else {
-        // No pcb.toml found, use common ancestor of tracked files
-        detect_workspace_root_from_files(&zen_path, &tracker.files())?
-    };
-
-    // Log workspace root info for debugging
-    info!("Using workspace root: {}", workspace_root.display());
+    // Use common workspace info gathering
+    let workspace = gather_workspace_info(zen_path)?;
 
     // Get version from git
-    let version = git_describe(&workspace_root)?;
+    let version = git_describe(&workspace.workspace_root)?;
 
     // Create release staging directory in workspace root:
     // Structure: {workspace_root}/.pcb/releases/{relative_path_to_zen}/{board_name}/{version}
     // Example: /workspace/.pcb/releases/boards/TestBoard/TestBoard/f20ac95-dirty
-    let zen_relative_path = zen_path.strip_prefix(&workspace_root)?;
+    let zen_relative_path = workspace.zen_path.strip_prefix(&workspace.workspace_root)?;
     let zen_dir = zen_relative_path
         .parent()
         .context("Zen file must have a parent directory")?;
-    let board_name = zen_path.file_stem().context("Zen file must have a name")?;
-    let staging_dir = workspace_root
+    let board_name = workspace
+        .zen_path
+        .file_stem()
+        .context("Zen file must have a name")?;
+    let staging_dir = workspace
+        .workspace_root
         .join(".pcb/releases")
         .join(zen_dir)
         .join(board_name)
@@ -147,21 +126,21 @@ fn gather_release_info(zen_path: PathBuf) -> Result<ReleaseInfo> {
     fs::create_dir_all(&staging_dir)?;
 
     // Extract layout path from evaluation
-    let layout_path = extract_layout_path(&zen_path, &eval)?;
+    let layout_path = extract_layout_path(&workspace.zen_path, &workspace.eval_result)?;
 
-    let schematic = eval
+    let schematic = workspace
+        .eval_result
         .output
+        .as_ref()
         .map(|m| m.sch_module.to_schematic())
         .transpose()?
         .context("No schematic output from zen file")?;
 
     Ok(ReleaseInfo {
-        zen_path,
-        workspace_root,
+        workspace,
         version,
         staging_dir,
         layout_path,
-        tracker,
         schematic,
     })
 }
@@ -180,8 +159,8 @@ fn display_release_info(info: &ReleaseInfo) {
 
     info!(
         "Release info gathered - zen: {}, workspace: {}, version: {}",
-        info.zen_path.display(),
-        info.workspace_root.display(),
+        info.workspace.zen_path.display(),
+        info.workspace.workspace_root.display(),
         info.version
     );
 }
@@ -194,8 +173,8 @@ fn create_metadata_json(info: &ReleaseInfo) -> serde_json::Value {
         "release": {
             "version": info.version,
             "created_at": rfc3339_timestamp,
-            "zen_file": info.zen_path,
-            "workspace_root": info.workspace_root,
+            "zen_file": info.workspace.zen_path,
+            "workspace_root": info.workspace.workspace_root,
             "staging_directory": info.staging_dir,
             "layout_path": info.layout_path
         },
@@ -207,107 +186,9 @@ fn create_metadata_json(info: &ReleaseInfo) -> serde_json::Value {
         },
         "git": {
             "describe": info.version.clone(),
-            "workspace": info.workspace_root.display().to_string()
+            "workspace": info.workspace.workspace_root.display().to_string()
         }
     })
-}
-
-/// Find workspace root by walking up from entry file to find pcb.toml
-fn find_workspace_root(entry: &Path) -> Result<PathBuf> {
-    let mut current_dir = entry.parent().unwrap_or(entry);
-    loop {
-        if current_dir.join("pcb.toml").exists() {
-            return Ok(current_dir.to_path_buf());
-        }
-        if let Some(parent) = current_dir.parent() {
-            current_dir = parent;
-        } else {
-            // Reached filesystem root without finding pcb.toml
-            break;
-        }
-    }
-
-    // Fallback: Use entry's parent as initial workspace root
-    let parent = entry
-        .parent()
-        .context("Entry file has no parent directory")?;
-    Ok(parent.to_path_buf())
-}
-
-/// Detect workspace root from tracked files when no pcb.toml is found
-fn detect_workspace_root_from_files(entry: &Path, tracked: &HashSet<PathBuf>) -> Result<PathBuf> {
-    let cache_root = cache_dir()?.canonicalize()?;
-
-    let mut paths: Vec<PathBuf> = tracked
-        .iter()
-        .filter_map(|p| p.canonicalize().ok())
-        .filter(|p| !p.starts_with(&cache_root))
-        .collect();
-
-    paths.push(entry.canonicalize()?);
-
-    let root = paths
-        .into_iter()
-        .reduce(|a, b| {
-            a.components()
-                .zip(b.components())
-                .take_while(|(x, y)| x == y)
-                .map(|(c, _)| c.as_os_str())
-                .collect()
-        })
-        .context("No paths found for workspace root calculation")?;
-
-    Ok(root)
-}
-
-/// Run the Starlark interpreter once and return both the tracker (for copying)
-/// and the evaluation output (for KiCad extraction).
-fn eval_zen_entrypoint(
-    entry: &Path,
-    workspace_root: &Path,
-) -> Result<(Arc<TrackingLoadResolver>, WithDiagnostics<EvalOutput>)> {
-    debug!("Starting zen file evaluation: {}", entry.display());
-
-    let file_provider = Arc::new(DefaultFileProvider);
-
-    let remote_fetcher = Arc::new(DefaultRemoteFetcher);
-    let base_resolver = Arc::new(CoreLoadResolver::new(
-        file_provider.clone(),
-        remote_fetcher,
-        Some(workspace_root.to_path_buf()),
-    ));
-
-    let tracking_resolver = Arc::new(TrackingLoadResolver::new(
-        base_resolver,
-        file_provider.clone(),
-    ));
-
-    // Pre-seed with the entrypoint itself
-    tracking_resolver.track(entry.to_path_buf());
-
-    let eval_context = EvalContext::new()
-        .set_file_provider(file_provider.clone())
-        .set_load_resolver(tracking_resolver.clone())
-        .set_source_path(entry.to_path_buf())
-        .set_inputs(InputMap::new());
-
-    let eval_result = eval_context.eval();
-
-    // Check for errors and bail if evaluation failed
-    if !eval_result.is_success() {
-        let errors: Vec<String> = eval_result
-            .diagnostics
-            .iter()
-            .filter(|d| d.is_error())
-            .map(|d| d.to_string())
-            .collect();
-        if !errors.is_empty() {
-            anyhow::bail!("Zen file evaluation failed:\n{}", errors.join("\n"));
-        }
-    }
-
-    info!("Zen file evaluation completed successfully");
-    Ok((tracking_resolver, eval_result))
 }
 
 /// Determine release version using clean git-based logic:
@@ -370,54 +251,6 @@ fn git_describe(path: &Path) -> Result<String> {
     Ok(commit_hash)
 }
 
-#[derive(Debug)]
-enum SrcKind<'a> {
-    Local(&'a Path),
-    Vendor,
-    Irrelevant,
-}
-
-fn classify_file<'a>(
-    workspace_root: &Path,
-    path: &'a Path,
-    tracker: &TrackingLoadResolver,
-) -> SrcKind<'a> {
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or_default();
-
-    let is_zen = ext == "zen";
-    let is_kicad = matches!(ext, "kicad_mod" | "kicad_sym") || ext.starts_with("kicad_");
-
-    if !(is_zen || is_kicad) {
-        return SrcKind::Irrelevant;
-    }
-
-    // Use proper path comparison instead of string matching
-    if path.starts_with(workspace_root) {
-        if let Ok(rel) = path.strip_prefix(workspace_root) {
-            debug!(
-                "Classified as local: {} (relative: {})",
-                path.display(),
-                rel.display()
-            );
-            SrcKind::Local(rel)
-        } else {
-            SrcKind::Irrelevant
-        }
-    } else if tracker.get_load_spec(path).is_some() {
-        debug!("Classified as vendor: {}", path.display());
-        SrcKind::Vendor
-    } else {
-        debug!(
-            "Classified as irrelevant: {} (outside workspace, no LoadSpec)",
-            path.display()
-        );
-        SrcKind::Irrelevant
-    }
-}
-
 /// Extract layout path from zen evaluation result
 fn extract_layout_path(zen_path: &Path, eval: &WithDiagnostics<EvalOutput>) -> Result<PathBuf> {
     let output = eval
@@ -450,20 +283,28 @@ fn extract_layout_path(zen_path: &Path, eval: &WithDiagnostics<EvalOutput>) -> R
 fn copy_sources(info: &ReleaseInfo) -> Result<()> {
     let mut vendor_files = HashSet::new();
 
-    for path in info.tracker.files() {
-        match classify_file(&info.workspace_root, &path, &info.tracker) {
-            SrcKind::Local(rel) => {
+    for path in info.workspace.tracker.files() {
+        match classify_file(
+            &info.workspace.workspace_root,
+            &path,
+            &info.workspace.tracker,
+        ) {
+            FileClassification::Local(rel) => {
                 let dest_path = info.staging_dir.join("src").join(rel);
                 if let Some(parent) = dest_path.parent() {
-                    fs::create_dir_all(parent)?;
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("Failed to create parent directory: {}", parent.display())
+                    })?;
                 }
-                fs::copy(&path, &dest_path)?;
+                fs::copy(&path, &dest_path).with_context(|| {
+                    format!(
+                        "Failed to copy {} -> {}",
+                        path.display(),
+                        dest_path.display()
+                    )
+                })?;
             }
-            SrcKind::Vendor => {
-                let load_spec = info
-                    .tracker
-                    .get_load_spec(&path)
-                    .context("Vendor file must have LoadSpec")?;
+            FileClassification::Vendor(load_spec) => {
                 let vendor_path = loadspec_to_vendor_path(&load_spec)?;
                 if vendor_files.insert(vendor_path.clone()) {
                     let dest_path = info
@@ -472,54 +313,23 @@ fn copy_sources(info: &ReleaseInfo) -> Result<()> {
                         .join("vendor")
                         .join(&vendor_path);
                     if let Some(parent) = dest_path.parent() {
-                        fs::create_dir_all(parent)?;
+                        fs::create_dir_all(parent).with_context(|| {
+                            format!("Failed to create parent directory: {}", parent.display())
+                        })?;
                     }
-                    fs::copy(&path, &dest_path)?;
+                    fs::copy(&path, &dest_path).with_context(|| {
+                        format!(
+                            "Failed to copy {} -> {}",
+                            path.display(),
+                            dest_path.display()
+                        )
+                    })?;
                 }
             }
-            SrcKind::Irrelevant => {}
+            FileClassification::Irrelevant => {}
         }
     }
     Ok(())
-}
-
-fn loadspec_to_vendor_path(spec: &LoadSpec) -> Result<PathBuf> {
-    // Resolve package aliases to canonical git form
-    let canonical_spec = match spec {
-        LoadSpec::Package { .. } => spec
-            .resolve(None, None)
-            .context("Failed to resolve package alias to canonical form")?,
-        _ => spec.clone(),
-    };
-
-    // Convert canonical spec to vendor path
-    match canonical_spec {
-        LoadSpec::Github {
-            user,
-            repo,
-            rev,
-            path,
-        } => Ok(PathBuf::from("github.com")
-            .join(user)
-            .join(repo)
-            .join(rev)
-            .join(path)),
-        LoadSpec::Gitlab {
-            project_path,
-            rev,
-            path,
-        } => Ok(PathBuf::from("gitlab.com")
-            .join(project_path)
-            .join(rev)
-            .join(path)),
-        LoadSpec::Package { package, tag, path } => {
-            warn!("Package spec not resolved to canonical form: {package}");
-            Ok(PathBuf::from("packages").join(package).join(tag).join(path))
-        }
-        LoadSpec::Path { .. } | LoadSpec::WorkspacePath { .. } => {
-            anyhow::bail!("Local path specs should not reach vendor handling - indicates a classification bug")
-        }
-    }
 }
 
 /// Copy KiCad layout files
@@ -528,7 +338,7 @@ fn copy_layout(info: &ReleaseInfo) -> Result<()> {
 
     // If build directory doesn't exist, generate layout files first
     if !build_dir.exists() {
-        pcb_layout::process_layout(&info.schematic, &info.zen_path)?;
+        pcb_layout::process_layout(&info.schematic, &info.workspace.zen_path)?;
     }
 
     let layout_staging_dir = info.staging_dir.join("layout");

--- a/crates/pcb/src/tracking_resolver.rs
+++ b/crates/pcb/src/tracking_resolver.rs
@@ -42,7 +42,7 @@ impl TrackingLoadResolver {
     fn derive_canonical_spec(&self, spec: &LoadSpec, current_file: &Path) -> LoadSpec {
         match spec {
             // Resolve packages to canonical form first
-            LoadSpec::Package { .. } => spec.resolve(None, None).unwrap_or_else(|_| spec.clone()),
+            LoadSpec::Package { .. } => spec.resolve(None).unwrap_or_else(|_| spec.clone()),
 
             // Already canonical
             LoadSpec::Github { .. } | LoadSpec::Gitlab { .. } => spec.clone(),

--- a/crates/pcb/src/upgrade/codemods/remove_directory_loads.rs
+++ b/crates/pcb/src/upgrade/codemods/remove_directory_loads.rs
@@ -18,7 +18,7 @@ impl Codemod for RemoveDirectoryLoads {
         let file_provider = Arc::new(DefaultFileProvider);
         let remote_fetcher = Arc::new(DefaultRemoteFetcher);
         let resolver =
-            CoreLoadResolver::for_file(file_provider.clone(), remote_fetcher, current_file);
+            CoreLoadResolver::for_file(file_provider.clone(), remote_fetcher, current_file, true);
 
         let ast = match AstModule::parse("<memory>", content.to_owned(), &Dialect::Extended) {
             Ok(a) => a,

--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -19,10 +19,6 @@ pub struct VendorArgs {
     /// If none specified, will auto-discover all .zen files in the workspace.
     pub zen_paths: Vec<PathBuf>,
 
-    /// Clean vendor directory before copying
-    #[arg(long)]
-    pub clean: bool,
-
     /// Check if vendor directory is up-to-date (useful for CI)
     #[arg(long)]
     pub check: bool,
@@ -84,17 +80,8 @@ pub fn execute(args: VendorArgs) -> Result<()> {
         }
     }
 
-    // Clean vendor directory if requested
-    if args.clean {
-        let clean_spinner = Spinner::builder("Cleaning vendor directory").start();
-        if vendor_info.vendor_dir.exists() {
-            fs::remove_dir_all(&vendor_info.vendor_dir)?;
-        }
-        clean_spinner.finish();
-        println!("{} Vendor directory cleaned", "✓".green());
-    }
-
     // Create vendor directory
+    let _ = fs::remove_dir_all(&vendor_info.vendor_dir);
     fs::create_dir_all(&vendor_info.vendor_dir)?;
 
     // Copy vendor dependencies

--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -1,52 +1,46 @@
-use crate::workspace::{
-    detect_workspace_root_from_files, gather_workspace_info, is_vendor_dependency,
-    loadspec_to_vendor_path, WorkspaceInfo,
-};
+use crate::workspace::{gather_workspace_info, is_vendor_dependency, loadspec_to_vendor_path};
 use anyhow::{Context, Result};
 use clap::Args;
 use log::{debug, info};
 use pcb_ui::{Colorize, Spinner, Style, StyledText};
-use pcb_zen_core::LoadSpec;
-use std::collections::{HashMap, HashSet};
+use pcb_zen_core::{workspace::find_workspace_root, DefaultFileProvider};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 #[derive(Args)]
 pub struct VendorArgs {
-    /// Path(s) to .zen file(s) or directories to analyze for dependencies.
-    /// Directories will be searched recursively for .zen files.
-    /// If none specified, will auto-discover all .zen files in the workspace.
-    pub zen_paths: Vec<PathBuf>,
+    /// Path to .zen file or directory to analyze for dependencies.
+    /// If a directory, will search recursively for .zen files.
+    pub zen_path: PathBuf,
 
     /// Check if vendor directory is up-to-date (useful for CI)
     #[arg(long)]
     pub check: bool,
 }
 
-/// Aggregated dependency information from multiple designs
-#[derive(Debug, Clone)]
-pub struct DependencyInfo {
-    /// LoadSpec for this dependency
-    pub load_spec: LoadSpec,
-    /// Canonical file path for this dependency
-    pub file_path: PathBuf,
-    /// Set of zen files that use this dependency
-    pub used_by: HashSet<PathBuf>,
-}
-
 /// Information needed for vendoring dependencies from multiple designs
 pub struct VendorInfo {
     /// Path to the vendor directory in workspace  
     pub vendor_dir: PathBuf,
-    /// Aggregated dependencies from all designs (keyed by normalized vendor path)
-    pub dependencies: HashMap<PathBuf, DependencyInfo>,
+    /// Dependencies: vendor path -> source file path
+    pub dependencies: HashMap<PathBuf, PathBuf>,
 }
 
 pub fn execute(args: VendorArgs) -> Result<()> {
+    let workspace_root =
+        find_workspace_root(&DefaultFileProvider, &args.zen_path).canonicalize()?;
+    if !workspace_root.join("pcb.toml").exists() {
+        anyhow::bail!(
+            "No pcb.toml found in workspace. \
+            Specify a path within a workspace that contains pcb.toml.",
+        );
+    }
+
     // Discover zen files to process
     let discovery_spinner = Spinner::builder("Discovering zen files").start();
-    let zen_files = discover_zen_files(&args)?;
+    let zen_files = discover_zen_files(&args.zen_path)?;
     discovery_spinner.finish();
     println!(
         "{} Found {} zen files to analyze",
@@ -57,7 +51,7 @@ pub fn execute(args: VendorArgs) -> Result<()> {
     // Gather vendor information from all zen files
     let info_spinner = Spinner::builder("Analyzing dependencies").start();
     let zen_files_count = zen_files.len();
-    let vendor_info = gather_vendor_info(zen_files)?;
+    let vendor_info = gather_vendor_info(zen_files, workspace_root)?;
     info_spinner.finish();
     println!("{} Dependencies analyzed", "✓".green());
 
@@ -112,51 +106,28 @@ pub fn execute(args: VendorArgs) -> Result<()> {
     Ok(())
 }
 
-/// Discover zen files to process based on arguments
-fn discover_zen_files(args: &VendorArgs) -> Result<Vec<PathBuf>> {
-    let search_paths = if args.zen_paths.is_empty() {
-        vec![std::env::current_dir().context("Failed to get current directory")?]
-    } else {
-        args.zen_paths.clone()
-    };
-
+/// Discover zen files to process
+fn discover_zen_files(path: &Path) -> Result<Vec<PathBuf>> {
     let mut zen_files = Vec::new();
-    let mut errors = Vec::new();
-    let search_paths_len = search_paths.len();
 
-    for path in search_paths {
-        if path.is_file() {
-            // Verify it's a zen file
-            if path.extension().and_then(|ext| ext.to_str()) == Some("zen") {
-                zen_files.push(path);
-            } else {
-                errors.push(format!("Not a zen file: {}", path.display()));
-            }
-        } else if path.is_dir() {
-            // Search directory for zen files
-            match find_zen_files_in_directory(&path) {
-                Ok(dir_zen_files) => zen_files.extend(dir_zen_files),
-                Err(e) => errors.push(format!("Directory {}: {}", path.display(), e)),
-            }
+    if path.is_file() {
+        // Verify it's a zen file
+        if path.extension().and_then(|ext| ext.to_str()) == Some("zen") {
+            zen_files.push(path.to_path_buf());
         } else {
-            errors.push(format!("Path does not exist: {}", path.display()));
+            anyhow::bail!("Not a zen file: {}", path.display());
         }
-    }
-
-    // Report all errors at once
-    if !errors.is_empty() {
-        anyhow::bail!("Invalid paths provided:\n{}", errors.join("\n"));
+    } else if path.is_dir() {
+        // Search directory for zen files
+        zen_files.extend(find_zen_files_in_directory(path)?);
+    } else {
+        anyhow::bail!("Path does not exist: {}", path.display());
     }
 
     if zen_files.is_empty() {
         anyhow::bail!("No zen files found in search paths");
     }
 
-    debug!(
-        "Found {} zen files from {} search paths",
-        zen_files.len(),
-        search_paths_len
-    );
     Ok(zen_files)
 }
 
@@ -224,106 +195,21 @@ fn find_zen_files_in_directory(dir: &std::path::Path) -> Result<Vec<PathBuf>> {
 }
 
 /// Gather and aggregate vendor information from multiple zen files
-fn gather_vendor_info(zen_files: Vec<PathBuf>) -> Result<VendorInfo> {
-    debug!(
-        "Starting vendor information gathering for {} files",
-        zen_files.len()
-    );
-
+fn gather_vendor_info(zen_files: Vec<PathBuf>, workspace_root: PathBuf) -> Result<VendorInfo> {
     if zen_files.is_empty() {
         anyhow::bail!("No zen files to process");
     }
 
-    // 1. Evaluate each zen file only once
-    let mut workspaces = Vec::with_capacity(zen_files.len());
-    for zen_file in zen_files {
-        workspaces.push(gather_workspace_info(zen_file)?);
-    }
-
-    // 2. Determine unified workspace root from evaluated workspaces
-    let workspace_root = unify_workspace_root(&workspaces)?;
+    let mut dependencies = HashMap::new();
     let vendor_dir = workspace_root.join("vendor");
 
-    // 3. Aggregate dependencies from the same workspaces (no re-evaluation)
-    let dependencies = aggregate_dependencies(&workspaces, &workspace_root)?;
+    // Evaluate each zen file and collect dependencies
+    for zen_file in &zen_files {
+        let workspace_info = gather_workspace_info(zen_file.clone())?;
 
-    info!(
-        "Aggregated {} unique dependencies from {} zen files",
-        dependencies.len(),
-        workspaces.len()
-    );
-
-    Ok(VendorInfo {
-        vendor_dir,
-        dependencies,
-    })
-}
-
-/// Determine unified workspace root from already-evaluated workspace infos
-fn unify_workspace_root(workspaces: &[WorkspaceInfo]) -> Result<PathBuf> {
-    // Group workspaces by their detected workspace root
-    let mut workspace_groups: HashMap<PathBuf, Vec<&WorkspaceInfo>> = HashMap::new();
-    for workspace in workspaces {
-        workspace_groups
-            .entry(workspace.workspace_root.clone())
-            .or_default()
-            .push(workspace);
-    }
-
-    // Check for pcb.toml conflicts
-    let pcb_toml_roots: Vec<_> = workspace_groups
-        .keys()
-        .filter(|root| root.join("pcb.toml").exists())
-        .collect();
-
-    match (workspace_groups.len(), pcb_toml_roots.len()) {
-        (1, _) => {
-            // All zen files share the same workspace root
-            Ok(workspace_groups.into_keys().next().unwrap())
-        }
-        (_, 1..) => {
-            // Multiple workspaces with pcb.toml files - this is a clear conflict
-            let conflicting_files = workspace_groups
-                .iter()
-                .flat_map(|(root, workspaces)| workspaces.iter().map(move |w| (root, &w.zen_path)))
-                .map(|(root, zen_path)| {
-                    format!("  {} (workspace: {})", zen_path.display(), root.display())
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            anyhow::bail!(
-                "Zen files from different workspaces cannot be vendored together:\n\
-                {}\n\
-                \n\
-                Solution: Run 'pcb vendor' separately for each workspace directory.",
-                conflicting_files
-            );
-        }
-        (_, 0) => {
-            // Multiple workspace roots but no pcb.toml - find common ancestor
-            let all_tracked_files: HashSet<PathBuf> = workspaces
-                .iter()
-                .flat_map(|w| w.tracker.files())
-                .chain(workspaces.iter().map(|w| w.zen_path.clone()))
-                .collect();
-
-            detect_workspace_root_from_files(&workspaces[0].zen_path, &all_tracked_files)
-        }
-    }
-}
-
-/// Aggregate dependencies from workspace infos
-fn aggregate_dependencies(
-    workspaces: &[WorkspaceInfo],
-    workspace_root: &Path,
-) -> Result<HashMap<PathBuf, DependencyInfo>> {
-    let mut aggregated_deps = HashMap::new();
-
-    for workspace in workspaces {
-        for path in workspace.tracker.files() {
-            if is_vendor_dependency(workspace_root, &path, &workspace.tracker) {
-                let load_spec = workspace
+        for path in workspace_info.tracker.files() {
+            if is_vendor_dependency(&workspace_root, &path, &workspace_info.tracker) {
+                let load_spec = workspace_info
                     .tracker
                     .get_load_spec(&path)
                     .context("Vendor file must have LoadSpec")?
@@ -331,20 +217,17 @@ fn aggregate_dependencies(
 
                 let vendor_path = loadspec_to_vendor_path(&load_spec)?;
 
-                aggregated_deps
+                dependencies
                     .entry(vendor_path)
-                    .or_insert_with(|| DependencyInfo {
-                        load_spec,
-                        file_path: path.to_path_buf(),
-                        used_by: HashSet::new(),
-                    })
-                    .used_by
-                    .insert(workspace.zen_path.clone());
+                    .or_insert(path.to_path_buf());
             }
         }
     }
 
-    Ok(aggregated_deps)
+    Ok(VendorInfo {
+        vendor_dir,
+        dependencies,
+    })
 }
 
 /// Check if vendor directory is up-to-date by vendoring to a temp directory and comparing
@@ -391,33 +274,18 @@ fn check_vendor_directory(info: &VendorInfo) -> Result<bool> {
 
 /// Copy vendor dependencies to vendor directory
 fn copy_vendor_dependencies(info: &VendorInfo) -> Result<usize> {
-    for dep_info in info.dependencies.values() {
-        let vendor_path = loadspec_to_vendor_path(&dep_info.load_spec)?;
-        let dest_path = info.vendor_dir.join(&vendor_path);
+    for (vendor_path, src_path) in &info.dependencies {
+        let dest_path = info.vendor_dir.join(vendor_path);
 
-        copy_with_context(&dep_info.file_path, &dest_path)?;
+        // Create parent directory
+        if let Some(parent) = dest_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
 
-        debug!(
-            "Vendored: {} -> {} (used by {} designs)",
-            dep_info.file_path.display(),
-            dest_path.display(),
-            dep_info.used_by.len()
-        );
+        // Copy the file
+        fs::copy(src_path, &dest_path)
+            .with_context(|| format!("copy {} -> {}", src_path.display(), dest_path.display()))?;
     }
 
     Ok(info.dependencies.len())
-}
-
-/// Copy a file with rich error context
-fn copy_with_context(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
-    // Create parent directory
-    if let Some(parent) = dst.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create parent directory: {}", parent.display()))?;
-    }
-
-    // Copy the file
-    fs::copy(src, dst)
-        .with_context(|| format!("Failed to copy {} -> {}", src.display(), dst.display()))
-        .map(|_| ())
 }

--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -29,8 +29,8 @@ pub struct VendorInfo {
 }
 
 pub fn execute(args: VendorArgs) -> Result<()> {
-    let workspace_root =
-        find_workspace_root(&DefaultFileProvider, &args.zen_path).canonicalize()?;
+    let zen_path = args.zen_path.canonicalize()?;
+    let workspace_root = find_workspace_root(&DefaultFileProvider, &zen_path).canonicalize()?;
     if !workspace_root.join("pcb.toml").exists() {
         anyhow::bail!(
             "No pcb.toml found in workspace. \
@@ -40,7 +40,7 @@ pub fn execute(args: VendorArgs) -> Result<()> {
 
     // Discover zen files to process
     let discovery_spinner = Spinner::builder("Discovering zen files").start();
-    let zen_files = discover_zen_files(&args.zen_path)?;
+    let zen_files = discover_zen_files(&zen_path)?;
     discovery_spinner.finish();
     println!(
         "{} Found {} zen files to analyze",

--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -1,0 +1,436 @@
+use crate::workspace::{
+    detect_workspace_root_from_files, gather_workspace_info, is_vendor_dependency,
+    loadspec_to_vendor_path, WorkspaceInfo,
+};
+use anyhow::{Context, Result};
+use clap::Args;
+use log::{debug, info};
+use pcb_ui::{Colorize, Spinner, Style, StyledText};
+use pcb_zen_core::LoadSpec;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+#[derive(Args)]
+pub struct VendorArgs {
+    /// Path(s) to .zen file(s) or directories to analyze for dependencies.
+    /// Directories will be searched recursively for .zen files.
+    /// If none specified, will auto-discover all .zen files in the workspace.
+    pub zen_paths: Vec<PathBuf>,
+
+    /// Clean vendor directory before copying
+    #[arg(long)]
+    pub clean: bool,
+
+    /// Check if vendor directory is up-to-date (useful for CI)
+    #[arg(long)]
+    pub check: bool,
+}
+
+/// Aggregated dependency information from multiple designs
+#[derive(Debug, Clone)]
+pub struct DependencyInfo {
+    /// LoadSpec for this dependency
+    pub load_spec: LoadSpec,
+    /// Canonical file path for this dependency
+    pub file_path: PathBuf,
+    /// Set of zen files that use this dependency
+    pub used_by: HashSet<PathBuf>,
+}
+
+/// Information needed for vendoring dependencies from multiple designs
+pub struct VendorInfo {
+    /// Path to the vendor directory in workspace  
+    pub vendor_dir: PathBuf,
+    /// Aggregated dependencies from all designs (keyed by normalized vendor path)
+    pub dependencies: HashMap<PathBuf, DependencyInfo>,
+}
+
+pub fn execute(args: VendorArgs) -> Result<()> {
+    // Discover zen files to process
+    let discovery_spinner = Spinner::builder("Discovering zen files").start();
+    let zen_files = discover_zen_files(&args)?;
+    discovery_spinner.finish();
+    println!(
+        "{} Found {} zen files to analyze",
+        "✓".green(),
+        zen_files.len()
+    );
+
+    // Gather vendor information from all zen files
+    let info_spinner = Spinner::builder("Analyzing dependencies").start();
+    let zen_files_count = zen_files.len();
+    let vendor_info = gather_vendor_info(zen_files)?;
+    info_spinner.finish();
+    println!("{} Dependencies analyzed", "✓".green());
+
+    // Handle check mode for CI
+    if args.check {
+        let check_spinner = Spinner::builder("Checking vendor directory").start();
+        debug!(
+            "Checking vendor directory: {}",
+            vendor_info.vendor_dir.display()
+        );
+        let is_up_to_date = check_vendor_directory(&vendor_info)?;
+        check_spinner.finish();
+
+        if is_up_to_date {
+            println!("{} Vendor directory is up-to-date", "✓".green());
+            return Ok(());
+        } else {
+            println!("{} Vendor directory is out-of-date", "✗".red());
+            anyhow::bail!("Vendor directory is not up-to-date. Run 'pcb vendor' to update it.");
+        }
+    }
+
+    // Clean vendor directory if requested
+    if args.clean {
+        let clean_spinner = Spinner::builder("Cleaning vendor directory").start();
+        if vendor_info.vendor_dir.exists() {
+            fs::remove_dir_all(&vendor_info.vendor_dir)?;
+        }
+        clean_spinner.finish();
+        println!("{} Vendor directory cleaned", "✓".green());
+    }
+
+    // Create vendor directory
+    fs::create_dir_all(&vendor_info.vendor_dir)?;
+
+    // Copy vendor dependencies
+    let vendor_spinner = Spinner::builder("Copying vendor dependencies").start();
+    let vendor_count = copy_vendor_dependencies(&vendor_info)?;
+    vendor_spinner.finish();
+
+    info!(
+        "Vendored {} dependencies to {}",
+        vendor_count,
+        vendor_info.vendor_dir.display()
+    );
+    println!();
+    println!(
+        "{} {}",
+        "✓".green().bold(),
+        format!("Vendored {vendor_count} dependencies from {zen_files_count} designs").bold()
+    );
+    println!(
+        "Vendor directory: {}",
+        vendor_info
+            .vendor_dir
+            .display()
+            .to_string()
+            .with_style(Style::Cyan)
+    );
+
+    Ok(())
+}
+
+/// Discover zen files to process based on arguments
+fn discover_zen_files(args: &VendorArgs) -> Result<Vec<PathBuf>> {
+    let search_paths = if args.zen_paths.is_empty() {
+        vec![std::env::current_dir().context("Failed to get current directory")?]
+    } else {
+        args.zen_paths.clone()
+    };
+
+    let mut zen_files = Vec::new();
+    let mut errors = Vec::new();
+    let search_paths_len = search_paths.len();
+
+    for path in search_paths {
+        if path.is_file() {
+            // Verify it's a zen file
+            if path.extension().and_then(|ext| ext.to_str()) == Some("zen") {
+                zen_files.push(path);
+            } else {
+                errors.push(format!("Not a zen file: {}", path.display()));
+            }
+        } else if path.is_dir() {
+            // Search directory for zen files
+            match find_zen_files_in_directory(&path) {
+                Ok(dir_zen_files) => zen_files.extend(dir_zen_files),
+                Err(e) => errors.push(format!("Directory {}: {}", path.display(), e)),
+            }
+        } else {
+            errors.push(format!("Path does not exist: {}", path.display()));
+        }
+    }
+
+    // Report all errors at once
+    if !errors.is_empty() {
+        anyhow::bail!("Invalid paths provided:\n{}", errors.join("\n"));
+    }
+
+    if zen_files.is_empty() {
+        anyhow::bail!("No zen files found in search paths");
+    }
+
+    debug!(
+        "Found {} zen files from {} search paths",
+        zen_files.len(),
+        search_paths_len
+    );
+    Ok(zen_files)
+}
+
+/// Find zen files in a directory, applying smart filtering including .gitignore
+fn find_zen_files_in_directory(dir: &std::path::Path) -> Result<Vec<PathBuf>> {
+    let mut zen_files = Vec::new();
+
+    // Configure ignore walker to skip vendor and other common directories
+    let mut builder = ignore::WalkBuilder::new(dir);
+    builder
+        .follow_links(false)
+        .add_custom_ignore_filename(".pcbignore") // Custom ignore file for PCB-specific exclusions
+        .filter_entry(|entry| {
+            // Additional filtering for directories that shouldn't contain source zen files
+            if let Some(file_name) = entry.file_name().to_str() {
+                // Always skip vendor directory to avoid recursive dependencies
+                if file_name == "vendor" {
+                    debug!("Skipping vendor directory: {}", entry.path().display());
+                    return false;
+                }
+                // Skip other common build/cache directories not typically in .gitignore
+                if matches!(file_name, ".pcb" | "target" | "build" | "dist" | "out") {
+                    debug!("Skipping build directory: {}", entry.path().display());
+                    return false;
+                }
+            }
+            true
+        });
+
+    // Use the configured walker with simplified filtering
+    for entry in builder
+        .build()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
+    {
+        let path = entry.into_path();
+
+        // Check if it's a zen file
+        if path.extension().and_then(|ext| ext.to_str()) != Some("zen") {
+            continue;
+        }
+
+        // Skip hidden files
+        if path
+            .file_name()
+            .is_some_and(|n| n.to_string_lossy().starts_with('.'))
+        {
+            continue;
+        }
+
+        zen_files.push(path);
+    }
+
+    if zen_files.is_empty() {
+        anyhow::bail!("No zen files found in directory: {}", dir.display());
+    }
+
+    debug!(
+        "Found {} zen files in {}: {:?}",
+        zen_files.len(),
+        dir.display(),
+        zen_files
+    );
+    Ok(zen_files)
+}
+
+/// Gather and aggregate vendor information from multiple zen files
+fn gather_vendor_info(zen_files: Vec<PathBuf>) -> Result<VendorInfo> {
+    debug!(
+        "Starting vendor information gathering for {} files",
+        zen_files.len()
+    );
+
+    if zen_files.is_empty() {
+        anyhow::bail!("No zen files to process");
+    }
+
+    // 1. Evaluate each zen file only once
+    let mut workspaces = Vec::with_capacity(zen_files.len());
+    for zen_file in zen_files {
+        workspaces.push(gather_workspace_info(zen_file)?);
+    }
+
+    // 2. Determine unified workspace root from evaluated workspaces
+    let workspace_root = unify_workspace_root(&workspaces)?;
+    let vendor_dir = workspace_root.join("vendor");
+
+    // 3. Aggregate dependencies from the same workspaces (no re-evaluation)
+    let dependencies = aggregate_dependencies(&workspaces, &workspace_root)?;
+
+    info!(
+        "Aggregated {} unique dependencies from {} zen files",
+        dependencies.len(),
+        workspaces.len()
+    );
+
+    Ok(VendorInfo {
+        vendor_dir,
+        dependencies,
+    })
+}
+
+/// Determine unified workspace root from already-evaluated workspace infos
+fn unify_workspace_root(workspaces: &[WorkspaceInfo]) -> Result<PathBuf> {
+    // Group workspaces by their detected workspace root
+    let mut workspace_groups: HashMap<PathBuf, Vec<&WorkspaceInfo>> = HashMap::new();
+    for workspace in workspaces {
+        workspace_groups
+            .entry(workspace.workspace_root.clone())
+            .or_default()
+            .push(workspace);
+    }
+
+    // Check for pcb.toml conflicts
+    let pcb_toml_roots: Vec<_> = workspace_groups
+        .keys()
+        .filter(|root| root.join("pcb.toml").exists())
+        .collect();
+
+    match (workspace_groups.len(), pcb_toml_roots.len()) {
+        (1, _) => {
+            // All zen files share the same workspace root
+            Ok(workspace_groups.into_keys().next().unwrap())
+        }
+        (_, 1..) => {
+            // Multiple workspaces with pcb.toml files - this is a clear conflict
+            let conflicting_files = workspace_groups
+                .iter()
+                .flat_map(|(root, workspaces)| workspaces.iter().map(move |w| (root, &w.zen_path)))
+                .map(|(root, zen_path)| {
+                    format!("  {} (workspace: {})", zen_path.display(), root.display())
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            anyhow::bail!(
+                "Zen files from different workspaces cannot be vendored together:\n\
+                {}\n\
+                \n\
+                Solution: Run 'pcb vendor' separately for each workspace directory.",
+                conflicting_files
+            );
+        }
+        (_, 0) => {
+            // Multiple workspace roots but no pcb.toml - find common ancestor
+            let all_tracked_files: HashSet<PathBuf> = workspaces
+                .iter()
+                .flat_map(|w| w.tracker.files())
+                .chain(workspaces.iter().map(|w| w.zen_path.clone()))
+                .collect();
+
+            detect_workspace_root_from_files(&workspaces[0].zen_path, &all_tracked_files)
+        }
+    }
+}
+
+/// Aggregate dependencies from workspace infos
+fn aggregate_dependencies(
+    workspaces: &[WorkspaceInfo],
+    workspace_root: &Path,
+) -> Result<HashMap<PathBuf, DependencyInfo>> {
+    let mut aggregated_deps = HashMap::new();
+
+    for workspace in workspaces {
+        for path in workspace.tracker.files() {
+            if is_vendor_dependency(workspace_root, &path, &workspace.tracker) {
+                let load_spec = workspace
+                    .tracker
+                    .get_load_spec(&path)
+                    .context("Vendor file must have LoadSpec")?
+                    .clone();
+
+                let vendor_path = loadspec_to_vendor_path(&load_spec)?;
+
+                aggregated_deps
+                    .entry(vendor_path)
+                    .or_insert_with(|| DependencyInfo {
+                        load_spec,
+                        file_path: path.to_path_buf(),
+                        used_by: HashSet::new(),
+                    })
+                    .used_by
+                    .insert(workspace.zen_path.clone());
+            }
+        }
+    }
+
+    Ok(aggregated_deps)
+}
+
+/// Check if vendor directory is up-to-date by vendoring to a temp directory and comparing
+fn check_vendor_directory(info: &VendorInfo) -> Result<bool> {
+    // If vendor directory doesn't exist, it's not up-to-date
+    if !info.vendor_dir.exists() {
+        debug!(
+            "Vendor directory does not exist: {}",
+            info.vendor_dir.display()
+        );
+        return Ok(false);
+    }
+
+    // Create temporary directory for comparison
+    let temp_dir = TempDir::new().context("Failed to create temporary directory")?;
+    let temp_vendor_dir = temp_dir.path().join("vendor");
+    fs::create_dir_all(&temp_vendor_dir)?;
+
+    // Create a temporary VendorInfo with the temp directory
+    let temp_info = VendorInfo {
+        vendor_dir: temp_vendor_dir.clone(),
+        dependencies: info.dependencies.clone(),
+    };
+
+    // Vendor dependencies to temp directory
+    copy_vendor_dependencies(&temp_info).context("Failed to vendor to temporary directory")?;
+
+    // Compare temp directory with actual vendor directory using dir-diff
+    let are_different = dir_diff::is_different(&temp_vendor_dir, &info.vendor_dir)
+        .context("Failed to compare vendor directories")?;
+
+    if are_different {
+        debug!(
+            "Vendor directory differs from expected (temp: {}, actual: {})",
+            temp_vendor_dir.display(),
+            info.vendor_dir.display()
+        );
+        Ok(false)
+    } else {
+        debug!("Vendor directory matches expected content");
+        Ok(true)
+    }
+}
+
+/// Copy vendor dependencies to vendor directory
+fn copy_vendor_dependencies(info: &VendorInfo) -> Result<usize> {
+    for dep_info in info.dependencies.values() {
+        let vendor_path = loadspec_to_vendor_path(&dep_info.load_spec)?;
+        let dest_path = info.vendor_dir.join(&vendor_path);
+
+        copy_with_context(&dep_info.file_path, &dest_path)?;
+
+        debug!(
+            "Vendored: {} -> {} (used by {} designs)",
+            dep_info.file_path.display(),
+            dest_path.display(),
+            dep_info.used_by.len()
+        );
+    }
+
+    Ok(info.dependencies.len())
+}
+
+/// Copy a file with rich error context
+fn copy_with_context(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
+    // Create parent directory
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create parent directory: {}", parent.display()))?;
+    }
+
+    // Copy the file
+    fs::copy(src, dst)
+        .with_context(|| format!("Failed to copy {} -> {}", src.display(), dst.display()))
+        .map(|_| ())
+}

--- a/crates/pcb/src/workspace.rs
+++ b/crates/pcb/src/workspace.rs
@@ -1,0 +1,349 @@
+//! Common workspace and dependency handling utilities
+
+use anyhow::{Context, Result};
+use log::{debug, info};
+use pcb_zen::load::{cache_dir, DefaultRemoteFetcher};
+use pcb_zen_core::{
+    CoreLoadResolver, DefaultFileProvider, EvalContext, EvalOutput, InputMap, LoadSpec,
+    WithDiagnostics,
+};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::tracking_resolver::TrackingLoadResolver;
+
+/// Normalize a path by resolving .. and . components
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                // Only pop if we have components to pop, otherwise keep the parent dir
+                if components.pop().is_none() {
+                    components.push(std::ffi::OsStr::new(".."));
+                }
+            }
+            std::path::Component::Normal(name) => {
+                components.push(name);
+            }
+            std::path::Component::CurDir => {
+                // Skip current directory
+            }
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                // Preserve prefix and root components (important for Windows)
+                components.push(component.as_os_str());
+            }
+        }
+    }
+    components.iter().collect()
+}
+
+/// Common workspace information used by both vendor and release commands
+pub struct WorkspaceInfo {
+    /// Canonical path to the .zen file being processed
+    pub zen_path: PathBuf,
+    /// Root directory of the workspace
+    pub workspace_root: PathBuf,
+    /// Dependency tracker for finding all referenced files
+    pub tracker: Arc<TrackingLoadResolver>,
+    /// Evaluation result containing the parsed zen file
+    pub eval_result: WithDiagnostics<EvalOutput>,
+}
+
+/// Classification of a tracked file
+#[derive(Debug)]
+pub enum FileClassification<'a> {
+    /// Local file within workspace (contains relative path)
+    Local(&'a Path),
+    /// Vendor dependency (contains LoadSpec)
+    Vendor(LoadSpec),
+    /// Not relevant for packaging
+    Irrelevant,
+}
+
+/// Gather common workspace information for both vendor and release commands
+pub fn gather_workspace_info(zen_path: PathBuf) -> Result<WorkspaceInfo> {
+    debug!("Starting workspace information gathering");
+
+    // Canonicalize the zen path
+    let zen_path = zen_path
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize zen path: {}", zen_path.display()))?;
+
+    // Try to find workspace root by walking up for pcb.toml
+    let initial_workspace_root = find_workspace_root(&zen_path)?;
+
+    // Evaluate the zen file and track dependencies
+    let (tracker, eval_result) = eval_zen_entrypoint(&zen_path, &initial_workspace_root)?;
+
+    // Refine workspace root based on tracked files if no pcb.toml was found
+    let workspace_root = if initial_workspace_root.join("pcb.toml").exists() {
+        initial_workspace_root
+    } else {
+        // No pcb.toml found, use common ancestor of tracked files
+        detect_workspace_root_from_files(&zen_path, &tracker.files())?
+    };
+
+    // Log workspace root info for debugging
+    info!("Using workspace root: {}", workspace_root.display());
+
+    Ok(WorkspaceInfo {
+        zen_path,
+        workspace_root,
+        tracker,
+        eval_result,
+    })
+}
+
+/// Find workspace root by walking up from entry file to find pcb.toml
+pub fn find_workspace_root(entry: &Path) -> Result<PathBuf> {
+    let mut current_dir = entry
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize entry path: {}", entry.display()))?;
+
+    // Start from parent directory if entry is a file
+    if current_dir.is_file() {
+        current_dir = current_dir
+            .parent()
+            .context("Entry file has no parent directory")?
+            .to_path_buf();
+    }
+
+    loop {
+        if current_dir.join("pcb.toml").exists() {
+            return Ok(current_dir);
+        }
+        if let Some(parent) = current_dir.parent() {
+            current_dir = parent.to_path_buf();
+        } else {
+            // Reached filesystem root without finding pcb.toml
+            break;
+        }
+    }
+
+    // Fallback: Use entry's parent as initial workspace root
+    let parent = entry
+        .parent()
+        .context("Entry file has no parent directory")?;
+    parent.canonicalize().with_context(|| {
+        format!(
+            "Failed to canonicalize fallback parent: {}",
+            parent.display()
+        )
+    })
+}
+
+/// Detect workspace root from tracked files when no pcb.toml is found
+pub fn detect_workspace_root_from_files(
+    entry: &Path,
+    tracked: &HashSet<PathBuf>,
+) -> Result<PathBuf> {
+    let cache_root = cache_dir()?.canonicalize()?;
+
+    let mut paths: Vec<PathBuf> = tracked
+        .iter()
+        .filter_map(|p| p.canonicalize().ok())
+        .filter(|p| !p.starts_with(&cache_root))
+        .collect();
+
+    paths.push(entry.canonicalize()?);
+
+    let root = paths
+        .into_iter()
+        .try_fold(None::<PathBuf>, |acc, path| -> Result<Option<PathBuf>> {
+            let current_root = match acc {
+                None => path.parent().map(|p| p.to_path_buf()),
+                Some(existing) => common_ancestor(&existing, &path),
+            };
+            Ok(current_root)
+        })?
+        .context("Unable to determine workspace root from tracked files")?;
+
+    info!("Detected workspace root from files: {}", root.display());
+    Ok(root)
+}
+
+/// Find common ancestor of two paths
+pub fn common_ancestor(a: &Path, b: &Path) -> Option<PathBuf> {
+    let mut a_components = a.components();
+    let mut b_components = b.components();
+    let mut common = PathBuf::new();
+
+    loop {
+        match (a_components.next(), b_components.next()) {
+            (Some(a_comp), Some(b_comp)) if a_comp == b_comp => {
+                common.push(a_comp);
+            }
+            _ => break,
+        }
+    }
+
+    if common.as_os_str().is_empty() {
+        None
+    } else {
+        Some(common)
+    }
+}
+
+/// Evaluate zen file and track dependencies
+pub fn eval_zen_entrypoint(
+    entry: &Path,
+    workspace_root: &Path,
+) -> Result<(Arc<TrackingLoadResolver>, WithDiagnostics<EvalOutput>)> {
+    debug!("Starting zen file evaluation: {}", entry.display());
+
+    let file_provider = Arc::new(DefaultFileProvider);
+
+    let remote_fetcher = Arc::new(DefaultRemoteFetcher);
+    let base_resolver = Arc::new(CoreLoadResolver::new(
+        file_provider.clone(),
+        remote_fetcher,
+        Some(workspace_root.to_path_buf()),
+    ));
+
+    let tracking_resolver = Arc::new(TrackingLoadResolver::new(
+        base_resolver,
+        file_provider.clone(),
+    ));
+
+    // Pre-seed with the entrypoint itself
+    tracking_resolver.track(entry.to_path_buf());
+
+    let eval_context = EvalContext::new()
+        .set_file_provider(file_provider.clone())
+        .set_load_resolver(tracking_resolver.clone())
+        .set_source_path(entry.to_path_buf())
+        .set_inputs(InputMap::new());
+
+    let eval_result = eval_context.eval();
+
+    // Check for errors and bail if evaluation failed
+    if !eval_result.is_success() {
+        let errors: Vec<String> = eval_result
+            .diagnostics
+            .iter()
+            .filter(|d| d.is_error())
+            .map(|d| d.to_string())
+            .collect();
+        if !errors.is_empty() {
+            anyhow::bail!("Zen file evaluation failed:\n{}", errors.join("\n"));
+        }
+    }
+
+    info!("Zen file evaluation completed successfully");
+    Ok((tracking_resolver, eval_result))
+}
+
+/// Convert LoadSpec to vendor path
+pub fn loadspec_to_vendor_path(spec: &LoadSpec) -> Result<PathBuf> {
+    // Resolve package aliases to canonical git form
+    let canonical_spec = match spec {
+        LoadSpec::Package { .. } => spec
+            .resolve(None, None)
+            .context("Failed to resolve package alias to canonical form")?,
+        _ => spec.clone(),
+    };
+
+    // Convert canonical spec to vendor path
+    match canonical_spec {
+        LoadSpec::Github {
+            user,
+            repo,
+            rev,
+            path,
+        } => {
+            let mut vendor_path = PathBuf::from("github.com").join(user).join(repo).join(rev);
+            // Normalize and add path components (handles .. and . components)
+            if !path.as_os_str().is_empty() && path != Path::new(".") {
+                vendor_path.push(normalize_path(&path));
+            }
+            Ok(vendor_path)
+        }
+        LoadSpec::Gitlab {
+            project_path,
+            rev,
+            path,
+        } => {
+            let mut vendor_path = PathBuf::from("gitlab.com").join(project_path).join(rev);
+            // Normalize and add path components (handles .. and . components)
+            if !path.as_os_str().is_empty() && path != Path::new(".") {
+                vendor_path.push(normalize_path(&path));
+            }
+            Ok(vendor_path)
+        }
+        LoadSpec::Package { package, tag, path } => {
+            info!("Package spec not resolved to canonical form: {package}");
+            let mut vendor_path = PathBuf::from("packages").join(package);
+            // Avoid creating empty tag directories
+            if !tag.is_empty() {
+                vendor_path.push(tag);
+            }
+            if !path.as_os_str().is_empty() && path != Path::new(".") {
+                vendor_path.push(normalize_path(&path));
+            }
+            Ok(vendor_path)
+        }
+        LoadSpec::Path { .. } | LoadSpec::WorkspacePath { .. } => {
+            anyhow::bail!(
+                "Local path dependency detected during vendoring. This typically indicates zen files \
+                from different workspaces are being processed together.\n\
+                \n\
+                Local dependencies should not be vendored - they belong to your workspace.\n\
+                \n\
+                Solution: Run 'pcb vendor' separately for each workspace, or ensure all zen files \
+                belong to the same workspace."
+            )
+        }
+    }
+}
+
+/// Classify a tracked file for packaging purposes
+pub fn classify_file<'a>(
+    workspace_root: &Path,
+    path: &'a Path,
+    tracker: &TrackingLoadResolver,
+) -> FileClassification<'a> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or_default();
+    if !matches!(ext, "zen" | "kicad_mod" | "kicad_sym") && !ext.starts_with("kicad_") {
+        return FileClassification::Irrelevant;
+    }
+
+    // Use proper path comparison instead of string matching
+    if path.starts_with(workspace_root) {
+        if let Ok(rel) = path.strip_prefix(workspace_root) {
+            debug!(
+                "Classified as local: {} (relative: {})",
+                path.display(),
+                rel.display()
+            );
+            FileClassification::Local(rel)
+        } else {
+            FileClassification::Irrelevant
+        }
+    } else if let Some(load_spec) = tracker.get_load_spec(path) {
+        debug!("Classified as vendor: {}", path.display());
+        FileClassification::Vendor(load_spec.clone())
+    } else {
+        debug!(
+            "Classified as irrelevant: {} (outside workspace, no LoadSpec)",
+            path.display()
+        );
+        FileClassification::Irrelevant
+    }
+}
+
+/// Check if a file is a vendor dependency (external to workspace) - compatibility helper
+pub fn is_vendor_dependency(
+    workspace_root: &Path,
+    path: &Path,
+    tracker: &TrackingLoadResolver,
+) -> bool {
+    matches!(
+        classify_file(workspace_root, path, tracker),
+        FileClassification::Vendor(_)
+    )
+}


### PR DESCRIPTION
Build from within a release dir to confirm `pcb build --offline` works:

```
> cargo run --release -- release test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
   Compiling pcb v0.2.0-prerelease.2 (/Users/akhilles/src/diode/pcb/crates/pcb)
    Finished `release` profile [optimized] target(s) in 2.68s
     Running `target/release/pcb release test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen`
✓ Release information gathered

Release Metadata
{
  "git": {
    "describe": "ac7c446",
    "workspace": "/Users/akhilles/src/diode/pcb/test-workspaces/with-pcb-toml"
  },
  "release": {
    "created_at": "2025-08-15T17:08:37.373435+00:00",
    "layout_path": "/Users/akhilles/src/diode/pcb/test-workspaces/with-pcb-toml/boards/build/WorkspaceTestBoard",
    "staging_directory": "/Users/akhilles/src/diode/pcb/test-workspaces/with-pcb-toml/.pcb/releases/boards/WorkspaceTestBoard/ac7c446",
    "version": "ac7c446",
    "workspace_root": "/Users/akhilles/src/diode/pcb/test-workspaces/with-pcb-toml",
    "zen_file": "/Users/akhilles/src/diode/pcb/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen"
  },
  "system": {
    "arch": "aarch64",
    "cli_version": "0.2.0-prerelease.2",
    "platform": "macos",
    "user": "akhilles"
  }
}
✓ Copying source files and dependencies
✓ Copying layout files
✓ Generating unmatched BOM
✓ Writing release metadata
✓ Creating release archive

✓ Release ac7c446 staged successfully
Archive: /Users/akhilles/src/diode/pcb/test-workspaces/with-pcb-toml/.pcb/releases/boards/WorkspaceTestBoard/ac7c446.zip

> cargo run --release -- build ./test-workspaces/with-pcb-toml/.pcb/releases/boards/WorkspaceTestBoard/ac7c446/src/boards --offline
    Finished `release` profile [optimized] target(s) in 0.16s
     Running `target/release/pcb build ./test-workspaces/with-pcb-toml/.pcb/releases/boards/WorkspaceTestBoard/ac7c446/src/boards --offline`
✓ WorkspaceTestBoard.zen (4 components)
```

One somewhat unrelated change I made is:

```
Standardize behavior of find_workspace_root. Most of the callsites would
fallback on parent dir of target .zen file. We should just do that
universally to reduce conditional code paths.
```

I can revert this if needed. But having each callsite handle `find_workspace_root` returning `None` in its own way seemed very error-prone and I was seeing inconsistent behavior across the various pcb commands. So, I figured it would be good to standardize on the behavior of `find_workspace_root` and use it everywhere.