### PR TITLE
Add support for `pcb build --config KEY=VALUE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `pcb build` and `pcb bom` now accept repeatable `--config key=value` overrides for root `config()` parameters.
 - Net type physical-value fields now coerce string and scalar inputs like `io()`/`config()`.
 - Unnamed `Net()`/typed nets and generated interface child nets now infer names from assignment targets when possible.
 - Add `io()` direction metadata plus `input()` / `output()` sugar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `pcb build` and `pcb bom` now accept repeatable `--config key=value` overrides for root `config()` parameters.
+- `pcb build` now accept repeatable `--config key=value` for setting `config()` parameters.
 - Net type physical-value fields now coerce string and scalar inputs like `io()`/`config()`.
 - Unnamed `Net()`/typed nets and generated interface child nets now infer names from assignment targets when possible.
 - Add `io()` direction metadata plus `input()` / `output()` sugar.

--- a/crates/pcb-docgen/src/signature.rs
+++ b/crates/pcb-docgen/src/signature.rs
@@ -20,7 +20,7 @@ pub enum SignatureResult {
 /// - It has io() or config() parameters in its signature, OR
 /// - It instantiates components/submodules (module_tree has more than just the root)
 pub fn try_get_signature(file: &Path, resolution_result: &ResolutionResult) -> SignatureResult {
-    let result = pcb_zen::eval(file, resolution_result.clone());
+    let result = pcb_zen::eval(file, resolution_result.clone(), Default::default());
 
     let Some(eval_output) = result.output else {
         let errors: Vec<String> = result

--- a/crates/pcb-layout/tests/fpid_change.rs
+++ b/crates/pcb-layout/tests/fpid_change.rs
@@ -38,7 +38,7 @@ fn test_fpid_change_replaces_footprint_geometry() -> Result<()> {
         pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path(), true)?;
     let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)?;
 
-    let (output, diagnostics) = pcb_zen::run(&zen_file, res.clone()).unpack();
+    let (output, diagnostics) = pcb_zen::run(&zen_file, res.clone(), Default::default()).unpack();
     if !diagnostics.is_empty() {
         eprintln!("Zen evaluation diagnostics (step 1):");
         for diag in diagnostics {
@@ -98,7 +98,7 @@ fn test_fpid_change_replaces_footprint_geometry() -> Result<()> {
     let board_0603_content = std::fs::read_to_string(temp.path().join("Board_0603.zen"))?;
     std::fs::write(&zen_file, board_0603_content)?;
 
-    let (output2, diagnostics2) = pcb_zen::run(&zen_file, res).unpack();
+    let (output2, diagnostics2) = pcb_zen::run(&zen_file, res, Default::default()).unpack();
     if !diagnostics2.is_empty() {
         eprintln!("Zen evaluation diagnostics (step 2):");
         for diag in diagnostics2 {
@@ -188,7 +188,7 @@ fn test_fpid_change_preserves_position() -> Result<()> {
         pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path(), true)?;
     let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)?;
 
-    let (output, _) = pcb_zen::run(&zen_file, res.clone()).unpack();
+    let (output, _) = pcb_zen::run(&zen_file, res.clone(), Default::default()).unpack();
     let schematic = output.expect("Zen evaluation should produce a schematic");
     let mut layout_diagnostics = Diagnostics::default();
     let model_dirs = res.kicad_model_dirs();
@@ -220,7 +220,7 @@ fn test_fpid_change_preserves_position() -> Result<()> {
     let board_0603_content = std::fs::read_to_string(temp.path().join("Board_0603.zen"))?;
     std::fs::write(&zen_file, board_0603_content)?;
 
-    let (output2, _) = pcb_zen::run(&zen_file, res).unpack();
+    let (output2, _) = pcb_zen::run(&zen_file, res, Default::default()).unpack();
     let schematic2 = output2.expect("Second Zen evaluation should produce a schematic");
     let mut layout_diagnostics2 = Diagnostics::default();
     let result2 = process_layout(

--- a/crates/pcb-layout/tests/layout_generation.rs
+++ b/crates/pcb-layout/tests/layout_generation.rs
@@ -33,7 +33,7 @@ macro_rules! layout_test {
                 let model_dirs = res.kicad_model_dirs();
 
                 // Evaluate the Zen file to generate a schematic
-                let (output, diagnostics) = pcb_zen::run(&zen_file, res).unpack();
+                let (output, diagnostics) = pcb_zen::run(&zen_file, res, Default::default()).unpack();
 
                 // Check for errors in evaluation
                 if !diagnostics.is_empty() {

--- a/crates/pcb-layout/tests/moved.rs
+++ b/crates/pcb-layout/tests/moved.rs
@@ -32,7 +32,7 @@ fn test_moved_renames_path_and_preserves_position() -> Result<()> {
     let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)?;
     let model_dirs = res.kicad_model_dirs();
 
-    let (output, diagnostics) = pcb_zen::run(&zen_file, res.clone()).unpack();
+    let (output, diagnostics) = pcb_zen::run(&zen_file, res.clone(), Default::default()).unpack();
     if !diagnostics.is_empty() {
         eprintln!("Zen evaluation diagnostics (step 1):");
         for diag in diagnostics {
@@ -78,7 +78,7 @@ fn test_moved_renames_path_and_preserves_position() -> Result<()> {
     let board_renamed_content = std::fs::read_to_string(temp.path().join("Board_renamed.zen"))?;
     std::fs::write(&zen_file, board_renamed_content)?;
 
-    let (output2, diagnostics2) = pcb_zen::run(&zen_file, res).unpack();
+    let (output2, diagnostics2) = pcb_zen::run(&zen_file, res, Default::default()).unpack();
     if !diagnostics2.is_empty() {
         eprintln!("Zen evaluation diagnostics (step 2):");
         for diag in diagnostics2 {

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -1220,16 +1220,30 @@ impl EvalContext {
         self
     }
 
-    /// Set inputs from already frozen parent values.
-    pub fn set_inputs_from_frozen_values(&mut self, parent_inputs: SmallMap<String, FrozenValue>) {
-        let eval = Evaluator::new(&self.module);
+    fn ensure_context_value(&mut self) {
         if self.module.extra_value().is_none() {
+            let eval = Evaluator::new(&self.module);
             let ctx_value = eval.heap().alloc_complex(ContextValue::from_context(self));
             self.module.set_extra_value(ctx_value);
         }
-        let extra_value = self.module.extra_value().unwrap();
-        let ctx_value = extra_value.downcast_ref::<ContextValue>().unwrap();
+    }
 
+    fn context_value(&self) -> &ContextValue<'_> {
+        self.module
+            .extra_value()
+            .unwrap()
+            .downcast_ref::<ContextValue>()
+            .unwrap()
+    }
+
+    /// Set inputs from already frozen parent values.
+    pub fn set_inputs_from_frozen_values(&mut self, parent_inputs: SmallMap<String, FrozenValue>) {
+        if parent_inputs.is_empty() {
+            return;
+        }
+
+        self.ensure_context_value();
+        let ctx_value = self.context_value();
         let mut module = ctx_value.module_mut();
         for (name, value) in parent_inputs.into_iter() {
             module.add_input(name, value.to_value());
@@ -1241,14 +1255,12 @@ impl EvalContext {
         &mut self,
         parent_properties: SmallMap<String, FrozenValue>,
     ) {
-        let eval = Evaluator::new(&self.module);
-        if self.module.extra_value().is_none() {
-            let ctx_value = eval.heap().alloc_complex(ContextValue::from_context(self));
-            self.module.set_extra_value(ctx_value);
+        if parent_properties.is_empty() {
+            return;
         }
-        let extra_value = self.module.extra_value().unwrap();
-        let ctx_value = extra_value.downcast_ref::<ContextValue>().unwrap();
 
+        self.ensure_context_value();
+        let ctx_value = self.context_value();
         for (name, value) in parent_properties.into_iter() {
             ctx_value.add_property(name, value.to_value());
         }
@@ -1259,14 +1271,12 @@ impl EvalContext {
         &mut self,
         parent_modifiers: Vec<FrozenValue>,
     ) {
-        let eval = Evaluator::new(&self.module);
-        if self.module.extra_value().is_none() {
-            let ctx_value = eval.heap().alloc_complex(ContextValue::from_context(self));
-            self.module.set_extra_value(ctx_value);
+        if parent_modifiers.is_empty() {
+            return;
         }
-        let extra_value = self.module.extra_value().unwrap();
-        let ctx_value = extra_value.downcast_ref::<ContextValue>().unwrap();
 
+        self.ensure_context_value();
+        let ctx_value = self.context_value();
         let mut module = ctx_value.module_mut();
         let unfrozen_modifiers: Vec<_> = parent_modifiers
             .into_iter()
@@ -1307,14 +1317,13 @@ impl EvalContext {
 
     /// Convert JSON inputs directly to heap values and set them (for external APIs)
     pub fn set_json_inputs(&mut self, json_inputs: SmallMap<String, serde_json::Value>) {
-        let eval = Evaluator::new(&self.module);
-        if self.module.extra_value().is_none() {
-            let ctx_value = eval.heap().alloc_complex(ContextValue::from_context(self));
-            self.module.set_extra_value(ctx_value);
+        if json_inputs.is_empty() {
+            return;
         }
-        let extra_value = self.module.extra_value().unwrap();
-        let ctx_value = extra_value.downcast_ref::<ContextValue>().unwrap();
 
+        self.ensure_context_value();
+        let eval = Evaluator::new(&self.module);
+        let ctx_value = self.context_value();
         let mut module = ctx_value.module_mut();
         for (name, json) in json_inputs.iter() {
             let value = json_value_to_heap_value(json, eval.heap());

--- a/crates/pcb-zen-core/src/lang/type_conversion.rs
+++ b/crates/pcb-zen-core/src/lang/type_conversion.rs
@@ -5,9 +5,12 @@ use starlark::values::{Value, ValueLike, float::StarlarkFloat};
 use crate::lang::r#enum::{EnumType, EnumValue};
 use crate::lang::net::{FrozenNetType, FrozenNetValue, NetType, NetValue};
 
+fn has_type_name<'v>(typ: Value<'v>, names: &[&str]) -> bool {
+    names.contains(&typ.get_type()) || names.contains(&typ.to_string().as_str())
+}
+
 fn is_float_type<'v>(typ: Value<'v>) -> bool {
-    matches!(typ.get_type(), "float" | "Float")
-        || matches!(typ.to_string().as_str(), "float" | "Float")
+    has_type_name(typ, &["float", "Float"])
 }
 
 fn is_supported_scalar<'v>(value: Value<'v>) -> bool {
@@ -148,6 +151,30 @@ pub(crate) fn try_implicit_type_conversion<'v>(
     typ: Value<'v>,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> anyhow::Result<Option<Value<'v>>> {
+    if let Some(raw) = value.unpack_str() {
+        if has_type_name(typ, &["bool", "Bool"]) {
+            if raw.eq_ignore_ascii_case("true") {
+                return Ok(Some(Value::new_bool(true)));
+            }
+
+            if raw.eq_ignore_ascii_case("false") {
+                return Ok(Some(Value::new_bool(false)));
+            }
+        }
+
+        if has_type_name(typ, &["int", "Int"])
+            && let Ok(parsed) = raw.parse::<i32>()
+        {
+            return Ok(Some(eval.heap().alloc(parsed).to_value()));
+        }
+
+        if is_float_type(typ)
+            && let Ok(parsed) = raw.parse::<f64>()
+        {
+            return Ok(Some(eval.heap().alloc(StarlarkFloat(parsed))));
+        }
+    }
+
     if let Some(converted) = try_net_conversion(value, typ, eval)? {
         return Ok(Some(converted));
     }

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use pcb_sch::Schematic;
 use pcb_zen_core::resolution::ResolutionResult;
 use pcb_zen_core::{DefaultFileProvider, EvalContext, EvalOutput};
+use serde_json::Value as JsonValue;
+use starlark::collections::SmallMap;
 
 pub use pcb_zen_core::file_extensions;
 pub use pcb_zen_core::{Diagnostic, Diagnostics, WithDiagnostics};
@@ -29,19 +31,30 @@ pub use starlark::errors::EvalSeverity;
 pub use workspace::{MemberPackage, WorkspaceInfo, get_workspace_info};
 
 /// Evaluate a .zen file and return EvalOutput (module + signature + prints) with diagnostics.
-pub fn eval(file: &Path, resolution_result: ResolutionResult) -> WithDiagnostics<EvalOutput> {
+pub fn eval(
+    file: &Path,
+    resolution_result: ResolutionResult,
+    inputs: SmallMap<String, JsonValue>,
+) -> WithDiagnostics<EvalOutput> {
     let abs_path = file
         .canonicalize()
         .expect("failed to canonicalise input path");
 
     let file_provider = Arc::new(DefaultFileProvider::new());
-    let ctx = EvalContext::new(file_provider, resolution_result);
-    ctx.set_source_path(abs_path).eval()
+    let mut ctx = EvalContext::new(file_provider, resolution_result).set_source_path(abs_path);
+    if !inputs.is_empty() {
+        ctx.set_json_inputs(inputs);
+    }
+    ctx.eval()
 }
 
 /// Evaluate `file` and return a [`Schematic`].
-pub fn run(file: &Path, resolution_result: ResolutionResult) -> WithDiagnostics<Schematic> {
-    let eval_result = eval(file, resolution_result);
+pub fn run(
+    file: &Path,
+    resolution_result: ResolutionResult,
+    inputs: SmallMap<String, JsonValue>,
+) -> WithDiagnostics<Schematic> {
+    let eval_result = eval(file, resolution_result, inputs);
 
     // Handle evaluation failure
     if eval_result.output.is_none() {

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -42,9 +42,7 @@ pub fn eval(
 
     let file_provider = Arc::new(DefaultFileProvider::new());
     let mut ctx = EvalContext::new(file_provider, resolution_result).set_source_path(abs_path);
-    if !inputs.is_empty() {
-        ctx.set_json_inputs(inputs);
-    }
+    ctx.set_json_inputs(inputs);
     ctx.eval()
 }
 

--- a/crates/pcb-zen/tests/common/mod.rs
+++ b/crates/pcb-zen/tests/common/mod.rs
@@ -124,7 +124,7 @@ impl TestProject {
         // We rely on resolution and allow the evaluator to fetch missing modules
         // into the shared cache when needed (e.g. stdlib) rather than requiring a
         // pre-populated ~/.pcb/cache.
-        pcb_zen::eval(&top_path, res)
+        pcb_zen::eval(&top_path, res, Default::default())
     }
 
     /// Parse a single text blob that contains multiple files and write them into

--- a/crates/pcb-zen/tests/spice_model.rs
+++ b/crates/pcb-zen/tests/spice_model.rs
@@ -15,7 +15,7 @@ macro_rules! sim_snapshot {
             .expect("dependency resolution");
 
         let mut buf = Vec::new();
-        let schematic = pcb_zen::run(&top_path, res)
+        let schematic = pcb_zen::run(&top_path, res, Default::default())
             .output_result()
             .expect("failed to compile schematic for simulation");
         gen_sim(&schematic, &mut buf)
@@ -318,7 +318,7 @@ builtin.set_sim_setup(content=".tran 1u 10m")
     let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)
         .expect("dependency resolution");
 
-    let result = pcb_zen::eval(&top_path, res);
+    let result = pcb_zen::eval(&top_path, res, Default::default());
     assert!(
         result.output.is_none(),
         "expected evaluation to fail due to duplicate set_sim_setup"

--- a/crates/pcb/src/bom.rs
+++ b/crates/pcb/src/bom.rs
@@ -2,6 +2,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use crate::build::create_diagnostics_passes;
+use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
 use crate::release::discover_layout_from_output;
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
@@ -71,6 +72,9 @@ pub struct BomArgs {
     #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
     pub file: PathBuf,
 
+    #[arg(long = "config", value_name = "KEY=VALUE", help = CONFIG_ARG_HELP)]
+    pub config: Vec<String>,
+
     /// Output format
     #[arg(short, long, default_value_t = BomFormat::Table)]
     pub format: BomFormat,
@@ -87,6 +91,7 @@ pub struct BomArgs {
 
 pub fn execute(args: BomArgs) -> Result<()> {
     crate::file_walker::require_zen_file(&args.file)?;
+    let config_inputs = parse_config_overrides(&args.config)?;
 
     // Resolve dependencies before evaluation
     let resolution_result = crate::resolve::resolve(Some(&args.file), args.offline, args.locked)?;
@@ -97,7 +102,7 @@ pub fn execute(args: BomArgs) -> Result<()> {
     let spinner = Spinner::builder(format!("{file_name}: Building")).start();
 
     // Evaluate the design
-    let eval_result = pcb_zen::eval(&args.file, resolution_result);
+    let eval_result = pcb_zen::eval(&args.file, resolution_result, config_inputs);
     let layout_path = eval_result
         .output
         .as_ref()

--- a/crates/pcb/src/build.rs
+++ b/crates/pcb/src/build.rs
@@ -48,9 +48,7 @@ impl BuildEvalState {
         )
         .set_source_path(source_path);
 
-        if !inputs.is_empty() {
-            ctx.set_json_inputs(inputs);
-        }
+        ctx.set_json_inputs(inputs);
         ctx.eval()
     }
 

--- a/crates/pcb/src/build.rs
+++ b/crates/pcb/src/build.rs
@@ -5,10 +5,13 @@ use pcb_sch::Schematic;
 use pcb_ui::prelude::*;
 use pcb_zen_core::resolution::ResolutionResult;
 use pcb_zen_core::{DefaultFileProvider, EvalContext, EvalContextConfig, FileProvider};
+use serde_json::Value as JsonValue;
+use starlark::collections::SmallMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{info_span, instrument};
 
+use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
 use crate::file_walker;
 
 struct BuildEvalState {
@@ -28,25 +31,34 @@ impl BuildEvalState {
         }
     }
 
-    fn eval(&self, zen_path: &Path) -> pcb_zen_core::WithDiagnostics<pcb_zen_core::EvalOutput> {
+    fn eval(
+        &self,
+        zen_path: &Path,
+        inputs: SmallMap<String, JsonValue>,
+    ) -> pcb_zen_core::WithDiagnostics<pcb_zen_core::EvalOutput> {
         self.session.prepare_for_root_eval();
         let source_path = self
             .file_provider
             .canonicalize(zen_path)
             .expect("failed to canonicalise input path");
 
-        EvalContext::from_session_and_config(
+        let mut ctx = EvalContext::from_session_and_config(
             self.session.clone(),
             EvalContextConfig::new(self.file_provider.clone(), self.resolution.clone()),
         )
-        .set_source_path(source_path)
-        .eval()
+        .set_source_path(source_path);
+
+        if !inputs.is_empty() {
+            ctx.set_json_inputs(inputs);
+        }
+        ctx.eval()
     }
 
     #[instrument(name = "build_file", skip_all, fields(file = %zen_path.file_name().unwrap().to_string_lossy()))]
     fn build(
         &self,
         zen_path: &Path,
+        inputs: SmallMap<String, JsonValue>,
         passes: Vec<Box<dyn pcb_zen_core::DiagnosticsPass>>,
         deny_warnings: bool,
         has_errors: &mut bool,
@@ -57,7 +69,7 @@ impl BuildEvalState {
         debug!("Compiling Zener file: {}", zen_path.display());
         let spinner = Spinner::builder(format!("{file_name}: Building")).start();
 
-        let eval_result = self.eval(zen_path);
+        let eval_result = self.eval(zen_path, inputs);
         let mut diagnostics = eval_result.diagnostics;
 
         let output = if let Some(eval_output) = eval_result.output {
@@ -162,6 +174,9 @@ pub struct BuildArgs {
     #[arg(value_name = "PATH", value_hint = clap::ValueHint::AnyPath)]
     pub path: Option<PathBuf>,
 
+    #[arg(long = "config", value_name = "KEY=VALUE", help = CONFIG_ARG_HELP)]
+    pub config: Vec<String>,
+
     /// Print JSON netlist to stdout (undocumented)
     #[arg(long = "netlist", hide = true)]
     pub netlist: bool,
@@ -215,6 +230,7 @@ pub fn print_build_success(file_name: &str, schematic: &Schematic) {
 #[instrument(name = "build_file", skip_all, fields(file = %zen_path.file_name().unwrap().to_string_lossy()))]
 pub fn build(
     zen_path: &Path,
+    inputs: SmallMap<String, JsonValue>,
     passes: Vec<Box<dyn pcb_zen_core::DiagnosticsPass>>,
     deny_warnings: bool,
     has_errors: &mut bool,
@@ -223,11 +239,32 @@ pub fn build(
 ) -> Option<Schematic> {
     let eval_state = BuildEvalState::new(resolution);
 
-    eval_state.build(zen_path, passes, deny_warnings, has_errors, has_warnings)
+    eval_state.build(
+        zen_path,
+        inputs,
+        passes,
+        deny_warnings,
+        has_errors,
+        has_warnings,
+    )
 }
 
 pub fn execute(args: BuildArgs) -> Result<()> {
     let mut has_errors = false;
+
+    if !args.config.is_empty() {
+        let Some(path) = args.path.as_deref() else {
+            anyhow::bail!("--config requires a single .zen file target");
+        };
+
+        if path.is_dir() {
+            anyhow::bail!("--config requires a single .zen file target");
+        }
+
+        file_walker::require_zen_file(path)?;
+    }
+
+    let config_inputs = parse_config_overrides(&args.config)?;
 
     // Resolve dependencies before finding .zen files
     let resolution = crate::resolve::resolve(args.path.as_deref(), args.offline, args.locked)?;
@@ -245,6 +282,7 @@ pub fn execute(args: BuildArgs) -> Result<()> {
         let file_name = zen_path.file_name().unwrap().to_string_lossy();
         let Some(schematic) = eval_state.build(
             zen_path,
+            config_inputs.clone(),
             create_diagnostics_passes(&args.suppress, &args.warn),
             deny_warnings,
             &mut has_errors,

--- a/crates/pcb/src/config_input.rs
+++ b/crates/pcb/src/config_input.rs
@@ -1,0 +1,93 @@
+use anyhow::{Result, bail};
+use serde_json::Value as JsonValue;
+use starlark::collections::SmallMap;
+
+pub const CONFIG_ARG_HELP: &str = "Override root config() parameters. Repeat as needed.\n\
+     Values parse as true/false, bare ints, bare floats, otherwise strings.";
+
+fn parse_config_value(raw: &str) -> JsonValue {
+    if raw.eq_ignore_ascii_case("true") {
+        return JsonValue::Bool(true);
+    }
+
+    if raw.eq_ignore_ascii_case("false") {
+        return JsonValue::Bool(false);
+    }
+
+    if let Ok(value) = raw.parse::<i32>() {
+        return JsonValue::Number(value.into());
+    }
+
+    if let Ok(value) = raw.parse::<f64>()
+        && let Some(number) = serde_json::Number::from_f64(value)
+    {
+        return JsonValue::Number(number);
+    }
+
+    JsonValue::String(raw.to_string())
+}
+
+pub fn parse_config_overrides(raw_configs: &[String]) -> Result<SmallMap<String, JsonValue>> {
+    let mut parsed = SmallMap::new();
+
+    for raw in raw_configs {
+        let Some((key, value)) = raw.split_once('=') else {
+            bail!("Invalid --config '{raw}'. Expected key=value");
+        };
+
+        if key.is_empty() {
+            bail!("Invalid --config '{raw}'. Key cannot be empty");
+        }
+
+        parsed.insert(key.to_string(), parse_config_value(value));
+    }
+
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_config_overrides;
+    use serde_json::Value as JsonValue;
+
+    #[test]
+    fn parse_config_overrides_converts_supported_scalars() {
+        let raw = vec![
+            "enabled=true".to_string(),
+            "count=42".to_string(),
+            "ratio=3.14".to_string(),
+            "voltage=5V".to_string(),
+            "enum_value=YES".to_string(),
+        ];
+
+        let parsed = parse_config_overrides(&raw).expect("config overrides should parse");
+
+        assert_eq!(parsed.get("enabled"), Some(&JsonValue::Bool(true)));
+        assert_eq!(parsed.get("count"), Some(&JsonValue::Number(42.into())));
+        assert_eq!(
+            parsed.get("ratio"),
+            Some(&JsonValue::Number(
+                serde_json::Number::from_f64(3.14).expect("finite float")
+            ))
+        );
+        assert_eq!(
+            parsed.get("voltage"),
+            Some(&JsonValue::String("5V".to_string()))
+        );
+        assert_eq!(
+            parsed.get("enum_value"),
+            Some(&JsonValue::String("YES".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_config_overrides_requires_key_value_syntax() {
+        let err = parse_config_overrides(&["missing_separator".to_string()])
+            .expect_err("missing separator should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid --config 'missing_separator'. Expected key=value"
+        );
+    }
+}

--- a/crates/pcb/src/config_input.rs
+++ b/crates/pcb/src/config_input.rs
@@ -3,29 +3,7 @@ use serde_json::Value as JsonValue;
 use starlark::collections::SmallMap;
 
 pub const CONFIG_ARG_HELP: &str = "Override root config() parameters. Repeat as needed.\n\
-     Values parse as true/false, bare ints, bare floats, otherwise strings.";
-
-fn parse_config_value(raw: &str) -> JsonValue {
-    if raw.eq_ignore_ascii_case("true") {
-        return JsonValue::Bool(true);
-    }
-
-    if raw.eq_ignore_ascii_case("false") {
-        return JsonValue::Bool(false);
-    }
-
-    if let Ok(value) = raw.parse::<i32>() {
-        return JsonValue::Number(value.into());
-    }
-
-    if let Ok(value) = raw.parse::<f64>()
-        && let Some(number) = serde_json::Number::from_f64(value)
-    {
-        return JsonValue::Number(number);
-    }
-
-    JsonValue::String(raw.to_string())
-}
+     Values are passed as strings and coerced by config() based on the declared parameter type.";
 
 pub fn parse_config_overrides(raw_configs: &[String]) -> Result<SmallMap<String, JsonValue>> {
     let mut parsed = SmallMap::new();
@@ -39,7 +17,7 @@ pub fn parse_config_overrides(raw_configs: &[String]) -> Result<SmallMap<String,
             bail!("Invalid --config '{raw}'. Key cannot be empty");
         }
 
-        parsed.insert(key.to_string(), parse_config_value(value));
+        parsed.insert(key.to_string(), JsonValue::String(value.to_string()));
     }
 
     Ok(parsed)
@@ -51,33 +29,32 @@ mod tests {
     use serde_json::Value as JsonValue;
 
     #[test]
-    fn parse_config_overrides_converts_supported_scalars() {
+    fn parse_config_overrides_preserves_values_as_strings() {
         let raw = vec![
             "enabled=true".to_string(),
             "count=42".to_string(),
             "ratio=3.14".to_string(),
             "voltage=5V".to_string(),
             "enum_value=YES".to_string(),
+            "package=0402".to_string(),
         ];
 
         let parsed = parse_config_overrides(&raw).expect("config overrides should parse");
 
-        assert_eq!(parsed.get("enabled"), Some(&JsonValue::Bool(true)));
-        assert_eq!(parsed.get("count"), Some(&JsonValue::Number(42.into())));
-        assert_eq!(
-            parsed.get("ratio"),
-            Some(&JsonValue::Number(
-                serde_json::Number::from_f64(3.14).expect("finite float")
-            ))
-        );
-        assert_eq!(
-            parsed.get("voltage"),
-            Some(&JsonValue::String("5V".to_string()))
-        );
-        assert_eq!(
-            parsed.get("enum_value"),
-            Some(&JsonValue::String("YES".to_string()))
-        );
+        for (key, value) in [
+            ("enabled", "true"),
+            ("count", "42"),
+            ("ratio", "3.14"),
+            ("voltage", "5V"),
+            ("enum_value", "YES"),
+            ("package", "0402"),
+        ] {
+            assert_eq!(
+                parsed.get(key),
+                Some(&JsonValue::String(value.to_string())),
+                "expected {key} to stay stringly"
+            );
+        }
     }
 
     #[test]

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -62,6 +62,7 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
 
     let Some(schematic) = build(
         zen_path,
+        Default::default(),
         create_diagnostics_passes(&args.suppress, &[]),
         false,
         &mut false.clone(),

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -14,6 +14,7 @@ mod bom;
 mod build;
 mod bundle;
 mod codegen;
+mod config_input;
 mod doc;
 mod drc;
 mod embed_step;

--- a/crates/pcb/src/mcp.rs
+++ b/crates/pcb/src/mcp.rs
@@ -432,6 +432,7 @@ fn run_layout(args: Option<Value>, ctx: &McpContext) -> Result<CallToolResult> {
     let mut has_warnings = false;
     let Some(schematic) = build(
         &zen_path,
+        Default::default(),
         create_diagnostics_passes(&[], &[]),
         false,
         &mut has_errors,

--- a/crates/pcb/src/open.rs
+++ b/crates/pcb/src/open.rs
@@ -29,7 +29,7 @@ pub fn execute(args: OpenArgs) -> Result<()> {
     let file_name = zen_path.file_name().unwrap().to_string_lossy();
 
     // Evaluate the zen file
-    let eval_result = pcb_zen::eval(zen_path, resolution_result);
+    let eval_result = pcb_zen::eval(zen_path, resolution_result, Default::default());
 
     let output = eval_result
         .output_result()

--- a/crates/pcb/src/package.rs
+++ b/crates/pcb/src/package.rs
@@ -341,7 +341,7 @@ fn resolve_package_layout_path(
     primary_zen: &Path,
     resolution: &ResolutionResult,
 ) -> Result<Option<PathBuf>> {
-    let eval_result = pcb_zen::eval(primary_zen, resolution.clone());
+    let eval_result = pcb_zen::eval(primary_zen, resolution.clone(), Default::default());
     let output = eval_result.output_result().map_err(|diagnostics| {
         let rendered_diagnostics = diagnostics
             .iter()
@@ -444,7 +444,7 @@ fn collect_bundle_resolved_paths(
     for zen_file in zen_files {
         let eval_result = {
             let _span = info_span!("eval_bundle_zen_file", path = %zen_file.display()).entered();
-            pcb_zen::eval(&zen_file, resolution.clone())
+            pcb_zen::eval(&zen_file, resolution.clone(), Default::default())
         };
         let pcb_zen::WithDiagnostics {
             diagnostics,

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -956,6 +956,7 @@ fn build_workspace(workspace: &WorkspaceInfo, suppress: &[String]) -> Result<()>
         let file_name = zen_path.file_name().unwrap().to_string_lossy();
         if let Some(schematic) = crate::build::build(
             zen_path,
+            Default::default(),
             crate::build::create_diagnostics_passes(suppress, &[]),
             false,
             &mut has_errors,

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -319,7 +319,7 @@ pub fn build_board_release(
 
         // Evaluate the zen file (still needed for schematic)
         // Pass resolution so Module() paths resolve correctly
-        let eval_result = pcb_zen::eval(&zen_path, resolution.clone());
+        let eval_result = pcb_zen::eval(&zen_path, resolution.clone(), Default::default());
 
         let has_eval_errors = eval_result.diagnostics.has_errors();
         if has_eval_errors || eval_result.output.is_none() {
@@ -724,6 +724,7 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<()> {
 
         let schematic = crate::build::build(
             &staged_zen_path,
+            Default::default(),
             passes,
             false, // don't deny warnings - we'll prompt user instead
             &mut has_errors,

--- a/crates/pcb/src/route.rs
+++ b/crates/pcb/src/route.rs
@@ -52,7 +52,8 @@ pub fn execute(args: RouteArgs) -> Result<()> {
     let board_name = zen_path.file_stem().unwrap().to_string_lossy();
 
     // Evaluate the .zen file to find the layout path
-    let (output, diagnostics) = pcb_zen::run(zen_path, resolution_result).unpack();
+    let (output, diagnostics) =
+        pcb_zen::run(zen_path, resolution_result, Default::default()).unpack();
 
     if diagnostics.has_errors() {
         anyhow::bail!("Failed to evaluate {}: build errors", zen_path.display());

--- a/crates/pcb/src/sim.rs
+++ b/crates/pcb/src/sim.rs
@@ -52,6 +52,7 @@ fn simulate_one(
 
     let Some(schematic) = build_zen(
         zen_path,
+        Default::default(),
         create_diagnostics_passes(&[], &[]),
         false,
         &mut false.clone(),

--- a/crates/pcb/src/test.rs
+++ b/crates/pcb/src/test.rs
@@ -86,7 +86,7 @@ pub fn test(
     let spinner = Spinner::builder(format!("{file_name}: Testing")).start();
 
     // Evaluate the design (use eval() not run() to get EvalOutput and collect TestBenches)
-    let eval_result = pcb_zen::eval(zen_path, resolution_result);
+    let eval_result = pcb_zen::eval(zen_path, resolution_result, Default::default());
 
     let mut diagnostics = eval_result.diagnostics;
 

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -197,6 +197,7 @@ Mode = enum("ONE", "TWO")
 enable_extra = config("enable_extra", bool, default=False)
 count = config("count", int, default=1)
 mode = config("mode", Mode, default=Mode("ONE"))
+package = config("package", str, default="0603")
 
 vcc = Power("VCC")
 gnd = Ground("GND")
@@ -205,16 +206,16 @@ for i in range(count):
     Resistor(
         name = "R{}".format(i + 1),
         value = "1kohm",
-        package = "0603",
+        package = package,
         P1 = vcc.NET,
         P2 = gnd.NET,
     )
 
 if enable_extra:
-    Resistor(name = "R_EXTRA", value = "2kohm", package = "0603", P1 = vcc.NET, P2 = gnd.NET)
+    Resistor(name = "R_EXTRA", value = "2kohm", package = package, P1 = vcc.NET, P2 = gnd.NET)
 
 if mode == Mode("TWO"):
-    Resistor(name = "R_MODE", value = "3kohm", package = "0603", P1 = vcc.NET, P2 = gnd.NET)
+    Resistor(name = "R_MODE", value = "3kohm", package = package, P1 = vcc.NET, P2 = gnd.NET)
 "#;
 
 #[test]
@@ -252,6 +253,8 @@ fn test_build_with_config_overrides() {
                 "count=2",
                 "--config",
                 "mode=TWO",
+                "--config",
+                "package=0402",
                 "board.zen",
             ],
         );

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -190,6 +190,33 @@ Part = Module("components/TestPart/Part.zen")
 Part(name = "U1", P1 = Net("A"), P2 = Net("B"))
 "#;
 
+const CONFIGURABLE_BUILD_ZEN: &str = r#"
+Resistor = Module("@stdlib/generics/Resistor.zen")
+Mode = enum("ONE", "TWO")
+
+enable_extra = config("enable_extra", bool, default=False)
+count = config("count", int, default=1)
+mode = config("mode", Mode, default=Mode("ONE"))
+
+vcc = Power("VCC")
+gnd = Ground("GND")
+
+for i in range(count):
+    Resistor(
+        name = "R{}".format(i + 1),
+        value = "1kohm",
+        package = "0603",
+        P1 = vcc.NET,
+        P2 = gnd.NET,
+    )
+
+if enable_extra:
+    Resistor(name = "R_EXTRA", value = "2kohm", package = "0603", P1 = vcc.NET, P2 = gnd.NET)
+
+if mode == Mode("TWO"):
+    Resistor(name = "R_MODE", value = "3kohm", package = "0603", P1 = vcc.NET, P2 = gnd.NET)
+"#;
+
 #[test]
 fn test_warning_and_error_mixed() {
     let mut sandbox = Sandbox::new();
@@ -209,6 +236,28 @@ fn test_warning_and_error_mixed() {
         .write("board.zen", WARNING_AND_ERROR_ZEN)
         .snapshot_run("pcb", ["build", "board.zen"]);
     assert_snapshot!("warning_and_error_mixed", output);
+}
+
+#[test]
+fn test_build_with_config_overrides() {
+    let output = Sandbox::new()
+        .write("board.zen", CONFIGURABLE_BUILD_ZEN)
+        .snapshot_run(
+            "pcb",
+            [
+                "build",
+                "--config",
+                "enable_extra=true",
+                "--config",
+                "count=2",
+                "--config",
+                "mode=TWO",
+                "board.zen",
+            ],
+        );
+
+    assert!(output.contains("Exit Code: 0"), "{output}");
+    assert!(output.contains("(4 components)"), "{output}");
 }
 
 #[test]

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -222,7 +222,7 @@ alias = Net("CLK")  # name is "CLK", not "alias"
 Net()               # uses an auto-generated name
 ```
 
