### PR TITLE
Fix release issues with workspace-as-package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Validate that member packages do not have `[workspace]` sections during workspace discovery
 - `pcb new --board` and `pcb new --package` no longer generate `[workspace]` sections in pcb.toml
 - `pcb update` now correctly respects interactive selection for breaking changes
+- `pcb release` now correctly identifies the board package when workspace root has dependencies
+- `copy_dir_all` now skips hidden files/directories to prevent copying `.pcb/`, `.git/`, etc.
 
 ## [0.3.26] - 2026-01-20
 

--- a/crates/pcb-zen/src/resolve_v2.rs
+++ b/crates/pcb-zen/src/resolve_v2.rs
@@ -888,13 +888,14 @@ pub fn vendor_deps(
     })
 }
 
-/// Recursively copy a directory, excluding .git and symlinks
+/// Recursively copy a directory, excluding hidden directories/files and symlinks
 pub fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let name = entry.file_name();
-        if name == ".git" {
+        // Skip hidden files/directories (starting with .)
+        if name.to_string_lossy().starts_with('.') {
             continue;
         }
         let src_path = entry.path();

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -165,12 +165,12 @@ impl WorkspaceInfoExt for WorkspaceInfo {
 
     fn package_url_for_zen(&self, zen_path: &Path) -> Option<String> {
         let canon_zen = zen_path.canonicalize().ok()?;
-        for (url, pkg) in &self.packages {
-            if canon_zen.starts_with(pkg.dir(&self.root)) {
-                return Some(url.clone());
-            }
-        }
-        None
+        // Longest prefix match: find most specific package containing this path
+        self.packages
+            .iter()
+            .filter(|(_, pkg)| canon_zen.starts_with(pkg.dir(&self.root)))
+            .max_by_key(|(_, pkg)| pkg.rel_path.as_os_str().len())
+            .map(|(url, _)| url.clone())
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves reliability of release workflows in workspaces with nested packages and cleans vendoring.
> 
> - **Workspace/package detection**: `package_url_for_zen` now uses a longest-prefix match to choose the most specific package, fixing `pcb release` misidentifying the board when the workspace root has dependencies.
> - **Vendoring/copy behavior**: `copy_dir_all` now skips hidden files/directories (dot-prefixed) and symlinks to avoid copying `.pcb/`, `.git/`, etc.
> - **Docs**: Update `CHANGELOG.md` with the above fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 455658b84e5dfb2c875a4da9d0e03febc6885ed9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->