### PR TITLE
Keep MOQ-expensive BOM offers but mark them hard to source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Stop syncing `Alternatives` and `Matcher` component metadata into KiCad footprint fields during layout sync.
+- `pcb bom` now keeps MOQ-expensive offers in BOM output but marks them hard to source in table summaries instead of dropping them.
 
 ## [0.3.54] - 2026-03-12
 

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -3,7 +3,9 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::{collections::HashMap, time::Duration};
 
-use pcb_sch::bom::availability::{NUM_BOARDS, is_small_generic_passive, tier_for_stock};
+use pcb_sch::bom::availability::{
+    HardToSourceReason, NUM_BOARDS, is_small_generic_passive, tier_for_stock,
+};
 use pcb_sch::bom::{Availability, AvailabilitySummary, Offer};
 
 /// Price break structure
@@ -71,6 +73,22 @@ impl ComponentOffer {
             part_id: self.distributor_part_id.clone(),
         }
     }
+}
+
+fn offer_passes_moq_affordability(offer: &ComponentOffer, target_qty: i32) -> bool {
+    let moq = offer.moq.unwrap_or(1);
+    moq <= target_qty || offer.unit_price_at_qty(moq).unwrap_or(f64::MAX) * moq as f64 <= 100.0
+}
+
+fn hard_to_source_reason_for_offers(
+    offers: &[&ComponentOffer],
+    target_qty: i32,
+) -> Option<HardToSourceReason> {
+    let _ = offers.first()?;
+    offers
+        .iter()
+        .all(|offer| !offer_passes_moq_affordability(offer, target_qty))
+        .then_some(HardToSourceReason::UnaffordableMoq)
 }
 
 /// Design BOM entry structure from the API
