### PR TITLE
Add `builtin.add_electrical_check`

### DIFF
--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -196,6 +196,12 @@ impl ModuleConverter {
         } else if value.downcast_ref::<FrozenTestBenchValue>().is_some() {
             // Skip TestBench values - they're not part of the schematic
             Ok(())
+        } else if value
+            .downcast_ref::<crate::lang::electrical_check::FrozenElectricalCheck>()
+            .is_some()
+        {
+            // Skip ElectricalCheck values - they're not part of the schematic
+            Ok(())
         } else {
             Err(anyhow::anyhow!("Unexpected value in module: {}", value))
         }
@@ -208,6 +214,10 @@ impl ModuleConverter {
             Ok(component_value.name().to_string())
         } else if let Some(testbench) = value.downcast_ref::<FrozenTestBenchValue>() {
             Ok(testbench.name().to_string())
+        } else if let Some(check) =
+            value.downcast_ref::<crate::lang::electrical_check::FrozenElectricalCheck>()
+        {
+            Ok(check.name.clone())
         } else {
             Err(anyhow::anyhow!("Unexpected value in module: {}", value))
         }

--- a/crates/pcb-zen-core/src/lang/electrical_check.rs
+++ b/crates/pcb-zen-core/src/lang/electrical_check.rs
@@ -1,0 +1,91 @@
+#![allow(clippy::needless_lifetimes)]
+
+use allocative::Allocative;
+use starlark::collections::SmallMap;
+use starlark::eval::Evaluator;
+use starlark::values::{starlark_value, ValueLike};
+use starlark::{
+    any::ProvidesStaticType,
+    starlark_complex_value,
+    values::{Coerce, Freeze, NoSerialize, StarlarkValue, Trace, Value, ValueLifetimeless},
+};
+
+use crate::Diagnostic;
+
+#[derive(Clone, Coerce, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
+#[repr(C)]
+pub struct ElectricalCheckGen<V: ValueLifetimeless> {
+    pub name: String,
+    pub inputs: SmallMap<String, V>,
+    pub check_func: V,
+    pub severity: String,
+    pub source_path: String,
+    #[freeze(identity)]
+    #[allocative(skip)]
+    pub call_span: Option<starlark::codemap::ResolvedSpan>,
+}
+
+starlark_complex_value!(pub ElectricalCheck);
+
+#[starlark_value(type = "ElectricalCheck")]
+impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for ElectricalCheckGen<V> where
+    Self: ProvidesStaticType<'v>
+{
+}
+
+impl<'v, V: ValueLike<'v>> std::fmt::Display for ElectricalCheckGen<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ElectricalCheck({})", self.name)
+    }
+}
+
+impl<'v, V: ValueLike<'v>> std::fmt::Debug for ElectricalCheckGen<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ElectricalCheck")
+            .field("name", &self.name)
+            .field("inputs", &self.inputs.len())
+            .finish()
+    }
+}
+
+/// Execute a single electrical check and create diagnostic
+pub fn execute_electrical_check<'v, V: ValueLike<'v>>(
+    eval: &mut Evaluator<'v, '_, '_>,
+    check: &ElectricalCheckGen<V>,
+    module_value: Value<'v>,
+) -> Diagnostic {
+    use starlark::errors::EvalSeverity;
+
+    let kwargs: Vec<_> = check
+        .inputs
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.to_value()))
+        .collect();
+
+    let result = eval.eval_function(check.check_func.to_value(), &[module_value], &kwargs);
+    let passed = result.is_ok();
+
+    let failure_severity = match check.severity.as_str() {
+        "warning" => EvalSeverity::Warning,
+        "advice" => EvalSeverity::Advice,
+        _ => EvalSeverity::Error,
+    };
+
+    Diagnostic {
+        path: check.source_path.clone(),
+        span: check.call_span,
+        severity: if passed {
+            EvalSeverity::Advice
+        } else {
+            failure_severity
+        },
+        body: format!(
+            "Electrical check '{}' {}",
+            check.name,
+            if passed { "passed" } else { "failed" }
+        ),
+        call_stack: None,
+        child: result.err().map(|e| Box::new(Diagnostic::from(e))),
+        source_error: None,
+    }
+}

