### PR TITLE
Add `Component()` pin/net compatibility warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add `io()` direction metadata plus `input()` / `output()` sugar.
 - `config()`, `io()`, `input()`, and `output()` now allow omitting the explicit name when assigned to a top-level variable.
 - `config()` now supports discrete `allowed=` sets for scalar and physical-value inputs.
+- Preserve KiCad symbol pin metadata and add `Component()` pin/net compatibility warnings.
 
 ### Changed
 

--- a/crates/pcb-eda/src/kicad/symbol.rs
+++ b/crates/pcb-eda/src/kicad/symbol.rs
@@ -1,5 +1,5 @@
 use crate::kicad::metadata::SymbolMetadata;
-use crate::{Part, Pin, PinAt, Symbol, is_placeholder_kicad_pin_name};
+use crate::{Part, Pin, PinAlternate, PinAt, Symbol, is_placeholder_kicad_pin_name};
 use anyhow::Result;
 use pcb_sexpr::{Sexpr, SexprKind, parse};
 use serde::Serialize;
@@ -87,6 +87,14 @@ pub struct KicadPin {
     pub(super) at: Option<PinAt>,
     pub(super) length: Option<f64>,
     pub(super) hidden: bool,
+    pub(super) alternates: Vec<KicadPinAlternate>,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct KicadPinAlternate {
+    pub(super) name: String,
+    pub(super) electrical_type: Option<String>,
+    pub(super) graphical_style: Option<String>,
 }
 
 impl From<KicadSymbol> for Symbol {
@@ -113,6 +121,15 @@ impl From<KicadSymbol> for Symbol {
                     at: pin.at,
                     length: pin.length,
                     hidden: pin.hidden,
+                    alternates: pin
+                        .alternates
+                        .into_iter()
+                        .map(|alternate| PinAlternate {
+                            name: alternate.name,
+                            electrical_type: alternate.electrical_type,
+                            graphical_style: alternate.graphical_style,
+                        })
+                        .collect(),
                 })
                 .collect(),
             raw_sexp: symbol.raw_sexp,
@@ -307,6 +324,11 @@ fn parse_pin_common(pin_data: &[Sexpr]) -> KicadPin {
                     }
                     "at" => pin.at = parse_pin_at(attr_data),
                     "length" => pin.length = parse_number(attr_data.get(1)),
+                    "alternate" => {
+                        if let Some(alternate) = parse_pin_alternate(attr_data) {
+                            pin.alternates.push(alternate);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -407,6 +429,25 @@ fn parse_pin_at(at: &[Sexpr]) -> Option<PinAt> {
     let y = parse_number(at.get(2))?;
     let rotation = parse_number(at.get(3));
     Some(PinAt { x, y, rotation })
+}
+
+fn parse_pin_alternate(alternate: &[Sexpr]) -> Option<KicadPinAlternate> {
+    let name = alternate
+        .get(1)
+        .and_then(|value| value.as_str().or_else(|| value.as_sym()))?
+        .to_string();
+
+    Some(KicadPinAlternate {
+        name,
+        electrical_type: alternate
+            .get(2)
+            .and_then(Sexpr::as_sym)
+            .map(ToOwned::to_owned),
+        graphical_style: alternate
+            .get(3)
+            .and_then(Sexpr::as_sym)
+            .map(ToOwned::to_owned),
+    })
 }
 
 fn parse_number(node: Option<&Sexpr>) -> Option<f64> {

--- a/crates/pcb-eda/src/lib.rs
+++ b/crates/pcb-eda/src/lib.rs
@@ -48,6 +48,17 @@ pub struct Pin {
     pub length: Option<f64>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub hidden: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub alternates: Vec<PinAlternate>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize)]
+pub struct PinAlternate {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub electrical_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub graphical_style: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize)]

--- a/crates/pcb-eda/tests/test_eda.rs
+++ b/crates/pcb-eda/tests/test_eda.rs
@@ -179,6 +179,44 @@ fn test_nested_unnamed_pin_preserved_and_uses_number_as_signal_name() {
 }
 
 #[test]
+fn test_pin_alternates() {
+    let content = r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "AlternatePinDemo"
+    (symbol "AlternatePinDemo_0_1"
+      (pin bidirectional line
+        (at 0 0 0)
+        (length 2.54)
+        (name "PIO1")
+        (number "1")
+        (alternate "GPIO1" bidirectional line)
+        (alternate "nRESET" input inverted)
+      )
+    )
+  )
+)"#;
+
+    let lib = SymbolLibrary::from_string(content, "kicad_sym").unwrap();
+    let symbol = lib.first_symbol().unwrap();
+    let pin = &symbol.pins[0];
+
+    assert_eq!(pin.alternates.len(), 2);
+    assert_eq!(pin.alternates[0].name, "GPIO1");
+    assert_eq!(
+        pin.alternates[0].electrical_type.as_deref(),
+        Some("bidirectional")
+    );
+    assert_eq!(pin.alternates[0].graphical_style.as_deref(), Some("line"));
+    assert_eq!(pin.alternates[1].name, "nRESET");
+    assert_eq!(pin.alternates[1].electrical_type.as_deref(), Some("input"));
+    assert_eq!(
+        pin.alternates[1].graphical_style.as_deref(),
+        Some("inverted")
+    );
+}
+
+#[test]
 fn test_kicad10_duplicate_pin_numbers_marked_as_jumpers_are_preserved() {
     let content = r#"(kicad_symbol_lib
   (version 20251024)

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -29,7 +29,7 @@ use crate::{
 
 use super::part::PartValue;
 use super::path::normalize_path_to_package_uri;
-use super::symbol::{SymbolType, SymbolValue};
+use super::symbol::{SymbolType, SymbolValue, symbol_pins_from_pad_map};
 use super::validation::validate_identifier_name;
 
 use crate::kicad_library::{
@@ -1376,6 +1376,7 @@ where
                         SymbolValue {
                             name: symbol_value.name.clone(),
                             pad_to_signal, // Use pin mappings from pin_defs
+                            pins: symbol_value.pins.clone(),
                             source_uri: symbol_value.source_uri.clone(),
                             raw_sexp: symbol_value.raw_sexp.clone(),
                             properties: symbol_value.properties.clone(),
@@ -1383,9 +1384,11 @@ where
                         }
                     } else {
                         // symbol is not a Symbol type, just use pin_defs
+                        let pins = symbol_pins_from_pad_map(&pad_to_signal);
                         SymbolValue {
                             name: None,
                             pad_to_signal,
+                            pins,
                             source_uri: None,
                             raw_sexp: None,
                             properties: SmallMap::new(),
@@ -1394,9 +1397,11 @@ where
                     }
                 } else {
                     // No symbol provided, create minimal SymbolValue from pin_defs
+                    let pins = symbol_pins_from_pad_map(&pad_to_signal);
                     SymbolValue {
                         name: None,
                         pad_to_signal,
+                        pins,
                         source_uri: None,
                         raw_sexp: None,
                         properties: SmallMap::new(),
@@ -1705,6 +1710,7 @@ mod tests {
         SymbolValue {
             name: Some("TestSymbol".to_string()),
             pad_to_signal: SmallMap::new(),
+            pins: Vec::new(),
             source_uri: None,
             raw_sexp: None,
             properties,

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -17,8 +17,7 @@ use starlark::{
         starlark_value,
     },
 };
-use std::cell::RefCell;
-use std::path::Path;
+use std::{cell::RefCell, collections::BTreeSet, path::Path};
 use tracing::info_span;
 
 use crate::{
@@ -27,6 +26,7 @@ use crate::{
     lang::{evaluator_ext::EvaluatorExt, spice_model::SpiceModelValue},
 };
 
+use super::net::{FrozenNetValue, NetValue};
 use super::part::PartValue;
 use super::path::normalize_path_to_package_uri;
 use super::symbol::{SymbolType, SymbolValue, symbol_pins_from_pad_map};
@@ -453,10 +453,7 @@ fn resolve_symbol_datasheet(
 }
 
 fn warn_invalid_symbol_datasheet(eval: &Evaluator<'_, '_, '_>, message: &str) {
-    let (path, span) = eval
-        .call_stack_top_location()
-        .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
-        .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
+    let (path, span) = diagnostic_location(eval);
     let diagnostic = crate::Diagnostic::categorized(
         &path,
         message,
@@ -466,6 +463,114 @@ fn warn_invalid_symbol_datasheet(eval: &Evaluator<'_, '_, '_>, message: &str) {
     .with_span(span)
     .with_call_stack(Some(eval.call_stack()));
     eval.add_diagnostic(diagnostic);
+}
+
+fn diagnostic_location(
+    eval: &Evaluator<'_, '_, '_>,
+) -> (String, Option<starlark::codemap::ResolvedSpan>) {
+    eval.call_stack_top_location()
+        .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
+        .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None))
+}
+
+fn net_kind_and_name<'v>(value: Value<'v>) -> Option<(&'v str, &'v str)> {
+    value
+        .downcast_ref::<NetValue>()
+        .map(|net| (net.net_type_name(), net.name()))
+        .or_else(|| {
+            value
+                .downcast_ref::<FrozenNetValue>()
+                .map(|net| (net.net_type_name(), net.name()))
+        })
+}
+
+fn signal_pin_type_candidates<'a>(symbol: &'a SymbolValue, signal_name: &str) -> Vec<&'a str> {
+    let pad_numbers: BTreeSet<&str> = symbol
+        .pad_to_signal()
+        .iter()
+        .filter_map(|(pad, signal)| (signal == signal_name).then_some(pad.as_str()))
+        .collect();
+
+    if pad_numbers.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates = BTreeSet::new();
+    for pin in symbol
+        .pins()
+        .iter()
+        .filter(|pin| pad_numbers.contains(pin.number.as_str()))
+    {
+        if let Some(pin_type) = pin.electrical_type.as_deref() {
+            candidates.insert(pin_type);
+        }
+        for alternate in &pin.alternates {
+            if let Some(pin_type) = alternate.electrical_type.as_deref() {
+                candidates.insert(pin_type);
+            }
+        }
+    }
+
+    candidates.into_iter().collect()
+}
+
+fn pin_type_accepts_net_kind(pin_type: &str, net_kind: &str) -> bool {
+    match pin_type {
+        "no_connect" => net_kind == "NotConnected",
+        "power_in" | "power_out" => matches!(net_kind, "Power" | "Ground" | "NotConnected"),
+        _ => true,
+    }
+}
+
+fn warn_pin_net_compatibility<'v>(
+    eval: &Evaluator<'v, '_, '_>,
+    component_name: &str,
+    symbol: &SymbolValue,
+    signal_name: &str,
+    net: Value<'v>,
+) {
+    let Some((net_kind, net_name)) = net_kind_and_name(net) else {
+        return;
+    };
+
+    let pin_types = signal_pin_type_candidates(symbol, signal_name);
+    if pin_types.is_empty()
+        || pin_types
+            .iter()
+            .any(|pin_type| pin_type_accepts_net_kind(pin_type, net_kind))
+    {
+        return;
+    }
+
+    let (kind, message) = if pin_types.contains(&"no_connect") {
+        (
+            "pin.no_connect",
+            format!(
+                "Pin '{signal_name}' on component '{component_name}' is marked no_connect but is connected to {net_kind} net '{net_name}'; use NotConnected()"
+            ),
+        )
+    } else if net_kind == "Net"
+        && pin_types
+            .iter()
+            .any(|pin_type| matches!(*pin_type, "power_in" | "power_out"))
+    {
+        (
+            "pin.power_net",
+            format!(
+                "Pin '{signal_name}' on component '{component_name}' is a power pin but is connected to plain Net '{net_name}'; consider using Power() or Ground()"
+            ),
+        )
+    } else {
+        return;
+    };
+
+    let (path, span) = diagnostic_location(eval);
+
+    eval.add_diagnostic(
+        crate::Diagnostic::categorized(&path, &message, kind, EvalSeverity::Warning)
+            .with_span(span)
+            .with_call_stack(Some(eval.call_stack())),
+    );
 }
 
 fn manifest_part_matches_symbol(part: &ManifestPart, symbol: &SymbolValue) -> bool {
@@ -1466,6 +1571,7 @@ where
                     ))));
                 }
 
