### PR TITLE
Canonicalize file-backed KiCad footprint IDs

### DIFF
--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 
 use include_dir::{Dir, include_dir};
 use pcb_kicad::PythonScriptBuilder;
-use pcb_sch::kicad_netlist::{format_footprint, write_fp_lib_table};
+use pcb_sch::kicad_netlist::{format_footprint_with_package_roots, write_fp_lib_table};
 
 mod kicad_project_patch;
 mod model_embed_discovery;
@@ -779,12 +779,9 @@ pub mod utils {
             }
 
             if let Some(AttributeValue::String(fp_attr)) = inst.attributes.get("footprint") {
-                let resolved_fp = schematic
-                    .resolve_package_uri(fp_attr)
-                    .with_context(|| format!("Failed to resolve footprint path '{fp_attr}'"))?
-                    .to_string_lossy()
-                    .into_owned();
-                if let (_, Some((lib_name, dir))) = format_footprint(&resolved_fp) {
+                if let (_, Some((lib_name, dir))) =
+                    format_footprint_with_package_roots(fp_attr, &schematic.package_roots)
+                {
                     fp_libs.entry(lib_name).or_insert(dir);
                 }
             }

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -224,7 +224,7 @@ class JsonNetlistParser:
             )
             if footprint_path:
                 # Use the format_footprint function to handle both file paths and lib:fp format
-                footprint = format_footprint(footprint_path)
+                footprint = format_footprint(footprint_path, parser.package_roots)
             else:
                 footprint = "unknown:unknown"
 
@@ -402,7 +402,62 @@ def is_kicad_lib_fp(s):
     return True
 
 
