### PR TITLE
Fix v2 test sandboxing, migrate more tests to v2

### DIFF
--- a/crates/pcb-zen/src/resolve_v2.rs
+++ b/crates/pcb-zen/src/resolve_v2.rs
@@ -2090,12 +2090,12 @@ fn fetch_via_git(
             }
         }
 
-        // Move subpath contents to root and clean up
+        // Move subpath contents to root and clean up the subpath root
         for entry in std::fs::read_dir(&subpath_dir)? {
             let entry = entry?;
             std::fs::rename(entry.path(), staging.join(entry.file_name()))?;
         }
-        std::fs::remove_dir_all(subpath_dir.parent().unwrap_or(&subpath_dir))?;
+        std::fs::remove_dir_all(staging.join(subpath_root))?;
     }
 
     Ok(())

--- a/crates/pcb-zen/tests/snapshots/module_loading__module_nonexistent_alias.snap
+++ b/crates/pcb-zen/tests/snapshots/module_loading__module_nonexistent_alias.snap
@@ -2,10 +2,10 @@
 source: crates/pcb-zen/tests/module_loading.rs
 expression: snapshot_output
 ---
-Error: File not found: [TEMP_DIR]does_not_exist/something.zen
+Error: File not found: [TEMP_DIR]does_not_exist.zen
    ╭─[ [TEMP_DIR]test.zen:3:17 ]
    │
- 3 │ MissingModule = Module("@missing/something.zen")
-   │                 ────────────────┬───────────────  
-   │                                 ╰───────────────── File not found: [TEMP_DIR]does_not_exist/something.zen
+ 3 │ MissingModule = Module("does_not_exist.zen")
+   │                 ──────────────┬─────────────  
+   │                               ╰─────────────── File not found: [TEMP_DIR]does_not_exist.zen
 ───╯

