### PR TITLE
Add structured diagnostics JSON export to releases

### DIFF
--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -48,12 +48,15 @@ pub mod attrs {
 // Re-export commonly used types
 pub use config::{BoardConfig, ModuleConfig, PcbToml, WorkspaceConfig};
 pub use diagnostics::{
-    Diagnostic, DiagnosticError, Diagnostics, DiagnosticsPass, LoadError, WithDiagnostics,
+    Diagnostic, DiagnosticError, DiagnosticFrame, DiagnosticReport, Diagnostics, DiagnosticsPass,
+    DiagnosticsReport, LoadError, WithDiagnostics,
 };
 pub use lang::error::{SuppressedDiagnostics, UnstableRefError};
 pub use lang::eval::{EvalContext, EvalOutput};
 pub use load_spec::LoadSpec;
-pub use passes::{AggregatePass, FilterHiddenPass, LspFilterPass, SortPass, SuppressPass};
+pub use passes::{
+    AggregatePass, FilterHiddenPass, JsonExportPass, LspFilterPass, SortPass, SuppressPass,
+};
 
 // Re-export file provider types
 pub use file_provider::InMemoryFileProvider;

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -897,10 +897,18 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<()> {
     let (has_errors, has_warnings) = spinner.suspend(|| {
         let mut has_errors = false;
         let mut has_warnings = false;
+
+        // Export diagnostics to JSON for release artifacts
+        let mut passes = crate::build::create_diagnostics_passes(&[]);
+        passes.push(Box::new(pcb_zen_core::JsonExportPass::new(
+            info.staging_dir.join("diagnostics.json"),
+            zen_file_rel.display().to_string(),
+        )));
+
         let _schematic = crate::build::build(
             &staged_zen_path,
             true, // offline mode since all dependencies should be vendored
-            crate::build::create_diagnostics_passes(&[]),
+            passes,
             false, // don't deny warnings - we'll prompt user instead
             &mut has_errors,
             &mut has_warnings,

--- a/crates/pcb/tests/snapshots/release__case_insensitive_tag.snap
+++ b/crates/pcb/tests/snapshots/release__case_insensitive_tag.snap
@@ -2,6 +2,10 @@
 source: crates/pcb/tests/release.rs
 expression: sb.snapshot_dir(staging_dir)
 ---
+=== diagnostics.json
+{
+  "CaseBoard.zen": []
+}
 === metadata.json
 {
   "git": {

--- a/crates/pcb/tests/snapshots/release__release_basic.snap
+++ b/crates/pcb/tests/snapshots/release__release_basic.snap
@@ -2,6 +2,10 @@
 source: crates/pcb/tests/release.rs
 expression: sb.snapshot_dir(staging_dir)
 ---
+=== diagnostics.json
+{
+  "boards/TestBoard.zen": []
+}
 === metadata.json
 {
   "git": {

--- a/crates/pcb/tests/snapshots/release__release_full.snap
+++ b/crates/pcb/tests/snapshots/release__release_full.snap
@@ -69,6 +69,10 @@ expression: sb.snapshot_dir(staging_dir)
     "dnp": false
   }
 ]
+=== diagnostics.json
+{
+  "boards/TestBoard.zen": []
+}
 === manufacturing/cpl.csv
 Designator,Val,Package,Mid X,Mid Y,Rotation,Layer
 "C1","100nF","C_0402_1005Metric",149.855000,-103.970000,0.000000,top

--- a/crates/pcb/tests/snapshots/release__release_with_description.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_description.snap
@@ -2,6 +2,10 @@
 source: crates/pcb/tests/release.rs
 expression: sb.snapshot_dir(staging_dir)
 ---
+=== diagnostics.json
+{
+  "boards/DescBoard.zen": []
+}
 === metadata.json
 {
   "git": {

--- a/crates/pcb/tests/snapshots/release__release_with_file.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_file.snap
@@ -2,6 +2,10 @@
 source: crates/pcb/tests/release.rs
 expression: sb.snapshot_dir(staging_dir)
 ---
+=== diagnostics.json
+{
+  "boards/TB0002.zen": []
+}
 === metadata.json
 {
   "git": {

--- a/crates/pcb/tests/snapshots/release__release_with_git.snap
+++ b/crates/pcb/tests/snapshots/release__release_with_git.snap
@@ -2,6 +2,10 @@
 source: crates/pcb/tests/release.rs
 expression: sb.snapshot_dir(staging_dir)
 ---
+=== diagnostics.json
+{
+  "boards/TB0001.zen": []
+}
 === metadata.json
 {
   "git": {


### PR DESCRIPTION
Example JSON structure:
```
  {
    "blinky.zen": [
      {
        "location": "path/to/file.zen:61:1-30",
        "severity": "warning",
        "body": "Error message",
        "suppressed": false,
        "occurrences": 1,
        "stack": []
      }
    ]
  }
```