### PR TITLE
Coerce physical values in net fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Net type physical-value fields now coerce string and scalar inputs like `io()`/`config()`.
+
 ## [0.3.67] - 2026-04-10
 
 ### Added

--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -231,7 +231,7 @@ fn create_field_value<'v>(
     heap: &'v Heap,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Value<'v>> {
-    if let Some(value) = validate_field(field_name, field_spec, provided_value, heap)? {
+    if let Some(value) = validate_field(field_name, field_spec, provided_value, eval)? {
         return Ok(value);
     }
 

--- a/crates/pcb-zen-core/src/lang/mod.rs
+++ b/crates/pcb-zen-core/src/lang/mod.rs
@@ -14,6 +14,7 @@ pub mod spice_model;
 pub mod stackup;
 pub mod symbol;
 pub mod test_bench;
+pub(crate) mod type_conversion;
 pub mod type_info;
 
 // Misc helpers (error/check)

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -9,6 +9,7 @@ use crate::lang::component::FrozenComponentValue;
 use crate::lang::electrical_check::FrozenElectricalCheck;
 use crate::lang::r#enum::{EnumType, EnumValue};
 use crate::lang::test_bench::FrozenTestBenchValue;
+use crate::lang::type_conversion::try_implicit_type_conversion;
 use allocative::Allocative;
 use pcb_sch::physical::PhysicalValueType;
 use serde::Serialize;
@@ -1225,115 +1226,6 @@ fn validate_type<'v>(
     );
 }
 
-// Add helper function to attempt converting a value to an enum variant when
-// `typ` is an EnumType / FrozenEnumType and the provided `value` is not yet an
-// `EnumValue`.  Returns `Ok(Some(converted))` if the conversion succeeds,
-// `Ok(None)` if `typ` is not an enum type, and `Err(..)` if the conversion was
-// attempted but failed.
-fn try_enum_conversion<'v>(
-    value: Value<'v>,
-    typ: Value<'v>,
-    eval: &mut Evaluator<'v, '_, '_>,
-) -> anyhow::Result<Option<Value<'v>>> {
-    // Only applicable for EnumType values.
-    if typ.downcast_ref::<EnumType>().is_none() {
-        return Ok(None);
-    }
-
-    // If the value is already an EnumValue, bail early – the caller should have
-    // succeeded the type check in that case.
-    if value.downcast_ref::<EnumValue>().is_some() {
-        return Ok(None);
-    }
-
-    // Attempt to call the enum factory with the provided `value` as a single
-    // positional argument.  This supports common call patterns like passing the
-    // variant label as a string (e.g. "NORTH") or the numeric variant index.
-    // Return Ok(None) on failure so other conversion strategies can be tried.
-    match eval.eval_function(typ, &[value], &[]) {
-        Ok(converted) => Ok(Some(converted)),
-        Err(_) => Ok(None), // Can't convert - let caller try other strategies
-    }
-}
-
-/// Attempt to convert scalar/string inputs to a PhysicalValue via the
-/// PhysicalValueType constructor.
-fn try_physical_conversion<'v>(
-    value: Value<'v>,
-    typ: Value<'v>,
-    eval: &mut Evaluator<'v, '_, '_>,
-) -> anyhow::Result<Option<Value<'v>>> {
-    if typ.downcast_ref::<PhysicalValueType>().is_none() {
-        return Ok(None);
-    }
-    let is_supported_scalar = value.unpack_str().is_some()
-        || value.unpack_i32().is_some()
-        || value.downcast_ref::<StarlarkFloat>().is_some();
-    if !is_supported_scalar {
-        return Ok(None);
-    }
-    match eval.eval_function(typ, &[value], &[]) {
-        Ok(converted) => Ok(Some(converted)),
-        Err(_) => Ok(None),
-    }
-}
-
-/// Determines if a net type can be promoted/demoted to another.
-///
-/// Net type promotion hierarchy:
-///   - NotConnected → any type (universal donor)
-///   - Power, Ground, etc. → Net (demotion to base type)
-///   - Net → nothing (cannot be promoted)
-///   - Nothing → NotConnected (NotConnected only accepts NotConnected)
-fn can_convert_net_type<'a>(actual: &'a str, expected: &'a str) -> Option<&'a str> {
-    match (actual, expected) {
-        // Same type - no conversion needed
-        (a, e) if a == e => None,
-        // NotConnected promotes to anything
-        ("NotConnected", expected) => Some(expected),
-        // Any typed net demotes to Net
-        (_, "Net") => Some("Net"),
-        // All other conversions are invalid
-        _ => None,
-    }
-}
-
-/// Attempts net type conversion when passing a typed net to a parameter
-/// expecting a different net type (e.g., NotConnected -> Power, Power -> Net).
-///
-/// Returns `Ok(Some(converted))` if conversion succeeds, `Ok(None)` if not applicable.
-fn try_net_conversion<'v>(
-    value: Value<'v>,
-    expected_typ: Value<'v>,
-    eval: &mut Evaluator<'v, '_, '_>,
-) -> anyhow::Result<Option<Value<'v>>> {
-    let expected = expected_typ
-        .downcast_ref::<NetType>()
-        .map(|nt| nt.type_name.as_str())
-        .or_else(|| {
-            expected_typ
-                .downcast_ref::<FrozenNetType>()
-                .map(|fnt| fnt.type_name.as_str())
-        });
-
-    let Some(expected) = expected else {
-        return Ok(None);
-    };
-
-    // Try conversion for NetValue or FrozenNetValue
-    if let Some(nv) = value.downcast_ref::<NetValue>() {
-        if let Some(target) = can_convert_net_type(nv.net_type_name(), expected) {
-            return Ok(Some(nv.with_net_type(target, eval.heap())));
-        }
-    } else if let Some(fnv) = value.downcast_ref::<FrozenNetValue>()
-        && let Some(target) = can_convert_net_type(fnv.net_type_name(), expected)
-    {
-        return Ok(Some(fnv.with_net_type(target, eval.heap())));
-    }
-
-    Ok(None)
-}
-
 fn validate_or_convert<'v>(
     name: &str,
     value: Value<'v>,
