### PR TITLE
Unify unpublished package version fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Stdlib `Crystal` and `MountingHole` no longer expose unused variant-specific ports.
+- Untagged `branch`/`rev` dependencies now use `0.1.1-0...` pseudo-versions so they outrank plain `0.1.0` deps.
 
 ## [0.3.62] - 2026-03-27
 

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -4,6 +4,8 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use semver::Version;
+
 pub mod config;
 pub mod convert;
 pub mod diagnostics;
@@ -22,10 +24,16 @@ pub mod workspace;
 pub const STDLIB_MODULE_PATH: &str = "stdlib";
 /// Legacy stdlib module path accepted for backward compatibility in load specs.
 pub const LEGACY_STDLIB_MODULE_PATH: &str = "github.com/diodeinc/stdlib";
+/// Initial version assigned to unpublished packages.
+pub const INITIAL_PACKAGE_VERSION: &str = "0.1.0";
 /// Version of this PCB toolchain release.
 ///
 /// Used in diagnostics/metadata for toolchain-managed assets.
 pub const TOOLCHAIN_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub fn initial_package_version() -> Version {
+    Version::new(0, 1, 0)
+}
 
 pub fn is_stdlib_module_path(path: &str) -> bool {
     path == STDLIB_MODULE_PATH || path == LEGACY_STDLIB_MODULE_PATH

--- a/crates/pcb-zen/src/auto_deps.rs
+++ b/crates/pcb-zen/src/auto_deps.rs
@@ -11,11 +11,11 @@ use crate::ast_utils::{skip_vendor, visit_string_literals};
 use crate::cache_index::CacheIndex;
 use crate::resolve::fetch_package;
 use crate::workspace::{WorkspaceInfo, WorkspaceInfoExt};
-use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::kicad_library::kicad_dependency_aliases;
 use pcb_zen_core::load_spec::LoadSpec;
 use pcb_zen_core::workspace::package_url_covers;
+use pcb_zen_core::{DefaultFileProvider, INITIAL_PACKAGE_VERSION};
 
 #[derive(Debug, Default)]
 pub struct AutoDepsSummary {
@@ -189,7 +189,10 @@ fn resolve_dep_candidate(
     {
         return Some(ResolvedDep {
             module_path: package_url.to_string(),
-            version: pkg.version.clone().unwrap_or_else(|| "0.1.0".to_string()),
+            version: pkg
+                .version
+                .clone()
+                .unwrap_or_else(|| INITIAL_PACKAGE_VERSION.to_string()),
         });
     }
 
@@ -410,7 +413,10 @@ fn mutate_manifest_dependencies(
 
     // Correct workspace member versions (but preserve branch/rev/path overrides)
     for (url, pkg) in packages {
-        let version = pkg.version.clone().unwrap_or_else(|| "0.1.0".to_string());
+        let version = pkg
+            .version
+            .clone()
+            .unwrap_or_else(|| INITIAL_PACKAGE_VERSION.to_string());
         if let Some(spec) = config.dependencies.get(url)
             && plain_version(spec).is_some_and(|v| is_upgrade_version(v, &version))
         {

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -14,7 +14,7 @@ use pcb_zen_core::resolution::{
     ModuleLine, NativePathResolver, PackagePathResolver, ResolutionResult, build_package_roots,
     build_resolution_map, pseudo_matches_rev, select_version_for_detail, semver_family,
 };
-use pcb_zen_core::{DefaultFileProvider, is_stdlib_module_path};
+use pcb_zen_core::{DefaultFileProvider, initial_package_version, is_stdlib_module_path};
 use rayon::ThreadPoolBuilder;
 use rayon::prelude::*;
 use semver::Version;
@@ -2056,9 +2056,13 @@ impl PseudoVersionContext {
             }
         };
 
-        let base_version = self.get_base_version(&bare_dir, repo_url, subpath);
+        let base_version = self
+            .get_base_version(&bare_dir, repo_url, subpath)
+            .unwrap_or_else(initial_package_version);
 
-        // Build pseudo-version: <base+1>-0.<timestamp>-<commit>
+        // Build pseudo-version:
+        // - tagged packages: <latest patch+1>-0.<timestamp>-<commit>
+        // - untagged packages: <initial patch+1>-0.<timestamp>-<commit>
         let dt = jiff::Timestamp::from_second(timestamp)?;
         let pseudo_str = format!(
             "{}.{}.{}-0.{}-{}",
@@ -2072,7 +2076,12 @@ impl PseudoVersionContext {
             .map_err(|e| anyhow::anyhow!("Failed to parse pseudo-version {}: {}", pseudo_str, e))
     }
 
-    fn get_base_version(&mut self, bare_dir: &Path, repo_url: &str, subpath: &str) -> Version {
+    fn get_base_version(
+        &mut self,
+        bare_dir: &Path,
+        repo_url: &str,
+        subpath: &str,
+    ) -> Option<Version> {
         if !self.base_versions.contains_key(repo_url) {
             let mut versions: HashMap<String, Version> = HashMap::new();
             if let Ok(tags) = git::list_all_tags(bare_dir) {
@@ -2095,7 +2104,6 @@ impl PseudoVersionContext {
             .get(repo_url)
             .and_then(|v| v.get(subpath))
             .cloned()
-            .unwrap_or_else(|| Version::new(0, 0, 0))
     }
 }
 

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -10,8 +10,8 @@ use colored::Colorize;
 use inquire::{Confirm, Select};
 use pcb_zen::workspace::{MemberPackage, WorkspaceInfo, WorkspaceInfoExt, get_workspace_info};
 use pcb_zen::{git, tags};
-use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::config::{DependencySpec, PcbToml};
+use pcb_zen_core::{DefaultFileProvider, initial_package_version};
 use petgraph::Direction;
 use petgraph::graph::{DiGraph, NodeIndex};
 use rayon::prelude::*;
@@ -1012,7 +1012,7 @@ fn preflight_checks(repo_root: &Path, remote: &str) -> Result<()> {
 
 fn compute_next_version(current: Option<&Version>, bump: ReleaseBump) -> Version {
     match current {
-        None => Version::new(0, 1, 0),
+        None => initial_package_version(),
         Some(v) => match bump {
             ReleaseBump::Patch => Version::new(v.major, v.minor, v.patch + 1),
             ReleaseBump::Minor => Version::new(v.major, v.minor + 1, 0),

--- a/crates/pcb/tests/auto_deps.rs
+++ b/crates/pcb/tests/auto_deps.rs
@@ -212,6 +212,10 @@ pcb-version = "0.3"
         "expected pseudo-version to be derived from pinned rev"
     );
     assert!(
+        dep_version.starts_with("0.1.1-0."),
+        "expected unpublished branch deps to resolve in the 0.1.1 pseudo-version family, got {dep_version}"
+    );
+    assert!(
         dep_lines[1].contains(&format!("{}/pcb.toml", dep_version)),
         "expected second lockfile line to be the dependency manifest hash"
     );

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -387,6 +387,9 @@ The lockfile records the full 40-character commit hash.
 The base version (0.3.15) is the next patch version after the most recent tag
 reachable from that commit. This ensures pseudo-versions sort correctly: they're
 newer than the tag they follow but older than the next official release.
+If the package has never been tagged, pseudo-versions start in the `0.1.1`
+family (for example `0.1.1-0.<timestamp>-<commit>`), one patch above the
+initial unpublished release version `0.1.0`.
 
 Pseudo-versions participate fully in MVS. If one package requires `stdlib@0.3.14`
 and another requires the pseudo-version above, MVS selects the pseudo-version


### PR DESCRIPTION
Fix inconsistency in minimum tag version and minimum pseudo version. It's 0.1.0 in both cases now. Previously, the unpublished, non-existent 0.1.0 would be privileged over an unpublished branch pseudo version.