### PR TITLE
Open layouts with the discovered pcbnew

### DIFF
--- a/crates/pcb-kicad/src/lib.rs
+++ b/crates/pcb-kicad/src/lib.rs
@@ -59,6 +59,26 @@ fn require_tool_path(
 }
 
 #[cfg(target_os = "macos")]
+fn pcbnew_app_bundle_path(pcbnew_path: &str) -> Result<String> {
+    let path = Path::new(pcbnew_path);
+
+    if path.extension().is_some_and(|ext| ext == "app") {
+        return Ok(pcbnew_path.to_string());
+    }
+
+    path.ancestors()
+        .find(|ancestor| ancestor.extension().is_some_and(|ext| ext == "app"))
+        .map(|ancestor| ancestor.to_string_lossy().to_string())
+        .ok_or_else(|| {
+            anyhow!(
+                "Failed to derive pcbnew.app bundle path from {}.\n\
+                 Set KICAD_PCBNEW to either the pcbnew.app bundle or the pcbnew binary inside it.",
+                pcbnew_path
+            )
+        })
+}
+
+#[cfg(target_os = "macos")]
 mod paths {
     pub(crate) fn python_interpreter() -> String {
         super::env_or_path(
@@ -251,9 +271,22 @@ pub fn open_pcbnew(pcb_path: impl AsRef<Path>) -> Result<()> {
         "Please ensure KiCad is installed.",
     )?;
 
-    Command::new(&pcbnew_path)
-        .arg(pcb_path)
-        .stdin(Stdio::null())
+    #[cfg(target_os = "macos")]
+    let mut cmd = {
+        let pcbnew_app = pcbnew_app_bundle_path(&pcbnew_path)?;
+        let mut cmd = Command::new("open");
+        cmd.arg("-a").arg(pcbnew_app).arg(pcb_path);
+        cmd
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let mut cmd = {
+        let mut cmd = Command::new(&pcbnew_path);
+        cmd.arg(pcb_path);
+        cmd
+    };
+
+    cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/crates/pcb-kicad/src/lib.rs
+++ b/crates/pcb-kicad/src/lib.rs
@@ -8,19 +8,70 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tempfile::NamedTempFile;
+
+fn expand_home(path: &str) -> String {
+    path.replace(
+        "~",
+        dirs::home_dir()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap_or_default(),
+    )
+}
+
+fn env_or_path(env_var: &str, default: &str) -> String {
+    expand_home(&std::env::var(env_var).unwrap_or_else(|_| default.to_string()))
+}
+
+#[cfg(target_os = "windows")]
+fn first_existing_path(candidates: &[&str]) -> String {
+    candidates
+        .iter()
+        .map(|path| expand_home(path))
+        .find(|path| Path::new(path).exists())
+        .unwrap_or_else(|| expand_home(candidates[0]))
+}
+
+#[cfg(target_os = "windows")]
+fn env_or_first_existing_path(env_var: &str, candidates: &[&str]) -> String {
+    std::env::var(env_var)
+        .map(|path| expand_home(&path))
+        .unwrap_or_else(|_| first_existing_path(candidates))
+}
+
+fn require_tool_path(
+    path: String,
+    tool_name: &str,
+    env_var: &str,
+    install_hint: &str,
+) -> Result<String> {
+    if Path::new(&path).exists() {
+        Ok(path)
+    } else {
+        Err(anyhow!(
+            "{tool_name} not found at expected location: {path}\n\
+             {install_hint}\n\
+             If {tool_name} is in a non-standard location, set the {env_var} environment variable."
+        ))
+    }
+}
 
 #[cfg(target_os = "macos")]
 mod paths {
     pub(crate) fn python_interpreter() -> String {
-        std::env::var("KICAD_PYTHON_INTERPRETER").unwrap_or_else(|_|
-            "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3".to_string()).replace("~", dirs::home_dir().unwrap_or_default().to_str().unwrap_or_default())
+        super::env_or_path(
+            "KICAD_PYTHON_INTERPRETER",
+            "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3",
+        )
     }
 
     pub(crate) fn python_site_packages() -> String {
-        std::env::var("KICAD_PYTHON_SITE_PACKAGES").unwrap_or_else(|_|
-            "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages".to_string()).replace("~", dirs::home_dir().unwrap_or_default().to_str().unwrap_or_default())
+        super::env_or_path(
+            "KICAD_PYTHON_SITE_PACKAGES",
+            "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages",
+        )
     }
 
     pub(crate) fn venv_site_packages() -> String {
@@ -36,56 +87,40 @@ mod paths {
     }
 
     pub(crate) fn kicad_cli() -> String {
-        std::env::var("KICAD_CLI")
-            .unwrap_or_else(|_| {
-                "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli".to_string()
-            })
-            .replace(
-                "~",
-                dirs::home_dir()
-                    .unwrap_or_default()
-                    .to_str()
-                    .unwrap_or_default(),
-            )
+        super::env_or_path(
+            "KICAD_CLI",
+            "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
+        )
+    }
+
+    pub(crate) fn pcbnew() -> String {
+        super::env_or_path(
+            "KICAD_PCBNEW",
+            "/Applications/KiCad/KiCad.app/Contents/Applications/pcbnew.app/Contents/MacOS/pcbnew",
+        )
     }
 }
 
 #[cfg(target_os = "windows")]
 mod paths {
-    fn expand_home(path: &str) -> String {
-        path.replace(
-            "~",
-            dirs::home_dir()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default(),
+    pub(crate) fn python_interpreter() -> String {
+        super::env_or_first_existing_path(
+            "KICAD_PYTHON_INTERPRETER",
+            &[
+                r"C:\Program Files\KiCad\10.0\bin\python.exe",
+                r"C:\Program Files\KiCad\9.0\bin\python.exe",
+            ],
         )
     }
 
-    fn first_existing_path(candidates: &[&str]) -> String {
-        candidates
-            .iter()
-            .map(|path| expand_home(path))
-            .find(|path| std::path::Path::new(path).exists())
-            .unwrap_or_else(|| expand_home(candidates[0]))
-    }
-
-    pub(crate) fn python_interpreter() -> String {
-        std::env::var("KICAD_PYTHON_INTERPRETER").unwrap_or_else(|_| {
-            first_existing_path(&[
-                r"C:\Program Files\KiCad\10.0\bin\python.exe",
-                r"C:\Program Files\KiCad\9.0\bin\python.exe",
-            ])
-        })
-    }
-
     pub(crate) fn python_site_packages() -> String {
-        std::env::var("KICAD_PYTHON_SITE_PACKAGES").unwrap_or_else(|_| {
-            first_existing_path(&[
+        super::env_or_first_existing_path(
+            "KICAD_PYTHON_SITE_PACKAGES",
+            &[
                 r"~\Documents\KiCad\10.0\3rdparty\Python311\site-packages",
                 r"~\Documents\KiCad\9.0\3rdparty\Python311\site-packages",
-            ])
-        })
+            ],
+        )
     }
 
     pub(crate) fn venv_site_packages() -> String {
@@ -100,24 +135,37 @@ mod paths {
     }
 
     pub(crate) fn kicad_cli() -> String {
-        std::env::var("KICAD_CLI").unwrap_or_else(|_| {
-            first_existing_path(&[
+        super::env_or_first_existing_path(
+            "KICAD_CLI",
+            &[
                 r"C:\Program Files\KiCad\10.0\bin\kicad-cli.exe",
                 r"C:\Program Files\KiCad\9.0\bin\kicad-cli.exe",
-            ])
-        })
+            ],
+        )
+    }
+
+    pub(crate) fn pcbnew() -> String {
+        super::env_or_first_existing_path(
+            "KICAD_PCBNEW",
+            &[
+                r"C:\Program Files\KiCad\10.0\bin\pcbnew.exe",
+                r"C:\Program Files\KiCad\9.0\bin\pcbnew.exe",
+            ],
+        )
     }
 }
 
 #[cfg(target_os = "linux")]
 mod paths {
     pub(crate) fn python_interpreter() -> String {
-        std::env::var("KICAD_PYTHON_INTERPRETER").unwrap_or_else(|_| "/usr/bin/python3".to_string())
+        super::env_or_path("KICAD_PYTHON_INTERPRETER", "/usr/bin/python3")
     }
 
     pub(crate) fn python_site_packages() -> String {
-        std::env::var("KICAD_PYTHON_SITE_PACKAGES")
-            .unwrap_or_else(|_| "/usr/lib/python3/dist-packages".to_string())
+        super::env_or_path(
+            "KICAD_PYTHON_SITE_PACKAGES",
+            "/usr/lib/python3/dist-packages",
+        )
     }
 
     pub(crate) fn venv_site_packages() -> String {
@@ -133,23 +181,22 @@ mod paths {
     }
 
     pub(crate) fn kicad_cli() -> String {
-        std::env::var("KICAD_CLI").unwrap_or_else(|_| "/usr/bin/kicad-cli".to_string())
+        super::env_or_path("KICAD_CLI", "/usr/bin/kicad-cli")
+    }
+
+    pub(crate) fn pcbnew() -> String {
+        super::env_or_path("KICAD_PCBNEW", "/usr/bin/pcbnew")
     }
 }
 
 /// Check if KiCad is installed and return a helpful error if not
 fn check_kicad_installed() -> Result<()> {
-    let kicad_path = paths::kicad_cli();
-
-    // First check if the file exists
-    if !Path::new(&kicad_path).exists() {
-        return Err(anyhow!(
-            "KiCad CLI not found at expected location: {}\n\
-             Please ensure KiCad is installed. You can download it from https://www.kicad.org/\n\
-             If KiCad is installed in a non-standard location, set the KICAD_CLI environment variable.",
-            kicad_path
-        ));
-    }
+    let kicad_path = require_tool_path(
+        paths::kicad_cli(),
+        "KiCad CLI",
+        "KICAD_CLI",
+        "Please ensure KiCad is installed. You can download it from https://www.kicad.org/",
+    )?;
 
     // Try to run kicad-cli --version to verify it's executable
     match Command::new(&kicad_path).arg("--version").output() {
@@ -168,17 +215,12 @@ fn check_kicad_installed() -> Result<()> {
 
 /// Check if KiCad Python is available and return a helpful error if not
 fn check_kicad_python() -> Result<()> {
-    let python_path = paths::python_interpreter();
-
-    // First check if the file exists
-    if !Path::new(&python_path).exists() {
-        return Err(anyhow!(
-            "KiCad Python interpreter not found at expected location: {}\n\
-             Please ensure KiCad is installed with Python support.\n\
-             If KiCad Python is in a non-standard location, set the KICAD_PYTHON_INTERPRETER environment variable.",
-            python_path
-        ));
-    }
+    let python_path = require_tool_path(
+        paths::python_interpreter(),
+        "KiCad Python interpreter",
+        "KICAD_PYTHON_INTERPRETER",
+        "Please ensure KiCad is installed with Python support.",
+    )?;
 
     // Try to run python --version to verify it's executable
     match Command::new(&python_path).arg("--version").output() {
@@ -193,6 +235,37 @@ fn check_kicad_python() -> Result<()> {
             e
         )),
     }
+}
+
+/// Open a KiCad board in the GUI that matches this toolchain's discovered install.
+pub fn open_pcbnew(pcb_path: impl AsRef<Path>) -> Result<()> {
+    let pcb_path = pcb_path.as_ref();
+    if !pcb_path.exists() {
+        anyhow::bail!("PCB file not found: {}", pcb_path.display());
+    }
+
+    let pcbnew_path = require_tool_path(
+        paths::pcbnew(),
+        "KiCad PCB Editor",
+        "KICAD_PCBNEW",
+        "Please ensure KiCad is installed.",
+    )?;
+
+    Command::new(&pcbnew_path)
+        .arg(pcb_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "Failed to launch KiCad PCB Editor at {} for {}",
+                pcbnew_path,
+                pcb_path.display()
+            )
+        })?;
+
+    Ok(())
 }
 
 /// Builder for KiCad CLI commands

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -73,6 +73,40 @@ def canonicalize_json(obj: Any) -> Any:
         return obj
 
 
+def normalize_via_type(via: Any) -> str:
+    """Map KiCad vias to stable semantic strings across KiCad versions."""
+    if hasattr(via, "IsMicroVia") and via.IsMicroVia():
+        return "microvia"
+
+    if (hasattr(via, "IsBlindVia") and via.IsBlindVia()) or (
+        hasattr(via, "IsBuriedVia") and via.IsBuriedVia()
+    ):
+        return "blind_buried"
+
+    via_type = via.GetViaType()
+    for attr_name, normalized_name in [
+        ("VIATYPE_THROUGH", "through"),
+        ("VIATYPE_BLIND_BURIED", "blind_buried"),
+        ("VIATYPE_MICROVIA", "microvia"),
+        ("VIATYPE_NOT_DEFINED", "not_defined"),
+    ]:
+        attr_value = getattr(pcbnew, attr_name, None)
+        if attr_value is not None and via_type == attr_value:
+            return normalized_name
+
+    # KiCad 9 and 10 expose different raw enum values in some environments.
+    via_type_str = str(via_type)
+    if via_type_str == "1":
+        return "microvia"
+    if via_type_str == "2":
+        return "blind_buried"
+    if via_type_str in {"3", "4"}:
+        return "through"
+    if via_type_str == "0":
+        return "not_defined"
+    return via_type_str
+
+
 # Read PYTHONPATH environment variable and add all folders to the search path
 python_path = os.environ.get("PYTHONPATH", "")
 path_separator = (
@@ -858,7 +892,7 @@ class FinalizeBoard(Step):
             "drill": via.GetDrillValue(),
             "diameter": via.GetWidth(pcbnew.F_Cu),
             "locked": via.IsLocked(),
-            "via_type": via.GetViaType(),
+            "via_type": normalize_via_type(via),
         }
 
     def _export_layout_snapshot(self):

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
@@ -3133,7 +3133,7 @@ expression: content
         "x": 148428999,
         "y": 108192125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3144,7 +3144,7 @@ expression: content
         "x": 148528999,
         "y": 103292125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3155,7 +3155,7 @@ expression: content
         "x": 148428999,
         "y": 106492125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3166,7 +3166,7 @@ expression: content
         "x": 148528999,
         "y": 104992125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3177,7 +3177,7 @@ expression: content
         "x": 148428999,
         "y": 101123475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3188,7 +3188,7 @@ expression: content
         "x": 148528999,
         "y": 96223475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3199,7 +3199,7 @@ expression: content
         "x": 148428999,
         "y": 99423475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3210,7 +3210,7 @@ expression: content
         "x": 148528999,
         "y": 97923475
       },
-      "via_type": 4
+      "via_type": "through"
     }
   ],
   "zones": [

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
@@ -1389,7 +1389,7 @@ expression: content
         "x": 147600000,
         "y": 103500000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1400,7 +1400,7 @@ expression: content
         "x": 147600000,
         "y": 99990000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1411,7 +1411,7 @@ expression: content
         "x": 149400000,
         "y": 102890000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1422,7 +1422,7 @@ expression: content
         "x": 149400000,
         "y": 106400000
       },
-      "via_type": 4
+      "via_type": "through"
     }
   ],
   "zones": []

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -128,7 +128,7 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
 
     // Open the layout if not disabled (or if using temp)
     if !args.no_open || args.temp {
-        open::that(&pcb_file)?;
+        pcb_kicad::open_pcbnew(&pcb_file)?;
     }
 
     Ok(())

--- a/crates/pcb/src/mcp.rs
+++ b/crates/pcb/src/mcp.rs
@@ -445,7 +445,7 @@ fn run_layout(args: Option<Value>, ctx: &McpContext) -> Result<CallToolResult> {
     match pcb_layout::process_layout(&schematic, &model_dirs, false, false, &mut diagnostics) {
         Ok(Some(result)) => {
             ctx.log("info", &format!("Generated: {}", result.pcb_file.display()));
-            let opened = !no_open && open::that(&result.pcb_file).is_ok();
+            let opened = !no_open && pcb_kicad::open_pcbnew(&result.pcb_file).is_ok();
             Ok(CallToolResult::json(&json!({
                 "pcb_file": result.pcb_file.display().to_string(),
                 "opened": opened

--- a/crates/pcb/src/open.rs
+++ b/crates/pcb/src/open.rs
@@ -49,8 +49,12 @@ pub fn execute(args: OpenArgs) -> Result<()> {
         );
     }
 
-    open::that(&layout_path)
-        .with_context(|| format!("Failed to open file: {}", layout_path.display()))?;
+    pcb_kicad::open_pcbnew(&layout_path).with_context(|| {
+        format!(
+            "Failed to open file in KiCad PCB Editor: {}",
+            layout_path.display()
+        )
+    })?;
 
     Ok(())
 }

--- a/crates/pcb/src/route.rs
+++ b/crates/pcb/src/route.rs
@@ -152,7 +152,7 @@ pub fn execute(args: RouteArgs) -> Result<()> {
                             println!("{}", format_progress(&status, stats.revision_number));
                             last_revision = stats.revision_number;
                             if !args.no_open {
-                                let _ = open::that(&board_path);
+                                let _ = pcb_kicad::open_pcbnew(&board_path);
                             }
                         }
                         Err(e) => {

--- a/crates/pcb/src/route.rs
+++ b/crates/pcb/src/route.rs
@@ -136,6 +136,7 @@ pub fn execute(args: RouteArgs) -> Result<()> {
     let start_time = Instant::now();
     let mut last_status: Option<RoutingJob> = None;
     let mut consecutive_errors = 0;
+    let mut board_opened = false;
 
     while running.load(Ordering::SeqCst) {
         match routing::get_routing_status(&ctx, &job_id) {
@@ -151,8 +152,11 @@ pub fn execute(args: RouteArgs) -> Result<()> {
                         Ok(()) => {
                             println!("{}", format_progress(&status, stats.revision_number));
                             last_revision = stats.revision_number;
-                            if !args.no_open {
-                                let _ = pcb_kicad::open_pcbnew(&board_path);
+                            if !args.no_open
+                                && !board_opened
+                                && pcb_kicad::open_pcbnew(&board_path).is_ok()
+                            {
+                                board_opened = true;
                             }
                         }
                         Err(e) => {


### PR DESCRIPTION
This is more convenient than `open <path to .kicad_pcb>` when juggling multiple KiCad installs.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the CLI locates and launches external KiCad binaries across OSes (new `KICAD_PCBNEW` handling) and alters layout snapshot data format for vias, which could affect tooling/tests expecting numeric enums.
> 
> **Overview**
> Updates layout opening to launch the **KiCad PCB Editor (`pcbnew`)** discovered from the active KiCad install (via new `KICAD_PCBNEW` + OS-specific default paths) instead of relying on the OS default `open` handler.
> 
> Adds `pcb_kicad::open_pcbnew()` (including macOS app-bundle launching) and centralizes executable path validation/error messaging for KiCad tools.
> 
> Makes layout JSON snapshots deterministic across KiCad versions by normalizing `via_type` from raw enum values to stable strings (e.g. `"through"`), and updates the golden snapshot tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd87e9274d38e6f13a36cbd9dfadda41fa447f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
