### PR TITLE
Improvement: add flag to limit build jobs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,33 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
+JOBS=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -j)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo -e "${RED}Error: -j requires a number (e.g. -j 4).${NC}"
+                echo "Usage: $0 [-j N]"
+                exit 1
+            fi
+            if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -le 0 ]]; then
+                echo -e "${RED}Error: -j must be a positive integer (got: $2).${NC}"
+                echo "Usage: $0 [-j N]"
+                exit 1
+            fi
+            JOBS="$2"
+            shift 2
+            ;;
+        *)
+            echo -e "${RED}Unknown argument: $1${NC}"
+            echo "Usage: $0 [-j N]"
+            exit 1
+            ;;
+    esac
+done
+
 echo "Installing..."
 echo ""
 
@@ -19,9 +46,17 @@ if ! command -v cargo &> /dev/null; then
     exit 1
 fi
 
-# Run cargo install from the script directory
+# Build command
+CARGO_CMD=(cargo install --path "$SCRIPT_DIR/crates/pcb")
+
+if [[ -n "$JOBS" ]]; then
+    echo -e "${YELLOW}Limiting build to $JOBS threads${NC}"
+    CARGO_CMD+=( -j "$JOBS" )
+fi
+
 echo "Building and installing pcb binary..."
-if cargo install --path "$SCRIPT_DIR/crates/pcb"; then
+
+if "${CARGO_CMD[@]}"; then
     echo ""
     echo -e "${GREEN}✓ Zener successfully installed!${NC}"
     echo ""
@@ -30,8 +65,9 @@ if cargo install --path "$SCRIPT_DIR/crates/pcb"; then
 else
     echo ""
     echo -e "${RED}✗ Installation failed.${NC}"
+    echo -e "${YELLOW} If the build failed because of memory issues, you can try limiting the number of jobs using the -j flag."
+    echo -e "Try running: ./install.sh -j 1 ${NC}"
+    echo ""
     echo "Please check the error messages above."
     exit 1
 fi
-
- 


### PR DESCRIPTION
Adds an optional flag to the install script to optionally limit the number of parallel builds with cargo. I had difficulty getting this to install on a M1 Macbook air (8GB memory) normally and was getting memory errors ("SIGBUS: access to undefined memory") but passing -j 2 had no issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to `install.sh`, adding simple argument parsing and passing `-j` to `cargo install` to reduce parallelism; main risk is minor usability/compatibility issues in the script's new CLI handling.
> 
> **Overview**
> `install.sh` now accepts an optional `-j N` argument, validates it as a positive integer, and forwards it to `cargo install` to limit parallel build threads.
> 
> The script builds the cargo command dynamically and improves failure guidance by suggesting retrying with `./install.sh -j 1` when builds fail due to memory pressure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46a1898df25730f267036bb8ca5a7d6305544213. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->