### PR TITLE
Make `pcb tag` and `pcb release` consistent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           # Test workspace with pcb.toml and workspace-relative loads
           cargo run -- bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
-          cargo run -- release test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
+          cargo run -- release -b WorkspaceTestBoard test-workspaces/with-pcb-toml
           cargo run -- vendor test-workspaces/with-pcb-toml
           cargo run -- build test-workspaces/with-pcb-toml/boards --offline
 

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -414,6 +414,20 @@ impl WorkspaceInfo {
             .find(|b| b.absolute_zen_path(&self.root) == canon)
             .map(|b| b.name.clone())
     }
+
+    /// Find a board by name, returning an error with available boards if not found
+    pub fn find_board_by_name(&self, board_name: &str) -> Result<&BoardInfo> {
+        self.boards
+            .iter()
+            .find(|b| b.name == board_name)
+            .ok_or_else(|| {
+                let available: Vec<_> = self.boards.iter().map(|b| b.name.as_str()).collect();
+                anyhow::anyhow!(
+                    "Board '{board_name}' not found. Available: [{}]",
+                    available.join(", ")
+                )
+            })
+    }
 }
 
 #[cfg(test)]

--- a/crates/pcb-zen/src/load.rs
+++ b/crates/pcb-zen/src/load.rs
@@ -680,7 +680,7 @@ mod tests {
         );
 
         // Test non-existent alias
