### PR TITLE
Auto-dep resolves relative paths that cross workspace member boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-dependency detection now resolves relative path imports that cross workspace member boundaries (e.g. `load("../../modules/Lib/Lib.zen", ...)`).
+
 ## [0.3.52] - 2026-03-07
 
 ### Added

--- a/crates/pcb-zen/src/auto_deps.rs
+++ b/crates/pcb-zen/src/auto_deps.rs
@@ -29,6 +29,7 @@ pub struct AutoDepsSummary {
 struct CollectedImports {
     aliases: HashSet<String>,
     urls: HashSet<String>,
+    relative_paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -189,7 +190,13 @@ fn resolve_dep_candidate(
     packages: &BTreeMap<String, crate::workspace::MemberPackage>,
     index: &CacheIndex,
 ) -> Option<ResolvedDep> {
-    // Try workspace members first (walk URL path segments upward).
+    // Try workspace members first: exact match, then walk URL path segments upward.
+    if let Some(pkg) = packages.get(url) {
+        return Some(ResolvedDep {
+            module_path: url.to_string(),
+            version: pkg.version.clone().unwrap_or_else(|| "0.1.0".to_string()),
+        });
+    }
     let without_file = url.rsplit_once('/')?.0;
     let mut path = without_file;
     while !path.is_empty() {
@@ -255,17 +262,59 @@ fn collect_imports_by_package(
 
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
-        let Some((aliases, urls)) = extract_imports(&content) else {
+        let Some(extracted) = extract_imports(&content) else {
             eprintln!("  Warning: Failed to parse {}", path.display());
             continue;
         };
 
-        let imports = result.entry(pcb_toml).or_default();
-        imports.aliases.extend(aliases);
-        imports.urls.extend(urls);
+        let imports = result.entry(pcb_toml.clone()).or_default();
+        imports.aliases.extend(extracted.aliases);
+        imports.urls.extend(extracted.urls);
+
+        // Resolve relative paths that escape the package boundary to workspace member URLs
+        if !extracted.relative_paths.is_empty() {
+            let file_dir = path.parent().unwrap_or(path);
+            let pkg_root = pcb_toml
+                .parent()
+                .unwrap_or(workspace_root)
+                .canonicalize()
+                .unwrap_or_else(|_| pcb_toml.parent().unwrap_or(workspace_root).to_path_buf());
+            for rel_path in &extracted.relative_paths {
+                let Ok(resolved) = file_dir.join(rel_path).canonicalize() else {
+                    continue;
+                };
+                if resolved.starts_with(&pkg_root) {
+                    continue; // within same package, no dep needed
+                }
+                if let Some(member_url) = find_owning_member(workspace_root, packages, &resolved) {
+                    imports.urls.insert(member_url);
+                }
+            }
+        }
     }
 
     Ok(result)
+}
+
+/// Find the workspace member URL that owns the given canonicalized path.
+fn find_owning_member(
+    workspace_root: &Path,
+    packages: &BTreeMap<String, crate::workspace::MemberPackage>,
+    resolved_path: &Path,
+) -> Option<String> {
+    // Find the longest-matching member directory (most specific package)
+    let mut best: Option<(&str, usize)> = None;
+    for (url, pkg) in packages {
+        let pkg_dir = pkg.dir(workspace_root);
+        let canonical = pkg_dir.canonicalize().unwrap_or(pkg_dir);
+        if resolved_path.starts_with(&canonical) {
+            let depth = canonical.components().count();
+            if best.as_ref().is_none_or(|(_, d)| depth > *d) {
+                best = Some((url.as_str(), depth));
+            }
+        }
+    }
+    best.map(|(url, _)| url.to_string())
 }
 
 /// Find nearest pcb.toml by walking up from a file (stopping at workspace root)
@@ -286,44 +335,42 @@ fn find_nearest_pcb_toml(from: &Path, workspace_root: &Path) -> Option<PathBuf> 
 }
 
 /// Extract imports from .zen file content
-fn extract_imports(content: &str) -> Option<(HashSet<String>, HashSet<String>)> {
+fn extract_imports(content: &str) -> Option<CollectedImports> {
     let mut dialect = Dialect::Extended;
     dialect.enable_f_strings = true;
 
     let ast = AstModule::parse("<memory>", content.to_owned(), &dialect).ok()?;
-    let mut aliases = HashSet::new();
-    let mut urls = HashSet::new();
+    let mut result = CollectedImports::default();
 
     ast.statement().visit_expr(|expr| {
         visit_string_literals(expr, &mut |s, _| {
-            extract_from_str(s, &mut aliases, &mut urls);
+            extract_from_str(s, &mut result);
         });
     });
 
     for stmt in top_level_stmts(ast.statement()) {
         if let StmtP::Load(load) = &stmt.node {
-            extract_from_str(&load.module.node, &mut aliases, &mut urls);
+            extract_from_str(&load.module.node, &mut result);
         }
     }
 
-    Some((aliases, urls))
+    Some(result)
 }
 
-/// Extract alias or URL from a string
-fn extract_from_str(s: &str, aliases: &mut HashSet<String>, urls: &mut HashSet<String>) {
+/// Extract alias, URL, or relative path from a string
+fn extract_from_str(s: &str, result: &mut CollectedImports) {
     if let Some(spec) = LoadSpec::parse(s) {
         match spec {
-            LoadSpec::Stdlib { .. } => {}
+            LoadSpec::Stdlib { .. } | LoadSpec::PackageUri { .. } => {}
             LoadSpec::Package { package, .. } => {
-                aliases.insert(package);
+                result.aliases.insert(package);
             }
-            LoadSpec::Github { .. } => {
-                urls.insert(s.to_string());
+            LoadSpec::Github { .. } | LoadSpec::Gitlab { .. } => {
+                result.urls.insert(s.to_string());
             }
-            LoadSpec::Gitlab { .. } => {
-                urls.insert(s.to_string());
+            LoadSpec::Path { path, .. } => {
+                result.relative_paths.push(path);
             }
-            LoadSpec::Path { .. } | LoadSpec::PackageUri { .. } => {}
         }
     }
 }
@@ -406,55 +453,58 @@ mod tests {
 
     #[test]
     fn test_extract_from_str() {
-        let mut aliases = HashSet::new();
-        let mut urls = HashSet::new();
+        let mut result = CollectedImports::default();
 
         // Aliases are treated generically.
         extract_from_str(
             "@kicad-footprints/Resistor_SMD.pretty/R_0603.kicad_mod",
-            &mut aliases,
-            &mut urls,
+            &mut result,
         );
-        assert!(aliases.contains("kicad-footprints"));
-        assert!(urls.is_empty());
+        assert!(result.aliases.contains("kicad-footprints"));
+        assert!(result.urls.is_empty());
 
         // stdlib is not considered by auto-deps.
-        aliases.clear();
-        urls.clear();
-        extract_from_str("@stdlib/units.zen", &mut aliases, &mut urls);
-        assert!(aliases.is_empty());
-        assert!(urls.is_empty());
+        result = CollectedImports::default();
+        extract_from_str("@stdlib/units.zen", &mut result);
+        assert!(result.aliases.is_empty());
+        assert!(result.urls.is_empty());
 
-        aliases.clear();
-        urls.clear();
-        extract_from_str(
-            "github.com/diodeinc/stdlib/units.zen",
-            &mut aliases,
-            &mut urls,
-        );
-        assert!(aliases.is_empty());
-        assert!(urls.is_empty());
+        result = CollectedImports::default();
+        extract_from_str("github.com/diodeinc/stdlib/units.zen", &mut result);
+        assert!(result.aliases.is_empty());
+        assert!(result.urls.is_empty());
 
         // Dynamic alias path still tracks alias.
-        aliases.clear();
-        urls.clear();
-        extract_from_str(
-            "@kicad-footprints/{}.pretty/{}.kicad_mod",
-            &mut aliases,
-            &mut urls,
-        );
-        assert!(aliases.contains("kicad-footprints"));
-        assert!(urls.is_empty());
+        result = CollectedImports::default();
+        extract_from_str("@kicad-footprints/{}.pretty/{}.kicad_mod", &mut result);
+        assert!(result.aliases.contains("kicad-footprints"));
+        assert!(result.urls.is_empty());
 
         // Direct URLs still participate in normal package auto-deps.
-        aliases.clear();
-        urls.clear();
+        result = CollectedImports::default();
         extract_from_str(
             "github.com/example/components/Resistor/Resistor.zen",
-            &mut aliases,
-            &mut urls,
+            &mut result,
         );
-        assert!(aliases.is_empty());
-        assert!(urls.contains("github.com/example/components/Resistor/Resistor.zen"));
+        assert!(result.aliases.is_empty());
+        assert!(
+            result
+                .urls
+                .contains("github.com/example/components/Resistor/Resistor.zen")
+        );
+
+        // Relative paths are collected for cross-package resolution.
+        result = CollectedImports::default();
+        extract_from_str("../../other-pkg/foo.zen", &mut result);
+        assert_eq!(result.relative_paths.len(), 1);
+        assert_eq!(
+            result.relative_paths[0],
+            PathBuf::from("../../other-pkg/foo.zen")
+        );
+
+        // All LoadSpec::Path values are collected (filtered at resolution time).
+        result = CollectedImports::default();
+        extract_from_str("VCC", &mut result);
+        assert_eq!(result.relative_paths.len(), 1);
     }
 }

--- a/crates/pcb/tests/auto_deps.rs
+++ b/crates/pcb/tests/auto_deps.rs
@@ -227,6 +227,54 @@ pcb-version = "0.3"
     assert_snapshot!("auto_deps_branch_dep_pins_rev_and_builds", snapshot);
 }
 
+/// Test that a relative path load("../../modules/Lib/Lib.zen") that escapes a board's
+/// package boundary into another workspace member triggers auto-dep for that member.
+#[test]
+fn test_auto_deps_relative_path_cross_member() {
+    let mut sandbox = Sandbox::new();
+
+    let workspace_toml = r#"[workspace]
+pcb-version = "0.3"
+members = ["boards/*", "modules/*"]
+"#;
+
+    let lib_toml = "[dependencies]\n";
+    let lib_zen = r#"
+P1 = io("P1", Net)
+P2 = io("P2", Net)
+"#;
+
+    // Board loads the library module via a relative path that escapes the board package
+    let board_toml = r#"[board]
+name = "Main"
+path = "Main.zen"
+"#;
+    let board_zen = r#"
+load("../../modules/Lib/Lib.zen", "P1", "P2")
+
+vcc = Net("VCC")
+gnd = Net("GND")
+"#;
+
+    let _output = sandbox
+        .write("pcb.toml", workspace_toml)
+        .write("modules/Lib/pcb.toml", lib_toml)
+        .write("modules/Lib/Lib.zen", lib_zen)
+        .write("boards/Main/pcb.toml", board_toml)
+        .write("boards/Main/Main.zen", board_zen)
+        .snapshot_run("pcb", ["build", "boards/Main/Main.zen"]);
+
+    // The board's pcb.toml should now contain a dependency on the Lib member
+    let board_pcb_toml =
+        std::fs::read_to_string(sandbox.default_cwd().join("boards/Main/pcb.toml"))
+            .unwrap_or_default();
+    assert!(
+        board_pcb_toml.contains("modules/Lib"),
+        "expected board pcb.toml to contain auto-dep on modules/Lib member, got:\n{}",
+        board_pcb_toml
+    );
+}
+
 #[test]
 fn test_branch_only_dep_rejected_in_locked_and_offline() {
     let mut sandbox = Sandbox::new();


### PR DESCRIPTION
Relative path loads like that escape a package boundary into another workspace member now trigger auto-dep detection. Previously, `LoadSpec::Path` was silently discarded during import scanning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auto-deps manifest mutation logic and filesystem path canonicalization, which could cause incorrect dependency additions in edge-case workspace layouts.
> 
> **Overview**
> Auto-dependency detection now tracks `LoadSpec::Path` imports and, when a relative `load("../..")` resolves outside the current package, maps the target file back to the owning workspace member and auto-adds that member as a dependency.
> 
> This refactors import extraction to return a `CollectedImports` struct (aliases, URLs, relative paths), improves workspace-member resolution with an exact-match fast path, adds `find_owning_member` longest-prefix matching, and includes a new integration test covering cross-member relative loads; the changelog is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4698fa61fa4fa6296aafb6fee52edd8b1010c607. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
