### PR TITLE
Refactor release upload to two-phase flow with better error messages

### DIFF
--- a/crates/pcb-diode-api/src/release.rs
+++ b/crates/pcb-diode-api/src/release.rs
@@ -1,8 +1,13 @@
 //! Release upload API client
+//!
+//! Two-phase upload flow:
+//! 1. Stage: POST /api/file/{hash} to get presigned S3 URL, then PUT to S3
+//! 2. Create: POST /api/workspaces/{workspace}/releases to finalize the release
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use base64::Engine;
-use reqwest::blocking::Client;
+use reqwest::blocking::{Client, Response};
+use reqwest::StatusCode;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::Read;
@@ -12,8 +17,17 @@ use std::time::Duration;
 use crate::auth::get_valid_token;
 use crate::get_api_base_url;
 
+/// Response from creating a release.
+#[derive(Debug)]
+pub struct ReleaseResult {
+    pub project_id: String,
+    pub commit_sha: Option<String>,
+    pub version: Option<String>,
+    pub release_id: Option<String>,
+}
+
 /// Upload a board release archive to the Diode API.
-pub fn upload_release(zip_path: &Path, workspace: &str) -> Result<()> {
+pub fn upload_release(zip_path: &Path, workspace: &str) -> Result<ReleaseResult> {
     let token = get_valid_token()?;
     let base_url = get_api_base_url();
 
@@ -22,63 +36,143 @@ pub fn upload_release(zip_path: &Path, workspace: &str) -> Result<()> {
         .timeout(Duration::from_secs(300))
         .build()?;
 
-    // Calculate SHA256 hash
-    let (sha256_hex, sha256_b64) = {
-        let mut file = fs::File::open(zip_path)?;
-        let mut hasher = Sha256::new();
-        let mut buf = [0u8; 8192];
-        loop {
-            let n = file.read(&mut buf)?;
-            if n == 0 {
-                break;
-            }
-            hasher.update(&buf[..n]);
-        }
-        let hash = hasher.finalize();
-        (
-            format!("{:x}", hash),
-            base64::engine::general_purpose::STANDARD.encode(hash),
-        )
-    };
+    let (sha256_hex, sha256_b64) = calculate_sha256(zip_path)?;
+    stage_artifact(
+        &client,
+        &base_url,
+        &token,
+        zip_path,
+        &sha256_hex,
+        &sha256_b64,
+    )?;
+    create_release(&client, &base_url, &token, workspace, &sha256_hex)
+}
 
-    // Get presigned upload URL (encode workspace name for URL safety)
-    let url = format!(
-        "{}/api/workspaces/{}/releases/upload",
-        base_url,
-        urlencoding::encode(workspace)
-    );
+fn calculate_sha256(path: &Path) -> Result<(String, String)> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let hash = hasher.finalize();
+    Ok((
+        format!("{:x}", hash),
+        base64::engine::general_purpose::STANDARD.encode(hash),
+    ))
+}
+
+fn stage_artifact(
+    client: &Client,
+    base_url: &str,
+    token: &str,
+    zip_path: &Path,
+    sha256_hex: &str,
+    sha256_b64: &str,
+) -> Result<()> {
+    let url = format!("{}/api/file/{}", base_url, sha256_hex);
     let resp = client
         .post(&url)
-        .bearer_auth(&token)
-        .json(&serde_json::json!({ "artifactHash": sha256_hex }))
+        .bearer_auth(token)
         .send()
-        .context("Failed to request upload URL")?;
+        .context("Failed to connect to Diode API")?;
 
-    if !resp.status().is_success() {
-        anyhow::bail!(
-            "Failed to get upload URL ({}): {}",
-            resp.status(),
-            resp.text().unwrap_or_default()
-        );
-    }
+    let resp = check_response(resp, |status, msg| match status {
+        StatusCode::UNAUTHORIZED => "Authentication failed. Run `pcb login` to sign in.".into(),
+        StatusCode::BAD_REQUEST => format!("Invalid request: {msg}"),
+        _ => format!("Failed to get upload URL ({status}): {msg}"),
+    })?;
 
     let upload_url = resp.json::<serde_json::Value>()?["uploadUrl"]
         .as_str()
         .context("Missing uploadUrl in response")?
         .to_string();
 
-    // Upload to S3
     let resp = client
         .put(&upload_url)
         .header("Content-Type", "application/zip")
         .header("x-amz-checksum-sha256", sha256_b64)
         .body(fs::read(zip_path)?)
         .send()
-        .context("Failed to upload release")?;
+        .context("Failed to upload to storage")?;
 
-    if !resp.status().is_success() {
-        anyhow::bail!("Upload failed: {}", resp.status());
+    check_response(resp, |status, _| match status {
+        StatusCode::BAD_REQUEST => "Upload rejected: checksum mismatch".into(),
+        _ => format!("Upload to storage failed ({status})"),
+    })
+    .map(|_| ())
+}
+
+fn create_release(
+    client: &Client,
+    base_url: &str,
+    token: &str,
+    workspace: &str,
+    sha256_hex: &str,
+) -> Result<ReleaseResult> {
+    let url = format!(
+        "{}/api/workspaces/{}/releases",
+        base_url,
+        urlencoding::encode(workspace)
+    );
+
+    let resp = client
+        .post(&url)
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "artifactHash": sha256_hex }))
+        .send()
+        .context("Failed to connect to Diode API")?;
+
+    let resp = check_response(resp, |status, msg| match status {
+        StatusCode::UNAUTHORIZED => "Authentication failed. Run `pcb login` to sign in.".into(),
+        StatusCode::NOT_FOUND if msg.contains("artifact") => {
+            "Staged artifact not found. The upload may have expired.".into()
+        }
+        StatusCode::NOT_FOUND => format!("Workspace '{workspace}' not found"),
+        StatusCode::CONFLICT => "Release version already exists".into(),
+        StatusCode::BAD_REQUEST if msg.contains("metadata.json") => {
+            "Invalid release archive: missing or malformed metadata.json".into()
+        }
+        StatusCode::BAD_REQUEST if msg.contains("Checksum") => "Checksum mismatch".into(),
+        StatusCode::BAD_REQUEST => format!("Invalid release: {msg}"),
+        _ => format!("Failed to create release ({status}): {msg}"),
+    })?;
+
+    let json: serde_json::Value = resp.json().context("Invalid response from server")?;
+
+    Ok(ReleaseResult {
+        project_id: json["projectId"]
+            .as_str()
+            .context("Missing projectId in response")?
+            .to_string(),
+        commit_sha: json["commitSha"].as_str().map(String::from),
+        version: json["version"].as_str().map(String::from),
+        release_id: json["releaseId"].as_str().map(String::from),
+    })
+}
+
+fn check_response(
+    resp: Response,
+    format_error: impl FnOnce(StatusCode, &str) -> String,
+) -> Result<Response> {
+    if resp.status().is_success() {
+        return Ok(resp);
     }
-
-    Ok(())
+    let status = resp.status();
+    let msg = resp
+        .text()
+        .ok()
+        .and_then(|body| {
+            serde_json::from_str::<serde_json::Value>(&body)
+                .ok()?
+                .get("error")?
+                .as_str()
+                .map(String::from)
+        })
+        .unwrap_or_default();
+    bail!("{}", format_error(status, &msg))
 }

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -324,8 +324,20 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
             .and_then(|n| n.to_str())
             .context("Invalid workspace root")?;
         eprintln!("Uploading release to Diode...");