+                warn_pin_net_compatibility(eval_ctx, &name, &final_symbol, &signal_name, v_val);
                 connections.insert(signal_name, v_val);
             }
 

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -26,7 +26,7 @@ use crate::{
     lang::{evaluator_ext::EvaluatorExt, spice_model::SpiceModelValue},
 };
 
-use super::net::{FrozenNetValue, NetValue};
+use super::net::{FrozenNetValue, NetValue, generate_net_id};
 use super::part::PartValue;
 use super::path::normalize_path_to_package_uri;
 use super::symbol::{SymbolType, SymbolValue, symbol_pins_from_pad_map};
@@ -522,6 +522,24 @@ fn pin_type_accepts_net_kind(pin_type: &str, net_kind: &str) -> bool {
     }
 }
 
+fn pin_types_are_only_no_connect(pin_types: &[&str]) -> bool {
+    !pin_types.is_empty() && pin_types.iter().all(|pin_type| *pin_type == "no_connect")
+}
+
+fn alloc_not_connected<'v>(heap: &'v Heap) -> Value<'v> {
+    heap.alloc(NetValue {
+        net_id: generate_net_id(),
+        name: String::new(),
+        template_name: None,
+        original_name: None,
+        assignment_inferable: false,
+        inferred_name: std::sync::OnceLock::new(),
+        inferred_original_name: std::sync::OnceLock::new(),
+        type_name: "NotConnected".to_string(),
+        properties: SmallMap::new(),
+    })
+}
+
 fn warn_pin_net_compatibility<'v>(
     eval: &Evaluator<'v, '_, '_>,
     component_name: &str,
