### PR TITLE
Print qualified `Module()` hint after component import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `pcb new component` now prints a `Module("...")` usage hint when it can infer a qualified URL.
+
 ### Fixed
 
 - Auto-deps now only upgrades synced workspace member dependency versions.

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -474,10 +474,7 @@ fn handle_already_exists(workspace_root: &Path, result: &AddComponentResult) -> 
         return false;
     }
 
-    let display_path = result
-        .component_path
-        .strip_prefix(workspace_root)
-        .unwrap_or(&result.component_path);
+    let display_path = component_display_path(workspace_root, &result.component_path);
     eprintln!(
         "{} Component already exists at: {}",
         "ℹ".blue().bold(),
@@ -488,16 +485,33 @@ fn handle_already_exists(workspace_root: &Path, result: &AddComponentResult) -> 
 
 // Helper: Show component added message
 fn show_component_added(workspace_root: &Path, result: &AddComponentResult) {
-    let display_path = result
-        .component_path
-        .strip_prefix(workspace_root)
-        .unwrap_or(&result.component_path);
+    let display_path = component_display_path(workspace_root, &result.component_path);
     eprintln!(
         "{} Added {} to {}",
         "✓".green().bold(),
         result.part_number.bold(),
         display_path.display().to_string().cyan()
     );
+    if let Some(module_url) = infer_component_module_url(workspace_root, &result.component_path) {
+        eprintln!("  Use with: Module(\"{}\")", module_url);
+    }
+}
+
+fn component_display_path<'a>(workspace_root: &'a Path, component_path: &'a Path) -> &'a Path {
+    component_path
+        .strip_prefix(workspace_root)
+        .unwrap_or(component_path)
+}
+
+fn infer_component_module_url(workspace_root: &Path, component_path: &Path) -> Option<String> {
+    let repo_root = pcb_zen::git::get_repo_root(workspace_root).ok()?;
+    let repo_url = pcb_zen::git::detect_repository_url(&repo_root).ok()?;
+    let rel_path = component_path.strip_prefix(&repo_root).ok()?;
+    Some(format!(
+        "{}/{}",
+        repo_url,
+        rel_path.to_string_lossy().replace('\\', "/")
+    ))
 }
 
 fn non_empty_trimmed(value: Option<&str>) -> Option<&str> {


### PR DESCRIPTION
```
✓ Resolved datasheet from symbol
✓ Added STM32G431CBT6 to components/STMicroelectronics/STM32G431CBT6/STM32G431CBT6.zen
  Use with: Module("github.com/diodeinc/registry/components/STMicroelectronics/STM32G431CBT6/STM32G431CBT6.zen")
```

Found it quite useful for human + model steering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to CLI output after adding components, with best-effort git URL inference that falls back silently if unavailable.
> 
> **Overview**
> After `pcb new component` adds a component, the CLI now **optionally prints a `Module("...")` usage hint** when it can infer a qualified repository URL for the generated `.zen` path.
> 
> Refactors the repeated workspace-relative path formatting into `component_display_path()` and documents the new behavior in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec0ff6a96979c6d33e28db4b92d32ba582c462fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
