### PR TITLE
Error out on `pcb.toml` parse failures

### DIFF
--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -5,6 +5,7 @@ use deunicode::deunicode;
 use indicatif::ProgressBar;
 use inquire::{Select, Text};
 use minijinja::Environment;
+use pcb_zen_core::config::find_workspace_root;
 use regex::Regex;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
@@ -1624,8 +1625,7 @@ fn execute_from_dir(dir: &Path, workspace_root: &Path) -> Result<()> {
 
 pub fn execute(args: SearchArgs) -> Result<()> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let workspace_root =
-        pcb_zen_core::config::find_workspace_root(&pcb_zen_core::DefaultFileProvider::new(), &cwd);
+    let workspace_root = find_workspace_root(&pcb_zen_core::DefaultFileProvider::new(), &cwd)?;
 
     // Handle --dir mode (local directory)
     if let Some(ref dir) = args.dir {

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -575,15 +575,15 @@ impl CoreLoadResolver {
         remote_fetcher: Arc<dyn RemoteFetcher>,
         file: &Path,
         use_vendor_dir: bool,
-    ) -> Self {
-        let workspace_root = config::find_workspace_root(file_provider.as_ref(), file);
-        Self::new(
+    ) -> anyhow::Result<Self> {
+        let workspace_root = config::find_workspace_root(file_provider.as_ref(), file)?;
+        Ok(Self::new(
             file_provider,
             remote_fetcher,
             workspace_root,
             use_vendor_dir,
             None,
-        )
+        ))
     }
 
     /// Get the effective workspace root for a given context, with caching.
@@ -603,7 +603,7 @@ impl CoreLoadResolver {
         } else {
             // Vendored dependency OR local file outside main workspace
             // Both cases: search for pcb.toml with [workspace]
-            config::find_workspace_root(self.file_provider.as_ref(), &context.current_file)
+            config::find_workspace_root(self.file_provider.as_ref(), &context.current_file)?
         };
 
         // Canonicalize the workspace root

--- a/crates/pcb-zen-core/src/workspace.rs
+++ b/crates/pcb-zen-core/src/workspace.rs
@@ -292,7 +292,7 @@ pub fn get_workspace_info<F: FileProvider>(
     file_provider: &F,
     start_path: &Path,
 ) -> Result<WorkspaceInfo, anyhow::Error> {
-    let workspace_root = find_workspace_root(file_provider, start_path);
+    let workspace_root = find_workspace_root(file_provider, start_path)?;
     let pcb_toml_path = workspace_root.join("pcb.toml");
 
     // Load root config

--- a/crates/pcb-zen-wasm/src/lib.rs
+++ b/crates/pcb-zen-wasm/src/lib.rs
@@ -253,7 +253,8 @@ pub fn evaluate_impl(
     };
 
     let main_path = PathBuf::from(&main_file);
-    let workspace_root = find_workspace_root(file_provider.as_ref(), &main_path);
+    let workspace_root = find_workspace_root(file_provider.as_ref(), &main_path)
+        .map_err(|e| format!("Failed to find workspace root: {e}"))?;
     let v2_resolutions = resolve_v2_packages(file_provider.clone(), &workspace_root);
 
     let load_resolver = Arc::new(pcb_zen_core::CoreLoadResolver::new(

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -61,7 +61,8 @@ pub fn eval(file: &Path, cfg: EvalConfig) -> WithDiagnostics<EvalOutput> {
         .expect("failed to canonicalise input path");
 
     let file_provider = Arc::new(DefaultFileProvider::new());
-    let workspace_root = find_workspace_root(&*file_provider, &abs_path);
+    let workspace_root =
+        find_workspace_root(&*file_provider, &abs_path).expect("failed to find workspace root");
 
     let remote_fetcher: Arc<dyn pcb_zen_core::RemoteFetcher> = if cfg.offline {
         Arc::new(NoopRemoteFetcher)

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -48,7 +48,8 @@ fn create_standard_load_resolver(
     file_provider: Arc<dyn FileProvider>,
     file_path: &Path,
 ) -> Arc<CoreLoadResolver> {
-    let workspace_root = find_workspace_root(file_provider.as_ref(), file_path);
+    let workspace_root = find_workspace_root(file_provider.as_ref(), file_path)
+        .expect("failed to find workspace root");
 
     // Resolve V2 dependencies if this is a V2 workspace
     // LSP uses locked=false since interactive development should allow auto-deps
@@ -122,7 +123,8 @@ impl LspEvalContext {
         current_file: &std::path::Path,
     ) -> Vec<Box<dyn pcb_zen_core::DiagnosticsPass>> {
         let file_provider = self.inner.file_provider();
-        let workspace_root = find_workspace_root(file_provider, current_file);
+        let workspace_root = find_workspace_root(file_provider, current_file)
+            .expect("failed to find workspace root");
         vec![
             Box::new(pcb_zen_core::FilterHiddenPass),
             Box::new(pcb_zen_core::LspFilterPass::new(workspace_root)),

--- a/crates/pcb/src/clean.rs
+++ b/crates/pcb/src/clean.rs
@@ -27,7 +27,7 @@ pub fn execute(args: CleanArgs) -> Result<()> {
     // Find the workspace root starting from current directory
     let current_dir = std::env::current_dir()?;
     let file_provider = DefaultFileProvider::new();
-    let project_root = find_workspace_root(&file_provider, &current_dir);
+    let project_root = find_workspace_root(&file_provider, &current_dir)?;
 
     // Define the temp directories to clean
     let temp_dirs = vec![project_root.join(".pcb")];

--- a/crates/pcb/src/migrate/codemods/remove_directory_loads.rs
+++ b/crates/pcb/src/migrate/codemods/remove_directory_loads.rs
@@ -23,7 +23,7 @@ impl Codemod for RemoveDirectoryLoads {
         let file_provider = Arc::new(DefaultFileProvider::new());
         let remote_fetcher = Arc::new(DefaultRemoteFetcher::default());
         let resolver =
-            CoreLoadResolver::for_file(file_provider.clone(), remote_fetcher, current_file, true);
+            CoreLoadResolver::for_file(file_provider.clone(), remote_fetcher, current_file, true)?;
 
         let ast = match AstModule::parse("<memory>", content.to_owned(), &Dialect::Extended) {
             Ok(a) => a,

--- a/crates/pcb/src/migrate/mod.rs
+++ b/crates/pcb/src/migrate/mod.rs
@@ -39,7 +39,7 @@ pub fn execute(args: MigrateArgs) -> Result<()> {
 
     // Step 1: Find workspace root
     eprintln!("Step 1: Detecting workspace root");
-    let workspace_root = find_workspace_root(&*file_provider, &start);
+    let workspace_root = find_workspace_root(&*file_provider, &start)?;
     eprintln!("  Workspace root: {}", workspace_root.display());
 
     // Step 2: Detect git repository info


### PR DESCRIPTION
```
Error: failed to parse /Users/akhilles/src/dioderobot/diode/boards/IP0005/pcb.toml
    ╭─[ /Users/akhilles/src/dioderobot/diode/boards/IP0005/pcb.toml:28:1 ]
    │
 28 │ "github.com/dioderobot/diode/components/Texas_Instruments/HD3SS3212IRKSR" = "0.1.0"
    │ ┬
    │ ╰── duplicate key `github.com/dioderobot/diode/components/Texas_Instruments/HD3SS3212IRKSR` in table `dependencies`
────╯
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces robust error handling for workspace discovery and manifest parsing with clear diagnostics.
> 
> - **`PcbToml::from_file`** now renders ariadne-style parse diagnostics and exits; `parse()` error text simplified
> - **`find_workspace_root`** changed to return `Result<PathBuf>` and fails if any discovered `pcb.toml` is invalid
> - **Propagates fallible workspace discovery**: updates all callers (`pcb-zen-core` resolver paths, `pcb-zen` eval/LSP, `pcb-zen-wasm`, `pcb` CLI, `pcb-diode-api`) to handle `?`/`expect` and error messages
> - **`CoreLoadResolver::for_file`** now returns `anyhow::Result<Self>`; downstream migration codemod updated accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc573dc64592d1bf2f025d51af3c1c9a0f14748. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->