### PR TITLE
Stabilize auto-named single-port `NotConnected()` net names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Stabilize auto-named single-port `NotConnected()` net names (e.g., `NC_R1_P2`) to reduce layout implicit renames.
 - Layout sync: explode single-pin multi-pad `NotConnected` nets into per-pad `unconnected-(...)` nets.
 - Accept KiCad copper role `jumper` when importing stackups.
 

--- a/crates/pcb-layout/src/scripts/lens/lens.py
+++ b/crates/pcb-layout/src/scripts/lens/lens.py
@@ -775,7 +775,7 @@ def check_lens_invariants(
         _add_diagnostic(
             "layout.sync.unknown_nets",
             "warning",
-            f"Routing references {len(unknown_nets)} unknown net(s): {sorted(unknown_nets)[:5]}... (will be fixed on apply)",
+            f"Routing references {len(unknown_nets)} unknown net(s): {sorted(unknown_nets)[:5]}...",
         )
 
 

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -175,6 +175,11 @@ vcc = Net("VCC", symbol=vcc_sym)
 - `voltage` (optional): Voltage specification for the net
 - `impedance` (optional): Impedance specification for single-ended nets (in Ohms)
 
+#### Unnamed nets
+
+- For `Net()` (and other non-`NotConnected` net types), an empty `name` is allowed but will emit a warning and the tool will assign an internal placeholder name like `N1234`.
+- For `NotConnected()` nets, omitting `name` is common. During schematic/layout generation, Zener assigns a stable, port-derived net name for single-port cases (e.g. `NC_R1_P2` for a net connected only to `R1.P2`) to keep layout sync stable. Multi-port `NotConnected` nets emit a warning.
+
 ### Symbol
 
 A `Symbol` represents a schematic symbol definition with its pins. Symbols can be created manually or loaded from KiCad symbol libraries.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core net naming in schematic conversion, which can affect downstream layout sync and any tooling depending on net names; covered by new unit/integration tests and limited to auto-named single-port `NotConnected` cases.
> 
> **Overview**
> Ensures unnamed single-port `NotConnected()` nets get a **stable, port-derived name** (e.g. `NC_R1_P2`) so schematic/layout generation no longer renames these nets when unrelated nets are added/removed.
> 
> Implements a deterministic naming helper (with sanitization and tests) in `pcb-zen-core` and adds an integration test proving stability across program variations; also tweaks a layout-sync diagnostic message to no longer claim unknown nets “will be fixed on apply”, and documents the unnamed-net behavior in the spec/changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b72d5296bc14f93c51b56a6c9f8e128c5f993af0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>b72d529</u></sup><!-- /BUGBOT_STATUS -->