### PR TITLE
Auto-replace footprints on FPID mismatch during layout sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Use source layout directly in release instead of separate copy
 - Change extra footprint sync diagnostic from error to warning
 - Show module path and FPID in layout sync diagnostics (extra_footprint, missing_footprint, fpid_mismatch)
+- `pcb layout` now auto-replaces footprints when FPID changes (preserving position and nets)
 
 ### Fixed
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces automatic footprint replacement when FPIDs differ, aligning board footprints with the netlist while preserving placement and connectivity.
> 
> - Add `needs_replacement` to change detection; FPID mismatch now signals full replacement instead of only erroring
> - Implement `replace_footprint()` to load from library and preserve position/orientation, board side (flip), pad net codes, and KIID path; then apply metadata
> - Update `ImportNetlist` to: emit `fpid_mismatch` error in `--dry-run`; otherwise replace the footprint and track it; continue applying normal metadata updates when no replacement needed
> - Minor improvements to diagnostics formatting (path/FPID context)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92275a5df0977735dc32fbb0315dcff7af4371c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->