### PR TITLE
Release x2 gerbers, separate PTH/NPTH drill files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb preview <path/to/board.zen>` to generate a preview link for a release.
 
+### Changed
+
+- Board release gerber exports now use Gerber X2 format.
+- Board release drill exports now generate separate PTH/NPTH Excellon files and both PDF + GerberX2 drill maps.
+
 ### Fixed
 
 - Restore `NotConnected` compatibility: keep normal connectivity (no per-pad net exploding), warn when it connects multiple pins, and only mark pads `no_connect` for single-pin cases.

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -1031,13 +1031,12 @@ fn generate_gerbers(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         .subcommand("gerbers")
         .arg("--output")
         .arg(gerbers_dir.to_string_lossy())
-        .arg("--no-x2")
         .arg("--use-drill-file-origin")
         .arg(kicad_pcb_path.to_string_lossy())
         .run()
         .context("Failed to generate gerber files")?;
 
-    // Generate drill files with PDF map
+    // Generate drill files (separate PTH/NPTH) with PDF map(s)
     KiCadCliBuilder::new()
         .command("pcb")
         .subcommand("export")
@@ -1052,12 +1051,36 @@ fn generate_gerbers(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         .arg("decimal")
         .arg("--excellon-units")
         .arg("mm")
+        .arg("--excellon-separate-th")
         .arg("--generate-map")
         .arg("--map-format")
         .arg("pdf")
         .arg(kicad_pcb_path.to_string_lossy())
         .run()
         .context("Failed to generate drill files")?;
+
+    // Generate drill map(s) as Gerber X2 as well (for CAM tooling that prefers Gerber over PDF)
+    KiCadCliBuilder::new()
+        .command("pcb")
+        .subcommand("export")
+        .subcommand("drill")
+        .arg("--output")
+        .arg(gerbers_dir.to_string_lossy())
+        .arg("--format")
+        .arg("excellon")
+        .arg("--drill-origin")
+        .arg("plot")
+        .arg("--excellon-zeros-format")
+        .arg("decimal")
+        .arg("--excellon-units")
+        .arg("mm")
+        .arg("--excellon-separate-th")
+        .arg("--generate-map")
+        .arg("--map-format")
+        .arg("gerberx2")
+        .arg(kicad_pcb_path.to_string_lossy())
+        .run()
+        .context("Failed to generate gerber drill map(s)")?;
 
     // Create gerbers.zip from the temp directory
     create_gerbers_zip(&gerbers_dir, &manufacturing_dir.join("gerbers.zip"))?;


### PR DESCRIPTION
```
.rw-r--r--  95k akhilles  1 Jan  1980 layout-NPTH-drl_map.gbr
.rw-r--r--  20k akhilles  1 Jan  1980 layout-NPTH-drl_map.pdf
.rw-r--r--  969 akhilles  1 Jan  1980 layout-NPTH.drl
.rw-r--r-- 234k akhilles  1 Jan  1980 layout-PTH-drl_map.gbr
.rw-r--r--  51k akhilles  1 Jan  1980 layout-PTH-drl_map.pdf
.rw-r--r--  10k akhilles  1 Jan  1980 layout-PTH.drl
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release manufacturing artifact formats and filenames, which may impact downstream fabrication/CAM workflows that expect the previous Gerber/drill outputs.
> 
> **Overview**
> Board release manufacturing output is updated to export Gerbers in **Gerber X2** (by no longer passing KiCad’s `--no-x2` flag).
> 
> Drill export now generates **separate PTH/NPTH Excellon** files via `--excellon-separate-th`, and produces drill maps in both **PDF** and **Gerber X2** (a second KiCad drill export run with `--map-format gerberx2`). The changelog is updated to document these release artifact changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18dc2626c340bf36ffdebb112fbe81a271fcd63c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->