### PR TITLE
Fix SaveBoard crash by detaching members before group deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- On layout sync, detach all items from removed KiCad groups before deleting the group to avoid `SaveBoard` crashes from stale group handles.
+
 ## [0.3.35] - 2026-02-06
 
 ### Added

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -677,6 +677,12 @@ def apply_changeset(
         if not group:
             continue
 
+        # Detach all members first. Deleting a group directly can leave stale
+        # parent-group pointers on BOARD_ITEMs, which later crashes KiCad in
+        # BOARD_ITEM::IsLocked() during SaveBoard.
+        for item in list(group.GetItems()):
+            group.RemoveItem(item)
+
         kicad_board.Delete(group)
         oplog.gr_remove(group_name, 0)
         logger.info(f"Removed group: {entity_id}")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to group deletion order during sync; risk is mainly unintended side effects if KiCad’s group APIs behave differently across versions.
> 
> **Overview**
> Fixes a KiCad `SaveBoard` crash during layout sync by **detaching all items from groups** before deleting groups marked for removal, preventing stale parent-group handles on `BOARD_ITEM`s.
> 
> Updates `CHANGELOG.md` under *Unreleased* to document the crash fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 356ed5c00ca409a7feca1ac0f6fa82b53a55d03b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->