### PR TITLE
Harden `pcb import` passive value parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Harden `pcb import` passive value parsing (e.g. `1 uF`, `2,2uF`, `1uF/16V`, `10 kΩ`, `R10`) so generic R/C auto-promotion is applied consistently.
+
 ## [0.3.40] - 2026-02-12
 
 ### Added


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized parsing changes with expanded unit tests; risk is mainly small behavior shifts for ambiguous value strings during import.
> 
> **Overview**
> Improves `pcb import` passive (R/C) value parsing so generic auto-promotion is more consistent across real-world BOM/value strings.
> 
> Parsing is hardened by tokenizing on additional separators (e.g. `/`, parentheses, brackets), normalizing Unicode and locale variants (Greek mu, ohm symbol variants, comma decimals), supporting resistor `R10`-style fractional notation, and attempting merged-token parses while avoiding accidental refdes/package merges (e.g. standalone `R` + `0402`). Tests are expanded to cover these cases, and the fix is documented in the Unreleased changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0e6b08e0d063c975272935453c37945529b0fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->