### PR TITLE
Default hidden symbol properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Deprecated the `Schematics()` helper.
 - Deprecated generic modules `generics/Bjt.zen`, `generics/Diode.zen`, `generics/Mosfet.zen`, and `generics/OperationalAmplifier.zen`.
 - Deprecated non-standard packages in `generics/Inductor.zen`.
+- Newly added KiCad symbol properties now default to `justify left top` and `hide yes`.
 
 ### Fixed
 - `pcb build --offline` now reuses selected locked pseudo-versions for rev-pinned workspace deps.

--- a/crates/pcb-sexpr/src/kicad/symbol.rs
+++ b/crates/pcb-sexpr/src/kicad/symbol.rs
@@ -177,6 +177,12 @@ fn default_property_node(name: &str, value: &str) -> Sexpr {
                     Sexpr::float(1.27),
                 ]),
             ]),
+            Sexpr::list(vec![
+                Sexpr::symbol("justify"),
+                Sexpr::symbol("left"),
+                Sexpr::symbol("top"),
+            ]),
+            Sexpr::list(vec![Sexpr::symbol("hide"), Sexpr::symbol("yes")]),
         ]),
     ])
 }
@@ -244,5 +250,10 @@ mod tests {
         assert_eq!(props.get("Reference"), Some(&"Q".to_string()));
         assert_eq!(props.get("Value"), Some(&"A".to_string()));
         assert!(!props.contains_key("Obsolete"));
+
+        let rendered = crate::formatter::format_tree(&parsed, crate::formatter::FormatMode::Normal);
+        assert!(rendered.contains("(property \"Value\" \"A\""));
+        assert!(rendered.contains("(justify left top)"));
+        assert!(rendered.contains("(hide yes)"));
     }
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts default S-expression emitted for newly created KiCad symbol `property` nodes and extends tests/changelog; no changes to parsing or rewrite semantics beyond new default fields.
> 
> **Overview**
> Newly created KiCad symbol `property` nodes now include default `(justify left top)` and `(hide yes)` in their `effects` block, making added properties hidden and consistently aligned.
> 
> Updates the `rewrite_symbol_properties` test to assert these defaults are present in the rendered `.kicad_sym`, and documents the behavior change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a39b8772ab1d179a3d136c048b96d3dd6b6079a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->