### PR TITLE
`NotConnected -> *` net type promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Warning for unnamed nets that fall back to auto-assigned `N{id}` names
-- Add better support for NotConnected
+- NotConnected nets now preserve their type in schematics and can be passed to any net type parameter
 
 ### Changed
 

--- a/crates/pcb-zen-core/tests/snapshots/net__ground_cannot_promote_to_not_connected.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__ground_cannot_promote_to_not_connected.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+Error: test.zen:8:1-32 Error instantiating `child`
+Error: /child.zen:4:6-28 Input 'nc' has wrong net type: expected NotConnected, got Ground

--- a/crates/pcb-zen-core/tests/snapshots/net__net_cannot_promote_to_not_connected.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__net_cannot_promote_to_not_connected.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+Error: test.zen:6:1-32 Error instantiating `child`
+Error: /child.zen:4:6-28 Input 'nc' has wrong net type: expected NotConnected, got Net

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_custom_type.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_custom_type.snap
@@ -1,0 +1,41 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+NotConnected promotes to Gpio: success
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+    child: Module {
+        path: child,
+        source: "/child.zen",
+        children: [
+            FrozenValue(
+                Component {
+                    name: "R1",
+                    footprint: "TEST:0402",
+                    prefix: "U",
+                    connections: {
+                        "1": FrozenValue(
+                            Net {
+                                name: "NC",
+                                id: "<ID>",
+                            },
+                        ),
+                    },
+                    symbol: FrozenValue(
+                        Symbol {
+                            name: None,
+                            pins: {
+                                "1": "1",
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_ground.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_ground.snap
@@ -1,0 +1,41 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+NotConnected promotes to Ground: success
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+    child: Module {
+        path: child,
+        source: "/child.zen",
+        children: [
+            FrozenValue(
+                Component {
+                    name: "R1",
+                    footprint: "TEST:0402",
+                    prefix: "U",
+                    connections: {
+                        "1": FrozenValue(
+                            Net {
+                                name: "NC",
+                                id: "<ID>",
+                            },
+                        ),
+                    },
+                    symbol: FrozenValue(
+                        Symbol {
+                            name: None,
+                            pins: {
+                                "1": "1",
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_net.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_net.snap
@@ -1,0 +1,41 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+NotConnected promotes to Net: success
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+    child: Module {
+        path: child,
+        source: "/child.zen",
+        children: [
+            FrozenValue(
+                Component {
+                    name: "R1",
+                    footprint: "TEST:0402",
+                    prefix: "U",
+                    connections: {
+                        "1": FrozenValue(
+                            Net {
+                                name: "NC",
+                                id: "<ID>",
+                            },
+                        ),
+                    },
+                    symbol: FrozenValue(
+                        Symbol {
+                            name: None,
+                            pins: {
+                                "1": "1",
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_power.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_power.snap
@@ -1,0 +1,41 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+NotConnected promotes to Power: success
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+    child: Module {
+        path: child,
+        source: "/child.zen",
+        children: [
+            FrozenValue(
+                Component {
+                    name: "R1",
+                    footprint: "TEST:0402",
+                    prefix: "U",
+                    connections: {
+                        "1": FrozenValue(
+                            Net {
+                                name: "NC",
+                                id: "<ID>",
+                            },
+                        ),
+                    },
+                    symbol: FrozenValue(
+                        Symbol {
+                            name: None,
+                            pins: {
+                                "1": "1",
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/net__power_cannot_promote_to_not_connected.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__power_cannot_promote_to_not_connected.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+Error: test.zen:8:1-32 Error instantiating `child`
+Error: /child.zen:4:6-28 Input 'nc' has wrong net type: expected NotConnected, got Power

--- a/crates/pcb/tests/snapshots/netlist__netlist_not_connected_promotion.snap
+++ b/crates/pcb/tests/snapshots/netlist__netlist_not_connected_promotion.snap
@@ -1,0 +1,15 @@
+---
+source: crates/pcb/tests/netlist.rs
+expression: output
+---
+{
+  "NC_PIN": {
+    "id": "<ID>",
+    "kind": "NotConnected",
+    "name": "NC_PIN",
+    "ports": [
+      "<TEMP_DIR>/boards/NCBoard.zen:<root>.U1.R1.1"
+    ],
+    "properties": {}
+  }
+}

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -930,6 +930,71 @@ main_rail = PowerRail("MAIN_RAIL",
 
 **Returns:** A callable net type constructor that creates typed net instances
 
+### Net Type Promotion
+
+When passing nets between modules, Zener supports automatic type promotion for compatible net types. This allows typed nets to be used in contexts expecting different (more general) types.
+
+**Promotion Hierarchy:**
+
+```
+NotConnected → any type (universal donor)
+Power, Ground → Net (demotion to base type)
+Net → nothing (cannot be promoted)
+```
+
+**Rules:**
+
+1. **NotConnected is the universal donor**: A `NotConnected` net can be passed wherever any other net type is expected. This is useful for leaving pins intentionally unconnected while still satisfying type requirements.
+
+2. **Power and Ground demote to Net**: Typed power and ground nets can be passed to parameters expecting a generic `Net`. The net retains its original type for schematic generation.
+
+3. **Net cannot be promoted**: A generic `Net` cannot be passed to a parameter expecting `Power`, `Ground`, or other typed nets.
+
+4. **Nothing promotes to NotConnected**: No net type can be converted to `NotConnected`. If a parameter expects `NotConnected`, only a `NotConnected` net can be passed.
+
+**Examples:**
+
+```python
+load("@stdlib/interfaces.zen", "Power", "Ground", "NotConnected")
+
+# Module expecting Power input
+PowerConsumer = Module("power_consumer.zen")  # has io("vcc", Power)
+
+# NotConnected promotes to Power - valid
+nc = NotConnected("NC")
+PowerConsumer(name = "consumer", vcc = nc)
+
+# Module expecting generic Net input
+GenericModule = Module("generic.zen")  # has io("sig", Net)
+
+# Power demotes to Net - valid
+vcc = Power("VCC")
+GenericModule(name = "mod", sig = vcc)
+
+# NotConnected promotes to Net - valid
+nc2 = NotConnected("NC2")
+GenericModule(name = "mod2", sig = nc2)
+```
+
+**Invalid promotions (will error):**
+
+```python
+# Net cannot promote to Power
+sig = Net("SIG")
+PowerConsumer(name = "consumer", vcc = sig)  # Error: expected Power, got Net
+
+# Power cannot promote to NotConnected
+NCModule = Module("nc_module.zen")  # has io("nc", NotConnected)
+vcc = Power("VCC")
+NCModule(name = "mod", nc = vcc)  # Error: expected NotConnected, got Power
+```
+
+**Use Cases:**
+
+- **Optional pins**: Use `NotConnected` as a default for optional module inputs that can accept any net type
+- **Generic modules**: Accept `Net` type to allow any typed net (Power, Ground, etc.) to be passed
+- **Type safety**: Require specific types (Power, Ground) when electrical semantics matter
+
 ### builtin.physical_value()
 
 **Built-in function** that creates unit-specific physical value constructor types for electrical quantities with optional tolerances.


### PR DESCRIPTION
Can pass in NotConnected nets to any net type signature.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core type-checking/conversion during module instantiation, which can affect many designs; mitigated by extensive new unit and netlist snapshot coverage.
> 
> **Overview**
> Enables **net type promotion** when wiring module `io()` parameters: `NotConnected` nets can now be passed to any expected net type (including custom types), and typed nets can still demote to `Net` as before.
> 
> Implements a centralized promotion/demotion decision (`can_convert_net_type`) and extends `try_net_conversion` to apply it for both `NetValue` and `FrozenNetValue`.
> 
> Adds comprehensive snapshot tests covering valid/invalid promotions plus a `pcb --netlist` test ensuring a promoted `NotConnected` net still renders with `kind: "NotConnected"`; updates `spec.mdx` and `CHANGELOG.md` to document the behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25919955536832b001ac93e1d8185c7a02b29021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->