### PR TITLE
Fix board .zen file discovery in pcb info v2

### DIFF
--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -254,19 +254,16 @@ pub fn get_workspace_info<F: FileProvider>(
     start_path: &Path,
 ) -> Result<WorkspaceInfo> {
     let mut info = pcb_zen_core::workspace::get_workspace_info(file_provider, start_path)?;
-    enrich_with_git_versions(&mut info);
-    Ok(info)
-}
 
-/// Enrich workspace info with version information from git tags
-pub fn enrich_with_git_versions(info: &mut WorkspaceInfo) {
+    // Enrich with git tag versions (native-only feature)
     let all_tags = git::list_all_tags_vec(&info.root);
     let workspace_path = info.path().map(|s| s.to_string());
-
     for pkg in info.packages.values_mut() {
         let tag_prefix = tags::compute_tag_prefix(Some(&pkg.rel_path), workspace_path.as_deref());
         pkg.version = tags::find_latest_version(&all_tags, &tag_prefix).map(|v| v.to_string());
     }
+
+    Ok(info)
 }
 
 #[cfg(test)]

--- a/crates/pcb/src/info.rs
+++ b/crates/pcb/src/info.rs
@@ -114,6 +114,7 @@ fn print_v2_human_readable(ws: &WorkspaceInfo) {
 
         for pkg in &boards {
             if let Some(board) = &pkg.config.board {
+                // board.path is already populated by populate_board_zen_paths()
                 let zen_path = board
                     .path
                     .as_ref()
@@ -126,7 +127,7 @@ fn print_v2_human_readable(ws: &WorkspaceInfo) {
                             format!("{}/{}", pkg_rel, p)
                         }
                     })
-                    .unwrap_or_else(|| "?.zen".to_string());
+                    .unwrap_or_else(|| "(no .zen file found)".to_string());
 
                 // Use package version (which is board version for board packages)
                 let version_str = format_version(&pkg.version, false);

--- a/crates/pcb/tests/snapshots/info__multiple_zen_files.snap
+++ b/crates/pcb/tests/snapshots/info__multiple_zen_files.snap
@@ -1,0 +1,16 @@
+---
+source: crates/pcb/tests/info.rs
+expression: output
+---
+Command: pcb info
+Exit Code: 0
+
+--- STDOUT ---
+Workspace
+Root: <TEMP_DIR>
+Toolchain: pcb >= 0.3
+
+Boards (1)
+  AmbiguousBoard (unpublished) - (no .zen file found)
+    Board with multiple zen files
+--- STDERR ---

--- a/crates/pcb/tests/snapshots/info__zen_discovery.snap
+++ b/crates/pcb/tests/snapshots/info__zen_discovery.snap
@@ -1,0 +1,15 @@
+---
+source: crates/pcb/tests/info.rs
+expression: output
+---
+Command: pcb info
+Exit Code: 0
+
+--- STDOUT ---
+Workspace
+Root: <TEMP_DIR>
+
+Boards (1)
+  DiscoveredBoard - boards/discovered/discovered.zen
+    Board with auto-discovered zen file
+--- STDERR ---

--- a/crates/pcb/tests/snapshots/info__zen_discovery_json.snap
+++ b/crates/pcb/tests/snapshots/info__zen_discovery_json.snap
@@ -1,0 +1,29 @@
+---
+source: crates/pcb/tests/info.rs
+expression: output
+---
+Command: pcb info -f json
+Exit Code: 0
+
+--- STDOUT ---
+{
+  "root": "<TEMP_DIR>",
+  "config": null,
+  "packages": {
+    "boards/discovered": {
+      "dir": "<TEMP_DIR>/boards/discovered",
+      "rel_path": "boards/discovered",
+      "config": {
+        "workspace": null,
+        "board": {
+          "name": "DiscoveredBoard",
+          "path": "discovered.zen",
+          "description": "Board with auto-discovered zen file"
+        }
+      },
+      "version": null
+    }
+  },
+  "errors": []
+}
+--- STDERR ---


### PR DESCRIPTION
Before:
```
Boards (3)
  DM0001 (v1.0.3) - ?.zen
    Compact 3-phase BLDC motor controller. Features STM32G4, CAN bus, and hall encoder support.
  DM0002 (v0.1.8) - ?.zen
    RP2040-based CMSIS-DAP debug probe. Supports SWD, UART, and USB passthrough.
  DM0003 (v1.0.0) - ?.zen
    Raspberry Pi CM5 carrier board. Features HDMI, PCIe M.2, USB-C PD, and Gigabit Ethernet.
```

after:
```
Boards (3)
  DM0001 (v1.0.3) - boards/DM0001/DM0001.zen
    Compact 3-phase BLDC motor controller. Features STM32G4, CAN bus, and hall encoder support.
  DM0002 (v0.1.8) - boards/DM0002/DM0002.zen
    RP2040-based CMSIS-DAP debug probe. Supports SWD, UART, and USB passthrough.
  DM0003 (v1.0.0) - boards/DM0003/DM0003.zen
    Raspberry Pi CM5 carrier board. Features HDMI, PCIe M.2, USB-C PD, and Gigabit Ethernet.
```

we were already doing this correctly in the release, so just incorporate it into `get_workspace_info()` for deduplication + early discovery.