@@ -1346,22 +1238,7 @@ fn validate_or_convert<'v>(
         return Ok(value);
     }
 
-    // 1. Try automatic conversions for values
-
-    // 1a. Try net type conversion (e.g., Power -> Net, NotConnected -> Net)
-    if let Some(converted) = try_net_conversion(value, typ, eval)? {
-        validate_type(name, converted, typ, eval.heap())?;
-        return Ok(converted);
-    }
-
-    // 1b. If expected type is enum and value is string, auto-convert (enum was downgraded)
-    if let Some(converted) = try_enum_conversion(value, typ, eval)? {
-        validate_type(name, converted, typ, eval.heap())?;
-        return Ok(converted);
-    }
-
-    // 1c. If expected type is PhysicalValue and value is string, auto-convert
-    if let Some(converted) = try_physical_conversion(value, typ, eval)? {
+    if let Some(converted) = try_implicit_type_conversion(value, typ, eval)? {
         validate_type(name, converted, typ, eval.heap())?;
         return Ok(converted);
     }
@@ -1381,18 +1258,7 @@ fn validate_or_convert<'v>(
         return Ok(converted);
     }
 
-    // 3. Try automatic int to float conversion (no custom converter)
-    let type_str = typ.to_string();
-    if (type_str == "float" || type_str == "Float")
-        && let Some(i) = value.unpack_i32()
-    {
-        let float_val = eval.heap().alloc(StarlarkFloat(i as f64));
-        if validate_type(name, float_val, typ, eval.heap()).is_ok() {
-            return Ok(float_val);
-        }
-    }
-
-    // 4. None of the conversion paths worked – propagate the original validation error
+    // 3. None of the conversion paths worked – propagate the original validation error
     validate_type(name, value, typ, eval.heap())?;
     unreachable!();
 }

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -25,6 +25,9 @@ use starlark_map::sorted_map::SortedMap;
 use crate::lang::evaluator_ext::EvaluatorExt;
 use crate::lang::naming;
 use crate::lang::symbol::SymbolValue;
+use crate::lang::type_conversion::{
+    try_implicit_type_conversion, try_physical_conversion_from_default,
+};
 
 use super::context::ContextValue;
 use super::validation::validate_identifier_name;
@@ -423,8 +426,10 @@ pub(crate) fn validate_field<'v>(
     field_name: &str,
     field_spec: Value<'v>,
     provided_value: Option<Value<'v>>,
