### PR TITLE
fix: add layout path to package manifest

### DIFF
--- a/crates/pcb/src/package.rs
+++ b/crates/pcb/src/package.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use clap::Args;
+use pcb_layout::utils as layout_utils;
 use pcb_zen::workspace::WorkspaceInfoExt;
 use pcb_zen::{get_workspace_info, git, resolve_dependencies};
 use pcb_zen_core::DefaultFileProvider;
@@ -169,6 +170,12 @@ fn package_workspace_target(target: WorkspaceTarget, args: &PackageArgs) -> Resu
         let _span = info_span!("resolve_package_bundle_dependencies").entered();
         resolve_dependencies(&mut workspace, false, locked)?
     };
+    let layout_path = target
+        .primary_zen
+        .as_ref()
+        .map(|primary_zen| resolve_package_layout_path(primary_zen, &resolution))
+        .transpose()?
+        .flatten();
     let closure = resolution.package_closure(&target.package_url);
     let resolved_paths = collect_bundle_resolved_paths(&resolution, &closure)?;
 
@@ -187,7 +194,7 @@ fn package_workspace_target(target: WorkspaceTarget, args: &PackageArgs) -> Resu
         workspace_root: &resolution.workspace_info.root,
         staging_dir: &staging_dir,
         zen_path: primary_zen,
-        layout_path: None,
+        layout_path: layout_path.as_deref(),
         description: target.description.as_deref(),
         include_kicad_version: false,
     })?;
@@ -327,6 +334,44 @@ fn resolve_workspace_target(
         primary_zen,
         None,
     )))
+}
+
+fn resolve_package_layout_path(
+    primary_zen: &Path,
+    resolution: &ResolutionResult,
+) -> Result<Option<PathBuf>> {
+    let eval_result = pcb_zen::eval(primary_zen, resolution.clone());
+    let output = eval_result.output_result().map_err(|diagnostics| {
+        let rendered_diagnostics = diagnostics
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::anyhow!(
+            "Failed to evaluate {} while resolving package layout path:\n{}",
+            primary_zen.display(),
+            rendered_diagnostics
+        )
+    })?;
+    let schematic = output
+        .to_schematic()
+        .with_context(|| format!("Failed to build schematic for {}", primary_zen.display()))?;
+    let Some(layout_path) = layout_utils::resolve_layout_dir(&schematic)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        layout_path
+            .strip_prefix(&resolution.workspace_info.root)
+            .with_context(|| {
+                format!(
+                    "Layout path {} is not within workspace root {}",
+                    layout_path.display(),
+                    resolution.workspace_info.root.display()
+                )
+            })?
+            .to_path_buf(),
+    ))
 }
 
 fn bundle_stem_from_package_dir(

--- a/crates/pcb/tests/package.rs
+++ b/crates/pcb/tests/package.rs
@@ -3,6 +3,7 @@
 use pcb_test_utils::sandbox::Sandbox;
 use serde_json::Value;
 use std::fs::File;
+use std::io::Read;
 use tar::Archive;
 use zstd::stream::read::Decoder;
 
@@ -31,6 +32,11 @@ P1 = io("P1", Net)
 P2 = io("P2", Net)
 
 Child(name = "U1", P1 = P1, P2 = P2)
+
+Layout(
+    name="Parent",
+    path="layout/Parent",
+)
 "#;
 
 fn write_module_workspace(sb: &mut Sandbox) {
@@ -40,6 +46,10 @@ fn write_module_workspace(sb: &mut Sandbox) {
         .write("modules/Child/Child.zen", CHILD_ZEN)
         .write("modules/Parent/pcb.toml", PARENT_PCB_TOML)
         .write("modules/Parent/Parent.zen", PARENT_ZEN)
+        .write(
+            "modules/Parent/layout/Parent/layout.kicad_pcb",
+            "(kicad_pcb)",
+        )
         .hash_globs(["**/diodeinc/stdlib/*.zen"])
         .init_git()
         .commit("Initial commit");
@@ -96,6 +106,27 @@ fn test_package_module_bundle() {
         entries
             .iter()
             .any(|path| path == "src/modules/Child/Child.zen")
+    );
+
+    let decoder = Decoder::new(File::open(&archive_path).unwrap()).unwrap();
+    let mut archive = Archive::new(decoder);
+    let mut metadata_json = None;
+    for entry in archive.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        let path = entry.path().unwrap().to_string_lossy().to_string();
+        if path == "metadata.json" {
+            let mut buf = String::new();
+            entry.read_to_string(&mut buf).unwrap();
+            metadata_json = Some(buf);
+            break;
+        }
+    }
+
+    let metadata_json: Value =
+        serde_json::from_str(&metadata_json.expect("metadata.json should exist")).unwrap();
+    assert_eq!(
+        metadata_json["release"]["layout_path"],
+        "modules/Parent/layout/Parent"
     );
 }
 
@@ -168,7 +199,7 @@ fn test_package_hash_only_json_output() {
     assert_eq!(json["package_url"], "modules/Parent");
     assert_eq!(
         json["content_hash"],
-        "h1:+9bG3s5EuNonXq+fkqSepe1+T09uRSaCYTQISn7IMaQ="
+        "h1:YP4ph0cGn32dy8JQnyqF7k24SDFyv0yB20pO3O4MrBw="
     );
     assert_eq!(
         json["manifest_hash"],


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an extra `pcb_zen::eval` during packaging to discover the layout directory, which could change packaging behavior/perf and introduce new failure modes if evaluation/layout resolution fails.
> 
> **Overview**
> **Package bundles now record the board layout directory in `metadata.json`.** The `pcb package` flow evaluates the primary `.zen` file, resolves the `Layout(...)` directory via `pcb_layout::utils`, validates it is under the workspace root, and passes the relative `layout_path` through to metadata generation.
> 
> Tests were extended to include a sample `Layout` declaration and dummy KiCad layout file, assert `metadata.json` contains `release.layout_path`, and update the expected hash-only `content_hash`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eefbb52cfaaaf7061d19c7121f279db93b2d940. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->