### PR TITLE
Make `pcb doc` more pretty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,6 +3669,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "open"
 version = "5.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3881,6 +3912,7 @@ dependencies = [
  "serde_json",
  "starlark",
  "starlark_syntax",
+ "syntect",
  "tempfile",
  "termimad",
  "terminal_size",
@@ -6443,6 +6475,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "regex-syntax 0.8.5",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.12",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ tar = "0.4"
 terminal_size = "0.4.0"
 terminal_hyperlink = "0.1"
 termimad = "0.31"
+syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-onig"] }
 textwrap = "0.11"
 typify = "0.3.0"
 unicode-width = "0.2.0"

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -68,6 +68,7 @@ crossterm = { workspace = true }
 ctrlc = { workspace = true }
 terminal_size = { workspace = true }
 termimad = { workspace = true }
+syntect = { workspace = true }
 unicode-width = { workspace = true }
 indicatif = { workspace = true }
 gltfpack-sys = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves terminal rendering of `pcb doc` output.
> 
> - Replace `termimad::print_text` with `print_highlighted_markdown` to syntax-highlight code blocks using `syntect` and apply a themed `MadSkin` for regular Markdown
> - Map common code fences (e.g., `python`, `starlark`, `zen`, `toml`, `rust`) to appropriate highlighters; retain plain printing when stdout isn't a TTY
> - Add `syntect` dependency (with `regex-onig`, default syntaxes/themes) and update workspace/crate `Cargo.toml`; lockfile gains `bincode`, `onig`, etc.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d01b10ae7706bb4764208d42b21acb1796723e5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->