### PR TITLE
Resolve standalone inline-manifest roots in file commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Added MCP tool `resolve_datasheet` to produce cached `datasheet.md` + `images/` from `datasheet_url`, `pdf_path`, or `kicad_sym_path`.
 
+### Fixed
+
+- Standalone `.zen` files with inline manifests now map `Board(..., layout_path=...)` to `package://workspace/...`, avoiding absolute-path leakage.
+
 ## [0.3.44] - 2026-02-20
 
 ### Added

--- a/crates/pcb/src/bom.rs
+++ b/crates/pcb/src/bom.rs
@@ -89,7 +89,7 @@ pub fn execute(args: BomArgs) -> Result<()> {
     crate::file_walker::require_zen_file(&args.file)?;
 
     // Resolve dependencies before evaluation
-    let resolution_result = crate::resolve::resolve(args.file.parent(), args.offline, args.locked)?;
+    let resolution_result = crate::resolve::resolve(Some(&args.file), args.offline, args.locked)?;
 
     let file_name = args.file.file_name().unwrap().to_string_lossy();
 

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -54,7 +54,7 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
     let locked = args.locked || std::env::var("CI").is_ok();
 
     // Resolve dependencies before building
-    let resolution_result = crate::resolve::resolve(args.file.parent(), args.offline, locked)?;
+    let resolution_result = crate::resolve::resolve(Some(&args.file), args.offline, locked)?;
 
     let zen_path = &args.file;
     let file_name = zen_path.file_name().unwrap().to_string_lossy().to_string();

--- a/crates/pcb/src/mcp.rs
+++ b/crates/pcb/src/mcp.rs
@@ -433,7 +433,7 @@ fn run_layout(args: Option<Value>, ctx: &McpContext) -> Result<CallToolResult> {
 
     let no_open = get_bool("no_open", false);
 
-    let resolution_result = crate::resolve::resolve(zen_path.parent(), false, false)?;
+    let resolution_result = crate::resolve::resolve(Some(&zen_path), false, false)?;
 
     let mut has_errors = false;
     let mut has_warnings = false;

--- a/crates/pcb/src/open.rs
+++ b/crates/pcb/src/open.rs
@@ -23,7 +23,7 @@ pub fn execute(args: OpenArgs) -> Result<()> {
     crate::file_walker::require_zen_file(&args.file)?;
 
     // Resolve dependencies before building
-    let resolution_result = crate::resolve::resolve(args.file.parent(), args.offline, args.locked)?;
+    let resolution_result = crate::resolve::resolve(Some(&args.file), args.offline, args.locked)?;
 
     let zen_path = &args.file;
     let file_name = zen_path.file_name().unwrap().to_string_lossy();

--- a/crates/pcb/src/route.rs
+++ b/crates/pcb/src/route.rs
@@ -46,7 +46,7 @@ pub fn execute(args: RouteArgs) -> Result<()> {
     }
 
     // Resolve dependencies
-    let resolution_result = crate::resolve::resolve(args.file.parent(), false, false)?;
+    let resolution_result = crate::resolve::resolve(Some(&args.file), false, false)?;
 
     let zen_path = &args.file;
     let board_name = zen_path.file_stem().unwrap().to_string_lossy();

--- a/crates/pcb/src/sim.rs
+++ b/crates/pcb/src/sim.rs
@@ -47,7 +47,7 @@ pub fn execute(args: SimArgs) -> Result<()> {
     let mut out = get_output_writer(&args.output.to_string_lossy())?;
 
     // Resolve dependencies before building
-    let resolution_result = crate::resolve::resolve(zen_path.parent(), args.offline, args.locked)?;
+    let resolution_result = crate::resolve::resolve(Some(zen_path), args.offline, args.locked)?;
 
     let Some(schematic) = build_zen(
         zen_path,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, mechanical change to how the resolve root is computed for several CLI/MCP entrypoints; main risk is unexpected workspace discovery differences when running commands from unusual directories.
> 
> **Overview**
> Fixes dependency resolution for file-based commands when invoked on standalone `.zen` files (including inline manifests) by passing the actual `.zen` path into `crate::resolve::resolve(...)` instead of only the parent directory, across `bom`, `layout`, `open`, `route`, `sim`, and MCP `run_layout`.
> 
> Updates the changelog to note the resulting behavior change: `Board(..., layout_path=...)` now resolves to `package://workspace/...` rather than leaking absolute paths for standalone inline-manifest `.zen` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 123ec98ca86f3a8fa5f939f02a3d4105fb86dc98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