@@ -534,21 +552,22 @@ fn warn_pin_net_compatibility<'v>(
     };
 
     let pin_types = signal_pin_type_candidates(symbol, signal_name);
-    if pin_types.is_empty()
-        || pin_types
-            .iter()
-            .any(|pin_type| pin_type_accepts_net_kind(pin_type, net_kind))
-    {
+    if pin_types.is_empty() {
         return;
     }
 
-    let (kind, message) = if pin_types.contains(&"no_connect") {
+    let (kind, message) = if pin_types_are_only_no_connect(&pin_types) {
         (
             "pin.no_connect",
             format!(
-                "Pin '{signal_name}' on component '{component_name}' is marked no_connect but is connected to {net_kind} net '{net_name}'; use NotConnected()"
+                "Pin '{signal_name}' on component '{component_name}' is marked no_connect but was explicitly connected to {net_kind} net '{net_name}'; omit it from `pins` and Component() will wire NotConnected() automatically"
             ),
         )
+    } else if pin_types
+        .iter()
+        .any(|pin_type| pin_type_accepts_net_kind(pin_type, net_kind))
+    {
+        return;
     } else if net_kind == "Net"
         && pin_types
             .iter()
@@ -1575,10 +1594,25 @@ where
                 connections.insert(signal_name, v_val);
             }
 
-            // Detect missing pins in connections
+            // Auto-fill unambiguously no_connect pins and error on all other missing pins.
             let mut missing_pins: Vec<&str> = final_symbol
                 .signal_names()
-                .filter(|n| !connections.contains_key(*n))
+                .filter(|signal_name| {
+                    if connections.contains_key(*signal_name) {
+                        return false;
+                    }
+
+                    let pin_types = signal_pin_type_candidates(&final_symbol, signal_name);
+                    if pin_types_are_only_no_connect(&pin_types) {
+                        connections.insert(
+                            (*signal_name).to_owned(),
+                            alloc_not_connected(eval_ctx.heap()),
+                        );
+                        false
+                    } else {
+                        true
+                    }
+                })
                 .collect();
 
             missing_pins.sort();

--- a/crates/pcb-zen-core/src/lang/symbol.rs
+++ b/crates/pcb-zen-core/src/lang/symbol.rs
@@ -47,11 +47,29 @@ pub fn invalidate_symbol_library(path: &Path, file_provider: &dyn crate::FilePro
 }
 
 /// Symbol represents a schematic symbol definition with pins
+#[derive(Clone, Debug, Trace, Allocative, Freeze, PartialEq)]
+pub struct SymbolPinAlternate {
+    pub name: String,
+    pub electrical_type: Option<String>,
+    pub graphical_style: Option<String>,
+}
+
+#[derive(Clone, Debug, Trace, Allocative, Freeze, PartialEq)]
+pub struct SymbolPin {
+    pub name: String,
+    pub number: String,
+    pub electrical_type: Option<String>,
+    pub graphical_style: Option<String>,
+    pub hidden: bool,
+    pub alternates: Vec<SymbolPinAlternate>,
+}
+
 #[derive(Clone, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
 #[repr(C)]
 pub struct SymbolValue {
     pub name: Option<String>,
     pub pad_to_signal: SmallMap<String, String>, // pad name -> signal name
+    pub pins: Vec<SymbolPin>, // Full pin metadata preserved from the source symbol
     pub source_uri: Option<String>, // Stable package URI for the symbol library when available
     pub raw_sexp: Option<String>, // Raw s-expression of the symbol (if loaded from file, otherwise None)
     pub properties: SmallMap<String, String>, // Properties from the symbol definition
@@ -221,9 +239,12 @@ impl<'v> SymbolValue {
                 }
             }
 
