### PR TITLE
Add `metadata()`, record ser/de support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 [[package]]
 name = "allocative"
 version = "0.3.4"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "allocative_derive",
  "bumpalo",
@@ -74,7 +74,7 @@ dependencies = [
 [[package]]
 name = "allocative_derive"
 version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 
 [[package]]
 name = "colorchoice"
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "either",
  "indenter",
@@ -952,9 +952,9 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
- "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=af998d7)",
+ "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=022889e9)",
 ]
 
 [[package]]
@@ -971,7 +971,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3694,7 +3694,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "starlark"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3703,8 +3703,8 @@ dependencies = [
  "debugserver-types",
  "derivative",
  "derive_more",
- "display_container 0.9.0 (git+https://github.com/diodeinc/starlark-rust?rev=af998d7)",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=af998d7)",
+ "display_container 0.9.0 (git+https://github.com/diodeinc/starlark-rust?rev=022889e9)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=022889e9)",
  "either",
  "erased-serde",
  "hashbrown 0.14.5",
@@ -3733,9 +3733,9 @@ dependencies = [
 [[package]]
 name = "starlark_derive"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=af998d7)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=022889e9)",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3744,10 +3744,10 @@ dependencies = [
 [[package]]
 name = "starlark_map"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "allocative",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=af998d7)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=022889e9)",
  "equivalent",
  "fxhash",
  "hashbrown 0.14.5",
@@ -3758,14 +3758,14 @@ dependencies = [
 [[package]]
 name = "starlark_syntax"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "allocative",
  "annotate-snippets",
  "anyhow",
  "derivative",
  "derive_more",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=af998d7)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=022889e9)",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "strong_hash"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "ref-cast",
  "strong_hash_derive",
@@ -3817,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "strong_hash_derive"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=af998d7#af998d700078bfc0007229baf14f5110c7ff5bc3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=022889e9#022889e9e56449497675d8e646bf3686c1a70db6"
 dependencies = [
  "quote",
  "syn 2.0.104",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ homepage = "https://github.com/diodeinc/pcb"
 authors = ["Diode Computers, Inc. <founders@diode.computer>"]
 
 [workspace.dependencies]
-starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "af998d7" }
-starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "af998d7" }
-starlark_derive = { git = "https://github.com/diodeinc/starlark-rust", rev = "af998d7" }
-starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "af998d7" }
-allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "af998d7" }
+starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "022889e9" }
+starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "022889e9" }
+starlark_derive = { git = "https://github.com/diodeinc/starlark-rust", rev = "022889e9" }
+starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "022889e9" }
+allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "022889e9" }
 
 pcb-command-runner = { path = "crates/pcb-command-runner" }
 pcb-eda = { path = "crates/pcb-eda" }

