### PR TITLE
Fix single-net interface net naming

### DIFF
--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -105,17 +105,20 @@ fn is_single_net_interface<'v, V>(factory: &InterfaceFactoryGen<V>) -> bool
 where
     V: ValueLike<'v> + InterfaceCell,
 {
-    if factory.fields.len() != 1 {
-        return false;
+    let mut net_field_count = 0;
+    let mut interface_field_count = 0;
+
+    for (_name, field_spec) in factory.fields.iter() {
+        let field_type = field_spec.to_value().get_type();
+        if field_type == "Net" || field_type == "NetType" {
+            net_field_count += 1;
+        } else if field_type == "InterfaceFactory" || field_type == "InterfaceValue" {
+            interface_field_count += 1;
+        }
     }
 
-    // Check if the single field is a Net type
-    if let Some((_field_name, field_spec)) = factory.fields.iter().next() {
-        let field_type = field_spec.to_value().get_type();
-        field_type == "Net" || field_type == "NetType"
-    } else {
-        false
-    }
+    // Single net interface: exactly 1 net field and no interface fields
+    net_field_count == 1 && interface_field_count == 0
 }
 
 /// Get promotion key for any value

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_comprehensive_net_promotion.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_comprehensive_net_promotion.snap
@@ -3,15 +3,15 @@ source: crates/pcb-zen-core/tests/interface.rs
 expression: output
 ---
 Basic Net promotion - Power -> Net: Net { name: "_VCC", id: "<ID>", symbol: Value(NoneType) }
-Deep promotion test - Level3 instance: Level3(level2=using(Level2(extra=42, level1=using(Level1(meta="level1", net=using(Net { name: "level2_level1_DEEP", id: "<ID>", symbol: Value(NoneType) }))))))
-Deep Net promotion - Level3 -> Net: Net { name: "level2_level1_DEEP", id: "<ID>", symbol: Value(NoneType) }
+Deep promotion test - Level3 instance: Level3(level2=using(Level2(extra=42, level1=using(Level1(meta="level1", net=using(Net { name: "level2_level1", id: "<ID>", symbol: Value(NoneType) }))))))
+Deep Net promotion - Level3 -> Net: Net { name: "level2_level1", id: "<ID>", symbol: Value(NoneType) }
 Intermediate promotions:
-  Level3 -> Level2: Level2(extra=42, level1=using(Level1(meta="level1", net=using(Net { name: "level2_level1_DEEP", id: "<ID>", symbol: Value(NoneType) }))))
-  Level3 -> Level1: Level1(meta="level1", net=using(Net { name: "level2_level1_DEEP", id: "<ID>", symbol: Value(NoneType) }))
+  Level3 -> Level2: Level2(extra=42, level1=using(Level1(meta="level1", net=using(Net { name: "level2_level1", id: "<ID>", symbol: Value(NoneType) }))))
+  Level3 -> Level1: Level1(meta="level1", net=using(Net { name: "level2_level1", id: "<ID>", symbol: Value(NoneType) }))
 Net consistency check:
-  Direct from Level3: Net { name: "level2_level1_DEEP", id: "<ID>", symbol: Value(NoneType) }
-  Via Level2: Net { name: "level2_level1_DEEP", id: "<ID>", symbol: Value(NoneType) }
-  Via Level1: Net { name: "level2_level1_DEEP", id: "<ID>", symbol: Value(NoneType) }
+  Direct from Level3: Net { name: "level2_level1", id: "<ID>", symbol: Value(NoneType) }
+  Via Level2: Net { name: "level2_level1", id: "<ID>", symbol: Value(NoneType) }
+  Via Level1: Net { name: "level2_level1", id: "<ID>", symbol: Value(NoneType) }
 Module {
     name: "<root>",
     source: "test.zen",

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_transitive_promotion.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_transitive_promotion.snap
@@ -27,7 +27,7 @@ expression: output
       "NET": {
         "Net": {
           "id": 9,
-          "name": "PWR_VCC",
+          "name": "PWR",
           "properties": {}
         }
       },
@@ -75,7 +75,7 @@ expression: output
             "NET": {
               "Net": {
                 "id": 12,
-                "name": "SYS_power_VCC",
+                "name": "SYS_power",
                 "properties": {}
               }
             },

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_using_chain_validation.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_using_chain_validation.snap
@@ -12,7 +12,7 @@ expression: output
             "NET": {
               "Net": {
                 "id": 10,
-                "name": "COMPLETE_power_VCC",
+                "name": "COMPLETE_power",
                 "properties": {}
               }
             },
@@ -68,7 +68,7 @@ expression: output
             "NET": {
               "Net": {
                 "id": 13,
-                "name": "BROKEN_power_VCC",
+                "name": "BROKEN_power",
                 "properties": {}
               }
             },

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_using_promotion_serialization.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_using_promotion_serialization.snap
@@ -9,7 +9,7 @@ expression: output
       "NET": {
         "Net": {
           "id": 11,
-          "name": "MAIN_VCC",
+          "name": "MAIN",
           "properties": {}
         }
       },
@@ -121,7 +121,7 @@ expression: output
             "NET": {
               "Net": {
                 "id": 19,
-                "name": "COMPLEX_power_field_VCC",
+                "name": "COMPLEX_power_field",
                 "properties": {}
               }
             },

--- a/crates/pcb-zen-core/tests/snapshots/interface__interface_using_serialization_roundtrip.snap
+++ b/crates/pcb-zen-core/tests/snapshots/interface__interface_using_serialization_roundtrip.snap
@@ -12,7 +12,7 @@ expression: output
             "NET": {
               "Net": {
                 "id": 7,
-                "name": "ORIGINAL_power_VCC",
+                "name": "ORIGINAL_power",
                 "properties": {}
               }
             },
@@ -68,7 +68,7 @@ expression: output
             "NET": {
               "Net": {
                 "id": 7,
-                "name": "ORIGINAL_power_VCC",
+                "name": "ORIGINAL_power",
                 "properties": {}
               }
             },
@@ -115,8 +115,8 @@ expression: output
   }
 }
 === Comparison ===
