### PR TITLE
update `pcb publish` behavior

### DIFF
--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -118,11 +118,11 @@ enum Commands {
     #[command(alias = "o")]
     Open(open::OpenArgs),
 
-    /// Publish packages and boards by creating version tags
+    /// Publish packages and boards through guided release flows
     #[command(alias = "p")]
     Publish(publish::PublishArgs),
 
-    /// Build and upload a preview release for a board
+    /// Build and upload a preview bundle for a board, including dirty worktrees
     #[cfg(feature = "api")]
     Preview(preview::PreviewArgs),
 

--- a/crates/pcb/src/preview.rs
+++ b/crates/pcb/src/preview.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
 use clap::Args;
-use colored::Colorize;
-use pcb_zen::git;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use crate::file_walker;
+use crate::publish;
 use crate::release;
 
 #[derive(Args, Debug)]
-#[command(about = "Build and upload a preview release for a board")]
+#[command(about = "Build and upload a preview bundle for a board, including dirty worktrees")]
 pub struct PreviewArgs {
     /// Path to a .zen file
     #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
@@ -25,36 +24,5 @@ pub struct PreviewArgs {
 
 pub fn execute(args: PreviewArgs) -> Result<()> {
     let target = file_walker::resolve_board_target(&args.file, "preview")?;
-
-    let version = preview_version(&target.workspace.root);
-
-    let zip_path = release::build_board_release(
-        target.workspace,
-        target.zen_path,
-        target.board_name,
-        args.suppress,
-        version,
-        args.exclude,
-        true,
-    )?;
-
-    eprintln!("Uploading preview release to Diode...");
-    let result = pcb_diode_api::upload_preview(&zip_path)?;
-
-    eprintln!(
-        "{} Preview uploaded: {}",
-        "✓".green(),
-        result.preview_url.cyan()
-    );
-
-    Ok(())
-}
-
-fn preview_version(workspace_root: &Path) -> Option<String> {
-    let short = git::rev_parse_short_head(workspace_root)?;
-
-    match git::has_uncommitted_changes(workspace_root).ok() {
-        Some(true) => Some(format!("{short}-dirty")),
-        _ => Some(short),
-    }
+    publish::run_board_preview(target, args.suppress, args.exclude, false, false)
 }

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -20,7 +20,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::path::Path;
 
-use crate::file_walker::{collect_zen_files, resolve_board_target};
+use crate::file_walker::{BoardTarget, collect_zen_files, resolve_board_target};
 use crate::release;
 
 /// Version bump type for publishing
@@ -32,13 +32,10 @@ pub enum BumpType {
     Minor,
     /// Breaking changes (X.0.0)
     Major,
-    /// Prompt interactively (used when --bump is passed without a value)
-    #[value(hide = true)]
-    Interactive,
 }
 
 #[derive(Args, Debug)]
-#[command(about = "Publish packages or board releases")]
+#[command(about = "Publish packages or boards through guided release flows")]
 pub struct PublishArgs {
     /// Skip preflight checks (uncommitted changes, branch, remote)
     #[arg(long, short = 'f', hide = true)]
@@ -52,12 +49,16 @@ pub struct PublishArgs {
     #[arg(long, hide = true)]
     pub no_push: bool,
 
+    /// Build the bundle locally without uploading, tagging, or pushing
+    #[arg(long)]
+    pub dry_run: bool,
+
     /// Suppress diagnostics by kind or severity
     #[arg(short = 'S', long = "suppress", value_name = "KIND")]
     pub suppress: Vec<String>,
 
-    /// Version bump type. Use --bump for interactive prompt, --bump=patch/minor/major for non-interactive.
-    #[arg(long, value_enum, num_args(0..=1), require_equals(true), default_missing_value("interactive"))]
+    /// Version bump type shortcut for non-interactive release publishing
+    #[arg(long, value_enum)]
     pub bump: Option<BumpType>,
 
     /// Exclude specific manufacturing artifacts from the release (can be specified multiple times)
@@ -84,6 +85,11 @@ struct WaveResult {
     tags: Vec<String>,
     commit: Option<String>,
     candidates: BTreeMap<String, PublishCandidate>,
+}
+
+enum BoardPublishMode {
+    PreviewCommit,
+    ReleaseNewVersion,
 }
 
 /// Expand the dirty set to include packages that depend on dirty packages.
@@ -227,66 +233,74 @@ pub fn execute(args: PublishArgs) -> Result<()> {
     publish_packages(&path, &args)
 }
 
-/// Publish a board release from a .zen file.
-///
-/// Two modes:
-/// - Local hash release (no --bump, non-interactive): just build the release archive
-/// - Versioned release (--bump provided): preflight checks, fetch tags, build, upload, tag, push
 fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
     let target = resolve_board_target(zen_path, "publish")?;
-
-    // Local hash release: no --bump, just build the archive
-    if args.bump.is_none() {
-        let _zip_path = release::build_board_release(
-            target.workspace,
-            target.zen_path,
-            target.board_name,
+    match resolve_board_publish_mode(args)? {
+        BoardPublishMode::PreviewCommit => run_board_preview(
+            target,
             args.suppress.clone(),
-            None, // version = None means use git hash
             args.exclude.clone(),
-            false,
-        )?;
-        return Ok(());
+            args.dry_run,
+            true,
+        ),
+        BoardPublishMode::ReleaseNewVersion => publish_board_release(target, args),
+    }
+}
+
+fn resolve_board_publish_mode(args: &PublishArgs) -> Result<BoardPublishMode> {
+    if args.bump.is_some() {
+        return Ok(BoardPublishMode::ReleaseNewVersion);
     }
 
-    let workspace = target.workspace;
-    let board_path = target.zen_path;
-    let board_name = target.board_name;
-    let pkg_rel_path = target.pkg_rel_path;
+    if !crate::tty::is_interactive() {
+        if args.dry_run {
+            return Ok(BoardPublishMode::PreviewCommit);
+        }
 
-    // Preflight checks and get remote (unless --no-push)
-    let remote = if !args.no_push {
-        let r = if args.force {
-            let branch = git::symbolic_ref_short_head(&workspace.root)
-                .ok_or_else(|| anyhow::anyhow!("Not on a branch (detached HEAD state)"))?;
-            git::get_branch_remote(&workspace.root, &branch)
-                .ok_or_else(|| anyhow::anyhow!("Branch '{}' is not tracking a remote", branch))?
-        } else {
-            preflight_checks(&workspace.root)?
-        };
-        eprintln!("Syncing tags from {}...", r.cyan());
-        git::fetch_tags(&workspace.root, &r)?;
-        Some(r)
+        bail!(
+            "Board publish needs an interactive terminal to choose between previewing the current commit and releasing a new version.\nUse `pcb preview <file>` to upload the current workspace state, `pcb publish <file> --bump <patch|minor|major>` for a versioned release, or add `--dry-run` to only build the current-commit bundle locally."
+        );
+    }
+
+    let options = vec!["Preview current commit", "Release new version"];
+    let selected = Select::new("What do you want to publish?", options)
+        .prompt()
+        .map_err(|e| anyhow::anyhow!("Prompt cancelled: {}", e))?;
+
+    Ok(if selected == "Preview current commit" {
+        BoardPublishMode::PreviewCommit
     } else {
-        None
-    };
+        BoardPublishMode::ReleaseNewVersion
+    })
+}
 
-    // Compute current version from tags (after fetch)
+fn publish_board_release(target: BoardTarget, args: &PublishArgs) -> Result<()> {
+    let BoardTarget {
+        workspace,
+        zen_path: board_path,
+        board_name,
+        pkg_rel_path,
+    } = target;
+
+    let remote =
+        prepare_board_release_remote(&workspace.root, args.force, args.no_push, args.dry_run)?;
+
+    if let Some(ref remote_name) = remote {
+        eprintln!("Syncing tags from {}...", remote_name.cyan());
+        git::fetch_tags(&workspace.root, remote_name)?;
+    }
+
     let tag_prefix = tags::compute_tag_prefix(Some(&pkg_rel_path), workspace.path());
     let all_tags = git::list_all_tags(&workspace.root).unwrap_or_default();
     let current = tags::find_latest_version(&all_tags, &tag_prefix);
-
-    // Resolve bump type (interactive prompt if --bump was passed without a value)
-    let bump = match args.bump.unwrap() {
-        BumpType::Interactive => prompt_single_bump(&board_name, current.as_ref())?,
-        b => b,
+    let bump = match args.bump {
+        Some(bump) => bump,
+        None => prompt_single_bump(&board_name, current.as_ref())?,
     };
 
     let next_version = compute_next_version(current.as_ref(), bump);
     let tag_name = tags::build_tag_name(&tag_prefix, &next_version);
-
-    // Build the release archive
-    let _zip_path = release::build_board_release(
+    let zip_path = release::build_board_release(
         workspace.clone(),
         board_path,
         board_name.clone(),
@@ -296,16 +310,24 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
         false,
     )?;
 
-    // Upload to API (must succeed before creating tag)
+    if args.dry_run {
+        eprintln!(
+            "{} Built release bundle locally: {}",
+            "✓".green(),
+            zip_path.display()
+        );
+        return Ok(());
+    }
+
     #[cfg(feature = "api")]
-    if remote.is_some() {
+    {
         let ws_name = workspace
             .root
             .file_name()
             .and_then(|n| n.to_str())
             .context("Invalid workspace root")?;
         eprintln!("Uploading release to Diode...");
-        let result = pcb_diode_api::upload_release(&_zip_path, ws_name)?;
+        let result = pcb_diode_api::upload_release(&zip_path, ws_name)?;
         if let Some(release_id) = result.release_id {
             eprintln!(
                 "{} Release uploaded: {}",
@@ -321,7 +343,6 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
         }
     }
 
-    // Create git tag
     git::create_tag(
         &workspace.root,
         &tag_name,
@@ -330,11 +351,100 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
     .context("Failed to create git tag")?;
     eprintln!("{} Created tag {}", "✓".green(), tag_name.bold());
 
-    // Push tag to remote
-    if let Some(ref r) = remote {
-        eprintln!("Pushing tag to {}...", r.cyan());
-        git::push_tag(&workspace.root, &tag_name, r).context("Failed to push tag")?;
-        eprintln!("{} Pushed {}", "✓".green(), tag_name.bold());
+    if args.no_push {
+        eprintln!("{} Left tag local (--no-push)", "✓".green());
+        return Ok(());
+    }
+
+    let remote = remote.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Branch 'main' is not tracking a remote.\nSet upstream with: git branch --set-upstream-to=<remote>/main"
+        )
+    })?;
+    eprintln!("Pushing tag to {}...", remote.cyan());
+    git::push_tag(&workspace.root, &tag_name, &remote).context("Failed to push tag")?;
+    eprintln!("{} Pushed {}", "✓".green(), tag_name.bold());
+
+    Ok(())
+}
+
+fn prepare_board_release_remote(
+    repo_root: &Path,
+    force: bool,
+    no_push: bool,
+    dry_run: bool,
+) -> Result<Option<String>> {
+    if !force {
+        ensure_clean_worktree(repo_root, "publishing")?;
+        require_main_branch(repo_root)?;
+        let sha = git::rev_parse(repo_root, "HEAD")
+            .ok_or_else(|| anyhow::anyhow!("Failed to get HEAD commit"))?;
+        println!("{} on main @ {}", "✓".green(), &sha[..8]);
+    }
+
+    let branch = git::symbolic_ref_short_head(repo_root)
+        .ok_or_else(|| anyhow::anyhow!("Not on a branch (detached HEAD state)"))?;
+
+    let remote = git::get_branch_remote(repo_root, &branch);
+    if !no_push && !dry_run && remote.is_none() {
+        bail!(
+            "Branch '{}' is not tracking a remote.\nSet upstream with: git branch --set-upstream-to=<remote>/{}",
+            branch,
+            branch
+        );
+    }
+
+    Ok(remote)
+}
+
+pub(crate) fn run_board_preview(
+    target: BoardTarget,
+    suppress: Vec<String>,
+    exclude: Vec<release::ArtifactType>,
+    dry_run: bool,
+    require_clean: bool,
+) -> Result<()> {
+    if require_clean {
+        ensure_clean_worktree(
+            &target.workspace.root,
+            "publishing a current-commit preview",
+        )?;
+    }
+
+    let version = Some(preview_version(&target.workspace.root, !require_clean)?);
+    let zip_path = release::build_board_release(
+        target.workspace,
+        target.zen_path,
+        target.board_name,
+        suppress,
+        version,
+        exclude,
+        true,
+    )?;
+
+    if dry_run {
+        eprintln!(
+            "{} Built preview bundle locally: {}",
+            "✓".green(),
+            zip_path.display()
+        );
+        return Ok(());
+    }
+
+    #[cfg(feature = "api")]
+    {
+        eprintln!("Uploading preview release to Diode...");
+        let result = pcb_diode_api::upload_preview(&zip_path)?;
+        eprintln!(
+            "{} Preview uploaded: {}",
+            "✓".green(),
+            result.preview_url.cyan()
+        );
+    }
+
+    #[cfg(not(feature = "api"))]
+    {
+        bail!("Preview uploads require the 'api' feature");
     }
 
     Ok(())
@@ -628,19 +738,8 @@ fn build_workspace(workspace: &WorkspaceInfo, suppress: &[String]) -> Result<()>
 }
 
 fn preflight_checks(repo_root: &Path) -> Result<String> {
-    if git::has_uncommitted_changes(repo_root)? {
-        bail!(
-            "Working directory has uncommitted changes.\nCommit or stash your changes before publishing."
-        );
-    }
-
-    let branch = git::symbolic_ref_short_head(repo_root).ok_or_else(|| {
-        anyhow::anyhow!("Not on a branch (detached HEAD state). Switch to main before publishing.")
-    })?;
-
-    if branch != "main" {
-        bail!("Must be on 'main' branch to publish.");
-    }
+    ensure_clean_worktree(repo_root, "publishing")?;
+    require_main_branch(repo_root)?;
 
     let remote = git::get_branch_remote(repo_root, "main")
         .ok_or_else(|| anyhow::anyhow!("Branch 'main' is not tracking a remote.\nSet upstream with: git branch --set-upstream-to=<remote>/main"))?;
@@ -650,6 +749,29 @@ fn preflight_checks(repo_root: &Path) -> Result<String> {
 
     println!("{} on main @ {}", "✓".green(), &sha[..8]);
     Ok(remote)
+}
+
+fn ensure_clean_worktree(repo_root: &Path, action: &str) -> Result<()> {
+    if git::has_uncommitted_changes(repo_root)? {
+        bail!(
+            "Working directory has uncommitted changes.\nCommit or stash your changes before {}.",
+            action
+        );
+    }
+
+    Ok(())
+}
+
+fn require_main_branch(repo_root: &Path) -> Result<()> {
+    let branch = git::symbolic_ref_short_head(repo_root).ok_or_else(|| {
+        anyhow::anyhow!("Not on a branch (detached HEAD state). Switch to main before publishing.")
+    })?;
+
+    if branch != "main" {
+        bail!("Must be on 'main' branch to publish.");
+    }
+
+    Ok(())
 }
 
 fn rollback(repo_root: &Path, tags: &[String], reset_to: Option<&String>) -> Result<()> {
@@ -675,9 +797,6 @@ fn compute_next_version(current: Option<&Version>, bump: BumpType) -> Version {
             BumpType::Minor => Version::new(v.major, v.minor + 1, 0),
             BumpType::Major if v.major == 0 => Version::new(0, v.minor + 1, 0),
             BumpType::Major => Version::new(v.major + 1, 0, 0),
-            BumpType::Interactive => {
-                unreachable!("Interactive should be resolved before calling compute_next_version")
-            }
         },
     }
 }
@@ -833,10 +952,7 @@ fn collect_all_bumps(
     print_dependency_tree(workspace, dirty_urls, &all_tags);
     println!();
 
-    // If CLI bump provided (and not interactive), use it for all
-    if let Some(bump) = cli_bump
-        && bump != BumpType::Interactive
-    {
+    if let Some(bump) = cli_bump {
         return Ok(waves
             .iter()
             .flat_map(|w| w.iter())
@@ -988,7 +1104,6 @@ fn prompt_single_bump(name: &str, current: Option<&Version>) -> Result<BumpType>
                     BumpType::Patch => "Patch",
                     BumpType::Minor => "Minor",
                     BumpType::Major => "Major",
-                    BumpType::Interactive => unreachable!(),
                 };
                 (
                     format!("{} → {}", label, compute_next_version(current, b)),
@@ -1008,6 +1123,17 @@ fn prompt_single_bump(name: &str, current: Option<&Version>) -> Result<BumpType>
         .find(|(l, _)| l == selected)
         .map(|(_, b)| *b)
         .unwrap_or(BumpType::Minor))
+}
+
+fn preview_version(workspace_root: &Path, allow_dirty: bool) -> Result<String> {
+    let short = git::rev_parse_short_head(workspace_root)
+        .ok_or_else(|| anyhow::anyhow!("Failed to determine current commit"))?;
+
+    if allow_dirty && git::has_uncommitted_changes(workspace_root).ok() == Some(true) {
+        Ok(format!("{short}-dirty"))
+    } else {
+        Ok(short)
+    }
 }
 
 #[cfg(test)]

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -119,12 +119,12 @@ gnd = Net("GND")
 SimpleComponent(name = "foo", P1 = vcc_3v3, P2 = gnd)
 "#;
 
-/// Helper to build args for source-only publish (excludes all manufacturing artifacts)
+/// Helper to build args for a local-only board bundle (excludes all manufacturing artifacts)
 fn source_only_args(board_zen: &str) -> Vec<&str> {
     vec![
         "publish",
         board_zen,
-        "--no-push",
+        "--dry-run",
         "--exclude",
         "drc",
         "--exclude",
@@ -182,8 +182,9 @@ fn test_publish_board_source_only() {
     sb.run("pcb", ["build", "boards/TestBoard.zen"])
         .run()
         .expect("build failed");
+    sb.commit("Add lockfile");
 
-    // Run source-only publish (no layout needed)
+    // Run local-only source bundle build (no layout needed)
     sb.run("pcb", source_only_args("boards/TestBoard.zen"))
         .run()
         .expect("Failed to run pcb publish command");
@@ -214,7 +215,7 @@ fn test_publish_board_with_version() {
     // Commit lockfile and tag an existing version
     sb.commit("Add lockfile").tag("boards/v1.2.3");
 
-    // Run source-only publish with bump (creates v1.3.0)
+    // Run versioned local-only publish (creates v1.3.0 bundle without uploading/tagging)
     let mut args = source_only_args("boards/TB0001.zen");
     args.push("--bump=minor");
     sb.run("pcb", &args)
@@ -264,18 +265,19 @@ fn test_publish_board_full() {
     sb.run("pcb", ["layout", "--no-open", "boards/TestBoard.zen"])
         .run()
         .expect("layout generation failed");
+    sb.commit("Add layout outputs");
 
-    // Run full publish (with all artifacts, suppress test board DRC issues)
+    // Run local-only full bundle build (with all artifacts, suppress test board DRC issues)
     sb.run(
         "pcb",
         [
             "publish",
             "boards/TestBoard.zen",
+            "--dry-run",
             "-S",
             "layout",
             "-S",
             "warnings",
-            "--no-push",
         ],
     )
     .run()
@@ -304,8 +306,9 @@ fn test_publish_board_with_file() {
     sb.run("pcb", ["build", "boards/TB0002.zen"])
         .run()
         .expect("build failed");
+    sb.commit("Add lockfile");
 
-    // Run source-only publish
+    // Run local-only source bundle build
     sb.run("pcb", source_only_args("boards/TB0002.zen"))
         .run()
         .expect("Failed to run pcb publish command");
@@ -340,8 +343,9 @@ fn test_publish_board_with_description() {
     sb.run("pcb", ["build", "boards/DescBoard.zen"])
         .run()
         .expect("build failed");
+    sb.commit("Add lockfile");
 
-    // Run source-only publish
+    // Run local-only source bundle build
     sb.run("pcb", source_only_args("boards/DescBoard.zen"))
         .run()
         .expect("Failed to run pcb publish command");
@@ -370,10 +374,30 @@ fn test_publish_board_from_board_dir() {
     sb.run("pcb", ["build", "boards/TestBoard.zen"])
         .run()
         .expect("build failed");
+    sb.commit("Add lockfile");
 
-    // Run publish from the board directory with a relative path
+    // Run local-only publish from the board directory with a relative path
     sb.cwd("src/boards")
         .run("pcb", source_only_args("TestBoard.zen"))
         .run()
         .expect("publish from board dir with relative path should work");
+}
+
+#[test]
+fn test_publish_board_requires_noninteractive_choice() {
+    let mut sb = Sandbox::new();
+    sb.cwd("src")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write("boards/modules/LedModule.zen", LED_MODULE_ZEN)
+        .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
+        .ignore_globs(["layout/*", "**/vendor/**", "**/build/**"])
+        .init_git()
+        .commit("Initial commit")
+        .run("pcb", ["build", "boards/TestBoard.zen"])
+        .run()
+        .expect("build failed");
+
+    let output = sb.snapshot_run("pcb", ["publish", "boards/TestBoard.zen"]);
+    assert_snapshot!("publish_board_requires_noninteractive_choice", output);
 }

--- a/crates/pcb/tests/snapshots/release__publish_board_requires_noninteractive_choice.snap
+++ b/crates/pcb/tests/snapshots/release__publish_board_requires_noninteractive_choice.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pcb/tests/release.rs
+assertion_line: 397
+expression: output
+---
+Command: pcb publish boards/TestBoard.zen
+Exit Code: 1
+
+--- STDOUT ---
+
+--- STDERR ---
+Error: Board publish needs an interactive terminal to choose between previewing the current commit and releasing a new version.
+Use `pcb preview <file>` to upload the current workspace state, `pcb publish <file> --bump <patch|minor|major>` for a versioned release, or add `--dry-run` to only build the current-commit bundle locally.

--- a/crates/pcb/tests/snapshots/simple__help.snap
+++ b/crates/pcb/tests/snapshots/simple__help.snap
@@ -26,8 +26,8 @@ Commands:
   layout    Layout PCB designs
   fmt       Format .zen files
   open      Open PCB layout files
-  publish   Publish packages and boards by creating version tags
-  preview   Build and upload a preview release for a board
+  publish   Publish packages and boards through guided release flows
+  preview   Build and upload a preview bundle for a board, including dirty worktrees
   vendor    Vendor external dependencies
   fork      Manage forked dependencies for local development
   scan      Scan PDF datasheets with OCR

--- a/crates/pcb/tests/tag.rs
+++ b/crates/pcb/tests/tag.rs
@@ -73,7 +73,7 @@ fn test_publish_board_simple_workspace() {
             "publish",
             "boards/Test/TB0001.zen",
             "--bump=minor",
-            "--no-push",
+            "--dry-run",
             "--force", // Skip preflight checks
             "-S",
             "layout.drc.invalid_outline",

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -449,13 +449,19 @@ limits updates to that single package's direct dependencies:
 
 ### pcb publish
 
-Publishes packages by creating annotated git tags. Discovers which packages
-have changed since their last published version and tags them.
+Publishes packages through an interactive versioning flow, and publishes boards
+through a guided flow that lets you either preview the current commit or release
+a new version.
 
 ```bash
-pcb publish                  # Publish all changed packages
-pcb publish --force          # Skip preflight checks
+pcb publish                     # Publish all changed packages
+pcb publish boards/TB0001.zen   # Choose preview current commit or release new version
+pcb publish boards/TB0001.zen --bump minor --dry-run
+pcb publish --force             # Skip preflight checks
 ```
+
+Package publishing still works by discovering which packages have changed since
+their last published version and tagging them.
 
 A package needs publishing if:
 - No version tag exists (unpublished)
@@ -469,6 +475,11 @@ Versions are computed automatically:
 
 Packages with interdependencies are published in waves—packages with no dirty
 dependencies first, then their dependents after `pcb.toml` files are updated.
+
+For boards:
+- **Preview current commit** uploads a preview bundle for the current clean `HEAD` commit without creating a tag
+- **Release new version** builds a versioned release bundle and creates a git tag
+- `--dry-run` builds the exact bundle locally without uploading, tagging, or pushing
 
 ### pcb info
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core release/publish CLI behavior and git-tag/push control flow; risk is mainly user-workflow regressions or unintended tag/remote handling in edge cases.
> 
> **Overview**
> `pcb publish` for boards is reworked into a *guided flow*: users either **preview the current commit** or **release a new version**, with non-interactive runs now erroring unless `--bump` is specified or `--dry-run` is used.
> 
> Adds `--dry-run` to build board preview/release bundles locally without uploading/tagging/pushing, centralizes preview logic in `publish::run_board_preview` (and updates `pcb preview` to call it), and tightens preflight checks into reusable helpers (clean worktree/main branch/remote handling). Tests, CLI help text, and docs are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 788c7be0fe9a83872d7d2384ff0ab18cf17a6b68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->