### PR TITLE
Fix MCP resolve_datasheet schema compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Normalize netlist `package_roots` cache paths to `<workspace>/.pcb/cache` for unvendored remote dependencies (including stdlib).
+- MCP `resolve_datasheet` now avoids top-level JSON Schema combinators in `inputSchema`, fixing strict MCP clients (e.g., Claude Code) that reject `oneOf` at schema root.
 
 ## [0.3.45] - 2026-02-25
 

--- a/crates/pcb-diode-api/src/mcp.rs
+++ b/crates/pcb-diode-api/src/mcp.rs
@@ -302,11 +302,10 @@ pub fn tools() -> Vec<ToolInfo> {
                         "description": "Symbol name to use when kicad_sym_path points to a library with multiple symbols"
                     }
                 },
-                "oneOf": [
-                    { "required": ["datasheet_url"] },
-                    { "required": ["pdf_path"] },
-                    { "required": ["kicad_sym_path"] }
-                ]
+                "additionalProperties": false,
+                "dependentRequired": {
+                    "symbol_name": ["kicad_sym_path"]
+                }
             }),
             output_schema: Some(json!({
                 "type": "object",
@@ -1006,5 +1005,30 @@ mod tests {
         assert!(changes.changed());
         assert_eq!(changes.primary_set, vec!["description".to_string()]);
         assert_eq!(changes.custom_removed, vec!["ki_description".to_string()]);
+    }
+
+    #[test]
+    fn input_schemas_avoid_top_level_combinators() {
+        for tool in tools() {
+            let schema = tool
+                .input_schema
+                .as_object()
+                .expect("tool input schema must be a JSON object");
+            assert!(
+                !schema.contains_key("oneOf"),
+                "tool '{}' input schema uses unsupported top-level oneOf",
+                tool.name
+            );
+            assert!(
+                !schema.contains_key("allOf"),
+                "tool '{}' input schema uses unsupported top-level allOf",
+                tool.name
+            );
+            assert!(
+                !schema.contains_key("anyOf"),
+                "tool '{}' input schema uses unsupported top-level anyOf",
+                tool.name
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/diodeinc/pcb/issues/582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only changes to MCP tool definitions plus a test; low risk, but could affect client-side validation expectations for `resolve_datasheet` inputs.
> 
> **Overview**
> Fixes MCP `resolve_datasheet` schema compatibility by removing the top-level `oneOf` from its `inputSchema` (which some strict MCP clients reject) and replacing it with a stricter object shape (`additionalProperties: false`) plus `dependentRequired` for `symbol_name`.
> 
> Adds a regression test that asserts no MCP tool `input_schema` uses top-level JSON Schema combinators (`oneOf`/`allOf`/`anyOf`), and documents the fix in the Unreleased changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 022480e5619233371301559aab4b1c2b9a15a6ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
