### PR TITLE
Block board publish with patch / branch deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Board publish now blocks outside CI when any `pcb.toml` uses `[patch]` or `branch`/`rev` dependencies.
+
 ### Changed
 
 - Show `Fetching <repo>` progress while populating shared bare repos under `~/.pcb/bare`.

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -489,6 +489,7 @@ pub fn execute(args: PublishArgs) -> Result<()> {
 /// - Versioned release (--bump provided): preflight checks, fetch tags, build, upload, tag, push
 fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
     let target = resolve_board_target(zen_path, "publish")?;
+    ensure_board_publish_has_no_workspace_overrides(&target.workspace)?;
 
     // Local hash release: no --bump, just build the archive
     if args.bump.is_none() {
@@ -594,6 +595,82 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn ensure_board_publish_has_no_workspace_overrides(workspace: &WorkspaceInfo) -> Result<()> {
+    if env::var("CI").is_ok() {
+        return Ok(());
+    }
+
+    let mut manifests = BTreeMap::new();
+    if let Some(root_config) = workspace.config.as_ref() {
+        manifests.insert(workspace.root.join("pcb.toml"), root_config);
+    }
+    for package in workspace.packages.values() {
+        manifests
+            .entry(workspace.root.join(&package.rel_path).join("pcb.toml"))
+            .or_insert(&package.config);
+    }
+
+    let violations = manifests
+        .into_iter()
+        .flat_map(|(manifest_path, manifest)| {
+            collect_unpublishable_manifest_entries(&manifest_path, manifest)
+        })
+        .collect::<Vec<_>>();
+
+    if violations.is_empty() {
+        return Ok(());
+    }
+
+    bail!(
+        "Board publish is blocked outside CI when workspace manifests contain [patch] directives or branch/rev dependencies.\n\
+         Remove those entries or publish in CI.\n\
+         Found:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn collect_unpublishable_manifest_entries(manifest_path: &Path, manifest: &PcbToml) -> Vec<String> {
+    let mut violations = Vec::new();
+
+    if !manifest.patch.is_empty() {
+        let mut patched_urls: Vec<_> = manifest.patch.keys().cloned().collect();
+        patched_urls.sort();
+        violations.push(format!(
+            "- {} [patch]: {}",
+            manifest_path.display(),
+            patched_urls.join(", ")
+        ));
+    }
+
+    let mut git_dependencies = manifest
+        .dependencies
+        .iter()
+        .filter_map(|(url, spec)| match spec {
+            DependencySpec::Detailed(detail) if detail.branch.is_some() || detail.rev.is_some() => {
+                let qualifiers = detail
+                    .branch
+                    .iter()
+                    .map(|branch| format!("branch={branch}"))
+                    .chain(detail.rev.iter().map(|rev| format!("rev={rev}")))
+                    .collect::<Vec<_>>();
+                Some(format!("{url} ({})", qualifiers.join(", ")))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    if !git_dependencies.is_empty() {
+        git_dependencies.sort();
+        violations.push(format!(
+            "- {} [dependencies]: {}",
+            manifest_path.display(),
+            git_dependencies.join(", ")
+        ));
+    }
+
+    violations
 }
 
 /// Publish dirty packages in the workspace

--- a/crates/pcb/tests/snapshots/tag__publish_board_with_patches.snap
+++ b/crates/pcb/tests/snapshots/tag__publish_board_with_patches.snap
@@ -1,0 +1,15 @@
+---
+source: crates/pcb/tests/tag.rs
+expression: output
+---
+Command: pcb publish boards/Test/TB0001.zen --bump=minor --no-push --force
+Exit Code: 1
+
+--- STDOUT ---
+
+--- STDERR ---
+Error: Board publish is blocked outside CI when workspace manifests contain [patch] directives or branch/rev dependencies.
+Remove those entries or publish in CI.
+Found:
+- <TEMP_DIR>/pcb.toml [patch]: github.com/example/components/Bar, github.com/example/components/Baz, github.com/example/components/Foo
+- <TEMP_DIR>/pcb.toml [dependencies]: github.com/example/components/Quux (rev=def5678), github.com/example/components/Qux (branch=main)

--- a/crates/pcb/tests/tag.rs
+++ b/crates/pcb/tests/tag.rs
@@ -26,6 +26,23 @@ name = "test_workspace"
 "gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"
 "#;
 
+const PCB_TOML_WITH_PATCH: &str = r#"
+[workspace]
+pcb-version = "0.3"
+name = "test_workspace"
+
+[dependencies]
+"gitlab.com/kicad/libraries/kicad-symbols" = "9.0.3"
+"gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"
+"github.com/example/components/Qux" = { version = "1.2.3", branch = "main" }
+"github.com/example/components/Quux" = { rev = "def5678" }
+
+[patch]
+"github.com/example/components/Foo" = { path = "forks/Foo" }
+"github.com/example/components/Bar" = { rev = "abc1234" }
+"github.com/example/components/Baz" = { branch = "main" }
+"#;
+
 const BOARD_TB0001_PCB_TOML: &str = r#"
 [board]
 name = "TB0001"
@@ -108,4 +125,24 @@ fn test_publish_board_invalid_path() {
             ],
         );
     assert_snapshot!("publish_board_invalid_path", output);
+}
+
+#[test]
+fn test_publish_board_with_patches() {
+    let mut sb = Sandbox::new();
+    let output = sb
+        .write("pcb.toml", PCB_TOML_WITH_PATCH)
+        .write("boards/Test/pcb.toml", BOARD_TB0001_PCB_TOML)
+        .write("boards/Test/TB0001.zen", SIMPLE_BOARD_ZEN)
+        .snapshot_run(
+            "pcb",
+            [
+                "publish",
+                "boards/Test/TB0001.zen",
+                "--bump=minor",
+                "--no-push",
+                "--force",
+            ],
+        );
+    assert_snapshot!("publish_board_with_patches", output);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `pcb publish` behavior for board releases by introducing new hard-fail validation based on manifest contents, which may block existing local release workflows. Logic is straightforward and covered by a new snapshot test, so regression surface is limited.
> 
> **Overview**
> **Board publishing now enforces reproducible dependency manifests outside CI.** `pcb publish <board>.zen` aborts locally (unless `CI` is set) if any workspace `pcb.toml` contains `[patch]` entries or `branch`/`rev` dependency specs, and prints a per-manifest list of offending URLs.
> 
> Adds a snapshot test covering the new failure mode and documents the behavior in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14c03a966bc65903f3dc2bce00f9ba564885adf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
