### PR TITLE
feat: warn on top-level variable rebinding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Never run `cargo insta accept` without explicit user approval.
 
 ## Documentation Rules
 
+- Add at most one `CHANGELOG.md` entry per PR under `Unreleased`, and keep it succinct and minimal while covering the user-visible change set as a whole.
 - If you change Zener language syntax, built-ins, core types, module/import behavior, type rules, or other user-visible language semantics, update `docs/pages/spec.mdx` in the same change.
 - If you change workspace manifests, dependency resolution, or package behavior, update the relevant docs in `docs/pages/`, especially `docs/pages/packages.mdx` when applicable.
 - Keep documentation updates concrete and example-driven; do not leave behavior changes documented only in code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Component generation no longer automatically scans datasheets.
 - `pcb new component` and `pcb search` component imports now place datasheet artifacts under each component's `docs/` subdirectory.
 - Layout sync and KiCad netlist export now normalize file- and package-based footprints to library-aware FPIDs.
+- Module-scoped variable rebinding is now a warning.
 - Removed the 10uF 100V 1210 stdlib house capacitor from generic matching due to severe derating.
 - `Net` and `Power` now expose unset `voltage` as `None`.
 

--- a/crates/pcb-kicad/src/drc.rs
+++ b/crates/pcb-kicad/src/drc.rs
@@ -171,6 +171,7 @@ impl DrcViolation {
             call_stack: None,
             child: None,
             source_error: Some(Arc::new(anyhow::Error::new(categorized))),
+            related: Vec::new(),
             suppressed: self.excluded, // Map KiCad exclusions to suppressed diagnostics
         })
     }

--- a/crates/pcb-kicad/src/erc.rs
+++ b/crates/pcb-kicad/src/erc.rs
@@ -133,6 +133,7 @@ impl ErcViolation {
             call_stack: None,
             child: None,
             source_error: Some(Arc::new(anyhow::Error::new(categorized))),
+            related: Vec::new(),
             suppressed: self.excluded,
         })
     }

--- a/crates/pcb-zen-core/src/diagnostics.rs
+++ b/crates/pcb-zen-core/src/diagnostics.rs
@@ -122,6 +122,26 @@ impl std::error::Error for LoadError {
 }
 
 #[derive(Debug, Clone)]
+pub struct DiagnosticReference {
+    pub path: String,
+    pub span: ResolvedSpan,
+    pub message: String,
+}
+
+impl serde::Serialize for DiagnosticReference {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("DiagnosticReference", 3)?;
+        state.serialize_field("path", &self.path)?;
+        state.serialize_field("span", &self.span.to_string())?;
+        state.serialize_field("message", &self.message)?;
+        state.end()
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Diagnostic {
     pub path: String,
     pub span: Option<ResolvedSpan>,
@@ -139,6 +159,9 @@ pub struct Diagnostic {
     /// for detailed analysis while keeping the diagnostic struct generic-free.
     /// Using Arc to preserve type information during clone operations.
     pub source_error: Option<Arc<anyhow::Error>>,
+
+    /// Additional related locations for editor integrations such as LSP.
+    pub related: Vec<DiagnosticReference>,
 
     /// If true, this diagnostic should be rendered but not cause build failure
     pub suppressed: bool,
@@ -170,6 +193,7 @@ impl From<starlark::Error> for Diagnostic {
             call_stack: Some(err.call_stack().clone()),
             child: None,
             source_error: Some(Arc::new(err.into_anyhow())),
+            related: Vec::new(),
             suppressed: false,
         }
     }
@@ -185,6 +209,7 @@ impl From<EvalMessage> for Diagnostic {
             call_stack: None,
             child: None,
             source_error: None, // EvalMessage doesn't have an underlying error to preserve
+            related: Vec::new(),
             suppressed: false,
         }
     }
@@ -202,6 +227,7 @@ impl From<anyhow::Error> for Diagnostic {
             call_stack: None,
             child: None,
             source_error: Some(Arc::new(err)),
+            related: Vec::new(),
             suppressed: false,
         }
     }
@@ -212,7 +238,7 @@ impl serde::Serialize for Diagnostic {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_struct("Diagnostic", 8)?;
+        let mut state = serializer.serialize_struct("Diagnostic", 9)?;
         state.serialize_field("path", &self.path)?;
         state.serialize_field("span", &self.span.map(|span| span.to_string()))?;
         state.serialize_field("severity", &self.severity)?;
@@ -226,6 +252,7 @@ impl serde::Serialize for Diagnostic {
             "source_error",
             &self.source_error.as_ref().map(|err| err.to_string()),
         )?;
+        state.serialize_field("related", &self.related)?;
         state.serialize_field("suppressed", &self.suppressed)?;
         state.end()
     }
@@ -241,6 +268,7 @@ impl Diagnostic {
             call_stack: None,
             child: None,
             source_error: None,
+            related: Vec::new(),
             suppressed: false,
         }
     }
