### PR TITLE
Remove `--sync-board-config` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - `pcb layout --check` now runs layout sync against a shadow copy.
+- Removed `--sync-board-config`; board config sync is now always enabled for layout sync (CLI, MCP `run_layout`, and `pcb_layout::process_layout`).
 
 ## [0.3.42] - 2026-02-13
 

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -525,12 +525,10 @@ class SetupBoard(Step):
         state: SyncState,
         board: pcbnew.BOARD,
         board_config_path: Optional[str] = None,
-        sync_board_config: bool = True,
     ):
         self.state = state
         self.board = board
         self.board_config_path = board_config_path
-        self.sync_board_config = sync_board_config
 
     # Configuration table: (json_path, ds_attribute, display_name, [custom_setter])
     CONFIG_MAPPINGS = [
@@ -956,10 +954,7 @@ class SetupBoard(Step):
         # Setup title block with variable placeholders
         self._setup_title_block()
 
-        # Apply board config logic
-        should_apply_config = self.board_config_path and self.sync_board_config
-
-        if should_apply_config:
+        if self.board_config_path:
             self._apply_board_config()
 
 
@@ -1611,12 +1606,6 @@ def main():
         help="""JSON file containing board setup configuration.""",
     )
     parser.add_argument(
-        "--sync-board-config",
-        type=bool,
-        default=True,
-        help="""Apply board config (default: true).""",
-    )
-    parser.add_argument(
         "--diagnostics",
         "-d",
         type=str,
@@ -1656,7 +1645,7 @@ def main():
         save_board = True
     else:
         steps = [
-            SetupBoard(state, board, args.board_config, args.sync_board_config),
+            SetupBoard(state, board, args.board_config),
             ImportNetlist(state, board, args.output, netlist),
             FinalizeBoard(state, board, snapshot_path, diagnostics_path),
         ]

--- a/crates/pcb-layout/tests/fpid_change.rs
+++ b/crates/pcb-layout/tests/fpid_change.rs
@@ -47,7 +47,7 @@ fn test_fpid_change_replaces_footprint_geometry() -> Result<()> {
     let schematic = output.expect("Zen evaluation should produce a schematic");
 
     let mut layout_diagnostics = Diagnostics::default();
-    let result = process_layout(&schematic, false, false, false, &mut layout_diagnostics)?.unwrap();
+    let result = process_layout(&schematic, false, false, &mut layout_diagnostics)?.unwrap();
     assert!(
         result.pcb_file.exists(),
         "PCB file should exist after initial sync"
@@ -99,8 +99,7 @@ fn test_fpid_change_replaces_footprint_geometry() -> Result<()> {
     let schematic2 = output2.expect("Second Zen evaluation should produce a schematic");
 
     let mut layout_diagnostics2 = Diagnostics::default();
-    let result2 =
-        process_layout(&schematic2, false, false, false, &mut layout_diagnostics2)?.unwrap();
+    let result2 = process_layout(&schematic2, false, false, &mut layout_diagnostics2)?.unwrap();
     assert!(
         result2.pcb_file.exists(),
         "PCB file should exist after FPID change sync"
@@ -175,7 +174,7 @@ fn test_fpid_change_preserves_position() -> Result<()> {
     let (output, _) = pcb_zen::run(&zen_file, res.clone()).unpack();
     let schematic = output.expect("Zen evaluation should produce a schematic");
     let mut layout_diagnostics = Diagnostics::default();
-    let result = process_layout(&schematic, false, false, false, &mut layout_diagnostics)?.unwrap();
+    let result = process_layout(&schematic, false, false, &mut layout_diagnostics)?.unwrap();
 
     let initial_snapshot: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&result.snapshot_file)?)?;
@@ -199,8 +198,7 @@ fn test_fpid_change_preserves_position() -> Result<()> {
     let (output2, _) = pcb_zen::run(&zen_file, res).unpack();
     let schematic2 = output2.expect("Second Zen evaluation should produce a schematic");
     let mut layout_diagnostics2 = Diagnostics::default();
-    let result2 =
-        process_layout(&schematic2, false, false, false, &mut layout_diagnostics2)?.unwrap();
+    let result2 = process_layout(&schematic2, false, false, &mut layout_diagnostics2)?.unwrap();
 
     let updated_snapshot: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&result2.snapshot_file)?)?;

--- a/crates/pcb-layout/tests/layout_generation.rs
+++ b/crates/pcb-layout/tests/layout_generation.rs
@@ -44,9 +44,9 @@ macro_rules! layout_test {
 
                 let schematic = output.expect("Zen evaluation should produce a schematic");
 
-                // Process the layout (enable sync_board_config for tests that need netclass assignment)
+                // Process the layout
                 let mut diagnostics = Diagnostics::default();
-                let result = process_layout(&schematic, $snapshot_kicad_pro, false, false, &mut diagnostics)?.unwrap();
+                let result = process_layout(&schematic, false, false, &mut diagnostics)?.unwrap();
 
                 // Verify the layout was created
                 assert!(result.pcb_file.exists(), "PCB file should exist");

--- a/crates/pcb-layout/tests/moved.rs
+++ b/crates/pcb-layout/tests/moved.rs
@@ -40,7 +40,7 @@ fn test_moved_renames_path_and_preserves_position() -> Result<()> {
     let schematic = output.expect("Zen evaluation should produce a schematic");
 
     let mut layout_diagnostics = Diagnostics::default();
-    let result = process_layout(&schematic, false, false, false, &mut layout_diagnostics)?.unwrap();
+    let result = process_layout(&schematic, false, false, &mut layout_diagnostics)?.unwrap();
     assert!(
         result.pcb_file.exists(),
         "PCB file should exist after initial sync"
@@ -85,8 +85,7 @@ fn test_moved_renames_path_and_preserves_position() -> Result<()> {
     );
 
     let mut layout_diagnostics2 = Diagnostics::default();
-    let result2 =
-        process_layout(&schematic2, false, false, false, &mut layout_diagnostics2)?.unwrap();
+    let result2 = process_layout(&schematic2, false, false, &mut layout_diagnostics2)?.unwrap();
     assert!(
         result2.pcb_file.exists(),
         "PCB file should exist after rename sync"

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -22,17 +22,6 @@ pub struct LayoutArgs {
     #[arg(long = "offline")]
     pub offline: bool,
 
-    /// Apply board config (default: true)
-    #[arg(
-        long = "sync-board-config",
-        action = clap::ArgAction::Set,
-        default_value_t = true,
-        value_parser = clap::builder::BoolishValueParser::new(),
-        num_args = 0..=1,
-        default_missing_value = "true"
-    )]
-    pub sync_board_config: bool,
-
     /// Generate layout in a temporary directory (fresh layout, opens KiCad)
     #[arg(long = "temp")]
     pub temp: bool,
@@ -91,7 +80,6 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
     let mut diagnostics = pcb_zen_core::Diagnostics::default();
     let result = process_layout(
         &schematic,
-        args.sync_board_config,
         args.temp,
         args.check, // check-mode (shadow copy)
         &mut diagnostics,

--- a/crates/pcb/src/mcp.rs
+++ b/crates/pcb/src/mcp.rs
@@ -133,10 +133,6 @@ fn local_tools() -> Vec<ToolInfo> {
                 "no_open": {
                     "type": "boolean",
                     "description": "Skip opening KiCad after layout generation (default: false). Set to true if you only need to sync without interacting."
-                },
-                "sync_board_config": {
-                    "type": "boolean",
-                    "description": "Apply board config including netclasses (default: true)"
                 }
             },
             "required": ["file"]
@@ -185,7 +181,6 @@ fn run_layout(args: Option<Value>, ctx: &McpContext) -> Result<CallToolResult> {
     );
     file_walker::require_zen_file(&zen_path)?;
 
-    let sync_board_config = get_bool("sync_board_config", true);
     let no_open = get_bool("no_open", false);
 
     let resolution_result = crate::resolve::resolve(zen_path.parent(), false, false)?;
@@ -204,13 +199,7 @@ fn run_layout(args: Option<Value>, ctx: &McpContext) -> Result<CallToolResult> {
     };
 
     let mut diagnostics = pcb_zen_core::Diagnostics::default();
-    match pcb_layout::process_layout(
-        &schematic,
-        sync_board_config,
-        false,
-        false,
-        &mut diagnostics,
-    ) {
+    match pcb_layout::process_layout(&schematic, false, false, &mut diagnostics) {
         Ok(Some(result)) => {
             ctx.log("info", &format!("Generated: {}", result.pcb_file.display()));
             let opened = !no_open && open::that(&result.pcb_file).is_ok();

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -1483,7 +1483,7 @@ fn run_kicad_drc(info: &ReleaseInfo, spinner: &Spinner) -> Result<()> {
 
     // Collect diagnostics from layout sync check (run on staged sources/layout).
     let Some(layout_result) =
-        pcb_layout::process_layout(&staged_schematic, false, false, true, &mut diagnostics)?
+        pcb_layout::process_layout(&staged_schematic, false, true, &mut diagnostics)?
     else {
         anyhow::bail!("No layout directory for DRC checks");
     };


### PR DESCRIPTION
AFAIK, no one every uses this. Just unnecessary complexity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is simplified by removing an unused flag; risk is limited to boards that previously depended on disabling board-config application during layout sync.
> 
> **Overview**
> Removes the `--sync-board-config` toggle and makes board-config application **always on** for all layout sync entry points.
> 
> This updates `pcb_layout::process_layout` and the Python `update_layout_file.py` to drop the flag/CLI arg, unconditionally apply board config when present, and adjusts callers (CLI `pcb layout`, MCP `run_layout`, release DRC check) plus related tests and changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1e6d5d1e4f6504ef7d4e3e969750b646c2faab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->