### PR TITLE
Fix flaky test race condition

### DIFF
--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -69,7 +69,7 @@ snapshot_eval!(component_with_symbol, {
 });
 
 snapshot_eval!(component_duplicate_pin_names, {
-    "test_symbol.kicad_sym" => r#"(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
+    "duplicate_pins_symbol.kicad_sym" => r#"(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
   (symbol "TestSymbol" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
     (property "Reference" "U" (id 0) (at 0 0 0))
     (symbol "TestSymbol_0_1"
@@ -95,7 +95,7 @@ snapshot_eval!(component_duplicate_pin_names, {
         Component(
             name = "test_comp",
             footprint = "test_footprint",
-            symbol = Symbol(library = "./test_symbol.kicad_sym"),
+            symbol = Symbol(library = "./duplicate_pins_symbol.kicad_sym"),
             pins = {
                 "in": Net("in"),
                 "out": Net("out"),

--- a/crates/pcb-zen-core/tests/snapshots/component__component_duplicate_pin_names.snap
+++ b/crates/pcb-zen-core/tests/snapshots/component__component_duplicate_pin_names.snap
@@ -36,7 +36,7 @@ Module {
                         "TestSymbol",
                     ),
                     "symbol_path": FrozenValue(
-                        "/test_symbol.kicad_sym",
+                        "/duplicate_pins_symbol.kicad_sym",
                     ),
                 },
                 symbol: FrozenValue(


### PR DESCRIPTION
Both component_duplicate_pin_names and
component_manufacturer_from_symbol were using test_symbol.kicad_sym,
which caused the contents of one test to be visible to the other. Use
different file names as a short-term fix for this.

Example CI flakes: https://github.com/diodeinc/pcb/actions/runs/18253545573/job/51971797596?pr=212

Signed-off-by: akhilles <akhilvelagapudi@gmail.com>