-Typed net fields validate against their declared field type and apply the same physical-value coercion used by module inputs, so `Power("VCC", voltage="3.3V")` is equivalent to `Power("VCC", voltage=Voltage("3.3V"))`.
+Typed net fields validate against their declared field type and use the same string coercions as module inputs, so `Power("VCC", voltage="3.3V")` is equivalent to `Power("VCC", voltage=Voltage("3.3V"))`.
 
 Net types follow automatic conversion rules across `io()` boundaries: `NotConnected` promotes to any type (universal donor), any specialized type demotes to `Net`, but `Net` cannot automatically promote to specialized types. For explicit casting, call the target constructor with an existing net: `Power(net, voltage=Voltage("3.3V"))` or `Net(power_net)`.
 
@@ -480,7 +480,7 @@ package = config("package", Package, default=Package("0603"))
 voltage = config("voltage", Voltage, optional=True)
 ```
 
-Values passed by the parent are automatically converted to the declared type when possible — strings become physical quantities (`"10k"` → `Resistance("10k")`), enum variants (`"0603"` → `Package("0603")`), etc. This is why `Resistor(name="R1", value="10k", package="0603", ...)` works even though `value` expects `Resistance` and `package` expects `Package`.
+Values passed by the parent are automatically converted to the declared type when possible. String inputs can coerce to primitives (`"true"` → `True`, `"42"` → `42`, `"3.3"` → `3.3`), physical quantities (`"10k"` → `Resistance("10k")`), and enum variants (`"0603"` → `Package("0603")`). This is why `Resistor(name="R1", value="10k", package="0603", ...)` works even though `value` expects `Resistance` and `package` expects `Package`.
 
 ### Writing a Module
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new input path into the evaluator and extends implicit type coercion (string→bool/int/float), which could change runtime behavior for existing builds if callers start passing inputs or rely on previous conversion failures.
> 
> **Overview**
> **Adds repeatable `--config KEY=VALUE` overrides to the CLI** for `pcb build` (and `pcb bom`), parsing overrides as string values and passing them into Zen evaluation as JSON inputs.
> 
> **Extends the `pcb_zen` evaluation API** (`eval`/`run`) to accept an inputs map and threads it through build flows and tests, alongside a small `EvalContext` refactor to lazily create/reuse the internal context value.
> 
> **Improves implicit type conversion** so string inputs can coerce to `bool`, `int`, and `float` (in addition to existing enum/net/physical conversions), and updates docs/changelog plus adds a CLI integration test covering config overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518669b52c284ac74f083fa88d4c6ab11ea0c015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