-Original: System(power=using(Power(NET=using(Net { name: "ORIGINAL_power_VCC", id: "<ID>", symbol: Value(NoneType) }), voltage="3.3V")), uart=using(Uart(RX=Net { name: "ORIGINAL_uart_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "ORIGINAL_uart_UART_TX", id: "<ID>", symbol: Value(NoneType) })))
-Deserialized: System(power=using(Power(NET=using(Net { name: "ORIGINAL_power_VCC", id: "<ID>", symbol: Value(NoneType) }), voltage="3.3V")), uart=using(Uart(RX=Net { name: "ORIGINAL_uart_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "ORIGINAL_uart_UART_TX", id: "<ID>", symbol: Value(NoneType) })))
+Original: System(power=using(Power(NET=using(Net { name: "ORIGINAL_power", id: "<ID>", symbol: Value(NoneType) }), voltage="3.3V")), uart=using(Uart(RX=Net { name: "ORIGINAL_uart_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "ORIGINAL_uart_UART_TX", id: "<ID>", symbol: Value(NoneType) })))
+Deserialized: System(power=using(Power(NET=using(Net { name: "ORIGINAL_power", id: "<ID>", symbol: Value(NoneType) }), voltage="3.3V")), uart=using(Uart(RX=Net { name: "ORIGINAL_uart_UART_RX", id: "<ID>", symbol: Value(NoneType) }, TX=Net { name: "ORIGINAL_uart_UART_TX", id: "<ID>", symbol: Value(NoneType) })))
 === Both factories still work ===
 New from original factory: {
   "Interface": {
@@ -127,7 +127,7 @@ New from original factory: {
             "NET": {
               "Net": {
                 "id": 10,
-                "name": "NEW_ORIGINAL_power_VCC",
+                "name": "NEW_ORIGINAL_power",
                 "properties": {}
               }
             },
@@ -182,7 +182,7 @@ New from deserialized factory: {
             "NET": {
               "Net": {
                 "id": 13,
-                "name": "NEW_DESERIALIZED_power_VCC",
+                "name": "NEW_DESERIALIZED_power",
                 "properties": {}
               }
             },

--- a/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_using_promotion_targets.snap
+++ b/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_using_promotion_targets.snap
@@ -66,7 +66,7 @@ expression: netlist
     (net (code "8") (name "GND")
       (node (ref "U1") (pin "3") (pintype "stereo"))
     )
-    (net (code "9") (name "MAIN_VCC")
+    (net (code "9") (name "MAIN")
       (node (ref "U1") (pin "2") (pintype "stereo"))
     )
     (net (code "10") (name "VIN")


### PR DESCRIPTION
Before: check that interface has 1 field and that it is a net
After: check that interface has 1 net field (and no interfaces)

This allows for adding metadata fields without changing the net naming.
This should (hopefully) not cause that much churn because we haven't
really used metadata fields in interfaces yet.

Signed-off-by: akhilles <akhilvelagapudi@gmail.com>
