### PR TITLE
Fix TUI package details not loading after fresh index download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix TUI package details not loading after fresh index download
+
 ## [0.3.19] - 2026-01-06
 
 ### Added


### PR DESCRIPTION
The detail worker thread exited immediately at startup if packages.db
didn't exist, before the search worker had a chance to download it.
Changed to lazily initialize the SQLite client on first request, allowing
hot-reload to work when the database becomes available.
