### PR TITLE
Disable LSP eager mode

### DIFF
--- a/crates/pcb/src/lsp.rs
+++ b/crates/pcb/src/lsp.rs
@@ -4,6 +4,6 @@ use clap::Args;
 pub struct LspArgs {}
 
 pub fn execute(_args: LspArgs) -> anyhow::Result<()> {
-    pcb_zen::lsp_with_eager(true)?;
+    pcb_zen::lsp_with_eager(false)?;
     Ok(())
 }

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use env_logger::Env;
 use std::ffi::OsString;
 use std::process::Command;
 
@@ -22,6 +23,9 @@ mod workspace;
 #[command(about = "PCB tool with build and layout capabilities", long_about = None)]
 #[command(version)]
 struct Cli {
+    /// Enable debug logging
+    #[arg(short = 'd', long = "debug", global = true)]
+    debug: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -78,10 +82,15 @@ enum Commands {
 }
 
 fn main() -> anyhow::Result<()> {
-    // Initialize logger
-    env_logger::init();
-
     let cli = Cli::parse();
+
+    // Initialize logger with default level depending on --debug (overridden by RUST_LOG)
+    let env = if cli.debug {
+        Env::default().default_filter_or("debug")
+    } else {
+        Env::default().default_filter_or("info")
+    };
+    env_logger::Builder::from_env(env).init();
 
     match cli.command {
         Commands::Build(args) => build::execute(args),


### PR DESCRIPTION
- Add a global `--debug` flag for enabling debug logging (this is useful when we don't have an easy way to control the env vars, like when launching the LSP)
- When enumerating workspace files in the LSP, ignore hidden folders (e.g. `.pcb`)
- Disable eager mode in the LSP, since we don't do any workspace-wide autocomplete right now anyway, and it makes schematic loading slow in a new window