### PR TITLE
Hyperfinify to reduce noise

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -62,28 +62,29 @@ jobs:
           repository: dioderobot/arduino
           path: workspaces/arduino
 
+      - name: Install hyperfine
+        run: |
+          wget -q https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine_1.19.0_amd64.deb
+          sudo dpkg -i hyperfine_1.19.0_amd64.deb
+
       - name: Run performance benchmarks
         run: |
           mkdir -p perf
           python3 bin/pcb-build-perf \
             --pcb "$RUNNER_TEMP/pcb-base-bin/pcb" \
             --workspace workspaces/demo \
-            --runs 20 \
             --output perf/demo-base.json
           python3 bin/pcb-build-perf \
             --pcb "$RUNNER_TEMP/pcb-base-bin/pcb" \
             --workspace workspaces/arduino \
-            --runs 20 \
             --output perf/arduino-base.json
           python3 bin/pcb-build-perf \
             --pcb "$RUNNER_TEMP/pcb-head/pcb" \
             --workspace workspaces/demo \
-            --runs 20 \
             --output perf/demo-head.json
           python3 bin/pcb-build-perf \
             --pcb "$RUNNER_TEMP/pcb-head/pcb" \
             --workspace workspaces/arduino \
-            --runs 20 \
             --output perf/arduino-head.json
 
       - name: Create PR comment body
@@ -98,35 +99,57 @@ jobs:
             with open(path, "r", encoding="utf-8") as handle:
               return json.load(handle)
 
-          def fmt_seconds(value):
-            return f"{value:.2f}s"
-
-          def fmt_ms(value, cv_pct=None):
-            ms = f"{value * 1000:.0f}ms"
-            if cv_pct is not None and cv_pct > 0:
-              return f"{ms} (±{cv_pct:.0f}%)"
-            return ms
-
-          def calc_cv_pct(entry):
-            mean = entry.get("mean_seconds", 0)
-            stdev = entry.get("stdev_seconds", 0)
-            if mean > 0:
-              return (stdev / mean) * 100
-            return None
+          def fmt_ms(value, stddev=None):
+            """Format time in ms with optional ± stddev."""
+            ms = value * 1000
+            if stddev is not None and stddev > 0:
+              stddev_ms = stddev * 1000
+              # Use 1 decimal for small values, 0 for larger
+              if stddev_ms < 1:
+                return f"{ms:.0f}ms ±{stddev_ms:.1f}"
+              return f"{ms:.0f}ms ±{stddev_ms:.0f}"
+            return f"{ms:.0f}ms"
 
           def analyze_change(base, head):
-            delta = head["mean_seconds"] - base["mean_seconds"]
-            pct = None
-            if base["mean_seconds"] > 0:
-              pct = (delta / base["mean_seconds"]) * 100
-            se = math.sqrt(base.get("se_seconds", 0.0) ** 2 + head.get("se_seconds", 0.0) ** 2)
+            """Compare base vs head using median and check for significance."""
+            base_median = base["median_seconds"]
+            head_median = head["median_seconds"]
+            base_stddev = base["stddev_seconds"]
+            head_stddev = head["stddev_seconds"]
+
+            delta = head_median - base_median
+            pct = (delta / base_median * 100) if base_median > 0 else None
+
+            # Use pooled stddev for significance check
+            # Change is significant if |delta| > combined noise floor
+            noise = math.sqrt(base_stddev ** 2 + head_stddev ** 2)
             significant = False
             if pct is not None and abs(pct) >= 5:
-              if se == 0:
+              # Require delta to exceed 2x the noise floor
+              if noise == 0 or abs(delta) > 2 * noise:
                 significant = True
-              elif abs(delta) > 2 * se:
-                significant = True
+
             return delta, pct, significant
