### PR TITLE
Add post-sync detection for stale `moved()` paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Post-sync detection of stale `moved()` paths that weren't renamed
+
 ### Changed
 
 - Bump stdlib to 0.5.2


### PR DESCRIPTION
Since moved() is best effort and there are some edge cases where can't respect it, better to warn when this happens. Typically, this'll occur when multiple refactors are done at the same time. Or if moved() directives are chained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a post-sync check to surface `moved()` renames that were skipped during pre-sync patching.
> 
> - Adds `detect_stale_moved_paths` in `pcb-layout/src/lib.rs`; runs after sync (non-dry-run) to find stale instance paths using `compute_moved_paths_patches` and emits `layout.moved.stale` warnings with example paths
> - Wires the check into `process_layout` after Python sync; updates `CHANGELOG.md` to note the new detection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3c84f7c0e37aa872b7f5282b3b7e3eccc3f0f7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->