### PR TITLE
Move e2e tests to a separate workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,102 @@
+name: E2E CLI Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  KICAD_VERSION: 9.0.7
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E (${{ matrix.config.name }})
+    runs-on: ${{ matrix.config.runs-on }}
+    container: ${{ matrix.config.container }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: macOS
+            runs-on: macos-15-xlarge
+          - name: Ubuntu
+            runs-on: ubicloud-standard-30-ubuntu-2204
+            container:
+              image: ghcr.io/diodeinc/kicad:9.0.7-trixie-full
+              options: --user root
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Dependencies (Ubuntu)
+        if: matrix.config.name == 'Ubuntu'
+        run: |
+          apt-get update
+          apt-get install -y curl build-essential pkg-config libssl-dev
+
+      - name: Cache KiCad (macOS)
+        if: matrix.config.name == 'macOS'
+        id: cache-kicad-mac
+        uses: actions/cache@v4
+        with:
+          path: /Applications/KiCad
+          key: ${{ runner.os }}-kicad-${{ env.KICAD_VERSION }}
+
+      - name: Install KiCad (macOS)
+        if: matrix.config.name == 'macOS' && steps.cache-kicad-mac.outputs.cache-hit != 'true'
+        run: |
+          brew update
+          brew uninstall --cask kicad 2>/dev/null || true
+          rm -rf /Applications/KiCad 2>/dev/null || true
+          brew install --cask kicad
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and install pcb CLI
+        run: |
+          cargo build --release -p pcb
+          cp target/release/pcb ~/.cargo/bin/pcb
+          pcb --help
+
+      - name: Build examples
+        run: pcb build examples
+
+      - name: Test workspace with pcb.toml
+        env:
+          RUST_LOG: info,pcb::release=debug,pcb::bom=debug
+        run: |
+          pcb bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
+          pcb layout test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen --no-open
+          pcb publish test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen -S layout.drc.invalid_outline
+
+      - name: Test pcb new
+        run: |
+          cd /tmp
+          pcb new --workspace test-ws --repo github.com/test/test-ws
+          cd test-ws
+          pcb new --board TB0001
+          pcb new --package reference/ref_a
+          pcb new --package modules/mod_a
+          pcb build .
+          cat .claude/skills/pcb/SKILL.md > /dev/null
+
+      - name: Checkout stdlib
+        uses: actions/checkout@v5
+        with:
+          repository: diodeinc/stdlib
+          path: stdlib
+
+      - name: Test stdlib builds
+        run: pcb build stdlib

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,50 +117,11 @@ jobs:
           # Only save cache from main branch to prevent cache proliferation
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Build CLI
-        run: cargo build -p pcb
-
       - name: Test All (Workspace)
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: full
         run: cargo test --verbose --workspace
-
-      - name: Build examples
-        run: cargo run -- build examples
-
-      - name: Test CLI (E2E)
-        env:
-          RUST_LOG: info,pcb::release=debug,pcb::bom=debug
-        run: |
-          # Test workspace with pcb.toml and workspace-relative loads
-          cargo run -- bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
-          cargo run -- layout test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen --no-open
-          cargo run -- publish test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen -S layout.drc.invalid_outline
-
-      - name: Test pcb new (E2E)
-        if: runner.os != 'Windows'
-        run: |
-          cd /tmp
-          cargo run --manifest-path $GITHUB_WORKSPACE/Cargo.toml -- new --workspace test-ws --repo github.com/test/test-ws
-          cd test-ws
-          cargo run --manifest-path $GITHUB_WORKSPACE/Cargo.toml -- new --board TB0001
-          cargo run --manifest-path $GITHUB_WORKSPACE/Cargo.toml -- new --package reference/ref_a
-          cargo run --manifest-path $GITHUB_WORKSPACE/Cargo.toml -- new --package modules/mod_a
-          cargo run --manifest-path $GITHUB_WORKSPACE/Cargo.toml -- build .
-          cat .claude/skills/pcb/SKILL.md > /dev/null
-
-      - name: Checkout stdlib
-        uses: actions/checkout@v5
-        with:
-          repository: diodeinc/stdlib
-          path: stdlib
-
-      - name: Test stdlib builds
-        shell: bash
-        run: |
-          $(pwd)/target/debug/pcb build stdlib
-          echo "All stdlib files built successfully!"
 
   python-tests:
     name: Python Tests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only refactor that changes workflow structure and execution environment, with primary risk being missed coverage or differing behavior between the new E2E job and the removed steps.
> 
> **Overview**
> Splits CLI end-to-end coverage into a new GitHub Actions workflow, `e2e.yml`, which runs on macOS and Ubuntu (Ubuntu via the KiCad container) and executes `pcb` build/example/workspace/new/stdlib build scenarios.
> 
> Updates `test.yml` to focus on unit/workspace tests (plus existing lint/python/readme checks) by removing the prior E2E CLI steps and associated build/example/stdlib invocations from the main `test` job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638e638931ce65054bfb77e940ac5316e9c1b860. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->