### PR TITLE
Speed up workspace discovery by pruning unrelated directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Change extra footprint sync diagnostic from error to warning
 - Show module path and FPID in layout sync diagnostics (extra_footprint, missing_footprint, fpid_mismatch)
 - `pcb layout` now auto-replaces footprints when FPID changes (preserving position and nets)
+- Speed up workspace discovery by pruning unrelated directories
 
 ### Fixed
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves performance of workspace member discovery by limiting directory traversal.
> 
> - Updates `walk_directories` to accept `members` patterns, compute prefix set, prune depth-1 dirs, and only collect dirs matching `include` and not `exclude`
> - Wires new `patterns` arg from `get_workspace_info` and updates docs/comments
> - Adds corresponding note to `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4a5e6b2efbe908fd4a8caf68f02cf3e8c7f884a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->