### PR TITLE
Fix dielectric stackup type serialization to avoid layout.sync drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Standalone `.zen` files with inline manifests now map `Board(..., layout_path=...)` to `package://workspace/...`, avoiding absolute-path leakage.
+- Stackup sync now emits dielectric `(type ...)` once per grouped layer (not per `addsublayer`), preventing spurious `layout.sync` drift.
 
 ## [0.3.44] - 2026-02-20
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to stackup S-expression formatting with a targeted regression test; low risk aside from potential minor formatting differences in synced KiCad files.
> 
> **Overview**
> Fixes KiCad stackup generation so grouped dielectric layers with `addsublayer` markers only serialize `(type ...)` on the first sublayer, matching KiCad output and preventing spurious `layout.sync` diffs.
> 
> Adds a regression test to ensure only one dielectric type is emitted for multi-sublayer dielectric groups, and updates the `CHANGELOG.md` entry accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9743dac398038c4a9946e1489c13744837e6e5f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->