### PR TITLE
Fix DiffPair impedance propagation for top-level parameters

### DIFF
--- a/crates/pcb-layout/tests/resources/netclass_assignment/diffpair_module.zen
+++ b/crates/pcb-layout/tests/resources/netclass_assignment/diffpair_module.zen
@@ -1,0 +1,12 @@
+load("@stdlib:v0.3.4/interfaces.zen", "DiffPair")
+
+# Accept DiffPair interface as input
+signal = io("signal", DiffPair)
+
+# Add a simple component inside the module to make it non-empty
+Component(
+    name="R_DIFFPAIR",
+    footprint="Resistor_SMD:R_0603_1608Metric",
+    pin_defs={"1": "1", "2": "2"},
+    pins={"1": signal.P, "2": signal.N},
+)

--- a/crates/pcb-layout/tests/resources/netclass_assignment/netclass.zen
+++ b/crates/pcb-layout/tests/resources/netclass_assignment/netclass.zen
@@ -1,6 +1,6 @@
 load("@stdlib:v0.3.4/board_config.zen", "Board")
 load("@stdlib:v0.3.4/units.zen", "Impedance")
-load("@stdlib:v0.3.4/interfaces.zen", "Usb2")
+load("@stdlib:v0.3.4/interfaces.zen", "Usb2", "DiffPair")
 
 # Test case 1: Single-ended 50Ω impedance → should match "50Ohm SE"
 clk_50 = Net("CLK_50", impedance=Impedance(50))
@@ -16,6 +16,14 @@ usb = Usb2("USB")
 UsbModule = Module("usb_module.zen")
 usb_module = UsbModule(name="USB_MOD", usb=usb)
 
+# Test case 6: Locally-created DiffPair with impedance passed to child module
+# Regression test: propagate_from_value() must check the interface itself for impedance,
+# not just nested fields. This tests that a DiffPair created with impedance=85 gets
+# properly propagated when passed as a parameter to a child module.
+hdmi_local = DiffPair("HDMI", impedance=Impedance(85))
+DiffPairModule = Module("diffpair_module.zen")
+diffpair_module = DiffPairModule(name="HDMI_MOD", signal=hdmi_local)
+
 # Test case 4: Unmatched impedance (no netclass for 1000Ω) → uses Default
 high_z = Net("HIGH_Z", impedance=Impedance(1000))
 
