### PR TITLE
Fix match_component on non-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `match_component()` now skips non-component children such as `ElectricalCheck` instead of failing on missing `mpn`.
 - `pcb update` no longer proposes updates for KiCad asset libraries (symbols, footprints, 3D models) which publish breaking changes in patch releases.
 - Auto-dependency detection now resolves relative path imports that cross workspace member boundaries (e.g. `load("../../modules/Lib/Lib.zen", ...)`).
 - Layout sync now applies pad assignments to all same-number KiCad pad objects in a footprint.

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -781,3 +781,39 @@ snapshot_eval!(module_schematic_invalid, {
         )
     "#
 });
+
+#[test]
+fn component_modifier_match_component_ignores_electrical_checks() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+        load("@stdlib/bom/helpers.zen", "match_component")
+
+        builtin.add_component_modifier(
+            match_component(
+                match={"resistance": "10k"},
+                parts=("RC0603FR-0710KL", "Yageo"),
+            )
+        )
+
+        Component(
+            name = "R1",
+            footprint = "0603",
+            pin_defs = {"1": "1", "2": "2"},
+            pins = {"1": Net("A"), "2": Net("B")},
+            properties = {"resistance": "10k"},
+        )
+
+        def check_ok(module):
+            return
+
+        builtin.add_electrical_check(
+            name = "noop",
+            check_fn = check_ok,
+        )
+    "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+}

--- a/stdlib/bom/helpers.zen
+++ b/stdlib/bom/helpers.zen
@@ -435,6 +435,10 @@ def match_component(match: dict, parts: tuple | list, matcher: str = "match_comp
     """
 
     def modifier(c):
+        # Component modifiers run on all direct children, including non-components.
+        if not hasattr(c, "mpn"):
+            return
+
         # Skip if already has MPN
         if c.mpn:
             return


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small guard added to `match_component()` plus a focused test; behavior only changes for modifier runs over non-component children.
> 
> **Overview**
> Fixes `@stdlib/bom/helpers.zen` `match_component()` to **skip non-component children** (e.g., `ElectricalCheck`) by returning early when the target lacks `mpn`, preventing modifier failures.
> 
> Adds a Rust test covering the mixed `Component` + `builtin.add_electrical_check` case, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03e01ba386895138e4a9e3f2782f159ccaa6e6d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->