### PR TITLE
Add `pcb build --locked`

### DIFF
--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -51,11 +51,12 @@ fn create_standard_load_resolver(
     let workspace_root = find_workspace_root(file_provider.as_ref(), file_path);
 
     // Resolve V2 dependencies if this is a V2 workspace
+    // LSP uses locked=false since interactive development should allow auto-deps
     let v2_resolutions = crate::get_workspace_info(&file_provider, file_path)
         .ok()
         .filter(|ws| ws.is_v2())
         .and_then(|mut ws| {
-            crate::resolve_dependencies(&mut ws, false)
+            crate::resolve_dependencies(&mut ws, false, false)
                 .ok()
                 .map(|res| res.package_resolutions)
         });

--- a/crates/pcb/src/bom.rs
+++ b/crates/pcb/src/bom.rs
@@ -78,12 +78,17 @@ pub struct BomArgs {
     /// Disable network access (offline mode) - only use vendored dependencies
     #[arg(long = "offline")]
     pub offline: bool,
+
+    /// Require that pcb.toml and pcb.sum are up-to-date. Fails if auto-deps would
+    /// add dependencies or if the lockfile would be modified. Recommended for CI.
+    #[arg(long)]
+    pub locked: bool,
 }
 
 pub fn execute(args: BomArgs) -> Result<()> {
     // V2 workspace-first architecture: resolve dependencies before evaluation
     let (_workspace_info, resolution_result) =
-        crate::resolve::resolve_v2_if_needed(args.file.parent(), args.offline)?;
+        crate::resolve::resolve_v2_if_needed(args.file.parent(), args.offline, args.locked)?;
 
     let file_name = args.file.file_name().unwrap().to_string_lossy();
 

--- a/crates/pcb/src/build.rs
+++ b/crates/pcb/src/build.rs
@@ -81,6 +81,11 @@ pub struct BuildArgs {
     /// Supports hierarchical matching (e.g., 'style' matches 'style.naming.io')
     #[arg(short = 'W', long = "warn", value_name = "KIND")]
     pub warn: Vec<String>,
+
+    /// Require that pcb.toml and pcb.sum are up-to-date. Fails if auto-deps would
+    /// add dependencies or if the lockfile would be modified. Recommended for CI.
+    #[arg(long)]
+    pub locked: bool,
 }
 
 /// Print success message with component count for a built schematic
@@ -190,6 +195,7 @@ pub fn execute(args: BuildArgs) -> Result<()> {
     let (workspace_info, resolution_result) = crate::resolve::resolve_v2_if_needed(
         args.paths.first().map(|p| p.as_path()),
         args.offline,
+        args.locked,
     )?;
 
     // Process .zen files using shared walker - always recursive for directories

--- a/crates/pcb/src/info.rs
+++ b/crates/pcb/src/info.rs
@@ -59,7 +59,7 @@ pub fn execute(args: InfoArgs) -> Result<()> {
         if workspace_info.is_v2() {
             println!();
             println!("{}", "Dependencies".with_style(Style::Blue).bold());
-            let result = pcb_zen::resolve_dependencies(&mut workspace_info, false)?;
+            let result = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)?;
             result.print_tree(&workspace_info);
         } else {
             eprintln!("Dependency tree is only available for V2 workspaces");

--- a/crates/pcb/src/open.rs
+++ b/crates/pcb/src/open.rs
@@ -15,6 +15,11 @@ pub struct OpenArgs {
     /// Disable network access (offline mode) - only use vendored dependencies
     #[arg(long = "offline")]
     pub offline: bool,
+
+    /// Require that pcb.toml and pcb.sum are up-to-date. Fails if auto-deps would
+    /// add dependencies or if the lockfile would be modified. Recommended for CI.
+    #[arg(long)]
+    pub locked: bool,
 }
 
 pub fn execute(args: OpenArgs) -> Result<()> {
@@ -22,6 +27,7 @@ pub fn execute(args: OpenArgs) -> Result<()> {
     let (workspace_info, resolution_result) = crate::resolve::resolve_v2_if_needed(
         args.paths.first().map(|p| p.as_path()),
         args.offline,
+        args.locked,
     )?;
 
     open_layout(&args, &workspace_info, resolution_result)

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -462,7 +462,7 @@ fn build_workspace(workspace: &WorkspaceInfo, suppress: &[String]) -> Result<()>
 
     let resolution_result = if workspace.is_v2() {
         let mut ws = workspace.clone();
-        let resolution = pcb_zen::resolve_dependencies(&mut ws, false)?;
+        let resolution = pcb_zen::resolve_dependencies(&mut ws, false, false)?;
         pcb_zen::vendor_deps(&ws, &resolution, &[], None)?;
         Some(resolution)
     } else {

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -331,7 +331,8 @@ pub fn execute(args: ReleaseArgs) -> Result<()> {
         // For V2: run resolution before eval to get package closure
         let (v2_resolution, v2_closure) = if is_v2 {
             info_spinner.set_message("Resolving V2 dependencies");
-            let resolution = pcb_zen::resolve_dependencies(&mut config_workspace_info, false)?;
+            let resolution =
+                pcb_zen::resolve_dependencies(&mut config_workspace_info, false, false)?;
 
             // Find the package URL for this board
             let closure = config_workspace_info
@@ -1061,8 +1062,8 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<()> {
     let staged_resolution = if info.v2_resolution.is_some() {
         let mut staged_workspace =
             get_workspace_info(&DefaultFileProvider::new(), &staged_zen_path)?;
-        // Staged sources have vendored deps, so run resolution in offline mode
-        let resolution = pcb_zen::resolve_dependencies(&mut staged_workspace, true)?;
+        // Staged sources have vendored deps, so run resolution in offline mode (locked=false for release)
+        let resolution = pcb_zen::resolve_dependencies(&mut staged_workspace, true, false)?;
         Some(resolution)
     } else {
         None

--- a/crates/pcb/src/resolve.rs
+++ b/crates/pcb/src/resolve.rs
@@ -7,9 +7,15 @@ use pcb_zen_core::DefaultFileProvider;
 /// This is a shared helper used by build, bom, layout, and open commands.
 ///
 /// If `input_path` is None or empty, defaults to the current working directory.
+///
+/// When `locked` is true:
+/// - Auto-deps will not modify pcb.toml files
+/// - The lockfile (pcb.sum) will not be written
+/// - Resolution will fail if pcb.toml or pcb.sum would need to be modified
 pub fn resolve_v2_if_needed(
     input_path: Option<&Path>,
     offline: bool,
+    locked: bool,
 ) -> Result<(pcb_zen::WorkspaceInfo, Option<pcb_zen::ResolutionResult>)> {
     let cwd;
     let path = match input_path {
@@ -23,7 +29,7 @@ pub fn resolve_v2_if_needed(
     let mut workspace_info = pcb_zen::get_workspace_info(&DefaultFileProvider::new(), path)?;
 
     let resolution = if workspace_info.is_v2() {
-        let res = pcb_zen::resolve_dependencies(&mut workspace_info, offline)?;
+        let res = pcb_zen::resolve_dependencies(&mut workspace_info, offline, locked)?;
         pcb_zen::vendor_deps(&workspace_info, &res, &[], None)?;
         Some(res)
     } else {

--- a/crates/pcb/src/update.rs
+++ b/crates/pcb/src/update.rs
@@ -86,8 +86,9 @@ pub fn execute(args: UpdateArgs) -> Result<()> {
         .unwrap_or_default();
 
     // Run resolution to update lockfile (will re-fetch branch commits)
+    // locked=false since update is explicitly for updating deps
     let mut ws = workspace.clone();
-    pcb_zen::resolve_dependencies(&mut ws, false)?;
+    pcb_zen::resolve_dependencies(&mut ws, false, false)?;
 
     // Check if lockfile changed (includes branch/rev pseudo-version updates)
     let lockfile_path = workspace.root.join("pcb.sum");

--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -43,8 +43,8 @@ pub fn execute(args: VendorArgs) -> Result<()> {
 fn execute_v2(workspace_info: &mut pcb_zen::WorkspaceInfo) -> Result<()> {
     println!("V2 workspace detected - using closure-based vendoring\n");
 
-    // Vendoring always needs network access (offline=false)
-    let resolution = resolve_dependencies(workspace_info, false)?;
+    // Vendoring always needs network access (offline=false) and allows modifications (locked=false)
+    let resolution = resolve_dependencies(workspace_info, false, false)?;
 
     // Vendor everything - pass ["**"] pattern to match all packages and assets
     let result = vendor_deps(workspace_info, &resolution, &["**".to_string()], None)?;


### PR DESCRIPTION
Skips auto-dep and fails if pcb.sum file would be updated. Useful in CI.