### PR TITLE
Silence Path `allow_not_exist` missing-path warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Use zstd level 17 (was 15) when embedding STEP 3D models into KiCad footprints.
+- `Path(..., allow_not_exist=True)` no longer emits missing-path warnings.
 
 ### Fixed
 

--- a/crates/pcb/tests/snapshots/path__path_local_mixed_build.snap
+++ b/crates/pcb/tests/snapshots/path__path_local_mixed_build.snap
@@ -13,22 +13,4 @@ Existing file: package://boards/existing.toml
 Nonexistent file: package://boards/missing.toml
 Existing directory: package://boards/config
 Nonexistent directory: package://boards/missing_dir
-Warning: Path 'build/LocalPathTest' does not exist
-    ╭─[ <TEMP_DIR>/.pcb/cache/github.com/diodeinc/stdlib/<STDLIB_VERSION>/properties.zen:68:37 ]
- 68 │        add_property("layout_path", Path(path, allow_not_exist=True))
-    │                                                    ╰──────────────── Path 'build/LocalPathTest' does not exist
-    ├─[ <TEMP_DIR>/boards/LocalPathTest.zen:4:1 ]
-  4 │Layout(name="LocalPathTest", path="build/LocalPathTest", bom_profile=None)
-    │                                     ╰───────────────────────────────────── Path does not exist in Layout call
-
-Warning: Path 'missing.toml' does not exist
-   ╭─[ <TEMP_DIR>/boards/LocalPathTest.zen:7:20 ]
- 7 │nonexistent_file = Path("missing.toml", allow_not_exist=True)
-   │                                        ╰───────────────────── Path 'missing.toml' does not exist
-
-Warning: Path 'missing_dir' does not exist
-   ╭─[ <TEMP_DIR>/boards/LocalPathTest.zen:9:19 ]
- 9 │nonexistent_dir = Path("missing_dir", allow_not_exist=True)
-   │                                      ╰───────────────────── Path 'missing_dir' does not exist
-
 ✓ LocalPathTest.zen (0 components)

