### PR TITLE
Add pcb skill

### DIFF
--- a/.agents/skills/pcb/SKILL.md
+++ b/.agents/skills/pcb/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: pcb
+description: Build, test, and layout PCB designs using the pcb CLI and MCP tools. Use when working with .zen files, searching for components, or managing PCB projects.
+---
+
+# PCB Skill
+
+## MCP Tools (available when skill loads)
+
+| Tool | Use |
+|------|-----|
+| `search_registry` | Find modules/components (try FIRST) |
+| `search_component` | Search Diode database (fallback) |
+| `add_component` | Download component to workspace |
+| `run_layout` | Sync schematic to KiCad |
+| `get_zener_docs` | Get language spec URLs |
+
+## CLI Commands
+
+```bash
+pcb build [PATHS...]     # Build and validate
+pcb test [PATHS...]      # Run TestBench tests
+pcb layout [PATHS...]    # Generate layout, open KiCad
+pcb fmt [PATHS...]       # Format .zen files
+pcb bom <FILE>           # Generate BOM
+pcb open [PATHS...]      # Open existing layout
+pcb update               # Update dependencies
+pcb fork <URL>           # Fork dependency for local dev
+pcb unfork <URL>         # Remove fork
+```
+
+## Key Flags
+
+| Flag | Effect |
+|------|--------|
+| `-D warnings` | Treat warnings as errors |
+| `-S <kind>` | Suppress diagnostics by kind |
+| `--locked` | CI mode: fail if lockfile changes |
+| `--offline` | Use only cached/vendored deps |
+| `--check` | Check only, don't modify (fmt/layout) |
+
+## Before Writing .zen Code
+
+Call `get_zener_docs` to get the language spec URL. Zener has unique syntax for modules, components, and nets that differs from Python/Starlark.

--- a/.agents/skills/pcb/mcp.json
+++ b/.agents/skills/pcb/mcp.json
@@ -1,0 +1,13 @@
+{
+  "pcb": {
+    "command": "pcb",
+    "args": ["mcp"],
+    "includeTools": [
+      "run_layout",
+      "get_zener_docs",
+      "search_registry",
+      "search_component",
+      "add_component"
+    ]
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new PCB-focused skill with MCP integration and usage docs.
> 
> - Adds `pcb` skill config in `mcp.json` exposing tools: `run_layout`, `get_zener_docs`, `search_registry`, `search_component`, `add_component`
> - Provides `SKILL.md` detailing tool usage, `pcb` CLI commands, key flags, and guidance for working with `.zen` files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56ebb7eaa7489a243ac9be81fd4e861497a09bb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->