### PR TITLE
Exclude nested packages when copying workspace packages into release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb publish` no longer fails on warnings in non-interactive mode (CI)
 
+### Fixed
+
+- `pcb publish` now correctly handles workspaces with nested packages
+
 ## [0.3.28] - 2026-01-26
 
 ### Added

--- a/crates/pcb-zen/src/fork.rs
+++ b/crates/pcb-zen/src/fork.rs
@@ -13,6 +13,7 @@ use pcb_zen_core::config::{split_repo_and_subpath, PatchSpec, PcbToml};
 use pcb_zen_core::DefaultFileProvider;
 use semver::Version;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -146,7 +147,7 @@ pub fn fork_package(options: ForkOptions) -> Result<ForkSuccess> {
 
     // Copy to fork directory (if needed)
     if !fork_dir.exists() {
-        copy_dir_all(&cache_dir, &fork_dir).with_context(|| {
+        copy_dir_all(&cache_dir, &fork_dir, &HashSet::new()).with_context(|| {
             format!(
                 "Failed to copy from {} to {}",
                 cache_dir.display(),
@@ -479,7 +480,7 @@ fn copy_dir_filtered(src: &Path, dst: &Path) -> Result<()> {
 
         if src_path.is_dir() {
             // Recurse into subdirectories (no filtering needed for nested dirs)
-            copy_dir_all(&src_path, &dst_path)?;
+            copy_dir_all(&src_path, &dst_path, &HashSet::new())?;
         } else {
             fs::copy(&src_path, &dst_path)?;
         }


### PR DESCRIPTION
When staging a release, copy_sources copied entire package directories including nested packages not in the closure. These nested packages have dependencies that weren't vendored, causing offline build failures.

Fix: compute nested package roots and exclude them during copy. Packages explicitly in the closure are still copied via their own iteration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents nested workspace packages from being copied into release sources, avoiding missing vendor deps and offline build failures.
> 
> - Extend `copy_dir_all(src, dst)` to `copy_dir_all(src, dst, excluded_roots)` to optionally skip specified directory roots
> - In release staging, precompute all package roots and call `copy_dir_all` with exclusions so only packages in the closure are copied
> - Update call sites (`fork.rs`, `resolve_v2.rs`) to use new signature with no exclusions
> - Update changelog noting `pcb publish` handles nested packages correctly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c7dea72cf08a62140e9e41af598ba4930095f07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->