### PR TITLE
fix(stdlib): remove 1210 10uF house cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Component generation no longer automatically scans datasheets.
 - `pcb new component` and `pcb search` component imports now place datasheet artifacts under each component's `docs/` subdirectory.
 
+### Removed
+- Removed the 10uF 100V 1210 stdlib house capacitor from generic matching due to severe derating.
+
 ## [0.3.67] - 2026-04-10
 
 ### Added

--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -199,7 +199,6 @@ HOUSE_CAPS_BY_PKG = {
     "1210": [
         murata_cap("X7R", "25V", "22uF 10%", "GRM32ER71E226KE15", ["K", "L"]),
         murata_cap("X7R", "10V", "47uF 10%", "GRM32ER71A476KE15", ["K", "L"]),
-        murata_cap("X7S", "100V", "10uF 10%", "GRM32EC72A106KE05", ["K", "L"]),
     ]
 }
 


### PR DESCRIPTION
## Summary
- remove the 1210 10uF 100V house capacitor from stdlib generic matching
- add an unreleased changelog entry for the removal
- note that the part was originally introduced by 5ff76758f7aa5a8700cf755a12c84457a8f89f15 (`stdlib: 10uF 100V house capacitor (#677)`)

## Verification
- cargo test -p pcb bom -- --nocapture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single stdlib generic capacitor match and documents it; impact is limited to BOM auto-selection for that specific 1210 cap value/voltage.
> 
> **Overview**
> Stops stdlib generic capacitor matching from auto-selecting the Murata 1210 `10uF 100V` house capacitor (removed from `HOUSE_CAPS_BY_PKG`).
> 
> Adds an *Unreleased* changelog entry noting the removal due to severe derating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9320f2a485c689b9a68a4754d45e4b9c294163f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->