### PR TITLE
Derive layout PCB path from .kicad_pro file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Layout discovery now uses only `.kicad_pro` files, ignoring extra `.kicad_pcb` files in the layout directory.
+
 ## [0.3.38] - 2026-02-11
 
 ### Added

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -631,8 +631,7 @@ fn discover_layout_from_output(
     };
     let layout_path = zen_parent_dir.join(clean_path_str);
 
-    // Discover KiCad files (accept a single top-level .kicad_pro or .kicad_pcb).
-    // If there are multiple candidates, treat it as an error (ambiguous).
+    // Discover KiCad files (require a single top-level .kicad_pro).
     let discovered = layout_utils::discover_kicad_files(&layout_path)?;
     if discovered.is_none() {
         if layout_path.exists() {


### PR DESCRIPTION
Previously, we tried to tolerative missing .kicad_pro file by also looking for a unique .kicad_pcb file but this is unnecessary complexity. We can safely assume a .kicad_pro file is present/necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the file-discovery contract for layout tooling; workflows/layout dirs that previously relied on a lone `.kicad_pcb` without a `.kicad_pro` will now be treated as missing layout and skip/fail related tasks.
> 
> **Overview**
> Layout discovery is tightened to **only** accept a single top-level `.kicad_pro` in a layout directory, and the corresponding `.kicad_pcb` path is now always derived from that project file (avoiding false ambiguity from autosave/extra `.kicad_pcb` files).
> 
> This behavior change is applied across the Rust `pcb-layout` utilities and the Python lens KiCad adapter, and `pcb` release/layout detection messaging is updated to reflect the new requirement; the changelog records the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d70dec89c9f74a7d54880cf280eba444b702a81b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->