@@ -27,10 +35,10 @@ data = Net("DATA")
 # Add components to create actual nets in schematic
 Component(
     name="U1",
-    footprint="Connector_PinHeader_2.54mm:PinHeader_2x04_P2.54mm_Vertical",
+    footprint="Connector_PinHeader_2.54mm:PinHeader_2x05_P2.54mm_Vertical",
     pin_defs={
-        "1": "1", "2": "2", "3": "3", "4": "4",
-        "5": "5", "6": "6", "7": "7", "8": "8"
+        "1": "1", "2": "2", "3": "3", "4": "4", "5": "5",
+        "6": "6", "7": "7", "8": "8", "9": "9", "10": "10"
     },
     pins={
         "1": clk_50,
@@ -38,9 +46,11 @@ Component(
         "3": clk_51,
         "4": usb.D.P,
         "5": usb.D.N,
-        "6": high_z,
-        "7": gnd,
-        "8": vcc,
+        "6": hdmi_local.P,
+        "7": hdmi_local.N,
+        "8": high_z,
+        "9": gnd,
+        "10": vcc,
     },
 )
 

--- a/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.layout.json.snap
@@ -13,18 +13,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 152760000,
-            "y": 105530000
+            "x": 154845000,
+            "y": 110390000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 149800000,
-            "y": 105530000
+            "x": 151885000,
+            "y": 110390000
           },
           "shape": 0,
           "start": {
-            "x": 149800000,
-            "y": 105530000
+            "x": 151885000,
+            "y": 110390000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -33,18 +33,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149800000,
-            "y": 105530000
+            "x": 151885000,
+            "y": 110390000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 149800000,
-            "y": 106990000
+            "x": 151885000,
+            "y": 111850000
           },
           "shape": 0,
           "start": {
-            "x": 149800000,
-            "y": 106990000
+            "x": 151885000,
+            "y": 111850000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -53,18 +53,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 152080000,
-            "y": 105847500
+            "x": 154165000,
+            "y": 110707500
           },
           "layer": "F.Fab",
           "position": {
-            "x": 150480000,
-            "y": 105847500
+            "x": 152565000,
+            "y": 110707500
           },
           "shape": 0,
           "start": {
-            "x": 150480000,
-            "y": 105847500
+            "x": 152565000,
+            "y": 110707500
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -73,18 +73,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 150480000,
-            "y": 105847500
+            "x": 152565000,
+            "y": 110707500
           },
           "layer": "F.Fab",
           "position": {
-            "x": 150480000,
-            "y": 106672500
+            "x": 152565000,
+            "y": 111532500
           },
           "shape": 0,
           "start": {
-            "x": 150480000,
-            "y": 106672500
+            "x": 152565000,
+            "y": 111532500
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -93,18 +93,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 151517258,
-            "y": 105737500
+            "x": 153602258,
+            "y": 110597500
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 151042742,
-            "y": 105737500
+            "x": 153127742,
+            "y": 110597500
           },
           "shape": 0,
           "start": {
-            "x": 151042742,
-            "y": 105737500
+            "x": 153127742,
+            "y": 110597500
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -113,18 +113,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 151517258,
-            "y": 106782500
+            "x": 153602258,
+            "y": 111642500
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 151042742,
-            "y": 106782500
+            "x": 153127742,
+            "y": 111642500
           },
           "shape": 0,
           "start": {
-            "x": 151042742,
-            "y": 106782500
+            "x": 153127742,
+            "y": 111642500
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -135,8 +135,8 @@ expression: content
           "end": null,
           "layer": "F.Fab",
           "position": {
-            "x": 151280000,
-            "y": 106260000
+            "x": 153365000,
+            "y": 111120000
           },
           "shape": null,
           "start": null,
@@ -147,18 +147,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 152080000,
-            "y": 106672500
+            "x": 154165000,
+            "y": 111532500
           },
           "layer": "F.Fab",
           "position": {
-            "x": 152080000,
-            "y": 105847500
+            "x": 154165000,
+            "y": 110707500
           },
           "shape": 0,
           "start": {
-            "x": 152080000,
-            "y": 105847500
+            "x": 154165000,
+            "y": 110707500
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -167,18 +167,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 150480000,
-            "y": 106672500
+            "x": 152565000,
+            "y": 111532500
           },
           "layer": "F.Fab",
           "position": {
-            "x": 152080000,
-            "y": 106672500
+            "x": 154165000,
+            "y": 111532500
           },
           "shape": 0,
           "start": {
-            "x": 152080000,
-            "y": 106672500
+            "x": 154165000,
+            "y": 111532500
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -187,18 +187,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 152760000,
-            "y": 106990000
+            "x": 154845000,
+            "y": 111850000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 152760000,
-            "y": 105530000
+            "x": 154845000,
+            "y": 110390000
           },
           "shape": 0,
           "start": {
-            "x": 152760000,
-            "y": 105530000
+            "x": 154845000,
+            "y": 110390000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -207,18 +207,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149800000,
-            "y": 106990000
+            "x": 151885000,
+            "y": 111850000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 152760000,
-            "y": 106990000
+            "x": 154845000,
+            "y": 111850000
           },
           "shape": 0,
           "start": {
-            "x": 152760000,
-            "y": 106990000
+            "x": 154845000,
+            "y": 111850000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -234,24 +234,24 @@ expression: content
           "layer": "F.Cu",
           "name": "1",
           "position": {
-            "x": 150455000,
-            "y": 106260000
+            "x": 152540000,
+            "y": 111120000
           }
         },
         {
           "layer": "F.Cu",
           "name": "2",
           "position": {
-            "x": 152105000,
-            "y": 106260000
+            "x": 154190000,
+            "y": 111120000
           }
         }
       ],
       "position": {
-        "x": 151280000,
-        "y": 106260000
+        "x": 153365000,
+        "y": 111120000
       },
