### PR TITLE
Include board config in release

### DIFF
--- a/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
+++ b/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
@@ -36,6 +36,7 @@ Exit Code: 0
 ✓ Copying source files and dependencies
 ✓ Validating build from staged sources
 ✓ Copying layout files
+✓ Generating board config
 ✓ Copying documentation
 ✓ Substituting version variables
 ✓ Generating design BOM

--- a/crates/pcb/tests/snapshots/tag__tag_older_version_allowed.snap
+++ b/crates/pcb/tests/snapshots/tag__tag_older_version_allowed.snap
@@ -13,6 +13,7 @@ Exit Code: 0
 ✓ Copying source files and dependencies
 ✓ Validating build from staged sources
 ✓ Copying layout files
+✓ Generating board config
 ✓ Copying documentation
 ✓ Substituting version variables
 ✓ Generating design BOM

--- a/crates/pcb/tests/snapshots/tag__tag_simple_workspace.snap
+++ b/crates/pcb/tests/snapshots/tag__tag_simple_workspace.snap
@@ -13,6 +13,7 @@ Exit Code: 0
 ✓ Copying source files and dependencies
 ✓ Validating build from staged sources
 ✓ Copying layout files
+✓ Generating board config
 ✓ Copying documentation
 ✓ Substituting version variables
 ✓ Generating design BOM


### PR DESCRIPTION
JSON contents are written to <staging_dir>/layout/board_config.json.

This should be the canonical structured data. Will add a human friendly PDF as follow up.