### PR TITLE
Add back range aliases to stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `pcb new` now uses subcommands (`workspace`, `board`, `package`, `component`) instead of `--workspace/--board/--package/--component` flags.
 - `pcb new component [DIR]` now imports local component directories; `pcb search --dir` support was removed.
 - `Net` is now defined in `@stdlib/interfaces.zen` and available via the stdlib prelude instead of being a language builtin.
-- Removed deprecated backward-compatibility shims: `builtin.physical_range()`, `builtin.Voltage`/`Current`/etc. attributes, `using()`, and `*Range` type aliases from `@stdlib/units.zen`.
+- Removed deprecated backward-compatibility shims: `builtin.physical_range()`, `builtin.Voltage`/`Current`/etc. attributes, `using()`.
 - `pcb scan` removed `--model` and `--json`; local PDF and URL flows now both resolve to markdown output with default processing.
 
 ### Fixed

--- a/stdlib/units.zen
+++ b/stdlib/units.zen
@@ -17,5 +17,22 @@ Energy = builtin.physical_value("J")
 MagneticFlux = builtin.physical_value("Wb")
 Conductance = builtin.physical_value("S")
 
+# DEPRECATED: Use Voltage instead
+VoltageRange = Voltage
+# DEPRECATED: Use Current instead
+CurrentRange = Current
+# DEPRECATED: Use Resistance instead
+ResistanceRange = Resistance
+# DEPRECATED: Use Capacitance instead
+CapacitanceRange = Capacitance
+# DEPRECATED: Use Inductance instead
+InductanceRange = Inductance
+# DEPRECATED: Use Frequency instead
+FrequencyRange = Frequency
+# DEPRECATED: Use Temperature instead
+TemperatureRange = Temperature
+# DEPRECATED: Use Time instead
+TimeRange = Time
+
 def unit(spec, type):
     return type(spec)


### PR DESCRIPTION
Turns out we're still using them in some board repos (mainly due to depending on old registry packages).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple stdlib alias additions and a changelog tweak; behavior should remain unchanged aside from improving backward compatibility.
> 
> **Overview**
> Restores deprecated `*Range` type aliases in `stdlib/units.zen` (e.g., `VoltageRange`, `CurrentRange`, etc.) as direct aliases to their corresponding unit types to maintain compatibility with older board/package code.
> 
> Updates the unreleased changelog entry to clarify that the removed backward-compat shims no longer include the `*Range` aliases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 525c6b5fe697f7bfee3135e8f524e195426c33cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
