### PR TITLE
Use nextest in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+# Nextest configuration
+# https://nexte.st/docs/configuration/reference/
+
+[profile.ci]
+fail-fast = false
+failure-output = "immediate-final"
+status-level = "skip"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
   KICAD_VERSION: 9.0.7  # Update container image below when changing this
 
 concurrency:
@@ -109,11 +111,20 @@ jobs:
           # Only save cache from main branch to prevent cache proliferation
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Test All (Workspace)
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: full
-        run: cargo test --verbose --workspace
+        run: cargo nextest run --workspace --profile ci --locked
+
+      - name: Run doctests
+        env:
+          RUST_LOG: debug
+          RUST_BACKTRACE: full
+        run: cargo test --doc --workspace --locked
 
   python-tests:
     name: Python Tests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only changes that adjust test runner/configuration; main risk is altered test execution/ordering or coverage (separate doctests) causing unexpected CI failures.
> 
> **Overview**
> CI now uses `cargo nextest` for workspace tests (with a new `.config/nextest.toml` `profile.ci`) instead of `cargo test`, and installs nextest during the workflow.
> 
> The workflow also disables incremental compilation and test debug info in CI env, and runs doctests separately via `cargo test --doc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4451df895c096e6674bf5a5ef7c13a22f895a6cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->