@@ -258,6 +286,7 @@ impl Diagnostic {
             call_stack: None,
             child: None,
             source_error: Some(Arc::new(anyhow::Error::new(categorized))),
+            related: Vec::new(),
             suppressed: false,
         }
     }
@@ -288,6 +317,11 @@ impl Diagnostic {
             source_error: source_error.map(|err| Arc::new(err.into())),
             ..self
         }
+    }
+
+    pub fn with_related(mut self, reference: DiagnosticReference) -> Self {
+        self.related.push(reference);
+        self
     }
 
     pub fn boxed(self) -> Box<Self> {

--- a/crates/pcb-zen-core/src/graph/starlark.rs
+++ b/crates/pcb-zen-core/src/graph/starlark.rs
@@ -113,6 +113,7 @@ impl<V: ValueLifetimeless> PathMatchesCallableGen<V> {
             call_stack: None,
             child: Some(Box::new(child)),
             source_error: None,
+            related: Vec::new(),
             suppressed: false,
         };
 

--- a/crates/pcb-zen-core/src/lang/assert.rs
+++ b/crates/pcb-zen-core/src/lang/assert.rs
@@ -68,6 +68,7 @@ fn make_diagnostic(
             call_stack: None,
             child: None,
             source_error: make_source_error(&msg, kind),
+            related: Vec::new(),
             suppressed,
         };
     }
@@ -103,6 +104,7 @@ fn make_diagnostic(
             } else {
                 None
             },
+            related: Vec::new(),
             suppressed,
         });
     }

