### PR TITLE
Don't include soldermask in step export

### DIFF
--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -1307,7 +1307,6 @@ fn generate_step_model(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         .arg("--no-unspecified")
         .arg("--include-pads")
         .arg("--include-silkscreen")
-        .arg("--include-soldermask")
         .arg(kicad_pcb_path.to_string_lossy())
         .log_file(devnull)
         .suppress_error_output(true)


### PR DESCRIPTION
For some reason, this adds ~19.5 minutes to a release on some boards.