### PR TITLE
style(stdlib): format zen files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      - name: Check stdlib .zen formatting
+        run: cargo run -p pcb -- fmt --check stdlib
+
       - name: Run Clippy
         run: cargo clippy --workspace -- -D warnings
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,11 @@ repos:
         types: [rust]
         pass_filenames: false
         priority: 1
+
+      - id: pcb-fmt-stdlib
+        name: pcb fmt stdlib
+        entry: cargo run -p pcb -- fmt stdlib
+        language: system
+        files: ^stdlib/.*\.zen$
+        pass_filenames: false
+        priority: 1

--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -199,7 +199,7 @@ HOUSE_CAPS_BY_PKG = {
     "1210": [
         murata_cap("X7R", "25V", "22uF 10%", "GRM32ER71E226KE15", ["K", "L"]),
         murata_cap("X7R", "10V", "47uF 10%", "GRM32ER71A476KE15", ["K", "L"]),
-    ]
+    ],
 }
 
 # House LED catalog by package

--- a/stdlib/generics/Crystal.zen
+++ b/stdlib/generics/Crystal.zen
@@ -131,6 +131,7 @@ def _spice_args(frequency, load_capacitance, package):
 
     return args
 
+
 Component(
     name="Y",
     part=builtin.Part(mpn=mpn, manufacturer=manufacturer) if mpn and manufacturer else None,

--- a/stdlib/generics/Fiducial.zen
+++ b/stdlib/generics/Fiducial.zen
@@ -32,6 +32,7 @@ def _footprint(variant: Variant) -> str:
     name = variant.value
     return f"@kicad-footprints/Fiducial.pretty/Fiducial_{name}.kicad_mod"
 
+
 Component(
     name="FID",
     symbol=Symbol(**_symbol(variant)),

--- a/stdlib/generics/Led.zen
+++ b/stdlib/generics/Led.zen
@@ -108,6 +108,7 @@ def _spice_args(color: Color, forward_voltage, forward_current):
 
     return args
 
+
 Component(
     name="LED",
     part=builtin.Part(mpn=mpn, manufacturer=manufacturer) if mpn and manufacturer else None,

--- a/stdlib/generics/MountingHole.zen
+++ b/stdlib/generics/MountingHole.zen
@@ -94,6 +94,7 @@ def _footprint(diameter: Diameter, standard: Standard | None = None, plating: Pl
         )
     return footprint_str
 
+
 # Mechanical holes have no electrical connection
 pins = {} if plating == Plating("Mechanical") else {"1": P1}
 

--- a/stdlib/generics/NetTie.zen
+++ b/stdlib/generics/NetTie.zen
@@ -183,6 +183,7 @@ def _spice_nets(P, pin_count):
 
     return nets
 
+
 Component(
     name="NT",
     part=builtin.Part(mpn=mpn, manufacturer=manufacturer) if mpn and manufacturer else None,

--- a/stdlib/generics/PinHeader.zen
+++ b/stdlib/generics/PinHeader.zen
@@ -117,6 +117,7 @@ def _footprint():
     name = prefix + "_" + row_prefix + pin_str + "_P" + pitch.value + "_" + orientation_suffix
     return "@kicad-footprints/" + pitch_dir + "/" + name + ".kicad_mod"
 
+
 io_ports = {"Pin_" + str(i): io("P" + str(i), Net) for i in range(1, pins * rows + 1)}
 
 Component(

--- a/stdlib/generics/SolderJumper.zen
+++ b/stdlib/generics/SolderJumper.zen
@@ -35,6 +35,7 @@ def _get_symbol(pin_count, style):
         else:
             return "Jumper:SolderJumper_3_Bridged123"
 
+
 pin_count = config("pin_count", int, default=2, optional=True, help="Number of pins (2 or 3)")
 style = config("style", SolderJumperStyle, help="Solder bridge style (Open, Bridged, etc.)")
 variant = config("variant", SolderJumperVariant, help="Pad shape variant")
@@ -93,6 +94,7 @@ def _pins_and_connections(pin_count):
         if net != None:
             pins[pin_name] = net
     return pins
+
 
 pins = _pins_and_connections(pin_count)
 

--- a/stdlib/generics/Standoff.zen
+++ b/stdlib/generics/Standoff.zen
@@ -146,6 +146,7 @@ def _footprint(thread: Thread, height) -> str:
 
     return footprint_str
 
+
 Component(
     name="Standoff",
     type="standoff",

--- a/stdlib/generics/TerminalBlock.zen
+++ b/stdlib/generics/TerminalBlock.zen
@@ -88,6 +88,7 @@ def _footprint():
             + "_P2.54mm_Horizontal.kicad_mod"
         )
 
+
 io_ports = {"Pin_" + str(i): io("P" + str(i), Net) for i in range(1, pins + 1)}
 
 properties = {

--- a/stdlib/generics/Thermistor.zen
+++ b/stdlib/generics/Thermistor.zen
@@ -89,6 +89,7 @@ def _spice_args(value, package):
         "CP": str(cp_table.get(package, Capacitance("0.05pF"))),
     }
 
+
 Component(
     name="TH",
     part=builtin.Part(mpn=mpn, manufacturer=manufacturer) if mpn and manufacturer else None,


### PR DESCRIPTION
## Summary
- run `cargo run -p pcb -- fmt stdlib`
- commit the resulting formatter changes in `stdlib/`
- bring the checked-in stdlib files back in line with `pcb fmt`

## Why
These files were dirty under the repository formatter, so the PR makes the checked-in `stdlib/` output match the current formatter behavior.

## Validation
- `cargo run -p pcb -- fmt stdlib`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are formatter-only updates to `stdlib/*.zen` plus new CI/pre-commit checks to prevent future drift; no functional logic changes expected beyond formatting-sensitive parsing edge cases.
> 
> **Overview**
> Aligns checked-in `stdlib/*.zen` files with the current `pcb` formatter output (mostly whitespace/newline/comma normalization).
> 
> Adds enforcement so drift is caught early: a new GitHub Actions lint step runs `cargo run -p pcb -- fmt --check stdlib`, and a new pre-commit hook formats `stdlib/**/*.zen` via `cargo run -p pcb -- fmt stdlib`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9fc084b687e6b104a536c7d713bf3a1765bd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
