### PR TITLE
Use smart rust cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,23 +115,19 @@ jobs:
           cargo run -- vendor test-workspaces/with-pcb-toml
           cargo run -- build test-workspaces/with-pcb-toml/boards --offline
 
+      - name: Checkout stdlib
+        uses: actions/checkout@v5
+        with:
+          repository: diodeinc/stdlib
+          path: stdlib
+
       - name: Test stdlib builds
         shell: bash
         run: |
-          # Save current directory
-          ORIGINAL_DIR=$(pwd)
+          # Save path to pcb binary
+          PCB_BIN="$(pwd)/target/debug/pcb"
 
-          # Clone the stdlib repository
-          git clone https://github.com/diodeinc/stdlib.git /tmp/stdlib
-
-          # Find all .star and .zen files and build them
-          cd /tmp/stdlib
-          find . -name "*.star" -o -name "*.zen" | while read -r file; do
-            echo "Building $file..."
-            if ! (cd "$ORIGINAL_DIR" && cargo run -p pcb -- build "/tmp/stdlib/$file"); then
-              echo "Failed to build $file"
-              exit 1
-            fi
-          done
+          # Find and build all .zen files
+          find stdlib -name "*.zen" -exec "$PCB_BIN" build {} +
 
           echo "All stdlib files built successfully!"


### PR DESCRIPTION
Out cache sizes are blowing up:

Cache Size: ~8914 MB (9346691088 B)
"C:\Program Files\Git\usr\bin\tar.exe" -xf C:/a/_temp/277318a1-9141-472d-bf1b-4d0461835b0b/cache.tzst -P -C C:/a/pcb/pcb --force-local --use-compress-program "zstd -d" Cache restored successfully
Cache restored from key: Windows-cargo-02b001115c33129b2426bd7db7faa11329497685bfa1d1e328c20e41bc781dca

Which is slowing down builds. Just fetching cargo cache took 6 mins.

Swatinem/rust-cache has much better default behavior:
- Cleans dependencies no longer used
- Cleans incremental build artifacts
- Cleans anything older than 1 week

It also only caches dependencies (and their built artifacts). Caching workspace crates is not that useful.