### PR TITLE
fix(ci): force msvc toolchain on windows

### DIFF
--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -1,4 +1,12 @@
-- name: Setup Rust toolchain
+- name: Setup Rust toolchain (Windows)
+  if: runner.os == 'Windows'
   uses: actions-rust-lang/setup-rust-toolchain@v1
   with:
-    toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
+    rustflags: ""
+    toolchain: stable-x86_64-pc-windows-msvc
+
+- name: Setup Rust toolchain
+  if: runner.os != 'Windows'
+  uses: actions-rust-lang/setup-rust-toolchain@v1
+  with:
+    toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,17 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
-      - name: "Setup Rust toolchain"
+      - name: "Setup Rust toolchain (Windows)"
+        if: runner.os == 'Windows'
         uses: "actions-rust-lang/setup-rust-toolchain@v1"
         with:
-          toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
+          rustflags: ""
+          toolchain: "stable-x86_64-pc-windows-msvc"
+      - name: "Setup Rust toolchain"
+        if: runner.os != 'Windows'
+        uses: "actions-rust-lang/setup-rust-toolchain@v1"
+        with:
+          toolchain: "stable"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,6 @@ jobs:
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           components: rustfmt, clippy
 
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
       - name: Check All
         run: cargo check --workspace --all
 
@@ -101,17 +96,20 @@ jobs:
         run: |
           choco install kicad --version ${{ env.KICAD_VERSION }} -y
 
-      - name: Install Rust
+      - name: Install Rust (Windows)
+        if: runner.os == 'Windows'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
+          rustflags: ""
+          toolchain: stable-x86_64-pc-windows-msvc
           components: rustfmt, clippy
 
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+      - name: Install Rust
+        if: runner.os != 'Windows'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          # Only save cache from main branch to prevent cache proliferation
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          toolchain: stable
+          components: rustfmt, clippy
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI pipeline changes affect how Rust is installed for tests and releases, especially on Windows; misconfiguration could break builds or alter artifact reproducibility. No product/runtime code is modified.
> 
> **Overview**
> **Forces the MSVC Rust toolchain on Windows across CI.** Workflows now use `actions-rust-lang/setup-rust-toolchain@v1` with `stable-x86_64-pc-windows-msvc` on Windows and `stable` elsewhere, including the `cargo-dist` release workflow and shared `build-setup`.
> 
> Also updates `test.yml` to stop using `dtolnay/rust-toolchain@stable` (and removes the Cargo cache step in the lint job), standardizing toolchain setup between lint/test and release jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64740dec4325313d6649629dabfd1176f111ebfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->