### PR TITLE
Require only one confirmation for `pcb publish`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Bump stdlib to 0.5.2
-- `moved()` directives are now skipped if the target path already exists in the layout (idempotency/collision safety)
+- `moved()` directives are now skipped if the target path already exists in the layout
+- `pcb publish` now uses single confirmation prompt instead of two
 
 ## [0.3.26] - 2026-01-20
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Streamlines the `pcb publish` flow to a single upfront confirmation, then pushes without a second prompt.
> 
> - Replace two prompts with one: `Publish and push N tag(s) to <remote>?` (default yes); skipped when `--no-push`
> - Remove final push confirmation and associated rollback-on-decline path; push happens immediately after publishing
> - Update `CHANGELOG.md` to reflect single confirmation and tweak wording on `moved()` note
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 098e5345b8b7127a543e17aebf049bb705cad985. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->