-      "reference": "U3",
+      "reference": "U4",
       "uuid": "309b9b9f-c1a5-5ad1-b227-1663d19ba7c8",
       "value": "?"
     },
@@ -264,18 +264,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149800000,
-            "y": 110580000
+            "x": 148295000,
+            "y": 111850000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 149800000,
-            "y": 107040000
+            "x": 148295000,
+            "y": 108310000
           },
           "shape": 0,
           "start": {
-            "x": 149800000,
-            "y": 107040000
+            "x": 148295000,
+            "y": 108310000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -284,18 +284,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 153340000,
-            "y": 110580000
+            "x": 151835000,
+            "y": 111850000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 149800000,
-            "y": 110580000
+            "x": 148295000,
+            "y": 111850000
           },
           "shape": 0,
           "start": {
-            "x": 149800000,
-            "y": 110580000
+            "x": 148295000,
+            "y": 111850000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -304,18 +304,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 151570000,
-            "y": 107430000
+            "x": 150065000,
+            "y": 108700000
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 150190000,
-            "y": 107430000
+            "x": 148685000,
+            "y": 108700000
           },
           "shape": 0,
           "start": {
-            "x": 150190000,
-            "y": 107430000
+            "x": 148685000,
+            "y": 108700000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -324,98 +324,98 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 150190000,
-            "y": 107430000
+            "x": 148685000,
+            "y": 108700000
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 150190000,
+            "x": 148685000,
+            "y": 110080000
+          },
+          "shape": 0,
+          "start": {
+            "x": 148685000,
+            "y": 110080000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 148685000,
+            "y": 111460000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 148685000,
+            "y": 111350000
+          },
+          "shape": 0,
+          "start": {
+            "x": 148685000,
+            "y": 111350000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 151445000,
+            "y": 111350000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 148685000,
+            "y": 111350000
+          },
+          "shape": 0,
+          "start": {
+            "x": 148685000,
+            "y": 111350000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 151445000,
+            "y": 111460000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 148685000,
+            "y": 111460000
+          },
+          "shape": 0,
+          "start": {
+            "x": 148685000,
+            "y": 111460000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 149430000,
             "y": 108810000
-          },
-          "shape": 0,
-          "start": {
-            "x": 150190000,
-            "y": 108810000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 150190000,
-            "y": 110190000
-          },
-          "layer": "F.Silkscreen",
-          "position": {
-            "x": 150190000,
-            "y": 110080000
-          },
-          "shape": 0,
-          "start": {
-            "x": 150190000,
-            "y": 110080000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 152950000,
-            "y": 110080000
-          },
-          "layer": "F.Silkscreen",
-          "position": {
-            "x": 150190000,
-            "y": 110080000
-          },
-          "shape": 0,
-          "start": {
-            "x": 150190000,
-            "y": 110080000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 152950000,
-            "y": 110190000
-          },
-          "layer": "F.Silkscreen",
-          "position": {
-            "x": 150190000,
-            "y": 110190000
-          },
-          "shape": 0,
-          "start": {
-            "x": 150190000,
-            "y": 110190000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 150935000,
-            "y": 107540000
           },
           "layer": "F.Fab",
           "position": {
-            "x": 150300000,
-            "y": 108175000
+            "x": 148795000,
+            "y": 109445000
           },
           "shape": 0,
           "start": {
-            "x": 150300000,
-            "y": 108175000
+            "x": 148795000,
+            "y": 109445000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -424,18 +424,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 150300000,
-            "y": 108175000
+            "x": 148795000,
+            "y": 109445000
           },
           "layer": "F.Fab",
           "position": {
-            "x": 150300000,
-            "y": 110080000
+            "x": 148795000,
+            "y": 111350000
           },
           "shape": 0,
           "start": {
-            "x": 150300000,
-            "y": 110080000
+            "x": 148795000,
+            "y": 111350000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -444,18 +444,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 152840000,
-            "y": 107540000
+            "x": 151335000,
+            "y": 108810000
           },
           "layer": "F.Fab",
           "position": {
-            "x": 150935000,
-            "y": 107540000
+            "x": 149430000,
+            "y": 108810000
           },
           "shape": 0,
           "start": {
-            "x": 150935000,
-            "y": 107540000
+            "x": 149430000,
+            "y": 108810000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -466,8 +466,8 @@ expression: content
           "end": null,
           "layer": "F.Fab",
           "position": {
-            "x": 151570000,
-            "y": 108810000
+            "x": 150065000,
+            "y": 110080000
           },
           "shape": null,
           "start": null,
@@ -478,18 +478,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 152840000,
-            "y": 110080000
+            "x": 151335000,
+            "y": 111350000
           },
           "layer": "F.Fab",
           "position": {
-            "x": 152840000,
-            "y": 107540000
+            "x": 151335000,
+            "y": 108810000
           },
           "shape": 0,
           "start": {
-            "x": 152840000,
-            "y": 107540000
+            "x": 151335000,
+            "y": 108810000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -498,18 +498,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 150300000,
-            "y": 110080000
+            "x": 148795000,
+            "y": 111350000
           },
           "layer": "F.Fab",
           "position": {
-            "x": 152840000,
-            "y": 110080000
+            "x": 151335000,
+            "y": 111350000
           },
           "shape": 0,
           "start": {
-            "x": 152840000,
-            "y": 110080000
+            "x": 151335000,
+            "y": 111350000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -518,18 +518,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 152950000,
-            "y": 110190000
+            "x": 151445000,
+            "y": 111460000
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 152950000,
-            "y": 110080000
+            "x": 151445000,
+            "y": 111350000
           },
           "shape": 0,
           "start": {
-            "x": 152950000,
-            "y": 110080000
+            "x": 151445000,
+            "y": 111350000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -538,18 +538,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149800000,
-            "y": 107040000
+            "x": 148295000,
+            "y": 108310000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 153340000,
-            "y": 107040000
+            "x": 151835000,
+            "y": 108310000
           },
           "shape": 0,
           "start": {
-            "x": 153340000,
-            "y": 107040000
+            "x": 151835000,
+            "y": 108310000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -558,18 +558,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 153340000,
-            "y": 107040000
+            "x": 151835000,
+            "y": 108310000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 153340000,
-            "y": 110580000
+            "x": 151835000,
+            "y": 111850000
           },
           "shape": 0,
           "start": {
-            "x": 153340000,
-            "y": 110580000
+            "x": 151835000,
+            "y": 111850000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -585,16 +585,16 @@ expression: content
           "layer": "F.Cu",
           "name": "1",
           "position": {
-            "x": 151570000,
-            "y": 108810000
+            "x": 150065000,
+            "y": 110080000
           }
         }
       ],
       "position": {
-        "x": 151570000,
-        "y": 108810000
+        "x": 150065000,
+        "y": 110080000
       },
