### PR TITLE
Add hidden `pcb embed-step` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,17 +4216,23 @@ name = "pcb-kicad"
 version = "0.3.67"
 dependencies = [
  "anyhow",
+ "atomicwrites",
+ "base64",
  "chrono",
  "dirs",
  "log",
  "pcb-command-runner",
+ "pcb-sexpr",
  "pcb-zen-core",
+ "regex",
  "regress",
  "serde",
  "serde_json",
+ "sha2",
  "starlark",
  "tempfile",
  "typify",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -1,22 +1,19 @@
 use anyhow::{Context, Result};
-use atomicwrites::{AtomicFile, OverwriteBehavior};
 use clap::Args;
 use colored::Colorize;
 use indicatif::ProgressBar;
 use inquire::{Select, Text};
 use pcb_eda::kicad::metadata::SymbolMetadata;
-use pcb_sexpr::formatter::{FormatMode, format_tree, prettify};
+use pcb_sexpr::formatter::{FormatMode, format_tree};
 use pcb_sexpr::kicad::symbol::{
     find_symbol_index, kicad_symbol_lib_items_mut, rewrite_symbol_properties, symbol_names,
     symbol_properties,
 };
 use pcb_zen_core::config::find_workspace_root;
-use regex::Regex;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -199,225 +196,6 @@ fn upgrade_footprint(footprint_path: &Path) -> Result<()> {
         .subcommand("upgrade")
         .arg(lib_dir.to_string_lossy().as_ref())
         .run()
-}
-
-/// Replace the model path in existing model blocks, preserving offset/scale/rotate.
-/// Returns (new_text, number_of_replacements).
-///
-/// This function ONLY replaces the filename/path in `(model "path")`, leaving any
-/// existing offset/scale/rotate parameters intact. This preserves manually-tuned
-/// transformations that users may have configured.
-fn replace_model_path(text: &str, new_path: &str) -> (String, usize) {
-    use regex::Regex;
-
-    // Regex to match: (whitespace)(model )(quoted or unquoted path)
-    // Captures group 1: the prefix including "(model "
-    // Matches but doesn't capture: the old path
-    let model_pattern = Regex::new(r#"(?m)(^\s*\(model\s+)(?:"[^"]+"|[^\s)]+)"#).unwrap();
-
-    let mut count = 0;
-    let result = model_pattern.replace_all(text, |caps: &regex::Captures| {
-        count += 1;
-        format!("{}\"{}\"", &caps[1], new_path)
-    });
-
-    (result.to_string(), count)
-}
-
-/// Find and extract an S-expression block starting with a given pattern.
-/// Returns Some((extracted_text, remaining_text)) or None if not found.
-///
-/// This function:
-/// 1. Finds the pattern in the text
-/// 2. Captures leading whitespace from the start of the line
-/// 3. Matches balanced parentheses to find the complete block
-/// 4. Includes trailing newline if present
-/// 5. Returns both the extracted block and the text with the block removed
-fn extract_sexp_block(text: &str, pattern: &str) -> Option<(String, String)> {
-    // Use regex to find the pattern at the start of a line (with optional leading whitespace)
-    let pattern_regex = Regex::new(&format!(r"(?m)^(\s*)({})", regex::escape(pattern))).unwrap();
-    let captures = pattern_regex.captures(text)?;
-    let line_start = captures.get(1)?.start();
-    let block_start = captures.get(2)?.start();
-
-    // Count parentheses to find the matching closing paren
-    let mut depth = 0;
-    let mut end_pos = block_start;
-
-    for (i, ch) in text[block_start..].char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' => {
-                depth -= 1;
-                if depth == 0 {
-                    end_pos = block_start + i + 1;
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
-
-    if end_pos <= block_start || depth != 0 {
-        return None;
-    }
-
-    // Include trailing newline if present
-    let extract_end = if text[end_pos..].starts_with('\n') {
-        end_pos + 1
-    } else {
-        end_pos
-    };
-
-    let extracted = text[line_start..extract_end].to_string();
-    let remaining = text[..line_start].to_string() + &text[extract_end..];
-
-    Some((extracted, remaining))
-}
-
-/// Embed a STEP file into a KiCad footprint using the KiCad 8/9 embedded files format.
-///
-/// This function:
-/// 1. Compresses the STEP data with ZSTD (level 17 - size/time tradeoff)
-/// 2. Base64 encodes the compressed data
-/// 3. Computes SHA256 checksum of raw STEP data
-/// 4. Inserts an (embedded_files ...) S-expression block into the footprint
-/// 5. Updates the model reference to use kicad-embed:// URI
-fn embed_step_in_footprint(
-    footprint_content: String,
-    step_bytes: Vec<u8>,
-    step_filename: &str,
-) -> Result<String> {
-    use base64::Engine;
-    use sha2::{Digest, Sha256};
-    use std::io::Write;
-
-    let filename = step_filename.replace(".stp", ".step");
-    let indent = "\t";
-
-    // Compress, encode, and checksum
-    let mut encoder = zstd::Encoder::new(Vec::new(), 17)?;
-    encoder.include_contentsize(true)?;
-    encoder.set_pledged_src_size(Some(step_bytes.len() as u64))?;
-    encoder.write_all(&step_bytes)?;
-    let compressed = encoder.finish()?;
-    let b64 = base64::engine::general_purpose::STANDARD.encode(&compressed);
-    let checksum = format!("{:x}", Sha256::digest(&step_bytes));
-
-    // Format base64: first line unindented, rest indented
-    let b64_formatted = b64
-        .as_bytes()
-        .chunks(80)
-        .enumerate()
-        .map(|(i, chunk)| {
-            let line = std::str::from_utf8(chunk).unwrap();
-            if i == 0 {
-                line.to_string()
-            } else {
-                format!("{indent}{indent}{indent}{indent}{line}")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let embed_block = format!(
-        "{indent}(embedded_files\n\
-         {indent}{indent}(file\n\
-         {indent}{indent}{indent}(name {filename})\n\
-         {indent}{indent}{indent}(type model)\n\
-         {indent}{indent}{indent}(data |{b64_formatted}|)\n\
-         {indent}{indent}{indent}(checksum \"{checksum}\")\n\
-         {indent}{indent})\n\
-         {indent})\n"
-    );
-
-    let model_block = format!(
-        "{indent}(model \"kicad-embed://{filename}\"\n\
-         {indent}{indent}(offset\n\
-         {indent}{indent}{indent}(xyz 0 0 0)\n\
-         {indent}{indent})\n\
-         {indent}{indent}(scale\n\
-         {indent}{indent}{indent}(xyz 1 1 1)\n\
-         {indent}{indent})\n\
-         {indent}{indent}(rotate\n\
-         {indent}{indent}{indent}(xyz 0 0 0)\n\
-         {indent}{indent})\n\
-         {indent})\n"
-    );
-
-    let mut text = footprint_content;
-
-    // Try to replace the path in existing model blocks, preserving offset/scale/rotate
-    let (new_text, num_replaced) = replace_model_path(&text, &format!("kicad-embed://{filename}"));
-    text = new_text;
-
-    // If a model block exists, we need to extract it and reinsert it at the end
-    // (after embedded_files) to maintain the correct order: embedded_files → model
-    let extracted_model = if num_replaced > 0 {
-        extract_sexp_block(&text, "(model ").map(|(model_text, remaining_text)| {
-            text = remaining_text;
-            model_text
-        })
-    } else {
-        None
-    };
-
-    // Add embedded_files block if not already present
-    if !text.contains("(embedded_files")
-        && let Some(pos) = text.rfind(')')
-    {
-        text.insert_str(pos, &embed_block);
-    }
-
-    // Add or re-insert model block at the end (after embedded_files)
-    if let Some(existing_model) = extracted_model {
-        // Re-insert the extracted model block
-        if let Some(pos) = text.rfind(')') {
-            text.insert_str(pos, &existing_model);
-        }
-    } else if num_replaced == 0 {
-        // No existing model block, add a new one with default transforms
-        if let Some(pos) = text.rfind(')') {
-            text.insert_str(pos, &model_block);
-        }
-    }
-
-    Ok(text)
-}
-
-/// Embed a STEP file into a footprint file, writing the result atomically.
-/// Optionally deletes the standalone STEP file after embedding.
-fn embed_step_into_footprint_file(
-    footprint_path: &Path,
-    step_path: &Path,
-    delete_step: bool,
-) -> Result<()> {
-    let footprint_content =
-        fs::read_to_string(footprint_path).context("Failed to read footprint file")?;
-    let step_bytes = fs::read(step_path).context("Failed to read STEP file")?;
-    let step_filename = step_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("model.step");
-
-    let embedded_content = embed_step_in_footprint(footprint_content, step_bytes, step_filename)?;
-
-    // Normalize line endings, format as KiCad S-expression, then write atomically.
-    let normalized_content = embedded_content.replace("\r\n", "\n");
-    let formatted_content = format_kicad_sexpr_source(&normalized_content, footprint_path)?;
-    AtomicFile::new(footprint_path, OverwriteBehavior::AllowOverwrite)
-        .write(|f| {
-            f.write_all(formatted_content.as_bytes())?;
-            f.flush()
-        })
-        .map_err(|err| anyhow::anyhow!("Failed to write footprint file: {err}"))?;
-
-    // Optionally delete standalone STEP file
-    if delete_step {
-        fs::remove_file(step_path).context("Failed to remove standalone STEP file")?;
-    }
-
-    Ok(())
 }
 
 // Helper: Show component already exists message and return early
@@ -903,7 +681,11 @@ fn finalize_component(
 
     if files.footprint_path.exists() {
         if files.step_path.exists() {
-            embed_step_into_footprint_file(&files.footprint_path, &files.step_path, true)?;
+            pcb_kicad::footprint::embed_step_into_footprint_file(
+                &files.footprint_path,
+                &files.step_path,
+                true,
+            )?;
         } else {
             format_kicad_sexpr_file(&files.footprint_path)?;
         }
@@ -1054,23 +836,10 @@ fn ensure_exactly_one_symbol<N: AsRef<str>>(
     }
 }
 
-fn format_kicad_sexpr_source(source: &str, path_for_error: &Path) -> Result<String> {
-    pcb_sexpr::parse(source)
-        .map_err(|e| anyhow::anyhow!(e))
-        .with_context(|| {
-            format!(
-                "Failed to parse KiCad S-expression file {}",
-                path_for_error.display()
-            )
-        })?;
-
-    Ok(prettify(source, FormatMode::Normal))
-}
-
 fn format_kicad_sexpr_file(path: &Path) -> Result<()> {
     let source = fs::read_to_string(path)
         .with_context(|| format!("Failed to read KiCad file {}", path.display()))?;
-    let formatted = format_kicad_sexpr_source(&source, path)?;
+    let formatted = pcb_kicad::footprint::format_kicad_sexpr_source(&source, path)?;
     fs::write(path, formatted)
         .with_context(|| format!("Failed to write KiCad file {}", path.display()))?;
 
@@ -2213,8 +1982,12 @@ mod tests {
 	)
 )"#;
         let step_data = b"STEP DATA HERE".to_vec();
-        let result =
-            embed_step_in_footprint(footprint.to_string(), step_data, "test.step").unwrap();
+        let result = pcb_kicad::footprint::embed_step_in_footprint(
+            footprint.to_string(),
+            step_data,
+            "test.step",
+        )
+        .unwrap();
 
         // Verify balanced parentheses
         assert_eq!(
@@ -2248,7 +2021,12 @@ mod tests {
 	)
 )"#;
         let step_data = b"NEW STEP DATA".to_vec();
-        let result = embed_step_in_footprint(footprint.to_string(), step_data, "new.step").unwrap();
+        let result = pcb_kicad::footprint::embed_step_in_footprint(
+            footprint.to_string(),
+            step_data,
+            "new.step",
+        )
+        .unwrap();
 
         // Verify the transforms were preserved
         assert!(result.contains("(xyz 1 2 3)"));

--- a/crates/pcb-kicad/Cargo.toml
+++ b/crates/pcb-kicad/Cargo.toml
@@ -9,14 +9,20 @@ description = "KiCad integration for PCB design tools"
 
 [dependencies]
 anyhow = { workspace = true }
+atomicwrites = { workspace = true }
+base64 = { workspace = true }
 dirs = { workspace = true }
+pcb-sexpr = { workspace = true }
 tempfile = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 typify = { workspace = true }
 chrono = { workspace = true }
 regress = { workspace = true }
+regex = { workspace = true }
 log = { workspace = true }
 pcb-command-runner = { workspace = true }
 pcb-zen-core = { workspace = true }
+sha2 = { workspace = true }
 starlark = { workspace = true }
+zstd = { workspace = true }

--- a/crates/pcb-kicad/src/footprint.rs
+++ b/crates/pcb-kicad/src/footprint.rs
@@ -1,0 +1,194 @@
+use anyhow::{Context, Result};
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use base64::Engine;
+use pcb_sexpr::formatter::{FormatMode, prettify};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+fn replace_model_path(text: &str, new_path: &str) -> (String, usize) {
+    use regex::Regex;
+
+    let model_pattern = Regex::new(r#"(?m)(^\s*\(model\s+)(?:"[^"]+"|[^\s)]+)"#).unwrap();
+
+    let mut count = 0;
+    let result = model_pattern.replace_all(text, |caps: &regex::Captures| {
+        count += 1;
+        format!("{}\"{}\"", &caps[1], new_path)
+    });
+
+    (result.to_string(), count)
+}
+
+fn extract_sexp_block(text: &str, pattern: &str) -> Option<(String, String)> {
+    let pattern_regex =
+        regex::Regex::new(&format!(r"(?m)^(\s*)({})", regex::escape(pattern))).unwrap();
+    let captures = pattern_regex.captures(text)?;
+    let line_start = captures.get(1)?.start();
+    let block_start = captures.get(2)?.start();
+
+    let mut depth = 0;
+    let mut end_pos = block_start;
+
+    for (i, ch) in text[block_start..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    end_pos = block_start + i + 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if end_pos <= block_start || depth != 0 {
+        return None;
+    }
+
+    let extract_end = if text[end_pos..].starts_with('\n') {
+        end_pos + 1
+    } else {
+        end_pos
+    };
+
+    let extracted = text[line_start..extract_end].to_string();
+    let remaining = text[..line_start].to_string() + &text[extract_end..];
+
+    Some((extracted, remaining))
+}
+
+pub fn format_kicad_sexpr_source(source: &str, path_for_error: &Path) -> Result<String> {
+    pcb_sexpr::parse(source)
+        .map_err(|e| anyhow::anyhow!(e))
+        .with_context(|| {
+            format!(
+                "Failed to parse KiCad S-expression file {}",
+                path_for_error.display()
+            )
+        })?;
+
+    Ok(prettify(source, FormatMode::Normal))
+}
+
+pub fn embed_step_in_footprint(
+    footprint_content: String,
+    step_bytes: Vec<u8>,
+    step_filename: &str,
+) -> Result<String> {
+    let filename = step_filename.replace(".stp", ".step");
+    let indent = "\t";
+
+    let mut encoder = zstd::Encoder::new(Vec::new(), 17)?;
+    encoder.include_contentsize(true)?;
+    encoder.set_pledged_src_size(Some(step_bytes.len() as u64))?;
+    encoder.write_all(&step_bytes)?;
+    let compressed = encoder.finish()?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&compressed);
+    let checksum = format!("{:x}", Sha256::digest(&step_bytes));
+
+    let b64_formatted = b64
+        .as_bytes()
+        .chunks(80)
+        .enumerate()
+        .map(|(i, chunk)| {
+            let line = std::str::from_utf8(chunk).unwrap();
+            if i == 0 {
+                line.to_string()
+            } else {
+                format!("{indent}{indent}{indent}{indent}{line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let embed_block = format!(
+        "{indent}(embedded_files\n\
+         {indent}{indent}(file\n\
+         {indent}{indent}{indent}(name {filename})\n\
+         {indent}{indent}{indent}(type model)\n\
+         {indent}{indent}{indent}(data |{b64_formatted}|)\n\
+         {indent}{indent}{indent}(checksum \"{checksum}\")\n\
+         {indent}{indent})\n\
+         {indent})\n"
+    );
+
+    let model_block = format!(
+        "{indent}(model \"kicad-embed://{filename}\"\n\
+         {indent}{indent}(offset\n\
+         {indent}{indent}{indent}(xyz 0 0 0)\n\
+         {indent}{indent})\n\
+         {indent}{indent}(scale\n\
+         {indent}{indent}{indent}(xyz 1 1 1)\n\
+         {indent}{indent})\n\
+         {indent}{indent}(rotate\n\
+         {indent}{indent}{indent}(xyz 0 0 0)\n\
+         {indent}{indent})\n\
+         {indent})\n"
+    );
+
+    let mut text = footprint_content;
+    let (new_text, num_replaced) = replace_model_path(&text, &format!("kicad-embed://{filename}"));
+    text = new_text;
+
+    let extracted_model = if num_replaced > 0 {
+        extract_sexp_block(&text, "(model ").map(|(model_text, remaining_text)| {
+            text = remaining_text;
+            model_text
+        })
+    } else {
+        None
+    };
+
+    if !text.contains("(embedded_files")
+        && let Some(pos) = text.rfind(')')
+    {
+        text.insert_str(pos, &embed_block);
+    }
+
+    if let Some(existing_model) = extracted_model {
+        if let Some(pos) = text.rfind(')') {
+            text.insert_str(pos, &existing_model);
+        }
+    } else if num_replaced == 0
+        && let Some(pos) = text.rfind(')')
+    {
+        text.insert_str(pos, &model_block);
+    }
+
+    Ok(text)
+}
+
+pub fn embed_step_into_footprint_file(
+    footprint_path: &Path,
+    step_path: &Path,
+    delete_step: bool,
+) -> Result<()> {
+    let footprint_content =
+        fs::read_to_string(footprint_path).context("Failed to read footprint file")?;
+    let step_bytes = fs::read(step_path).context("Failed to read STEP file")?;
+    let step_filename = step_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("model.step");
+
+    let embedded_content = embed_step_in_footprint(footprint_content, step_bytes, step_filename)?;
+    let normalized_content = embedded_content.replace("\r\n", "\n");
+    let formatted_content = format_kicad_sexpr_source(&normalized_content, footprint_path)?;
+
+    AtomicFile::new(footprint_path, OverwriteBehavior::AllowOverwrite)
+        .write(|f| {
+            f.write_all(formatted_content.as_bytes())?;
+            f.flush()
+        })
+        .map_err(|err| anyhow::anyhow!("Failed to write footprint file: {err}"))?;
+
+    if delete_step {
+        fs::remove_file(step_path).context("Failed to remove standalone STEP file")?;
+    }
+
+    Ok(())
+}

--- a/crates/pcb-kicad/src/lib.rs
+++ b/crates/pcb-kicad/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod drc;
 pub mod erc;
+pub mod footprint;
 
 use anyhow::{Context, Result, anyhow};
 use pcb_command_runner::CommandRunner;

--- a/crates/pcb/src/embed_step.rs
+++ b/crates/pcb/src/embed_step.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+#[command(about = "Embed a STEP model into a KiCad footprint")]
+pub struct EmbedStepArgs {
+    /// Path to the .kicad_mod footprint to modify
+    #[arg(value_name = "FOOTPRINT", value_hint = clap::ValueHint::FilePath)]
+    pub footprint: PathBuf,
+
+    /// Path to the .step or .stp model to embed
+    #[arg(value_name = "STEP", value_hint = clap::ValueHint::FilePath)]
+    pub step: PathBuf,
+}
+
+pub fn execute(args: EmbedStepArgs) -> Result<()> {
+    pcb_kicad::footprint::embed_step_into_footprint_file(&args.footprint, &args.step, false)
+}

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -16,6 +16,7 @@ mod bundle;
 mod codegen;
 mod doc;
 mod drc;
+mod embed_step;
 mod file_walker;
 mod fmt;
 mod fork;
@@ -133,6 +134,10 @@ enum Commands {
     /// Manage forked dependencies for local development
     Fork(fork::ForkArgs),
 
+    /// Embed a STEP model into a KiCad footprint
+    #[command(hide = true)]
+    EmbedStep(embed_step::EmbedStepArgs),
+
     /// Scan datasheets from local PDFs or URLs
     #[cfg(feature = "api")]
     Scan(api::ScanArgs),
@@ -227,6 +232,7 @@ fn run() -> anyhow::Result<()> {
         Commands::Scan(args) => api::execute_scan(args),
         #[cfg(feature = "api")]
         Commands::Search(args) => api::execute_search(args),
+        Commands::EmbedStep(args) => embed_step::execute(args),
         #[cfg(feature = "api")]
         Commands::Route(args) => route::execute(args),
         Commands::Simulate(args) => sim::execute(args),


### PR DESCRIPTION
I will pay the tax.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new CLI path that rewrites `.kicad_mod` files and refactors STEP-embedding/formatting logic across crates, which could break builds or alter footprint contents if wiring or formatting differs.
> 
> **Overview**
> Adds a hidden `pcb embed-step` CLI command that embeds a STEP/ STP model into a KiCad footprint file.
> 
> Refactors the STEP embedding + KiCad S-expression formatting/atomic write logic out of `pcb-diode-api` into a new `pcb-kicad` `footprint` module, and updates component finalization/tests to call the shared implementation. `pcb-diode-api` also re-exports an embedding entrypoint for the CLI to invoke.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd1e35749dd45cf0c050d0646782142cab18bdb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
