### PR TITLE
Fail workspace-namespace deps locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Auto-deps now only upgrades synced workspace member dependency versions.
+- Workspace-namespace dependencies now fail locally with a clear missing-member error instead of remote fetch fallback.
 
 ## [0.3.60] - 2026-03-25
 

--- a/crates/pcb-zen-core/src/workspace.rs
+++ b/crates/pcb-zen-core/src/workspace.rs
@@ -20,6 +20,21 @@ fn is_default<T: Default + PartialEq>(value: &T) -> bool {
 
 pub(crate) const LOCAL_WORKSPACE_ROOT_URL: &str = "workspace";
 
+pub fn package_url_covers(prefix: &str, url: &str) -> bool {
+    url == prefix
+        || url
+            .strip_prefix(prefix)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
+fn build_workspace_base_url(repository: Option<&str>, path: Option<&str>) -> Option<String> {
+    match (repository, path) {
+        (Some(repo), Some(path)) => Some(format!("{repo}/{path}")),
+        (Some(repo), None) => Some(repo.to_string()),
+        _ => None,
+    }
+}
+
 /// A discovered member package in the workspace
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemberPackage {
@@ -180,6 +195,22 @@ impl WorkspaceInfo {
             .as_ref()
             .and_then(|c| c.workspace.as_ref())
             .and_then(|w| w.repository.as_deref())
+    }
+
+    /// The workspace package namespace derived from `[workspace].repository` and
+    /// optional `[workspace].path`.
+    ///
+    /// Member package URLs are constructed under this base URL during workspace
+    /// discovery. When absent, the workspace has no explicit package namespace.
+    pub fn workspace_base_url(&self) -> Option<String> {
+        build_workspace_base_url(self.repository(), self.path())
+    }
+
+    /// Whether `url` belongs to this workspace's declared package namespace.
+    pub fn is_workspace_namespace_url(&self, url: &str) -> bool {
+        self.workspace_base_url()
+            .as_deref()
+            .is_some_and(|base| package_url_covers(base, url))
     }
 
     /// Get optional subpath within repository
@@ -446,11 +477,10 @@ pub fn get_workspace_info<F: FileProvider>(
         .and_then(|c| c.workspace.clone())
         .unwrap_or_default();
 
-    let base_url = match (&workspace_config.repository, &workspace_config.path) {
-        (Some(repo), Some(p)) => Some(format!("{}/{}", repo, p)),
-        (Some(repo), None) => Some(repo.clone()),
-        _ => None,
-    };
+    let base_url = build_workspace_base_url(
+        workspace_config.repository.as_deref(),
+        workspace_config.path.as_deref(),
+    );
 
     let mut packages = BTreeMap::new();
     let mut errors = Vec::new();

--- a/crates/pcb-zen/src/auto_deps.rs
+++ b/crates/pcb-zen/src/auto_deps.rs
@@ -15,6 +15,7 @@ use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::kicad_library::kicad_dependency_aliases;
 use pcb_zen_core::load_spec::LoadSpec;
+use pcb_zen_core::workspace::package_url_covers;
 
 #[derive(Debug, Default)]
 pub struct AutoDepsSummary {
@@ -135,14 +136,7 @@ fn is_url_covered_by_manifest(url: &str, config: &PcbToml) -> bool {
     config
         .dependencies
         .keys()
-        .any(|dep| dep_covers_url(dep, url))
-}
-
-fn dep_covers_url(dep: &str, url: &str) -> bool {
-    url == dep
-        || url
-            .strip_prefix(dep)
-            .is_some_and(|rest| rest.starts_with('/'))
+        .any(|dep| package_url_covers(dep, url))
 }
 
 fn push_unknown(summary: &mut Vec<(PathBuf, Vec<String>)>, path: &Path, items: Vec<String>) {
@@ -219,7 +213,7 @@ fn find_matching_package_url<'a>(
 ) -> Option<&'a str> {
     packages
         .keys()
-        .filter(|package_url| dep_covers_url(package_url, url))
+        .filter(|package_url| package_url_covers(package_url, url))
         .max_by_key(|package_url| package_url.len())
         .map(|package_url| package_url.as_str())
 }
@@ -442,7 +436,7 @@ fn resolve_kicad_url(
     configured_kicad_versions
         .iter()
         .find_map(|(repo, version)| {
-            dep_covers_url(repo, url).then(|| ResolvedDep {
+            package_url_covers(repo, url).then(|| ResolvedDep {
                 module_path: repo.clone(),
                 version: version.to_string(),
             })

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -90,6 +90,45 @@ struct UnresolvedDep {
     spec: DependencySpec,
 }
 
+fn missing_workspace_member_error(workspace_info: &WorkspaceInfo, url: &str) -> anyhow::Error {
+    let missing_manifest_hint = workspace_info
+        .workspace_base_url()
+        .as_deref()
+        .and_then(|base_url| url.strip_prefix(base_url))
+        .and_then(|rest| rest.strip_prefix('/'))
+        .filter(|rel| !rel.is_empty())
+        .and_then(|rel| {
+            let dir = workspace_info.root.join(rel);
+            dir.is_dir()
+                .then_some((rel, dir.join("pcb.toml")))
+                .filter(|(_, pcb_toml)| !pcb_toml.exists())
+        });
+
+    if let Some((rel, _)) = missing_manifest_hint {
+        anyhow::anyhow!(
+            "Dependency '{}' is in this workspace, but no workspace member provides it.\n  \
+            Found directory '{}' with no pcb.toml.\n  \
+            Add pcb.toml there so the workspace can discover it.",
+            url,
+            rel
+        )
+    } else {
+        anyhow::anyhow!(
+            "Dependency '{}' is in this workspace, but no workspace member provides it.\n  \
+            Fix the dependency URL or remove it.",
+            url
+        )
+    }
+}
+
+fn ensure_workspace_member_dependency(workspace_info: &WorkspaceInfo, url: &str) -> Result<()> {
+    if workspace_info.is_workspace_namespace_url(url) && !workspace_info.packages.contains_key(url)
+    {
+        return Err(missing_workspace_member_error(workspace_info, url));
+    }
+    Ok(())
+}
+
 /// Path resolver that uses MVS family matching for package resolution.
 ///
 /// This wraps a precomputed map of `url -> family -> path` and delegates
@@ -728,6 +767,10 @@ pub fn resolve_dependencies(
             manifest_cache.insert((line.clone(), version.clone()), manifest.clone());
 
             for (dep_path, dep_spec) in &manifest.dependencies {
+                ensure_workspace_member_dependency(workspace_info, dep_path).with_context(
+                    || format!("Dependency '{}' in {}@v{}", dep_path, line.path, version),
+                )?;
+
                 // Apply branch/rev patch overrides before resolution
                 let patch_override = get_patch_override(dep_path, &patches);
                 let spec = patch_override.as_ref().unwrap_or(dep_spec);
@@ -1224,6 +1267,8 @@ fn collect_deps_recursive(
     workspace_info: &WorkspaceInfo,
 ) -> Result<()> {
     for (url, spec) in current_deps {
+        ensure_workspace_member_dependency(workspace_info, url)?;
+
         // Skip if already seen
         if deps.contains_key(url) {
             continue;

--- a/crates/pcb/tests/simple.rs
+++ b/crates/pcb/tests/simple.rs
@@ -127,6 +127,18 @@ pcb-version = "0.3"
 "gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"
 "#;
 
+const WORKSPACE_NAMESPACE_PCB_TOML: &str = r#"
+[workspace]
+pcb-version = "0.3"
+repository = "github.com/acme/workspace"
+members = ["modules/*"]
+"#;
+
+const REMOTE_IO_MODULE_ZEN: &str = r#"
+P1 = io("P1", Net)
+P2 = io("P2", Net)
+"#;
+
 #[test]
 #[cfg(not(target_os = "windows"))]
 fn test_pcb_build_should_fail_without_fixture() {
@@ -201,4 +213,202 @@ pcb-version = "0.3"
 fn test_pcb_help() {
     let output = Sandbox::new().snapshot_run("pcb", ["help"]);
     assert_snapshot!("help", output);
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_workspace_namespace_dependency_does_not_fallback_to_remote() {
+    let mut sandbox = Sandbox::new();
+
+    sandbox
+        .git_fixture("https://github.com/acme/workspace.git")
+        .write("modules/Missing/pcb.toml", "")
+        .write("modules/Missing/Missing.zen", REMOTE_IO_MODULE_ZEN)
+        .commit("Add remote-only missing package")
+        .tag("modules/Missing/v1.0.0", false)
+        .push_mirror();
+
+    let result = sandbox
+        .write("pcb.toml", WORKSPACE_NAMESPACE_PCB_TOML)
+        .write(
+            "modules/Board/pcb.toml",
+            r#"
+[board]
+name = "Board"
+path = "Board.zen"
+
+[dependencies]
+"github.com/acme/workspace/modules/Missing" = "1.0.0"
+"#,
+        )
+        .write(
+            "modules/Board/Board.zen",
+            r#"
+Missing = Module("github.com/acme/workspace/modules/Missing/Missing.zen")
+
+Layout(name="Board", path="build/Board", bom_profile=None)
+
+p1 = Net("P1")
+p2 = Net("P2")
+
+Missing(name="U1", P1=p1, P2=p2)
+"#,
+        )
+        .run("pcb", ["build", "modules/Board/Board.zen"])
+        .stderr_capture()
+        .stdout_capture()
+        .unchecked()
+        .run()
+        .expect("build command failed");
+
+    assert!(
+        !result.status.success(),
+        "expected workspace-namespace build to fail"
+    );
+
+    let stderr = sandbox.sanitize_output(&String::from_utf8_lossy(&result.stderr));
+    assert!(
+        stderr.contains("is in this workspace, but no workspace member provides it."),
+        "stderr should explain missing workspace member:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Fix the dependency URL or remove it."),
+        "stderr should explain how to fix the missing workspace member:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Failed to fetch github.com/acme/workspace/modules/Missing"),
+        "stderr should not contain remote fetch failure:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("git sparse checkout"),
+        "stderr should not mention remote sparse checkout fallback:\n{stderr}"
+    );
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_workspace_namespace_dependency_missing_manifest_gets_specific_hint() {
+    let mut sandbox = Sandbox::new();
+
+    let result = sandbox
+        .write("pcb.toml", WORKSPACE_NAMESPACE_PCB_TOML)
+        .write("modules/Missing/Missing.zen", REMOTE_IO_MODULE_ZEN)
+        .write(
+            "modules/Board/pcb.toml",
+            r#"
+[board]
+name = "Board"
+path = "Board.zen"
+
+[dependencies]
+"github.com/acme/workspace/modules/Missing" = "1.0.0"
+"#,
+        )
+        .write(
+            "modules/Board/Board.zen",
+            r#"
+Layout(name="Board", path="build/Board", bom_profile=None)
+"#,
+        )
+        .run("pcb", ["build", "modules/Board/Board.zen"])
+        .stderr_capture()
+        .stdout_capture()
+        .unchecked()
+        .run()
+        .expect("build command failed");
+
+    assert!(
+        !result.status.success(),
+        "expected workspace-namespace build to fail"
+    );
+
+    let stderr = sandbox.sanitize_output(&String::from_utf8_lossy(&result.stderr));
+    assert!(
+        stderr.contains("Found directory 'modules/Missing' with no pcb.toml."),
+        "stderr should explain the missing manifest case:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Add pcb.toml there so the workspace can discover it."),
+        "stderr should suggest adding pcb.toml:\n{stderr}"
+    );
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_transitive_workspace_namespace_dependency_fails_before_remote_fallback() {
+    let mut sandbox = Sandbox::new();
+
+    sandbox
+        .git_fixture("https://github.com/acme/workspace.git")
+        .write("modules/Missing/pcb.toml", "")
+        .write("modules/Missing/Missing.zen", REMOTE_IO_MODULE_ZEN)
+        .commit("Add remote-only missing package")
+        .tag("modules/Missing/v1.0.0", false)
+        .push_mirror();
+
+    sandbox
+        .git_fixture("https://github.com/vendor/components.git")
+        .write(
+            "Thing/pcb.toml",
+            r#"
+[dependencies]
+"github.com/acme/workspace/modules/Missing" = "1.0.0"
+"#,
+        )
+        .write("Thing/Thing.zen", REMOTE_IO_MODULE_ZEN)
+        .commit("Add external package with bad transitive workspace dep")
+        .tag("Thing/v1.0.0", false)
+        .push_mirror();
+
+    let result = sandbox
+        .write("pcb.toml", WORKSPACE_NAMESPACE_PCB_TOML)
+        .write(
+            "modules/Board/pcb.toml",
+            r#"
+[board]
+name = "Board"
+path = "Board.zen"
+
+[dependencies]
+"github.com/vendor/components/Thing" = "1.0.0"
+"#,
+        )
+        .write(
+            "modules/Board/Board.zen",
+            r#"
+Thing = Module("github.com/vendor/components/Thing/Thing.zen")
+
+Layout(name="Board", path="build/Board", bom_profile=None)
+
+p1 = Net("P1")
+p2 = Net("P2")
+
+Thing(name="U1", P1=p1, P2=p2)
+"#,
+        )
+        .run("pcb", ["build", "modules/Board/Board.zen"])
+        .stderr_capture()
+        .stdout_capture()
+        .unchecked()
+        .run()
+        .expect("build command failed");
+
+    assert!(
+        !result.status.success(),
+        "expected transitive workspace-namespace build to fail"
+    );
+
+    let stderr = sandbox.sanitize_output(&String::from_utf8_lossy(&result.stderr));
+    assert!(
+        stderr.contains("Dependency 'github.com/acme/workspace/modules/Missing' in github.com/vendor/components/Thing@v1.0.0"),
+        "stderr should identify the external package that introduced the bad dep:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("is in this workspace, but no workspace member provides it."),
+        "stderr should explain missing workspace member:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Failed to fetch github.com/acme/workspace/modules/Missing"),
+        "stderr should not contain remote fetch failure:\n{stderr}"
+    );
 }


### PR DESCRIPTION
Generic missing workspace member:

```
Dependency 'github.com/acme/workspace/modules/Missing' is in this workspace, but no workspace member provides it.
Fix the dependency URL or remove it.
```

Directory exists but has no pcb.toml:

```
Dependency 'github.com/acme/workspace/modules/Missing' is in this workspace, but no workspace member provides it.
Found directory 'modules/Missing' with no pcb.toml.
Add pcb.toml there so the workspace can discover it.
```



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution to error when a dependency URL falls under the workspace’s declared namespace but no local workspace member provides it, which can alter build outcomes for misconfigured workspaces and transitive deps.
> 
> **Overview**
> Prevents *workspace-namespace* dependency URLs (derived from `[workspace].repository` + optional `path`) from falling back to remote fetch when the corresponding workspace member is missing.
> 
> Adds shared URL-prefix matching utilities (`package_url_covers`) and workspace namespace helpers (`workspace_base_url`, `is_workspace_namespace_url`), and enforces the new validation during both direct and transitive dependency collection/fetch with clearer, actionable error messages (including a specific hint when the directory exists but lacks `pcb.toml`).
> 
> Adds integration tests covering direct and transitive failure cases and updates the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b29df27373e32dfd858a56ff6e03076cd6f68c66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
