### PR TITLE
Deprecate all `@stdlib/kicad/` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- All `@stdlib/kicad/` modules (`PinHeader`, `PinSocket`, `MolexPicoBlade`, `SolderWire`, `TagConnect`) now emit deprecation warnings.
+
 ### Added
 
 - `pcb publish` now supports inferred package bumps from conventional commits with `--bump=infer`.

--- a/stdlib/kicad/MolexPicoBlade.zen
+++ b/stdlib/kicad/MolexPicoBlade.zen
@@ -2,7 +2,7 @@ load("../interfaces.zen", "Net")
 load("../properties.zen", "Properties")
 
 warn(
-    "kicad/MolexPicoBlade.zen is deprecated. Use connectors/MolexPicoBlade.zen instead.",
+    "kicad/MolexPicoBlade.zen is deprecated. Use connectors/MolexPicoBlade in registry instead.",
     kind="deprecated.kicad.MolexPicoBlade",
 )
 

--- a/stdlib/kicad/SolderWire.zen
+++ b/stdlib/kicad/SolderWire.zen
@@ -1,6 +1,8 @@
 load("../interfaces.zen", "Net")
 load("../utils.zen", "format_value")
 
+warn("kicad/SolderWire.zen is deprecated. Use generics/NetTie.zen instead.", kind="deprecated.kicad.SolderWire")
+
 # -----------------------------------------------------------------------------
 # Component types
 # -----------------------------------------------------------------------------

--- a/stdlib/kicad/TagConnect.zen
+++ b/stdlib/kicad/TagConnect.zen
@@ -1,6 +1,8 @@
 load("../interfaces.zen", "Net")
 load("../properties.zen", "Properties")
 
+warn("kicad/TagConnect.zen is deprecated.", kind="deprecated.kicad.TagConnect")
+
 # -----------------------------------------------------------------------------
 # Component types
 # -----------------------------------------------------------------------------


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds/updates runtime `warn()` deprecation notices and changelog text, with no behavior changes to component generation beyond emitting warnings.
> 
> **Overview**
> Marks the remaining `@stdlib/kicad/` modules as deprecated by emitting `warn()` messages at load time, and updates the `MolexPicoBlade` warning text to point users to the registry replacement.
> 
> Updates `CHANGELOG.md` to document that `PinHeader`, `PinSocket`, `MolexPicoBlade`, `SolderWire`, and `TagConnect` now emit deprecation warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04d8cdf49474b66435d8582d1246a6955eccbb4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->