### PR TITLE
Add v2 dep resolution support to pcb sim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add V2 dependency resolution support to `pcb sim` (adds `--offline` and `--locked` flags)
+
 ## [0.3.24] - 2026-01-14
 
 ### Added


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces V2, workspace-first dependency resolution to `pcb sim`, resolving deps before build and threading results through the existing build flow.
> 
> - Add CLI flags `--offline` and `--locked` to control network access and lockfile enforcement
> - Invoke `resolve_v2_if_needed(...)` prior to build and pass `resolution_result` and `offline` into `build_zen`
> - Update `CHANGELOG.md` to document the new flags and behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7471877d9a1c26ccd1443224ad4bd8389ed9ed4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->