### PR TITLE
Add severity to diagnostic ordering key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,12 +243,12 @@ dependencies = [
 
 [[package]]
 name = "ariadne"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
 dependencies = [
  "concolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
  "yansi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ pcb-docgen = { path = "crates/pcb-docgen" }
 
 anyhow = "1.0"
 arboard = "3.4"
-ariadne = { version = "0.5", features = ["auto-color"] }
+ariadne = { version = "0.6", features = ["auto-color"] }
 axoupdater = { version = "0.9", features = ["blocking"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "wrap_help"] }

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -72,7 +72,7 @@ pub use lang::eval::{EvalContext, EvalOutput};
 pub use load_spec::LoadSpec;
 pub use passes::{
     AggregatePass, CommentSuppressPass, FilterHiddenPass, JsonExportPass, LspFilterPass,
-    PromotePass, SortPass, StylePromotePass, SuppressPass,
+    PromotePass, StylePromotePass, SuppressPass,
 };
 
 // Re-export file provider types

--- a/crates/pcb-zen-core/src/passes.rs
+++ b/crates/pcb-zen-core/src/passes.rs
@@ -65,17 +65,6 @@ impl DiagnosticsPass for SuppressPass {
     }
 }
 
-/// A pass that sorts diagnostics by severity (warnings first, then errors) while maintaining stability
-pub struct SortPass;
-
-impl DiagnosticsPass for SortPass {
-    fn apply(&self, diagnostics: &mut Diagnostics) {
-        diagnostics
-            .diagnostics
-            .sort_by_key(|diag| severity_sort_order(diag.severity));
-    }
-}
-
 /// A pass that aggregates similar warnings by combining them into a single representative warning
 pub struct AggregatePass;
 
@@ -124,16 +113,6 @@ impl DiagnosticsPass for AggregatePass {
         }
 
         diagnostics.diagnostics = result;
-    }
-}
-
-/// Return sort order for severity (lower numbers come first)
-fn severity_sort_order(severity: EvalSeverity) -> u8 {
-    match severity {
-        EvalSeverity::Warning => 0,
-        EvalSeverity::Error => 1,
-        EvalSeverity::Advice => 2,
-        EvalSeverity::Disabled => 3,
     }
 }
 