--- a/crates/pcb-zen-core/src/lang/binding.rs
+++ b/crates/pcb-zen-core/src/lang/binding.rs
@@ -1,0 +1,201 @@
+//! Binding diagnostics for top-level rebinds.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use starlark::codemap::{CodeMap, Span};
+use starlark::errors::EvalSeverity;
+use starlark::syntax::AstModule;
+use starlark_syntax::syntax::ast::{AssignP, AstAssignTarget, AstStmt, Stmt};
+
+use crate::Diagnostic;
+
+/// Diagnostic emitted when a name is rebound in module scope.
+pub const BINDING_REBIND: &str = "binding.rebind";
+
+struct BindingChecker<'a> {
+    path: &'a Path,
+    codemap: CodeMap,
+    diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Clone, Default)]
+struct ScopeState {
+    /// Names that are bound on at least one path reaching the current point.
+    maybe_bound: HashMap<String, Span>,
+    /// Names that are bound on every path reaching the current point.
+    definitely_bound: HashMap<String, Span>,
+}
+
+impl ScopeState {
+    fn bind(&mut self, name: &str, span: Span) {
+        self.maybe_bound.insert(name.to_owned(), span);
+        self.definitely_bound.insert(name.to_owned(), span);
+    }
+
+    fn merge(lhs: Self, rhs: Self) -> Self {
+        let mut maybe_bound = lhs.maybe_bound;
+        maybe_bound.extend(rhs.maybe_bound);
+
+        let rhs_definitely = rhs.definitely_bound;
+        let mut definitely_bound = HashMap::new();
+        let rhs_names: HashSet<_> = rhs_definitely.keys().cloned().collect();
+        for (name, span) in lhs.definitely_bound {
+            if rhs_names.contains(&name) {
+                definitely_bound.insert(name, span);
+            }
+        }
+
+        Self {
+            maybe_bound,
+            definitely_bound,
+        }
+    }
+}
+
+impl<'a> BindingChecker<'a> {
+    fn new(path: &'a Path, contents: &str) -> Self {
+        Self {
+            path,
+            codemap: CodeMap::new(path.to_string_lossy().to_string(), contents.to_owned()),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn check(mut self, ast: &AstModule) -> Vec<Diagnostic> {
+        self.visit_stmt(ast.statement(), ScopeState::default());
+        self.diagnostics
+    }
+
+    fn bind_name(&mut self, state: &mut ScopeState, name: &str, span: Span) {
+        if let Some(previous) = state.maybe_bound.get(name).copied() {
+            let previous = self.codemap.file_span(previous).resolve_span();
+            let message =
+                format!("Rebinding '{name}' in the same scope; previous binding at {previous}");
+            self.diagnostics.push(
+                Diagnostic::categorized(
+                    &self.path.to_string_lossy(),
+                    &message,
+                    BINDING_REBIND,
+                    EvalSeverity::Warning,
+                )
+                .with_span(Some(self.codemap.file_span(span).resolve_span())),
+            );
+        }
+
+        state.bind(name, span);
+    }
+
+    fn visit_lvalue(&mut self, state: &mut ScopeState, target: &AstAssignTarget) {
+        target.visit_lvalue(|ident| self.bind_name(state, ident.ident.as_str(), ident.span));
+    }
+
+    fn visit_stmt(&mut self, stmt: &AstStmt, mut state: ScopeState) -> ScopeState {
+        match &**stmt {
+            Stmt::Statements(stmts) => {
+                for stmt in stmts {
+                    state = self.visit_stmt(stmt, state);
+                }
+                state
+            }
+            Stmt::Break
+            | Stmt::Continue
+            | Stmt::Pass
+            | Stmt::Return(None)
+            | Stmt::Return(Some(_))
+            | Stmt::Expression(_) => state,
+            Stmt::If(_, then_branch) => {
+                ScopeState::merge(self.visit_stmt(then_branch, state.clone()), state)
+            }
+            Stmt::IfElse(_, branches) => ScopeState::merge(
+                self.visit_stmt(&branches.0, state.clone()),
+                self.visit_stmt(&branches.1, state),
+            ),
+            Stmt::Assign(AssignP { lhs, ty: _, rhs: _ }) => {
+                self.visit_lvalue(&mut state, lhs);
+                state
+            }
+            Stmt::AssignModify(_, _, _) => state,
+            Stmt::Def(_) => state,
+            Stmt::For(_) => state,
+            Stmt::Load(_) => state,
+        }
+    }
+}
+
+pub fn check_bindings(ast: &AstModule, path: &Path, contents: &str) -> Vec<Diagnostic> {
+    BindingChecker::new(path, contents).check(ast)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BINDING_REBIND, check_bindings};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use crate::lang::error::CategorizedDiagnostic;
+    use starlark::syntax::{AstModule, Dialect};
+
+    fn stdlib_files(root: &Path, out: &mut Vec<PathBuf>) {
+        for entry in fs::read_dir(root).expect("read_dir failed") {
+            let entry = entry.expect("dir entry failed");
+            let path = entry.path();
+            if path.is_dir() {
+                stdlib_files(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "zen") {
+                out.push(path);
+            }
+        }
+    }
+
+    #[test]
+    fn stdlib_has_no_rebinding_warnings() {
+        let mut dialect = Dialect::Extended;
+        dialect.enable_f_strings = true;
+
+        let stdlib_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../stdlib")
+            .canonicalize()
+            .expect("canonicalize stdlib path");
+
+        let mut files = Vec::new();
+        stdlib_files(&stdlib_root, &mut files);
+        files.sort();
+
+        let mut offenders = Vec::new();
+        for path in files {
+            let contents = fs::read_to_string(&path).expect("read stdlib file");
+            let ast = AstModule::parse(
+                path.to_str().expect("path is not valid utf-8"),
+                contents.clone(),
+                &dialect,
+            )
+            .unwrap_or_else(|err| panic!("failed to parse {}: {err}", path.display()));
+
+            let diagnostics = check_bindings(&ast, &path, &contents);
+            for diagnostic in diagnostics {
+                let Some(kind) = diagnostic
+                    .source_error
+                    .as_ref()
+                    .and_then(|err| err.downcast_ref::<CategorizedDiagnostic>())
+                    .map(|cat| cat.kind.as_str())
+                else {
+                    continue;
+                };
+                if kind == BINDING_REBIND {
+                    offenders.push(format!(
+                        "{}: {}",
+                        path.strip_prefix(&stdlib_root).unwrap_or(&path).display(),
+                        diagnostic.body
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "stdlib rebinding diagnostics found:\n{}",
+            offenders.join("\n")
+        );
+    }
+}

--- a/crates/pcb-zen-core/src/lang/binding.rs
+++ b/crates/pcb-zen-core/src/lang/binding.rs
@@ -1,6 +1,6 @@
 //! Binding diagnostics for top-level rebinds.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 
 use starlark::codemap::{CodeMap, Span};
@@ -8,7 +8,7 @@ use starlark::errors::EvalSeverity;
 use starlark::syntax::AstModule;
 use starlark_syntax::syntax::ast::{AssignP, AstAssignTarget, AstStmt, Stmt};
 
-use crate::Diagnostic;
+use crate::{Diagnostic, DiagnosticReference};
 
 /// Diagnostic emitted when a name is rebound in module scope.
 pub const BINDING_REBIND: &str = "binding.rebind";
@@ -23,33 +23,18 @@ struct BindingChecker<'a> {
 struct ScopeState {
     /// Names that are bound on at least one path reaching the current point.
     maybe_bound: HashMap<String, Span>,
-    /// Names that are bound on every path reaching the current point.
-    definitely_bound: HashMap<String, Span>,
 }
 
 impl ScopeState {
     fn bind(&mut self, name: &str, span: Span) {
         self.maybe_bound.insert(name.to_owned(), span);
-        self.definitely_bound.insert(name.to_owned(), span);
     }
 
     fn merge(lhs: Self, rhs: Self) -> Self {
         let mut maybe_bound = lhs.maybe_bound;
         maybe_bound.extend(rhs.maybe_bound);
 
-        let rhs_definitely = rhs.definitely_bound;
-        let mut definitely_bound = HashMap::new();
-        let rhs_names: HashSet<_> = rhs_definitely.keys().cloned().collect();
-        for (name, span) in lhs.definitely_bound {
-            if rhs_names.contains(&name) {
-                definitely_bound.insert(name, span);
-            }
-        }
-
-        Self {
-            maybe_bound,
-            definitely_bound,
-        }
+        Self { maybe_bound }
     }
 }
 
@@ -70,8 +55,7 @@ impl<'a> BindingChecker<'a> {
     fn bind_name(&mut self, state: &mut ScopeState, name: &str, span: Span) {
         if let Some(previous) = state.maybe_bound.get(name).copied() {
             let previous = self.codemap.file_span(previous).resolve_span();
-            let message =
-                format!("Rebinding '{name}' in the same scope; previous binding at {previous}");
+            let message = format!("Rebinding '{name}' in the same scope");
             self.diagnostics.push(
                 Diagnostic::categorized(
                     &self.path.to_string_lossy(),
@@ -79,7 +63,12 @@ impl<'a> BindingChecker<'a> {
                     BINDING_REBIND,
                     EvalSeverity::Warning,
                 )
-                .with_span(Some(self.codemap.file_span(span).resolve_span())),
+                .with_span(Some(self.codemap.file_span(span).resolve_span()))
+                .with_related(DiagnosticReference {
+                    path: self.path.to_string_lossy().to_string(),
+                    span: previous,
+                    message: "Previous binding is here".to_string(),
+                }),
             );
         }
 

--- a/crates/pcb-zen-core/src/lang/context.rs
+++ b/crates/pcb-zen-core/src/lang/context.rs
@@ -249,6 +249,7 @@ impl<'v> ContextValue<'v> {
             call_stack,
             child: None,
             source_error: None,
+            related: Vec::new(),
             suppressed: false,
         };
         self.add_diagnostic(diag);

--- a/crates/pcb-zen-core/src/lang/electrical_check.rs
+++ b/crates/pcb-zen-core/src/lang/electrical_check.rs
@@ -87,6 +87,7 @@ pub fn execute_electrical_check<'v, V: ValueLike<'v>>(
         call_stack: None,
         child: result.err().map(|e| Box::new(Diagnostic::from(e))),
         source_error: None,
+        related: Vec::new(),
         suppressed: false,
     }
 }

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -1587,6 +1587,7 @@ impl EvalContext {
                             call_stack: Some(net_info.call_stack.clone()),
                             child: None,
                             source_error: None,
+                            related: Vec::new(),
                             suppressed: false,
                         });
                     } else if net_info.auto_named {
@@ -1601,6 +1602,7 @@ impl EvalContext {
                             call_stack: Some(net_info.call_stack.clone()),
                             child: None,
                             source_error: None,
+                            related: Vec::new(),
                             suppressed: false,
                         });
                     }
@@ -2046,6 +2048,7 @@ impl EvalContext {
                 call_stack: None,
                 child: Some(Box::new(first_error.clone())),
                 source_error: None,
+                related: Vec::new(),
                 suppressed: false,
             };
             return Err(diagnostic.into());
@@ -2071,6 +2074,7 @@ impl EvalContext {
                 call_stack: None,
                 child: None,
                 source_error: None,
+                related: Vec::new(),
                 suppressed: false,
             };
             Err(diagnostic.into())
@@ -2093,6 +2097,7 @@ impl EvalContext {
                 call_stack: None,
                 child: Some(Box::new(diag.clone())),
                 source_error: None,
+                related: Vec::new(),
                 suppressed: false,
             });
         }
@@ -2140,6 +2145,7 @@ impl EvalContext {
                     call_stack: Some(pending.call_stack.clone()),
                     child: Some(Box::new(child_diag.clone())),
                     source_error: None,
+                    related: Vec::new(),
                     suppressed: false,
                 }
             })
@@ -2180,6 +2186,7 @@ impl EvalContext {
                 call_stack: Some(pending.call_stack.clone()),
                 child: None,
                 source_error: None,
+                related: Vec::new(),
                 suppressed: false,
             });
         }

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -28,6 +28,7 @@ use tracing::{info_span, instrument};
 
 use crate::lang::assert::assert_globals;
 use crate::lang::{
+    binding,
     builtin::builtin_globals,
     component::component_globals,
     r#enum::EnumValue,
@@ -1399,6 +1400,10 @@ impl EvalContext {
             Ok(ast) => ast,
             Err(err) => return EvalMessage::from_error(source_path, &err).into(),
         };
+
+        for diagnostic in binding::check_bindings(&ast, source_path, &contents_owned) {
+            self.add_load_diagnostic(diagnostic);
+        }
 
         // Make prelude symbols available before user code runs.
         self.inject_prelude();

--- a/crates/pcb-zen-core/src/lang/mod.rs
+++ b/crates/pcb-zen-core/src/lang/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod binding;
 pub mod builtin;
 pub mod component;
 pub mod context;

--- a/crates/pcb-zen-core/src/lang/test_bench.rs
+++ b/crates/pcb-zen-core/src/lang/test_bench.rs
@@ -349,6 +349,7 @@ pub fn execute_deferred_check<'v, V: ValueLike<'v>>(
             }
             .into(),
         )),
