### PR TITLE
Deprecate `pcb fork add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - KiCad symbol is now the source of truth for component metadata (footprint, datasheet, part); generated `.zen` files are minimal wrappers.
 - `Component()` inherits `skip_bom` from the KiCad symbol `in_bom` flag (inverted) when not explicitly set.
+- `pcb fork add` is now blocked and points users to `pcb sandbox`; `pcb fork remove` and `pcb fork upstream` remain for existing forks.
 
 ### Added
 

--- a/crates/pcb/src/fork.rs
+++ b/crates/pcb/src/fork.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use colored::Colorize;
 use pcb_ui::{Style, StyledText};
-use pcb_zen::fork::{ForkOptions, fork_package, upstream_forks};
+use pcb_zen::fork::upstream_forks;
 use pcb_zen::get_workspace_info;
 use pcb_zen::git::has_uncommitted_changes_in_path;
 use pcb_zen_core::DefaultFileProvider;
@@ -19,7 +19,7 @@ pub struct ForkArgs {
 
 #[derive(Subcommand)]
 pub enum ForkCommands {
-    /// Fork a package for local development
+    /// Deprecated: use `pcb sandbox` for local dependency development
     Add(AddArgs),
 
     /// Remove a fork and revert to remote dependency
@@ -74,47 +74,12 @@ pub fn execute(args: ForkArgs) -> Result<()> {
     }
 }
 
-fn execute_add(args: AddArgs) -> Result<()> {
-    println!("{} {}", "Forking".cyan().bold(), args.url.bold());
-    if is_stdlib_module_path(args.url.trim()) {
-        println!("  {} Materializing embedded stdlib...", "→".dimmed());
-    } else {
-        println!("  {} Discovering versions...", "→".dimmed());
-    }
-
-    let result = fork_package(ForkOptions {
-        url: args.url,
-        version: args.version,
-        force: args.force,
-    })?;
-
-    // Success message
-    println!();
-    println!("{} Forked successfully!", "✓".green().bold());
-    println!();
-    println!(
-        "  {} {}",
-        "Fork location:".dimmed(),
-        result
-            .fork_dir
-            .display()
-            .to_string()
-            .with_style(Style::Cyan)
+fn execute_add(_args: AddArgs) -> Result<()> {
+    anyhow::bail!(
+        "`pcb fork add` is deprecated and no longer supported.\n\
+         Use `pcb sandbox` instead.\n\
+         Existing forks can still be cleaned up with `pcb fork remove` or upstreamed with `pcb fork upstream`."
     );
-    println!(
-        "  {} [patch].\"{}\" = {{ path = \"{}\" }}",
-        "Patch entry:".dimmed(),
-        result.module_url,
-        result.patch_path
-    );
-    println!();
-    println!(
-        "{}",
-        "You can now edit files in the fork directory. Changes will be used by 'pcb build'."
-            .dimmed()
-    );
-
-    Ok(())
 }
 
 fn execute_remove(args: RemoveArgs) -> Result<()> {

--- a/crates/pcb/tests/simple.rs
+++ b/crates/pcb/tests/simple.rs
@@ -217,6 +217,20 @@ fn test_pcb_help() {
 
 #[test]
 #[cfg(not(target_os = "windows"))]
+fn test_pcb_fork_add_is_blocked() {
+    let output = Sandbox::new().snapshot_run(
+        "pcb",
+        [
+            "fork",
+            "add",
+            "github.com/diodeinc/registry/modules/UsbPdController",
+        ],
+    );
+    assert_snapshot!("fork_add_is_blocked", output);
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
 fn test_workspace_namespace_dependency_does_not_fallback_to_remote() {
     let mut sandbox = Sandbox::new();
 

--- a/crates/pcb/tests/snapshots/simple__fork_add_is_blocked.snap
+++ b/crates/pcb/tests/snapshots/simple__fork_add_is_blocked.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pcb/tests/simple.rs
+expression: output
+---
+Command: pcb fork add github.com/diodeinc/registry/modules/UsbPdController
+Exit Code: 1
+
+--- STDOUT ---
+
+--- STDERR ---
+Error: `pcb fork add` is deprecated and no longer supported.
+Use `pcb sandbox` instead.
+Existing forks can still be cleaned up with `pcb fork remove` or upstreamed with `pcb fork upstream`.

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -490,49 +490,26 @@ pcb info --format json       # Machine-readable output
 
 ### pcb fork
 
-Manages local editable copies of remote dependencies for development.
+Manages deprecated local fork workflows for existing workspaces.
+New local dependency development should use `pcb sandbox` instead.
 
 #### pcb fork add
 
-Creates a local editable copy of a remote dependency. Useful when you need to
-modify a dependency without publishing changes upstream.
+`pcb fork add` is deprecated and now blocked.
+Use `pcb sandbox` instead for new local dependency development.
 
 ```bash
-pcb fork add github.com/diodeinc/registry/modules/UsbPdController
-pcb fork add github.com/diodeinc/registry/modules/UsbPdController@1.2.3
-pcb fork add github.com/diodeinc/registry/modules/UsbPdController --version 1.2.3
-pcb fork add github.com/diodeinc/registry/modules/UsbPdController --force
+pcb fork add github.com/diodeinc/registry/modules/UsbPdController  # errors and points to `pcb sandbox`
 ```
-
-The command:
-1. Fetches the package to the global cache
-2. Copies it to `fork/<package-url>/<version>/` in your workspace
-3. Adds a `[patch]` entry in `pcb.toml` to redirect resolution to the local copy
-
-```toml
-[patch."github.com/diodeinc/registry/modules/UsbPdController"]
-path = "fork/github.com/diodeinc/registry/modules/UsbPdController/0.10.1"
-```
-
-**After forking:**
-- Edit files in the fork directory freely
-- Changes are immediately reflected in `pcb build`
-- The forked package is excluded from `pcb.sum` (local patches are not locked)
-- Re-running `pcb fork add` without `--force` is idempotent (preserves your changes)
-
-**Flags:**
-- `--version <VERSION>`: Fork a specific version (default: latest)
-- `@<VERSION>` suffix on the URL is also supported
-- `--force`: Overwrite existing fork and patch entry
 
 <Warning>
-Forked packages are local development overrides. They are not versioned or locked.
-For production builds, remove the patch and use published versions.
+`pcb fork remove` and `pcb fork upstream` remain available as an offramp for
+existing fork-based workspaces.
 </Warning>
 
 #### pcb fork remove
 
-Removes a local fork and its patch entry, reverting to the remote dependency.
+Removes a legacy local fork and its patch entry, reverting to the remote dependency.
 
 ```bash
 pcb fork remove github.com/diodeinc/registry/modules/UsbPdController
@@ -552,7 +529,7 @@ The command:
 
 #### pcb fork upstream
 
-Pushes all forked packages to a branch on the upstream registry for creating PRs.
+Pushes legacy forked packages to a branch on the upstream registry for creating PRs.
 
 ```bash
 pcb fork upstream


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it intentionally breaks an existing CLI workflow (`pcb fork add`) and may impact users/scripts that rely on it, though changes are localized to the fork command and docs/tests.
> 
> **Overview**
> **`pcb fork add` is now hard-disabled.** The CLI no longer performs forking and instead exits with an error message instructing users to use `pcb sandbox`, while `pcb fork remove` and `pcb fork upstream` remain supported for existing forks.
> 
> Documentation and release notes are updated to reflect the deprecation, and a new snapshot test asserts the blocked behavior and error output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc8ab6278b1b4c39a54fa9853daa84b0a0b59d2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
