### PR TITLE
Deprecate legacy stdlib net types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Loading deprecated stdlib physical-unit `*Range` aliases now emits a deprecation warning pointing to the corresponding base unit type.
+- Deprecated stdlib `Analog`, `Gpio`, and `Pwm` net types in favor of `Net`.
 - Deprecated the stdlib `pins.zen` and `metadata.zen` modules.
 - Deprecated the `Schematics()` helper.
 - Deprecated generic modules `generics/Bjt.zen`, `generics/Diode.zen`, `generics/Mosfet.zen`, and `generics/OperationalAmplifier.zen`.

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -414,6 +414,15 @@ impl<V> NetTypeGen<V> {
     fn ty_name(&self) -> String {
         format!("{}Type", self.type_name)
     }
+
+    fn deprecation_message(&self) -> Option<&'static str> {
+        match self.type_name.as_str() {
+            "Analog" => Some("Analog is deprecated. Use Net instead."),
+            "Pwm" => Some("Pwm is deprecated. Use Net instead."),
+            "Gpio" => Some("Gpio is deprecated. Use Net instead."),
+            _ => None,
+        }
+    }
 }
 
 impl<V> fmt::Display for NetTypeGen<V> {
@@ -684,6 +693,31 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
             false,
         )
     }
+
+    fn warn_if_deprecated(&self, eval: &Evaluator<'v, '_, '_>) {
+        let Some(message) = self.deprecation_message() else {
+            return;
+        };
+
+        let (path, span) = match eval.call_stack_top_location() {
+            Some(location) => (
+                location.filename().to_owned(),
+                Some(location.resolve_span()),
+            ),
+            None => (eval.source_path().unwrap_or_default(), None),
+        };
+
+        eval.add_diagnostic(
+            crate::Diagnostic::categorized(
+                &path,
+                message,
+                "deprecated",
+                starlark::errors::EvalSeverity::Warning,
+            )
+            .with_span(span)
+            .with_call_stack(Some(eval.call_stack())),
+        );
+    }
 }
 
 /// Process a field specification: validate provided value or apply default.
@@ -811,6 +845,8 @@ where
         args: &Arguments<'v, '_>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> starlark::Result<Value<'v>> {
