### PR TITLE
Fix fetching a commit from a non-default branch

### DIFF
--- a/crates/pcb-test-utils/src/sandbox.rs
+++ b/crates/pcb-test-utils/src/sandbox.rs
@@ -636,8 +636,9 @@ impl FixtureRepo {
     }
 
     /// Mirror-push all refs to the bare “remote”.
-    pub fn push_mirror(&mut self) {
+    pub fn push_mirror(&mut self) -> &mut Self {
         run_git(&["-C", self.work_str(), "push", "--mirror", "origin"]);
+        self
     }
 
     pub fn work_dir(&self) -> &Path {
@@ -645,6 +646,13 @@ impl FixtureRepo {
     }
     pub fn bare_dir(&self) -> &Path {
         &self.bare
+    }
+
+    pub fn rev_parse_head(&self) -> String {
+        let output = duct::cmd("git", ["-C", self.work_str(), "rev-parse", "HEAD"])
+            .read()
+            .expect("get HEAD");
+        output.trim().to_string()
     }
 
     fn work_str(&self) -> &str {

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -97,11 +97,9 @@ pub fn clone_as_branch_or_tag(remote_url: &str, rev: &str, dest_dir: &Path) -> a
 }
 
 /// Clone default branch of a Git repository (shallow)
-pub fn clone_default_branch(remote_url: &str, dest_dir: &Path) -> anyhow::Result<()> {
+pub fn clone(remote_url: &str, dest_dir: &Path) -> anyhow::Result<()> {
     let status = Command::new("git")
         .arg("clone")
-        .arg("--depth")
-        .arg("1")
         .arg("--quiet")
         .arg(remote_url)
         .arg(dest_dir)
@@ -116,30 +114,8 @@ pub fn clone_default_branch(remote_url: &str, dest_dir: &Path) -> anyhow::Result
     }
 }
 
-/// Fetch a specific commit from origin (shallow)
-pub fn fetch_commit(repo_root: &Path, rev: &str) -> anyhow::Result<()> {
-    let status = Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
-        .arg("fetch")
-        .arg("--depth")
-        .arg("1")
-        .arg("--quiet")
-        .arg("origin")
-        .arg(rev)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!("Git fetch failed for commit {rev}"))
-    }
-}
-
-/// Checkout a specific revision
-pub fn checkout_revision(repo_root: &Path, rev: &str) -> anyhow::Result<()> {
+/// Checkout a specific commit
+pub fn checkout_commit(repo_root: &Path, rev: &str) -> anyhow::Result<()> {
     let status = Command::new("git")
         .arg("-C")
         .arg(repo_root)

--- a/crates/pcb-zen/src/load.rs
+++ b/crates/pcb-zen/src/load.rs
@@ -79,7 +79,7 @@ fn classify_remote(cache_root: &Path, spec: &LoadSpec) -> Option<RemoteRefMeta> 
         if git::tag_exists(cache_root, expected_ref) && tag_sha1 == Some(sha1.clone()) {
             debug!("Tag {expected_ref} exists, and it's at HEAD");
             RefKind::Tag
-        } else if expected_ref.len() > 7 && sha1.starts_with(expected_ref) {
+        } else if expected_ref.len() >= 7 && sha1.starts_with(expected_ref) {
             debug!("Hash matches {expected_ref} ref");
             RefKind::Commit
         } else {
@@ -183,9 +183,8 @@ pub fn cache_dir() -> anyhow::Result<PathBuf> {
 
 fn try_clone_and_fetch_commit(remote_url: &str, rev: &str, dest_dir: &Path) -> anyhow::Result<()> {
     log::debug!("Cloning default branch then fetching commit: {remote_url} @ {rev}");
-    git::clone_default_branch(remote_url, dest_dir)?;
-    git::fetch_commit(dest_dir, rev)?;
-    git::checkout_revision(dest_dir, rev)
+    git::clone(remote_url, dest_dir)?;
+    git::checkout_commit(dest_dir, rev)
 }
 
 /// Try Git clone with 2-pass strategy for multiple URLs

--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -224,7 +224,6 @@ pub fn sync_tracked_files(
             fs::copy(path, dest_path)?;
             synced_files += 1;
         } else {
-            dbg!(&path, &dest_path);
             synced_files += copy_dir_all(path, dest_path)?;
         }
     }

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -579,3 +579,30 @@ SimpleResistor = Module("@github/mycompany/components:main/SimpleResistor.zen")
         .snapshot_run("pcb", ["build", "board.zen"]);
     assert_snapshot!("unstable_ref_wrong_tag", output);
 }
+
+#[test]
+fn test_commit_stable_ref() {
+    let mut sandbox = Sandbox::new();
+
+    let short_hash = &sandbox
+        .git_fixture("https://github.com/mycompany/components.git")
+        .branch("foo")
+        .write("SimpleResistor.zen", SIMPLE_RESISTOR_ZEN)
+        .write("test.kicad_mod", TEST_KICAD_MOD)
+        .commit("Add simple resistor component")
+        .push_mirror()
+        .rev_parse_head()[0..7];
+
+    // Create a board that uses branch unstabe ref
+    let unstable_default_zen = format!(
+        r#"
+SimpleResistor = Module("@github/mycompany/components:{}/SimpleResistor.zen")
+"#,
+        short_hash
+    );
+
+    let output = sandbox
+        .write("board.zen", unstable_default_zen)
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert_snapshot!("commit_stable_ref", output);
+}

--- a/crates/pcb/tests/snapshots/build__commit_stable_ref.snap
+++ b/crates/pcb/tests/snapshots/build__commit_stable_ref.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pcb/tests/build.rs
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+✓ board.zen (0 components)


### PR DESCRIPTION
Previously, we would do a shallow clone of the default branch and then attempt to checkout the commit. This doesn't work if the commit is not on the default branch.

Also, allow specifying short hash (len 7).