### PR TITLE
Remove `pcb search --add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Add V2 dependency resolution support to `pcb sim` (adds `--offline` and `--locked` flags)
 
+### Removed
+
+- Remove `--add` flag from `pcb search`
+
 ## [0.3.24] - 2026-01-14
 
 ### Added

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -12,8 +12,8 @@ pub use bom::{
 };
 pub use component::{
     add_component_to_workspace, download_component, execute as execute_search,
-    execute_new_component_tui, search_and_add_single, search_components, AddComponentResult,
-    ComponentDownloadResult, ComponentSearchResult, ModelAvailability, SearchArgs,
+    execute_new_component_tui, search_components, AddComponentResult, ComponentDownloadResult,
+    ComponentSearchResult, ModelAvailability, SearchArgs,
 };
 pub use registry::{
     DigikeyData, EDatasheetComponentId, EDatasheetData, PackageDependency, PackageRelations,


### PR DESCRIPTION
You should pretty much never do this.

We have too many cli subcommands + args. Trying to simplify stuff (so I can add more :P).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CLI simplification for `pcb search`**
> 
> - Remove `--add` flag and the non-interactive single-match path (`search_and_add_single`); default flow is TUI/registry search or `--dir` mode
> - Hide `--scan-model` option and adjust `--dir` to only conflict with `--json`
> - Delete unused helper and update re-exports in `lib.rs`
> - Update `CHANGELOG.md` to note removal
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81236ad77e5610e12c3949fbc2315b2154a74bf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->