-        assert!(aliases.get("nonexistent").is_none());
+        assert!(!aliases.contains_key("nonexistent"));
     }
 
     #[test]

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -224,21 +224,7 @@ fn gather_release_info(
     let workspace_info = get_workspace_info(&DefaultFileProvider, Path::new(start_path))?;
 
     // Find the zen file for the given board
-    let board_info = workspace_info
-        .boards
-        .iter()
-        .find(|b| b.name == board_name)
-        .ok_or_else(|| {
-            let available: Vec<_> = workspace_info
-                .boards
-                .iter()
-                .map(|b| b.name.as_str())
-                .collect();
-            anyhow::anyhow!(
-                "Board '{board_name}' not found. Available: [{}]",
-                available.join(", ")
-            )
-        })?;
+    let board_info = workspace_info.find_board_by_name(&board_name)?;
 
     let zen_path = board_info.absolute_zen_path(&workspace_info.root);
 

--- a/crates/pcb/src/tag.rs
+++ b/crates/pcb/src/tag.rs
@@ -38,17 +38,8 @@ pub fn execute(args: TagArgs) -> Result<()> {
     let workspace_info = get_workspace_info(&DefaultFileProvider, Path::new(start_path))?;
     let board_name = args.board;
 
-    if !workspace_info.boards.iter().any(|b| b.name == board_name) {
-        let available: Vec<_> = workspace_info
-            .boards
-            .iter()
-            .map(|b| b.name.as_str())
-            .collect();
-        anyhow::bail!(
-            "Board '{board_name}' not found. Available: [{}]",
-            available.join(", ")
-        );
-    }
+    // Validate that the board exists
+    workspace_info.find_board_by_name(&board_name)?;
 
     let version = Version::parse(&args.version)
         .map_err(|_| anyhow::anyhow!("Invalid semantic version: '{}'", args.version))?;

--- a/crates/pcb/tests/path.rs
+++ b/crates/pcb/tests/path.rs
@@ -174,7 +174,7 @@ gnd = Net("GND")
 
     // Parse JSON output to get staging directory
     let json: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
-    let staging_dir = json["staging_directory"]
+    let staging_dir = json["release"]["staging_directory"]
         .as_str()
         .expect("Missing staging_directory in JSON");
 

--- a/crates/pcb/tests/path.rs
+++ b/crates/pcb/tests/path.rs
@@ -9,6 +9,12 @@ const SIMPLE_WORKSPACE_PCB_TOML: &str = r#"
 name = "simple_workspace"
 "#;
 
+const LOCAL_PATH_TEST_BOARD_PCB_TOML: &str = r#"
+[board]
+name = "LocalPathTest" 
+path = "LocalPathTest.zen"
+"#;
+
 const PATH_MODULE_ZEN: &str = r#"
 config_path = Path("module_config.toml", allow_not_exist = True) # this file doesn't exist
 data_path = Path("module_data.json")
@@ -139,7 +145,8 @@ gnd = Net("GND")
     )
     .write("boards/existing.toml", "# This file exists")
     .write("config/settings.json", r#"{"debug": true}"#) // Make config dir exist
-    .write("pcb.toml", SIMPLE_WORKSPACE_PCB_TOML);
+    .write("pcb.toml", SIMPLE_WORKSPACE_PCB_TOML)
+    .write("boards/pcb.toml", LOCAL_PATH_TEST_BOARD_PCB_TOML);
 
     // Build should succeed with mixed existing/non-existing paths
     assert_snapshot!(
@@ -155,7 +162,8 @@ gnd = Net("GND")
             cargo_bin!("pcb"),
             [
                 "release",
-                "boards/LocalPathTest.zen",
+                "--board",
+                "LocalPathTest",
                 "--source-only",
                 "-f",
                 "json",

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -55,6 +55,36 @@ name = "test_workspace"
 stdlib = "@github/diodeinc/stdlib:v0.2.4"
 "#;
 
+const BOARD_PCB_TOML: &str = r#"
+[board]
+name = "TestBoard"
+path = "TestBoard.zen"
+
+[packages]
+stdlib = "@github/diodeinc/stdlib:v0.2.4"
+"#;
+
+const TB0001_BOARD_PCB_TOML: &str = r#"
+[board]
+name = "TB0001"
+path = "TB0001.zen"
+
+[packages]
+stdlib = "@github/diodeinc/stdlib:v0.2.4"
+"#;
+
+const CASE_BOARD_PCB_TOML: &str = r#"
+[board]
+name = "CaseBoard"
+path = "CaseBoard.zen"
+"#;
+
+const TB0002_BOARD_PCB_TOML: &str = r#"
+[board]
+name = "TB0002"
+path = "TB0002.zen"
+"#;
+
 const SIMPLE_COMPONENT: &str = r#"
 value = config("value", str, default = "10kOhm")
 
@@ -97,6 +127,7 @@ fn test_pcb_release_source_only() {
         .seed_stdlib(&["v0.2.4"])
         .seed_kicad(&["9.0.0"])
         .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
         .hash_globs(["*.kicad_mod", "**/diodeinc/stdlib/*.zen"])
@@ -108,7 +139,8 @@ fn test_pcb_release_source_only() {
             cargo_bin!("pcb"),
             [
                 "release",
-                "boards/TestBoard.zen",
+                "--board",
+                "TestBoard",
                 "--source-only",
                 "-f",
                 "json",
@@ -149,6 +181,7 @@ fn test_pcb_release_with_git() {
         .seed_kicad(&["9.0.0"])
         .write(".gitignore", ".pcb")
         .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", TB0001_BOARD_PCB_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TB0001.zen", TEST_BOARD_ZEN)
         .init_git()
@@ -158,7 +191,8 @@ fn test_pcb_release_with_git() {
             cargo_bin!("pcb"),
             [
                 "release",
-                "boards/TB0001.zen",
+                "--board",
+                "TB0001",
                 "--source-only",
                 "-f",
                 "json",
@@ -201,6 +235,7 @@ fn test_pcb_release_full() {
         .seed_stdlib(&["v0.2.4"])
         .seed_kicad(&["9.0.0"])
         .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
         .hash_globs(&["*.kicad_mod", "**/diodeinc/stdlib/*.zen"])
@@ -210,7 +245,7 @@ fn test_pcb_release_full() {
     let output = sb
         .cmd(
             cargo_bin!("pcb"),
-            ["release", "boards/TestBoard.zen", "-f", "json"],
+            ["release", "--board", "TestBoard", "-f", "json"],
         )
         .read()
         .expect("Failed to run pcb release command");
@@ -250,6 +285,7 @@ n2 = Net("N2")
     let output = sb
         .cwd("src")
         .ignore_globs(["layout/*"])
+        .write("boards/pcb.toml", CASE_BOARD_PCB_TOML)
         .write("boards/CaseBoard.zen", board_zen)
         .init_git()
         .commit("Initial commit")
@@ -258,7 +294,8 @@ n2 = Net("N2")
             cargo_bin!("pcb"),
             [
                 "release",
-                "boards/CaseBoard.zen",
+                "--board",
+                "CaseBoard",
                 "--source-only",
                 "-f",
                 "json",
@@ -299,6 +336,7 @@ fn test_pcb_release_with_file() {
     const DATASHEET_CONTENTS: &str = "Simple component datasheet.";
     sb.cwd("src")
         .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", TB0002_BOARD_PCB_TOML)
         .write("modules/component.zen", SIMPLE_COMPONENT)
         .write("modules/test.kicad_mod", TEST_KICAD_MOD)
         .write("modules/datasheet.txt", DATASHEET_CONTENTS)
@@ -311,7 +349,8 @@ fn test_pcb_release_with_file() {
             cargo_bin!("pcb"),
             [
                 "release",
-                "boards/TB0002.zen",
+                "--board",
+                "TB0002",
                 "--source-only",
                 "-f",
                 "json",

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -151,7 +151,7 @@ fn test_pcb_release_source_only() {
 
     // Parse JSON output to get staging directory
     let json: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
-    let staging_dir = json["staging_directory"]
+    let staging_dir = json["release"]["staging_directory"]
         .as_str()
         .expect("Missing staging_directory in JSON");
 
@@ -203,7 +203,7 @@ fn test_pcb_release_with_git() {
 
     // Parse JSON output to get staging directory and verify git version
     let json: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
-    let staging_dir = json["staging_directory"].as_str().unwrap();
+    let staging_dir = json["release"]["staging_directory"].as_str().unwrap();
 
     let metadata_file = File::open(format!("{staging_dir}/metadata.json")).unwrap();
     let metadata_json: Value = serde_json::from_reader(metadata_file).unwrap();
@@ -238,8 +238,8 @@ fn test_pcb_release_full() {
         .write("boards/pcb.toml", BOARD_PCB_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
-        .hash_globs(&["*.kicad_mod", "**/diodeinc/stdlib/*.zen"])
-        .ignore_globs(&["layout/*", "3d/*"]);
+        .hash_globs(["*.kicad_mod", "**/diodeinc/stdlib/*.zen"])
+        .ignore_globs(["layout/*", "3d/*"]);
 
     // Run full release with JSON output
     let output = sb
@@ -252,7 +252,7 @@ fn test_pcb_release_full() {
 
     // Parse JSON output to get staging directory
     let json: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
-    let staging_dir = json["staging_directory"]
+    let staging_dir = json["release"]["staging_directory"]
         .as_str()
         .expect("Missing staging_directory in JSON");
 
@@ -306,7 +306,7 @@ n2 = Net("N2")
 
     // Parse JSON output to get staging directory
     let json: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
-    let staging_dir = json["staging_directory"].as_str().unwrap();
+    let staging_dir = json["release"]["staging_directory"].as_str().unwrap();
 
     // Snapshot the build from release contents
     let build_ouput = sb.snapshot_run(
@@ -361,7 +361,7 @@ fn test_pcb_release_with_file() {
 
     // Parse JSON output to get staging directory
     let json: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
-    let staging_dir = json["staging_directory"]
+    let staging_dir = json["release"]["staging_directory"]
         .as_str()
         .expect("Missing staging_directory in JSON");
 

--- a/crates/pcb/tests/simple.rs
+++ b/crates/pcb/tests/simple.rs
@@ -105,6 +105,13 @@ const SIMPLE_WORKSPACE_PCB_TOML: &str = r#"
 name = "simple_workspace"
 "#;
 
+const TEST_BOARD_PCB_TOML: &str = r#"
+[board]
+name = "TestBoard"
+path = "TestBoard.zen"
+description = "Main test board for validation"
+"#;
+
 #[test]
 #[cfg(not(target_os = "windows"))]
 fn test_pcb_build_should_fail_without_fixture() {
@@ -146,6 +153,7 @@ fn test_pcb_release_simple_workspace() {
         .seed_kicad(&["9.0.0"])
         .write("pcb.toml", SIMPLE_WORKSPACE_PCB_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
+        .write("boards/pcb.toml", TEST_BOARD_PCB_TOML)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN);
 
     // Test BOM first
@@ -157,7 +165,7 @@ fn test_pcb_release_simple_workspace() {
     // Test release
     assert_snapshot!(
         "simple_workspace_release",
-        sb.snapshot_run("pcb", ["release", "boards/TestBoard.zen", "-f", "json"])
+        sb.snapshot_run("pcb", ["release", "-b", "TestBoard", "-f", "json"])
     );
 }
 

--- a/crates/pcb/tests/snapshots/path__path_local_mixed_release.snap
+++ b/crates/pcb/tests/snapshots/path__path_local_mixed_release.snap
@@ -15,7 +15,7 @@ expression: sb.snapshot_dir(staging_dir)
     "layout_path": "<TEMP_DIR>/boards/build/LocalPathTest",
     "schema_version": "1",
     "source_only": true,
-    "staging_directory": "<TEMP_DIR>/.pcb/releases/LocalPathTest/unknown",
+    "staging_directory": "<TEMP_DIR>/.pcb/releases/LocalPathTest-unknown",
     "workspace_root": "<TEMP_DIR>",
     "zen_file": "boards/LocalPathTest.zen"
   },

--- a/crates/pcb/tests/snapshots/release__case_insensitive_tag.snap
+++ b/crates/pcb/tests/snapshots/release__case_insensitive_tag.snap
@@ -15,7 +15,7 @@ expression: sb.snapshot_dir(staging_dir)
     "layout_path": "<TEMP_DIR>/src/boards/build/CaseBoard",
     "schema_version": "1",
     "source_only": true,
-    "staging_directory": "<TEMP_DIR>/src/boards/.pcb/releases/CaseBoard/v9.9.9",
+    "staging_directory": "<TEMP_DIR>/src/boards/.pcb/releases/CaseBoard-v9.9.9",
     "workspace_root": "<TEMP_DIR>/src/boards",
     "zen_file": "CaseBoard.zen"
   },
@@ -32,3 +32,8 @@ add_property("layout_path", "build/CaseBoard")
 
 n1 = Net("N1")
 n2 = Net("N2")
+=== src/pcb.toml
+
+[board]
+name = "CaseBoard"
+path = "CaseBoard.zen"

--- a/crates/pcb/tests/snapshots/release__case_insensitive_tag_build.snap
+++ b/crates/pcb/tests/snapshots/release__case_insensitive_tag_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build --offline <TEMP_DIR>/src/boards/.pcb/releases/CaseBoard/v9.9.9/src/CaseBoard.zen
+Command: pcb build --offline <TEMP_DIR>/src/boards/.pcb/releases/CaseBoard-v9.9.9/src/CaseBoard.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__release_basic.snap
+++ b/crates/pcb/tests/snapshots/release__release_basic.snap
@@ -15,7 +15,7 @@ expression: sb.snapshot_dir(staging_dir)
     "layout_path": "<TEMP_DIR>/src/boards/build/TestBoard",
     "schema_version": "1",
     "source_only": true,
-    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TestBoard/unknown",
+    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TestBoard-unknown",
     "workspace_root": "<TEMP_DIR>/src",
     "zen_file": "boards/TestBoard.zen"
   },
@@ -46,6 +46,14 @@ Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
 
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+=== src/boards/pcb.toml
+
+[board]
+name = "TestBoard"
+path = "TestBoard.zen"
+
+[packages]
+stdlib = "@github/diodeinc/stdlib:v0.2.4"
 === src/modules/LedModule.zen
 
 load("@stdlib/interfaces.zen", "Gpio", "Ground", "Power")

--- a/crates/pcb/tests/snapshots/release__release_basic_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_basic_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TestBoard/unknown/src/boards/TestBoard.zen
+Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TestBoard-unknown/src/boards/TestBoard.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__release_full.snap
+++ b/crates/pcb/tests/snapshots/release__release_full.snap
@@ -84,7 +84,7 @@ Designator,Val,Package,Mid X,Mid Y,Rotation,Layer
     "layout_path": "<TEMP_DIR>/src/boards/build/TestBoard",
     "schema_version": "1",
     "source_only": false,
-    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TestBoard/unknown",
+    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TestBoard-unknown",
     "workspace_root": "<TEMP_DIR>/src",
     "zen_file": "boards/TestBoard.zen"
   },
@@ -115,6 +115,14 @@ Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
 
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+=== src/boards/pcb.toml
+
+[board]
+name = "TestBoard"
+path = "TestBoard.zen"
+
+[packages]
+stdlib = "@github/diodeinc/stdlib:v0.2.4"
 === src/modules/LedModule.zen
 
 load("@stdlib/interfaces.zen", "Gpio", "Ground", "Power")

--- a/crates/pcb/tests/snapshots/release__release_full_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_full_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TestBoard/unknown/src/boards/TestBoard.zen
+Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TestBoard-unknown/src/boards/TestBoard.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__release_with_file.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_file.snap
@@ -15,7 +15,7 @@ expression: sb.snapshot_dir(staging_dir)
     "layout_path": "<TEMP_DIR>/src/boards/build/TestBoard",
     "schema_version": "1",
     "source_only": true,
-    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TB0002/unknown",
+    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TB0002-unknown",
     "workspace_root": "<TEMP_DIR>/src",
     "zen_file": "boards/TB0002.zen"
   },

--- a/crates/pcb/tests/snapshots/release__release_with_file_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_file_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TB0002/unknown/src/boards/TB0002.zen
+Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TB0002-unknown/src/boards/TB0002.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/release__release_with_git.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_git.snap
@@ -15,7 +15,7 @@ expression: sb.snapshot_dir(staging_dir)
     "layout_path": "<TEMP_DIR>/src/boards/build/TestBoard",
     "schema_version": "1",
     "source_only": true,
-    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TB0001/v1.2.3",
+    "staging_directory": "<TEMP_DIR>/src/.pcb/releases/TB0001-v1.2.3",
     "workspace_root": "<TEMP_DIR>/src",
     "zen_file": "boards/TB0001.zen"
   },
@@ -46,6 +46,14 @@ Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
 
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+=== src/boards/pcb.toml
+
+[board]
+name = "TB0001"
+path = "TB0001.zen"
+
+[packages]
+stdlib = "@github/diodeinc/stdlib:v0.2.4"
 === src/modules/LedModule.zen
 
 load("@stdlib/interfaces.zen", "Gpio", "Ground", "Power")

--- a/crates/pcb/tests/snapshots/release__release_with_git_build.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_git_build.snap
@@ -2,7 +2,7 @@
 source: crates/pcb/tests/release.rs
 expression: build_ouput
 ---
-Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TB0001/v1.2.3/src/boards/TB0001.zen
+Command: pcb build --offline <TEMP_DIR>/src/.pcb/releases/TB0001-v1.2.3/src/boards/TB0001.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
+++ b/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/pcb/tests/simple.rs
-expression: "sb.snapshot_run(\"pcb\", [\"release\", \"boards/TestBoard.zen\", \"-f\", \"json\"])"
+expression: "sb.snapshot_run(\"pcb\", [\"release\", \"-b\", \"TestBoard\", \"-f\", \"json\"])"
 ---
-Command: pcb release boards/TestBoard.zen -f json
+Command: pcb release -b TestBoard -f json
 Exit Code: 0
 
 --- STDOUT ---
 {
-  "archive": "<TEMP_DIR>/.pcb/releases/TestBoard/unknown.zip",
-  "staging_directory": "<TEMP_DIR>/.pcb/releases/TestBoard/unknown",
+  "archive": "<TEMP_DIR>/.pcb/releases/TestBoard-unknown.zip",
+  "staging_directory": "<TEMP_DIR>/.pcb/releases/TestBoard-unknown",
   "version": "unknown"
 }
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
+++ b/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
@@ -7,8 +7,43 @@ Exit Code: 0
 
 --- STDOUT ---
 {
-  "archive": "<TEMP_DIR>/.pcb/releases/TestBoard-unknown.zip",
-  "staging_directory": "<TEMP_DIR>/.pcb/releases/TestBoard-unknown",
-  "version": "unknown"
+  "git": {
+    "describe": "unknown",
+    "hash": "unknown",
+    "workspace": "<TEMP_DIR>"
+  },
+  "release": {
+    "created_at": "<TIMESTAMP>",
+    "git_version": "unknown",
+    "layout_path": "<TEMP_DIR>/boards/build/TestBoard",
+    "schema_version": "1",
+    "source_only": false,
+    "staging_directory": "<TEMP_DIR>/.pcb/releases/TestBoard-unknown",
+    "workspace_root": "<TEMP_DIR>",
+    "zen_file": "boards/TestBoard.zen"
+  },
+  "system": {
+    "arch": "<ARCH>",
+    "cli_version": "<CLI_VERSION>",
+    "platform": "<PLATFORM>",
+    "user": "<USER>"
+  }
 }
 --- STDERR ---
+✓ Release information gathered
+✓ Copying source files and dependencies
+✓ Validating build from staged sources
+✓ Copying layout files
+✓ Copying documentation
+✓ Substituting version variables
+✓ Generating design BOM
+✓ Generating gerber files
+✓ Generating pick-and-place file
+✓ Generating assembly drawings
+✓ Generating ODB++ files
+✓ Generating 3D models
+✓ Writing release metadata
+✓ Creating release archive
+✓ Release unknown staged successfully
+Release Summary
+Archive: <TEMP_DIR>/.pcb/releases/TestBoard-unknown.zip


### PR DESCRIPTION
Before:
```
  pcb tag --board <BOARD> --version <VERSION> [PATH]
  pcb release <zen_path>  # inconsistent - used file path
```

After:
```
  pcb tag --board <BOARD> --version <VERSION> [PATH]
  pcb release --board <BOARD> [PATH]  # now consistent
```

Also, prefix the board name so that the folders + zip file names are easier to grok.

Before:
  - Staging: .pcb/releases/MyBoard/v1.0.0/
  - Zip: .pcb/releases/MyBoard/v1.0.0.zip (just v1.0.0.zip, not MyBoard.v1.0.0.zip)

After:
  - Staging: .pcb/releases/MyBoard-v1.0.0/
  - Zip: .pcb/releases/MyBoard-v1.0.0.zip