### PR TITLE
Only delete worktrees on `pcb clean`

### DIFF
--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -131,6 +131,24 @@ pub fn fetch_in_bare_repo(bare_repo: &Path) -> anyhow::Result<()> {
     }
 }
 
+/// Prune stale worktree administrative data
+pub fn prune_worktrees(bare_repo: &Path) -> anyhow::Result<()> {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(bare_repo)
+        .arg("worktree")
+        .arg("prune")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("Git worktree prune failed"))
+    }
+}
+
 /// Create a worktree from a bare repository for a specific ref
 pub fn create_worktree(bare_repo: &Path, worktree_dir: &Path, rev: &str) -> anyhow::Result<()> {
     let status = Command::new("git")

--- a/crates/pcb-zen/src/load.rs
+++ b/crates/pcb-zen/src/load.rs
@@ -204,6 +204,10 @@ fn ensure_git_worktree(
     log::debug!("Fetching updates in bare repository");
     let _ = git::fetch_in_bare_repo(&bare_repo);
 
+    // Prune stale worktree metadata before creating new worktree
+    log::debug!("Pruning stale worktrees");
+    let _ = git::prune_worktrees(&bare_repo);
+
     // Create worktree for the specific ref
     log::debug!("Creating worktree for {rev}");
     git::create_worktree(&bare_repo, dest_dir, rev)?;

--- a/crates/pcb/src/clean.rs
+++ b/crates/pcb/src/clean.rs
@@ -3,11 +3,17 @@ use clap::Args;
 use pcb_zen::load::cache_dir;
 use pcb_zen_core::config::find_workspace_root;
 use pcb_zen_core::DefaultFileProvider;
+use std::fs;
+use walkdir::WalkDir;
 
 #[derive(Args, Debug)]
 #[command(about = "Clean generated files")]
 pub struct CleanArgs {
-    #[arg(short, long, help = "Remove all generated files")]
+    #[arg(
+        short,
+        long,
+        help = "Remove all cache files including shared repositories"
+    )]
     pub force: bool,
 
     #[arg(
@@ -34,16 +40,77 @@ pub fn execute(args: CleanArgs) -> Result<()> {
         }
     }
 
-    // Remove remote cache directory
+    // Handle remote cache directory
     if !args.keep_cache {
         if let Ok(cache_dir) = cache_dir() {
             if cache_dir.exists() {
-                println!("Removing cache directory {}", cache_dir.display());
-                std::fs::remove_dir_all(&cache_dir)?;
+                if args.force {
+                    // Force mode: delete everything
+                    println!("Removing cache directory {}", cache_dir.display());
+                    std::fs::remove_dir_all(&cache_dir)?;
+                } else {
+                    // Default mode: only delete worktree directories, keep .repo bare repos
+                    clean_worktrees(&cache_dir)?;
+                }
             }
         }
     }
 
     println!("Clean complete");
+    Ok(())
+}
+
+/// Clean only worktree directories, preserving .repo bare repositories and .repo.lock files
+fn clean_worktrees(cache_dir: &std::path::Path) -> Result<()> {
+    let mut deleted_count = 0;
+
+    // Walk through github/ and gitlab/ subdirectories
+    for provider in ["github", "gitlab"] {
+        let provider_dir = cache_dir.join(provider);
+        if !provider_dir.exists() {
+            continue;
+        }
+
+        // Walk through repos and find worktree directories
+        for entry in WalkDir::new(&provider_dir)
+            .min_depth(1)
+            .max_depth(10)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+
+            // Skip .repo directories, .repo.lock files, and anything inside .repo
+            if path.file_name().and_then(|n| n.to_str()) == Some(".repo")
+                || path.file_name().and_then(|n| n.to_str()) == Some(".repo.lock")
+                || path
+                    .ancestors()
+                    .any(|p| p.file_name().and_then(|n| n.to_str()) == Some(".repo"))
+            {
+                continue;
+            }
+
+            // If it's a directory that's not .repo, it's a worktree - delete it
+            if path.is_dir() && path != provider_dir {
+                // Check if this is a repo root level (contains .repo as sibling)
+                if let Some(parent) = path.parent() {
+                    if parent.join(".repo").exists() {
+                        println!("Removing {}", path.display());
+                        match fs::remove_dir_all(path) {
+                            Ok(()) => deleted_count += 1,
+                            Err(e) => {
+                                eprintln!("Warning: Failed to remove {}: {}", path.display(), e)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if deleted_count == 0 {
+        println!("No worktree directories to clean");
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Leave the bare repos as they're just stable object stores.

If `--force` is set, nuke everything.

Signed-off-by: akhilles <akhilvelagapudi@gmail.com>
