### PR TITLE
Add `pcb doc --install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb scan` now accepts `http(s)` datasheet URLs in addition to local PDF paths and prints the resolved markdown path.
 - `Part` is now in the standard library prelude. Use `Part(mpn=..., manufacturer=...)` with `Component(part=...)` for manufacturer sourcing.
+- `pcb doc --install` writes embedded documentation to `~/.pcb/docs`; runs automatically on first use and after `pcb self update`.
 
 ### Changed
 

--- a/crates/pcb/src/doc.rs
+++ b/crates/pcb/src/doc.rs
@@ -30,12 +30,21 @@ pub struct DocArgs {
     /// Show only the latest release notes (requires --changelog)
     #[arg(long, requires = "changelog")]
     pub latest: bool,
+
+    /// Install documentation files to ~/.pcb/docs
+    #[arg(long)]
+    pub install: bool,
 }
 
 // Include the generated changelog constants
 include!(concat!(env!("OUT_DIR"), "/changelog.rs"));
 
 pub fn execute(args: DocArgs) -> Result<()> {
+    // --install flag: write embedded docs to ~/.pcb/docs
+    if args.install {
+        return install_docs();
+    }
+
     // --changelog flag: show embedded changelog
     if args.changelog {
         if args.latest {
@@ -64,6 +73,34 @@ pub fn execute(args: DocArgs) -> Result<()> {
 
     // Show embedded static docs
     render_embedded_docs(&args.path, args.list)
+}
+
+/// Install embedded documentation files to ~/.pcb/docs
+fn install_docs() -> Result<()> {
+    let docs_dir = dirs::home_dir()
+        .context("Cannot determine home directory")?
+        .join(".pcb/docs");
+
+    // Clear existing docs
+    if docs_dir.exists() {
+        std::fs::remove_dir_all(&docs_dir)
+            .with_context(|| format!("Failed to remove {}", docs_dir.display()))?;
+    }
+    std::fs::create_dir_all(&docs_dir)
+        .with_context(|| format!("Failed to create {}", docs_dir.display()))?;
+
+    // Write each embedded page as a .md file
+    for page in pcb_docs::list_pages() {
+        let file_path = docs_dir.join(format!("{}.md", page.slug));
+        std::fs::write(&file_path, page.markdown)
+            .with_context(|| format!("Failed to write {}", file_path.display()))?;
+    }
+
+    // Write changelog
+    std::fs::write(docs_dir.join("CHANGELOG.md"), CHANGELOG_MD)
+        .context("Failed to write CHANGELOG.md")?;
+
+    Ok(())
 }
 
 fn render_changelog() -> Result<()> {

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -201,6 +201,7 @@ fn run() -> anyhow::Result<()> {
     // Skip auto-update check in CI environments or when running the update command
     if std::env::var("CI").is_err() && !is_update_command(&cli.command) {
         check_and_update();
+        ensure_docs_installed();
     }
 
     match cli.command {
@@ -284,6 +285,26 @@ fn run() -> anyhow::Result<()> {
 
 fn is_update_command(command: &Commands) -> bool {
     matches!(command, Commands::Update(_) | Commands::SelfUpdate(_))
+}
+
+fn ensure_docs_installed() {
+    if let Some(home) = dirs::home_dir() {
+        let docs_dir = home.join(".pcb/docs");
+        let is_empty = docs_dir
+            .read_dir()
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(true);
+        if is_empty {
+            let _ = doc::execute(doc::DocArgs {
+                path: String::new(),
+                list: false,
+                package: None,
+                changelog: false,
+                latest: false,
+                install: true,
+            });
+        }
+    }
 }
 
 fn check_and_update() {

--- a/crates/pcb/src/self_update.rs
+++ b/crates/pcb/src/self_update.rs
@@ -29,8 +29,11 @@ pub fn execute(args: SelfUpdateArgs) -> anyhow::Result<()> {
 
             match updater.run_sync()? {
                 Some(result) => {
-                    // Update was performed - print changelog from NEW binary
+                    // Update was performed - install docs and print changelog from NEW binary
                     println!();
+                    let _ = std::process::Command::new("pcb")
+                        .args(["doc", "--install"])
+                        .status();
                     let _ = std::process::Command::new("pcb")
                         .args(["doc", "--changelog", "--latest"])
                         .status();


### PR DESCRIPTION
Installs docs in ~/.pcb/docs. Runs automatically on first use and after `pcb self update`. I want to start indexing into these docs in system/user context rather than rely on skills that ask the model to run `pcb doc`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically writes to and deletes `~/.pcb/docs` on startup/self-update, which could surprise users or fail under unusual filesystem/permission conditions; failures are mostly ignored so impact should be limited to missing docs.
> 
> **Overview**
> Adds `pcb doc --install` to materialize embedded markdown docs (and `CHANGELOG.md`) into `~/.pcb/docs`, clearing and rewriting the directory each time.
> 
> Updates CLI startup to auto-install docs on first run when `~/.pcb/docs` is missing/empty, and updates `pcb self update` to run `pcb doc --install` before showing the latest release notes. Documentation is updated in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc281e4a2bb9389d0f563482e126eaddd1d9c878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
