### PR TITLE
Add `mirror=x|y` support to `pcb:sch` comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - `Component(..., designator = "R1")` now supports manual reference designators, duplicate checks, and reserved-ID skipping during auto-assignment.
+- `pcb:sch` comments now support optional `mirror=x|y`, and netlist `instances.*.symbol_positions.*` now serializes `mirror` when set.
 
 ## [0.3.36] - 2026-02-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,7 +4210,6 @@ dependencies = [
  "pcb-sexpr",
  "rust_decimal",
  "rust_decimal_macros",
- "scan_fmt",
  "serde",
  "serde_json",
  "starlark",
@@ -5877,15 +5876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scan_fmt"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
-dependencies = [
- "regex",
 ]
 
 [[package]]

--- a/crates/pcb-sch/Cargo.toml
+++ b/crates/pcb-sch/Cargo.toml
@@ -20,7 +20,6 @@ log = { workspace = true }
 pcb-sexpr = { workspace = true }
 rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }
-scan_fmt = { workspace = true }
 natord = { workspace = true }
 csv = { workspace = true }
 starlark = { workspace = true }

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use itertools::Itertools;
 use pcb_sch::physical::PhysicalValue;
-use pcb_sch::position::Position;
+use pcb_sch::position::{MirrorAxis, Position};
 use pcb_sch::{AttributeValue, Instance, InstanceRef, ModuleRef, Net, Schematic};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
@@ -840,6 +840,10 @@ impl ModuleConverter {
                     x: pos.x,
                     y: pos.y,
                     rotation: pos.rotation,
+                    mirror: pos
+                        .mirror
+                        .as_deref()
+                        .and_then(MirrorAxis::from_comment_value),
                 };
 
                 // Determine position type and convert to unified format using the remapped key

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -183,15 +183,24 @@ pub struct Position {
     pub x: f64,
     pub y: f64,
     pub rotation: f64,
+    pub mirror: Option<String>,
 }
 
 impl std::fmt::Display for Position {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Position({:.1}, {:.1}, {:.0})",
-            self.x, self.y, self.rotation
-        )
+        if let Some(mirror) = &self.mirror {
+            write!(
+                f,
+                "Position({:.1}, {:.1}, {:.0}, mirror={})",
+                self.x, self.y, self.rotation, mirror
+            )
+        } else {
+            write!(
+                f,
+                "Position({:.1}, {:.1}, {:.0})",
+                self.x, self.y, self.rotation
+            )
+        }
     }
 }
 
@@ -223,6 +232,7 @@ pub fn parse_positions(content: &str) -> PositionMap {
                     x: v.x,
                     y: v.y,
                     rotation: v.rotation,
+                    mirror: v.mirror.map(|axis| axis.to_string()),
                 },
             )
         })

--- a/crates/pcb/tests/netlist.rs
+++ b/crates/pcb/tests/netlist.rs
@@ -119,6 +119,34 @@ pcb-version = "0.3"
 members = ["boards/*", "modules/*"]
 "#;
 
+const SIMPLE_BOARD_WITH_MIRROR_POSITIONS_ZEN: &str = r#"
+# ```pcb
+# [workspace]
+# pcb-version = "0.3"
+# ```
+
+load("@stdlib/interfaces.zen", "Power", "Ground")
+
+Resistor = Module("@stdlib/generics/Resistor.zen")
+Led = Module("@stdlib/generics/Led.zen")
+
+vcc = Power("VCC_3V3")
+gnd = Ground("GND")
+led_anode = Net("LED_ANODE")
+
+Resistor(name="R1", value="330Ohm", package="0603", P1=vcc, P2=led_anode)
+Led(name="D1", color="red", package="0603", A=led_anode, K=gnd)
+
+# Position comments with optional mirror
+# pcb:sch R1 x=100.0000 y=200.0000 rot=0 mirror=x
+# pcb:sch D1 x=150.0000 y=200.0000 rot=90
+# pcb:sch VCC_3V3_VCC.1 x=80.0000 y=180.0000 rot=0 mirror=y
+# pcb:sch VCC_3V3_VCC.2 x=120.0000 y=180.0000 rot=0
+# pcb:sch GND_GND.1 x=80.0000 y=220.0000 rot=0
+# pcb:sch GND_GND.2 x=170.0000 y=220.0000 rot=0
+# pcb:sch LED_ANODE x=125.0000 y=200.0000 rot=0
+"#;
+
 const LED_MODULE_ZEN: &str = r#"
 load("@stdlib/interfaces.zen", "Gpio", "Ground", "Power")
 
@@ -231,6 +259,21 @@ Led(name="D1", color="red", package="0603", A=sig, K=gnd)
         &["build", "boards/MixedPositions.zen", "--netlist"],
     );
     assert_snapshot!("netlist_mixed_position_formats", output);
