### PR TITLE
Use % formatting for symmetric PhysicalValue tolerances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `PhysicalValue` now formats symmetric tolerances as `10k 5%` (instead of `min–max (nominal nom.)`).
+
 ## [0.3.32] - 2026-02-02
 
 ### Changed

--- a/crates/pcb-zen/tests/snapshots/test_physical__physical_types.snap
+++ b/crates/pcb-zen/tests/snapshots/test_physical__physical_types.snap
@@ -7,7 +7,7 @@ has abs: True
 abs value: 3.3V
 
 --- Frequency Parsing ---
-Frequency: 999k–1.001MHz (1MHz nom.)
+Frequency: 1MHz 0.1%
 Value: 1e+06
 Tolerance: 0.001
 Unit: Hz

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -411,6 +411,11 @@ resistance = Voltage("5V") / Current("100mA")  # 50Ω
 - **Comparison** (`<`, `>`, `<=`, `>=`, `==`) - Compare nominal values
 - **Unary negation** (`-`) - Negate and swap bounds
 
+**String formatting** (`str(value)`):
+- Point values (`min == nominal == max`) format as a single value (e.g., `"3.3V"`, `"4.7k"`)
+- Symmetric tolerances (clean percent) format as `"nominal <percent>%"` (e.g., `"10k 5%"`, `"1MHz 0.1%"`)
+- Other bounded values format as an explicit range with nominal (e.g., `"11–26V (16V nom.)"`)
+
 **Range aliases**:
 - `VoltageRange`, `CurrentRange`, etc. are aliases of `Voltage`, `Current`, etc. (same type, same behavior)
 


### PR DESCRIPTION
Just to be consistent stylistically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formatting change with straightforward guardrails and updated golden tests; main risk is downstream snapshot/string-compare expectations changing.
> 
> **Overview**
> `PhysicalValue` display output changes for symmetric (nominal-centered) bounds: it now prefers `"<nominal> <percent>%"` (e.g., `10k 5%`, `1MHz 0.1%`) instead of emitting an explicit `min–max (nominal nom.)` range.
> 
> To avoid noisy output, the percent form is only used when the computed tolerance is non-zero and has a small decimal scale; otherwise formatting falls back to the existing range-with-nominal representation. Tests/snapshots and the spec + changelog are updated to match the new formatting behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 984536e653a1a75065a7fbb4a2a3cb2a776bcd97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->