### PR TITLE
No warnings on unnamed NotConnected nets

### DIFF
--- a/crates/pcb-zen-core/src/lang/context.rs
+++ b/crates/pcb-zen-core/src/lang/context.rs
@@ -325,11 +325,15 @@ impl<'v> ContextValue<'v> {
         &self,
         id: NetId,
         local_name: &str,
+        net_type: &str,
         call_stack: starlark::eval::CallStack,
     ) -> anyhow::Result<String> {
-        self.module
-            .borrow_mut()
-            .register_net(id, local_name.to_string(), call_stack)
+        self.module.borrow_mut().register_net(
+            id,
+            local_name.to_string(),
+            net_type.to_string(),
+            call_stack,
+        )
     }
 
     /// Unregister a previously registered net from the current module.

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -1050,7 +1050,13 @@ impl EvalContext {
                 diagnostics.extend(extra.diagnostics().iter().cloned());
 
                 // Emit warnings for nets renamed due to collisions or unnamed nets
+                // Skip warnings for NotConnected nets (they're expected to have no name or duplicate names)
                 for (_id, net_info) in extra.module.introduced_nets() {
+                    // Skip all warnings for NotConnected nets
+                    if net_info.net_type == "NotConnected" {
+                        continue;
+                    }
+
                     let location = net_info
                         .call_stack
                         .frames

--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -121,7 +121,14 @@ fn clone_net_template<'v>(
         eval.module()
             .extra_value()
             .and_then(|e| e.downcast_ref::<ContextValue>())
-            .map(|ctx| ctx.register_net(new_net.id(), &net_name, call_stack.clone()))
+            .map(|ctx| {
+                ctx.register_net(
+                    new_net.id(),
+                    &net_name,
+                    &new_net.type_name,
+                    call_stack.clone(),
+                )
+            })
             .transpose()?
             .unwrap_or(net_name)
     } else {

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -69,6 +69,8 @@ pub struct IntroducedNet {
     pub original_name: Option<String>,
     /// True if the net name was auto-generated due to an empty/whitespace input name
     pub auto_named: bool,
+    /// The net type name (e.g., "Net", "Power", "Ground", "NotConnected")
+    pub net_type: String,
     /// Call stack at the time the net was registered (for diagnostic context)
     #[freeze(identity)]
     #[allocative(skip)]
@@ -589,6 +591,7 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
         &mut self,
         id: NetId,
         local_name: String,
+        net_type: String,
         call_stack: starlark::eval::CallStack,
     ) -> anyhow::Result<String> {
         // If this id was already registered, keep the first assignment (idempotent)
@@ -635,6 +638,7 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
                 final_name: unique_name.clone(),
                 original_name: if had_collision { Some(base_name) } else { None },
                 auto_named: was_auto_named,
+                net_type,
                 call_stack,
             },
         );

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -681,7 +681,9 @@ where
                     eval.module()
                         .extra_value()
                         .and_then(|e| e.downcast_ref::<ContextValue>())
-                        .map(|ctx| ctx.register_net(net_id, &net_name, call_stack.clone()))
+                        .map(|ctx| {
+                            ctx.register_net(net_id, &net_name, &self.type_name, call_stack.clone())
+                        })
                         .transpose()
                         .map_err(|e| anyhow::anyhow!(e.to_string()))?
                         .unwrap_or_else(|| net_name.clone())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is narrowly scoped to `NotConnected` nets and only affects diagnostics/uniqueness checks, with minimal impact on other net types or core evaluation logic.
> 
> **Overview**
> Suppresses diagnostics noise for `NotConnected` nets by tracking each introduced net’s `net_type` and skipping unnamed/renamed warnings during evaluation.
> 
> Adjusts schematic conversion’s global net-name uniqueness guard to *exclude* `NotConnected` nets from duplicate-name errors, allowing multiple unnamed/duplicate NC nets while keeping strict uniqueness for all other net types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29497673a246a0dd6de63aa5833b2bfac0f1cfb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->