### PR TITLE
Fix footprint inference error message

### DIFF
--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -385,11 +385,12 @@ fn infer_kicad_footprint_fallback(
     let resolved = eval_ctx
         .get_config()
         .resolve_path(&inferred_url, current_file)
-        .map_err(|e| {
+        .map_err(|_e| {
             starlark::Error::new_other(anyhow!(
-                "Failed to infer footprint from KiCad symbol property '{}': {}",
+                "Failed to infer footprint from KiCad symbol property '{}': could not resolve inferred footprint path '{}'. \
+                Add a matching entry to [assets] in pcb.toml",
                 footprint_prop,
-                e
+                inferred_url
             ))
         })?;
 

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -521,14 +521,10 @@ impl EvalContextConfig {
         });
 
         let Some((matched_dep, root_path)) = best_match else {
-            let package_hint = full_url
-                .rsplit_once('/')
-                .map(|(prefix, _)| prefix)
-                .unwrap_or(&full_url);
             anyhow::bail!(
-                "No declared dependency matches '{}'\n  \
-                Add a dependency that covers this path to [dependencies] in pcb.toml",
-                package_hint
+                "No declared dependency or asset matches '{}'\n  \
+                Add a dependency to [dependencies] or an asset to [assets] in pcb.toml that covers this path",
+                full_url
             );
         };
 

--- a/crates/pcb-zen-core/tests/component_footprint_inference.rs
+++ b/crates/pcb-zen-core/tests/component_footprint_inference.rs
@@ -316,7 +316,7 @@ Component(
         .collect::<Vec<_>>()
         .join("\n");
     assert!(
-        rendered.contains("No declared dependency matches"),
+        rendered.contains("could not resolve inferred footprint path"),
         "unexpected diagnostics: {rendered}"
     );
 }

--- a/crates/pcb-zen-core/tests/cross_package_load.rs
+++ b/crates/pcb-zen-core/tests/cross_package_load.rs
@@ -178,7 +178,7 @@ fn cross_package_relative_load_without_repository() {
 #[test]
 #[cfg(not(target_os = "windows"))]
 fn cross_package_relative_load_undeclared_dependency() {
-    // No dependencies declared — should fail with "No declared dependency matches"
+    // No dependencies declared — should fail with "No declared dependency or asset matches"
     let deps = BTreeMap::new();
 
     let (file_provider, resolution, main_path) =
@@ -196,10 +196,10 @@ fn cross_package_relative_load_undeclared_dependency() {
     let errors: Vec<String> = result.diagnostics.iter().map(|d| d.to_string()).collect();
     let has_dep_error = errors
         .iter()
-        .any(|e| e.contains("No declared dependency matches"));
+        .any(|e| e.contains("No declared dependency or asset matches"));
     assert!(
         has_dep_error,
-        "Should get 'No declared dependency matches' error, got: {:?}",
+        "Should get 'No declared dependency or asset matches' error, got: {:?}",
         errors
     );
 }

--- a/crates/pcb-zen-core/tests/snapshots/component_footprint_inference__libfp_requires_declared_dependency.snap
+++ b/crates/pcb-zen-core/tests/snapshots/component_footprint_inference__libfp_requires_declared_dependency.snap
@@ -3,5 +3,4 @@ source: crates/pcb-zen-core/tests/component_footprint_inference.rs
 assertion_line: 339
 expression: output
 ---
-Error: test.zen:2:1-6:2 Failed to infer footprint from KiCad symbol property 'Package_SO:TSSOP-8_4.4x3mm_P0.65mm': No declared dependency matches 'gitlab.com/kicad/libraries/kicad-footprints/Package_SO.pretty'
-  Add a dependency that covers this path to [dependencies] in pcb.toml
+Error: test.zen:2:1-6:2 Failed to infer footprint from KiCad symbol property 'Package_SO:TSSOP-8_4.4x3mm_P0.65mm': could not resolve inferred footprint path 'gitlab.com/kicad/libraries/kicad-footprints/Package_SO.pretty/TSSOP-8_4.4x3mm_P0.65mm.kicad_mod'. Add a matching entry to [assets] in pcb.toml

--- a/crates/pcb/tests/snapshots/simple__no_fixture.snap
+++ b/crates/pcb/tests/snapshots/simple__no_fixture.snap
@@ -8,18 +8,18 @@ Exit Code: 1
 --- STDOUT ---
 
 --- STDERR ---
-Error: No declared dependency matches 'github.com/nonexistent/repo:main'
-  Add a dependency that covers this path to [dependencies] in pcb.toml
+Error: No declared dependency or asset matches 'github.com/nonexistent/repo:main/interfaces.zen'
+  Add a dependency to [dependencies] or an asset to [assets] in pcb.toml that covers this path
    ╭─[ <TEMP_DIR>/boards/TestBoard.zen:2:1 ]
    │
  2 │ load("github.com/nonexistent/repo:main/interfaces.zen", "Gpio", "Ground", "Power")
    │ ─────────────────────────────────────────┬────────────────────────────────────────  
-   │                                          ╰────────────────────────────────────────── No declared dependency matches 'github.com/nonexistent/repo:main'
+   │                                          ╰────────────────────────────────────────── No declared dependency or asset matches 'github.com/nonexistent/repo:main/interfaces.zen'
 ───╯
 
 Stack trace (most recent call last):
-    <TEMP_DIR>/boards/TestBoard.zen:2:1 (No declared dependency matches 'github.com/nonexistent/repo:main'
-  Add a dependency that covers this path to [dependencies] in pcb.toml)
+    <TEMP_DIR>/boards/TestBoard.zen:2:1 (No declared dependency or asset matches 'github.com/nonexistent/repo:main/interfaces.zen'
+  Add a dependency to [dependencies] or an asset to [assets] in pcb.toml that covers this path)
 
 ✗ TestBoard.zen: Build failed
 Error: Build failed with errors

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -270,8 +270,8 @@ my_symbol = Symbol(
 
 Component(
     name = "U1",                   # Required: instance name
-    footprint = "SOIC-8",          # Optional when inferable from symbol Footprint property
     symbol = my_symbol,            # Symbol defines the pins
+    footprint = "footprints/SOIC-8.kicad_mod",  # Optional override path; usually omit and use symbol Footprint inference
     pins = {                       # Required: pin connections
         "VCC": vcc_net,
         "GND": gnd_net,
@@ -292,7 +292,7 @@ Component(
 Key parameters:
 
 - `name`: Instance name (required)
-- `footprint`: PCB footprint. Optional only when a file-backed `symbol` provides an inferable `Footprint` property.
+- `footprint`: PCB footprint override. Usually omit this and let `Component()` infer from `symbol` `Footprint` property.
 - `symbol`: Symbol object defining pins. Required unless `pin_defs` is provided.
 - `pin_defs`: Legacy pin mapping dict. Required unless `symbol` is provided.
 - `pins`: Pin connections to nets (required)
@@ -305,8 +305,8 @@ When `footprint` is omitted, inference follows this order:
 
 - Accept symbol `Footprint` property as either bare `<stem>` (canonical) or legacy `<stem>:<stem>`.
 - Derive candidate file as `<symbol_dir>/<stem>.kicad_mod`.
-- Also accept KiCad's `<lib>:<fp>` form and resolve it as `gitlab.com/kicad/libraries/kicad-footprints/<lib>.pretty/<fp>.kicad_mod` (which must resolve through the package's declared dependencies).
-- If inference fails, provide `footprint = ...` explicitly.
+- Also accept KiCad's `<lib>:<fp>` form and resolve it as `gitlab.com/kicad/libraries/kicad-footprints/<lib>.pretty/<fp>.kicad_mod` (which must resolve through declared `[assets]` in `pcb.toml`).
+- Only provide `footprint = ...` to override the symbol-provided footprint, or when inference fails.
 
 During `pcb build`, reference designators are allocated per-prefix using a deterministic ordering of component hierarchical instance names. The ordering is "natural" (so `R2` sorts before `R10`).
 


### PR DESCRIPTION
before: `Add a dependency that covers this path to [dependencies] in pcb.toml`
after: `Add a matching entry to [assets] in pcb.toml`

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String/message-only changes plus test/doc updates; no behavior changes beyond what error text is shown to users.
> 
> **Overview**
> Improves error reporting when inferring KiCad `<lib>:<fp>` footprints by emitting a clearer message that includes the inferred URL and instructs users to add a matching `[assets]` entry, rather than surfacing a generic resolution error.
> 
> Updates URL resolution failures to report **“No declared dependency or asset matches …”** (including the full requested path) and points users at either `[dependencies]` or `[assets]`. Tests/snapshots and the language spec are updated to match the new messaging and clarify that the `Component(footprint=...)` parameter is primarily an override path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a86f2c0136b48e5d709bbb8b455cf5bc462d98f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
