### PR TITLE
Prefer resolved deps over lockfile pseudo-version seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `PhysicalValue` is now hashable in Starlark, including after freezing.
 - Layout sync no longer creates empty footprint `(embedded_files)` blocks that KiCad removes on save.
 - Fixed an LSP memory leak during reparsing.
+- Rev-pinned dependencies now override stale lockfile-seeded pseudo-versions during resolution.
 
 ## [0.3.66] - 2026-04-06
 

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -23,7 +23,7 @@ pub use pcb_zen_core::file_extensions;
 pub use pcb_zen_core::{Diagnostic, Diagnostics, WithDiagnostics};
 pub use resolve::{
     VendorResult, copy_dir_all, ensure_sparse_checkout, print_dep_tree, resolve_dependencies,
-    vendor_deps,
+    resolve_dependencies_for_update, vendor_deps,
 };
 pub use starlark::errors::EvalSeverity;
 pub use workspace::{MemberPackage, WorkspaceInfo, get_workspace_info};

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -90,6 +90,24 @@ struct UnresolvedDep {
     spec: DependencySpec,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequirementSource {
+    LockfileSeed,
+    Dependency,
+}
+
+impl RequirementSource {
+    fn is_stronger_than(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (
+                RequirementSource::Dependency,
+                RequirementSource::LockfileSeed
+            )
+        )
+    }
+}
+
 fn missing_workspace_member_error(workspace_info: &WorkspaceInfo, url: &str) -> anyhow::Error {
     let missing_manifest_hint = workspace_info
         .workspace_base_url()
@@ -564,6 +582,7 @@ pub fn resolve_dependencies(
 
     // MVS state
     let mut selected: HashMap<ModuleLine, Version> = HashMap::new();
+    let mut selected_sources: HashMap<ModuleLine, RequirementSource> = HashMap::new();
     let mut work_queue: VecDeque<ModuleLine> = VecDeque::new();
     let mut manifest_cache: HashMap<(ModuleLine, Version), PcbToml> = HashMap::new();
 
@@ -595,8 +614,10 @@ pub fn resolve_dependencies(
                 entry.module_path.clone(),
                 version,
                 &mut selected,
+                &mut selected_sources,
                 &mut work_queue,
                 &patches,
+                RequirementSource::LockfileSeed,
             );
         }
     }
@@ -683,15 +704,25 @@ pub fn resolve_dependencies(
                 dep.url.clone(),
                 version,
                 &mut selected,
+                &mut selected_sources,
                 &mut work_queue,
                 &patches,
+                RequirementSource::Dependency,
             );
         }
     }
 
     // Seed MVS with implicit stdlib asset requirements from workspace configuration.
     for (repo, version) in workspace_info.stdlib_asset_dep_versions() {
-        add_requirement(repo, version, &mut selected, &mut work_queue, &patches);
+        add_requirement(
+            repo,
+            version,
+            &mut selected,
+            &mut selected_sources,
+            &mut work_queue,
+            &patches,
+            RequirementSource::Dependency,
+        );
     }
 
     let fetch_pool = build_fetch_pool()?;
@@ -800,8 +831,10 @@ pub fn resolve_dependencies(
                     dep_path.clone(),
                     dep_version,
                     &mut selected,
+                    &mut selected_sources,
                     &mut work_queue,
                     &patches,
+                    RequirementSource::Dependency,
                 );
                 if work_queue.len() > before {
                     new_deps += 1;
@@ -2127,15 +2160,18 @@ impl PseudoVersionContext {
     }
 }
 
-/// Add a requirement to the MVS state (monotonic upgrade)
+/// Add a requirement to the MVS state.
 ///
