### PR TITLE
fix: speculative fix for LSP memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Deprecated generic modules `generics/Bjt.zen`, `generics/Diode.zen`, `generics/Mosfet.zen`, and `generics/OperationalAmplifier.zen`.
 - Deprecated non-standard packages in `generics/Inductor.zen`.
 
+### Fixed
+- Fixed an LSP memory leak during reparsing.
+
 ## [0.3.66] - 2026-04-06
 
 ## [0.3.65] - 2026-04-03

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -814,6 +814,7 @@ impl EvalSession {
     /// since schematic conversion reads the shared module tree from the session.
     pub fn prepare_for_root_eval(&self) {
         self.clear_module_tree();
+        self.reset_frozen_heap();
     }
 
     // --- Module tree ---
@@ -828,6 +829,10 @@ impl EvalSession {
 
     fn clear_module_tree(&self) {
         self.module_tree.write().unwrap().clear();
+    }
+
+    fn reset_frozen_heap(&self) {
+        *self.frozen_heap.lock().unwrap() = FrozenHeap::new();
     }
 
     // --- Load cache ---
@@ -1621,7 +1626,7 @@ impl EvalContext {
         contents: String,
     ) -> WithDiagnostics<ParseAndAnalyzeOutput> {
         self.session.clear_load_cache();
-        self.session.clear_module_tree();
+        self.session.prepare_for_root_eval();
         self.session.clear_symbol_maps(&path);
 
         // Update the in-memory file contents


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core evaluation-session lifecycle by resetting the shared Starlark `FrozenHeap` on each root reparse, which could impact memory/performance and any code relying on cross-parse frozen references.
> 
> **Overview**
> Addresses an LSP reparse memory leak by expanding `EvalSession::prepare_for_root_eval()` to also reset the shared Starlark `FrozenHeap`, and switching `parse_and_analyze_file()` to use this full per-root reset instead of only clearing the module tree.
> 
> Updates the changelog to note the LSP memory-leak fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faab247ceb45d0adbab9b81ade4297e1517b2437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
