### PR TITLE
Simplify pcb scan datasheet resolution and output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Deprecated non-standard packages in `generics/Inductor.zen`.
 - Newly added KiCad symbol properties now default to `justify left top` and `hide yes`.
 - `pcb scan` now resolves local PDFs through the shared datasheet materialization cache by default, and `--output` copies the materialized Markdown and images out of that cache.
+- `pcb scan` now prints both `PDF:` and `Markdown:` output paths, with local PDF scans reporting the original input PDF path and URL scans reporting the materialized cached PDF path.
 
 ### Fixed
 - `pcb build --offline` now reuses selected locked pseudo-versions for rev-pinned workspace deps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Deprecated generic modules `generics/Bjt.zen`, `generics/Diode.zen`, `generics/Mosfet.zen`, and `generics/OperationalAmplifier.zen`.
 - Deprecated non-standard packages in `generics/Inductor.zen`.
 - Newly added KiCad symbol properties now default to `justify left top` and `hide yes`.
+- `pcb scan` now resolves local PDFs through the shared datasheet materialization cache by default, and `--output` copies the materialized Markdown and images out of that cache.
 
 ### Fixed
 - `pcb build --offline` now reuses selected locked pseudo-versions for rev-pinned workspace deps.

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -616,15 +616,7 @@ fn process_component_datasheet(
         return (DatasheetProcessingOutcome::NotResolved, warnings);
     }
 
