### PR TITLE
Fix repeated gitignore parsing when walking multiple directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Remove stdlib hijacking from evaluator. The toolchain now relies on the pinned stdlib version instead of replacing types at runtime.
 
+### Fixed
+
+- Fix repeated gitignore parsing when walking multiple directories
+
 ## [0.3.22] - 2026-01-13
 
 ### Added


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Optimizes multi-directory traversal to avoid re-parsing gitignore patterns.
> 
> - Switch to a single `WalkBuilder` with `.add()` for multiple roots in `auto_deps.rs` and `file_walker.rs`, preserving `hidden`, gitignore, and `skip_vendor` settings
> - Early-return on empty input; file filtering remains `.zen`-only
> - Update `CHANGELOG.md` under **Fixed** to note the gitignore parsing issue
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0beb36834568b9cf2f8ce0b8a9cc872687f5afa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->