+        related: Vec::new(),
         suppressed: false,
     };
 

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -76,8 +76,8 @@ pub mod attrs {
 // Re-export commonly used types
 pub use config::{BoardConfig, LockEntry, Lockfile, ModuleConfig, PcbToml, WorkspaceConfig};
 pub use diagnostics::{
-    Diagnostic, DiagnosticError, DiagnosticFrame, DiagnosticReport, Diagnostics, DiagnosticsPass,
-    DiagnosticsReport, LoadError, WithDiagnostics,
+    Diagnostic, DiagnosticError, DiagnosticFrame, DiagnosticReference, DiagnosticReport,
+    Diagnostics, DiagnosticsPass, DiagnosticsReport, LoadError, WithDiagnostics,
 };
 pub use lang::error::SuppressedDiagnostics;
 pub use lang::eval::{EvalContext, EvalContextConfig, EvalOutput};

--- a/crates/pcb-zen-core/tests/binding.rs
+++ b/crates/pcb-zen-core/tests/binding.rs
@@ -1,0 +1,130 @@
+#[macro_use]
+mod common;
+
+use pcb_zen_core::lang::error::CategorizedDiagnostic;
+use starlark::errors::EvalSeverity;
+
+fn binding_kinds(result: &pcb_zen_core::WithDiagnostics<pcb_zen_core::EvalOutput>) -> Vec<String> {
+    result
+        .diagnostics
+        .iter()
+        .filter(|diag| matches!(diag.severity, EvalSeverity::Warning))
+        .filter_map(|diag| {
+            diag.innermost()
+                .downcast_error_ref::<CategorizedDiagnostic>()
+                .map(|cat| cat.kind.clone())
+        })
+        .collect()
+}
+
+#[test]
+fn rebinding_emits_warning() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            value = "A"
+            value = "B"
+        "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success());
+    let kinds = binding_kinds(&result);
+    assert_eq!(kinds, vec!["binding.rebind"]);
+}
+
+#[test]
+fn shadowing_does_not_emit_warning() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            value = "outer"
+
+            def demo(arg = lambda value: value):
+                value = "inner"
+                return value
+        "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success());
+    assert!(binding_kinds(&result).is_empty());
+}
+
+#[test]
+fn function_local_rebinding_does_not_emit_warning() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            def demo():
+                value = "A"
+                value = "B"
+                return value
+        "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success());
+    assert!(binding_kinds(&result).is_empty());
+}
+
+#[test]
+fn mutually_exclusive_top_level_bindings_do_not_warn() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            communication_type = "I2C"
+
+            if communication_type == "I2C":
+                COMMS = "i2c"
+                I2C_ADDR_GPIO = "gpio"
+                i2c_pullup = True
+
+            elif communication_type == "SPI":
+                COMMS = "spi"
+        "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success());
+    assert!(binding_kinds(&result).is_empty());
+}
+
+#[test]
+fn binding_after_mutually_exclusive_assignment_warns() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            mode = "a"
+
+            if mode == "a":
+                value = "A"
+            else:
+                value = "B"
+
+            value = "C"
+        "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success());
+    assert_eq!(binding_kinds(&result), vec!["binding.rebind"]);
+}
+
+#[test]
+fn for_loop_bindings_do_not_emit_warning() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            for i in [1, 2]:
+                value = i
+
+            for i in [3, 4]:
+                value = i
+        "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success());
+    assert!(binding_kinds(&result).is_empty());
+}

