### PR TITLE
Remove unused spec field in BoardConfig

### DIFF
--- a/crates/pcb-zen-core/src/lang/stackup.rs
+++ b/crates/pcb-zen-core/src/lang/stackup.rs
@@ -2,7 +2,7 @@ use pcb_sch::physical::PhysicalValue;
 use pcb_sexpr::{kv, ListBuilder, Sexpr};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use std::{borrow::Cow, collections::HashMap, fmt, path::PathBuf, str::FromStr};
+use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr};
 use thiserror::Error;
 
 // Helper functions for layer mapping
@@ -316,8 +316,6 @@ pub struct BoardConfig {
     pub stackup: Option<Stackup>,
     #[serde(default = "default_num_user_layers")]
     pub num_user_layers: usize,
-    #[serde(default)]
-    pub spec: Option<PathBuf>,
 }
 
 impl BoardConfig {

--- a/examples/board_config.zen
+++ b/examples/board_config.zen
@@ -130,7 +130,6 @@ BoardConfig = record(
     design_rules=field(DesignRules | None, None),
     stackup=field(Stackup | None, None),  # Board stackup configuration
     num_user_layers=field(int, 4),  # Number of User.N layers (User.1, User.2, etc.)
-    spec=field(str | None, None),  # Path to a specification file
 )
 
 


### PR DESCRIPTION
The intent was to maybe have some other file format to store this stuff, but we never implemented that and it's just confusing to keep this around.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely removes an unused config field and corresponding example/schema entry; main risk is breaking consumers that still provide/read `spec` in JSON.
> 
> **Overview**
> Removes the unused `spec` path from `BoardConfig` (and its related `PathBuf` import), simplifying the JSON schema and configuration model.
> 
> Updates the `examples/board_config.zen` schema to drop the `spec` field so generated/merged configs no longer reference it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36a90e948afe04305a66ac6b9b23abdfd2f36f18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->