### PR TITLE
Add allowed config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Unnamed `Net()`/typed nets and generated interface child nets now infer names from assignment targets when possible.
 - Add `io()` direction metadata plus `input()` / `output()` sugar.
 - `config()`, `io()`, `input()`, and `output()` now allow omitting the explicit name when assigned to a top-level variable.
+- `config()` now supports discrete `allowed=` sets for scalar and physical-value inputs.
 
 ### Changed
 

--- a/crates/pcb-docgen/src/render.rs
+++ b/crates/pcb-docgen/src/render.rs
@@ -195,8 +195,8 @@ fn render_module(module: &ModuleDoc, depth: usize) -> String {
 
     if !module.signature.configs.is_empty() {
         out.push_str("**Config:**\n\n");
-        out.push_str("| Parameter | Type | Default |\n");
-        out.push_str("|-----------|------|--------|\n");
+        out.push_str("| Parameter | Type | Default | Allowed |\n");
+        out.push_str("|-----------|------|---------|---------|\n");
         for param in &module.signature.configs {
             let default = if param.has_default && !param.default_repr.is_empty() {
                 param.default_repr.clone()
@@ -206,9 +206,14 @@ fn render_module(module: &ModuleDoc, depth: usize) -> String {
                 "required".to_string()
             };
             let type_repr = param.type_repr.replace('|', "\\|");
+            let allowed = param
+                .allowed_repr
+                .clone()
+                .unwrap_or_default()
+                .replace('|', "\\|");
             out.push_str(&format!(
-                "| {} | {} | {} |\n",
-                param.name, type_repr, default
+                "| {} | {} | {} | {} |\n",
+                param.name, type_repr, default, allowed
             ));
         }
         out.push('\n');
@@ -265,6 +270,7 @@ mod tests {
                         default_repr: "\"0603\"".to_string(),
                         optional: false,
                         direction: None,
+                        allowed_repr: None,
                     },
                     ParamDoc {
                         name: "value".to_string(),
@@ -273,6 +279,7 @@ mod tests {
                         default_repr: String::new(),
                         optional: false,
                         direction: None,
+                        allowed_repr: None,
                     },
                 ],
                 ios: vec![
@@ -283,6 +290,7 @@ mod tests {
                         default_repr: String::new(),
                         optional: false,
                         direction: Some(IoDirection::Input),
+                        allowed_repr: None,
                     },
                     ParamDoc {
                         name: "P2".to_string(),
@@ -291,6 +299,7 @@ mod tests {
                         default_repr: String::new(),
                         optional: false,
                         direction: Some(IoDirection::Output),
+                        allowed_repr: None,
                     },
                 ],
             },

--- a/crates/pcb-docgen/src/signature.rs
+++ b/crates/pcb-docgen/src/signature.rs
@@ -68,6 +68,13 @@ pub fn try_get_signature(file: &Path, resolution_result: &ResolutionResult) -> S
                 .unwrap_or_default(),
             optional: !param.required,
             direction: param.direction,
+            allowed_repr: param.allowed_display.as_ref().map(|values| {
+                values
+                    .iter()
+                    .map(|value| format_default_display(value))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            }),
         };
 
         if param.is_config() {

--- a/crates/pcb-docgen/src/types.rs
+++ b/crates/pcb-docgen/src/types.rs
@@ -82,4 +82,5 @@ pub struct ParamDoc {
     pub default_repr: String,
     pub optional: bool,
     pub direction: Option<IoDirection>,
+    pub allowed_repr: Option<String>,
 }

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -73,10 +73,23 @@ struct ParameterInfo {
     value: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_value: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_values: Option<Vec<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_display: Option<Vec<String>>,
 }
 
 fn serialize_signature_value(value: FrozenValue) -> Option<JsonValue> {
     Some(serialize_value(value.to_value()))
+}
+
+fn serialize_signature_values(values: Option<&Vec<FrozenValue>>) -> Option<Vec<JsonValue>> {
+    values.map(|values| {
+        values
+            .iter()
+            .filter_map(|value| serialize_signature_value(*value))
+            .collect()
+    })
 }
 
 fn serialize_value(value: Value) -> JsonValue {
@@ -104,6 +117,14 @@ fn serialize_value(value: Value) -> JsonValue {
 
     if let Some(interface) = value.downcast_ref::<FrozenInterfaceValue>() {
         return serialize_interface(interface);
+    }
+
+    if let Some(enum_value) = value.downcast_ref::<EnumValue>() {
+        return JsonValue::String(enum_value.value().to_string());
+    }
+
+    if let Some(&physical) = value.downcast_ref::<PhysicalValue>() {
+        return JsonValue::String(physical.to_string());
     }
 
     match value.to_json_value() {
@@ -513,6 +534,8 @@ impl ModuleConverter {
                 direction: param.direction,
                 value: param.actual_value.and_then(serialize_signature_value),
                 default_value: param.default_value.and_then(serialize_signature_value),
+                allowed_values: serialize_signature_values(param.allowed_values.as_ref()),
+                allowed_display: param.allowed_display(),
             });
         }
 

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use pcb_sch::physical::PhysicalValueWarningHandler;
+use pcb_sch::physical::{PhysicalValue, PhysicalValueWarningHandler};
 use starlark::{
     PrintHandler,
     environment::{GlobalsBuilder, LibraryExtension},
@@ -30,6 +30,7 @@ use crate::lang::assert::assert_globals;
 use crate::lang::{
     builtin::builtin_globals,
     component::component_globals,
+    r#enum::EnumValue,
     type_info::{ParameterInfo, TypeInfo},
 };
 use crate::lang::{
@@ -105,6 +106,18 @@ fn emit_physical_value_deprecation<'v>(eval: &Evaluator<'v, '_, '_>, message: &s
             .with_span(span)
             .with_call_stack(Some(eval.call_stack())),
     );
+}
+
+fn serialize_parameter_value(value: Value<'_>) -> Option<serde_json::Value> {
+    if let Some(enum_value) = value.downcast_ref::<EnumValue>() {
+        return Some(serde_json::Value::String(enum_value.value().to_string()));
+    }
+
+    if let Some(&physical) = value.downcast_ref::<PhysicalValue>() {
+        return Some(serde_json::Value::String(physical.to_string()));
+    }
+
+    value.to_json_value().ok()
 }
 
 #[derive(Clone)]
@@ -1452,11 +1465,17 @@ impl EvalContext {
                         let default_value = param
                             .default_value
                             .as_ref()
-                            .and_then(|v| v.to_value().to_json_value().ok());
+                            .and_then(|v| serialize_parameter_value(v.to_value()));
 
                         // Get human-readable display of default value
-                        let default_display =
-                            param.default_value.as_ref().map(|v| v.to_value().to_repr());
+                        let default_display = param.default_display();
+                        let allowed_values = param.allowed_values.as_ref().map(|values| {
+                            values
+                                .iter()
+                                .filter_map(|value| serialize_parameter_value(value.to_value()))
+                                .collect()
+                        });
+                        let allowed_display = param.allowed_display();
 
                         ParameterInfo {
                             name: param.name.clone(),
@@ -1464,6 +1483,8 @@ impl EvalContext {
                             required: !param.optional,
                             default_value,
                             default_display,
+                            allowed_values,
+                            allowed_display,
                             help: param.help.clone(),
                             direction: param.direction,
                         }

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -26,7 +26,7 @@ use starlark::{
     starlark_complex_value, starlark_module, starlark_simple_value,
     values::{
         Coerce, Freeze, NoSerialize, StarlarkValue, Trace, Value, ValueLike, float::StarlarkFloat,
-        list::ListRef, starlark_value,
+        list::ListRef, starlark_value, tuple::TupleRef,
     },
 };
 
@@ -270,6 +270,8 @@ pub struct ParameterMetadataGen<V: ValueLifetimeless> {
     pub optional: bool,
     /// Default value if provided
     pub default_value: Option<V>,
+    /// Finite set of allowed values if provided
+    pub allowed_values: Option<Vec<V>>,
     /// Whether this is a config parameter (vs io parameter)
     pub is_config: bool,
     /// Help text describing the parameter
@@ -315,6 +317,7 @@ impl<'v, V: ValueLike<'v>> ParameterMetadataGen<V> {
         type_value: V,
         optional: bool,
         default_value: Option<V>,
+        allowed_values: Option<Vec<V>>,
         is_config: bool,
         help: Option<String>,
         direction: Option<IoDirection>,
@@ -326,6 +329,7 @@ impl<'v, V: ValueLike<'v>> ParameterMetadataGen<V> {
             type_value,
             optional,
             default_value,
+            allowed_values,
             is_config,
             help,
             direction,
@@ -333,6 +337,21 @@ impl<'v, V: ValueLike<'v>> ParameterMetadataGen<V> {
             declaration_span,
             declaration_call_stack,
         }
+    }
+
+    pub fn default_display(&self) -> Option<String> {
+        self.default_value
+            .as_ref()
+            .map(|value| value.to_value().to_repr())
+    }
+
+    pub fn allowed_display(&self) -> Option<Vec<String>> {
+        self.allowed_values.as_ref().map(|values| {
+            values
+                .iter()
+                .map(|value| value.to_value().to_repr())
+                .collect()
+        })
     }
 }
 
@@ -354,6 +373,7 @@ pub(crate) struct ParameterMetadataInput<'v> {
     pub(crate) typ: Value<'v>,
     pub(crate) optional: bool,
     pub(crate) default: Option<Value<'v>>,
+    pub(crate) allowed_values: Option<Vec<Value<'v>>>,
     pub(crate) is_config: bool,
     pub(crate) help: Option<String>,
     pub(crate) direction: Option<IoDirection>,
@@ -385,6 +405,7 @@ pub(crate) fn record_parameter_metadata<'v>(
             metadata.typ,
             metadata.optional,
             metadata.default,
+            metadata.allowed_values,
             metadata.is_config,
             metadata.help.clone(),
             metadata.direction,
@@ -654,6 +675,7 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
         type_value: V,
         optional: bool,
         default_value: Option<V>,
+        allowed_values: Option<Vec<V>>,
         is_config: bool,
         help: Option<String>,
         direction: Option<IoDirection>,
@@ -668,6 +690,7 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
                 type_value,
                 optional,
                 default_value,
+                allowed_values,
                 is_config,
                 help,
                 direction,
@@ -1419,24 +1442,125 @@ pub(crate) fn validate_or_convert<'v>(
         return Ok(converted);
     }
 
-    // 2. If a custom converter is provided, use it for other conversions
+    // Keep the deprecated custom converter path working until it is fully removed.
     if let Some(conv_fn) = convert {
-        log::debug!("Converting {name} from {value} to {typ}");
         let converted = eval
             .eval_function(conv_fn, &[value], &[])
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-
-        log::debug!("Converted {name} to {converted}");
-
-        // Ensure the converted value now matches the expected type.
         validate_type(name, converted, typ, eval.heap())?;
-        log::debug!("Converted {name} to {converted} and validated");
         return Ok(converted);
     }
 
-    // 3. None of the conversion paths worked – propagate the original validation error
+    // None of the conversion paths worked – propagate the original validation error.
     validate_type(name, value, typ, eval.heap())?;
     unreachable!();
+}
+
+fn config_allowed_type_supported<'v>(typ: Value<'v>) -> bool {
+    if typ.downcast_ref::<EnumType>().is_some() || typ.downcast_ref::<PhysicalValueType>().is_some()
+    {
+        return true;
+    }
+
+    let type_name = typ.to_string();
+    matches!(
+        type_name.as_str(),
+        "str" | "string" | "String" | "int" | "Int" | "float" | "Float" | "bool" | "Bool"
+    )
+}
+
+pub(crate) fn normalize_allowed_values<'v>(
+    name: &str,
+    typ: Value<'v>,
+    allowed: Option<Value<'v>>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Vec<Value<'v>>>> {
+    let Some(allowed) = allowed else {
+        return Ok(None);
+    };
+
+    if !config_allowed_type_supported(typ) {
+        anyhow::bail!(
+            "config `{name}` uses unsupported type for `allowed`: expected str, int, float, bool, enum, or physical value type"
+        );
+    }
+
+    let mut normalized = Vec::new();
+    let mut seen = HashSet::new();
+    for candidate in allowed_candidates(name, allowed)? {
+        let value = validate_or_convert(name, candidate, typ, None, eval)?;
+        let key = value.to_repr();
+
+        if !seen.insert(key.clone()) {
+            anyhow::bail!("duplicate allowed value for config `{name}`: {key}");
+        }
+
+        normalized.push(value);
+    }
+
+    if normalized.is_empty() {
+        anyhow::bail!("config `{name}` expects `allowed` to be non-empty");
+    }
+
+    Ok(Some(normalized))
+}
+
+fn allowed_candidates<'v>(name: &str, allowed: Value<'v>) -> anyhow::Result<Vec<Value<'v>>> {
+    if let Some(list) = ListRef::from_value(allowed) {
+        return Ok(list.iter().collect());
+    }
+
+    if let Some(tuple) = TupleRef::from_value(allowed) {
+        return Ok(tuple.iter().collect());
+    }
+
+    if let Some(dict) = DictRef::from_value(allowed) {
+        return Ok(dict.iter().map(|(key, _)| key).collect());
+    }
+
+    anyhow::bail!("config `{name}` expects `allowed` to be a list, tuple, or dict");
+}
+
+pub(crate) fn validate_allowed_config_value<'v>(
+    name: &str,
+    value: Value<'v>,
+    allowed_values: Option<&[Value<'v>]>,
+) -> anyhow::Result<()> {
+    let Some(allowed_values) = allowed_values else {
+        return Ok(());
+    };
+
+    let got = value.to_repr();
+    let expected = allowed_values
+        .iter()
+        .map(|allowed| allowed.to_repr())
+        .collect::<Vec<_>>();
+
+    if expected.iter().any(|allowed| allowed == &got) {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "invalid value for config `{name}`: got {got}; expected one of {}",
+        expected.join(", ")
+    );
+}
+
+pub(crate) fn normalize_config_default<'v>(
+    name: &str,
+    default: Option<Value<'v>>,
+    typ: Value<'v>,
+    allowed_values: Option<&[Value<'v>]>,
+    convert: Option<Value<'v>>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    let Some(default) = default else {
+        return Ok(None);
+    };
+
+    let default = validate_or_convert(name, default, typ, convert, eval)?;
+    validate_allowed_config_value(name, default, allowed_values)?;
+    Ok(Some(default))
 }
 
 /// Generate default value for io() parameters, optionally registering nets

--- a/crates/pcb-zen-core/src/lang/param_decl.rs
+++ b/crates/pcb-zen-core/src/lang/param_decl.rs
@@ -12,8 +12,9 @@ use crate::lang::{evaluator_ext::EvaluatorExt, io_direction::IoDirection};
 
 use super::module::{
     DeclarationSite, MissingInputError, ParameterMetadataInput, current_declaration_site,
-    default_for_type, io_declaration_site, io_generated_default, record_parameter_metadata,
-    run_checks, validate_or_convert,
+    default_for_type, io_declaration_site, io_generated_default, normalize_allowed_values,
+    normalize_config_default, record_parameter_metadata, run_checks, validate_allowed_config_value,
+    validate_or_convert,
 };
 
 #[derive(Debug, Clone, Trace, Allocative)]
@@ -21,6 +22,7 @@ struct DeclArgs<'v> {
     typ: Value<'v>,
     checks: Option<Value<'v>>,
     default: Option<Value<'v>>,
+    allowed: Option<Value<'v>>,
     convert: Option<Value<'v>>,
     optional: Option<bool>,
     help: Option<String>,
@@ -49,6 +51,10 @@ impl ParamKind {
     }
 
     fn allows_convert(self) -> bool {
+        matches!(self, ParamKind::Config)
+    }
+
+    fn allows_allowed(self) -> bool {
         matches!(self, ParamKind::Config)
     }
 
@@ -192,6 +198,7 @@ fn parse_decl_args<'v>(
 
     let mut default = None;
     let mut checks = None;
+    let mut allowed = None;
     let mut convert = None;
     let mut optional = None;
     let mut help = None;
@@ -201,6 +208,7 @@ fn parse_decl_args<'v>(
         match arg_name.as_str() {
             "checks" => checks = none_if_none(value),
             "default" => default = none_if_none(value),
+            "allowed" if kind.allows_allowed() => allowed = none_if_none(value),
             "convert" if kind.allows_convert() => convert = none_if_none(value),
             "optional" => optional = Some(unpack_bool_arg(value, function, "optional")?),
             "help" => help = unpack_optional_string_arg(value, function, "help")?,
@@ -257,6 +265,7 @@ fn parse_decl_args<'v>(
             typ,
             checks: checks.or(positional_checks),
             default,
+            allowed,
             convert,
             optional,
             help,
@@ -324,29 +333,51 @@ fn resolve_config<'v>(
     declaration_site: &DeclarationSite,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Value<'v>> {
-    let is_optional = args.optional.unwrap_or(args.default.is_some());
+    let convert_value = |eval: &mut Evaluator<'v, '_, '_>, value| {
+        validate_or_convert(name, value, args.typ, args.convert, eval)
+            .map_err(starlark::Error::from)
+    };
+    let allowed_values = normalize_allowed_values(name, args.typ, args.allowed, eval)
+        .map_err(starlark::Error::from)?;
+    let default_value = normalize_config_default(
+        name,
+        args.default,
+        args.typ,
+        allowed_values.as_deref(),
+        args.convert,
+        eval,
+    )
+    .map_err(starlark::Error::from)?;
+    let is_optional = args.optional.unwrap_or(default_value.is_some());
 
     let value = if let Some(provided) = eval.request_input(name)? {
-        validate_or_convert(name, provided, args.typ, args.convert, eval)?
+        convert_value(eval, provided)?
     } else if is_optional {
-        if let Some(default) = args.default {
-            validate_or_convert(name, default, args.typ, args.convert, eval)?
-        } else {
-            Value::new_none()
-        }
+        default_value.unwrap_or_else(Value::new_none)
     } else {
         if strict_io_config(eval) {
             note_missing_input(name, eval);
             eval.add_diagnostic(missing_input_diag(name, declaration_site));
         }
 
-        if let Some(default) = args.default {
-            validate_or_convert(name, default, args.typ, args.convert, eval)?
+        if let Some(default) = default_value {
+            default
+        } else if let Some(first_allowed) = allowed_values
+            .as_ref()
+            .and_then(|values| values.first())
+            .copied()
+        {
+            first_allowed
         } else {
             let generated = default_for_type(eval, args.typ)?;
-            validate_or_convert(name, generated, args.typ, args.convert, eval)?
+            convert_value(eval, generated)?
         }
     };
+
+    if !value.is_none() {
+        validate_allowed_config_value(name, value, allowed_values.as_deref())
+            .map_err(starlark::Error::from)?;
+    }
 
     finish_resolution(
         name,
@@ -354,7 +385,8 @@ fn resolve_config<'v>(
         ParameterMetadataInput {
             typ: args.typ,
             optional: is_optional,
-            default: args.default,
+            default: default_value,
+            allowed_values,
             is_config: true,
             help: args.help.clone(),
             direction: None,
@@ -418,6 +450,7 @@ fn resolve_io<'v>(
             typ: args.typ,
             optional: is_optional,
             default: metadata_default,
+            allowed_values: None,
             is_config: false,
             help: args.help.clone(),
             direction: args.direction,

--- a/crates/pcb-zen-core/src/lang/type_info.rs
+++ b/crates/pcb-zen-core/src/lang/type_info.rs
@@ -198,15 +198,13 @@ pub struct ParameterInfo {
     /// Human-readable display of the default value (uses Starlark's Display impl)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_display: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_values: Option<Vec<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_display: Option<Vec<String>>,
     pub help: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub direction: Option<IoDirection>,
-}
-
-impl ParameterInfo {
-    pub fn is_config(&self) -> bool {
-        !self.type_info.is_io_type()
-    }
 }
 
 impl std::fmt::Debug for ParameterInfo {
@@ -217,10 +215,22 @@ impl std::fmt::Debug for ParameterInfo {
         debug.field("required", &self.required);
         debug.field("default_value", &self.default_value);
         debug.field("default_display", &self.default_display);
+        if self.allowed_values.is_some() {
+            debug.field("allowed_values", &self.allowed_values);
+        }
+        if self.allowed_display.is_some() {
+            debug.field("allowed_display", &self.allowed_display);
+        }
         debug.field("help", &self.help);
         if let Some(direction) = &self.direction {
             debug.field("direction", direction);
         }
         debug.finish()
+    }
+}
+
+impl ParameterInfo {
+    pub fn is_config(&self) -> bool {
+        !self.type_info.is_io_type()
     }
 }

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -1149,3 +1149,138 @@ fn prelude_injects_io_helpers_from_stdlib() {
         eval_result.diagnostics
     );
 }
+
+#[test]
+fn config_allowed_physical_metadata() {
+    let result = eval_zen(vec![
+        (
+            "Module.zen".to_string(),
+            r#"
+                Capacitance = builtin.physical_value("F")
+
+                capacitance = config(
+                    "capacitance",
+                    Capacitance,
+                    allowed = ["100mF", "220mF"],
+                    default = "100mF",
+                )
+
+                print("capacitance:", capacitance)
+            "#
+            .to_string(),
+        ),
+        (
+            "top.zen".to_string(),
+            r#"
+                Mod = Module("Module.zen")
+
+                Mod(name = "U1", capacitance = "0.1F")
+            "#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(
+        result.is_success(),
+        "expected eval success, got diagnostics: {:?}",
+        result.diagnostics
+    );
+
+    let output = result.output.expect("expected eval output");
+    let module_tree = output.module_tree();
+    let child_module = module_tree
+        .values()
+        .find(|module| module.path().name() == "U1")
+        .expect("expected instantiated child module");
+    let param = child_module
+        .signature()
+        .iter()
+        .find(|param| param.name == "capacitance")
+        .expect("expected capacitance parameter in child signature");
+
+    assert_eq!(
+        param.allowed_values.as_ref().map(Vec::len),
+        Some(2),
+        "expected two allowed values in signature metadata"
+    );
+    let default_display = param
+        .default_value
+        .as_ref()
+        .expect("expected normalized default value")
+        .to_value()
+        .to_repr();
+    let allowed_display: Vec<String> = param
+        .allowed_values
+        .as_ref()
+        .expect("expected normalized allowed values")
+        .iter()
+        .map(|value| value.to_value().to_repr())
+        .collect();
+    let actual_display = param
+        .actual_value
+        .as_ref()
+        .expect("expected resolved config value")
+        .to_value()
+        .to_repr();
+
+    assert!(
+        allowed_display
+            .iter()
+            .any(|value| value == &default_display),
+        "default should be one of the normalized allowed values: {:?}",
+        allowed_display
+    );
+    assert!(
+        allowed_display.iter().any(|value| value == &actual_display),
+        "resolved value should match one of the normalized allowed values: {:?}",
+        allowed_display
+    );
+}
+
+snapshot_eval!(config_allowed_invalid_value, {
+    "Module.zen" => r#"
+        package = config(
+            "package",
+            str,
+            allowed = {"0402": 1, "0603": 2},
+        )
+    "#,
+    "top.zen" => r#"
+        Mod = Module("Module.zen")
+
+        Mod(name = "U1", package = "0805")
+    "#
+});
+
+snapshot_eval!(config_allowed_invalid_default, {
+    "Module.zen" => r#"
+        Voltage = builtin.physical_value("V")
+
+        output_voltage = config(
+            "output_voltage",
+            Voltage,
+            allowed = ["1.0V"],
+            default = "0.9V",
+        )
+    "#,
+    "top.zen" => r#"
+        Mod = Module("Module.zen")
+
+        Mod(name = "U1", output_voltage = "1.0V")
+    "#
+});
+
+snapshot_eval!(config_allowed_unsupported_type, {
+    "test.zen" => r#"
+        Range = record(
+            min = field(float),
+            max = field(float),
+        )
+
+        value = config(
+            "value",
+            Range,
+            allowed = [Range(min = 0.0, max = 1.0)],
+        )
+    "#
+});

--- a/crates/pcb-zen-core/tests/snapshots/input__config_allowed_invalid_default.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_allowed_invalid_default.snap
@@ -1,0 +1,7 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+assertion_line: 795
+expression: output
+---
+Error: top.zen:5:7-27 Error loading module `Module.zen`
+Error: /Module.zen:7:18-12:2 invalid value for config `output_voltage`: got 900mV; expected one of 1V

--- a/crates/pcb-zen-core/tests/snapshots/input__config_allowed_invalid_value.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_allowed_invalid_value.snap
@@ -1,0 +1,7 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+assertion_line: 780
+expression: output
+---
+Error: top.zen:7:1-35 Error instantiating `Module`
+Error: /Module.zen:5:11-9:2 invalid value for config `package`: got "0805"; expected one of "0402", "0603"

--- a/crates/pcb-zen-core/tests/snapshots/input__config_allowed_unsupported_type.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_allowed_unsupported_type.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+assertion_line: 813
+expression: output
+---
+Error: test.zen:10:9-14:2 config `value` uses unsupported type for `allowed`: expected str, int, float, bool, enum, or physical value type

--- a/crates/pcb/tests/doc.rs
+++ b/crates/pcb/tests/doc.rs
@@ -17,6 +17,15 @@ P1 = io("P1", Net, direction = "input")
 P2 = io("P2", Net, direction = "output")
 "#;
 
+const ALLOWED_CONFIG_MODULE: &str = r#"
+package = config(
+    "package",
+    str,
+    allowed = ["0402", "0603"],
+    default = "0603",
+)
+"#;
+
 fn seed_remote_package(sb: &mut Sandbox) {
     let mut fixture = sb.git_fixture("https://github.com/mycompany/components.git");
     fixture
@@ -108,4 +117,28 @@ fn test_pcb_doc_remote_package_defaults_to_latest() {
         !pinned_stdout.contains("| value | str | \"4.7kOhm\" |"),
         "explicit version should not resolve the newer tag:\n{pinned_stdout}"
     );
+}
+
+#[test]
+fn test_pcb_doc_shows_allowed_values_for_config() {
+    let mut sb = Sandbox::new();
+    sb.write("pcb.toml", "")
+        .write("Widget.zen", ALLOWED_CONFIG_MODULE);
+
+    let output = run_doc(&mut sb, ".");
+
+    assert!(
+        output.status.success(),
+        "doc command failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).trim().is_empty(),
+        "doc command wrote to stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = sb.sanitize_output(&String::from_utf8_lossy(&output.stdout));
+    insta::assert_snapshot!("doc_allowed_values", stdout);
 }

--- a/crates/pcb/tests/snapshots/doc__doc_allowed_values.snap
+++ b/crates/pcb/tests/snapshots/doc__doc_allowed_values.snap
@@ -1,0 +1,14 @@
+---
+source: crates/pcb/tests/doc.rs
+assertion_line: 131
+expression: stdout
+---
+<!-- source: <TEMP_DIR> -->
+
+## Widget.zen
+
+**Config:**
+
+| Parameter | Type | Default | Allowed |
+|-----------|------|---------|---------|
+| package | str | "0603" | "0402", "0603" |

--- a/crates/pcb/tests/snapshots/release__publish_full.snap
+++ b/crates/pcb/tests/snapshots/release__publish_full.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb/tests/release.rs
+assertion_line: 298
 expression: sb.snapshot_dir(&staging_dir)
 ---
 === bom/design_bom.json
@@ -117,7 +118,7 @@ Designator,Val,Package,Mid X,Mid Y,Rotation,Layer
     "user": "<USER>"
   }
 }
-=== netlist.json <73006 bytes, sha256: 0f3d886>
+=== netlist.json <71244 bytes, sha256: cd83e9b>
 === src/boards/TestBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcb/tests/snapshots/release__publish_source_only.snap
+++ b/crates/pcb/tests/snapshots/release__publish_source_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb/tests/release.rs
+assertion_line: 205
 expression: sb.snapshot_dir(&staging_dir)
 ---
 === diagnostics.json
@@ -43,7 +44,7 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <73006 bytes, sha256: 0f3d886>
+=== netlist.json <71244 bytes, sha256: cd83e9b>
 === src/boards/TestBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcb/tests/snapshots/release__publish_with_description.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_description.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb/tests/release.rs
+assertion_line: 363
 expression: sb.snapshot_dir(&staging_dir)
 ---
 === diagnostics.json
@@ -44,7 +45,7 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <73006 bytes, sha256: 42cb844>
+=== netlist.json <71244 bytes, sha256: e63cc51>
 === src/boards/DescBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcb/tests/snapshots/release__publish_with_version.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_version.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb/tests/release.rs
+assertion_line: 252
 expression: sb.snapshot_dir(staging_dir)
 ---
 === diagnostics.json
@@ -43,7 +44,7 @@ expression: sb.snapshot_dir(staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <72267 bytes, sha256: 243c2ef>
+=== netlist.json <70505 bytes, sha256: 4e64f8a>
 === src/boards/TB0001.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -467,12 +467,13 @@ CS = input(Net)
 
 Declare a typed configuration input for a module. This defines parameters that control the module's behavior — values (not nets) provided by the parent.
 
-**Signature:** `config(name, typ, checks=None, default=None, optional=None, help=None)` or `config(typ, checks=None, default=None, optional=None, help=None)`
+**Signature:** `config(name, typ, checks=None, default=None, allowed=None, optional=None, help=None)` or `config(typ, checks=None, default=None, allowed=None, optional=None, help=None)`
 
 - `name`: Optional explicit input name (conventionally lowercase). If omitted, `config()` must be assigned to a top-level variable and that variable name is used.
 - `typ`: Expected type — primitives (`str`, `int`, `float`, `bool`), `enum`, `record`, or physical quantity constructors.
 - `checks`: Optional check function or list of checks.
 - `default`: Default value. When provided, `optional` defaults to `True`.
+- `allowed`: Optional finite set of allowed values. Accepts a `list`, `tuple`, or `dict` (using only the keys). Supported for `str`, `int`, `float`, `bool`, `enum`, and physical quantity types.
 - `optional`: Explicit override. When `True` with no default, returns `None`.
 - `help`: Help text.
 
@@ -481,9 +482,15 @@ value = config("value", Resistance)
 package = config("package", Package, default=Package("0603"))
 voltage = config("voltage", Voltage, optional=True)
 manufacturer = config(str, default="Acme")
+output_voltage = config(
+    "output_voltage",
+    Voltage,
+    allowed=["0.8V", "0.9V", "1.0V", "1.1V"],
+    default="1.0V",
+)
 ```
 
-Values passed by the parent are automatically converted to the declared type when possible. String inputs can coerce to primitives (`"true"` → `True`, `"42"` → `42`, `"3.3"` → `3.3`), physical quantities (`"10k"` → `Resistance("10k")`), and enum variants (`"0603"` → `Package("0603")`). This is why `Resistor(name="R1", value="10k", package="0603", ...)` works even though `value` expects `Resistance` and `package` expects `Package`.
+Values passed by the parent are automatically converted to the declared type when possible. String inputs can coerce to primitives (`"true"` → `True`, `"42"` → `42`, `"3.3"` → `3.3`), physical quantities (`"10k"` → `Resistance("10k")`), and enum variants (`"0603"` → `Package("0603")`). This is why `Resistor(name="R1", value="10k", package="0603", ...)` works even though `value` expects `Resistance` and `package` expects `Package`. When `allowed` is present, both the allowed set and the provided value are normalized through that same coercion path before membership is checked, and physical values are surfaced using their canonical formatting.
 
 ### Writing a Module
 


### PR DESCRIPTION
This does touch `__signature` in netlist, but should be backwards compatible.

Closes ENG-247.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new `config()` validation/default-selection behavior and extends serialized `__signature` metadata, which could affect module instantiation errors and downstream consumers of netlist/signature JSON.
> 
> **Overview**
> Adds `allowed=` to `config()` so module authors can declare a finite set of permitted values (list/tuple/dict keys), with normalization/coercion for primitives, enums, and physical values and runtime validation of provided/default values.
> 
> Extends signature metadata end-to-end (`pcb-zen-core` parameter metadata, eval output, and netlist `__signature` JSON) to include `allowed_values`/display forms, and updates `pcb-docgen`/`pcb doc` output to render an **Allowed** column for config parameters.
> 
> Updates docs/spec and adds targeted tests + snapshots for allowed-value behavior (valid/invalid/default/unsupported type) and doc rendering; release snapshots change due to the enriched signature payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2eeb7f3b682237511293899f5991448d508321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
