### PR TITLE
Copy all tracked files to release src

### DIFF
--- a/crates/pcb-test-utils/src/sandbox.rs
+++ b/crates/pcb-test-utils/src/sandbox.rs
@@ -360,18 +360,16 @@ impl Sandbox {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
 
-        // Sanitize temp paths and timestamps to make snapshots deterministic
-        let sanitized_stdout = self.sanitize_output(&stdout);
-        let sanitized_stderr = self.sanitize_output(&stderr);
-
-        format!(
+        let manifest = format!(
             "Command: {} {}\nExit Code: {}\n\n--- STDOUT ---\n{}\n--- STDERR ---\n{}",
             program,
             args.join(" "),
             exit_code,
-            sanitized_stdout.trim_end(),
-            sanitized_stderr.trim_end()
-        )
+            stdout.trim_end(),
+            stderr.trim_end()
+        );
+        // Sanitize temp paths and timestamps to make snapshots deterministic
+        self.sanitize_output(&manifest)
     }
 
     /// Sanitize temporary paths and timestamps in output to make snapshots deterministic

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -749,6 +749,7 @@ impl CoreLoadResolver {
             .lock()
             .unwrap()
             .keys()
+            .filter(|p| p.is_file())
             .cloned()
             .collect::<HashSet<_>>();
         files.extend(self.tracked_local_files.lock().unwrap().iter().cloned());

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -710,6 +710,12 @@ impl CoreLoadResolver {
                 })
                 .collect::<HashMap<PathBuf, LoadSpec>>();
             self.path_to_spec.lock().unwrap().extend(pcb_toml_specs);
