### PR TITLE
Use self-hosted windows runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,14 +93,6 @@ jobs:
           # Install KiCad fresh
           brew install --cask kicad
 
-      - name: Cache KiCad (Windows)
-        if: matrix.config.name == 'Windows'
-        id: cache-kicad-windows
-        uses: actions/cache@v4
-        with:
-          path: C:\Program Files\KiCad
-          key: ${{ runner.os }}-kicad-${{ env.KICAD_VERSION }}
-
       - name: Install KiCad (Windows)
         if: matrix.config.name == 'Windows' && steps.cache-kicad-windows.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI behavior changes may cause Windows jobs to fail or run slower depending on self-hosted runner availability/configuration and the removed KiCad cache.
> 
> **Overview**
> Moves the CI Windows test matrix to a *self-hosted* runner by changing `runs-on` from `windows-large` to `[self-hosted, windows-large]`.
> 
> Removes the Windows KiCad cache step from the workflow, leaving Windows KiCad installation to run without `actions/cache`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaadc10f90262044d2dc89a1666a32f9bc91150c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->