### PR TITLE
Add docs full-text search ranker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Newly added KiCad symbol properties now default to `justify left top` and `hide yes`.
 - `pcb scan` now resolves local PDFs through the shared datasheet materialization cache by default, and `--output` copies the materialized Markdown and images out of that cache.
 - `pcb scan` now prints both `PDF:` and `Markdown:` output paths, with local PDF scans reporting the original input PDF path and URL scans reporting the materialized cached PDF path.
+- `pcb search` now merges docs full-text results for registry packages and KiCad symbols, with consistent phrase handling across indices.
 
 ### Fixed
 - `pcb build --offline` now reuses selected locked pseudo-versions for rev-pinned workspace deps.

--- a/crates/pcb-diode-api/README.md
+++ b/crates/pcb-diode-api/README.md
@@ -6,12 +6,12 @@ Diode API client library for PCB toolchain integration.
 
 - **Authentication**: OAuth2 flow with token refresh
 - **Component Search**: Search and download components from Diode's component library
-- **Registry Search**: Hybrid search across a local parts registry with trigram, word, and semantic indices
+- **Registry Search**: Hybrid search across a local parts registry with trigram, word, semantic, and docs full-text indices
 - **BOM Matching**: Match bill of materials against distributor availability
 
 ## Registry Search System
 
-The registry search uses a hybrid retrieval approach combining three indices:
+The registry search uses a hybrid retrieval approach combining four indices:
 
 ### Indices
 
@@ -19,22 +19,22 @@ The registry search uses a hybrid retrieval approach combining three indices:
 |-------|------|------------------|----------|
 | **Trigram** | FTS5 | Canonicalized MPN (alphanumeric, uppercase) | Exact/partial MPN lookups |
 | **Word** | FTS5 | Tokenized descriptions with prefix matching | Keyword-based queries |
+| **Docs Full Text** | FTS5 + BM25 | Full package docs text | Supporting evidence from datasheets and other package docs |
 | **Semantic** | Vector (1024-dim) | Titan embeddings via AWS Bedrock | Natural language queries |
 
 ### Fusion Algorithm
 
-Results from all three indices are merged using **Reciprocal Rank Fusion (RRF)**.
+Results from all four indices are merged using **Reciprocal Rank Fusion (RRF)**.
 
 #### RRF Formula
 
-For each document `d` appearing in any ranker's top-20 results:
+For each document `d` appearing in any ranker's top results:
 
 ```
-score(d) = Σ w_i / (K + rank_i(d))
+score(d) = Σ 1 / (K + rank_i(d))
 ```
 
 Where:
-- `w_i` = weight for ranker `i` (currently all 1.0)
 - `K` = smoothing constant (10)
 - `rank_i(d)` = 1-based position of document in ranker `i`'s results
 
@@ -42,12 +42,12 @@ Where:
 
 Query: `"voltage regulator 3.3v"`
 
-| Document | Trigram Rank | Word Rank | Semantic Rank | RRF Score |
-|----------|--------------|-----------|---------------|-----------|
-| LDO_A    | -            | 1         | 2             | 1/(10+1) + 1/(10+2) = 0.091 + 0.083 = **0.174** |
-| LDO_B    | -            | 3         | 1             | 1/(10+3) + 1/(10+1) = 0.077 + 0.091 = **0.168** |
-| LDO_C    | -            | 2         | 5             | 1/(10+2) + 1/(10+5) = 0.083 + 0.067 = **0.150** |
-| REG_X    | -            | 8         | -             | 1/(10+8) = **0.056** |
+| Document | Trigram Rank | Word Rank | Docs FT Rank | Semantic Rank | RRF Score |
+|----------|--------------|-----------|--------------|---------------|-----------|
+| LDO_A    | -            | 1         | 4            | 2             | 1/(10+1) + 1/(10+4) + 1/(10+2) = 0.091 + 0.071 + 0.083 = **0.246** |
+| LDO_B    | -            | 3         | -            | 1             | 1/(10+3) + 1/(10+1) = 0.077 + 0.091 = **0.168** |
+| LDO_C    | -            | 2         | 1            | 5             | 1/(10+2) + 1/(10+1) + 1/(10+5) = 0.083 + 0.091 + 0.067 = **0.241** |
+| REG_X    | -            | 8         | -            | -             | 1/(10+8) = **0.056** |
 
 Documents appearing in multiple rankers naturally score higher (consensus effect).
 
