### PR TITLE
Skip KiCad asset libraries in `pcb update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `pcb update` no longer proposes updates for KiCad asset libraries (symbols, footprints, 3D models) which publish breaking changes in patch releases.
 - Auto-dependency detection now resolves relative path imports that cross workspace member boundaries (e.g. `load("../../modules/Lib/Lib.zen", ...)`).
 - Layout sync now applies pad assignments to all same-number KiCad pad objects in a footprint.
 

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -376,6 +376,15 @@ pub struct KicadLibraryConfig {
     pub http_mirror: Option<String>,
 }
 
+impl KicadLibraryConfig {
+    /// All repository URLs (symbols, footprints, models) in this entry.
+    pub fn repo_urls(&self) -> impl Iterator<Item = &str> {
+        [self.symbols.as_str(), self.footprints.as_str()]
+            .into_iter()
+            .chain(self.models.values().map(|s| s.as_str()))
+    }
+}
+
 pub const DEFAULT_KICAD_HTTP_MIRROR_TEMPLATE: &str =
     "https://kicad-mirror.api.diode.computer/{repo_name}-{version}.tar.zst";
 

--- a/crates/pcb/src/update.rs
+++ b/crates/pcb/src/update.rs
@@ -319,6 +319,8 @@ fn find_version_updates(
     policy: AutoUpdatePolicy,
 ) -> Result<Vec<PendingUpdate>> {
     let workspace_members: HashSet<&String> = workspace.packages.keys().collect();
+    let kicad_entries = workspace.kicad_library_entries();
+    let kicad_lib_repos: HashSet<&str> = kicad_entries.iter().flat_map(|e| e.repo_urls()).collect();
     let mut version_cache: BTreeMap<String, BTreeMap<String, Vec<Version>>> = BTreeMap::new();
     let mut pending = Vec::new();
 
@@ -326,8 +328,14 @@ fn find_version_updates(
         let config = PcbToml::from_file(&DefaultFileProvider::new(), &pcb_toml_path)?;
 
         for (url, spec) in &config.dependencies {
-            // Skip workspace members and filtered packages.
-            if workspace_members.contains(url) || !matches_filter(url, filter) {
+            // Skip workspace members, filtered packages, and KiCad asset libraries.
+            // TODO: Re-enable updates for KiCad asset libraries once we handle
+            // their non-semver versioning properly (they publish breaking changes
+            // in patch releases).
+            if workspace_members.contains(url)
+                || !matches_filter(url, filter)
+                || kicad_lib_repos.contains(url.as_str())
+            {
                 continue;
             }
 


### PR DESCRIPTION
KiCad symbol/footprint libraries publish breaking changes in patch releases, which breaks our semver-based update model. Disable update proposals for asset-derived dependencies until we have a proper versioning solution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to dependency update filtering; main risk is unintentionally suppressing updates for repos that match the KiCad library URL list.
> 
> **Overview**
> `pcb update` now **skips proposing version bumps** for configured KiCad asset library repos (symbols, footprints, and 3D models), avoiding semver-based update suggestions for repos that ship breaking changes in patch releases.
> 
> This adds `KicadLibraryConfig::repo_urls()` to enumerate all KiCad library repo URLs and uses it in the update scanner to filter those dependencies out; the changelog is updated to document the behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b791261698feabafdc497332f19ed3f29ea3283a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
