### PR TITLE
Sandbox config/auth in snapshot tests

### DIFF
--- a/crates/pcb-diode-api/src/auth.rs
+++ b/crates/pcb-diode-api/src/auth.rs
@@ -46,8 +46,12 @@ impl AuthTokens {
 }
 
 fn get_auth_file_path() -> Result<PathBuf> {
-    let home_dir = dirs::home_dir().context("Failed to get home directory")?;
-    let pcb_dir = home_dir.join(".pcb");
+    let pcb_dir = if let Ok(config_dir) = std::env::var("PCB_CONFIG_DIR") {
+        PathBuf::from(config_dir)
+    } else {
+        let home_dir = dirs::home_dir().context("Failed to get home directory")?;
+        home_dir.join(".pcb")
+    };
     fs::create_dir_all(&pcb_dir)?;
     Ok(pcb_dir.join("auth.toml"))
 }

--- a/crates/pcb-test-utils/src/sandbox.rs
+++ b/crates/pcb-test-utils/src/sandbox.rs
@@ -542,6 +542,12 @@ impl Sandbox {
             if cfg!(windows) { "NUL" } else { "/dev/null" }.into(),
         );
 
+        // Always isolate config dir (auth.toml)
+        env_map.insert(
+            "PCB_CONFIG_DIR".into(),
+            self.home.join(".pcb").to_string_lossy().into_owned(),
+        );
+
         if self.allow_network {
             // Network mode: pass through real HOME to access ~/.pcb/cache
             if let Ok(home) = std::env::var("HOME") {


### PR DESCRIPTION
Without this, bom tests pickup auth data in ~/.pcb/auth.toml and try to fetch availability data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an overridable auth config location and ensures snapshot tests use an isolated one.
> 
> - In `auth.rs`, `get_auth_file_path()` now honors `PCB_CONFIG_DIR` (falls back to `~/.pcb`) and creates the directory before using `auth.toml`.
> - In `sandbox.rs`, always injects `PCB_CONFIG_DIR` pointing to the sandbox `home/.pcb`, isolating `auth.toml` during tests—even when `HOME` is passed through in network mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 293e5c7b997581f2b55c6904862be7b41cc56219. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->