### PR TITLE
Prevent cascading net deduplication

### DIFF
--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -650,45 +650,6 @@ impl EvalContext {
         }
     }
 
-    /// Introspect a module by evaluating it with empty inputs and non-strict IO config.
-    /// Returns the used inputs and their types.
-    pub fn introspect_module(
-        &self,
-        source_path: &Path,
-        module_name: &str,
-    ) -> WithDiagnostics<HashMap<String, String>> {
-        self.child_context()
-            .set_source_path(source_path.to_path_buf())
-            .set_module_name(module_name.to_string())
-            .set_inputs(InputMap::new()) // Empty inputs
-            .set_strict_io_config(false) // Non-strict so we don't fail on missing inputs
-            .eval()
-            .map(|output| {
-                output
-                    .signature
-                    .iter()
-                    .map(|param| (param.name.clone(), format!("{:?}", param.type_info)))
-                    .collect()
-            })
-    }
-
-    /// Introspect a module and return structured type information.
-    /// This is a richer API that returns TypeInfo instead of just strings.
-    pub fn introspect_module_typed(
-        &self,
-        source_path: &Path,
-        module_name: &str,
-    ) -> WithDiagnostics<Vec<crate::lang::type_info::ParameterInfo>> {
-        // First evaluate the module with empty inputs to get the used inputs
-        self.child_context()
-            .set_source_path(source_path.to_path_buf())
-            .set_module_name(module_name.to_string())
-            .set_inputs(InputMap::new())
-            .set_strict_io_config(false)
-            .eval()
-            .map(|output| output.signature)
-    }
-
     /// Get the file contents from the in-memory cache
     pub fn get_file_contents(&self, path: &Path) -> Option<String> {
         if let Ok(state) = self.state.lock() {

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -108,3 +108,27 @@ snapshot_eval!(net_duplicate_names_uniq, {
         print("en2:", en2.name)
     "#,
 });
+
+snapshot_eval!(interface_net_template_naming, {
+    "test.zen" => r#"
+        # Test that interface net templates use original names for prefixing, not deduped names
+        
+        # Create a regular net with same name as template
+        net = Net("VCC")
+        
+        # Define interface with using(Net("VCC")) - should get deduped name internally
+        # but use original "VCC" for interface prefixing
+        Power = interface(
+            NET = using(Net("VCC")),
+        )
+        
+        # Create power interface instance - should use "VCC" not "VCC_2" for prefix
+        power = Power("VCC")
+        
+        print("regular net:", net.name)
+        print("interface net:", power.NET.name)
+        
+        # Check that interface uses original name for prefixing
+        check(power.NET.name == "VCC_VCC", "Interface should use original name VCC for prefixing")
+    "#,
+});

--- a/crates/pcb-zen-core/tests/snapshots/net__interface_net_template_naming.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__interface_net_template_naming.snap
@@ -1,0 +1,12 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+assertion_line: 112
+expression: output
+---
+regular net: VCC
+interface net: VCC_VCC
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]


### PR DESCRIPTION
Preserve original user-requested names for generating fully qualified local names in interfaces. Deduplication should be done once at the end, not at every layer.

Also, unregister nets immediately in using().