### PR TITLE
`pcb update` now correctly respects interactive selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `pcb publish` now uses single confirmation prompt instead of two
 - `pcb release` now works for boards without a layout directory
 
+### Fixed
+
+- `pcb update` now correctly respects interactive selection for breaking changes
+
 ### Removed
 
 - Remove `board_config.json` generation from `pcb release`

--- a/crates/pcb/src/update.rs
+++ b/crates/pcb/src/update.rs
@@ -147,7 +147,7 @@ fn apply_version_updates(pending: &[PendingUpdate]) -> Result<usize> {
     }
 
     // Auto-apply non-breaking, prompt for breaking
-    let mut urls_to_apply: HashSet<&str> = non_breaking.iter().map(|u| u.url.as_str()).collect();
+    let mut selected_breaking_urls: HashSet<&str> = HashSet::new();
 
     if !breaking.is_empty() {
         let options: Vec<String> = breaking
@@ -161,15 +161,21 @@ fn apply_version_updates(pending: &[PendingUpdate]) -> Result<usize> {
 
         for (i, u) in breaking.iter().enumerate() {
             if selected.contains(&options[i]) {
-                urls_to_apply.insert(&u.url);
+                selected_breaking_urls.insert(&u.url);
             }
         }
     }
 
-    // Apply
+    // Apply: non-breaking always, breaking only if selected
     let to_apply: Vec<_> = pending
         .iter()
-        .filter(|u| urls_to_apply.contains(u.url.as_str()))
+        .filter(|u| {
+            if u.is_breaking {
+                selected_breaking_urls.contains(u.url.as_str())
+            } else {
+                true
+            }
+        })
         .collect();
 
     for u in &to_apply {


### PR DESCRIPTION
Previously, if there was a patch version bump and major version bump for the same dependency, we'd bump the major version regardless of the user selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect application of breaking updates during `pcb update`.
> 
> - Adjusts update filtering in `crates/pcb/src/update.rs` to always apply non-breaking updates and apply breaking updates only when chosen via `MultiSelect`
> - Adds a **Fixed** entry to `CHANGELOG.md` noting that interactive selection for breaking changes is now respected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc573448e9e216b8f89bcc83a38dbd2928659aad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->