### PR TITLE
Validate pin identifiers in Component pins map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `Component(pins=...)` now validates pin names as identifiers (ASCII, non-empty, no whitespace, no `.` or `@`) during component construction.
+
 ## [0.3.43] - 2026-02-18
 
 ### Added

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -960,6 +960,7 @@ where
                         starlark::Error::new_other(anyhow!("pin names must be strings"))
                     })?
                     .to_owned();
+                validate_identifier_name(&signal_name, "Pin name")?;
 
                 if !final_symbol.signal_names().any(|n| n == signal_name) {
                     return Err(starlark::Error::new_other(anyhow!(format!(

--- a/crates/pcb-zen-core/tests/common/mod.rs
+++ b/crates/pcb-zen-core/tests/common/mod.rs
@@ -3,6 +3,7 @@
 use pcb_zen_core::{FileProvider, FileProviderError};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// In-memory file provider for tests
 #[derive(Clone)]
@@ -26,6 +27,19 @@ impl InMemoryFileProvider {
         }
         Self { files: path_files }
     }
+}
+
+pub fn eval_single_file(src: &str) -> pcb_zen_core::WithDiagnostics<pcb_zen_core::EvalOutput> {
+    let mut files = HashMap::new();
+    files.insert("test.zen".to_string(), src.to_string());
+    let file_provider: Arc<dyn pcb_zen_core::FileProvider> =
+        Arc::new(InMemoryFileProvider::new(files));
+    pcb_zen_core::EvalContext::new(
+        file_provider,
+        pcb_zen_core::resolution::ResolutionResult::empty(),
+    )
+    .set_source_path(PathBuf::from("test.zen"))
+    .eval()
 }
 
 impl FileProvider for InMemoryFileProvider {

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -300,6 +300,8 @@ Key parameters:
 - `type`: Component type
 - `properties`: Additional properties dict
 
+Pin names in `pins = {...}` must be valid identifiers (ASCII, non-empty, no whitespace, no `.` or `@`).
+
 During `pcb build`, reference designators are allocated per-prefix using a deterministic ordering of component hierarchical instance names. The ordering is "natural" (so `R2` sorts before `R10`).
 
 The allocator also supports **opportunistic refdes hints** encoded in the *hierarchical instance path*: any **non-leaf** path segment that matches a valid reference designator pattern (1-3 capital letters followed by 1-3 digits, no leading zeros) may be used as the assigned reference designator **when it is safe and unambiguous**.


### PR DESCRIPTION
We shouldn't allow `.` in pin names as parsing it becomes ambiguous. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized validation change that may surface new errors for designs previously using dotted/invalid pin names, but does not affect security or data integrity.
> 
> **Overview**
> `Component(pins=...)` now validates each pin name using `validate_identifier_name`, rejecting non-identifier keys (ASCII-only, non-empty, no whitespace, and disallowing `.`/`@`) at component construction time.
> 
> Tests add a lightweight `eval_single_file` helper and a new regression test that asserts dotted pin names fail evaluation, and docs/`CHANGELOG.md` are updated to document the new pin-name constraint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2726298714bba247a6d7bf066c4e21ee488ddebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->