### PR TITLE
Warn on invalid inherited symbol datasheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `pcb layout` no longer crashes when a managed component path is numeric-only, such as `1053091102`.
+- `pcb build` now warns and drops invalid inherited symbol datasheet paths instead of failing the build.
 
 ## [0.3.64] - 2026-04-02
 

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -7,6 +7,7 @@ use starlark::{
     any::ProvidesStaticType,
     collections::SmallMap,
     environment::GlobalsBuilder,
+    errors::EvalSeverity,
     eval::{Arguments, Evaluator, ParametersSpec, ParametersSpecParam},
     starlark_module, starlark_simple_value,
     values::{
@@ -391,6 +392,7 @@ fn resolve_component_sourcing<'v>(
 fn resolve_symbol_datasheet(
     final_symbol: &SymbolValue,
     eval_ctx: &crate::EvalContext,
+    eval: &Evaluator<'_, '_, '_>,
 ) -> starlark::Result<Option<String>> {
     let Some(datasheet_prop) = final_symbol
         .properties()
@@ -423,17 +425,24 @@ fn resolve_symbol_datasheet(
             ))
         })?;
 
-    let resolved = eval_ctx
+    let resolved = match eval_ctx
         .get_config()
         .resolve_path(datasheet_prop, &symbol_source)
