### PR TITLE
feat: add more metadata to `pcb ipc2581 info`

### DIFF
--- a/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
@@ -23,8 +23,7 @@ pub struct StackupDetails {
 }
 
 impl StackupDetails {
-    /// Calculate outer copper weight if consistent across all outer layers
-    pub fn outer_copper_weight(&self) -> Option<String> {
+    pub fn outer_copper_oz(&self) -> Option<f64> {
         let outer_layers: Vec<_> = self
             .layers
             .iter()
@@ -42,7 +41,7 @@ impl StackupDetails {
                         .unwrap_or(false)
                 });
                 if all_same {
-                    Some(Self::format_copper_weight(thickness))
+                    Some(Self::copper_weight_oz(thickness))
                 } else {
                     None
                 }
@@ -50,8 +49,13 @@ impl StackupDetails {
         })
     }
 
-    /// Calculate inner copper weight if consistent across all inner layers
-    pub fn inner_copper_weight(&self) -> Option<String> {
+    /// Calculate outer copper weight if consistent across all outer layers
+    pub fn outer_copper_weight(&self) -> Option<String> {
+        self.outer_copper_oz()
+            .map(Self::format_copper_weight_from_oz)
+    }
+
+    pub fn inner_copper_oz(&self) -> Option<f64> {
         let inner_layers: Vec<_> = self
             .layers
             .iter()
@@ -66,7 +70,7 @@ impl StackupDetails {
                         .unwrap_or(false)
                 });
                 if all_same {
-                    Some(Self::format_copper_weight(thickness))
+                    Some(Self::copper_weight_oz(thickness))
                 } else {
                     None
                 }
@@ -74,9 +78,17 @@ impl StackupDetails {
         })
     }
 
-    /// Format copper weight from thickness in mm (1 oz/ft² = 0.0348 mm)
-    fn format_copper_weight(thickness_mm: f64) -> String {
-        let oz = thickness_mm / 0.0348;
+    /// Calculate inner copper weight if consistent across all inner layers
+    pub fn inner_copper_weight(&self) -> Option<String> {
+        self.inner_copper_oz()
+            .map(Self::format_copper_weight_from_oz)
+    }
+
+    fn copper_weight_oz(thickness_mm: f64) -> f64 {
+        thickness_mm / 0.0348
+    }
+
+    fn format_copper_weight_from_oz(oz: f64) -> String {
         let standard_oz = if oz < 0.75 {
             0.5
         } else if oz < 1.25 {

--- a/crates/pcb-ipc2581-tools/src/commands/info.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/info.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use anyhow::Result;
@@ -557,6 +558,117 @@ fn output_json(accessor: &IpcAccessor) -> Result<()> {
             "loss_tangents": imp.loss_tangents,
         });
     }
+
+    if let Some(stackup_details) = accessor.stackup_details() {
+        info["stackup_details"] = json!({
+            "surface_finish_name": stackup_details.surface_finish.as_ref().map(|f| f.name.clone()),
+            "soldermask_name": stackup_details
+                .soldermask_color
+                .as_ref()
+                .and_then(|c| c.name.clone()),
+            "outer_copper_oz": stackup_details.outer_copper_oz(),
+            "inner_copper_oz": stackup_details.inner_copper_oz(),
+        });
+    }
+
+    let component_map: BTreeMap<String, (String, String, Option<String>, Option<String>)> =
+        accessor
+            .first_step()
+            .map(|step| {
+                step.components
+                    .iter()
+                    .filter_map(|component| {
+                        let designator = ipc.resolve(component.ref_des).to_string();
+                        if designator.is_empty() {
+                            return None;
+                        }
+
+                        let package = ipc.resolve(component.package_ref).to_string();
+                        let layer_ref = ipc.resolve(component.layer_ref).to_string();
+                        let mount_type = component.mount_type.map(|mt| match mt {
+                            ipc2581::types::MountType::Smt => "SMT".to_string(),
+                            ipc2581::types::MountType::Tht => "THT".to_string(),
+                            ipc2581::types::MountType::Other => "OTHER".to_string(),
+                        });
+                        let part_mpn = component
+                            .part
+                            .map(|sym| ipc.resolve(sym).to_string())
+                            .filter(|v| !v.is_empty());
+
+                        Some((designator, (package, layer_ref, mount_type, part_mpn)))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+    let mut seen_designators = BTreeSet::new();
+    let mut component_placements = Vec::new();
+
+    if let Some(bom_section) = ipc.bom() {
+        for item in &bom_section.items {
+            if matches!(item.category, Some(ipc2581::types::BomCategory::Document)) {
+                continue;
+            }
+
+            let avl_lookup = accessor.lookup_avl(item.oem_design_number_ref);
+
+            for ref_des in &item.ref_des_list {
+                let designator = ipc.resolve(ref_des.name).to_string();
+                if designator.is_empty() {
+                    continue;
+                }
+
+                let fallback = component_map.get(&designator);
+                let bom_package = ipc.resolve(ref_des.package_ref).to_string();
+                let bom_layer = ipc.resolve(ref_des.layer_ref).to_string();
+
+                let package = if !bom_package.is_empty() {
+                    bom_package
+                } else {
+                    fallback.map(|v| v.0.clone()).unwrap_or_default()
+                };
+                let layer_ref = if !bom_layer.is_empty() {
+                    bom_layer
+                } else {
+                    fallback.map(|v| v.1.clone()).unwrap_or_default()
+                };
+                let mount_type = fallback.and_then(|v| v.2.clone());
+                let mpn = avl_lookup
+                    .primary_mpn
+                    .clone()
+                    .or_else(|| fallback.and_then(|v| v.3.clone()));
+
+                component_placements.push(json!({
+                    "designator": designator,
+                    "package": package,
+                    "mpn": mpn,
+                    "dnp": !ref_des.populate,
+                    "layer_ref": layer_ref,
+                    "mount_type": mount_type,
+                    "pin_count": item.pin_count,
+                }));
+                seen_designators.insert(ipc.resolve(ref_des.name).to_string());
+            }
+        }
+    }
+
+    for (designator, (package, layer_ref, mount_type, part_mpn)) in component_map {
+        if seen_designators.contains(&designator) {
+            continue;
+        }
+
+        component_placements.push(json!({
+            "designator": designator,
+            "package": package,
+            "mpn": part_mpn,
+            "dnp": false,
+            "layer_ref": layer_ref,
+            "mount_type": mount_type,
+            "pin_count": serde_json::Value::Null,
+        }));
+    }
+
+    info["component_placements"] = json!(component_placements);
 
     println!("{}", serde_json::to_string_pretty(&info)?);
     Ok(())


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: expands the `info` JSON schema and adds non-trivial BOM/component merging logic, which could affect downstream consumers and produce incomplete/incorrect placement data when source fields are missing or inconsistent.
> 
> **Overview**
> Adds new stackup metadata to `pcb ipc2581 info` JSON output, including `surface_finish_name`, soldermask name, and numeric `outer_copper_oz`/`inner_copper_oz` values.
> 
> Refactors stackup copper weight helpers to compute oz as `f64` (`outer_copper_oz`/`inner_copper_oz`) and formats strings from oz, while keeping the existing `outer_copper_weight`/`inner_copper_weight` API.
> 
> Introduces a new `component_placements` JSON array built by merging BOM entries with component data (fallbacks for package/layer, MPN from AVL or component `part`, and DNP/mount type/pin count), and includes components not present in the BOM.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a028119b9befc0462371db116fec8334c9a92b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->