+
+          def compute_speedup(base, head):
+            """Compute speedup ratio with uncertainty (like hyperfine comparison)."""
+            base_mean = base["mean_seconds"]
+            head_mean = head["mean_seconds"]
+            base_stddev = base["stddev_seconds"]
+            head_stddev = head["stddev_seconds"]
+
+            if head_mean <= 0 or base_mean <= 0:
+              return None, None
+
+            ratio = base_mean / head_mean  # >1 means head is faster
+
+            # Propagate uncertainty: for ratio r = a/b, σ_r/r = sqrt((σ_a/a)² + (σ_b/b)²)
+            rel_err_base = base_stddev / base_mean if base_mean > 0 else 0
+            rel_err_head = head_stddev / head_mean if head_mean > 0 else 0
+            rel_err = math.sqrt(rel_err_base ** 2 + rel_err_head ** 2)
+            ratio_err = ratio * rel_err
+
+            return ratio, ratio_err
 
           rows = []
           has_significant = False
@@ -137,6 +160,7 @@ jobs:
             base_boards = {b["zen_path"]: b for b in base.get("boards", [])}
             head_boards = {b["zen_path"]: b for b in head.get("boards", [])}
             all_paths = sorted(set(base_boards) | set(head_boards))
+
             for zen_path in all_paths:
               base_board = base_boards.get(zen_path)
               head_board = head_boards.get(zen_path)
@@ -146,43 +170,55 @@ jobs:
               elif base_board and base_board.get("name"):
                 board_name = base_board["name"]
               label = f"{name}/{board_name}"
+
               if not base_board or not head_board:
-                rows.append((label, "—", "—", "missing", ""))
+                rows.append((label, "—", "—", "—", "missing"))
+                continue
+
+              delta, pct, significant = analyze_change(base_board, head_board)
+              ratio, ratio_err = compute_speedup(base_board, head_board)
+
+              base_str = fmt_ms(base_board["median_seconds"], base_board["stddev_seconds"])
+              head_str = fmt_ms(head_board["median_seconds"], head_board["stddev_seconds"])
+
+              if pct is None:
+                change_text = "—"
+              elif not significant:
+                change_text = f"{pct:+.1f}%"
               else:
-                delta, pct, significant = analyze_change(base_board, head_board)
-                base_cv = calc_cv_pct(base_board)
-                head_cv = calc_cv_pct(head_board)
-                base_mean = fmt_ms(base_board["mean_seconds"], base_cv)
-                head_mean = fmt_ms(head_board["mean_seconds"], head_cv)
-                if pct is None:
-                  change_text = "—"
-                  status = ""
-                elif not significant:
-                  change_text = f"{pct:+.1f}%"
-                  status = ""
-                elif pct < 0:
-                  change_text = f"**{pct:+.1f}%**"
-                  status = "faster"
-                  has_significant = True
+                has_significant = True
+                if ratio is not None and ratio_err is not None:
+                  if pct < 0:
+                    change_text = f"**{ratio:.2f}× ±{ratio_err:.2f} faster**"
+                  else:
+                    change_text = f"**{1/ratio:.2f}× ±{ratio_err/ratio**2:.2f} slower**"
                 else:
-                  change_text = f"**{pct:+.1f}%**"
-                  status = "slower"
-                  has_significant = True
-                rows.append((label, base_mean, head_mean, change_text, status))
+                  if pct < 0:
+                    change_text = f"**{pct:+.1f}% faster**"
+                  else:
+                    change_text = f"**{pct:+.1f}% slower**"
+
+              rows.append((label, base_str, head_str, change_text))
 
           lines = ["### Build Performance", ""]
-          lines.append("| Board | Base | Head | Change | |")
-          lines.append("|:------|-----:|-----:|-------:|:--|")
-          for label, base, head, change, status in rows:
-            lines.append(f"| {label} | {base} | {head} | {change} | {status} |")
+          lines.append("| Board | Base (median) | Head (median) | Change |")
+          lines.append("|:------|-----:|-----:|:------|")
+          for label, base, head, change in rows:
+            lines.append(f"| {label} | {base} | {head} | {change} |")
+          lines.append("")
+          lines.append("<sub>Measured with [hyperfine](https://github.com/sharkdp/hyperfine). Times show median ±stddev.</sub>")
           lines.append("")
           lines.append("<!-- pcb-build-perf -->")
 
           body = "\n".join(lines)
           Path("perf/comment.txt").write_text(body, encoding="utf-8")
 
