### PR TITLE
Prefer symbol datasheet, hydrate symbols with mpn + mfr data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Use zstd level 17 (was 15) when embedding STEP 3D models into KiCad footprints.
 - `Path(..., allow_not_exist=True)` no longer emits missing-path warnings.
 - `pcb search` component add now prefers symbol datasheets, using fallback URL scan only when needed.
+- `pcb search` add-component now rewrites symbol `Manufacturer_Part_Number`/`Manufacturer_Name` metadata before generating `.zen`.
 
 ### Fixed
 

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -169,7 +169,6 @@ pub fn generate_component_zen(args: GenerateComponentZenArgs<'_>) -> Result<Stri
             "pin_defs": pin_defs_vec,
             "pin_groups": pin_groups_vec,
             "pin_mappings": pin_mappings,
-            "description": args.symbol.description,
             "datasheet_file": args.datasheet_filename,
             "generated_by": args.generated_by,
             "include_skip_bom": args.include_skip_bom,

--- a/crates/pcb-component-gen/templates/component.zen.jinja
+++ b/crates/pcb-component-gen/templates/component.zen.jinja
@@ -1,9 +1,5 @@
 """
 {{ component_name }}
-{%- if description %}
-
-{{ description }}
-{%- endif %}
 
 Auto-generated using `{{ generated_by }}`.
 """
@@ -33,9 +29,6 @@ Component(
 {%- endif %}
 {%- if include_skip_pos %}
     skip_pos = skip_pos,
-{%- endif %}
-{%- if description %}
-    description = "{{ description }}",
 {%- endif %}
 {%- if datasheet_file %}
     datasheet = File("{{ datasheet_file }}"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the `pcb search add-component` materialization pipeline (datasheet resolution, symbol mutation, and `.zen` generation), which can affect generated component artifacts and user workflows if edge cases aren’t handled (missing symbols, failed moves/copies, unexpected symbol structures).
> 
> **Overview**
> **Improves `pcb search add-component` component materialization** by resolving datasheets from the downloaded `.kicad_sym` first (via `resolve_datasheet` and copying the resulting PDF/markdown/`images/` into the component dir), and only falling back to downloading/scanning the `datasheet_url` when symbol-based resolution fails.
> 
> **Hydrates and normalizes downloaded symbols before `.zen` generation** by structurally rewriting KiCad symbol properties (including `Footprint`, `Manufacturer_Part_Number`, and `Manufacturer_Name`), failing fast if the symbol file is missing or contains multiple symbols, and tightening output checks (e.g., asserting the `.zen` file was created). Also removes symbol `description` from the generated `.zen` template and tweaks download progress output (shared spinner + per-file status lines).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1f990e179b2b9b2d3167b4e20af688bb5d1272f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