-        pcb_diode_api::upload_release(&_zip_path, ws_name)?;
-        eprintln!("{} Release uploaded", "✓".green());
+        let result = pcb_diode_api::upload_release(&_zip_path, ws_name)?;
+        if let Some(release_id) = result.release_id {
+            eprintln!(
+                "{} Release uploaded: {}",
+                "✓".green(),
+                format!(
+                    "https://app.diode.computer/{}/{}/releases/{}",
+                    ws_name, board_name, release_id
+                )
+                .cyan()
+            );
+        } else {
+            eprintln!("{} Release uploaded", "✓".green());
+        }
     }
 
     // Create git tag


### PR DESCRIPTION
Prints dashboard url on successful release upload:

```
Archive: /Users/akhilles/src/dioderobot/demo/.pcb/releases/DM0002-v2.2.1.zip
Uploading release to Diode...
✓ Release uploaded: https://app.diode.computer/demo/DM0002/releases/84a9aa39-e9f1-4c1d-83d7-47abe72b8897
✓ Created tag boards/DM0002/v2.2.1
Pushing tag to origin...
✓ Pushed boards/DM0002/v2.2.1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the release upload to a two-phase flow with clearer errors and returns release metadata.
> 
> - Implement two-step upload: stage artifact via `POST /api/file/{hash}` (receive presigned URL, then `PUT` to storage) and finalize with `POST /api/workspaces/{workspace}/releases`
> - Centralize HTTP error handling via `check_response`, mapping status codes to actionable messages (auth, bad request, not found, conflict, checksum)
> - `upload_release` now returns `ReleaseResult` (`project_id`, optional `commit_sha`, `version`, `release_id`)
> - CLI publisher prints the release dashboard URL when `release_id` is available
> - Extract helpers: `calculate_sha256`, `stage_artifact`, `create_release`; improved checksum handling with `x-amz-checksum-sha256`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff7362d8d6946e8e56954e8e1282558d3a8f1150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->