### PR TITLE
ipc2581: parse FunctionMode level as numeric (spec-compliant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Stabilize auto-named single-port `NotConnected()` net names (e.g., `NC_R1_P2`) to reduce layout implicit renames.
 - Layout sync: explode single-pin multi-pad `NotConnected` nets into per-pad `unconnected-(...)` nets.
 - Accept KiCad copper role `jumper` when importing stackups.
+- IPC-2581 rev B: parse `FunctionMode` `level` attribute as numeric.
 
 ## [0.3.34] - 2026-02-03
 

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -199,6 +199,31 @@ mod tests {
     }
 
     #[test]
+    fn parse_function_mode_with_numeric_level() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="B" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="ASSEMBLY" level="1"/>
+    <DictionaryColor/>
+    <DictionaryLineDesc units="MILLIMETER"/>
+    <DictionaryFillDesc units="MILLIMETER"/>
+    <DictionaryStandard units="MILLIMETER"/>
+    <DictionaryUser units="MILLIMETER"/>
+  </Content>
+</IPC-2581>"#;
+
+        let result = Ipc2581::parse(xml);
+        assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+        let doc = result.unwrap();
+        assert_eq!(doc.revision(), "B");
+        assert_eq!(
+            doc.content().function_mode.level,
+            Some(types::content::Level(1))
+        );
+    }
+
+    #[test]
     fn parse_document_with_avl() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -160,14 +160,20 @@ impl Parser {
     }
 
     fn parse_level(&self, s: &str) -> Result<Level> {
-        match s {
-            "FULL" => Ok(Level::Full),
-            "PARTIAL" => Ok(Level::Partial),
-            _ => Err(Ipc2581Error::InvalidAttribute(format!(
-                "Unknown level: {}",
+        let level: u8 = s.parse().map_err(|_| {
+            Ipc2581Error::InvalidAttribute(format!(
+                "Invalid level (expected positive integer): {}",
                 s
-            ))),
+            ))
+        })?;
+
+        if level == 0 {
+            return Err(Ipc2581Error::InvalidAttribute(
+                "Invalid level (expected positive integer): 0".to_string(),
+            ));
         }
+
+        Ok(Level(level))
     }
 
     fn parse_dictionary_color(&mut self, node: &Node) -> Result<DictionaryColor> {

--- a/crates/ipc2581/src/types/content.rs
+++ b/crates/ipc2581/src/types/content.rs
@@ -37,7 +37,4 @@ pub enum Mode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Level {
-    Full,
-    Partial,
-}
+pub struct Level(pub u8);


### PR DESCRIPTION
This adds support for revision="B" IPC files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IPC-2581 parsing and public types for `FunctionMode.level`, which may break downstream code expecting the prior enum representation and could affect parsing of existing files if assumptions differed.
> 
> **Overview**
> Makes IPC-2581 rev B `FunctionMode` parsing spec-compliant by treating the optional `level` attribute as a **positive integer** rather than a `FULL`/`PARTIAL` enum.
> 
> This updates the `Level` type to `struct Level(u8)`, adds validation/error messaging for non-numeric or zero values in `parse_level`, and adds a regression test covering `revision="B"` with `level="1"`. The changelog is updated to note the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4ea19fed9dab3019a12470e3a21885e4221dd2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->