### PR TITLE
Create `pcb.sum` in new workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `pcb new workspace` now creates an empty `pcb.sum`, so `pcb build --locked --offline` works immediately.
 - `pcb scan` now accepts `http(s)` datasheet URLs in addition to local PDF paths and prints the resolved markdown path.
 - `Part` is now in the standard library prelude. Use `Part(mpn=..., manufacturer=...)` with `Component(part=...)` for manufacturer sourcing.
 - `pcb doc --install` writes embedded documentation to `~/.pcb/docs`; runs automatically on first use and after `pcb self update`.

--- a/crates/pcb/src/new.rs
+++ b/crates/pcb/src/new.rs
@@ -266,8 +266,8 @@ fn prompt_new_package() -> Result<()> {
     execute_new_package(&path)
 }
 
-/// Initialize workspace scaffolding in an existing directory: pcb.toml, README,
-/// .gitignore, git init, and skill path. `repository` may be empty.
+/// Initialize workspace scaffolding in an existing directory: pcb.toml, pcb.sum,
+/// README, .gitignore, git init, and skill path. `repository` may be empty.
 pub(crate) fn init_workspace(dir: &Path, repository: &str) -> Result<()> {
     if !dir.join(".git").exists() {
         let status = Command::new("git")
@@ -294,6 +294,7 @@ pub(crate) fn init_workspace(dir: &Path, repository: &str) -> Result<()> {
         .render(&ctx)
         .context("Failed to render pcb.toml template")?;
     std::fs::write(dir.join("pcb.toml"), pcb_toml_content).context("Failed to write pcb.toml")?;
+    std::fs::write(dir.join("pcb.sum"), "").context("Failed to write pcb.sum")?;
 
     let readme_content = env
         .get_template("workspace_readme")

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -103,6 +103,7 @@ A Zener project is a git repository containing a workspace with boards, modules,
 ```
 my-project/
 ├── pcb.toml              # Workspace manifest
+├── pcb.sum               # Dependency lock file
 ├── boards/
 │   └── MainBoard/
 │       ├── pcb.toml      # Board manifest


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small scaffold/documentation change that only adds creation of an empty file and should not affect existing workspaces or dependency logic.
> 
> **Overview**
> `pcb new workspace` now scaffolds an empty `pcb.sum` lockfile alongside `pcb.toml`, enabling `pcb build --locked --offline` to work immediately.
> 
> Docs and release notes are updated to reflect the lockfile being present in newly-created workspaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93000d360aa94d6b23b519b073d595975942e40c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
