### PR TITLE
Only upgrade workspace auto-dep versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-deps now only upgrades synced workspace member dependency versions.
+
 ## [0.3.60] - 2026-03-25
 
 ### Added

--- a/crates/pcb-zen/src/auto_deps.rs
+++ b/crates/pcb-zen/src/auto_deps.rs
@@ -418,7 +418,7 @@ fn mutate_manifest_dependencies(
     for (url, pkg) in packages {
         let version = pkg.version.clone().unwrap_or_else(|| "0.1.0".to_string());
         if let Some(spec) = config.dependencies.get(url)
-            && plain_version(spec).is_some_and(|v| v != version)
+            && plain_version(spec).is_some_and(|v| is_upgrade_version(v, &version))
         {
             config
                 .dependencies
@@ -459,6 +459,16 @@ fn plain_version(spec: &DependencySpec) -> Option<&str> {
             d.version.as_deref()
         }
         _ => None,
+    }
+}
+
+fn is_upgrade_version(current: &str, target: &str) -> bool {
+    match (
+        crate::tags::parse_relaxed_version(current),
+        crate::tags::parse_relaxed_version(target),
+    ) {
+        (Some(current), Some(target)) => target > current,
+        _ => false,
     }
 }
 
@@ -521,5 +531,14 @@ mod tests {
         result = CollectedImports::default();
         extract_from_str("VCC", &mut result);
         assert_eq!(result.relative_paths.len(), 1);
+    }
+
+    #[test]
+    fn test_is_upgrade_version() {
+        assert!(is_upgrade_version("0.1.0", "0.2.0"));
+        assert!(is_upgrade_version("1.2", "1.3.0"));
+        assert!(!is_upgrade_version("1.2.3", "1.2.3"));
+        assert!(!is_upgrade_version("1.2.3", "0.1.0"));
+        assert!(!is_upgrade_version("not-a-version", "1.0.0"));
     }
 }

--- a/crates/pcb/tests/auto_deps.rs
+++ b/crates/pcb/tests/auto_deps.rs
@@ -427,6 +427,46 @@ P1 = io("P1", Net)
 }
 
 #[test]
+fn test_workspace_member_sync_does_not_downgrade_existing_version() {
+    let mut sandbox = Sandbox::new();
+
+    let output = sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.3"
+repository = "github.com/example/demo"
+members = ["boards/*", "libs/*"]
+
+[dependencies]
+"github.com/example/demo/libs/Helper" = "1.2.3"
+"#,
+        )
+        .write(
+            "board.zen",
+            r#"Helper = Module("github.com/example/demo/libs/Helper/Helper.zen")
+
+Helper(name = "X", P1 = Net("P1"))
+"#,
+        )
+        .write("libs/Helper/pcb.toml", "[dependencies]\n")
+        .write("libs/Helper/Helper.zen", "P1 = io(\"P1\", Net)\n")
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert!(
+        output.contains("Exit Code: 0"),
+        "expected root package build to succeed:\n{output}"
+    );
+
+    let root_pcb_toml =
+        std::fs::read_to_string(sandbox.default_cwd().join("pcb.toml")).unwrap_or_default();
+    assert!(
+        root_pcb_toml.contains("\"github.com/example/demo/libs/Helper\" = \"1.2.3\""),
+        "expected existing version to be preserved, got:\n{}",
+        root_pcb_toml
+    );
+}
+
+#[test]
 fn test_root_package_url_to_member_locked() {
     let mut sandbox = Sandbox::new();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to auto-deps version comparison logic plus added regression tests to prevent unintended downgrades.
> 
> **Overview**
> Auto-deps workspace-member version syncing now **only updates dependency specs when the member’s version is higher**, instead of rewriting any mismatched version (which could downgrade pinned versions).
> 
> Adds `is_upgrade_version()` based on relaxed semver parsing and introduces a regression test ensuring an existing higher version in `pcb.toml` is preserved. Updates the changelog accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2fae90d90fe8db2bdb5aa8847a5732420f0b4f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
