### PR TITLE
Infer `config()` and `io()` names from assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Net type physical-value fields now coerce string and scalar inputs like `io()`/`config()`.
 - Unnamed `Net()`/typed nets and generated interface child nets now infer names from assignment targets when possible.
 - Add `io()` direction metadata plus `input()` / `output()` sugar.
+- `config()`, `io()`, `input()`, and `output()` now allow omitting the explicit name when assigned to a top-level variable.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 [[package]]
 name = "allocative"
 version = "0.3.4"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "allocative_derive",
  "bumpalo",
@@ -83,7 +83,7 @@ dependencies = [
 [[package]]
 name = "allocative_derive"
 version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 
 [[package]]
 name = "collection_literals"
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "either",
  "indenter",
@@ -1574,9 +1574,9 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
- "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e)",
+ "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
 ]
 
 [[package]]
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6506,7 +6506,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "starlark"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "allocative",
  "anyhow",
@@ -6515,8 +6515,8 @@ dependencies = [
  "debugserver-types",
  "derivative",
  "derive_more 1.0.0",
- "display_container 0.9.0 (git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e)",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e)",
+ "display_container 0.9.0 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
  "either",
  "erased-serde",
  "hashbrown 0.14.5",
@@ -6546,9 +6546,9 @@ dependencies = [
 [[package]]
 name = "starlark_derive"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -6557,10 +6557,10 @@ dependencies = [
 [[package]]
 name = "starlark_map"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "allocative",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
  "equivalent",
  "fxhash",
  "hashbrown 0.14.5",
@@ -6571,14 +6571,14 @@ dependencies = [
 [[package]]
 name = "starlark_syntax"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "allocative",
  "annotate-snippets",
  "anyhow",
  "derivative",
  "derive_more 1.0.0",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -6627,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "strong_hash"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "ref-cast",
  "strong_hash_derive",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "strong_hash_derive"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=41c8e1b317996a7b71f482886e66f89aa006272e#41c8e1b317996a7b71f482886e66f89aa006272e"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
 dependencies = [
  "quote",
  "syn 2.0.104",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 [[package]]
 name = "allocative"
 version = "0.3.4"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "allocative_derive",
  "bumpalo",
@@ -83,7 +83,7 @@ dependencies = [
 [[package]]
 name = "allocative_derive"
 version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 
 [[package]]
 name = "collection_literals"
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "either",
  "indenter",
@@ -1574,9 +1574,9 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
- "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
+ "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94)",
 ]
 
 [[package]]
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6506,7 +6506,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "starlark"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "allocative",
  "anyhow",
@@ -6515,8 +6515,8 @@ dependencies = [
  "debugserver-types",
  "derivative",
  "derive_more 1.0.0",
- "display_container 0.9.0 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
+ "display_container 0.9.0 (git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94)",
  "either",
  "erased-serde",
  "hashbrown 0.14.5",
@@ -6546,9 +6546,9 @@ dependencies = [
 [[package]]
 name = "starlark_derive"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94)",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -6557,10 +6557,10 @@ dependencies = [
 [[package]]
 name = "starlark_map"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "allocative",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94)",
  "equivalent",
  "fxhash",
  "hashbrown 0.14.5",
@@ -6571,14 +6571,14 @@ dependencies = [
 [[package]]
 name = "starlark_syntax"
 version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "allocative",
  "annotate-snippets",
  "anyhow",
  "derivative",
  "derive_more 1.0.0",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94)",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -6627,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "strong_hash"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "ref-cast",
  "strong_hash_derive",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "strong_hash_derive"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=be171dcffa01b85d8827e3fa1e2afe7c638ceabe#be171dcffa01b85d8827e3fa1e2afe7c638ceabe"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=78a00c907de1f31ec4edee929447459612da9c94#78a00c907de1f31ec4edee929447459612da9c94"
 dependencies = [
  "quote",
  "syn 2.0.104",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ authors = ["Diode Computers, Inc. <founders@diode.computer>"]
 
 [workspace.dependencies]
 glam = "0.31.0"
-starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "41c8e1b317996a7b71f482886e66f89aa006272e" }
-starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "41c8e1b317996a7b71f482886e66f89aa006272e" }
-starlark_derive = { git = "https://github.com/diodeinc/starlark-rust", rev = "41c8e1b317996a7b71f482886e66f89aa006272e" }
-starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "41c8e1b317996a7b71f482886e66f89aa006272e" }
-allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "41c8e1b317996a7b71f482886e66f89aa006272e" }
+starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
+starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
+starlark_derive = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
+starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
+allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
 
 ruff_python_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.13.0" }
 ruff_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.13.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ authors = ["Diode Computers, Inc. <founders@diode.computer>"]
 
 [workspace.dependencies]
 glam = "0.31.0"
-starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
-starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
-starlark_derive = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
-starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
-allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "be171dcffa01b85d8827e3fa1e2afe7c638ceabe" }
+starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "78a00c907de1f31ec4edee929447459612da9c94" }
+starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "78a00c907de1f31ec4edee929447459612da9c94" }
+starlark_derive = { git = "https://github.com/diodeinc/starlark-rust", rev = "78a00c907de1f31ec4edee929447459612da9c94" }
+starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "78a00c907de1f31ec4edee929447459612da9c94" }
+allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "78a00c907de1f31ec4edee929447459612da9c94" }
 
 ruff_python_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.13.0" }
 ruff_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.13.0" }

