### PR TITLE
Package-scoped `pcb update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `pcb new --board` now generates `README.md` and `CHANGELOG.md` files from templates
 - `pcb new --package` now generates `README.md` and `CHANGELOG.md` files from templates
 
+### Changed
+
+- `pcb update <path>` limits updates to a single workspace package when `<path>` points to that package directory.
+
 ### Fixed
 
 - Layout sync: explode single-pin multi-pad `NotConnected` nets into per-pad `unconnected-(...)` nets.

--- a/crates/pcb/src/update.rs
+++ b/crates/pcb/src/update.rs
@@ -15,6 +15,7 @@ use pcb_zen_core::resolution::semver_family;
 use pcb_zen_core::DefaultFileProvider;
 use semver::Version;
 use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Args, Debug)]
@@ -37,20 +38,86 @@ struct PendingUpdate {
     pcb_toml_path: PathBuf,
 }
 
-/// Collect all pcb.toml paths in the workspace
-fn collect_pcb_tomls(workspace: &WorkspaceInfo) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    let root = workspace.root.join("pcb.toml");
-    if root.exists() {
-        paths.push(root);
+#[derive(Debug, Clone)]
+enum UpdateScope {
+    Workspace,
+    Package { pcb_toml_path: PathBuf },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AutoUpdatePolicy {
+    /// Auto-update within the same semver family (current behavior).
+    SemverFamily,
+    /// Auto-update only patch versions (same major+minor).
+    PatchOnly,
+}
+
+fn is_patch_bump(current: &Version, candidate: &Version) -> bool {
+    candidate.major == current.major && candidate.minor == current.minor && candidate > current
+}
+
+fn detect_update_scope(workspace: &WorkspaceInfo, start_path: &Path) -> UpdateScope {
+    // Start from a directory; if a file was provided, use its parent dir.
+    let candidate_dir = if start_path.is_file() {
+        start_path.parent().unwrap_or(start_path)
+    } else {
+        start_path
+    };
+
+    // Normalize paths to reduce false negatives when comparing.
+    let candidate_dir = candidate_dir
+        .canonicalize()
+        .unwrap_or_else(|_| candidate_dir.to_path_buf());
+    let ws_root = workspace
+        .root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.root.clone());
+
+    let candidate_pcb_toml = candidate_dir.join("pcb.toml");
+    if !candidate_pcb_toml.exists() {
+        return UpdateScope::Workspace;
     }
+
+    // If the path is the workspace root, keep workspace-wide behavior.
+    if candidate_dir == ws_root {
+        return UpdateScope::Workspace;
+    }
+
+    // Only scope to a package if the directory matches a discovered workspace member.
     for pkg in workspace.packages.values() {
-        let p = pkg.dir(&workspace.root).join("pcb.toml");
-        if p.exists() {
-            paths.push(p);
+        let pkg_dir = pkg
+            .dir(&workspace.root)
+            .canonicalize()
+            .unwrap_or_else(|_| pkg.dir(&workspace.root));
+        if pkg_dir == candidate_dir {
+            return UpdateScope::Package {
+                pcb_toml_path: candidate_pcb_toml,
+            };
         }
     }
-    paths
+
+    UpdateScope::Workspace
+}
+
+/// Collect all pcb.toml paths in the workspace
+fn collect_pcb_tomls(workspace: &WorkspaceInfo, scope: &UpdateScope) -> Vec<PathBuf> {
+    match scope {
+        UpdateScope::Workspace => {
+            let mut paths = Vec::new();
+            let root = workspace.root.join("pcb.toml");
+            if root.exists() {
+                paths.push(root);
+            }
+            for pkg in workspace.packages.values() {
+                let p = pkg.dir(&workspace.root).join("pcb.toml");
+                if p.exists() {
+                    paths.push(p);
+                }
+            }
+            paths
+        }
+        UpdateScope::Package { pcb_toml_path } => vec![pcb_toml_path.clone()],
+    }
 }
 
 fn matches_filter(url: &str, filter: &[String]) -> bool {
@@ -74,7 +141,21 @@ pub fn execute(args: UpdateArgs) -> Result<()> {
     let index = CacheIndex::open()?;
     index.clear_branch_commits()?;
 
-    let version_updates = find_version_updates(&workspace, &args.packages)?;
+    let scope = detect_update_scope(&workspace, &start_path);
+    if let UpdateScope::Package { pcb_toml_path } = &scope {
+        println!(
+            "{} {}",
+            "Limiting updates to:".cyan(),
+            pcb_toml_path.display()
+        );
+    }
+
+    let policy = match scope {
+        UpdateScope::Workspace => AutoUpdatePolicy::SemverFamily,
+        UpdateScope::Package { .. } => AutoUpdatePolicy::PatchOnly,
+    };
+
+    let version_updates = find_version_updates(&workspace, &args.packages, &scope, policy)?;
 
     // Display and apply version updates
     let applied_count = apply_version_updates(&version_updates)?;
@@ -212,12 +293,14 @@ fn apply_version_updates(pending: &[PendingUpdate]) -> Result<usize> {
 fn find_version_updates(
     workspace: &WorkspaceInfo,
     filter: &[String],
+    scope: &UpdateScope,
+    policy: AutoUpdatePolicy,
 ) -> Result<Vec<PendingUpdate>> {
     let workspace_members: HashSet<&String> = workspace.packages.keys().collect();
     let mut version_cache: BTreeMap<String, BTreeMap<String, Vec<Version>>> = BTreeMap::new();
     let mut pending = Vec::new();
 
-    for pcb_toml_path in collect_pcb_tomls(workspace) {
+    for pcb_toml_path in collect_pcb_tomls(workspace, scope) {
         let config = PcbToml::from_file(&DefaultFileProvider::new(), &pcb_toml_path)?;
 
         for (url, spec) in &config.dependencies {
@@ -253,11 +336,17 @@ fn find_version_updates(
 
             let current_family = semver_family(&current);
 
-            // Non-breaking update (same family)
-            if let Some(v) = available
-                .iter()
-                .find(|v| semver_family(v) == current_family && *v > &current)
-            {
+            // Auto-update policy (non-breaking)
+            let non_breaking = match policy {
+                AutoUpdatePolicy::SemverFamily => available
+                    .iter()
+                    .find(|v| semver_family(v) == current_family && *v > &current),
+                AutoUpdatePolicy::PatchOnly => {
+                    available.iter().find(|v| is_patch_bump(&current, v))
+                }
+            };
+
+            if let Some(v) = non_breaking {
                 pending.push(PendingUpdate {
                     url: url.clone(),
                     current: current.clone(),
@@ -284,4 +373,85 @@ fn find_version_updates(
     }
 
     Ok(pending)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pcb_zen::MemberPackage;
+    use pcb_zen_core::config::PcbToml;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_is_patch_bump() {
+        let cur = Version::parse("1.2.3").unwrap();
+        assert!(is_patch_bump(&cur, &Version::parse("1.2.4").unwrap()));
+        assert!(!is_patch_bump(&cur, &Version::parse("1.3.0").unwrap()));
+        assert!(!is_patch_bump(&cur, &Version::parse("2.0.0").unwrap()));
+        assert!(!is_patch_bump(&cur, &Version::parse("1.2.3").unwrap()));
+
+        let cur0 = Version::parse("0.3.2").unwrap();
+        assert!(is_patch_bump(&cur0, &Version::parse("0.3.9").unwrap()));
+        assert!(!is_patch_bump(&cur0, &Version::parse("0.4.0").unwrap()));
+    }
+
+    #[test]
+    fn test_detect_update_scope_member_package_dir() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().to_path_buf();
+
+        let member_rel = PathBuf::from("packages/foo");
+        let member_abs = root.join(&member_rel);
+        std::fs::create_dir_all(&member_abs).unwrap();
+        std::fs::write(member_abs.join("pcb.toml"), "").unwrap();
+
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "github.com/example/foo".to_string(),
+            MemberPackage {
+                rel_path: member_rel,
+                config: PcbToml::default(),
+                version: None,
+                dirty: false,
+            },
+        );
+
+        let ws = WorkspaceInfo {
+            root: root.clone(),
+            config: None,
+            packages,
+            lockfile: None,
+            errors: vec![],
+        };
+
+        let scope = detect_update_scope(&ws, &member_abs);
+        match scope {
+            UpdateScope::Package { pcb_toml_path } => {
+                let expected = member_abs.join("pcb.toml").canonicalize().unwrap();
+                assert_eq!(pcb_toml_path, expected);
+            }
+            UpdateScope::Workspace => panic!("expected package scope"),
+        }
+    }
+
+    #[test]
+    fn test_detect_update_scope_non_member_dir_with_pcb_toml() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().to_path_buf();
+
+        let other = root.join("other");
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(other.join("pcb.toml"), "").unwrap();
+
+        let ws = WorkspaceInfo {
+            root: root.clone(),
+            config: None,
+            packages: BTreeMap::new(),
+            lockfile: None,
+            errors: vec![],
+        };
+
+        let scope = detect_update_scope(&ws, &other);
+        assert!(matches!(scope, UpdateScope::Workspace));
+    }
 }

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -389,12 +389,19 @@ Updates dependencies to newer versions.
 
 ```bash
 pcb update                   # Update all dependencies
