### PR TITLE
Don't suffix inner net name for single-net instances

### DIFF
--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -51,7 +51,7 @@ pub fn reset_net_id_counter() {
 pub struct NetValueGen<V> {
     id: NetId,
     name: String,
-    original_name: Option<String>, // The name originally requested before deduplication
+    pub original_name: Option<String>, // The name originally requested before deduplication
     properties: SmallMap<String, V>,
     symbol: V, // The Symbol value if one was provided (None if not)
 }

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -111,24 +111,23 @@ snapshot_eval!(net_duplicate_names_uniq, {
 
 snapshot_eval!(interface_net_template_naming, {
     "test.zen" => r#"
-        # Test that interface net templates use original names for prefixing, not deduped names
+        # Test single-net interface naming behavior with name conflicts
         
-        # Create a regular net with same name as template
+        # Create a regular net with same name as interface instance
         net = Net("VCC")
         
-        # Define interface with using(Net("VCC")) - should get deduped name internally
-        # but use original "VCC" for interface prefixing
+        # Define single-net interface
         Power = interface(
             NET = using(Net("VCC")),
         )
         
-        # Create power interface instance - should use "VCC" not "VCC_2" for prefix
-        power = Power("VCC")
+        # Create power interface instance - with single-net naming, uses instance name directly
+        power = Power("POWER")
         
         print("regular net:", net.name)
         print("interface net:", power.NET.name)
         
-        # Check that interface uses original name for prefixing
-        check(power.NET.name == "VCC_VCC", "Interface should use original name VCC for prefixing")
+        # Check that single-net interface uses instance name directly
+        check(power.NET.name == "POWER", "Single-net interface should use instance name directly")
     "#,
 });

--- a/crates/pcb-zen-core/tests/snapshots/input__interface_net_template_basic.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__interface_net_template_basic.snap
@@ -15,7 +15,7 @@ Module {
                 connections: {
                     "1": FrozenValue(
                         Net {
-                            name: "PREFIX_MYTEST",
+                            name: "PREFIX",
                             id: "<ID>",
                             symbol: FrozenValue(
                                 NoneType,

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_comprehensive_net_promotion.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_comprehensive_net_promotion.snap
@@ -2,7 +2,7 @@
 source: crates/pcb-zen-core/tests/interface.rs
 expression: output
 ---
-Basic Net promotion - Power -> Net: Net { name: "VCC", id: "<ID>", symbol: Value(NoneType) }
+Basic Net promotion - Power -> Net: Net { name: "_VCC", id: "<ID>", symbol: Value(NoneType) }
 Deep promotion test - Level3 instance: Level3(level2=using(Level2(extra=42, level1=using(Level1(meta="level1", net=using(Net { name: "LEVEL2_LEVEL1_DEEP", id: "<ID>", symbol: Value(NoneType) }))))))
 Deep Net promotion - Level3 -> Net: Net { name: "LEVEL2_LEVEL1_DEEP", id: "<ID>", symbol: Value(NoneType) }
 Intermediate promotions:

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_invoke_with_net_override.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_invoke_with_net_override.snap
@@ -2,7 +2,7 @@
 source: crates/pcb-zen-core/tests/interface.rs
 expression: output
 ---
-Default instance net: Net { name: "INST1_DEFAULT", id: "<ID>", properties: {"symbol_name": Value("DefaultSymbol")}, symbol: Value(Symbol { name: Some("DefaultSymbol"), pins: {"1": "A"} }) }
+Default instance net: Net { name: "INST1", id: "<ID>", properties: {"symbol_name": Value("DefaultSymbol")}, symbol: Value(Symbol { name: Some("DefaultSymbol"), pins: {"1": "A"} }) }
 Override instance net: Net { name: "OVERRIDE", id: "<ID>", properties: {"symbol_name": Value("OverrideSymbol")}, symbol: Value(Symbol { name: Some("OverrideSymbol"), pins: {"2": "B"} }) }
 Module {
     name: "<root>",

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_multiple_instances_independent_symbols.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_multiple_instances_independent_symbols.snap
@@ -2,8 +2,8 @@
 source: crates/pcb-zen-core/tests/interface.rs
 expression: output
 ---
-IO1 net: Net { name: "IO1_IO", id: "<ID>", properties: {"symbol_name": Value("IOSymbol")}, symbol: Value(Symbol { name: Some("IOSymbol"), pins: {"1": "IO"} }) }
-IO2 net: Net { name: "IO2_IO", id: "<ID>", properties: {"symbol_name": Value("IOSymbol")}, symbol: Value(Symbol { name: Some("IOSymbol"), pins: {"1": "IO"} }) }
+IO1 net: Net { name: "IO1", id: "<ID>", properties: {"symbol_name": Value("IOSymbol")}, symbol: Value(Symbol { name: Some("IOSymbol"), pins: {"1": "IO"} }) }
+IO2 net: Net { name: "IO2", id: "<ID>", properties: {"symbol_name": Value("IOSymbol")}, symbol: Value(Symbol { name: Some("IOSymbol"), pins: {"1": "IO"} }) }
 Module {
     name: "<root>",
     source: "test.zen",

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_nested_symbol_copy.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_nested_symbol_copy.snap
@@ -2,7 +2,7 @@
 source: crates/pcb-zen-core/tests/interface.rs
 expression: output
 ---
-Data net: Net { name: "SYS_DATA_DATA", id: "<ID>", properties: {"symbol_name": Value("DataSymbol")}, symbol: Value(Symbol { name: Some("DataSymbol"), pins: {"1": "DATA", "2": "DATA"} }) }
+Data net: Net { name: "SYS_DATA", id: "<ID>", properties: {"symbol_name": Value("DataSymbol")}, symbol: Value(Symbol { name: Some("DataSymbol"), pins: {"1": "DATA", "2": "DATA"} }) }
 Power net: Net { name: "SYS_POWER", id: "<ID>", properties: {"symbol_name": Value("PowerSymbol")}, symbol: Value(Symbol { name: Some("PowerSymbol"), pins: {"1": "VCC", "2": "GND"} }) }
 Module {
     name: "<root>",

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_post_init_callback.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_post_init_callback.snap
@@ -2,9 +2,9 @@
 source: crates/pcb-zen-core/tests/interface.rs
 expression: output
 ---
-Validating power interface: MAIN_VCC
+Validating power interface: MAIN
 Power validation: PASS
-Validating power interface: CPU_VCC
+Validating power interface: CPU
 Power validation: PASS
 --- Serialized JSON ---
 {
@@ -13,7 +13,7 @@ Power validation: PASS
       "net": {
         "Net": {
           "id": 2,
-          "name": "MAIN_VCC",
+          "name": "MAIN",
           "properties": {}
         }
       }

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_promotion_deserialization.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_promotion_deserialization.snap
@@ -3,13 +3,13 @@ source: crates/pcb-zen-core/tests/interface.rs
 expression: output
 ---
 === Test 1: Net promotion ===
-Power -> Net: Net { name: "VCC", id: "<ID>", symbol: Value(NoneType) }
+Power -> Net: Net { name: "_VCC", id: "<ID>", symbol: Value(NoneType) }
 === Test 2: Interface promotion ===
 Usart -> Uart: Uart(RX=Net { name: "UART_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "UART_UART_TX", id: "<ID>", symbol: Value(NoneType) })
 === Test 3: Deep transitive promotion ===
-Level3 -> Level2: Level2(level1=using(Level1(net=using(Net { name: "LEVEL2_LEVEL1_L1", id: "<ID>", symbol: Value(NoneType) }))))
-Level3 -> Level1: Level1(net=using(Net { name: "LEVEL2_LEVEL1_L1", id: "<ID>", symbol: Value(NoneType) }))
-Level3 -> Net: Net { name: "LEVEL2_LEVEL1_L1", id: "<ID>", symbol: Value(NoneType) }
+Level3 -> Level2: Level2(level1=using(Level1(net=using(Net { name: "LEVEL2_LEVEL1", id: "<ID>", symbol: Value(NoneType) }))))
+Level3 -> Level1: Level1(net=using(Net { name: "LEVEL2_LEVEL1", id: "<ID>", symbol: Value(NoneType) }))
+Level3 -> Net: Net { name: "LEVEL2_LEVEL1", id: "<ID>", symbol: Value(NoneType) }
 Module {
     name: "<root>",
     source: "test.zen",

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_serialization_formats.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_serialization_formats.snap
@@ -17,7 +17,7 @@ expression: output
       "NET": {
         "Net": {
           "id": 3,
-          "name": "PWR_VCC",
+          "name": "PWR",
           "properties": {}
         }
       }
@@ -56,7 +56,7 @@ expression: output
             "NET": {
               "Net": {
                 "id": 5,
-                "name": "SYS_POWER_VCC",
+                "name": "SYS_POWER",
                 "properties": {}
               }
             }

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_single_net_naming.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_single_net_naming.snap
@@ -1,0 +1,15 @@
+---
+source: crates/pcb-zen-core/tests/interface.rs
+expression: output
+---
+_INNER
+LEVEL1
+LEVEL2_LEVEL1
+L1
+L2_LEVEL1
+L3_LEVEL2_LEVEL1
+Module {
+    name: "<root>",
+    source: "test.zen",
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_transitive_promotion.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_transitive_promotion.snap
@@ -9,7 +9,7 @@ expression: output
       "reset": {
         "Net": {
           "id": 8,
-          "name": "CTRL_RESET",
+          "name": "CTRL",
           "properties": {}
         }
       }

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_using_deep_recursion.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_using_deep_recursion.snap
@@ -19,7 +19,7 @@ expression: output
                   "net": {
                     "Net": {
                       "id": 4,
-                      "name": "L3_LEVEL2_LEVEL1_LEVEL1",
+                      "name": "L3_LEVEL2_LEVEL1",
                       "properties": {}
                     }
                   }

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_using_deserialization_roundtrip.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_using_deserialization_roundtrip.snap
@@ -15,7 +15,7 @@ expression: output
                   "net": {
                     "Net": {
                       "id": 8,
-                      "name": "DEEP_LEVEL2_LEVEL1_LEVEL1",
+                      "name": "DEEP_LEVEL2_LEVEL1",
                       "properties": {}
                     }
                   }
@@ -80,7 +80,7 @@ expression: output
                   "net": {
                     "Net": {
                       "id": 8,
-                      "name": "DEEP_LEVEL2_LEVEL1_LEVEL1",
+                      "name": "DEEP_LEVEL2_LEVEL1",
                       "properties": {}
                     }
                   }
@@ -133,8 +133,8 @@ expression: output
   }
 }
 === Verification ===
-Original display: Level3(level2=using(Level2(level1=using(Level1(net=using(Net { name: "DEEP_LEVEL2_LEVEL1_LEVEL1", id: "<ID>", symbol: Value(NoneType) }))))), uart=using(Uart(RX=Net { name: "DEEP_UART_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "DEEP_UART_UART_TX", id: "<ID>", symbol: Value(NoneType) })))
-Deserialized display: Level3(level2=using(Level2(level1=using(Level1(net=using(Net { name: "DEEP_LEVEL2_LEVEL1_LEVEL1", id: "<ID>", symbol: Value(NoneType) }))))), uart=using(Uart(RX=Net { name: "DEEP_UART_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "DEEP_UART_UART_TX", id: "<ID>", symbol: Value(NoneType) })))
+Original display: Level3(level2=using(Level2(level1=using(Level1(net=using(Net { name: "DEEP_LEVEL2_LEVEL1", id: "<ID>", symbol: Value(NoneType) }))))), uart=using(Uart(RX=Net { name: "DEEP_UART_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "DEEP_UART_UART_TX", id: "<ID>", symbol: Value(NoneType) })))
+Deserialized display: Level3(level2=using(Level2(level1=using(Level1(net=using(Net { name: "DEEP_LEVEL2_LEVEL1", id: "<ID>", symbol: Value(NoneType) }))))), uart=using(Uart(RX=Net { name: "DEEP_UART_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "DEEP_UART_UART_TX", id: "<ID>", symbol: Value(NoneType) })))
 === Factory Integrity Check ===
 New from original: {
   "Interface": {
@@ -148,7 +148,7 @@ New from original: {
                   "net": {
                     "Net": {
                       "id": 11,
-                      "name": "NEW_FROM_ORIGINAL_LEVEL2_LEVEL1_LEVEL1",
+                      "name": "NEW_FROM_ORIGINAL_LEVEL2_LEVEL1",
                       "properties": {}
                     }
                   }
@@ -212,7 +212,7 @@ New from deserialized: {
                   "net": {
                     "Net": {
                       "id": 14,
-                      "name": "NEW_FROM_DESERIALIZED_LEVEL2_LEVEL1_LEVEL1",
+                      "name": "NEW_FROM_DESERIALIZED_LEVEL2_LEVEL1",
                       "properties": {}
                     }
                   }

--- a/crates/pcb-zen-core/tests/snapshots/net__interface_net_template_naming.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__interface_net_template_naming.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/pcb-zen-core/tests/net.rs
-assertion_line: 112
 expression: output
 ---
 regular net: VCC
-interface net: VCC_VCC
+interface net: POWER
 Module {
     name: "<root>",
     source: "test.zen",

--- a/crates/pcb-zen/tests/interface_templates.rs
+++ b/crates/pcb-zen/tests/interface_templates.rs
@@ -30,10 +30,11 @@ Component(
     assert!(result.diagnostics.is_empty(), "Should have no errors");
 
     // The netlist output should contain our net with the proper name
+    // For single-net interfaces, the instance name becomes the net name directly
     let netlist = result.output.unwrap();
     assert!(
-        netlist.contains("PREFIX_MYTEST"),
-        "Should contain PREFIX_MYTEST net"
+        netlist.contains("PREFIX"),
+        "Should contain PREFIX net (single-net interface uses instance name directly)"
     );
 }
 
@@ -234,6 +235,13 @@ Component(
     assert!(result.diagnostics.is_empty(), "Should have no errors");
 
     let netlist = result.output.unwrap();
-    assert!(netlist.contains("A_SHARED"), "Should contain A_SHARED net");
-    assert!(netlist.contains("B_SHARED"), "Should contain B_SHARED net");
+    // For single-net interfaces, the instance name becomes the net name directly
+    assert!(
+        netlist.contains("A"),
+        "Should contain A net (single-net interface uses instance name directly)"
+    );
+    assert!(
+        netlist.contains("B"),
+        "Should contain B net (single-net interface uses instance name directly)"
+    );
 }

--- a/crates/pcb-zen/tests/snapshots/input__correct_usage_with_explicit_net_access.snap
+++ b/crates/pcb-zen/tests/snapshots/input__correct_usage_with_explicit_net_access.snap
@@ -33,7 +33,7 @@ expression: netlist
     (net (code "1") (name "N2")
       (node (ref "U1") (pin "2") (pintype "stereo"))
     )
-    (net (code "2") (name "SIG_SIGNAL")
+    (net (code "2") (name "SIG")
       (node (ref "U1") (pin "1") (pintype "stereo"))
     )
   )

--- a/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_net_template_basic.snap
+++ b/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_net_template_basic.snap
@@ -33,7 +33,7 @@ expression: netlist
     (net (code "1") (name "GND")
       (node (ref "U1") (pin "2") (pintype "stereo"))
     )
-    (net (code "2") (name "PREFIX_MYTEST")
+    (net (code "2") (name "PREFIX")
       (node (ref "U1") (pin "1") (pintype "stereo"))
     )
   )

--- a/crates/pcb-zen/tests/snapshots/spice_model__snapshot_sim_divider.snap
+++ b/crates/pcb-zen/tests/snapshots/spice_model__snapshot_sim_divider.snap
@@ -5,5 +5,5 @@ expression: result
 .SUBCKT my_resistor p n PARAMS: RVAL={0}
 R1 p n {RVAL}
 .ENDS my_resistor
-XR1 vin_VCC vout_NET my_resistor RVAL=10000.0
-XR2 vout_NET gnd_GND my_resistor RVAL=20000.0
+XR1 VIN VOUT my_resistor RVAL=10000.0
+XR2 VOUT GND my_resistor RVAL=20000.0


### PR DESCRIPTION
Mainly affects power, gnd net naming.

```
Level1 = interface(
    net = Net("INNER"),
)

# Level 2: Interface that uses Level1
Level2 = interface(
    level1 = Level1(),
)

# Level 3: Interface that uses Level2
Level3 = interface(
    level2 = Level2(),
)

l1 = Level1()
print(l1.net.name)
l2 = Level2()
print(l2.level1.net.name)
l3 = Level3()
print(l3.level2.level1.net.name)

l1_named = Level1("L1")
print(l1_named.net.name)
l2_named = Level2("L2")
print(l2_named.level1.net.name)
l3_named = Level3("L3")
print(l3_named.level2.level1.net.name)
```

before:
```
INNER
LEVEL1_INNER
LEVEL2_LEVEL1_INNER
L1_INNER
L2_LEVEL1_INNER
L3_LEVEL2_LEVEL1_INNER
```

after:
```
_INNER
LEVEL1
LEVEL2_LEVEL1
L1
L2_LEVEL1
L3_LEVEL2_LEVEL1
```