### PR TITLE
Use common offers -> Availability code in search, bom

### DIFF
--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -1507,10 +1507,8 @@ pub fn search_components_with_availability(
         return Ok(Vec::new());
     }
 
-    // Fetch availability for all results (limit to first 10)
     let keys: Vec<_> = results
         .iter()
-        .take(10)
         .map(|r| crate::bom::ComponentKey {
             mpn: r.part_number.clone(),
             manufacturer: r.manufacturer.clone(),
@@ -1520,8 +1518,7 @@ pub fn search_components_with_availability(
     let availability_results =
         crate::bom::fetch_pricing_batch(auth_token, &keys).unwrap_or_default();
 
-    // Pad with None for results beyond 10
-    let all_availability: Vec<Option<crate::bom::Availability>> = availability_results
+    let all_availability: Vec<_> = availability_results
         .into_iter()
         .map(|p| {
             if p.us.is_some() || p.global.is_some() || !p.offers.is_empty() {
@@ -1530,8 +1527,6 @@ pub fn search_components_with_availability(
                 None
             }
         })
-        .chain(std::iter::repeat(None))
-        .take(results.len())
         .collect();
 
     let combined: Vec<ComponentResult> = results


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies and simplifies availability computation across BOM and search.
> 
> - Introduces shared helpers: `ComponentOffer::to_bom_offer`, `ComponentOffer::to_offer`, and `build_availability` used by BOM population and batch pricing
> - Refactors MOQ filtering and best-offer selection via a per-geo `process_geo` flow; `calculate_alt_stock` now dedupes by `(distributor, mpn)` using best price at `qty`
> - Cleans up `unit_price_at_qty` and adds `Display` for `Geography`; optimizes `format_number_with_commas`
> - Replaces ad-hoc JSON offer construction with helper methods; removes `component_offer_to_bom_offer`
> - Removes 10-result cap/padding in availability fetching for search and registry results (now processes all with MPN)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10d725ef2f66cdfa81a7591e691078ce5f80c898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->