### PR TITLE
Parse more ipc primitives

### DIFF
--- a/crates/ipc2581/src/types/primitives.rs
+++ b/crates/ipc2581/src/types/primitives.rs
@@ -1,49 +1,65 @@
 use crate::Symbol;
 use std::str::FromStr;
 
+/// 2D point
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+/// 2D size (width × height)
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Size {
+    pub width: f64,
+    pub height: f64,
+}
+
+/// Wrapper for primitives with optional fill and line styling
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Styled<T> {
+    pub shape: T,
+    pub fill_property: Option<FillProperty>,
+    pub line_desc_ref: Option<Symbol>,
+}
+
 /// Standard geometric primitives
 #[derive(Debug, Clone, PartialEq)]
 pub enum StandardPrimitive {
-    Circle(Circle),
-    RectCenter(RectCenter),
-    RectRound(RectRound),
-    RectCham(RectCham),
-    RectCorner(RectCorner),
-    Oval(Oval),
-    Butterfly(Butterfly),
-    Diamond(Diamond),
-    Donut(Donut),
-    Ellipse(Ellipse),
-    Hexagon(Hexagon),
-    Moire(Moire),
-    Octagon(Octagon),
-    Thermal(Thermal),
-    Triangle(Triangle),
-    Contour(Contour),
+    Circle(Styled<Circle>),
+    RectCenter(Styled<RectCenter>),
+    RectRound(Styled<RectRound>),
+    RectCham(Styled<RectCham>),
+    RectCorner(Styled<RectCorner>),
+    Oval(Styled<Oval>),
+    Butterfly(Styled<Butterfly>),
+    Diamond(Styled<Diamond>),
+    Donut(Styled<Donut>),
+    Ellipse(Styled<Ellipse>),
+    Hexagon(Styled<Hexagon>),
+    Moire(Moire), // Moire doesn't have styling
+    Octagon(Styled<Octagon>),
+    Thermal(Styled<Thermal>),
+    Triangle(Styled<Triangle>),
+    Contour(Contour), // Contour has its own structure
 }
 
 /// Circle primitive defined by diameter
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Circle {
     pub diameter: f64,
-    pub fill_property: Option<FillProperty>,
-    pub line_desc_ref: Option<Symbol>,
 }
 
 /// Rectangle centered at origin
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RectCenter {
-    pub width: f64,
-    pub height: f64,
-    pub fill_property: Option<FillProperty>,
-    pub line_desc_ref: Option<Symbol>,
+    pub size: Size,
 }
 
 /// Rectangle with rounded corners
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RectRound {
-    pub width: f64,
-    pub height: f64,
+    pub size: Size,
     pub radius: f64,
     pub upper_right: bool,
     pub upper_left: bool,
@@ -54,8 +70,7 @@ pub struct RectRound {
 /// Rectangle with chamfered corners
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RectCham {
-    pub width: f64,
-    pub height: f64,
+    pub size: Size,
     pub chamfer: f64,
     pub upper_right: bool,
     pub upper_left: bool,
@@ -66,17 +81,14 @@ pub struct RectCham {
 /// Rectangle defined by corner coordinates
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RectCorner {
-    pub lower_left_x: f64,
-    pub lower_left_y: f64,
-    pub upper_right_x: f64,
-    pub upper_right_y: f64,
+    pub lower_left: Point,
+    pub upper_right: Point,
 }
 
 /// Oval (rectangle with rounded ends)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Oval {
-    pub width: f64,
-    pub height: f64,
+    pub size: Size,
 }
 
 /// Butterfly shape (round or square with 2 quadrants removed)
@@ -95,20 +107,20 @@ pub enum ButterflyShape {
 /// Diamond (4-sided with equal sides)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Diamond {
-    pub width: f64,
-    pub height: f64,
+    pub size: Size,
 }
 
 /// Donut (concentric shapes)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Donut {
-    pub shape: DonutShape,
+    pub shape: ConcentricShape,
     pub outer_diameter: f64,
     pub inner_diameter: f64,
 }
 
+/// Shape used for Donut and Thermal primitives
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DonutShape {
+pub enum ConcentricShape {
     Round,
     Square,
     Hexagon,
@@ -118,8 +130,7 @@ pub enum DonutShape {
 /// Ellipse
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Ellipse {
-    pub width: f64,
-    pub height: f64,
+    pub size: Size,
 }
 
 /// Hexagon (6-sided regular polygon)
@@ -149,20 +160,12 @@ pub struct Octagon {
 /// Thermal relief pattern
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Thermal {
-    pub shape: ThermalShape,
+    pub shape: ConcentricShape,
     pub outer_diameter: f64,
     pub inner_diameter: f64,
     pub spoke_count: u32,
     pub spoke_width: Option<f64>,
     pub spoke_start_angle: Option<f64>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ThermalShape {
-    Round,
-    Square,
-    Hexagon,
-    Octagon,
 }
 
 /// Triangle (isosceles)
@@ -187,11 +190,7 @@ pub struct Polygon {
 }
 
 /// Polygon starting point
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PolyBegin {
-    pub x: f64,
-    pub y: f64,
-}
+pub type PolyBegin = Point;
 
 /// Polygon continuation step
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -203,17 +202,14 @@ pub enum PolyStep {
 /// Straight line segment in polygon
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PolyStepSegment {
-    pub x: f64,
-    pub y: f64,
+    pub point: Point,
 }
 
 /// Curved arc segment in polygon
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PolyStepCurve {
-    pub x: f64,
-    pub y: f64,
-    pub center_x: f64,
-    pub center_y: f64,
+    pub point: Point,
+    pub center: Point,
     pub clockwise: bool,
 }
 
@@ -227,21 +223,16 @@ pub struct Polyline {
 /// Line segment
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Line {
-    pub start_x: f64,
-    pub start_y: f64,
-    pub end_x: f64,
-    pub end_y: f64,
+    pub start: Point,
+    pub end: Point,
 }
 
 /// Arc segment
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Arc {
-    pub start_x: f64,
-    pub start_y: f64,
-    pub end_x: f64,
-    pub end_y: f64,
-    pub center_x: f64,
-    pub center_y: f64,
+    pub start: Point,
+    pub end: Point,
+    pub center: Point,
     pub clockwise: bool,
 }
 
@@ -342,30 +333,16 @@ impl FromStr for ButterflyShape {
     }
 }
 
-impl FromStr for DonutShape {
+impl FromStr for ConcentricShape {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "ROUND" => Ok(DonutShape::Round),
-            "SQUARE" => Ok(DonutShape::Square),
-            "HEXAGON" => Ok(DonutShape::Hexagon),
-            "OCTAGON" => Ok(DonutShape::Octagon),
-            _ => Err(format!("Unknown donutShape: {}", s)),
-        }
-    }
-}
-
-impl FromStr for ThermalShape {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ROUND" => Ok(ThermalShape::Round),
-            "SQUARE" => Ok(ThermalShape::Square),
-            "HEXAGON" => Ok(ThermalShape::Hexagon),
-            "OCTAGON" => Ok(ThermalShape::Octagon),
-            _ => Err(format!("Unknown thermalShape: {}", s)),
+            "ROUND" => Ok(ConcentricShape::Round),
+            "SQUARE" => Ok(ConcentricShape::Square),
+            "HEXAGON" => Ok(ConcentricShape::Hexagon),
+            "OCTAGON" => Ok(ConcentricShape::Octagon),
+            _ => Err(format!("Unknown concentricShape: {}", s)),
         }
     }
 }

--- a/crates/ipc2581/tests/testcases.rs
+++ b/crates/ipc2581/tests/testcases.rs
@@ -108,24 +108,24 @@ fn parse_and_validate(path: &Path) {
                 // Validate primitive-specific constraints
                 match &entry.primitive {
                     StandardPrimitive::Circle(c) => {
-                        assert!(c.diameter > 0.0, "Circle diameter must be positive");
+                        assert!(c.shape.diameter > 0.0, "Circle diameter must be positive");
                     }
                     StandardPrimitive::RectCenter(r) => {
                         assert!(
-                            r.width > 0.0 && r.height > 0.0,
+                            r.shape.size.width > 0.0 && r.shape.size.height > 0.0,
                             "Rectangle dimensions must be positive"
                         );
                     }
                     StandardPrimitive::RectRound(r) => {
                         assert!(
-                            r.width > 0.0 && r.height > 0.0,
+                            r.shape.size.width > 0.0 && r.shape.size.height > 0.0,
                             "Rectangle dimensions must be positive"
                         );
-                        assert!(r.radius >= 0.0, "Radius must be non-negative");
+                        assert!(r.shape.radius >= 0.0, "Radius must be non-negative");
                     }
                     StandardPrimitive::Oval(o) => {
                         assert!(
-                            o.width > 0.0 && o.height > 0.0,
+                            o.shape.size.width > 0.0 && o.shape.size.height > 0.0,
                             "Oval dimensions must be positive"
                         );
                     }
@@ -324,11 +324,11 @@ fn test_kicad_dm0002() {
 
         match &entry.primitive {
             StandardPrimitive::Circle(c) => {
-                assert!(c.diameter > 0.0, "Circle diameter must be positive");
+                assert!(c.shape.diameter > 0.0, "Circle diameter must be positive");
             }
             StandardPrimitive::RectCenter(r) => {
                 assert!(
-                    r.width > 0.0 && r.height > 0.0,
+                    r.shape.size.width > 0.0 && r.shape.size.height > 0.0,
                     "Rectangle dimensions must be positive"
                 );
             }
@@ -461,8 +461,8 @@ fn test_testcase1_metadata() {
 
             for step in &polygon.steps {
                 let (x, y) = match step {
-                    ipc2581::PolyStep::Segment(s) => (s.x, s.y),
-                    ipc2581::PolyStep::Curve(c) => (c.x, c.y),
+                    ipc2581::PolyStep::Segment(s) => (s.point.x, s.point.y),
+                    ipc2581::PolyStep::Curve(c) => (c.point.x, c.point.y),
                 };
                 min_x = min_x.min(x);
                 max_x = max_x.max(x);
@@ -688,8 +688,8 @@ fn print_testcase_metadata(
 
             for step in &polygon.steps {
                 let (x, y) = match step {
-                    ipc2581::PolyStep::Segment(s) => (s.x, s.y),
-                    ipc2581::PolyStep::Curve(c) => (c.x, c.y),
+                    ipc2581::PolyStep::Segment(s) => (s.point.x, s.point.y),
+                    ipc2581::PolyStep::Curve(c) => (c.point.x, c.point.y),
                 };
                 min_x = min_x.min(x);
                 max_x = max_x.max(x);

--- a/crates/pcb-ipc2581-tools/src/commands/info.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/info.rs
@@ -132,17 +132,17 @@ fn calculate_board_dimensions(step: &Step) -> Option<(f64, f64)> {
         for step in &profile.polygon.steps {
             match step {
                 ipc2581::types::PolyStep::Segment(seg) => {
-                    min_x = min_x.min(seg.x);
-                    max_x = max_x.max(seg.x);
-                    min_y = min_y.min(seg.y);
-                    max_y = max_y.max(seg.y);
+                    min_x = min_x.min(seg.point.x);
+                    max_x = max_x.max(seg.point.x);
+                    min_y = min_y.min(seg.point.y);
+                    max_y = max_y.max(seg.point.y);
                 }
                 ipc2581::types::PolyStep::Curve(curve) => {
                     // TODO: Calculate actual arc bounding box, not just endpoints
-                    min_x = min_x.min(curve.x);
-                    max_x = max_x.max(curve.x);
-                    min_y = min_y.min(curve.y);
-                    max_y = max_y.max(curve.y);
+                    min_x = min_x.min(curve.point.x);
+                    max_x = max_x.max(curve.point.x);
+                    min_y = min_y.min(curve.point.y);
+                    max_y = max_y.max(curve.point.y);
                 }
             }
         }


### PR DESCRIPTION
```
| Primitive  | Attributes                                                                      | Notes                              |
|------------|---------------------------------------------------------------------------------|------------------------------------|
| Butterfly  | shape (ROUND/SQUARE), diameter/side                                             | Shape-dependent sizing             |
| Diamond    | width, height                                                                   | 4-sided with equal sides           |
| Donut      | shape (ROUND/SQUARE/HEXAGON/OCTAGON), outerDiameter, innerDiameter              | Concentric shapes                  |
| Ellipse    | width, height                                                                   | Standard ellipse                   |
| Hexagon    | length (point-to-point)                                                         | 6-sided regular polygon            |
| Moire      | diameter, ringWidth, ringGap, ringNumber, lineWidth*, lineLength*, lineAngle*   | Registration target (* = optional) |
| Octagon    | length (point-to-point)                                                         | 8-sided regular polygon            |
| RectCorner | lowerLeftX, lowerLeftY, upperRightX, upperRightY                                | Rectangle by corner coords         |
| Thermal    | shape, outerDiameter, innerDiameter, spokeCount*, spokeWidth*, spokeStartAngle* | Thermal relief (* = optional)      |
| Triangle   | base, height                                                                    | Isosceles triangle                 |
```