-        .map_err(|e| {
-            starlark::Error::new_other(anyhow!(
-                "Failed to resolve symbol datasheet path '{}' relative to '{}': {}",
-                datasheet_prop,
-                symbol_source.display(),
-                e
-            ))
-        })?;
+    {
+        Ok(resolved) => resolved,
+        Err(error) => {
+            warn_invalid_symbol_datasheet(
+                eval,
+                &format!(
+                    "Failed to resolve symbol datasheet path '{}' relative to '{}': {}; dropping inherited datasheet field",
+                    datasheet_prop,
+                    symbol_source.display(),
+                    error
+                ),
+            );
+            return Ok(None);
+        }
+    };
 
     Ok(Some(
         eval_ctx
@@ -441,6 +450,22 @@ fn resolve_symbol_datasheet(
             .format_package_uri(&resolved)
             .unwrap_or_else(|| resolved.to_string_lossy().into_owned()),
     ))
+}
+
+fn warn_invalid_symbol_datasheet(eval: &Evaluator<'_, '_, '_>, message: &str) {
+    let (path, span) = eval
+        .call_stack_top_location()
+        .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
+        .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
+    let diagnostic = crate::Diagnostic::categorized(
+        &path,
+        message,
+        "component.datasheet.invalid_path",
+        EvalSeverity::Warning,
+    )
+    .with_span(span)
+    .with_call_stack(Some(eval.call_stack()));
+    eval.add_diagnostic(diagnostic);
 }
 
 fn manifest_part_matches_symbol(part: &ManifestPart, symbol: &SymbolValue) -> bool {
@@ -1516,7 +1541,7 @@ where
             let final_datasheet = if let Some(datasheet) = explicit_datasheet {
                 Some(normalize_path_to_package_uri(&datasheet, Some(ctx)))
             } else {
-                resolve_symbol_datasheet(&final_symbol, ctx)?
+                resolve_symbol_datasheet(&final_symbol, ctx, eval_ctx)?
             };
 
             // If description is not explicitly provided, try to get it from properties, then symbol properties

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -173,6 +173,23 @@ warn("Warning 3")  # suppress: warnings
 warn("Warning 4 should NOT be suppressed")
 "#;
 
+const INVALID_INHERITED_SYMBOL_DATASHEET_COMPONENT_ZEN: &str = r#"
+P1 = io("P1", Net)
+P2 = io("P2", Net)
+
+Component(
+    name = "U",
+    symbol = Symbol(library = "Part.kicad_sym"),
+    pins = {"P1": P1, "P2": P2},
+)
+"#;
+
+const INVALID_INHERITED_SYMBOL_DATASHEET_BOARD_ZEN: &str = r#"
+Part = Module("components/TestPart/Part.zen")
+
+Part(name = "U1", P1 = Net("A"), P2 = Net("B"))
+"#;
+
 #[test]
 fn test_warning_and_error_mixed() {
     let mut sandbox = Sandbox::new();
@@ -192,6 +209,36 @@ fn test_warning_and_error_mixed() {
         .write("board.zen", WARNING_AND_ERROR_ZEN)
         .snapshot_run("pcb", ["build", "board.zen"]);
     assert_snapshot!("warning_and_error_mixed", output);
+}
+
+#[test]
+fn test_invalid_inherited_symbol_datasheet_is_warning() {
+    let output = Sandbox::new()
+        .write(
+            "components/TestPart/Part.kicad_sym",
+            r#"(kicad_symbol_lib
+  (version 20241209)
+  (symbol "Part"
+    (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "Part" (at 0 -2.54 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Part" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (property "Datasheet" "missing-datasheet.pdf" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (symbol "Part_0_1"
+      (pin input line (at -5.08 0 0) (length 2.54) (name "P1" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      (pin input line (at 5.08 0 180) (length 2.54) (name "P2" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)"#,
+        )
+        .write("components/TestPart/Part.kicad_mod", TEST_KICAD_MOD)
+        .write(
+            "components/TestPart/Part.zen",
+            INVALID_INHERITED_SYMBOL_DATASHEET_COMPONENT_ZEN,
+        )
+        .write("board.zen", INVALID_INHERITED_SYMBOL_DATASHEET_BOARD_ZEN)
+        .snapshot_run("pcb", ["build", "board.zen"]);
+
+    assert_snapshot!("invalid_inherited_symbol_datasheet_is_warning", output);
 }
 
 #[test]

--- a/crates/pcb/tests/part.rs
+++ b/crates/pcb/tests/part.rs
@@ -448,6 +448,57 @@ Part(name = "U1", P1 = Net("A"), P2 = Net("B"))
 }
 
 #[test]
+fn component_drops_invalid_inherited_symbol_datasheet() {
+    let output = Sandbox::new()
+        .write(
+            "components/TestPart/Part.kicad_sym",
+            r#"(kicad_symbol_lib
+  (version 20241209)
+  (symbol "TestPart"
+    (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "TestPart" (at 0 -2.54 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Part" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (property "Datasheet" "missing/Part.pdf" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (symbol "TestPart_0_1"
+      (pin input line (at -5.08 0 0) (length 2.54) (name "P1" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      (pin input line (at 5.08 0 180) (length 2.54) (name "P2" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+    )
+  )
+)"#,
+        )
+        .write("components/TestPart/Part.kicad_mod", TEST_KICAD_MOD)
+        .write(
+            "components/TestPart/Part.zen",
+            r#"
+P1 = io("P1", Net)
+P2 = io("P2", Net)
+
+Component(
+    name = "U",
+    symbol = Symbol(library = "Part.kicad_sym"),
+    pins = {"P1": P1, "P2": P2},
+)
+"#,
+        )
+        .write(
+            "board.zen",
+            r#"
+Part = Module("components/TestPart/Part.zen")
+
+Part(name = "U1", P1 = Net("A"), P2 = Net("B"))
+"#,
+        )
+        .snapshot_run("pcb", ["build", "board.zen", "--netlist"]);
+
+    let netlist = parse_netlist_json(&output);
+    let attrs = component_attrs(&netlist);
+    assert!(
+        !attrs.contains_key("datasheet"),
+        "expected invalid inherited datasheet to be dropped, attrs were: {attrs:#?}"
+    );
+}
+
+#[test]
 fn component_inherits_skip_bom_from_symbol_in_bom() {
     let sym_not_in_bom = r#"(kicad_symbol_lib
   (version 20241209)

--- a/crates/pcb/tests/snapshots/build__invalid_inherited_symbol_datasheet_is_warning.snap
+++ b/crates/pcb/tests/snapshots/build__invalid_inherited_symbol_datasheet_is_warning.snap
@@ -1,0 +1,23 @@
+---
+source: crates/pcb/tests/build.rs
+assertion_line: 241
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+Warning: Failed to resolve symbol datasheet path 'missing-datasheet.pdf' relative to '<TEMP_DIR>/components/TestPart/Part.kicad_sym': File not found: <TEMP_DIR>/components/TestPart/missing-datasheet.pdf; dropping inherited datasheet field
+1 similar warning(s) were suppressed
+   ╭─[ <TEMP_DIR>/components/TestPart/Part.zen:5:1 ]
+ 5 │╭▶Component(
+   ┆┆ 
+ 9 │├▶)
+   │╰──── Failed to resolve symbol datasheet path 'missing-datasheet.pdf' relative to '<TEMP_DIR>/components/TestPart/Part.kicad_sym': File not found: <TEMP_DIR>/components/TestPart/missing-datasheet.pdf; dropping inherited datasheet field
+   ├─[ <TEMP_DIR>/board.zen:2:8 ]
+ 2 │Part = Module("components/TestPart/Part.zen")
+   │                          ╰─────────────────── Warning from `components/TestPart/Part.zen`
+
+✓ board.zen (1 components)


### PR DESCRIPTION
Warn instead of error when an inherited symbol datasheet path is invalid, and drop the inherited datasheet field.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `pcb build` behavior from hard-failing to emitting a warning and omitting the datasheet when a symbol-inherited datasheet path cannot be resolved, which could hide missing-documentation issues if consumers relied on the failure.
> 
> **Overview**
> `pcb build` no longer fails when a component inherits a local datasheet path from a KiCad symbol that can’t be resolved; it now emits a categorized warning (`component.datasheet.invalid_path`) with call-site span/call stack and drops the inherited datasheet field.
> 
> Adds regression coverage to ensure builds succeed with this warning and that the generated netlist omits `datasheet` when the inherited path is invalid, and documents the change in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40839c5e6998c85a98199fe563bae99686243a70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->