### PR TITLE
Add support for kicad schematic bom as fallback

### DIFF
--- a/crates/pcb-sch/src/bom.rs
+++ b/crates/pcb-sch/src/bom.rs
@@ -535,7 +535,7 @@ fn extract_kicad_symbol_entry(
         package: properties
             .get("Footprint")
             .or_else(|| properties.get("Package"))
-            .cloned(),
+            .map(|pkg| pkg.split(':').next_back().unwrap_or(pkg).to_string()),
         value: properties.get("Value").cloned(),
         description: properties.get("Description").cloned(),
         generic_data: None,

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -18,7 +18,10 @@ pub mod kicad_schematic;
 pub mod position;
 
 // Re-export BOM functionality
-pub use bom::{Bom, BomMatchingKey, BomMatchingRule, GenericMatchingKey, Offer};
+pub use bom::{
+    bom_from_kicad_schematic, bom_from_kicad_schematic_file, Bom, BomMatchingKey, BomMatchingRule,
+    GenericMatchingKey, KiCadBomError, Offer,
+};
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -19,8 +19,8 @@ pub mod position;
 
 // Re-export BOM functionality
 pub use bom::{
-    bom_from_kicad_schematic, bom_from_kicad_schematic_file, Bom, BomMatchingKey, BomMatchingRule,
-    GenericMatchingKey, KiCadBomError, Offer,
+    bom_from_kicad_schematic, bom_from_kicad_schematic_file, generate_bom_with_fallback, Bom,
+    BomMatchingKey, BomMatchingRule, GenericMatchingKey, KiCadBomError, Offer,
 };
 
 use std::collections::HashMap;


### PR DESCRIPTION
If there is no Zen BOM and there is a kicad_sch file, then try to parse BOM from the kicad_sch file instead and generate our standard-structure design BOM.

This also works with the `pcb bom` command.

Example releases:
- https://app.diode.computer/singularity/SN0001/releases/a772b2f7-b371-4ee6-86f9-7603f3f6db97/bom
- https://app.diode.computer/singularity/SN0002/releases/4e0647e2-c4be-42c6-9b4c-f5d1812655eb/bom