### PR TITLE
fix: restore publish after empty pcb.sum change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Git HTTPS fallback probes now run non-interactively before falling back to SSH.
-- Empty lockfiles no longer rewrite `pcb.sum` with a blank line.
 - Exclude `pcb.sum` in canonical package hash
 - LSP now watches `**/pcb.toml` and `**/pcb.sum` for dependency and workspace updates.
 - Auto-deps now sync workspace member versions against tags reachable from the current `HEAD`, avoiding version bumps from future history on historical checkouts.

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -849,9 +849,10 @@ pub fn resolve_dependencies(
                 );
             }
         } else {
+            let lockfile_exists = lockfile_path.exists();
             let old_content = std::fs::read_to_string(&lockfile_path).unwrap_or_default();
             let new_content = new_lockfile.to_string();
-            if new_content != old_content {
+            if !lockfile_exists || new_content != old_content {
                 std::fs::write(&lockfile_path, &new_content)?;
                 log::debug!("  Updated {}", lockfile_path.display());
                 lockfile_changed = true;

--- a/crates/pcb/tests/auto_deps.rs
+++ b/crates/pcb/tests/auto_deps.rs
@@ -227,6 +227,37 @@ pcb-version = "0.3"
     assert_snapshot!("auto_deps_branch_dep_pins_rev_and_builds", snapshot);
 }
 
+#[test]
+fn test_build_writes_empty_pcb_sum_for_local_only_workspace() {
+    let mut sandbox = Sandbox::new();
+
+    let output = sandbox
+        .write("pcb.toml", PCB_TOML)
+        .write(
+            "board.zen",
+            r#"
+Layout(name="LocalOnly", path="build/LocalOnly", bom_profile=None)
+
+vcc = Net("VCC")
+gnd = Net("GND")
+"#,
+        )
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert!(
+        output.contains("Exit Code: 0"),
+        "expected build to succeed:\n{output}"
+    );
+
+    let pcb_sum_path = sandbox.default_cwd().join("pcb.sum");
+    assert!(
+        pcb_sum_path.exists(),
+        "expected pcb.sum to be created even when the lockfile is empty"
+    );
+
+    let pcb_sum = std::fs::read_to_string(pcb_sum_path).expect("expected pcb.sum to be readable");
+    assert_eq!(pcb_sum, "", "expected empty pcb.sum without a blank line");
+}
+
 /// Test that a relative path load("../../modules/Lib/Lib.zen") that escapes a board's
 /// package boundary into another workspace member triggers auto-dep for that member.
 #[test]


### PR DESCRIPTION
## Summary
- write `pcb.sum` when the lockfile is empty but the file does not exist yet
- add a regression test covering local-only builds that should create an empty `pcb.sum`
- drop the changelog bullet for the earlier empty-lockfile formatting tweak

## Root cause
`d5b17fdb` changed empty lockfile serialization from a lone newline to an empty string. That made the resolver treat a missing `pcb.sum` and an empty serialized lockfile as equivalent, so local-only `pcb build` no longer materialized `pcb.sum`. Board publish then failed because it requires the lockfile to exist on disk.

## Validation
- `cargo test -p pcb test_build_writes_empty_pcb_sum_for_local_only_workspace -- --exact`
- `cargo test -p pcb publish_board -- --nocapture`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to lockfile write condition plus a focused regression test; primary impact is ensuring `pcb.sum` materializes on disk for local-only builds used by publish flows.
> 
> **Overview**
> Restores creation of `pcb.sum` on disk when a workspace has **no resolved dependencies** by treating a missing lockfile as needing a write even if the serialized content is empty.
> 
> Adds a regression test covering `pcb build` on a local-only workspace to assert `pcb.sum` is created and remains an empty string (no trailing newline), and removes the corresponding changelog bullet about the earlier empty-lockfile formatting tweak.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 537e97fe4b4248097ecba5d660c417063a3db9bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
