### PR TITLE
Reject same-package package URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Reject same-package package URLs in `Module()` and require relative paths instead of adding self-dependencies.
+
 ## [0.3.55] - 2026-03-14
 
 ### Fixed

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -525,11 +525,16 @@ impl EvalContextConfig {
         resolved_map: &'a BTreeMap<String, PathBuf>,
         full_url: &str,
     ) -> Option<(&'a String, &'a PathBuf)> {
-        resolved_map.iter().rev().find(|(dep_url, _)| {
-            full_url.starts_with(dep_url.as_str())
-                && (full_url.len() == dep_url.len()
-                    || full_url.as_bytes().get(dep_url.len()) == Some(&b'/'))
-        })
+        resolved_map
+            .iter()
+            .rev()
+            .find(|(dep_url, _)| Self::url_matches_prefix(dep_url, full_url))
+    }
+
+    fn url_matches_prefix(prefix: &str, full_url: &str) -> bool {
+        full_url.starts_with(prefix)
+            && (full_url.len() == prefix.len()
+                || full_url.as_bytes().get(prefix.len()) == Some(&b'/'))
     }
 
     /// Expand alias using the resolution map.
@@ -563,6 +568,22 @@ impl EvalContextConfig {
                 .to_full_url()
                 .expect("try_resolve_workspace called with non-URL spec")
         };
+
+        let canonical_root = self.file_provider.canonicalize(package_root)?;
+        if let Some(package_url) = self.find_url_for_package_root(&canonical_root)
+            && {
+                let package_roots = self.resolution.package_roots();
+                Self::find_best_dep_match(&package_roots, &full_url)
+                    .is_some_and(|(matched_url, _)| matched_url == &package_url)
+            }
+        {
+            anyhow::bail!(
+                "{} uses package URL '{}' that points into its own package '{}'; use a relative path instead",
+                context.current_file.display(),
+                full_url,
+                package_url
+            );
+        }
 
         let resolved_map = self.resolution.package_resolutions.get(package_root);
         let best_match = resolved_map.and_then(|map| Self::find_best_dep_match(map, &full_url));

--- a/crates/pcb-zen/src/auto_deps.rs
+++ b/crates/pcb-zen/src/auto_deps.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use crate::ast_utils::{skip_vendor, visit_string_literals};
 use crate::cache_index::CacheIndex;
 use crate::resolve::fetch_package;
-use crate::workspace::WorkspaceInfo;
+use crate::workspace::{WorkspaceInfo, WorkspaceInfoExt};
 use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::kicad_library::kicad_dependency_aliases;
