### PR TITLE
Add support for "jumper" copper role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Layout sync: explode single-pin multi-pad `NotConnected` nets into per-pad `unconnected-(...)` nets.
+- Accept KiCad copper role `jumper` when importing stackups.
 
 ## [0.3.34] - 2026-02-03
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to stackup role parsing/formatting with added test coverage; minimal impact outside KiCad stackup import/export paths.
> 
> **Overview**
> Adds a new `CopperRole::Jumper` and wires it through stackup serialization/deserialization so KiCad layer roles can round-trip as `jumper` (including `to_kicad_str`, display formatting, and KiCad `(layers ...)` parsing).
> 
> Updates tests and fixtures to validate `jumper` parsing from KiCad PCB content and JSON layer arrays, and documents the import fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcf1cab3df2162808b488964d8a69013e1ebba52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->