--- a/crates/pcb-zen/tests/snapshots/module_loading__module_with_github_package.snap
+++ b/crates/pcb-zen/tests/snapshots/module_loading__module_with_github_package.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pcb-zen/tests/module_loading.rs
-expression: netlist
+assertion_line: 177
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -9,17 +10,17 @@ expression: netlist
     (tool "pcb"))
   (components
     (comp (ref "R1")
-      (value "SMD 0402 1kOhms +/-10%")
-      (footprint "Resistor_SMD:R_0402_1005Metric")
-      (libsource (lib "lib") (part "SMD 0402 1kOhms +/-10%") (description "unknown"))
+      (value "resistor")
+      (footprint "R_0402_1005Metric:R_0402_1005Metric")
+      (libsource (lib "lib") (part "resistor") (description "unknown"))
       (sheetpath (names "R1.R") (tstamps "d527c2b8-3606-5386-bbed-5a45ed7b31a6"))
       (tstamps "d527c2b8-3606-5386-bbed-5a45ed7b31a6")
       (property (name "Reference") (value "R1"))
-      (property (name "Mount") (value "SMD"))
-      (property (name "Package") (value "0402"))
-      (property (name "Resistance") (value "1kOhms +/-10%"))
-      (property (name "Value") (value "SMD 0402 1kOhms +/-10%"))
-      (property (name "description") (value "SMD 0402 1kOhms +/-10%"))
+      (property (name "description") (value "1k"))
+      (property (name "package") (value "0402"))
+      (property (name "resistance") (value "1k"))
+      (property (name "value") (value "1k"))
+      (property (name "voltage") (value "None"))
     )
   )
   (libparts

--- a/crates/pcb/tests/bom.rs
+++ b/crates/pcb/tests/bom.rs
@@ -224,7 +224,6 @@ members = ["boards/*", "modules/*"]
 #[test]
 fn test_bom_json_format() {
     let output = Sandbox::new()
-        .allow_network()
         .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
@@ -235,7 +234,6 @@ fn test_bom_json_format() {
 #[test]
 fn test_bom_table_format() {
     let output = Sandbox::new()
-        .allow_network()
         .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
@@ -246,7 +244,6 @@ fn test_bom_table_format() {
 #[test]
 fn test_bom_default_format() {
     let output = Sandbox::new()
-        .allow_network()
         .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
         .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
@@ -257,7 +254,7 @@ fn test_bom_default_format() {
 #[test]
 fn test_bom_simple_resistors() {
     let output = Sandbox::new()
-        .allow_network()
+        .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("boards/SimpleResistors.zen", SIMPLE_RESISTOR_BOARD_ZEN)
         .snapshot_run("pcb", ["bom", "boards/SimpleResistors.zen", "-f", "json"]);
     assert_snapshot!("bom_simple_resistors_json", output);
@@ -266,7 +263,7 @@ fn test_bom_simple_resistors() {
 #[test]
 fn test_bom_simple_resistors_table() {
     let output = Sandbox::new()
-        .allow_network()
+        .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("boards/SimpleResistors.zen", SIMPLE_RESISTOR_BOARD_ZEN)
         .snapshot_run("pcb", ["bom", "boards/SimpleResistors.zen", "-f", "table"]);
     assert_snapshot!("bom_simple_resistors_table", output);
@@ -275,7 +272,7 @@ fn test_bom_simple_resistors_table() {
 #[test]
 fn test_bom_capacitors_with_dielectric() {
     let output = Sandbox::new()
-        .allow_network()
+        .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("boards/Capacitors.zen", CAPACITOR_BOARD_ZEN)
         .snapshot_run("pcb", ["bom", "boards/Capacitors.zen", "-f", "json"]);
     assert_snapshot!("bom_capacitors_json", output);
@@ -284,7 +281,7 @@ fn test_bom_capacitors_with_dielectric() {
 #[test]
 fn test_bom_capacitors_table() {
     let output = Sandbox::new()
-        .allow_network()
+        .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("boards/Capacitors.zen", CAPACITOR_BOARD_ZEN)
         .snapshot_run("pcb", ["bom", "boards/Capacitors.zen", "-f", "table"]);
     assert_snapshot!("bom_capacitors_table", output);
@@ -321,7 +318,7 @@ fn test_bom_kicad_fallback_json() {
 fn test_bom_skip_bom_filtering() {
     // Test that components with skip_bom are excluded from BOM output
     let output = Sandbox::new()
-        .allow_network()
+        .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("boards/SkipBom.zen", SKIP_BOM_BOARD_ZEN)
         .snapshot_run("pcb", ["bom", "boards/SkipBom.zen", "-f", "json"]);
     assert_snapshot!("bom_skip_bom_json", output);
@@ -331,7 +328,7 @@ fn test_bom_skip_bom_filtering() {
 fn test_bom_skip_bom_filtering_table() {
     // Test skip_bom filtering in table format
     let output = Sandbox::new()
-        .allow_network()
+        .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("boards/SkipBom.zen", SKIP_BOM_BOARD_ZEN)
         .snapshot_run("pcb", ["bom", "boards/SkipBom.zen", "-f", "table"]);
     assert_snapshot!("bom_skip_bom_table", output);
@@ -341,7 +338,7 @@ fn test_bom_skip_bom_filtering_table() {
 fn test_bom_dnp_components() {
     // Test that DNP components appear in BOM (dnp is for assembly, not procurement)
     let output = Sandbox::new()
-        .allow_network()
+        .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("boards/DnpBoard.zen", DNP_BOARD_ZEN)
         .snapshot_run("pcb", ["bom", "boards/DnpBoard.zen", "-f", "json"]);
     assert_snapshot!("bom_dnp_json", output);
@@ -351,7 +348,7 @@ fn test_bom_dnp_components() {
 fn test_bom_module_dnp_propagation() {
     // Test that module-level dnp=True propagates to all child components
     let output = Sandbox::new()
-        .allow_network()
+        .write("pcb.toml", V2_WORKSPACE_TOML)
         .write("boards/ModuleDnp.zen", MODULE_DNP_BOARD_ZEN)
         .snapshot_run("pcb", ["bom", "boards/ModuleDnp.zen", "-f", "json"]);
     assert_snapshot!("bom_module_dnp_json", output);

--- a/crates/pcb/tests/info.rs
+++ b/crates/pcb/tests/info.rs
@@ -5,12 +5,8 @@ use pcb_test_utils::sandbox::Sandbox;
 
 const WORKSPACE_PCB_TOML: &str = r#"
 [workspace]
-name = "BoardDiscoveryTest"
+pcb-version = "0.3"
 members = ["boards/*", "special/custom-board"]
-default_board = "TestBoard"
-
-[packages]
-stdlib = "@github/diodeinc/stdlib:v1.0.0"
 "#;
 
 const TEST_BOARD_PCB_TOML: &str = r#"
@@ -50,13 +46,16 @@ internal_net = Net("INTERNAL")
 
 #[test]
 fn test_pcb_info_empty_workspace() {
-    let output = Sandbox::new().snapshot_run("pcb", ["info"]);
+    let output = Sandbox::new()
+        .write("pcb.toml", V2_WORKSPACE_PCB_TOML)
+        .snapshot_run("pcb", ["info"]);
     assert_snapshot!("empty_workspace", output);
 }
 
 #[test]
 fn test_pcb_info_single_board() {
     let output = Sandbox::new()
+        .write("pcb.toml", V2_WORKSPACE_PCB_TOML)
         .write("boards/TestBoard/pcb.toml", TEST_BOARD_PCB_TOML)
         .write("boards/TestBoard/test_board.zen", TEST_BOARD_ZEN)
         .snapshot_run("pcb", ["info"]);
@@ -93,30 +92,11 @@ fn test_pcb_info_json_format() {
 #[test]
 fn test_pcb_info_with_path() {
     let output = Sandbox::new()
-        .write("subdir/pcb.toml", WORKSPACE_PCB_TOML)
+        .write("subdir/pcb.toml", V2_WORKSPACE_PCB_TOML)
         .write("subdir/boards/test-board/pcb.toml", TEST_BOARD_PCB_TOML)
         .write("subdir/boards/test-board/test_board.zen", TEST_BOARD_ZEN)
         .snapshot_run("pcb", ["info", "subdir"]);
     assert_snapshot!("with_path", output);
-}
-
-#[test]
-fn test_pcb_info_no_workspace_config() {
-    let output = Sandbox::new()
-        .write("boards/TestBoard/pcb.toml", TEST_BOARD_PCB_TOML)
-        .write("boards/TestBoard/test_board.zen", TEST_BOARD_ZEN)
-        .snapshot_run("pcb", ["info"]);
-    assert_snapshot!("no_workspace_config", output);
-}
-
-#[test]
-fn test_pcb_info_board_without_pcb_toml() {
-    let output = Sandbox::new()
-        .write("boards/BoardWithoutToml/board.zen", TEST_BOARD_ZEN)
-        .write("boards/BoardWithToml/pcb.toml", TEST_BOARD_PCB_TOML)
-        .write("boards/BoardWithToml/test_board.zen", TEST_BOARD_ZEN)
-        .snapshot_run("pcb", ["info"]);
-    assert_snapshot!("board_without_pcb_toml", output);
 }
 
 // Board config without explicit path - should discover the single .zen file
@@ -130,6 +110,7 @@ description = "Board with auto-discovered zen file"
 fn test_pcb_info_zen_discovery() {
     // Test that a single .zen file is auto-discovered when path is not specified
     let output = Sandbox::new()
+        .write("pcb.toml", V2_WORKSPACE_PCB_TOML)
         .write("boards/discovered/pcb.toml", BOARD_NO_PATH_PCB_TOML)
         .write("boards/discovered/discovered.zen", TEST_BOARD_ZEN)
         .snapshot_run("pcb", ["info"]);
@@ -140,6 +121,7 @@ fn test_pcb_info_zen_discovery() {
 fn test_pcb_info_zen_discovery_json() {
     // Test JSON output includes discovered path
     let output = Sandbox::new()
+        .write("pcb.toml", V2_WORKSPACE_PCB_TOML)
         .write("boards/discovered/pcb.toml", BOARD_NO_PATH_PCB_TOML)
         .write("boards/discovered/discovered.zen", TEST_BOARD_ZEN)
         .snapshot_run("pcb", ["info", "-f", "json"]);

--- a/crates/pcb/tests/netlist.rs
+++ b/crates/pcb/tests/netlist.rs
@@ -141,7 +141,7 @@ Led(name="D1", color=led_color, package=package, A=led_anode, K=CTRL)
 
 #[test]
 fn test_netlist_simple_board_with_positions() {
-    let mut sandbox = Sandbox::new().allow_network();
+    let mut sandbox = Sandbox::new();
     sandbox.write("boards/SimpleBoard.zen", SIMPLE_BOARD_WITH_POSITIONS_ZEN);
     let output = snapshot_netlist_positions(
         &mut sandbox,
@@ -153,7 +153,7 @@ fn test_netlist_simple_board_with_positions() {
 
 #[test]
 fn test_netlist_hierarchical_board_with_positions() {
-    let mut sandbox = Sandbox::new().allow_network();
+    let mut sandbox = Sandbox::new();
     sandbox
         .write("pcb.toml", WORKSPACE_PCB_TOML)
         .write("modules/LedModule.zen", LED_MODULE_ZEN)
@@ -187,7 +187,7 @@ gnd = Ground("GND")
 Resistor(name="R1", value="1kOhm", package="0603", P1=vcc, P2=gnd)
 "#;
 
-    let mut sandbox = Sandbox::new().allow_network();
+    let mut sandbox = Sandbox::new();
     sandbox.write("boards/NoPositions.zen", board_zen);
     let output = snapshot_netlist_positions(
         &mut sandbox,
@@ -223,7 +223,7 @@ Led(name="D1", color="red", package="0603", A=sig, K=gnd)
 # pcb:sch SIGNAL.2 x=125.0000 y=150.0000 rot=0
 "#;
 
-    let mut sandbox = Sandbox::new().allow_network();
+    let mut sandbox = Sandbox::new();
     sandbox.write("boards/MixedPositions.zen", board_zen);
     let output = snapshot_netlist_positions(
         &mut sandbox,
@@ -286,7 +286,7 @@ PowerConsumer(name = "U1", vcc = nc)
 
 #[test]
 fn test_netlist_not_connected_promotion() {
-    let mut sandbox = Sandbox::new().allow_network();
+    let mut sandbox = Sandbox::new();
     sandbox
         .write("boards/PowerConsumer.zen", NOT_CONNECTED_MODULE_ZEN)
         .write("boards/NCBoard.zen", NOT_CONNECTED_BOARD_ZEN);

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -161,7 +161,7 @@ fn find_staging_dir(sb: &Sandbox, board_name: &str) -> String {
 
 #[test]
 fn test_publish_board_source_only() {
-    let mut sb = Sandbox::new().allow_network();
+    let mut sb = Sandbox::new();
     sb.cwd("src")
         .write("pcb.toml", PCB_TOML)
         .write("boards/pcb.toml", BOARD_PCB_TOML)
@@ -188,7 +188,7 @@ fn test_publish_board_source_only() {
 
 #[test]
 fn test_publish_board_with_version() {
-    let mut sb = Sandbox::new().allow_network();
+    let mut sb = Sandbox::new();
     sb.cwd("src")
         .ignore_globs(["layout/*", "**/vendor/**", "**/build/**"])
         .hash_globs(["*.kicad_mod", "**/diodeinc/stdlib/*.zen", "**/netlist.json"])
@@ -235,7 +235,7 @@ fn test_publish_board_with_version() {
 
 #[test]
 fn test_publish_board_full() {
-    let mut sb = Sandbox::new().allow_network();
+    let mut sb = Sandbox::new();
     sb.cwd("src")
         .write("pcb.toml", PCB_TOML)
         .write("boards/pcb.toml", BOARD_PCB_TOML)
@@ -280,7 +280,7 @@ fn test_publish_board_full() {
 
 #[test]
 fn test_publish_board_with_file() {
-    let mut sb = Sandbox::new().allow_network();
+    let mut sb = Sandbox::new();
     const DATASHEET_CONTENTS: &str = "Simple component datasheet.";
     sb.cwd("src")
         .write("pcb.toml", PCB_TOML)
@@ -318,7 +318,7 @@ fn test_publish_board_with_file() {
 
 #[test]
 fn test_publish_board_with_description() {
-    let mut sb = Sandbox::new().allow_network();
+    let mut sb = Sandbox::new();
     sb.cwd("src")
         .write("pcb.toml", PCB_TOML)
         .write("boards/pcb.toml", BOARD_WITH_DESCRIPTION_PCB_TOML)

--- a/crates/pcb/tests/snapshots/info__board_without_pcb_toml.snap
+++ b/crates/pcb/tests/snapshots/info__board_without_pcb_toml.snap
@@ -8,8 +8,9 @@ Exit Code: 0
 --- STDOUT ---
 Workspace
 Root: <TEMP_DIR>
+Toolchain: pcb >= 0.3
 
 Boards (1)
-  TestBoard - boards/BoardWithToml/test_board.zen
+  TestBoard (unpublished) - boards/BoardWithToml/test_board.zen
     Main test board for validation
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__empty_workspace.snap
+++ b/crates/pcb/tests/snapshots/info__empty_workspace.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb/tests/info.rs
-assertion_line: 54
+assertion_line: 52
 expression: output
 ---
 Command: pcb info
@@ -9,7 +9,10 @@ Exit Code: 0
 --- STDOUT ---
 Workspace
 Root: <TEMP_DIR>
+Toolchain: pcb >= 0.3
 
 No boards discovered
-Searched for pcb.toml files with [board] sections
+
+Packages (1)
+  root (unpublished) (workspace root)
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__json_format.snap
+++ b/crates/pcb/tests/snapshots/info__json_format.snap
@@ -10,15 +10,11 @@ Exit Code: 0
   "root": "<TEMP_DIR>",
   "config": {
     "workspace": {
-      "name": "BoardDiscoveryTest",
+      "pcb-version": "0.3",
       "members": [
         "boards/*",
         "special/custom-board"
-      ],
-      "default_board": "TestBoard"
-    },
-    "packages": {
-      "stdlib": "@github/diodeinc/stdlib:v1.0.0"
+      ]
     }
   },
   "packages": {

--- a/crates/pcb/tests/snapshots/info__multiple_boards.snap
+++ b/crates/pcb/tests/snapshots/info__multiple_boards.snap
@@ -8,14 +8,14 @@ Exit Code: 0
 --- STDOUT ---
 Workspace
 Root: <TEMP_DIR>
-Name: BoardDiscoveryTest
+Toolchain: pcb >= 0.3
 Members: boards/*, special/custom-board
 
 Boards (4)
-  BrokenBoard - boards/broken-board/broken.zen
-  CustomBoard - special/custom-board/custom.zen
-    Special custom board with unique features
-  MainBoard - boards/main-board/main_board.zen
-  TestBoard (default) - boards/test-board/test_board.zen
+  BrokenBoard (unpublished) - boards/broken-board/broken.zen
+  MainBoard (unpublished) - boards/main-board/main_board.zen
+  TestBoard (unpublished) - boards/test-board/test_board.zen
     Main test board for validation
+  CustomBoard (unpublished) - special/custom-board/custom.zen
+    Special custom board with unique features
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__no_workspace_config.snap
+++ b/crates/pcb/tests/snapshots/info__no_workspace_config.snap
@@ -8,8 +8,9 @@ Exit Code: 0
 --- STDOUT ---
 Workspace
 Root: <TEMP_DIR>
+Toolchain: pcb >= 0.3
 
 Boards (1)
-  TestBoard - boards/TestBoard/test_board.zen
+  TestBoard (unpublished) - boards/TestBoard/test_board.zen
     Main test board for validation
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__single_board.snap
+++ b/crates/pcb/tests/snapshots/info__single_board.snap
@@ -8,8 +8,9 @@ Exit Code: 0
 --- STDOUT ---
 Workspace
 Root: <TEMP_DIR>
+Toolchain: pcb >= 0.3
 
 Boards (1)
-  TestBoard - boards/TestBoard/test_board.zen
+  TestBoard (unpublished) - boards/TestBoard/test_board.zen
     Main test board for validation
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__with_path.snap
+++ b/crates/pcb/tests/snapshots/info__with_path.snap
@@ -8,10 +8,9 @@ Exit Code: 0
 --- STDOUT ---
 Workspace
 Root: <TEMP_DIR>/subdir
-Name: BoardDiscoveryTest
-Members: boards/*, special/custom-board
+Toolchain: pcb >= 0.3
 
 Boards (1)
-  TestBoard (default) - boards/test-board/test_board.zen
+  TestBoard (unpublished) - boards/test-board/test_board.zen
     Main test board for validation
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__zen_discovery.snap
+++ b/crates/pcb/tests/snapshots/info__zen_discovery.snap
@@ -8,8 +8,9 @@ Exit Code: 0
 --- STDOUT ---
 Workspace
 Root: <TEMP_DIR>
+Toolchain: pcb >= 0.3
 
 Boards (1)
-  DiscoveredBoard - boards/discovered/discovered.zen
+  DiscoveredBoard (unpublished) - boards/discovered/discovered.zen
     Board with auto-discovered zen file
 --- STDERR ---

--- a/crates/pcb/tests/snapshots/info__zen_discovery_json.snap
+++ b/crates/pcb/tests/snapshots/info__zen_discovery_json.snap
@@ -8,6 +8,14 @@ Exit Code: 0
 --- STDOUT ---
 {
   "root": "<TEMP_DIR>",
+  "config": {
+    "workspace": {
+      "pcb-version": "0.3",
+      "members": [
+        "boards/*"
+      ]
+    }
+  },
   "packages": {
     "boards/discovered": {
       "rel_path": "boards/discovered",

--- a/crates/pcb/tests/snapshots/simple__workspace_relative_paths_local_alias.snap
+++ b/crates/pcb/tests/snapshots/simple__workspace_relative_paths_local_alias.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/pcb/tests/simple.rs
-assertion_line: 259
+assertion_line: 225
 expression: output
 ---
-Command: pcb build build-ws/foo.zen
+Command: pcb build foo.zen
 Exit Code: 0
 
 --- STDOUT ---

--- a/crates/pcb/tests/tag.rs
+++ b/crates/pcb/tests/tag.rs
@@ -35,7 +35,7 @@ internal_net = Net("INTERNAL")
 
 #[test]
 fn test_publish_board_simple_workspace() {
-    let mut sb = Sandbox::new().allow_network();
+    let mut sb = Sandbox::new();
     sb.write("pcb.toml", PCB_TOML)
         .write("boards/Test/pcb.toml", "[board]\nname = \"TB0001\"\n")
         .write("boards/Test/TB0001.zen", SIMPLE_BOARD_ZEN)
@@ -80,8 +80,8 @@ fn test_publish_board_simple_workspace() {
 
 #[test]
 fn test_publish_board_invalid_path() {
-    let output = Sandbox::new()
-        .allow_network()
+    let mut sb = Sandbox::new();
+    let output = sb
         .write("pcb.toml", PCB_TOML)
         .write("boards/Test/pcb.toml", "[board]\nname = \"TB0001\"\n")
         .write("boards/Test/TB0001.zen", SIMPLE_BOARD_ZEN)

--- a/crates/pcb/tests/test_bench.rs
+++ b/crates/pcb/tests/test_bench.rs
@@ -12,62 +12,67 @@ const FACTORY_CHECKS_TESTBENCH_ZEN: &str =
 const FAILING_CHECKS_TESTBENCH_ZEN: &str =
     include_str!("assets/testbench/failing_checks_testbench.zen");
 
+const PCB_TOML_V2: &str = r#"
+[workspace]
+pcb-version = "0.3"
+"#;
+
 #[test]
 fn test_simple_testbench() {
-    let mut sandbox = Sandbox::new().allow_network();
-    sandbox
+    let output = Sandbox::new()
+        .write("pcb.toml", PCB_TOML_V2)
         .write("matchers.zen", MATCHERS_ZEN)
         .write("simple_module.zen", SIMPLE_MODULE_ZEN)
-        .write("simple_testbench.zen", SIMPLE_TESTBENCH_ZEN);
-    let output = sandbox.snapshot_run("pcb", ["test", "simple_testbench.zen"]);
+        .write("simple_testbench.zen", SIMPLE_TESTBENCH_ZEN)
+        .snapshot_run("pcb", ["test", "simple_testbench.zen"]);
 
     assert_snapshot!("simple_testbench", output);
 }
 
 #[test]
 fn test_factory_pattern_checks() {
-    let mut sandbox = Sandbox::new().allow_network();
-    sandbox
+    let output = Sandbox::new()
+        .write("pcb.toml", PCB_TOML_V2)
         .write("matchers.zen", MATCHERS_ZEN)
         .write("simple_module.zen", SIMPLE_MODULE_ZEN)
-        .write("factory_checks_testbench.zen", FACTORY_CHECKS_TESTBENCH_ZEN);
-    let output = sandbox.snapshot_run("pcb", ["test", "factory_checks_testbench.zen"]);
+        .write("factory_checks_testbench.zen", FACTORY_CHECKS_TESTBENCH_ZEN)
+        .snapshot_run("pcb", ["test", "factory_checks_testbench.zen"]);
 
     assert_snapshot!("factory_pattern_checks", output);
 }
 
 #[test]
 fn test_failing_checks() {
-    let mut sandbox = Sandbox::new().allow_network();
-    sandbox
+    let output = Sandbox::new()
+        .write("pcb.toml", PCB_TOML_V2)
         .write("matchers.zen", MATCHERS_ZEN)
         .write("simple_module.zen", SIMPLE_MODULE_ZEN)
-        .write("failing_checks_testbench.zen", FAILING_CHECKS_TESTBENCH_ZEN);
-    let output = sandbox.snapshot_run("pcb", ["test", "failing_checks_testbench.zen"]);
+        .write("failing_checks_testbench.zen", FAILING_CHECKS_TESTBENCH_ZEN)
+        .snapshot_run("pcb", ["test", "failing_checks_testbench.zen"]);
 
     assert_snapshot!("failing_checks", output);
 }
 
 #[test]
 fn test_json_output() {
-    let mut sandbox = Sandbox::new().allow_network();
-    sandbox
+    let output = Sandbox::new()
+        .write("pcb.toml", PCB_TOML_V2)
         .write("matchers.zen", MATCHERS_ZEN)
         .write("simple_module.zen", SIMPLE_MODULE_ZEN)
-        .write("simple_testbench.zen", SIMPLE_TESTBENCH_ZEN);
-    let output = sandbox.snapshot_run("pcb", ["test", "simple_testbench.zen", "-f", "json"]);
+        .write("simple_testbench.zen", SIMPLE_TESTBENCH_ZEN)
+        .snapshot_run("pcb", ["test", "simple_testbench.zen", "-f", "json"]);
 
     assert_snapshot!("json_output", output);
 }
 
 #[test]
 fn test_tap_output() {
-    let mut sandbox = Sandbox::new().allow_network();
-    sandbox
+    let output = Sandbox::new()
+        .write("pcb.toml", PCB_TOML_V2)
         .write("matchers.zen", MATCHERS_ZEN)
         .write("simple_module.zen", SIMPLE_MODULE_ZEN)
-        .write("simple_testbench.zen", SIMPLE_TESTBENCH_ZEN);
-    let output = sandbox.snapshot_run("pcb", ["test", "simple_testbench.zen", "-f", "tap"]);
+        .write("simple_testbench.zen", SIMPLE_TESTBENCH_ZEN)
+        .snapshot_run("pcb", ["test", "simple_testbench.zen", "-f", "tap"]);
 
     assert_snapshot!("tap_output", output);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches test infrastructure that controls git/caching/network behavior and changes how many integration tests resolve dependencies, so failures may be widespread if rewrite or seeding logic is incomplete or platform-sensitive.
> 
> **Overview**
> The test `Sandbox` is reworked to be **always hermetic/offline**: it now always isolates `HOME`/`XDG` + caches, blocks network protocols, and rewrites only *registered* fixture GitHub/GitLab repos to local `file://` paths (tracking per-repo rewrites and regenerating `.gitconfig` on demand). It also auto-seeds the V2 cache for stdlib + KiCad assets on creation by symlinking from the global cache or fetching once.
> 
> V2 sparse-checkout cleanup is fixed to remove only the extracted subpath root directory. Integration tests are migrated away from `allow_network` and V1-style `[packages]` aliases toward V2 `[workspace] pcb-version = "0.3"` + `[dependencies]` usage, updating fixtures/tags to match nested-package tag naming and adjusting snapshots accordingly (notably `pcb info` and module-loading outputs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 564d3c62d1ead7c0590607b705a14c2d31f53f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>564d3c6</u></sup><!-- /BUGBOT_STATUS -->