+        self.warn_if_deprecated(eval);
+
         self.parameters_spec()
             .parser(args, eval, |param_parser, eval| {
                 let type_name = self.instance_ty_name();

--- a/crates/pcb-zen-core/tests/load.rs
+++ b/crates/pcb-zen-core/tests/load.rs
@@ -141,3 +141,72 @@ fn stdlib_units_primary_type_does_not_warn_on_constructor() {
         "did not expect deprecation warning, got: {warning_bodies:?}"
     );
 }
+
+#[test]
+fn stdlib_analog_warns_on_constructor() {
+    let result = eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            load("@stdlib/interfaces.zen", "Analog")
+            Analog("A0")
+        "#
+        .to_string(),
+    )]);
+
+    let warning_bodies = warning_bodies(&result);
+
+    assert!(
+        warning_bodies
+            .iter()
+            .any(|body| body == "Analog is deprecated. Use Net instead."),
+        "expected deprecation warning, got: {warning_bodies:?}"
+    );
+}
+
+#[test]
+fn stdlib_gpio_and_pwm_warn_on_constructor() {
+    let result = eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            load("@stdlib/interfaces.zen", "Gpio", "Pwm")
+            Gpio("GPIO0")
+            Pwm("PWM0")
+        "#
+        .to_string(),
+    )]);
+
+    let warning_bodies = warning_bodies(&result);
+
+    assert!(
+        warning_bodies
+            .iter()
+            .any(|body| body == "Gpio is deprecated. Use Net instead."),
+        "expected gpio deprecation warning, got: {warning_bodies:?}"
+    );
+    assert!(
+        warning_bodies
+            .iter()
+            .any(|body| body == "Pwm is deprecated. Use Net instead."),
+        "expected pwm deprecation warning, got: {warning_bodies:?}"
+    );
+}
+
+#[test]
+fn stdlib_analog_does_not_warn_on_load() {
+    let result = eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            load("@stdlib/interfaces.zen", "Analog")
+        "#
+        .to_string(),
+    )]);
+
+    let warning_bodies = warning_bodies(&result);
+
+    assert!(
+        !warning_bodies
+            .iter()
+            .any(|body| body.contains("Analog is deprecated")),
+        "did not expect deprecation warning, got: {warning_bodies:?}"
+    );
+}

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -386,12 +386,12 @@ snapshot_eval!(power_ground_have_default_symbols, {
             symbol=field(Symbol, default=Symbol(name="GND", definition=[("GND", ["1"])])),
         )
 
-        Analog = builtin.net_type("Analog")
-        Gpio = builtin.net_type("Gpio")
-        Pwm = builtin.net_type("Pwm")
+        Signal = builtin.net_type("Signal")
+        Control = builtin.net_type("Control")
+        Clock = builtin.net_type("Clock")
     "#,
     "test.zen" => r#"
-        load("interfaces.zen", "Power", "Ground", "Analog", "Gpio", "Pwm")
+        load("interfaces.zen", "Power", "Ground", "Signal", "Control", "Clock")
 
         # Test that Power has default symbol
         vcc = Power("VCC")
@@ -405,14 +405,14 @@ snapshot_eval!(power_ground_have_default_symbols, {
         print("Ground symbol:", gnd.symbol)
         check(gnd.symbol != None, "Ground should have default symbol")
 
-        # Test that Analog/Gpio/Pwm work (no default symbols expected)
-        analog = Analog("ANALOG")
-        gpio = Gpio("GPIO")
-        pwm = Pwm("PWM")
+        # Test that custom typed nets work (no default symbols expected)
+        signal = Signal("SIGNAL")
+        control = Control("CONTROL")
+        clock = Clock("CLOCK")
 
-        print("Analog net:", analog.name)
-        print("Gpio net:", gpio.name)
-        print("Pwm net:", pwm.name)
+        print("Signal net:", signal.name)
+        print("Control net:", control.name)
+        print("Clock net:", clock.name)
     "#
 });
 
@@ -511,19 +511,19 @@ snapshot_eval!(not_connected_promotes_to_net, {
 
 snapshot_eval!(not_connected_promotes_to_custom_type, {
     "interfaces.zen" => r#"
-        Gpio = builtin.net_type("Gpio")
+        Signal = builtin.net_type("Signal")
         NotConnected = builtin.net_type("NotConnected")
     "#,
     "child.zen" => r#"
-        load("interfaces.zen", "Gpio")
+        load("interfaces.zen", "Signal")
 
-        gpio = io("gpio", Gpio)
+        signal = io("signal", Signal)
 
         Component(
             name = "R1",
             footprint = "TEST:0402",
             pin_defs = {"1": "1"},
-            pins = {"1": gpio},
+            pins = {"1": signal},
         )
     "#,
     "test.zen" => r#"
@@ -533,9 +533,9 @@ snapshot_eval!(not_connected_promotes_to_custom_type, {
 
         # NotConnected should promote to any custom net type
         nc = NotConnected("NC")
-        Child(name = "child", gpio = nc)
+        Child(name = "child", signal = nc)
 
-        print("NotConnected promotes to Gpio: success")
+        print("NotConnected promotes to Signal: success")
     "#
 });
 

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_custom_type.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_custom_type.snap
@@ -2,7 +2,7 @@
 source: crates/pcb-zen-core/tests/net.rs
 expression: output
 ---
-NotConnected promotes to Gpio: success
+NotConnected promotes to Signal: success
 {
     <root>: Module {
         path: <root>,

--- a/crates/pcb-zen-core/tests/snapshots/net__power_ground_have_default_symbols.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__power_ground_have_default_symbols.snap
@@ -6,9 +6,9 @@ Power net: VCC
 Power symbol: Symbol { name: "VCC", pins: { "1": "VCC" } }
 Ground net: GND
 Ground symbol: Symbol { name: "GND", pins: { "1": "GND" } }
-Analog net: ANALOG
-Gpio net: GPIO
-Pwm net: PWM
+Signal net: SIGNAL
+Control net: CONTROL
+Clock net: CLOCK
 {
     <root>: Module {
         path: <root>,

--- a/crates/pcb-zen/tests/spice_model.rs
+++ b/crates/pcb-zen/tests/spice_model.rs
@@ -124,7 +124,6 @@ Component(
     env.add_file(
         "divider.zen",
         r#"
-load("@stdlib/interfaces.zen", "Analog")
 Resistor = Module("myresistor.zen")
 
 # Configuration parameters
@@ -133,7 +132,7 @@ r2_value = config("r2_value", str, default="20kohms", optional=True)
 
 # IO ports
 vin = io("vin", Power)
-vout = io("vout", Analog)
+vout = io("vout", Net)
 gnd = io("gnd", Ground)
 
 # Create the voltage divider
@@ -201,14 +200,13 @@ Component(
     env.add_file(
         "divider.zen",
         r#"
-load("@stdlib/interfaces.zen", "Analog")
 Resistor = Module("myresistor.zen")
 
 r1_value = config("r1_value", str, default="10kohms", optional=True)
 r2_value = config("r2_value", str, default="20kohms", optional=True)
 
 vin = io("vin", Power)
-vout = io("vout", Analog)
+vout = io("vout", Net)
 gnd = io("gnd", Ground)
 
 Resistor(name="R1", value=r1_value, package="0603", P1=vin.NET, P2=vout.NET)
@@ -279,14 +277,13 @@ Component(
     env.add_file(
         "divider.zen",
         r#"
-load("@stdlib/interfaces.zen", "Analog")
 Resistor = Module("myresistor.zen")
 
 r1_value = config("r1_value", str, default="10kohms", optional=True)
 r2_value = config("r2_value", str, default="20kohms", optional=True)
 
 vin = io("vin", Power)
-vout = io("vout", Analog)
+vout = io("vout", Net)
 gnd = io("gnd", Ground)
 
 Resistor(name="R1", value=r1_value, package="0603", P1=vin.NET, P2=vout.NET)

--- a/crates/pcb/tests/bom.rs
+++ b/crates/pcb/tests/bom.rs
@@ -5,8 +5,6 @@ use pcb_test_utils::sandbox::Sandbox;
 use std::fs;
 
 const LED_MODULE_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Led = Module("@stdlib/generics/Led.zen")
 
@@ -16,7 +14,7 @@ package = config("package", str, default = "0603")
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-CTRL = io("CTRL", Gpio)
+CTRL = io("CTRL", Net)
 
 led_anode = Net("LED_ANODE")
 
@@ -25,8 +23,6 @@ Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.N
 "#;
 
 const TEST_BOARD_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 LedModule = Module("../modules/LedModule.zen")
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -34,15 +30,15 @@ Crystal = Module("@stdlib/generics/Crystal.zen")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-led_ctrl = Gpio("LED_CTRL")
-osc_xi = Gpio("OSC_XI")
-osc_xo = Gpio("OSC_XO")
+led_ctrl = Net("LED_CTRL")
+osc_xi = Net("OSC_XI")
+osc_xo = Net("OSC_XO")
 
 Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
 Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
-LedModule(name = "LED2", led_color = "red", VCC = vcc_3v3, GND = gnd, CTRL = Gpio(NET = gnd.NET))
+LedModule(name = "LED2", led_color = "red", VCC = vcc_3v3, GND = gnd, CTRL = Net(NET = gnd.NET))
 
 Crystal(name = "X1", frequency = "16MHz", load_capacitance = "18pF", package = "5032_2Pin", XIN = osc_xi.NET, XOUT = osc_xo.NET)
 

--- a/crates/pcb/tests/info.rs
+++ b/crates/pcb/tests/info.rs
@@ -43,11 +43,9 @@ description = "Special custom board with unique features"
 "#;
 
 const TEST_BOARD_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-test_signal = Gpio("TEST_SIGNAL")
+test_signal = Net("TEST_SIGNAL")
 internal_net = Net("INTERNAL")
 "#;
 

--- a/crates/pcb/tests/netlist.rs
+++ b/crates/pcb/tests/netlist.rs
@@ -91,15 +91,13 @@ Led(name="D1", color="red", package="0603", A=led_anode, K=gnd)
 "#;
 
 const HIERARCHICAL_BOARD_WITH_POSITIONS_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 LedModule = Module("../modules/LedModule.zen")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
 
-LedModule(name="LED1", led_color="green", VCC=vcc_3v3, GND=gnd, CTRL=Gpio(NET=Net("LED_CTRL")))
-LedModule(name="LED2", led_color="red", VCC=vcc_3v3, GND=gnd, CTRL=Gpio(NET=Net("LED_CTRL2")))
+LedModule(name="LED1", led_color="green", VCC=vcc_3v3, GND=gnd, CTRL=Net(NET=Net("LED_CTRL")))
+LedModule(name="LED2", led_color="red", VCC=vcc_3v3, GND=gnd, CTRL=Net(NET=Net("LED_CTRL2")))
 
 # Position comments for hierarchical design
 # pcb:sch LED1.R1 x=100.0000 y=100.0000 rot=0
@@ -155,8 +153,6 @@ Led(name="D1", color="red", package="0603", A=led_anode, K=gnd)
 "#;
 
 const LED_MODULE_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Led = Module("@stdlib/generics/Led.zen")
 
@@ -166,7 +162,7 @@ package = config("package", str, default="0603")
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-CTRL = io("CTRL", Gpio)
+CTRL = io("CTRL", Net)
 
 led_anode = Net("LED_ANODE")
 

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -7,8 +7,6 @@ use pcb_test_utils::sandbox::Sandbox;
 use serde_json::Value;
 
 const LED_MODULE_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Led = Module("@stdlib/generics/Led.zen")
 
@@ -18,7 +16,7 @@ package = config("package", str, default = "0603")
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-CTRL = io("CTRL", Gpio)
+CTRL = io("CTRL", Net)
 
 led_anode = Net("LED_ANODE")
 
@@ -27,8 +25,6 @@ Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.N
 "#;
 
 const TEST_BOARD_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 Layout(name="TestBoard", path="build/TestBoard", bom_profile=None)
 
 LedModule = Module("modules/LedModule.zen")
@@ -37,7 +33,7 @@ Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-led_ctrl = Gpio("LED_CTRL")
+led_ctrl = Net("LED_CTRL")
 
 Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
 Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)

--- a/crates/pcb/tests/simple.rs
+++ b/crates/pcb/tests/simple.rs
@@ -2,8 +2,6 @@ use pcb_test_utils::assert_snapshot;
 use pcb_test_utils::sandbox::Sandbox;
 
 const LED_MODULE_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Led = Module("@stdlib/generics/Led.zen")
 
@@ -13,7 +11,7 @@ package = config("package", str, default = "0603")
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-CTRL = io("CTRL", Gpio)
+CTRL = io("CTRL", Net)
 
 led_anode = Net("LED_ANODE")
 
@@ -22,8 +20,6 @@ Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.N
 "#;
 
 const TEST_BOARD_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 Layout(name="TestBoard", path="build/TestBoard", bom_profile=None)
 
 LedModule = Module("modules/LedModule.zen")
@@ -33,15 +29,15 @@ Crystal = Module("@stdlib/generics/Crystal.zen")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-led_ctrl = Gpio("LED_CTRL")
-osc_xi = Gpio("OSC_XI")
-osc_xo = Gpio("OSC_XO")
+led_ctrl = Net("LED_CTRL")
+osc_xi = Net("OSC_XI")
+osc_xo = Net("OSC_XO")
 
 Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
 Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
-LedModule(name = "LED2", led_color = "red", VCC = vcc_3v3, GND = gnd, CTRL = Gpio(NET = gnd.NET))
+LedModule(name = "LED2", led_color = "red", VCC = vcc_3v3, GND = gnd, CTRL = Net(NET = gnd.NET))
 
 Crystal(name = "X1", frequency = "16MHz", load_capacitance = "18pF", package = "5032_2Pin", XIN = osc_xi.NET, XOUT = osc_xo.NET)
 
@@ -52,16 +48,14 @@ Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 =
 "#;
 
 const SIMPLE_BOARD_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-test_signal = Gpio("TEST_SIGNAL")
+test_signal = Net("TEST_SIGNAL")
 internal_net = Net("INTERNAL")
 "#;
 
 const NONEXISTENT_REPO_BOARD_ZEN: &str = r#"
-load("github.com/nonexistent/repo:main/interfaces.zen", "Gpio", "Ground", "Power")
+load("github.com/nonexistent/repo:main/interfaces.zen", "Net", "Ground", "Power")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")

--- a/crates/pcb/tests/snapshots/release__publish_full.snap
+++ b/crates/pcb/tests/snapshots/release__publish_full.snap
@@ -72,7 +72,7 @@ expression: sb.snapshot_dir(&staging_dir)
 {
   "boards/TestBoard.zen": [
     {
-      "location": "<TEMP_DIR>/src/.pcb/releases/TestBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:12:7-24",
+      "location": "<TEMP_DIR>/src/.pcb/releases/TestBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:10:7-24",
       "severity": "warning",
       "body": "io() 'GND' in module 'LED1' is not connected to any ports",
       "suppressed": false,
@@ -117,10 +117,8 @@ Designator,Val,Package,Mid X,Mid Y,Rotation,Layer
     "user": "<USER>"
   }
 }
-=== netlist.json <73006 bytes, sha256: 0f3d886>
+=== netlist.json <73005 bytes, sha256: 0df785c>
 === src/boards/TestBoard.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Layout(name="TestBoard", path="build/TestBoard", bom_profile=None)
 
@@ -130,7 +128,7 @@ Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-led_ctrl = Gpio("LED_CTRL")
+led_ctrl = Net("LED_CTRL")
 
 Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
 Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
@@ -139,8 +137,6 @@ LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = l
 
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
 === src/boards/modules/LedModule.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Led = Module("@stdlib/generics/Led.zen")
@@ -151,7 +147,7 @@ package = config("package", str, default = "0603")
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-CTRL = io("CTRL", Gpio)
+CTRL = io("CTRL", Net)
 
 led_anode = Net("LED_ANODE")
 

--- a/crates/pcb/tests/snapshots/release__publish_source_only.snap
+++ b/crates/pcb/tests/snapshots/release__publish_source_only.snap
@@ -6,7 +6,7 @@ expression: sb.snapshot_dir(&staging_dir)
 {
   "boards/TestBoard.zen": [
     {
-      "location": "<TEMP_DIR>/src/.pcb/releases/TestBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:12:7-24",
+      "location": "<TEMP_DIR>/src/.pcb/releases/TestBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:10:7-24",
       "severity": "warning",
       "body": "io() 'GND' in module 'LED1' is not connected to any ports",
       "suppressed": false,
@@ -43,10 +43,8 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <73006 bytes, sha256: 0f3d886>
+=== netlist.json <73005 bytes, sha256: 0df785c>
 === src/boards/TestBoard.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Layout(name="TestBoard", path="build/TestBoard", bom_profile=None)
 
@@ -56,7 +54,7 @@ Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-led_ctrl = Gpio("LED_CTRL")
+led_ctrl = Net("LED_CTRL")
 
 Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
 Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
@@ -65,8 +63,6 @@ LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = l
 
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
 === src/boards/modules/LedModule.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Led = Module("@stdlib/generics/Led.zen")
@@ -77,7 +73,7 @@ package = config("package", str, default = "0603")
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-CTRL = io("CTRL", Gpio)
+CTRL = io("CTRL", Net)
 
 led_anode = Net("LED_ANODE")
 

--- a/crates/pcb/tests/snapshots/release__publish_with_description.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_description.snap
@@ -6,7 +6,7 @@ expression: sb.snapshot_dir(&staging_dir)
 {
   "boards/DescBoard.zen": [
     {
-      "location": "<TEMP_DIR>/src/.pcb/releases/DescBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:12:7-24",
+      "location": "<TEMP_DIR>/src/.pcb/releases/DescBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:10:7-24",
       "severity": "warning",
       "body": "io() 'GND' in module 'LED1' is not connected to any ports",
       "suppressed": false,
@@ -44,10 +44,8 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <73006 bytes, sha256: 42cb844>
+=== netlist.json <73005 bytes, sha256: cb278e5>
 === src/boards/DescBoard.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Layout(name="TestBoard", path="build/TestBoard", bom_profile=None)
 
@@ -57,7 +55,7 @@ Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-led_ctrl = Gpio("LED_CTRL")
+led_ctrl = Net("LED_CTRL")
 
 Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
 Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
@@ -66,8 +64,6 @@ LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = l
 
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
 === src/boards/modules/LedModule.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Led = Module("@stdlib/generics/Led.zen")
@@ -78,7 +74,7 @@ package = config("package", str, default = "0603")
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-CTRL = io("CTRL", Gpio)
+CTRL = io("CTRL", Net)
 
 led_anode = Net("LED_ANODE")
 

--- a/crates/pcb/tests/snapshots/release__publish_with_version.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_version.snap
@@ -6,7 +6,7 @@ expression: sb.snapshot_dir(staging_dir)
 {
   "boards/TB0001.zen": [
     {
-      "location": "<TEMP_DIR>/src/.pcb/releases/TB0001-v1.3.0/src/boards/modules/LedModule.zen:12:7-24",
+      "location": "<TEMP_DIR>/src/.pcb/releases/TB0001-v1.3.0/src/boards/modules/LedModule.zen:10:7-24",
       "severity": "warning",
       "body": "io() 'GND' in module 'LED1' is not connected to any ports",
       "suppressed": false,
@@ -43,10 +43,8 @@ expression: sb.snapshot_dir(staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <72267 bytes, sha256: 243c2ef>
+=== netlist.json <72266 bytes, sha256: babcc6d>
 === src/boards/TB0001.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Layout(name="TestBoard", path="build/TestBoard", bom_profile=None)
 
@@ -56,7 +54,7 @@ Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-led_ctrl = Gpio("LED_CTRL")
+led_ctrl = Net("LED_CTRL")
 
 Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
 Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
@@ -65,8 +63,6 @@ LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = l
 
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
 === src/boards/modules/LedModule.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Led = Module("@stdlib/generics/Led.zen")
@@ -77,7 +73,7 @@ package = config("package", str, default = "0603")
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-CTRL = io("CTRL", Gpio)
+CTRL = io("CTRL", Net)
 
 led_anode = Net("LED_ANODE")
 

--- a/crates/pcb/tests/snapshots/simple__no_fixture.snap
+++ b/crates/pcb/tests/snapshots/simple__no_fixture.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb/tests/simple.rs
+assertion_line: 142
 expression: output
 ---
 Command: pcb build boards/TestBoard.zen
@@ -12,9 +13,9 @@ Error: No declared dependency matches 'github.com/nonexistent/repo:main/interfac
   Add a dependency to [dependencies] in pcb.toml that covers this path
    ╭─[ <TEMP_DIR>/boards/TestBoard.zen:2:1 ]
    │
- 2 │ load("github.com/nonexistent/repo:main/interfaces.zen", "Gpio", "Ground", "Power")
-   │ ─────────────────────────────────────────┬────────────────────────────────────────  
-   │                                          ╰────────────────────────────────────────── No declared dependency matches 'github.com/nonexistent/repo:main/interfaces.zen'
+ 2 │ load("github.com/nonexistent/repo:main/interfaces.zen", "Net", "Ground", "Power")
+   │ ────────────────────────────────────────┬────────────────────────────────────────  
+   │                                         ╰────────────────────────────────────────── No declared dependency matches 'github.com/nonexistent/repo:main/interfaces.zen'
 ───╯
 
 Stack trace (most recent call last):

--- a/crates/pcb/tests/snapshots/simple__simple_workspace_build.snap
+++ b/crates/pcb/tests/snapshots/simple__simple_workspace_build.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb/tests/simple.rs
+assertion_line: 165
 expression: output
 ---
 Command: pcb build boards/TestBoard.zen
@@ -9,8 +10,8 @@ Exit Code: 0
 
 --- STDERR ---
 Warning: io() 'GND' in module 'LED1' is not connected to any ports
-    ╭─[ <TEMP_DIR>/boards/modules/LedModule.zen:12:7 ]
- 12 │GND = io("GND", Ground)
+    ╭─[ <TEMP_DIR>/boards/modules/LedModule.zen:10:7 ]
+ 10 │GND = io("GND", Ground)
     │              ╰───────── io() 'GND' in module 'LED1' is not connected to any ports
 
 ✓ TestBoard.zen (10 components)

--- a/crates/pcb/tests/snapshots/tag__publish_board_simple_workspace.snap
+++ b/crates/pcb/tests/snapshots/tag__publish_board_simple_workspace.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb/tests/tag.rs
-assertion_line: 86
+assertion_line: 100
 expression: sb.snapshot_dir(&staging_dir)
 ---
 === diagnostics.json
@@ -36,16 +36,14 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <1522 bytes, sha256: 013f6ec>
+=== netlist.json <1521 bytes, sha256: 5c30f82>
 === src/boards/Test/TB0001.zen
-
-load("@stdlib/interfaces.zen", "Gpio")
 
 Layout(name="TB0001", path="build/TB0001", bom_profile=None)
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-test_signal = Gpio("TEST_SIGNAL")
+test_signal = Net("TEST_SIGNAL")
 internal_net = Net("INTERNAL")
 === src/boards/Test/pcb.toml
 

--- a/crates/pcb/tests/tag.rs
+++ b/crates/pcb/tests/tag.rs
@@ -49,13 +49,11 @@ name = "TB0001"
 "#;
 
 const SIMPLE_BOARD_ZEN: &str = r#"
-load("@stdlib/interfaces.zen", "Gpio")
-
 Layout(name="TB0001", path="build/TB0001", bom_profile=None)
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-test_signal = Gpio("TEST_SIGNAL")
+test_signal = Net("TEST_SIGNAL")
 internal_net = Net("INTERNAL")
 "#;
 

--- a/docs/internal/design.md
+++ b/docs/internal/design.md
@@ -1,0 +1,41 @@
+# Design Principles
+
+This page captures the design philosophy used when evolving Zener and its
+standard library. It is not part of the language specification.
+
+## Language
+
+Zener should bias toward one obvious way to write a design once the design
+intent is known. That generally means a small set of general, composable
+concepts rather than many narrow ones. Prefer powerful primitives over
+opinionated features that have not yet proven their value, and if something can
+live in the standard library or another library, it usually should not be part
+of the language itself.
+
+Zener should keep builtin language features to a minimum, stay close to
+Starlark, and read as much like ordinary Python as possible. Its concepts
+should also feel familiar to EEs coming from traditional ECAD tools. It should
+minimize multiple sources of truth and other forms of repeated technical
+description that can drift over time.
+
+Types are useful, but they should be used conservatively. Use types for
+semantic, stable, composable distinctions. Prefer imperative checks for
+contextual rules, and be skeptical of modeling concepts as types when their
+meaning depends on context or usage.
+
+Zener is pre-1.0, so some churn is expected, but that churn should decrease
+over time. The path to 1.0 should cut scope aggressively to stabilize a small,
+durable core.
+
+## Standard Library
+
+Anything in the standard library becomes part of Zener's blessed vocabulary, so
+the bar for inclusion should be high.
+
+Standard library concepts should be broadly useful, mostly context-free, and
+unambiguous enough to model consistently.
+
+If the system cannot meaningfully use a distinction, it probably should not be
+a stdlib type. The standard library should help designs converge on one
+obvious representation, not introduce more competing ways to describe the same
+thing.

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -205,7 +205,7 @@ GND = Ground()  # inferred from assignment; voltage defaults to 0V
 nc = NotConnected()
 ```
 
-`Net(name, voltage=None, impedance=None)` — all parameters optional. `Power` and `Ground` additionally accept a `voltage` parameter. Additional net types (`Analog`, `Pwm`, `Gpio`) are available from `@stdlib/interfaces.zen`.
+`Net(name, voltage=None, impedance=None)` — all parameters optional. `Power` and `Ground` additionally accept a `voltage` parameter. Use `Net` for ordinary signal nets.
 
 If a net constructor omits `name`, the assigned variable name is used when available:
 
@@ -223,7 +223,7 @@ Net()               # uses an auto-generated name
 
 Typed net fields validate against their declared field type and apply the same physical-value coercion used by module inputs, so `Power("VCC", voltage="3.3V")` is equivalent to `Power("VCC", voltage=Voltage("3.3V"))`.
 
-Net types follow automatic conversion rules across `io()` boundaries: `NotConnected` promotes to any type (universal donor), any specialized type demotes to `Net`, but `Net` cannot automatically promote to specialized types. For explicit casting, call the target constructor with an existing net: `Power(net, voltage=Voltage("3.3V"))` or `Net(power_net)`.
+Net types follow automatic conversion rules across `io()` boundaries: `NotConnected` promotes to any type (universal donor), typed nets demote to `Net`, but `Net` cannot automatically promote to a more specific type. For explicit casting, call the target constructor with an existing net: `Power(net, voltage=Voltage("3.3V"))` or `Net(power_net)`.
 
 ### Interfaces
 

--- a/examples/HighSideCurrentSense/HighSideCurrentSense.zen
+++ b/examples/HighSideCurrentSense/HighSideCurrentSense.zen
@@ -2,7 +2,7 @@
 Type: High Side Current Sensor
 Description: High side current sensor using INA240A with 2mohm shunt resistor, 20x V/V gain. 80Vin Max
 """
-load("@stdlib/interfaces.zen", "Analog")
+
 load("@stdlib/units.zen", "Resistance")
 
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -20,10 +20,10 @@ ref_config = config("ref_config", str, default="GROUND")
 power_bus_in = io("power_bus_in", Power)  # Input power bus
 power_bus_out = io("power_bus_out", Power)  # Output power bus
 power_3v3 = io("power_3v3", Power)  # Digital power supply
-isense_out = io("isense_out", Analog)  # Current sense output
+isense_out = io("isense_out", Net)  # Current sense output
 gnd = io("gnd", Ground)  # Ground reference
-_IN_P = Analog()
-_IN_N = Analog()
+_IN_P = Net()
+_IN_N = Net()
 
 shunt_properties = {}
 if shunt_mpn:

--- a/examples/HighSideCurrentSense/HighSideCurrentSense.zen
+++ b/examples/HighSideCurrentSense/HighSideCurrentSense.zen
@@ -32,17 +32,9 @@ if shunt_mpn:
     }
 
 # Create nettie modules for power connections
-NetTie(
-    name="isense_shunt_high",
-    P1 = power_bus_in.NET,
-    P2 = _IN_P.NET
-)
+NetTie(name="isense_shunt_high", P1=power_bus_in.NET, P2=_IN_P.NET)
 
-NetTie(
-    name="isense_shunt_low", 
-    P1 = power_bus_out.NET,
-    P2 = _IN_N.NET
-)
+NetTie(name="isense_shunt_low", P1=power_bus_out.NET, P2=_IN_N.NET)
 
 # Shunt resistor
 Resistor(

--- a/examples/INA240A/INA240A.zen
+++ b/examples/INA240A/INA240A.zen
@@ -24,8 +24,6 @@ Features:
   * CUSTOM: REF pins left unconnected for manual configuration
 """
 
-load("@stdlib/interfaces.zen", "Analog")
-
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 Gain = enum("A1", "A2", "A3", "A4")
@@ -36,16 +34,16 @@ ImplementationType = enum("NO_PASSIVES", "WITH_PASSIVES")
 component_config = {
     "symbols": {
         Package("SOIC"): {
-            Gain("A1"): Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A1D"),
-            Gain("A2"): Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A2D"),
-            Gain("A3"): Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A3D"),
-            Gain("A4"): Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A4D"),
+            Gain("A1"): Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA240A1D"),
+            Gain("A2"): Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA240A2D"),
+            Gain("A3"): Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA240A3D"),
+            Gain("A4"): Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA240A4D"),
         },
         Package("TSSOP"): {
-            Gain("A1"): Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A1PW"),
-            Gain("A2"): Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A2PW"),
-            Gain("A3"): Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A3PW"),
-            Gain("A4"): Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A4PW"),
+            Gain("A1"): Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA240A1PW"),
+            Gain("A2"): Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA240A2PW"),
+            Gain("A3"): Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA240A3PW"),
+            Gain("A4"): Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA240A4PW"),
         },
     },
     "mpns": {
@@ -69,13 +67,13 @@ package = config("package", Package, default=Package("TSSOP"))
 ref_config = config("ref_config", RefConfig, default=RefConfig("GROUND"))
 implementation_type = config("implementation_type", ImplementationType, default=ImplementationType("WITH_PASSIVES"))
 
-properties = config("properties", dict, optional = True)
+properties = config("properties", dict, optional=True)
 
 power = io("power", Power)
 gnd = io("gnd", Ground)
-in_p = io("in_p", Analog)
-in_n = io("in_n", Analog)
-out = io("out", Analog)
+in_p = io("in_p", Net)
+in_n = io("in_n", Net)
+out = io("out", Net)
 
 ref_pins = {
     "ref1": gnd,
@@ -111,14 +109,14 @@ elif ref_config == RefConfig("CUSTOM"):
 
 symbol = component_config["symbols"][package][gain]
 part = Part(
-    mpn = component_config["mpns"][package][gain],
-    manufacturer = "Texas Instruments",
+    mpn=component_config["mpns"][package][gain],
+    manufacturer="Texas Instruments",
 )
 
 Component(
     name=component_config["mpns"][package][gain],
     description="Automotive-qualified, voltage-output, current-sense amplifier with enhanced PWM rejection",
-    symbol = symbol,
+    symbol=symbol,
     part=part,
     pins={
         "+": in_p.NET,
@@ -128,7 +126,7 @@ Component(
         "REF2": ref_pins["ref2"].NET,
         "REF1": ref_pins["ref1"].NET,
         "8": out.NET,
-    }
+    },
 )
 
 if implementation_type == ImplementationType("WITH_PASSIVES"):

--- a/examples/L6387E/L6387E.zen
+++ b/examples/L6387E/L6387E.zen
@@ -12,20 +12,20 @@ Features:
 - Interlocking function to prevent simultaneous turn-on
 """
 
-load("@stdlib/interfaces.zen", "Gpio")
-
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 ImplementationType = enum("NO_PASSIVES", "WITH_PASSIVES")
 Package = enum("DIP", "SOIC")
 
-implementation_type = config("implementation_type", ImplementationType, default=ImplementationType("WITH_PASSIVES"), optional=True)
+implementation_type = config(
+    "implementation_type", ImplementationType, default=ImplementationType("WITH_PASSIVES"), optional=True
+)
 package = config("package", Package, default=Package("SOIC"))
 bootstrap_cap_value = config("bootstrap_cap_value", str, default="100nF 10%")
 
 component_config = {
     "symbols": {
-        Package("SOIC"): Symbol(library = "./L6387ED.kicad_sym"),
+        Package("SOIC"): Symbol(library="./L6387ED.kicad_sym"),
     },
     "footprints": {
         Package("SOIC"): "Package_SOIC:SOIC-8_3.9x4.9mm_P1.27mm",
@@ -38,21 +38,21 @@ component_config = {
 
 properties = config("properties", dict, optional=True)
 
-lin = io("lin", Gpio)            # Low side driver logic input
-hin = io("hin", Gpio)            # High side driver logic input
-vcc = io("vcc", Power)           # Low voltage power supply (max 17V)
-gnd = io("gnd", Ground)          # Ground
-LVG = io("LVG", Net)            # Low side driver output
-OUT = io("OUT", Net)             # High side driver floating reference (max 580V)
-HVG = io("HVG", Net)             # High side driver output
-VBOOT = io("VBOOT", Net)         # Bootstrap supply voltage (VBOOT-OUT ≤ 17V)
+lin = io("lin", Net)  # Low side driver logic input
+hin = io("hin", Net)  # High side driver logic input
+vcc = io("vcc", Power)  # Low voltage power supply (max 17V)
+gnd = io("gnd", Ground)  # Ground
+LVG = io("LVG", Net)  # Low side driver output
+OUT = io("OUT", Net)  # High side driver floating reference (max 580V)
+HVG = io("HVG", Net)  # High side driver output
+VBOOT = io("VBOOT", Net)  # Bootstrap supply voltage (VBOOT-OUT ≤ 17V)
 
 symbol = component_config["symbols"][package]
 footprint = component_config["footprints"][package]
 mpn = component_config["mpns"][package]
 part = Part(
-    mpn = mpn,
-    manufacturer = "STMicroelectronics",
+    mpn=mpn,
+    manufacturer="STMicroelectronics",
 )
 
 Component(
@@ -65,11 +65,11 @@ Component(
         "HIN": hin.NET,
         "VCC": vcc.NET,
         "GND": gnd.NET,
-        "LVG": LVG, 
+        "LVG": LVG,
         "OUT": OUT,
         "HVG": HVG,
         "VBOOT": VBOOT,
-    }
+    },
 )
 
 # Add passive components if configured
@@ -78,11 +78,4 @@ if implementation_type == ImplementationType("WITH_PASSIVES"):
     # Based on datasheet recommendation, CBOOT should be much larger than the external
     # MOSFET gate capacitance. A typical value of 100nF is used.
     # For a MOSFET with 30nC gate charge at 10V, the expected voltage drop would be ~300mV.
-    Capacitor(
-        name="C_BOOT",
-        value=bootstrap_cap_value,
-        voltage="50V",
-        package="0805",
-        P1=VBOOT,
-        P2=OUT
-    )
+    Capacitor(name="C_BOOT", value=bootstrap_cap_value, voltage="50V", package="0805", P1=VBOOT, P2=OUT)

--- a/examples/PhaseDriver/PhaseDriver.zen
+++ b/examples/PhaseDriver/PhaseDriver.zen
@@ -1,5 +1,3 @@
-load("@stdlib/interfaces.zen", "Gpio", "Analog", "Pwm")
-
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
 Resistor = Module("@stdlib/generics/Resistor.zen")
 HighSideCurrentSense = Module("../HighSideCurrentSense/HighSideCurrentSense.zen")
@@ -9,16 +7,16 @@ L6387E = Module("../L6387E/L6387E.zen")
 POWER_GATE_DRIVE = io("POWER_GATE_DRIVE", Power)
 POWER_PHASE = io("POWER_PHASE", Power)
 POWER_3V3 = io("POWER_3V3", Power)
-PWM_LOW = io("PWM_LOW", Pwm)
-PWM_HIGH = io("PWM_HIGH", Pwm)
-ISENSE = io("ISENSE", Analog)
-PHASE_BEMF = io("PHASE_BEMF", Analog)
+PWM_LOW = io("PWM_LOW", Net)
+PWM_HIGH = io("PWM_HIGH", Net)
+ISENSE = io("ISENSE", Net)
+PHASE_BEMF = io("PHASE_BEMF", Net)
 PHASE_OUT = io("PHASE_OUT", Net)
 P_GROUND = io("P_GROUND", Ground)
 D_GROUND = io("D_GROUND", Ground)
-GPIO_BEMF = io("GPIO_BEMF", Gpio)
-RUN_ENABLE = io("RUN_ENABLE", Gpio)
-N_RUN_ENABLE = io("N_RUN_ENABLE", Gpio)
+GPIO_BEMF = io("GPIO_BEMF", Net)
+RUN_ENABLE = io("RUN_ENABLE", Net)
+N_RUN_ENABLE = io("N_RUN_ENABLE", Net)
 
 POWER_PHASE_POST_SHUNT = Power()
 VBOOT_NET = Net()
@@ -37,53 +35,53 @@ L6387E(
     gnd = P_GROUND,
     VBOOT = VBOOT_NET,
     OUT = PHASE_OUT,
-    lin = Gpio(NET = PWM_LOW.NET),
-    hin = Gpio(NET = PWM_HIGH.NET),
+    lin = PWM_LOW,
+    hin = PWM_HIGH,
     LVG = LOW_SIDE_GATE_P1,
     HVG = HIGH_SIDE_GATE_P1,
 )
 
 Component(
-    name = "D_BOOTSTRAP",
-    symbol = Symbol(library = "./B05100W-TP.kicad_sym"),
-    footprint = "Diode_SMD:D_SOD-123",
-    properties = {
+    name="D_BOOTSTRAP",
+    symbol=Symbol(library="./B05100W-TP.kicad_sym"),
+    footprint="Diode_SMD:D_SOD-123",
+    properties={
         "mpn": "B05100W",
         "description": "Schottky Diode",
         "voltage": "100V",
         "current": "1A",
     },
-    pins = {
+    pins={
         "A": POWER_GATE_DRIVE.NET,
         "K": VBOOT_NET,
     }
 )
 
 Capacitor(
-    name = "C_VCC",
-    value = "470nF 10%",
-    voltage = "25V",
-    package = "0402",
-    P1 = POWER_GATE_DRIVE.NET,
-    P2 = P_GROUND.NET,
+    name="C_VCC",
+    value="470nF 10%",
+    voltage="25V",
+    package="0402",
+    P1=POWER_GATE_DRIVE.NET,
+    P2=P_GROUND.NET,
 )
 
 Capacitor(
-    name = "C_HIGH_IN",
-    value = "100pF 10%",
-    voltage = "25V",
-    package = "0402",
-    P1 = PWM_HIGH.NET,
-    P2 = P_GROUND.NET,
+    name="C_HIGH_IN",
+    value="100pF 10%",
+    voltage="25V",
+    package="0402",
+    P1=PWM_HIGH.NET,
+    P2=P_GROUND.NET,
 )
 
 Capacitor(
-    name = "C_LOW_IN",
-    value = "100pF 10%",
-    voltage = "25V", 
-    package = "0402",
-    P1 = PWM_LOW.NET,
-    P2 = P_GROUND.NET,
+    name="C_LOW_IN",
+    value="100pF 10%",
+    voltage="25V",
+    package="0402",
+    P1=PWM_LOW.NET,
+    P2=P_GROUND.NET,
 )
 
 # Fets
@@ -102,14 +100,14 @@ HighSideCurrentSense(
 )
 
 Component(
-    name = "STL100N8F7-high",
-    symbol = Symbol(library = "./STL100N8F7.kicad_sym"),
-    footprint = "Package_TO_SOT_SMD:TO-252-2",
-    part = Part(
-        mpn = "STL100N8F7",
-        manufacturer = "STMicroelectronics",
+    name="STL100N8F7-high",
+    symbol=Symbol(library="./STL100N8F7.kicad_sym"),
+    footprint="Package_TO_SOT_SMD:TO-252-2",
+    part=Part(
+        mpn="STL100N8F7",
+        manufacturer="STMicroelectronics",
     ),
-    properties = {
+    properties={
         "description": "N-Channel MOSFET",
         "voltage": "80V",
         "current": "100A",
@@ -125,18 +123,18 @@ Component(
         "S_1": PHASE_OUT,
         "S_2": PHASE_OUT,
         "S_3": PHASE_OUT,
-    }
+    },
 )
 
 Component(
-    name = "STL100N8F7-low",
-    symbol = Symbol(library = "./STL100N8F7.kicad_sym"),
-    footprint = "Package_TO_SOT_SMD:TO-252-2",
-    part = Part(
-        mpn = "STL100N8F7",
-        manufacturer = "STMicroelectronics",
+    name="STL100N8F7-low",
+    symbol=Symbol(library="./STL100N8F7.kicad_sym"),
+    footprint="Package_TO_SOT_SMD:TO-252-2",
+    part=Part(
+        mpn="STL100N8F7",
+        manufacturer="STMicroelectronics",
     ),
-    properties = {
+    properties={
         "description": "N-Channel MOSFET",
         "voltage": "80V",
         "current": "100A",
@@ -152,10 +150,10 @@ Component(
         "S_1": P_GROUND.NET,
         "S_2": P_GROUND.NET,
         "S_3": P_GROUND.NET,
-    }
+    },
 )
 
-# Connecting Components 
+# Connecting Components
 
 Resistor(
     name = "R_HIGH_GATE",
@@ -211,43 +209,43 @@ Capacitor(
 
 
 Capacitor(
-    name = "C_IN",
-    value = "10uF 20%",
-    voltage = "100V",
-    package = "1210",
-    P1 = POWER_PHASE.NET,
-    P2 = P_GROUND.NET,
-    properties = {
+    name="C_IN",
+    value="10uF 20%",
+    voltage="100V",
+    package="1210",
+    P1=POWER_PHASE.NET,
+    P2=P_GROUND.NET,
+    properties={
         "mpn": "GMC32X7S106K100NT",
-    }
+    },
 )
 
 # Bemf
 
 Component(
-    name = "bemf_d1",
-    symbol = Symbol(library = "./BAT30KFILM.kicad_sym"),
-    footprint = "Diode_SMD:D_SOD-123",
-    properties = {
+    name="bemf_d1",
+    symbol=Symbol(library="./BAT30KFILM.kicad_sym"),
+    footprint="Diode_SMD:D_SOD-123",
+    properties={
         "mpn": "BAT30KFILM",
         "description": "Schottky Diode",
         "voltage": "30V",
         "current": "200mA",
     },
-    pins = {
+    pins={
         "A": PHASE_BEMF.NET,
         "K": POWER_3V3.NET,
-    }
+    },
 )
 
 BEMF_R_NET = Net()
 
 Resistor(
-    name = "bemf_r_top",
-    value = "120kohm 1%",
-    package = "0402",
-    P1 = PHASE_OUT,
-    P2 = PHASE_BEMF.NET,
+    name="bemf_r_top",
+    value="120kohm 1%",
+    package="0402",
+    P1=PHASE_OUT,
+    P2=PHASE_BEMF.NET,
 )
 
 Resistor(
@@ -259,10 +257,10 @@ Resistor(
 )
 
 Component(
-    name = "bemf_d2",
-    symbol = Symbol(library = "./BAT30KFILM.kicad_sym"),
-    footprint = "Diode_SMD:D_SOD-123",
-    properties = {
+    name="bemf_d2",
+    symbol=Symbol(library="./BAT30KFILM.kicad_sym"),
+    footprint="Diode_SMD:D_SOD-123",
+    properties={
         "mpn": "BAT30KFILM",
         "description": "Schottky Diode",
         "voltage": "30V",
@@ -271,5 +269,5 @@ Component(
     pins = {
         "A": BEMF_R_NET,
         "K": GPIO_BEMF.NET,
-    }
+    },
 )

--- a/examples/PhaseDriver/PhaseDriver.zen
+++ b/examples/PhaseDriver/PhaseDriver.zen
@@ -28,17 +28,17 @@ LOW_SIDE_GATE_P2 = Net()
 
 # Gate Driver
 L6387E(
-    name = "L6387ED",
-    package = "SOIC",
-    bootstrap_cap_value = "1uF 10%",
-    vcc = POWER_GATE_DRIVE,
-    gnd = P_GROUND,
-    VBOOT = VBOOT_NET,
-    OUT = PHASE_OUT,
-    lin = PWM_LOW,
-    hin = PWM_HIGH,
-    LVG = LOW_SIDE_GATE_P1,
-    HVG = HIGH_SIDE_GATE_P1,
+    name="L6387ED",
+    package="SOIC",
+    bootstrap_cap_value="1uF 10%",
+    vcc=POWER_GATE_DRIVE,
+    gnd=P_GROUND,
+    VBOOT=VBOOT_NET,
+    OUT=PHASE_OUT,
+    lin=PWM_LOW,
+    hin=PWM_HIGH,
+    LVG=LOW_SIDE_GATE_P1,
+    HVG=HIGH_SIDE_GATE_P1,
 )
 
 Component(
@@ -54,7 +54,7 @@ Component(
     pins={
         "A": POWER_GATE_DRIVE.NET,
         "K": VBOOT_NET,
-    }
+    },
 )
 
 Capacitor(
@@ -87,16 +87,16 @@ Capacitor(
 # Fets
 
 HighSideCurrentSense(
-    name = "R_SHUNT",
-    ref_config = "MIDSUPPLY",
-    shunt_value = "0.010ohm 1%",
-    shunt_package = "2512",
-    shunt_mpn = "WSLP2010R0100FEA",
-    power_bus_in = POWER_PHASE,
-    power_bus_out = POWER_PHASE_POST_SHUNT,
-    power_3v3 = POWER_3V3,
-    isense_out = ISENSE,
-    gnd = D_GROUND,
+    name="R_SHUNT",
+    ref_config="MIDSUPPLY",
+    shunt_value="0.010ohm 1%",
+    shunt_package="2512",
+    shunt_mpn="WSLP2010R0100FEA",
+    power_bus_in=POWER_PHASE,
+    power_bus_out=POWER_PHASE_POST_SHUNT,
+    power_3v3=POWER_3V3,
+    isense_out=ISENSE,
+    gnd=D_GROUND,
 )
 
 Component(
@@ -113,7 +113,7 @@ Component(
         "current": "100A",
         "rds_on": "7.5mOhm",
     },
-    pins = {
+    pins={
         "G": HIGH_SIDE_GATE_P2,
         "D_1": POWER_PHASE_POST_SHUNT.NET,
         "D_2": POWER_PHASE_POST_SHUNT.NET,
@@ -140,7 +140,7 @@ Component(
         "current": "100A",
         "rds_on": "7.5mOhm",
     },
-    pins = {
+    pins={
         "G": LOW_SIDE_GATE_P2,
         "D_1": PHASE_OUT,
         "D_2": PHASE_OUT,
@@ -156,55 +156,55 @@ Component(
 # Connecting Components
 
 Resistor(
-    name = "R_HIGH_GATE",
-    value = "33ohms 1%",
-    package = "0402",
-    P1 = HIGH_SIDE_GATE_P1,
-    P2 = HIGH_SIDE_GATE_P2,
+    name="R_HIGH_GATE",
+    value="33ohms 1%",
+    package="0402",
+    P1=HIGH_SIDE_GATE_P1,
+    P2=HIGH_SIDE_GATE_P2,
 )
 
 Resistor(
-    name = "R_LOW_GATE",
-    value = "33ohms 1%", 
-    package = "0402",
-    P1 = LOW_SIDE_GATE_P1,
-    P2 = LOW_SIDE_GATE_P2,
+    name="R_LOW_GATE",
+    value="33ohms 1%",
+    package="0402",
+    P1=LOW_SIDE_GATE_P1,
+    P2=LOW_SIDE_GATE_P2,
 )
 
 # Gate-Source discharge resistors
 Resistor(
-    name = "R_HIGH_GS",
-    value = "10kohm 1%",
-    package = "0402",
-    P1 = HIGH_SIDE_GATE_P2,
-    P2 = PHASE_OUT,
+    name="R_HIGH_GS",
+    value="10kohm 1%",
+    package="0402",
+    P1=HIGH_SIDE_GATE_P2,
+    P2=PHASE_OUT,
 )
 
 Resistor(
-    name = "R_LOW_GS", 
-    value = "10kohm 1%",
-    package = "0402",
-    P1 = LOW_SIDE_GATE_P2,
-    P2 = P_GROUND.NET,
+    name="R_LOW_GS",
+    value="10kohm 1%",
+    package="0402",
+    P1=LOW_SIDE_GATE_P2,
+    P2=P_GROUND.NET,
 )
 
 PHASE_R_OUT = Net()
 
 Resistor(
-    name = "R_OUT",
-    value = "1ohm 1%",
-    package = "0603",
-    P1 = PHASE_OUT,
-    P2 = PHASE_R_OUT,
+    name="R_OUT",
+    value="1ohm 1%",
+    package="0603",
+    P1=PHASE_OUT,
+    P2=PHASE_R_OUT,
 )
 
 Capacitor(
-    name = "C_OUT",
-    value = "10nF 1%",
-    voltage = "100V",
-    package = "0603",
-    P1 = PHASE_R_OUT,
-    P2 = P_GROUND.NET,
+    name="C_OUT",
+    value="10nF 1%",
+    voltage="100V",
+    package="0603",
+    P1=PHASE_R_OUT,
+    P2=P_GROUND.NET,
 )
 
 
@@ -249,11 +249,11 @@ Resistor(
 )
 
 Resistor(
-    name = "bemf_r_bottom",
-    value = "4.7kohm 1%",
-    package = "0402",
-    P1 = BEMF_R_NET,
-    P2 = PHASE_BEMF.NET,
+    name="bemf_r_bottom",
+    value="4.7kohm 1%",
+    package="0402",
+    P1=BEMF_R_NET,
+    P2=PHASE_BEMF.NET,
 )
 
 Component(
@@ -266,7 +266,7 @@ Component(
         "voltage": "30V",
         "current": "200mA",
     },
-    pins = {
+    pins={
         "A": BEMF_R_NET,
         "K": GPIO_BEMF.NET,
     },

--- a/examples/RCFilter/RCFilter.zen
+++ b/examples/RCFilter/RCFilter.zen
@@ -3,15 +3,14 @@ A simple RC low-pass filter using standard KiCad components.
 This demonstrates using both resistors and capacitors from the standard library.
 """
 
-load("@stdlib/interfaces.zen", "Analog")
 Resistor = Module("@stdlib/generics/Resistor.zen")
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
 
 r_value = config("r_value", str, default="1kohms", optional=True)
 c_value = config("c_value", str, default="100nF", optional=True)
 
-input = io("input", Analog)
-output = io("output", Analog)
+input = io("input", Net)
+output = io("output", Net)
 gnd = io("gnd", Ground)
 
 Resistor(name="R1", value=r_value, package="0603", P1=input.NET, P2=output.NET)

--- a/examples/VoltageDivider/VoltageDivider.zen
+++ b/examples/VoltageDivider/VoltageDivider.zen
@@ -3,14 +3,13 @@ A simple voltage divider circuit using standard KiCad components.
 This demonstrates basic module structure without external dependencies.
 """
 
-load("@stdlib/interfaces.zen", "Analog")
 Resistor = Module("@stdlib/generics/Resistor.zen")
 
 r1_value = config("r1_value", str, default="10kohms", optional=True)
 r2_value = config("r2_value", str, default="10kohms", optional=True)
 
 vin = io("vin", Power)
-vout = io("vout", Analog)
+vout = io("vout", Net)
 gnd = io("gnd", Ground)
 
 Resistor(name="R1", value=r1_value, package="0603", P1=vin.NET, P2=vout.NET)


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new deprecation warnings to `NetType` constructor invocation for `Analog`, `Gpio`, and `Pwm`, which can change evaluation output and potentially impact workflows/tests that treat warnings as failures.
> 
> **Overview**
> Deprecates the stdlib net types `Analog`, `Gpio`, and `Pwm` in favor of `Net` by emitting **runtime deprecation diagnostics** when those constructors are called (but not when they are `load()`ed).
> 
> Updates tests, snapshots, docs/spec text, and example designs to stop using these legacy types (replacing them with `Net` or custom `builtin.net_type(...)` names like `Signal`), and refreshes related golden outputs to match the new warning behavior and source locations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d47649685c23977044a97a2196c018200fa968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->