### PR TITLE
Reduce severity of the new moved() diagnostic

### DIFF
--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -796,7 +796,7 @@ impl ModuleConverter {
                         path_depth(old),
                         path_depth(new)
                     );
-                    let diagnostic = Diagnostic::new(body, EvalSeverity::Error, source);
+                    let diagnostic = Diagnostic::new(body, EvalSeverity::Warning, source);
                     diagnostics.push(diagnostic.with_span(span));
                     continue;
                 }


### PR DESCRIPTION
Don't want to break a bunch of existing boards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces strictness of `moved()` directive validation.
> 
> - In `convert.rs` (`validate_and_filter_moved_directives`), the diagnostic for invalid path depth in `moved(old, new)` is downgraded from `Error` to `Warning`, affecting how these cases surface in diagnostics without halting processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a331cff17bc68ed78a24c7131760f7ac7afd0211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->