### PR TITLE
Fail fast on ambiguous .kicad_sym in pcb search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Move board-config/title-block patching to Rust; simplify Python sync; only update `.kicad_pro` netclass patterns when assignments exist.
 - `pcb search` now formats generated component `.kicad_sym` and `.kicad_mod` files with the KiCad S-expression formatter.
 - `pcb search` now rewrites imported symbol `property "Footprint"` to the local `lib:footprint` form (`<stem>:<stem>`), matching fp-lib-table resolution during layout sync.
+- `pcb search` now fails fast unless imported `.kicad_sym` contains exactly one symbol.
 
 ### Fixed
 


### PR DESCRIPTION
Require imported symbol libraries to contain exactly one symbol during `pcb search` finalization (including `--dir` mode), and surface a clear error with symbol names when ambiguous.

`Symbol(library=...)` evaluation already fails later when a `.kicad_sym` has multiple symbols and no explicit name; this change fails fast earlier in `pcb search` where we cannot pick a symbol unambiguously anyway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized behavior change that only affects component import/finalization error handling; main risk is rejecting previously-accepted multi-symbol `.kicad_sym` inputs.
> 
> **Overview**
> `pcb search` now **requires imported/selected `.kicad_sym` files to contain exactly one symbol**, failing early with a clearer error that includes the symbol names when the library is empty or ambiguous.
> 
> This enforcement is applied both when finalizing downloaded components and when generating from a local directory (`--dir`), and is covered by new unit tests; the changelog is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96debc3fa0d99eae1d27b7c0e28971903cd28da3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->