### PR TITLE
Consolidate BOM availability types into single unified model

### DIFF
--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -1493,7 +1493,7 @@ pub struct ComponentResult {
     #[serde(flatten)]
     pub component: ComponentSearchResult,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub availability: Option<crate::bom::Availability>,
+    pub availability: Option<pcb_sch::bom::Availability>,
 }
 
 /// Search for components and fetch availability data in batch
@@ -1585,10 +1585,10 @@ fn execute_web_search(query: &str, json: bool) -> Result<()> {
 }
 
 /// Print a compact availability summary line for CLI output
-fn print_availability_summary(avail: &crate::bom::Availability) {
+fn print_availability_summary(avail: &pcb_sch::bom::Availability) {
     use crate::bom::{format_number_with_commas, format_price};
 
-    let format_region = |avail: Option<&crate::bom::AvailabilitySummary>, name: &str| -> String {
+    let format_region = |avail: Option<&pcb_sch::bom::AvailabilitySummary>, name: &str| -> String {
         if let Some(a) = avail {
             let stock_str = format_number_with_commas(a.stock);
             let price_str = a.price.map(format_price).unwrap_or_else(|| "—".to_string());

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -7,9 +7,7 @@ pub mod routing;
 pub mod scan;
 
 pub use auth::{execute as execute_auth, login, logout, status, AuthArgs, AuthCommand, AuthTokens};
-pub use bom::{
-    fetch_and_populate_availability, BomLine, ComponentOffer, MatchBomResponse, PriceBreak,
-};
+pub use bom::fetch_and_populate_availability;
 pub use component::{
     add_component_to_workspace, download_component, execute as execute_search,
     execute_web_components_tui, search_components, search_components_with_availability,

--- a/crates/pcb-diode-api/src/mcp.rs
+++ b/crates/pcb-diode-api/src/mcp.rs
@@ -58,7 +58,7 @@ pub struct RegistrySearchResult {
     #[serde(flatten)]
     pub part: crate::RegistryPart,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub availability: Option<crate::bom::Availability>,
+    pub availability: Option<pcb_sch::bom::Availability>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/crates/pcb-diode-api/src/registry/tui/app.rs
+++ b/crates/pcb-diode-api/src/registry/tui/app.rs
@@ -513,7 +513,7 @@ pub struct App {
     /// Channel to receive availability responses from worker
     availability_rx: Receiver<PricingResponse>,
     /// Cached availability data for all components (keyed by component_id/url)
-    pub availability_cache: std::collections::HashMap<String, crate::bom::Availability>,
+    pub availability_cache: std::collections::HashMap<String, pcb_sch::bom::Availability>,
     /// When we started waiting for current availability request (Some = waiting)
     availability_request_started: Option<Instant>,
 }

--- a/crates/pcb-diode-api/src/registry/tui/search.rs
+++ b/crates/pcb-diode-api/src/registry/tui/search.rs
@@ -876,7 +876,7 @@ pub fn spawn_component_worker(
 pub type PricingRequest = Vec<(String, String, Option<String>)>;
 
 /// Batch availability response: Map of id -> availability
-pub type PricingResponse = HashMap<String, crate::bom::Availability>;
+pub type PricingResponse = HashMap<String, pcb_sch::bom::Availability>;
 
 /// Spawn a worker thread that fetches availability for components in batches
 pub fn spawn_availability_worker(
@@ -887,7 +887,7 @@ pub fn spawn_availability_worker(
         use crate::bom::ComponentKey;
 
         let mut auth_token: Option<String> = None;
-        let mut cache: HashMap<ComponentKey, crate::bom::Availability> = HashMap::new();
+        let mut cache: HashMap<ComponentKey, pcb_sch::bom::Availability> = HashMap::new();
 
         while let Ok(mut req) = req_rx.recv() {
             // Coalesce rapid requests - keep only the latest
@@ -901,7 +901,7 @@ pub fn spawn_availability_worker(
             }
 
             // Check cache, collect uncached
-            let mut result: HashMap<String, crate::bom::Availability> = HashMap::new();
+            let mut result: HashMap<String, pcb_sch::bom::Availability> = HashMap::new();
             let mut uncached: Vec<&(String, String, Option<String>)> = Vec::new();
 
             for item in &req {

--- a/crates/pcb-diode-api/src/registry/tui/ui.rs
+++ b/crates/pcb-diode-api/src/registry/tui/ui.rs
@@ -491,7 +491,7 @@ fn render_component_details(
     frame: &mut Frame,
     result: &crate::component::ComponentSearchResult,
     area: Rect,
-    availability: Option<&crate::bom::Availability>,
+    availability: Option<&pcb_sch::bom::Availability>,
     is_loading_availability: bool,
 ) {
     use crate::component::sanitize_mpn_for_path;
@@ -643,7 +643,7 @@ fn format_price(price: f64) -> String {
 /// Format availability line: "US:     $3.22 (1,234)" or "US:     ..." while loading
 fn format_avail_line<'a>(
     region: &str,
-    avail: Option<&crate::bom::AvailabilitySummary>,
+    avail: Option<&pcb_sch::bom::AvailabilitySummary>,
     is_loading: bool,
 ) -> Line<'a> {
     let label = format!("{:<8}", format!("{}:", region));
@@ -696,7 +696,7 @@ fn format_avail_line<'a>(
 }
 
 /// Format offer lines with dynamic column widths based on content
-fn format_offer_lines(offers: &[&crate::bom::Offer]) -> Vec<Line<'static>> {
+fn format_offer_lines(offers: &[&pcb_sch::bom::Offer]) -> Vec<Line<'static>> {
     if offers.is_empty() {
         return Vec::new();
     }

--- a/crates/pcb-ipc2581-tools/src/accessors/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/bom.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use ipc2581::types::{BomCategory, Characteristics};
-use pcb_sch::Alternative;
+use pcb_sch::bom::Alternative;
 use serde::{Deserialize, Serialize};
 
 use super::IpcAccessor;

--- a/crates/pcb-sch/src/bom/availability.rs
+++ b/crates/pcb-sch/src/bom/availability.rs
@@ -1,5 +1,11 @@
-/// BOM availability domain logic - tier classification and offer selection
-use crate::GenericComponent;
+//! BOM availability types and domain logic.
+//!
+//! Contains both the JSON-facing availability types (shared between BOM JSON output
+//! and MCP/search results) and domain logic for tier classification and offer selection.
+
+use serde::{Deserialize, Serialize};
+
+use super::GenericComponent;
 
 /// Number of boards to use for availability and pricing calculations
 pub const NUM_BOARDS: i32 = 20;
@@ -58,4 +64,52 @@ pub fn tier_for_stock(stock: i32, qty: i32, is_small_passive: bool) -> Tier {
     } else {
         Tier::Limited
     }
+}
+
+/// Pricing and availability data for a component
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Availability {
+    /// Best US availability summary (price @ stock)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub us: Option<AvailabilitySummary>,
+    /// Best Global availability summary (price @ stock)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub global: Option<AvailabilitySummary>,
+    /// All raw offers for detailed display
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub offers: Vec<Offer>,
+}
+
+/// Compact availability summary for a region
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AvailabilitySummary {
+    /// Unit price at target quantity
+    pub price: Option<f64>,
+    /// Stock available (best offer)
+    pub stock: i32,
+    /// Combined stock from alternative offers
+    pub alt_stock: i32,
+    /// Price breaks for computing prices at different quantities (internal only)
+    #[serde(skip, default)]
+    pub price_breaks: Option<Vec<(i32, f64)>>,
+    /// LCSC part IDs for hyperlinks (internal only)
+    #[serde(skip, default)]
+    pub lcsc_part_ids: Vec<(String, String)>,
+    /// MPN from the offer (internal only)
+    #[serde(skip, default)]
+    pub mpn: Option<String>,
+    /// Manufacturer from the offer (internal only)
+    #[serde(skip, default)]
+    pub manufacturer: Option<String>,
+}
+
+/// Distributor offer with live pricing/stock data
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Offer {
+    pub region: String,
+    pub distributor: String,
+    pub stock: i32,
+    pub price: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub part_id: Option<String>,
 }

--- a/crates/pcb-sch/src/bom/mod.rs
+++ b/crates/pcb-sch/src/bom/mod.rs
@@ -4,5 +4,8 @@ mod core;
 // Re-export core BOM types
 pub use core::*;
 
-// Re-export availability helpers for convenience
-pub use availability::{is_small_generic_passive, tier_for_stock, Tier, NUM_BOARDS};
+// Re-export availability types and helpers
+pub use availability::{
+    is_small_generic_passive, tier_for_stock, Availability, AvailabilitySummary, Offer, Tier,
+    NUM_BOARDS,
+};

--- a/crates/pcb-sch/src/bom_table.rs
+++ b/crates/pcb-sch/src/bom_table.rs
@@ -6,8 +6,8 @@ use terminal_hyperlink::Hyperlink as _;
 use urlencoding::encode as urlencode;
 
 use crate::bom::availability::{is_small_generic_passive, tier_for_stock, Tier, NUM_BOARDS};
-use crate::bom::RegionAvailability;
-use crate::{Bom, GenericComponent};
+use crate::bom::AvailabilitySummary;
+use crate::bom::{Bom, GenericComponent};
 
 /// Create a cell with quantity and percentage (percentage in grey)
 fn qty_with_percentage_cell(qty: usize, percentage: f64) -> Cell {
@@ -157,7 +157,7 @@ struct RegionDisplayData {
 
 impl RegionDisplayData {
     fn from_region_avail(
-        avail: Option<&RegionAvailability>,
+        avail: Option<&AvailabilitySummary>,
         qty: usize,
         is_small_passive: bool,
     ) -> Self {
@@ -165,7 +165,7 @@ impl RegionDisplayData {
             return Self::default();
         };
 
-        let tier = tier_for_stock(a.stock_total, qty as i32, is_small_passive);
+        let tier = tier_for_stock(a.stock, qty as i32, is_small_passive);
         let (price_single, price_boards) = match &a.price_breaks {
             Some(breaks) => {
                 let unit_single = unit_price_from_breaks(breaks, qty as i32);
@@ -179,8 +179,8 @@ impl RegionDisplayData {
         };
 
         RegionDisplayData {
-            stock: a.stock_total,
-            alt_stock: a.alt_stock_total,
+            stock: a.stock,
+            alt_stock: a.alt_stock,
             price_single,
             price_boards,
             tier,

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -21,12 +21,6 @@ pub mod natural_string;
 pub mod physical;
 pub mod position;
 
-// Re-export BOM functionality
-pub use bom::{
-    parse_kicad_csv_bom, Alternative, AvailabilityData, Bom, BomEntry, BomMatchingKey,
-    BomMatchingRule, BomOffer, Capacitor, Dielectric, GenericComponent, GenericMatchingKey,
-    GroupedBomEntry, KiCadBomError, Offer, RegionAvailability, Resistor, UngroupedBomEntry,
-};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
@@ -655,8 +649,8 @@ impl Schematic {
         ref_map
     }
 
-    pub fn bom(&self) -> Bom {
-        Bom::from_schematic(self)
+    pub fn bom(&self) -> bom::Bom {
+        bom::Bom::from_schematic(self)
     }
 }
 

--- a/crates/pcb/src/bom.rs
+++ b/crates/pcb/src/bom.rs
@@ -5,7 +5,7 @@ use crate::build::create_diagnostics_passes;
 use crate::release::extract_layout_path;
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
-use pcb_sch::{parse_kicad_csv_bom, Bom};
+use pcb_sch::bom::{parse_kicad_csv_bom, Bom};
 use pcb_ui::prelude::*;
 
 /// Generate BOM with KiCad fallback if design BOM is empty


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies pricing/availability across crates and simplifies BOM JSON.
> 
> - Introduces unified `pcb_sch::bom::{Availability, AvailabilitySummary, Offer}` and moves availability logic into `pcb_sch::bom::availability`
> - Removes legacy types (`BomOffer`, `RegionAvailability`, `AvailabilityData`) and `offers`/tier fields from BOM JSON; `ungrouped_json` now embeds `availability`
> - Refactors `pcb-diode-api` BOM matcher to populate unified `Availability` (US/Global summaries + `offers`) and adds `fetch_pricing_batch` for batch queries; updates component search/CLI/TUI and MCP schemas to the new types
> - Updates ipc2581 tools and CLI to new `pcb_sch::bom` paths; renames matching rule `Offer` → `ApprovedSource` and `offers` → `sources`
> - Narrows public re-exports to the new API and removes deprecated ones
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 169b3b5872d9f2c2abf29120af668433f12412bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->