### PR TITLE
Temporarily disable assert

### DIFF
--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -684,7 +684,11 @@ impl CoreLoadResolver {
         } = &spec
         {
             let path_str = path.to_string_lossy();
-            assert!(path.is_absolute(), "Relative paths are not allowed");
+
+            // TODO: re-enable after `InMemoryFileProvider::canonicalize` with wasm can give back
+            // absolute paths
+            // assert!(path.is_absolute(), "Relative paths are not allowed");
+
             assert!(!workspace_relative, "Relative paths are not allowed");
             // TODO: remove after we drop support for stdlib <= v0.2.6
             // Workaround for https://github.com/diodeinc/stdlib/pull/35


### PR DESCRIPTION
We use `InMemoryFileProvider` in WASM to mock out a file system where we don't really have one, and as part of this we re-implement path canonicalization. It turns out "/some/path" in wasm is not counted as "absolute" according to `std::fs`, which causes this assert to wrongfully trigger when running in WASM.