@@ -167,12 +185,14 @@ fn build_availability_summary(
     alt_stock: i32,
     target_qty: i32,
     include_internal_fields: bool,
+    hard_to_source_reason: Option<HardToSourceReason>,
 ) -> AvailabilitySummary {
     if !include_internal_fields {
         return AvailabilitySummary {
             price: offer.unit_price_at_qty(target_qty),
             stock: offer.stock_available.unwrap_or_default(),
             alt_stock,
+            hard_to_source_reason,
             ..Default::default()
         };
     }
@@ -197,6 +217,7 @@ fn build_availability_summary(
         price: offer.unit_price_at_qty(target_qty),
         stock: offer.stock_available.unwrap_or_default(),
         alt_stock,
+        hard_to_source_reason,
         price_breaks: offer
             .price_breaks
             .as_ref()
@@ -275,27 +296,22 @@ pub fn fetch_and_populate_availability(
 
         let target_qty = qty * NUM_BOARDS;
 
-        // Filter: MOQ <= target OR price_at_moq <= $100
-        let moq_ok = |o: &&ComponentOffer| {
-            let moq = o.moq.unwrap_or(1);
-            moq <= target_qty || o.unit_price_at_qty(moq).unwrap_or(f64::MAX) * moq as f64 <= 100.0
-        };
-
         // Process each geography
         let process_geo = |geo: Geography| {
             let offers: Vec<_> = resolved_offers
                 .iter()
                 .copied()
                 .filter(|o| o.geography == geo)
-                .filter(moq_ok)
                 .collect();
             let best = select_best_offer(offers.iter().copied(), qty, is_small_passive);
             let alt = calculate_alt_stock(&offers, best, qty);
-            (offers, best, alt)
+            let hard_to_source_reason = hard_to_source_reason_for_offers(&offers, target_qty);
+            (offers, best, alt, hard_to_source_reason)
         };
 
-        let (us_offers, best_us, us_alt) = process_geo(Geography::Us);
-        let (global_offers, best_global, global_alt) = process_geo(Geography::Global);
+        let (us_offers, best_us, us_alt, us_hard_to_source_reason) = process_geo(Geography::Us);
+        let (global_offers, best_global, global_alt, global_hard_to_source_reason) =
+            process_geo(Geography::Global);
 
         // Build offers for JSON output
         let all_offers: Vec<_> = us_offers
@@ -307,9 +323,24 @@ pub fn fetch_and_populate_availability(
         bom.availability.insert(
             path.to_string(),
             Availability {
-                us: best_us.map(|o| build_availability_summary(o, us_alt, target_qty, true)),
-                global: best_global
-                    .map(|o| build_availability_summary(o, global_alt, target_qty, true)),
+                us: best_us.map(|o| {
+                    build_availability_summary(
+                        o,
+                        us_alt,
+                        target_qty,
+                        true,
+                        us_hard_to_source_reason,
+                    )
+                }),
+                global: best_global.map(|o| {
+                    build_availability_summary(
+                        o,
+                        global_alt,
+                        target_qty,
+                        true,
+                        global_hard_to_source_reason,
+                    )
+                }),
                 offers: all_offers,
             },
         );
@@ -399,7 +430,7 @@ pub fn fetch_pricing_batch(
                 .collect();
             let best = select_best_offer(filtered.iter().copied(), 1, false);
             let alt = calculate_alt_stock(&filtered, best, 1);
-            best.map(|o| build_availability_summary(o, alt, 1, false))
+            best.map(|o| build_availability_summary(o, alt, 1, false, None))
         };
 
         *slot = Availability {
@@ -443,4 +474,67 @@ pub fn fetch_availability_for_results(
         .filter(|(_, p)| p.us.is_some() || p.global.is_some() || !p.offers.is_empty())
         .map(|((idx, _), p)| (idx, p))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn offer(id: &str, moq: Option<i32>, breaks: &[(i32, f64)]) -> ComponentOffer {
+        ComponentOffer {
+            id: id.to_string(),
+            geography: Geography::Us,
+            distributor: Some("testdist".to_string()),
+            distributor_part_id: Some(id.to_string()),
+            mpn: Some("TEST-MPN".to_string()),
+            manufacturer: Some("Test Manufacturer".to_string()),
+            moq,
+            price_breaks: Some(
+                breaks
+                    .iter()
+                    .map(|(qty, price)| PriceBreak {
+                        qty: *qty,
+                        price: *price,
+                    })
+                    .collect(),
+            ),
+            stock_available: Some(100),
+            product_url: None,
+        }
+    }
+
+    #[test]
+    fn affordable_moq_passes() {
+        let offer = offer("affordable", Some(1000), &[(1000, 0.05)]);
+        assert!(offer_passes_moq_affordability(&offer, 20));
+    }
+
+    #[test]
+    fn expensive_moq_fails() {
+        let offer = offer("expensive", Some(1000), &[(1000, 0.124)]);
+        assert!(!offer_passes_moq_affordability(&offer, 20));
+    }
+
+    #[test]
+    fn mixed_offers_do_not_flag_hard_to_source() {
+        let expensive_best = offer("expensive", Some(1000), &[(1000, 0.124)]);
+        let affordable_alt = offer("affordable", Some(1000), &[(1000, 0.09)]);
+
+        let offers = vec![&expensive_best, &affordable_alt];
+
+        assert_eq!(hard_to_source_reason_for_offers(&offers, 20), None);
+    }
+
+    #[test]
+    fn all_unaffordable_offers_flag_hard_to_source() {
+        let expensive_a = offer("expensive-a", Some(1000), &[(1000, 0.124)]);
+        let expensive_b = offer("expensive-b", Some(1000), &[(1000, 0.132)]);
+
+        let offers = vec![&expensive_a, &expensive_b];
+
+        assert_eq!(
+            hard_to_source_reason_for_offers(&offers, 20),
+            Some(HardToSourceReason::UnaffordableMoq)
+        );
+    }
 }

--- a/crates/pcb-sch/src/bom/availability.rs
+++ b/crates/pcb-sch/src/bom/availability.rs
@@ -31,6 +31,12 @@ impl Tier {
     }
 }
 
+/// Internal reason why an otherwise-stocked offer is still hard to source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HardToSourceReason {
+    UnaffordableMoq,
+}
+
 /// Check if component is a small generic passive requiring higher stock threshold
 pub fn is_small_generic_passive(
     generic_data: Option<&GenericComponent>,
@@ -89,6 +95,9 @@ pub struct AvailabilitySummary {
     pub stock: i32,
     /// Combined stock from alternative offers
     pub alt_stock: i32,
+    /// Internal reason code for hard-to-source classification
+    #[serde(skip, default)]
+    pub hard_to_source_reason: Option<HardToSourceReason>,
     /// Price breaks for computing prices at different quantities (internal only)
     #[serde(skip, default)]
     pub price_breaks: Option<Vec<(i32, f64)>>,

--- a/crates/pcb-sch/src/bom_table.rs
+++ b/crates/pcb-sch/src/bom_table.rs
@@ -6,7 +6,9 @@ use terminal_hyperlink::Hyperlink as _;
 use urlencoding::encode as urlencode;
 
 use crate::bom::AvailabilitySummary;
-use crate::bom::availability::{NUM_BOARDS, Tier, is_small_generic_passive, tier_for_stock};
+use crate::bom::availability::{
+    HardToSourceReason, NUM_BOARDS, Tier, is_small_generic_passive, tier_for_stock,
+};
 use crate::bom::{Bom, GenericComponent};
 
 /// Create a cell with quantity and percentage (percentage in grey)
@@ -150,6 +152,7 @@ struct RegionDisplayData {
     price_single: Option<f64>,
     price_boards: Option<f64>,
     tier: Tier,
+    hard_to_source_reason: Option<HardToSourceReason>,
     lcsc_ids: Vec<(String, String)>,
     mpn: Option<String>,
     manufacturer: Option<String>,
@@ -165,7 +168,11 @@ impl RegionDisplayData {
             return Self::default();
         };
 
-        let tier = tier_for_stock(a.stock, qty as i32, is_small_passive);
+        let tier = if a.hard_to_source_reason.is_some() {
+            Tier::Insufficient
+        } else {
+            tier_for_stock(a.stock, qty as i32, is_small_passive)
+        };
         let (price_single, price_boards) = match &a.price_breaks {
             Some(breaks) => {
                 let unit_single = unit_price_from_breaks(breaks, qty as i32);
@@ -184,6 +191,7 @@ impl RegionDisplayData {
             price_single,
             price_boards,
             tier,
+            hard_to_source_reason: a.hard_to_source_reason,
             lcsc_ids: a.lcsc_part_ids.clone(),
             mpn: a.mpn.clone(),
             manufacturer: a.manufacturer.clone(),
@@ -286,7 +294,6 @@ impl Bom {
 
         let json: serde_json::Value = serde_json::from_str(&self.grouped_json()).unwrap();
         let mut entries: Vec<&serde_json::Value> = json.as_array().unwrap().iter().collect();
-
         // Sort entries: non-DNP first (sorted by first designator), then DNP items (sorted by first designator)
         entries.sort_by(|a, b| {
             let a_dnp = a.get("dnp").and_then(|v| v.as_bool()).unwrap_or(false);
@@ -409,20 +416,25 @@ impl Bom {
                 autofill_from_availability(original_manufacturer, &avail_manufacturer);
 
             // Designator tier:
+            // - Red: any region is explicitly hard to source due to MOQ affordability
             // - Green: both regions Plenty AND has MPN/manufacturer
             // - Red: both regions Insufficient
             // - Yellow: everything else
-            let designator_tier =
-                if us_data.tier == Tier::Insufficient && global_data.tier == Tier::Insufficient {
-                    Tier::Insufficient
-                } else if us_data.tier == Tier::Plenty
-                    && global_data.tier == Tier::Plenty
-                    && has_complete_part_info(original_mpn, original_manufacturer)
-                {
-                    Tier::Plenty
-                } else {
-                    Tier::Limited
-                };
+            let hard_to_source = us_data.hard_to_source_reason.is_some()
+                || global_data.hard_to_source_reason.is_some();
+
+            let designator_tier = if hard_to_source
+                || (us_data.tier == Tier::Insufficient && global_data.tier == Tier::Insufficient)
+            {
+                Tier::Insufficient
+            } else if us_data.tier == Tier::Plenty
+                && global_data.tier == Tier::Plenty
+                && has_complete_part_info(original_mpn, original_manufacturer)
+            {
+                Tier::Plenty
+            } else {
+                Tier::Limited
+            };
 
             // Track summary stats
             if has_availability {
@@ -695,5 +707,30 @@ impl Bom {
             writeln!(writer, "{house_table}")?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hard_to_source_availability_forces_red_tier() {
+        let avail = AvailabilitySummary {
+            stock: 78_000,
+            hard_to_source_reason: Some(HardToSourceReason::UnaffordableMoq),
+            price_breaks: Some(vec![(1000, 0.124)]),
+            ..Default::default()
+        };
+
+        let region = RegionDisplayData::from_region_avail(Some(&avail), 1, false);
+
+        assert_eq!(region.tier, Tier::Insufficient);
+        assert_eq!(
+            region.hard_to_source_reason,
+            Some(HardToSourceReason::UnaffordableMoq)
+        );
+        assert_eq!(region.stock, 78_000);
+        assert_eq!(region.price_single, Some(0.124));
     }
 }


### PR DESCRIPTION
This makes `pcb bom` consistent with `pcb search`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BOM offer handling and tier classification logic, which can alter which parts are shown as sourceable and how summaries are colored. Risk is moderate because it affects procurement-facing output but is gated to BOM availability/table rendering and covered by new unit tests.
> 
> **Overview**
> `pcb bom` no longer drops offers solely because their MOQ is unaffordable; it keeps them in the offer list but annotates per-region availability with a new internal `HardToSourceReason::UnaffordableMoq` flag.
> 
> The BOM table rendering treats any region with this flag as *Insufficient* (red) and forces grouped designators to red if either region is flagged, aligning table summaries with this new “hard to source” classification. Adds unit tests for MOQ affordability detection and tier forcing, and updates the changelog entry accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11405d296793cb8941b49a85f2917493c69ed1cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
