### PR TITLE
Add vouch trust workflows and seed current contributors

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,21 @@
+# Vouched contributors for this repository.
+#
+# See https://github.com/mitchellh/vouch for details.
+#
+# Syntax:
+#   - One handle per line (without @), sorted alphabetically.
+#   - Optional platform prefix: platform:username (e.g., github:user).
+#   - Denounce with minus prefix: -username or -platform:username.
+#   - Optional details after a space following the handle.
+github:0xcaff
+github:actions-user
+github:akhilles
+github:areddy2022
+github:dezash123
+github:dioderobot
+github:hexdae
+github:Hugo-Villagrana
+github:Jon-Liang
+github:LK
+github:therishidesai
+github:ychen306

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,28 @@
+name: Vouch Check PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check PR Author Trust
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/recheck'))
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@main
+        with:
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -1,0 +1,29 @@
+name: Vouch Manage by Issue
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  manage:
+    name: Update Vouched List
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: mitchellh/vouch/action/manage-by-issue@main
+        with:
+          repo: ${{ github.repository }}
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+This repository uses [vouch](https://github.com/mitchellh/vouch) for contributor trust management.
+You must be vouched to open pull requests. Pull requests from unvouched users may be closed automatically.
+Denounced users are always blocked.
+
+## Getting Vouched
+
+1. Open an issue describing what you want to change and why.
+2. Keep the proposal concise and concrete.
+3. A maintainer can vouch for you by commenting `vouch` on your issue.
+4. Once vouched, you can open pull requests normally.
+
+## Maintainer Commands
+
+Maintainers can manage trust status in issue comments with:
+
+- `vouch`
+- `vouch @username <optional reason>`
+- `denounce`
+- `denounce @username <optional reason>`
+- `unvouch`
+- `unvouch @username`
+
+These commands update `.github/VOUCHED.td` through GitHub Actions.


### PR DESCRIPTION
## Summary
- add vouch PR trust check workflow (`pull_request_target` + `/recheck` support)
- add vouch issue-comment management workflow for `vouch` / `denounce` / `unvouch`
- add initial `.github/VOUCHED.td` trust list seeded from current repository contributors
- add `CONTRIBUTING.md` documenting vouched contributor flow

## Notes
- seeded users are in `github:<login>` format and sorted
- workflows reference `mitchellh/vouch` actions directly

## Testing
- not run locally (GitHub Actions workflows)
