### PR TITLE
Migrate `pcb new` to subcommands and drop `search --dir`

### DIFF
--- a/.agents/skills/pcb/SKILL.md
+++ b/.agents/skills/pcb/SKILL.md
@@ -47,10 +47,11 @@ pcb mcp eval 'tools.resolve_datasheet({kicad_sym_path: "/Applications/KiCad/KiCa
 
 ```bash
 # scaffolding
-pcb new --workspace <NAME>   # Create new workspace with git init
-pcb new --board <NAME>       # Add board to existing workspace (boards/<NAME>/)
-pcb new --package <PATH>     # Create package at path (modules, etc.)
-pcb new --component          # Interactive TUI (use search_component + add_component MCP tools instead)
+pcb new                                # Interactive mode
+pcb new workspace <NAME> --repo <URL>  # Create new workspace with git init
+pcb new board <NAME>                   # Add board to existing workspace (boards/<NAME>/)
+pcb new package <PATH>                 # Create package at path (modules, etc.)
+pcb new component [DIR]                # Interactive TUI, or import from local DIR
 ```
 
 ```bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,11 +84,11 @@ jobs:
       - name: Test pcb new
         run: |
           cd /tmp
-          pcb new --workspace test-ws --repo github.com/test/test-ws
+          pcb new workspace test-ws --repo github.com/test/test-ws
           cd test-ws
-          pcb new --board TB0001
-          pcb new --package reference/ref_a
-          pcb new --package modules/mod_a
+          pcb new board TB0001
+          pcb new package reference/ref_a
+          pcb new package modules/mod_a
           pcb build .
           cat .claude/skills/pcb/SKILL.md > /dev/null
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `pcb new` now uses subcommands (`workspace`, `board`, `package`, `component`) instead of `--workspace/--board/--package/--component` flags.
+- `pcb new component [DIR]` now imports local component directories; `pcb search --dir` support was removed.
+
 ### Fixed
 
 - Auto-dependency detection now resolves relative path imports that cross workspace member boundaries (e.g. `load("../../modules/Lib/Lib.zen", ...)`).

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -1136,10 +1136,6 @@ pub struct SearchArgs {
     #[arg(short = 'm', long, value_enum)]
     pub mode: Option<crate::registry::tui::SearchMode>,
 
-    /// Generate .zen from local directory instead of search
-    #[arg(long = "dir", value_name = "DIR", conflicts_with = "format")]
-    pub dir: Option<PathBuf>,
-
     /// Model to use for datasheet scanning
     #[arg(
         long = "scan-model",
@@ -1476,14 +1472,15 @@ fn execute_from_dir(dir: &Path, workspace_root: &Path) -> Result<()> {
     Ok(())
 }
 
+pub fn execute_component_from_local_dir(dir: &Path) -> Result<()> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let workspace_root = find_workspace_root(&pcb_zen_core::DefaultFileProvider::new(), &cwd)?;
+    execute_from_dir(dir, &workspace_root)
+}
+
 pub fn execute(args: SearchArgs) -> Result<()> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let workspace_root = find_workspace_root(&pcb_zen_core::DefaultFileProvider::new(), &cwd)?;
-
-    // Handle --dir mode (local directory)
-    if let Some(ref dir) = args.dir {
-        return execute_from_dir(dir, &workspace_root);
-    }
 
     // Search mode (local registry database with TUI or API)
     let query = args.query.as_deref().unwrap_or("");

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -13,8 +13,8 @@ pub use bom::fetch_and_populate_availability;
 pub use component::{
     AddComponentResult, ComponentDownloadResult, ComponentResult, ComponentSearchResult,
     ModelAvailability, SearchArgs, add_component_to_workspace, download_component,
-    execute as execute_search, execute_web_components_tui, search_components,
-    search_components_with_availability,
+    execute as execute_search, execute_component_from_local_dir, execute_web_components_tui,
+    search_components, search_components_with_availability,
 };
 pub use registry::{
     DigikeyData, EDatasheetComponentId, EDatasheetData, PackageDependency, PackageRelations,

--- a/crates/pcb-diode-api/src/registry/tui/app.rs
+++ b/crates/pcb-diode-api/src/registry/tui/app.rs
@@ -1445,7 +1445,7 @@ pub fn run_with_mode(mode: Option<SearchMode>) -> Result<TuiResult> {
     run_with_preflight(preflight)
 }
 
-/// Run the TUI in WebComponents mode only (for pcb new --component)
+/// Run the TUI in WebComponents mode only (for pcb new component)
 pub fn run_web_components_only() -> Result<TuiResult> {
     // Check authentication first
     crate::auth::get_valid_token()?;

--- a/crates/pcb/src/import/materialize.rs
+++ b/crates/pcb/src/import/materialize.rs
@@ -74,7 +74,7 @@ fn copy_layout_sources(
     selected: &SelectedKicadFiles,
     board_dir: &Path,
 ) -> Result<(PathBuf, PathBuf, PathBuf)> {
-    // This matches the default `pcb new --board` template: `layout_path = "layout"`.
+    // This matches the default `pcb new board` template: `layout_path = "layout"`.
     let layout_dir = board_dir.join("layout");
     fs::create_dir_all(&layout_dir)
         .with_context(|| format!("Failed to create layout directory {}", layout_dir.display()))?;

--- a/crates/pcb/src/new.rs
+++ b/crates/pcb/src/new.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Result, bail};
-use clap::Args;
+use clap::{Args, Subcommand};
 use colored::Colorize;
 use globset::Glob;
 use inquire::{Select, Text};
 use minijinja::{Environment, context};
 use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::config::{PcbToml, find_workspace_root};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::codegen;
@@ -47,31 +47,62 @@ fn create_template_env() -> Environment<'static> {
     about = "Create a new PCB workspace, board, package, or component",
     long_about = "Create a new PCB workspace, board, package, or component.\n\n\
         Examples:\n  \
-        pcb new --workspace my-project --repo https://github.com/user/my-project\n  \
-        pcb new --board MainBoard\n  \
-        pcb new --package modules/power_supply\n  \
-        pcb new --component"
+        pcb new workspace my-project --repo https://github.com/user/my-project\n  \
+        pcb new board MainBoard\n  \
+        pcb new package modules/power_supply\n  \
+        pcb new component\n  \
+        pcb new component path/to/component-dir"
 )]
 pub struct NewArgs {
-    /// Create a new workspace directory with git init
-    #[arg(long, value_name = "NAME", conflicts_with_all = ["board", "package", "component"])]
-    pub workspace: Option<String>,
+    #[command(subcommand)]
+    pub command: Option<NewCommand>,
+}
 
-    /// Git repository URL for the workspace
-    #[arg(long, value_name = "URL", requires = "workspace")]
-    pub repo: Option<String>,
+#[derive(Subcommand, Debug)]
+pub enum NewCommand {
+    /// Create a new workspace directory with git init
+    Workspace(NewWorkspaceArgs),
 
     /// Create a new board in boards/<NAME>/ (requires existing workspace)
-    #[arg(long, value_name = "NAME", conflicts_with_all = ["workspace", "package", "component"])]
-    pub board: Option<String>,
+    Board(NewBoardArgs),
 
     /// Create a new package at the given path (requires existing workspace)
-    #[arg(long, value_name = "PATH", conflicts_with_all = ["workspace", "board", "component"])]
-    pub package: Option<String>,
+    Package(NewPackageArgs),
 
-    /// Create a new component by searching online (requires existing workspace)
-    #[arg(long, conflicts_with_all = ["workspace", "board", "package"])]
-    pub component: bool,
+    /// Create a new component by searching online, or import from local directory
+    Component(NewComponentArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct NewWorkspaceArgs {
+    /// Workspace name (directory name)
+    #[arg(value_name = "NAME")]
+    pub name: String,
+
+    /// Git repository URL for the workspace
+    #[arg(long, value_name = "URL")]
+    pub repo: String,
+}
+
+#[derive(Args, Debug)]
+pub struct NewBoardArgs {
+    /// Board name
+    #[arg(value_name = "NAME")]
+    pub name: String,
+}
+
+#[derive(Args, Debug)]
+pub struct NewPackageArgs {
+    /// Package path (for example: modules/power_supply)
+    #[arg(value_name = "PATH")]
+    pub path: String,
+}
+
+#[derive(Args, Debug)]
+pub struct NewComponentArgs {
+    /// Local component directory to import
+    #[arg(value_name = "DIR")]
+    pub dir: Option<PathBuf>,
 }
 
 /// Validate a name for use as directory/git repo name (used for workspaces and boards)
@@ -139,12 +170,12 @@ fn clean_repo_url(url: &str) -> Result<String> {
 }
 
 pub fn execute(args: NewArgs) -> Result<()> {
-    match (&args.workspace, &args.board, &args.package, args.component) {
-        (Some(workspace), _, _, _) => execute_new_workspace(workspace, args.repo.as_deref()),
-        (_, Some(board), _, _) => execute_new_board(board),
-        (_, _, Some(package), _) => execute_new_package(package),
-        (_, _, _, true) => execute_new_component(),
-        _ => execute_interactive(),
+    match args.command {
+        Some(NewCommand::Workspace(command)) => execute_new_workspace(&command.name, &command.repo),
+        Some(NewCommand::Board(command)) => execute_new_board(&command.name),
+        Some(NewCommand::Package(command)) => execute_new_package(&command.path),
+        Some(NewCommand::Component(command)) => execute_new_component(command.dir.as_deref()),
+        None => execute_interactive(),
     }
 }
 
@@ -170,13 +201,17 @@ fn require_workspace() -> Result<(std::path::PathBuf, PcbToml)> {
 }
 
 #[cfg(feature = "api")]
-fn execute_new_component() -> Result<()> {
+fn execute_new_component(component_dir: Option<&Path>) -> Result<()> {
+    if let Some(dir) = component_dir {
+        return pcb_diode_api::execute_component_from_local_dir(dir);
+    }
+
     let (workspace_root, _) = require_workspace()?;
     pcb_diode_api::execute_web_components_tui(&workspace_root, None)
 }
 
 #[cfg(not(feature = "api"))]
-fn execute_new_component() -> Result<()> {
+fn execute_new_component(_component_dir: Option<&Path>) -> Result<()> {
     bail!("Component creation requires the 'api' feature")
 }
 
@@ -195,7 +230,7 @@ fn execute_interactive() -> Result<()> {
             "board" => prompt_new_board(),
             "package" => prompt_new_package(),
             #[cfg(feature = "api")]
-            "component" => execute_new_component(),
+            "component" => execute_new_component(None),
             _ => unreachable!(),
         }
     } else {
@@ -212,7 +247,7 @@ fn prompt_new_workspace() -> Result<()> {
         .prompt()
         .context("Failed to get repository URL")?;
 
-    execute_new_workspace(&name, Some(&repo))
+    execute_new_workspace(&name, &repo)
 }
 
 fn prompt_new_board() -> Result<()> {
@@ -275,15 +310,13 @@ pub(crate) fn init_workspace(dir: &Path, repository: &str) -> Result<()> {
     Ok(())
 }
 
-fn execute_new_workspace(workspace: &str, repo: Option<&str>) -> Result<()> {
+fn execute_new_workspace(workspace: &str, repo: &str) -> Result<()> {
     if get_workspace().is_some() {
         bail!("Cannot create a workspace inside an existing workspace");
     }
 
     validate_name(workspace, "Workspace")?;
 
-    let repo =
-        repo.ok_or_else(|| anyhow::anyhow!("--repo is required when creating a workspace"))?;
     let repository = clean_repo_url(repo)?;
 
     let workspace_path = Path::new(workspace);
@@ -476,6 +509,13 @@ fn execute_new_package(package_path: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    struct TestCli {
+        #[command(flatten)]
+        args: NewArgs,
+    }
 
     #[test]
     fn test_validate_name() {
@@ -529,5 +569,33 @@ mod tests {
         // Invalid
         assert!(clean_repo_url("invalid").is_err());
         assert!(clean_repo_url("github.com/user").is_err());
+    }
+
+    #[test]
+    fn test_component_accepts_optional_directory() {
+        let parsed = TestCli::try_parse_from(["pcb", "component"]).unwrap();
+        assert!(matches!(
+            parsed.args.command,
+            Some(NewCommand::Component(NewComponentArgs { dir: None }))
+        ));
+
+        let parsed = TestCli::try_parse_from(["pcb", "component", "components/foo"]).unwrap();
+        assert!(matches!(
+            parsed.args.command,
+            Some(NewCommand::Component(NewComponentArgs {
+                dir: Some(ref dir)
+            })) if dir == &PathBuf::from("components/foo")
+        ));
+
+        let parsed = TestCli::try_parse_from(["pcb"]).unwrap();
+        assert!(parsed.args.command.is_none());
+    }
+
+    #[test]
+    fn test_old_flag_forms_are_rejected() {
+        assert!(TestCli::try_parse_from(["pcb", "--workspace", "my-project"]).is_err());
+        assert!(TestCli::try_parse_from(["pcb", "--board", "MainBoard"]).is_err());
+        assert!(TestCli::try_parse_from(["pcb", "--package", "modules/power_supply"]).is_err());
+        assert!(TestCli::try_parse_from(["pcb", "--component"]).is_err());
     }
 }

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -96,7 +96,7 @@ See [Packages](/pages/packages) for complete details on version resolution and d
 
 ### Project Structure
 
-A Zener project is a git repository containing a workspace with boards, modules, and components. Create a new project with `pcb new --workspace`:
+A Zener project is a git repository containing a workspace with boards, modules, and components. Create a new project with `pcb new workspace`:
 
 ```
 my-project/
@@ -115,7 +115,7 @@ my-project/
         └── TPS54331.zen
 ```
 
-Use `pcb new --board <name>` to add boards and `pcb new --package <path>` to add modules or components.
+Use `pcb new board <name>` to add boards and `pcb new package <path>` to add modules or components.
 
 **Workspace manifest** (root `pcb.toml`):
 


### PR DESCRIPTION
`pcb new component [DIR]` replaces `pcb search --dir <dir>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a user-facing breaking change to core CLI scaffolding (`pcb new`) and changes how local component import is invoked, so downstream scripts/docs may break despite limited internal logic changes.
> 
> **Overview**
> `pcb new` is migrated from mutually-exclusive `--workspace/--board/--package/--component` flags to explicit subcommands (`workspace`, `board`, `package`, `component`), with interactive mode remaining as `pcb new`.
> 
> Local component directory import is moved off `pcb search --dir` and into `pcb new component [DIR]` (wiring through a new `execute_component_from_local_dir` entrypoint in `pcb-diode-api`), and CI/docs/changelog are updated to the new command forms; new tests ensure the old flag syntax is rejected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bba217aa73e79ab673989c9132560d716e01d5ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
