### PR TITLE
Re-tag "latest" on push to `main`

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -38,8 +38,9 @@ jobs:
 
       - name: Update latest prerelease
         run: |
-          # Delete existing prerelease if it exists
+          # Delete existing prerelease and tag if they exist
           gh release delete latest --yes || true
+          git push origin --delete refs/tags/latest || true
           # Create new prerelease
           gh release create latest target/release/pcb \
             --title "Latest Main Build" \


### PR DESCRIPTION
Currently, we only delete + push the release. But the release still points to the old tag.