### PR TITLE
fix: keep pcb.sum in package output

### DIFF
--- a/crates/pcb-canonical/src/lib.rs
+++ b/crates/pcb-canonical/src/lib.rs
@@ -25,12 +25,14 @@ use unicode_normalization::UnicodeNormalization;
 #[derive(Debug, Clone, Copy)]
 pub struct CanonicalTarOptions {
     pub exclude_nested_packages: bool,
+    pub exclude_lockfile: bool,
 }
 
 impl Default for CanonicalTarOptions {
     fn default() -> Self {
         Self {
             exclude_nested_packages: true,
+            exclude_lockfile: false,
         }
     }
 }
@@ -99,7 +101,7 @@ fn collect_canonical_entries(
         // Only include files - directories are implicit from file paths in tar
         // This avoids issues with empty directories (which git doesn't track anyway)
         if file_type.is_file() {
-            if should_exclude_canonical_path(entry_path) {
+            if options.exclude_lockfile && should_exclude_canonical_path(entry_path) {
                 continue;
             }
             let canonical = canonicalize_path(rel_path)?;
@@ -208,7 +210,14 @@ pub fn create_canonical_tar<W: std::io::Write>(
 pub fn compute_content_hash_from_dir(cache_dir: &Path) -> Result<String> {
     // Stream canonical tar directly to BLAKE3 hasher (avoids buffering entire tar in memory)
     let mut hasher = blake3::Hasher::new();
-    create_canonical_tar(cache_dir, &mut hasher, None)?;
+    create_canonical_tar(
+        cache_dir,
+        &mut hasher,
+        Some(CanonicalTarOptions {
+            exclude_lockfile: true,
+            ..Default::default()
+        }),
+    )?;
     let hash = hasher.finalize();
     Ok(format!("h1:{}", STANDARD.encode(hash.as_bytes())))
 }

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -1065,6 +1065,7 @@ pub fn copy_remote_package_to_vendor(
         dst,
         Some(CanonicalTarOptions {
             exclude_nested_packages: true,
+            ..Default::default()
         }),
     )?;
     Ok(RemotePackageVendorStatus::Copied)

--- a/crates/pcb/src/bundle.rs
+++ b/crates/pcb/src/bundle.rs
@@ -131,6 +131,7 @@ pub(crate) fn write_canonical_bundle(staging_dir: &Path, output_path: &Path) -> 
         &mut encoder,
         Some(pcb_canonical::CanonicalTarOptions {
             exclude_nested_packages: false,
+            ..Default::default()
         }),
     )?;
     encoder.finish()?;

--- a/crates/pcb/src/package.rs
+++ b/crates/pcb/src/package.rs
@@ -205,6 +205,7 @@ fn package_workspace_target(target: WorkspaceTarget, args: &PackageArgs) -> Resu
             &staging_dir,
             Some(pcb_canonical::CanonicalTarOptions {
                 exclude_nested_packages: false,
+                ..Default::default()
             }),
         )?;
         for entry in &entries {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the inputs to `compute_content_hash_from_dir` by excluding `pcb.sum`, which can affect package integrity verification and cache/index behavior. Scope is small but touches hashing/packaging paths used across vendoring and bundle creation.
> 
> **Overview**
> Adds an `exclude_lockfile` flag to `CanonicalTarOptions`, making `pcb.sum` exclusion from canonical tar/listing/copying opt-in instead of unconditional.
> 
> Updates directory content hashing (`compute_content_hash_from_dir`) to **exclude `pcb.sum` from the content hash**, while bundle/vendoring tar creation continues to include it by default (call sites updated to use `..Default::default()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d52da74c84319d4ca0e5c75c485bb0581364d232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->