--- a/crates/pcb-zen-core/src/lang/builtin.rs
+++ b/crates/pcb-zen-core/src/lang/builtin.rs
@@ -8,7 +8,7 @@ use starlark::{
     any::ProvidesStaticType,
     collections::SmallMap,
     environment::{GlobalsBuilder, Methods, MethodsBuilder, MethodsStatic},
-    eval::Evaluator,
+    eval::{Arguments, Evaluator},
     starlark_module, starlark_simple_value,
     values::{
         Freeze, StarlarkValue, Value,
@@ -22,8 +22,8 @@ use starlark::{
 use crate::{
     attrs,
     lang::{
-        evaluator_ext::EvaluatorExt, io_direction::IoDirection, module::declare_io, net::*,
-        part::PartValue, stackup::BoardConfig,
+        evaluator_ext::EvaluatorExt, net::*, param_decl::invoke_builtin_io, part::PartValue,
+        stackup::BoardConfig,
     },
 };
 
@@ -156,29 +156,12 @@ fn builtin_methods(methods: &mut MethodsBuilder) {
         Ok(eval.heap().alloc(net_type))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn io<'v>(
         #[allow(unused_variables)] this: &Builtin,
-        #[starlark(require = pos)] name: String,
-        #[starlark(require = pos)] typ: Value<'v>,
-        #[starlark(default = NoneOr::None)] checks: NoneOr<Value<'v>>,
-        #[starlark(require = named, default = NoneOr::None)] default: NoneOr<Value<'v>>,
-        #[starlark(require = named)] optional: Option<bool>,
-        #[starlark(require = named, default = NoneOr::None)] help: NoneOr<String>,
-        #[starlark(require = named, default = NoneOr::None)] direction: NoneOr<String>,
+        args: &Arguments<'v, '_>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> starlark::Result<Value<'v>> {
-        let direction = IoDirection::parse_optional(direction.into_option().as_deref())?;
-        declare_io(
-            name,
-            typ,
-            checks.into_option(),
-            default.into_option(),
-            optional,
-            help.into_option(),
-            direction,
-            eval,
-        )
+        invoke_builtin_io(args, eval)
     }
 
     #[allow(non_snake_case)]

--- a/crates/pcb-zen-core/src/lang/mod.rs
+++ b/crates/pcb-zen-core/src/lang/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod interface;
 pub mod io_direction;
 pub mod module;
 pub mod net;
+pub(crate) mod param_decl;
 pub mod part;
 pub(crate) mod path;
 pub mod spice_model;

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -37,6 +37,7 @@ use crate::lang::interface::{
     FrozenInterfaceFactory, FrozenInterfaceValue, InterfaceFactory, InterfaceValue,
 };
 use crate::lang::naming;
+use crate::lang::param_decl::invoke_config;
 use crate::lang::validation::validate_identifier_name;
 use regex::Regex;
 use starlark::codemap::{CodeMap, Pos, ResolvedSpan, Span};
@@ -248,7 +249,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[error("Input '{name}' is required but was not provided")]
 pub struct MissingInputError {
-    name: String,
+    pub(crate) name: String,
 }
 
 impl From<MissingInputError> for starlark::Error {
@@ -340,9 +341,79 @@ fn is_io_wrapper_path(path: &str) -> bool {
     normalized == "stdlib/io.zen" || normalized.ends_with("/stdlib/io.zen")
 }
 
-fn io_declaration_site(
-    eval: &Evaluator<'_, '_, '_>,
-) -> (String, Option<ResolvedSpan>, starlark::eval::CallStack) {
+#[derive(Debug, Clone, Trace, Allocative)]
+pub(crate) struct DeclarationSite {
+    pub(crate) path: String,
+    #[allocative(skip)]
+    pub(crate) span: Option<ResolvedSpan>,
+    #[allocative(skip)]
+    pub(crate) call_stack: starlark::eval::CallStack,
+}
+
+pub(crate) struct ParameterMetadataInput<'v> {
+    pub(crate) typ: Value<'v>,
+    pub(crate) optional: bool,
+    pub(crate) default: Option<Value<'v>>,
+    pub(crate) is_config: bool,
+    pub(crate) help: Option<String>,
+    pub(crate) direction: Option<IoDirection>,
+    pub(crate) actual_value: Value<'v>,
+}
+
+pub(crate) fn current_declaration_site(eval: &Evaluator<'_, '_, '_>) -> DeclarationSite {
+    let (path, span) = eval
+        .call_stack_top_location()
+        .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
+        .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
+    DeclarationSite {
+        path,
+        span,
+        call_stack: eval.call_stack().clone(),
+    }
+}
+
+pub(crate) fn record_parameter_metadata<'v>(
+    name: &str,
+    metadata: ParameterMetadataInput<'v>,
+    declaration_site: &DeclarationSite,
+    eval: &mut Evaluator<'v, '_, '_>,
+) {
+    if let Some(ctx) = eval.context_value() {
+        let mut module = ctx.module_mut();
+        module.add_parameter_metadata(
+            name.to_owned(),
+            metadata.typ,
+            metadata.optional,
+            metadata.default,
+            metadata.is_config,
+            metadata.help.clone(),
+            metadata.direction,
+            Some(metadata.actual_value),
+            declaration_site.span,
+            declaration_site.call_stack.clone(),
+        );
+    }
+
+    let diag = if metadata.is_config {
+        naming::check_config_naming(
+            name,
+            declaration_site.span,
+            Path::new(&declaration_site.path),
+        )
+    } else {
+        naming::check_io_naming(
+            name,
+            declaration_site.span,
+            Path::new(&declaration_site.path),
+        )
+    };
+
+    if let Some(diag) = diag {
+        eval.add_diagnostic(diag);
+    }
+}
+
+pub(crate) fn io_declaration_site(eval: &Evaluator<'_, '_, '_>) -> DeclarationSite {
     let original_call_stack = eval.call_stack().clone();
     let mut declaration_call_stack = original_call_stack.clone();
     declaration_call_stack.frames.retain(|frame| {
@@ -376,7 +447,11 @@ fn io_declaration_site(
         .unwrap_or_else(|| eval.source_path().unwrap_or_default());
     let span = declaration_location.map(|loc| loc.resolve_span());
 
-    (path, span, declaration_call_stack)
+    DeclarationSite {
+        path,
+        span,
+        call_stack: declaration_call_stack,
+    }
 }
 
 #[derive(Clone, Coerce, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
@@ -1108,7 +1183,7 @@ where
 }
 
 // Helper: given a Starlark `typ` value build a sensible default instance of that type.
-fn default_for_type<'v>(
+pub(crate) fn default_for_type<'v>(
     eval: &mut Evaluator<'v, '_, '_>,
     typ: Value<'v>,
 ) -> anyhow::Result<Value<'v>> {
@@ -1327,7 +1402,7 @@ fn validate_type<'v>(
     );
 }
 
-fn validate_or_convert<'v>(
+pub(crate) fn validate_or_convert<'v>(
     name: &str,
     value: Value<'v>,
     typ: Value<'v>,
@@ -1365,7 +1440,7 @@ fn validate_or_convert<'v>(
 }
 
 /// Generate default value for io() parameters, optionally registering nets
-fn io_generated_default<'v>(
+pub(crate) fn io_generated_default<'v>(
     eval: &mut Evaluator<'v, '_, '_>,
     typ: Value<'v>,
     name: &str,
@@ -1401,7 +1476,7 @@ fn io_generated_default<'v>(
 }
 
 /// Run check functions on a value
