### PR TITLE
Standardize pcb info paths

### DIFF
--- a/crates/pcb/src/info.rs
+++ b/crates/pcb/src/info.rs
@@ -100,19 +100,9 @@ fn print_human_readable(info: &pcb_zen_core::config::WorkspaceInfo) {
             };
 
             if board.description.is_empty() {
-                println!(
-                    "  {} - {} in {}",
-                    name_display,
-                    board.zen_path,
-                    board.directory.display()
-                );
+                println!("  {} - {}", name_display, board.zen_path);
             } else {
-                println!(
-                    "  {} - {} in {}",
-                    name_display,
-                    board.zen_path,
-                    board.directory.display()
-                );
+                println!("  {} - {}", name_display, board.zen_path);
                 println!("    {}", board.description);
             }
         }

--- a/crates/pcb/tests/snapshots/info__board_without_pcb_toml.snap
+++ b/crates/pcb/tests/snapshots/info__board_without_pcb_toml.snap
@@ -10,7 +10,7 @@ Workspace Information
 Root: <TEMP_DIR>
 
 Boards (2)
-  TestBoard - test_board.zen in <TEMP_DIR>/boards/BoardWithToml
+  TestBoard - boards/BoardWithToml/test_board.zen
     Main test board for validation
-  board (default) - board.zen in <TEMP_DIR>/boards/BoardWithoutToml
+  board (default) - boards/BoardWithoutToml/board.zen
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__json_format.snap
+++ b/crates/pcb/tests/snapshots/info__json_format.snap
@@ -19,14 +19,12 @@ Exit Code: 0
   "boards": [
     {
       "name": "MainBoard",
-      "zen_path": "main_board.zen",
-      "directory": "<TEMP_DIR>/boards/main-board"
+      "zen_path": "boards/main-board/main_board.zen"
     },
     {
       "name": "TestBoard",
-      "zen_path": "test_board.zen",
-      "description": "Main test board for validation",
-      "directory": "<TEMP_DIR>/boards/test-board"
+      "zen_path": "boards/test-board/test_board.zen",
+      "description": "Main test board for validation"
     }
   ]
 }

--- a/crates/pcb/tests/snapshots/info__multiple_boards.snap
+++ b/crates/pcb/tests/snapshots/info__multiple_boards.snap
@@ -12,10 +12,10 @@ Name: BoardDiscoveryTest
 Members: boards/*, special/custom-board
 
 Boards (4)
-  BrokenBoard - broken.zen in <TEMP_DIR>/boards/broken-board
-  CustomBoard - custom.zen in <TEMP_DIR>/special/custom-board
+  BrokenBoard - boards/broken-board/broken.zen
+  CustomBoard - special/custom-board/custom.zen
     Special custom board with unique features
-  MainBoard - main_board.zen in <TEMP_DIR>/boards/main-board
-  TestBoard (default) - test_board.zen in <TEMP_DIR>/boards/test-board
+  MainBoard - boards/main-board/main_board.zen
+  TestBoard (default) - boards/test-board/test_board.zen
     Main test board for validation
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__no_workspace_config.snap
+++ b/crates/pcb/tests/snapshots/info__no_workspace_config.snap
@@ -10,6 +10,6 @@ Workspace Information
 Root: <TEMP_DIR>
 
 Boards (1)
-  TestBoard (default) - test_board.zen in <TEMP_DIR>/boards/TestBoard
+  TestBoard (default) - boards/TestBoard/test_board.zen
     Main test board for validation
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__single_board.snap
+++ b/crates/pcb/tests/snapshots/info__single_board.snap
@@ -10,6 +10,6 @@ Workspace Information
 Root: <TEMP_DIR>
 
 Boards (1)
-  TestBoard (default) - test_board.zen in <TEMP_DIR>/boards/TestBoard
+  TestBoard (default) - boards/TestBoard/test_board.zen
     Main test board for validation
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__with_path.snap
+++ b/crates/pcb/tests/snapshots/info__with_path.snap
@@ -7,11 +7,11 @@ Exit Code: 0
 
 --- STDOUT ---
 Workspace Information
-Root: subdir
+Root: <TEMP_DIR>/subdir
 Name: BoardDiscoveryTest
 Members: boards/*, special/custom-board
 
 Boards (1)
-  TestBoard (default) - test_board.zen in subdir/boards/test-board
+  TestBoard (default) - boards/test-board/test_board.zen
     Main test board for validation
 --- STDERR ---


### PR DESCRIPTION
`pcb info` would mix and match absolute vs relative paths for workspace root and board .zen paths. Enforce consistent behavior:
- Workspace root: always show full canonical path
- Board paths: always relative to workspace root

Also, removed the removed redundant directory field.

Made `find_workspace_root` behave in a consistent manner whether a file path or dir is passed in.