### PR TITLE
Fix package fetch race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix `pcb layout` crash due to stale SWIG wrappers after removing empty groups
+- Fix intermittent "No such file or directory" errors during package fetch caused by race conditions between concurrent `pcb` processes
 
 ## [0.3.21] - 2026-01-10
 

--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -347,6 +347,8 @@ pub fn ensure_bare_repo(repo_url: &str) -> Result<PathBuf> {
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
     let bare_dir = home.join(".pcb/bare").join(repo_url);
 
+    let _lock = git::lock_dir(&bare_dir)?;
+
     if bare_dir.join("HEAD").exists() {
         git::fetch_in_bare_repo(&bare_dir)?;
     } else {

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -577,3 +577,15 @@ mod tests {
         );
     }
 }
+
+/// Acquire a file lock for a directory to prevent concurrent access.
+/// Returns a guard that releases the lock when dropped.
+pub fn lock_dir(dir: &Path) -> anyhow::Result<fslock::LockFile> {
+    if let Some(parent) = dir.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let lock_path = dir.with_extension("lock");
+    let mut lock = fslock::LockFile::open(&lock_path)?;
+    lock.lock()?;
+    Ok(lock)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Eliminates intermittent cache corruption and "No such file or directory" errors during concurrent fetches by serializing filesystem access.
> 
> - Introduces `git::lock_dir` (fslock-based) and uses it in `ensure_sparse_checkout` and `ensure_bare_repo` to serialize checkout/bare-repo operations
> - In `ensure_sparse_checkout`, differentiates ready markers (`pcb.toml` for code, `.git` for assets) and removes incomplete directories before retrying
> - Updates `CHANGELOG.md` under Fixed to document the race-condition fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96b0f1576d41934235049f5e80e728311512805e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->