--- a/crates/pcb-zen/tests/common/mod.rs
+++ b/crates/pcb-zen/tests/common/mod.rs
@@ -165,7 +165,9 @@ impl TestProject {
 #[macro_export]
 macro_rules! star_snapshot {
     ($env:expr, $entry:expr $(,)?) => {{
-        let netlist = $env.eval_netlist($entry);
+        let result = $env.eval_netlist($entry);
+        let mut snapshot_output = result.output.as_ref().map(|v| v.to_string()).unwrap_or_default();
+        snapshot_output.push_str(&pcb_zen::diagnostics::render_diagnostics_to_string(&result.diagnostics));
         let root_path = $env.root().to_string_lossy();
 
         // Get the cache directory path for filtering
@@ -196,7 +198,7 @@ macro_rules! star_snapshot {
         insta::with_settings!({
             filters => filters,
         }, {
-            insta::assert_snapshot!(netlist);
+            insta::assert_snapshot!(snapshot_output);
         });
     }};
 }

--- a/crates/pcb-zen/tests/snapshots/assert__snapshot_check_false_should_error.snap
+++ b/crates/pcb-zen/tests/snapshots/assert__snapshot_check_false_should_error.snap
@@ -1,5 +1,11 @@
 ---
 source: crates/pcb-zen/tests/assert.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test.zen:3:1-34 failing condition
+Error: failing condition
+   ╭─[ [TEMP_DIR]test.zen:3:1 ]
+   │
+ 3 │ check(False, "failing condition")
+   │ ────────────────┬────────────────  
+   │                 ╰────────────────── failing condition
+───╯

--- a/crates/pcb-zen/tests/snapshots/assert__snapshot_error_function_should_error.snap
+++ b/crates/pcb-zen/tests/snapshots/assert__snapshot_error_function_should_error.snap
@@ -1,5 +1,11 @@
 ---
 source: crates/pcb-zen/tests/assert.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test.zen:2:1-14 boom
+Error: boom
+   ╭─[ [TEMP_DIR]test.zen:2:1 ]
+   │
+ 2 │ error("boom")
+   │ ──────┬──────  
+   │       ╰──────── boom
+───╯

--- a/crates/pcb-zen/tests/snapshots/input__component_rejects_interface_even_with_single_net.snap
+++ b/crates/pcb-zen/tests/snapshots/input__component_rejects_interface_even_with_single_net.snap
@@ -1,5 +1,13 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test.zen:9:1-17:2 Pin 'in' must be connected to a Net, got InterfaceValue
+Error: Pin 'in' must be connected to a Net, got InterfaceValue
+    ╭─[ [TEMP_DIR]test.zen:9:1 ]
+    │
+  9 │ ╭─▶ Component(
+    ┆ ┆   
+ 17 │ ├─▶ )
+    │ │       
+    │ ╰─────── Pin 'in' must be connected to a Net, got InterfaceValue
+────╯

--- a/crates/pcb-zen/tests/snapshots/input__interface_input.snap
+++ b/crates/pcb-zen/tests/snapshots/input__interface_input.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -22,9 +22,30 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]top.zen Net name 'PDM_power' should be UPPERCASE: 'PDM_POWER'Advice: [TEMP_DIR]top.zen Net name 'PDM_data' should be UPPERCASE: 'PDM_DATA'Advice: [TEMP_DIR]top.zen Net name 'PDM_select' should be UPPERCASE: 'PDM_SELECT'Advice: [TEMP_DIR]top.zen Net name 'PDM_clock' should be UPPERCASE: 'PDM_CLOCK'Advice: [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
-Advice: [TEMP_DIR]sub.zen Net name 'pdm_power' should be UPPERCASE: 'PDM_POWER'Advice: [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
-Advice: [TEMP_DIR]sub.zen Net name 'pdm_data' should be UPPERCASE: 'PDM_DATA'Advice: [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
-Advice: [TEMP_DIR]sub.zen Net name 'pdm_select' should be UPPERCASE: 'PDM_SELECT'Advice: [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
-Advice: [TEMP_DIR]sub.zen Net name 'pdm_clock' should be UPPERCASE: 'PDM_CLOCK'Advice: [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
-Advice: [TEMP_DIR]sub.zen:5:7-24 io() parameter 'pdm' should be UPPERCASE: 'PDM'
+Advice: [TEMP_DIR]top.zen Net name 'PDM_power' should be UPPERCASE: 'PDM_POWER'
+
+Advice: [TEMP_DIR]top.zen Net name 'PDM_data' should be UPPERCASE: 'PDM_DATA'
+
+Advice: [TEMP_DIR]top.zen Net name 'PDM_select' should be UPPERCASE: 'PDM_SELECT'
+
+Advice: [TEMP_DIR]top.zen Net name 'PDM_clock' should be UPPERCASE: 'PDM_CLOCK'
+
+Advice: [TEMP_DIR]sub.zen Net name 'pdm_power' should be UPPERCASE: 'PDM_POWER'
+  in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
+
+Advice: [TEMP_DIR]sub.zen Net name 'pdm_data' should be UPPERCASE: 'PDM_DATA'
+  in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
+
+Advice: [TEMP_DIR]sub.zen Net name 'pdm_select' should be UPPERCASE: 'PDM_SELECT'
+  in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
+
+Advice: [TEMP_DIR]sub.zen Net name 'pdm_clock' should be UPPERCASE: 'PDM_CLOCK'
+  in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
+
+Advice: io() parameter 'pdm' should be UPPERCASE: 'PDM'
+   ╭─[ [TEMP_DIR]sub.zen:5:7 ]
+ 5 │pdm = io("pdm", PdmMic)
+   │              ╰───────── io() parameter 'pdm' should be UPPERCASE: 'PDM'
+   ├─[ [TEMP_DIR]top.zen:7:1 ]
+ 7 │Sub(name = "sub", pdm = pdm)
+   │              ╰────────────── Issue in `sub`

--- a/crates/pcb-zen/tests/snapshots/input__module_io_rejects_interface_when_net_expected.snap
+++ b/crates/pcb-zen/tests/snapshots/input__module_io_rejects_interface_when_net_expected.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -16,5 +16,18 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]parent.zen Net name 'SIG_signal' should be UPPERCASE: 'SIG_SIGNAL'Error: [TEMP_DIR]parent.zen:8:1-36 Error instantiating `child`
-Error: [TEMP_DIR]child.zen:2:10-27 Input 'signal' (type) has wrong type for this placeholder: expected Net, got SingleNet(signal=Net(name: "SIG_signal", id: <ID>))
+Advice: [TEMP_DIR]parent.zen Net name 'SIG_signal' should be UPPERCASE: 'SIG_SIGNAL'
+
+Error: Input 'signal' (type) has wrong type for this placeholder: expected Net, got SingleNet(signal=Net(name: "SIG_signal", id: <ID>))
+   ╭─[ [TEMP_DIR]child.zen:2:10 ]
+   │
+ 2 │ signal = io("signal", Net)
+   │          ────────┬────────  
+   │                  ╰────────── Input 'signal' (type) has wrong type for this placeholder: expected Net, got SingleNet(signal=Net(name: "SIG_signal", id: <ID>))
+   │
+   ├─[ [TEMP_DIR]parent.zen:8:1 ]
+   │
+ 8 │ Child(name="child1", signal=sig_if)  # Should fail - interface not accepted for Net io
+   │ ─────────────────┬─────────────────  
+   │                  ╰─────────────────── Error instantiating `child`
+───╯

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_io_and_config_with_values.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_io_and_config_with_values.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -34,6 +34,15 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]top.zen:4:1-8:2 Issue in `my_sub`
-Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'Advice: [TEMP_DIR]top.zen:4:1-8:2 Issue in `my_sub`
-Advice: [TEMP_DIR]my_sub.zen:3:7-21 io() parameter 'pwr' should be UPPERCASE: 'PWR'
+Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'
+  in [TEMP_DIR]top.zen:4:1-8:2 Issue in `my_sub`
+
+Advice: io() parameter 'pwr' should be UPPERCASE: 'PWR'
+   ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]
+ 3 │pwr = io("pwr", Net)
+   │             ╰─────── io() parameter 'pwr' should be UPPERCASE: 'PWR'
+   ├─[ [TEMP_DIR]top.zen:4:1 ]
+ 4 │╭▶Sub(
+   ┆┆ 
+ 8 │├▶)
+   │╰──── Issue in `my_sub`

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_missing_required_inputs_should_error.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_missing_required_inputs_should_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -14,5 +14,18 @@ expression: netlist
   (nets
   )
 )
-Error: [TEMP_DIR]top.zen:4:1-7:2 Error instantiating `my_sub`
-Error: [TEMP_DIR]my_sub.zen:3:7-21 Input 'pwr' is required but was not provided and no default value was given
+Error: Input 'pwr' is required but was not provided and no default value was given
+   ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]
+   │
+ 3 │ pwr = io("pwr", Net)
+   │       ───────┬──────  
+   │              ╰──────── Input 'pwr' is required but was not provided and no default value was given
+   │
+   ├─[ [TEMP_DIR]top.zen:4:1 ]
+   │
+ 4 │ ╭─▶ Sub(
+   ┆ ┆   
+ 7 │ ├─▶ )
+   │ │       
+   │ ╰─────── Error instantiating `my_sub`
+───╯

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_optional_inputs_return_none.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_optional_inputs_return_none.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -36,6 +36,15 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]top.zen:4:1-7:2 Issue in `my_sub`
-Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'Advice: [TEMP_DIR]top.zen:4:1-7:2 Issue in `my_sub`
-Advice: [TEMP_DIR]my_sub.zen:3:7-38 io() parameter 'pwr' should be UPPERCASE: 'PWR'
+Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'
+  in [TEMP_DIR]top.zen:4:1-7:2 Issue in `my_sub`
+
+Advice: io() parameter 'pwr' should be UPPERCASE: 'PWR'
+   ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]
+ 3 │pwr = io("pwr", Net, optional = True)
+   │                     ╰──────────────── io() parameter 'pwr' should be UPPERCASE: 'PWR'
+   ├─[ [TEMP_DIR]top.zen:4:1 ]
+ 4 │╭▶Sub(
+   ┆┆ 
+ 7 │├▶)
+   │╰──── Issue in `my_sub`

