### PR TITLE
Fix publish staging to include non-KiCad asset files (e.g. SPICE models)

### DIFF
--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -828,14 +828,6 @@ print("Text variables updated successfully")
     Ok(())
 }
 
-fn is_kicad_library_file(path: &Path) -> bool {
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| {
-            ext.eq_ignore_ascii_case("kicad_sym") || ext.eq_ignore_ascii_case("kicad_mod")
-        })
-}
-
 fn stage_resolved_file_for_release_bundle(
     staged_src: &Path,
     sch: &pcb_sch::Schematic,
@@ -849,7 +841,7 @@ fn stage_resolved_file_for_release_bundle(
     let Ok(rel_path) = resolved_path.strip_prefix(&dep_root) else {
         return Ok(());
     };
-    if rel_path.as_os_str().is_empty() || !is_kicad_library_file(rel_path) {
+    if rel_path.as_os_str().is_empty() {
         return Ok(());
     }
     if !resolved_path.exists() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small change to release-bundling file selection that may increase staged contents but doesn’t alter core build/artifact generation logic.
> 
> **Overview**
> Release staging now copies **all** resolved files from KiCad library package roots into the release bundle’s `src/vendor/...` tree, instead of only `.kicad_sym` and `.kicad_mod` files.
> 
> This ensures referenced non-KiCad assets (e.g., SPICE models or other ancillary files) are included during `pcb publish` staging and offline validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23ef0d04f05d2ce3bc4d259e265838c6ad27aebe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
