### PR TITLE
Read MPN from component properties

### DIFF
--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -106,3 +106,41 @@ snapshot_eval!(component_duplicate_pin_names, {
         )
     "#
 });
+
+snapshot_eval!(component_mpn_from_properties, {
+    "test.zen" => r#"
+        Component(
+            name = "U1",
+            footprint = "test_footprint",
+            mpn = "1234567890",
+            pins = {
+                "in": Net("in"),
+                "out": Net("out"),
+            },
+            pin_defs = {"in": "1", "out": "2"},
+        )
+
+        Component(
+            name = "U2",
+            footprint = "test_footprint",
+            properties = {"mpn": "1234567890"},
+            pins = {
+                "in": Net("in"),
+                "out": Net("out"),
+            },
+            pin_defs = {"in": "1", "out": "2"},
+        )
+
+        Component(
+            name = "U3",
+            footprint = "test_footprint",
+            mpn = "1234567890",
+            properties = {"mpn": "WRONG"},
+            pins = {
+                "in": Net("in"),
+                "out": Net("out"),
+            },
+            pin_defs = {"in": "1", "out": "2"},
+        )
+    "#
+});

--- a/crates/pcb-zen-core/tests/snapshots/component__component_mpn_from_properties.snap.new
+++ b/crates/pcb-zen-core/tests/snapshots/component__component_mpn_from_properties.snap.new
@@ -1,0 +1,133 @@
+---
+source: crates/pcb-zen-core/tests/component.rs
+assertion_line: 110
+expression: output
+---
+Module {
+    name: "<root>",
+    source: "test.zen",
+    children: [
+        FrozenValue(
+            Component {
+                name: "U1",
+                mpn: "1234567890",
+                footprint: "test_footprint",
+                prefix: "U",
+                connections: {
+                    "in": FrozenValue(
+                        Net {
+                            name: "in",
+                            id: "<ID>",
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
+                        },
+                    ),
+                    "out": FrozenValue(
+                        Net {
+                            name: "out",
+                            id: "<ID>",
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
+                        },
+                    ),
+                },
+                symbol: FrozenValue(
+                    Symbol {
+                        name: None,
+                        pins: {
+                            "1": "in",
+                            "2": "out",
+                        },
+                    },
+                ),
+            },
+        ),
+        FrozenValue(
+            Component {
+                name: "U2",
+                mpn: "1234567890",
+                footprint: "test_footprint",
+                prefix: "U",
+                connections: {
+                    "in": FrozenValue(
+                        Net {
+                            name: "in_2",
+                            id: "<ID>",
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
+                        },
+                    ),
+                    "out": FrozenValue(
+                        Net {
+                            name: "out_2",
+                            id: "<ID>",
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
+                        },
+                    ),
+                },
+                properties: {
+                    "mpn": FrozenValue(
+                        "1234567890",
+                    ),
+                },
+                symbol: FrozenValue(
+                    Symbol {
+                        name: None,
+                        pins: {
+                            "1": "in",
+                            "2": "out",
+                        },
+                    },
+                ),
+            },
+        ),
+        FrozenValue(
+            Component {
+                name: "U3",
+                mpn: "1234567890",
+                footprint: "test_footprint",
+                prefix: "U",
+                connections: {
+                    "in": FrozenValue(
+                        Net {
+                            name: "in_3",
+                            id: "<ID>",
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
+                        },
+                    ),
+                    "out": FrozenValue(
+                        Net {
+                            name: "out_3",
+                            id: "<ID>",
+                            symbol: FrozenValue(
+                                NoneType,
+                            ),
+                        },
+                    ),
+                },
+                properties: {
+                    "mpn": FrozenValue(
+                        "WRONG",
+                    ),
+                },
+                symbol: FrozenValue(
+                    Symbol {
+                        name: None,
+                        pins: {
+                            "1": "in",
+                            "2": "out",
+                        },
+                    },
+                ),
+            },
+        ),
+    ],
+}
+[]


### PR DESCRIPTION
In `stdlib/config.zen` we put the component MPN in to the `properties` field, to be compatible with BOM, etc we should parse this and attach it as the true component MPN.