+            let pins = symbol_pins_from_pad_map(&pad_to_signal);
+
             Ok(SymbolValue {
                 name: Some(name),
                 pad_to_signal,
+                pins,
                 source_uri: None,
                 raw_sexp: None,
                 properties: SmallMap::new(),
@@ -303,12 +324,6 @@ impl<'v> SymbolValue {
                 (symbol_name, symbol, resolved_path.clone())
             };
 
-            // Convert EDA Symbol to SymbolValue.
-            let mut pad_to_signal: SmallMap<String, String> = SmallMap::new();
-            for pin in &symbol.pins {
-                pad_to_signal.insert(pin.number.clone(), pin.signal_name().to_owned());
-            }
-
             let source_uri = eval_ctx
                 .resolution()
                 .format_package_uri(&source_path)
@@ -328,14 +343,12 @@ impl<'v> SymbolValue {
                 properties.insert(key.clone(), value.clone());
             }
 
-            Ok(SymbolValue {
-                name: Some(symbol.name.clone()),
-                pad_to_signal,
-                source_uri: Some(source_uri),
-                raw_sexp: sexpr,
+            Ok(SymbolValue::from_eda_symbol(
+                &symbol,
+                Some(source_uri),
+                sexpr,
                 properties,
-                in_bom: symbol.in_bom,
-            })
+            ))
         } else {
             Err(starlark::Error::new_other(anyhow!(
                 "Symbol requires either 'definition' or 'library' parameter"
@@ -349,6 +362,10 @@ impl<'v> SymbolValue {
 
     pub fn pad_to_signal(&self) -> &SmallMap<String, String> {
         &self.pad_to_signal
+    }
+
+    pub fn pins(&self) -> &[SymbolPin] {
+        &self.pins
     }
 
     pub fn source_uri(&self) -> Option<&str> {
@@ -366,6 +383,62 @@ impl<'v> SymbolValue {
     pub fn properties(&self) -> &SmallMap<String, String> {
         &self.properties
     }
+
+    fn from_eda_symbol(
+        symbol: &pcb_eda::Symbol,
+        source_uri: Option<String>,
+        raw_sexp: Option<String>,
+        properties: SmallMap<String, String>,
+    ) -> Self {
+        let mut pad_to_signal: SmallMap<String, String> = SmallMap::new();
+        let pins = symbol
+            .pins
+            .iter()
+            .map(|pin| {
+                pad_to_signal.insert(pin.number.clone(), pin.signal_name().to_owned());
+                SymbolPin {
+                    name: pin.name.clone(),
+                    number: pin.number.clone(),
+                    electrical_type: pin.electrical_type.clone(),
+                    graphical_style: pin.graphical_style.clone(),
+                    hidden: pin.hidden,
+                    alternates: pin
+                        .alternates
+                        .iter()
+                        .map(|alternate| SymbolPinAlternate {
+                            name: alternate.name.clone(),
+                            electrical_type: alternate.electrical_type.clone(),
+                            graphical_style: alternate.graphical_style.clone(),
+                        })
+                        .collect(),
+                }
+            })
+            .collect();
+
+        Self {
+            name: Some(symbol.name.clone()),
+            pad_to_signal,
+            pins,
+            source_uri,
+            raw_sexp,
+            properties,
+            in_bom: symbol.in_bom,
+        }
+    }
+}
+
+pub(crate) fn symbol_pins_from_pad_map(pad_to_signal: &SmallMap<String, String>) -> Vec<SymbolPin> {
+    pad_to_signal
+        .iter()
+        .map(|(pad, signal)| SymbolPin {
+            name: signal.clone(),
+            number: pad.clone(),
+            electrical_type: None,
+            graphical_style: None,
+            hidden: false,
+            alternates: Vec::new(),
+        })
+        .collect()
 }
 
 /// SymbolType is a factory for creating Symbol values
@@ -707,4 +780,68 @@ fn load_split_library_symbol(
         symbol,
         dir.join(format!("{symbol_name}.kicad_sym")),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_pin_metadata() {
+        let symbol = pcb_eda::Symbol::from_string(
+            r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "AlternatePinDemo"
+    (property "Reference" "U")
+    (symbol "AlternatePinDemo_0_1"
+      (pin bidirectional line
+        (at 1.27 2.54 180)
+        (length 2.54)
+        (name "PIO1")
+        (number "1")
+        (alternate "GPIO1" bidirectional line)
+        (alternate "nRESET" input inverted)
+      )
+    )
+  )
+)"#,
+            "kicad_sym",
+        )
+        .expect("symbol should parse");
+
+        let mut properties = SmallMap::new();
+        properties.insert("Reference".to_string(), "U".to_string());
+
+        let symbol_value = SymbolValue::from_eda_symbol(
+            &symbol,
+            Some("package://demo/AlternatePinDemo.kicad_sym".to_string()),
+            Some("(symbol \"AlternatePinDemo\")".to_string()),
+            properties,
+        );
+
+        assert_eq!(
+            symbol_value.pad_to_signal().get("1").map(String::as_str),
+            Some("PIO1")
+        );
+        assert_eq!(symbol_value.pins().len(), 1);
+
+        let pin = &symbol_value.pins()[0];
+        assert_eq!(pin.name, "PIO1");
+        assert_eq!(pin.number, "1");
+        assert_eq!(pin.electrical_type.as_deref(), Some("bidirectional"));
+        assert_eq!(pin.graphical_style.as_deref(), Some("line"));
+        assert_eq!(pin.alternates.len(), 2);
+        assert_eq!(pin.alternates[0].name, "GPIO1");
+        assert_eq!(
+            pin.alternates[0].electrical_type.as_deref(),
+            Some("bidirectional")
+        );
+        assert_eq!(pin.alternates[1].name, "nRESET");
+        assert_eq!(pin.alternates[1].electrical_type.as_deref(), Some("input"));
+        assert_eq!(
+            pin.alternates[1].graphical_style.as_deref(),
+            Some("inverted")
+        );
+    }
 }

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -784,9 +784,108 @@ Component(
         warnings
             .iter()
             .any(|diag| diag.body.contains("marked no_connect")
-                && diag.body.contains("NotConnected()")),
+                && diag.body.contains("omit it from `pins`")),
         "expected no_connect warning, got: {:?}",
         warnings
+    );
+}
+
+#[test]
+fn warns_for_explicit_not_connected_pin() {
+    let diagnostics = eval_component_diagnostics(vec![
+        (
+            "nc_pin.kicad_sym".to_string(),
+            r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "NcPin"
+    (property "Reference" "U")
+    (symbol "NcPin_0_1"
+      (pin no_connect line
+        (at 0 0 0)
+        (length 2.54)
+        (name "NC")
+        (number "1")
+      )
+    )
+  )
+)"#
+            .to_string(),
+        ),
+        (
+            "test.zen".to_string(),
+            r#"
+NotConnected = builtin.net_type("NotConnected")
+symbol = Symbol(library = "nc_pin.kicad_sym")
+
+Component(
+    name = "U1",
+    footprint = "TEST:0402",
+    symbol = symbol,
+    pins = {
+        "NC": NotConnected(),
+    },
+)
+"#
+            .to_string(),
+        ),
+    ]);
+
+    let warnings = diagnostics.warnings();
+    let kinds = warning_kinds(&diagnostics);
+
+    assert!(kinds.contains("pin.no_connect"));
+    assert!(
+        warnings
+            .iter()
+            .any(|diag| diag.body.contains("explicitly connected to NotConnected")),
+        "expected explicit NotConnected warning, got: {:?}",
+        warnings
+    );
+}
+
+#[test]
+fn omitting_no_connect_pin_is_allowed() {
+    let diagnostics = eval_component_diagnostics(vec![
+        (
+            "nc_pin.kicad_sym".to_string(),
+            r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "NcPin"
+    (property "Reference" "U")
+    (symbol "NcPin_0_1"
+      (pin no_connect line
+        (at 0 0 0)
+        (length 2.54)
+        (name "NC")
+        (number "1")
+      )
+    )
+  )
+)"#
+            .to_string(),
+        ),
+        (
+            "test.zen".to_string(),
+            r#"
+symbol = Symbol(library = "nc_pin.kicad_sym")
+
+Component(
+    name = "U1",
+    footprint = "TEST:0402",
+    symbol = symbol,
+    pins = {},
+)
+"#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(
+        !warning_kinds(&diagnostics).contains("pin.no_connect"),
+        "did not expect pin.no_connect warning, got: {:?}",
+        diagnostics.warnings()
     );
 }
 

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -1,6 +1,10 @@
 #[macro_use]
 mod common;
 
