### PR TITLE
Add resolve_datasheet LSP endpoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added MCP tool `resolve_datasheet` to produce cached `datasheet.md` + `images/` from `datasheet_url`, `pdf_path`, or `kicad_sym_path`.
+- Added LSP request `pcb/resolveDatasheet`, sharing the same resolve flow as the MCP tool.
 
 ## [0.3.44] - 2026-02-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3992,6 +3992,7 @@ dependencies = [
  "pcb-sch",
  "pcb-sexpr",
  "pcb-sim",
+ "pcb-starlark-lsp",
  "pcb-test-utils",
  "pcb-ui",
  "pcb-zen",

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -29,6 +29,7 @@ clap = { workspace = true }
 glam = { workspace = true }
 pcb-zen-core = { workspace = true, features = ["table"] }
 pcb-zen = { workspace = true }
+pcb-starlark-lsp = { workspace = true }
 pcb-sch = { workspace = true, features = ["table"] }
 pcb-layout = { workspace = true }
 pcb-sim = { workspace = true }

--- a/crates/pcb/src/lsp.rs
+++ b/crates/pcb/src/lsp.rs
@@ -3,7 +3,48 @@ use clap::Args;
 #[derive(Args)]
 pub struct LspArgs {}
 
+#[cfg(feature = "api")]
+const RESOLVE_DATASHEET_METHOD: &str = "pcb/resolveDatasheet";
+
 pub fn execute(_args: LspArgs) -> anyhow::Result<()> {
-    pcb_zen::lsp_with_eager(false)?;
-    Ok(())
+    #[cfg(feature = "api")]
+    {
+        let ctx = pcb_zen::lsp::LspEvalContext::default()
+            .set_eager(false)
+            .with_custom_request_handler(handle_custom_request);
+        pcb_starlark_lsp::server::stdio_server(ctx)
+    }
+
+    #[cfg(not(feature = "api"))]
+    {
+        pcb_zen::lsp_with_eager(false)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "api")]
+fn handle_custom_request(
+    method: &str,
+    params: &serde_json::Value,
+) -> anyhow::Result<Option<serde_json::Value>> {
+    if method != RESOLVE_DATASHEET_METHOD {
+        return Ok(None);
+    }
+
+    let input = pcb_diode_api::datasheet::parse_resolve_request(Some(params))?;
+    let token = pcb_diode_api::auth::get_valid_token()?;
+    let response = pcb_diode_api::datasheet::resolve_datasheet(&token, &input)?;
+    Ok(Some(serde_json::to_value(response)?))
+}
+
+#[cfg(all(test, feature = "api"))]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn custom_request_handler_ignores_other_methods() {
+        let result = handle_custom_request("pcb/somethingElse", &json!({})).unwrap();
+        assert!(result.is_none());
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new LSP entry point that triggers authenticated network-backed datasheet resolution and modifies caching/materialization behavior, which could affect I/O paths and cache correctness if edge cases are missed.
> 
> **Overview**
> Adds a custom LSP request `pcb/resolveDatasheet` to the `pcb lsp` server (behind the `api` feature), routing requests through `pcb_diode_api::datasheet::parse_resolve_request` + `resolve_datasheet` to return the cached `datasheet.md`/`images/`/PDF paths.
> 
> Generalizes and hardens datasheet caching: request parsing now accepts both snake_case and camelCase fields, cache lookup is refactored into a reusable `first_valid_file_in_dir`, and materialization now ensures a valid PDF is copied into the materialized cache directory before returning cached results. `pcb-zen`’s LSP context gains a pluggable custom request handler hook used by `pcb` to implement the new endpoint, and workspace deps are updated to include `pcb-starlark-lsp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bad479bf008f0116ba46b706dffdd25f808be726. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
