### PR TITLE
Un-nuke `builtin.physical_range`

### DIFF
--- a/crates/pcb-docgen/src/parser.rs
+++ b/crates/pcb-docgen/src/parser.rs
@@ -164,10 +164,12 @@ fn extract_types_and_constants(
                             name: name.clone(),
                             kind: "net_type".to_string(),
                         }),
-                        "builtin.physical_value" => types.push(TypeDoc {
-                            name: name.clone(),
-                            kind: "PhysicalValue".to_string(),
-                        }),
+                        "builtin.physical_value" | "builtin.physical_range" => {
+                            types.push(TypeDoc {
+                                name: name.clone(),
+                                kind: "PhysicalValue".to_string(),
+                            })
+                        }
                         _ => {
                             if is_constant_name(&name) {
                                 constants.push(ConstDoc { name: name.clone() });

--- a/crates/pcb-zen/tests/test_physical_range_shim.rs
+++ b/crates/pcb-zen/tests/test_physical_range_shim.rs
@@ -1,0 +1,42 @@
+mod common;
+
+use common::TestProject;
+
+#[test]
+fn test_physical_range_shim() {
+    let env = TestProject::new();
+
+    env.add_file(
+        "test_physical_range_shim.zen",
+        r#"
+VoltageA = builtin.physical_value("V")
+VoltageB = builtin.physical_range("V")
+
+check(str(VoltageA) == str(VoltageB), "constructor types should have same display")
+
+v1 = VoltageA("3.3V")
+v2 = VoltageB("3.3V")
+check(v1.unit == v2.unit, "constructed units should match")
+check(v1.value == v2.value, "constructed values should match")
+
+v = VoltageB("3.3V")
+check(v.unit == "V", "expected V unit")
+check(v.value == 3.3, "expected value 3.3")
+
+r = VoltageB(min="1V", max="2V", nominal="1.5V")
+check(r.min == 1.0, "expected min 1.0")
+check(r.nominal == 1.5, "expected nominal 1.5")
+check(r.max == 2.0, "expected max 2.0")
+
+print("ok")
+        "#,
+    );
+
+    let result = env.eval_module("test_physical_range_shim.zen");
+    if result.output.is_none() {
+        panic!("Evaluation failed: {:?}", result.diagnostics);
+    }
+
+    let stdout = result.output.unwrap().print_output.join("\n");
+    assert!(stdout.contains("ok"));
+}

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -542,6 +542,10 @@ Voltage("11–26V (12V)")
 Voltage("15V 10%")  # Expands to 13.5–16.5 V
 ```
 
+### builtin.physical_range()
+
+Backward-compatibility alias for `builtin.physical_value()`. It returns the same `PhysicalValueType` constructor and accepts the same `unit` parameter.
+
 ### builtin.add_board_config()
 
 **Built-in function** for registering board configurations with the layout system.


### PR DESCRIPTION
Unfortunately we still need at least a shim for backcompat with old stdlib.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive backcompat change that mostly reintroduces an alias and adds tests/docs; minimal risk beyond potential name/behavior conflicts if `physical_range` was intentionally removed.
> 
> **Overview**
> Restores `builtin.physical_range()` as a backward-compatibility shim by adding a new builtin method that returns the same `PhysicalValueType` constructor as `builtin.physical_value()` (shared parsing logic extracted into `physical_value_type_from_unit`).
> 
> Updates doc generation to treat both `builtin.physical_value` and `builtin.physical_range` assignments as `PhysicalValue` types, adds a regression test ensuring both constructors behave identically, and documents `builtin.physical_range()` as an alias in the language spec.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54b3a38eda61cf6bf11c2287af529a7aa1318c9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>54b3a38</u></sup><!-- /BUGBOT_STATUS -->