### PR TITLE
Add `spec` to `BoardConfg()` and `datasheet` to `Component()`

### DIFF
--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -1949,8 +1949,12 @@ class ImportNetlist(Step):
             fp.GetFieldByName("Path").SetVisible(False)
 
             for prop in part.properties:
-                # Skip value, Reference, reference, and specially handled properties
-                if prop.name.lower() not in [
+                # Handle datasheet specially - use the built-in KiCad "Datasheet" field
+                if prop.name.lower() == "datasheet":
+                    fp.GetFieldByName("Datasheet").SetText(prop.value)
+                    fp.GetFieldByName("Datasheet").SetVisible(False)
+                # Skip built-in fields and specially handled properties
+                elif prop.name.lower() not in [
                     "value",
                     "reference",
                     "dnp",  # Skip the standardized dnp attribute (handled above)

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -430,6 +430,13 @@ impl ModuleConverter {
             comp_inst.add_attribute(crate::attrs::TYPE, AttributeValue::String(ctype.to_owned()));
         }
 
+        if let Some(datasheet) = component.datasheet() {
+            comp_inst.add_attribute(
+                crate::attrs::DATASHEET,
+                AttributeValue::String(datasheet.to_owned()),
+            );
+        }
+
         // Add any properties defined directly on the component.
         for (key, val) in component.properties().iter() {
             let attr_value = to_attribute_value(*val)?;

--- a/crates/pcb-zen-core/src/lang/stackup.rs
+++ b/crates/pcb-zen-core/src/lang/stackup.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr};
+use std::{borrow::Cow, collections::HashMap, fmt, path::PathBuf, str::FromStr};
 use thiserror::Error;
 
 use pcb_sexpr::{kv, ListBuilder, Sexpr};
@@ -297,6 +297,8 @@ pub struct BoardConfig {
     pub stackup: Option<Stackup>,
     #[serde(default = "default_num_user_layers")]
     pub num_user_layers: usize,
+    #[serde(default)]
+    pub spec: Option<PathBuf>,
 }
 
 impl BoardConfig {

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod attrs {
     pub const SYMBOL_VALUE: &str = "__symbol_value";
     pub const PADS: &str = "pads";
     pub const DNP: &str = "dnp";
+    pub const DATASHEET: &str = "datasheet";
 
     pub mod net {
         pub mod kind {

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -996,8 +996,19 @@ Board(
 BoardConfig = record(
     design_rules=DesignRules,     # PCB design rules and constraints  
     stackup=Stackup,              # Layer stackup and materials
+    num_user_layers=int,          # Number of User.N layers (default: 4)
+    spec=str | None,              # Optional path to specification file
 )
 ```
+
+**Parameters:**
+- `design_rules`: Optional PCB design rules and constraints
+- `stackup`: Optional layer stackup and materials configuration
+- `num_user_layers`: Number of User.N layers to create (default: 4)
+- `spec`: Optional path to a specification markdown file. Use `Path()` to resolve the path:
+  ```python
+  BoardConfig(spec=Path("./docs/my-spec.md"))
+  ```
 
 **Design Rules Examples:**
 

--- a/examples/board_config.zen
+++ b/examples/board_config.zen
@@ -120,6 +120,7 @@ BoardConfig = record(
     design_rules=field(DesignRules | None, None),
     stackup=field(Stackup | None, None),  # Board stackup configuration
     num_user_layers=field(int, 4),  # Number of User.N layers (User.1, User.2, etc.)
+    spec=field(str | None, None), # Path to a specification file
 )
 
 
@@ -369,14 +370,16 @@ BASE_PREDEFINED_SIZES = PredefinedSizes(
     ],
 )
 
+BASE_DESIGN_RULES = DesignRules(
+    constraints=BASE_CONSTRAINTS,
+    predefined_sizes=BASE_PREDEFINED_SIZES,
+    netclasses=[DEFAULT_NETCLASS],
+)
+
 # Base board configurations that can be extended
 
 # Complete base 4-layer board configuration (1oz outer, 0.5oz inner, base constraints)
 BASE_4L = BoardConfig(
-    design_rules=DesignRules(
-        constraints=BASE_CONSTRAINTS,
-        predefined_sizes=BASE_PREDEFINED_SIZES,
-        netclasses=[DEFAULT_NETCLASS],
-    ),
+    design_rules=BASE_DESIGN_RULES,
     stackup=BASE_4L_STACKUP,
 )


### PR DESCRIPTION
Also, sets the built-in "Datasheet" field instead of adding a custom "datasheet" field.