### PR TITLE
fix/extra footprint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Use source layout directly in release instead of separate copy
 - Change extra footprint sync diagnostic from error to warning
+- Show module path and FPID in layout sync diagnostics (extra_footprint, missing_footprint, fpid_mismatch)
 
 ### Fixed
 


### PR DESCRIPTION
- **Fix `pcb layout --check` only reporting first extra footprint**
- **Change extra footprint sync diagnostic from error to warning**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Fix:** `pcb layout --check` now reports all `extra_footprint` items instead of only the first.
> - **Changed:** `layout.sync.extra_footprint` severity lowered from `error` to `warning`.
> - **Diagnostics:** Include module path/context and `FPID` in `extra_footprint`, `missing_footprint`, and `fpid_mismatch` messages.
> - *Internal:* Use `footprints_by_uuid` map during sync for reliable enumeration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8da4da88ffacd752bc7cb5760badbf3dc6d5d165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->