### PR TITLE
Vendor all resolved remotes for board publish

### DIFF
--- a/crates/pcb/src/bundle.rs
+++ b/crates/pcb/src/bundle.rs
@@ -26,8 +26,15 @@ pub(crate) struct MetadataInput<'a> {
 pub(crate) struct SourceBundlePlan<'a> {
     pub resolution: &'a ResolutionResult,
     pub closure: Option<&'a PackageClosure>,
+    pub remote_vendoring: RemoteVendoring,
     pub staged_src: &'a Path,
     pub resolved_paths: &'a [PathBuf],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteVendoring {
+    ClosureOnly,
+    AllResolved,
 }
 
 #[instrument(name = "write_bundle_metadata", skip_all)]
@@ -74,15 +81,21 @@ pub(crate) fn stage_source_bundle(plan: &SourceBundlePlan<'_>) -> Result<()> {
     {
         let _span = info_span!("copy_remote_packages").entered();
         let vendor_dir = plan.staged_src.join("vendor");
-        if let Some(closure) = plan.closure {
-            vendor_remote_closure_packages(plan.resolution, closure, &vendor_dir)?;
-        } else {
-            vendor_deps(
-                plan.resolution,
-                &["**".to_string()],
-                Some(&vendor_dir),
-                true,
-            )?;
+        match plan.remote_vendoring {
+            RemoteVendoring::AllResolved => {
+                vendor_deps(
+                    plan.resolution,
+                    &["**".to_string()],
+                    Some(&vendor_dir),
+                    true,
+                )?;
+            }
+            RemoteVendoring::ClosureOnly => {
+                let closure = plan
+                    .closure
+                    .context("closure is required for closure-only remote vendoring")?;
+                vendor_remote_closure_packages(plan.resolution, closure, &vendor_dir)?;
+            }
         }
     }
 
@@ -343,7 +356,7 @@ fn vendor_remote_closure_packages(
 
 #[cfg(test)]
 mod tests {
-    use super::{SourceBundlePlan, stage_source_bundle};
+    use super::{RemoteVendoring, SourceBundlePlan, stage_source_bundle};
     use pcb_test_utils::sandbox::Sandbox;
     use pcb_zen::resolve_dependencies;
     use pcb_zen::workspace::get_workspace_info;
@@ -373,6 +386,7 @@ pcb-version = "0.3"
         stage_source_bundle(&SourceBundlePlan {
             resolution: &resolution,
             closure: None,
+            remote_vendoring: RemoteVendoring::AllResolved,
             staged_src: &staged_src,
             resolved_paths: &[],
         })

--- a/crates/pcb/src/package.rs
+++ b/crates/pcb/src/package.rs
@@ -175,6 +175,7 @@ fn package_workspace_target(target: WorkspaceTarget, args: &PackageArgs) -> Resu
     bundle::stage_source_bundle(&SourceBundlePlan {
         resolution: &resolution,
         closure: Some(&closure),
+        remote_vendoring: bundle::RemoteVendoring::ClosureOnly,
         staged_src: &staging_dir.join("src"),
         resolved_paths: &resolved_paths,
     })?;

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -6,7 +6,7 @@ use pcb_layout::utils as layout_utils;
 use pcb_ui::{Colorize, Spinner, Style, StyledText};
 
 use crate::bom::generate_bom_with_fallback;
-use crate::bundle::{self, MetadataInput, SourceBundlePlan};
+use crate::bundle::{self, MetadataInput, RemoteVendoring, SourceBundlePlan};
 use pcb_zen::WorkspaceInfo;
 use pcb_zen::workspace::{WorkspaceInfoExt, get_workspace_info};
 use pcb_zen_core::DefaultFileProvider;
@@ -558,6 +558,7 @@ fn copy_sources(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
     bundle::stage_source_bundle(&SourceBundlePlan {
         resolution: &info.resolution,
         closure: info.closure.as_ref(),
+        remote_vendoring: RemoteVendoring::AllResolved,
         staged_src: &info.staging_dir.join("src"),
         resolved_paths: &info.schematic.resolved_paths,
     })

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -117,6 +117,21 @@ gnd = Net("GND")
 SimpleComponent(name = "foo", P1 = vcc_3v3, P2 = gnd)
 "#;
 
+const WORKSPACE_WITH_UNUSED_REMOTE_PCB_TOML: &str = r#"
+[workspace]
+pcb-version = "0.3"
+members = ["boards", "modules/*"]
+"#;
+
+const UNUSED_REMOTE_DEP_PCB_TOML: &str = r#"
+[dependencies]
+"github.com/mycompany/components/UnusedRemote" = "1.0.0"
+"#;
+
+const UNUSED_REMOTE_ZEN: &str = r#"
+P1 = io("P1", Net)
+"#;
+
 /// Helper to build args for source-only publish (excludes all manufacturing artifacts)
 fn source_only_args(board_zen: &str) -> Vec<&str> {
     vec![
@@ -346,6 +361,51 @@ fn test_publish_board_with_description() {
 
     let staging_dir = find_staging_dir(&sb, "DescBoard");
     assert_snapshot!("publish_with_description", sb.snapshot_dir(&staging_dir));
+}
+
+#[test]
+fn test_publish_board_vendors_workspace_remote_deps_for_validation() {
+    let mut sb = Sandbox::new();
+    const DATASHEET_CONTENTS: &str = "Simple component datasheet.";
+
+    sb.git_fixture("https://github.com/mycompany/components.git")
+        .write("UnusedRemote/pcb.toml", "[dependencies]\n")
+        .write("UnusedRemote/UnusedRemote.zen", UNUSED_REMOTE_ZEN)
+        .commit("Add unused remote package")
+        .tag("UnusedRemote/v1.0.0", false)
+        .push_mirror();
+
+    sb.cwd("src")
+        .write("pcb.toml", WORKSPACE_WITH_UNUSED_REMOTE_PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write("boards/modules/component.zen", SIMPLE_COMPONENT)
+        .write("boards/modules/test.kicad_mod", TEST_KICAD_MOD)
+        .write("boards/modules/datasheet.txt", DATASHEET_CONTENTS)
+        .write("boards/TestBoard.zen", SIMPLE_BOARD_ZEN)
+        .write("modules/Unused/pcb.toml", UNUSED_REMOTE_DEP_PCB_TOML)
+        .ignore_globs(["layout/*", "**/vendor/**", "**/build/**"])
+        .init_git()
+        .commit("Initial commit");
+
+    sb.run("pcb", ["build", "boards/TestBoard.zen"])
+        .run()
+        .expect("build failed");
+
+    sb.run("pcb", source_only_args("boards/TestBoard.zen"))
+        .run()
+        .expect("publish should succeed with unrelated locked remote dependencies");
+
+    let staging_dir = find_staging_dir(&sb, "TestBoard");
+    let vendored_remote = sb
+        .root_path()
+        .join("src")
+        .join(&staging_dir)
+        .join("src/vendor/github.com/mycompany/components/UnusedRemote/1.0.0/pcb.toml");
+
+    assert!(
+        vendored_remote.exists(),
+        "expected unrelated locked remote package to be staged for offline validation"
+    );
 }
 
 /// Test that `pcb publish` works when run from the board directory with a relative .zen path.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the dependency vendoring behavior for board publishing, which can impact release bundle contents/size and offline build validation; scoped but touches core release packaging logic.
> 
> **Overview**
> Board release/publish staging now supports *configurable remote dependency vendoring* via new `RemoteVendoring` modes on `SourceBundlePlan`.
> 
> `pcb publish`/board releases switch to vendoring **all resolved remote deps** into `src/vendor/` to enable offline validation even when the workspace lockfile contains unrelated remote packages, while `pcb package` bundling remains **closure-only** for slimmer bundles. Tests were updated/added to cover the new behavior and ensure unrelated locked remotes are staged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a39eaa161678bf582d34646dffe06e21e7bb64cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