--- a/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_cyclic_load_error.snap
+++ b/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_cyclic_load_error.snap
@@ -1,6 +1,17 @@
 ---
 source: crates/pcb-zen/tests/load_diagnostics.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]a.zen:3:6-15 Error loading module `./b.zen`
-Error: [TEMP_DIR]b.zen:3:1-26 cyclic load detected while loading `[TEMP_DIR]a.zen`
+Error: cyclic load detected while loading `[TEMP_DIR]a.zen`
+   ╭─[ [TEMP_DIR]b.zen:3:1 ]
+   │
+ 3 │ load("./a.zen", "a_func")
+   │ ────────────┬────────────  
+   │             ╰────────────── cyclic load detected while loading `[TEMP_DIR]a.zen`
+   │
+   ├─[ [TEMP_DIR]a.zen:3:6 ]
+   │
+ 3 │ load("./b.zen", "b_func")
+   │      ────┬────  
+   │          ╰────── Error loading module `./b.zen`
+───╯

--- a/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_load_file_with_syntax_error.snap
+++ b/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_load_file_with_syntax_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/load_diagnostics.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test.zen:3:6-20 Error loading module `./broken.zen`
 Error: [TEMP_DIR]broken.zen:5:1 Parse error: unexpected new line here, expected one of ")", "*", "**", "/" or "IDENTIFIER"
