### PR TITLE
Fix group layout syncing regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb release` now generates a canonical `netlist.json` in the release staging directory
 
+### Fixed
+
+- Fix `pcb layout` group splitting regression where running layout twice would cause module groups to split into two (one with footprints, one with tracks/zones)
+
 ## [0.3.23] - 2026-01-13
 
 ### Added

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -1130,19 +1130,15 @@ def build_groups_registry(board: pcbnew.BOARD) -> Dict[str, Any]:
 
     Returns a dict mapping group name -> PCB_GROUP. Anonymous groups are excluded.
 
-    We use board.GetDrawings() + Cast_to_PCB_GROUP() instead of board.Groups()
-    because the latter returns stale SWIG wrappers after groups are removed.
+    Note: We use board.Groups() to enumerate groups. The stale SWIG wrapper issue
+    (which motivated the previous GetDrawings() approach) is handled by ensuring
+    the registry is updated after any group deletion in _sync_groups().
     """
     registry = {}
-    for item in board.GetDrawings():
-        try:
-            group = pcbnew.Cast_to_PCB_GROUP(item)
-            if group is not None:
-                name = group.GetName()
-                if name:
-                    registry[name] = group
-        except (AttributeError, RuntimeError):
-            continue
+    for group in board.Groups():
+        name = group.GetName()
+        if name:
+            registry[name] = group
     return registry
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fixes group sync regression**
> 
> - Change `build_groups_registry` to enumerate via `board.Groups()` (instead of `GetDrawings()`/`Cast_to_PCB_GROUP`) and rely on `_sync_groups()` to refresh the registry after deletions, avoiding stale wrappers
> - Resolves repeated `pcb layout` runs splitting module groups into separate footprints vs tracks/zones
> - Update `CHANGELOG.md` under Unreleased with the fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f595d047ef19f10b3a8c2a581ca981de4fe0f3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->