### PR TITLE
fix path resolution for layout_path

### DIFF
--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -654,6 +654,12 @@ pub mod utils {
             .and_then(|v| v.string());
         match uri {
             None => Ok(None),
+            Some(s) if !s.starts_with(pcb_sch::PACKAGE_URI_PREFIX) => {
+                // Absolute or relative path produced by Path() in stdlib when the project
+                // directory is not a registered package root (e.g. a standalone .zen file
+                // outside of any declared workspace package). Use the path directly.
+                Ok(Some(PathBuf::from(s)))
+            }
             Some(s) => schematic
                 .resolve_package_uri(s)
                 .map(Some)


### PR DESCRIPTION
Without this change, I had to go back to version 0.3.38 to get the `blinky.zen` example to successfully do the layout command. Otherwise I would always get the following error when doing `layout`, but `build` would work.

```
$ pcb layout blinky.zen 
A new version of pcb is available!
Run pcb self update to update.
Error: Failed to resolve layout_path '/home/nemik/code/pcb/blinky/layout'
  expected package:// URI, got: /home/nemik/code/pcb/blinky/layout
```

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to path parsing for `layout_path`; main risk is altered behavior for previously-invalid values and platform-specific path edge cases.
> 
> **Overview**
> Fixes `layout_path` resolution to support non-`package://` values. When `layout_path` is an absolute/relative filesystem path (e.g., produced by `Path()` when the project isn’t under a registered package root), it now bypasses `resolve_package_uri` and is used directly; `package://` URIs continue to be resolved as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cf37160b63fb6cfc66b0f0f567ccf51612136be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->