### PR TITLE
Apply net type promotion to io() defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `io()` default values now correctly apply net type promotion (e.g., `default=NotConnected()` promotes to the expected net type)
+
 ## [0.3.30] - 2026-02-01
 
 ### Added

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -1709,8 +1709,9 @@ pub fn module_globals(builder: &mut GlobalsBuilder) {
                                for_metadata_only: bool|
          -> starlark::Result<Value<'v>> {
             if let Some(explicit_default) = default {
-                validate_type(name.as_str(), explicit_default, typ, eval.heap())?;
-                Ok(explicit_default)
+                // Use validate_or_convert to allow net type promotion (e.g., NotConnected -> Net)
+                let converted = validate_or_convert(&name, explicit_default, typ, None, eval)?;
+                Ok(converted)
             } else if matches!(typ.get_type(), "NetType" | "InterfaceFactory") {
                 io_generated_default(eval, typ, &name, for_metadata_only)
             } else {

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -582,3 +582,30 @@ snapshot_eval!(ground_cannot_promote_to_not_connected, {
         Child(name = "child", nc = gnd)
     "#
 });
+
+snapshot_eval!(io_default_not_connected_promotes_to_net, {
+    "interfaces.zen" => r#"
+        NotConnected = builtin.net_type("NotConnected")
+    "#,
+    "child.zen" => r#"
+        load("interfaces.zen", "NotConnected")
+
+        # io() with optional=True and default=NotConnected() should promote to Net
+        MH = io("MH", Net, optional = True, default = NotConnected("MH_NC"))
+
+        Component(
+            name = "R1",
+            footprint = "TEST:0402",
+            pin_defs = {"1": "1"},
+            pins = {"1": MH},
+        )
+    "#,
+    "test.zen" => r#"
+        Child = Module("child.zen")
+
+        # Instantiate without providing MH - should use default NotConnected promoted to Net
+        Child(name = "child")
+
+        print("io() default NotConnected promotes to Net: success")
+    "#
+});

--- a/crates/pcb-zen-core/tests/snapshots/net__io_default_not_connected_promotes_to_net.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__io_default_not_connected_promotes_to_net.snap
@@ -1,0 +1,41 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+io() default NotConnected promotes to Net: success
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+    child: Module {
+        path: child,
+        source: "/child.zen",
+        children: [
+            FrozenValue(
+                Component {
+                    name: "R1",
+                    footprint: "TEST:0402",
+                    prefix: "U",
+                    connections: {
+                        "1": FrozenValue(
+                            Net {
+                                name: "MH_NC",
+                                id: "<ID>",
+                            },
+                        ),
+                    },
+                    symbol: FrozenValue(
+                        Symbol {
+                            name: None,
+                            pins: {
+                                "1": "1",
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+}
+[]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to `io()` default handling with added test coverage; minimal risk beyond potential behavior change for previously-invalid default values now being accepted via conversion.
> 
> **Overview**
> `io()` now applies `validate_or_convert` to *explicit* `default=` values, so net-type promotion/casting is performed consistently with provided inputs (e.g., `default=NotConnected()` can satisfy a `Net`-typed parameter).
> 
> Adds a regression test and snapshot asserting that an optional `io()` with a `NotConnected` default successfully instantiates and yields a `Net` connection; updates the changelog to document the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12ebdfb9904f689f46cdc61407e416ebe18ddac7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->