### PR TITLE
Fix numeric-only layout paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 - Added 10uF 100V 1210 house capacitor in stdlib
 
+### Fixed
+- `pcb layout` no longer crashes when a managed component path is numeric-only, such as `1053091102`.
+
 ## [0.3.64] - 2026-04-02
 
 ### Added

--- a/crates/pcb-layout/src/scripts/lens/changeset.py
+++ b/crates/pcb-layout/src/scripts/lens/changeset.py
@@ -35,7 +35,7 @@ from .types import (
 def format_value(value: Any) -> str:
     """Format a value for serialization."""
     if isinstance(value, str):
-        if " " in value or "=" in value or '"' in value or "," in value or not value:
+        if _string_needs_quotes(value):
             escaped = value.replace("\\", "\\\\").replace('"', '\\"')
             return f'"{escaped}"'
         return value
@@ -47,6 +47,28 @@ def format_value(value: Any) -> str:
         formatted = ", ".join(format_value(v) for v in value)
         return f"[{formatted}]"
     return str(value)
+
+
+def _string_needs_quotes(value: str) -> bool:
+    """Quote strings the parser would otherwise reinterpret as non-strings."""
+    if (
+        " " in value
+        or "=" in value
+        or '"' in value
+        or "," in value
+        or not value
+        or value in {"true", "false"}
+    ):
+        return True
+
+    try:
+        if "." in value:
+            float(value)
+        else:
+            int(value)
+        return True
+    except ValueError:
+        return False
 
 
 def parse_value(s: str) -> Any:

--- a/crates/pcb-layout/src/scripts/lens/lens.py
+++ b/crates/pcb-layout/src/scripts/lens/lens.py
@@ -811,7 +811,6 @@ def run_lens_sync(
     import time
     from .kicad_adapter import apply_changeset
     from .changeset import (
-        SyncChangeset,
         build_sync_changeset,
         log_lens_state,
         log_changeset,
@@ -873,11 +872,6 @@ def run_lens_sync(
             path = d.get("path", "")
             body = d.get("body", "")
             logger.info(f"  [{level}] {kind} @ {path}: {body}")
-
-    changeset_text = changeset.to_plaintext()
-    changeset = SyncChangeset.from_plaintext(
-        changeset_text, changeset.view, changeset.complement
-    )
 
     oplog = apply_changeset(
         changeset,

--- a/crates/pcb-layout/src/scripts/lens/tests/test_changeset.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_changeset.py
@@ -134,6 +134,30 @@ class TestSyncChangesetSerialization:
         assert "fpid=Resistor_SMD:R_0603" in output
         assert "value=10k" in output
 
+    def test_numeric_only_path_serialization(self):
+        """Numeric-only entity paths should remain valid sync inputs."""
+        part_id = EntityId.from_string("1053091102")
+
+        changeset = SyncChangeset(
+            view=BoardView(
+                footprints={
+                    part_id: make_footprint_view(
+                        "1053091102",
+                        reference="U1",
+                        value="1053091102",
+                        fpid="CONN-TH_2P_1053091102:CONN-TH_2P_1053091102",
+                    )
+                },
+            ),
+            complement=BoardComplement(
+                footprints={part_id: make_footprint_complement()}
+            ),
+            added_footprints={part_id},
+        )
+
+        output = changeset.to_plaintext()
+        assert 'FP_ADD path="1053091102"' in output
+
     def test_removed_footprint_serialization(self):
         """Removed footprint should serialize with FP_REMOVE command."""
         r1_id = EntityId.from_string("Legacy.R_OLD")

--- a/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 105
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -20,7 +19,7 @@ INFO: Changes: +4 -0 footprints
 INFO: NEW FPV path=HDMI_MOD.C_DIFFPAIR.C ref=C1 value=0F fpid=C_0603_1608Metric:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
 INFO: NEW FPV path=U1 ref=U1 value=? fpid=PinHeader_2x05_P2.54mm_Vertical:PinHeader_2x05_P2.54mm_Vertical fields=["Prefix=U"]
 INFO: NEW FPV path=U2 ref=U2 value=? fpid=PinHeader_1x01_P2.54mm_Vertical:PinHeader_1x01_P2.54mm_Vertical fields=["Prefix=U"]
-INFO: NEW FPV path=USB_MOD.R_USB.R ref=R1 value=0 fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=0", "Type=resistor"]
+INFO: NEW FPV path=USB_MOD.R_USB.R ref=R1 value="0" fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=0", "Type=resistor"]
 INFO: NEW FPC path=HDMI_MOD.C_DIFFPAIR.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=U1 x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=U2 x=0 y=0 orient=0.0 layer=F.Cu
@@ -28,7 +27,7 @@ INFO: NEW FPC path=USB_MOD.R_USB.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: CHANGESET FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=C_0603_1608Metric:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
 INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=PinHeader_2x05_P2.54mm_Vertical:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
 INFO: CHANGESET FP_ADD path=U2 ref=U2 fpid=PinHeader_1x01_P2.54mm_Vertical:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=0 x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu
 INFO: Added footprint: HDMI_MOD.C_DIFFPAIR.C
 INFO: Added footprint: U1
 INFO: Added footprint: U2
@@ -37,7 +36,7 @@ INFO: HierPlace: placed 4 items
 INFO: OPLOG FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=C_0603_1608Metric:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=PinHeader_2x05_P2.54mm_Vertical:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=10
 INFO: OPLOG FP_ADD path=U2 ref=U2 fpid=PinHeader_1x01_P2.54mm_Vertical:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=1
-INFO: OPLOG FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=0 x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=HDMI_N
 INFO: OPLOG NET_ADD name=HDMI_P
 INFO: OPLOG NET_ADD name=CLK_50


### PR DESCRIPTION
## What changed
- quote numeric-looking string values in the lens changeset plaintext serializer so identifiers like `1053091102` stay strings
- remove the runtime changeset serialize/deserialize round-trip from layout sync

## Why
`pcb layout` crashed for components whose managed path was numeric-only because the plaintext changeset parser reinterpreted `path=1053091102` as an integer, and `EntityPath.from_string()` then tried to call `.split()` on that integer.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the lens changeset plaintext serialization used by `pcb layout` sync; incorrect quoting could change how values are parsed and applied during layout updates, though coverage is added via a targeted regression test and snapshot update.
> 
> **Overview**
> Fixes a `pcb layout` crash when managed component `path` values are numeric-only by updating the lens changeset plaintext serializer to quote strings that would otherwise be parsed as `int`/`float`/`bool`.
> 
> Removes the runtime changeset `to_plaintext()` → `from_plaintext()` round-trip in `run_lens_sync`, adds a regression test for numeric-only paths, and updates the affected log snapshot; release notes are added to `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 974a2630b526a37064b9eb23ab6a6cc719d3fbf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
