### PR TITLE
`pcb layout` stackup sync now also patches `general (thickness ...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Removed `--sync-board-config`; board config sync is now always enabled for layout sync (CLI, MCP `run_layout`, and `pcb_layout::process_layout`).
 - `pcb fmt` now formats KiCad S-expression files (for example `.kicad_pcb`, `.kicad_sch`, `fp-lib-table`) only when an explicit file path is provided; default/discovery mode remains `.zen`-only.
 - Stackup/layers patching in `pcb layout` now uses structural S-expression mutation + canonical KiCad-style formatting, with unconditional patch/write.
+- `pcb layout` stackup sync now also patches `general (thickness ...)` from computed stackup thickness.
 
 ## [0.3.42] - 2026-02-13
 


### PR DESCRIPTION
Also, only rewrite the subset of the layout file we're patching. Not the whole thing. We were already using this strategy for net rename and other Rust-based kicad file patching. We should use it for board config patching as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches layout file patching/formatting logic and changes how `.kicad_pcb` content is rewritten; errors could cause malformed boards or noisy diffs, though changes are localized and covered by new tests.
> 
> **Overview**
> `pcb layout` stackup sync now also patches `general (thickness ...)` using a computed board thickness (including KiCad’s fixed solder mask contribution) and formats the value in KiCad-style mm text.
> 
> Stackup/layers syncing is refactored to generate a `PatchSet` that replaces only the relevant S-expression spans (`layers`, `setup.stackup`, and `general.thickness`) and then runs `prettify`, reducing unrelated churn compared to reformatting the entire parsed tree.
> 
> `pcb-sexpr` parsing/formatting is extended to preserve original numeric lexemes (e.g. `12.000000`) via a new `raw_atom` field, ensuring round-trips and targeted patches don’t normalize unrelated numeric precision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5d5a1c1c38e666ef141f26b3975920a32032a7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->