-    heap: &'v Heap,
+    eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Option<Value<'v>>> {
+    let heap = eval.heap();
+
     // Try to extract default from field() spec first (before type compilation)
     let default = if let Some(fg) = field_spec.downcast_ref::<FieldGen<Value>>() {
         fg.default().map(|d| d.to_value())
@@ -451,20 +456,28 @@ pub(crate) fn validate_field<'v>(
         }
     };
 
+    let field_type_error = |provided_val: Value<'v>| {
+        anyhow::anyhow!(
+            "Field `{}` has wrong type: expected `{}`, got value `{}` of type `{}`",
+            field_name,
+            type_compiled,
+            provided_val.to_repr(),
+            provided_val.get_type()
+        )
+    };
+
     if let Some(provided_val) = provided_value {
-        // User provided a value - validate it against the field's type spec
-        // Validate provided value against type
         if type_compiled.matches(provided_val) {
             Ok(Some(provided_val))
         } else {
-            Err(anyhow::anyhow!(
-                "Field `{}` has wrong type: expected `{}`, got value `{}` of type `{}`",
-                field_name,
-                type_compiled,
-                provided_val.to_repr(),
-                provided_val.get_type()
-            )
-            .into())
+            let converted = try_implicit_type_conversion(provided_val, field_spec, eval)?.or(
+                try_physical_conversion_from_default(provided_val, default, eval)?,
+            );
+
+            match converted {
+                Some(converted) if type_compiled.matches(converted) => Ok(Some(converted)),
+                _ => Err(field_type_error(provided_val).into()),
+            }
         }
     } else {
         // No provided value - use default if available
@@ -593,7 +606,7 @@ where
                         field_name,
                         field_spec.to_value(),
                         field_values.get(field_name).copied(),
-                        heap,
+                        eval,
                     )?;
 
                     if let Some(field_value) = result {

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -470,9 +470,10 @@ pub(crate) fn validate_field<'v>(
         if type_compiled.matches(provided_val) {
             Ok(Some(provided_val))
         } else {
-            let converted = try_implicit_type_conversion(provided_val, field_spec, eval)?.or(
-                try_physical_conversion_from_default(provided_val, default, eval)?,
-            );
+            let converted = match try_implicit_type_conversion(provided_val, field_spec, eval)? {
+                Some(converted) => Some(converted),
+                None => try_physical_conversion_from_default(provided_val, default, eval)?,
+            };
 
             match converted {
                 Some(converted) if type_compiled.matches(converted) => Ok(Some(converted)),

--- a/crates/pcb-zen-core/src/lang/type_conversion.rs
+++ b/crates/pcb-zen-core/src/lang/type_conversion.rs
@@ -1,0 +1,170 @@
+use pcb_sch::physical::{PhysicalUnitDims, PhysicalValue, PhysicalValueType};
+use starlark::eval::Evaluator;
+use starlark::values::{Value, ValueLike, float::StarlarkFloat};
+
+use crate::lang::r#enum::{EnumType, EnumValue};
+use crate::lang::net::{FrozenNetType, FrozenNetValue, NetType, NetValue};
+
+fn is_float_type<'v>(typ: Value<'v>) -> bool {
+    matches!(typ.get_type(), "float" | "Float")
+        || matches!(typ.to_string().as_str(), "float" | "Float")
+}
+
+fn is_supported_scalar<'v>(value: Value<'v>) -> bool {
+    value.unpack_str().is_some()
+        || value.unpack_i32().is_some()
+        || value.downcast_ref::<StarlarkFloat>().is_some()
+}
+
+fn try_function_conversion<'v>(
+    converter: Value<'v>,
+    value: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    match eval.eval_function(converter, &[value], &[]) {
+        Ok(converted) => Ok(Some(converted)),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Determines if a net type can be promoted/demoted to another.
+///
+/// Net type promotion hierarchy:
+///   - NotConnected -> any type (universal donor)
+///   - Power, Ground, etc. -> Net (demotion to base type)
+///   - Net -> nothing (cannot be promoted)
+///   - Nothing -> NotConnected (NotConnected only accepts NotConnected)
+fn can_convert_net_type<'a>(actual: &'a str, expected: &'a str) -> Option<&'a str> {
+    match (actual, expected) {
+        (a, e) if a == e => None,
+        ("NotConnected", expected) => Some(expected),
+        (_, "Net") => Some("Net"),
+        _ => None,
+    }
+}
+
+/// Attempt to convert a value to another compatible net type.
+pub(crate) fn try_net_conversion<'v>(
+    value: Value<'v>,
+    expected_typ: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    let expected = expected_typ
+        .downcast_ref::<NetType>()
+        .map(|nt| nt.type_name.as_str())
+        .or_else(|| {
+            expected_typ
+                .downcast_ref::<FrozenNetType>()
+                .map(|fnt| fnt.type_name.as_str())
+        });
+
+    let Some(expected) = expected else {
+        return Ok(None);
+    };
+
+    if let Some(nv) = value.downcast_ref::<NetValue>() {
+        if let Some(target) = can_convert_net_type(nv.net_type_name(), expected) {
+            return Ok(Some(nv.with_net_type(target, eval.heap())));
+        }
+    } else if let Some(fnv) = value.downcast_ref::<FrozenNetValue>()
+        && let Some(target) = can_convert_net_type(fnv.net_type_name(), expected)
+    {
+        return Ok(Some(fnv.with_net_type(target, eval.heap())));
+    }
+
+    Ok(None)
+}
+
+/// Attempt to convert a plain string/scalar to an enum variant.
+pub(crate) fn try_enum_conversion<'v>(
+    value: Value<'v>,
+    typ: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    if typ.downcast_ref::<EnumType>().is_none() {
+        return Ok(None);
+    }
+
+    if value.downcast_ref::<EnumValue>().is_some() {
+        return Ok(None);
+    }
+
+    try_function_conversion(typ, value, eval)
+}
+
+fn try_physical_conversion_for_unit<'v>(
+    value: Value<'v>,
+    unit: PhysicalUnitDims,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    if !is_supported_scalar(value) {
+        return Ok(None);
+    }
+
+    try_function_conversion(eval.heap().alloc(PhysicalValueType::new(unit)), value, eval)
+}
+
+/// Attempt to convert scalar/string inputs to a PhysicalValue via the
+/// PhysicalValueType constructor.
+pub(crate) fn try_physical_conversion<'v>(
+    value: Value<'v>,
+    typ: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    if typ.downcast_ref::<PhysicalValueType>().is_none() {
+        return Ok(None);
+    }
+
+    if !is_supported_scalar(value) {
+        return Ok(None);
+    }
+
+    try_function_conversion(typ, value, eval)
+}
+
+/// Attempt physical-value conversion by inferring the unit from a typed default.
+///
+/// This is primarily used for `field(Voltage, default=Voltage("0V"))` style net
+/// fields, where the Starlark `field(...)` wrapper preserves the compiled matcher
+/// and default value but not the original constructor value.
+pub(crate) fn try_physical_conversion_from_default<'v>(
+    value: Value<'v>,
+    default: Option<Value<'v>>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    let Some(default) = default else {
+        return Ok(None);
+    };
+    let Some(physical) = default.downcast_ref::<PhysicalValue>() else {
+        return Ok(None);
+    };
+
+    try_physical_conversion_for_unit(value, physical.unit, eval)
+}
+
+/// Try the same implicit conversions used by module placeholders.
+pub(crate) fn try_implicit_type_conversion<'v>(
+    value: Value<'v>,
+    typ: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    if let Some(converted) = try_net_conversion(value, typ, eval)? {
+        return Ok(Some(converted));
+    }
+
+    if let Some(converted) = try_enum_conversion(value, typ, eval)? {
+        return Ok(Some(converted));
+    }
+
+    if let Some(converted) = try_physical_conversion(value, typ, eval)? {
+        return Ok(Some(converted));
+    }
+
+    if is_float_type(typ)
+        && let Some(i) = value.unpack_i32()
+    {
+        return Ok(Some(eval.heap().alloc(StarlarkFloat(i as f64))));
+    }
+
+    Ok(None)
+}

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -609,3 +609,35 @@ snapshot_eval!(io_default_not_connected_promotes_to_net, {
         print("io() default NotConnected promotes to Net: success")
     "#
 });
