### PR TITLE
Limit workspace version sync to reachable tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Git HTTPS fallback probes now run non-interactively before falling back to SSH.
 - Exclude `pcb.sum` in canonical package hash
 - LSP now watches `**/pcb.toml` and `**/pcb.sum` for dependency and workspace updates.
+- Auto-deps now sync workspace member versions against tags reachable from the current `HEAD`, avoiding version bumps from future history on historical checkouts.
 
 ## [0.3.59] - 2026-03-23
 

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -147,6 +147,14 @@ pub fn list_all_tags_vec(repo_root: &Path) -> Vec<String> {
     })
 }
 
+pub fn list_tags_merged_into(repo_root: &Path, commit: &str) -> Vec<String> {
+    run_lines({
+        let mut cmd = git(repo_root);
+        cmd.args(["tag", "--merged", commit]);
+        cmd
+    })
+}
+
 pub fn log_subjects(repo_root: &Path, range: Option<&str>, pathspec: Option<&Path>) -> Vec<String> {
     run_lines({
         let mut cmd = git(repo_root);

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -58,7 +58,7 @@ impl WorkspaceInfoExt for WorkspaceInfo {
     }
 
     fn dirty_packages(&self) -> BTreeMap<String, DirtyReason> {
-        let tags = git::list_all_tags_vec(&self.root);
+        let tags = git::list_tags_merged_into(&self.root, "HEAD");
         let tag_annotations = git::get_all_tag_annotations(&self.root);
         let workspace_path = self.path().map(|s| s.to_string());
 
@@ -213,7 +213,7 @@ pub fn get_workspace_info<F: FileProvider>(
     // update if we find a tag (don't overwrite with None)
     if enrich_versions {
         let _span = info_span!("enrich_workspace_versions").entered();
-        let all_tags = git::list_all_tags_vec(&info.root);
+        let all_tags = git::list_tags_merged_into(&info.root, "HEAD");
         let tag_timestamps = git::get_all_tag_timestamps(&info.root);
         let workspace_path = info.path().map(|s| s.to_string());
         for pkg in info.packages.values_mut() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how workspace package versions and dirty status are derived from git tags by filtering to tags reachable from the current `HEAD`, which could alter publish/version behavior on repos with unusual tag history.
> 
> **Overview**
> Limits workspace version enrichment and dirty-package detection to git tags **merged into the current `HEAD`** rather than all tags in the repository, preventing historical checkouts from picking up “future” tags.
> 
> Adds `git::list_tags_merged_into()` (using `git tag --merged <commit>`) and updates the changelog to document the auto-deps version-sync fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5562b663a240fa13361c459cbd2fa7389b8872d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
