### PR TITLE
Set required config values in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `config()` physical-value coercion now accepts numeric scalars (`int`/`float`) in addition to strings, matching constructor behavior.
+
 ## [0.3.41] - 2026-02-12
 
 ### Fixed

--- a/crates/pcb-layout/tests/resources/module_layout/Module.zen
+++ b/crates/pcb-layout/tests/resources/module_layout/Module.zen
@@ -11,6 +11,7 @@ gnd = io("gnd", Net)
 Capacitor(
     name = "C1",
     package = "0402",
+    value = "0F",
     P1 = power,
     P2 = gnd,
 )
@@ -19,6 +20,7 @@ Capacitor(
 Capacitor(
     name = "C2",
     package = "0603",
+    value = "0F",
     P1 = power,
     P2 = gnd,
 )

--- a/crates/pcb-layout/tests/resources/netclass_assignment/diffpair_module.zen
+++ b/crates/pcb-layout/tests/resources/netclass_assignment/diffpair_module.zen
@@ -8,6 +8,7 @@ signal = io("SIGNAL", DiffPair)
 # Add a simple component inside the module to make it non-empty
 Capacitor(
     name="C_DIFFPAIR",
+    value="0F",
     P1=signal.P,
     P2=signal.N,
 )

--- a/crates/pcb-layout/tests/resources/netclass_assignment/usb_module.zen
+++ b/crates/pcb-layout/tests/resources/netclass_assignment/usb_module.zen
@@ -11,6 +11,7 @@ usb = io("USB", Usb2)
 # Add a simple component inside the module to make it non-empty
 Resistor(
     name="R_USB",
+    value=0,
     P1=usb.D.P,
     P2=usb.D.N,
 )

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -1239,7 +1239,8 @@ fn try_enum_conversion<'v>(
     }
 }
 
-/// Attempt to convert a string to a PhysicalValue.
+/// Attempt to convert scalar/string inputs to a PhysicalValue via the
+/// PhysicalValueType constructor.
 fn try_physical_conversion<'v>(
     value: Value<'v>,
     typ: Value<'v>,
@@ -1248,7 +1249,10 @@ fn try_physical_conversion<'v>(
     if typ.downcast_ref::<PhysicalValueType>().is_none() {
         return Ok(None);
     }
-    if value.unpack_str().is_none() {
+    let is_supported_scalar = value.unpack_str().is_some()
+        || value.unpack_i32().is_some()
+        || value.downcast_ref::<StarlarkFloat>().is_some();
+    if !is_supported_scalar {
         return Ok(None);
     }
     match eval.eval_function(typ, &[value], &[]) {

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -680,21 +680,25 @@ snapshot_eval!(config_string_to_physical_value, {
     "types.zen" => r#"
         Voltage = builtin.physical_value("V")
         Resistance = builtin.physical_value("Ω")
+        Current = builtin.physical_value("A")
     "#,
     "child.zen" => r#"
-        load("types.zen", "Voltage", "Resistance")
+        load("types.zen", "Voltage", "Resistance", "Current")
 
         voltage = config("voltage", Voltage)
         resistance = config("resistance", Resistance)
+        current = config("current", Current)
 
         print("voltage:", voltage)
         print("resistance:", resistance)
+        print("current:", current)
     "#,
     "test.zen" => r#"
         Child = Module("child.zen")
 
-        # Provide string values that should be converted to PhysicalValues
-        Child(name = "test", voltage = "3.3V", resistance = "10k")
+        # Provide mixed scalar/string values that should be converted
+        # through the PhysicalValue constructor path.
+        Child(name = "test", voltage = "3.3V", resistance = 10000, current = 0.02)
 
         print("String to PhysicalValue conversion: success")
     "#

--- a/crates/pcb-zen/tests/spice_model.rs
+++ b/crates/pcb-zen/tests/spice_model.rs
@@ -69,7 +69,7 @@ R1 p n {RVAL}
         "myresistor.zen",
         r#"
 load("@stdlib/generics/SolderJumper.zen", "pin_defs")
-load("@stdlib/config.zen", "config_properties", "config_unit")
+load("@stdlib/config.zen", "config_properties")
 load("@stdlib/units.zen", "Resistance", "Voltage")
 load("@stdlib/utils.zen", "format_value")
 
@@ -85,10 +85,10 @@ Package = enum("0201", "0402", "0603", "0805", "1206", "1210", "2010", "2512")
 
 # Required
 package = config("package", Package, default = Package("0603"))
-value = config_unit("value", Resistance)
+value = config("value", Resistance)
 
 # Optional
-voltage = config_unit("voltage", Voltage, optional = True)
+voltage = config("voltage", Voltage, optional = True)
 
 # Properties - combined and normalized
 properties = config_properties({

--- a/crates/pcb/src/import/semantic.rs
+++ b/crates/pcb/src/import/semantic.rs
@@ -806,7 +806,7 @@ fn parse_capacitance_token(token: &str) -> Option<String> {
     }
 
     // Normalize trailing 'F' but always emit an explicit Farads unit to satisfy
-    // stdlib `config_unit("value", Capacitance)` parsing.
+    // stdlib `config("value", Capacitance)` parsing.
     if s.ends_with('F') && s.len() > 1 {
         s.pop();
     }

--- a/examples/HighSideCurrentSense/HighSideCurrentSense.zen
+++ b/examples/HighSideCurrentSense/HighSideCurrentSense.zen
@@ -4,7 +4,6 @@ Description: High side current sensor using INA240A with 2mohm shunt resistor, 2
 """
 load("@stdlib/interfaces.zen", "Power", "Analog", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/config.zen", "config_unit")
 
 Resistor = Module("@stdlib/generics/Resistor.zen")
 NetTie = Module("@stdlib/generics/NetTie.zen")


### PR DESCRIPTION
Also, support int/float -> physical value promotion in config().

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to type coercion in `config()` plus test/fixture updates; low risk outside of potential edge-case coercion differences for numeric inputs.
> 
> **Overview**
> Expands `config()`’s automatic PhysicalValue coercion to accept numeric scalars (`int`/`float`) in addition to strings, by routing scalars through the PhysicalValue constructor.
> 
> Updates tests/resources to provide required component `value` fields (and shifts some sample code from `config_unit` to `config`) so fixtures align with stricter/expected config handling, plus refreshes the config→PhysicalValue snapshot to cover mixed string+numeric inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 012277cf1b052f74c77ebafdd9040a80add774af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->