### PR TITLE
In CI, don't prompt on warning diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `pcb publish` no longer fails on warnings in non-interactive mode (CI)
+
 ## [0.3.28] - 2026-01-26
 
 ### Added


### PR DESCRIPTION
This is consistent with the previous `pcb release` behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts release flow to avoid CI failures from warnings.
> 
> - `pcb publish` now only prompts on warnings in interactive TTY; CI/non-interactive runs proceed without failing on warnings
> - Update `CHANGELOG.md` to reflect the new behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d732f304ffc76b4cc55477790d41a762dd03f55f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->