--- a/crates/pcb-zen-core/src/lang/metadata.rs
+++ b/crates/pcb-zen-core/src/lang/metadata.rs
@@ -1,0 +1,357 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use allocative::Allocative;
+use anyhow::anyhow;
+use serde_json;
+use starlark::any::ProvidesStaticType;
+use starlark::environment::GlobalsBuilder;
+use starlark::eval::Evaluator;
+use starlark::starlark_module;
+use starlark::starlark_simple_value;
+use starlark::values::list::AllocList;
+use starlark::values::starlark_value;
+use starlark::values::types::record::ty_record_type::TyRecordData;
+use starlark::values::types::record::{FrozenRecordType, RecordType};
+use starlark::values::{NoSerialize, StarlarkValue, Value, ValueLike};
+
+use crate::lang::evaluator_ext::EvaluatorExt;
+use crate::lang::input::InputValue;
+
+/// Helper to access metadata store with error handling
+fn with_metadata_store<T, F>(eval: &Evaluator, f: F) -> anyhow::Result<T>
+where
+    F: FnOnce(&MetadataStore) -> T,
+{
+    eval.context_value()
+        .ok_or_else(|| anyhow!("No evaluation context available for metadata operation"))?
+        .parent_context()
+        .with_metadata_store(f)
+}
+
+/// Helper to access mutable metadata store with error handling  
+fn with_metadata_store_mut<T, F>(eval: &Evaluator, f: F) -> anyhow::Result<anyhow::Result<T>>
+where
+    F: FnOnce(&mut MetadataStore) -> anyhow::Result<T>,
+{
+    eval.context_value()
+        .ok_or_else(|| anyhow!("No evaluation context available for metadata operation"))?
+        .parent_context()
+        .with_metadata_store_mut(f)
+}
+
+/// Type information stored in metadata containers
+#[derive(Debug, Clone, Allocative)]
+pub enum MetadataTypeInfo {
+    /// Simple built-in types (str, int, float, bool, etc.)
+    Simple(String),
+    /// Complex record types with full type information
+    Record(Arc<TyRecordData>),
+}
+
+/// Global storage for metadata containers that persists across module boundaries.
+/// Uses JSON strings for storage to ensure values can cross module boundaries.
+#[derive(Debug)]
+pub struct MetadataStore {
+    /// Map from reference ID to list of JSON-serialized values
+    containers: HashMap<String, Vec<String>>,
+    /// Atomic counter for generating unique reference IDs
+    ref_allocator: AtomicU64,
+}
+
+impl Default for MetadataStore {
+    fn default() -> Self {
+        Self {
+            containers: HashMap::new(),
+            ref_allocator: AtomicU64::new(1),
+        }
+    }
+}
+
+impl MetadataStore {
+    /// Generate a unique reference ID
+    pub fn allocate_ref(&self) -> String {
+        format!("meta_{}", self.ref_allocator.fetch_add(1, Ordering::SeqCst))
+    }
+
+    /// Push a JSON-serialized value to a container
+    pub fn push(&mut self, ref_id: &str, json_value: String) -> anyhow::Result<()> {
+        self.containers
+            .entry(ref_id.to_string())
+            .or_default()
+            .push(json_value);
+        Ok(())
+    }
+
+    /// Get the most recently pushed value (latest)
+    pub fn get_latest(&self, ref_id: &str) -> Option<&String> {
+        self.containers.get(ref_id)?.last()
+    }
+
+    /// Get all values in chronological order
+    pub fn get_all(&self, ref_id: &str) -> Option<&Vec<String>> {
+        self.containers.get(ref_id)
+    }
+}
+
+/// A metadata container that holds a reference ID and type information.
+/// The actual data is stored in the global MetadataStore.
+#[derive(Debug, Clone, NoSerialize, ProvidesStaticType, Allocative)]
+pub struct MetadataContainer {
+    /// Unique reference ID for this container
+    pub ref_id: String,
+    /// Type information for validation and deserialization
+    pub type_info: MetadataTypeInfo,
+}
+
+impl MetadataContainer {
+    pub fn new(ref_id: String, type_info: MetadataTypeInfo) -> Self {
+        Self { ref_id, type_info }
+    }
+
+    /// Get the type name for display and validation purposes
+    pub fn type_name(&self) -> &str {
+        match &self.type_info {
+            MetadataTypeInfo::Simple(name) => name,
+            MetadataTypeInfo::Record(ty_record_data) => &ty_record_data.name,
+        }
+    }
+
+    /// Deserialize a JSON string to a Starlark value based on type info
+    fn deserialize_value<'v>(
+        &self,
+        json_str: &str,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let input_value: InputValue = serde_json::from_str(json_str)
+            .map_err(|e| anyhow!("Failed to deserialize JSON: {}", e))?;
+
+        match &self.type_info {
+            MetadataTypeInfo::Simple(_) => input_value.to_value(eval, None),
+            MetadataTypeInfo::Record(ty_record_data) => {
+                let type_value = eval.module().get(&ty_record_data.name);
+                input_value.to_value(eval, type_value)
+            }
+        }
+    }
+
+    /// Validate that a value matches this container's type
+    fn validate_type(&self, value: Value) -> anyhow::Result<()> {
+        let value_type = value.get_type();
+        let expected_type_name = self.type_name();
+
+        let type_matches = match &self.type_info {
+            MetadataTypeInfo::Simple(expected_type) => {
+                validate_simple_type(expected_type, value_type)
+            }
+            MetadataTypeInfo::Record(_) => value_type == "record",
+        };
+
+        if !type_matches && expected_type_name != "typing.Any" {
+            return Err(anyhow!(
+                "Type mismatch: expected {}, got {}",
+                expected_type_name,
+                value_type
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+starlark_simple_value!(MetadataContainer);
+
+impl std::fmt::Display for MetadataContainer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MetadataContainer({}:{})", self.type_name(), self.ref_id)
+    }
+}
+
+#[starlark_value(type = "MetadataContainer")]
+impl<'v> StarlarkValue<'v> for MetadataContainer {
+    type Canonical = MetadataContainer;
+}
+
+/// Validate that a simple type matches the expected type
+fn validate_simple_type(expected_type: &str, value_type: &str) -> bool {
+    match expected_type {
+        "str" => value_type == "string",
+        "int" => value_type == "int",
+        "float" => value_type == "float",
+        "bool" => value_type == "bool",
+        "list" => value_type == "list",
+        "dict" => value_type == "dict",
+        other => {
+            if other.starts_with("enum(") && value_type == "enum" {
+                true
+            } else {
+                value_type == other
+            }
+        }
+    }
+}
+
+/// Extract type info from a Starlark value
+fn extract_type_info(type_value: Value) -> anyhow::Result<MetadataTypeInfo> {
+    if let Some(rt) = type_value.downcast_ref::<RecordType>() {
+        let ty_record_data = rt
+            .ty_record_data()
+            .cloned()
+            .ok_or_else(|| anyhow!("Record type must be assigned to a variable"))?;
+        Ok(MetadataTypeInfo::Record(ty_record_data))
+    } else if let Some(frt) = type_value.downcast_ref::<FrozenRecordType>() {
+        let ty_record_data = frt
+            .ty_record_data()
+            .cloned()
+            .ok_or_else(|| anyhow!("Record type must be assigned to a variable"))?;
+        Ok(MetadataTypeInfo::Record(ty_record_data))
+    } else {
+        let type_name = if type_value.get_type() == "function" {
+            type_value.to_string()
+        } else {
+            type_value.get_type().to_string()
+        };
+        Ok(MetadataTypeInfo::Simple(type_name))
+    }
+}
+
+#[starlark_module]
+pub fn metadata_globals(builder: &mut GlobalsBuilder) {
+    /// Create a new typed metadata container
+    fn metadata<'v>(
+        type_value: Value<'v>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let ref_id = with_metadata_store(eval, |store| store.allocate_ref())?;
+        let type_info = extract_type_info(type_value)?;
+        let container = MetadataContainer::new(ref_id, type_info);
+        Ok(eval.heap().alloc(container))
+    }
+
+    /// Push a value to a metadata container
+    fn push_metadata<'v>(
+        container: Value<'v>,
+        value: Value<'v>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let container = container
+            .downcast_ref::<MetadataContainer>()
+            .ok_or_else(|| anyhow!("Expected MetadataContainer"))?;
+
+        container.validate_type(value)?;
+
+        let input_value = InputValue::from_value(value);
+        let json_value = serde_json::to_string(&input_value)
+            .map_err(|e| anyhow!("Failed to serialize value to JSON: {}", e))?;
+
+        with_metadata_store_mut(eval, |store| store.push(&container.ref_id, json_value))??;
+
+        Ok(Value::new_none())
+    }
+
+    /// Get all values from a metadata container as a list of automatically deserialized Starlark values
+    fn list_metadata<'v>(
+        container: Value<'v>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let container = container
+            .downcast_ref::<MetadataContainer>()
+            .ok_or_else(|| anyhow!("Expected MetadataContainer"))?;
+
+        let json_values = with_metadata_store(eval, |store| {
+            store
+                .get_all(&container.ref_id)
+                .cloned()
+                .unwrap_or_default()
+        })?;
+
+        let mut list_values = Vec::new();
+        for json_str in &json_values {
+            let starlark_value = container.deserialize_value(json_str, eval)?;
+            list_values.push(starlark_value);
+        }
+
+        Ok(eval.heap().alloc(AllocList(list_values)).to_value())
+    }
+
+    /// Get the most recent value from a metadata container, automatically deserialized
+    fn get_metadata<'v>(
+        container: Value<'v>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let container = container
+            .downcast_ref::<MetadataContainer>()
+            .ok_or_else(|| anyhow!("Expected MetadataContainer"))?;
+
+        let json_opt =
+            with_metadata_store(eval, |store| store.get_latest(&container.ref_id).cloned())?;
+
+        match json_opt {
+            Some(json_value) => container.deserialize_value(&json_value, eval),
+            None => Ok(Value::new_none()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metadata_store_allocation() {
+        let store = MetadataStore::default();
+        let ref1 = store.allocate_ref();
+        let ref2 = store.allocate_ref();
+
+        assert_ne!(ref1, ref2);
+        assert!(ref1.starts_with("meta_"));
+        assert!(ref2.starts_with("meta_"));
+    }
+
+    #[test]
+    fn test_metadata_store_push_get() {
+        let mut store = MetadataStore::default();
+        let ref_id = store.allocate_ref();
+
+        store.push(&ref_id, "\"hello\"".to_string()).unwrap();
+        store.push(&ref_id, "\"world\"".to_string()).unwrap();
+
+        assert_eq!(store.get_latest(&ref_id), Some(&"\"world\"".to_string()));
+        assert_eq!(store.get_all(&ref_id).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_metadata_container_creation() {
+        let container = MetadataContainer::new(
+            "test_ref".to_string(),
+            MetadataTypeInfo::Simple("str".to_string()),
+        );
+        assert_eq!(container.ref_id, "test_ref");
+        assert_eq!(container.type_name(), "str");
+    }
+
+    #[test]
+    fn test_metadata_type_info() {
+        // Test simple type info
+        let simple_info = MetadataTypeInfo::Simple("str".to_string());
+        match simple_info {
+            MetadataTypeInfo::Simple(name) => assert_eq!(name, "str"),
+            _ => panic!("Expected Simple type info"),
+        }
+
+        // Test container creation and type_name method
+        let container = MetadataContainer::new(
+            "test_ref".to_string(),
+            MetadataTypeInfo::Simple("int".to_string()),
+        );
+
+        assert_eq!(container.ref_id, "test_ref");
+        assert_eq!(container.type_name(), "int");
+
+        match &container.type_info {
+            MetadataTypeInfo::Simple(name) => assert_eq!(name, "int"),
+            _ => panic!("Container should have Simple type info"),
+        }
+    }
+}

--- a/crates/pcb-zen-core/src/lang/mod.rs
+++ b/crates/pcb-zen-core/src/lang/mod.rs
@@ -19,3 +19,6 @@ pub(crate) mod file;
 
 // Add public error module and Result alias
 pub mod error;
+
+// Metadata system for global mutable state
+pub mod metadata;

--- a/crates/pcb-zen-core/tests/snapshots/input__complex_record_enum_fields.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__complex_record_enum_fields.snap
@@ -1,0 +1,14 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+Retrieved device from metadata: record[DeviceRecord](name="Sensor1", direction=DirectionEnum("EAST"), status=StatusEnum("ACTIVE"), value=42.5)
+Retrieved device name: Sensor1
+Retrieved device direction: DirectionEnum("EAST")
+Retrieved device status: StatusEnum("ACTIVE")
+Retrieved device value: 42.5
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__comprehensive_serialization_test.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__comprehensive_serialization_test.snap
@@ -1,0 +1,62 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+=== Comprehensive Serialization Test ===
+
+1. Testing simple types...
+String: hello world -> {
+  "String": "hello world"
+} -> hello world
+Int: 42 -> {
+  "Int": 42
+} -> 42
+Float: 3.14159 -> {
+  "Float": 3.14159
+} -> 3.14159
+Bool: True -> {
+  "Bool": true
+} -> True
+List length: 4 == 4
+Dict keys: 3 == 3
+✓ Simple types serialization works
+
+2. Testing record with enum fields...
+Original item: record[ItemRecord](name="Widget", color=ColorEnum("BLUE"), count=5, active=False)
+Serialized: {
+  "Record": {
+    "fields": {
+      "name": {
+        "String": "Widget"
+      },
+      "color": {
+        "Enum": {
+          "variant": "BLUE"
+        }
+      },
+      "count": {
+        "Int": 5
+      },
+      "active": {
+        "Bool": false
+      }
+    }
+  }
+}
+Deserialized: record[ItemRecord](name="Widget", color=ColorEnum("BLUE"), count=5, active=False)
+✓ Record with enum serialization works
+
+3. Testing metadata with mixed types...
+Retrieved string: metadata test
+Retrieved int: 999
+Retrieved item: record[ItemRecord](name="Widget", color=ColorEnum("BLUE"), count=5, active=False)
+Retrieved item name: Widget
+Retrieved item color: ColorEnum("BLUE")
+✓ Mixed type metadata works
+
+=== All Serialization Tests Passed! ===
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__enhanced_metadata_coverage.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__enhanced_metadata_coverage.snap
@@ -1,0 +1,41 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+=== Enhanced Metadata Coverage Test ===
+
+1. Testing multiple containers of same type...
+Container 1 latest string: container1_value2
+Container 2 latest string: container2_value1
+Container 1 int count: 2
+Container 2 int count: 1
+
+2. Testing mixed record and enum metadata...
+Task count: 3
+Latest task title: Release
+Latest task priority: PriorityEnum("CRITICAL")
+Latest task completed: False
+Latest task points: 5
+
+3. Testing complex record with multiple enum fields...
+Total requests: 3
+Latest request ID: 1003
+Latest request type: TypeEnum("EXCHANGE")
+Latest request status: StatusEnum("PENDING")
+
+4. Testing empty metadata containers...
+Empty string latest: None
+Empty string list length: 0
+Empty task latest: None
+Empty task list length: 0
+
+✓ Enhanced metadata coverage complete!
+✓ Multiple containers work independently
+✓ Complex records with multiple enums supported
+✓ Empty containers handle None correctly
+✓ All metadata operations preserve type information
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__record_enum_deserialization.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__record_enum_deserialization.snap
@@ -1,0 +1,47 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+Original voltage record: record[UnitRecord](value=3.3, unit=UnitEnum("V"), tolerance=0.05)
+Serialized JSON: {
+  "Record": {
+    "fields": {
+      "value": {
+        "Float": 3.3
+      },
+      "unit": {
+        "Enum": {
+          "variant": "V"
+        }
+      },
+      "tolerance": {
+        "Float": 0.05
+      }
+    }
+  }
+}
+Deserialized voltage: record[UnitRecord](value=3.3, unit=UnitEnum("V"), tolerance=0.05)
+Original current record: record[UnitRecord](value=0.1, unit=UnitEnum("A"), tolerance=0.0)
+Current serialized JSON: {
+  "Record": {
+    "fields": {
+      "value": {
+        "Float": 0.1
+      },
+      "unit": {
+        "Enum": {
+          "variant": "A"
+        }
+      },
+      "tolerance": {
+        "Float": 0.0
+      }
+    }
+  }
+}
+Deserialized current: record[UnitRecord](value=0.1, unit=UnitEnum("A"), tolerance=0.0)
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__record_enum_metadata_integration.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__record_enum_metadata_integration.snap
@@ -1,0 +1,14 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+Latest temperature (auto-deserialized): record[TempRecord](value=100.0, unit=TempEnum("C"), tolerance=0.0)
+Latest temp value: 100.0
+Latest temp unit: TempEnum("C")
+All temperatures: [record[TempRecord](value=25.0, unit=TempEnum("K"), tolerance=0.1), record[TempRecord](value=100.0, unit=TempEnum("C"), tolerance=0.0)]
+Number of temperatures: 2
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_collections.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_collections.snap
@@ -1,0 +1,26 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+=== Collections Serialize/Deserialize Test ===
+
+1. Testing list serialization...
+List length: 0 -> 0 equal: True
+List length: 3 -> 3 equal: True
+List length: 3 -> 3 equal: True
+List length: 2 -> 2 equal: True
+List length: 4 -> 4 equal: True
+List length: 2 -> 2 equal: True
+
+2. Testing dict serialization...
+Dict keys: 0 -> 0 equal: True
+Dict keys: 1 -> 1 equal: True
+Dict keys: 3 -> 3 equal: True
+Dict keys: 3 -> 3 equal: True
+Dict keys: 1 -> 1 equal: True
+✓ Collections serialize/deserialize correctly
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_complex_types.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_complex_types.snap
@@ -1,0 +1,28 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+=== Complex Type Serialize/Deserialize Test ===
+
+1. Testing record with collection fields...
+Original data: record[DataRecord](name="TestData", tags=["tag1", "tag2", "tag3"], metadata={"version": 1, "created": "2024-01-01"}, active=True)
+Restored data: record[DataRecord](name="TestData", tags=["tag1", "tag2", "tag3"], metadata={"version": 1, "created": "2024-01-01"}, active=True)
+Tags match: True
+Metadata match: True
+
+2. Testing mixed type lists...
+Original mixed list: [1, "hello", 3.14, True, [1, 2], {"key": "value"}]
+Restored mixed list: [1, "hello", 3.14, True, [1, 2], {"key": "value"}]
+Lists equal: True
+
+3. Testing nested dictionaries...
+Original dict keys: 2
+Restored dict keys: 2
+Dicts equal: True
+Nested level2 equal: True
+✓ Complex types serialize/deserialize correctly
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_enums.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_enums.snap
@@ -1,0 +1,45 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+=== Enum Serialize/Deserialize Test ===
+
+1. Testing basic enum...
+Enum: ColorEnum("RED") -> {
+  "Enum": {
+    "variant": "RED"
+  }
+} -> ColorEnum("RED")
+Enum: ColorEnum("GREEN") -> {
+  "Enum": {
+    "variant": "GREEN"
+  }
+} -> ColorEnum("GREEN")
+Enum: ColorEnum("BLUE") -> {
+  "Enum": {
+    "variant": "BLUE"
+  }
+} -> ColorEnum("BLUE")
+
+2. Testing enum with numbers...
+Status: StatusEnum("STATUS_0") -> {
+  "Enum": {
+    "variant": "STATUS_0"
+  }
+} -> StatusEnum("STATUS_0")
+Status: StatusEnum("STATUS_1") -> {
+  "Enum": {
+    "variant": "STATUS_1"
+  }
+} -> StatusEnum("STATUS_1")
+Status: StatusEnum("STATUS_2") -> {
+  "Enum": {
+    "variant": "STATUS_2"
+  }
+} -> StatusEnum("STATUS_2")
+✓ Enums serialize/deserialize correctly
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_records.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_records.snap
@@ -1,0 +1,21 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+=== Record Serialize/Deserialize Test ===
+
+1. Testing simple record...
+Person: record[PersonRecord](name="Alice", age=30, active=True) -> 183 chars -> record[PersonRecord](name="Alice", age=30, active=True)
+
+2. Testing record with enum fields...
+Item: record[ItemRecord](id=42, name="Test Item", type=TypeEnum("TYPE_B"), value=99.5)
+Restored: record[ItemRecord](id=42, name="Test Item", type=TypeEnum("TYPE_B"), value=99.5)
+
+3. Testing record with defaults...
+Default config: record[ConfigRecord](enabled=False, count=1, name="unnamed") -> record[ConfigRecord](enabled=False, count=1, name="unnamed")
+✓ Records serialize/deserialize correctly
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_simple_types.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__serialize_deserialize_simple_types.snap
@@ -1,0 +1,77 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+=== Simple Types Serialize/Deserialize Test ===
+
+1. Testing string serialization...
+String: "hello" -> {
+  "String": "hello"
+} -> "hello"
+String: "world with spaces" -> {
+  "String": "world with spaces"
+} -> "world with spaces"
+String: "unicode: \xf1" -> {
+  "String": "unicode: ñ"
+} -> "unicode: \xf1"
+String: "" -> {
+  "String": ""
+} -> ""
+String: "123" -> {
+  "String": "123"
+} -> "123"
+
+2. Testing numeric types...
+Int: 0 -> {
+  "Int": 0
+} -> 0
+Int: 1 -> {
+  "Int": 1
+} -> 1
+Int: -1 -> {
+  "Int": -1
+} -> -1
+Int: 42 -> {
+  "Int": 42
+} -> 42
+Int: -999 -> {
+  "Int": -999
+} -> -999
+Int: 2147483647 -> {
+  "Int": 2147483647
+} -> 2147483647
+Float: 0.0 -> {
+  "Float": 0.0
+} -> 0.0
+Float: 1.0 -> {
+  "Float": 1.0
+} -> 1.0
+Float: -1.0 -> {
+  "Float": -1.0
+} -> -1.0
+Float: 3.14159 -> {
+  "Float": 3.14159
+} -> 3.14159
+Float: -2.71828 -> {
+  "Float": -2.71828
+} -> -2.71828
+Float: 1e-10 -> {
+  "Float": 1e-10
+} -> 1e-10
+Float: 1e+10 -> {
+  "Float": 10000000000.0
+} -> 1e+10
+
+3. Testing boolean types...
+Bool: True -> {
+  "Bool": true
+} -> True
+Bool: False -> {
+  "Bool": false
+} -> False
+✓ Simple types serialize/deserialize correctly
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]


### PR DESCRIPTION
Also added `push_metadata()`, `get_metadata()`, `list_metadata()`.

TODO:
- **Integrate with interfaces**
- Support nested records in metadata (imo, less of a priority)
- Improve metadata type validation (we type check simple types, but not records)
- Add variable arguments to `push_metadata()` (e.g. `push_metadata(container, a, b, c)`)
- Add `has_metadata()`