+  in [TEMP_DIR]test.zen:3:6-20 Error loading module `./broken.zen`

--- a/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_load_nonexistent_file.snap
+++ b/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_load_nonexistent_file.snap
@@ -1,5 +1,11 @@
 ---
 source: crates/pcb-zen/tests/load_diagnostics.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test.zen:3:1-33 File not found: [TEMP_DIR]nonexistent.zen
+Error: File not found: [TEMP_DIR]nonexistent.zen
+   ╭─[ [TEMP_DIR]test.zen:3:1 ]
+   │
+ 3 │ load("./nonexistent.zen", "foo")
+   │ ────────────────┬───────────────  
+   │                 ╰───────────────── File not found: [TEMP_DIR]nonexistent.zen
+───╯

--- a/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_nested_load_errors.snap
+++ b/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_nested_load_errors.snap
@@ -1,8 +1,29 @@
 ---
 source: crates/pcb-zen/tests/load_diagnostics.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test.zen:3:6-20 Error loading module `./level1.zen`
-Error: [TEMP_DIR]level1.zen:3:6-20 Error loading module `./level2.zen`
-Error: [TEMP_DIR]level2.zen:3:6-20 Error loading module `./level3.zen`
-Error: [TEMP_DIR]level3.zen:3:1-19 Variable `undefined_variable` not found
+Error: Variable `undefined_variable` not found
+   ╭─[ [TEMP_DIR]level3.zen:3:1 ]
+   │
+ 3 │ undefined_variable + 1
+   │ ─────────┬────────  
+   │          ╰────────── Variable `undefined_variable` not found
+   │
+   ├─[ [TEMP_DIR]test.zen:3:6 ]
+   │
+ 3 │ load("./level1.zen", "something")
+   │      ───────┬──────  
+   │             ╰──────── Error loading module `./level1.zen`
+   │
+   ├─[ [TEMP_DIR]level1.zen:3:6 ]
+   │
+ 3 │ load("./level2.zen", "something")
+   │      ───────┬──────  
+   │             ╰──────── Error loading module `./level2.zen`
+   │
+   ├─[ [TEMP_DIR]level2.zen:3:6 ]
+   │
+ 3 │ load("./level3.zen", "something")
+   │      ───────┬──────  
+   │             ╰──────── Error loading module `./level3.zen`
+───╯

--- a/crates/pcb-zen/tests/snapshots/module_loading__module_nonexistent_alias.snap
+++ b/crates/pcb-zen/tests/snapshots/module_loading__module_nonexistent_alias.snap
@@ -1,5 +1,11 @@
 ---
 source: crates/pcb-zen/tests/module_loading.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test.zen:3:17-49 File not found: [TEMP_DIR]does_not_exist/something.zen
+Error: File not found: [TEMP_DIR]does_not_exist/something.zen
+   ╭─[ [TEMP_DIR]test.zen:3:17 ]
+   │
+ 3 │ MissingModule = Module("@missing/something.zen")
+   │                 ────────────────┬───────────────  
+   │                                 ╰───────────────── File not found: [TEMP_DIR]does_not_exist/something.zen
+───╯

--- a/crates/pcb-zen/tests/snapshots/module_loading__module_nonexistent_file.snap
+++ b/crates/pcb-zen/tests/snapshots/module_loading__module_nonexistent_file.snap
@@ -1,5 +1,11 @@
 ---
 source: crates/pcb-zen/tests/module_loading.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test.zen:3:17-45 File not found: [TEMP_DIR]does_not_exist.zen
+Error: File not found: [TEMP_DIR]does_not_exist.zen
+   ╭─[ [TEMP_DIR]test.zen:3:17 ]
+   │
+ 3 │ MissingModule = Module("does_not_exist.zen")
+   │                 ──────────────┬─────────────  
+   │                               ╰─────────────── File not found: [TEMP_DIR]does_not_exist.zen
+───╯

