### PR TITLE
Fix inconsistent handling of invalid pcb.toml files between `pcb build` and `pcb publish`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix inconsistent handling of invalid pcb.toml files between `pcb build` and `pcb publish`
+
 ## [0.3.20] - 2026-01-09
 
 ### Added

--- a/crates/pcb-zen-core/src/workspace.rs
+++ b/crates/pcb-zen-core/src/workspace.rs
@@ -346,17 +346,8 @@ pub fn get_workspace_info<F: FileProvider>(
                 continue;
             }
 
-            let pkg_config = match file_provider.read_file(&pkg_toml_path) {
-                Ok(content) => match PcbToml::parse(&content) {
-                    Ok(cfg) => cfg,
-                    Err(e) => {
-                        errors.push(DiscoveryError {
-                            path: pkg_toml_path,
-                            error: e.to_string(),
-                        });
-                        continue;
-                    }
-                },
+            let pkg_config = match PcbToml::from_file(file_provider, &pkg_toml_path) {
+                Ok(cfg) => cfg,
                 Err(e) => {
                     errors.push(DiscoveryError {
                         path: pkg_toml_path,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves error reporting and aligns behavior when encountering invalid `pcb.toml` files.
> 
> - Add `PcbToml::parse_with_path` and use it in `from_file`; return ariadne-formatted diagnostics instead of exiting the process
> - Workspace discovery (`workspace.rs`) now parses manifests via `from_file`; errors are collected uniformly
> - `pcb publish` and shared resolver now print collected diagnostics and bail when workspace discovery finds invalid `pcb.toml` files (consistent with `pcb build`)
> - `publish` build step filters `.zen` files to workspace member packages and no-ops when none are found
> - Update changelog under Unreleased: fixed inconsistent handling of invalid `pcb.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51a695c5280f023097756fde26a4c69df9dfe2ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->