-fn run_checks<'v>(
+pub(crate) fn run_checks<'v>(
     eval: &mut Evaluator<'v, '_, '_>,
     checks: Option<Value<'v>>,
     value: Value<'v>,
@@ -1718,111 +1793,11 @@ pub fn module_globals(builder: &mut GlobalsBuilder) {
 
     /// Declare a configuration value requirement. Works analogously to `io()` but typically
     /// used for primitive types coming from user configuration.
-    #[allow(clippy::too_many_arguments)]
     fn config<'v>(
-        #[starlark(require = pos)] name: String,
-        #[starlark(require = pos)] typ: Value<'v>,
-        checks: Option<Value<'v>>, // list of check functions to run on the value
-        #[starlark(require = named)] default: Option<Value<'v>>,
-        #[starlark(require = named)] convert: Option<Value<'v>>,
-        #[starlark(require = named)] optional: Option<bool>,
-        #[starlark(require = named)] help: Option<String>,
+        args: &Arguments<'v, '_>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> starlark::Result<Value<'v>> {
-        // Warn if deprecated `convert` parameter is used
-        if convert.is_some() {
-            let (path, span) = eval
-                .call_stack_top_location()
-                .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
-                .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
-            let msg =
-                "config() parameter `convert` is deprecated and will be removed in a future release"
-                    .to_string();
-            let mut diag = EvalMessage::from_any_error(Path::new(&path), &msg);
-            diag.span = span;
-            diag.severity = starlark::errors::EvalSeverity::Warning;
-            eval.add_diagnostic(diag);
-        }
-
-        // Config defaults imply optional input unless explicitly overridden.
-        let is_optional = optional.unwrap_or(default.is_some());
-
-        // Compute the actual value
-        let result_value = if let Some(provided) = eval.request_input(&name)? {
-            // Value provided - validate/convert it
-            validate_or_convert(&name, provided, typ, convert, eval)?
-        } else if is_optional {
-            // Optional parameter with no provided value
-            if let Some(default_val) = default {
-                validate_or_convert(&name, default_val, typ, convert, eval)?
-            } else {
-                Value::new_none()
-            }
-        } else {
-            // Required parameter with no provided value
-            let strict = eval
-                .context_value()
-                .map(|ctx| ctx.strict_io_config())
-                .unwrap_or(false);
-
-            if strict {
-                if let Some(ctx) = eval.context_value() {
-                    ctx.add_missing_input(name.clone());
-                }
-
-                let (path, span) = eval
-                    .call_stack_top_location()
-                    .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
-                    .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
-                let mut diag = EvalMessage::from_any_error(
-                    Path::new(&path),
-                    &MissingInputError { name: name.clone() }.to_string(),
-                );
-                diag.span = span;
-                eval.add_diagnostic(diag);
-            }
-
-            // Use default or generate one
-            if let Some(default_val) = default {
-                validate_or_convert(&name, default_val, typ, convert, eval)?
-            } else {
-                let gen_value = default_for_type(eval, typ)?;
-                validate_or_convert(&name, gen_value, typ, convert, eval)?
-            }
-        };
-
-        // Run checks
-        run_checks(eval, checks, result_value)?;
-
-        let (path, span) = eval
-            .call_stack_top_location()
-            .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
-            .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
-        let declaration_call_stack = eval.call_stack().clone();
-
-        // Record metadata
-        if let Some(ctx) = eval.context_value() {
-            let mut module = ctx.module_mut();
-            module.add_parameter_metadata(
-                name.clone(),
-                typ,
-                is_optional,
-                default,
-                true, // is_config
-                help,
-                None,
-                Some(result_value),
-                span,
-                declaration_call_stack,
-            );
-        }
-
-        // Check naming convention (config parameters should be snake_case)
-        if let Some(diag) = naming::check_config_naming(&name, span, Path::new(&path)) {
-            eval.add_diagnostic(diag);
-        }
-
-        Ok(result_value)
+        invoke_config(args, eval)
     }
 
     fn add_property<'v>(
