### PR TITLE
Add `moved()` directive

### DIFF
--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -66,6 +66,39 @@ if python_path:
 import pcbnew
 
 
+class Remapper:
+    """Longest-prefix remapper for old -> new path mapping."""
+
+    def __init__(self, moved_paths: Dict[str, str]):
+        """Initialize remapper from moved_paths dictionary (old_path -> new_path)."""
+        self.map = moved_paths.copy()
+
+    def remap(self, path: str) -> Optional[str]:
+        """Remap a path using longest-prefix matching."""
+        search_path = path
+
+        while True:
+            if search_path in self.map:
+                # path = prefix + remainder, where remainder is "" or ".foo.bar"
+                new_prefix = self.map[search_path]
+                remainder = path[len(search_path) :]
+                return new_prefix + remainder
+
+            # Find previous dot; stop if none
+            dot_pos = search_path.rfind(".")
+            if dot_pos == -1:
+                break
+            search_path = search_path[:dot_pos]
+
+        return None
+
+    @classmethod
+    def from_schematic(cls, schematic_data: Dict[str, Any]) -> "Remapper":
+        """Build a remapper from schematic JSON data."""
+        moved_paths = schematic_data.get("moved_paths", {})
+        return cls(moved_paths)
+
+
 ####################################################################################################
 # JSON Netlist Parser
 #

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -485,6 +485,9 @@ pub struct Schematic {
 
     /// Symbol library - maps symbol paths to their s-expression content
     pub symbols: HashMap<String, String>,
+
+    /// Path remapping rules for moved() directives (old_path -> new_path)
+    pub moved_paths: HashMap<String, String>,
 }
 
 impl Schematic {

--- a/crates/pcb-zen-core/src/lang/context.rs
+++ b/crates/pcb-zen-core/src/lang/context.rs
@@ -140,6 +140,12 @@ impl<'v> ContextValue<'v> {
         self.module.borrow_mut().add_property(name, value);
     }
 
+    pub(crate) fn add_moved_directive(&self, old_path: String, new_path: String) {
+        self.module
+            .borrow_mut()
+            .add_moved_directive(old_path, new_path);
+    }
+
     pub(crate) fn add_missing_input(&self, name: String) {
         self.missing_inputs.borrow_mut().push(name);
     }

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -12,6 +12,7 @@ mod file_provider;
 pub mod graph;
 pub mod lang;
 pub mod load_spec;
+mod moved;
 pub mod passes;
 pub mod warnings;
 

--- a/crates/pcb-zen-core/src/moved.rs
+++ b/crates/pcb-zen-core/src/moved.rs
@@ -1,0 +1,272 @@
+use crate::lang::module::FrozenModuleValue;
+use pcb_sch::InstanceRef;
+use std::collections::HashMap;
+
+/// Apply moved directives to remap a path
+///
+/// This simplified implementation supports exact path matching and module hierarchy remapping:
+/// - If the old path matches exactly, it gets remapped to the new path
+/// - If the old path is a prefix (module), all child paths are automatically remapped
+pub fn apply_moved_directives(
+    path: &str,
+    moved_directives: &HashMap<String, String>,
+) -> Option<String> {
+    // Try exact match first
+    if let Some(new_path) = moved_directives.get(path) {
+        return Some(new_path.clone());
+    }
+
+    // Try prefix matches (module hierarchy remapping)
+    for (old_path, new_path) in moved_directives.iter() {
+        // Check if path starts with old_path as a module prefix
+        if path.starts_with(old_path) {
+            let remaining = &path[old_path.len()..];
+            // Ensure we're matching at module boundaries (either end of string or followed by '.')
+            if remaining.is_empty() {
+                // Exact match - already handled above
+                continue;
+            } else if remaining.starts_with('.') {
+                // Module hierarchy match: old_path.something -> new_path.something
+                return Some(format!("{}{}", new_path, remaining));
+            }
+        }
+    }
+
+    None
+}
+
+/// Process position remapping with module scoping for all modules in a hierarchy
+pub fn process_position_remapping(
+    module_instances: &[(InstanceRef, FrozenModuleValue)],
+) -> HashMap<String, String> {
+    let mut all_moved_directives = HashMap::new();
+
+    for (instance_ref, module) in module_instances {
+        let module_path = instance_ref.instance_path.join(".");
+        for (old_path, new_path) in module.moved_directives().iter() {
+            // Apply module scope: prefix both old and new paths with module path
+            let scoped_old_path = if module_path.is_empty() {
+                old_path.clone()
+            } else {
+                format!("{}.{}", module_path, old_path)
+            };
+            let scoped_new_path = if module_path.is_empty() {
+                new_path.clone()
+            } else {
+                format!("{}.{}", module_path, new_path)
+            };
+            all_moved_directives.insert(scoped_old_path, scoped_new_path);
+        }
+    }
+
+    all_moved_directives
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exact_matching() {
+        let mut directives = HashMap::new();
+        directives.insert("OldComponent".to_string(), "NewComponent".to_string());
+        directives.insert(
+            "Power.OldReg.C1".to_string(),
+            "PowerMgmt.VoltageReg.C1".to_string(),
+        );
+
+        assert_eq!(
+            apply_moved_directives("OldComponent", &directives),
+            Some("NewComponent".to_string())
+        );
+
+        assert_eq!(
+            apply_moved_directives("Power.OldReg.C1", &directives),
+            Some("PowerMgmt.VoltageReg.C1".to_string())
+        );
+
+        assert_eq!(
+            apply_moved_directives("UnknownComponent", &directives),
+            None
+        );
+    }
+
+    #[test]
+    fn test_module_hierarchy_remapping() {
+        let mut directives = HashMap::new();
+        // Move module POW.PS1 to PS1 - this should handle all children automatically
+        directives.insert("POW.PS1".to_string(), "PS1".to_string());
+        directives.insert("Power".to_string(), "PWR".to_string());
+
+        // Direct module match
+        assert_eq!(
+            apply_moved_directives("POW.PS1", &directives),
+            Some("PS1".to_string())
+        );
+
+        // Module hierarchy - children get remapped automatically
+        assert_eq!(
+            apply_moved_directives("POW.PS1.some_resistor", &directives),
+            Some("PS1.some_resistor".to_string())
+        );
+
+        assert_eq!(
+            apply_moved_directives("POW.PS1.inner.component", &directives),
+            Some("PS1.inner.component".to_string())
+        );
+
+        // Different module
+        assert_eq!(
+            apply_moved_directives("Power.Regulator", &directives),
+            Some("PWR.Regulator".to_string())
+        );
+
+        // Partial matches shouldn't work (POW.PS10 shouldn't match POW.PS1)
+        assert_eq!(apply_moved_directives("POW.PS10", &directives), None);
+    }
+
+    #[test]
+    fn test_net_remapping() {
+        let mut directives = HashMap::new();
+        directives.insert(
+            "AN_OLD_FILTERED_VCC_VCC".to_string(),
+            "FILTERED_VCC_VCC".to_string(),
+        );
+
+        // Direct net name remapping
+        assert_eq!(
+            apply_moved_directives("AN_OLD_FILTERED_VCC_VCC", &directives),
+            Some("FILTERED_VCC_VCC".to_string())
+        );
+
+        // Net symbol remapping (for position comments)
+        assert_eq!(
+            apply_moved_directives("AN_OLD_FILTERED_VCC_VCC.1", &directives),
+            Some("FILTERED_VCC_VCC.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_component_moves() {
+        let mut directives = HashMap::new();
+        directives.insert(
+            "ModuleA.ComponentX".to_string(),
+            "ModuleB.ComponentX".to_string(),
+        );
+
+        assert_eq!(
+            apply_moved_directives("ModuleA.ComponentX", &directives),
+            Some("ModuleB.ComponentX".to_string())
+        );
+
+        // Properties should also get remapped
+        assert_eq!(
+            apply_moved_directives("ModuleA.ComponentX.pin1", &directives),
+            Some("ModuleB.ComponentX.pin1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_no_false_matches() {
+        let mut directives = HashMap::new();
+        directives.insert("Power".to_string(), "PWR".to_string());
+
+        // PowerSupply shouldn't match "Power" prefix
+        assert_eq!(apply_moved_directives("PowerSupply", &directives), None);
+
+        // Power.Main should match
+        assert_eq!(
+            apply_moved_directives("Power.Main", &directives),
+            Some("PWR.Main".to_string())
+        );
+    }
+
+    #[test]
+    fn test_moved_directive_storage() {
+        use crate::lang::eval::EvalContext;
+        use crate::lang::input::InputMap;
+        use starlark::values::ValueLike;
+
+        let test_content = r#"
+moved("old.path.component", "new.path.component")
+moved("POW.PS1", "PS1")
+moved("Power.Reg1", "PowerMgmt.Reg1")
+"#;
+
+        // Create a temporary file
+        let temp_path = std::env::temp_dir().join("test_moved.zen");
+        std::fs::write(&temp_path, test_content).unwrap();
+
+        // Evaluate it
+        let result = EvalContext::new()
+            .set_source_path(temp_path.clone())
+            .set_module_name("test_moved".to_string())
+            .set_inputs(InputMap::new())
+            .eval();
+
+        // Clean up the temp file
+        std::fs::remove_file(&temp_path).ok();
+
+        // Check the result
+        assert!(result.output.is_some(), "Evaluation should succeed");
+        let output = result.output.unwrap();
+
+        if let Some(frozen_ctx) = output
+            .star_module
+            .extra_value()
+            .and_then(|extra| extra.downcast_ref::<crate::lang::context::FrozenContextValue>())
+        {
+            let moved_directives = frozen_ctx.module.moved_directives();
+            assert_eq!(moved_directives.len(), 3, "Should have 3 moved directives");
+
+            assert_eq!(
+                moved_directives.get("old.path.component").unwrap(),
+                "new.path.component"
+            );
+            assert_eq!(moved_directives.get("POW.PS1").unwrap(), "PS1");
+            assert_eq!(
+                moved_directives.get("Power.Reg1").unwrap(),
+                "PowerMgmt.Reg1"
+            );
+        } else {
+            panic!("Could not access frozen context");
+        }
+    }
+
+    #[test]
+    fn test_moved_directive_empty() {
+        use crate::lang::eval::EvalContext;
+        use crate::lang::input::InputMap;
+        use starlark::values::ValueLike;
+
+        let test_content = r#"
+# No moved directives
+"#;
+
+        // Create a temporary file
+        let temp_path = std::env::temp_dir().join("test_moved_empty.zen");
+        std::fs::write(&temp_path, test_content).unwrap();
+
+        // Evaluate it
+        let result = EvalContext::new()
+            .set_source_path(temp_path.clone())
+            .set_module_name("test_moved_empty".to_string())
+            .set_inputs(InputMap::new())
+            .eval();
+
+        // Clean up the temp file
+        std::fs::remove_file(&temp_path).ok();
+
+        // Check the result
+        if let Some(output) = result.output {
+            if let Some(frozen_ctx) = output
+                .star_module
+                .extra_value()
+                .and_then(|extra| extra.downcast_ref::<crate::lang::context::FrozenContextValue>())
+            {
+                let moved_directives = frozen_ctx.module.moved_directives();
+                assert_eq!(moved_directives.len(), 0, "Should have no moved directives");
+            }
+        }
+    }
+}

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -418,6 +418,52 @@ Properties accessible via the TestBench value:
 
 ## Built-in Functions
 
+### moved
+
+The `moved()` directive allows you to specify path remapping for refactoring support. When modules or components are moved or renamed, downstream artifacts (like layout files) may still reference the old paths. The `moved()` directive provides a mapping from old paths to new paths.
+
+```python
+moved("old_path", "new_path")
+```
+
+#### Module-level Remapping
+
+If the path refers to a module, all children of that module are automatically remapped:
+
+```python
+# This single directive handles:
+# POW.PS1 -> PS1
+# POW.PS1.some_resistor -> PS1.some_resistor  
+# POW.PS1.inner.component -> PS1.inner.component
+moved("POW.PS1", "PS1")
+```
+
+#### Usage Examples
+
+```python
+# Moved a power supply module from POW namespace to root
+moved("POW.PS1", "PS1")
+
+# Renamed a component
+moved("OLD_COMP", "NEW_COMP")
+
+# Moved components between modules
+moved("ModuleA.ComponentX", "ModuleB.ComponentX")
+
+# Net remapping for position comments
+moved("AN_OLD_FILTERED_VCC_VCC", "FILTERED_VCC_VCC")
+```
+
+**Type**: `moved`  
+**Constructor**: `moved(old_path, new_path)`
+
+- `old_path`: The old path that should be remapped
+- `new_path`: The new path to remap to
+#### Scoping
+
+`moved()` directives are scoped to the module where they are defined. They affect how paths from that module are resolved in downstream artifacts.
+```
+
 ### io(name, type, default=None, optional=False)
 
 Declares a net or interface input for a module.

--- a/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
+++ b/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
@@ -4,7 +4,7 @@ This board uses modules referenced via // paths to test that workspace
 root detection works correctly with pcb.toml files.
 """
 
-load("@stdlib:v0.2.2/interfaces.zen", "Ground", "Power", "Spi")
+load("@stdlib:v0.2.8/interfaces.zen", "Ground", "Power", "Spi")
 
 # Use workspace-relative paths for modules - this tests // path resolution
 PowerSupplyModule = Module("//modules/PowerSupplyModule.zen")
@@ -43,8 +43,8 @@ LedIndicatorModule(
 
 Flash(
     name="FLASH",
-    VCC=vcc_3v3.NET,
-    GND=gnd.NET,
+    VCC=vcc_3v3,
+    GND=gnd,
     HOLD=Net(),
     spi=Spi(),
     properties = {
@@ -52,11 +52,15 @@ Flash(
     },
 )
 
-# pcb:sch FILTERED_VCC_VCC.1 x=1134.3800 y=37.1000 rot=0
+# Fix orphaned position comment - the net was renamed but the comment still uses the old name
+moved("AN_OLD_FILTERED_VCC_VCC", "FILTERED_VCC_VCC")
+moved("POW.PS1", "PS1")
+
+# pcb:sch AN_OLD_FILTERED_VCC_VCC.1 x=1134.3800 y=37.1000 rot=0
 # pcb:sch FLASH x=203.2000 y=-127.0000 rot=0
 # pcb:sch GND_GND.1 x=1230.9000 y=341.9000 rot=0
-# pcb:sch PS1.C_FILTER.C x=1299.4800 y=-51.8000 rot=0
-# pcb:sch PS1.R_PULLUP.R x=1233.4400 y=-51.8000 rot=0
+# pcb:sch POW.PS1.C_FILTER.C x=1299.4800 y=-51.8000 rot=0
+# pcb:sch POW.PS1.R_PULLUP.R x=1233.4400 y=-51.8000 rot=0
 # pcb:sch STATUS1.D_STATUS.LED x=1218.2000 y=235.2200 rot=270
 # pcb:sch STATUS1.R_LIMIT.R x=1233.4400 y=113.3000 rot=0
 # pcb:sch VCC_3V3_VCC.1 x=1235.9800 y=-140.7000 rot=0

--- a/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
+++ b/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
@@ -47,4 +47,16 @@ Flash(
     GND=gnd.NET,
     HOLD=Net(),
     spi=Spi(),
+    properties = {
+        "embed": "true",
+    },
 )
+
+# pcb:sch FILTERED_VCC_VCC.1 x=1134.3800 y=37.1000 rot=0
+# pcb:sch FLASH x=203.2000 y=-127.0000 rot=0
+# pcb:sch GND_GND.1 x=1230.9000 y=341.9000 rot=0
+# pcb:sch PS1.C_FILTER.C x=1299.4800 y=-51.8000 rot=0
+# pcb:sch PS1.R_PULLUP.R x=1233.4400 y=-51.8000 rot=0
+# pcb:sch STATUS1.D_STATUS.LED x=1218.2000 y=235.2200 rot=270
+# pcb:sch STATUS1.R_LIMIT.R x=1233.4400 y=113.3000 rot=0
+# pcb:sch VCC_3V3_VCC.1 x=1235.9800 y=-140.7000 rot=0

--- a/test-workspaces/with-pcb-toml/boards/pcb.toml
+++ b/test-workspaces/with-pcb-toml/boards/pcb.toml
@@ -3,4 +3,4 @@ name = "WorkspaceTestBoard"
 path = "WorkspaceTestBoard.zen"
 
 [packages]
-kicad = "@github/diodeinc/kicad"
+kicad = "@github/diodeinc/kicad:v0.0.1"


### PR DESCRIPTION
See spec.mdx for actual semantics. Ended up going with a much simpler approach without globs/wildcard for now.

`pcb:sch` comments are updated on any save operation, we don't clean up old comments. `pcb layout` will always "repair" old footprints, groups.

What's expected of the user is to just add a `moved()` directive whenever they move something, and all the downstream artifacts will understand this.