### PR TITLE
Flow diagnostics up the tree as retvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Bump stdlib to 0.5.2
+- Deterministic diagnostic ordering during parallel module evaluation
 - `moved()` directives are now skipped if the target path already exists in the layout
 - `pcb publish` now uses single confirmation prompt instead of two
 - `pcb release` now works for boards without a layout directory

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -72,7 +72,7 @@ pub use lang::eval::{EvalContext, EvalOutput};
 pub use load_spec::LoadSpec;
 pub use passes::{
     AggregatePass, CommentSuppressPass, FilterHiddenPass, JsonExportPass, LspFilterPass,
-    PromotePass, StylePromotePass, SuppressPass,
+    PromotePass, SortPass, StylePromotePass, SuppressPass,
 };
 
 // Re-export file provider types

--- a/crates/pcb-zen-core/src/passes.rs
+++ b/crates/pcb-zen-core/src/passes.rs
@@ -65,6 +65,16 @@ impl DiagnosticsPass for SuppressPass {
     }
 }
 
+/// A pass that sorts diagnostics by key for deterministic output.
+/// Should be applied before rendering.
+pub struct SortPass;
+
+impl DiagnosticsPass for SortPass {
+    fn apply(&self, diagnostics: &mut Diagnostics) {
+        diagnostics.diagnostics.sort_by(|a, b| a.cmp_key(b));
+    }
+}
+
 /// A pass that aggregates similar warnings by combining them into a single representative warning
 pub struct AggregatePass;
 

--- a/crates/pcb-zen-core/tests/snapshots/input__io_interface_incompatible.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__io_interface_incompatible.snap
@@ -2,6 +2,6 @@
 source: crates/pcb-zen-core/tests/input.rs
 expression: output
 ---
-Advice: parent.zen Net name 'SIG_signal' should be UPPERCASE: 'SIG_SIGNAL'
 Error: parent.zen:7:1-30 Error instantiating `Module`
 Error: /Module.zen:2:10-27 Input 'signal' (type) has wrong type for this placeholder: expected Net, got SingleNet(signal=Net(name: "SIG_signal", id: <ID>))
+Advice: parent.zen Net name 'SIG_signal' should be UPPERCASE: 'SIG_SIGNAL'

--- a/crates/pcb-zen/tests/snapshots/input__interface_input.snap
+++ b/crates/pcb-zen/tests/snapshots/input__interface_input.snap
@@ -22,14 +22,6 @@ expression: snapshot_output
     )
   )
 )
-Advice: [TEMP_DIR]top.zen Net name 'PDM_power' should be UPPERCASE: 'PDM_POWER'
-
-Advice: [TEMP_DIR]top.zen Net name 'PDM_data' should be UPPERCASE: 'PDM_DATA'
-
-Advice: [TEMP_DIR]top.zen Net name 'PDM_select' should be UPPERCASE: 'PDM_SELECT'
-
-Advice: [TEMP_DIR]top.zen Net name 'PDM_clock' should be UPPERCASE: 'PDM_CLOCK'
-
 Advice: [TEMP_DIR]sub.zen Net name 'pdm_power' should be UPPERCASE: 'PDM_POWER'
   in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
 
@@ -49,3 +41,11 @@ Advice: io() parameter 'pdm' should be UPPERCASE: 'PDM'
    ├─[ [TEMP_DIR]top.zen:7:1 ]
  7 │Sub(name = "sub", pdm = pdm)
    │              ╰────────────── Issue in `sub`
+
+Advice: [TEMP_DIR]top.zen Net name 'PDM_power' should be UPPERCASE: 'PDM_POWER'
+
+Advice: [TEMP_DIR]top.zen Net name 'PDM_data' should be UPPERCASE: 'PDM_DATA'
+
+Advice: [TEMP_DIR]top.zen Net name 'PDM_select' should be UPPERCASE: 'PDM_SELECT'
+
+Advice: [TEMP_DIR]top.zen Net name 'PDM_clock' should be UPPERCASE: 'PDM_CLOCK'

--- a/crates/pcb-zen/tests/snapshots/input__module_io_rejects_interface_when_net_expected.snap
+++ b/crates/pcb-zen/tests/snapshots/input__module_io_rejects_interface_when_net_expected.snap
@@ -16,8 +16,6 @@ expression: snapshot_output
     )
   )
 )
-Advice: [TEMP_DIR]parent.zen Net name 'SIG_signal' should be UPPERCASE: 'SIG_SIGNAL'
-
 Error: Input 'signal' (type) has wrong type for this placeholder: expected Net, got SingleNet(signal=Net(name: "SIG_signal", id: <ID>))
    ╭─[ [TEMP_DIR]child.zen:2:10 ]
    │
@@ -31,3 +29,5 @@ Error: Input 'signal' (type) has wrong type for this placeholder: expected Net, 
    │ ─────────────────┬─────────────────  
    │                  ╰─────────────────── Error instantiating `child`
 ───╯
+
+Advice: [TEMP_DIR]parent.zen Net name 'SIG_signal' should be UPPERCASE: 'SIG_SIGNAL'

--- a/crates/pcb-zen/tests/snapshots/test__net_passing.snap
+++ b/crates/pcb-zen/tests/snapshots/test__net_passing.snap
@@ -40,14 +40,21 @@ expression: snapshot_output
 )
 Advice: [TEMP_DIR]MyComponent.zen Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'
   in [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
+  in [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
 
 Advice: [TEMP_DIR]MyComponent.zen Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'
   in [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
+  in [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
 
 Advice: io() parameter 'input' should be UPPERCASE: 'INPUT'
    ╭─[ [TEMP_DIR]MyComponent.zen:3:9 ]
  3 │input = io("input", ComponentInterface)
    │                       ╰──────────────── io() parameter 'input' should be UPPERCASE: 'INPUT'
+   ├─[ [TEMP_DIR]top.zen:4:1 ]
+ 4 │╭▶Test(
+   ┆┆ 
+ 6 │├▶)
+   │╰──── Issue in `test`
    ├─[ [TEMP_DIR]test.zen:5:1 ]
  5 │╭▶MyComponent(
    ┆┆ 


### PR DESCRIPTION
This is a clearer ownership model. It fixes an issue with callstack propagation (see snapshot diffs). It also removes lock contention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bold, high-level changes to diagnostics flow and ordering.
> 
> - Refactor evaluation to collect diagnostics per-context and return them via `WithDiagnostics`; remove session-level diagnostics store; `process_pending_child` now returns `Vec<Diagnostic>` and callers accumulate
> - Add `Diagnostic::cmp_key` and new `SortPass` to ensure deterministic diagnostic ordering; export `SortPass` and apply in tests for stable snapshots
> - Update `load()`/module evaluation to wrap child warnings and propagate errors through nested diagnostics; improved callstack context visible in updated snapshots
> - Update `CHANGELOG.md` (stdlib 0.5.2; note deterministic ordering)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfda557a0581384f5f51cab18906ca5222d2256a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->