### PR TITLE
Expose skill content programmatically

### DIFF
--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -1050,64 +1050,6 @@ fn sanitize_nc_fragment(s: &str) -> String {
         .collect()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn inst_ref(path: &[&str]) -> InstanceRef {
-        InstanceRef {
-            module: ModuleRef::new("/test.zen", "<root>"),
-            instance_path: path.iter().map(|s| (*s).to_string()).collect(),
-        }
-    }
-
-    #[test]
-    fn stable_single_port_not_connected_scoped_name_root_two_segments() {
-        assert_eq!(
-            stable_single_port_not_connected_scoped_name(&inst_ref(&["R1", "P2"])).as_deref(),
-            Some("NC_R1_P2")
-        );
-    }
-
-    #[test]
-    fn stable_single_port_not_connected_scoped_name_with_module_prefix() {
-        assert_eq!(
-            stable_single_port_not_connected_scoped_name(&inst_ref(&["Power", "DcDc", "U1", "SW"]))
-                .as_deref(),
-            Some("Power.DcDc.NC_U1_SW")
-        );
-    }
-
-    #[test]
-    fn stable_single_port_not_connected_scoped_name_one_segment() {
-        assert_eq!(
-            stable_single_port_not_connected_scoped_name(&inst_ref(&["SW"])).as_deref(),
-            Some("NC_SW")
-        );
-    }
-
-    #[test]
-    fn stable_single_port_not_connected_scoped_name_empty_path_returns_none() {
-        assert_eq!(
-            stable_single_port_not_connected_scoped_name(&inst_ref(&[])),
-            None
-        );
-    }
-
-    #[test]
-    fn stable_single_port_not_connected_scoped_name_sanitizes_fragments() {
-        assert_eq!(
-            stable_single_port_not_connected_scoped_name(&inst_ref(&[
-                "Top",
-                "U1@A.B",
-                "PF0 OSC_IN"
-            ]))
-            .as_deref(),
-            Some("Top.NC_U1_A_B_PF0_OSC_IN")
-        );
-    }
-}
-
 /// Propagate impedance from DiffPair interfaces to P/N nets
 fn propagate_diffpair_impedance(
     net_info: &mut HashMap<NetId, NetInfo>,
@@ -1211,4 +1153,62 @@ fn to_attribute_value(v: starlark::values::FrozenValue) -> anyhow::Result<Attrib
 
     // Any other type – fall back to string representation
     Ok(AttributeValue::String(v.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inst_ref(path: &[&str]) -> InstanceRef {
+        InstanceRef {
+            module: ModuleRef::new("/test.zen", "<root>"),
+            instance_path: path.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn stable_single_port_not_connected_scoped_name_root_two_segments() {
+        assert_eq!(
+            stable_single_port_not_connected_scoped_name(&inst_ref(&["R1", "P2"])).as_deref(),
+            Some("NC_R1_P2")
+        );
+    }
+
+    #[test]
+    fn stable_single_port_not_connected_scoped_name_with_module_prefix() {
+        assert_eq!(
+            stable_single_port_not_connected_scoped_name(&inst_ref(&["Power", "DcDc", "U1", "SW"]))
+                .as_deref(),
+            Some("Power.DcDc.NC_U1_SW")
+        );
+    }
+
+    #[test]
+    fn stable_single_port_not_connected_scoped_name_one_segment() {
+        assert_eq!(
+            stable_single_port_not_connected_scoped_name(&inst_ref(&["SW"])).as_deref(),
+            Some("NC_SW")
+        );
+    }
+
+    #[test]
+    fn stable_single_port_not_connected_scoped_name_empty_path_returns_none() {
+        assert_eq!(
+            stable_single_port_not_connected_scoped_name(&inst_ref(&[])),
+            None
+        );
+    }
+
+    #[test]
+    fn stable_single_port_not_connected_scoped_name_sanitizes_fragments() {
+        assert_eq!(
+            stable_single_port_not_connected_scoped_name(&inst_ref(&[
+                "Top",
+                "U1@A.B",
+                "PF0 OSC_IN"
+            ]))
+            .as_deref(),
+            Some("Top.NC_U1_A_B_PF0_OSC_IN")
+        );
+    }
 }

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -158,6 +158,10 @@ enum Commands {
     #[command(hide = true)]
     Run(run::RunArgs),
 
+    /// Print the PCB skill content
+    #[command(hide = true)]
+    Skill,
+
     /// External subcommands are forwarded to pcb-<command>
     #[command(external_subcommand)]
     External(Vec<OsString>),
@@ -225,6 +229,10 @@ fn run() -> anyhow::Result<()> {
         Commands::Ipc2581(args) => ipc2581::execute(args),
         Commands::Package(args) => package::execute(args),
         Commands::Run(args) => run::execute(args),
+        Commands::Skill => {
+            print!("{}", run::AGENTS_SKILL_MD);
+            Ok(())
+        }
         Commands::External(args) => {
             if args.is_empty() {
                 anyhow::bail!("No external command specified");

--- a/crates/pcb/src/mcp.rs
+++ b/crates/pcb/src/mcp.rs
@@ -106,7 +106,19 @@ fn execute_server() -> Result<()> {
 }
 
 fn local_tools() -> Vec<ToolInfo> {
-    vec![ToolInfo {
+    vec![
+        ToolInfo {
+            name: "get_skill",
+            description: "Get instructions and documentation for working with PCB designs in the Zener hardware description language. \
+                Returns context on CLI commands, language concepts, and available MCP tools. \
+                Call this at the start of a conversation involving .zen files or PCB design.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {}
+            }),
+            output_schema: None,
+        },
+        ToolInfo {
         name: "run_layout",
         description: "Sync schematic changes to KiCad and open the layout for interaction. \
             Call this ONLY when you need to: (1) interact with the PCB layout in KiCad, or \
@@ -137,7 +149,8 @@ fn local_tools() -> Vec<ToolInfo> {
                 "error": {"type": "string", "description": "Error message if layout failed"}
             }
         })),
-    }]
+    },
+    ]
 }
 
 fn handle_local(
@@ -146,6 +159,13 @@ fn handle_local(
     ctx: &McpContext,
 ) -> Option<Result<CallToolResult>> {
     match name {
+        "get_skill" => Some(Ok(CallToolResult {
+            content: vec![pcb_mcp::CallToolResultContent::Text {
+                text: crate::run::AGENTS_SKILL_MD.to_string(),
+            }],
+            structured_content: None,
+            is_error: false,
+        })),
         "run_layout" => Some(run_layout(args, ctx)),
         _ => None,
     }

--- a/crates/pcb/src/run.rs
+++ b/crates/pcb/src/run.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const AGENTS_SKILL_MD: &str = include_str!("../../../.agents/skills/pcb/SKILL.md");
+pub(crate) const AGENTS_SKILL_MD: &str = include_str!("../../../.agents/skills/pcb/SKILL.md");
 const AGENTS_MCP_JSON: &str = include_str!("../../../.agents/skills/pcb/mcp.json");
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
Add undocumented `pcb skill` command and `get_skill` MCP tool for fetching the content of the skill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a hidden CLI command and MCP tool that only return embedded markdown content; changes are isolated and don’t affect build/layout logic.
> 
> **Overview**
> Exposes the embedded PCB skill documentation programmatically by adding a hidden `pcb skill` CLI subcommand that prints `AGENTS_SKILL_MD`.
> 
> Extends the MCP server with a new local `get_skill` tool that returns the same skill markdown, and makes `AGENTS_SKILL_MD` visible to the MCP module. Also moves `stable_single_port_not_connected_scoped_name` unit tests in `convert.rs` to the end of the file without changing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 977b961efe589a41d5cc64e434af6728ae294650. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->