@@ -42,7 +42,7 @@ struct ResolvedDep {
 pub fn auto_add_zen_deps(workspace_info: &WorkspaceInfo) -> Result<AutoDepsSummary> {
     let workspace_root = &workspace_info.root;
     let packages = &workspace_info.packages;
-    let mut package_imports = collect_imports_by_package(workspace_root, packages)?;
+    let mut package_imports = collect_imports_by_package(workspace_info)?;
     let mut summary = AutoDepsSummary::default();
     let file_provider = DefaultFileProvider::new();
     let kicad_entries = workspace_info.kicad_library_entries();
@@ -190,23 +190,13 @@ fn resolve_dep_candidate(
     packages: &BTreeMap<String, crate::workspace::MemberPackage>,
     index: &CacheIndex,
 ) -> Option<ResolvedDep> {
-    // Try workspace members first: exact match, then walk URL path segments upward.
-    if let Some(pkg) = packages.get(url) {
+    if let Some(package_url) = find_matching_package_url(url, packages)
+        && let Some(pkg) = packages.get(package_url)
+    {
         return Some(ResolvedDep {
-            module_path: url.to_string(),
+            module_path: package_url.to_string(),
             version: pkg.version.clone().unwrap_or_else(|| "0.1.0".to_string()),
         });
-    }
-    let without_file = url.rsplit_once('/')?.0;
-    let mut path = without_file;
-    while !path.is_empty() {
-        if let Some(pkg) = packages.get(path) {
-            return Some(ResolvedDep {
-                module_path: path.to_string(),
-                version: pkg.version.clone().unwrap_or_else(|| "0.1.0".to_string()),
-            });
-        }
-        path = path.rsplit_once('/').map(|(p, _)| p).unwrap_or("");
     }
 
     // Fall back to remote package discovery (git tags, cached per repo).
@@ -223,11 +213,23 @@ fn resolve_dep_candidate(
     }
 }
 
+fn find_matching_package_url<'a>(
+    url: &str,
+    packages: &'a BTreeMap<String, crate::workspace::MemberPackage>,
+) -> Option<&'a str> {
+    packages
+        .keys()
+        .filter(|package_url| dep_covers_url(package_url, url))
+        .max_by_key(|package_url| package_url.len())
+        .map(|package_url| package_url.as_str())
+}
+
 /// Scan .zen files in workspace member packages and group found imports by their nearest pcb.toml
 fn collect_imports_by_package(
-    workspace_root: &Path,
-    packages: &BTreeMap<String, crate::workspace::MemberPackage>,
+    workspace_info: &WorkspaceInfo,
 ) -> Result<HashMap<PathBuf, CollectedImports>> {
+    let workspace_root = &workspace_info.root;
+    let packages = &workspace_info.packages;
     let mut result: HashMap<PathBuf, CollectedImports> = HashMap::new();
 
     // Determine directories to scan: member packages if any, otherwise workspace root
@@ -266,6 +268,19 @@ fn collect_imports_by_package(
             eprintln!("  Warning: Failed to parse {}", path.display());
             continue;
         };
+
+        if let Some(current_package_url) = workspace_info.package_url_for_zen(path)
+            && let Some(url) = extracted.urls.iter().find(|url| {
+                find_matching_package_url(url, packages) == Some(current_package_url.as_str())
+            })
+        {
+            anyhow::bail!(
+                "{} uses package URL '{}' that points into its own package '{}'; use a relative path instead",
+                path.display(),
+                url,
+                current_package_url
+            );
+        }
 
         let imports = result.entry(pcb_toml.clone()).or_default();
         imports.aliases.extend(extracted.aliases);

--- a/crates/pcb/tests/auto_deps.rs
+++ b/crates/pcb/tests/auto_deps.rs
@@ -276,6 +276,174 @@ gnd = Net("GND")
 }
 
 #[test]
+fn test_same_package_url_rejected() {
+    for locked in [false, true] {
+        let mut sandbox = Sandbox::new();
+
+        let cmd = if locked {
+            vec!["build", "boards/Main/Main.zen", "--locked"]
+        } else {
+            vec!["build", "boards/Main/Main.zen"]
+        };
+
+        let result = sandbox
+            .write(
+                "pcb.toml",
+                r#"[workspace]
+pcb-version = "0.3"
+repository = "github.com/example/demo"
+members = ["boards/*"]
+"#,
+            )
+            .write(
+                "boards/Main/pcb.toml",
+                r#"[board]
+name = "Main"
+path = "Main.zen"
+"#,
+            )
+            .write(
+                "boards/Main/Main.zen",
+                r#"
+Child = Module("github.com/example/demo/boards/Main/src/Child.zen")
+
+Child(name = "X", P1 = Net("P1"))
+"#,
+            )
+            .write(
+                "boards/Main/src/Child.zen",
+                r#"
+P1 = io("P1", Net)
+"#,
+            )
+            .run("pcb", cmd)
+            .stderr_capture()
+            .stdout_capture()
+            .unchecked()
+            .run()
+            .expect("same-package URL run should execute");
+
+        let output = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&result.stdout),
+            String::from_utf8_lossy(&result.stderr),
+        );
+        assert!(
+            !result.status.success(),
+            "expected build to fail:\n{output}"
+        );
+        assert!(
+            output.contains("use a relative path instead"),
+            "expected relative-path guidance, got:\n{output}"
+        );
+
+        let board_pcb_toml =
+            std::fs::read_to_string(sandbox.default_cwd().join("boards/Main/pcb.toml"))
+                .unwrap_or_default();
+        assert!(
+            !board_pcb_toml.contains("\"github.com/example/demo/boards/Main\""),
+            "expected build to avoid self-dependency, got:\n{}",
+            board_pcb_toml
+        );
+    }
+}
+
+#[test]
+fn test_root_package_url_to_member_auto_dep() {
+    let mut sandbox = Sandbox::new();
+
+    let output = sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.3"
+repository = "github.com/example/demo"
+members = ["boards/*", "libs/*"]
+
+[dependencies]
+"github.com/example/demo/libs/Helper" = "0.1.0"
+"#,
+        )
+        .write(
+            "board.zen",
+            r#"Child = Module("github.com/example/demo/boards/Child/Child.zen")
+
+Child(name = "X", P1 = Net("P1"))
+"#,
+        )
+        .write("boards/Child/pcb.toml", "[dependencies]\n")
+        .write(
+            "boards/Child/Child.zen",
+            r#"
+P1 = io("P1", Net)
+"#,
+        )
+        .write("libs/Helper/pcb.toml", "[dependencies]\n")
+        .write("libs/Helper/Helper.zen", "P1 = io(\"P1\", Net)\n")
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert!(
+        output.contains("Exit Code: 0"),
+        "expected root package build to succeed:\n{output}"
+    );
+
+    let root_pcb_toml =
+        std::fs::read_to_string(sandbox.default_cwd().join("pcb.toml")).unwrap_or_default();
+    assert!(
+        root_pcb_toml.contains("\"github.com/example/demo/boards/Child\""),
+        "expected root pcb.toml to gain member dependency, got:\n{}",
+        root_pcb_toml
+    );
+}
+
+#[test]
+fn test_root_package_url_to_member_locked() {
+    let mut sandbox = Sandbox::new();
+
+    let result = sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.3"
+repository = "github.com/example/demo"
+members = ["boards/*"]
+
+[dependencies]
+"github.com/example/demo/boards/Child" = "0.1.0"
+"#,
+        )
+        .write(
+            "board.zen",
+            r#"Child = Module("github.com/example/demo/boards/Child/Child.zen")
+
+Child(name = "X", P1 = Net("P1"))
+"#,
+        )
+        .write("boards/Child/pcb.toml", "[dependencies]\n")
+        .write(
+            "boards/Child/Child.zen",
+            r#"
+P1 = io("P1", Net)
+"#,
+        )
+        .run("pcb", ["build", "board.zen", "--locked"])
+        .stderr_capture()
+        .stdout_capture()
+        .unchecked()
+        .run()
+        .expect("locked root package run should execute");
+
+    let output = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr),
+    );
+    assert!(
+        result.status.success(),
+        "expected locked root package build to succeed:\n{output}"
+    );
+}
+
+#[test]
 fn test_branch_only_dep_rejected_in_locked_and_offline() {
     let mut sandbox = Sandbox::new();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core URL-based module resolution and auto-dependency inference; could break workspaces that previously (incorrectly) used full package URLs to reference files within the same package or relied on prefix-matching edge cases.
> 
> **Overview**
> Prevents creating accidental *self-dependencies* by rejecting `Module()`/URL load specs that resolve into the caller’s own package, instructing users to use relative paths instead.
> 
> Updates auto-dependency detection to use longest-prefix matching for workspace member URLs and to error early when a `.zen` file references its own package via a package URL; adds tests covering rejection behavior (locked/unlocked) and root-workspace-to-member auto-dep handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea7a288f7ff175671edef1e898a15927c48c66b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
