### PR TITLE
GitHub managed -> ubicloud runners

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     steps:
       - uses: actions/checkout@v4
       - uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/stdlib-version-check.yml
+++ b/.github/workflows/stdlib-version-check.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check-stdlib:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
 
   python-tests:
     name: Python Tests
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     timeout-minutes: 10
     defaults:
       run:
@@ -180,7 +180,7 @@ jobs:
 
   check_readme:
     name: Check README Sync
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-16
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   wasm_build:
     name: Build WASM
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-16
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Silly me for thinking we can rely on GitHub managed workers for some stuff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that swaps runner types; primary risk is workflow failures due to runner availability/compatibility rather than product behavior changes.
> 
> **Overview**
> Migrates several GitHub Actions workflows (`npm-publish`, `stdlib-version-check`, `wasm`, and parts of `test`) off `ubuntu-latest` to Ubicloud runner flavors (e.g., `ubicloud-standard-*`) with updated sizing per job.
> 
> No build/test logic changes are introduced; the PR purely changes where these jobs execute.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd69ed20b73c4153a009e94a01ece32736ba3050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->