### PR TITLE
Nuke physical ranges

### DIFF
--- a/crates/pcb-docgen/src/parser.rs
+++ b/crates/pcb-docgen/src/parser.rs
@@ -168,10 +168,6 @@ fn extract_types_and_constants(
                             name: name.clone(),
                             kind: "PhysicalValue".to_string(),
                         }),
-                        "builtin.physical_range" => types.push(TypeDoc {
-                            name: name.clone(),
-                            kind: "PhysicalValue".to_string(),
-                        }),
                         _ => {
                             if is_constant_name(&name) {
                                 constants.push(ConstDoc { name: name.clone() });

--- a/crates/pcb-layout/tests/resources/complex/Board.zen
+++ b/crates/pcb-layout/tests/resources/complex/Board.zen
@@ -1,4 +1,4 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
 MyModule = Module("Module.zen")
 
@@ -11,4 +11,4 @@ MyModule(name = "M1", P1 = P1, P2 = P2)
 
 MyModule(name = "M2", P1 = P3, P2 = P4)
 
-Layout(name = "Board", path = "build/layout")
+Layout(name = "Board", path = "build/layout", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/complex/Module.zen
+++ b/crates/pcb-layout/tests/resources/complex/Module.zen
@@ -1,4 +1,4 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
 Submodule = Module("Submodule.zen")
 
@@ -17,4 +17,4 @@ Submodule(
     P2 = P2,
 )
 
-Layout(name = "Module", path = "module")
+Layout(name = "Module", path = "module", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/complex/Submodule.zen
+++ b/crates/pcb-layout/tests/resources/complex/Submodule.zen
@@ -1,6 +1,6 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
-Resistor = Module("@stdlib:v0.3.4/generics/Resistor.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
 
 P1 = io("P1", Net)
 P2 = io("P2", Net)
@@ -21,4 +21,4 @@ Resistor(
     P2 = P2,
 )
 
-Layout(name = "Submodule", path = "submodule/")
+Layout(name = "Submodule", path = "submodule/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/component_side_sync/Board.zen
+++ b/crates/pcb-layout/tests/resources/component_side_sync/Board.zen
@@ -1,7 +1,7 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
 MyModule = Module("Module.zen")
 
 MyModule(name = "MyModule")
 
-Layout(name = "Board", path = "build/layout/")
+Layout(name = "Board", path = "build/layout/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/component_side_sync/Module.zen
+++ b/crates/pcb-layout/tests/resources/component_side_sync/Module.zen
@@ -1,6 +1,6 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
-Resistor = Module("@stdlib:v0.3.4/generics/Resistor.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
 
 P1 = Net("P1")
 P2 = Net("P2")
@@ -37,4 +37,4 @@ Resistor(
     P2 = P2,
 )
 
-Layout(name = "Module", path = "module/")
+Layout(name = "Module", path = "module/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/dnp/MyBoard.zen
+++ b/crates/pcb-layout/tests/resources/dnp/MyBoard.zen
@@ -1,4 +1,4 @@
-Resistor = Module("@stdlib:v0.3.4/generics/Resistor.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
 
 P1 = Net("P1")
 P2 = Net("P2")

--- a/crates/pcb-layout/tests/resources/fpid_change/Board.zen
+++ b/crates/pcb-layout/tests/resources/fpid_change/Board.zen
@@ -14,4 +14,4 @@ Resistor(
     value = "10k",
 )
 
-Layout(name = "Board", path = "build/")
+Layout(name = "Board", path = "build/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/fpid_change/Board_0603.zen
+++ b/crates/pcb-layout/tests/resources/fpid_change/Board_0603.zen
@@ -14,4 +14,4 @@ Resistor(
     value = "10k",
 )
 
-Layout(name = "Board", path = "build/")
+Layout(name = "Board", path = "build/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/graphics/Board.zen
+++ b/crates/pcb-layout/tests/resources/graphics/Board.zen
@@ -1,4 +1,4 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
 Graphics = Module("Module.zen")
 
@@ -8,4 +8,4 @@ P2 = Net("BOARD_TWO")
 Graphics(name = "G1", P1 = P1, P2 = P2)
 Graphics(name = "G2", P1 = P1, P2 = P2)
 
-Layout(name = "Board", path = "build/layout/")
+Layout(name = "Board", path = "build/layout/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/graphics/Module.zen
+++ b/crates/pcb-layout/tests/resources/graphics/Module.zen
@@ -1,6 +1,6 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
-Resistor = Module("@stdlib:v0.3.4/generics/Resistor.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
 
 P1 = io("P1", Net)
 P2 = io("P2", Net)
@@ -13,4 +13,4 @@ Resistor(
     P2 = P2,
 )
 
-Layout(name = "Module", path = "module/")
+Layout(name = "Module", path = "module/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/module_layout/Module.zen
+++ b/crates/pcb-layout/tests/resources/module_layout/Module.zen
@@ -1,4 +1,4 @@
-Capacitor = Module("@stdlib:v0.3.8/generics/Capacitor.zen")
+Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 # Define module inputs/outputs
 power = io("power", Net)

--- a/crates/pcb-layout/tests/resources/moved/Board.zen
+++ b/crates/pcb-layout/tests/resources/moved/Board.zen
@@ -15,4 +15,4 @@ Resistor(
     value = "10k",
 )
 
-Layout(name = "Board", path = "build/")
+Layout(name = "Board", path = "build/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/moved/Board_renamed.zen
+++ b/crates/pcb-layout/tests/resources/moved/Board_renamed.zen
@@ -18,4 +18,4 @@ Resistor(
     value = "10k",
 )
 
-Layout(name = "Board", path = "build/")
+Layout(name = "Board", path = "build/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/netclass_assignment/diffpair_module.zen
+++ b/crates/pcb-layout/tests/resources/netclass_assignment/diffpair_module.zen
@@ -1,4 +1,4 @@
-load("@stdlib:v0.3.4/interfaces.zen", "DiffPair")
+load("@stdlib/interfaces.zen", "DiffPair")
 
 # Accept DiffPair interface as input
 signal = io("signal", DiffPair)

--- a/crates/pcb-layout/tests/resources/netclass_assignment/netclass.zen
+++ b/crates/pcb-layout/tests/resources/netclass_assignment/netclass.zen
@@ -1,6 +1,6 @@
-load("@stdlib:v0.3.4/board_config.zen", "Board")
-load("@stdlib:v0.3.4/units.zen", "Impedance")
-load("@stdlib:v0.3.4/interfaces.zen", "Usb2", "DiffPair")
+load("@stdlib/board_config.zen", "Board")
+load("@stdlib/units.zen", "Impedance")
+load("@stdlib/interfaces.zen", "Usb2", "DiffPair")
 
 # Test case 1: Single-ended 50Ω impedance → should match "50Ohm SE"
 clk_50 = Net("CLK_50", impedance=Impedance(50))
@@ -66,4 +66,5 @@ Board(
     name="netclass_test",
     layout_path="module/",
     layers=4,
+    bom_profile=None,
 )

--- a/crates/pcb-layout/tests/resources/netclass_assignment/usb_module.zen
+++ b/crates/pcb-layout/tests/resources/netclass_assignment/usb_module.zen
@@ -1,4 +1,4 @@
-load("@stdlib:v0.3.4/interfaces.zen", "Usb2")
+load("@stdlib/interfaces.zen", "Usb2")
 
 # Accept Usb2 interface as input
 # When parent passes a Usb2 with DiffPair(impedance=90Ω) to this module,

--- a/crates/pcb-layout/tests/resources/not_connected/Board.zen
+++ b/crates/pcb-layout/tests/resources/not_connected/Board.zen
@@ -1,6 +1,6 @@
 load("@stdlib/interfaces.zen", "Power", "Ground", "NotConnected")
 
-Resistor = Module("@stdlib:v0.3.4/generics/Resistor.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
 
 # Regular nets
 vcc = Power("VCC")

--- a/crates/pcb-layout/tests/resources/tracks/Board.zen
+++ b/crates/pcb-layout/tests/resources/tracks/Board.zen
@@ -1,4 +1,4 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
 M = Module("Module.zen")
 
@@ -8,4 +8,4 @@ P2 = Net("BOARD_TWO")
 M(name = "M1", P1 = P1, P2 = P2)
 M(name = "M2", P1 = P1, P2 = P2)
 
-Layout(name = "Board", path = "build/layout/")
+Layout(name = "Board", path = "build/layout/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/tracks/Module.zen
+++ b/crates/pcb-layout/tests/resources/tracks/Module.zen
@@ -1,6 +1,6 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
-Resistor = Module("@stdlib:v0.3.4/generics/Resistor.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
 
 P1 = io("P1", Net)
 P2 = io("P2", Net)
@@ -21,4 +21,4 @@ Resistor(
     P2 = P2,
 )
 
-Layout(name = "Module", path = "module/")
+Layout(name = "Module", path = "module/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/zones/Board.zen
+++ b/crates/pcb-layout/tests/resources/zones/Board.zen
@@ -1,4 +1,4 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
 MyModule = Module("Module.zen")
 
@@ -7,4 +7,4 @@ P2 = Net("BOARD_TWO")
 
 MyModule(name = "MyModule", P1 = P1, P2 = P2)
 
-Layout(name = "Board", path = "build/layout/")
+Layout(name = "Board", path = "build/layout/", bom_profile=None)

--- a/crates/pcb-layout/tests/resources/zones/Module.zen
+++ b/crates/pcb-layout/tests/resources/zones/Module.zen
@@ -1,6 +1,6 @@
-load("@stdlib:v0.3.4/properties.zen", "Layout")
+load("@stdlib/properties.zen", "Layout")
 
-Resistor = Module("@stdlib:v0.3.4/generics/Resistor.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
 
 P1 = io("P1", Net)
 P2 = io("P2", Net)
@@ -21,4 +21,4 @@ Resistor(
     P2 = P2,
 )
 
-Layout(name = "Module", path = "module/")
+Layout(name = "Module", path = "module/", bom_profile=None)

--- a/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step1.log.snap
+++ b/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step1.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/fpid_change.rs
+assertion_line: 61
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -19,12 +20,12 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=ERJ-2RKF1002X fpid=R_0402_1005Metric:R_0402_1005Metric fields=["Alternatives={\"mpn\": \"ERJ-PA2F1002X\", \"manufacturer\": \"Panasonic Electronic Components\"},{\"mpn\": \"0402WGF1002TCE\", \"manufacturer\": \"Panasonic Electronic Components\"}", "Manufacturer=Panasonic Electronic Components", "Matcher=assign_house_resistor", "Mpn=ERJ-2RKF1002X", "Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=R_0402_1005Metric:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=R_0402_1005Metric:R_0402_1005Metric value=ERJ-2RKF1002X x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=R_0402_1005Metric:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu
 INFO: Added footprint: R1.R
 INFO: HierPlace: placed 1 items
-INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=R_0402_1005Metric:R_0402_1005Metric value=ERJ-2RKF1002X x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=R_0402_1005Metric:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG PLACE_FP path=R1.R x=147545000 y=104505000 w=1910000 h=990000

--- a/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step2.log.snap
+++ b/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step2.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/fpid_change.rs
+assertion_line: 121
 expression: content
 ---
 INFO: Parsing JSON netlist from <TEMP_DIR>
@@ -17,18 +18,18 @@ INFO: Starting ImportNetlist...
 INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
-INFO: OLD FPV path=R1.R ref=R1 value=ERJ-2RKF1002X fpid=R_0402_1005Metric:R_0402_1005Metric fields=["Alternatives={\"mpn\": \"ERJ-PA2F1002X\", \"manufacturer\": \"Panasonic Electronic Components\"},{\"mpn\": \"0402WGF1002TCE\", \"manufacturer\": \"Panasonic Electronic Components\"}", "Manufacturer=Panasonic Electronic Components", "Matcher=assign_house_resistor", "Mpn=ERJ-2RKF1002X", "Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
+INFO: OLD FPV path=R1.R ref=R1 value=10k fpid=R_0402_1005Metric:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
 INFO: OLD FPC path=R1.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103830000 val_x=148500000 val_y=106170000
 INFO: Changes: +1 -1 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=ERJ-3EKF1002V fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Alternatives={\"mpn\": \"ERJ-PA3F1002V\", \"manufacturer\": \"Panasonic Electronic Components\"}", "Manufacturer=Panasonic Electronic Components", "Matcher=assign_house_resistor", "Mpn=ERJ-3EKF1002V", "Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=ERJ-3EKF1002V x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
 INFO: CHANGESET FP_REMOVE path=R1.R fpid=R_0402_1005Metric:R_0402_1005Metric x=148500000 y=105000000 orient=0.0 layer=F.Cu
 INFO: Removed footprint: R1.R
 INFO: Added footprint: R1.R
 INFO: HierPlace: placed 1 items
 INFO: OPLOG FP_REMOVE path=R1.R
-INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=ERJ-3EKF1002V x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG PLACE_FP_INHERIT path=R1.R x=148500000 y=105000000 old_fpid=R_0402_1005Metric:R_0402_1005Metric new_fpid=R_0603_1608Metric:R_0603_1608Metric
 INFO: Sync completed in X.XXXs
 INFO: Lens sync complete: +1 -1 footprints

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 99
 expression: content
 ---
 {

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 99
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -32,14 +33,14 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 8 footprints, 6 groups, 4 nets
 INFO: Changes: +8 -0 footprints
-INFO: NEW FPV path=M1.S1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S1.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S2.R1.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S2.R2.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S1.R1.R ref=R5 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S1.R2.R ref=R6 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S2.R1.R ref=R7 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S2.R2.R ref=R8 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M1.S1.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M1.S2.R1.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M1.S2.R2.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M2.S1.R1.R ref=R5 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M2.S1.R2.R ref=R6 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M2.S2.R1.R ref=R7 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M2.S2.R2.R ref=R8 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
 INFO: NEW GRV path=M1 members=[M1.S1.R1.R, M1.S1.R2.R, M1.S2.R1.R, M1.S2.R2.R] layout=module
 INFO: NEW GRV path=M1.S1 members=[M1.S1.R1.R, M1.S1.R2.R] layout=submodule
 INFO: NEW GRV path=M1.S2 members=[M1.S2.R1.R, M1.S2.R2.R] layout=submodule

--- a/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.layout.json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 87
 expression: content
 ---
 {

--- a/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 87
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -23,10 +24,10 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 1 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R3.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R4.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=MyModule.R3.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=MyModule.R4.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
 INFO: NEW GRV path=MyModule members=[MyModule.R1.R, MyModule.R2.R, MyModule.R3.R, MyModule.R4.R] layout=module
 INFO: NEW FPC path=MyModule.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R2.R x=0 y=0 orient=0.0 layer=F.Cu

--- a/crates/pcb-layout/tests/snapshots/layout_generation__dnp.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__dnp.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 91
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -22,10 +23,10 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 0 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=dnp.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric dnp=true fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=exclude_from_bom.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric bom=false pos=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=exclude_from_bom_and_dnp.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric dnp=true bom=false pos=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=normal.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=dnp.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric dnp=true fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=exclude_from_bom.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=exclude_from_bom_and_dnp.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric dnp=true bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=normal.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
 INFO: NEW FPC path=dnp.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=exclude_from_bom.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=exclude_from_bom_and_dnp.R x=0 y=0 orient=0.0 layer=F.Cu

--- a/crates/pcb-layout/tests/snapshots/layout_generation__graphics.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__graphics.layout.json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 97
 expression: content
 ---
 {

--- a/crates/pcb-layout/tests/snapshots/layout_generation__graphics.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__graphics.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 97
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -22,8 +23,8 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 2 groups, 2 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=G1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=G2.R1.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=G1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=G2.R1.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
 INFO: NEW GRV path=G1 members=[G1.R1.R] layout=module
 INFO: NEW GRV path=G2 members=[G2.R1.R] layout=module
 INFO: NEW FPC path=G1.R1.R x=0 y=0 orient=0.0 layer=F.Cu

--- a/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 101
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -23,7 +24,7 @@ INFO: Updated minimum uvia diameter: 0.200mm -> 0.15mm
 DEBUG: minimum uvia hole unchanged: 0.1mm
 INFO: Updated silkscreen minimum item clearance: 0.000mm -> 0.1mm
 INFO: Updating track width list: 5 widths
-INFO: Updating via dimensions list: 2 dimensions
+INFO: Updating via dimensions list: 5 dimensions
 DEBUG: Netclass names differ - desired: ['100Ohm Diff', '50Ohm SE', '85Ohm Diff', '90Ohm Diff', 'Default'], existing: []
 INFO: Updating netclasses: 5 netclasses
 INFO: Completed SetupBoard in X.XXX seconds

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 103
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -20,8 +21,8 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 0 groups, 3 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
-INFO: NEW FPV path=R2.R ref=R2 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=R2.R ref=R2 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=R2.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 95
 expression: content
 ---
 {

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 95
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -24,10 +25,10 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 2 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=M1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.R1.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.R2.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M1.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M2.R1.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=M2.R2.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
 INFO: NEW GRV path=M1 members=[M1.R1.R, M1.R2.R] layout=module
 INFO: NEW GRV path=M2 members=[M2.R1.R, M2.R2.R] layout=module
 INFO: NEW FPC path=M1.R1.R x=0 y=0 orient=0.0 layer=F.Cu

--- a/crates/pcb-layout/tests/snapshots/layout_generation__zones.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__zones.layout.json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 93
 expression: content
 ---
 {

--- a/crates/pcb-layout/tests/snapshots/layout_generation__zones.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__zones.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
+assertion_line: 93
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -21,8 +22,8 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 1 groups, 2 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor", "Voltage=None"]
 INFO: NEW GRV path=MyModule members=[MyModule.R1.R, MyModule.R2.R] layout=module
 INFO: NEW FPC path=MyModule.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R2.R x=0 y=0 orient=0.0 layer=F.Cu

--- a/crates/pcb-layout/tests/snapshots/moved__moved_step1.log.snap
+++ b/crates/pcb-layout/tests/snapshots/moved__moved_step1.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/moved.rs
+assertion_line: 71
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -19,12 +20,12 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
-INFO: NEW FPV path=OldModule.R ref=R1 value=ERJ-3EKF1002V fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Alternatives={\"mpn\": \"ERJ-PA3F1002V\", \"manufacturer\": \"Panasonic Electronic Components\"}", "Manufacturer=Panasonic Electronic Components", "Matcher=assign_house_resistor", "Mpn=ERJ-3EKF1002V", "Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=OldModule.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
 INFO: NEW FPC path=OldModule.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=OldModule.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=ERJ-3EKF1002V x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=OldModule.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
 INFO: Added footprint: OldModule.R
 INFO: HierPlace: placed 1 items
-INFO: OPLOG FP_ADD path=OldModule.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=ERJ-3EKF1002V x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=OldModule.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG PLACE_FP path=OldModule.R x=146995000 y=104245000 w=3010000 h=1510000

--- a/crates/pcb-layout/tests/snapshots/moved__moved_step2.log.snap
+++ b/crates/pcb-layout/tests/snapshots/moved__moved_step2.log.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-layout/tests/moved.rs
+assertion_line: 134
 expression: content
 ---
 INFO: Parsing JSON netlist from <TEMP_DIR>
@@ -17,10 +18,10 @@ INFO: Starting ImportNetlist...
 INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
-INFO: OLD FPV path=NewModule.R ref=R1 value=ERJ-3EKF1002V fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Alternatives={\"mpn\": \"ERJ-PA3F1002V\", \"manufacturer\": \"Panasonic Electronic Components\"}", "Manufacturer=Panasonic Electronic Components", "Matcher=assign_house_resistor", "Mpn=ERJ-3EKF1002V", "Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
+INFO: OLD FPV path=NewModule.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
 INFO: OLD FPC path=NewModule.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103570000 val_x=148500000 val_y=106430000
 INFO: Changes: +0 -0 footprints
-INFO: NEW FPV path=NewModule.R ref=R1 value=ERJ-3EKF1002V fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Alternatives={\"mpn\": \"ERJ-PA3F1002V\", \"manufacturer\": \"Panasonic Electronic Components\"}", "Manufacturer=Panasonic Electronic Components", "Matcher=assign_house_resistor", "Mpn=ERJ-3EKF1002V", "Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
+INFO: NEW FPV path=NewModule.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor", "Voltage=None"]
 INFO: NEW FPC path=NewModule.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103570000 val_x=148500000 val_y=106430000
 INFO: Sync completed in X.XXXs
 INFO: Lens sync complete: +0 -0 footprints

--- a/crates/pcb-sch/src/physical.rs
+++ b/crates/pcb-sch/src/physical.rs
@@ -3518,7 +3518,7 @@ mod tests {
             .unwrap());
     }
 
-    // Helper for creating PhysicalValue from bounds (replaces old physical_range)
+    // Helper for creating PhysicalValue from explicit bounds
     #[cfg(test)]
     fn physical_value_bounds(min: f64, max: f64, unit: PhysicalUnit) -> PhysicalValue {
         PhysicalValue::from_bounds(

--- a/crates/pcb-sch/test/kicad-bom.zen
+++ b/crates/pcb-sch/test/kicad-bom.zen
@@ -3,4 +3,5 @@ load("@stdlib/properties.zen", "Layout")
 Layout(
     name = "kicad-bom",
     path = "kicad-bom",
+    bom_profile=None,
 )

--- a/crates/pcb-zen-core/src/lang/builtin.rs
+++ b/crates/pcb-zen-core/src/lang/builtin.rs
@@ -199,24 +199,6 @@ fn builtin_methods(methods: &mut MethodsBuilder) {
         }
     }
 
-    /// Backwards compatibility alias for physical_value (used by stdlib)
-    fn physical_range(
-        #[allow(unused_variables)] this: &Builtin,
-        unit: NoneOr<String>,
-    ) -> starlark::Result<PhysicalValueType> {
-        match unit {
-            NoneOr::Other(u) => {
-                let unit: pcb_sch::PhysicalUnit = u.parse().map_err(|err| {
-                    Error::new_other(anyhow::anyhow!("Failed to parse unit: {}", err))
-                })?;
-                Ok(PhysicalValueType::new(unit.into()))
-            }
-            NoneOr::None => Ok(PhysicalValueType::new(
-                pcb_sch::physical::PhysicalUnitDims::DIMENSIONLESS,
-            )),
-        }
-    }
-
     fn net_type<'v>(
         #[allow(unused_variables)] this: &Builtin,
         name: String,

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -700,14 +700,14 @@ snapshot_eval!(config_string_to_physical_value, {
     "#
 });
 
-snapshot_eval!(config_string_to_physical_range, {
+snapshot_eval!(config_string_to_physical_value_with_bounds, {
     "types.zen" => r#"
-        VoltageRange = builtin.physical_range("V")
+        Voltage = builtin.physical_value("V")
     "#,
     "child.zen" => r#"
-        load("types.zen", "VoltageRange")
+        load("types.zen", "Voltage")
 
-        voltage = config("voltage", VoltageRange)
+        voltage = config("voltage", Voltage)
 
         print("voltage:", voltage)
     "#,
@@ -716,6 +716,6 @@ snapshot_eval!(config_string_to_physical_range, {
 
         Child(name = "test", voltage = "3.0V to 3.6V")
 
-        print("String to PhysicalRange conversion: success")
+        print("String to PhysicalValue (bounds) conversion: success")
     "#
 });

--- a/crates/pcb-zen-core/tests/snapshots/input__config_string_to_physical_value_with_bounds.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_string_to_physical_value_with_bounds.snap
@@ -2,7 +2,7 @@
 source: crates/pcb-zen-core/tests/input.rs
 expression: output
 ---
-String to PhysicalRange conversion: success
+String to PhysicalValue (bounds) conversion: success
 {
     <root>: Module {
         path: <root>,

--- a/crates/pcb-zen/tests/module_loading.rs
+++ b/crates/pcb-zen/tests/module_loading.rs
@@ -203,7 +203,7 @@ fn module_with_stdlib_alias() {
         "test.zen",
         r#"
 # Test that Module() can resolve @stdlib imports (using units as an example)
-Units = Module("@stdlib:v0.2.10/units.zen")
+Units = Module("@stdlib/units.zen")
 
 # We don't instantiate Units since it's just definitions,
 # but the Module() call should resolve correctly

--- a/crates/pcb-zen/tests/snapshots/test_physical__physical_types.snap
+++ b/crates/pcb-zen/tests/snapshots/test_physical__physical_types.snap
@@ -21,7 +21,7 @@ d.unit:
 builtin.Voltage(1.5): VoltageType
 
 --- PhysicalValue with bounds ---
-range has abs: True
-range min/max: 11–26V (18.5V nom.)
-range with nominal: 11–26V (16V nom.)
-range override nominal: 11–26V (16V nom.)
+bounded has abs: True
+bounded min/max: 11–26V (18.5V nom.)
+bounded with nominal: 11–26V (16V nom.)
+bounded override nominal: 11–26V (16V nom.)

--- a/crates/pcb-zen/tests/spice_model.rs
+++ b/crates/pcb-zen/tests/spice_model.rs
@@ -65,10 +65,10 @@ R1 p n {RVAL}
     env.add_file(
         "myresistor.zen",
         r#"
-load("@stdlib:v0.3.20/generics/SolderJumper.zen", "pin_defs")
-load("@stdlib:v0.3.20/config.zen", "config_properties", "config_unit")
-load("@stdlib:v0.3.20/units.zen", "Resistance", "Voltage")
-load("@stdlib:v0.3.20/utils.zen", "format_value")
+load("@stdlib/generics/SolderJumper.zen", "pin_defs")
+load("@stdlib/config.zen", "config_properties", "config_unit")
+load("@stdlib/units.zen", "Resistance", "Voltage")
+load("@stdlib/utils.zen", "format_value")
 
 # -----------------------------------------------------------------------------
 # Component types
@@ -126,7 +126,7 @@ Component(
     env.add_file(
         "divider.zen",
         r#"
-load("@stdlib:v0.3.20/interfaces.zen", "Power", "Ground", "Analog")
+load("@stdlib/interfaces.zen", "Power", "Ground", "Analog")
 Resistor = Module("myresistor.zen")
 
 # Configuration parameters

--- a/crates/pcb-zen/tests/test_physical.rs
+++ b/crates/pcb-zen/tests/test_physical.rs
@@ -9,7 +9,7 @@ fn test_physical_types() {
     env.add_file(
         "test_physical.zen",
         r#"
-load("@stdlib:v0.3.20/units.zen", "Voltage", "VoltageRange", "Frequency")
+load("@stdlib/units.zen", "Voltage", "Frequency")
 
 print("--- PhysicalValue ---")
 # Test PhysicalValue.abs() exists and works
@@ -39,12 +39,11 @@ print("d.unit:", d.unit)
 print("builtin.Voltage(1.5):", builtin.Voltage(1.5))
 
 print("\n--- PhysicalValue with bounds ---")
-# Test PhysicalValue with bounds (formerly PhysicalRange) now has abs()
-r1 = VoltageRange("1V to 3V")
-print("range has abs:", hasattr(r1, "abs"))
-print("range min/max:", VoltageRange(min=11, max=26))
-print("range with nominal:", VoltageRange(min=11, max=26, nominal=16))
-print("range override nominal:", VoltageRange("11–26V", nominal="16V"))
+r1 = Voltage("1V to 3V")
+print("bounded has abs:", hasattr(r1, "abs"))
+print("bounded min/max:", Voltage(min=11, max=26))
+print("bounded with nominal:", Voltage(min=11, max=26, nominal=16))
+print("bounded override nominal:", Voltage("11–26V", nominal="16V"))
 
 # We need to define a dummy module/component to satisfy the runner
 Component(

--- a/crates/pcb-zen/tests/test_physical_constructor_casting.rs
+++ b/crates/pcb-zen/tests/test_physical_constructor_casting.rs
@@ -9,7 +9,7 @@ fn test_unit_constructor_casts_from_other_physical_value() {
     env.add_file(
         "cast_ok.zen",
         r#"
-load("@stdlib:v0.3.20/units.zen", "Voltage", "Resistance")
+load("@stdlib/units.zen", "Voltage", "Resistance")
 
 v = Voltage("3.3V")
 r = Resistance(v)  # Cast/re-tag Voltage -> Resistance
@@ -44,7 +44,7 @@ fn test_unit_constructor_rejects_mismatched_unit_string() {
     env.add_file(
         "cast_err.zen",
         r#"
-load("@stdlib:v0.3.20/units.zen", "Resistance")
+load("@stdlib/units.zen", "Resistance")
 
 # Explicit unit strings must match the constructor unit.
 Resistance("3.3V")

--- a/crates/pcb-zen/tests/test_physical_negative_tolerance.rs
+++ b/crates/pcb-zen/tests/test_physical_negative_tolerance.rs
@@ -21,7 +21,7 @@ fn test_negative_tolerance_rejected_numeric() {
     env.add_file(
         "neg_tol_numeric.zen",
         r#"
-load("@stdlib:v0.3.20/units.zen", "Voltage")
+load("@stdlib/units.zen", "Voltage")
 
 Voltage("3.3V").with_tolerance(-0.05)
 "#,
@@ -35,7 +35,7 @@ fn test_negative_tolerance_rejected_percent_string() {
     env.add_file(
         "neg_tol_string.zen",
         r#"
-load("@stdlib:v0.3.20/units.zen", "Voltage")
+load("@stdlib/units.zen", "Voltage")
 
 Voltage("3.3V").with_tolerance("-5%")
 "#,
@@ -49,7 +49,7 @@ fn test_negative_tolerance_rejected_in_constructor_kwarg() {
     env.add_file(
         "neg_tol_ctor.zen",
         r#"
-load("@stdlib:v0.3.20/units.zen", "Voltage")
+load("@stdlib/units.zen", "Voltage")
 
 Voltage("3.3V", tolerance=-0.05)
 "#,
@@ -63,7 +63,7 @@ fn test_negative_tolerance_rejected_in_parsed_string() {
     env.add_file(
         "neg_tol_parse.zen",
         r#"
-load("@stdlib:v0.3.20/units.zen", "Voltage")
+load("@stdlib/units.zen", "Voltage")
 
 Voltage("3.3V -5%")
 "#,

--- a/crates/pcb/tests/info.rs
+++ b/crates/pcb/tests/info.rs
@@ -40,7 +40,7 @@ description = "Special custom board with unique features"
 "#;
 
 const TEST_BOARD_ZEN: &str = r#"
-load("@stdlib:v0.2.10/interfaces.zen", "Gpio", "Ground", "Power")
+load("@stdlib/interfaces.zen", "Gpio", "Ground", "Power")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")

--- a/crates/pcb/tests/simple.rs
+++ b/crates/pcb/tests/simple.rs
@@ -52,7 +52,7 @@ Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 =
 "#;
 
 const SIMPLE_BOARD_ZEN: &str = r#"
-load("@stdlib:v0.2.10/interfaces.zen", "Gpio", "Ground", "Power")
+load("@stdlib/interfaces.zen", "Gpio", "Ground", "Power")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
@@ -127,7 +127,7 @@ fn test_pcb_build_should_fail_without_fixture() {
 #[cfg(not(target_os = "windows"))]
 fn test_pcb_build_simple_board() {
     let output = Sandbox::new()
-        .seed_stdlib(&["v0.2.10"])
+        .seed_stdlib(&["v0.5.5"])
         .seed_kicad(&["9.0.0"])
         .write("boards/SimpleBoard.zen", SIMPLE_BOARD_ZEN)
         .snapshot_run("pcb", ["build", "boards/SimpleBoard.zen"]);

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -147,7 +147,7 @@ See [Packages](/pages/packages) for the complete manifest reference.
 
 ### Net
 
-A `Net` represents an electrical connection between component pins. Nets can optionally specify electrical properties like impedance, voltage range, and schematic symbols.
+A `Net` represents an electrical connection between component pins. Nets can optionally specify electrical properties like impedance, voltage bounds, and schematic symbols.
 
 ```python
 # Create a net with optional name
@@ -158,9 +158,9 @@ net2 = Net("VCC")
 load("@stdlib/units.zen", "Impedance")
 clk = Net("CLK", impedance=Impedance(50))  # 50Ω single-ended
 
-# Net with voltage range
-load("@stdlib/units.zen", "VoltageRange")
-vdd = Net("VDD_3V3", voltage=VoltageRange("3.0V to 3.6V"))  # VoltageRange is an alias of Voltage
+# Net with voltage bounds
+load("@stdlib/units.zen", "Voltage")
+vdd = Net("VDD_3V3", voltage=Voltage("3.0V to 3.6V"))
 
 # Net with custom schematic symbol
 vcc_sym = Symbol(library="@kicad-symbols/power.kicad_sym", name="VCC")
@@ -172,7 +172,7 @@ vcc = Net("VCC", symbol=vcc_sym)
 
 - `name` (optional): String identifier for the net
 - `symbol` (optional): Symbol object for schematic representation
-- `voltage` (optional): Voltage (or VoltageRange alias) specification for the net
+- `voltage` (optional): Voltage specification for the net
 - `impedance` (optional): Impedance specification for single-ended nets (in Ohms)
 
 ### Symbol
@@ -351,7 +351,8 @@ system = SystemInterface("MAIN", debug=True)
 Note: `Power` and `Ground` are net types from `@stdlib/interfaces.zen`, not interfaces. Use them like:
 ```python
 load("@stdlib/interfaces.zen", "Power", "Ground")
-vcc = Power("VCC_3V3", voltage=VoltageRange("3.3V"))
+load("@stdlib/units.zen", "Voltage")
+vcc = Power("VCC_3V3", voltage=Voltage("3.3V"))
 gnd = Ground("GND")
 ```
 
@@ -415,9 +416,6 @@ resistance = Voltage("5V") / Current("100mA")  # 50Ω
 - Point values (`min == nominal == max`) format as a single value (e.g., `"3.3V"`, `"4.7k"`)
 - Symmetric tolerances (clean percent) format as `"nominal <percent>%"` (e.g., `"10k 5%"`, `"1MHz 0.1%"`)
 - Other bounded values format as an explicit range with nominal (e.g., `"11–26V (16V nom.)"`)
-
-**Range aliases**:
-- `VoltageRange`, `CurrentRange`, etc. are aliases of `Voltage`, `Current`, etc. (same type, same behavior)
 
 ### builtin.physical_value()
 
@@ -542,15 +540,6 @@ Voltage("1.1–3.6V")
 Voltage("11V to 26V")
 Voltage("11–26V (12V)")
 Voltage("15V 10%")  # Expands to 13.5–16.5 V
-```
-
-### builtin.physical_range()
-
-**Backwards-compatibility alias** for `builtin.physical_value()`. Range constructors like `VoltageRange` return the same `PhysicalValue` type as `Voltage`.
-
-```python
-VoltageRange = builtin.physical_range("V")
-value = VoltageRange("1V to 2V")  # Same PhysicalValue type as Voltage(...)
 ```
 
 ### builtin.add_board_config()

--- a/examples/power_checks.zen
+++ b/examples/power_checks.zen
@@ -1,4 +1,4 @@
-VoltageRange = builtin.physical_range("V")
+load("@stdlib/units.zen", "Voltage")
 
 Severity = enum("error", "warning", "advice")
 
@@ -8,17 +8,17 @@ def ElectricalCheck(check_fn: typing.Callable, **kwargs):
 
 Power = builtin.net_type(
     "Power",
-    voltage=VoltageRange,
+    voltage=Voltage,
 )
 
 
 def check_voltage_within(
-    within: str | VoltageRange, name: str = "voltage_check", severity: Severity = Severity("error")
+    within: str | Voltage, name: str = "voltage_check", severity: Severity = Severity("error")
 ) -> typing.Callable:
-    def ensure_voltage_within(_module, net_name: str, voltage: VoltageRange, within: str | VoltageRange):
-        within = VoltageRange(within)
+    def ensure_voltage_within(_module, net_name: str, voltage: Voltage, within: str | Voltage):
+        within = Voltage(within)
         # drop nominal in within:
-        within = VoltageRange(min=within.min, max=within.max)
+        within = Voltage(min=within.min, max=within.max)
         # ensure voltage is within within
         min_valid = voltage.min >= within.min
         max_valid = voltage.max <= within.max
@@ -37,10 +37,10 @@ def check_voltage_within(
     return check_gen
 
 # Option 1: Use stdlib ElectricalCheck
-vbat = Power("VBAT", voltage=VoltageRange("11–26 V (12 V nom.)"))
+vbat = Power("VBAT", voltage=Voltage("11–26 V (12 V nom.)"))
 ElectricalCheck(
     severity=Severity("warning"),
-    check_fn=check_voltage_within(VoltageRange("20–30 V")),
+    check_fn=check_voltage_within(Voltage("20–30 V")),
     power=vbat,
 )
 

--- a/examples/units.zen
+++ b/examples/units.zen
@@ -17,16 +17,5 @@ Energy = builtin.physical_value("J")
 MagneticFlux = builtin.physical_value("Wb")
 Conductance = builtin.physical_value("S")
 
-VoltageRange = builtin.physical_range("V")
-CurrentRange = builtin.physical_range("A")
-ResistanceRange = builtin.physical_range("Ohm")
-CapacitanceRange = builtin.physical_range("F")
-InductanceRange = builtin.physical_range("H")
-FrequencyRange = builtin.physical_range("Hz")
-TemperatureRange = builtin.physical_range("K")
-TimeRange = builtin.physical_range("s")
-PowerRange = builtin.physical_range("W")
-
-
 def unit(spec, type):
     return type(spec)

--- a/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
+++ b/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
@@ -45,7 +45,7 @@ Flash(
     name="FLASH",
     VCC=vcc_3v3,
     GND=gnd,
-    HOLD=Net(),
+    HOLD=Net("HODL"),
     spi=Spi(),
     properties={
         "embed": "true",

--- a/test-workspaces/with-pcb-toml/boards/pcb.toml
+++ b/test-workspaces/with-pcb-toml/boards/pcb.toml
@@ -2,4 +2,4 @@
 name = "WorkspaceTestBoard"
 
 [dependencies]
-"github.com/diodeinc/kicad" = "0.1.2"
+"github.com/diodeinc/kicad" = "0.1.5"

--- a/test-workspaces/with-pcb-toml/pcb.sum
+++ b/test-workspaces/with-pcb-toml/pcb.sum
@@ -1,9 +1,7 @@
-github.com/diodeinc/kicad 0.1.2 h1:1/ttxxBG2Fu1YciHTblwd/iWh5BfuDoIwfpGR4TSykY=
-github.com/diodeinc/kicad 0.1.2/pcb.toml h1:tgMoqeyjDbifBj3PAXn7H3oSw4xLvlV6FB0Jp4G1Hus=
-github.com/diodeinc/stdlib 0.4.10 h1:XkpYbciIx8kNCvuV6e3UHxGUmIyqrLduOaj6q64JUeE=
-github.com/diodeinc/stdlib 0.4.10/pcb.toml h1:47E7qCZRIN1CGyQN1qtbrh7RQgTWyfgwvbhlcSpLFeQ=
-github.com/diodeinc/stdlib 0.5.2 h1:tkh2D/G7WFQYGwx9z5NapQjCGptHYKAaiSx5xtgvMpE=
-github.com/diodeinc/stdlib 0.5.2/pcb.toml h1:p7AGSnxAhTOByyaQk5BJRGFTv4TSojhTFzSHcWHX4sM=
+github.com/diodeinc/kicad 0.1.5 h1:47V6qFMRuQmMmTw4E2vZa+7JC3QDv4liaNIYyWMJtP0=
+github.com/diodeinc/kicad 0.1.5/pcb.toml h1:WJbNNnWmT1GE55n6WQytu/QDikSIOnHSheQaQLikv+c=
+github.com/diodeinc/stdlib 0.5.4 h1:LbAqHU7cetqF2uQbZYrEbgyyGM7wHjOfBu22q6aw/Ig=
+github.com/diodeinc/stdlib 0.5.4/pcb.toml h1:p7AGSnxAhTOByyaQk5BJRGFTv4TSojhTFzSHcWHX4sM=
 gitlab.com/kicad/libraries/kicad-footprints/Battery.pretty/BatteryHolder_Keystone_500.kicad_mod 9.0.3 h1:2x3MM99d54ubc6J1kTbZ6eH9LcEvLqllQyjvyzDYKB0=
 gitlab.com/kicad/libraries/kicad-footprints/Button_Switch_SMD.pretty/SW_SPST_B3U-1000P.kicad_mod 9.0.3 h1:W0npk90bmVE1xq/0aeY3CFAAXbMotC3wEc4ConXzDhE=
 gitlab.com/kicad/libraries/kicad-footprints/Button_Switch_THT.pretty/SW_PUSH_6mm.kicad_mod 9.0.3 h1:6179h4/sFBJ19neuO+ZeE7qftaq5DNsd3t987aPEaZo=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core language builtins and widespread fixtures/docs; runtime risk is mainly compatibility break for scripts using `builtin.physical_range()` and any consumers relying on older stdlib import/versioned paths.
> 
> **Overview**
> Removes the `builtin.physical_range()` backward-compatibility alias and updates Zen usage/docs/tests to use `builtin.physical_value()`/unit types (e.g., `Voltage`) for bounded values (“ranges”) instead.
> 
> Updates many `.zen` test fixtures to use unversioned `@stdlib/...` imports, adds explicit `bom_profile=None` to `Layout(...)`/`Board(...)` calls, and refreshes layout/log snapshots accordingly. Also bumps test workspace deps (`kicad` 0.1.2→0.1.5, `stdlib`→0.5.4) and makes a small fixture net rename (`HOLD` net name).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bff7ae6b1813847837cffd6a25742b5d8b1f206. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>8bff7ae</u></sup><!-- /BUGBOT_STATUS -->