### PR TITLE
clear module cache on LSP save to avoid polluting context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Normalize net and component symbol source paths to `package://...`, so emitted schematic/netlist `symbol_path` values no longer leak absolute cache paths.
-- Fix LSP simulation diagnostics leaking components across unrelated files due to shared module tree state.
 
 ## [0.3.47] - 2026-02-27
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches evaluation-session caching and LSP save/viewer paths; mistakes could lead to stale/incorrect diagnostics or state, though scope is limited to editor workflows.
> 
> **Overview**
> Prevents cross-file contamination in the shared evaluation `module_tree` by clearing it during `EvalContext::parse_and_analyze_file`.
> 
> Updates the LSP to cache the computed `pcb_sch::Schematic` (instead of the full `EvalOutput`) immediately after evaluation, and reuses that schematic for `viewer/getState` and `on_save_diagnostics`, clearing the cache on failures and file close.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34b86cb564e772c866318084430595f7f5b19c95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->