@@ -64,9 +64,6 @@ Documents appearing in multiple rankers naturally score higher (consensus effect
 const PER_INDEX_LIMIT: usize = 20;  // Top 20 from each ranker
 const MERGED_LIMIT: usize = 50;     // Top 50 after fusion
 const K: f64 = 10.0;                // RRF smoothing constant
-const W_TRIGRAM: f64 = 1.0;         // Equal weights
-const W_WORD: f64 = 1.0;
-const W_SEMANTIC: f64 = 1.0;
 ```
 
 ## Search Pipeline & Next Steps
@@ -77,7 +74,8 @@ const W_SEMANTIC: f64 = 1.0;
 Query
   │
   ├──► Trigram FTS (top 20)  ──┐
-  ├──► Word FTS (top 20)     ──┼──► RRF Fusion ──► Top 50 Results
+  ├──► Word FTS (top 20)     ──┤
+  ├──► Docs Full Text (top 20)─┼──► RRF Fusion ──► Top 50 Results
   └──► Semantic (top 20)     ──┘
 ```
 
@@ -89,7 +87,8 @@ The next improvement is to add LLM-based reranking after RRF fusion:
 Query
   │
   ├──► Trigram FTS (top 20)  ──┐
-  ├──► Word FTS (top 20)     ──┼──► RRF Fusion ──► Top 50 ──► LLM Reranker ──► Final Results
+  ├──► Word FTS (top 20)     ──┤
+  ├──► Docs Full Text (top 20)─┼──► RRF Fusion ──► Top 50 ──► LLM Reranker ──► Final Results
   └──► Semantic (top 20)     ──┘
 ```
 

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -1866,10 +1866,11 @@ fn print_search_scoring(scoring: Option<&crate::registry::tui::search::PartScori
     };
 
     println!(
-        "  {} tri={} word={} sem={}",
+        "  {} tri={} word={} docs={} sem={}",
         "score".dimmed(),
         format_source(scoring.trigram_position, scoring.trigram_rank).dimmed(),
         format_source(scoring.word_position, scoring.word_rank).dimmed(),
+        format_source(scoring.docs_full_text_position, scoring.docs_full_text_rank).dimmed(),
         format_source(scoring.semantic_position, scoring.semantic_rank).dimmed(),
     );
 }

--- a/crates/pcb-diode-api/src/kicad_symbols/mod.rs
+++ b/crates/pcb-diode-api/src/kicad_symbols/mod.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use crate::SearchHit;
 use crate::bom::ComponentKey;
 use crate::registry::{
-    ParsedQuery, RrfSearchOutput, build_docs_full_text_fts_query, collect_deduped_hits_by_url,
-    embeddings, merge_rrf_hit_lists,
+    ParsedQuery, RrfSearchOutput, build_prefix_fts_query, collect_deduped_hits_by_url, embeddings,
+    merge_rrf_hit_lists, normalize_semantic_query,
 };
 
 pub mod download;
@@ -200,8 +200,9 @@ impl KicadSymbolsClient {
         let docs_full_text = self
             .search_docs_full_text_hits(&parsed, PER_INDEX_LIMIT)
             .unwrap_or_default();
-        let semantic = embeddings::get_query_embedding(query_text)
-            .and_then(|emb| self.search_semantic_hits(&emb, SEMANTIC_FETCH_LIMIT))
+        let semantic = normalize_semantic_query(query_text)
+            .and_then(|q| embeddings::get_query_embedding(&q).ok())
+            .and_then(|emb| self.search_semantic_hits(&emb, SEMANTIC_FETCH_LIMIT).ok())
             .unwrap_or_default()
             .into_iter()
             .filter(|hit| {
@@ -333,12 +334,9 @@ impl KicadSymbolsClient {
             return Ok(Vec::new());
         }
 
-        let fts_query = parsed
-            .word_tokens
-            .iter()
-            .map(|token| format!("{}*", escape_fts5(token)))
-            .collect::<Vec<_>>()
-            .join(" ");
+        let Some(fts_query) = build_prefix_fts_query(&parsed.original) else {
+            return Ok(Vec::new());
+        };
 
         let mut stmt = self.conn.prepare(
             r#"
@@ -375,7 +373,7 @@ impl KicadSymbolsClient {
             return Ok(Vec::new());
         }
 
-        let Some(fts_query) = build_docs_full_text_fts_query(&parsed.original) else {
+        let Some(fts_query) = build_prefix_fts_query(&parsed.original) else {
             return Ok(Vec::new());
         };
         let fetch_limit = limit.saturating_mul(4);

--- a/crates/pcb-diode-api/src/kicad_symbols/mod.rs
+++ b/crates/pcb-diode-api/src/kicad_symbols/mod.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use crate::SearchHit;
 use crate::bom::ComponentKey;
 use crate::registry::{
-    ParsedQuery, RrfSearchOutput, build_prefix_fts_query, collect_deduped_hits_by_url, embeddings,
-    merge_rrf_hit_lists, normalize_semantic_query,
+    ParsedQuery, RrfSearchOutput, build_prefix_fts_query, build_query_embedding,
+    collect_deduped_hits_by_url, merge_rrf_hit_lists,
 };
 
 pub mod download;
@@ -200,9 +200,11 @@ impl KicadSymbolsClient {
         let docs_full_text = self
             .search_docs_full_text_hits(&parsed, PER_INDEX_LIMIT)
             .unwrap_or_default();
-        let semantic = normalize_semantic_query(query_text)
-            .and_then(|q| embeddings::get_query_embedding(&q).ok())
-            .and_then(|emb| self.search_semantic_hits(&emb, SEMANTIC_FETCH_LIMIT).ok())
+        let semantic = build_query_embedding(query_text)
+            .and_then(|embedding| {
+                self.search_semantic_hits(&embedding, SEMANTIC_FETCH_LIMIT)
+                    .ok()
+            })
             .unwrap_or_default()
             .into_iter()
             .filter(|hit| {
@@ -330,10 +332,6 @@ impl KicadSymbolsClient {
     }
 
     fn search_word_hits(&self, parsed: &ParsedQuery, limit: usize) -> Result<Vec<SearchHit>> {
-        if parsed.word_tokens.is_empty() {
-            return Ok(Vec::new());
-        }
-
         let Some(fts_query) = build_prefix_fts_query(&parsed.original) else {
             return Ok(Vec::new());
         };

--- a/crates/pcb-diode-api/src/kicad_symbols/mod.rs
+++ b/crates/pcb-diode-api/src/kicad_symbols/mod.rs
@@ -1,13 +1,14 @@
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension};
 use serde::Serialize;
-use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::SearchHit;
 use crate::bom::ComponentKey;
-use crate::registry::{ParsedQuery, RrfSearchOutput, embeddings};
+use crate::registry::{
+    ParsedQuery, RrfSearchOutput, build_docs_full_text_fts_query, collect_deduped_hits_by_url,
+    embeddings, merge_rrf_hit_lists,
+};
 
 pub mod download;
 
@@ -15,7 +16,6 @@ const SEMANTIC_DISTANCE_THRESHOLD: f64 = 1.3;
 const SEMANTIC_FETCH_LIMIT: usize = 100;
 const PER_INDEX_LIMIT: usize = 50;
 const MERGED_LIMIT: usize = 100;
-const RRF_K: f64 = 10.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EnsureIndexResult {
@@ -197,6 +197,9 @@ impl KicadSymbolsClient {
         let word = self
             .search_word_hits(&parsed, PER_INDEX_LIMIT)
             .unwrap_or_default();
+        let docs_full_text = self
+            .search_docs_full_text_hits(&parsed, PER_INDEX_LIMIT)
+            .unwrap_or_default();
         let semantic = embeddings::get_query_embedding(query_text)
             .and_then(|emb| self.search_semantic_hits(&emb, SEMANTIC_FETCH_LIMIT))
             .unwrap_or_default()
@@ -209,39 +212,15 @@ impl KicadSymbolsClient {
             .take(PER_INDEX_LIMIT)
             .collect::<Vec<_>>();
 
-        let mut rrf_scores: HashMap<String, f64> = HashMap::new();
-        for (idx, hit) in trigram.iter().enumerate() {
-            *rrf_scores.entry(hit.url.clone()).or_default() += 1.0 / (RRF_K + (idx + 1) as f64);
-        }
-        for (idx, hit) in word.iter().enumerate() {
-            *rrf_scores.entry(hit.url.clone()).or_default() += 1.0 / (RRF_K + (idx + 1) as f64);
-        }
-        for (idx, hit) in semantic.iter().enumerate() {
-            *rrf_scores.entry(hit.url.clone()).or_default() += 1.0 / (RRF_K + (idx + 1) as f64);
-        }
-
-        let mut all_hits: HashMap<String, SearchHit> = HashMap::new();
-        for hit in trigram.iter().chain(word.iter()).chain(semantic.iter()) {
-            all_hits
-                .entry(hit.url.clone())
-                .or_insert_with(|| hit.clone());
-        }
-
-        let mut merged: Vec<_> = all_hits
-            .into_iter()
-            .map(|(url, hit)| (rrf_scores.get(&url).copied().unwrap_or_default(), hit))
-            .collect();
-        merged.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(Ordering::Equal));
+        let merged =
+            merge_rrf_hit_lists(&[&trigram, &word, &docs_full_text, &semantic], MERGED_LIMIT);
 
         RrfSearchOutput {
             trigram,
             word,
+            docs_full_text,
             semantic,
-            merged: merged
-                .into_iter()
-                .take(MERGED_LIMIT)
-                .map(|(_, hit)| hit)
-                .collect(),
+            merged,
         }
     }
 
@@ -385,6 +364,47 @@ impl KicadSymbolsClient {
         let rows = stmt.query_map([&fts_query, &limit.to_string()], map_search_hit)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(Into::into)
+    }
+
+    fn search_docs_full_text_hits(
+        &self,
+        parsed: &ParsedQuery,
+        limit: usize,
+    ) -> Result<Vec<SearchHit>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let Some(fts_query) = build_docs_full_text_fts_query(&parsed.original) else {
+            return Ok(Vec::new());
+        };
+        let fetch_limit = limit.saturating_mul(4);
+
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT s.id,
+                   '@kicad-symbols/' || s.symbol_library || '.kicad_sym:' || s.symbol_name,
+                   s.symbol_name,
+                   s.manufacturer,
+                   COALESCE(
+                     (SELECT mpn FROM symbol_mpns sm WHERE sm.symbol_id = s.id ORDER BY mpn LIMIT 1),
+                     s.symbol_name
+                   ),
+                   COALESCE(NULLIF(s.phase3_description, ''), s.kicad_description),
+                   s.symbol_library,
+                   bm25(symbol_ocr_docs_fts) AS score
+            FROM symbol_ocr_docs_fts
+            JOIN symbol_ocr_docs d ON d.id = symbol_ocr_docs_fts.rowid
+            JOIN symbols s ON s.id = d.symbol_id
+            WHERE symbol_ocr_docs_fts MATCH ?1
+            ORDER BY score
+            LIMIT ?2
+            "#,
+        )?;
+
+        let rows = stmt.query_map([&fts_query, &fetch_limit.to_string()], map_search_hit)?;
+
+        collect_deduped_hits_by_url(rows, limit)
     }
 
     fn search_semantic_hits(

--- a/crates/pcb-diode-api/src/registry/mod.rs
+++ b/crates/pcb-diode-api/src/registry/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::bom::ComponentKey;
@@ -11,6 +11,8 @@ pub mod embeddings;
 pub mod tui;
 
 pub use tui::search::SearchFilter;
+
+pub(crate) const RRF_K: f64 = 10.0;
 
 /// Digikey distribution data parsed from JSON
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -67,6 +69,51 @@ pub struct SearchHit {
     pub package_category: Option<String>,
     pub rank: Option<f64>,
     pub availability_lookups: Vec<ComponentKey>,
+}
+
+pub(crate) fn collect_deduped_hits_by_url<I>(rows: I, limit: usize) -> Result<Vec<SearchHit>>
+where
+    I: IntoIterator<Item = rusqlite::Result<SearchHit>>,
+{
+    let mut seen_urls = HashSet::new();
+    let mut deduped = Vec::with_capacity(limit);
+    for row in rows {
+        let hit = row?;
+        if seen_urls.insert(hit.url.clone()) {
+            deduped.push(hit);
+            if deduped.len() >= limit {
+                break;
+            }
+        }
+    }
+
+    Ok(deduped)
+}
+
+pub(crate) fn merge_rrf_hit_lists(lists: &[&[SearchHit]], limit: usize) -> Vec<SearchHit> {
+    let mut rrf_scores: HashMap<String, f64> = HashMap::new();
+    for hits in lists {
+        for (idx, hit) in hits.iter().enumerate() {
+            *rrf_scores.entry(hit.url.clone()).or_default() += 1.0 / (RRF_K + (idx + 1) as f64);
+        }
+    }
+
+    let mut all_hits: HashMap<String, SearchHit> = HashMap::new();
+    for hits in lists {
+        for hit in hits.iter() {
+            all_hits
+                .entry(hit.url.clone())
+                .or_insert_with(|| hit.clone());
+        }
+    }
+
+    let mut scored: Vec<_> = all_hits
+        .into_iter()
+        .map(|(url, hit)| (rrf_scores.get(&url).copied().unwrap_or(0.0), hit))
+        .collect();
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    scored.into_iter().take(limit).map(|(_, hit)| hit).collect()
 }
 
 /// Extract package name from URL (last path segment)
@@ -311,6 +358,47 @@ fn tokenize_for_words(s: &str) -> Vec<String> {
         .collect()
 }
 
+fn push_docs_full_text_tokens(chunk: &str, clauses: &mut Vec<String>) {
+    clauses.extend(
+        tokenize_for_words(chunk)
+            .into_iter()
+            .map(|token| format!("{}*", escape_fts5(&token))),
+    );
+}
+
+fn normalize_phrase_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub(crate) fn build_docs_full_text_fts_query(query: &str) -> Option<String> {
+    let mut clauses = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in query.chars() {
+        if ch == '"' {
+            if in_quotes {
+                let phrase = normalize_phrase_whitespace(&current);
+                if !phrase.is_empty() {
+                    clauses.push(format!("\"{}\"", phrase.replace('"', "\"\"")));
+                }
+                current.clear();
+                in_quotes = false;
+            } else {
+                push_docs_full_text_tokens(&current, &mut clauses);
+                current.clear();
+                in_quotes = true;
+            }
+        } else {
+            current.push(ch);
+        }
+    }
+
+    push_docs_full_text_tokens(&current, &mut clauses);
+
+    (!clauses.is_empty()).then(|| clauses.join(" AND "))
+}
+
 /// Detect if query looks like an MPN vs natural language
 /// MPNs typically: have digits, are single "word", have specific patterns
 fn detect_mpn_query(original: &str, canon: &str) -> bool {
@@ -529,6 +617,55 @@ impl RegistryClient {
             )?
         };
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Lightweight full-text search over package docs, deduped to one hit per package.
+    pub fn search_docs_full_text_hits_filtered(
+        &self,
+        parsed: &ParsedQuery,
+        limit: usize,
+        filter: Option<SearchFilter>,
+    ) -> Result<Vec<SearchHit>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let Some(fts_query) = build_docs_full_text_fts_query(&parsed.original) else {
+            return Ok(Vec::new());
+        };
+        let (filter_clause, url_pattern) = filter
+            .map(|f| f.sql_clause(3))
+            .unwrap_or(("", String::new()));
+        let fetch_limit = limit.saturating_mul(4);
+
+        let sql = format!(
+            r#"
+            SELECT p.id, p.url, p.mpn, p.manufacturer, p.short_description, p.version, p.package_category,
+                   bm25(package_ocr_docs_fts) AS score
+            FROM package_ocr_docs_fts
+            JOIN package_ocr_docs d ON d.id = package_ocr_docs_fts.rowid
+            JOIN packages p ON p.id = d.package_id
+            WHERE package_ocr_docs_fts MATCH ?1 {}
+            ORDER BY score
+            LIMIT ?2
+            "#,
+            filter_clause
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = if filter.is_some() {
+            stmt.query_map(
+                rusqlite::params![&fts_query, fetch_limit as i64, &url_pattern],
+                Self::map_search_hit,
+            )?
+        } else {
+            stmt.query_map(
+                rusqlite::params![&fts_query, fetch_limit as i64],
+                Self::map_search_hit,
+            )?
+        };
+
+        collect_deduped_hits_by_url(rows, limit)
     }
 
     /// Row mapper for SearchHit (shared by FTS search methods)
@@ -943,7 +1080,6 @@ impl RegistryClient {
         const MERGED_LIMIT: usize = 100;
         const SEMANTIC_FETCH_LIMIT: usize = 100;
         const SEMANTIC_DISTANCE_THRESHOLD: f64 = 1.3;
-        const K: f64 = 10.0;
 
         let query_text = query.trim();
         if query_text.is_empty() {
@@ -952,12 +1088,15 @@ impl RegistryClient {
 
         let parsed = ParsedQuery::parse(query_text);
 
-        // Run all three searches
+        // Run all four searches
         let trigram = self
             .search_trigram_hits_filtered(&parsed, PER_INDEX_LIMIT, filter)
             .unwrap_or_default();
         let word = self
             .search_words_hits_filtered(&parsed, PER_INDEX_LIMIT, filter)
+            .unwrap_or_default();
+        let docs_full_text = self
+            .search_docs_full_text_hits_filtered(&parsed, PER_INDEX_LIMIT, filter)
             .unwrap_or_default();
         let semantic = embeddings::get_query_embedding(query_text)
             .and_then(|emb| self.search_semantic_hits(&emb, SEMANTIC_FETCH_LIMIT))
@@ -972,41 +1111,13 @@ impl RegistryClient {
             .take(PER_INDEX_LIMIT)
             .collect::<Vec<_>>();
 
-        // Calculate RRF scores
-        let mut rrf_scores: HashMap<String, f64> = HashMap::new();
-        for (i, hit) in trigram.iter().enumerate() {
-            *rrf_scores.entry(hit.url.clone()).or_default() += 1.0 / (K + (i + 1) as f64);
-        }
-        for (i, hit) in word.iter().enumerate() {
-            *rrf_scores.entry(hit.url.clone()).or_default() += 1.0 / (K + (i + 1) as f64);
-        }
-        for (i, hit) in semantic.iter().enumerate() {
-            *rrf_scores.entry(hit.url.clone()).or_default() += 1.0 / (K + (i + 1) as f64);
-        }
-
-        // Collect unique hits and sort by RRF score
-        let mut all_hits: HashMap<String, SearchHit> = HashMap::new();
-        for hit in trigram.iter().chain(word.iter()).chain(semantic.iter()) {
-            all_hits
-                .entry(hit.url.clone())
-                .or_insert_with(|| hit.clone());
-        }
-
-        let mut scored: Vec<_> = all_hits
-            .into_iter()
-            .map(|(url, hit)| (rrf_scores.get(&url).copied().unwrap_or(0.0), hit))
-            .collect();
-        scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-
-        let merged: Vec<SearchHit> = scored
-            .into_iter()
-            .take(MERGED_LIMIT)
-            .map(|(_, hit)| hit)
-            .collect();
+        let merged =
+            merge_rrf_hit_lists(&[&trigram, &word, &docs_full_text, &semantic], MERGED_LIMIT);
 
         RrfSearchOutput {
             trigram,
             word,
+            docs_full_text,
             semantic,
             merged,
         }
@@ -1036,6 +1147,7 @@ impl RegistryClient {
 pub struct RrfSearchOutput {
     pub trigram: Vec<SearchHit>,
     pub word: Vec<SearchHit>,
+    pub docs_full_text: Vec<SearchHit>,
     pub semantic: Vec<SearchHit>,
     pub merged: Vec<SearchHit>,
 }
@@ -1097,6 +1209,30 @@ mod tests {
             vec!["voltage", "regulator", "3.3v"]
         );
         assert_eq!(tokenize_for_words("a b cd"), vec!["cd"]); // filters short tokens
+    }
+
+    #[test]
+    fn test_build_docs_full_text_fts_query_unquoted_tokens() {
+        assert_eq!(
+            build_docs_full_text_fts_query("hall effect current sensor"),
+            Some("hall* AND effect* AND current* AND sensor*".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_docs_full_text_fts_query_honors_phrases() {
+        assert_eq!(
+            build_docs_full_text_fts_query("\"absolute maximum ratings\" sensor"),
+            Some("\"absolute maximum ratings\" AND sensor*".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_docs_full_text_fts_query_mixes_tokens_and_phrases() {
+        assert_eq!(
+            build_docs_full_text_fts_query("hall \"absolute maximum ratings\" current"),
+            Some("hall* AND \"absolute maximum ratings\" AND current*".to_string())
+        );
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/registry/mod.rs
+++ b/crates/pcb-diode-api/src/registry/mod.rs
@@ -358,7 +358,7 @@ fn tokenize_for_words(s: &str) -> Vec<String> {
         .collect()
 }
 
-fn push_docs_full_text_tokens(chunk: &str, clauses: &mut Vec<String>) {
+fn push_prefix_fts_tokens(chunk: &str, clauses: &mut Vec<String>) {
     clauses.extend(
         tokenize_for_words(chunk)
             .into_iter()
@@ -370,7 +370,7 @@ fn normalize_phrase_whitespace(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-pub(crate) fn build_docs_full_text_fts_query(query: &str) -> Option<String> {
+pub(crate) fn build_prefix_fts_query(query: &str) -> Option<String> {
     let mut clauses = Vec::new();
     let mut current = String::new();
     let mut in_quotes = false;
@@ -385,7 +385,7 @@ pub(crate) fn build_docs_full_text_fts_query(query: &str) -> Option<String> {
                 current.clear();
                 in_quotes = false;
             } else {
-                push_docs_full_text_tokens(&current, &mut clauses);
+                push_prefix_fts_tokens(&current, &mut clauses);
                 current.clear();
                 in_quotes = true;
             }
@@ -394,9 +394,15 @@ pub(crate) fn build_docs_full_text_fts_query(query: &str) -> Option<String> {
         }
     }
 
-    push_docs_full_text_tokens(&current, &mut clauses);
+    push_prefix_fts_tokens(&current, &mut clauses);
 
     (!clauses.is_empty()).then(|| clauses.join(" AND "))
+}
+
+pub(crate) fn normalize_semantic_query(query: &str) -> Option<String> {
+    let normalized = query.replace('"', " ");
+    let collapsed = normalized.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!collapsed.is_empty()).then_some(collapsed)
 }
 
 /// Detect if query looks like an MPN vs natural language
@@ -582,12 +588,9 @@ impl RegistryClient {
             return Ok(Vec::new());
         }
 
-        let fts_query = parsed
-            .word_tokens
-            .iter()
-            .map(|t| format!("{}*", escape_fts5(t)))
-            .collect::<Vec<_>>()
-            .join(" ");
+        let Some(fts_query) = build_prefix_fts_query(&parsed.original) else {
+            return Ok(Vec::new());
+        };
         let (filter_clause, url_pattern) = filter
             .map(|f| f.sql_clause(3))
             .unwrap_or(("", String::new()));
@@ -630,7 +633,7 @@ impl RegistryClient {
             return Ok(Vec::new());
         }
 
-        let Some(fts_query) = build_docs_full_text_fts_query(&parsed.original) else {
+        let Some(fts_query) = build_prefix_fts_query(&parsed.original) else {
             return Ok(Vec::new());
         };
         let (filter_clause, url_pattern) = filter
@@ -1098,8 +1101,9 @@ impl RegistryClient {
         let docs_full_text = self
             .search_docs_full_text_hits_filtered(&parsed, PER_INDEX_LIMIT, filter)
             .unwrap_or_default();
-        let semantic = embeddings::get_query_embedding(query_text)
-            .and_then(|emb| self.search_semantic_hits(&emb, SEMANTIC_FETCH_LIMIT))
+        let semantic = normalize_semantic_query(query_text)
+            .and_then(|q| embeddings::get_query_embedding(&q).ok())
+            .and_then(|emb| self.search_semantic_hits(&emb, SEMANTIC_FETCH_LIMIT).ok())
             .unwrap_or_default()
             .into_iter()
             .filter(|hit| {
@@ -1212,26 +1216,34 @@ mod tests {
     }
 
     #[test]
-    fn test_build_docs_full_text_fts_query_unquoted_tokens() {
+    fn test_build_prefix_fts_query_unquoted_tokens() {
         assert_eq!(
-            build_docs_full_text_fts_query("hall effect current sensor"),
+            build_prefix_fts_query("hall effect current sensor"),
             Some("hall* AND effect* AND current* AND sensor*".to_string())
         );
     }
 
     #[test]
-    fn test_build_docs_full_text_fts_query_honors_phrases() {
+    fn test_build_prefix_fts_query_honors_phrases() {
         assert_eq!(
-            build_docs_full_text_fts_query("\"absolute maximum ratings\" sensor"),
+            build_prefix_fts_query("\"absolute maximum ratings\" sensor"),
             Some("\"absolute maximum ratings\" AND sensor*".to_string())
         );
     }
 
     #[test]
-    fn test_build_docs_full_text_fts_query_mixes_tokens_and_phrases() {
+    fn test_build_prefix_fts_query_mixes_tokens_and_phrases() {
         assert_eq!(
-            build_docs_full_text_fts_query("hall \"absolute maximum ratings\" current"),
+            build_prefix_fts_query("hall \"absolute maximum ratings\" current"),
             Some("hall* AND \"absolute maximum ratings\" AND current*".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_semantic_query_strips_quotes() {
+        assert_eq!(
+            normalize_semantic_query("hall \"absolute maximum ratings\" current"),
+            Some("hall absolute maximum ratings current".to_string())
         );
     }
 

--- a/crates/pcb-diode-api/src/registry/mod.rs
+++ b/crates/pcb-diode-api/src/registry/mod.rs
@@ -311,15 +311,13 @@ pub fn build_registry_search_results(
         .collect()
 }
 
-/// Preprocessed query ready for FTS search
+/// Preprocessed query ready for identifier-aware search.
 #[derive(Debug)]
 pub struct ParsedQuery {
     /// Original query string
     pub original: String,
     /// Canonicalized form for trigram MPN search (alphanumeric only, uppercase)
     pub mpn_canon: String,
-    /// Tokens for word-based FTS search
-    pub word_tokens: Vec<String>,
     /// Whether the query looks like an MPN (vs natural language description)
     pub looks_like_mpn: bool,
 }
@@ -328,13 +326,11 @@ impl ParsedQuery {
     pub fn parse(query: &str) -> Self {
         let original = query.trim().to_string();
         let mpn_canon = canonicalize_mpn(&original);
-        let word_tokens = tokenize_for_words(&original);
         let looks_like_mpn = detect_mpn_query(&original, &mpn_canon);
 
         Self {
             original,
             mpn_canon,
-            word_tokens,
             looks_like_mpn,
         }
     }
@@ -403,6 +399,10 @@ pub(crate) fn normalize_semantic_query(query: &str) -> Option<String> {
     let normalized = query.replace('"', " ");
     let collapsed = normalized.split_whitespace().collect::<Vec<_>>().join(" ");
     (!collapsed.is_empty()).then_some(collapsed)
+}
+
+pub(crate) fn build_query_embedding(query: &str) -> Option<[f32; 1024]> {
+    normalize_semantic_query(query).and_then(|q| embeddings::get_query_embedding(&q).ok())
 }
 
 /// Detect if query looks like an MPN vs natural language
@@ -584,10 +584,6 @@ impl RegistryClient {
         limit: usize,
         filter: Option<SearchFilter>,
     ) -> Result<Vec<SearchHit>> {
-        if parsed.word_tokens.is_empty() {
-            return Ok(Vec::new());
-        }
-
         let Some(fts_query) = build_prefix_fts_query(&parsed.original) else {
             return Ok(Vec::new());
         };
@@ -711,26 +707,10 @@ impl RegistryClient {
             "#,
         )?;
 
-        let rows = stmt.query_map(rusqlite::params![embedding_bytes, limit as i64], |row| {
-            let url: String = row.get(1)?;
-            let mpn: Option<String> = row.get(2)?;
-            let manufacturer: Option<String> = row.get(3)?;
-            Ok(SearchHit {
-                id: row.get(0)?,
-                name: extract_package_name(&url),
-                url,
-                availability_lookups: search_hit_availability_lookups(
-                    mpn.clone(),
-                    manufacturer.clone(),
-                ),
-                mpn,
-                manufacturer,
-                short_description: row.get(4)?,
-                version: row.get(5)?,
-                package_category: row.get(6)?,
-                rank: row.get(7)?,
-            })
-        })?;
+        let rows = stmt.query_map(
+            rusqlite::params![embedding_bytes, limit as i64],
+            Self::map_search_hit,
+        )?;
 
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
@@ -939,17 +919,9 @@ impl RegistryClient {
         parsed: &ParsedQuery,
         limit: usize,
     ) -> Result<Vec<RegistryPackage>> {
-        if parsed.word_tokens.is_empty() {
+        let Some(fts_query) = build_prefix_fts_query(&parsed.original) else {
             return Ok(Vec::new());
-        }
-
-        // Build FTS5 query with prefix matching for each token
-        let fts_query = parsed
-            .word_tokens
-            .iter()
-            .map(|t| format!("{}*", escape_fts5(t)))
-            .collect::<Vec<_>>()
-            .join(" ");
+        };
 
         let mut stmt = self.conn.prepare(
             r#"
@@ -987,12 +959,7 @@ impl RegistryClient {
             })
         })?;
 
-        let mut results = Vec::new();
-        for row in rows {
-            results.push(row?);
-        }
-
-        Ok(results)
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
     /// Get count of packages matching a filter (None = all packages)
@@ -1101,9 +1068,11 @@ impl RegistryClient {
         let docs_full_text = self
             .search_docs_full_text_hits_filtered(&parsed, PER_INDEX_LIMIT, filter)
             .unwrap_or_default();
-        let semantic = normalize_semantic_query(query_text)
-            .and_then(|q| embeddings::get_query_embedding(&q).ok())
-            .and_then(|emb| self.search_semantic_hits(&emb, SEMANTIC_FETCH_LIMIT).ok())
+        let semantic = build_query_embedding(query_text)
+            .and_then(|embedding| {
+                self.search_semantic_hits(&embedding, SEMANTIC_FETCH_LIMIT)
+                    .ok()
+            })
             .unwrap_or_default()
             .into_iter()
             .filter(|hit| {
@@ -1232,6 +1201,14 @@ mod tests {
     }
 
     #[test]
+    fn test_build_prefix_fts_query_phrase_only() {
+        assert_eq!(
+            build_prefix_fts_query("\"absolute maximum ratings\""),
+            Some("\"absolute maximum ratings\"".to_string())
+        );
+    }
+
+    #[test]
     fn test_build_prefix_fts_query_mixes_tokens_and_phrases() {
         assert_eq!(
             build_prefix_fts_query("hall \"absolute maximum ratings\" current"),
@@ -1264,6 +1241,6 @@ mod tests {
 
         let q = ParsedQuery::parse("n-channel mosfet 60v");
         assert!(!q.looks_like_mpn);
-        assert_eq!(q.word_tokens, vec!["n-channel", "mosfet", "60v"]);
+        assert_eq!(q.original, "n-channel mosfet 60v");
     }
 }

--- a/crates/pcb-diode-api/src/registry/tui/search.rs
+++ b/crates/pcb-diode-api/src/registry/tui/search.rs
@@ -84,6 +84,8 @@ pub struct PartScoring {
     pub trigram_rank: Option<f64>,
     pub word_position: Option<usize>,
     pub word_rank: Option<f64>,
+    pub docs_full_text_position: Option<usize>,
+    pub docs_full_text_rank: Option<f64>,
     pub semantic_position: Option<usize>,
     pub semantic_rank: Option<f64>,
 }
@@ -94,6 +96,7 @@ pub struct SearchResults {
     pub query_id: u64,
     pub trigram: Vec<SearchHit>,
     pub word: Vec<SearchHit>,
+    pub docs_full_text: Vec<SearchHit>,
     pub semantic: Vec<SearchHit>,
     pub merged: Vec<SearchHit>,
     pub scoring: HashMap<String, PartScoring>,
@@ -106,6 +109,7 @@ impl Default for SearchResults {
             query_id: 0,
             trigram: Vec::new(),
             word: Vec::new(),
+            docs_full_text: Vec::new(),
             semantic: Vec::new(),
             merged: Vec::new(),
             scoring: HashMap::new(),
@@ -390,6 +394,13 @@ pub(crate) fn build_scoring(
         entry.word_position = Some(idx);
         entry.word_rank = hit.rank;
     }
+    for (idx, hit) in rrf.docs_full_text.iter().enumerate() {
+        let entry = scoring
+            .entry(hit.url.clone())
+            .or_insert_with(PartScoring::default);
+        entry.docs_full_text_position = Some(idx);
+        entry.docs_full_text_rank = hit.rank;
+    }
     for (idx, hit) in rrf.semantic.iter().enumerate() {
         let entry = scoring
             .entry(hit.url.clone())
@@ -573,6 +584,7 @@ pub fn spawn_worker(
                         query_id: query.id,
                         trigram: rrf.trigram,
                         word: rrf.word,
+                        docs_full_text: rrf.docs_full_text,
                         semantic: rrf.semantic,
                         merged: rrf.merged,
                         scoring,
@@ -642,6 +654,7 @@ pub fn spawn_worker(
                         query_id: query.id,
                         trigram: rrf.trigram,
                         word: rrf.word,
+                        docs_full_text: rrf.docs_full_text,
                         semantic: rrf.semantic,
                         merged: rrf.merged,
                         scoring,

--- a/crates/pcb-diode-api/src/registry/tui/ui.rs
+++ b/crates/pcb-diode-api/src/registry/tui/ui.rs
@@ -107,13 +107,13 @@ fn render_results_panels(frame: &mut Frame, app: &mut App, area: Rect) {
             // Semantic on left, Trigram + Word stacked on right
             let cols = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([
-                    Constraint::Percentage(50), // Semantic
-                    Constraint::Percentage(50), // Trigram + Word stacked
-                ])
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
                 .split(rows[0]);
 
-            // Right column: Trigram on top, Word on bottom
+            let left_rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(cols[0]);
             let right_rows = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
@@ -123,7 +123,7 @@ fn render_results_panels(frame: &mut Frame, app: &mut App, area: Rect) {
                 frame,
                 "Semantic",
                 &app.results.semantic,
-                cols[0],
+                left_rows[0],
                 Color::Cyan,
                 None,
                 true,
@@ -132,7 +132,7 @@ fn render_results_panels(frame: &mut Frame, app: &mut App, area: Rect) {
                 frame,
                 "Trigram",
                 &app.results.trigram,
-                right_rows[0],
+                left_rows[1],
                 Color::Yellow,
                 None,
                 true,
@@ -141,8 +141,17 @@ fn render_results_panels(frame: &mut Frame, app: &mut App, area: Rect) {
                 frame,
                 "Word",
                 &app.results.word,
-                right_rows[1],
+                right_rows[0],
                 Color::Green,
+                None,
+                true,
+            );
+            render_result_list(
+                frame,
+                "Docs",
+                &app.results.docs_full_text,
+                right_rows[1],
+                Color::LightMagenta,
                 None,
                 true,
             );
@@ -1076,6 +1085,13 @@ fn render_kicad_symbol_detail_lines(
         ]));
     }
 
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "─── Search Scoring ───",
+        Style::default().fg(Color::DarkGray),
+    )));
+    append_search_scoring_for_url(&mut lines, app, &symbol.clipboard_url(), label_style);
+
     lines
 }
 
@@ -1349,7 +1365,7 @@ fn append_detail_body(
         "─── Search Scoring ───",
         Style::default().fg(Color::DarkGray),
     )));
-    append_search_scoring(lines, app, part, dim_style);
+    append_search_scoring_for_url(lines, app, &part.url, dim_style);
 }
 
 /// Append DigiKey parameters with priority ordering
@@ -1417,8 +1433,8 @@ fn append_parameters(
 }
 
 /// Append search scoring section
-fn append_search_scoring(lines: &mut Vec<Line>, app: &App, part: &RegistryPart, dim_style: Style) {
-    let scoring = app.results.scoring.get(&part.url);
+fn append_search_scoring_for_url(lines: &mut Vec<Line>, app: &App, url: &str, dim_style: Style) {
+    let scoring = app.results.scoring.get(url);
 
     let format_result = |pos: Option<usize>, rank: Option<f64>, total: usize| -> Vec<Span> {
         match pos {
@@ -1442,6 +1458,9 @@ fn append_search_scoring(lines: &mut Vec<Line>, app: &App, part: &RegistryPart, 
     let (word_pos, word_rank) = scoring
         .map(|s| (s.word_position, s.word_rank))
         .unwrap_or((None, None));
+    let (docs_pos, docs_rank) = scoring
+        .map(|s| (s.docs_full_text_position, s.docs_full_text_rank))
+        .unwrap_or((None, None));
     let (sem_pos, sem_rank) = scoring
         .map(|s| (s.semantic_position, s.semantic_rank))
         .unwrap_or((None, None));
@@ -1457,19 +1476,38 @@ fn append_search_scoring(lines: &mut Vec<Line>, app: &App, part: &RegistryPart, 
     word_line.extend(format_result(word_pos, word_rank, app.results.word.len()));
     lines.push(Line::from(word_line));
 
+    let mut docs_line = vec![Span::styled(
+        "Docs     ",
+        Style::default().fg(Color::LightMagenta),
+    )];
+    docs_line.extend(format_result(
+        docs_pos,
+        docs_rank,
+        app.results.docs_full_text.len(),
+    ));
+    lines.push(Line::from(docs_line));
+
     let mut sem_line = vec![Span::styled("Semantic ", Style::default().fg(Color::Cyan))];
     sem_line.extend(format_result(sem_pos, sem_rank, app.results.semantic.len()));
     lines.push(Line::from(sem_line));
 
     // RRF score calculation
-    const K: f64 = 10.0;
-    let rrf = |pos: Option<usize>| pos.map(|p| 1.0 / (K + (p + 1) as f64)).unwrap_or(0.0);
-    let rrf_score = rrf(tri_pos) + rrf(word_pos) + rrf(sem_pos);
+    let rrf = |pos: Option<usize>| {
+        pos.map(|p| 1.0 / (crate::registry::RRF_K + (p + 1) as f64))
+            .unwrap_or(0.0)
+    };
+    let rrf_score = rrf(tri_pos) + rrf(word_pos) + rrf(docs_pos) + rrf(sem_pos);
 
-    let rrf_parts: Vec<String> = [tri_pos, word_pos, sem_pos]
+    let rrf_parts: Vec<String> = [tri_pos, word_pos, docs_pos, sem_pos]
         .iter()
         .filter_map(|&pos| {
-            pos.map(|p| format!("1/(10+{})={:.3}", p + 1, 1.0 / (K + (p + 1) as f64)))
+            pos.map(|p| {
+                format!(
+                    "1/(10+{})={:.3}",
+                    p + 1,
+                    1.0 / (crate::registry::RRF_K + (p + 1) as f64)
+                )
+            })
         })
         .collect();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new FTS/BM25 index into the `pcb search` ranking pipeline and changes query parsing/embedding normalization, which can noticeably affect relevance and result ordering across registry and KiCad symbol search.
> 
> **Overview**
> `pcb search` now includes a **docs full-text (OCR) ranker** for both registry packages and KiCad symbols, and merges it into the existing trigram/word/semantic pipeline via shared Reciprocal Rank Fusion helpers.
> 
> Query handling was updated to build a consistent FTS5 query that supports quoted phrases and to normalize semantic queries (strip quotes) before embedding; CLI/TUI debug output and scoring panels were extended to show the new `docs` contribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738fe6a3ce5e8a135f8c88fb7273482dc9d5a10d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