--- a/crates/pcb/tests/snapshots/release__publish_source_only.snap
+++ b/crates/pcb/tests/snapshots/release__publish_source_only.snap
@@ -5,21 +5,7 @@ expression: sb.snapshot_dir(&staging_dir)
 ---
 === diagnostics.json
 {
-  "boards/TestBoard.zen": [
-    {
-      "location": "<TEMP_DIR>/src/.pcb/releases/TestBoard-<GIT_HASH>/src/vendor/github.com/diodeinc/stdlib/<STDLIB_VERSION>/properties.zen:68:37-69",
-      "severity": "warning",
-      "body": "Path 'build/TestBoard' does not exist",
-      "suppressed": false,
-      "occurrences": 1,
-      "stack": [
-        {
-          "location": "<TEMP_DIR>/src/.pcb/releases/TestBoard-<GIT_HASH>/src/boards/TestBoard.zen:5:1-67",
-          "message": "Path does not exist in Layout call"
-        }
-      ]
-    }
-  ]
+  "boards/TestBoard.zen": []
 }
 === metadata.json
 {

--- a/crates/pcb/tests/snapshots/release__publish_with_description.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_description.snap
@@ -5,21 +5,7 @@ expression: sb.snapshot_dir(&staging_dir)
 ---
 === diagnostics.json
 {
-  "boards/DescBoard.zen": [
-    {
-      "location": "<TEMP_DIR>/src/.pcb/releases/DescBoard-<GIT_HASH>/src/vendor/github.com/diodeinc/stdlib/<STDLIB_VERSION>/properties.zen:68:37-69",
-      "severity": "warning",
-      "body": "Path 'build/TestBoard' does not exist",
-      "suppressed": false,
-      "occurrences": 1,
-      "stack": [
-        {
-          "location": "<TEMP_DIR>/src/.pcb/releases/DescBoard-<GIT_HASH>/src/boards/DescBoard.zen:5:1-67",
-          "message": "Path does not exist in Layout call"
-        }
-      ]
-    }
-  ]
+  "boards/DescBoard.zen": []
 }
 === metadata.json
 {

--- a/crates/pcb/tests/snapshots/release__publish_with_file.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_file.snap
@@ -1,24 +1,11 @@
 ---
 source: crates/pcb/tests/release.rs
+assertion_line: 319
 expression: sb.snapshot_dir(&staging_dir)
 ---
 === diagnostics.json
 {
-  "boards/TB0002.zen": [
-    {
-      "location": "<TEMP_DIR>/src/.pcb/releases/TB0002-<GIT_HASH>/src/vendor/github.com/diodeinc/stdlib/<STDLIB_VERSION>/properties.zen:68:37-69",
-      "severity": "warning",
-      "body": "Path 'build/TestBoard' does not exist",
-      "suppressed": false,
-      "occurrences": 1,
-      "stack": [
-        {
-          "location": "<TEMP_DIR>/src/.pcb/releases/TB0002-<GIT_HASH>/src/boards/TB0002.zen:4:1-67",
-          "message": "Path does not exist in Layout call"
-        }
-      ]
-    }
-  ]
+  "boards/TB0002.zen": []
 }
 === metadata.json
 {

--- a/crates/pcb/tests/snapshots/release__publish_with_version.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_version.snap
@@ -5,21 +5,7 @@ expression: sb.snapshot_dir(staging_dir)
 ---
 === diagnostics.json
 {
-  "boards/TB0001.zen": [
-    {
-      "location": "<TEMP_DIR>/src/.pcb/releases/TB0001-v1.3.0/src/vendor/github.com/diodeinc/stdlib/<STDLIB_VERSION>/properties.zen:68:37-69",
-      "severity": "warning",
-      "body": "Path 'build/TestBoard' does not exist",
-      "suppressed": false,
-      "occurrences": 1,
-      "stack": [
-        {
-          "location": "<TEMP_DIR>/src/.pcb/releases/TB0001-v1.3.0/src/boards/TB0001.zen:5:1-67",
-          "message": "Path does not exist in Layout call"
-        }
-      ]
-    }
-  ]
+  "boards/TB0001.zen": []
 }
 === metadata.json
 {

--- a/crates/pcb/tests/snapshots/simple__simple_workspace_build.snap
+++ b/crates/pcb/tests/snapshots/simple__simple_workspace_build.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb/tests/simple.rs
+assertion_line: 152
 expression: output
 ---
 Command: pcb build boards/TestBoard.zen
@@ -8,12 +9,4 @@ Exit Code: 0
 --- STDOUT ---
 
 --- STDERR ---
-Warning: Path 'build/TestBoard' does not exist
-    ╭─[ <TEMP_DIR>/.pcb/cache/github.com/diodeinc/stdlib/<STDLIB_VERSION>/properties.zen:68:37 ]
- 68 │        add_property("layout_path", Path(path, allow_not_exist=True))
-    │                                                    ╰──────────────── Path 'build/TestBoard' does not exist
-    ├─[ <TEMP_DIR>/boards/TestBoard.zen:5:1 ]
-  5 │Layout(name="TestBoard", path="build/TestBoard", bom_profile=None)
-    │                                 ╰───────────────────────────────── Path does not exist in Layout call
-
 ✓ TestBoard.zen (10 components)

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -518,6 +518,23 @@ When the parent does not provide a value:
 - `optional=True`: returns `default` (after conversion) when present, otherwise `None`.
 - `optional=False`: during strict module instantiation, emits a missing-input error diagnostic, then continues evaluation using fallback behavior (`default` if provided, otherwise a generated type default).
 
+### Path()
+
+Resolve a file or directory path and return a stable path string (for example, `package://...` when applicable).
+
+**Signature:** `Path(path, allow_not_exist=False)`
+
+- `path`: Local path or other supported load-spec string.
+- `allow_not_exist`: Named boolean (default `False`).
+  - `False`: unresolved/missing paths raise an error.
+  - `True`: missing local paths are allowed and no diagnostic is emitted.
+  - Can only be used with local path specs.
+
+```python
+existing = Path("config/settings.toml")
+future_output = Path("build/MyBoard", allow_not_exist=True)
+```
+
 ### builtin.physical_value()
 
 **Built-in function** that creates unit-specific physical value constructor types for electrical quantities.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk behavior change limited to diagnostics: missing local paths marked `allow_not_exist=True` no longer produce warning output, which could reduce visibility of unintended missing paths but does not affect resolution/IO correctness.
> 
> **Overview**
> **Stops emitting warning diagnostics for missing paths when callers explicitly pass `allow_not_exist=True` to `Path()`.** The `Path()` builtin now relies solely on `LoadSpec`’s `allow_not_exist` behavior (error vs allow) and no longer constructs call-stack warning chains for non-existent paths.
> 
> Updates CLI/release snapshot tests to expect empty `diagnostics.json` and no stderr warnings, and adds spec docs + changelog entry documenting the `Path(path, allow_not_exist=False)` semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 305406018f8def51b1bc4f772fa1ba5016baa975. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