+
+#[test]
+fn net_field_physical_value_coerces_from_string() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+        Power = builtin.net_type("Power", voltage=Voltage)
+
+        vcc = Power("VCC", voltage="5V")
+        check(vcc.voltage == Voltage("5V"), "voltage string should coerce to Voltage")
+    "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+}
+
+#[test]
+fn net_field_physical_value_coerces_from_string_with_field_default() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+        Ground = builtin.net_type("Ground", voltage=field(Voltage, default=Voltage("0V")))
+
+        gnd = Ground("GND", voltage="0V")
+        check(gnd.voltage == Voltage("0V"), "field(...) voltage string should coerce to Voltage")
+    "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+}

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -190,14 +190,14 @@ Local definitions shadow prelude symbols. The prelude does not apply to stdlib m
 A `Net` represents an electrical connection between component pins. `Net` is the base net type; specialized types like `Power`, `Ground`, and `NotConnected` add metadata (schematic symbols, voltage) while remaining fundamentally nets.
 
 ```python
-load("@stdlib/units.zen", "Voltage", "Impedance")
+load("@stdlib/units.zen", "Impedance")
 
 # Basic nets
 CLK = Net("CLK")
 DATA = Net("DATA", impedance=Impedance(50))  # controlled impedance
 
 # Power and ground (prelude — no load needed)
-vcc = Power("VCC_3V3", voltage=Voltage("3.3V"))
+vcc = Power("VCC_3V3", voltage="3.3V")
 gnd = Ground("GND")  # voltage defaults to 0V
 
 # Intentionally unconnected
@@ -463,10 +463,9 @@ Instantiated by a parent board:
 
 ```python
 # boards/MainBoard/MainBoard.zen
