### PR TITLE
Fix wasm build regression

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,60 @@
+name: WASM Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasm_build:
+    name: Build WASM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Only save cache from main branch to prevent cache proliferation
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build WASM
+        run: cargo build --package pcb-zen-wasm --target wasm32-unknown-unknown --release
+
+      - name: Check WASM artifact size
+        run: |
+          WASM_FILE="target/wasm32-unknown-unknown/release/pcb_zen_wasm.wasm"
+          
+          if [ ! -f "$WASM_FILE" ]; then
+            echo "Error: WASM artifact not found"
+            exit 1
+          fi
+          
+          # Get file size in bytes
+          SIZE=$(stat -c%s "$WASM_FILE" 2>/dev/null || stat -f%z "$WASM_FILE")
+          SIZE_MB=$((SIZE / 1024 / 1024))
+          
+          echo "WASM bundle size: ${SIZE_MB}MB"
+          ls -lh "$WASM_FILE"
+          
+          # Fail if size exceeds 30MB
+          if [ $SIZE -gt 31457280 ]; then
+            echo "Error: WASM bundle is too large (${SIZE_MB}MB > 30MB)"
+            exit 1
+          fi
+          
+          echo "WASM build successful! Size is within limits."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,6 @@ dependencies = [
  "log",
  "natord",
  "pathdiff",
- "pcb-kicad",
  "pcb-sexpr",
  "rust_decimal",
  "scan_fmt",

--- a/crates/pcb-sch/Cargo.toml
+++ b/crates/pcb-sch/Cargo.toml
@@ -20,7 +20,6 @@ pcb-sexpr = { workspace = true }
 rust_decimal = { workspace = true }
 scan_fmt = { workspace = true }
 natord = { workspace = true }
-pcb-kicad = { workspace = true }
 csv = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -19,8 +19,8 @@ pub mod position;
 
 // Re-export BOM functionality
 pub use bom::{
-    generate_bom_with_fallback, Bom, BomMatchingKey, BomMatchingRule, GenericMatchingKey,
-    KiCadBomError, Offer,
+    parse_kicad_csv_bom, Bom, BomMatchingKey, BomMatchingRule, GenericMatchingKey, KiCadBomError,
+    Offer,
 };
 
 use std::collections::HashMap;

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -3,8 +3,9 @@ use clap::{Args, ValueEnum};
 
 use log::{debug, info, warn};
 use pcb_kicad::{KiCadCliBuilder, PythonScriptBuilder};
-use pcb_sch::generate_bom_with_fallback;
 use pcb_ui::{Colorize, Spinner, Style, StyledText};
+
+use crate::bom::generate_bom_with_fallback;
 use pcb_zen_core::config::get_workspace_info;
 use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::{EvalOutput, WithDiagnostics};


### PR DESCRIPTION
My last PR added a transitive dependency on pcb-kicad to pcb-zen-wasm, which caused the wasm build to fail.

Build wasm bundle in CI to prevent future regressions.