+use pcb_zen_core::DiagnosticsPass;
+use pcb_zen_core::SortPass;
+use pcb_zen_core::lang::error::CategorizedDiagnostic;
+
 snapshot_eval!(component_properties, {
     "C146731.kicad_sym" => include_str!("resources/C146731.kicad_sym"),
     "test_props.zen" => r#"
@@ -712,6 +716,184 @@ snapshot_eval!(component_modifier_order_independent, {
         # This is verified by the module snapshot
     "#
 });
+
+fn warning_kinds(diagnostics: &pcb_zen_core::Diagnostics) -> std::collections::HashSet<String> {
+    diagnostics
+        .warnings()
+        .into_iter()
+        .filter_map(|diag| {
+            diag.innermost()
+                .downcast_error_ref::<CategorizedDiagnostic>()
+                .map(|err| err.kind.clone())
+        })
+        .collect()
+}
+
+fn eval_component_diagnostics(files: Vec<(String, String)>) -> pcb_zen_core::Diagnostics {
+    let result = common::eval_zen(files);
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+    let mut diagnostics = result.diagnostics;
+    SortPass.apply(&mut diagnostics);
+    diagnostics
+}
+
+#[test]
+fn warns_for_no_connect_pin() {
+    let diagnostics = eval_component_diagnostics(vec![
+        (
+            "nc_pin.kicad_sym".to_string(),
+            r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "NcPin"
+    (property "Reference" "U")
+    (symbol "NcPin_0_1"
+      (pin no_connect line
+        (at 0 0 0)
+        (length 2.54)
+        (name "NC")
+        (number "1")
+      )
+    )
+  )
+)"#
+            .to_string(),
+        ),
+        (
+            "test.zen".to_string(),
+            r#"
+symbol = Symbol(library = "nc_pin.kicad_sym")
+
+Component(
+    name = "U1",
+    footprint = "TEST:0402",
+    symbol = symbol,
+    pins = {
+        "NC": Net("SIG"),
+    },
+)
+"#
+            .to_string(),
+        ),
+    ]);
+    let warnings = diagnostics.warnings();
+    let kinds = warning_kinds(&diagnostics);
+
+    assert!(kinds.contains("pin.no_connect"));
+    assert!(
+        warnings
+            .iter()
+            .any(|diag| diag.body.contains("marked no_connect")
+                && diag.body.contains("NotConnected()")),
+        "expected no_connect warning, got: {:?}",
+        warnings
+    );
+}
+
+#[test]
+fn warns_for_power_pin_on_plain_net() {
+    let diagnostics = eval_component_diagnostics(vec![
+        (
+            "power_pin.kicad_sym".to_string(),
+            r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "PowerPin"
+    (property "Reference" "U")
+    (symbol "PowerPin_0_1"
+      (pin power_in line
+        (at 0 0 0)
+        (length 2.54)
+        (name "VCC")
+        (number "1")
+      )
+    )
+  )
+)"#
+            .to_string(),
+        ),
+        (
+            "test.zen".to_string(),
+            r#"
+symbol = Symbol(library = "power_pin.kicad_sym")
+
+Component(
+    name = "U1",
+    footprint = "TEST:0402",
+    symbol = symbol,
+    pins = {
+        "VCC": Net("VCC"),
+    },
+)
+"#
+            .to_string(),
+        ),
+    ]);
+    let warnings = diagnostics.warnings();
+    let kinds = warning_kinds(&diagnostics);
+
+    assert!(kinds.contains("pin.power_net"));
+    assert!(
+        warnings.iter().any(
+            |diag| diag.body.contains("power pin") && diag.body.contains("Power() or Ground()")
+        ),
+        "expected power pin warning, got: {:?}",
+        warnings
+    );
+}
+
+#[test]
+fn alternate_pin_suppresses_warning() {
+    let diagnostics = eval_component_diagnostics(vec![
+        (
+            "alt_pin.kicad_sym".to_string(),
+            r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "AltPin"
+    (property "Reference" "U")
+    (symbol "AltPin_0_1"
+      (pin power_in line
+        (at 0 0 0)
+        (length 2.54)
+        (name "PIO1")
+        (number "1")
+        (alternate "GPIO1" input line)
+      )
+    )
+  )
+)"#
+            .to_string(),
+        ),
+        (
+            "test.zen".to_string(),
+            r#"
+symbol = Symbol(library = "alt_pin.kicad_sym")
+
+Component(
+    name = "U1",
+    footprint = "TEST:0402",
+    symbol = symbol,
+    pins = {
+        "PIO1": Net("SIG"),
+    },
+)
+"#
+            .to_string(),
+        ),
+    ]);
+    let kinds = warning_kinds(&diagnostics);
+
+    assert!(!kinds.contains("pin.power_net"));
+    assert!(
+        diagnostics
+            .warnings()
+            .iter()
+            .all(|diag| !diag.body.contains("power pin")),
+        "did not expect power pin warning, got: {:?}",
+        diagnostics.warnings()
+    );
+}
 
 snapshot_eval!(module_schematic_collapse, {
     "SubModule.zen" => r#"

--- a/crates/pcb-zen/tests/kicad_inference_snapshot.rs
+++ b/crates/pcb-zen/tests/kicad_inference_snapshot.rs
@@ -31,8 +31,8 @@ Component(
     pins = {
         "+": Net("INP"),
         "-": Net("INN"),
-        "V+": Net("VP"),
-        "GND": Net("GND"),
+        "V+": Power("VP"),
+        "GND": Ground("GND"),
         "REF1": Net("R1"),
         "REF2": Net("R2"),
         "5": Net("OUT"),

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -291,7 +291,7 @@ Component(
 |-----------|----------|-------------|
 | `name` | yes | Instance name |
 | `symbol` | yes | Symbol object defining the schematic representation |
-| `pins` | yes | Dict mapping pin names to nets |
+| `pins` | yes | Dict mapping pin names to nets; omit KiCad `no_connect` pins |
 | `part` | no | `Part` object specifying manufacturer sourcing (preferred) |
 | `prefix` | no | Reference designator prefix (default: `"U"`) |
 | `manufacturer` | no | Manufacturer name (legacy — prefer `part`) |
@@ -302,6 +302,12 @@ Component(
 | `dnp` | no | Do Not Populate flag |
 | `skip_bom` | no | Exclude from BOM (default: inverse of symbol `in_bom` flag) |
 | `datasheet` | no | Datasheet path (default: symbol `Datasheet` property; local paths resolved relative to the `.kicad_sym` file) |
+
+When KiCad symbol pin metadata is available:
+
+- omitted `no_connect` pins are auto-wired to `NotConnected()`
+- explicit `no_connect` entries warn
+- `power_in` and `power_out` pins warn if connected to plain `Net` instead of `Power` or `Ground`
 
 ### Part
 


### PR DESCRIPTION
Adds two non-fatal `Component()` constructor warnings based on KiCad symbol pin electrical types:
- `pin.no_connect`: warns when a `no_connect` pin is bound to anything other than `NotConnected()`
- `pin.power_net`: warns when a `power_in` or `power_out` pin is bound to a plain `Net()` instead of `Power()` or `Ground()`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new symbol/pin metadata plumbing and changes `Component()` connection handling (auto-wiring `no_connect` pins and emitting new warnings), which can affect build diagnostics and connectivity expectations.
> 
> **Overview**
> **Preserves KiCad symbol pin metadata end-to-end** by parsing pin `alternate` entries in `.kicad_sym` files and surfacing them via new `PinAlternate`/`SymbolPin*` structures.
> 
> **Adds `Component()` pin/net compatibility warnings and smarter missing-pin handling**: emits categorized warnings for explicitly connecting KiCad `no_connect` pins (`pin.no_connect`) and for wiring `power_in`/`power_out` pins to plain `Net` instead of `Power`/`Ground` (`pin.power_net`), and auto-fills omitted unambiguous `no_connect` pins with `NotConnected()`.
> 
> Updates docs, changelog, and tests (including a snapshot expecting `Power()`/`Ground()` for power pins) to reflect the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2681d78e22d5a52e7a8c46e920205aea7ecb86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