-      "reference": "U2",
+      "reference": "U3",
       "uuid": "36c85f89-8191-5cff-96a2-01503cd7115a",
       "value": "?"
     },
@@ -602,23 +602,23 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Connector_PinHeader_2.54mm:PinHeader_2x04_P2.54mm_Vertical",
+      "footprint": "Connector_PinHeader_2.54mm:PinHeader_2x05_P2.54mm_Vertical",
       "graphical_items": [
         {
           "angle": null,
           "end": {
-            "x": 143660000,
-            "y": 110580000
+            "x": 142155000,
+            "y": 111850000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 143660000,
-            "y": 99420000
+            "x": 142155000,
+            "y": 98150000
           },
           "shape": 0,
           "start": {
-            "x": 143660000,
-            "y": 99420000
+            "x": 142155000,
+            "y": 98150000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -627,18 +627,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149750000,
-            "y": 110580000
+            "x": 148245000,
+            "y": 111850000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 143660000,
-            "y": 110580000
+            "x": 142155000,
+            "y": 111850000
           },
           "shape": 0,
           "start": {
-            "x": 143660000,
-            "y": 110580000
+            "x": 142155000,
+            "y": 111850000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -647,18 +647,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 145430000,
-            "y": 99810000
+            "x": 143925000,
+            "y": 98540000
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 144050000,
-            "y": 99810000
+            "x": 142545000,
+            "y": 98540000
           },
           "shape": 0,
           "start": {
-            "x": 144050000,
-            "y": 99810000
+            "x": 142545000,
+            "y": 98540000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -667,137 +667,97 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 144050000,
-            "y": 99810000
+            "x": 142545000,
+            "y": 98540000
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 144050000,
-            "y": 101190000
-          },
-          "shape": 0,
-          "start": {
-            "x": 144050000,
-            "y": 101190000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 144050000,
-            "y": 110190000
-          },
-          "layer": "F.Silkscreen",
-          "position": {
-            "x": 144050000,
-            "y": 102460000
-          },
-          "shape": 0,
-          "start": {
-            "x": 144050000,
-            "y": 102460000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 146700000,
-            "y": 102460000
-          },
-          "layer": "F.Silkscreen",
-          "position": {
-            "x": 144050000,
-            "y": 102460000
-          },
-          "shape": 0,
-          "start": {
-            "x": 144050000,
-            "y": 102460000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 149350000,
-            "y": 110190000
-          },
-          "layer": "F.Silkscreen",
-          "position": {
-            "x": 144050000,
-            "y": 110190000
-          },
-          "shape": 0,
-          "start": {
-            "x": 144050000,
-            "y": 110190000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 145430000,
-            "y": 99920000
-          },
-          "layer": "F.Fab",
-          "position": {
-            "x": 144160000,
-            "y": 101190000
-          },
-          "shape": 0,
-          "start": {
-            "x": 144160000,
-            "y": 101190000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 100000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 144160000,
-            "y": 101190000
-          },
-          "layer": "F.Fab",
-          "position": {
-            "x": 144160000,
-            "y": 110080000
-          },
-          "shape": 0,
-          "start": {
-            "x": 144160000,
-            "y": 110080000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 100000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 149240000,
-            "y": 99920000
-          },
-          "layer": "F.Fab",
-          "position": {
-            "x": 145430000,
+            "x": 142545000,
             "y": 99920000
           },
           "shape": 0,
           "start": {
-            "x": 145430000,
+            "x": 142545000,
+            "y": 99920000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 142545000,
+            "y": 111460000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 142545000,
+            "y": 101190000
+          },
+          "shape": 0,
+          "start": {
+            "x": 142545000,
+            "y": 101190000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 145195000,
+            "y": 101190000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 142545000,
+            "y": 101190000
+          },
+          "shape": 0,
+          "start": {
+            "x": 142545000,
+            "y": 101190000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147845000,
+            "y": 111460000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 142545000,
+            "y": 111460000
+          },
+          "shape": 0,
+          "start": {
+            "x": 142545000,
+            "y": 111460000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 143925000,
+            "y": 98650000
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 142655000,
+            "y": 99920000
+          },
+          "shape": 0,
+          "start": {
+            "x": 142655000,
             "y": 99920000
           },
           "text": null,
@@ -807,18 +767,58 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149350000,
-            "y": 99810000
+            "x": 142655000,
+            "y": 99920000
           },
-          "layer": "F.Silkscreen",
+          "layer": "F.Fab",
           "position": {
-            "x": 146700000,
-            "y": 99810000
+            "x": 142655000,
+            "y": 111350000
           },
           "shape": 0,
           "start": {
-            "x": 146700000,
-            "y": 99810000
+            "x": 142655000,
+            "y": 111350000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147735000,
+            "y": 98650000
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 143925000,
+            "y": 98650000
+          },
+          "shape": 0,
+          "start": {
+            "x": 143925000,
+            "y": 98650000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147845000,
+            "y": 98540000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 145195000,
+            "y": 98540000
+          },
+          "shape": 0,
+          "start": {
+            "x": 145195000,
+            "y": 98540000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -827,18 +827,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 146700000,
-            "y": 99810000
+            "x": 145195000,
+            "y": 98540000
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 146700000,
-            "y": 102460000
+            "x": 145195000,
+            "y": 101190000
           },
           "shape": 0,
           "start": {
-            "x": 146700000,
-            "y": 102460000
+            "x": 145195000,
+            "y": 101190000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -849,7 +849,7 @@ expression: content
           "end": null,
           "layer": "F.Fab",
           "position": {
-            "x": 146700000,
+            "x": 145195000,
             "y": 105000000
           },
           "shape": null,
@@ -861,18 +861,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149240000,
-            "y": 110080000
+            "x": 147735000,
+            "y": 111350000
           },
           "layer": "F.Fab",
           "position": {
-            "x": 149240000,
-            "y": 99920000
+            "x": 147735000,
+            "y": 98650000
           },
           "shape": 0,
           "start": {
-            "x": 149240000,
-            "y": 99920000
+            "x": 147735000,
+            "y": 98650000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -881,18 +881,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 144160000,
-            "y": 110080000
+            "x": 142655000,
+            "y": 111350000
           },
           "layer": "F.Fab",
           "position": {
-            "x": 149240000,
-            "y": 110080000
+            "x": 147735000,
+            "y": 111350000
           },
           "shape": 0,
           "start": {
-            "x": 149240000,
-            "y": 110080000
+            "x": 147735000,
+            "y": 111350000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -901,18 +901,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149350000,
-            "y": 110190000
+            "x": 147845000,
+            "y": 111460000
           },
           "layer": "F.Silkscreen",
           "position": {
-            "x": 149350000,
-            "y": 99810000
+            "x": 147845000,
+            "y": 98540000
           },
           "shape": 0,
           "start": {
-            "x": 149350000,
-            "y": 99810000
+            "x": 147845000,
+            "y": 98540000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -921,18 +921,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 143660000,
-            "y": 99420000
+            "x": 142155000,
+            "y": 98150000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 149750000,
-            "y": 99420000
+            "x": 148245000,
+            "y": 98150000
           },
           "shape": 0,
           "start": {
-            "x": 149750000,
-            "y": 99420000
+            "x": 148245000,
+            "y": 98150000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -941,18 +941,18 @@ expression: content
         {
           "angle": null,
           "end": {
-            "x": 149750000,
-            "y": 99420000
+            "x": 148245000,
+            "y": 98150000
           },
           "layer": "F.Courtyard",
           "position": {
-            "x": 149750000,
-            "y": 110580000
+            "x": 148245000,
+            "y": 111850000
           },
           "shape": 0,
           "start": {
-            "x": 149750000,
-            "y": 110580000
+            "x": 148245000,
+            "y": 111850000
           },
           "text": null,
           "type": "PCB_SHAPE",
@@ -968,73 +968,340 @@ expression: content
           "layer": "F.Cu",
           "name": "1",
           "position": {
-            "x": 145430000,
-            "y": 101190000
+            "x": 143925000,
+            "y": 99920000
           }
         },
         {
           "layer": "F.Cu",
           "name": "2",
           "position": {
-            "x": 147970000,
-            "y": 101190000
+            "x": 146465000,
+            "y": 99920000
           }
         },
         {
           "layer": "F.Cu",
           "name": "3",
           "position": {
-            "x": 145430000,
-            "y": 103730000
+            "x": 143925000,
+            "y": 102460000
           }
         },
         {
           "layer": "F.Cu",
           "name": "4",
           "position": {
-            "x": 147970000,
-            "y": 103730000
+            "x": 146465000,
+            "y": 102460000
           }
         },
         {
           "layer": "F.Cu",
           "name": "5",
           "position": {
-            "x": 145430000,
-            "y": 106270000
+            "x": 143925000,
+            "y": 105000000
           }
         },
         {
           "layer": "F.Cu",
           "name": "6",
           "position": {
-            "x": 147970000,
-            "y": 106270000
+            "x": 146465000,
+            "y": 105000000
           }
         },
         {
           "layer": "F.Cu",
           "name": "7",
           "position": {
-            "x": 145430000,
-            "y": 108810000
+            "x": 143925000,
+            "y": 107540000
           }
         },
         {
           "layer": "F.Cu",
           "name": "8",
           "position": {
-            "x": 147970000,
-            "y": 108810000
+            "x": 146465000,
+            "y": 107540000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "9",
+          "position": {
+            "x": 143925000,
+            "y": 110080000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "10",
+          "position": {
+            "x": 146465000,
+            "y": 110080000
           }
         }
       ],
       "position": {
-        "x": 145430000,
-        "y": 101190000
+        "x": 143925000,
+        "y": 99920000
+      },
+      "reference": "U2",
+      "uuid": "bb9170a7-68d4-539c-bed9-f036cbc8d7db",
+      "value": "?"
+    },
+    {
+      "dnp": false,
+      "exclude_from_bom": false,
+      "exclude_from_pos_files": false,
+      "footprint": "Resistor_SMD:R_0603_1608Metric",
+      "graphical_items": [
+        {
+          "angle": null,
+          "end": {
+            "x": 151255000,
+            "y": 106800000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 148295000,
+            "y": 106800000
+          },
+          "shape": 0,
+          "start": {
+            "x": 148295000,
+            "y": 106800000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 148295000,
+            "y": 106800000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 148295000,
+            "y": 108260000
+          },
+          "shape": 0,
+          "start": {
+            "x": 148295000,
+            "y": 108260000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150575000,
+            "y": 107117500
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 148975000,
+            "y": 107117500
+          },
+          "shape": 0,
+          "start": {
+            "x": 148975000,
+            "y": 107117500
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 148975000,
+            "y": 107117500
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 148975000,
+            "y": 107942500
+          },
+          "shape": 0,
+          "start": {
+            "x": 148975000,
+            "y": 107942500
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150012258,
+            "y": 107007500
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 149537742,
+            "y": 107007500
+          },
+          "shape": 0,
+          "start": {
+            "x": 149537742,
+            "y": 107007500
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150012258,
+            "y": 108052500
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 149537742,
+            "y": 108052500
+          },
+          "shape": 0,
+          "start": {
+            "x": 149537742,
+            "y": 108052500
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": null,
+          "layer": "F.Fab",
+          "position": {
+            "x": 149775000,
+            "y": 107530000
+          },
+          "shape": null,
+          "start": null,
+          "text": "${REFERENCE}",
+          "type": "PCB_TEXT",
+          "width": null
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150575000,
+            "y": 107942500
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 150575000,
+            "y": 107117500
+          },
+          "shape": 0,
+          "start": {
+            "x": 150575000,
+            "y": 107117500
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 148975000,
+            "y": 107942500
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 150575000,
+            "y": 107942500
+          },
+          "shape": 0,
+          "start": {
+            "x": 150575000,
+            "y": 107942500
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 151255000,
+            "y": 108260000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 151255000,
+            "y": 106800000
+          },
+          "shape": 0,
+          "start": {
+            "x": 151255000,
+            "y": 106800000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 148295000,
+            "y": 108260000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 151255000,
+            "y": 108260000
+          },
+          "shape": 0,
+          "start": {
+            "x": 151255000,
+            "y": 108260000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        }
+      ],
+      "group": null,
+      "layer": "F.Cu",
+      "locked": false,
+      "orientation": 0.0,
+      "pads": [
+        {
+          "layer": "F.Cu",
+          "name": "1",
+          "position": {
+            "x": 148950000,
+            "y": 107530000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "2",
+          "position": {
+            "x": 150600000,
+            "y": 107530000
+          }
+        }
+      ],
+      "position": {
+        "x": 149775000,
+        "y": 107530000
       },
       "reference": "U1",
-      "uuid": "bb9170a7-68d4-539c-bed9-f036cbc8d7db",
+      "uuid": "d46924ad-0704-596b-aec7-b052974f9171",
       "value": "?"
     }
   ],

--- a/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.netclass_patterns.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.netclass_patterns.json.snap
@@ -12,6 +12,14 @@ expression: content
     "pattern": "CLK_51"
   },
   {
+    "netclass": "85Ohm Diff",
+    "pattern": "HDMI_N"
+  },
+  {
+    "netclass": "85Ohm Diff",
+    "pattern": "HDMI_P"
+  },
+  {
     "netclass": "50Ohm SE",
     "pattern": "SPI_CLK_50"
   },


### PR DESCRIPTION
propagate_from_value() was only checking nested interface fields for impedance, missing the case where a module parameter is itself a DiffPair with impedance. For example:

TX1 = DiffPair("TX1", impedance=Impedance(85))
ADRV9004x(TX1=TX1)  # impedance was lost

Fixed by checking the interface itself first before recursing into nested fields.