### PR TITLE
Make bump interactive if `--bump` is passed without a value

### DIFF
--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -210,7 +210,7 @@ fn test_publish_board_with_version() {
 
     // Run source-only publish with bump (creates v1.3.0)
     let mut args = source_only_args("boards/TB0001.zen");
-    args.extend(["--bump", "minor"]);
+    args.push("--bump=minor");
     sb.run("pcb", &args)
         .run()
         .expect("Failed to run pcb publish command");

--- a/crates/pcb/tests/snapshots/tag__publish_board_invalid_path.snap
+++ b/crates/pcb/tests/snapshots/tag__publish_board_invalid_path.snap
@@ -3,7 +3,7 @@ source: crates/pcb/tests/tag.rs
 assertion_line: 102
 expression: output
 ---
-Command: pcb publish boards/NonExistent.zen --bump minor --no-push --force
+Command: pcb publish boards/NonExistent.zen --bump=minor --no-push --force
 Exit Code: 1
 
 --- STDOUT ---

--- a/crates/pcb/tests/tag.rs
+++ b/crates/pcb/tests/tag.rs
@@ -61,8 +61,7 @@ fn test_publish_board_simple_workspace() {
         [
             "publish",
             "boards/Test/TB0001.zen",
-            "--bump",
-            "minor",
+            "--bump=minor",
             "--no-push",
             "--force", // Skip preflight checks
             "-S",
@@ -93,8 +92,7 @@ fn test_publish_board_invalid_path() {
             [
                 "publish",
                 "boards/NonExistent.zen",
-                "--bump",
-                "minor",
+                "--bump=minor",
                 "--no-push",
                 "--force",
             ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces interactive version bump selection and refines CLI behavior for publishing.
> 
> - Adds hidden `BumpType::Interactive` and updates `PublishArgs.bump` to accept zero-or-one value with `--bump` (interactive) or `--bump=patch|minor|major` (non-interactive)
> - Board publish flow now resolves bump via `prompt_single_bump` when interactive; `compute_next_version` asserts interactive is pre-resolved
> - Package publish `collect_all_bumps` uses CLI bump when provided and non-interactive; otherwise prompts per strategy
> - Minor wording tweak in version computation comment
> - Updates tests and snapshots to use `--bump=minor` syntax
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a05d450cbcc3811f7351010ca23a8207d8e6ccc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->