### PR TITLE
Add "ground" copper role, don't use role in symmetric checks

### DIFF
--- a/crates/pcb-zen-core/src/lang/stackup.rs
+++ b/crates/pcb-zen-core/src/lang/stackup.rs
@@ -173,11 +173,24 @@ where
     l.build()
 }
 
+impl CopperRole {
+    /// Convert to KiCad format string (Ground maps to "power" for KiCad compatibility)
+    pub fn to_kicad_str(&self) -> &'static str {
+        match self {
+            CopperRole::Signal => "signal",
+            CopperRole::Power => "power",
+            CopperRole::Ground => "power", // KiCad doesn't have ground, map to power
+            CopperRole::Mixed => "mixed",
+        }
+    }
+}
+
 impl fmt::Display for CopperRole {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             CopperRole::Signal => "signal",
             CopperRole::Power => "power",
+            CopperRole::Ground => "ground",
             CopperRole::Mixed => "mixed",
         })
     }
@@ -229,6 +242,7 @@ pub struct Material {
 pub enum CopperRole {
     Signal,
     Power,
+    Ground,
     Mixed,
 }
 
@@ -531,7 +545,7 @@ impl Stackup {
         for (i, layer) in copper_layers.iter().enumerate() {
             if let Layer::Copper { role, .. } = layer {
                 let (id, name) = copper_layer_mapping(i, copper_layers.len());
-                lines.push(format!("\t\t({} \"{}\" {})", id, name, role));
+                lines.push(format!("\t\t({} \"{}\" {})", id, name, role.to_kicad_str()));
             }
         }
 
@@ -1377,5 +1391,84 @@ mod tests {
         assert!(sexpr_str.contains("RO4350B"));
         assert!(sexpr_str.contains("3.54")); // epsilon_r for RO4450F
         assert!(sexpr_str.contains("3.48")); // epsilon_r for RO4350B
+    }
+
+    #[test]
+    fn test_ground_role_maps_to_power_in_kicad() {
+        // Test that Ground role is mapped to "power" when generating KiCad output
+        let stackup = Stackup {
+            materials: Some(vec![Material {
+                name: Some("FR4".to_string()),
+                vendor: None,
+                relative_permittivity: Some(4.6),
+                loss_tangent: Some(0.02),
+                reference_frequency: None,
+            }]),
+            thickness: None,
+            symmetric: None,
+            layers: Some(vec![
+                Layer::Copper {
+                    thickness: 0.035,
+                    role: CopperRole::Signal,
+                },
+                Layer::Dielectric {
+                    thickness: 0.2,
+                    material: "FR4".to_string(),
+                    form: DielectricForm::Prepreg,
+                },
+                Layer::Copper {
+                    thickness: 0.035,
+                    role: CopperRole::Ground, // Ground role
+                },
+                Layer::Dielectric {
+                    thickness: 1.1,
+                    material: "FR4".to_string(),
+                    form: DielectricForm::Core,
+                },
+                Layer::Copper {
+                    thickness: 0.035,
+                    role: CopperRole::Power, // Power role
+                },
+                Layer::Dielectric {
+                    thickness: 0.2,
+                    material: "FR4".to_string(),
+                    form: DielectricForm::Prepreg,
+                },
+                Layer::Copper {
+                    thickness: 0.035,
+                    role: CopperRole::Signal,
+                },
+            ]),
+            silk_screen_color: None,
+            solder_mask_color: None,
+            copper_finish: None,
+        };
+
+        // Generate KiCad layers sexpr
+        let layers_sexpr = stackup.generate_layers_sexpr(0);
+
+        // Verify Ground role is written as "power" in KiCad format
+        // The output should contain "power" for both Ground and Power roles
+        assert!(
+            layers_sexpr.contains("signal"),
+            "Expected 'signal' in layers output"
+        );
+        assert!(
+            layers_sexpr.contains("power"),
+            "Expected 'power' in layers output for both Ground and Power roles"
+        );
+        // Should NOT contain "ground" as a role string
+        assert!(
+            !layers_sexpr.contains(" ground)"),
+            "Should not contain 'ground' role in KiCad output"
+        );
+
+        // Verify the internal representation still has Ground
+        if let Some(layers) = &stackup.layers {
+            let copper_layers: Vec<_> = layers.iter().filter(|l| l.is_copper()).collect();
+            if let Layer::Copper { role, .. } = copper_layers[1] {
+                assert_eq!(*role, CopperRole::Ground, "Internal role should be Ground");
+            }
+        }
     }
 }

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -934,7 +934,7 @@ load("@stdlib/board_config.zen",
 )
 ```
 
-### Board(name, config, layout_path, layout_hints=None, default=False)
+### Board(name, layout_path, config=None, layers=None, layout_hints=None, default=False)
 
 **Stdlib function** for declaring board configurations for PCB layout generation.
 
@@ -942,20 +942,28 @@ load("@stdlib/board_config.zen",
 # Load from stdlib
 load("@stdlib/board_config.zen", "Board", "BoardConfig", "DesignRules", "Stackup", "Material", "CopperLayer", "DielectricLayer")
 
-# Define board configuration
+# Simple usage with predefined layer count (recommended for most projects)
+Board(
+    name="MyBoard",
+    layout_path="layout/",
+    layers=4,
+    default=True
+)
+
+# Advanced usage with custom configuration
 config = BoardConfig(
     stackup=Stackup(
         materials=[
             Material(
                 name="FR-4",
-                vendor="Isola", 
+                vendor="Isola",
                 relative_permittivity=4.21,
                 loss_tangent=0.025,
                 reference_frequency=1e9,
             ),
         ],
         silk_screen_color="#44805BFF",
-        solder_mask_color="#191919E6", 
+        solder_mask_color="#191919E6",
         thickness=1.605,
         symmetric=True,
         copper_finish="ENIG",
@@ -963,7 +971,7 @@ config = BoardConfig(
             CopperLayer(thickness=0.035, role="mixed"),
             DielectricLayer(thickness=0.2, material="FR-4", form="prepreg"),
             CopperLayer(thickness=0.035, role="power"),
-            DielectricLayer(thickness=1.065, material="FR-4", form="core"), 
+            DielectricLayer(thickness=1.065, material="FR-4", form="core"),
             CopperLayer(thickness=0.035, role="power"),
             DielectricLayer(thickness=0.2, material="FR-4", form="prepreg"),
             CopperLayer(thickness=0.035, role="mixed"),
@@ -971,22 +979,29 @@ config = BoardConfig(
     )
 )
 
-# Declare board using stdlib function
+# Declare board using custom configuration
 Board(
     name="MyBoard",
-    config=config,
     layout_path="layout/",
+    config=config,
     default=True
 )
 ```
 
 **Parameters:**
 
-- `name`: String identifier for the board configuration
-- `config`: `BoardConfig` record containing design rules and stackup
-- `layout_path`: Directory path where layout files will be generated
-- `layout_hints`: Optional list of layout optimization hints  
+- `name`: String identifier for the board configuration (required)
+- `layout_path`: Directory path where layout files will be generated (required)
+- `config`: `BoardConfig` record containing design rules and stackup (optional, mutually exclusive with `layers`)
+- `layers`: Number of layers - 2, 4, 6, or 8 (optional, mutually exclusive with `config`). When specified, uses predefined stackups from the stdlib:
+  - `layers=2`: 2-layer board (1.6mm, 1oz copper, SIG/SIG)
+  - `layers=4`: 4-layer board (1.6mm, 1oz outer/0.5oz inner, SIG/GND/PWR/SIG)
+  - `layers=6`: 6-layer board (1.6mm, 1oz outer/0.5oz inner, SIG/GND/(SIG/PWR)/(SIG/PWR)/GND/SIG)
+  - `layers=8`: 8-layer board (1.6mm, 1oz outer/0.5oz inner, SIG/GND/SIG/PWR/GND/SIG/GND/SIG)
+- `layout_hints`: Optional list of layout optimization hints
 - `default`: If True, this becomes the default board config for the project
+
+**Note:** Either `config` or `layers` must be provided, but not both. If neither is provided, an error will be raised.
 
 **Implementation:** The stdlib `Board()` function calls the language builtin `builtin.add_board_config()` and sets layout properties.
 

--- a/examples/board_config.zen
+++ b/examples/board_config.zen
@@ -120,7 +120,7 @@ BoardConfig = record(
     design_rules=field(DesignRules | None, None),
     stackup=field(Stackup | None, None),  # Board stackup configuration
     num_user_layers=field(int, 4),  # Number of User.N layers (User.1, User.2, etc.)
-    spec=field(str | None, None), # Path to a specification file
+    spec=field(str | None, None),  # Path to a specification file
 )
 
 
@@ -239,11 +239,32 @@ def merge_configs(*configs: BoardConfig) -> BoardConfig:
 
 def Board(
     name: str,
-    config: BoardConfig,
     layout_path: str,
+    config: BoardConfig | None = None,
+    layers: int | None = None,
     layout_hints: list | None = None,
     default: bool = False,
 ):
+    # If config is not provided, construct it from layers
+    if config == None:
+        if layers == None:
+            error("Either 'config' or 'layers' must be provided")
+        elif layers == 2:
+            stackup = BASE_2L_STACKUP
+        elif layers == 4:
+            stackup = BASE_4L_STACKUP
+        elif layers == 6:
+            stackup = BASE_6L_STACKUP
+        elif layers == 8:
+            stackup = BASE_8L_STACKUP
+        else:
+            error("layers must be 2, 4, 6, or 8")
+
+        config = BoardConfig(
+            design_rules=BASE_DESIGN_RULES,
+            stackup=stackup,
+        )
+
     builtin.add_board_config(
         name=name,
         default=default,
@@ -273,7 +294,24 @@ BASE_PREPREG = Material(
 
 # Common stackup configurations
 
+# Base 2-layer stackup (1.6mm, 1oz outer)
+# SIG/SIG
+BASE_2L_STACKUP = Stackup(
+    materials=[FR4_CORE],
+    thickness=1.6,
+    symmetric=True,
+    copper_finish="HAL SnPb",
+    silk_screen_color="White",
+    solder_mask_color="Black",
+    layers=[
+        CopperLayer(thickness=0.035, role="mixed"),  # Top layer (1oz)
+        DielectricLayer(thickness=1.53, material="FR4-Core", form="core"),
+        CopperLayer(thickness=0.035, role="mixed"),  # Bottom layer (1oz)
+    ],
+)
+
 # Base 4-layer stackup (1.6mm, 1oz outer/0.5oz inner)
+# SIG/GND/PWR/SIG
 BASE_4L_STACKUP = Stackup(
     materials=[FR4_CORE, BASE_PREPREG],
     thickness=1.6,
@@ -288,6 +326,84 @@ BASE_4L_STACKUP = Stackup(
         DielectricLayer(thickness=1.065, material="FR4-Core", form="core"),
         CopperLayer(thickness=0.0152, role="power"),  # Inner L3 (0.5oz)
         DielectricLayer(thickness=0.21040, material="Prepreg", form="prepreg"),
+        CopperLayer(thickness=0.035, role="mixed"),  # Bottom layer (1oz)
+    ],
+)
+
+# Base 6-layer stackup (1.6mm, 1oz outer/0.5oz inner)
+# SIG/GND/(SIG/PWR)/(SIG/PWR)/GND/SIG
+BASE_6L_STACKUP = Stackup(
+    materials=[
+        FR4_CORE,
+        Material(
+            name="2116",
+            relative_permittivity=4.16,
+            loss_tangent=0.025,
+        ),
+        Material(
+            name="3313",
+            relative_permittivity=4.1,
+            loss_tangent=0.025,
+        ),
+    ],
+    thickness=1.6,
+    symmetric=True,
+    copper_finish="HAL SnPb",
+    silk_screen_color="White",
+    solder_mask_color="Black",
+    layers=[
+        CopperLayer(thickness=0.035, role="mixed"),  # Top layer (1oz)
+        DielectricLayer(thickness=0.09940, material="3313", form="prepreg"),
+        CopperLayer(thickness=0.0152, role="power"),  # Inner L2 (0.5oz)
+        DielectricLayer(thickness=0.55, material="FR4-Core", form="core"),
+        CopperLayer(thickness=0.0152, role="mixed"),  # Inner L3 (0.5oz)
+        DielectricLayer(thickness=0.11640, material="2116", form="prepreg"),
+        CopperLayer(thickness=0.0152, role="mixed"),  # Inner L4 (0.5oz)
+        DielectricLayer(thickness=0.55, material="FR4-Core", form="core"),
+        CopperLayer(thickness=0.0152, role="power"),  # Inner L5 (0.5oz)
+        DielectricLayer(thickness=0.09940, material="3313", form="prepreg"),
+        CopperLayer(thickness=0.035, role="mixed"),  # Bottom layer (1oz)
+    ],
+)
+
+# Base 8-layer stackup (1.6mm, 1oz outer/0.5oz inner)
+# SIG/GND/SIG/PWR/GND/SIG/GND/SIG
+BASE_8L_STACKUP = Stackup(
+    materials=[
+        FR4_CORE,
+        Material(
+            name="2116",
+            relative_permittivity=4.16,
+            loss_tangent=0.025,
+        ),
+        Material(
+            name="1080",
+            relative_permittivity=3.91,
+            loss_tangent=0.025,
+        ),
+    ],
+    thickness=1.6,
+    symmetric=True,
+    copper_finish="HAL SnPb",
+    silk_screen_color="White",
+    solder_mask_color="Black",
+    layers=[
+        CopperLayer(thickness=0.035, role="mixed"),  # Top layer (1oz)
+        DielectricLayer(thickness=0.1164, material="2116", form="prepreg"),
+        CopperLayer(thickness=0.0152, role="power"),  # Inner L2 (0.5oz)
+        DielectricLayer(thickness=0.3, material="FR4-Core", form="core"),
+        CopperLayer(thickness=0.0152, role="mixed"),  # Inner L3 (0.5oz)
+        DielectricLayer(thickness=0.0764, material="1080", form="prepreg"),
+        DielectricLayer(thickness=0.0764, material="1080", form="prepreg"),
+        CopperLayer(thickness=0.0152, role="power"),  # Inner L4 (0.5oz)
+        DielectricLayer(thickness=0.3, material="FR4-Core", form="core"),
+        CopperLayer(thickness=0.0152, role="power"),  # Inner L5 (0.5oz)
+        DielectricLayer(thickness=0.0764, material="1080", form="prepreg"),
+        DielectricLayer(thickness=0.0764, material="1080", form="prepreg"),
+        CopperLayer(thickness=0.0152, role="mixed"),  # Inner L6 (0.5oz)
+        DielectricLayer(thickness=0.3, material="FR4-Core", form="core"),
+        CopperLayer(thickness=0.0152, role="power"),  # Inner L7 (0.5oz)
+        DielectricLayer(thickness=0.1164, material="2116", form="prepreg"),
         CopperLayer(thickness=0.035, role="mixed"),  # Bottom layer (1oz)
     ],
 )
@@ -370,13 +486,12 @@ BASE_PREDEFINED_SIZES = PredefinedSizes(
     ],
 )
 
+# Base board configurations that can be extended
 BASE_DESIGN_RULES = DesignRules(
     constraints=BASE_CONSTRAINTS,
     predefined_sizes=BASE_PREDEFINED_SIZES,
     netclasses=[DEFAULT_NETCLASS],
 )
-
-# Base board configurations that can be extended
 
 # Complete base 4-layer board configuration (1oz outer, 0.5oz inner, base constraints)
 BASE_4L = BoardConfig(


### PR DESCRIPTION
This is only for internal use as kicad only supports power.