--- a/crates/pcb-zen-core/src/lang/mod.rs
+++ b/crates/pcb-zen-core/src/lang/mod.rs
@@ -1,6 +1,7 @@
 pub mod builtin;
 pub mod component;
 pub(crate) mod context;
+pub mod electrical_check;
 pub mod eval;
 pub(crate) mod evaluator_ext;
 pub mod input;

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -660,6 +660,30 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
     }
 }
 
+impl FrozenModuleValue {
+    /// Collect all ElectricalCheck values with their defining modules (recursively)
+    pub fn collect_electrical_checks(
+        &self,
+    ) -> Vec<(
+        &crate::lang::electrical_check::FrozenElectricalCheck,
+        &FrozenModuleValue,
+    )> {
+        let mut checks = Vec::new();
+        for child in &self.children {
+            let child_value = child.to_value();
+            if let Some(check) =
+                child_value.downcast_ref::<crate::lang::electrical_check::FrozenElectricalCheck>()
+            {
+                checks.push((check, self));
+            }
+            if let Some(module) = child_value.downcast_ref::<FrozenModuleValue>() {
+                checks.extend(module.collect_electrical_checks());
+            }
+        }
+        checks
+    }
+}
+
 #[derive(Clone, Debug, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
 pub struct ModuleLoader {
     pub name: String,

--- a/crates/pcb-zen/src/diagnostics.rs
+++ b/crates/pcb-zen/src/diagnostics.rs
@@ -63,8 +63,9 @@ fn render_diagnostic(diagnostic: &Diagnostic) {
     // Identify deepest message in the chain.
     let deepest_error_msg: &Diagnostic = messages.last().copied().unwrap_or(diagnostic);
 
-    // Determine ReportKind from deepest error severity (more relevant).
-    let kind = match deepest_error_msg.severity {
+    // Determine ReportKind from parent (outermost) diagnostic severity
+    // This allows wrapper diagnostics (like electrical checks) to control the severity
+    let kind = match diagnostic.severity {
         EvalSeverity::Error => ReportKind::Error,
         EvalSeverity::Warning => ReportKind::Warning,
         EvalSeverity::Advice => ReportKind::Advice,

--- a/crates/pcb/tests/electrical_checks.rs
+++ b/crates/pcb/tests/electrical_checks.rs
@@ -1,0 +1,108 @@
+#![cfg(not(target_os = "windows"))]
+
+use pcb_test_utils::assert_snapshot;
+use pcb_test_utils::sandbox::Sandbox;
+
+#[test]
+fn test_electrical_check_error_severity() {
+    let output = Sandbox::new()
+        .write(
+            "board.zen",
+            r#"
+def check_critical(module):
+    error("Critical check failed")
+
+builtin.add_electrical_check(
+    name="critical",
+    check_fn=check_critical,
+)
+"#,
+        )
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert_snapshot!("error_severity", output);
+}
+
+#[test]
+fn test_electrical_check_warning_severity() {
+    let output = Sandbox::new()
+        .write(
+            "board.zen",
+            r#"
+def check_recommended(module, min_value):
+    if min_value > 5:
+        error("Recommended value should be at least {}".format(min_value))
+
+builtin.add_electrical_check(
+    name="recommended",
+    check_fn=check_recommended,
+    inputs={"min_value": 10},
+    severity="warning",
+)
+"#,
+        )
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert_snapshot!("warning_severity", output);
+}
+
+#[test]
+fn test_electrical_check_passing() {
+    let output = Sandbox::new()
+        .write(
+            "board.zen",
+            r#"
+def check_passes(module):
+    # No error means check passes
+    pass
+
+builtin.add_electrical_check(
+    name="passing_check",
+    check_fn=check_passes,
+)
+"#,
+        )
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert_snapshot!("passing_check", output);
+}
+
+#[test]
+fn test_electrical_check_invalid_severity() {
+    let output = Sandbox::new()
+        .write(
+            "board.zen",
+            r#"
+def check_fn(module):
+    pass
+
+builtin.add_electrical_check(
+    name="test",
+    check_fn=check_fn,
+    severity="invalid",
+)
+"#,
+        )
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert_snapshot!("invalid_severity", output);
+}
+
+#[test]
+fn test_electrical_check_with_inputs() {
+    let output = Sandbox::new()
+        .write(
+            "board.zen",
+            r#"
+def check_range(module, min_val, max_val, name):
+    actual = 150
+    if actual < min_val or actual > max_val:
+        error("{} out of range {}-{}: got {}".format(name, min_val, max_val, actual))
+
+builtin.add_electrical_check(
+    name="range_check",
+    check_fn=check_range,
+    inputs={"min_val": 0, "max_val": 100, "name": "voltage"},
+    severity="warning",
+)
+"#,
+        )
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert_snapshot!("with_inputs", output);
+}

--- a/crates/pcb/tests/snapshots/build__deny_warnings_flag.snap
+++ b/crates/pcb/tests/snapshots/build__deny_warnings_flag.snap
@@ -19,5 +19,5 @@ Error: '@github/mycompany/components:main' is an unstable reference. Use a pinne
 Stack trace (most recent call last):
     <TEMP_DIR>/board.zen:2:18 ('@github/mycompany/components:main' is an unstable reference. Use a pinned version.)
 
-✓ board.zen (1 components)
+✗ board.zen: Build failed
 Error: Build failed with errors

--- a/crates/pcb/tests/snapshots/electrical_checks__error_severity.snap
+++ b/crates/pcb/tests/snapshots/electrical_checks__error_severity.snap
@@ -1,0 +1,32 @@
+---
+source: crates/pcb/tests/electrical_checks.rs
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 1
+
+--- STDOUT ---
+
+--- STDERR ---
+Error: Critical check failed
+   ╭─[ <TEMP_DIR>/board.zen:3:5 ]
+   │
+ 3 │         error("Critical check failed")
+   │         ───────────────┬──────────────  
+   │                        ╰──────────────── Critical check failed
+   │ 
+ 5 │ ╭─▶ builtin.add_electrical_check(
+   ┆ ┆   
+ 8 │ ├─▶ )
+   │ │       
+   │ ╰─────── Electrical check 'critical' failed
+───╯
+
+Stack trace (most recent call last):
+    <TEMP_DIR>/board.zen:5:1 (Electrical check 'critical' failed)
+    <TEMP_DIR>/board.zen:3:5 (Critical check failed)
+      ├─ check_critical
+      ╰─ error (called from <TEMP_DIR>/board.zen:3:5-35)
+
+✗ board.zen: Build failed
+Error: Build failed with errors

--- a/crates/pcb/tests/snapshots/electrical_checks__invalid_severity.snap
+++ b/crates/pcb/tests/snapshots/electrical_checks__invalid_severity.snap
@@ -1,0 +1,26 @@
+---
+source: crates/pcb/tests/electrical_checks.rs
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 1
+
+--- STDOUT ---
+
+--- STDERR ---
+Error: Invalid severity 'invalid'. Must be 'error', 'warning', or 'advice'
+   ╭─[ <TEMP_DIR>/board.zen:5:1 ]
+   │
+ 5 │ ╭─▶ builtin.add_electrical_check(
+   ┆ ┆   
+ 9 │ ├─▶ )
+   │ │       
+   │ ╰─────── Invalid severity 'invalid'. Must be 'error', 'warning', or 'advice'
+───╯
+
+Stack trace (most recent call last):
+    <TEMP_DIR>/board.zen:5:1 (Invalid severity 'invalid'. Must be 'error', 'warning', or 'advice')
+      ╰─ add_electrical_check (called from <TEMP_DIR>/board.zen:5:1-9:2)
+
+✗ board.zen: Build failed
+Error: Build failed with errors

--- a/crates/pcb/tests/snapshots/electrical_checks__passing_check.snap
+++ b/crates/pcb/tests/snapshots/electrical_checks__passing_check.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pcb/tests/electrical_checks.rs
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+✓ board.zen (0 components)

--- a/crates/pcb/tests/snapshots/electrical_checks__warning_severity.snap
+++ b/crates/pcb/tests/snapshots/electrical_checks__warning_severity.snap
@@ -1,0 +1,31 @@
+---
+source: crates/pcb/tests/electrical_checks.rs
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+Warning: Recommended value should be at least 10
+    ╭─[ <TEMP_DIR>/board.zen:4:9 ]
+    │
+  4 │             error("Recommended value should be at least {}".format(min_value))
+    │             ─────────────────────────────────┬────────────────────────────────  
+    │                                              ╰────────────────────────────────── Recommended value should be at least 10
+    │ 
+  6 │ ╭─▶ builtin.add_electrical_check(
+    ┆ ┆   
+ 11 │ ├─▶ )
+    │ │       
+    │ ╰─────── Electrical check 'recommended' failed
+────╯
+
+Stack trace (most recent call last):
+    <TEMP_DIR>/board.zen:6:1 (Electrical check 'recommended' failed)
+    <TEMP_DIR>/board.zen:4:9 (Recommended value should be at least 10)
+      ├─ check_recommended
+      ╰─ error (called from <TEMP_DIR>/board.zen:4:9-75)
+
+✓ board.zen (0 components)

--- a/crates/pcb/tests/snapshots/electrical_checks__with_inputs.snap
+++ b/crates/pcb/tests/snapshots/electrical_checks__with_inputs.snap
@@ -1,0 +1,31 @@
+---
+source: crates/pcb/tests/electrical_checks.rs
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+Warning: voltage out of range 0-100: got 150
+    ╭─[ <TEMP_DIR>/board.zen:5:9 ]
+    │
+  5 │             error("{} out of range {}-{}: got {}".format(name, min_val, max_val, actual))
+    │             ──────────────────────────────────────┬──────────────────────────────────────  
+    │                                                   ╰──────────────────────────────────────── voltage out of range 0-100: got 150
+    │ 
+  7 │ ╭─▶ builtin.add_electrical_check(
+    ┆ ┆   
+ 12 │ ├─▶ )
+    │ │       
+    │ ╰─────── Electrical check 'range_check' failed
+────╯
+
+Stack trace (most recent call last):
+    <TEMP_DIR>/board.zen:7:1 (Electrical check 'range_check' failed)
+    <TEMP_DIR>/board.zen:5:9 (voltage out of range 0-100: got 150)
+      ├─ check_range
+      ╰─ error (called from <TEMP_DIR>/board.zen:5:9-86)
+
+✓ board.zen (0 components)

--- a/crates/pcb/tests/snapshots/path__path_local_mixed_release.snap
+++ b/crates/pcb/tests/snapshots/path__path_local_mixed_release.snap
@@ -51,6 +51,7 @@ Error: Path 'missing_dir' does not exist
 Stack trace (most recent call last):
     <TEMP_DIR>/.pcb/releases/LocalPathTest-unknown/src/boards/LocalPathTest.zen:8:19 (Path 'missing_dir' does not exist)
 
+✗ LocalPathTest.zen: Build failed
 ✗ Validating build from staged sources failed
 Error: Validating build from staged sources failed
 

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -806,6 +806,94 @@ See [PhysicalRange](#physicalrange) in Core Types for detailed information about
 
 This builtin is typically called through the stdlib `Board()` function rather than directly.
 
+### builtin.add_electrical_check(name, check_fn, inputs=None)
+
+**Built-in function** for registering electrical validation checks that run during `pcb build`.
+
+**Parameters:**
+- `name`: String identifier for the check (required)
+- `check_fn`: Function to execute for validation (required)
+- `inputs`: Optional dictionary of input parameters to pass to the check function
+
+Electrical checks use lazy evaluation - they are registered during module evaluation but execute after the design is fully evaluated. This allows checks to validate electrical properties, design rules, or other constraints across the entire design.
+
+The check function receives the module as its first argument, followed by any specified inputs as keyword arguments:
+
+```python
+def voltage_range_check(module, min_voltage, max_voltage):
+    """Check that supply voltage is within acceptable range"""
+    supply = module.supply_voltage
+    if supply < min_voltage or supply > max_voltage:
+        error("Supply voltage {} is outside range {}-{}".format(
+            supply, min_voltage, max_voltage
+        ))
+
+builtin.add_electrical_check(
+    name="supply_voltage_range",
+    check_fn=voltage_range_check,
+    inputs={
+        "min_voltage": 3.0,
+        "max_voltage": 5.5,
+    }
+)
+```
+
+**Check Function Signature:**
+```python
+def check_function(module, **kwargs):
+    # Validation logic
+    # Raise error() or fail assertion to indicate failure
+    pass
+```
+
+**Example - Basic Check:**
+```python
+def check_no_floating_nets(module):
+    """Ensure all nets are connected to at least 2 pins"""
+    for net in module.nets:
+        if len(net.pins) < 2:
+            error("Net '{}' is floating (only {} pin connected)".format(
+                net.name, len(net.pins)
+            ))
+
+builtin.add_electrical_check(
+    name="no_floating_nets",
+    check_fn=check_no_floating_nets
+)
+```
+
+**Example - Parameterized Check:**
+```python
+def check_power_capacity(module, max_current):
+    """Verify power supply can handle load current"""
+    total_load = sum([c.max_current for c in module.components])
+    if total_load > max_current:
+        error("Total load current {}A exceeds supply capacity {}A".format(
+            total_load, max_current
+        ))
+
+builtin.add_electrical_check(
+    name="power_capacity",
+    check_fn=check_power_capacity,
+    inputs={"max_current": 3.0}
+)
+```
+
+**Execution Model:**
+
+1. Checks are registered during module evaluation via `builtin.add_electrical_check()`
+2. Check functions and inputs are stored as frozen values
+3. During `pcb build`, after evaluation completes, all checks are collected from the module tree
+4. Each check executes with a fresh evaluator context
+5. Check failures generate error diagnostics that are reported through the standard diagnostic system
+6. Build fails if any electrical checks fail
+
+**Notes:**
+- Checks run only during `pcb build`, not during `pcb test` (use `TestBench` for test-specific validation)
+- Check failures generate error-level diagnostics
+- Checks can access the entire module structure, including components, nets, interfaces, and properties
+- Multiple checks with the same name are allowed (they execute independently)
+
 ## Board Configuration Types
 
 The board configuration record types are provided by `@stdlib/board_config.zen` and offer comprehensive control over PCB manufacturing specifications.

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -564,7 +564,7 @@ moved("ModuleA.ComponentX", "ModuleB.ComponentX")
 moved("AN_OLD_FILTERED_VCC_VCC", "FILTERED_VCC_VCC")
 ```
 
-### io(name, type, default=None, optional=False)
+### io(name, type, checks=None, default=None, optional=False)
 
 Declares a net or interface input for a module.
 
@@ -578,14 +578,31 @@ power = io("power", PowerInterface, optional=True)
 
 # With explicit default
 data = io("data", Net, default=Net("DATA"))
+
+# With validation checks (single function)
+def check_voltage_within(within):
+    def check_fn(power_value):
+        voltage = power_value.voltage
+        check(voltage.min >= within.min and voltage.max <= within.max,
+              f"Voltage {voltage} not within {within}")
+    return check_fn
+
+vbat = io("VBAT", Power, check_voltage_within(VoltageRange("10–30 V")))
+
+# Or with multiple checks as a list
+vbat = io("VBAT", Power, [check_voltage_within(VoltageRange("10–30 V")), check_current()])
+
+# Or as a named argument
+vbat = io("VBAT", Power, checks=check_voltage_within(VoltageRange("10–30 V")))
 ```
 
 **Parameters:**
 
-- `name`: String identifier for the input
-- `type`: Expected type (`Net` or interface type)
-- `default`: Default value if not provided by parent
-- `optional`: If True, returns None when not provided (unless default is specified)
+- `name`: String identifier for the input (positional)
+- `type`: Expected type - `Net` or interface type (positional)
+- `checks`: Optional check function or list of check functions to run on the value at eval time (3rd positional or named)
+- `default`: Default value if not provided by parent (named)
+- `optional`: If True, returns None when not provided (unless default is specified) (named)
 
 ### config(name, type, default=None, convert=None, optional=False)
 

--- a/examples/electrical_checks.zen
+++ b/examples/electrical_checks.zen
@@ -1,0 +1,139 @@
+# Comprehensive test of builtin.add_electrical_check with different severities
+
+# ============================================================================
+# ERROR SEVERITY CHECKS (default - fails build)
+# ============================================================================
+
+def check_critical_requirement(module):
+    """This check must pass or build fails"""
+    # Simulate a critical failure
+    error("Critical requirement not met - this fails the build")
+
+builtin.add_electrical_check(
+    name="critical_requirement",
+    check_fn=check_critical_requirement,
+    # severity defaults to "error"
+)
+
+# ============================================================================
+# WARNING SEVERITY CHECKS (doesn't fail build)
+# ============================================================================
+
+def check_recommended_practice(module, min_value):
+    """This check produces a warning but doesn't fail build"""
+    actual_value = 5
+    if actual_value < min_value:
+        error("Recommended: value should be at least {}, got {}".format(
+            min_value, actual_value
+        ))
+
+builtin.add_electrical_check(
+    name="recommended_practice",
+    check_fn=check_recommended_practice,
+    inputs={"min_value": 10},
+    severity="warning",
+)
+
+# ============================================================================
+# ADVICE SEVERITY CHECKS (informational only)
+# ============================================================================
+
+def check_optional_optimization(module, target):
+    """This check is purely informational"""
+    actual = 3
+    if actual != target:
+        error("Info: could optimize to {} (currently {})".format(target, actual))
+
+builtin.add_electrical_check(
+    name="optional_optimization",
+    check_fn=check_optional_optimization,
+    inputs={"target": 5},
+    severity="advice",
+)
+
+# ============================================================================
+# PASSING CHECKS (various severities)
+# ============================================================================
+
+def check_passing_error(module):
+    """This check passes - no diagnostic shown"""
+    # No error means check passes
+    pass
+
+builtin.add_electrical_check(
+    name="passing_error_check",
+    check_fn=check_passing_error,
+)
+
+def check_passing_warning(module, expected):
+    """This check passes with warning severity"""
+    if expected != 42:
+        error("Should be 42")
+
+builtin.add_electrical_check(
+    name="passing_warning_check",
+    check_fn=check_passing_warning,
+    inputs={"expected": 42},
+    severity="warning",
+)
+
+# ============================================================================
+# PARAMETERIZED CHECKS
+# ============================================================================
+
+def check_with_multiple_params(module, min_val, max_val, name):
+    """Check with multiple input parameters"""
+    actual = 50
+    if actual < min_val or actual > max_val:
+        error("{} out of range {}-{}: got {}".format(
+            name, min_val, max_val, actual
+        ))
+
+builtin.add_electrical_check(
+    name="range_check",
+    check_fn=check_with_multiple_params,
+    inputs={
+        "min_val": 0,
+        "max_val": 100,
+        "name": "voltage",
+    },
+    severity="warning",
+)
+
+# ============================================================================
+# EDGE CASES
+# ============================================================================
+
+# Check with no inputs
+def check_no_inputs(module):
+    """Check without any input parameters"""
+    pass
+
+builtin.add_electrical_check(
+    name="no_inputs_check",
+    check_fn=check_no_inputs,
+    severity="advice",
+)
+
+# Check that uses check() builtin instead of error()
+def check_using_check_builtin(module, value):
+    """Using check() instead of error()"""
+    check(value > 0, "value must be positive, got {}".format(value))
+
+builtin.add_electrical_check(
+    name="check_builtin_usage",
+    check_fn=check_using_check_builtin,
+    inputs={"value": -5},
+    severity="warning",
+)
+
+# ============================================================================
+# INVALID SEVERITY TEST (commented out - would fail immediately)
+# ============================================================================
+
+# Uncomment to test invalid severity validation:
+# builtin.add_electrical_check(
+#     name="invalid_severity",
+#     check_fn=check_no_inputs,
+#     severity="invalid",  # Should error immediately
+# )

--- a/examples/power_checks.zen
+++ b/examples/power_checks.zen
@@ -1,0 +1,67 @@
+VoltageRange = builtin.physical_range("V")
+
+Severity = enum("error", "warning", "advice")
+
+
+def ElectricalCheck(check_fn: typing.Callable, *args):
+    check_fn(*args)
+
+
+Power = interface(
+    NET=using(Net("VCC", symbol=Symbol(library="@kicad-symbols/power.kicad_sym", name="VCC"))),
+    voltage=field(VoltageRange | None, None),
+)
+
+
+def ensure_voltage_within(_module, voltage: Power | VoltageRange | None, within: str | VoltageRange):
+    if not voltage:
+        return
+    if isinstance(voltage, Power):
+        voltage = voltage.voltage
+    if isinstance(within, str):
+        within = VoltageRange(within)
+    # drop nominal in within:
+    within = VoltageRange(min=within.min, max=within.max)
+    # ensure voltage is within within
+    min_valid = voltage.min >= within.min
+    max_valid = voltage.max <= within.max
+    check(min_valid and max_valid, "Voltage range " + str(voltage) + " is not within " + str(within))
+
+
+def check_voltage_within(
+    within: str | VoltageRange, name: str = "voltage_check", severity: Severity = Severity("error")
+) -> typing.Callable[[Power | VoltageRange], None]:
+    def check_gen(voltage: Power | VoltageRange):
+        check_name = name
+        if not voltage:
+            return
+        if isinstance(voltage, Power):
+            check_name = voltage.NET.name + "_" + name
+            voltage = voltage.voltage
+        builtin.add_electrical_check(
+            name=check_name,
+            check_fn=ensure_voltage_within,
+            inputs={"voltage": voltage, "within": within},
+            severity=severity.value,
+        )
+
+    return check_gen
+
+
+# Option 1: Use builtin.add_electrical_check
+vbat = Power("VBAT", voltage=VoltageRange("11–26 V (12 V nom.)"))
+builtin.add_electrical_check(
+    name="vbat_voltage_check",
+    check_fn=ensure_voltage_within,
+    inputs={"voltage": vbat, "within": "10–30 V"},
+)
+
+# Option 2: Use stdlib ElectricalCheck
+vbat = Power("VBAT", voltage=VoltageRange("11–26 V (12 V nom.)"))
+ElectricalCheck(
+    check_voltage_within("10–30 V", severity=Severity("warning")),
+    vbat,
+)
+
+# Option 3: Use helper in io()
+vbat = io("VBAT", Power, check_voltage_within("20–30 V"))

--- a/examples/power_checks.zen
+++ b/examples/power_checks.zen
@@ -13,57 +13,37 @@ Power = interface(
 )
 
 
-def ensure_voltage_within(_module, voltage: Power | VoltageRange | None, within: str | VoltageRange):
-    if not voltage:
-        return
-    if isinstance(voltage, Power):
-        voltage = voltage.voltage
-    if isinstance(within, str):
-        within = VoltageRange(within)
-    # drop nominal in within:
-    within = VoltageRange(min=within.min, max=within.max)
-    # ensure voltage is within within
-    min_valid = voltage.min >= within.min
-    max_valid = voltage.max <= within.max
-    check(min_valid and max_valid, "Voltage range " + str(voltage) + " is not within " + str(within))
-
-
 def check_voltage_within(
     within: str | VoltageRange, name: str = "voltage_check", severity: Severity = Severity("error")
 ) -> typing.Callable:
-    def check_gen(voltage: Power | VoltageRange, severity: Severity = severity, name: str = name):
-        check_name = name
-        if not voltage:
+    def ensure_voltage_within(_module, net_name: str, voltage: VoltageRange, within: str | VoltageRange):
+        within = VoltageRange(within)
+        # drop nominal in within:
+        within = VoltageRange(min=within.min, max=within.max)
+        # ensure voltage is within within
+        min_valid = voltage.min >= within.min
+        max_valid = voltage.max <= within.max
+        err_msg = "Voltage range " + str(voltage) + " of " + net_name + " is not within " + str(within)
+        check(min_valid and max_valid, err_msg)
+    def check_gen(power: Power, severity: Severity = severity, name: str = name):
+        check_name = power.NET.name + "_" + name
+        if not power.voltage:
             return
-        if isinstance(voltage, Power):
-            check_name = voltage.NET.name + "_" + name
-            voltage = voltage.voltage
         builtin.add_electrical_check(
             name=check_name,
             check_fn=ensure_voltage_within,
-            inputs={"voltage": voltage, "within": within},
+            inputs={"voltage": power.voltage, "within": within, "net_name": power.NET.name},
             severity=severity.value,
         )
-
     return check_gen
 
-
-# Option 1: Use builtin.add_electrical_check
-vbat = Power("VBAT", voltage=VoltageRange("11–26 V (12 V nom.)"))
-builtin.add_electrical_check(
-    name="vbat_voltage_check",
-    check_fn=ensure_voltage_within,
-    inputs={"voltage": vbat, "within": "10–30 V"},
-)
-
-# Option 2: Use stdlib ElectricalCheck
+# Option 1: Use stdlib ElectricalCheck
 vbat = Power("VBAT", voltage=VoltageRange("11–26 V (12 V nom.)"))
 ElectricalCheck(
-    name="override_name",
     severity=Severity("warning"),
-    check_fn=check_voltage_within("20–30 V"),
-    voltage=vbat,
+    check_fn=check_voltage_within(VoltageRange("20–30 V")),
+    power=vbat,
 )
 
-# Option 3: Use helper in io()
+# Option 2: Use helper in io()
 vbat = io("VBAT", Power, check_voltage_within("20–30 V"))

--- a/examples/power_checks.zen
+++ b/examples/power_checks.zen
@@ -3,8 +3,8 @@ VoltageRange = builtin.physical_range("V")
 Severity = enum("error", "warning", "advice")
 
 
-def ElectricalCheck(check_fn: typing.Callable, *args):
-    check_fn(*args)
+def ElectricalCheck(check_fn: typing.Callable, **kwargs):
+    check_fn(**kwargs)
 
 
 Power = interface(
@@ -30,8 +30,8 @@ def ensure_voltage_within(_module, voltage: Power | VoltageRange | None, within:
 
 def check_voltage_within(
     within: str | VoltageRange, name: str = "voltage_check", severity: Severity = Severity("error")
-) -> typing.Callable[[Power | VoltageRange], None]:
-    def check_gen(voltage: Power | VoltageRange):
+) -> typing.Callable:
+    def check_gen(voltage: Power | VoltageRange, severity: Severity = severity, name: str = name):
         check_name = name
         if not voltage:
             return
@@ -59,8 +59,10 @@ builtin.add_electrical_check(
 # Option 2: Use stdlib ElectricalCheck
 vbat = Power("VBAT", voltage=VoltageRange("11–26 V (12 V nom.)"))
 ElectricalCheck(
-    check_voltage_within("10–30 V", severity=Severity("warning")),
-    vbat,
+    name="override_name",
+    severity=Severity("warning"),
+    check_fn=check_voltage_within("20–30 V"),
+    voltage=vbat,
 )
 
 # Option 3: Use helper in io()


### PR DESCRIPTION
This is the precursor to erc checks with more syntactic sugar, but this is enough to do a lot in stdlib.

Check fns are evaluated lazily. There are provided the frozen module as well as the inputs. No fancy reporting like `pcb test`. We just raise warning/error diagnostics based on the results of the check fn. Severity can be set through an argument, so we can warning-only checks, or even ignore checks by dropping them to "advice" severity.