-pcb update stdlib            # Update specific package
+pcb update -p diodeinc       # Update deps matching a substring (workspace-wide)
+pcb update path/to/package   # Update only that workspace member package
 ```
 
 Non-breaking updates (within the same semver family) are applied automatically.
 Breaking updates are shown separately, and you can interactively select which
 ones to apply.
+
+If the `path` argument points at a workspace member package directory (a directory
+containing a `pcb.toml` that is also listed as a workspace member), `pcb update`
+limits updates to that single package's direct dependencies:
+- Auto-applies patch bumps only
+- Prompts only for breaking bumps
 
 ### pcb publish
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dependency update behavior based on the provided path, which can alter which manifests get rewritten and which versions are auto-applied; adds new scoping/policy logic but is covered by unit tests and docs updates.
> 
> **Overview**
> `pcb update <path>` now detects when `<path>` points to a workspace member package directory and **limits dependency updates to that package’s `pcb.toml`** (printing the scoped target).
> 
> When package-scoped, non-breaking auto-updates are tightened to **patch-only** bumps (same major+minor), while workspace-wide updates keep the prior semver-family auto-update behavior; breaking updates remain interactive. Documentation and changelog are updated, and unit tests cover scope detection and patch-bump logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5c4be387a80809b2047b50fb85cf6437284157. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->