+        } else {
+            // If no spec, then the pcb.toml files are local. So, add it to the tracked local files
+            // TODO: remove after tracked_local_files, path_to_spec unification
+            pcb_toml_files.iter().for_each(|p| {
+                self.tracked_local_files.lock().unwrap().insert(p.clone());
+            });
         }
 
         // Iterate in reverse to prioritize the deepest (closest to leaf) pcb.toml files

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -424,7 +424,6 @@ fn copy_sources(info: &ReleaseInfo) -> Result<()> {
                     })?;
                 }
                 fs::copy(&path, &dest_path).with_context(|| {
-                    dbg!("remote", &load_spec, &path, &dest_path);
                     format!(
                         "Failed to copy {} -> {}",
                         path.display(),
@@ -434,8 +433,10 @@ fn copy_sources(info: &ReleaseInfo) -> Result<()> {
             }
         } else {
             let Ok(rel) = path.strip_prefix(info.workspace.root()) else {
-                // local dep not in workspace
-                continue;
+                anyhow::bail!(
+                    "Cannot release with local path outside of workspace: {}",
+                    path.display()
+                )
             };
             let dest_path = info.staging_dir.join("src").join(rel);
             if let Some(parent) = dest_path.parent() {
@@ -444,7 +445,6 @@ fn copy_sources(info: &ReleaseInfo) -> Result<()> {
                 })?;
             }
             fs::copy(&path, &dest_path).with_context(|| {
-                dbg!("local", &path, &dest_path);
                 format!(
                     "Failed to copy {} -> {}",
                     path.display(),

--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -1,8 +1,9 @@
-use crate::workspace::{gather_workspace_info, is_vendor_dependency, loadspec_to_vendor_path};
+use crate::workspace::{gather_workspace_info, loadspec_to_vendor_path};
 use anyhow::{Context, Result};
 use clap::Args;
 use log::{debug, info};
 use pcb_ui::{Colorize, Spinner, Style, StyledText};
+use pcb_zen_core::LoadSpec;
 use pcb_zen_core::{config::find_workspace_root, DefaultFileProvider};
 use std::collections::HashMap;
 use std::fs;
@@ -209,14 +210,17 @@ fn gather_vendor_info(zen_files: Vec<PathBuf>, workspace_root: PathBuf) -> Resul
         let workspace_info = gather_workspace_info(zen_file.clone(), false)?;
 
         for path in workspace_info.resolver.get_tracked_files() {
-            if is_vendor_dependency(&workspace_root, &path, &workspace_info.resolver) {
-                if let Some(load_spec) = workspace_info.resolver.get_load_spec_for_path(&path) {
-                    let vendor_path = loadspec_to_vendor_path(&load_spec)?;
-
-                    dependencies
-                        .entry(vendor_path)
-                        .or_insert(path.to_path_buf());
+            if let Some(load_spec) = workspace_info.resolver.get_load_spec_for_path(&path) {
+                let is_remote =
+                    matches!(load_spec, LoadSpec::Github { .. } | LoadSpec::Gitlab { .. });
+                if !is_remote {
+                    continue;
                 }
+                let vendor_path = loadspec_to_vendor_path(&load_spec)?;
+
+                dependencies
+                    .entry(vendor_path)
+                    .or_insert(path.to_path_buf());
             }
         }
     }

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -55,6 +55,41 @@ name = "test_workspace"
 stdlib = "@github/diodeinc/stdlib:v0.2.4"
 "#;
 
+const SIMPLE_COMPONENT: &str = r#"
+value = config("value", str, default = "10kOhm")
+
+P1 = io("P1", Net)
+P2 = io("P2", Net)
+
+Component(
+    name = "R",
+    prefix = "R",
+    footprint = File("test.kicad_mod"),
+    pin_defs = {"P1": "1", "P2": "2"},
+    pins = {"P1": P1, "P2": P2},
+    properties = {
+        "value": value,
+        "type": "resistor",
+        "datasheet": File("datasheet.txt"),
+    }
+)
+"#;
+
+const TEST_KICAD_MOD: &str = r#"(footprint "test"
+  (layer "F.Cu")
+  (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu"))
+  (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu"))
+)
+"#;
+
+const SIMPLE_BOARD_ZEN: &str = r#"
+SimpleComponent = Module("../modules/component.zen")
+add_property("layout_path", "build/TestBoard")
+vcc_3v3 = Net("VCC_3V3")
+gnd = Net("GND")
+SimpleComponent(name = "foo", P1 = vcc_3v3, P2 = gnd)
+"#;
+
 #[test]
 fn test_pcb_release_source_only() {
     let mut sb = Sandbox::new();
@@ -64,8 +99,8 @@ fn test_pcb_release_source_only() {
         .write("pcb.toml", PCB_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
-        .hash_globs(&["*.kicad_mod", "**/diodeinc/stdlib/*.zen"])
-        .ignore_globs(&["layout/*"]);
+        .hash_globs(["*.kicad_mod", "**/diodeinc/stdlib/*.zen"])
+        .ignore_globs(["layout/*"]);
 
     // Run source-only release with JSON output
     let output = sb
@@ -90,6 +125,13 @@ fn test_pcb_release_source_only() {
 
     // Snapshot the staging directory contents
     assert_snapshot!("release_basic", sb.snapshot_dir(staging_dir));
+
+    // Snapshot the build from release contents
+    let build_ouput = sb.snapshot_run(
+        "pcb",
+        ["build", &format!("{staging_dir}/src/boards/TestBoard.zen")],
+    );
+    assert_snapshot!("release_basic_build", build_ouput);
 }
 
 #[test]
@@ -97,8 +139,8 @@ fn test_pcb_release_with_git() {
     let mut sb = Sandbox::new();
     let output = sb
         .cwd("src")
-        .ignore_globs(&["layout/*"])
-        .hash_globs(&["*.kicad_mod", "**/diodeinc/stdlib/*.zen"])
+        .ignore_globs(["layout/*"])
+        .hash_globs(["*.kicad_mod", "**/diodeinc/stdlib/*.zen"])
         .seed_stdlib(&["v0.2.4"])
         .seed_kicad(&["9.0.0"])
         .write(".gitignore", ".pcb")
@@ -134,6 +176,13 @@ fn test_pcb_release_with_git() {
 
     // Snapshot the staging directory contents
     assert_snapshot!("release_with_git", sb.snapshot_dir(staging_dir));
+
+    // Snapshot the build from release contents
+    let build_ouput = sb.snapshot_run(
+        "pcb",
+        ["build", &format!("{staging_dir}/src/boards/TB0001.zen")],
+    );
+    assert_snapshot!("release_with_git_build", build_ouput);
 }
 
 #[test]
@@ -166,6 +215,13 @@ fn test_pcb_release_full() {
 
     // Snapshot the staging directory contents
     assert_snapshot!("release_full", sb.snapshot_dir(staging_dir));
+
+    // Snapshot the build from release contents
+    let build_ouput = sb.snapshot_run(
+        "pcb",
+        ["build", &format!("{staging_dir}/src/boards/TestBoard.zen")],
+    );
+    assert_snapshot!("release_full_build", build_ouput);
 }
 
 #[test]
@@ -181,7 +237,7 @@ n2 = Net("N2")
     let mut sb = Sandbox::new();
     let output = sb
         .cwd("src")
-        .ignore_globs(&["layout/*"])
+        .ignore_globs(["layout/*"])
         .write("boards/CaseBoard.zen", board_zen)
         .init_git()
         .commit("Initial commit")
@@ -203,6 +259,13 @@ n2 = Net("N2")
     let json: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
     let staging_dir = json["staging_directory"].as_str().unwrap();
 
+    // Snapshot the build from release contents
+    let build_ouput = sb.snapshot_run(
+        "pcb",
+        ["build", &format!("{staging_dir}/src/CaseBoard.zen")],
+    );
+    assert_snapshot!("case_insensitive_tag_build", build_ouput);
+
     // Load and sanitize metadata.json for stable snapshot
     let metadata_path = format!("{staging_dir}/metadata.json");
     let metadata_file = File::open(&metadata_path).unwrap();
@@ -212,4 +275,52 @@ n2 = Net("N2")
     let git_version = meta["release"]["git_version"].as_str().unwrap();
     assert_eq!(git_version, "v9.9.9");
     assert_snapshot!("case_insensitive_tag", sb.snapshot_dir(staging_dir));
+}
+
+#[test]
+fn test_pcb_release_with_file() {
+    let mut sb = Sandbox::new();
+    const DATASHEET_CONTENTS: &str = "Simple component datasheet.";
+    sb.cwd("src")
+        .write("pcb.toml", PCB_TOML)
+        .write("modules/component.zen", SIMPLE_COMPONENT)
+        .write("modules/test.kicad_mod", TEST_KICAD_MOD)
+        .write("modules/datasheet.txt", DATASHEET_CONTENTS)
+        .write("boards/TB0002.zen", SIMPLE_BOARD_ZEN)
+        .ignore_globs(["layout/*"]);
+
+    // Run source-only release with JSON output
+    let output = sb
+        .cmd(
+            cargo_bin!("pcb"),
+            [
+                "release",
+                "boards/TB0002.zen",
+                "--source-only",
+                "-f",
+                "json",
+            ],
+        )
+        .read()
+        .expect("Failed to run pcb release command");
+
+    // Parse JSON output to get staging directory
+    let json: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
+    let staging_dir = json["staging_directory"]
+        .as_str()
+        .expect("Missing staging_directory in JSON");
+
+    let datasheet_path = format!("{staging_dir}/src/modules/datasheet.txt");
+    let datasheet_contents = std::fs::read_to_string(&datasheet_path).unwrap();
+    assert_eq!(datasheet_contents, DATASHEET_CONTENTS);
+
+    // Snapshot the staging directory contents
+    assert_snapshot!("release_with_file", sb.snapshot_dir(staging_dir));
+
+    // Snapshot the build from release contents
+    let build_ouput = sb.snapshot_run(
+        "pcb",
+        ["build", &format!("{staging_dir}/src/boards/TB0002.zen")],
+    );
+    assert_snapshot!("release_with_file_build", build_ouput);
 }

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -129,7 +129,11 @@ fn test_pcb_release_source_only() {
     // Snapshot the build from release contents
     let build_ouput = sb.snapshot_run(
         "pcb",
-        ["build", &format!("{staging_dir}/src/boards/TestBoard.zen")],
+        [
+            "build",
+            "--offline",
+            &format!("{staging_dir}/src/boards/TestBoard.zen"),
+        ],
     );
     assert_snapshot!("release_basic_build", build_ouput);
 }
@@ -180,7 +184,11 @@ fn test_pcb_release_with_git() {
     // Snapshot the build from release contents
     let build_ouput = sb.snapshot_run(
         "pcb",
-        ["build", &format!("{staging_dir}/src/boards/TB0001.zen")],
+        [
+            "build",
+            "--offline",
+            &format!("{staging_dir}/src/boards/TB0001.zen"),
+        ],
     );
     assert_snapshot!("release_with_git_build", build_ouput);
 }
@@ -219,7 +227,11 @@ fn test_pcb_release_full() {
     // Snapshot the build from release contents
     let build_ouput = sb.snapshot_run(
         "pcb",
-        ["build", &format!("{staging_dir}/src/boards/TestBoard.zen")],
+        [
+            "build",
+            "--offline",
+            &format!("{staging_dir}/src/boards/TestBoard.zen"),
+        ],
     );
     assert_snapshot!("release_full_build", build_ouput);
 }
@@ -262,7 +274,11 @@ n2 = Net("N2")
     // Snapshot the build from release contents
     let build_ouput = sb.snapshot_run(
         "pcb",
-        ["build", &format!("{staging_dir}/src/CaseBoard.zen")],
+        [
+            "build",
+            "--offline",
+            &format!("{staging_dir}/src/CaseBoard.zen"),
+        ],
     );
     assert_snapshot!("case_insensitive_tag_build", build_ouput);
 
@@ -320,7 +336,11 @@ fn test_pcb_release_with_file() {
     // Snapshot the build from release contents
     let build_ouput = sb.snapshot_run(
         "pcb",
-        ["build", &format!("{staging_dir}/src/boards/TB0002.zen")],
+        [
+            "build",
+            "--offline",
+            &format!("{staging_dir}/src/boards/TB0002.zen"),
+        ],
     );
     assert_snapshot!("release_with_file_build", build_ouput);
 }

--- a/crates/pcb/tests/simple.rs
+++ b/crates/pcb/tests/simple.rs
@@ -144,6 +144,7 @@ fn test_pcb_release_simple_workspace() {
     let mut sb = Sandbox::new();
     sb.seed_stdlib(&["v0.2.2"])
         .seed_kicad(&["9.0.0"])
+        .write("pcb.toml", SIMPLE_WORKSPACE_PCB_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN);
 

--- a/crates/pcb/tests/snapshots/release__case_insensitive_tag_build.snap
+++ b/crates/pcb/tests/snapshots/release__case_insensitive_tag_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build <TEMP_DIR>/src/boards/.pcb/releases/CaseBoard/v9.9.9/src/CaseBoard.zen
+Command: pcb build --offline <TEMP_DIR>/src/boards/.pcb/releases/CaseBoard/v9.9.9/src/CaseBoard.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__case_insensitive_tag_build.snap
+++ b/crates/pcb/tests/snapshots/release__case_insensitive_tag_build.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pcb/tests/release.rs
+expression: build_ouput
+---
+Command: pcb build <TEMP_DIR>/src/boards/.pcb/releases/CaseBoard/v9.9.9/src/CaseBoard.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+✓ CaseBoard.zen (0 components)

--- a/crates/pcb/tests/snapshots/release__release_basic_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_basic_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build <TEMP_DIR>/src/.pcb/releases/TestBoard/unknown/src/boards/TestBoard.zen
+Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TestBoard/unknown/src/boards/TestBoard.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__release_basic_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_basic_build.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pcb/tests/release.rs
+expression: build_ouput
+---
+Command: pcb build <TEMP_DIR>/src/.pcb/releases/TestBoard/unknown/src/boards/TestBoard.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+✓ TestBoard.zen (5 components)

--- a/crates/pcb/tests/snapshots/release__release_full_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_full_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build /private/var/folders/ds/0jn6lccn1g331vcm8wgshsgm0000gn/T/.tmpl3HCQ7/src/.pcb/releases/TestBoard/unknown/src/boards/TestBoard.zen
+Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TestBoard/unknown/src/boards/TestBoard.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__release_full_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_full_build.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pcb/tests/release.rs
+expression: build_ouput
+---
+Command: pcb build /private/var/folders/ds/0jn6lccn1g331vcm8wgshsgm0000gn/T/.tmpl3HCQ7/src/.pcb/releases/TestBoard/unknown/src/boards/TestBoard.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+✓ TestBoard.zen (5 components)

--- a/crates/pcb/tests/snapshots/release__release_with_file.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_file.snap
@@ -1,0 +1,69 @@
+---
+source: crates/pcb/tests/release.rs
+expression: sb.snapshot_dir(staging_dir)
+---
+=== metadata.json
+{
+  "git": {
+    "describe": "unknown",
+    "hash": "unknown",
+    "workspace": "<TEMP_DIR>/src"
+  },
+  "release": {
+    "created_at": "<TIMESTAMP>",
+    "git_version": "unknown",
+    "layout_path": "<TEMP_DIR>/src/boards/build/TestBoard",
+    "schema_version": "1",
+    "source_only": true,
+    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TB0002/unknown",
+    "workspace_root": "<TEMP_DIR>/src",
+    "zen_file": "boards/TB0002.zen"
+  },
+  "system": {
+    "arch": "<ARCH>",
+    "cli_version": "<CLI_VERSION>",
+    "platform": "<PLATFORM>",
+    "user": "<USER>"
+  }
+}
+=== src/boards/TB0002.zen
+
+SimpleComponent = Module("../modules/component.zen")
+add_property("layout_path", "build/TestBoard")
+vcc_3v3 = Net("VCC_3V3")
+gnd = Net("GND")
+SimpleComponent(name = "foo", P1 = vcc_3v3, P2 = gnd)
+=== src/modules/component.zen
+
+value = config("value", str, default = "10kOhm")
+
+P1 = io("P1", Net)
+P2 = io("P2", Net)
+
+Component(
+    name = "R",
+    prefix = "R",
+    footprint = File("test.kicad_mod"),
+    pin_defs = {"P1": "1", "P2": "2"},
+    pins = {"P1": P1, "P2": P2},
+    properties = {
+        "value": value,
+        "type": "resistor",
+        "datasheet": File("datasheet.txt"),
+    }
+)
+=== src/modules/datasheet.txt
+Simple component datasheet.
+=== src/modules/test.kicad_mod
+(footprint "test"
+  (layer "F.Cu")
+  (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu"))
+  (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu"))
+)
+=== src/pcb.toml
+
+[workspace]
+name = "test_workspace"
+
+[packages]
+stdlib = "@github/diodeinc/stdlib:v0.2.4"

--- a/crates/pcb/tests/snapshots/release__release_with_file_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_file_build.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pcb/tests/release.rs
+expression: build_ouput
+---
+Command: pcb build <TEMP_DIR>/src/.pcb/releases/TB0002/unknown/src/boards/TB0002.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+✓ TB0002.zen (1 components)

--- a/crates/pcb/tests/snapshots/release__release_with_file_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_file_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build <TEMP_DIR>/src/.pcb/releases/TB0002/unknown/src/boards/TB0002.zen
+Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TB0002/unknown/src/boards/TB0002.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__release_with_git_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_git_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build <TEMP_DIR>/src/.pcb/releases/TB0001/v1.2.3/src/boards/TB0001.zen
+Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TB0001/v1.2.3/src/boards/TB0001.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__release_with_git_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_git_build.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pcb/tests/release.rs
+expression: build_ouput
+---
+Command: pcb build <TEMP_DIR>/src/.pcb/releases/TB0001/v1.2.3/src/boards/TB0001.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+✓ TB0001.zen (5 components)

--- a/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
+++ b/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
@@ -7,8 +7,8 @@ Exit Code: 0
 
 --- STDOUT ---
 {
-  "archive": "<TEMP_DIR>/boards/.pcb/releases/TestBoard/unknown.zip",
-  "staging_directory": "<TEMP_DIR>/boards/.pcb/releases/TestBoard/unknown",
+  "archive": "<TEMP_DIR>/.pcb/releases/TestBoard/unknown.zip",
+  "staging_directory": "<TEMP_DIR>/.pcb/releases/TestBoard/unknown",
   "version": "unknown"
 }
 --- STDERR ---


### PR DESCRIPTION
Remove the filtering that I added, it's not needed. This can be further
simplified in the future by merging tracked_local_files into
path_to_spec.

Also, build after release in snapshot tests.