### PR TITLE
Watch pcb manifests in LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Git HTTPS fallback probes now run non-interactively before falling back to SSH.
 - Exclude `pcb.sum` in canonical package hash
+- LSP now watches `**/pcb.toml` and `**/pcb.sum` for dependency and workspace updates.
 
 ## [0.3.59] - 2026-03-23
 

--- a/crates/pcb-starlark-lsp/src/server.rs
+++ b/crates/pcb-starlark-lsp/src/server.rs
@@ -1572,6 +1572,38 @@ impl<T: LspContext> Backend<T> {
         })
     }
 
+    fn register_manifest_watchers(&self) {
+        if !self.supports_dynamic_watched_files {
+            return;
+        }
+
+        let kind = Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
+        self.send_client_request(
+            "client/registerCapability",
+            RegistrationParams {
+                registrations: vec![Registration {
+                    id: "manifest-watched-files".to_owned(),
+                    method: "workspace/didChangeWatchedFiles".to_owned(),
+                    register_options: Some(
+                        serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
+                            watchers: vec![
+                                FileSystemWatcher {
+                                    glob_pattern: GlobPattern::String("**/pcb.toml".to_owned()),
+                                    kind,
+                                },
+                                FileSystemWatcher {
+                                    glob_pattern: GlobPattern::String("**/pcb.sum".to_owned()),
+                                    kind,
+                                },
+                            ],
+                        })
+                        .unwrap(),
+                    ),
+                }],
+            },
+        );
+    }
+
     fn sync_watched_file_registrations(&self) {
         if !self.supports_dynamic_watched_files {
             return;
@@ -1664,6 +1696,7 @@ impl<T: LspContext> Backend<T> {
 
     fn main_loop(&self, initialize_params: InitializeParams) -> anyhow::Result<()> {
         self.log_message(MessageType::INFO, "Starlark server initialised");
+        self.register_manifest_watchers();
 
         // Pre-parse relevant files.
         self.preload_workspace(&initialize_params);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes LSP client capability registration and file watching behavior, which can affect editor integrations and trigger extra revalidation work.
> 
> **Overview**
> Ensures the Starlark LSP reacts to workspace/dependency manifest edits by dynamically registering `workspace/didChangeWatchedFiles` watchers for `**/pcb.toml` and `**/pcb.sum` at server startup (when supported).
> 
> Updates the changelog to note that manifest watching now drives dependency/workspace updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35717cd99a981a4ad2760dca8842195cdde7fa9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
