### PR TITLE
Skip <workspace root>/.pcb/cache symlinking if workspace root == HOME

### DIFF
--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -328,6 +328,13 @@ pub fn cache_base() -> PathBuf {
 /// Creates <workspace_root>/.pcb/cache as a symlink to ~/.pcb/cache.
 /// This provides stable workspace-relative paths in generated files.
 pub fn ensure_workspace_cache_symlink(workspace_root: &std::path::Path) -> Result<()> {
+    let home_dir = dirs::home_dir().expect("Cannot determine home directory");
+
+    // Skip if workspace_root is home directory - would create self-symlink
+    if workspace_root == home_dir {
+        return Ok(());
+    }
+
     let workspace_cache = workspace_root.join(".pcb/cache");
     let home_cache = cache_base();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents erroneous self-symlink creation under certain workspace setups.
> 
> - Adds an early return in `ensure_workspace_cache_symlink` to skip symlink creation when `workspace_root == dirs::home_dir()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 283113f7b1fe47923c6e7489dc68f556ed76c538. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->