--- a/crates/pcb-zen-core/tests/component_footprint_inference.rs
+++ b/crates/pcb-zen-core/tests/component_footprint_inference.rs
@@ -62,11 +62,11 @@ fn single_pin_symbol(footprint_prop: &str) -> String {
 
 fn component_zen_without_footprint() -> String {
     r#"
-Net = builtin.net_type("Net")
+
 Component(
     name = "U1",
     symbol = Symbol(library = "Part.kicad_sym", name = "Part"),
-    pins = {"P": Net("N")},
+    pins = {"P": builtin.net_type("Net")("N")},
 )
 "#
     .to_string()

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -1242,8 +1242,6 @@ snapshot_eval!(config_allowed_invalid_value, {
 
 snapshot_eval!(config_allowed_invalid_default, {
     "Module.zen" => r#"
-        Voltage = builtin.physical_value("V")
-
         output_voltage = config(
             "output_voltage",
             Voltage,

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -934,17 +934,10 @@ snapshot_eval!(io_invalid_type, {
 });
 
 snapshot_eval!(config_string_to_physical_value, {
-    "types.zen" => r#"
-        Voltage = builtin.physical_value("V")
-        Resistance = builtin.physical_value("Ω")
-        Current = builtin.physical_value("A")
-    "#,
     "child.zen" => r#"
-        load("types.zen", "Voltage", "Resistance", "Current")
-
-        voltage = config("voltage", Voltage)
-        resistance = config("resistance", Resistance)
-        current = config("current", Current)
+        voltage = config("voltage", builtin.physical_value("V"))
+        resistance = config("resistance", builtin.physical_value("Ω"))
+        current = config("current", builtin.physical_value("A"))
 
         print("voltage:", voltage)
         print("resistance:", resistance)
@@ -962,13 +955,8 @@ snapshot_eval!(config_string_to_physical_value, {
 });
 
 snapshot_eval!(config_string_to_physical_value_with_bounds, {
-    "types.zen" => r#"
-        Voltage = builtin.physical_value("V")
-    "#,
     "child.zen" => r#"
-        load("types.zen", "Voltage")
-
-        voltage = config("voltage", Voltage)
+        voltage = config("voltage", builtin.physical_value("V"))
 
         print("voltage:", voltage)
     "#,

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -263,13 +263,11 @@ snapshot_eval!(net_field_with_enum, {
 
 snapshot_eval!(net_field_with_physical_value, {
     "test.zen" => r#"
-        Voltage = builtin.physical_value("V")
-        
         # Create net type with physical value field
-        Power = builtin.net_type("Power", voltage=Voltage)
+        Power = builtin.net_type("Power", voltage=builtin.physical_value("V"))
         
         # Create instance
-        vcc = Power("VCC", voltage=Voltage("5V"))
+        vcc = Power("VCC", voltage="5V")
         
         print("vcc.voltage:", vcc.voltage)
     "#

--- a/crates/pcb-zen-core/tests/snapshots/input__config_allowed_invalid_default.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_allowed_invalid_default.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pcb-zen-core/tests/input.rs
-assertion_line: 795
 expression: output
 ---
 Error: top.zen:5:7-27 Error loading module `Module.zen`
-Error: /Module.zen:7:18-12:2 invalid value for config `output_voltage`: got 900mV; expected one of 1V
+Error: /Module.zen:5:18-10:2 invalid value for config `output_voltage`: got 900mV; expected one of 1V

--- a/crates/pcb-zen-core/tests/test.rs
+++ b/crates/pcb-zen-core/tests/test.rs
@@ -4,14 +4,14 @@ mod common;
 snapshot_eval!(net_passing, {
     "MyComponent.zen" => r#"
         ComponentInterface = interface(p1 = Net, p2 = Net)
-        input = io("input", ComponentInterface)
+        component_input = io("input", ComponentInterface)
 
         Component(
             name = "capacitor",
             type = "capacitor",
             pin_defs = { "P1": "1", "P2": "2" },
             footprint = "SMD:0805",
-            pins = { "P1": input.p1, "P2": input.p2 },
+            pins = { "P1": component_input.p1, "P2": component_input.p2 },
         )
     "#,
     "test.zen" => r#"

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -481,7 +481,22 @@ impl LspEvalContext {
             DiagnosticRelatedInformation, DiagnosticSeverity, Location, Position, Range,
         };
 
-        // Build relatedInformation from each child diagnostic message that carries a span + valid path.
+        let to_location = |path: &str, span: &starlark::codemap::ResolvedSpan| Location {
+            uri: lsp_types::Url::from_file_path(path)
+                .unwrap_or_else(|_| lsp_types::Url::parse(&format!("file://{}", path)).unwrap()),
+            range: Range {
+                start: Position {
+                    line: span.begin.line as u32,
+                    character: span.begin.column as u32,
+                },
+                end: Position {
+                    line: span.end.line as u32,
+                    character: span.end.column as u32,
+                },
+            },
+        };
+
+        // Build relatedInformation from explicit related references and child diagnostics.
         let mut related: Vec<DiagnosticRelatedInformation> = Vec::new();
 
         // Convert primary span (if any).
@@ -512,34 +527,26 @@ impl LspEvalContext {
             (range, true)
         };
 
-        // Add child diagnostics as related information
-        let mut current = &diag.child;
-        while let Some(child) = current {
-            if let Some(span) = &child.span
-                && !child.path.is_empty()
-            {
-                let child_range = Range {
-                    start: Position {
-                        line: span.begin.line as u32,
-                        character: span.begin.column as u32,
-                    },
-                    end: Position {
-                        line: span.end.line as u32,
-                        character: span.end.column as u32,
-                    },
-                };
-
+        let mut current_opt: Option<&pcb_zen_core::Diagnostic> = Some(diag);
+        while let Some(current) = current_opt {
+            for reference in &current.related {
                 related.push(DiagnosticRelatedInformation {
-                    location: Location {
-                        uri: lsp_types::Url::from_file_path(&child.path).unwrap_or_else(|_| {
-                            lsp_types::Url::parse(&format!("file://{}", child.path)).unwrap()
-                        }),
-                        range: child_range,
-                    },
-                    message: child.body.clone(),
+                    location: to_location(&reference.path, &reference.span),
+                    message: reference.message.clone(),
                 });
             }
-            current = &child.child;
+
+            if let Some(span) = &current.span
+                && !current.path.is_empty()
+                && !std::ptr::eq(current, diag)
+            {
+                related.push(DiagnosticRelatedInformation {
+                    location: to_location(&current.path, span),
+                    message: current.body.clone(),
+                });
+            }
+
+            current_opt = current.child.as_deref();
         }
 
         let severity = match diag.severity {

--- a/crates/pcb-zen/tests/snapshots/test__net_passing.snap
+++ b/crates/pcb-zen/tests/snapshots/test__net_passing.snap
@@ -40,9 +40,9 @@ expression: snapshot_output
   )
 )
 Advice: Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'
-   ╭─[ [TEMP_DIR]MyComponent.zen:3:9 ]
- 3 │input = io("input", ComponentInterface)
-   │                       ╰──────────────── Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'
+   ╭─[ [TEMP_DIR]MyComponent.zen:3:19 ]
+ 3 │component_input = io("input", ComponentInterface)
+   │                                 ╰──────────────── Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'
    ├─[ [TEMP_DIR]top.zen:4:1 ]
  4 │╭▶Test(
    ┆┆ 
@@ -55,9 +55,9 @@ Advice: Net name 'input_p1' should be UPPERCASE: 'INPUT_P1'
    │╰──── Issue in `MyComponent`
 
 Advice: Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'
-   ╭─[ [TEMP_DIR]MyComponent.zen:3:9 ]
- 3 │input = io("input", ComponentInterface)
-   │                       ╰──────────────── Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'
+   ╭─[ [TEMP_DIR]MyComponent.zen:3:19 ]
+ 3 │component_input = io("input", ComponentInterface)
+   │                                 ╰──────────────── Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'
    ├─[ [TEMP_DIR]top.zen:4:1 ]
  4 │╭▶Test(
    ┆┆ 
@@ -70,9 +70,9 @@ Advice: Net name 'input_p2' should be UPPERCASE: 'INPUT_P2'
    │╰──── Issue in `MyComponent`
 
 Advice: io() parameter 'input' should be UPPERCASE: 'INPUT'
-   ╭─[ [TEMP_DIR]MyComponent.zen:3:9 ]
- 3 │input = io("input", ComponentInterface)
-   │                       ╰──────────────── io() parameter 'input' should be UPPERCASE: 'INPUT'
+   ╭─[ [TEMP_DIR]MyComponent.zen:3:19 ]
+ 3 │component_input = io("input", ComponentInterface)
+   │                                 ╰──────────────── io() parameter 'input' should be UPPERCASE: 'INPUT'
    ├─[ [TEMP_DIR]top.zen:4:1 ]
  4 │╭▶Test(
    ┆┆ 

--- a/crates/pcb-zen/tests/test.rs
+++ b/crates/pcb-zen/tests/test.rs
@@ -9,14 +9,14 @@ fn test_net_passing() {
         "MyComponent.zen",
         r#"
 ComponentInterface = interface(p1 = Net, p2 = Net)
-input = io("input", ComponentInterface)
+component_input = io("input", ComponentInterface)
 
 Component(
     name = "capacitor",
     type = "capacitor",
     pin_defs = { "P1": "1", "P2": "2" },
     footprint = "SMD:0805",
-    pins = { "P1": input.p1, "P2": input.p2 },
+    pins = { "P1": component_input.p1, "P2": component_input.p2 },
 )
         "#,
     );

--- a/crates/pcb/tests/simple.rs
+++ b/crates/pcb/tests/simple.rs
@@ -258,13 +258,11 @@ Component(
     let online_output = sandbox
         .write(
             "pcb.toml",
-            format!(
-                r#"[workspace]
+            r#"[workspace]
 pcb-version = "0.3"
 members = ["boards/*"]
 vendor = ["github.com/mycompany/components/**"]
-"#
-            ),
+"#,
         )
         .write(
             "boards/A/pcb.toml",

--- a/stdlib/generics/Capacitor.zen
+++ b/stdlib/generics/Capacitor.zen
@@ -30,18 +30,21 @@ if exclude_from_bom:
 P1 = io("P1", Net)
 P2 = io("P2", Net)
 
-if not voltage and P1.voltage and P2.voltage:
-    voltage = Voltage(P1.voltage.diff(P2.voltage) * 1.5)
+effective_voltage = (
+    Voltage(P1.voltage.diff(P2.voltage) * 1.5)
+    if not voltage and hasattr(P1, "voltage") and hasattr(P2, "voltage")
+    else voltage
+)
 
 # Properties
 properties = {
-    "value": format_value(value, voltage, dielectric, esr),
+    "value": format_value(value, effective_voltage, dielectric, esr),
     "package": package,
     "capacitance": value,
 }
 
-if voltage:
-    properties["voltage"] = voltage
+if effective_voltage:
+    properties["voltage"] = effective_voltage
 if dielectric:
     properties["dielectric"] = dielectric
 if esr:

--- a/stdlib/generics/Capacitor.zen
+++ b/stdlib/generics/Capacitor.zen
@@ -30,11 +30,7 @@ if exclude_from_bom:
 P1 = io("P1", Net)
 P2 = io("P2", Net)
 
-effective_voltage = (
-    Voltage(P1.voltage.diff(P2.voltage) * 1.5)
-    if not voltage and hasattr(P1, "voltage") and hasattr(P2, "voltage")
-    else voltage
-)
+effective_voltage = Voltage(P1.voltage.diff(P2.voltage) * 1.5) if not voltage and P1.voltage and P2.voltage else voltage
 
 # Properties
 properties = {

--- a/stdlib/generics/FerriteBead.zen
+++ b/stdlib/generics/FerriteBead.zen
@@ -22,17 +22,17 @@ mount = config("mount", Mount, default=Mount("SMD"), optional=True, help="Mounti
 current = config("current", Current, optional=True, help="Maximum rated current")
 
 # Backwards compatibility: if resistance is specified, use it as impedance
+effective_impedance = resistance if resistance else impedance
 if resistance:
-    impedance = resistance
     warn("resistance is deprecated. Use value instead.", kind="deprecated")
 
 # Ensure we have an effective impedance
-if not impedance:
+if not effective_impedance:
     error("FerriteBead requires 'value' to be specified")
 properties = {
-    "value": format_value(impedance, current, frequency),
+    "value": format_value(effective_impedance, current, frequency),
     "package": package,
-    "impedance": impedance,
+    "impedance": effective_impedance,
 }
 
 if dcr:
@@ -116,7 +116,7 @@ Component(
         "spice/FerriteBead.lib",
         "FB",
         nets=[P1, P2],
-        args=_spice_args(impedance, frequency, dcr),
+        args=_spice_args(effective_impedance, frequency, dcr),
     ),
     properties=properties,
     type="ferrite_bead",

--- a/stdlib/generics/Resistor.zen
+++ b/stdlib/generics/Resistor.zen
@@ -19,6 +19,7 @@ use_us_symbol = config("use_us_symbol", bool, default=False, optional=True, help
 do_not_populate = config("do_not_populate", bool, default=False, help="Do not populate the component in the BOM")
 exclude_from_bom = config("exclude_from_bom", bool, default=False, help="Exclude the component from the BOM")
 skip_bom = config("skip_bom", bool, default=False, help="Skip the BOM generation")
+skip_bom = True
 
 if do_not_populate:
     warn("do_not_populate is deprecated. Use dnp instead.", kind="deprecated")

--- a/stdlib/generics/Resistor.zen
+++ b/stdlib/generics/Resistor.zen
@@ -19,7 +19,6 @@ use_us_symbol = config("use_us_symbol", bool, default=False, optional=True, help
 do_not_populate = config("do_not_populate", bool, default=False, help="Do not populate the component in the BOM")
 exclude_from_bom = config("exclude_from_bom", bool, default=False, help="Exclude the component from the BOM")
 skip_bom = config("skip_bom", bool, default=False, help="Skip the BOM generation")
-skip_bom = True
 
 if do_not_populate:
     warn("do_not_populate is deprecated. Use dnp instead.", kind="deprecated")

--- a/stdlib/generics/Tvs.zen
+++ b/stdlib/generics/Tvs.zen
@@ -1,6 +1,5 @@
 load("../io.zen", "io")
-load("../units.zen", "Power", "Voltage")
-Watts = Power
+load("../units.zen", Watts="Power", "Voltage")
 load("../interfaces.zen", "Ground", "Net", "Power")
 load("../utils.zen", "format_value")
 

--- a/stdlib/generics/Tvs.zen
+++ b/stdlib/generics/Tvs.zen
@@ -1,5 +1,5 @@
 load("../io.zen", "io")
-load("../units.zen", Watts="Power", "Voltage")
+load("../units.zen", "Voltage", Watts="Power")
 load("../interfaces.zen", "Ground", "Net", "Power")
 load("../utils.zen", "format_value")
 


### PR DESCRIPTION
Variable rebindings makes schematics harder to follow and makes it harder to reason about, eg:

```
VCC = io(Power)

C1(
  ...
  VIN = VCC
)

VCC = Power()

C2(
  ...
  VIN = VCC
)
```

With this change this becomes a warning. This is intentionally designed to be somewhat restricted:
  - it only considers module-scoped bindings, not function-scoped bindings
  - it allows multiple branches of an if/elif/else block to bind the same variables
  - it ignores for loop bindings


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new AST-based analysis pass that emits warning diagnostics during module load; this can change user-visible diagnostics and IDE/LSP output but does not alter evaluation results.
> 
> **Overview**
> Adds a module-load binding check that emits a `binding.rebind` *warning* when a top-level variable is assigned more than once in the same module scope, while intentionally ignoring function locals, `for` loop bindings, and mutually-exclusive `if/elif/else` branches.
> 
> Extends `pcb_zen_core::Diagnostic` with a `related` list (`DiagnosticReference`) and updates JSON serialization plus LSP conversion to surface these related locations (and child diagnostic spans) as `relatedInformation`. Propagates the new field across diagnostic constructors (including KiCad DRC/ERC adapters) and updates stdlib/tests/snapshots to avoid new warnings and reflect updated spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad35fcbd37cf5a120c8e7c3eb7abc6dd20290766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->