### PR TITLE
Fix inconsistent vendoring with folder assets and subfiles

### DIFF
--- a/crates/pcb-zen/src/resolve_v2.rs
+++ b/crates/pcb-zen/src/resolve_v2.rs
@@ -866,8 +866,13 @@ pub fn vendor_deps(
     }
 
     // Copy matching assets from workspace vendor or cache (handling subpaths)
+    // Sort assets so directories come before files within them - this ensures
+    // we copy the full directory instead of individual files when both are declared
+    let mut sorted_assets: Vec<_> = resolution.assets.keys().collect();
+    sorted_assets.sort_by(|(a, _), (b, _)| a.cmp(b));
+
     let mut asset_count = 0;
-    for (asset_key, ref_str) in resolution.assets.keys() {
+    for (asset_key, ref_str) in sorted_assets {
         if !glob_set.is_match(asset_key) {
             continue;
         }


### PR DESCRIPTION
In cases where we have an asset folder along with individual sub-files listed in the `pcb.sum`, if we decided to vendor the individual file first, we would skip vendoring the full folder to avoid duplicate copying (see `crates/pcb-zen/src/resolve_v2.rs:911`). This change sorts the order in which we choose to vendor dependencies such that folders always appear before their children to avoid this conflict.