-load("@stdlib/units.zen", "Voltage")
 LedIndicator = Module("./modules/LedIndicator.zen")
 
-vcc = Power("VCC_3V3", voltage=Voltage("3.3V"))
+vcc = Power("VCC_3V3", voltage="3.3V")
 gnd = Ground("GND")
 
 LedIndicator(name="LED1", VCC=vcc, GND=gnd, color="green")

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -206,6 +206,8 @@ nc = NotConnected()
 
 `Net(name, voltage=None, impedance=None)` — all parameters optional. `Power` and `Ground` additionally accept a `voltage` parameter. Additional net types (`Analog`, `Pwm`, `Gpio`) are available from `@stdlib/interfaces.zen`.
 
+Typed net fields validate against their declared field type and apply the same physical-value coercion used by module inputs, so `Power("VCC", voltage="3.3V")` is equivalent to `Power("VCC", voltage=Voltage("3.3V"))`.
+
 Net types follow automatic conversion rules across `io()` boundaries: `NotConnected` promotes to any type (universal donor), any specialized type demotes to `Net`, but `Net` cannot automatically promote to specialized types. For explicit casting, call the target constructor with an existing net: `Power(net, voltage=Voltage("3.3V"))` or `Net(power_net)`.
 
 ### Interfaces

--- a/examples/power_checks.zen
+++ b/examples/power_checks.zen
@@ -37,7 +37,7 @@ def check_voltage_within(
     return check_gen
 
 # Option 1: Use stdlib ElectricalCheck
-vbat = Power("VBAT", voltage=Voltage("11–26 V (12 V nom.)"))
+vbat = Power("VBAT", voltage="11–26 V (12 V nom.)")
 ElectricalCheck(
     severity=Severity("warning"),
     check_fn=check_voltage_within(Voltage("20–30 V")),


### PR DESCRIPTION
`Power("VCC", voltage="5V")` now works.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime type-conversion behavior during net instantiation and refactors shared conversion logic, which could subtly affect existing net-field validation and implicit casting paths.
> 
> **Overview**
> **Typed net fields now support implicit coercion for physical values.** When constructing typed nets (and when instantiating interfaces that include net fields), string/scalar inputs for physical-value fields (e.g. `voltage="3.3V"`) are now converted to the declared physical type, including cases where the field is declared via `field(...)` with a typed default.
> 
> The implicit conversion logic used by `io()`/`config()` is refactored into a new `type_conversion` module and reused for both module placeholder validation and net field validation; docs/examples are updated accordingly and new tests cover the new coercion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9ded37dd791fe52ac61a30e7465c4f54a8b621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
