### PR TITLE
Add a Rust setup step to cargo-dist release

### DIFF
--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -1,0 +1,2 @@
+- name: Setup Rust toolchain
+  uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "Setup Rust toolchain"
+        uses: "actions-rust-lang/setup-rust-toolchain@v1"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,6 +17,8 @@ install-path = "CARGO_HOME"
 install-updater = true
 # Which actions to run on pull requests
 pr-run-mode = "skip"
+# Additional build setup steps for generated release workflow
+github-build-setup = "../build-setup.yml"
 
 [dist.github-custom-runners]
 global = "ubicloud-standard-30-ubuntu-2204"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
Previously, we assumed some cargo/rust version was pre-installed in the runner and we'd just use that. We should instead respect rust-toolchain.toml.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes that primarily make builds more deterministic; risk is limited to potential workflow/toolchain setup incompatibilities on some runners.
> 
> **Overview**
> The release workflow now **explicitly sets up Rust** via `actions-rust-lang/setup-rust-toolchain@v1`, avoiding reliance on whatever `cargo` happens to be on the runner.
> 
> This introduces a shared `.github/build-setup.yml` referenced from `dist-workspace.toml` (`github-build-setup`) and adds a repo `rust-toolchain.toml` (stable) so CI builds/releases consistently use the intended Rust toolchain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf8fce352b099ffd7a41b86287d2d3bafaacf58f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->