@@ -1846,93 +1821,4 @@ pub fn module_globals(builder: &mut GlobalsBuilder) {
         }
         Ok(Value::new_none())
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn declare_io<'v>(
-    name: String,
-    typ: Value<'v>,
-    checks: Option<Value<'v>>,
-    default: Option<Value<'v>>,
-    optional: Option<bool>,
-    help: Option<String>,
-    direction: Option<IoDirection>,
-    eval: &mut Evaluator<'v, '_, '_>,
-) -> starlark::Result<Value<'v>> {
-    let type_name = typ.get_type();
-    if !matches!(type_name, "NetType" | "InterfaceFactory") {
-        return Err(anyhow::anyhow!(
-            "builtin.io() requires a Net or interface type, got {type_name}."
-        )
-        .into());
-    }
-
-    let is_optional = optional.unwrap_or(false);
-
-    let compute_default = |eval: &mut Evaluator<'v, '_, '_>,
-                           for_metadata_only: bool|
-     -> starlark::Result<Value<'v>> {
-        if let Some(explicit_default) = default {
-            let converted = validate_or_convert(&name, explicit_default, typ, None, eval)?;
-            Ok(converted)
-        } else if matches!(typ.get_type(), "NetType" | "InterfaceFactory") {
-            io_generated_default(eval, typ, &name, for_metadata_only)
-        } else {
-            Ok(default_for_type(eval, typ)?)
-        }
-    };
-
-    let (result_value, default_for_metadata) = if let Some(provided) = eval.request_input(&name)? {
-        let value = validate_or_convert(&name, provided, typ, None, eval)?;
-        let metadata_default = compute_default(eval, true)?;
-        (value, Some(metadata_default))
-    } else if is_optional {
-        let default_val = compute_default(eval, false)?;
-        if matches!(typ.get_type(), "NetType" | "InterfaceFactory") {
-            (default_val, Some(default_val))
-        } else {
-            (Value::new_none(), Some(default_val))
-        }
-    } else {
-        let strict = eval
-            .context_value()
-            .map(|ctx| ctx.strict_io_config())
-            .unwrap_or(false);
-
-        if strict {
-            if let Some(ctx) = eval.context_value() {
-                ctx.add_missing_input(name.clone());
-            }
-            return Err(MissingInputError { name: name.clone() }.into());
-        }
-
-        let default_val = compute_default(eval, false)?;
-        (default_val, Some(default_val))
-    };
-
-    run_checks(eval, checks, result_value)?;
-
-    let (path, span, declaration_call_stack) = io_declaration_site(eval);
-
-    if let Some(ctx) = eval.context_value() {
-        let mut module = ctx.module_mut();
-        module.add_parameter_metadata(
-            name.clone(),
-            typ,
-            is_optional,
-            default_for_metadata,
-            false,
-            help,
-            direction,
-            Some(result_value),
-            span,
-            declaration_call_stack,
-        );
-    }
-
-    if let Some(diag) = naming::check_io_naming(&name, span, Path::new(&path)) {
-        eval.add_diagnostic(diag);
-    }
-
-    Ok(result_value)
 }

--- a/crates/pcb-zen-core/src/lang/param_decl.rs
+++ b/crates/pcb-zen-core/src/lang/param_decl.rs
@@ -243,6 +243,7 @@ fn parse_decl_args<'v>(
         }
         _ => unreachable!(),
     };