-def format_footprint(fp_str):
+def _path_under_root(path_obj, root_obj):
+    try:
+        path_obj.relative_to(root_obj)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_package_uri(uri, package_roots):
+    """Resolve a package:// URI to an absolute filesystem path."""
+    rest = uri[len("package://") :]
+
+    best_url = None
+    best_root = None
+
+    for url, root in package_roots.items():
+        if rest.startswith(url) and (len(rest) == len(url) or rest[len(url)] == "/"):
+            if best_url is None or len(url) > len(best_url):
+                best_url = url
+                best_root = root
+
+    if best_url is None or best_root is None:
+        raise ValueError(f"Unknown package in URI: {uri}")
+
+    rel = rest[len(best_url) :].lstrip("/")
+    if rel:
+        return Path(best_root) / rel
+    return Path(best_root)
+
+
+def _package_library_name(fp_path, package_roots):
+    if not package_roots:
+        return None
+
+    best_match = None
+    for coord, root in package_roots.items():
+        root_path = Path(root)
+        if not _path_under_root(fp_path, root_path):
+            continue
+
+        repo = coord.rsplit("@", 1)[0]
+        depth = len(root_path.parts)
+        if best_match is None or depth > best_match[0]:
+            best_match = (depth, repo, root_path)
+
+    if best_match is None:
+        return None
+
+    _, repo, root_path = best_match
+    if fp_path.parent != root_path:
+        return None
+
+    return repo.rsplit("/", 1)[-1]
+
+
+def format_footprint(fp_str, package_roots=None):
     """Convert footprint strings that may point to a .kicad_mod file into a KiCad lib:fp identifier.
 
     This matches the Rust implementation in kicad_netlist.rs
@@ -411,12 +466,30 @@ def format_footprint(fp_str):
         return fp_str
 
     # Extract the footprint name from the file path
-    fp_path = Path(fp_str)
+    if fp_str.startswith("package://") and package_roots:
+        try:
+            fp_path = resolve_package_uri(fp_str, package_roots)
+        except ValueError:
+            fp_path = Path(fp_str)
+    else:
+        fp_path = Path(fp_str)
     stem = fp_path.stem
     if not stem:
         return "UNKNOWN:UNKNOWN"
 
-    return f"{stem}:{stem}"
+    parent = fp_path.parent
+    lib_name = None
+
+    if parent.suffix == ".pretty":
+        lib_name = parent.stem or parent.name
+
+    if not lib_name:
+        lib_name = _package_library_name(fp_path, package_roots or {})
+
+    if not lib_name:
+        lib_name = parent.stem or parent.name or stem
+
+    return f"{lib_name}:{stem}"
 
 
 ####################################################################################################

--- a/crates/pcb-sch/src/kicad_netlist.rs
+++ b/crates/pcb-sch/src/kicad_netlist.rs
@@ -1,12 +1,12 @@
 // Module implementing KiCad net-list export functionality for `pcb_sch::Schematic`.
 
 use pathdiff::diff_paths;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
-use crate::{AttributeValue, InstanceKind, InstanceRef, Schematic};
+use crate::{AttributeValue, InstanceKind, InstanceRef, PACKAGE_URI_PREFIX, Schematic};
 
 #[derive(Debug)]
 struct CompInfo<'a> {
@@ -180,7 +180,8 @@ pub fn to_kicad_netlist(sch: &Schematic) -> String {
                 _ => None,
             })
             .unwrap_or("UNKNOWN:UNKNOWN");
-        let (fp_string, _lib_info) = format_footprint(fp_attr);
+        let (fp_string, _lib_info) =
+            format_footprint_with_package_roots(fp_attr, &sch.package_roots);
 
         writeln!(out, "    (comp (ref \"{}\")", escape_kicad_string(refdes)).unwrap();
         writeln!(
@@ -410,24 +411,86 @@ fn collect_pins_for_component(
 /// Returns the (possibly modified) footprint string and optional `(lib_name, dir)` tuple that can be
 /// used to populate the fp-lib-table.
 pub fn format_footprint(fp: &str) -> (String, Option<(String, PathBuf)>) {
+    format_footprint_with_package_roots(fp, &BTreeMap::new())
+}
+
+/// Package-aware variant of [`format_footprint`].
+pub fn format_footprint_with_package_roots(
+    fp: &str,
+    package_roots: &BTreeMap<String, PathBuf>,
+) -> (String, Option<(String, PathBuf)>) {
     if is_kicad_lib_fp(fp) {
         return (fp.to_owned(), None);
     }
-    let p = Path::new(fp);
+
+    let resolved = if fp.starts_with(PACKAGE_URI_PREFIX) {
+        crate::resolve_package_uri(fp, package_roots).unwrap_or_else(|_| PathBuf::from(fp))
+    } else {
+        PathBuf::from(fp)
+    };
+
+    let p = resolved.as_path();
     let Some(stem_os) = p.file_stem() else {
         return ("UNKNOWN:UNKNOWN".to_owned(), None);
     };
-    let stem = stem_os.to_string_lossy();
-    let lib_name = stem.to_string();
-    let footprint_name = stem.to_string();
+    let footprint_name = stem_os.to_string_lossy().to_string();
     let dir = p
         .parent()
         .map(|d| d.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
+    let lib_name =
+        footprint_library_name(p, package_roots).unwrap_or_else(|| footprint_name.clone());
     (
         format!("{lib_name}:{footprint_name}"),
         Some((lib_name, dir)),
     )
+}
+
+fn footprint_library_name(p: &Path, package_roots: &BTreeMap<String, PathBuf>) -> Option<String> {
+    let parent = p.parent()?;
+
+    if let Some(pretty_name) = parent
+        .file_stem()
+        .filter(|_| parent.extension().is_some_and(|ext| ext == "pretty"))
+    {
+        let pretty_name = pretty_name.to_string_lossy().to_string();
+        if !pretty_name.is_empty() {
+            return Some(pretty_name);
+        }
+    }
+
+    if let Some((repo, package_root)) = package_coord_for_path(p, package_roots)
+        && parent == package_root
+    {
+        let repo_name = repo.rsplit('/').next().unwrap_or(&repo);
+        return Some(repo_name.to_string());
+    }
+
+    parent
+        .file_stem()
+        .or_else(|| parent.file_name())
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+}
+
+fn package_coord_for_path(
+    path: &Path,
+    package_roots: &BTreeMap<String, PathBuf>,
+) -> Option<(String, PathBuf)> {
+    package_roots
+        .iter()
+        .filter_map(|(coord, root)| {
+            if !path.starts_with(root) {
+                return None;
+            }
+            let repo = coord
+                .rsplit_once('@')
+                .map(|(repo, _)| repo)
+                .unwrap_or(coord);
+            Some((root.components().count(), repo.to_string(), root.clone()))
+        })
+        .max_by_key(|(depth, _, _)| *depth)
+        .map(|(_, repo, root)| (repo, root))
 }
 
 /// Determine whether a given string is a KiCad `lib:footprint` reference rather than a file path.
@@ -553,8 +616,21 @@ pub fn write_fp_lib_table(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::path::Path;
+
+    fn assert_formatted_footprint(
+        formatted: (String, Option<(String, PathBuf)>),
+        expected_fp: &str,
+        expected_lib: &str,
+        expected_dir: &str,
+    ) {
+        assert_eq!(formatted.0, expected_fp);
+        assert_eq!(
+            formatted.1,
+            Some((expected_lib.to_string(), PathBuf::from(expected_dir)))
+        );
+    }
 
     #[test]
     fn test_escape_kicad_string() {
@@ -602,6 +678,66 @@ mod tests {
 
         // Multiple colons (should return false since split_once will only match first)
         assert!(is_kicad_lib_fp("lib:footprint:extra")); // This will be treated as lib "lib" and footprint "footprint:extra"
+    }
+
+    #[test]
+    fn test_format_footprint_for_pretty_library_path() {
+        assert_formatted_footprint(
+            format_footprint(
+            "/tmp/cache/kicad-footprints/Capacitor_SMD.pretty/C_0402_1005Metric.kicad_mod",
+            ),
+            "Capacitor_SMD:C_0402_1005Metric",
+            "Capacitor_SMD",
+            "/tmp/cache/kicad-footprints/Capacitor_SMD.pretty",
+        );
+    }
+
+    #[test]
+    fn test_format_footprint_for_plain_directory_path() {
+        assert_formatted_footprint(
+            format_footprint("/tmp/components/TLV9001IDBVR/SOT95P280X145-5N.kicad_mod"),
+            "TLV9001IDBVR:SOT95P280X145-5N",
+            "TLV9001IDBVR",
+            "/tmp/components/TLV9001IDBVR",
+        );
+    }
+
+    #[test]
+    fn test_format_footprint_for_versioned_package_root_uri() {
+        let mut package_roots = BTreeMap::new();
+        package_roots.insert(
+            "github.com/diodeinc/registry/components/BSS138-7-F@0.3.2".to_string(),
+            PathBuf::from("/tmp/vendor/github.com/diodeinc/registry/components/BSS138-7-F/0.3.2"),
+        );
+
+        assert_formatted_footprint(
+            format_footprint_with_package_roots(
+                "package://github.com/diodeinc/registry/components/BSS138-7-F@0.3.2/SOT96P240X115-3N.kicad_mod",
+                &package_roots,
+            ),
+            "BSS138-7-F:SOT96P240X115-3N",
+            "BSS138-7-F",
+            "/tmp/vendor/github.com/diodeinc/registry/components/BSS138-7-F/0.3.2",
+        );
+    }
+
+    #[test]
+    fn test_format_footprint_for_workspace_package_root_path() {
+        let mut package_roots = BTreeMap::new();
+        package_roots.insert(
+            "workspace/components/MyPart".to_string(),
+            PathBuf::from("/tmp/workspace/components/MyPart"),
+        );
+
+        assert_formatted_footprint(
+            format_footprint_with_package_roots(
+                "/tmp/workspace/components/MyPart/Thing.kicad_mod",
+                &package_roots,
+            ),
+            "MyPart:Thing",
+            "MyPart",
+            "/tmp/workspace/components/MyPart",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Before, if a footprint came from a file like: `.../Capacitor_SMD.pretty/C_0402_1005Metric.kicad_mod`

we were emitting: `C_0402_1005Metric:C_0402_1005Metric`

Now we emit: `Capacitor_SMD:C_0402_1005Metric`

and similarly:
- plain local dir `.../TLV9001IDBVR/SOT95P280X145-5N.kicad_mod` -> `TLV9001IDBVR:SOT95P280X145-5N`
- versioned package-root footprint `.../BSS138-7-F/0.3.2/SOT96P240X115-3N.kicad_mod` -> `BSS138-7-F:SOT96P240X115-3N`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how footprints are normalized into KiCad `lib:footprint` identifiers across both Rust netlist generation and the Python layout sync, which can affect footprint library lookup and fp-lib-table contents. Logic is well-covered by new unit tests but may surface edge cases in path/package-root matching.
> 
> **Overview**
> **Canonicalizes file-backed KiCad footprint IDs** so footprints referenced by `.kicad_mod` paths (including `.pretty` libraries and `package://` URIs) emit stable `lib:fp` identifiers instead of `stem:stem`.
> 
> This updates Rust netlist export and fp-lib-table generation to use a new `format_footprint_with_package_roots` path/package-root aware formatter, mirrors the same behavior in `update_layout_file.py`, and adds focused tests covering `.pretty` paths, plain directories, and package-root/versioned URI cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca13a4633a188c921bab2e8556fb34441638a1cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
