### PR TITLE
Filter sourcing metadata from layout sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop syncing `Alternatives` and `Matcher` component metadata into KiCad footprint fields during layout sync.
+
 ## [0.3.54] - 2026-03-12
 
 ### Added

--- a/crates/pcb-layout/src/scripts/lens/lens.py
+++ b/crates/pcb-layout/src/scripts/lens/lens.py
@@ -109,6 +109,8 @@ def get(netlist: Any) -> BoardView:
             elif name_lower == "description":
                 fields["Description"] = prop.value
             elif name_lower not in {
+                "alternatives",
+                "matcher",
                 "value",
                 "reference",
                 "symbol_name",

--- a/crates/pcb-layout/src/scripts/lens/tests/test_not_connected.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_not_connected.py
@@ -35,6 +35,14 @@ class MockPart:
         self.properties = []
 
 
+class MockProperty:
+    """Mock part property."""
+
+    def __init__(self, name: str, value: str):
+        self.name = name
+        self.value = value
+
+
 class MockNetlist:
     """Mock netlist object for testing get()."""
 
@@ -194,3 +202,26 @@ class TestNotConnectedInGet:
         assert "NC_EMPTY" in view.nets
         assert view.nets["NC_EMPTY"].kind == "NotConnected"
         assert len(view.nets["NC_EMPTY"].connections) == 0
+
+    def test_sourcing_metadata_is_not_mirrored_to_layout_fields(self):
+        """Sourcing-only metadata should stay out of KiCad footprint fields."""
+        part = MockPart(
+            path="Power.C1",
+            ref="C1",
+            footprint="Capacitor_SMD:C_0603",
+            value="10uF",
+        )
+        part.properties = [
+            MockProperty("alternatives", '{"mpn":"ALT-1","manufacturer":"AltCorp"}'),
+            MockProperty("matcher", "generic/capacitor"),
+            MockProperty("datasheet", "https://example.com/c1"),
+            MockProperty("manufacturer", "PrimaryCorp"),
+        ]
+
+        view = get(MockNetlist(parts=[part]))
+        footprint = next(iter(view.footprints.values()))
+
+        assert "Alternatives" not in footprint.fields
+        assert "Matcher" not in footprint.fields
+        assert footprint.fields["Datasheet"] == "https://example.com/c1"
+        assert footprint.fields["Manufacturer"] == "PrimaryCorp"


### PR DESCRIPTION
It just adds unnecessary noise and diff to the layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small filtering change limited to footprint field generation, plus a focused unit test to prevent regressions.
> 
> **Overview**
> Stops mirroring sourcing-only component properties (`alternatives`, `matcher`) into KiCad footprint fields during `layout.sync`, reducing noisy layout diffs.
> 
> Adds a regression test ensuring these properties are ignored while normal fields like `datasheet` and `manufacturer` still propagate, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 377cfb665c34bbd55af3bec6dc2e30779d4bc00a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
