### PR TITLE
Prefer KiCad style-1 pin names for symbol variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Standardized KiCad unnamed-pin handling: empty/placeholder names now fall back to pin numbers in both import and runtime symbol loading, fixing `Unknown pin name` errors for imported components.
+- KiCad symbol variant parsing now selects one style per unit using named-pin coverage (tie: lowest style index), avoiding pin-name overrides while supporting `_N_0` symbols.
 
 ## [0.3.42] - 2026-02-13
 


### PR DESCRIPTION
Fixes regression introduced in 1587a790 (unnamed-pin fallback unification).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes KiCad symbol parsing logic that affects how pins are named/selected across many imported symbols; mistakes could silently alter net connectivity or pin labeling.
> 
> **Overview**
> Fixes KiCad nested-symbol variant pin parsing to **select exactly one style per unit** (instead of merging pins across styles), choosing the candidate with the most *named* pins and breaking ties by lowest style index.
> 
> Adds targeted tests covering style preference (e.g., prefer style-1 when it has names), style-0-only symbols, and deterministic tie-breaking, and documents the behavior in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 189192613f60b0f8175eb6042490c640379d5205. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->