### PR TITLE
Add `Part` to stdlib prelude and use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - `pcb scan` now accepts `http(s)` datasheet URLs in addition to local PDF paths and prints the resolved markdown path.
+- `Part` is now in the standard library prelude. Use `Part(mpn=..., manufacturer=...)` with `Component(part=...)` for manufacturer sourcing.
 
 ### Changed
 

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -60,7 +60,7 @@ const PRELUDE: &[(&str, &[&str])] = &[
         "@stdlib/interfaces.zen",
         &["Net", "Power", "Ground", "NotConnected"],
     ),
-    ("@stdlib/properties.zen", &["Layout"]),
+    ("@stdlib/properties.zen", &["Layout", "Part"]),
     ("@stdlib/board_config.zen", &["Board"]),
 ];
 

--- a/crates/pcb-zen/tests/part.rs
+++ b/crates/pcb-zen/tests/part.rs
@@ -13,12 +13,12 @@ fn part_and_alternatives_serialize_in_pcb_zen_layer() {
 P1 = Net("P1")
 P2 = Net("P2")
 
-primary = builtin.Part(
+primary = Part(
     mpn = "RC0603FR-0710KL",
     manufacturer = "Yageo",
     qualifications = ["AEC-Q200"],
 )
-alt = builtin.Part(
+alt = Part(
     mpn = "ERJ-3EKF1001V",
     manufacturer = "Panasonic",
 )
@@ -114,14 +114,14 @@ P2 = Net("P2")
 
 def mutate(component):
     if component.name == "R1":
-        component.part = builtin.Part(
+        component.part = Part(
             mpn = "PART-MOD",
             manufacturer = "MFR-MOD",
             qualifications = ["Preferred"],
         )
-        component.alternatives = [builtin.Part(mpn = "ALT-1", manufacturer = "ALT-MFR-1")]
+        component.alternatives = [Part(mpn = "ALT-1", manufacturer = "ALT-MFR-1")]
         component.alternatives.append(
-            builtin.Part(mpn = "ALT-2", manufacturer = "ALT-MFR-2")
+            Part(mpn = "ALT-2", manufacturer = "ALT-MFR-2")
         )
 
 builtin.add_component_modifier(mutate)
@@ -211,7 +211,7 @@ Component(
     footprint = "Resistor_SMD:R_0603_1005Metric",
     pin_defs = {"1": "1", "2": "2"},
     pins = {"1": P1, "2": P2},
-    part = builtin.Part(
+    part = Part(
         mpn = "PART-123",
         manufacturer = "ACME",
         qualifications = ["Q1"],

--- a/crates/pcb/tests/part.rs
+++ b/crates/pcb/tests/part.rs
@@ -51,13 +51,13 @@ Component(
     footprint = "Resistor_SMD:R_0603_1005Metric",
     pin_defs = {"1": "1", "2": "2"},
     pins = {"1": P1, "2": P2},
-    part = builtin.Part(
+    part = Part(
         mpn = "PART-123",
         manufacturer = "ACME",
         qualifications = ["Q1"],
     ),
     properties = {
-        "alternatives": [builtin.Part(mpn = "ALT-1", manufacturer = "ALT-MFR-1")],
+        "alternatives": [Part(mpn = "ALT-1", manufacturer = "ALT-MFR-1")],
     },
 )
 "#;
@@ -119,14 +119,14 @@ P2 = Net("P2")
 
 def mutate(component):
     if component.name == "R1":
-        component.part = builtin.Part(
+        component.part = Part(
             mpn = "PART-MOD",
             manufacturer = "MFR-MOD",
             qualifications = ["Preferred"],
         )
-        component.alternatives = [builtin.Part(mpn = "ALT-1", manufacturer = "ALT-MFR-1")]
+        component.alternatives = [Part(mpn = "ALT-1", manufacturer = "ALT-MFR-1")]
         component.alternatives.append(
-            builtin.Part(mpn = "ALT-2", manufacturer = "ALT-MFR-2")
+            Part(mpn = "ALT-2", manufacturer = "ALT-MFR-2")
         )
 
 builtin.add_component_modifier(mutate)

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -166,7 +166,7 @@ These stdlib symbols are available in every user `.zen` file without `load()`:
 
 - `Net`, `Power`, `Ground`, `NotConnected` — from `@stdlib/interfaces.zen`
 - `Board` — from `@stdlib/board_config.zen`
-- `Layout` — from `@stdlib/properties.zen`
+- `Layout`, `Part` — from `@stdlib/properties.zen`
 
 Local definitions shadow prelude symbols. The prelude does not apply to stdlib modules themselves.
 
@@ -229,8 +229,7 @@ Component(
         "OUT": output_net,
     },
     prefix = "U",
-    manufacturer = "TI",
-    mpn = "LM358",
+    part = Part(mpn="LM358", manufacturer="TI"),
 )
 ```
 
@@ -241,16 +240,51 @@ Component(
 | `name` | yes | Instance name |
 | `symbol` | yes | Symbol object defining the schematic representation |
 | `pins` | yes | Dict mapping pin names to nets |
+| `part` | no | `Part` object specifying manufacturer sourcing (preferred) |
 | `prefix` | no | Reference designator prefix (default: `"U"`) |
-| `manufacturer` | no | Manufacturer name |
-| `mpn` | no | Manufacturer part number |
+| `manufacturer` | no | Manufacturer name (legacy — prefer `part`) |
+| `mpn` | no | Manufacturer part number (legacy — prefer `part`) |
 | `footprint` | no | PCB footprint path (usually omit — inferred from symbol) |
 | `type` | no | Component type string |
 | `properties` | no | Additional properties dict |
 | `dnp` | no | Do Not Populate flag |
 | `skip_bom` | no | Exclude from BOM |
 
-When `footprint`, `mpn`, or `manufacturer` are omitted, they are inferred from the symbol's metadata. Provide them explicitly to override.
+When `footprint` is omitted, it is inferred from the symbol's metadata. When `part` is provided, its `mpn` and `manufacturer` override any scalar `mpn`/`manufacturer` parameters or symbol metadata.
+
+### Part
+
+`Part` specifies manufacturer sourcing for a component. It is a prelude symbol — available in all `.zen` files without `load()`.
+
+**Constructor**: `Part(mpn, manufacturer, qualifications=[])`
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `mpn` | yes | Manufacturer part number (non-empty string) |
+| `manufacturer` | yes | Manufacturer name (non-empty string) |
+| `qualifications` | no | List of qualification strings (e.g. `["AEC-Q200"]`) |
+
+**Attributes**: `.mpn`, `.manufacturer`, `.qualifications`
+
+Use `Part` with the `part` parameter on `Component()` for primary sourcing, and in `properties["alternatives"]` for alternate parts:
+
+```python
+Component(
+    name = "R1",
+    symbol = Symbol(library="@kicad-symbols/Device.kicad_sym", name="R"),
+    pins = {"P1": vcc, "P2": gnd},
+    part = Part(
+        mpn = "RC0603FR-0710KL",
+        manufacturer = "Yageo",
+        qualifications = ["AEC-Q200"],
+    ),
+    properties = {
+        "alternatives": [
+            Part(mpn="ERJ-3EKF1001V", manufacturer="Panasonic"),
+        ],
+    },
+)
+```
 
 During `pcb build`, reference designators are automatically allocated per-prefix (e.g. `R1`, `R2`, `C1`).
 

--- a/examples/AD7171/AD7171.zen
+++ b/examples/AD7171/AD7171.zen
@@ -54,7 +54,7 @@ else:
 Component(
     name = "AD7171",
     symbol = Symbol(library = "@kicad-symbols/Analog_ADC.kicad_sym", name = "AD7171"),
-    part = builtin.Part(
+    part = Part(
         mpn = "AD7171",
         manufacturer = "Analog Devices",
         qualifications = ["Precision ADC"],

--- a/examples/INA240A/INA240A.zen
+++ b/examples/INA240A/INA240A.zen
@@ -115,7 +115,7 @@ elif ref_config == RefConfig("CUSTOM"):
 
 # Get the appropriate symbol for the selected gain/package
 symbol = component_config["symbols"][package][gain]
-part = builtin.Part(
+part = Part(
     mpn = component_config["mpns"][package][gain],
     manufacturer = "Texas Instruments",
 )

--- a/examples/L6387E/L6387E.zen
+++ b/examples/L6387E/L6387E.zen
@@ -55,7 +55,7 @@ VBOOT = io("VBOOT", Net)         # Bootstrap supply voltage (VBOOT-OUT ≤ 17V)
 symbol = component_config["symbols"][package]
 footprint = component_config["footprints"][package]
 mpn = component_config["mpns"][package]
-part = builtin.Part(
+part = Part(
     mpn = mpn,
     manufacturer = "STMicroelectronics",
 )

--- a/examples/PhaseDriver/PhaseDriver.zen
+++ b/examples/PhaseDriver/PhaseDriver.zen
@@ -105,7 +105,7 @@ Component(
     name = "STL100N8F7-high",
     symbol = Symbol(library = "./STL100N8F7.kicad_sym"),
     footprint = "Package_TO_SOT_SMD:TO-252-2",
-    part = builtin.Part(
+    part = Part(
         mpn = "STL100N8F7",
         manufacturer = "STMicroelectronics",
     ),
@@ -132,7 +132,7 @@ Component(
     name = "STL100N8F7-low",
     symbol = Symbol(library = "./STL100N8F7.kicad_sym"),
     footprint = "Package_TO_SOT_SMD:TO-252-2",
-    part = builtin.Part(
+    part = Part(
         mpn = "STL100N8F7",
         manufacturer = "STMicroelectronics",
     ),

--- a/stdlib/properties.zen
+++ b/stdlib/properties.zen
@@ -1,5 +1,7 @@
 load("bom/match_generics.zen", "assign_house_parts")
 
+Part = builtin.Part
+
 Hint = struct(
     near=lambda a, b: "near({}, {})".format(a, b),
     right=lambda a, b: "right({}, {})".format(a, b),

--- a/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
+++ b/test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
@@ -46,14 +46,14 @@ Component(
     footprint = "Resistor_SMD:R_0603_1005Metric",
     pin_defs = {"1": "1", "2": "2"},
     pins = {"1": filtered_vcc.NET, "2": part_demo_net},
-    part = builtin.Part(
+    part = Part(
         mpn = "RC0603FR-0710KL",
         manufacturer = "Yageo",
         qualifications = ["AEC-Q200"],
     ),
     properties = {
         "alternatives": [
-            builtin.Part(mpn = "ERJ-3EKF1001V", manufacturer = "Panasonic"),
+            Part(mpn = "ERJ-3EKF1001V", manufacturer = "Panasonic"),
         ],
     },
 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly a surface-level API exposure and call-site updates; minimal runtime risk beyond potential name shadowing/compatibility with user-defined `Part` symbols.
> 
> **Overview**
> `Part` is now injected into the implicit stdlib prelude (via `@stdlib/properties.zen`), allowing user `.zen` files to write `Part(...)` without `load()` or `builtin.` qualification.
> 
> Updates the stdlib (`Part = builtin.Part`), documentation/spec, changelog, tests, examples, and a workspace fixture to consistently use `Part(...)` and clarify that `Component(part=...)` is the preferred manufacturer sourcing API (with `mpn`/`manufacturer` kept as legacy scalar params).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87b4a35fb3e35dfc163e8885bf13d258b94876fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
