### PR TITLE
Fix File() to `package://` uri resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure `File()` footprint paths resolve to `package://...` when dependency files are read from `~/.pcb/cache`.
+
 ## [0.3.46] - 2026-02-26
 
 ### Changed


### PR DESCRIPTION
Follow-up to https://github.com/diodeinc/pcb/pull/578. Since we use `<workspace root>/.pcb/cache` over `~/.pcb/cache` for package roots, we need to do the same when normalizing absolute file paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-scoped path-normalization change plus a unit test; main risk is subtle path rewriting edge cases if `cache_dir` contains non-cache paths.
> 
> **Overview**
> Fixes `ResolutionResult::format_package_uri` to **rewrite absolute paths under the global cache (`~/.pcb/cache`) to the workspace-local cache (`<workspace>/.pcb/cache`)** before longest-prefix matching, ensuring dependency files referenced via `File()` normalize to stable `package://...` URIs.
> 
> Adds a regression test covering the cache rewrite behavior, and updates the unreleased changelog entry to document the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5c3bb09ea6f7d34fcb39c5af519fc2a6e534111. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
