### PR TITLE
Use single label matcher for windows runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         config:
           - name: Windows
-            runs-on: [self-hosted, windows-large]
+            runs-on: diode-windows
           - name: macOS
             runs-on: macos-15-xlarge
           - name: Ubuntu

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,7 +22,7 @@ pr-run-mode = "skip"
 global = "ubicloud-standard-30-ubuntu-2204"
 x86_64-apple-darwin = "macos-15-large"
 aarch64-apple-darwin = "macos-15-xlarge"
-x86_64-pc-windows-msvc = "windows-large"
+x86_64-pc-windows-msvc = "diode-windows"
 x86_64-unknown-linux-gnu = "ubicloud-standard-30-ubuntu-2204"
 
 [[dist.extra-artifacts]]


### PR DESCRIPTION
cargo-dist doesn't support multiple labels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only CI runner label change; risk is limited to potential CI failures if the new runner label is misconfigured or unavailable.
> 
> **Overview**
> Standardizes Windows execution to a single GitHub runner label by switching the CI test matrix from a multi-label selector (`[self-hosted, windows-large]`) to `diode-windows`.
> 
> Updates `cargo-dist`’s `dist-workspace.toml` custom runner mapping for `x86_64-pc-windows-msvc` to also use `diode-windows`, keeping release builds aligned with CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532a0b05f726b045ac53cbe5b461574b297fa35f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->