+    let positional_checks = positional_checks.and_then(none_if_none);
 
     if checks.is_some() && positional_checks.is_some() {
         return Err(starlark::Error::new_other(anyhow::anyhow!(

--- a/crates/pcb-zen-core/src/lang/param_decl.rs
+++ b/crates/pcb-zen-core/src/lang/param_decl.rs
@@ -1,0 +1,469 @@
+use std::fmt::Display;
+use std::path::Path;
+
+use allocative::Allocative;
+use starlark::{
+    any::ProvidesStaticType,
+    eval::{Arguments, Evaluator},
+    values::{Freeze, Heap, NoSerialize, StarlarkValue, Trace, Value, starlark_value},
+};
+
+use crate::lang::{evaluator_ext::EvaluatorExt, io_direction::IoDirection};
+
+use super::module::{
+    DeclarationSite, MissingInputError, ParameterMetadataInput, current_declaration_site,
+    default_for_type, io_declaration_site, io_generated_default, record_parameter_metadata,
+    run_checks, validate_or_convert,
+};
+
+#[derive(Debug, Clone, Trace, Allocative)]
+struct DeclArgs<'v> {
+    typ: Value<'v>,
+    checks: Option<Value<'v>>,
+    default: Option<Value<'v>>,
+    convert: Option<Value<'v>>,
+    optional: Option<bool>,
+    help: Option<String>,
+    direction: Option<IoDirection>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Trace, Allocative)]
+enum ParamKind {
+    Config,
+    Io,
+}
+
+impl ParamKind {
+    fn kind_name(self) -> &'static str {
+        match self {
+            ParamKind::Config => "config",
+            ParamKind::Io => "io",
+        }
+    }
+
+    fn repr(self) -> &'static str {
+        match self {
+            ParamKind::Config => "config(...)",
+            ParamKind::Io => "io(...)",
+        }
+    }
+
+    fn allows_convert(self) -> bool {
+        matches!(self, ParamKind::Config)
+    }
+
+    fn allows_direction(self) -> bool {
+        matches!(self, ParamKind::Io)
+    }
+
+    fn unresolved_error(self) -> &'static str {
+        match self {
+            ParamKind::Config => {
+                "config() without an explicit name must be assigned to a top-level variable"
+            }
+            ParamKind::Io => {
+                "io() without an explicit name must be assigned to a top-level variable"
+            }
+        }
+    }
+
+    fn declaration_site(self, eval: &Evaluator<'_, '_, '_>) -> DeclarationSite {
+        match self {
+            ParamKind::Config => current_declaration_site(eval),
+            ParamKind::Io => io_declaration_site(eval),
+        }
+    }
+
+    fn resolve<'v>(
+        self,
+        variable_name: &str,
+        args: &DeclArgs<'v>,
+        declaration_site: &DeclarationSite,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> starlark::Result<Value<'v>> {
+        match self {
+            ParamKind::Config => resolve_config(variable_name, args, declaration_site, eval),
+            ParamKind::Io => resolve_io(variable_name, args, declaration_site, eval),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Trace, ProvidesStaticType, NoSerialize, Allocative)]
+#[repr(C)]
+struct DeferredParam<'v> {
+    kind: ParamKind,
+    args: DeclArgs<'v>,
+    declaration_site: DeclarationSite,
+}
+
+impl<'v> starlark::values::AllocValue<'v> for DeferredParam<'v> {
+    fn alloc_value(self, heap: &'v Heap) -> Value<'v> {
+        heap.alloc_complex(self)
+    }
+}
+
+impl<'v> Freeze for DeferredParam<'v> {
+    type Frozen = starlark::values::none::NoneType;
+
+    fn freeze(
+        self,
+        _freezer: &starlark::values::Freezer,
+    ) -> starlark::values::FreezeResult<Self::Frozen> {
+        Err(starlark::values::FreezeError::new(
+            self.kind.unresolved_error().to_owned(),
+        ))
+    }
+}
+
+impl<'v> Display for DeferredParam<'v> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.kind.repr())
+    }
+}
+
+#[starlark_value(type = "DeferredParameter")]
+impl<'v> StarlarkValue<'v> for DeferredParam<'v>
+where
+    Self: ProvidesStaticType<'v>,
+{
+    fn export_as(
+        &self,
+        variable_name: &str,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> starlark::Result<()> {
+        let value = self
+            .kind
+            .resolve(variable_name, &self.args, &self.declaration_site, eval)?;
+        eval.set_export_as_replacement(value)?;
+        Ok(())
+    }
+
+    fn collect_repr(&self, collector: &mut String) {
+        collector.push_str(self.kind.repr());
+    }
+}
+
+fn unpack_bool_arg(value: Value<'_>, function: &str, parameter: &str) -> starlark::Result<bool> {
+    value.unpack_bool().ok_or_else(|| {
+        starlark::Error::new_other(anyhow::anyhow!("{function}() `{parameter}` must be a bool"))
+    })
+}
+
+fn unpack_string_arg(
+    value: Value<'_>,
+    function: &str,
+    parameter: &str,
+) -> starlark::Result<String> {
+    value.unpack_str().map(str::to_owned).ok_or_else(|| {
+        starlark::Error::new_other(anyhow::anyhow!(
+            "{function}() `{parameter}` must be a string"
+        ))
+    })
+}
+
+fn unpack_optional_string_arg(
+    value: Value<'_>,
+    function: &str,
+    parameter: &str,
+) -> starlark::Result<Option<String>> {
+    if value.is_none() {
+        Ok(None)
+    } else {
+        unpack_string_arg(value, function, parameter).map(Some)
+    }
+}
+
+fn none_if_none(value: Value<'_>) -> Option<Value<'_>> {
+    (!value.is_none()).then_some(value)
+}
+
+fn parse_decl_args<'v>(
+    kind: ParamKind,
+    args: &Arguments<'v, '_>,
+    heap: &'v Heap,
+) -> starlark::Result<(Option<String>, DeclArgs<'v>)> {
+    let function = kind.kind_name();
+    let positional_values: Vec<Value<'v>> = args.positions(heap)?.collect();
+    if positional_values.is_empty() || positional_values.len() > 3 {
+        return Err(starlark::Error::new_other(anyhow::anyhow!(
+            "{function}() accepts `{function}(name, typ, checks?)` or `{function}(typ, checks?)`"
+        )));
+    }
+
+    let mut default = None;
+    let mut checks = None;
+    let mut convert = None;
+    let mut optional = None;
+    let mut help = None;
+    let mut direction = None;
+
+    for (arg_name, value) in args.names_map()? {
+        match arg_name.as_str() {
+            "checks" => checks = none_if_none(value),
+            "default" => default = none_if_none(value),
+            "convert" if kind.allows_convert() => convert = none_if_none(value),
+            "optional" => optional = Some(unpack_bool_arg(value, function, "optional")?),
+            "help" => help = unpack_optional_string_arg(value, function, "help")?,
+            "direction" if kind.allows_direction() => {
+                direction = IoDirection::parse_optional(
+                    unpack_optional_string_arg(value, function, "direction")?.as_deref(),
+                )?
+            }
+            other => {
+                return Err(starlark::Error::new_other(anyhow::anyhow!(
+                    "{function}() got unexpected named argument `{other}`"
+                )));
+            }
+        }
+    }
+
+    let (name, typ, positional_checks) = match positional_values.as_slice() {
+        [name_or_type] => {
+            if name_or_type.unpack_str().is_some() {
+                return Err(starlark::Error::new_other(anyhow::anyhow!(
+                    "{function}(name, ...) requires a type as the second positional argument"
+                )));
+            }
+            (None, *name_or_type, None)
+        }
+        [name_or_type, second] => {
+            if let Some(name) = name_or_type.unpack_str() {
+                (Some(name.to_owned()), *second, None)
+            } else {
+                (None, *name_or_type, Some(*second))
+            }
+        }
+        [name_or_type, typ, checks] => {
+            let Some(name) = name_or_type.unpack_str() else {
+                return Err(starlark::Error::new_other(anyhow::anyhow!(
+                    "{function}(typ, checks) accepts at most two positional arguments"
+                )));
+            };
+            (Some(name.to_owned()), *typ, Some(*checks))
+        }
+        _ => unreachable!(),
+    };
+
+    if checks.is_some() && positional_checks.is_some() {
+        return Err(starlark::Error::new_other(anyhow::anyhow!(
+            "{function}() got `checks` both positionally and by name"
+        )));
+    }
+
+    Ok((
+        name,
+        DeclArgs {
+            typ,
+            checks: checks.or(positional_checks),
+            default,
+            convert,
+            optional,
+            help,
+            direction,
+        },
+    ))
+}
+
+fn warn_deprecated_config_convert(
+    declaration_site: &DeclarationSite,
+    eval: &mut Evaluator<'_, '_, '_>,
+) {
+    let msg = "config() parameter `convert` is deprecated and will be removed in a future release"
+        .to_string();
+    let mut diag =
+        starlark::errors::EvalMessage::from_any_error(Path::new(&declaration_site.path), &msg);
+    diag.span = declaration_site.span;
+    diag.severity = starlark::errors::EvalSeverity::Warning;
+    eval.add_diagnostic(diag);
+}
+
+fn note_missing_input(name: &str, eval: &mut Evaluator<'_, '_, '_>) {
+    if let Some(ctx) = eval.context_value() {
+        ctx.add_missing_input(name.to_owned());
+    }
+}
+
+fn missing_input_diag(
+    name: &str,
+    declaration_site: &DeclarationSite,
+) -> starlark::errors::EvalMessage {
+    let mut diag = starlark::errors::EvalMessage::from_any_error(
+        Path::new(&declaration_site.path),
+        &MissingInputError {
+            name: name.to_owned(),
+        }
+        .to_string(),
+    );
+    diag.span = declaration_site.span;
+    diag
+}
+
+fn strict_io_config(eval: &mut Evaluator<'_, '_, '_>) -> bool {
+    eval.context_value()
+        .map(|ctx| ctx.strict_io_config())
+        .unwrap_or(false)
+}
+
+fn finish_resolution<'v>(
+    name: &str,
+    args: &DeclArgs<'v>,
+    metadata: ParameterMetadataInput<'v>,
+    declaration_site: &DeclarationSite,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> starlark::Result<Value<'v>> {
+    let actual_value = metadata.actual_value;
+    run_checks(eval, args.checks, actual_value)?;
+    record_parameter_metadata(name, metadata, declaration_site, eval);
+    Ok(actual_value)
+}
+
+fn resolve_config<'v>(
+    name: &str,
+    args: &DeclArgs<'v>,
+    declaration_site: &DeclarationSite,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> starlark::Result<Value<'v>> {
+    let is_optional = args.optional.unwrap_or(args.default.is_some());
+
+    let value = if let Some(provided) = eval.request_input(name)? {
+        validate_or_convert(name, provided, args.typ, args.convert, eval)?
+    } else if is_optional {
+        if let Some(default) = args.default {
+            validate_or_convert(name, default, args.typ, args.convert, eval)?
+        } else {
+            Value::new_none()
+        }
+    } else {
+        if strict_io_config(eval) {
+            note_missing_input(name, eval);
+            eval.add_diagnostic(missing_input_diag(name, declaration_site));
+        }
+
+        if let Some(default) = args.default {
+            validate_or_convert(name, default, args.typ, args.convert, eval)?
+        } else {
+            let generated = default_for_type(eval, args.typ)?;
+            validate_or_convert(name, generated, args.typ, args.convert, eval)?
+        }
+    };
+
+    finish_resolution(
+        name,
+        args,
+        ParameterMetadataInput {
+            typ: args.typ,
+            optional: is_optional,
+            default: args.default,
+            is_config: true,
+            help: args.help.clone(),
+            direction: None,
+            actual_value: value,
+        },
+        declaration_site,
+        eval,
+    )
+}
+
+fn resolve_io<'v>(
+    name: &str,
+    args: &DeclArgs<'v>,
+    declaration_site: &DeclarationSite,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> starlark::Result<Value<'v>> {
+    let type_name = args.typ.get_type();
+    if !matches!(type_name, "NetType" | "InterfaceFactory") {
+        return Err(anyhow::anyhow!(
+            "builtin.io() requires a Net or interface type, got {type_name}."
+        )
+        .into());
+    }
+
+    let is_optional = args.optional.unwrap_or(false);
+    let compute_default = |eval: &mut Evaluator<'v, '_, '_>, for_metadata_only: bool| {
+        if let Some(default) = args.default {
+            validate_or_convert(name, default, args.typ, None, eval).map_err(starlark::Error::from)
+        } else {
+            io_generated_default(eval, args.typ, name, for_metadata_only)
+        }
+    };
+
+    let (value, metadata_default) = if let Some(provided) = eval.request_input(name)? {
+        (
+            validate_or_convert(name, provided, args.typ, None, eval)?,
+            Some(compute_default(eval, true)?),
+        )
+    } else if is_optional {
+        let default = compute_default(eval, false)?;
+        if matches!(type_name, "NetType" | "InterfaceFactory") {
+            (default, Some(default))
+        } else {
+            (Value::new_none(), Some(default))
+        }
+    } else if strict_io_config(eval) {
+        note_missing_input(name, eval);
+        return Err(MissingInputError {
+            name: name.to_owned(),
+        }
+        .into());
+    } else {
+        let default = compute_default(eval, false)?;
+        (default, Some(default))
+    };
+
+    finish_resolution(
+        name,
+        args,
+        ParameterMetadataInput {
+            typ: args.typ,
+            optional: is_optional,
+            default: metadata_default,
+            is_config: false,
+            help: args.help.clone(),
+            direction: args.direction,
+            actual_value: value,
+        },
+        declaration_site,
+        eval,
+    )
+}
+
+fn invoke_decl<'v>(
+    kind: ParamKind,
+    args: DeclArgs<'v>,
+    declaration_site: DeclarationSite,
+    eval: &mut Evaluator<'v, '_, '_>,
+    explicit_name: Option<String>,
+) -> starlark::Result<Value<'v>> {
+    if let Some(name) = explicit_name {
+        return kind.resolve(&name, &args, &declaration_site, eval);
+    }
+
+    Ok(eval.heap().alloc(DeferredParam {
+        kind,
+        args,
+        declaration_site,
+    }))
+}
+
+pub(crate) fn invoke_config<'v>(
+    args: &Arguments<'v, '_>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> starlark::Result<Value<'v>> {
+    let kind = ParamKind::Config;
+    let declaration_site = kind.declaration_site(eval);
+    let (name, args) = parse_decl_args(kind, args, eval.heap())?;
+    if args.convert.is_some() {
+        warn_deprecated_config_convert(&declaration_site, eval);
+    }
+    invoke_decl(kind, args, declaration_site, eval, name)
+}
+
+pub(crate) fn invoke_builtin_io<'v>(
+    args: &Arguments<'v, '_>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> starlark::Result<Value<'v>> {
+    let kind = ParamKind::Io;
+    let declaration_site = kind.declaration_site(eval);
+    let (name, args) = parse_decl_args(kind, args, eval.heap())?;
+    invoke_decl(kind, args, declaration_site, eval, name)
+}

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -188,6 +188,42 @@ fn io_named_checks() {
 }
 
 #[test]
