### PR TITLE
Normalize KiCad footprint library names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Net type physical-value fields now coerce string and scalar inputs like `io()`/`config()`.
 
 ### Changed
+
 - Component generation no longer automatically scans datasheets.
 - `pcb new component` and `pcb search` component imports now place datasheet artifacts under each component's `docs/` subdirectory.
+- Layout sync and KiCad netlist export now normalize file- and package-based footprints to library-aware FPIDs.
 
 ## [0.3.67] - 2026-04-10
 

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 
 use include_dir::{Dir, include_dir};
 use pcb_kicad::PythonScriptBuilder;
-use pcb_sch::kicad_netlist::{format_footprint, write_fp_lib_table};
+use pcb_sch::kicad_netlist::{try_format_footprint_with_package_roots, write_fp_lib_table};
 
 mod kicad_project_patch;
 mod model_embed_discovery;
@@ -539,9 +539,8 @@ pub fn process_layout(
     utils::write_footprint_library_table(&layout_dir, schematic)?;
 
     // Write JSON netlist for Python script
-    let json_content = schematic
-        .to_json()
-        .context("Failed to serialize schematic to JSON")?;
+    let json_content =
+        utils::layout_json_netlist(schematic).context("Failed to serialize layout JSON netlist")?;
     fs::write(&paths.json_netlist, json_content).with_context(|| {
         format!(
             "Failed to write JSON netlist: {}",
@@ -766,6 +765,48 @@ pub mod utils {
         BoardConfig::from_json_str(config_json).ok()
     }
 
+    /// Serialize the schematic to JSON for Python layout sync, enriching component
+    /// instances with a derived `footprint_fpid` field while preserving the original
+    /// authored `attributes.footprint` value.
+    pub fn layout_json_netlist(schematic: &Schematic) -> anyhow::Result<String> {
+        let mut json: serde_json::Value = serde_json::from_str(
+            &schematic
+                .to_json()
+                .context("Failed to serialize schematic")?,
+        )?;
+
+        let instances = json
+            .get_mut("instances")
+            .and_then(serde_json::Value::as_object_mut)
+            .context("Schematic JSON missing instances object")?;
+
+        for (inst_ref, inst) in &schematic.instances {
+            if inst.kind != InstanceKind::Component {
+                continue;
+            }
+
+            let Some(AttributeValue::String(fp_attr)) = inst.attributes.get("footprint") else {
+                continue;
+            };
+
+            let (footprint_fpid, _) =
+                try_format_footprint_with_package_roots(fp_attr, &schematic.package_roots)
+                    .with_context(|| format!("Failed to resolve footprint path '{fp_attr}'"))?;
+
+            let instance = instances
+                .get_mut(&inst_ref.to_string())
+                .and_then(serde_json::Value::as_object_mut)
+                .with_context(|| format!("Missing component instance in JSON: {inst_ref}"))?;
+
+            instance.insert(
+                "footprint_fpid".to_string(),
+                serde_json::Value::String(footprint_fpid),
+            );
+        }
+
+        serde_json::to_string(&json).context("Failed to serialize enriched layout JSON")
+    }
+
     /// Write footprint library table for a layout
     pub fn write_footprint_library_table(
         layout_dir: &Path,
@@ -778,15 +819,12 @@ pub mod utils {
                 continue;
             }
 
-            if let Some(AttributeValue::String(fp_attr)) = inst.attributes.get("footprint") {
-                let resolved_fp = schematic
-                    .resolve_package_uri(fp_attr)
-                    .with_context(|| format!("Failed to resolve footprint path '{fp_attr}'"))?
-                    .to_string_lossy()
-                    .into_owned();
-                if let (_, Some((lib_name, dir))) = format_footprint(&resolved_fp) {
-                    fp_libs.entry(lib_name).or_insert(dir);
-                }
+            if let Some(AttributeValue::String(fp_attr)) = inst.attributes.get("footprint")
+                && let (_, Some((lib_name, dir))) =
+                    try_format_footprint_with_package_roots(fp_attr, &schematic.package_roots)
+                        .with_context(|| format!("Failed to resolve footprint path '{fp_attr}'"))?
+            {
+                fp_libs.entry(lib_name).or_insert(dir);
             }
         }
 
@@ -807,6 +845,9 @@ pub mod utils {
 #[cfg(test)]
 mod diff_tests {
     use super::*;
+    use pcb_sch::{Instance, InstanceRef, ModuleRef, Schematic};
+    use serde_json::Value;
+    use std::path::PathBuf;
 
     #[test]
     fn files_differ_ignores_trailing_whitespace() -> anyhow::Result<()> {
@@ -844,6 +885,44 @@ mod diff_tests {
         fs::write(&generated, r#"{"a":1, "b":2}"#)?;
 
         assert!(files_differ(&original, &generated, "project")?);
+        Ok(())
+    }
+
+    #[test]
+    fn layout_json_netlist_adds_derived_footprint_fpid() -> anyhow::Result<()> {
+        let mut schematic = Schematic::new();
+        schematic.package_roots.insert(
+            "gitlab.com/kicad/libraries/kicad-footprints@10.0.0".to_string(),
+            PathBuf::from("/tmp/vendor/gitlab.com/kicad/libraries/kicad-footprints/10.0.0"),
+        );
+
+        let module_ref = ModuleRef::new("/tmp/demo.zen", "<root>");
+        let component_ref = InstanceRef::new(module_ref.clone(), vec!["R".into()]);
+
+        let mut component = Instance::component(module_ref);
+        component.reference_designator = Some("R1".to_string());
+        component.attributes.insert(
+            "footprint".into(),
+            AttributeValue::String(
+                "package://gitlab.com/kicad/libraries/kicad-footprints@10.0.0/Resistor_SMD.pretty/R_0603_1608Metric.kicad_mod"
+                    .to_string(),
+            ),
+        );
+
+        schematic.add_instance(component_ref.clone(), component);
+
+        let json: Value = serde_json::from_str(&utils::layout_json_netlist(&schematic)?)?;
+        let instance = &json["instances"][component_ref.to_string()];
+
+        assert_eq!(
+            instance["attributes"]["footprint"]["String"],
+            "package://gitlab.com/kicad/libraries/kicad-footprints@10.0.0/Resistor_SMD.pretty/R_0603_1608Metric.kicad_mod"
+        );
+        assert_eq!(
+            instance["footprint_fpid"],
+            "Resistor_SMD@10.0.0:R_0603_1608Metric"
+        );
+
         Ok(())
     }
 }

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -253,14 +253,17 @@ class JsonNetlistParser:
                     break
 
             # Get footprint
-            footprint_path = (
-                instance["attributes"].get("footprint", {}).get("String", "")
-            )
-            if footprint_path:
-                # Use the format_footprint function to handle both file paths and lib:fp format
-                footprint = format_footprint(footprint_path)
-            else:
-                footprint = "unknown:unknown"
+            footprint = instance.get("footprint_fpid", "")
+            if not footprint:
+                footprint_path = (
+                    instance["attributes"].get("footprint", {}).get("String", "")
+                )
+                if footprint_path:
+                    # Backward-compatible fallback for older JSON netlists that do not
+                    # include the derived footprint_fpid field yet.
+                    footprint = format_footprint(footprint_path, parser.package_roots)
+                else:
+                    footprint = "unknown:unknown"
 
             # Build hierarchical path - this needs to match the Rust implementation
             # Extract the instance path after the root module
@@ -436,7 +439,63 @@ def is_kicad_lib_fp(s):
     return True
 
 
-def format_footprint(fp_str):
+def _path_under_root(path_obj, root_obj):
+    try:
+        path_obj.relative_to(root_obj)
+        return True
+    except ValueError:
+        return False
+
+
+def _package_coord_for_path(fp_path, package_roots):
+    if not package_roots:
+        return None
+
+    best_match = None
+    for coord, root in package_roots.items():
+        root_path = Path(root)
+        if not _path_under_root(fp_path, root_path):
+            continue
+
+        depth = len(root_path.parts)
+        if best_match is None or depth > best_match[0]:
+            best_match = (depth, coord.rsplit("/", 1)[-1], root_path)
+
+    if best_match is None:
+        return None
+
+    _, package_name, root_path = best_match
+    return package_name, root_path
+
+
+def _package_library_name(fp_path, package_match):
+    if not package_match:
+        return None
+
+    package_name, root_path = package_match
+    if fp_path.parent != root_path:
+        return None
+
+    return package_name
+
+
+def _pretty_library_name(parent, package_name=None):
+    if parent.suffix != ".pretty":
+        return None
+
+    pretty_name = parent.stem or parent.name
+    if not pretty_name:
+        return None
+
+    if package_name and package_name.startswith("kicad-footprints@"):
+        version = package_name.removeprefix("kicad-footprints@")
+        if version:
+            return f"{pretty_name}@{version}"
+
+    return pretty_name
+
+
+def format_footprint(fp_str, package_roots=None):
     """Convert footprint strings that may point to a .kicad_mod file into a KiCad lib:fp identifier.
 
     This matches the Rust implementation in kicad_netlist.rs
@@ -445,12 +504,30 @@ def format_footprint(fp_str):
         return fp_str
 
     # Extract the footprint name from the file path
-    fp_path = Path(fp_str)
+    if fp_str.startswith("package://") and package_roots:
+        try:
+            fp_path = resolve_package_uri(fp_str, package_roots)
+        except ValueError:
+            fp_path = Path(fp_str)
+    else:
+        fp_path = Path(fp_str)
     stem = fp_path.stem
     if not stem:
         return "UNKNOWN:UNKNOWN"
 
-    return f"{stem}:{stem}"
+    parent = fp_path.parent
+    package_roots = package_roots or {}
+    package_match = _package_coord_for_path(fp_path, package_roots)
+    package_name = package_match[0] if package_match else None
+    lib_name = _pretty_library_name(parent, package_name)
+
+    if not lib_name:
+        lib_name = _package_library_name(fp_path, package_match)
+
+    if not lib_name:
+        lib_name = parent.name or stem
+
+    return f"{lib_name}:{stem}"
 
 
 ####################################################################################################
@@ -529,7 +606,7 @@ class SyncState:
 
 # Import the lens module (extracted to temp dir by Rust and added to PYTHONPATH)
 from lens import run_lens_sync  # noqa: E402
-from lens.kicad_adapter import get_footprint_field  # noqa: E402
+from lens.kicad_adapter import get_footprint_field, resolve_package_uri  # noqa: E402
 
 
 class ImportNetlist(Step):

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -73,6 +73,40 @@ def canonicalize_json(obj: Any) -> Any:
         return obj
 
 
+def normalize_via_type(via: Any) -> str:
+    """Map KiCad vias to stable semantic strings across KiCad versions."""
+    if hasattr(via, "IsMicroVia") and via.IsMicroVia():
+        return "microvia"
+
+    if (hasattr(via, "IsBlindVia") and via.IsBlindVia()) or (
+        hasattr(via, "IsBuriedVia") and via.IsBuriedVia()
+    ):
+        return "blind_buried"
+
+    via_type = via.GetViaType()
+    for attr_name, normalized_name in [
+        ("VIATYPE_THROUGH", "through"),
+        ("VIATYPE_BLIND_BURIED", "blind_buried"),
+        ("VIATYPE_MICROVIA", "microvia"),
+        ("VIATYPE_NOT_DEFINED", "not_defined"),
+    ]:
+        attr_value = getattr(pcbnew, attr_name, None)
+        if attr_value is not None and via_type == attr_value:
+            return normalized_name
+
+    # KiCad 9 and 10 expose different raw enum values in some environments.
+    via_type_str = str(via_type)
+    if via_type_str == "1":
+        return "microvia"
+    if via_type_str == "2":
+        return "blind_buried"
+    if via_type_str in {"3", "4"}:
+        return "through"
+    if via_type_str == "0":
+        return "not_defined"
+    return via_type_str
+
+
 # Read PYTHONPATH environment variable and add all folders to the search path
 python_path = os.environ.get("PYTHONPATH", "")
 path_separator = (
@@ -858,7 +892,7 @@ class FinalizeBoard(Step):
             "drill": via.GetDrillValue(),
             "diameter": via.GetWidth(pcbnew.F_Cu),
             "locked": via.IsLocked(),
-            "via_type": via.GetViaType(),
+            "via_type": normalize_via_type(via),
         }
 
     def _export_layout_snapshot(self):

--- a/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step1.log.snap
+++ b/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step1.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/fpid_change.rs
-assertion_line: 57
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -14,12 +13,12 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=R_0402_1005Metric:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=R_0402_1005Metric:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu
 INFO: Added footprint: R1.R
 INFO: HierPlace: placed 1 items
-INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=R_0402_1005Metric:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG PLACE_FP path=R1.R x=147545000 y=104505000 w=1910000 h=990000

--- a/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step2.log.snap
+++ b/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step2.log.snap
@@ -11,19 +11,19 @@ INFO: Starting ImportNetlist...
 INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
-INFO: OLD FPV path=R1.R ref=R1 value=10k fpid=R_0402_1005Metric:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: OLD FPV path=R1.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: OLD FPC path=R1.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103830000 val_x=148500000 val_y=106170000
 INFO: Changes: +1 -1 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_REMOVE path=R1.R fpid=R_0402_1005Metric:R_0402_1005Metric x=148500000 y=105000000 orient=0.0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_REMOVE path=R1.R fpid=Resistor_SMD@9.0.3:R_0402_1005Metric x=148500000 y=105000000 orient=0.0 layer=F.Cu
 INFO: Removed footprint: R1.R
 INFO: Added footprint: R1.R
 INFO: HierPlace: placed 1 items
 INFO: OPLOG FP_REMOVE path=R1.R
-INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG PLACE_FP_INHERIT path=R1.R x=148500000 y=105000000 old_fpid=R_0402_1005Metric:R_0402_1005Metric new_fpid=R_0603_1608Metric:R_0603_1608Metric
+INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG PLACE_FP_INHERIT path=R1.R x=148500000 y=105000000 old_fpid=Resistor_SMD@9.0.3:R_0402_1005Metric new_fpid=Resistor_SMD@9.0.3:R_0603_1608Metric
 INFO: Sync completed in X.XXXs
 INFO: Lens sync complete: +1 -1 footprints
 INFO: Completed ImportNetlist in X.XXX seconds

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
@@ -3133,7 +3133,7 @@ expression: content
         "x": 148428999,
         "y": 108192125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3144,7 +3144,7 @@ expression: content
         "x": 148528999,
         "y": 103292125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3155,7 +3155,7 @@ expression: content
         "x": 148428999,
         "y": 106492125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3166,7 +3166,7 @@ expression: content
         "x": 148528999,
         "y": 104992125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3177,7 +3177,7 @@ expression: content
         "x": 148428999,
         "y": 101123475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3188,7 +3188,7 @@ expression: content
         "x": 148528999,
         "y": 96223475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3199,7 +3199,7 @@ expression: content
         "x": 148428999,
         "y": 99423475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3210,7 +3210,7 @@ expression: content
         "x": 148528999,
         "y": 97923475
       },
-      "via_type": 4
+      "via_type": "through"
     }
   ],
   "zones": [

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -1012,7 +1012,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -1263,7 +1263,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -1514,7 +1514,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -1765,7 +1765,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 103
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -27,14 +26,14 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 8 footprints, 6 groups, 4 nets
 INFO: Changes: +8 -0 footprints
-INFO: NEW FPV path=M1.S1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S1.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S2.R1.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S2.R2.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S1.R1.R ref=R5 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S1.R2.R ref=R6 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S2.R1.R ref=R7 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S2.R2.R ref=R8 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S1.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S1.R2.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S2.R1.R ref=R3 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S2.R2.R ref=R4 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.S1.R1.R ref=R5 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.S1.R2.R ref=R6 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.S2.R1.R ref=R7 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.S2.R2.R ref=R8 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=M1 members=[M1.S1.R1.R, M1.S1.R2.R, M1.S2.R1.R, M1.S2.R2.R] layout=module
 INFO: NEW GRV path=M1.S1 members=[M1.S1.R1.R, M1.S1.R2.R] layout=submodule
 INFO: NEW GRV path=M1.S2 members=[M1.S2.R1.R, M1.S2.R2.R] layout=submodule
@@ -49,14 +48,14 @@ INFO: NEW FPC path=M2.S1.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.S1.R2.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.S2.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.S2.R2.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.S1.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.S1.R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.S2.R1.R ref=R3 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.S2.R2.R ref=R4 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.S1.R1.R ref=R5 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.S1.R2.R ref=R6 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.S2.R1.R ref=R7 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.S2.R2.R ref=R8 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.S1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.S1.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.S2.R1.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.S2.R2.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.S1.R1.R ref=R5 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.S1.R2.R ref=R6 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.S2.R1.R ref=R7 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.S2.R2.R ref=R8 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=M1 members=4 fragment=true
 INFO: CHANGESET GR_ADD path=M1.S1 members=2 fragment=true
 INFO: CHANGESET GR_ADD path=M1.S2 members=2 fragment=true
@@ -85,14 +84,14 @@ INFO: Authoritative fragments: ['M1', 'M2']
 INFO: Applied fragment routing to M1: 23 tracks, 4 vias, 2 zones, 10 graphics
 INFO: Applied fragment routing to M2: 23 tracks, 4 vias, 2 zones, 10 graphics
 INFO: HierPlace: placed 10 items
-INFO: OPLOG FP_ADD path=M1.S1.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M1.S1.R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M1.S2.R1.R ref=R3 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M1.S2.R2.R ref=R4 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.S1.R1.R ref=R5 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.S1.R2.R ref=R6 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.S2.R1.R ref=R7 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.S2.R2.R ref=R8 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.S1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.S1.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.S2.R1.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.S2.R2.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.S1.R1.R ref=R5 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.S1.R2.R ref=R6 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.S2.R1.R ref=R7 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.S2.R2.R ref=R8 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=M1
 INFO: OPLOG GR_ADD path=M1.S1
 INFO: OPLOG GR_ADD path=M1.S2

--- a/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.layout.json.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 87
 expression: content
 ---
 {
@@ -9,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -260,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -511,7 +510,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -762,7 +761,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 91
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -18,19 +17,19 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 1 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R3.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R4.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R3.R ref=R3 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R4.R ref=R4 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=MyModule members=[MyModule.R1.R, MyModule.R2.R, MyModule.R3.R, MyModule.R4.R] layout=module
 INFO: NEW FPC path=MyModule.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R2.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R3.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R4.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R3.R ref=R3 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R4.R ref=R4 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R3.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R4.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=MyModule members=4 fragment=true
 INFO: Added footprint: MyModule.R1.R
 INFO: Added footprint: MyModule.R2.R
@@ -39,10 +38,10 @@ INFO: Added footprint: MyModule.R4.R
 INFO: Added group: MyModule
 INFO: Authoritative fragments: ['MyModule']
 INFO: HierPlace: placed 5 items
-INFO: OPLOG FP_ADD path=MyModule.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MyModule.R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MyModule.R3.R ref=R3 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MyModule.R4.R ref=R4 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R3.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R4.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=MyModule
 INFO: OPLOG NET_ADD name=MyModule.P1
 INFO: OPLOG NET_ADD name=MyModule.P2

--- a/crates/pcb-layout/tests/snapshots/layout_generation__dnp.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__dnp.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": true,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": true,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__dnp.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__dnp.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 95
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -17,27 +16,27 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 0 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=dnp.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric dnp=true fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=exclude_from_bom.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=exclude_from_bom_and_dnp.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric dnp=true bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=normal.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=dnp.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric dnp=true fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=exclude_from_bom.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=exclude_from_bom_and_dnp.R ref=R3 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric dnp=true bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=normal.R ref=R4 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW FPC path=dnp.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=exclude_from_bom.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=exclude_from_bom_and_dnp.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=normal.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=dnp.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=exclude_from_bom.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=exclude_from_bom_and_dnp.R ref=R3 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=normal.R ref=R4 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=dnp.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=exclude_from_bom.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=exclude_from_bom_and_dnp.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=normal.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: Added footprint: dnp.R
 INFO: Added footprint: exclude_from_bom.R
 INFO: Added footprint: exclude_from_bom_and_dnp.R
 INFO: Added footprint: normal.R
 INFO: HierPlace: placed 4 items
-INFO: OPLOG FP_ADD path=dnp.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=exclude_from_bom.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=exclude_from_bom_and_dnp.R ref=R3 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=normal.R ref=R4 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=dnp.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=exclude_from_bom.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=exclude_from_bom_and_dnp.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=normal.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=P1
 INFO: OPLOG NET_ADD name=P2
 INFO: OPLOG PLACE_FP path=dnp.R x=146995000 y=104245000 w=3010000 h=1510000

--- a/crates/pcb-layout/tests/snapshots/layout_generation__graphics.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__graphics.layout.json.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 97
 expression: content
 ---
 {
@@ -9,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -260,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__graphics.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__graphics.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 101
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -17,14 +16,14 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 2 groups, 2 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=G1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=G2.R1.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=G1.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=G2.R1.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=G1 members=[G1.R1.R] layout=module
 INFO: NEW GRV path=G2 members=[G2.R1.R] layout=module
 INFO: NEW FPC path=G1.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=G2.R1.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=G1.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=G2.R1.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=G1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=G2.R1.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=G1 members=1 fragment=true
 INFO: CHANGESET GR_ADD path=G2 members=1 fragment=true
 INFO: Added footprint: G1.R1.R
@@ -35,8 +34,8 @@ INFO: Authoritative fragments: ['G1', 'G2']
 INFO: Applied fragment routing to G1: 0 tracks, 0 vias, 0 zones, 2 graphics
 INFO: Applied fragment routing to G2: 0 tracks, 0 vias, 0 zones, 2 graphics
 INFO: HierPlace: placed 4 items
-INFO: OPLOG FP_ADD path=G1.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=G2.R1.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=G1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=G2.R1.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=G1
 INFO: OPLOG GR_ADD path=G2
 INFO: OPLOG NET_ADD name=BOARD_ONE

--- a/crates/pcb-layout/tests/snapshots/layout_generation__module_layout.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__module_layout.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "C_0402_1005Metric:C_0402_1005Metric",
+      "footprint": "Capacitor_SMD@9.0.3:C_0402_1005Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "C_0402_1005Metric:C_0402_1005Metric",
+      "footprint": "Capacitor_SMD@9.0.3:C_0402_1005Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "C_0603_1608Metric:C_0603_1608Metric",
+      "footprint": "Capacitor_SMD@9.0.3:C_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "C_0603_1608Metric:C_0603_1608Metric",
+      "footprint": "Capacitor_SMD@9.0.3:C_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__module_layout.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__module_layout.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 89
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -19,20 +18,20 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 2 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=MODULE1.C1.C ref=C1 value=0F fpid=C_0402_1005Metric:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=MODULE1.C2.C ref=C2 value=0F fpid=C_0603_1608Metric:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=MODULE2.C1.C ref=C3 value=0F fpid=C_0402_1005Metric:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=MODULE2.C2.C ref=C4 value=0F fpid=C_0603_1608Metric:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=MODULE1.C1.C ref=C1 value=0F fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=MODULE1.C2.C ref=C2 value=0F fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=MODULE2.C1.C ref=C3 value=0F fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=MODULE2.C2.C ref=C4 value=0F fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
 INFO: NEW GRV path=MODULE1 members=[MODULE1.C1.C, MODULE1.C2.C] layout=module_layout
 INFO: NEW GRV path=MODULE2 members=[MODULE2.C1.C, MODULE2.C2.C] layout=module_layout
 INFO: NEW FPC path=MODULE1.C1.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MODULE1.C2.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MODULE2.C1.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MODULE2.C2.C x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MODULE1.C1.C ref=C1 fpid=C_0402_1005Metric:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MODULE1.C2.C ref=C2 fpid=C_0603_1608Metric:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MODULE2.C1.C ref=C3 fpid=C_0402_1005Metric:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MODULE2.C2.C ref=C4 fpid=C_0603_1608Metric:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MODULE1.C1.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MODULE1.C2.C ref=C2 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MODULE2.C1.C ref=C3 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MODULE2.C2.C ref=C4 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=MODULE1 members=2 fragment=true
 INFO: CHANGESET GR_ADD path=MODULE2 members=2 fragment=true
 INFO: Added footprint: MODULE1.C1.C
@@ -44,10 +43,10 @@ INFO: Added group: MODULE2
 WARNING: Fragment package://workspace/build/module_layout not found, using HierPlace: Layout fragment not found: <TEMP_DIR>
 WARNING: Fragment package://workspace/build/module_layout not found, using HierPlace: Layout fragment not found: <TEMP_DIR>
 INFO: HierPlace: placed 4 items
-INFO: OPLOG FP_ADD path=MODULE1.C1.C ref=C1 fpid=C_0402_1005Metric:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MODULE1.C2.C ref=C2 fpid=C_0603_1608Metric:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MODULE2.C1.C ref=C3 fpid=C_0402_1005Metric:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MODULE2.C2.C ref=C4 fpid=C_0603_1608Metric:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MODULE1.C1.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MODULE1.C2.C ref=C2 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MODULE2.C1.C ref=C3 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MODULE2.C2.C ref=C4 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=MODULE1
 INFO: OPLOG GR_ADD path=MODULE2
 INFO: OPLOG NET_ADD name=MAIN_GND

--- a/crates/pcb-layout/tests/snapshots/layout_generation__multi_pads.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__multi_pads.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
+      "footprint": "Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
       "graphical_items": [
         {
           "angle": null,
@@ -851,7 +851,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
+      "footprint": "Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__multi_pads.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__multi_pads.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 93
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -13,17 +12,17 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 0 groups, 4 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=C0 ref=U1 value=? fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
-INFO: NEW FPV path=C1 ref=U2 value=? fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
+INFO: NEW FPV path=C0 ref=U1 value=? fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
+INFO: NEW FPV path=C1 ref=U2 value=? fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
 INFO: NEW FPC path=C0 x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=C1 x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=C0 ref=U1 fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=C1 ref=U2 fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=C0 ref=U1 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=C1 ref=U2 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
 INFO: Added footprint: C0
 INFO: Added footprint: C1
 INFO: HierPlace: placed 2 items
-INFO: OPLOG FP_ADD path=C0 ref=U1 fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
-INFO: OPLOG FP_ADD path=C1 ref=U2 fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
+INFO: OPLOG FP_ADD path=C0 ref=U1 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
+INFO: OPLOG FP_ADD path=C1 ref=U2 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
 INFO: OPLOG NET_ADD name=A
 INFO: OPLOG NET_ADD name=B
 INFO: OPLOG NET_ADD name=IN

--- a/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "C_0603_1608Metric:C_0603_1608Metric",
+      "footprint": "Capacitor_SMD@9.0.3:C_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "PinHeader_1x01_P2.54mm_Vertical:PinHeader_1x01_P2.54mm_Vertical",
+      "footprint": "Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical",
       "graphical_items": [
         {
           "angle": null,
@@ -602,7 +602,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "PinHeader_2x05_P2.54mm_Vertical:PinHeader_2x05_P2.54mm_Vertical",
+      "footprint": "Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical",
       "graphical_items": [
         {
           "angle": null,
@@ -1057,7 +1057,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.log.snap
@@ -16,27 +16,27 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 0 groups, 11 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=HDMI_MOD.C_DIFFPAIR.C ref=C1 value=0F fpid=C_0603_1608Metric:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=U1 ref=U1 value=? fpid=PinHeader_2x05_P2.54mm_Vertical:PinHeader_2x05_P2.54mm_Vertical fields=["Prefix=U"]
-INFO: NEW FPV path=U2 ref=U2 value=? fpid=PinHeader_1x01_P2.54mm_Vertical:PinHeader_1x01_P2.54mm_Vertical fields=["Prefix=U"]
-INFO: NEW FPV path=USB_MOD.R_USB.R ref=R1 value="0" fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=0", "Type=resistor"]
+INFO: NEW FPV path=HDMI_MOD.C_DIFFPAIR.C ref=C1 value=0F fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=U1 ref=U1 value=? fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical fields=["Prefix=U"]
+INFO: NEW FPV path=U2 ref=U2 value=? fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical fields=["Prefix=U"]
+INFO: NEW FPV path=USB_MOD.R_USB.R ref=R1 value="0" fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=0", "Type=resistor"]
 INFO: NEW FPC path=HDMI_MOD.C_DIFFPAIR.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=U1 x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=U2 x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=USB_MOD.R_USB.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=C_0603_1608Metric:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=PinHeader_2x05_P2.54mm_Vertical:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=U2 ref=U2 fpid=PinHeader_1x01_P2.54mm_Vertical:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=U2 ref=U2 fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu
 INFO: Added footprint: HDMI_MOD.C_DIFFPAIR.C
 INFO: Added footprint: U1
 INFO: Added footprint: U2
 INFO: Added footprint: USB_MOD.R_USB.R
 INFO: HierPlace: placed 4 items
-INFO: OPLOG FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=C_0603_1608Metric:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=PinHeader_2x05_P2.54mm_Vertical:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=10
-INFO: OPLOG FP_ADD path=U2 ref=U2 fpid=PinHeader_1x01_P2.54mm_Vertical:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=1
-INFO: OPLOG FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=10
+INFO: OPLOG FP_ADD path=U2 ref=U2 fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=1
+INFO: OPLOG FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=HDMI_N
 INFO: OPLOG NET_ADD name=HDMI_P
 INFO: OPLOG NET_ADD name=CLK_50

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 107
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -15,17 +14,17 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 0 groups, 3 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
-INFO: NEW FPV path=R2.R ref=R2 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R2.R ref=R2 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=R2.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
 INFO: Added footprint: R1.R
 INFO: Added footprint: R2.R
 INFO: HierPlace: placed 2 items
-INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=NC_PIN
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG NET_ADD name=GND

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
+      "footprint": "Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 109
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -13,12 +12,12 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
-INFO: NEW FPV path=U1 ref=U1 value=? fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
+INFO: NEW FPV path=U1 ref=U1 value=? fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
 INFO: NEW FPC path=U1 x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
 INFO: Added footprint: U1
 INFO: HierPlace: placed 1 items
-INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
+INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
 INFO: OPLOG NET_ADD name=unconnected-(U1:5)
 INFO: OPLOG NET_ADD name=unconnected-(U1:17)
 INFO: OPLOG PLACE_FP path=U1 x=146345000 y=102845000 w=4310000 h=4310000

--- a/crates/pcb-layout/tests/snapshots/layout_generation__simple.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__simple.layout.json.snap
@@ -8,7 +8,258 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "BMI270:BMI270",
+      "footprint": "Capacitor_SMD@9.0.3:C_0402_1005Metric",
+      "graphical_items": [
+        {
+          "angle": null,
+          "end": null,
+          "layer": "F.Fab",
+          "position": {
+            "x": 146885000,
+            "y": 102700000
+          },
+          "shape": null,
+          "start": null,
+          "text": "${REFERENCE}",
+          "type": "PCB_TEXT",
+          "width": null
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 145975000,
+            "y": 102240000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 145975000,
+            "y": 103160000
+          },
+          "shape": 0,
+          "start": {
+            "x": 145975000,
+            "y": 103160000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 145975000,
+            "y": 103160000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 147795000,
+            "y": 103160000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147795000,
+            "y": 103160000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146385000,
+            "y": 102450000
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 146385000,
+            "y": 102950000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146385000,
+            "y": 102950000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146385000,
+            "y": 102950000
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 147385000,
+            "y": 102950000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147385000,
+            "y": 102950000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146992836,
+            "y": 102340000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 146777164,
+            "y": 102340000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146777164,
+            "y": 102340000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 146992836,
+            "y": 103060000
+          },
+          "layer": "F.Silkscreen",
+          "position": {
+            "x": 146777164,
+            "y": 103060000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146777164,
+            "y": 103060000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 120000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147385000,
+            "y": 102450000
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 146385000,
+            "y": 102450000
+          },
+          "shape": 0,
+          "start": {
+            "x": 146385000,
+            "y": 102450000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147385000,
+            "y": 102950000
+          },
+          "layer": "F.Fab",
+          "position": {
+            "x": 147385000,
+            "y": 102450000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147385000,
+            "y": 102450000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 100000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147795000,
+            "y": 102240000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 145975000,
+            "y": 102240000
+          },
+          "shape": 0,
+          "start": {
+            "x": 145975000,
+            "y": 102240000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        },
+        {
+          "angle": null,
+          "end": {
+            "x": 147795000,
+            "y": 103160000
+          },
+          "layer": "F.Courtyard",
+          "position": {
+            "x": 147795000,
+            "y": 102240000
+          },
+          "shape": 0,
+          "start": {
+            "x": 147795000,
+            "y": 102240000
+          },
+          "text": null,
+          "type": "PCB_SHAPE",
+          "width": 50000
+        }
+      ],
+      "group": "BMI270",
+      "layer": "F.Cu",
+      "locked": false,
+      "orientation": 0.0,
+      "pads": [
+        {
+          "layer": "F.Cu",
+          "name": "1",
+          "position": {
+            "x": 146405000,
+            "y": 102700000
+          }
+        },
+        {
+          "layer": "F.Cu",
+          "name": "2",
+          "position": {
+            "x": 147365000,
+            "y": 102700000
+          }
+        }
+      ],
+      "position": {
+        "x": 146885000,
+        "y": 102700000
+      },
+      "reference": "C1",
+      "uuid": "394660df-0570-5ff9-815b-abf03e6c9830",
+      "value": "0F"
+    },
+    {
+      "dnp": false,
+      "exclude_from_bom": false,
+      "exclude_from_pos_files": false,
+      "footprint": "eda:BMI270",
       "graphical_items": [
         {
           "angle": null,
@@ -390,257 +641,6 @@ expression: content
       "reference": "IC1",
       "uuid": "233c70a3-0882-5e15-a03d-8be81cfdc04b",
       "value": "BMI270"
-    },
-    {
-      "dnp": false,
-      "exclude_from_bom": false,
-      "exclude_from_pos_files": false,
-      "footprint": "C_0402_1005Metric:C_0402_1005Metric",
-      "graphical_items": [
-        {
-          "angle": null,
-          "end": null,
-          "layer": "F.Fab",
-          "position": {
-            "x": 146885000,
-            "y": 102700000
-          },
-          "shape": null,
-          "start": null,
-          "text": "${REFERENCE}",
-          "type": "PCB_TEXT",
-          "width": null
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 145975000,
-            "y": 102240000
-          },
-          "layer": "F.Courtyard",
-          "position": {
-            "x": 145975000,
-            "y": 103160000
-          },
-          "shape": 0,
-          "start": {
-            "x": 145975000,
-            "y": 103160000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 50000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 145975000,
-            "y": 103160000
-          },
-          "layer": "F.Courtyard",
-          "position": {
-            "x": 147795000,
-            "y": 103160000
-          },
-          "shape": 0,
-          "start": {
-            "x": 147795000,
-            "y": 103160000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 50000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 146385000,
-            "y": 102450000
-          },
-          "layer": "F.Fab",
-          "position": {
-            "x": 146385000,
-            "y": 102950000
-          },
-          "shape": 0,
-          "start": {
-            "x": 146385000,
-            "y": 102950000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 100000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 146385000,
-            "y": 102950000
-          },
-          "layer": "F.Fab",
-          "position": {
-            "x": 147385000,
-            "y": 102950000
-          },
-          "shape": 0,
-          "start": {
-            "x": 147385000,
-            "y": 102950000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 100000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 146992836,
-            "y": 102340000
-          },
-          "layer": "F.Silkscreen",
-          "position": {
-            "x": 146777164,
-            "y": 102340000
-          },
-          "shape": 0,
-          "start": {
-            "x": 146777164,
-            "y": 102340000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 146992836,
-            "y": 103060000
-          },
-          "layer": "F.Silkscreen",
-          "position": {
-            "x": 146777164,
-            "y": 103060000
-          },
-          "shape": 0,
-          "start": {
-            "x": 146777164,
-            "y": 103060000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 120000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 147385000,
-            "y": 102450000
-          },
-          "layer": "F.Fab",
-          "position": {
-            "x": 146385000,
-            "y": 102450000
-          },
-          "shape": 0,
-          "start": {
-            "x": 146385000,
-            "y": 102450000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 100000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 147385000,
-            "y": 102950000
-          },
-          "layer": "F.Fab",
-          "position": {
-            "x": 147385000,
-            "y": 102450000
-          },
-          "shape": 0,
-          "start": {
-            "x": 147385000,
-            "y": 102450000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 100000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 147795000,
-            "y": 102240000
-          },
-          "layer": "F.Courtyard",
-          "position": {
-            "x": 145975000,
-            "y": 102240000
-          },
-          "shape": 0,
-          "start": {
-            "x": 145975000,
-            "y": 102240000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 50000
-        },
-        {
-          "angle": null,
-          "end": {
-            "x": 147795000,
-            "y": 103160000
-          },
-          "layer": "F.Courtyard",
-          "position": {
-            "x": 147795000,
-            "y": 102240000
-          },
-          "shape": 0,
-          "start": {
-            "x": 147795000,
-            "y": 102240000
-          },
-          "text": null,
-          "type": "PCB_SHAPE",
-          "width": 50000
-        }
-      ],
-      "group": "BMI270",
-      "layer": "F.Cu",
-      "locked": false,
-      "orientation": 0.0,
-      "pads": [
-        {
-          "layer": "F.Cu",
-          "name": "1",
-          "position": {
-            "x": 146405000,
-            "y": 102700000
-          }
-        },
-        {
-          "layer": "F.Cu",
-          "name": "2",
-          "position": {
-            "x": 147365000,
-            "y": 102700000
-          }
-        }
-      ],
-      "position": {
-        "x": 146885000,
-        "y": 102700000
-      },
-      "reference": "C1",
-      "uuid": "394660df-0570-5ff9-815b-abf03e6c9830",
-      "value": "0F"
     }
   ],
   "groups": [

--- a/crates/pcb-layout/tests/snapshots/layout_generation__simple.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__simple.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 87
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -15,20 +14,20 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 1 groups, 10 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=BMI270.C.C ref=C1 value=0F fpid=C_0402_1005Metric:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=BMI270.IC ref=IC1 value=BMI270 fpid=BMI270:BMI270 fields=["Manufacturer=BOSCH", "Mpn=BMI270", "Prefix=IC"]
+INFO: NEW FPV path=BMI270.C.C ref=C1 value=0F fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=BMI270.IC ref=IC1 value=BMI270 fpid=eda:BMI270 fields=["Manufacturer=BOSCH", "Mpn=BMI270", "Prefix=IC"]
 INFO: NEW GRV path=BMI270 members=[BMI270.C.C, BMI270.IC]
 INFO: NEW FPC path=BMI270.C.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=BMI270.IC x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=BMI270.C.C ref=C1 fpid=C_0402_1005Metric:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=BMI270.IC ref=IC1 fpid=BMI270:BMI270 value=BMI270 x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=BMI270.C.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=BMI270.IC ref=IC1 fpid=eda:BMI270 value=BMI270 x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=BMI270 members=2
 INFO: Added footprint: BMI270.C.C
 INFO: Added footprint: BMI270.IC
 INFO: Added group: BMI270
 INFO: HierPlace: placed 2 items
-INFO: OPLOG FP_ADD path=BMI270.C.C ref=C1 fpid=C_0402_1005Metric:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=BMI270.IC ref=IC1 fpid=BMI270:BMI270 value=BMI270 x=0 y=0 layer=F.Cu pads=14
+INFO: OPLOG FP_ADD path=BMI270.C.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=BMI270.IC ref=IC1 fpid=eda:BMI270 value=BMI270 x=0 y=0 layer=F.Cu pads=14
 INFO: OPLOG GR_ADD path=BMI270
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG NET_ADD name=POWER

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
@@ -1389,7 +1389,7 @@ expression: content
         "x": 147600000,
         "y": 103500000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1400,7 +1400,7 @@ expression: content
         "x": 147600000,
         "y": 99990000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1411,7 +1411,7 @@ expression: content
         "x": 149400000,
         "y": 102890000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1422,7 +1422,7 @@ expression: content
         "x": 149400000,
         "y": 106400000
       },
-      "via_type": 4
+      "via_type": "through"
     }
   ],
   "zones": []

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 99
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -19,20 +18,20 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 2 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=M1.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.R1.R ref=R3 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.R2.R ref=R4 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.R2.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.R1.R ref=R3 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.R2.R ref=R4 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=M1 members=[M1.R1.R, M1.R2.R] layout=module
 INFO: NEW GRV path=M2 members=[M2.R1.R, M2.R2.R] layout=module
 INFO: NEW FPC path=M1.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M1.R2.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.R2.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.R1.R ref=R3 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.R2.R ref=R4 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.R1.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.R2.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=M1 members=2 fragment=true
 INFO: CHANGESET GR_ADD path=M2 members=2 fragment=true
 INFO: Added footprint: M1.R1.R
@@ -45,10 +44,10 @@ INFO: Authoritative fragments: ['M1', 'M2']
 INFO: Applied fragment routing to M1: 12 tracks, 2 vias, 0 zones, 0 graphics
 INFO: Applied fragment routing to M2: 12 tracks, 2 vias, 0 zones, 0 graphics
 INFO: HierPlace: placed 6 items
-INFO: OPLOG FP_ADD path=M1.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M1.R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.R1.R ref=R3 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.R2.R ref=R4 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.R1.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.R2.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=M1
 INFO: OPLOG GR_ADD path=M2
 INFO: OPLOG NET_ADD name=BOARD_ONE

--- a/crates/pcb-layout/tests/snapshots/layout_generation__zones.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__zones.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "R_0603_1608Metric:R_0603_1608Metric",
+      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__zones.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__zones.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 97
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -16,13 +15,13 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 1 groups, 2 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=MyModule members=[MyModule.R1.R, MyModule.R2.R] layout=module
 INFO: NEW FPC path=MyModule.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R2.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=MyModule members=2 fragment=true
 INFO: Added footprint: MyModule.R1.R
 INFO: Added footprint: MyModule.R2.R
@@ -30,8 +29,8 @@ INFO: Added group: MyModule
 INFO: Authoritative fragments: ['MyModule']
 INFO: Applied fragment routing to MyModule: 0 tracks, 0 vias, 1 zones, 0 graphics
 INFO: HierPlace: placed 3 items
-INFO: OPLOG FP_ADD path=MyModule.R1.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MyModule.R2.R ref=R2 fpid=R_0603_1608Metric:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=MyModule
 INFO: OPLOG NET_ADD name=BOARD_ONE
 INFO: OPLOG NET_ADD name=BOARD_TWO

--- a/crates/pcb-layout/tests/snapshots/moved__moved_step1.log.snap
+++ b/crates/pcb-layout/tests/snapshots/moved__moved_step1.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/moved.rs
-assertion_line: 66
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -14,12 +13,12 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
-INFO: NEW FPV path=OldModule.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=OldModule.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=OldModule.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=OldModule.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=OldModule.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
 INFO: Added footprint: OldModule.R
 INFO: HierPlace: placed 1 items
-INFO: OPLOG FP_ADD path=OldModule.R ref=R1 fpid=R_0603_1608Metric:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=OldModule.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG PLACE_FP path=OldModule.R x=146995000 y=104245000 w=3010000 h=1510000

--- a/crates/pcb-layout/tests/snapshots/moved__moved_step2.log.snap
+++ b/crates/pcb-layout/tests/snapshots/moved__moved_step2.log.snap
@@ -11,10 +11,10 @@ INFO: Starting ImportNetlist...
 INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
-INFO: OLD FPV path=NewModule.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: OLD FPV path=NewModule.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: OLD FPC path=NewModule.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103570000 val_x=148500000 val_y=106430000
 INFO: Changes: +0 -0 footprints
-INFO: NEW FPV path=NewModule.R ref=R1 value=10k fpid=R_0603_1608Metric:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=NewModule.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=NewModule.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103570000 val_x=148500000 val_y=106430000
 INFO: Sync completed in X.XXXs
 INFO: Lens sync complete: +0 -0 footprints

--- a/crates/pcb-sch/src/kicad_netlist.rs
+++ b/crates/pcb-sch/src/kicad_netlist.rs
@@ -1,12 +1,12 @@
 // Module implementing KiCad net-list export functionality for `pcb_sch::Schematic`.
 
 use pathdiff::diff_paths;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
-use crate::{AttributeValue, InstanceKind, InstanceRef, Schematic};
+use crate::{AttributeValue, InstanceKind, InstanceRef, PACKAGE_URI_PREFIX, Schematic};
 
 #[derive(Debug)]
 struct CompInfo<'a> {
@@ -180,7 +180,8 @@ pub fn to_kicad_netlist(sch: &Schematic) -> String {
                 _ => None,
             })
             .unwrap_or("UNKNOWN:UNKNOWN");
-        let (fp_string, _lib_info) = format_footprint(fp_attr);
+        let (fp_string, _lib_info) =
+            format_footprint_with_package_roots(fp_attr, &sch.package_roots);
 
         writeln!(out, "    (comp (ref \"{}\")", escape_kicad_string(refdes)).unwrap();
         writeln!(
@@ -410,24 +411,134 @@ fn collect_pins_for_component(
 /// Returns the (possibly modified) footprint string and optional `(lib_name, dir)` tuple that can be
 /// used to populate the fp-lib-table.
 pub fn format_footprint(fp: &str) -> (String, Option<(String, PathBuf)>) {
+    format_footprint_with_package_roots(fp, &BTreeMap::new())
+}
+
+/// Package-aware variant of [`format_footprint`].
+pub fn format_footprint_with_package_roots(
+    fp: &str,
+    package_roots: &BTreeMap<String, PathBuf>,
+) -> (String, Option<(String, PathBuf)>) {
     if is_kicad_lib_fp(fp) {
         return (fp.to_owned(), None);
     }
-    let p = Path::new(fp);
+
+    let resolved = if fp.starts_with(PACKAGE_URI_PREFIX) {
+        crate::resolve_package_uri(fp, package_roots).unwrap_or_else(|_| PathBuf::from(fp))
+    } else {
+        PathBuf::from(fp)
+    };
+
+    format_resolved_footprint_path(resolved.as_path(), package_roots)
+}
+
+/// Fallible package-aware formatter used by layout prep, which should reject
+/// unresolved package URIs before invoking KiCad.
+pub fn try_format_footprint_with_package_roots(
+    fp: &str,
+    package_roots: &BTreeMap<String, PathBuf>,
+) -> anyhow::Result<(String, Option<(String, PathBuf)>)> {
+    if is_kicad_lib_fp(fp) {
+        return Ok((fp.to_owned(), None));
+    }
+
+    let resolved = if fp.starts_with(PACKAGE_URI_PREFIX) {
+        crate::resolve_package_uri(fp, package_roots)?
+    } else {
+        PathBuf::from(fp)
+    };
+
+    Ok(format_resolved_footprint_path(
+        resolved.as_path(),
+        package_roots,
+    ))
+}
+
+fn format_resolved_footprint_path(
+    p: &Path,
+    package_roots: &BTreeMap<String, PathBuf>,
+) -> (String, Option<(String, PathBuf)>) {
     let Some(stem_os) = p.file_stem() else {
         return ("UNKNOWN:UNKNOWN".to_owned(), None);
     };
-    let stem = stem_os.to_string_lossy();
-    let lib_name = stem.to_string();
-    let footprint_name = stem.to_string();
+    let footprint_name = stem_os.to_string_lossy().to_string();
     let dir = p
         .parent()
         .map(|d| d.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
+    let lib_name =
+        footprint_library_name(p, package_roots).unwrap_or_else(|| footprint_name.clone());
     (
         format!("{lib_name}:{footprint_name}"),
         Some((lib_name, dir)),
     )
+}
+
+fn footprint_library_name(p: &Path, package_roots: &BTreeMap<String, PathBuf>) -> Option<String> {
+    let parent = p.parent()?;
+    let package_match = package_coord_for_path(p, package_roots);
+
+    if let Some(pretty_name) = pretty_library_name(
+        parent,
+        package_match
+            .as_ref()
+            .map(|(package_name, _)| package_name.as_str()),
+    ) {
+        return Some(pretty_name);
+    }
+
+    if let Some((package_name, package_root)) = package_match
+        && parent == package_root
+    {
+        return Some(package_name);
+    }
+
+    parent
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+}
+
+fn pretty_library_name(parent: &Path, package_name: Option<&str>) -> Option<String> {
+    let pretty_name = parent
+        .file_stem()
+        .filter(|_| parent.extension().is_some_and(|ext| ext == "pretty"))?
+        .to_string_lossy();
+
+    let version = package_name
+        .and_then(|package_name| package_name.strip_prefix("kicad-footprints@"))
+        .filter(|version| !version.is_empty());
+
+    if let Some(version) = version {
+        return Some(format!("{pretty_name}@{version}"));
+    }
+
+    if pretty_name.is_empty() {
+        None
+    } else {
+        Some(pretty_name.into_owned())
+    }
+}
+
+fn package_coord_for_path(
+    path: &Path,
+    package_roots: &BTreeMap<String, PathBuf>,
+) -> Option<(String, PathBuf)> {
+    package_roots
+        .iter()
+        .filter_map(|(coord, root)| {
+            if !path.starts_with(root) {
+                return None;
+            }
+            let package_name = coord.rsplit('/').next().unwrap_or(coord);
+            Some((
+                root.components().count(),
+                package_name.to_string(),
+                root.clone(),
+            ))
+        })
+        .max_by_key(|(depth, _, _)| *depth)
+        .map(|(_, package_name, root)| (package_name, root))
 }
 
 /// Determine whether a given string is a KiCad `lib:footprint` reference rather than a file path.
@@ -512,16 +623,12 @@ pub fn serialize_fp_lib_table(layout_dir: &Path, libs: &HashMap<String, PathBuf>
         }
 
         // Construct final URI: use project-relative `${KIPRJMOD}` only for relative paths.
-        let mut uri = if rel_path.is_relative() {
+        let uri = if rel_path.is_relative() {
             format!("${{KIPRJMOD}}/{path_str}")
         } else {
             // Absolute path – use it directly.
             path_str.clone()
         };
-
-        if !uri.ends_with('/') {
-            uri.push('/');
-        }
 
         table.push_str(&format!(
             "  (lib (name \"{}\") (type \"KiCad\") (uri \"{}\") (options \"\") (descr \"\"))\n",
@@ -553,8 +660,21 @@ pub fn write_fp_lib_table(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::path::Path;
+
+    fn assert_formatted_footprint(
+        formatted: (String, Option<(String, PathBuf)>),
+        expected_fp: &str,
+        expected_lib: &str,
+        expected_dir: &str,
+    ) {
+        assert_eq!(formatted.0, expected_fp);
+        assert_eq!(
+            formatted.1,
+            Some((expected_lib.to_string(), PathBuf::from(expected_dir)))
+        );
+    }
 
     #[test]
     fn test_escape_kicad_string() {
@@ -602,6 +722,95 @@ mod tests {
 
         // Multiple colons (should return false since split_once will only match first)
         assert!(is_kicad_lib_fp("lib:footprint:extra")); // This will be treated as lib "lib" and footprint "footprint:extra"
+    }
+
+    #[test]
+    fn test_format_footprint_for_pretty_library_path() {
+        assert_formatted_footprint(
+            format_footprint(
+                "/tmp/cache/kicad-footprints/Capacitor_SMD.pretty/C_0402_1005Metric.kicad_mod",
+            ),
+            "Capacitor_SMD:C_0402_1005Metric",
+            "Capacitor_SMD",
+            "/tmp/cache/kicad-footprints/Capacitor_SMD.pretty",
+        );
+    }
+
+    #[test]
+    fn test_format_footprint_for_kicad_pretty_package_root_uri() {
+        let mut package_roots = BTreeMap::new();
+        package_roots.insert(
+            "gitlab.com/kicad/libraries/kicad-footprints@10.0.0".to_string(),
+            PathBuf::from("/tmp/vendor/gitlab.com/kicad/libraries/kicad-footprints/10.0.0"),
+        );
+
+        assert_formatted_footprint(
+            format_footprint_with_package_roots(
+                "package://gitlab.com/kicad/libraries/kicad-footprints@10.0.0/Capacitor_SMD.pretty/C_0402_1005Metric.kicad_mod",
+                &package_roots,
+            ),
+            "Capacitor_SMD@10.0.0:C_0402_1005Metric",
+            "Capacitor_SMD@10.0.0",
+            "/tmp/vendor/gitlab.com/kicad/libraries/kicad-footprints/10.0.0/Capacitor_SMD.pretty",
+        );
+    }
+
+    #[test]
+    fn test_format_footprint_for_plain_directory_path() {
+        assert_formatted_footprint(
+            format_footprint("/tmp/components/TLV9001IDBVR/SOT95P280X145-5N.kicad_mod"),
+            "TLV9001IDBVR:SOT95P280X145-5N",
+            "TLV9001IDBVR",
+            "/tmp/components/TLV9001IDBVR",
+        );
+    }
+
+    #[test]
+    fn test_format_footprint_preserves_dotted_directory_name() {
+        assert_formatted_footprint(
+            format_footprint("/tmp/components/lib.v2/SOT95P280X145-5N.kicad_mod"),
+            "lib.v2:SOT95P280X145-5N",
+            "lib.v2",
+            "/tmp/components/lib.v2",
+        );
+    }
+
+    #[test]
+    fn test_format_footprint_for_versioned_package_root_uri() {
+        let mut package_roots = BTreeMap::new();
+        package_roots.insert(
+            "github.com/diodeinc/registry/components/BSS138-7-F@0.3.2".to_string(),
+            PathBuf::from("/tmp/vendor/github.com/diodeinc/registry/components/BSS138-7-F/0.3.2"),
+        );
+
+        assert_formatted_footprint(
+            format_footprint_with_package_roots(
+                "package://github.com/diodeinc/registry/components/BSS138-7-F@0.3.2/SOT96P240X115-3N.kicad_mod",
+                &package_roots,
+            ),
+            "BSS138-7-F@0.3.2:SOT96P240X115-3N",
+            "BSS138-7-F@0.3.2",
+            "/tmp/vendor/github.com/diodeinc/registry/components/BSS138-7-F/0.3.2",
+        );
+    }
+
+    #[test]
+    fn test_format_footprint_for_workspace_package_root_path() {
+        let mut package_roots = BTreeMap::new();
+        package_roots.insert(
+            "workspace/components/MyPart".to_string(),
+            PathBuf::from("/tmp/workspace/components/MyPart"),
+        );
+
+        assert_formatted_footprint(
+            format_footprint_with_package_roots(
+                "/tmp/workspace/components/MyPart/Thing.kicad_mod",
+                &package_roots,
+            ),
+            "MyPart:Thing",
+            "MyPart",
+            "/tmp/workspace/components/MyPart",
+        );
     }
 
     #[test]

--- a/crates/pcb-zen/tests/snapshots/kicad_inference_snapshot__snapshot_kicad_symbol_footprint_inference.snap
+++ b/crates/pcb-zen/tests/snapshots/kicad_inference_snapshot__snapshot_kicad_symbol_footprint_inference.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-zen/tests/kicad_inference_snapshot.rs
-assertion_line: 27
 expression: snapshot_output
 ---
 (export (version "E")
@@ -11,7 +10,7 @@ expression: snapshot_output
   (components
     (comp (ref "U1")
       (value "?")
-      (footprint "SOIC-8_3.9x4.9mm_P1.27mm:SOIC-8_3.9x4.9mm_P1.27mm")
+      (footprint "Package_SO@9.0.3:SOIC-8_3.9x4.9mm_P1.27mm")
       (libsource (lib "lib") (part "?") (description "unknown"))
       (sheetpath (names "U1") (tstamps "bb9170a7-68d4-539c-bed9-f036cbc8d7db"))
       (tstamps "bb9170a7-68d4-539c-bed9-f036cbc8d7db")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how footprints are resolved/serialized for layout sync and KiCad netlist export, which can affect FPID matching and library table generation across workspaces and vendored packages. Also tweaks layout snapshot serialization (via type normalization), so downstream tooling/tests may need to adapt if any edge cases are missed.
> 
> **Overview**
> Layout sync and KiCad netlist export now **normalize footprint identifiers (FPIDs)** for file paths and `package://` URIs into stable `lib:footprint` strings (including versioned KiCad `.pretty` libraries like `Resistor_SMD@10.0.0:...`). The Rust netlist formatter gains package-aware `format_*footprint*_with_package_roots` helpers and uses them when emitting netlists and generating `fp-lib-table` entries.
> 
> For Python sync, the Rust side now emits an enriched JSON netlist that preserves the authored `attributes.footprint` but adds a derived `footprint_fpid` field; the Python importer prefers this field and falls back to the older path-based formatter for backwards compatibility. Layout snapshot export also normalizes `via_type` to semantic strings for stability across KiCad versions, and test snapshots/changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 811632f29ccc55f14b106ab2332771cc64e190ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