-    match crate::scan::scan_from_source_path(
-        auth_token,
-        source_path,
-        component_dir,
-        scan_model,
-        true,  // images
-        false, // json
-        false, // show_output
-    ) {
+    match crate::scan::scan_from_source_path(auth_token, source_path, component_dir, scan_model) {
         Ok(_) => {
             if final_pdf_path.exists()
                 && let Err(e) = fs::remove_file(&final_pdf_path)

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -1461,15 +1461,15 @@ fn execute_from_dir(dir: &Path, workspace_root: &Path) -> Result<()> {
             &token,
             &crate::datasheet::ResolveDatasheetInput::PdfPath(datasheet_path),
         ) {
-            Ok(resolved) => {
-                crate::datasheet::copy_resolved_outputs(
-                    &resolved,
-                    &component_dir,
-                    Some(&format!("{}.md", &sanitized_mpn)),
-                    Some(&format!("{}.pdf", &sanitized_mpn)),
-                )?;
-                println!("  {}", "✓".green());
-            }
+            Ok(resolved) => match crate::datasheet::copy_resolved_outputs(
+                &resolved,
+                &component_dir,
+                Some(&format!("{}.md", &sanitized_mpn)),
+                Some(&format!("{}.pdf", &sanitized_mpn)),
+            ) {
+                Ok(_) => println!("  {}", "✓".green()),
+                Err(e) => println!("  {} scan failed: {}", "✗".red(), e),
+            },
             Err(e) => println!("  {} scan failed: {}", "✗".red(), e),
         }
     }

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -14,7 +14,7 @@ use pcb_zen_core::config::find_workspace_root;
 use regex::Regex;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -557,43 +557,12 @@ fn materialize_symbol_datasheet(
         },
     )?;
 
-    let target_pdf = component_dir.join(format!("{}.pdf", sanitized_mpn));
-    let target_md = component_dir.join(format!("{}.md", sanitized_mpn));
-    let target_images = component_dir.join("images");
-
-    copy_file_to_dir(
-        Path::new(&resolved.pdf_path),
+    crate::datasheet::copy_resolved_outputs(
+        &resolved,
         component_dir,
-        target_pdf
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("datasheet.pdf"),
+        Some(&format!("{}.md", sanitized_mpn)),
+        Some(&format!("{}.pdf", sanitized_mpn)),
     )?;
-    copy_file_to_dir(
-        Path::new(&resolved.markdown_path),
-        component_dir,
-        target_md
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("datasheet.md"),
-    )?;
-
-    if target_images.exists() {
-        fs::remove_dir_all(&target_images)
-            .with_context(|| format!("Failed to remove directory {}", target_images.display()))?;
-    }
-    let images_src = Path::new(&resolved.images_dir);
-    if images_src.exists() {
-        pcb_zen::copy_dir_all(images_src, &target_images, &HashSet::new()).with_context(|| {
-            format!(
-                "Failed to copy images directory {} -> {}",
-                images_src.display(),
-                target_images.display()
-            )
-        })?;
-    } else {
-        fs::create_dir_all(&target_images)?;
-    }
 
     Ok(())
 }
@@ -1488,13 +1457,19 @@ fn execute_from_dir(dir: &Path, workspace_root: &Path) -> Result<()> {
         println!("{} Scanning datasheet...", "→".blue().bold());
         let datasheet_path = component_dir.join(format!("{}.pdf", &sanitized_mpn));
         let token = crate::auth::get_valid_token()?;
-        match crate::scan::scan_with_defaults(
+        match crate::datasheet::resolve_datasheet(
             &token,
-            datasheet_path,
-            Some(component_dir.clone()),
-            true, // images
+            &crate::datasheet::ResolveDatasheetInput::PdfPath(datasheet_path),
         ) {
-            Ok(r) => println!("  {} ({} pages)", "✓".green(), r.page_count),
+            Ok(resolved) => {
+                crate::datasheet::copy_resolved_outputs(
+                    &resolved,
+                    &component_dir,
+                    Some(&format!("{}.md", &sanitized_mpn)),
+                    Some(&format!("{}.pdf", &sanitized_mpn)),
+                )?;
+                println!("  {}", "✓".green());
+            }
             Err(e) => println!("  {} scan failed: {}", "✗".red(), e),
         }
     }

--- a/crates/pcb-diode-api/src/datasheet.rs
+++ b/crates/pcb-diode-api/src/datasheet.rs
@@ -550,12 +550,6 @@ fn materialized_dir(materialization_id: &str) -> PathBuf {
         .join(materialization_id)
 }
 
-pub(crate) fn materialized_output_dir_for_pdf(pdf_path: &Path) -> Result<PathBuf> {
-    let pdf_sha256 = calculate_sha256(pdf_path)?;
-    let materialization_id = materialization_id_for_key(&pdf_sha256)?;
-    Ok(materialized_dir(&materialization_id))
-}
-
 fn url_pdf_cache_root_dir() -> PathBuf {
     cache_base().join("datasheets").join("pdfs")
 }

--- a/crates/pcb-diode-api/src/datasheet.rs
+++ b/crates/pcb-diode-api/src/datasheet.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::scan::{
     build_scan_client, calculate_sha256, download_file, download_process_artifacts, extract_zip,
-    request_process, request_upload_url, upload_pdf,
+    process_local_pdf, request_process,
 };
 
 const DATASHEET_NAMESPACE_UUID: &str = "fe255507-b3f4-4ec0-98cb-9e3f90cfd8eb";
@@ -34,6 +34,50 @@ pub struct ResolveDatasheetResponse {
     pub pdf_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub datasheet_url: Option<String>,
+}
+
+pub(crate) fn copy_resolved_outputs(
+    resolved: &ResolveDatasheetResponse,
+    output_dir: &Path,
+    markdown_filename: Option<&str>,
+    pdf_filename: Option<&str>,
+) -> Result<PathBuf> {
+    fs::create_dir_all(output_dir)?;
+
+    if let Some(pdf_filename) = pdf_filename {
+        let source_pdf = Path::new(&resolved.pdf_path);
+        let target_pdf = output_dir.join(pdf_filename);
+        copy_if_different(source_pdf, &target_pdf, "PDF")?;
+    }
+
+    let source_markdown = Path::new(&resolved.markdown_path);
+    let target_markdown = output_dir.join(markdown_filename.unwrap_or_else(|| {
+        source_markdown
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("datasheet.md")
+    }));
+    copy_if_different(source_markdown, &target_markdown, "markdown")?;
+
+    let source_images_dir = Path::new(&resolved.images_dir);
+    let target_images_dir = output_dir.join("images");
+    if target_images_dir.exists() {
+        fs::remove_dir_all(&target_images_dir).with_context(|| {
+            format!("Failed to remove directory {}", target_images_dir.display())
+        })?;
+    }
+    if source_images_dir.exists() {
+        pcb_zen::copy_dir_all(source_images_dir, &target_images_dir, &Default::default())
+            .with_context(|| {
+                format!(
+                    "Failed to copy images directory {} -> {}",
+                    source_images_dir.display(),
+                    target_images_dir.display()
+                )
+            })?;
+    }
+
+    Ok(target_markdown)
 }
 
 #[derive(Debug, Clone)]
@@ -141,7 +185,6 @@ fn execute_resolve_execution(
     execution: ResolveExecution,
     prefetched_process: Option<crate::scan::ProcessResponse>,
 ) -> Result<ResolveDatasheetResponse> {
-    let api_base_url = crate::get_api_base_url();
     let materialization_id = materialization_id_for_key(&execution.pdf_sha256)?;
     let materialized_dir = materialized_dir(&materialization_id);
     let markdown_path = materialized_dir.join(inferred_markdown_filename(&execution.pdf_path));
@@ -177,24 +220,11 @@ fn execute_resolve_execution(
             fs::create_dir_all(parent)?;
         }
 
-        let filename = inferred_pdf_filename(&execution.pdf_path);
-        let upload = request_upload_url(
+        process_local_pdf(
             client,
             auth_token,
-            &api_base_url,
-            &execution.pdf_sha256,
-            &filename,
-        )?;
-        if let Some(upload_url) = upload.upload_url.as_deref() {
-            upload_pdf(client, upload_url, &execution.pdf_path)?;
-        }
-
-        request_process(
-            client,
-            auth_token,
-            &api_base_url,
-            Some(&upload.source_path),
-            None,
+            &execution.pdf_path,
+            Some(&execution.pdf_sha256),
             None,
         )?
     };
@@ -356,6 +386,22 @@ fn resolve_local_datasheet_path_from_kicad_sym(
     Ok(symbol_dir.join(datasheet_path))
 }
 
+fn copy_if_different(source: &Path, target: &Path, label: &str) -> Result<()> {
+    if source == target {
+        return Ok(());
+    }
+
+    fs::copy(source, target).with_context(|| {
+        format!(
+            "Failed to copy {} {} -> {}",
+            label,
+            source.display(),
+            target.display()
+        )
+    })?;
+    Ok(())
+}
+
 fn select_symbol_from_library<'a>(
     symbol_lib: &'a pcb_eda::SymbolLibrary,
     path: &Path,
@@ -502,6 +548,12 @@ fn materialized_dir(materialization_id: &str) -> PathBuf {
         .join("datasheets")
         .join("materialized")
         .join(materialization_id)
+}
+
+pub(crate) fn materialized_output_dir_for_pdf(pdf_path: &Path) -> Result<PathBuf> {
+    let pdf_sha256 = calculate_sha256(pdf_path)?;
+    let materialization_id = materialization_id_for_key(&pdf_sha256)?;
+    Ok(materialized_dir(&materialization_id))
 }
 
 fn url_pdf_cache_root_dir() -> PathBuf {

--- a/crates/pcb-diode-api/src/datasheet.rs
+++ b/crates/pcb-diode-api/src/datasheet.rs
@@ -11,7 +11,8 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::scan::{
-    calculate_sha256, download_file, extract_zip, request_process, request_upload_url, upload_pdf,
+    build_scan_client, calculate_sha256, download_file, download_process_artifacts, extract_zip,
+    request_process, request_upload_url, upload_pdf,
 };
 
 const DATASHEET_NAMESPACE_UUID: &str = "fe255507-b3f4-4ec0-98cb-9e3f90cfd8eb";
@@ -84,9 +85,7 @@ pub fn resolve_datasheet(
     auth_token: &str,
     input: &ResolveDatasheetInput,
 ) -> Result<ResolveDatasheetResponse> {
-    let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(180))
-        .build()?;
+    let client = build_scan_client()?;
 
     match input {
         ResolveDatasheetInput::DatasheetUrl(url) => {
@@ -261,16 +260,20 @@ fn materialize_process_outputs(
     fs::create_dir_all(materialized_dir)?;
     let _ = fs::remove_file(complete_marker);
 
-    download_file(client, &process.markdown_url, markdown_path)
-        .context("Failed to download markdown output")?;
+    let zip_path = materialized_dir.join("images.zip");
+    download_process_artifacts(
+        client,
+        process,
+        markdown_path,
+        None,
+        process.images_zip_url.as_ref().map(|_| zip_path.as_path()),
+    )
+    .context("Failed to download datasheet outputs")?;
 
-    if let Some(images_zip_url) = process.images_zip_url.as_deref() {
-        let zip_path = materialized_dir.join("images.zip");
+    if process.images_zip_url.is_some() {
         let temp_images_dir = materialized_dir.join(format!(".images-{}", Uuid::new_v4()));
 
         let extract_result = (|| -> Result<()> {
-            download_file(client, images_zip_url, &zip_path)
-                .context("Failed to download image archive")?;
             fs::create_dir_all(&temp_images_dir)?;
             extract_zip(&zip_path, &temp_images_dir)?;
 

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -28,7 +28,7 @@ pub use registry::{
 pub use release::{upload_preview, upload_release};
 pub use scan::{
     ScanArgs, ScanModel, ScanModelArg, ScanOptions, ScanResult, execute as execute_scan,
-    scan_from_source_path, scan_pdf, scan_with_defaults,
+    scan_from_source_path, scan_pdf,
 };
 
 pub fn get_api_base_url() -> String {

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -26,10 +26,7 @@ pub use registry::{
     ParsedQuery, RegistryClient, RegistryPackage, RegistryPart, RegistrySearchResult, SearchHit,
 };
 pub use release::{upload_preview, upload_release};
-pub use scan::{
-    ScanArgs, ScanModel, ScanModelArg, ScanOptions, ScanResult, execute as execute_scan,
-    scan_from_source_path, scan_pdf,
-};
+pub use scan::{ScanArgs, ScanModel, ScanModelArg, execute as execute_scan};
 
 pub fn get_api_base_url() -> String {
     WorkspaceContext::from_cwd()

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -59,26 +59,6 @@ pub struct ScanOptions {
     pub images: bool,
 }
 
-pub fn scan_with_defaults(
-    auth_token: &str,
-    file: PathBuf,
-    output: Option<PathBuf>,
-    images: bool,
-) -> Result<ScanResult> {
-    let output_dir = match output {
-        Some(output_dir) => output_dir,
-        None => crate::datasheet::materialized_output_dir_for_pdf(&file)?,
-    };
-
-    let options = ScanOptions {
-        file,
-        output_dir,
-        images,
-    };
-
-    scan_pdf(auth_token, options)
-}
-
 /// Scan a PDF that already exists in Supabase storage (no upload needed)
 ///
 /// # Arguments

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -588,12 +588,22 @@ pub fn execute(args: ScanArgs) -> Result<()> {
     let input = parse_scan_input(&args.input)?;
 
     let token = crate::auth::get_valid_token()?;
-    let resolve_input = match input {
-        ScanInput::LocalPdf(file) => crate::datasheet::ResolveDatasheetInput::PdfPath(file),
-        ScanInput::DatasheetUrl(url) => crate::datasheet::ResolveDatasheetInput::DatasheetUrl(url),
+    let (resolve_input, input_pdf_path) = match input {
+        ScanInput::LocalPdf(file) => (
+            crate::datasheet::ResolveDatasheetInput::PdfPath(file.clone()),
+            Some(file),
+        ),
+        ScanInput::DatasheetUrl(url) => (
+            crate::datasheet::ResolveDatasheetInput::DatasheetUrl(url),
+            None,
+        ),
     };
     let spinner = Spinner::builder("Resolving datasheet...").start();
     let response = crate::datasheet::resolve_datasheet(&token, &resolve_input)?;
+    let pdf_path = input_pdf_path
+        .unwrap_or_else(|| PathBuf::from(&response.pdf_path))
+        .display()
+        .to_string();
     let markdown_path = if let Some(output_dir) = args.output.as_deref() {
         crate::datasheet::copy_resolved_outputs(&response, output_dir, None, None)?
             .display()
@@ -603,7 +613,8 @@ pub fn execute(args: ScanArgs) -> Result<()> {
     };
     spinner.finish();
 
-    println!("{markdown_path}");
+    println!("PDF: {pdf_path}");
+    println!("Markdown: {markdown_path}");
 
     Ok(())
 }

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
 use clap::{Args, ValueEnum};
-use colored::Colorize;
 use pcb_ui::Spinner;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
@@ -53,12 +52,6 @@ impl std::str::FromStr for ScanModel {
     }
 }
 
-pub struct ScanOptions {
-    pub file: PathBuf,
-    pub output_dir: PathBuf,
-    pub images: bool,
-}
-
 /// Scan a PDF that already exists in Supabase storage (no upload needed)
 ///
 /// # Arguments
@@ -66,18 +59,12 @@ pub struct ScanOptions {
 /// * `source_path` - Path in Supabase storage, e.g. "components/cse/Bosch/BMI323/datasheet.pdf"
 /// * `output_dir` - Directory to save markdown and images
 /// * `model` - Optional model to use for OCR
-/// * `images` - Whether to download and extract images
-/// * `json` - Whether to download the document JSON
-/// * `show_output` - Whether to show progress and completion output
-pub fn scan_from_source_path(
+pub(crate) fn scan_from_source_path(
     auth_token: &str,
     source_path: &str,
     output_dir: impl AsRef<Path>,
     model: Option<ScanModel>,
-    images: bool,
-    json: bool,
-    show_output: bool,
-) -> Result<ScanResult> {
+) -> Result<()> {
     let output_dir = output_dir.as_ref();
     fs::create_dir_all(output_dir)?;
 
@@ -85,15 +72,6 @@ pub fn scan_from_source_path(
         .split('/')
         .next_back()
         .context("Invalid source_path")?;
-
-    if show_output {
-        println!(
-            "\n{} {} (from {})",
-            "Scanning".green().bold(),
-            filename.bold(),
-            source_path.dimmed()
-        );
-    }
 
     let client = build_scan_client()?;
 
@@ -107,43 +85,14 @@ pub fn scan_from_source_path(
         model.as_ref().map(|m| m.as_str()),
     )?;
 
-    let result = materialize_scan_outputs(
+    materialize_scan_outputs(
         &client,
         &process_response,
         output_dir,
         filename,
-        images,
-        json,
-    )?;
-
-    if show_output {
-        println!();
-        println!("{}", "✓ Scan complete!".green().bold());
-        println!(
-            "  Output: {}",
-            result.output_path.display().to_string().cyan()
-        );
-        println!(
-            "  Pages: {} | Images: {} | Time: {:.1}s",
-            result.page_count,
-            result.image_count,
-            result.processing_time_ms as f64 / 1000.0
-        );
-        if let Some(model) = &result.model {
-            println!("  Model: {}", model.dimmed());
-        }
-    }
-
-    Ok(result)
-}
-
-#[derive(Debug)]
-pub struct ScanResult {
-    pub output_path: PathBuf,
-    pub page_count: u32,
-    pub image_count: u32,
-    pub processing_time_ms: u32,
-    pub model: Option<String>,
+        true,
+        false,
+    )
 }
 
 #[derive(Serialize)]
@@ -184,27 +133,6 @@ pub(crate) struct ProcessResponse {
     pub(crate) images_zip_url: Option<String>,
     #[serde(rename = "sourcePdfUrl")]
     pub(crate) source_pdf_url: Option<String>,
-    metadata: ProcessMetadata,
-}
-
-#[derive(Deserialize)]
-struct ProcessMetadata {
-    page_count: u32,
-    image_count: u32,
-    #[allow(dead_code)]
-    timestamp: String,
-    model: Option<String>,
-    processing_time_ms: u32,
-    #[allow(dead_code)]
-    ocr_cache_hit: Option<bool>,
-}
-
-fn with_spinner<F, R>(spinner: &Spinner, message: &str, f: F) -> Result<R>
-where
-    F: FnOnce() -> Result<R>,
-{
-    spinner.set_message(message.to_string());
-    f()
 }
 
 pub(crate) fn build_scan_client() -> Result<Client> {
@@ -214,19 +142,6 @@ pub(crate) fn build_scan_client() -> Result<Client> {
         .map_err(Into::into)
 }
 
-fn scan_result_from_process(
-    output_path: PathBuf,
-    process_response: &ProcessResponse,
-) -> ScanResult {
-    ScanResult {
-        output_path,
-        page_count: process_response.metadata.page_count,
-        image_count: process_response.metadata.image_count,
-        processing_time_ms: process_response.metadata.processing_time_ms,
-        model: process_response.metadata.model.clone(),
-    }
-}
-
 fn materialize_scan_outputs(
     client: &Client,
     process_response: &ProcessResponse,
@@ -234,7 +149,7 @@ fn materialize_scan_outputs(
     filename: &str,
     images: bool,
     json: bool,
-) -> Result<ScanResult> {
+) -> Result<()> {
     let markdown_path = output_dir.join(filename.replace(".pdf", ".md"));
     let document_json_path = json.then(|| output_dir.join(filename.replace(".pdf", ".json")));
     let images_zip_path = images.then(|| output_dir.join("images.zip"));
@@ -252,50 +167,11 @@ fn materialize_scan_outputs(
         (images_zip_path.as_deref(), images_dir.as_deref())
         && process_response.images_zip_url.is_some()
     {
-        extract_images_archive(images_zip_path, images_dir)?;
+        extract_zip(images_zip_path, images_dir)?;
+        fs::remove_file(images_zip_path)?;
     }
 
-    Ok(scan_result_from_process(markdown_path, process_response))
-}
-
-pub fn scan_pdf(auth_token: &str, options: ScanOptions) -> Result<ScanResult> {
-    validate_local_pdf_path(&options.file)?;
-
-    fs::create_dir_all(&options.output_dir)?;
-
-    let filename = options
-        .file
-        .file_name()
-        .context("Invalid filename")?
-        .to_string_lossy()
-        .to_string();
-
-    let spinner = Spinner::builder(format!("{}: Scanning", filename)).start();
-
-    let sha256 = with_spinner(&spinner, "Calculating hash...", || {
-        calculate_sha256(&options.file)
-    })?;
-
-    let client = build_scan_client()?;
-
-    let process_response = with_spinner(&spinner, "Processing PDF...", || {
-        process_local_pdf(&client, auth_token, &options.file, Some(&sha256), None)
-    })?;
-
-    let result = with_spinner(&spinner, "Materializing scan outputs...", || {
-        materialize_scan_outputs(
-            &client,
-            &process_response,
-            &options.output_dir,
-            &filename,
-            options.images,
-            false,
-        )
-    })?;
-
-    spinner.finish();
-
-    Ok(result)
+    Ok(())
 }
 
 pub(crate) fn calculate_sha256(path: &Path) -> Result<String> {
@@ -468,12 +344,6 @@ pub(crate) fn download_process_artifacts(
         }
         Ok(())
     })
-}
-
-pub(crate) fn extract_images_archive(zip_path: &Path, output_dir: &Path) -> Result<()> {
-    extract_zip(zip_path, output_dir)?;
-    fs::remove_file(zip_path)?;
-    Ok(())
 }
 
 pub(crate) fn extract_zip(zip_path: &Path, output_dir: &Path) -> Result<()> {

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -65,7 +65,10 @@ pub fn scan_with_defaults(
     output: Option<PathBuf>,
     images: bool,
 ) -> Result<ScanResult> {
-    let output_dir = output.unwrap_or(crate::datasheet::materialized_output_dir_for_pdf(&file)?);
+    let output_dir = match output {
+        Some(output_dir) => output_dir,
+        None => crate::datasheet::materialized_output_dir_for_pdf(&file)?,
+    };
 
     let options = ScanOptions {
         file,

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -116,9 +116,7 @@ pub fn scan_from_source_path(
         );
     }
 
-    let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(180))
-        .build()?;
+    let client = build_scan_client()?;
 
     let api_base_url = crate::get_api_base_url();
     let process_response = request_process(
@@ -130,50 +128,14 @@ pub fn scan_from_source_path(
         model.as_ref().map(|m| m.as_str()),
     )?;
 
-    let md_path = output_dir.join(filename.replace(".pdf", ".md"));
-    let json_path = output_dir.join(filename.replace(".pdf", ".json"));
-    let images_zip_path = output_dir.join("images.zip");
-
-    // Download markdown, JSON, and images in parallel
-    std::thread::scope(|s| -> Result<()> {
-        let md_handle =
-            s.spawn(|| download_file(&client, &process_response.markdown_url, &md_path));
-
-        let json_handle = process_response
-            .document_json_url
-            .as_ref()
-            .filter(|_| json)
-            .map(|url| s.spawn(|| download_file(&client, url, &json_path)));
-
-        let images_handle = process_response
-            .images_zip_url
-            .as_ref()
-            .filter(|_| images)
-            .map(|url| s.spawn(|| download_file(&client, url, &images_zip_path)));
-
-        md_handle.join().unwrap()?;
-        if let Some(h) = json_handle {
-            h.join().unwrap()?;
-        }
-        if let Some(h) = images_handle {
-            h.join().unwrap()?;
-        }
-        Ok(())
-    })?;
-
-    // Extract images
-    if images && process_response.images_zip_url.is_some() {
-        extract_zip(&images_zip_path, &output_dir.join("images"))?;
-        fs::remove_file(&images_zip_path)?;
-    }
-
-    let result = ScanResult {
-        output_path: md_path,
-        page_count: process_response.metadata.page_count,
-        image_count: process_response.metadata.image_count,
-        processing_time_ms: process_response.metadata.processing_time_ms,
-        model: process_response.metadata.model,
-    };
+    let result = materialize_scan_outputs(
+        &client,
+        &process_response,
+        output_dir,
+        filename,
+        images,
+        json,
+    )?;
 
     if show_output {
         println!();
@@ -266,6 +228,79 @@ where
     f()
 }
 
+pub(crate) fn build_scan_client() -> Result<Client> {
+    Client::builder()
+        .timeout(std::time::Duration::from_secs(180))
+        .build()
+        .map_err(Into::into)
+}
+
+fn scan_result_from_process(
+    output_path: PathBuf,
+    process_response: &ProcessResponse,
+) -> ScanResult {
+    ScanResult {
+        output_path,
+        page_count: process_response.metadata.page_count,
+        image_count: process_response.metadata.image_count,
+        processing_time_ms: process_response.metadata.processing_time_ms,
+        model: process_response.metadata.model.clone(),
+    }
+}
+
+struct ScanOutputPaths {
+    markdown_path: PathBuf,
+    document_json_path: Option<PathBuf>,
+    images_zip_path: Option<PathBuf>,
+    images_dir: Option<PathBuf>,
+}
+
+fn build_scan_output_paths(
+    output_dir: &Path,
+    filename: &str,
+    images: bool,
+    json: bool,
+) -> ScanOutputPaths {
+    ScanOutputPaths {
+        markdown_path: output_dir.join(filename.replace(".pdf", ".md")),
+        document_json_path: json.then(|| output_dir.join(filename.replace(".pdf", ".json"))),
+        images_zip_path: images.then(|| output_dir.join("images.zip")),
+        images_dir: images.then(|| output_dir.join("images")),
+    }
+}
+
+fn materialize_scan_outputs(
+    client: &Client,
+    process_response: &ProcessResponse,
+    output_dir: &Path,
+    filename: &str,
+    images: bool,
+    json: bool,
+) -> Result<ScanResult> {
+    let output_paths = build_scan_output_paths(output_dir, filename, images, json);
+
+    download_process_artifacts(
+        client,
+        process_response,
+        &output_paths.markdown_path,
+        output_paths.document_json_path.as_deref(),
+        output_paths.images_zip_path.as_deref(),
+    )?;
+
+    if let (Some(images_zip_path), Some(images_dir)) = (
+        output_paths.images_zip_path.as_deref(),
+        output_paths.images_dir.as_deref(),
+    ) && process_response.images_zip_url.is_some()
+    {
+        extract_images_archive(images_zip_path, images_dir)?;
+    }
+
+    Ok(scan_result_from_process(
+        output_paths.markdown_path,
+        process_response,
+    ))
+}
+
 pub fn scan_pdf(auth_token: &str, options: ScanOptions) -> Result<ScanResult> {
     validate_local_pdf_path(&options.file)?;
 
@@ -284,9 +319,7 @@ pub fn scan_pdf(auth_token: &str, options: ScanOptions) -> Result<ScanResult> {
         calculate_sha256(&options.file)
     })?;
 
-    let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(180))
-        .build()?;
+    let client = build_scan_client()?;
 
     let api_base_url = crate::get_api_base_url();
 
@@ -311,38 +344,20 @@ pub fn scan_pdf(auth_token: &str, options: ScanOptions) -> Result<ScanResult> {
         )
     })?;
 
-    let md_filename = filename.replace(".pdf", ".md");
-    let md_path = options.output_dir.join(&md_filename);
-
-    with_spinner(&spinner, "Downloading markdown...", || {
-        download_file(&client, &process_response.markdown_url, &md_path)
+    let result = with_spinner(&spinner, "Materializing scan outputs...", || {
+        materialize_scan_outputs(
+            &client,
+            &process_response,
+            &options.output_dir,
+            &filename,
+            options.images,
+            false,
+        )
     })?;
-
-    if options.images
-        && let Some(images_url) = &process_response.images_zip_url
-    {
-        let images_zip_path = options.output_dir.join("images.zip");
-        with_spinner(&spinner, "Downloading images...", || {
-            download_file(&client, images_url, &images_zip_path)
-        })?;
-
-        let images_dir = options.output_dir.join("images");
-        with_spinner(&spinner, "Extracting images...", || {
-            extract_zip(&images_zip_path, &images_dir)?;
-            fs::remove_file(&images_zip_path)?;
-            Ok(())
-        })?;
-    }
 
     spinner.finish();
 
-    Ok(ScanResult {
-        output_path: md_path,
-        page_count: process_response.metadata.page_count,
-        image_count: process_response.metadata.image_count,
-        processing_time_ms: process_response.metadata.processing_time_ms,
-        model: process_response.metadata.model,
-    })
+    Ok(result)
 }
 
 pub(crate) fn calculate_sha256(path: &Path) -> Result<String> {
@@ -448,6 +463,46 @@ pub(crate) fn download_file(client: &Client, url: &str, path: &Path) -> Result<(
             f.flush()
         })
         .map_err(|err| anyhow::anyhow!("Download write failed: {err}"))?;
+    Ok(())
+}
+
+pub(crate) fn download_process_artifacts(
+    client: &Client,
+    process_response: &ProcessResponse,
+    markdown_path: &Path,
+    document_json_path: Option<&Path>,
+    images_zip_path: Option<&Path>,
+) -> Result<()> {
+    std::thread::scope(|s| -> Result<()> {
+        let md_handle =
+            s.spawn(|| download_file(client, &process_response.markdown_url, markdown_path));
+
+        let json_handle = process_response
+            .document_json_url
+            .as_ref()
+            .zip(document_json_path)
+            .map(|(url, path)| s.spawn(|| download_file(client, url, path)));
+
+        let images_handle = process_response
+            .images_zip_url
+            .as_ref()
+            .zip(images_zip_path)
+            .map(|(url, path)| s.spawn(|| download_file(client, url, path)));
+
+        md_handle.join().unwrap()?;
+        if let Some(h) = json_handle {
+            h.join().unwrap()?;
+        }
+        if let Some(h) = images_handle {
+            h.join().unwrap()?;
+        }
+        Ok(())
+    })
+}
+
+pub(crate) fn extract_images_archive(zip_path: &Path, output_dir: &Path) -> Result<()> {
+    extract_zip(zip_path, output_dir)?;
+    fs::remove_file(zip_path)?;
     Ok(())
 }
 

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -65,11 +65,7 @@ pub fn scan_with_defaults(
     output: Option<PathBuf>,
     images: bool,
 ) -> Result<ScanResult> {
-    let output_dir = output.unwrap_or_else(|| {
-        file.parent()
-            .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| PathBuf::from("."))
-    });
+    let output_dir = output.unwrap_or(crate::datasheet::materialized_output_dir_for_pdf(&file)?);
 
     let options = ScanOptions {
         file,
@@ -248,27 +244,6 @@ fn scan_result_from_process(
     }
 }
 
-struct ScanOutputPaths {
-    markdown_path: PathBuf,
-    document_json_path: Option<PathBuf>,
-    images_zip_path: Option<PathBuf>,
-    images_dir: Option<PathBuf>,
-}
-
-fn build_scan_output_paths(
-    output_dir: &Path,
-    filename: &str,
-    images: bool,
-    json: bool,
-) -> ScanOutputPaths {
-    ScanOutputPaths {
-        markdown_path: output_dir.join(filename.replace(".pdf", ".md")),
-        document_json_path: json.then(|| output_dir.join(filename.replace(".pdf", ".json"))),
-        images_zip_path: images.then(|| output_dir.join("images.zip")),
-        images_dir: images.then(|| output_dir.join("images")),
-    }
-}
-
 fn materialize_scan_outputs(
     client: &Client,
     process_response: &ProcessResponse,
@@ -277,28 +252,27 @@ fn materialize_scan_outputs(
     images: bool,
     json: bool,
 ) -> Result<ScanResult> {
-    let output_paths = build_scan_output_paths(output_dir, filename, images, json);
+    let markdown_path = output_dir.join(filename.replace(".pdf", ".md"));
+    let document_json_path = json.then(|| output_dir.join(filename.replace(".pdf", ".json")));
+    let images_zip_path = images.then(|| output_dir.join("images.zip"));
+    let images_dir = images.then(|| output_dir.join("images"));
 
     download_process_artifacts(
         client,
         process_response,
-        &output_paths.markdown_path,
-        output_paths.document_json_path.as_deref(),
-        output_paths.images_zip_path.as_deref(),
+        &markdown_path,
+        document_json_path.as_deref(),
+        images_zip_path.as_deref(),
     )?;
 
-    if let (Some(images_zip_path), Some(images_dir)) = (
-        output_paths.images_zip_path.as_deref(),
-        output_paths.images_dir.as_deref(),
-    ) && process_response.images_zip_url.is_some()
+    if let (Some(images_zip_path), Some(images_dir)) =
+        (images_zip_path.as_deref(), images_dir.as_deref())
+        && process_response.images_zip_url.is_some()
     {
         extract_images_archive(images_zip_path, images_dir)?;
     }
 
-    Ok(scan_result_from_process(
-        output_paths.markdown_path,
-        process_response,
-    ))
+    Ok(scan_result_from_process(markdown_path, process_response))
 }
 
 pub fn scan_pdf(auth_token: &str, options: ScanOptions) -> Result<ScanResult> {
@@ -321,27 +295,8 @@ pub fn scan_pdf(auth_token: &str, options: ScanOptions) -> Result<ScanResult> {
 
     let client = build_scan_client()?;
 
-    let api_base_url = crate::get_api_base_url();
-
-    let upload_response = with_spinner(&spinner, "Requesting upload URL...", || {
-        request_upload_url(&client, auth_token, &api_base_url, &sha256, &filename)
-    })?;
-
-    if let Some(upload_url) = &upload_response.upload_url {
-        with_spinner(&spinner, "Uploading PDF...", || {
-            upload_pdf(&client, upload_url, &options.file)
-        })?;
-    }
-
     let process_response = with_spinner(&spinner, "Processing PDF...", || {
-        request_process(
-            &client,
-            auth_token,
-            &api_base_url,
-            Some(&upload_response.source_path),
-            None,
-            None,
-        )
+        process_local_pdf(&client, auth_token, &options.file, Some(&sha256), None)
     })?;
 
     let result = with_spinner(&spinner, "Materializing scan outputs...", || {
@@ -399,6 +354,38 @@ pub(crate) fn request_upload_url(
     }
 
     Ok(response.json()?)
+}
+
+pub(crate) fn process_local_pdf(
+    client: &Client,
+    auth_token: &str,
+    file_path: &Path,
+    file_sha256: Option<&str>,
+    model: Option<&str>,
+) -> Result<ProcessResponse> {
+    let api_base_url = crate::get_api_base_url();
+    let filename = file_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("Invalid filename")?;
+    let sha256 = match file_sha256 {
+        Some(sha256) => sha256.to_owned(),
+        None => calculate_sha256(file_path)?,
+    };
+
+    let upload = request_upload_url(client, auth_token, &api_base_url, &sha256, filename)?;
+    if let Some(upload_url) = upload.upload_url.as_deref() {
+        upload_pdf(client, upload_url, file_path)?;
+    }
+
+    request_process(
+        client,
+        auth_token,
+        &api_base_url,
+        Some(&upload.source_path),
+        None,
+        model,
+    )
 }
 
 pub(crate) fn upload_pdf(client: &Client, upload_url: &str, file_path: &Path) -> Result<()> {
@@ -574,15 +561,9 @@ fn validate_local_pdf_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn parse_scan_input(input: &str, output: Option<&PathBuf>, no_images: bool) -> Result<ScanInput> {
+fn parse_scan_input(input: &str) -> Result<ScanInput> {
     let lower = input.to_ascii_lowercase();
     if lower.starts_with("http://") || lower.starts_with("https://") {
-        if output.is_some() {
-            anyhow::bail!("--output is only supported for local PDF inputs");
-        }
-        if no_images {
-            anyhow::bail!("--no-images is only supported for local PDF inputs");
-        }
         let url = Url::parse(input).with_context(|| format!("Invalid URL input: {input}"))?;
         return Ok(ScanInput::DatasheetUrl(url.to_string()));
     }
@@ -601,33 +582,26 @@ pub struct ScanArgs {
 
     #[arg(short, long, value_name = "DIR")]
     pub output: Option<PathBuf>,
-
-    /// Skip downloading images from the scanned PDF
-    #[arg(long)]
-    pub no_images: bool,
 }
 
 pub fn execute(args: ScanArgs) -> Result<()> {
-    let input = parse_scan_input(&args.input, args.output.as_ref(), args.no_images)?;
+    let input = parse_scan_input(&args.input)?;
 
     let token = crate::auth::get_valid_token()?;
-    let markdown_path = match input {
-        ScanInput::LocalPdf(file) => {
-            scan_with_defaults(&token, file, args.output, !args.no_images)?
-                .output_path
-                .display()
-                .to_string()
-        }
-        ScanInput::DatasheetUrl(url) => {
-            let spinner = Spinner::builder("Resolving datasheet URL...").start();
-            let response = crate::datasheet::resolve_datasheet(
-                &token,
-                &crate::datasheet::ResolveDatasheetInput::DatasheetUrl(url),
-            )?;
-            spinner.finish();
-            response.markdown_path
-        }
+    let resolve_input = match input {
+        ScanInput::LocalPdf(file) => crate::datasheet::ResolveDatasheetInput::PdfPath(file),
+        ScanInput::DatasheetUrl(url) => crate::datasheet::ResolveDatasheetInput::DatasheetUrl(url),
     };
+    let spinner = Spinner::builder("Resolving datasheet...").start();
+    let response = crate::datasheet::resolve_datasheet(&token, &resolve_input)?;
+    let markdown_path = if let Some(output_dir) = args.output.as_deref() {
+        crate::datasheet::copy_resolved_outputs(&response, output_dir, None, None)?
+            .display()
+            .to_string()
+    } else {
+        response.markdown_path
+    };
+    spinner.finish();
 
     println!("{markdown_path}");
 
@@ -640,7 +614,7 @@ mod tests {
 
     #[test]
     fn parse_scan_input_accepts_http_url() {
-        let parsed = parse_scan_input("https://example.com/datasheet.pdf", None, false).unwrap();
+        let parsed = parse_scan_input("https://example.com/datasheet.pdf").unwrap();
         match parsed {
             ScanInput::DatasheetUrl(url) => {
                 assert_eq!(url, "https://example.com/datasheet.pdf");
@@ -651,25 +625,12 @@ mod tests {
 
     #[test]
     fn parse_scan_input_rejects_non_http_url() {
-        assert!(parse_scan_input("ftp://example.com/datasheet.pdf", None, false).is_err());
-    }
-
-    #[test]
-    fn parse_scan_input_rejects_url_with_output() {
-        let output = PathBuf::from("/tmp/out");
-        assert!(
-            parse_scan_input("https://example.com/datasheet.pdf", Some(&output), false).is_err()
-        );
-    }
-
-    #[test]
-    fn parse_scan_input_rejects_url_with_no_images() {
-        assert!(parse_scan_input("https://example.com/datasheet.pdf", None, true).is_err());
+        assert!(parse_scan_input("ftp://example.com/datasheet.pdf").is_err());
     }
 
     #[test]
     fn parse_scan_input_windows_path_not_treated_as_url() {
-        let err = match parse_scan_input(r"C:\__unlikely__\datasheet.pdf", None, false) {
+        let err = match parse_scan_input(r"C:\__unlikely__\datasheet.pdf") {
             Ok(_) => panic!("expected local file validation error"),
             Err(err) => err.to_string(),
         };
@@ -679,7 +640,7 @@ mod tests {
 
     #[test]
     fn parse_scan_input_windows_forward_slash_path_not_treated_as_url() {
-        let err = match parse_scan_input("C:/__unlikely__/datasheet.pdf", None, false) {
+        let err = match parse_scan_input("C:/__unlikely__/datasheet.pdf") {
             Ok(_) => panic!("expected local file validation error"),
             Err(err) => err.to_string(),
         };
@@ -692,7 +653,7 @@ mod tests {
         let file = std::env::temp_dir().join(format!("scan-local-{}.pdf", uuid::Uuid::new_v4()));
         fs::write(&file, b"%PDF-1.4\n").unwrap();
 
-        let parsed = parse_scan_input(file.to_str().unwrap(), None, false).unwrap();
+        let parsed = parse_scan_input(file.to_str().unwrap()).unwrap();
         match parsed {
             ScanInput::LocalPdf(path) => assert_eq!(path, file),
             _ => panic!("expected local PDF input"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `pcb scan` CLI behavior and refactors scan/datasheet internals to always use the shared materialization cache, which could affect output paths and file copying semantics for existing workflows.
> 
> **Overview**
> `pcb scan` is refactored to always resolve both local PDFs and URL inputs through the shared datasheet materialization cache, with `--output` now copying the materialized markdown/images (and optionally PDF) out of that cache instead of scanning directly into the destination.
> 
> The scan implementation is simplified by removing the legacy `ScanResult`/`scan_with_defaults` flow and centralizing upload/process/download logic into reusable helpers (`build_scan_client`, `process_local_pdf`, `download_process_artifacts`, and `copy_resolved_outputs`), with the CLI now printing both `PDF:` and `Markdown:` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57e575319d1654263b65950a748608173a403afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