-          has_changes = "true" if has_significant else "false"
+          # Always write to job summary
           import os
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+            f.write(body + "\n")
+
+          has_changes = "true" if has_significant else "false"
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(f"has_changes={has_changes}\n")
           PY

--- a/bin/pcb-build-perf
+++ b/bin/pcb-build-perf
@@ -1,52 +1,10 @@
 #!/usr/bin/env python3
 import argparse
 import json
-import math
 import os
-import statistics
 import subprocess
 import sys
-import time
-
-
-T_CRITICAL_95 = {
-    1: 12.706,
-    2: 4.303,
-    3: 3.182,
-    4: 2.776,
-    5: 2.571,
-    6: 2.447,
-    7: 2.365,
-    8: 2.306,
-    9: 2.262,
-    10: 2.228,
-    11: 2.201,
-    12: 2.179,
-    13: 2.160,
-    14: 2.145,
-    15: 2.131,
-    16: 2.120,
-    17: 2.110,
-    18: 2.101,
-    19: 2.093,
-    20: 2.086,
-    21: 2.080,
-    22: 2.074,
-    23: 2.069,
-    24: 2.064,
-    25: 2.060,
-    26: 2.056,
-    27: 2.052,
-    28: 2.048,
-    29: 2.045,
-    30: 2.042,
-}
-
-
-def t_critical_95(df: int) -> float:
-    if df <= 0:
-        return 0.0
-    return T_CRITICAL_95.get(df, 1.96)
+import tempfile
 
 
 def run_json(cmd: list[str], cwd: str | None) -> dict:
@@ -66,17 +24,31 @@ def run_json(cmd: list[str], cwd: str | None) -> dict:
         ) from exc
 
 
