### PR TITLE
Auto convert strings to PhysicalValue/PhysicalRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `config()` now auto-converts strings to PhysicalValue/PhysicalRange types (e.g., `voltage = "3.3V"`)
+
 ### Fixed
 
 - `io()` default values now correctly apply net type promotion (e.g., `default=NotConnected()` promotes to the expected net type)

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -675,3 +675,47 @@ snapshot_eval!(io_invalid_type, {
         value = io("value", int)
     "#
 });
+
+snapshot_eval!(config_string_to_physical_value, {
+    "types.zen" => r#"
+        Voltage = builtin.physical_value("V")
+        Resistance = builtin.physical_value("Ω")
+    "#,
+    "child.zen" => r#"
+        load("types.zen", "Voltage", "Resistance")
+
+        voltage = config("voltage", Voltage)
+        resistance = config("resistance", Resistance)
+
+        print("voltage:", voltage)
+        print("resistance:", resistance)
+    "#,
+    "test.zen" => r#"
+        Child = Module("child.zen")
+
+        # Provide string values that should be converted to PhysicalValues
+        Child(name = "test", voltage = "3.3V", resistance = "10k")
+
+        print("String to PhysicalValue conversion: success")
+    "#
+});
+
+snapshot_eval!(config_string_to_physical_range, {
+    "types.zen" => r#"
+        VoltageRange = builtin.physical_range("V")
+    "#,
+    "child.zen" => r#"
+        load("types.zen", "VoltageRange")
+
+        voltage = config("voltage", VoltageRange)
+
+        print("voltage:", voltage)
+    "#,
+    "test.zen" => r#"
+        Child = Module("child.zen")
+
+        Child(name = "test", voltage = "3.0V to 3.6V")
+
+        print("String to PhysicalRange conversion: success")
+    "#
+});

--- a/crates/pcb-zen-core/tests/snapshots/input__config_string_to_physical_range.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_string_to_physical_range.snap
@@ -1,0 +1,16 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+String to PhysicalRange conversion: success
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+    test: Module {
+        path: test,
+        source: "/child.zen",
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/input__config_string_to_physical_value.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_string_to_physical_value.snap
@@ -1,0 +1,16 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+expression: output
+---
+String to PhysicalValue conversion: success
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+    test: Module {
+        path: test,
+        source: "/child.zen",
+    },
+}
+[]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core `config()` value validation/conversion and default construction paths, which could subtly change behavior for modules relying on type errors or constructor semantics.
> 
> **Overview**
> **`config()` now accepts unit strings for physical types.** When a `config()` parameter expects a `PhysicalValue`/`PhysicalRange`, string inputs like `"3.3V"` or `"3.0V to 3.6V"` are automatically converted by invoking the type constructor.
> 
> The evaluator also generates sensible zero defaults for `PhysicalValueType`/`PhysicalRangeType`, and adds snapshot tests plus a changelog entry covering the new conversions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfec136a773020a111432acb2ecb37702688b5a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->