### PR TITLE
fallback on automatic manufacturer on mcp

### DIFF
--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -512,7 +512,7 @@ pub fn add_component_to_workspace(
     let download = download_component(auth_token, component_id)?;
     spinner.finish_and_clear();
 
-    let manufacturer = search_manufacturer;
+    let manufacturer = search_manufacturer.or(download.metadata.manufacturer.as_deref());
     let component_dir = component_dir_path(workspace_root, manufacturer, part_number);
     let sanitized_mpn = pcb_component_gen::sanitize_mpn_for_path(part_number);
     let zen_file = component_dir.join(format!("{}.zen", &sanitized_mpn));


### PR DESCRIPTION
- when using the cli code mode, the manufacturer folder sometimes is left empty
- this causes the model to download in unknown/<PART>
- this PR adds a sane fallback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to path selection only; primary risk is minor behavior change in where new components are stored when manufacturer was previously omitted.
> 
> **Overview**
> Fixes component installation path selection by **falling back to the manufacturer returned by the download API** when `search_manufacturer` is missing, instead of always using `unknown/<MPN>`.
> 
> This changes `add_component_to_workspace` to compute `manufacturer` as `search_manufacturer.or(download.metadata.manufacturer.as_deref())`, ensuring downloaded components are stored under the correct manufacturer folder when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da72ef10bfce239be80598b89ed57ac1cdf4a06c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->