### PR TITLE
Fix unnamed KiCad pin handling by unifying fallback across import and runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `pcb fmt` now formats KiCad S-expression files (for example `.kicad_pcb`, `.kicad_sch`, `fp-lib-table`) only when an explicit file path is provided; default/discovery mode remains `.zen`-only.
 - Stackup/layers patching in `pcb layout` now uses structural S-expression mutation + canonical KiCad-style formatting, with unconditional patch/write.
 - `pcb layout` stackup sync now also patches `general (thickness ...)` from computed stackup thickness.
-
-### Changed
-
 - Removed MCP resource `zener-docs` (https://docs.pcb.new/llms.txt) from `pcb mcp`, with Zener docs now embedded in `pcb doc`.
+
+### Fixed
+
+- Standardized KiCad unnamed-pin handling: empty/placeholder names now fall back to pin numbers in both import and runtime symbol loading, fixing `Unknown pin name` errors for imported components.
 
 ## [0.3.42] - 2026-02-13
 

--- a/crates/pcb-eda/tests/test_eda.rs
+++ b/crates/pcb-eda/tests/test_eda.rs
@@ -142,6 +142,43 @@ fn test_pin_metadata_preserved_for_hidden_rotated_pin() {
 }
 
 #[test]
+fn test_nested_unnamed_pin_preserved_and_uses_number_as_signal_name() {
+    let content = r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "Demo:Led"
+    (symbol "Led_1_1"
+      (pin unspecified line
+        (at 0 0 0)
+        (length 2.54)
+        (name "")
+        (number "2")
+      )
+      (pin unspecified line
+        (at 10.16 0 180)
+        (length 2.54)
+        (name "")
+        (number "1")
+      )
+    )
+  )
+)"#;
+
+    let lib = SymbolLibrary::from_string(content, "kicad_sym").unwrap();
+    let symbol = lib.first_symbol().unwrap();
+    assert_eq!(symbol.pins.len(), 2);
+
+    let pin_map: HashMap<_, _> = symbol
+        .pins
+        .iter()
+        .map(|pin| (pin.number.clone(), pin.signal_name().to_string()))
+        .collect();
+
+    assert_eq!(pin_map.get("1"), Some(&"1".to_string()));
+    assert_eq!(pin_map.get("2"), Some(&"2".to_string()));
+}
+
+#[test]
 fn test_pcm2903cdb_manufacturer() {
     test_symbol_option_property(
         "PCM2903CDB",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches KiCad symbol parsing and the pin-to-signal mapping used for connectivity, so mistakes could rename signals or change net mapping for some symbols, though the change is narrow and covered by a new test.
> 
> **Overview**
> Fixes KiCad symbol pin parsing and runtime symbol loading to **preserve unnamed pins** (empty `name`), and consistently fall back to using the pin `number` as the signal name, avoiding `Unknown pin name` failures for imported components.
> 
> Refactors pin parsing in `pcb-eda` to share a single `parse_pin_common` implementation for both top-level and nested symbol pin formats, and adds a regression test covering nested unnamed pins; the Starlark `Symbol` loader in `pcb-zen-core` now builds `pad_to_signal` using `pin.signal_name()` from the unified EDA `Symbol` representation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29a45b17c2933fe3b1c24d3bccd0411a346e4984. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->