### PR TITLE
Skip version prompt for unpublished packages in `pcb publish` (always 0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Skip version prompt for unpublished packages in `pcb publish` (always 0.1.0)
 - Error on path dependencies that point to workspace members
 - Error on pcb.toml parse failures
 

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -803,8 +803,15 @@ fn collect_all_bumps(
                 if let Some(pkg) = workspace.packages.get(url) {
                     let tag_prefix = tags::compute_tag_prefix(Some(&pkg.rel_path), ws_path);
                     let current = tags::find_latest_version(&all_tags, &tag_prefix);
-                    let display_name = pkg.rel_path.display().to_string();
-                    let bump = prompt_single_bump(&display_name, current.as_ref())?;
+
+                    // Skip prompt for unpublished packages - they always get 0.1.0
+                    let bump = if current.is_none() {
+                        BumpType::Minor
+                    } else {
+                        let display_name = pkg.rel_path.display().to_string();
+                        prompt_single_bump(&display_name, current.as_ref())?
+                    };
+
                     map.insert(url.clone(), bump);
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Streamlines publishing by auto-versioning new packages.
> 
> - In `publish.rs`, `collect_all_bumps` now skips prompting for packages with no existing tag/version and sets their bump to `Minor` (resulting in `0.1.0`)
> - Update `CHANGELOG.md` under Unreleased to note the behavior change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86ff05ee3a5d1410171bf5d7363fa508873b0781. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->