### PR TITLE
Fail gracefully when current file has no spec

### DIFF
--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -245,6 +245,11 @@ pub fn sync_tracked_files(
 ) -> Result<usize> {
     let mut synced_files = 0;
     for (path, load_spec) in tracked_files {
+        // Skip paths that don't exist to avoid panics
+        if !path.exists() {
+            log::debug!("Skipping non-existent path: {}", path.display());
+            continue;
+        }
         let dest_path = if load_spec.is_remote() {
             // remote file
             vendor_dir.join(load_spec.vendor_path()?)


### PR DESCRIPTION
LSP should never panic. Just propagate the error to the client. This should just be a transient state. Also, remove redundant file existence check.