### PR TITLE
Fix `execute_tools` image serialization

### DIFF
--- a/crates/pcb-mcp/src/codemoder.rs
+++ b/crates/pcb-mcp/src/codemoder.rs
@@ -722,8 +722,7 @@ mod tests {
         let caller = Arc::new(MockToolCaller {
             tools: vec![ToolInfo {
                 name: "structured_with_extra_image",
-                description:
-                    "Return structured content with more image objects than content images",
+                description: "Return structured content with more image objects than content images",
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {}

--- a/crates/pcb/src/mcp.rs
+++ b/crates/pcb/src/mcp.rs
@@ -263,15 +263,17 @@ fn parse_image_index(value: &Value) -> Option<usize> {
     if let Some(idx) = value.as_u64() {
         return Some(idx as usize);
     }
-    if let Some(idx) = value.as_i64() {
-        if idx >= 0 {
-            return Some(idx as usize);
-        }
+    if let Some(idx) = value.as_i64()
+        && idx >= 0
+    {
+        return Some(idx as usize);
     }
-    if let Some(idx) = value.as_f64() {
-        if idx.is_finite() && idx >= 0.0 && idx.fract() == 0.0 {
-            return Some(idx as usize);
-        }
+    if let Some(idx) = value.as_f64()
+        && idx.is_finite()
+        && idx >= 0.0
+        && idx.fract() == 0.0
+    {
+        return Some(idx as usize);
     }
     None
 }


### PR DESCRIPTION
It was dumping huge image data and sometimes hiding useful tool output, so now it keeps the useful output and swaps raw image blobs for file references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the serialization contract between `pcb-mcp` and the `pcb` CLI for image handling; mistakes could drop images or mis-associate indices in eval output.
> 
> **Overview**
> Fixes `execute_with_tools` / `eval` output so image payloads are no longer embedded as base64 blobs in returned JSON.
> 
> On the MCP JS side (`pcb-mcp`), tool results now collect images into `ExecutionResult.images` and replace image blocks in both `content` and `structured_content` with lightweight markers (`imageIndex`, `mimeType`), only stripping `data` when a resolvable index exists. On the CLI side (`pcb`), eval output rewriting is updated to resolve these markers (or legacy inline `data`) into written `image_file` references, with added tests covering structured output, resource links, and marker rewriting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5de9739e14619976023bb5f2f51607b02c4cb48f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
