### PR TITLE
Fix layout sync when using `Path()`

### DIFF
--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -15,6 +15,7 @@ pub struct LayoutResult {
     pub layout_dir: PathBuf,
     pub pcb_file: PathBuf,
     pub netlist_file: PathBuf,
+    pub json_netlist_file: PathBuf,
     pub snapshot_file: PathBuf,
     pub log_file: PathBuf,
     pub created: bool, // true if new, false if updated
@@ -146,6 +147,7 @@ pub fn process_layout(
         layout_dir,
         pcb_file: paths.pcb,
         netlist_file: paths.netlist,
+        json_netlist_file: paths.json_netlist,
         snapshot_file: paths.snapshot,
         log_file: paths.log,
         created: !pcb_exists,

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -18,7 +18,7 @@ use starlark::values::FrozenValue;
 use starlark::values::ValueLike;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Convert a [`FrozenModuleValue`] to a [`Schematic`].
 pub(crate) struct ModuleConverter {
@@ -201,11 +201,12 @@ impl ModuleConverter {
                         .map(|p| p.to_string_lossy().to_string())
                         .unwrap_or_default();
 
-                    let full_layout_path = if module_dir.is_empty() {
-                        layout_path
-                    } else {
-                        format!("{module_dir}/{layout_path}")
-                    };
+                    let full_layout_path =
+                        if module_dir.is_empty() || PathBuf::from(&layout_path).is_absolute() {
+                            layout_path
+                        } else {
+                            format!("{module_dir}/{layout_path}")
+                        };
 
                     inst.add_attribute(key.clone(), AttributeValue::String(full_layout_path));
                 } else {


### PR DESCRIPTION
Since `Path()` resolves to an absolute path, we shouldn't prefix it with module path.

I tested this with non-vendored and vendored workspaces