### PR TITLE
Include version in dependency/dependent URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb publish` now supports inferred package bumps from conventional commits with `--bump=infer`.
 - `pcb publish -y` now skips the final package publish confirmation prompt.
+- Include version in dependency/dependent URLs in search results (e.g. `...@1.0`).
 
 ### Fixed
 

--- a/crates/pcb-diode-api/src/registry/mod.rs
+++ b/crates/pcb-diode-api/src/registry/mod.rs
@@ -173,7 +173,18 @@ pub struct PackageDependency {
     pub id: i64,
     pub url: String,
     pub name: String,
+    pub version: Option<String>,
     pub package_category: Option<String>,
+}
+
+impl PackageDependency {
+    /// Format as `url@version` when version is available.
+    pub fn url_with_version(&self) -> String {
+        match self.version.as_deref() {
+            Some(v) if !v.is_empty() => format!("{}@{v}", self.url),
+            _ => self.url.clone(),
+        }
+    }
 }
 
 /// Dependencies and dependents for a package
@@ -216,12 +227,12 @@ pub fn build_registry_search_results(
             result.dependencies = relations
                 .dependencies
                 .into_iter()
-                .map(|dependency| dependency.url)
+                .map(|d| d.url_with_version())
                 .collect();
             result.dependents = relations
                 .dependents
                 .into_iter()
-                .map(|dependent| dependent.url)
+                .map(|d| d.url_with_version())
                 .collect();
             result.cache_path = cache_paths
                 .and_then(|paths| paths.get(idx))
@@ -870,7 +881,7 @@ impl RegistryClient {
     pub fn get_dependencies(&self, package_id: i64) -> Result<Vec<PackageDependency>> {
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT p.id, p.url, p.package_category
+            SELECT p.id, p.url, p.version, p.package_category
             FROM package_deps d
             JOIN packages p ON p.id = d.dependency_id
             WHERE d.package_id = ?1
@@ -884,7 +895,8 @@ impl RegistryClient {
                 id: row.get(0)?,
                 name: extract_package_name(&url),
                 url,
-                package_category: row.get(2)?,
+                version: row.get(2)?,
+                package_category: row.get(3)?,
             })
         })?;
 
@@ -895,7 +907,7 @@ impl RegistryClient {
     pub fn get_dependents(&self, package_id: i64) -> Result<Vec<PackageDependency>> {
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT p.id, p.url, p.package_category
+            SELECT p.id, p.url, p.version, p.package_category
             FROM package_deps d
             JOIN packages p ON p.id = d.package_id
             WHERE d.dependency_id = ?1
@@ -909,7 +921,8 @@ impl RegistryClient {
                 id: row.get(0)?,
                 name: extract_package_name(&url),
                 url,
-                package_category: row.get(2)?,
+                version: row.get(2)?,
+                package_category: row.get(3)?,
             })
         })?;
 

--- a/crates/pcb-diode-api/src/registry/tui/ui.rs
+++ b/crates/pcb-diode-api/src/registry/tui/ui.rs
@@ -1209,9 +1209,15 @@ fn render_dependency_tree(lines: &mut Vec<Line>, deps: &[PackageDependency]) {
             _ => Color::White,
         };
 
+        let version_suffix = match dep.version.as_deref() {
+            Some(v) if !v.is_empty() => format!("@{v}"),
+            _ => String::new(),
+        };
+
         lines.push(Line::from(vec![
             Span::styled(registry_prefix, Style::default().fg(Color::Gray)),
             Span::styled(rest_path, Style::default().fg(path_color)),
+            Span::styled(version_suffix, Style::default().fg(Color::DarkGray)),
         ]));
     }
 


### PR DESCRIPTION
`pcb doc --package` requires a version, so this is very useful especially for models.

Before:
```
    "dependencies": [
      "github.com/diodeinc/registry/components/RT9013-33GB"
    ],
    "dependents": [
      "github.com/diodeinc/registry/modules/PicoProbe",
      "github.com/diodeinc/registry/modules/UsbPdController"
    ]
```

After:
```
    "dependencies": [
      "github.com/diodeinc/registry/components/RT9013-33GB@0.3.2"
    ],
    "dependents": [
      "github.com/diodeinc/registry/modules/PicoProbe@0.12.1",
      "github.com/diodeinc/registry/modules/UsbPdController@0.16.2"
    ]
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape/content of search result `dependencies`/`dependents` strings by appending `@version`, which may affect downstream consumers expecting bare URLs. Touches registry DB query mapping and TUI rendering but does not change core resolution or publishing logic.
> 
> **Overview**
> Registry search results now include *version-qualified* dependency and dependent URLs (formatted as `url@version` when a version exists) instead of returning bare package URLs.
> 
> This extends `PackageDependency` with an optional `version`, updates dependency/dependent queries to fetch `p.version`, and updates both JSON output assembly and the TUI dependency tree rendering to display the version suffix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c633a7f36e2ff3a0fa61c4c310e6c95871f6d53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
