### PR TITLE
prek pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,20 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+        priority: 0
+
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+        priority: 0
+
+      - id: clippy
+        name: clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+        priority: 1

--- a/crates/ipc2581/tests/testcases.rs
+++ b/crates/ipc2581/tests/testcases.rs
@@ -4,6 +4,23 @@ use ipc2581::Ipc2581;
 use std::fs;
 use std::path::Path;
 
+type TestcaseMetadata = (
+    usize,
+    usize,
+    usize,
+    usize,
+    usize,
+    usize,
+    usize,
+    usize,
+    usize,
+    usize,
+    usize,
+    f64,
+    f64,
+    f64,
+);
+
 // Helper to get BOM stats without loading the whole document
 fn get_bom_stats() -> (u32, u32, usize, usize) {
     let bom_path = Path::new("tests/data/testcase1-revc/testcase1-revc-bom.xml");
@@ -609,25 +626,7 @@ testcase_metadata_test!(
 );
 
 // Helper function to extract and print testcase metadata
-fn print_testcase_metadata(
-    doc: &Ipc2581,
-    testcase_name: &str,
-) -> (
-    usize,
-    usize,
-    usize,
-    usize,
-    usize,
-    usize,
-    usize,
-    usize,
-    usize,
-    usize,
-    usize,
-    f64,
-    f64,
-    f64,
-) {
+fn print_testcase_metadata(doc: &Ipc2581, testcase_name: &str) -> TestcaseMetadata {
     if let Some(ecad) = doc.ecad() {
         let step = &ecad.cad_data.steps[0];
 

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -1570,7 +1570,7 @@ mod tests {
         // Chinese (transliterates - exact output depends on deunicode library)
         let chinese_result = sanitize_mpn_for_path("电阻器");
         assert!(!chinese_result.is_empty());
-        assert_eq!(chinese_result.chars().all(|c| c.is_ascii()), true);
+        assert!(chinese_result.is_ascii());
 
         // Accented characters
         assert_eq!(sanitize_mpn_for_path("Café-IC"), "Cafe-IC");

--- a/crates/pcb-ipc2581-tools/src/commands/view.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/view.rs
@@ -166,7 +166,7 @@ mod tests {
     fn test_assembly_minimal_exclusions() {
         let excluded = excluded_sections(ViewMode::Assembly);
         assert!(excluded.contains(&"Stackup"));
-        assert!(!excluded.iter().any(|&e| e == "Component"));
+        assert!(!excluded.contains(&"Component"));
     }
 
     #[test]

--- a/crates/pcb-sch/src/physical.rs
+++ b/crates/pcb-sch/src/physical.rs
@@ -2979,10 +2979,10 @@ mod tests {
         assert_eq!(result.tolerance, Decimal::ZERO);
 
         // Test float
-        let starlark_val = heap.alloc(3.14);
+        let starlark_val = heap.alloc(3.15);
         let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
         assert_eq!(result.unit, PhysicalUnitDims::DIMENSIONLESS);
-        assert_eq!(result.value, Decimal::from_f64(3.14).unwrap());
+        assert_eq!(result.value, Decimal::from_f64(3.15).unwrap());
         assert_eq!(result.tolerance, Decimal::ZERO);
     }
 
@@ -4274,7 +4274,7 @@ mod tests {
         // This calls loose.is_in(tight), checking if tight is in loose
         let is_in_result = loose.downcast_ref::<PhysicalValue>().unwrap().is_in(tight);
         assert!(is_in_result.is_ok());
-        assert_eq!(is_in_result.unwrap(), true);
+        assert!(is_in_result.unwrap());
 
         // loose.within(tight) should be false (loose doesn't fit in tight)
         let within_result2 = eval
@@ -4289,7 +4289,7 @@ mod tests {
         // tight.is_in(loose) checks if loose is in tight, should be false
         let is_in_result2 = tight.downcast_ref::<PhysicalValue>().unwrap().is_in(loose);
         assert!(is_in_result2.is_ok());
-        assert_eq!(is_in_result2.unwrap(), false);
+        assert!(!is_in_result2.unwrap());
     }
 
     #[test]

--- a/crates/pcb-sexpr/src/lib.rs
+++ b/crates/pcb-sexpr/src/lib.rs
@@ -617,7 +617,7 @@ mod tests {
     fn test_parse_atom() {
         assert_eq!(parse("hello").unwrap(), Sexpr::Symbol("hello".to_string()));
         assert_eq!(parse("123").unwrap(), Sexpr::Int(123));
-        assert_eq!(parse("3.14").unwrap(), Sexpr::F64(3.14));
+        assert_eq!(parse("3.15").unwrap(), Sexpr::F64(3.15));
         assert_eq!(
             parse("symbol-with-dashes").unwrap(),
             Sexpr::Symbol("symbol-with-dashes".to_string())


### PR DESCRIPTION
Also fix some straggling clippy errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Tooling:** Add Rust pre-commit hooks `cargo fmt --check` and `cargo clippy -D warnings`; set hook priorities in `.pre-commit-config.yaml`.
> - **Tests/cleanup:** Introduce `TestcaseMetadata` alias and update `print_testcase_metadata` signature; simplify assertions (`is_ascii()`, `contains` checks), and adjust float literals in tests (`3.14`→`3.15`) across crates.
> - **Refactor:** Move `lock_dir` in `pcb-zen/src/git.rs` to a shared location and remove duplicate definition (no behavioral change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d163d427a6626fafe3d4ac47d2e4af082c66550d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->