### PR TITLE
Bunch of minor fixes from testing against read boards

### DIFF
--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -358,8 +358,11 @@ fn patch_stackup_if_needed(pcb_path: &Path, board_config_json: &str) -> Result<(
 
     info!("Updating stackup configuration in {}", pcb_path.display());
 
+    // Get number of user layers from board config
+    let num_user_layers = board_config.num_user_layers;
+
     // Generate new S-expressions
-    let layers_sexpr = zen_stackup.generate_layers_sexpr();
+    let layers_sexpr = zen_stackup.generate_layers_sexpr(num_user_layers);
     let stackup_sexpr = zen_stackup.generate_stackup_sexpr();
 
     // Use surgical string replacement to avoid parsing issues with hex numbers
@@ -391,7 +394,6 @@ fn replace_section_in_pcb_content(
         // Replace the section with the new content
         let mut result = String::with_capacity(content.len() + new_section.len());
         result.push_str(&content[..start_pos]);
-        result.push('\t');
         result.push_str(new_section);
         result.push_str(&content[end_pos + 1..]);
         Ok(result)

--- a/examples/board_config.zen
+++ b/examples/board_config.zen
@@ -70,6 +70,8 @@ NetClass = record(
     microvia_drill=field(float | None, None),  # Microvia drill/hole in mm
     diff_pair_width=field(float | None, None),  # Differential pair width in mm
     diff_pair_gap=field(float | None, None),  # Differential pair gap in mm
+    diff_pair_via_gap=field(float | None, None),  # Differential pair via gap in mm
+    priority=field(int | None, None),  # Priority for netclass resolution (higher = higher priority)
     color=field(str | None, None),  # PCB color (hex like "#FF0000" or CSS name)
 )
 
@@ -104,12 +106,12 @@ DielectricLayer = record(
 
 # Board stackup configuration
 Stackup = record(
-    materials=field(list | None, None),  # List of Material objects
+    materials=field(list[Material] | None, None),  # List of Material objects
     silk_screen_color=field(str | None, None),  # Hex color like "#44805BFF"
     solder_mask_color=field(str | None, None),  # Hex color like "#191919E6"
     thickness=field(float | None, None),  # Total thickness in mm
     symmetric=field(bool | None, None),  # Assert symmetric stackup (default: True)
-    layers=field(list | None, None),  # Ordered list of stackup layers
+    layers=field(list[CopperLayer | DielectricLayer] | None, None),  # Ordered list of stackup layers
     copper_finish=field(str | None, None),  # Surface finish: "ENIG", "HAL SnPb", "HAL lead-free"
 )
 
@@ -117,6 +119,7 @@ Stackup = record(
 BoardConfig = record(
     design_rules=field(DesignRules | None, None),
     stackup=field(Stackup | None, None),  # Board stackup configuration
+    num_user_layers=field(int, 4),  # Number of User.N layers (User.1, User.2, etc.)
 )
 
 


### PR DESCRIPTION
- Make # of user layers configurable (defaults to 4)
- Preserve all kicad standard technical layers
- Add 0 value placeholder entries for predefined sizes
- Fix layers sexpr formatting
- Make netclass diff_pair_via_gap and priority configureable
- For "Default" netclass, modify the default
- Add better type hints