### PR TITLE
fix(stdlib): fix UartPair() and UsartPair()

### DIFF
--- a/stdlib/interfaces.zen
+++ b/stdlib/interfaces.zen
@@ -672,8 +672,8 @@ Usart = interface(
 def UartPair(name_a: str, name_b: str) -> (Uart, Uart):
     txa_rxb = Net(name_a + "_TX/" + name_b + "_RX")
     rxa_txb = Net(name_a + "_RX/" + name_b + "_TX")
-    uart_a = Uart(name=name_a, tx=txa_rxb, rx=rxa_txb)
-    uart_b = Uart(name=name_b, tx=rxa_txb, rx=txa_rxb)
+    uart_a = Uart(name=name_a, TX=txa_rxb, RX=rxa_txb)
+    uart_b = Uart(name=name_b, TX=rxa_txb, RX=txa_rxb)
     return (uart_a, uart_b)
 
 
@@ -683,8 +683,8 @@ def UsartPair(name_a: str, name_b: str) -> (Usart, Usart):
     rtsa_ctsb = Net(name_a + "_RTS/" + name_b + "_CTS")
     ctsa_rtsb = Net(name_a + "_CTS/" + name_b + "_RTS")
     ck = Net(name_a + "_CK/" + name_b + "_CK")
-    usart_a = Usart(name=name_a, tx=txa_rxb, rx=rxa_txb, ck=ck, rts=rtsa_ctsb, cts=ctsa_rtsb)
-    usart_b = Usart(name=name_b, tx=rxa_txb, rx=txa_rxb, ck=ck, rts=ctsa_rtsb, cts=rtsa_ctsb)
+    usart_a = Usart(name=name_a, TX=txa_rxb, RX=rxa_txb, CK=ck, RTS=rtsa_ctsb, CTS=ctsa_rtsb)
+    usart_b = Usart(name=name_b, TX=rxa_txb, RX=txa_rxb, CK=ck, RTS=ctsa_rtsb, CTS=rtsa_ctsb)
     return (usart_a, usart_b)
 
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small stdlib fix that only changes named arguments in `UartPair()`/`UsartPair()` to match the interface field names, affecting only UART/USART pair construction.
> 
> **Overview**
> Fixes `UartPair()` and `UsartPair()` in `stdlib/interfaces.zen` to pass nets using the correct uppercase field names (`TX`, `RX`, `CK`, `RTS`, `CTS`) instead of lowercase, so the returned interfaces are wired as intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ac49c68f9fcc1d1b8ffeecbff76b84bb84c1ad6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->