### PR TITLE
Use workspace `.pcb/cache` for package_roots fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalize netlist `package_roots` cache paths to `<workspace>/.pcb/cache` for unvendored remote dependencies (including stdlib).
+
 ## [0.3.45] - 2026-02-25
 
 ### Added

--- a/crates/pcb-zen-core/src/workspace.rs
+++ b/crates/pcb-zen-core/src/workspace.rs
@@ -98,6 +98,11 @@ pub struct WorkspaceInfo {
 }
 
 impl WorkspaceInfo {
+    /// Workspace-local cache path (typically a symlink to `~/.pcb/cache`).
+    pub fn workspace_cache_dir(&self) -> PathBuf {
+        self.root.join(".pcb/cache")
+    }
+
     /// Get workspace config section (with defaults if not present)
     pub fn workspace_config(&self) -> WorkspaceConfig {
         self.config

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -1184,7 +1184,7 @@ fn build_native_resolution_map(
     offline: bool,
 ) -> Result<HashMap<PathBuf, BTreeMap<String, PathBuf>>> {
     // Use workspace cache path (symlink) for stable workspace-relative paths in generated files
-    let cache = workspace_info.root.join(".pcb/cache");
+    let cache = workspace_info.workspace_cache_dir();
     let vendor = workspace_info.root.join("vendor");
 
     // Build patch map (only path patches - branch/rev patches use normal fetch)
@@ -1671,8 +1671,7 @@ pub(crate) fn fetch_asset_repo(
     // Cache paths
     let home_cache_dir = cache_base().join(repo_url).join(ref_str);
     let workspace_cache_dir = workspace_info
-        .root
-        .join(".pcb/cache")
+        .workspace_cache_dir()
         .join(repo_url)
         .join(ref_str);
 


### PR DESCRIPTION
Want to avoid paths outside the workspace as much as possible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small path-resolution change limited to cache fallback behavior plus a regression test; low risk aside from potential impact on consumers that expected home-cache absolute paths.
> 
> **Overview**
> Normalizes dependency root paths so when a closure package isn’t vendored, `package_roots()` and native resolution mapping now point at the workspace-local cache (`<workspace>/.pcb/cache`) instead of the global `~/.pcb/cache`, reducing absolute path leakage in generated files.
> 
> Adds `WorkspaceInfo::workspace_cache_dir()` to centralize the workspace cache path, updates call sites to use it, and adds a regression test covering unvendored closure packages (including stdlib). Updates the changelog entry under *Unreleased* to document the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ae99d95a17fc77f666a9c071e77c0332023c09c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->