### PR TITLE
Standardize file walking in all pcb subcommands

### DIFF
--- a/crates/pcb/src/file_walker.rs
+++ b/crates/pcb/src/file_walker.rs
@@ -1,0 +1,81 @@
+use anyhow::Result;
+use ignore::WalkBuilder;
+use pcb_zen::file_extensions;
+use std::path::{Path, PathBuf};
+
+/// Walk directories and process .zen files with a callback
+///
+/// Features:
+/// - Always recursive traversal
+/// - Always skips vendor/ directories  
+/// - Always respects git ignore patterns
+/// - Filters to .zen files only
+pub fn walk_zen_files<F>(
+    paths: &[impl AsRef<Path>],
+    hidden: bool,
+    mut processor: F,
+) -> Result<usize>
+where
+    F: FnMut(&Path) -> Result<()>,
+{
+    let walk_paths: Vec<_> = if paths.is_empty() {
+        vec![std::env::current_dir()?]
+    } else {
+        paths.iter().map(|p| p.as_ref().to_path_buf()).collect()
+    };
+
+    let mut found_files = 0;
+
+    for root in walk_paths {
+        let mut builder = WalkBuilder::new(&root);
+
+        // Always use these settings: recursive, respect gitignore, skip vendor
+        builder
+            .hidden(!hidden)
+            .git_ignore(true)
+            .git_exclude(true)
+            .git_global(true)
+            .filter_entry(|entry| {
+                // Skip vendor directories
+                if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                    if let Some(name) = entry.file_name().to_str() {
+                        if name == "vendor" {
+                            return false;
+                        }
+                    }
+                }
+                true
+            });
+
+        for result in builder.build() {
+            let entry = result?;
+            let path = entry.path();
+
+            // Only process .zen files
+            if path.is_file() && file_extensions::is_starlark_file(path.extension()) {
+                processor(path)?;
+                found_files += 1;
+            }
+        }
+    }
+
+    Ok(found_files)
+}
+
+/// Walk directories and collect .zen file paths into a Vec
+///
+/// Features:
+/// - Always recursive traversal
+/// - Always skips vendor/ directories  
+/// - Always respects git ignore patterns
+/// - Filters to .zen files only
+/// - Returns deterministically sorted paths
+pub fn collect_zen_files(paths: &[impl AsRef<Path>], hidden: bool) -> Result<Vec<PathBuf>> {
+    let mut zen_files = Vec::new();
+    walk_zen_files(paths, hidden, |path| {
+        zen_files.push(path.to_path_buf());
+        Ok(())
+    })?;
+    zen_files.sort(); // Deterministic ordering
+    Ok(zen_files)
+}

--- a/crates/pcb/src/fmt.rs
+++ b/crates/pcb/src/fmt.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
 use clap::Args;
+use ignore::WalkBuilder;
 use log::debug;
 use pcb_fmt::RuffFormatter;
 use pcb_ui::prelude::*;
 use pcb_zen::file_extensions;
-use std::collections::HashSet;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 #[derive(Args, Debug, Default, Clone)]
@@ -48,62 +47,119 @@ fn format_file(formatter: &RuffFormatter, file_path: &Path, args: &FmtArgs) -> R
     }
 }
 
