### PR TITLE
Warn on no net name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Warning for unnamed nets that fall back to auto-assigned `N{id}` names
+
 ## [0.3.29] - 2026-01-26
 
 ### Changed

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -67,6 +67,8 @@ pub struct IntroducedNet {
     pub final_name: String,
     /// Original name before deduplication (only set if collision occurred)
     pub original_name: Option<String>,
+    /// True if the net name was auto-generated due to an empty/whitespace input name
+    pub auto_named: bool,
     /// Call stack at the time the net was registered (for diagnostic context)
     #[freeze(identity)]
     #[allocative(skip)]
@@ -595,7 +597,8 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
         }
 
         // If the provided name is empty/whitespace, fall back to a stable placeholder.
-        let base_name = if local_name.trim().is_empty() {
+        let was_auto_named = local_name.trim().is_empty();
+        let base_name = if was_auto_named {
             format!("N{id}")
         } else {
             local_name
@@ -631,6 +634,7 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             IntroducedNet {
                 final_name: unique_name.clone(),
                 original_name: if had_collision { Some(base_name) } else { None },
+                auto_named: was_auto_named,
                 call_stack,
             },
         );

--- a/crates/pcb-zen/tests/snapshots/assert__snapshot_check_true_should_pass.snap
+++ b/crates/pcb-zen/tests/snapshots/assert__snapshot_check_true_should_pass.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/assert.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -34,3 +34,7 @@ expression: netlist
     )
   )
 )
+Warning: Net had no explicit name; assigned 'N1'
+    ╭─[ [TEMP_DIR]test.zen:10:18 ]
+ 10 │    pins = {"P": Net()},
+    │                   ╰─── Net had no explicit name; assigned 'N1'

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -455,6 +455,53 @@ x = 1 + 2
     assert_snapshot!("inline_manifest_v2", output);
 }
 
+#[test]
+fn test_inline_manifest_v2_unnamed_net_warning() {
+    let mut sandbox = Sandbox::new().allow_network();
+
+    let io_module = r#"
+P1 = io("P1", Net, optional = True)
+
+Component(
+    name = "R1",
+    footprint = "TEST:0402",
+    pin_defs = {"P1": "1"},
+    pins = {"P1": P1},
+)
+"#;
+
+    let inline_manifest_zen = r#"# ```pcb
+# [workspace]
+# pcb-version = "0.3"
+# ```
+
+I2s = interface(
+    BCLK = Net(),
+    LRCLK = Net(),
+    SDATA = Net(),
+    MCLK = Net(),
+)
+
+IoModule = Module("IoModule.zen")
+IoModule(name = "IO")
+
+unnamed = Net()
+
+Component(
+    name = "U1",
+    footprint = "TEST:0402",
+    pin_defs = {"P1": "1"},
+    pins = {"P1": unnamed},
+)
+"#;
+
+    let output = sandbox
+        .write("IoModule.zen", io_module)
+        .write("standalone.zen", inline_manifest_zen)
+        .snapshot_run("pcb", ["build", "standalone.zen"]);
+    assert_snapshot!("inline_manifest_v2_unnamed_net_warning", output);
+}
+
 // Tests for -S flag with kind-based suppression
 
 #[test]

--- a/crates/pcb/tests/snapshots/build__inline_manifest_v2_unnamed_net_warning.snap
+++ b/crates/pcb/tests/snapshots/build__inline_manifest_v2_unnamed_net_warning.snap
@@ -1,0 +1,17 @@
+---
+source: crates/pcb/tests/build.rs
+assertion_line: 502
+expression: output
+---
+Command: pcb build standalone.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+Warning: Net had no explicit name; assigned 'N6'
+    ╭─[ <TEMP_DIR>/standalone.zen:16:11 ]
+ 16 │unnamed = Net()
+    │            ╰─── Net had no explicit name; assigned 'N6'
+
+✓ standalone.zen (2 components)


### PR DESCRIPTION
Don't warn Net() calls in interface() spec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds additional warning diagnostics and test coverage without changing core net naming behavior or data formats.
> 
> **Overview**
> Adds a new warning when a `Net()` is created without an explicit name and is auto-assigned a stable `N{id}` placeholder.
> 
> This threads an `auto_named` flag through `IntroducedNet` tracking and updates evaluation diagnostics to emit the new warning with proper source location, plus updates/extends snapshot tests and the changelog to cover the new output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b846ef2fa6d8b203cf81e3457c98cd373eb5fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->