+fn config_positional_none_checks_is_ignored() {
+    let eval_result = eval_zen(vec![(
+        "Module.zen".to_string(),
+        r#"
+            value = config("value", int, None)
+            check(value == 0, "config() should still resolve with positional None checks")
+        "#
+        .to_string(),
+    )]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "eval produced unexpected errors: {:?}",
+        eval_result.diagnostics
+    );
+}
+
+#[test]
+fn io_positional_none_checks_is_ignored() {
+    let eval_result = eval_zen(vec![(
+        "Module.zen".to_string(),
+        r#"
+            VIN = io("VIN", Net, None, optional = True)
+            check(VIN != None, "io() should still resolve with positional None checks")
+        "#
+        .to_string(),
+    )]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "eval produced unexpected errors: {:?}",
+        eval_result.diagnostics
+    );
+}
+
+#[test]
 fn config_name_infers_from_assignment() {
     let eval_result = eval_zen(vec![
         (

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -4,6 +4,8 @@ mod common;
 use crate::common::{InMemoryFileProvider, eval_zen, stdlib_test_files, test_resolution};
 use pcb_zen_core::lang::error::CategorizedDiagnostic;
 use pcb_zen_core::lang::io_direction::IoDirection;
+use pcb_zen_core::lang::net::FrozenNetValue;
+use starlark::values::ValueLike;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -117,6 +119,240 @@ snapshot_eval!(interface_io, {
         Mod(name = "U1", pdm = pdm)
     "#
 });
+
+#[test]
+fn config_named_checks() {
+    let eval_result = eval_zen(vec![
+        (
+            "Module.zen".to_string(),
+            r#"
+                def nonnegative(value):
+                    check(value >= 0, "value must be nonnegative")
+
+                value = config("value", int, checks = nonnegative)
+            "#
+            .to_string(),
+        ),
+        (
+            "top.zen".to_string(),
+            r#"
+                Mod = Module("Module.zen")
+                Mod(name = "U1", value = 1)
+            "#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "eval produced unexpected errors: {:?}",
+        eval_result.diagnostics
+    );
+}
+
+#[test]
+fn io_named_checks() {
+    let eval_result = eval_zen(vec![
+        (
+            "Module.zen".to_string(),
+            r#"
+                def present(net):
+                    check(net != None, "net must be present")
+
+                pwr = io("pwr", Net, checks = present)
+
+                Component(
+                    name = "comp0",
+                    footprint = "TEST:0402",
+                    pin_defs = {"V": "1"},
+                    pins = {"V": pwr},
+                )
+            "#
+            .to_string(),
+        ),
+        (
+            "top.zen".to_string(),
+            r#"
+                Mod = Module("Module.zen")
+                Mod(name = "U1", pwr = Net("VCC"))
+            "#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "eval produced unexpected errors: {:?}",
+        eval_result.diagnostics
+    );
+}
+
+#[test]
+fn config_name_infers_from_assignment() {
+    let eval_result = eval_zen(vec![
+        (
+            "Module.zen".to_string(),
+            r#"
+                description = config(str)
+                skip_bom = config(bool, default = True)
+
+                Component(
+                    name = "R1",
+                    footprint = "TEST:0402",
+                    pin_defs = {"P": "1"},
+                    pins = {"P": Net("SIG")},
+                    description = description,
+                    skip_bom = skip_bom,
+                )
+            "#
+            .to_string(),
+        ),
+        (
+            "top.zen".to_string(),
+            r#"
+                Mod = Module("Module.zen")
+                Mod(name = "U1", description = "Acme")
+            "#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "eval produced unexpected errors: {:?}",
+        eval_result.diagnostics
+    );
+
+    let output = eval_result.output.expect("expected eval output");
+    let module_tree = output.module_tree();
+    let child_module = module_tree
+        .values()
+        .find(|module| module.path().to_string() == "U1")
+        .expect("expected instantiated child module");
+    let component = child_module
+        .components()
+        .find(|component| component.name() == "R1")
+        .expect("expected child component");
+
+    assert_eq!(component.description(), Some("Acme"));
+    assert!(
+        component.skip_bom(),
+        "defaulted inferred config should still apply"
+    );
+}
+
+#[test]
+fn inferred_config_values_work_in_component_kwargs() {
+    let eval_result = eval_zen(vec![(
+        "Module.zen".to_string(),
+        r#"
+            manufacturer = config(str, default = "Acme")
+            skip_bom = config(bool, default = True)
+
+            Component(
+                name = "R1",
+                footprint = "TEST:0402",
+                pin_defs = {"P": "1"},
+                pins = {"P": Net("SIG")},
+                manufacturer = manufacturer,
+                skip_bom = skip_bom,
+            )
+        "#
+        .to_string(),
+    )]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "eval produced unexpected errors: {:?}",
+        eval_result.diagnostics
+    );
+}
+
+#[test]
+fn unused_nameless_config_is_ignored() {
+    let eval_result = eval_zen(vec![(
+        "Module.zen".to_string(),
+        r#"
+            config(int)
+        "#
+        .to_string(),
+    )]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "unused nameless config() should be ignored, got: {:?}",
+        eval_result.diagnostics
+    );
+}
+
+#[test]
+fn io_name_infers_from_assignment() {
+    let eval_result = eval_zen(vec![
+        (
+            "Module.zen".to_string(),
+            r#"
+                SIG = io(Net)
+
+                Component(
+                    name = "R1",
+                    footprint = "TEST:0402",
+                    pin_defs = {"P": "1"},
+                    pins = {"P": SIG},
+                )
+            "#
+            .to_string(),
+        ),
+        (
+            "top.zen".to_string(),
+            r#"
+                Mod = Module("Module.zen")
+                Mod(name = "U1", SIG = Net("INPUT"))
+            "#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "eval produced unexpected errors: {:?}",
+        eval_result.diagnostics
+    );
+
+    let output = eval_result.output.expect("expected eval output");
+    let module_tree = output.module_tree();
+    let child_module = module_tree
+        .values()
+        .find(|module| module.path().to_string() == "U1")
+        .expect("expected instantiated child module");
+    let component = child_module
+        .components()
+        .find(|component| component.name() == "R1")
+        .expect("expected child component");
+    let net = component
+        .connections()
+        .get("P")
+        .and_then(|value| value.downcast_ref::<FrozenNetValue>())
+        .expect("expected connected net");
+
+    assert_eq!(net.name(), "INPUT");
+}
+
+#[test]
+fn unused_nameless_io_is_ignored() {
+    let eval_result = eval_zen(vec![(
+        "Module.zen".to_string(),
+        r#"
+            io(Net)
+        "#
+        .to_string(),
+    )]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "unused nameless io() should be ignored, got: {:?}",
+        eval_result.diagnostics
+    );
+}
 
 #[test]
 fn unused_io_warns_only_for_unconnected_ports() {
@@ -851,9 +1087,9 @@ fn prelude_injects_io_helpers_from_stdlib() {
     files.insert(
         "test.zen".to_string(),
         r#"
-            VIN = input("VIN", Power)
-            VOUT = output("VOUT", Net)
-            GND = io("GND", Ground)
+            VIN = input(Power)
+            VOUT = output(Net)
+            GND = io(Ground)
 
             Component(
                 name = "test",

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -433,9 +433,9 @@ Declare a net or interface input for a module. This defines the module's electri
 
 `io`, `input`, and `output` are prelude symbols re-exported from `@stdlib/io.zen`. The low-level builtin is `builtin.io(...)`.
 
-**Signature:** `io(name, typ, checks=None, default=None, optional=False, help=None, direction=None)`
+**Signature:** `io(name, typ, checks=None, default=None, optional=False, help=None, direction=None)` or `io(typ, checks=None, default=None, optional=False, help=None, direction=None)`
 
-- `name`: Input name (conventionally UPPERCASE).
+- `name`: Optional explicit input name (conventionally UPPERCASE). If omitted, `io()` must be assigned to a top-level variable and that variable name is used.
 - `typ`: A net type (`Net`, `Power`, `Ground`, etc.) or an interface factory (`Spi`, `Uart`, etc.).
 - `checks`: Optional check function or list of checks applied to the resolved value.
 - `default`: Explicit default value.
@@ -448,26 +448,28 @@ VCC = io("VCC", Power)
 GND = io("GND", Ground)
 SPI = io("SPI", Spi, optional=True)
 DATA = io("DATA", Net)
+CS = io(Net)
 VIN = io("VIN", Power, direction="input")
 VOUT = io("VOUT", Power, direction="output")
 ```
 
 Use `direction` for genuinely one-way ports like signal or power flow. Shared rails such as `GND` should usually remain plain `io()` declarations.
 
-`input(name, typ, ...)` and `output(name, typ, ...)` are equivalent to `io(...)` with `direction="input"` or `direction="output"` respectively.
+`input(name, typ, ...)` and `output(name, typ, ...)` are equivalent to `io(...)` with `direction="input"` or `direction="output"` respectively, and they also support omitted explicit names when assigned to top-level variables.
 
 ```python
 VIN = input("VIN", Power)
 VOUT = output("VOUT", Power)
+CS = input(Net)
 ```
 
 ### config()
 
 Declare a typed configuration input for a module. This defines parameters that control the module's behavior — values (not nets) provided by the parent.
 
-**Signature:** `config(name, typ, checks=None, default=None, optional=None, help=None)`
+**Signature:** `config(name, typ, checks=None, default=None, optional=None, help=None)` or `config(typ, checks=None, default=None, optional=None, help=None)`
 
-- `name`: Input name (conventionally lowercase).
+- `name`: Optional explicit input name (conventionally lowercase). If omitted, `config()` must be assigned to a top-level variable and that variable name is used.
 - `typ`: Expected type — primitives (`str`, `int`, `float`, `bool`), `enum`, `record`, or physical quantity constructors.
 - `checks`: Optional check function or list of checks.
 - `default`: Default value. When provided, `optional` defaults to `True`.
@@ -478,6 +480,7 @@ Declare a typed configuration input for a module. This defines parameters that c
 value = config("value", Resistance)
 package = config("package", Package, default=Package("0603"))
 voltage = config("voltage", Voltage, optional=True)
+manufacturer = config(str, default="Acme")
 ```
 
 Values passed by the parent are automatically converted to the declared type when possible — strings become physical quantities (`"10k"` → `Resistance("10k")`), enum variants (`"0603"` → `Package("0603")`), etc. This is why `Resistor(name="R1", value="10k", package="0603", ...)` works even though `value` expects `Resistance` and `package` expects `Package`.

--- a/stdlib/io.zen
+++ b/stdlib/io.zen
@@ -2,38 +2,38 @@ io = builtin.io
 
 
 def input(
-    name,
-    typ,
+    name_or_typ,
+    typ=None,
     checks=None,
     default=None,
     optional=False,
     help=None,
 ):
-    return io(
-        name,
-        typ,
-        checks,
-        default=default,
-        optional=optional,
-        help=help,
-        direction="input",
-    )
+    name = name_or_typ if typ != None else None
+    typ = typ if typ != None else name_or_typ
+    if name != None:
+        if checks != None:
+            return io(name, typ, checks, default=default, optional=optional, help=help, direction="input")
+        return io(name, typ, default=default, optional=optional, help=help, direction="input")
+    if checks != None:
+        return io(typ, checks, default=default, optional=optional, help=help, direction="input")
+    return io(typ, default=default, optional=optional, help=help, direction="input")
 
 
 def output(
-    name,
-    typ,
+    name_or_typ,
+    typ=None,
     checks=None,
     default=None,
     optional=False,
     help=None,
 ):
-    return io(
-        name,
-        typ,
-        checks,
-        default=default,
-        optional=optional,
-        help=help,
-        direction="output",
-    )
+    name = name_or_typ if typ != None else None
+    typ = typ if typ != None else name_or_typ
+    if name != None:
+        if checks != None:
+            return io(name, typ, checks, default=default, optional=optional, help=help, direction="output")
+        return io(name, typ, default=default, optional=optional, help=help, direction="output")
+    if checks != None:
+        return io(typ, checks, default=default, optional=optional, help=help, direction="output")
+    return io(typ, default=default, optional=optional, help=help, direction="output")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core Zen/Starlark parameter declaration semantics by introducing deferred resolution via `export_as`, which could affect module signatures and input resolution edge cases despite added tests and docs updates.
> 
> **Overview**
> **Zen parameter declarations now support name inference.** `config()` and `builtin.io()` accept an alternate calling form without an explicit `name` (e.g. `foo = config(str)` / `SIG = io(Net)`), resolving the parameter name from the top-level assignment.
> 
> Implementation refactors parameter handling into new `lang/param_decl.rs`, replacing the inlined `config()`/`declare_io()` logic with shared parsing + deferred `DeferredParameter` values that finalize on `export_as` and then record metadata/diagnostics.
> 
> Updates stdlib `input()`/`output()` wrappers, docs/spec, changelog, and adds tests covering inferred names, `checks` handling (including positional `None`), and ensuring unused nameless declarations are ignored. Also bumps the workspace `starlark-rust` git revision in `Cargo.toml`/`Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b2455a92583a7d8625144272aaf3681e3363d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
