### PR TITLE
Stabilize via type snapshots across KiCad versions

### DIFF
--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -73,6 +73,40 @@ def canonicalize_json(obj: Any) -> Any:
         return obj
 
 
+def normalize_via_type(via: Any) -> str:
+    """Map KiCad vias to stable semantic strings across KiCad versions."""
+    if hasattr(via, "IsMicroVia") and via.IsMicroVia():
+        return "microvia"
+
+    if (hasattr(via, "IsBlindVia") and via.IsBlindVia()) or (
+        hasattr(via, "IsBuriedVia") and via.IsBuriedVia()
+    ):
+        return "blind_buried"
+
+    via_type = via.GetViaType()
+    for attr_name, normalized_name in [
+        ("VIATYPE_THROUGH", "through"),
+        ("VIATYPE_BLIND_BURIED", "blind_buried"),
+        ("VIATYPE_MICROVIA", "microvia"),
+        ("VIATYPE_NOT_DEFINED", "not_defined"),
+    ]:
+        attr_value = getattr(pcbnew, attr_name, None)
+        if attr_value is not None and via_type == attr_value:
+            return normalized_name
+
+    # KiCad 9 and 10 expose different raw enum values in some environments.
+    via_type_str = str(via_type)
+    if via_type_str == "1":
+        return "microvia"
+    if via_type_str == "2":
+        return "blind_buried"
+    if via_type_str in {"3", "4"}:
+        return "through"
+    if via_type_str == "0":
+        return "not_defined"
+    return via_type_str
+
+
 # Read PYTHONPATH environment variable and add all folders to the search path
 python_path = os.environ.get("PYTHONPATH", "")
 path_separator = (
@@ -858,7 +892,7 @@ class FinalizeBoard(Step):
             "drill": via.GetDrillValue(),
             "diameter": via.GetWidth(pcbnew.F_Cu),
             "locked": via.IsLocked(),
-            "via_type": via.GetViaType(),
+            "via_type": normalize_via_type(via),
         }
 
     def _export_layout_snapshot(self):

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
@@ -3133,7 +3133,7 @@ expression: content
         "x": 148428999,
         "y": 108192125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3144,7 +3144,7 @@ expression: content
         "x": 148528999,
         "y": 103292125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3155,7 +3155,7 @@ expression: content
         "x": 148428999,
         "y": 106492125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3166,7 +3166,7 @@ expression: content
         "x": 148528999,
         "y": 104992125
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3177,7 +3177,7 @@ expression: content
         "x": 148428999,
         "y": 101123475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3188,7 +3188,7 @@ expression: content
         "x": 148528999,
         "y": 96223475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3199,7 +3199,7 @@ expression: content
         "x": 148428999,
         "y": 99423475
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -3210,7 +3210,7 @@ expression: content
         "x": 148528999,
         "y": 97923475
       },
-      "via_type": 4
+      "via_type": "through"
     }
   ],
   "zones": [

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
@@ -1389,7 +1389,7 @@ expression: content
         "x": 147600000,
         "y": 103500000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1400,7 +1400,7 @@ expression: content
         "x": 147600000,
         "y": 99990000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1411,7 +1411,7 @@ expression: content
         "x": 149400000,
         "y": 102890000
       },
-      "via_type": 4
+      "via_type": "through"
     },
     {
       "diameter": 600000,
@@ -1422,7 +1422,7 @@ expression: content
         "x": 149400000,
         "y": 106400000
       },
-      "via_type": 4
+      "via_type": "through"
     }
   ],
   "zones": []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the layout snapshot schema for `via_type` from a raw KiCad enum value to a normalized string, which could affect any tooling/tests consuming these JSON snapshots. Logic is localized to snapshot export and primarily reduces cross-version nondeterminism.
> 
> **Overview**
> Makes via type export deterministic across KiCad versions by introducing `normalize_via_type()` and using it when generating layout JSON snapshots.
> 
> Updates existing snapshot fixtures to expect semantic strings like `"through"` instead of version-dependent numeric enum values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d98692bc1782e891975ee06778ffc3af8e7348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
