### PR TITLE
Add better single-pin multi-pad NotConnected support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Layout sync: explode single-pin multi-pad `NotConnected` nets into per-pad `unconnected-(...)` nets.
+
 ## [0.3.34] - 2026-02-03
 
 ### Added

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.log.snap
@@ -16,7 +16,7 @@ INFO: --------------------------------------------------------------------------
 INFO: Starting ImportNetlist...
 INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
-INFO: Source: 1 footprints, 0 groups, 1 nets
+INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
 INFO: NEW FPV path=U1 ref=U1 value=? fpid=Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
 INFO: NEW FPC path=U1 x=0 y=0 orient=0.0 layer=F.Cu
@@ -24,7 +24,8 @@ INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5
 INFO: Added footprint: U1
 INFO: HierPlace: placed 1 items
 INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
-INFO: OPLOG NET_ADD name=NC_PIN
+INFO: OPLOG NET_ADD name=unconnected-(U1:5)
+INFO: OPLOG NET_ADD name=unconnected-(U1:17)
 INFO: OPLOG PLACE_FP path=U1 x=146157500 y=102845000 w=4685000 h=4310000
 INFO: Sync completed in X.XXXs
 INFO: Lens sync complete: +1 -0 footprints


### PR DESCRIPTION
This change actually does change electrical connectivity. So, it's not strictly backwards compatible. But this is limited to the case where the `NotConnected` net is only assigned to a single port, so should be fairly safe?™

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes net generation in the layout sync pipeline and can alter electrical connectivity for affected designs; risk is limited to `NotConnected` nets with a single logical port that maps to multiple pads.
> 
> **Overview**
> Fixes layout sync connectivity for the case where a `NotConnected` net is assigned to a single logical port that fans out to multiple pads by **splitting it into per-pad `unconnected-(...)` nets** (avoids accidentally shorting those pads together).
> 
> Updates `lens.get()` to normalize/deduplicate net connections, adds helpers for deterministic `unconnected-(path:pad)` naming (with collision handling), and refreshes tests/snapshots to assert the new net explosion behavior while leaving multi-port `NotConnected` nets unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d337259331d0665180266c281eef892abcdae862. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->