### PR TITLE
`Net` and `Power` now expose unset `voltage` as `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Component generation no longer automatically scans datasheets.
 - `pcb new component` and `pcb search` component imports now place datasheet artifacts under each component's `docs/` subdirectory.
 - Layout sync and KiCad netlist export now normalize file- and package-based footprints to library-aware FPIDs.
-
-### Removed
 - Removed the 10uF 100V 1210 stdlib house capacitor from generic matching due to severe derating.
 
 ## [0.3.67] - 2026-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `pcb new component` and `pcb search` component imports now place datasheet artifacts under each component's `docs/` subdirectory.
 - Layout sync and KiCad netlist export now normalize file- and package-based footprints to library-aware FPIDs.
 - Removed the 10uF 100V 1210 stdlib house capacitor from generic matching due to severe derating.
+- `Net` and `Power` now expose unset `voltage` as `None`.
 
 ## [0.3.67] - 2026-04-10
 

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -55,6 +55,14 @@ fn is_builtin_optional_net_field(type_name: &str, field_name: &str) -> bool {
     builtin_optional_net_fields(type_name).contains(&field_name)
 }
 
+fn is_unset_builtin_optional_net_field<'v>(
+    type_name: &str,
+    field_name: &str,
+    value: Value<'v>,
+) -> bool {
+    value.is_none() && is_builtin_optional_net_field(type_name, field_name)
+}
+
 /// Reset the net ID counter to 1. This is only intended for use in tests
 /// to ensure reproducible net IDs across test runs.
 #[cfg(test)]
@@ -142,26 +150,26 @@ where
     }
 
     fn get_attr(&self, attribute: &str, heap: &'v Heap) -> Option<Value<'v>> {
-        // Check if the attribute is a field stored in properties
         self.properties
             .get(attribute)
             .map(|v| v.to_value())
-            .or_else(|| self.implied_attr(attribute, heap))
+            .or_else(|| {
+                self.is_builtin_optional_attr(attribute)
+                    .then(|| heap.alloc(starlark::values::none::NoneType))
+            })
     }
 
     fn has_attr(&self, attribute: &str, _heap: &'v Heap) -> bool {
-        self.properties.contains_key(attribute) || self.implied_attr_name(attribute)
+        self.properties.contains_key(attribute) || self.is_builtin_optional_attr(attribute)
     }
 
     fn dir_attr(&self) -> Vec<String> {
-        // Return all field names from properties
         let mut attrs: Vec<String> = self.properties.keys().cloned().collect();
-        for attr in self.implied_attr_names() {
+        for attr in self.builtin_optional_attrs() {
             if !attrs.iter().any(|existing| existing == attr) {
                 attrs.push(attr.to_string());
             }
         }
-        // Also include the built-in attributes from methods
         attrs.extend(vec![
             "name".to_string(),
             "net_id".to_string(),
@@ -187,17 +195,12 @@ impl<'v, V: ValueLike<'v>> std::fmt::Display for NetValueGen<V> {
 }
 
 impl<V> NetValueGen<V> {
-    fn implied_attr_name(&self, attribute: &str) -> bool {
+    fn is_builtin_optional_attr(&self, attribute: &str) -> bool {
         is_builtin_optional_net_field(&self.type_name, attribute)
     }
 
-    fn implied_attr_names(&self) -> &'static [&'static str] {
+    fn builtin_optional_attrs(&self) -> &'static [&'static str] {
         builtin_optional_net_fields(&self.type_name)
-    }
-
-    fn implied_attr<'v>(&self, attribute: &str, heap: &'v Heap) -> Option<Value<'v>> {
-        self.implied_attr_name(attribute)
-            .then(|| heap.alloc(starlark::values::none::NoneType))
     }
 
     fn resolved_name(&self) -> &str {
@@ -521,18 +524,23 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
         };
 
         for (field_name, field_spec) in &self.fields {
-            let result = validate_field(
-                field_name,
-                field_spec.to_value(),
-                field_values.get(field_name).copied(),
-                eval,
-            )?;
+            let provided_value = field_values.get(field_name).copied();
+            let result = validate_field(field_name, field_spec.to_value(), provided_value, eval)?;
 
             if let Some(field_value) = result {
-                let omit_builtin_none = field_value.is_none()
-                    && is_builtin_optional_net_field(&self.type_name, field_name);
-                if !omit_builtin_none {
-                    properties.insert(field_name.clone(), field_value);
+                match (
+                    is_unset_builtin_optional_net_field(&self.type_name, field_name, field_value),
+                    provided_value.is_some(),
+                ) {
+                    // Preserve inherited built-in values when the field was omitted.
+                    (true, false) => {}
+                    // But let an explicit `field=None` clear any inherited value.
+                    (true, true) => {
+                        properties.shift_remove(field_name.as_str());
+                    }
+                    (false, _) => {
+                        properties.insert(field_name.clone(), field_value);
+                    }
                 }
             }
         }

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -43,6 +43,18 @@ pub fn generate_net_id() -> NetId {
     NEXT_NET_ID.fetch_add(1, Ordering::Relaxed)
 }
 
+fn builtin_optional_net_fields(type_name: &str) -> &'static [&'static str] {
+    match type_name {
+        "Net" => &["voltage", "impedance"],
+        "Power" => &["voltage"],
+        _ => &[],
+    }
+}
+
+fn is_builtin_optional_net_field(type_name: &str, field_name: &str) -> bool {
+    builtin_optional_net_fields(type_name).contains(&field_name)
+}
+
 /// Reset the net ID counter to 1. This is only intended for use in tests
 /// to ensure reproducible net IDs across test runs.
 #[cfg(test)]
@@ -129,18 +141,26 @@ where
         RES.methods(builtin_net_methods)
     }
 
-    fn get_attr(&self, attribute: &str, _heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attribute: &str, heap: &'v Heap) -> Option<Value<'v>> {
         // Check if the attribute is a field stored in properties
-        self.properties.get(attribute).map(|v| v.to_value())
+        self.properties
+            .get(attribute)
+            .map(|v| v.to_value())
+            .or_else(|| self.implied_attr(attribute, heap))
     }
 
     fn has_attr(&self, attribute: &str, _heap: &'v Heap) -> bool {
-        self.properties.contains_key(attribute)
+        self.properties.contains_key(attribute) || self.implied_attr_name(attribute)
     }
 
     fn dir_attr(&self) -> Vec<String> {
         // Return all field names from properties
         let mut attrs: Vec<String> = self.properties.keys().cloned().collect();
+        for attr in self.implied_attr_names() {
+            if !attrs.iter().any(|existing| existing == attr) {
+                attrs.push(attr.to_string());
+            }
+        }
         // Also include the built-in attributes from methods
         attrs.extend(vec![
             "name".to_string(),
@@ -167,6 +187,19 @@ impl<'v, V: ValueLike<'v>> std::fmt::Display for NetValueGen<V> {
 }
 
 impl<V> NetValueGen<V> {
+    fn implied_attr_name(&self, attribute: &str) -> bool {
+        is_builtin_optional_net_field(&self.type_name, attribute)
+    }
+
+    fn implied_attr_names(&self) -> &'static [&'static str] {
+        builtin_optional_net_fields(&self.type_name)
+    }
+
+    fn implied_attr<'v>(&self, attribute: &str, heap: &'v Heap) -> Option<Value<'v>> {
+        self.implied_attr_name(attribute)
+            .then(|| heap.alloc(starlark::values::none::NoneType))
+    }
+
     fn resolved_name(&self) -> &str {
         self.inferred_name
             .get()
@@ -496,7 +529,11 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
             )?;
 
             if let Some(field_value) = result {
-                properties.insert(field_name.clone(), field_value);
+                let omit_builtin_none = field_value.is_none()
+                    && is_builtin_optional_net_field(&self.type_name, field_name);
+                if !omit_builtin_none {
+                    properties.insert(field_name.clone(), field_value);
+                }
             }
         }
 

--- a/crates/pcb-zen-core/tests/common/mod.rs
+++ b/crates/pcb-zen-core/tests/common/mod.rs
@@ -109,7 +109,7 @@ pub fn stdlib_test_files() -> HashMap<String, String> {
 const ZEN_TEST_PREAMBLE: &str = "\
 Voltage = builtin.physical_value(\"V\")\n\
 Impedance = builtin.physical_value(\"Ohm\")\n\
-Net = builtin.net_type(\"Net\", symbol=Symbol, voltage=Voltage, impedance=Impedance)\n";
+Net = builtin.net_type(\"Net\", symbol=Symbol, voltage=field(Voltage | None, default=None), impedance=field(Impedance | None, default=None))\n";
 
 /// Prepend `ZEN_TEST_PREAMBLE` to a `.zen` source string, matching the
 /// existing indentation so that `dedent` still works correctly.

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -234,6 +234,18 @@ snapshot_eval!(net_cast_base_attrs, {
     "#
 });
 
+snapshot_eval!(net_explicit_none_clears_inherited_voltage, {
+    "test.zen" => r#"
+        Power = builtin.net_type("Power", voltage=field(str | None, default=None))
+
+        vcc = Power("VCC", voltage="5V")
+        cleared = Power(vcc, voltage=None)
+
+        print("base voltage:", vcc.voltage)
+        print("cleared voltage:", cleared.voltage)
+    "#
+});
+
 snapshot_eval!(net_field_with_enum, {
     "test.zen" => r#"
         # Create enum and net type with enum field

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -209,6 +209,31 @@ snapshot_eval!(net_field_default_applied, {
     "#
 });
 
+snapshot_eval!(net_base_attrs_unset, {
+    "test.zen" => r#"
+        n = Net("N")
+
+        print("has voltage:", hasattr(n, "voltage"))
+        print("has impedance:", hasattr(n, "impedance"))
+        print("voltage:", n.voltage)
+        print("impedance:", n.impedance)
+    "#
+});
+
+snapshot_eval!(net_cast_base_attrs, {
+    "test.zen" => r#"
+        Signal = builtin.net_type("Signal")
+
+        sig = Signal("SIG")
+        base = sig.NET
+
+        print("has voltage:", hasattr(base, "voltage"))
+        print("has impedance:", hasattr(base, "impedance"))
+        print("voltage:", base.voltage)
+        print("impedance:", base.impedance)
+    "#
+});
+
 snapshot_eval!(net_field_with_enum, {
     "test.zen" => r#"
         # Create enum and net type with enum field

--- a/crates/pcb-zen-core/tests/snapshots/net__net_base_attrs_unset.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__net_base_attrs_unset.snap
@@ -1,0 +1,15 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+has voltage: True
+has impedance: True
+voltage: None
+impedance: None
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/net__net_cast_base_attrs.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__net_cast_base_attrs.snap
@@ -1,0 +1,15 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+has voltage: True
+has impedance: True
+voltage: None
+impedance: None
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/net__net_explicit_none_clears_inherited_voltage.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__net_explicit_none_clears_inherited_voltage.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pcb-zen-core/tests/net.rs
+expression: output
+---
+base voltage: 5V
+cleared voltage: None
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+    },
+}
+[]

--- a/stdlib/checks.zen
+++ b/stdlib/checks.zen
@@ -17,7 +17,7 @@ def voltage_within(
 
     def check_gen(power: Power, severity: Severity = severity, name: str = name):
         check_name = power.NET.name + "_" + name
-        if not hasattr(power, "voltage"):
+        if not power.voltage:
             return
         builtin.add_electrical_check(
             name=check_name,

--- a/stdlib/generics/Capacitor.zen
+++ b/stdlib/generics/Capacitor.zen
@@ -29,7 +29,7 @@ if exclude_from_bom:
 P1 = io("P1", Net)
 P2 = io("P2", Net)
 
-if not voltage and hasattr(P1, "voltage") and hasattr(P2, "voltage"):
+if not voltage and P1.voltage and P2.voltage:
     voltage = Voltage(P1.voltage.diff(P2.voltage) * 1.5)
 
 # Properties

--- a/stdlib/generics/Tvs.zen
+++ b/stdlib/generics/Tvs.zen
@@ -43,7 +43,7 @@ if reverse_clamping_voltage and reverse_clamping_voltage.min < reverse_standoff_
         + ")"
     )
 
-if hasattr(K, "voltage") and hasattr(A, "voltage"):
+if K.voltage and A.voltage:
     net_v_diff = K.voltage.diff(A.voltage)
     if reverse_clamping_voltage and net_v_diff.max > reverse_clamping_voltage.min:
         error(

--- a/stdlib/interfaces.zen
+++ b/stdlib/interfaces.zen
@@ -3,14 +3,14 @@ load("units.zen", "Voltage", "Impedance")
 Net = builtin.net_type(
     "Net",
     symbol=Symbol,
-    voltage=Voltage,
-    impedance=Impedance,
+    voltage=field(Voltage | None, default=None),
+    impedance=field(Impedance | None, default=None),
 )
 
 Power = builtin.net_type(
     "Power",
     symbol=field(Symbol, default=Symbol(library="@kicad-symbols/power.kicad_sym", name="VCC")),
-    voltage=Voltage,
+    voltage=field(Voltage | None, default=None),
 )
 
 Ground = builtin.net_type(


### PR DESCRIPTION
Can do:
```starlark
if VIN.voltage:
```
instead of:
```starlark
if hasattr(VIN, "voltage") and VIN.voltage:
```

cc @hexdae 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Starlark-visible attribute existence/lookup semantics for `Net`/`Power` and tweaks inheritance/clearing behavior when instantiating nets, which could subtly affect user code that relied on `hasattr` or inherited fields.
> 
> **Overview**
> `Net` and `Power` now always report built-in optional fields (notably `voltage`, plus `impedance` for `Net`) as present, returning `None` when unset, so callers can do truthy checks like `if net.voltage:` instead of `hasattr` guards.
> 
> Core net instantiation logic is updated to **preserve inherited built-in values when a field is omitted**, while treating an explicit `field=None` as a request to clear any inherited value. Stdlib definitions and generics (`checks.zen`, `generics/Capacitor.zen`, `generics/Tvs.zen`) are updated to use the new truthiness pattern, and new tests/snapshots cover the unset/cast/explicit-clear cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78ffd9286b05ebb8b091cf6a571cac7ceebcc3ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
