### PR TITLE
feat: support nested net symbol paths

### DIFF
--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -958,12 +958,15 @@ impl ModuleConverter {
                         (child_instance.kind == InstanceKind::Module).then_some(child_ref)
                     })?;
 
-            let descendant_module =
+            let Some(descendant_module) =
                 self.module_instances
                     .iter()
                     .find_map(|(candidate_ref, module)| {
                         (candidate_ref == descendant_ref).then_some(module)
-                    })?;
+                    })
+            else {
+                continue;
+            };
 
             let descendant_local_key = format!("{}.{}", segments[split_idx..].join("."), suffix);
             if descendant_module


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts net symbol position key resolution during schematic conversion, which can change how existing saved symbol positions are matched and applied. Risk is moderate due to new hierarchical traversal that could mis-resolve paths in edge cases or with mixed module/component names.
> 
> **Overview**
> **Adds support for nested net symbol paths when applying `positions()` during schematic conversion.** `find_net_symbol_key` now first checks whether a dot-separated net key targets a descendant module that defines an overridden net symbol position, and if so emits a `sym:<nested_path>#<suffix>` key.
> 
> This introduces `find_descendant_override_net_symbol_key`, which walks the instance hierarchy (module-only via `InstanceKind::Module`) and detects descendant `positions()` entries to decide when to treat a nested path as a valid net-symbol key, enabling position mapping for nets referenced through nested module paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f3746b1ab2b4b306acaca1f22bc22bf32d5b9d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->