### PR TITLE
Restore old NotConnected() behavior, but add warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb preview <path/to/board.zen>` to generate a preview link for a release.
 
+### Fixed
+
+- Restore `NotConnected` compatibility: keep normal connectivity (no per-pad net exploding), warn when it connects multiple pins, and only mark pads `no_connect` for single-pin cases.
+
 ## [0.3.33] - 2026-02-03
 
 ### Changed

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -815,9 +815,11 @@ def apply_changeset(
                                 kicad_board.Add(net_info)
                                 oplog.net_add(net.name)
                             pad.SetNet(net_info)
-                            pad.SetPinType(
-                                "no_connect" if net.kind == "NotConnected" else ""
+                            mark_no_connect = (
+                                net.kind == "NotConnected"
+                                and len(net.logical_ports) <= 1
                             )
+                            pad.SetPinType("no_connect" if mark_no_connect else "")
                             break
 
     # ==========================================================================

--- a/crates/pcb-layout/src/scripts/lens/types.py
+++ b/crates/pcb-layout/src/scripts/lens/types.py
@@ -138,6 +138,10 @@ class NetView:
     name: str
     connections: Tuple[Tuple[EntityId, str], ...]
     kind: str = "Net"  # Net type kind (e.g., "Net", "Power", "Ground", "NotConnected")
+    # Unique logical ports touched by this net, as (refdes, pin_name) pairs.
+    # This is SOURCE-derived metadata used for diagnostics and adapter behavior
+    # (e.g. when it's valid to mark pads as no_connect).
+    logical_ports: Tuple[Tuple[str, str], ...] = ()
 
     def has_connection_to(self, entity_id: EntityId) -> bool:
         return any(fp_id == entity_id for fp_id, _ in self.connections)

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -330,7 +330,15 @@ class JsonNetlistParser:
                     ]
 
                     for pad_num in pad_nums:
-                        nodes.append((ref_des, pad_num, net_name))
+                        # Preserve the logical port identity (component pin) separately
+                        # from the physical pad number. A single logical pin can map to
+                        # multiple pads (e.g. SW pins, thermal pads, stitched pads).
+                        #
+                        # The node tuple is (ref_des, pad_num, pin_name). The third
+                        # field is ignored for net connectivity, but is used for
+                        # pin-vs-pad aware behavior (e.g. NotConnected handling).
+                        pin_name = port_parts[-1] if port_parts else ""
+                        nodes.append((ref_des, pad_num, pin_name))
 
             if nodes:
                 # Extract net kind (defaults to "Net" if not specified)

--- a/crates/pcb-layout/tests/layout_generation.rs
+++ b/crates/pcb-layout/tests/layout_generation.rs
@@ -101,3 +101,5 @@ layout_test!("complex", "Board");
 layout_test!("netclass_assignment", "netclass", true);
 
 layout_test!("not_connected", "Board");
+
+layout_test!("not_connected_single_pin_multi_pad", "Board");

--- a/crates/pcb-layout/tests/resources/not_connected/Board.zen
+++ b/crates/pcb-layout/tests/resources/not_connected/Board.zen
@@ -6,7 +6,7 @@ Resistor = Module("@stdlib:v0.3.4/generics/Resistor.zen")
 vcc = Power("VCC")
 gnd = Ground("GND")
 
-# NotConnected net - should become unconnected-(...) in KiCad
+# NotConnected net - treated as a regular net in layout sync
 nc = NotConnected("NC_PIN")
 
 # R1: one pin to VCC, one pin to NotConnected
@@ -18,7 +18,6 @@ Resistor(
 )
 
 # R2: one pin to GND, one pin to same NotConnected net
-# Both NC pads should get unique unconnected-(...) names
 Resistor(
     name = "R2",
     value = "10kohms",

--- a/crates/pcb-layout/tests/resources/not_connected_single_pin_multi_pad/Board.zen
+++ b/crates/pcb-layout/tests/resources/not_connected_single_pin_multi_pad/Board.zen
@@ -1,0 +1,23 @@
+load("@stdlib/interfaces.zen", "NotConnected")
+
+# NotConnected net connected to a single logical port that fans out to multiple pads.
+# This should NOT warn: (component, pin) count is 1, even though (component, pad) count > 1.
+nc = NotConnected("NC_PIN")
+
+Component(
+    name = "U1",
+    footprint = "Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
+    symbol = Symbol(
+        definition = [
+            ("GND", ["5", "17"]),  # Pin 5 and thermal pad (17) share the same logical port
+        ]
+    ),
+    pins = {
+        "GND": nc,
+    }
+)
+
+# HACK: Put the layout in build/ so that the snapshot ends up there, which
+# is what the test expects.
+add_property("layout_path", "build/")
+

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
@@ -18,7 +18,7 @@ INFO: --------------------------------------------------------------------------
 INFO: Starting ImportNetlist...
 INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
-INFO: Source: 2 footprints, 0 groups, 4 nets
+INFO: Source: 2 footprints, 0 groups, 3 nets
 INFO: Changes: +2 -0 footprints
 INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPV path=R2.R ref=R2 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
@@ -31,10 +31,9 @@ INFO: Added footprint: R2.R
 INFO: HierPlace: placed 2 items
 INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG FP_ADD path=R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG NET_ADD name=unconnected-(R1.R:2)
+INFO: OPLOG NET_ADD name=NC_PIN
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG NET_ADD name=GND
-INFO: OPLOG NET_ADD name=unconnected-(R2.R:2)
 INFO: OPLOG PLACE_FP path=R1.R x=146995000 y=104245000 w=3010000 h=1510000
 INFO: OPLOG PLACE_FP path=R2.R x=146995000 y=102735000 w=3010000 h=1510000
 INFO: Sync completed in X.XXXs

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.layout.json.snap
@@ -1,0 +1,855 @@
+---
+source: crates/pcb-layout/tests/layout_generation.rs
+expression: content
+---
+{
+  "footprints": [
+    {
+      "dnp": false,
+      "exclude_from_bom": false,
+      "exclude_from_pos_files": false,
+      "footprint": "Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
+      "graphical_items": [
+        {
+          "angle": null,
+          "end": null,
+          "layer": "F.Fab",
+          "position": {
+            "x": 148687500,
+            "y": 105000000
+          },
+          "shape": null,
+          "start": null,
+          "text": "${REFERENCE}",
+          "type": "PCB_TEXT",
+          "width": null
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 147937500,
+            "y": 103500000
+          },
+          "shape": 4,
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 146547500,
+            "y": 104250000
+          },
+          "shape": 4,
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146557500,
+            "y": 103870000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 146557500,
+            "y": 106130000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146557500,
+            "y": 106130000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146557500,
+            "y": 106130000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 146937500,
+            "y": 106130000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146937500,
+            "y": 106130000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146937500,
+            "y": 103250000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 146937500,
+            "y": 103870000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146937500,
+            "y": 103870000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146937500,
+            "y": 103870000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 146557500,
+            "y": 103870000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146557500,
+            "y": 103870000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146937500,
+            "y": 106130000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 146937500,
+            "y": 106750000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146937500,
+            "y": 106750000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146937500,
+            "y": 106750000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 147557500,
+            "y": 106750000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147557500,
+            "y": 106750000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147077500,
+            "y": 103390000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 147077500,
+            "y": 103865000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147077500,
+            "y": 103865000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147077500,
+            "y": 106135000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 147077500,
+            "y": 106610000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147077500,
+            "y": 106610000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147077500,
+            "y": 106610000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 147552500,
+            "y": 106610000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147552500,
+            "y": 106610000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147552500,
+            "y": 103390000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 147077500,
+            "y": 103390000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147077500,
+            "y": 103390000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147557500,
+            "y": 102870000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 147557500,
+            "y": 103250000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147557500,
+            "y": 103250000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147557500,
+            "y": 103250000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 146937500,
+            "y": 103250000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146937500,
+            "y": 103250000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147557500,
+            "y": 106750000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 147557500,
+            "y": 107130000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147557500,
+            "y": 107130000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147557500,
+            "y": 107130000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 149817500,
+            "y": 107130000
+          },
+          "shape": 0,
+          "start": {
+            "x": 149817500,
+            "y": 107130000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 149817500,
+            "y": 102870000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 147557500,
+            "y": 102870000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147557500,
+            "y": 102870000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 149817500,
+            "y": 103250000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 149817500,
+            "y": 102870000
+          },
+          "shape": 0,
+          "start": {
+            "x": 149817500,
+            "y": 102870000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 149817500,
+            "y": 106750000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 150437500,
+            "y": 106750000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150437500,
+            "y": 106750000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 149817500,
+            "y": 107130000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 149817500,
+            "y": 106750000
+          },
+          "shape": 0,
+          "start": {
+            "x": 149817500,
+            "y": 106750000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 149822500,
+            "y": 106610000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 150297500,
+            "y": 106610000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150297500,
+            "y": 106610000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150297500,
+            "y": 103390000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 149822500,
+            "y": 103390000
+          },
+          "shape": 0,
+          "start": {
+            "x": 149822500,
+            "y": 103390000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150297500,
+            "y": 103865000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 150297500,
+            "y": 103390000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150297500,
+            "y": 103390000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150297500,
+            "y": 106610000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 150297500,
+            "y": 106135000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150297500,
+            "y": 106135000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150437500,
+            "y": 103250000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 149817500,
+            "y": 103250000
+          },
+          "shape": 0,
+          "start": {
+            "x": 149817500,
+            "y": 103250000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150437500,
+            "y": 103870000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 150437500,
+            "y": 103250000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150437500,
+            "y": 103250000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150437500,
+            "y": 106130000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 150817500,
+            "y": 106130000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150817500,
+            "y": 106130000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150437500,
+            "y": 106750000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 150437500,
+            "y": 106130000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150437500,
+            "y": 106130000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150817500,
+            "y": 103870000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 150437500,
+            "y": 103870000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150437500,
+            "y": 103870000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 150817500,
+            "y": 106130000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 150817500,
+            "y": 103870000
+          },
+          "shape": 0,
+          "start": {
+            "x": 150817500,
+            "y": 103870000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        }
+      ],
+      "group": null,
+      "layer": "F.Cu",
+      "locked": false,
+      "orientation": 0.0,
+      "pads": [
+        {
+          "layer": "F.Cu",
+          "name": "",
+          "position": {
+            "x": 148262500,
+            "y": 104575000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "",
+          "position": {
+            "x": 148262500,
+            "y": 105425000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "",
+          "position": {
+            "x": 149112500,
+            "y": 104575000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "",
+          "position": {
+            "x": 149112500,
+            "y": 105425000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "1",
+          "position": {
+            "x": 147225000,
+            "y": 104250000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "10",
+          "position": {
+            "x": 150150000,
+            "y": 105250000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "11",
+          "position": {
+            "x": 150150000,
+            "y": 104750000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "12",
+          "position": {
+            "x": 150150000,
+            "y": 104250000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "13",
+          "position": {
+            "x": 149437500,
+            "y": 103537500
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "14",
+          "position": {
+            "x": 148937500,
+            "y": 103537500
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "15",
+          "position": {
+            "x": 148437500,
+            "y": 103537500
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "16",
+          "position": {
+            "x": 147937500,
+            "y": 103537500
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "17",
+          "position": {
+            "x": 148087500,
+            "y": 104400000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "17",
+          "position": {
+            "x": 148087500,
+            "y": 105600000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "17",
+          "position": {
+            "x": 148687500,
+            "y": 105000000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "17",
+          "position": {
+            "x": 148687500,
+            "y": 105000000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "17",
+          "position": {
+            "x": 149287500,
+            "y": 104400000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "17",
+          "position": {
+            "x": 149287500,
+            "y": 105600000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "2",
+          "position": {
+            "x": 147225000,
+            "y": 104750000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "3",
+          "position": {
+            "x": 147225000,
+            "y": 105250000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "4",
+          "position": {
+            "x": 147225000,
+            "y": 105750000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "5",
+          "position": {
+            "x": 147937500,
+            "y": 106462500
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "6",
+          "position": {
+            "x": 148437500,
+            "y": 106462500
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "7",
+          "position": {
+            "x": 148937500,
+            "y": 106462500
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "8",
+          "position": {
+            "x": 149437500,
+            "y": 106462500
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "9",
+          "position": {
+            "x": 150150000,
+            "y": 105750000
+          }
+        }
+      ],
+      "position": {
+        "x": 148687500,
+        "y": 105000000
+      },
+      "reference": "U1",
+      "uuid": "bb9170a7-68d4-539c-bed9-f036cbc8d7db",
+      "value": "?"
+    }
+  ],
+  "groups": [],
+  "tracks": [],
+  "vias": [],
+  "zones": []
+}

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.log.snap
@@ -1,0 +1,39 @@
+---
+source: crates/pcb-layout/tests/layout_generation.rs
+expression: content
+---
+INFO: Creating new board file at <TEMP_DIR>
+INFO: Parsing JSON netlist from <TEMP_DIR>
+INFO: --------------------------------------------------------------------------------
+INFO: Running step: SetupBoard
+INFO: --------------------------------------------------------------------------------
+INFO: Starting SetupBoard...
+INFO: Configured title block with variable placeholders
+INFO: Completed SetupBoard in X.XXX seconds
+INFO: --------------------------------------------------------------------------------
+INFO: Running step: ImportNetlist
+INFO: --------------------------------------------------------------------------------
+INFO: Starting ImportNetlist...
+INFO: Running lens-based netlist sync
+INFO: Starting lens-based layout sync
+INFO: Source: 1 footprints, 0 groups, 1 nets
+INFO: Changes: +1 -0 footprints
+INFO: NEW FPV path=U1 ref=U1 value=? fpid=Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
+INFO: NEW FPC path=U1 x=0 y=0 orient=0.0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
+INFO: Added footprint: U1
+INFO: HierPlace: placed 1 items
+INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
+INFO: OPLOG NET_ADD name=NC_PIN
+INFO: OPLOG PLACE_FP path=U1 x=146157500 y=102845000 w=4685000 h=4310000
+INFO: Sync completed in X.XXXs
+INFO: Lens sync complete: +1 -0 footprints
+INFO: Completed ImportNetlist in X.XXX seconds
+INFO: --------------------------------------------------------------------------------
+INFO: Running step: FinalizeBoard
+INFO: --------------------------------------------------------------------------------
+INFO: Starting FinalizeBoard...
+INFO: Saved layout snapshot to <TEMP_DIR>
+INFO: Snapshot export took X.XXX seconds
+INFO: Board saving took X.XXX seconds
+INFO: Completed FinalizeBoard in X.XXX seconds

--- a/crates/pcb-zen-core/tests/not_connected.rs
+++ b/crates/pcb-zen-core/tests/not_connected.rs
@@ -1,0 +1,110 @@
+use std::sync::Arc;
+
+use pcb_zen_core::{CoreLoadResolver, DiagnosticsPass, EvalContext, NoopRemoteFetcher, SortPass};
+
+mod common;
+use common::InMemoryFileProvider;
+
+fn eval_to_schematic(
+    files: std::collections::HashMap<String, String>,
+    main: &str,
+) -> pcb_zen_core::WithDiagnostics<pcb_sch::Schematic> {
+    let load_resolver = Arc::new(CoreLoadResolver::new(
+        Arc::new(InMemoryFileProvider::new(files)),
+        Arc::new(NoopRemoteFetcher::default()),
+        std::path::PathBuf::from("/"),
+        true,
+        None,
+    ));
+
+    let ctx = EvalContext::new(load_resolver).set_source_path(std::path::PathBuf::from(main));
+    let eval = ctx.eval();
+    assert!(eval.is_success(), "eval failed: {:?}", eval.diagnostics);
+    let eval_output = eval.output.expect("expected EvalOutput on success");
+    eval_output.to_schematic_with_diagnostics()
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn not_connected_warns_on_multiple_ports() {
+    let mut files = std::collections::HashMap::new();
+    files.insert(
+        "test.zen".to_string(),
+        r#"
+NotConnected = builtin.net_type("NotConnected")
+nc = NotConnected("NC_PIN")
+
+Component(
+    name = "R1",
+    prefix = "R",
+    footprint = "TEST:0402",
+    pin_defs = {"P2": "2"},
+    pins = {"P2": nc},
+)
+
+Component(
+    name = "R2",
+    prefix = "R",
+    footprint = "TEST:0402",
+    pin_defs = {"P2": "2"},
+    pins = {"P2": nc},
+)
+"#
+        .to_string(),
+    );
+
+    let mut result = eval_to_schematic(files, "test.zen");
+    SortPass.apply(&mut result.diagnostics);
+    let warnings = result.diagnostics.warnings();
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.body.contains("NotConnected net connects to 2 ports")),
+        "expected multi-port NotConnected warning, got: {:?}",
+        warnings
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.body.contains("R1.P2") && w.body.contains("R2.P2")),
+        "expected warning to mention ports, got: {:?}",
+        warnings
+    );
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn not_connected_does_not_warn_on_single_port_multiple_pads() {
+    let mut files = std::collections::HashMap::new();
+    files.insert(
+        "test.zen".to_string(),
+        r#"
+NotConnected = builtin.net_type("NotConnected")
+nc = NotConnected("NC_PIN")
+
+Component(
+    name = "U1",
+    prefix = "U",
+    footprint = "TEST:0402",
+    symbol = Symbol(
+        definition = [
+            ("GND", ["5", "17"]),
+        ]
+    ),
+    pins = {"GND": nc},
+)
+"#
+        .to_string(),
+    );
+
+    let mut result = eval_to_schematic(files, "test.zen");
+    SortPass.apply(&mut result.diagnostics);
+    let warnings = result.diagnostics.warnings();
+    assert!(
+        warnings
+            .iter()
+            .all(|w| !w.body.contains("NotConnected net connects to")),
+        "did not expect multi-port NotConnected warning, got: {:?}",
+        warnings
+    );
+}

--- a/crates/pcb-zen/tests/snapshots/input__correct_usage_with_explicit_net_access.snap
+++ b/crates/pcb-zen/tests/snapshots/input__correct_usage_with_explicit_net_access.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -38,4 +38,5 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]test.zen Net name 'sig_signal' should be UPPERCASE: 'SIG_SIGNAL'
+Advice: [net] Net name 'sig_signal' should be UPPERCASE: 'SIG_SIGNAL'
+  at [TEMP_DIR]test.zen

--- a/crates/pcb-zen/tests/snapshots/input__interface_input.snap
+++ b/crates/pcb-zen/tests/snapshots/input__interface_input.snap
@@ -22,17 +22,21 @@ expression: snapshot_output
     )
   )
 )
-Advice: [TEMP_DIR]sub.zen Net name 'pdm_power' should be UPPERCASE: 'PDM_POWER'
-  in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
+Advice: [net] Net name 'pdm_power' should be UPPERCASE: 'PDM_POWER'
+  at [TEMP_DIR]sub.zen
+  in [TEMP_DIR]top.zen:7:1-29: Issue in `sub`
 
-Advice: [TEMP_DIR]sub.zen Net name 'pdm_data' should be UPPERCASE: 'PDM_DATA'
-  in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
+Advice: [net] Net name 'pdm_data' should be UPPERCASE: 'PDM_DATA'
+  at [TEMP_DIR]sub.zen
+  in [TEMP_DIR]top.zen:7:1-29: Issue in `sub`
 
-Advice: [TEMP_DIR]sub.zen Net name 'pdm_select' should be UPPERCASE: 'PDM_SELECT'
-  in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
+Advice: [net] Net name 'pdm_select' should be UPPERCASE: 'PDM_SELECT'
+  at [TEMP_DIR]sub.zen
+  in [TEMP_DIR]top.zen:7:1-29: Issue in `sub`
 
-Advice: [TEMP_DIR]sub.zen Net name 'pdm_clock' should be UPPERCASE: 'PDM_CLOCK'
-  in [TEMP_DIR]top.zen:7:1-29 Issue in `sub`
+Advice: [net] Net name 'pdm_clock' should be UPPERCASE: 'PDM_CLOCK'
+  at [TEMP_DIR]sub.zen
+  in [TEMP_DIR]top.zen:7:1-29: Issue in `sub`
 
 Advice: io() parameter 'pdm' should be UPPERCASE: 'PDM'
    ╭─[ [TEMP_DIR]sub.zen:5:7 ]
@@ -42,10 +46,14 @@ Advice: io() parameter 'pdm' should be UPPERCASE: 'PDM'
  7 │Sub(name = "sub", pdm = pdm)
    │              ╰────────────── Issue in `sub`
 
-Advice: [TEMP_DIR]top.zen Net name 'PDM_power' should be UPPERCASE: 'PDM_POWER'
+Advice: [net] Net name 'PDM_power' should be UPPERCASE: 'PDM_POWER'
+  at [TEMP_DIR]top.zen
 
-Advice: [TEMP_DIR]top.zen Net name 'PDM_data' should be UPPERCASE: 'PDM_DATA'
+Advice: [net] Net name 'PDM_data' should be UPPERCASE: 'PDM_DATA'
+  at [TEMP_DIR]top.zen
 
-Advice: [TEMP_DIR]top.zen Net name 'PDM_select' should be UPPERCASE: 'PDM_SELECT'
+Advice: [net] Net name 'PDM_select' should be UPPERCASE: 'PDM_SELECT'
+  at [TEMP_DIR]top.zen
 
-Advice: [TEMP_DIR]top.zen Net name 'PDM_clock' should be UPPERCASE: 'PDM_CLOCK'
+Advice: [net] Net name 'PDM_clock' should be UPPERCASE: 'PDM_CLOCK'
+  at [TEMP_DIR]top.zen

--- a/crates/pcb-zen/tests/snapshots/input__module_io_rejects_interface_when_net_expected.snap
+++ b/crates/pcb-zen/tests/snapshots/input__module_io_rejects_interface_when_net_expected.snap
@@ -30,4 +30,5 @@ Error: Input 'signal' (type) has wrong type for this placeholder: expected Net, 
    │                  ╰─────────────────── Error instantiating `child`
 ───╯
 
-Advice: [TEMP_DIR]parent.zen Net name 'SIG_signal' should be UPPERCASE: 'SIG_SIGNAL'
+Advice: [net] Net name 'SIG_signal' should be UPPERCASE: 'SIG_SIGNAL'
+  at [TEMP_DIR]parent.zen

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_io_and_config_with_values.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_io_and_config_with_values.snap
@@ -34,8 +34,9 @@ expression: snapshot_output
     )
   )
 )
-Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'
-  in [TEMP_DIR]top.zen:4:1-8:2 Issue in `my_sub`
+Advice: [net] Net name 'pwr' should be UPPERCASE: 'PWR'
+  at [TEMP_DIR]my_sub.zen
+  in [TEMP_DIR]top.zen:4:1-8:2: Issue in `my_sub`
 
 Advice: io() parameter 'pwr' should be UPPERCASE: 'PWR'
    ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_optional_inputs_return_none.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_optional_inputs_return_none.snap
@@ -36,8 +36,9 @@ expression: snapshot_output
     )
   )
 )
-Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'
-  in [TEMP_DIR]top.zen:4:1-7:2 Issue in `my_sub`
+Advice: [net] Net name 'pwr' should be UPPERCASE: 'PWR'
+  at [TEMP_DIR]my_sub.zen
+  in [TEMP_DIR]top.zen:4:1-7:2: Issue in `my_sub`
 
 Advice: io() parameter 'pwr' should be UPPERCASE: 'PWR'
    ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]

--- a/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_mixed_templates_and_types.snap
+++ b/crates/pcb-zen/tests/snapshots/interface_templates_snapshot__interface_mixed_templates_and_types.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/interface_templates_snapshot.rs
-expression: netlist
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -50,4 +50,5 @@ expression: netlist
     )
   )
 )
-Advice: [TEMP_DIR]test.zen Net name 'CHIP_signal' should be UPPERCASE: 'CHIP_SIGNAL'
+Advice: [net] Net name 'CHIP_signal' should be UPPERCASE: 'CHIP_SIGNAL'
+  at [TEMP_DIR]test.zen

--- a/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_load_file_with_syntax_error.snap
+++ b/crates/pcb-zen/tests/snapshots/load_diagnostics__snapshot_load_file_with_syntax_error.snap
@@ -2,5 +2,6 @@
 source: crates/pcb-zen/tests/load_diagnostics.rs
 expression: snapshot_output
 ---
-Error: [TEMP_DIR]broken.zen:5:1 Parse error: unexpected new line here, expected one of ")", "*", "**", "/" or "IDENTIFIER"
-  in [TEMP_DIR]test.zen:3:6-20 Error loading module `./broken.zen`
+Error: Parse error: unexpected new line here, expected one of ")", "*", "**", "/" or "IDENTIFIER"
+  at [TEMP_DIR]broken.zen:5:1
+  in [TEMP_DIR]test.zen:3:6-20: Error loading module `./broken.zen`

--- a/crates/pcb-zen/tests/snapshots/placeholder__snapshot_io_and_config_placeholders.snap
+++ b/crates/pcb-zen/tests/snapshots/placeholder__snapshot_io_and_config_placeholders.snap
@@ -34,8 +34,9 @@ expression: snapshot_output
     )
   )
 )
-Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'
-  in [TEMP_DIR]top.zen:4:1-8:2 Issue in `my_sub`
+Advice: [net] Net name 'pwr' should be UPPERCASE: 'PWR'
+  at [TEMP_DIR]my_sub.zen
+  in [TEMP_DIR]top.zen:4:1-8:2: Issue in `my_sub`
 
 Advice: io() parameter 'pwr' should be UPPERCASE: 'PWR'
    ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]

--- a/crates/pcb-zen/tests/snapshots/placeholder__snapshot_undefined_placeholder.snap
+++ b/crates/pcb-zen/tests/snapshots/placeholder__snapshot_undefined_placeholder.snap
@@ -34,8 +34,9 @@ expression: snapshot_output
     )
   )
 )
-Advice: [TEMP_DIR]my_sub.zen Net name 'pwr' should be UPPERCASE: 'PWR'
-  in [TEMP_DIR]top.zen:4:1-7:2 Issue in `my_sub`
+Advice: [net] Net name 'pwr' should be UPPERCASE: 'PWR'
+  at [TEMP_DIR]my_sub.zen
+  in [TEMP_DIR]top.zen:4:1-7:2: Issue in `my_sub`
 
 Advice: io() parameter 'pwr' should be UPPERCASE: 'PWR'
    ╭─[ [TEMP_DIR]my_sub.zen:3:7 ]

--- a/crates/pcb-zen/tests/snapshots/test__net_passing.snap
+++ b/crates/pcb-zen/tests/snapshots/test__net_passing.snap
@@ -38,13 +38,15 @@ expression: snapshot_output
     )
   )
 )
-Advice: [TEMP_DIR]MyComponent.zen Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'
-  in [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
-  in [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
+Advice: [net] Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'
+  at [TEMP_DIR]MyComponent.zen
+  in [TEMP_DIR]test.zen:5:1-8:2: Issue in `MyComponent`
+  in [TEMP_DIR]top.zen:4:1-6:2: Issue in `test`
 
-Advice: [TEMP_DIR]MyComponent.zen Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'
-  in [TEMP_DIR]test.zen:5:1-8:2 Issue in `MyComponent`
-  in [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
+Advice: [net] Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'
+  at [TEMP_DIR]MyComponent.zen
+  in [TEMP_DIR]test.zen:5:1-8:2: Issue in `MyComponent`
+  in [TEMP_DIR]top.zen:4:1-6:2: Issue in `test`
 
 Advice: io() parameter 'input' should be UPPERCASE: 'INPUT'
    ╭─[ [TEMP_DIR]MyComponent.zen:3:9 ]
@@ -61,8 +63,10 @@ Advice: io() parameter 'input' should be UPPERCASE: 'INPUT'
  8 │├▶)
    │╰──── Issue in `MyComponent`
 
-Advice: [TEMP_DIR]test.zen Net name 'INTERFACE_p1' should be UPPERCASE: 'INTERFACE_P1'
-  in [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
+Advice: [net] Net name 'INTERFACE_p1' should be UPPERCASE: 'INTERFACE_P1'
+  at [TEMP_DIR]test.zen
+  in [TEMP_DIR]top.zen:4:1-6:2: Issue in `test`
 
-Advice: [TEMP_DIR]test.zen Net name 'INTERFACE_p2' should be UPPERCASE: 'INTERFACE_P2'
-  in [TEMP_DIR]top.zen:4:1-6:2 Issue in `test`
+Advice: [net] Net name 'INTERFACE_p2' should be UPPERCASE: 'INTERFACE_P2'
+  at [TEMP_DIR]test.zen
+  in [TEMP_DIR]top.zen:4:1-6:2: Issue in `test`

--- a/crates/pcb/src/drc.rs
+++ b/crates/pcb/src/drc.rs
@@ -1,20 +1,12 @@
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use pcb_ui::prelude::*;
-use pcb_zen_core::diagnostics::{Diagnostic, DiagnosticsPass, Severity};
+use pcb_zen_core::diagnostics::{
+    compact_diagnostic, diagnostic_headline, diagnostic_location, DiagnosticsPass, Severity,
+};
 use pcb_zen_core::passes::{FilterHiddenPass, SuppressPass};
 use starlark::errors::EvalSeverity;
 
 type ColorFn = fn(String) -> colored::ColoredString;
-
-/// Extract the short kind (last segment) from a diagnostic, if it has one.
-fn diagnostic_kind_short(diagnostic: &Diagnostic) -> Option<String> {
-    use pcb_zen_core::lang::error::CategorizedDiagnostic;
-    diagnostic
-        .source_error
-        .as_ref()
-        .and_then(|e| e.downcast_ref::<CategorizedDiagnostic>())
-        .map(|c| c.kind.rsplit('.').next().unwrap_or(&c.kind).to_string())
-}
 
 /// Render diagnostics (filter, print, show summary table)
 pub fn render_diagnostics(diagnostics: &mut pcb_zen_core::Diagnostics, suppress_kinds: &[String]) {
@@ -35,20 +27,18 @@ pub fn render_diagnostics(diagnostics: &mut pcb_zen_core::Diagnostics, suppress_
                 EvalSeverity::Advice => Some(("Advice", Style::Blue)),
                 EvalSeverity::Disabled => None,
             } {
-                let lines: Vec<&str> = diagnostic.body.lines().collect();
-                if let Some(first_line) = lines.first() {
-                    // Prepend [kind_short] if available
-                    let prefix = diagnostic_kind_short(diagnostic)
-                        .map(|k| format!("[{}] ", k))
-                        .unwrap_or_default();
+                let parts = compact_diagnostic(diagnostic);
+                if !parts.first_line.is_empty() {
                     eprintln!(
-                        "{}: {}{}",
+                        "{}: {}",
                         severity_str.with_style(severity_color).bold(),
-                        prefix,
-                        first_line
+                        diagnostic_headline(diagnostic)
                     );
-                    for line in lines.iter().skip(1) {
+                    for line in parts.extra_lines {
                         eprintln!("{}", line.dimmed());
+                    }
+                    if let Some(loc) = diagnostic_location(diagnostic) {
+                        eprintln!("{}", format!("  at {loc}").dimmed());
                     }
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect netlist/layout sync semantics and KiCad pad `no_connect` assignment; misclassification could alter connectivity or DRC outcomes, though behavior is covered by updated tests and snapshots.
> 
> **Overview**
> **Restores `NotConnected` net compatibility by keeping normal net connectivity** (no more per-pad `unconnected-(...)` net exploding) and instead driving KiCad behavior via pad pin types.
> 
> `lens.get()` now tracks *logical ports* (refdes + pin/port name) on each net (`NetView.logical_ports`), `update_layout_file.py` preserves this pin identity in netlist nodes, and the KiCad adapter only sets pads to `no_connect` when a `NotConnected` net touches **<= 1 logical port** (allowing multi-pad fanout for a single pin, but avoiding incorrect `no_connect` when multiple pins/components share the net).
> 
> On the core side, schematic conversion adds a new warning (`net.notconnected.multi_port`) when a `NotConnected` net connects to multiple logical ports, and diagnostic rendering was refactored/standardized (new compact helpers in `pcb-zen-core`, updated CLI renderers and snapshots). Tests and layout snapshots were updated, and a new layout fixture/test covers the single-pin/multi-pad case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2906fcf2881c4b8376947b69f40ed23fc4b82292. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->