### PR TITLE
Fetch all tags and branches when updating git dependencies

### DIFF
--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -119,7 +119,12 @@ pub fn fetch_in_bare_repo(bare_repo: &Path) -> anyhow::Result<()> {
         .arg(bare_repo)
         .arg("fetch")
         .arg("origin")
+        .arg("--tags")
+        .arg("--force")
+        .arg("--prune")
+        .arg("--prune-tags")
         .arg("--quiet")
+        .arg("+refs/heads/*:refs/heads/*")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()?;


### PR DESCRIPTION
The previous implementation only fetched the default refspec, which could
miss new tags, branches, or force-updated refs. This caused worktree
creation to fail when trying to check out newly published versions.

Now explicitly fetches:
- All tags (--tags)
- All branches (+refs/heads/*:refs/heads/*)
- Force-updated refs (--force)
- Prunes deleted refs (--prune, --prune-tags)

Signed-off-by: akhilles <akhilvelagapudi@gmail.com>