+}
+
+#[test]
+fn test_netlist_positions_with_mirror() {
+    let mut sandbox = Sandbox::new();
+    sandbox.write(
+        "boards/SimpleBoardWithMirror.zen",
+        SIMPLE_BOARD_WITH_MIRROR_POSITIONS_ZEN,
+    );
+    let output = snapshot_netlist_positions(
+        &mut sandbox,
+        "pcb",
+        &["build", "boards/SimpleBoardWithMirror.zen", "--netlist"],
+    );
+    assert_snapshot!("netlist_positions_with_mirror", output);
 }
 
 /// Helper to run netlist command and extract just the nets section for focused snapshot testing.

--- a/crates/pcb/tests/snapshots/netlist__netlist_positions_with_mirror.snap
+++ b/crates/pcb/tests/snapshots/netlist__netlist_positions_with_mirror.snap
@@ -1,0 +1,48 @@
+---
+source: crates/pcb/tests/netlist.rs
+assertion_line: 276
+expression: output
+---
+{
+  "<TEMP_DIR>/boards/SimpleBoardWithMirror.zen:<root>": {
+    "symbol_positions": {
+      "comp:D1": {
+        "rotation": 90,
+        "x": 150,
+        "y": 200
+      },
+      "comp:R1": {
+        "mirror": "x",
+        "rotation": 0,
+        "x": 100,
+        "y": 200
+      },
+      "sym:GND#1": {
+        "rotation": 0,
+        "x": 80,
+        "y": 220
+      },
+      "sym:GND#2": {
+        "rotation": 0,
+        "x": 170,
+        "y": 220
+      },
+      "sym:LED_ANODE#1": {
+        "rotation": 0,
+        "x": 125,
+        "y": 200
+      },
+      "sym:VCC_3V3#1": {
+        "mirror": "y",
+        "rotation": 0,
+        "x": 80,
+        "y": 180
+      },
+      "sym:VCC_3V3#2": {
+        "rotation": 0,
+        "x": 120,
+        "y": 180
+      }
+    }
+  }
+}

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -20,8 +20,9 @@ of Starlark. For the base Starlark language features, please refer to the
 ## Table of Contents
 
 1. [Modules and Imports](#modules-and-imports)
-2. [Core Types](#core-types)
-3. [Built-in Functions](#built-in-functions)
+2. [Schematic Position Comments](#schematic-position-comments)
+3. [Core Types](#core-types)
+4. [Built-in Functions](#built-in-functions)
 
 ## Modules and Imports
 
@@ -139,6 +140,48 @@ path = "MainBoard.zen"
 Packages (modules, components) don't have a `[board]` section—they're libraries meant to be instantiated by boards or other modules.
 
 See [Packages](/pages/packages) for the complete manifest reference.
+
+## Schematic Position Comments
+
+Zener supports persisted schematic placement metadata in trailing comment blocks.
+These comments are consumed by tooling and surfaced in netlist output.
+
+Canonical line format:
+
+```text
+# pcb:sch <id> x=<f64> y=<f64> rot=<f64> [mirror=<x|y>]
+```
+
+- `id`: Position key (component or net symbol key in comment form, e.g. `R1`, `VCC.1`)
+- `x`, `y`: Schematic coordinates
+- `rot`: Rotation in degrees
+- `mirror` (optional): Mirror axis (`x` or `y`)
+
+Examples:
+
+```text
+# pcb:sch R1 x=100.0000 y=200.0000 rot=0
+# pcb:sch U1 x=150.0000 y=200.0000 rot=90 mirror=x
+```
+
+### Netlist Serialization
+
+Position comments are serialized under each instance in `symbol_positions`.
+
+```json
+{
+  "instances": {
+    "<instance>": {
+      "symbol_positions": {
+        "comp:R1": { "x": 100, "y": 200, "rotation": 0, "mirror": "x" },
+        "sym:VCC#1": { "x": 80, "y": 180, "rotation": 0 }
+      }
+    }
+  }
+}
+```
+
+- `mirror` is optional and omitted when unset.
 
 ## Core Types
 


### PR DESCRIPTION
Without this, many kicad schematics are not visually representable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches schematic position parsing/serialization and netlist output; stricter parsing (rejecting extra tokens/invalid mirror) could drop previously-tolerated comment lines and affect downstream tooling.
> 
> **Overview**
> Adds optional `mirror=x|y` support to persisted `# pcb:sch` position comments and carries this through to netlist output.
> 
> This replaces the previous `scan_fmt`-based parser with a stricter tokenizer, introduces a typed `MirrorAxis` on `pcb-sch::Position`, updates formatting/writing logic to include `mirror` only when present, and plumbs the value through `pcb-zen-core` so `instances.*.symbol_positions.*` includes `mirror` when set. Tests, snapshots, and the language spec/changelog are updated accordingly, and the `scan_fmt` dependency is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f5b0c5c0a296c7fb63471603f7bf9471c8f252c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->