+/// Lockfile-preseeded versions are weak hints; dependency-derived versions are authoritative.
 /// Patches are checked here - they override version selection with ultimate authority.
 fn add_requirement(
     path: String,
     version: Version,
     selected: &mut HashMap<ModuleLine, Version>,
+    selected_sources: &mut HashMap<ModuleLine, RequirementSource>,
     work_queue: &mut VecDeque<ModuleLine>,
     patches: &BTreeMap<String, pcb_zen_core::config::PatchSpec>,
+    source: RequirementSource,
 ) {
     if is_stdlib_module_path(&path) {
         return;
@@ -2152,23 +2188,32 @@ fn add_requirement(
     };
 
     let line = ModuleLine::new(path.clone(), &final_version);
-
-    let needs_update = match selected.get(&line) {
-        None => true,
-        Some(current) => final_version > *current,
+    let current_version = selected.get(&line);
+    let current_source = selected_sources.get(&line).copied();
+    let needs_update = match (current_version, current_source) {
+        (None, _) => true,
+        (Some(_), Some(existing_source)) if source.is_stronger_than(existing_source) => true,
+        (Some(_), Some(existing_source)) if existing_source.is_stronger_than(source) => false,
+        (Some(current), _) => final_version > *current,
     };
 
     if needs_update {
-        let action = if selected.contains_key(&line) {
-            "Upgrading"
-        } else {
-            "Adding"
+        let version_changed = current_version != Some(&final_version);
+        let action = match current_version {
+            None => "Adding",
+            Some(current) if final_version > *current => "Upgrading",
+            Some(_) => "Selecting",
         };
         let suffix = if is_patched { " (patched)" } else { "" };
-        log::debug!("  → {} {}@v{}{}", action, path, final_version, suffix);
+        if version_changed {
+            log::debug!("  → {} {}@v{}{}", action, path, final_version, suffix);
+        }
 
         selected.insert(line.clone(), final_version);
-        work_queue.push_back(line);
+        selected_sources.insert(line.clone(), source);
+        if version_changed {
+            work_queue.push_back(line);
+        }
     }
 }
 
@@ -2825,5 +2870,46 @@ mod tests {
         .expect("expected matching locked pseudo-version");
 
         assert_eq!(version, pseudo);
+    }
+
+    #[test]
+    fn test_dependency_requirement_overrides_lockfile_seed_for_same_line() {
+        let dep = "github.com/mycompany/components/SimpleResistor".to_string();
+        let lockfile_seed =
+            Version::parse("0.1.1-0.20260101000000-f000000000000000000000000000000000000000")
+                .unwrap();
+        let resolved_dep =
+            Version::parse("0.1.1-0.20260101000000-1000000000000000000000000000000000000000")
+                .unwrap();
+        let line = ModuleLine::new(dep.clone(), &lockfile_seed);
+        let mut selected = HashMap::new();
+        let mut selected_sources = HashMap::new();
+        let mut work_queue = VecDeque::new();
+        let patches = BTreeMap::new();
+
+        add_requirement(
+            dep.clone(),
+            lockfile_seed,
+            &mut selected,
+            &mut selected_sources,
+            &mut work_queue,
+            &patches,
+            RequirementSource::LockfileSeed,
+        );
+        add_requirement(
+            dep,
+            resolved_dep.clone(),
+            &mut selected,
+            &mut selected_sources,
+            &mut work_queue,
+            &patches,
+            RequirementSource::Dependency,
+        );
+
+        assert_eq!(selected.get(&line), Some(&resolved_dep));
+        assert_eq!(
+            selected_sources.get(&line),
+            Some(&RequirementSource::Dependency)
+        );
     }
 }

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -411,20 +411,17 @@ fn normalize_or_validate_branch_deps(
 /// Refresh `{ branch = "...", rev = "..." }` dependencies to current branch tip.
 ///
 /// Returns the number of dependency entries whose `rev` changed.
-pub fn refresh_branch_pins_in_manifests(
-    pcb_toml_paths: &[PathBuf],
+fn refresh_branch_pins(
+    workspace_info: &mut WorkspaceInfo,
     package_filter: &[String],
 ) -> Result<usize> {
     let file_provider = DefaultFileProvider::new();
     let mut refreshed = 0usize;
 
-    for pcb_toml_path in pcb_toml_paths {
-        if !pcb_toml_path.exists() {
-            continue;
-        }
-
-        let _manifest_lock = git::lock_manifest(pcb_toml_path)?;
-        let mut config = PcbToml::from_file(&file_provider, pcb_toml_path)?;
+    for pkg in workspace_info.packages.values() {
+        let pcb_toml_path = pkg.dir(&workspace_info.root).join("pcb.toml");
+        let _manifest_lock = git::lock_manifest(&pcb_toml_path)?;
+        let mut config = PcbToml::from_file(&file_provider, &pcb_toml_path)?;
         let mut changed = false;
 
         for (dep_url, spec) in &mut config.dependencies {
@@ -463,11 +460,24 @@ pub fn refresh_branch_pins_in_manifests(
         }
 
         if changed {
-            std::fs::write(pcb_toml_path, toml::to_string_pretty(&config)?)?;
+            std::fs::write(&pcb_toml_path, toml::to_string_pretty(&config)?)?;
         }
     }
 
+    if refreshed > 0 {
+        workspace_info.reload()?;
+    }
+
     Ok(refreshed)
+}
+
+pub fn resolve_dependencies_for_update(
+    workspace_info: &mut WorkspaceInfo,
+    package_filter: &[String],
+) -> Result<(ResolutionResult, usize)> {
+    let refreshed_branch_pins = refresh_branch_pins(workspace_info, package_filter)?;
+    let resolution = resolve_dependencies(workspace_info, false, false)?;
+    Ok((resolution, refreshed_branch_pins))
 }
 
 /// Dependency resolution.

--- a/crates/pcb/src/update.rs
+++ b/crates/pcb/src/update.rs
@@ -9,7 +9,7 @@ use colored::Colorize;
 use inquire::MultiSelect;
 use pcb_zen::cache_index::CacheIndex;
 use pcb_zen::workspace::get_workspace_info;
-use pcb_zen::{WorkspaceInfo, resolve, tags};
+use pcb_zen::{WorkspaceInfo, resolve_dependencies_for_update, tags};
 use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::config::{DependencySpec, PcbToml, split_repo_and_subpath};
 use pcb_zen_core::resolution::semver_family;
@@ -128,27 +128,6 @@ fn detect_update_scope(workspace: &WorkspaceInfo, start_path: &Path) -> UpdateSc
     }
 }
 
-/// Collect all pcb.toml paths in the workspace
-fn collect_pcb_tomls(workspace: &WorkspaceInfo, scope: &UpdateScope) -> Vec<PathBuf> {
-    match scope {
-        UpdateScope::Workspace => {
-            let mut paths = Vec::new();
-            let root = workspace.root.join("pcb.toml");
-            if root.exists() {
-                paths.push(root);
-            }
-            for pkg in workspace.packages.values() {
-                let p = pkg.dir(&workspace.root).join("pcb.toml");
-                if p.exists() {
-                    paths.push(p);
-                }
-            }
-            paths
-        }
-        UpdateScope::Package { pcb_toml_path } => vec![pcb_toml_path.clone()],
-    }
-}
-
 fn matches_filter(url: &str, filter: &[String]) -> bool {
     filter.is_empty() || filter.iter().any(|p| url.contains(p))
 }
@@ -181,10 +160,9 @@ pub fn execute(args: UpdateArgs) -> Result<()> {
 
     // Display and apply version updates
     let applied_count = apply_version_updates(&version_updates)?;
-    let refreshed_branch_pins = resolve::refresh_branch_pins_in_manifests(
-        &collect_pcb_tomls(&workspace, &scope),
-        &args.packages,
-    )?;
+    let mut ws = workspace.clone();
+    let (resolution, refreshed_branch_pins) =
+        resolve_dependencies_for_update(&mut ws, &args.packages)?;
     if refreshed_branch_pins > 0 {
         println!(
             "{}",
@@ -192,10 +170,6 @@ pub fn execute(args: UpdateArgs) -> Result<()> {
         );
     }
 
-    // Run resolution to update lockfile (will re-fetch branch commits)
-    // locked=false since update is explicitly for updating deps
-    let mut ws = workspace.clone();
-    let resolution = pcb_zen::resolve_dependencies(&mut ws, false, false)?;
     let lockfile_changed = resolution.lockfile_changed;
 
     if applied_count > 0 || refreshed_branch_pins > 0 || lockfile_changed {
@@ -324,7 +298,16 @@ fn find_version_updates(
     let mut version_cache: BTreeMap<String, BTreeMap<String, Vec<Version>>> = BTreeMap::new();
     let mut pending = Vec::new();
 
-    for pcb_toml_path in collect_pcb_tomls(workspace, scope) {
+    let pcb_toml_paths: Vec<_> = match scope {
+        UpdateScope::Workspace => workspace
+            .packages
+            .values()
+            .map(|pkg| pkg.dir(&workspace.root).join("pcb.toml"))
+            .collect(),
+        UpdateScope::Package { pcb_toml_path } => vec![pcb_toml_path.clone()],
+    };
+
+    for pcb_toml_path in pcb_toml_paths {
         let config = PcbToml::from_file(&DefaultFileProvider::new(), &pcb_toml_path)?;
 
         for (url, spec) in &config.dependencies {


### PR DESCRIPTION
Follow up to https://github.com/diodeinc/pcb/pull/688. The previous change made offline and online consistent. This change actually makes both correct by by making manifest-resolved rev pins override lockfile-seeded versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency version selection precedence inside MVS resolution, which can alter resolved versions and lockfile output across builds/updates. Risk is moderate because it touches core dependency resolution behavior but is scoped and covered by a new unit test.
> 
> **Overview**
> **Dependency resolution now treats lockfile entries as weak seeds.** During MVS selection, requirements originating from manifests (including rev/branch pins) can override stale pseudo-versions preseeded from `pcb.sum`, preventing lockfile hints from winning over current dependency constraints.
> 
> **`pcb update` flow is consolidated.** Branch-pin refreshing is moved behind a new `resolve_dependencies_for_update` helper (exported from `pcb-zen`) so update runs refresh + resolve/lockfile update in one call, and the changelog notes the corrected rev-pin behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5dba0d6d6683ffa67c9d4e5225b13bbdfb4d9f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