-def run_timed(cmd: list[str], cwd: str | None) -> float:
-    start = time.perf_counter()
-    subprocess.run(
-        cmd,
-        cwd=cwd,
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    end = time.perf_counter()
-    return end - start
+def run_hyperfine(cmd: list[str], cwd: str, warmup: int) -> dict:
+    """Run hyperfine and return its results."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        tmp_path = f.name
+    try:
+        # With --shell=none, hyperfine expects the command as a single string
+        cmd_str = " ".join(cmd)
+        subprocess.run(
+            [
+                "hyperfine",
+                "--warmup", str(warmup),
+                "--export-json", tmp_path,
+                "--shell=none",
+                cmd_str,
+            ],
+            cwd=cwd,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        with open(tmp_path) as f:
+            data = json.load(f)
+        return data["results"][0]
+    finally:
+        os.unlink(tmp_path)
 
 
 def normalize_rel_path(rel_path: object) -> str:
@@ -113,30 +85,6 @@ def collect_boards(workspace_info: dict) -> list[dict]:
     return boards
 
 
-def summarize_runtimes(runtimes: list[float]) -> dict:
-    n = len(runtimes)
-    mean = statistics.mean(runtimes) if runtimes else 0.0
-    if n >= 2:
-        stdev = statistics.stdev(runtimes)
-        se = stdev / math.sqrt(n)
-        t_value = t_critical_95(n - 1)
-        margin = t_value * se
-    else:
-        stdev = 0.0
-        se = 0.0
-        t_value = 0.0
-        margin = 0.0
-    return {
-        "n": n,
-        "mean_seconds": mean,
-        "stdev_seconds": stdev,
-        "se_seconds": se,
-        "t_critical_95": t_value,
-        "ci95_low_seconds": mean - margin,
-        "ci95_high_seconds": mean + margin,
-    }
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Measure pcb build performance across boards in a workspace."
@@ -168,14 +116,8 @@ def main() -> int:
     parser.add_argument(
         "--warmup",
         type=int,
-        default=2,
-        help="Warmup runs per board (default: 2).",
-    )
-    parser.add_argument(
-        "--runs",
-        type=int,
-        default=5,
-        help="Measured runs per board (default: 5).",
+        default=3,
+        help="Warmup runs per board (default: 3).",
     )
     args = parser.parse_args()
 
@@ -183,7 +125,7 @@ def main() -> int:
     if not os.path.isdir(workspace):
         raise SystemExit(f"Workspace directory not found: {workspace}")
 
-    pcb_path = args.pcb
+    pcb_path = os.path.abspath(args.pcb) if not args.pcb.startswith("/") and args.pcb != "pcb" else args.pcb
 
     info = run_json([pcb_path, "info", "-f", "json", workspace], cwd=None)
     boards = collect_boards(info)
@@ -196,36 +138,38 @@ def main() -> int:
     if args.offline:
         build_flags.append("--offline")
 
-    if args.warmup < 0 or args.runs < 1:
-        raise SystemExit("--warmup must be >= 0 and --runs must be >= 1")
+    if args.warmup < 0:
+        raise SystemExit("--warmup must be >= 0")
 
-    board_runs = []
+    board_results = []
     for board in boards:
         zen_path = board["zen_path"]
-        for _ in range(args.warmup):
-            run_timed([pcb_path, "build", *build_flags, zen_path], cwd=workspace)
+        cmd = [pcb_path, "build", *build_flags, zen_path]
 
-        runtimes = []
-        for _ in range(args.runs):
-            duration = run_timed([pcb_path, "build", *build_flags, zen_path], cwd=workspace)
-            runtimes.append(duration)
+        hf = run_hyperfine(cmd, cwd=workspace, warmup=args.warmup)
 
-        stats = summarize_runtimes(runtimes)
-        board_runs.append(
+        board_results.append(
             {
                 "name": board["name"],
                 "zen_path": zen_path,
-                "runs": runtimes,
-                **stats,
+                # Hyperfine metrics (all times in seconds)
+                "mean_seconds": hf["mean"],
+                "stddev_seconds": hf["stddev"],
+                "median_seconds": hf["median"],
+                "min_seconds": hf["min"],
+                "max_seconds": hf["max"],
+                "user_seconds": hf["user"],
+                "system_seconds": hf["system"],
+                "runs": hf["times"],
+                "n": len(hf["times"]),
             }
         )
 
     output = {
         "workspace": workspace,
-        "board_count": len(board_runs),
-        "boards": board_runs,
+        "board_count": len(board_results),
+        "boards": board_results,
         "warmup_runs": args.warmup,
-        "measured_runs": args.runs,
     }
 
     payload = json.dumps(output, indent=2, sort_keys=True)

--- a/test-workspaces/with-pcb-toml/pcb.sum
+++ b/test-workspaces/with-pcb-toml/pcb.sum
@@ -2,6 +2,8 @@ github.com/diodeinc/kicad 0.1.2 h1:1/ttxxBG2Fu1YciHTblwd/iWh5BfuDoIwfpGR4TSykY=
 github.com/diodeinc/kicad 0.1.2/pcb.toml h1:tgMoqeyjDbifBj3PAXn7H3oSw4xLvlV6FB0Jp4G1Hus=
 github.com/diodeinc/stdlib 0.4.10 h1:XkpYbciIx8kNCvuV6e3UHxGUmIyqrLduOaj6q64JUeE=
 github.com/diodeinc/stdlib 0.4.10/pcb.toml h1:47E7qCZRIN1CGyQN1qtbrh7RQgTWyfgwvbhlcSpLFeQ=
+github.com/diodeinc/stdlib 0.5.2 h1:tkh2D/G7WFQYGwx9z5NapQjCGptHYKAaiSx5xtgvMpE=
+github.com/diodeinc/stdlib 0.5.2/pcb.toml h1:p7AGSnxAhTOByyaQk5BJRGFTv4TSojhTFzSHcWHX4sM=
 gitlab.com/kicad/libraries/kicad-footprints/Battery.pretty/BatteryHolder_Keystone_500.kicad_mod 9.0.3 h1:2x3MM99d54ubc6J1kTbZ6eH9LcEvLqllQyjvyzDYKB0=
 gitlab.com/kicad/libraries/kicad-footprints/Button_Switch_SMD.pretty/SW_SPST_B3U-1000P.kicad_mod 9.0.3 h1:W0npk90bmVE1xq/0aeY3CFAAXbMotC3wEc4ConXzDhE=
 gitlab.com/kicad/libraries/kicad-footprints/Button_Switch_THT.pretty/SW_PUSH_6mm.kicad_mod 9.0.3 h1:6179h4/sFBJ19neuO+ZeE7qftaq5DNsd3t987aPEaZo=
@@ -208,6 +210,7 @@ gitlab.com/kicad/libraries/kicad-footprints/Sensor_Humidity.pretty/Sensirion_DFN
 gitlab.com/kicad/libraries/kicad-footprints/Sensor_Motion.pretty/Analog_LGA-16_3.25x3mm_P0.5mm_LayoutBorder3x5y.kicad_mod 9.0.3 h1:dxQDVG8uooxmHqE3XU0ApPb5Edrr3k03xMAV0PH9acs=
 gitlab.com/kicad/libraries/kicad-footprints/Sensor_Motion.pretty/InvenSense_QFN-24_3x3mm_P0.4mm.kicad_mod 9.0.3 h1:mxklEurRAZfrc+MMVAZoMAxP8BjJpwB23ZZmKbqiYsM=
 gitlab.com/kicad/libraries/kicad-footprints/Sensor_Motion.pretty/InvenSense_QFN-24_4x4mm_P0.5mm.kicad_mod 9.0.3 h1:ztd26+84/R0K2rayX5cz+aUo9A6A1n2iWp3vmp42gnA=
+gitlab.com/kicad/libraries/kicad-footprints/TerminalBlock.pretty 9.0.3 h1:cmhanP9j6WuGsA7BgfJJjuftY8IR7AO5XRuL+9QDtoY=
 gitlab.com/kicad/libraries/kicad-footprints/TestPoint.pretty 9.0.3 h1:YnUr1VplDrlq+r2HEjBknkf9W+asw3QBenjPJaRAAIY=
 gitlab.com/kicad/libraries/kicad-symbols/Amplifier_Current.kicad_sym 9.0.3 h1:/tuIZeIc47l9ZKIMDLH3dSw3FIarnG2Q2mm8wWKGA9I=
 gitlab.com/kicad/libraries/kicad-symbols/Analog.kicad_sym 9.0.3 h1:TpPZkRXh2TtLI5szp4paz8ElBhEPdkNG7iEFALhUtns=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Switch benchmarks to hyperfine and refine reporting**
> 
> - Install and use `hyperfine` in workflow; `bin/pcb-build-perf` rewritten to invoke hyperfine (default `--warmup 3`), removing manual timing, `--runs`, and CI95/SE logic
> - Collect hyperfine metrics per board (`mean`, `median`, `stddev`, `min/max`, `user/system`, per-run times) and resolve `--pcb` to absolute path when needed
> - PR comment now shows median ±stddev and determines significance via pooled stddev; displays speedup ratios with propagated uncertainty; always writes to job summary
> - Table format simplified (Base/Head medians, Change) and handling of missing boards clarified
> - Test workspace sums updated (add stdlib 0.5.2 and TerminalBlock.pretty)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 211e6ab180aa43ca6c97fff3977e9bf0b9987bed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->