### PR TITLE
Migrate pcb-zen tests to v2

### DIFF
--- a/crates/pcb-zen/tests/module_loading.rs
+++ b/crates/pcb-zen/tests/module_loading.rs
@@ -46,7 +46,7 @@ def DummyFunction():
     env.add_file(
         "sub.zen",
         r#"
-load("//nested/file/import.zen", DummyFunction = "DummyFunction")
+load("./nested/file/import.zen", DummyFunction = "DummyFunction")
 
 DummyFunction()
 
@@ -101,8 +101,8 @@ P1 = io("P1", Net)
     env.add_file(
         "nested/test.zen",
         r#"
-# Test workspace root reference
-Submodule = Module("//submodule.zen")
+# Test that Module() can load a sibling file from a nested directory via relative paths
+Submodule = Module("../submodule.zen")
 
 Submodule(
     name = "Submodule",
@@ -228,8 +228,8 @@ pcb-version = "0.3"
     env.add_file(
         "src/test.zen",
         r#"
-# Test that Module() works with workspace-relative path from subdirectory
-MyModule = Module("//modules/MyModule.zen")
+# Test that Module() works with relative paths from a subdirectory
+MyModule = Module("../modules/MyModule.zen")
 
 MyModule(
     name = "M1",

--- a/crates/pcb-zen/tests/test_physical.rs
+++ b/crates/pcb-zen/tests/test_physical.rs
@@ -55,7 +55,7 @@ Component(
         "#,
     );
 
-    let result = env.eval_module("test_physical.zen");
+    let result = env.eval("test_physical.zen");
 
     // Check for evaluation errors
     if result.output.is_none() {

--- a/crates/pcb-zen/tests/test_physical_constructor_casting.rs
+++ b/crates/pcb-zen/tests/test_physical_constructor_casting.rs
@@ -29,7 +29,7 @@ Component(
 "#,
     );
 
-    let result = env.eval_module("cast_ok.zen");
+    let result = env.eval("cast_ok.zen");
     assert!(
         result.output.is_some(),
         "expected module to eval, got diagnostics: {:?}",
@@ -51,7 +51,7 @@ Resistance("3.3V")
 "#,
     );
 
-    let result = env.eval_module("cast_err.zen");
+    let result = env.eval("cast_err.zen");
     assert!(
         result.output.is_none(),
         "expected eval failure, but module evaluated successfully"

--- a/crates/pcb-zen/tests/test_physical_negative_tolerance.rs
+++ b/crates/pcb-zen/tests/test_physical_negative_tolerance.rs
@@ -3,7 +3,7 @@ mod common;
 use common::TestProject;
 
 fn assert_eval_fails(env: &TestProject, rel_path: &str, expected_substring: &str) {
-    let result = env.eval_module(rel_path);
+    let result = env.eval(rel_path);
     assert!(
         result.output.is_none(),
         "expected eval failure, but module evaluated successfully"

--- a/crates/pcb-zen/tests/test_physical_range_shim.rs
+++ b/crates/pcb-zen/tests/test_physical_range_shim.rs
@@ -32,7 +32,7 @@ print("ok")
         "#,
     );
 
-    let result = env.eval_module("test_physical_range_shim.zen");
+    let result = env.eval("test_physical_range_shim.zen");
     if result.output.is_none() {
         panic!("Evaluation failed: {:?}", result.diagnostics);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to test code and test harness behavior. Main risk is altered test expectations/flake potential due to dependency resolution and cache fetch behavior.
> 
> **Overview**
> Integration test harness now writes a default V2 `pcb.toml` into each `TestProject` and evaluates modules via explicit V2 dependency resolution (`get_workspace_info` + `resolve_dependencies`), allowing missing modules (e.g. stdlib) to be fetched into cache during tests.
> 
> Test utilities were adjusted by replacing `eval_module`/absolute-path netlist evaluation with a unified `eval` API that preserves diagnostics and converts eval output to a netlist, and module-loading tests were updated to prefer relative import/module paths (e.g. `./` and `../`) over `//` workspace-root references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84565f7ca892a02ec309430cbaa0f082d624674d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->