### PR TITLE
Avoid blank-line writes to empty pcb.sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Git HTTPS fallback probes now run non-interactively before falling back to SSH.
+- Empty lockfiles no longer rewrite `pcb.sum` with a blank line.
 - Exclude `pcb.sum` in canonical package hash
 - LSP now watches `**/pcb.toml` and `**/pcb.sum` for dependency and workspace updates.
 - Auto-deps now sync workspace member versions against tags reachable from the current `HEAD`, avoiding version bumps from future history on historical checkouts.

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -710,7 +710,11 @@ impl std::fmt::Display for Lockfile {
             }
         }
 
-        writeln!(f, "{}", lines.join("\n"))
+        if lines.is_empty() {
+            Ok(())
+        } else {
+            writeln!(f, "{}", lines.join("\n"))
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to `Lockfile` formatting to avoid emitting a newline when there are no entries, affecting only how empty `pcb.sum` files are written.
> 
> **Overview**
> Prevents empty lockfiles from rewriting `pcb.sum` with a stray blank line by making `Lockfile`’s `Display` implementation emit no output when there are zero entries.
> 
> Updates the changelog to document the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff9aebab8b70a2cb6d84f4f2b96b94ed194206ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->