-/// Recursively collect .zen files from a directory
-fn collect_files_recursive(dir: &Path, files: &mut HashSet<PathBuf>, hidden: bool) -> Result<()> {
-    for entry in fs::read_dir(dir)?.flatten() {
-        let path = entry.path();
-        if !hidden
-            && path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("")
-                .starts_with('.')
-        {
-            continue;
-        }
-        if path.is_file() && file_extensions::is_starlark_file(path.extension()) {
-            files.insert(path);
-        } else if path.is_dir() {
-            // Recursively traverse subdirectories
-            collect_files_recursive(&path, files, hidden)?;
-        }
-    }
-    Ok(())
-}
+/// Process .zen files using ignore crate for efficient traversal
+fn process_files(
+    formatter: &RuffFormatter,
+    paths: &[PathBuf],
+    args: &FmtArgs,
+) -> Result<(bool, Vec<PathBuf>)> {
+    let mut all_formatted = true;
+    let mut files_needing_format = Vec::new();
 
-/// Collect .zen files from the provided paths
-pub fn collect_files(paths: &[PathBuf], hidden: bool) -> Result<Vec<PathBuf>> {
-    let mut unique: HashSet<PathBuf> = HashSet::new();
+    // Determine root paths to walk
+    let walk_paths = if paths.is_empty() {
+        vec![std::env::current_dir()?]
+    } else {
+        paths.to_vec()
+    };
 
-    if !paths.is_empty() {
-        // Collect files from the provided paths (recursive for directories)
-        for user_path in paths {
-            // Resolve path relative to current directory if not absolute
-            let resolved = if user_path.is_absolute() {
-                user_path.clone()
-            } else {
-                std::env::current_dir()?.join(user_path)
-            };
+    let mut found_files = false;
 
-            if resolved.is_file() {
-                if file_extensions::is_starlark_file(resolved.extension()) {
-                    unique.insert(resolved);
+    for root in walk_paths {
+        let mut builder = WalkBuilder::new(&root);
+
+        // Configure the walker
+        builder
+            .hidden(!args.hidden)
+            .git_ignore(true)
+            .git_exclude(true)
+            .git_global(true)
+            // Explicitly add vendor/ to ignored patterns
+            .add_custom_ignore_filename(".pcbignore")
+            .filter_entry(|entry| {
+                // Skip vendor directories
+                if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                    if let Some(name) = entry.file_name().to_str() {
+                        if name == "vendor" {
+                            return false;
+                        }
+                    }
                 }
-            } else if resolved.is_dir() {
-                // Recursively collect files from the directory
-                collect_files_recursive(&resolved, &mut unique, hidden)?;
+                true
+            });
+
+        for result in builder.build() {
+            let entry = result?;
+            let path = entry.path();
+
+            // Only process .zen files
+            if path.is_file() && file_extensions::is_starlark_file(path.extension()) {
+                found_files = true;
+                let file_name = path.file_name().unwrap().to_string_lossy();
+
+                // Show spinner while processing
+                let spinner = if args.check {
+                    Spinner::builder(format!("{file_name}: Checking format")).start()
+                } else if args.diff {
+                    Spinner::builder(format!("{file_name}: Checking diff")).start()
+                } else {
+                    Spinner::builder(format!("{file_name}: Formatting")).start()
+                };
+
+                match format_file(formatter, path, args) {
+                    Ok(is_formatted) => {
+                        spinner.finish();
+
+                        if args.check {
+                            if is_formatted {
+                                println!(
+                                    "{} {} (needs formatting)",
+                                    pcb_ui::icons::warning(),
+                                    file_name.with_style(Style::Yellow).bold()
+                                );
+                                all_formatted = false;
+                                files_needing_format.push(path.to_path_buf());
+                            } else {
+                                println!(
+                                    "{} {}",
+                                    pcb_ui::icons::success(),
+                                    file_name.with_style(Style::Green).bold()
+                                );
+                            }
+                        } else {
+                            // For both diff mode and regular format mode, show success
+                            println!(
+                                "{} {}",
+                                pcb_ui::icons::success(),
+                                file_name.with_style(Style::Green).bold()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        spinner.error(format!("{file_name}: Format failed"));
+                        eprintln!("Error: {e}");
+                        all_formatted = false;
+                    }
+                }
             }
         }
-    } else {
-        // Fallback: find all Starlark files in the current directory tree (recursive)
-        let cwd = std::env::current_dir()?;
-        collect_files_recursive(&cwd, &mut unique, hidden)?;
     }
 
-    // Convert to vec and keep deterministic ordering
-    let mut paths_vec: Vec<_> = unique.into_iter().collect();
-    paths_vec.sort();
-    Ok(paths_vec)
+    if !found_files {
+        let root_display = if paths.is_empty() {
+            let cwd = std::env::current_dir()?;
+            cwd.canonicalize().unwrap_or(cwd).display().to_string()
+        } else {
+            paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        anyhow::bail!("No .zen files found in {}", root_display);
+    }
+
+    Ok((all_formatted, files_needing_format))
 }
 
 pub fn execute(args: FmtArgs) -> Result<()> {
@@ -113,76 +169,12 @@ pub fn execute(args: FmtArgs) -> Result<()> {
     // Print version info in debug mode
     debug!("Using ruff formatter");
 
-    // Determine which files to format
-    let starlark_paths = collect_files(&args.paths, args.hidden)?;
-
-    if starlark_paths.is_empty() {
-        let cwd = std::env::current_dir()?;
-        anyhow::bail!(
-            "No .zen files found in {}",
-            cwd.canonicalize().unwrap_or(cwd).display()
-        );
-    }
-
-    let mut all_formatted = true;
-    let mut files_needing_format = Vec::new();
-
-    // Process each file
-    for file_path in starlark_paths {
-        let file_name = file_path.file_name().unwrap().to_string_lossy();
-
-        // Show spinner while processing
-        let spinner = if args.check {
-            Spinner::builder(format!("{file_name}: Checking format")).start()
-        } else if args.diff {
-            Spinner::builder(format!("{file_name}: Checking diff")).start()
-        } else {
-            Spinner::builder(format!("{file_name}: Formatting")).start()
-        };
-
-        match format_file(&formatter, &file_path, &args) {
-            Ok(is_formatted) => {
-                spinner.finish();
-
-                if args.check {
-                    if is_formatted {
-                        println!(
-                            "{} {} (needs formatting)",
-                            pcb_ui::icons::warning(),
-                            file_name.with_style(Style::Yellow).bold()
-                        );
-                        all_formatted = false;
-                        files_needing_format.push(file_path.clone());
-                    } else {
-                        println!(
-                            "{} {}",
-                            pcb_ui::icons::success(),
-                            file_name.with_style(Style::Green).bold()
-                        );
-                    }
-                } else {
-                    // For both diff mode and regular format mode, show success
-                    println!(
-                        "{} {}",
-                        pcb_ui::icons::success(),
-                        file_name.with_style(Style::Green).bold()
-                    );
-                }
-            }
-            Err(e) => {
-                spinner.error(format!("{file_name}: Format failed"));
-                eprintln!("Error: {e}");
-                all_formatted = false;
-            }
-        }
-    }
+    // Process files with streaming approach
+    let (all_formatted, files_needing_format) = process_files(&formatter, &args.paths, &args)?;
 
     // Handle check mode results
     if args.check && !all_formatted {
-        eprintln!("\n{} files need formatting:", files_needing_format.len());
-        for file in &files_needing_format {
-            eprintln!("  {}", file.display());
-        }
+        eprintln!("\n{} files need formatting.", files_needing_format.len());
         eprintln!(
             "\nRun 'pcb fmt {}' to format these files.",
             files_needing_format

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 mod bom;
 mod build;
 mod clean;
+mod file_walker;
 mod fmt;
 mod info;
 mod layout;

--- a/crates/pcb/src/open.rs
+++ b/crates/pcb/src/open.rs
@@ -4,7 +4,7 @@ use inquire::Select;
 use pcb_layout::utils;
 use std::path::{Path, PathBuf};
 
-use crate::build::collect_files;
+use crate::file_walker;
 
 #[derive(Args, Debug)]
 pub struct OpenArgs {
@@ -19,9 +19,9 @@ pub fn execute(args: OpenArgs) -> Result<()> {
 
 fn open_layout(zen_paths: Vec<PathBuf>) -> Result<()> {
     // Collect .zen files to process
-    let zen_paths = collect_files(&zen_paths)?;
+    let zen_files = file_walker::collect_zen_files(&zen_paths, false)?;
 
-    if zen_paths.is_empty() {
+    if zen_files.is_empty() {
         // Try to find a layout file in the current directory
         let cwd = std::env::current_dir()?;
         let layout_files: Vec<_> = std::fs::read_dir(&cwd)?
@@ -54,7 +54,7 @@ fn open_layout(zen_paths: Vec<PathBuf>) -> Result<()> {
     let mut available_layouts = Vec::new();
 
     // Process each .zen/.zen file to find available layouts
-    for zen_path in zen_paths {
+    for zen_path in zen_files {
         let file_name = zen_path.file_name().unwrap().to_string_lossy();
 
         // Evaluate the zen file


### PR DESCRIPTION
By default:
```
/// - Always recursive traversal
/// - Always skips vendor/ directories  
/// - Always respects git ignore patterns
/// - Filters to .zen files only
```