### PR TITLE
Discover KiCad layout via .kicad_pro (derive .kicad_pcb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- KiCad layout discovery no longer assumes `layout.kicad_pcb`; it now discovers a single top-level `.kicad_pro` (preferred) or `.kicad_pcb` in the layout directory and errors on ambiguity.
+
 ## [0.3.37] - 2026-02-09
 
 ### Added

--- a/crates/pcb-layout/src/scripts/lens/tests/strategies.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/strategies.py
@@ -208,7 +208,7 @@ def group_view_strategy(
     if member_ids is None:
         member_ids = ()
 
-    layout_path = draw(st.one_of(st.none(), st.just("./layout.kicad_pcb")))
+    layout_path = draw(st.one_of(st.none(), st.just("./layout")))
 
     return GroupView(
         entity_id=entity_id,

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -120,7 +120,9 @@ class JsonNetlistParser:
 
         def __init__(self, path, layout_path=None):
             self.path = path  # Hierarchical path like "BMI270" or "Power.Regulator"
-            self.layout_path = layout_path  # Path to .kicad_pcb file if it has a layout
+            self.layout_path = (
+                layout_path  # Path to layout directory (not a specific file)
+            )
 
     class SheetPath:
         """Represents the hierarchical sheet path."""

--- a/crates/pcb/src/route.rs
+++ b/crates/pcb/src/route.rs
@@ -61,24 +61,13 @@ pub fn execute(args: RouteArgs) -> Result<()> {
 
     let schematic = output.context("No schematic output from evaluation")?;
 
-    // Extract layout path from schematic
-    let layout_path_attr = utils::extract_layout_path(&schematic)
+    let layout_dir = utils::resolve_layout_dir(&schematic, zen_path)
         .context("No layout path defined in schematic. Add layout=\"path\" to your module.")?;
 
-    // Convert relative path to absolute based on zen file location
-    let layout_dir = if layout_path_attr.is_relative() {
-        zen_path
-            .parent()
-            .unwrap_or(Path::new("."))
-            .join(&layout_path_attr)
-    } else {
-        layout_path_attr
-    };
-
-    // Get the actual file paths
-    let layout_paths = utils::get_layout_paths(&layout_dir);
-    let board_path = layout_paths.pcb;
-    let project_path = layout_dir.join("layout.kicad_pro");
+    // Discover KiCad project + board paths
+    let kicad_files = utils::require_kicad_files(&layout_dir)?;
+    let board_path = kicad_files.kicad_pcb();
+    let project_path = kicad_files.kicad_pro;
 
     // Validate files exist
     if !board_path.exists() {


### PR DESCRIPTION
For generation, we still default the names to `layout.kicad_pcb`. But this change adds a bit more flexibility as it allows `<board name>.kicad_pro` and `<board name>.kicad_pcb`. This is better for importing kicad projects as it allows for preserving the "name" of the project. The name of the `.kicad_pro` file is used in KiCad in a bunch of places as the name of the board/project (e.g. it's the board name in the IPC-2581 xml file), so we should consider standardizing on `<board name>.kicad_pro` and `<board name>.kicad_pcb` for non-imported projects as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes layout file discovery and propagates new error-returning APIs through `pcb` CLI flows (open/route/release/bom), which can alter behavior for existing projects and introduce new failure modes when multiple KiCad files exist.
> 
> **Overview**
> **KiCad layout discovery is now project-based instead of hard-coded.** Layout resolution no longer assumes `layout/layout.kicad_pcb`; it discovers a single top-level `.kicad_pro` (preferred) or `.kicad_pcb` within the layout directory and derives related files by extension, **erroring if multiple candidates exist**.
> 
> This refactors Rust and Python paths to use the new discovery (`KiCadLayoutFiles`, `discover/require/resolve_kicad_files`, `get_layout_paths_for_pcb`), updates fragment loading/routing in the lens sync to find the correct PCB file, and updates CLI commands (`pcb open`, `pcb route`, `pcb release`, BOM fallback) to use the discovered KiCad files and propagate errors instead of silently assuming `layout.*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20aa1447019df936abf260feb6fa1e08f335b3dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->