### PR TITLE
Use zstd level 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use zstd level 17 (was 15) when embedding STEP 3D models into KiCad footprints.
+
 ### Fixed
 
 - Normalize netlist `package_roots` cache paths to `<workspace>/.pcb/cache` for unvendored remote dependencies (including stdlib).

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -318,7 +318,7 @@ fn extract_sexp_block(text: &str, pattern: &str) -> Option<(String, String)> {
 /// Embed a STEP file into a KiCad footprint using the KiCad 8/9 embedded files format.
 ///
 /// This function:
-/// 1. Compresses the STEP data with ZSTD (level 3 - balanced)
+/// 1. Compresses the STEP data with ZSTD (level 17 - size/time tradeoff)
 /// 2. Base64 encodes the compressed data
 /// 3. Computes SHA256 checksum of raw STEP data
 /// 4. Inserts an (embedded_files ...) S-expression block into the footprint
@@ -336,7 +336,7 @@ fn embed_step_in_footprint(
     let indent = "\t";
 
     // Compress, encode, and checksum
-    let mut encoder = zstd::Encoder::new(Vec::new(), 15)?;
+    let mut encoder = zstd::Encoder::new(Vec::new(), 17)?;
     encoder.include_contentsize(true)?;
     encoder.set_pledged_src_size(Some(step_bytes.len() as u64))?;
     encoder.write_all(&step_bytes)?;


### PR DESCRIPTION
This is the sweetspot; results in 11.5% smaller output on average.

90-file STEP/STP sample

```
Original total: 48,687,567 B (46.4 MiB)

Level      Time    Compressed       Ratio    Saved
15         2.6 s   6,730,598 B      0.138    86.2%
17         6.1 s   5,956,851 B      0.122    87.8%
19        14.9 s   5,815,981 B      0.119    88.1%
21        15.0 s   5,815,981 B      0.119    88.1%
22-ultra  31.0 s   5,818,080 B      0.119    88.1%
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single parameter change that only affects STEP model embedding output size/performance, with no security/auth or data-model changes.
> 
> **Overview**
> **Reduces embedded 3D model size** by increasing Zstandard compression from level 15 to level 17 when embedding STEP files into KiCad footprints (and updates the related inline documentation).
> 
> Updates `CHANGELOG.md` to note the new compression level under *Unreleased*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bb4f1e5f527280bc7ebc809a9290563ee62ec61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
