### PR TITLE
Reduce stdlib-version-check cron freq to once a day

### DIFF
--- a/.github/workflows/stdlib-version-check.yml
+++ b/.github/workflows/stdlib-version-check.yml
@@ -2,8 +2,8 @@ name: Check stdlib version
 
 on:
   schedule:
-    # Run every hour
-    - cron: '0 * * * *'
+    # Run once a day at midnight UTC
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The stdlib -> pcb dispatch workflow actually works. So the cron job is
only needed as a fallback in case the dispatch fails due to some github
outage (which is unfortunately very likely). But once a day should still
be enough.

stdlib -> pcb dispatch working:
https://github.com/diodeinc/stdlib/actions/runs/20256822805/job/58160597226
https://github.com/diodeinc/pcb/actions/runs/20256824804
https://github.com/diodeinc/pcb/pull/359