### PR TITLE
Add groups to VDOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor layout sync to use a groups registry (virtual DOM pattern) as source of truth instead of querying KiCad directly
+
+### Fixed
+
+- Fix `pcb layout` crash due to stale SWIG wrappers after removing empty groups
+
 ## [0.3.21] - 2026-01-10
 
 ### Added


### PR DESCRIPTION
ALso, fix `pcb layout` crash due to stale SWIG wrappers after removing empty groups

With this change:

- build_groups_registry(board) - Single function using GetDrawings() + Cast_to_PCB_GROUP() to safely enumerate groups
- state.groups_registry - Initialized once in main() after loading board
- All mutations update both KiCad AND registry - ApplyMovedPaths renames, ImportNetlist creates/deletes
- All reads use registry - SyncLayouts, FinalizeBoard snapshot

Future Plan (Virtual DOM Reconciliation):

- Make VirtualElement.move_by() update virtual state only
- Add _virtual_pos and _placement_dirty flags
- Single reconcile_virtual_board() pass applies dirty placements at the end
- Extend pattern to groups, then other mutations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Python-side groups registry as the authoritative source for KiCad groups, replacing direct `board.Groups()` queries to eliminate stale SWIG wrapper issues.
> 
> - Add `build_groups_registry(board)` and initialize `state.groups_registry` in `main`
> - Remap, create, delete, and reference groups via the registry (updates on rename/create/remove)
> - Update `ImportNetlist._sync_groups`, `SyncLayouts` (group linking), and `FinalizeBoard` (snapshot) to use the registry
> - Remove reliance on `board.Groups()`; snapshot iterates `state.groups_registry.values()`
> - Virtual DOM is built from `Path` fields, decoupled from KiCad `PCB_GROUP`s
> - Fix `pcb layout` crash caused by stale SWIG wrappers when removing empty groups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14afd6a6419874a0b41d8f09648c15ebe84d6cc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->