### PR TITLE
Prefer raw external tools during discovery (disable nested code-mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `Component()` now infers missing `footprint` from symbol `Footprint` (`<stem>` or KiCad `<lib>:<fp>`), reducing duplicated footprint data over `.kicad_sym`.
 
+### Changed
+
+- MCP external tool discovery now prefers `mcp --code-mode=false` (raw tools) and falls back to `mcp` only when needed, avoiding nested code-mode wrappers for compatible `pcb-*` backends.
+
 ### Fixed
 
 - Reduced `layout.sync` false positives in publish/check flows by normalizing `.kicad_pro` newline writes and ignoring trailing whitespace-only drift when comparing synced layout files.


### PR DESCRIPTION
Top-level code-mode can still use the discovered mcp tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to external MCP process spawning/discovery logic with a straightforward fallback path; main risk is compatibility with older backends that behave differently under `--code-mode=false`.
> 
> **Overview**
> External MCP tool discovery now spawns `pcb-*` backends using `mcp --code-mode false` to avoid nested code-mode wrappers, falling back to plain `mcp` when the flag isn’t supported.
> 
> `ExternalMcpServer::spawn` was refactored to try multiple MCP CLI argument sets via a new `spawn_with_mcp_args` helper, and the change is documented in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4c7a34040524c4d521597f82cb088f2b96dfde9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