--- a/crates/pcb-zen/tests/snapshots/placeholder__snapshot_io_and_config_placeholders.snap
+++ b/crates/pcb-zen/tests/snapshots/placeholder__snapshot_io_and_config_placeholders.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/placeholder.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -34,6 +34,15 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]top.zen:4:1-8:2 Issue in `my_sub`
-Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'Advice: [TEMP_DIR]top.zen:4:1-8:2 Issue in `my_sub`
-Advice: [TEMP_DIR]my_sub.zen:3:7-21 io() parameter 'pwr' should be UPPERCASE: 'PWR'
+Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'
+  in [TEMP_DIR]top.zen:4:1-8:2 Issue in `my_sub`
+
+Advice: io() parameter 'pwr' should be UPPERCASE: 'PWR'
+   ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]
+ 3 │pwr = io("pwr", Net)
+   │             ╰─────── io() parameter 'pwr' should be UPPERCASE: 'PWR'
+   ├─[ [TEMP_DIR]top.zen:4:1 ]
+ 4 │╭▶Sub(
+   ┆┆ 
+ 8 │├▶)
+   │╰──── Issue in `my_sub`

--- a/crates/pcb-zen/tests/snapshots/placeholder__snapshot_undefined_placeholder.snap
+++ b/crates/pcb-zen/tests/snapshots/placeholder__snapshot_undefined_placeholder.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/placeholder.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -34,6 +34,15 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]top.zen:4:1-7:2 Issue in `my_sub`
-Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'Advice: [TEMP_DIR]top.zen:4:1-7:2 Issue in `my_sub`
-Advice: [TEMP_DIR]my_sub.zen:3:7-38 io() parameter 'pwr' should be UPPERCASE: 'PWR'
+Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'
+  in [TEMP_DIR]top.zen:4:1-7:2 Issue in `my_sub`
+
+Advice: io() parameter 'pwr' should be UPPERCASE: 'PWR'
+   ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]
+ 3 │pwr = io("pwr", Net, optional = True)
+   │                     ╰──────────────── io() parameter 'pwr' should be UPPERCASE: 'PWR'
+   ├─[ [TEMP_DIR]top.zen:4:1 ]
+ 4 │╭▶Sub(
+   ┆┆ 
+ 7 │├▶)
+   │╰──── Issue in `my_sub`

