### PR TITLE
Fix publish layout sync false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced `layout.sync` false positives in publish/check flows by normalizing `.kicad_pro` newline writes and ignoring trailing whitespace-only drift when comparing synced layout files.
+
 ## [0.3.43] - 2026-02-18
 
 ### Added


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrowly scoped normalization around file comparisons and `.kicad_pro` output formatting; main risk is potentially missing a meaningful change if it only differs by trailing whitespace.
> 
> **Overview**
> Reduces `layout.sync` false positives during `pcb publish`/`--check` by treating synced KiCad layout files as equal when they only differ in trailing whitespace.
> 
> This changes `pcb-layout`'s drift detection to compare file contents after trimming ASCII whitespace at EOF, and updates `pcb release`’s `.kicad_pro` writer to always end the pretty-printed JSON with a newline. Targeted unit tests were added for both behaviors, and the fix is documented in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d70f0d6baf1bf5037527f917438f5d41398fe406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->