### PR TITLE
Don't include pads in step file as well

### DIFF
--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -1305,7 +1305,6 @@ fn generate_step_model(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         .arg(step_path.to_string_lossy())
         .arg("--no-dnp")
         .arg("--no-unspecified")
-        .arg("--include-pads")
         .arg("--include-silkscreen")
         .arg(kicad_pcb_path.to_string_lossy())
         .log_file(devnull)


### PR DESCRIPTION
They're not mechanically significant, and increase step export times by
2x and file sizes by 2x to 7x.