--- a/crates/pcb-zen/tests/snapshots/test__net_passing.snap
+++ b/crates/pcb-zen/tests/snapshots/test__net_passing.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/test.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -38,9 +38,24 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
-Advice: [TEMP_DIR]MyComponent.zen Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'Advice: [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
-Advice: [TEMP_DIR]MyComponent.zen Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'Advice: [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
-Advice: [TEMP_DIR]MyComponent.zen:3:9-40 io() parameter 'input' should be UPPERCASE: 'INPUT'Advice: [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
-Advice: [TEMP_DIR]test.zen Net name 'INTERFACE_p1' should be UPPERCASE: 'INTERFACE_P1'Advice: [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
+Advice: [TEMP_DIR]MyComponent.zen Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'
+  in [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
+
+Advice: [TEMP_DIR]MyComponent.zen Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'
+  in [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
+
+Advice: io() parameter 'input' should be UPPERCASE: 'INPUT'
+   ╭─[ [TEMP_DIR]MyComponent.zen:3:9 ]
+ 3 │input = io("input", ComponentInterface)
+   │                       ╰──────────────── io() parameter 'input' should be UPPERCASE: 'INPUT'
+   ├─[ [TEMP_DIR]test.zen:5:1 ]
+ 5 │╭▶MyComponent(
+   ┆┆ 
+ 8 │├▶)
+   │╰──── Issue in `MyComponent`
+
+Advice: [TEMP_DIR]test.zen Net name 'INTERFACE_p1' should be UPPERCASE: 'INTERFACE_P1'
+  in [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
+
 Advice: [TEMP_DIR]test.zen Net name 'INTERFACE_p2' should be UPPERCASE: 'INTERFACE_P2'
+  in [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`

--- a/crates/pcb-zen/tests/snapshots/test__snapshot_missing_pins_should_error.snap
+++ b/crates/pcb-zen/tests/snapshots/test__snapshot_missing_pins_should_error.snap
@@ -1,5 +1,13 @@
 ---
 source: crates/pcb-zen/tests/test.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test_missing.zen:3:1-11:2 Unconnected pin(s): GND, OE, Q2, Q3, Q4, VDD
+Error: Unconnected pin(s): GND, OE, Q2, Q3, Q4, VDD
+    ╭─[ [TEMP_DIR]test_missing.zen:3:1 ]
+    │
+  3 │ ╭─▶ Component(
+    ┆ ┆   
+ 11 │ ├─▶ )
+    │ │       
+    │ ╰─────── Unconnected pin(s): GND, OE, Q2, Q3, Q4, VDD
+────╯

--- a/crates/pcb-zen/tests/snapshots/test__snapshot_unknown_pin_should_error.snap
+++ b/crates/pcb-zen/tests/snapshots/test__snapshot_unknown_pin_should_error.snap
@@ -1,5 +1,13 @@
 ---
 source: crates/pcb-zen/tests/test.rs
-expression: netlist
+expression: snapshot_output
 ---
-Error: [TEMP_DIR]test_unknown.zen:3:1-18:2 Unknown pin name 'INVALID' (expected one of: ICLK, Q1, Q2, Q3, OE, VDD, GND, Q4)
+Error: Unknown pin name 'INVALID' (expected one of: ICLK, Q1, Q2, Q3, OE, VDD, GND, Q4)
+    ╭─[ [TEMP_DIR]test_unknown.zen:3:1 ]
+    │
+  3 │ ╭─▶ Component(
+    ┆ ┆   
+ 18 │ ├─▶ )
+    │ │       
+    │ ╰─────── Unknown pin name 'INVALID' (expected one of: ICLK, Q1, Q2, Q3, OE, VDD, GND, Q4)
+────╯

--- a/crates/pcb-zen/tests/snapshots/test__snapshot_unused_inputs_should_error.snap
+++ b/crates/pcb-zen/tests/snapshots/test__snapshot_unused_inputs_should_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/test.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -14,4 +14,12 @@ expression: netlist
   (nets
   )
 )
-Error: [TEMP_DIR]top.zen:4:1-7:2 Unknown argument(s) provided to module my_module: unused
+Error: Unknown argument(s) provided to module my_module: unused
+   ╭─[ [TEMP_DIR]top.zen:4:1 ]
+   │
+ 4 │ ╭─▶ MyModule(
+   ┆ ┆   
+ 7 │ ├─▶ )
+   │ │       
+   │ ╰─────── Unknown argument(s) provided to module my_module: unused
+───╯

--- a/crates/pcb/src/build.rs
+++ b/crates/pcb/src/build.rs
@@ -40,7 +40,6 @@ pub fn create_diagnostics_passes(
     }
 
     passes.push(Box::new(pcb_zen_core::AggregatePass));
-    passes.push(Box::new(pcb_zen_core::SortPass));
     passes.push(Box::new(pcb_zen::diagnostics::RenderPass));
 
     passes

--- a/crates/pcb/src/drc.rs
+++ b/crates/pcb/src/drc.rs
@@ -1,7 +1,7 @@
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use pcb_ui::prelude::*;
 use pcb_zen_core::diagnostics::{DiagnosticsPass, Severity};
-use pcb_zen_core::passes::{FilterHiddenPass, SortPass, SuppressPass};
+use pcb_zen_core::passes::{FilterHiddenPass, SuppressPass};
 use starlark::errors::EvalSeverity;
 
 type ColorFn = fn(String) -> colored::ColoredString;
@@ -12,7 +12,6 @@ pub fn render_diagnostics(diagnostics: &mut pcb_zen_core::Diagnostics, suppress_
     for pass in [
         &FilterHiddenPass as &dyn DiagnosticsPass,
         &SuppressPass::new(suppress_kinds.to_vec()),
-        &SortPass,
     ] {
         pass.apply(diagnostics);
     }


### PR DESCRIPTION
This eliminates the need for the sorting diagnostic pass. Also, use the
main render_diagnostics code for rendering diagnostics in snapshots.

Also, make some tweaks to how we render diagnostics without spans.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies and stabilizes diagnostic output across CLI and tests.
> 
> - Diagnostics now use a severity-first ordering key in `EvalSession` (removes need for `SortPass`); exported `SortPass` and its call sites removed
> - Refactors rendering to a writer with optional color; adds `render_diagnostics_to_string` and uses the main Ariadne renderer for test snapshots
> - Improves fallback rendering for diagnostics without spans and includes stack traces for errors in CLI mode
> - Updates snapshots to new formatted output; minor dependency bump: `ariadne` to `0.6` (and `unicode-width` 0.2)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3bcafc5708aada7d8a686d3c372bc54aeb8cee7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->