### PR TITLE
Fix board publish major bump semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - CLI and MCP component search JSON outputs are now aligned, with cleaner payloads and per-source caps for `web:components`.
 
+### Fixed
+
+- `pcb publish` now shows `patch`, `minor`, and `major` bumps for boards consistently, and `major` on `0.x` now produces `1.0.0`.
+
 ## [0.3.53] - 2026-03-11
 
 ### Added

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -37,6 +37,8 @@ pub enum BumpType {
     Interactive,
 }
 
+const SELECTABLE_BUMPS: [BumpType; 3] = [BumpType::Patch, BumpType::Minor, BumpType::Major];
+
 #[derive(Args, Debug)]
 #[command(about = "Publish packages or board releases")]
 pub struct PublishArgs {
@@ -776,7 +778,6 @@ fn compute_next_version(current: Option<&Version>, bump: BumpType) -> Version {
         Some(v) => match bump {
             BumpType::Patch => Version::new(v.major, v.minor, v.patch + 1),
             BumpType::Minor => Version::new(v.major, v.minor + 1, 0),
-            BumpType::Major if v.major == 0 => Version::new(0, v.minor + 1, 0),
             BumpType::Major => Version::new(v.major + 1, 0, 0),
             BumpType::Interactive => {
                 unreachable!("Interactive should be resolved before calling compute_next_version")
@@ -1062,44 +1063,32 @@ fn prompt_bump_type() -> Result<BumpType> {
         .unwrap_or(BumpType::Minor))
 }
 
+fn bump_name(bump: BumpType) -> &'static str {
+    match bump {
+        BumpType::Patch => "Patch",
+        BumpType::Minor => "Minor",
+        BumpType::Major => "Major",
+        BumpType::Interactive => unreachable!(),
+    }
+}
+
+fn single_bump_options(current: Option<&Version>) -> Vec<(String, BumpType)> {
+    SELECTABLE_BUMPS
+        .into_iter()
+        .map(|b| {
+            (
+                format!("{} → {}", bump_name(b), compute_next_version(current, b)),
+                b,
+            )
+        })
+        .collect()
+}
+
 fn prompt_single_bump(name: &str, current: Option<&Version>) -> Result<BumpType> {
     let ver = current
         .map(|v| v.to_string())
         .unwrap_or_else(|| "unpublished".to_string());
-    let is_pre_1_0 = current.is_none_or(|v| v.major == 0);
-
-    let options: Vec<_> = if is_pre_1_0 {
-        [BumpType::Patch, BumpType::Minor]
-            .into_iter()
-            .map(|b| {
-                let label = if b == BumpType::Patch {
-                    "Patch"
-                } else {
-                    "Minor/Major"
-                };
-                (
-                    format!("{} → {}", label, compute_next_version(current, b)),
-                    b,
-                )
-            })
-            .collect()
-    } else {
-        [BumpType::Patch, BumpType::Minor, BumpType::Major]
-            .into_iter()
-            .map(|b| {
-                let label = match b {
-                    BumpType::Patch => "Patch",
-                    BumpType::Minor => "Minor",
-                    BumpType::Major => "Major",
-                    BumpType::Interactive => unreachable!(),
-                };
-                (
-                    format!("{} → {}", label, compute_next_version(current, b)),
-                    b,
-                )
-            })
-            .collect()
-    };
+    let options = single_bump_options(current);
 
     let labels: Vec<_> = options.iter().map(|(l, _)| l.as_str()).collect();
     let selected = Select::new(&format!("{} ({})", name, ver), labels)
@@ -1275,11 +1264,11 @@ mod tests {
 
     #[test]
     fn test_version_bump_major_pre_1_0() {
-        // For 0.x, major bump should increment minor (semver convention)
+        // For 0.x, a major bump promotes the release to 1.0.0
         let v = Version::new(0, 3, 5);
         assert_eq!(
             compute_next_version(Some(&v), BumpType::Major),
-            Version::new(0, 4, 0)
+            Version::new(1, 0, 0)
         );
     }
 
@@ -1297,5 +1286,31 @@ mod tests {
             compute_next_version(None, BumpType::Major),
             Version::new(0, 1, 0)
         );
+    }
+
+    #[test]
+    fn test_single_bump_options_always_show_patch_minor_major() {
+        let cases = [
+            (
+                Some(Version::new(0, 3, 5)),
+                vec![
+                    ("Patch → 0.3.6".to_string(), BumpType::Patch),
+                    ("Minor → 0.4.0".to_string(), BumpType::Minor),
+                    ("Major → 1.0.0".to_string(), BumpType::Major),
+                ],
+            ),
+            (
+                None,
+                vec![
+                    ("Patch → 0.1.0".to_string(), BumpType::Patch),
+                    ("Minor → 0.1.0".to_string(), BumpType::Minor),
+                    ("Major → 0.1.0".to_string(), BumpType::Major),
+                ],
+            ),
+        ];
+
+        for (current, expected) in cases {
+            assert_eq!(single_bump_options(current.as_ref()), expected);
+        }
     }
 }

--- a/docs/pages/docs_changelog.mdx
+++ b/docs/pages/docs_changelog.mdx
@@ -72,8 +72,6 @@ Avoid:
 - **Minor** (0.3.x → 0.4.0): New non-breaking functionality — optional pins, new config options, additional footprint variants.
 - **Major** (0.x → 1.0): Breaking changes requiring design updates — changed pin definitions, restructured interfaces, removed features.
 
-Pre-1.0: `pcb publish` bumps minor (0.3.2 → 0.4.0) since minor versions are treated as potentially breaking.
-
 ## Tooling
 
 1. **`pcb publish`** — reads `[Unreleased]` as the release body for the annotated git tag.

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -467,8 +467,7 @@ A package needs publishing if:
 
 Versions are computed automatically:
 - **Unpublished**: starts at `0.1.0`
-- **0.x packages**: bumps minor (`0.3.2` → `0.4.0`)
-- **1.x+ packages**: bumps patch (`1.2.3` → `1.2.4`)
+- **Published packages**: apply the requested semver bump (`patch`, `minor`, or `major`)
 
 Packages with interdependencies are published in waves—packages with no dirty
 dependencies first, then their dependents after `pcb.toml` files are updated.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes board release version computation and interactive bump selection in `pcb publish`, which can affect generated tags and downstream release workflows.
> 
> **Overview**
> `pcb publish` board releases now treat a `major` bump on `0.x` as a promotion to `1.0.0` (instead of incrementing the `0.y` minor), and the interactive bump prompt always offers `patch`, `minor`, and `major` with consistent labels.
> 
> Docs and changelog entries are updated to match the new board/versioning semantics and remove the old pre-1.0 guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6501bdc4867c73aa3652a2f70d76d3708ddf350d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->