### PR TITLE
Dont copy docs to top-level dir in release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Remove `pcb search --legacy` flag and the old interactive API search. Use the default TUI-based registry search instead.
 - Remove `pcb clean` command. To recover from cache issues, manually delete files in `~/.pcb`.
 - Remove `fab_drawing.html` from release artifacts (replaced by IPC-2581 HTML export)
+- Remove `docs/` directory from release staging output
 
 ### Fixed
 

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -225,7 +225,6 @@ const BASE_TASKS: &[(&str, TaskFn)] = &[
     ("Copying source files and dependencies", copy_sources),
     ("Validating build from staged sources", validate_build),
     ("Generating board config", generate_board_config),
-    ("Copying documentation", copy_docs),
     ("Substituting version variables", substitute_variables),
 ];
 
@@ -837,44 +836,6 @@ fn generate_board_config(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         .context("Failed to write board config file")?;
 
     debug!("Generated board config at: {}", board_config_path.display());
-    Ok(())
-}
-
-/// Copy documentation files from docs directory adjacent to zen file
-fn copy_docs(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
-    // Look for docs directory adjacent to zen file
-    let docs_source_dir = info.zen_path.parent().unwrap().join("docs");
-
-    // Only proceed if docs directory exists
-    if !docs_source_dir.exists() {
-        debug!("No docs directory found at: {}", docs_source_dir.display());
-        return Ok(());
-    }
-
-    // Copy all files from docs source to staging docs directory
-    let docs_staging_dir = info.staging_dir.join("docs");
-    for entry in walkdir::WalkDir::new(&docs_source_dir)
-        .follow_links(false)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|e| e.file_type().is_file())
-    {
-        let relative_path = entry.path().strip_prefix(&docs_source_dir)?;
-        let dest_path = docs_staging_dir.join(relative_path);
-
-        // Ensure parent directory exists
-        if let Some(parent) = dest_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        fs::copy(entry.path(), dest_path)?;
-    }
-
-    debug!(
-        "Copied docs from: {} to: {}",
-        docs_source_dir.display(),
-        docs_staging_dir.display()
-    );
     Ok(())
 }
 

--- a/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
+++ b/crates/pcb/tests/snapshots/simple__simple_workspace_release.snap
@@ -38,7 +38,6 @@ Exit Code: 0
 ✓ Copying source files and dependencies
 ✓ Validating build from staged sources
 ✓ Generating board config
-✓ Copying documentation
 ✓ Substituting version variables
 
 ┌───────────────────────────────────────────────────────────────────────┐

--- a/crates/pcb/tests/snapshots/tag__tag_older_version_allowed.snap
+++ b/crates/pcb/tests/snapshots/tag__tag_older_version_allowed.snap
@@ -13,7 +13,6 @@ Exit Code: 0
 ✓ Copying source files and dependencies
 ✓ Validating build from staged sources
 ✓ Generating board config
-✓ Copying documentation
 ✓ Substituting version variables
 
 ┌──────────────────────────────────────────────────────────────────────┐

--- a/crates/pcb/tests/snapshots/tag__tag_simple_workspace.snap
+++ b/crates/pcb/tests/snapshots/tag__tag_simple_workspace.snap
@@ -13,7 +13,6 @@ Exit Code: 0
 ✓ Copying source files and dependencies
 ✓ Validating build from staged sources
 ✓ Generating board config
-✓ Copying documentation
 ✓ Substituting version variables
 
 ┌──────────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
We don't use this anyways, we look in boards/<board name>/docs. Avoid
multiple sources of truth.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes documentation staging from the release pipeline.
> 
> - Drops `copy_docs` task and its function from `crates/pcb/src/release.rs` (no longer copies `docs/` alongside staged sources)
> - Updates `CHANGELOG.md` to note removal of `docs/` from release output
> - Refreshes test snapshots to exclude the "Copying documentation" step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c8f1f1bd62260cad6cd6d23ced8c386893528eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->