### PR TITLE
Add `pin.no_connect` ERC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `config()` now supports discrete `allowed=` sets for scalar and physical-value inputs.
 - Preserve KiCad symbol pin metadata and add `Component()` pin/net compatibility warnings.
 - Added style advice for redundant explicit names on `io()`, `config()`, nets, and interfaces.
+- Add pass-based schematic ERC plumbing and net-site `pin.no_connect` diagnostics with inline suppression support.
 
 ### Changed
 

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -603,6 +603,9 @@ impl ModuleConverter {
     fn update_net(&mut self, net: &FrozenNetValue, instance_ref: &InstanceRef) {
         let net_info = self.net_info_mut(net.id());
         net_info.ports.push(instance_ref.clone());
+        if net_info.original_type_name.is_empty() {
+            net_info.original_type_name = net.net_type_name().to_string();
+        }
 
         // For auto-named NotConnected nets, always use a stable port-derived name.
         // This may overwrite the module-introduced name (e.g. `NC_2`), which is not stable

--- a/crates/pcb-zen-core/src/diagnostics.rs
+++ b/crates/pcb-zen-core/src/diagnostics.rs
@@ -333,8 +333,27 @@ impl Diagnostic {
         matches!(self.severity, EvalSeverity::Error)
     }
 
+    pub fn categorized_kind(&self) -> Option<&str> {
+        use crate::lang::error::CategorizedDiagnostic;
+        self.innermost()
+            .downcast_error_ref::<CategorizedDiagnostic>()
+            .map(|categorized| categorized.kind.as_str())
+    }
+
+    /// Return `true` when two diagnostics represent the same underlying issue.
+    /// This compares the innermost diagnostic identity so wrapped child diagnostics
+    /// deduplicate cleanly against flat diagnostics.
+    pub fn same_identity(&self, other: &Self) -> bool {
+        let a = self.innermost();
+        let b = other.innermost();
+        std::mem::discriminant(&a.severity) == std::mem::discriminant(&b.severity)
+            && a.categorized_kind() == b.categorized_kind()
+            && a.path == b.path
+            && a.span == b.span
+            && a.body == b.body
+    }
+
     /// Compare two diagnostics for deterministic ordering without allocating.
-    /// Uses innermost diagnostic properties for uniqueness (matches AggregatePass behavior).
     /// Severity ordering: Warning(0) < Error(1) < Advice(2) < Disabled(3)
     pub fn cmp_key(&self, other: &Self) -> std::cmp::Ordering {
         let severity_rank = |d: &Diagnostic| match d.severity {
@@ -680,6 +699,16 @@ impl<T> WithDiagnostics<T> {
 }
 
 impl Diagnostics {
+    pub fn push_unique(&mut self, diagnostic: Diagnostic) {
+        if !self
+            .diagnostics
+            .iter()
+            .any(|existing| existing.same_identity(&diagnostic))
+        {
+            self.diagnostics.push(diagnostic);
+        }
+    }
+
     pub fn errors(&self) -> Vec<Diagnostic> {
         self.diagnostics
             .iter()
@@ -760,6 +789,53 @@ impl<T> From<WithDiagnostics<T>> for Result<T, Diagnostics> {
         } else {
             Err(eval.diagnostics)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Diagnostic, Diagnostics};
+    use starlark::errors::EvalSeverity;
+    use std::path::Path;
+
+    #[test]
+    fn same_identity_uses_innermost_wrapped_diagnostic() {
+        let inner = Diagnostic::categorized(
+            "child.zen",
+            "Pin 'NC' on component 'U1' is marked no_connect but was explicitly connected",
+            "pin.no_connect",
+            EvalSeverity::Warning,
+        );
+        let wrapped = Diagnostic::new(
+            "Warning from `child`",
+            EvalSeverity::Warning,
+            Path::new("board.zen"),
+        )
+        .with_child(Some(inner.clone().boxed()));
+
+        assert!(wrapped.same_identity(&inner));
+    }
+
+    #[test]
+    fn push_unique_deduplicates_wrapped_diagnostic() {
+        let inner = Diagnostic::categorized(
+            "child.zen",
+            "Pin 'NC' on component 'U1' is marked no_connect but was explicitly connected",
+            "pin.no_connect",
+            EvalSeverity::Warning,
+        );
+        let wrapped = Diagnostic::new(
+            "Warning from `child`",
+            EvalSeverity::Warning,
+            Path::new("board.zen"),
+        )
+        .with_child(Some(inner.clone().boxed()));
+
+        let mut diagnostics = Diagnostics::default();
+        diagnostics.push_unique(wrapped);
+        diagnostics.push_unique(inner);
+
+        assert_eq!(diagnostics.diagnostics.len(), 1);
     }
 }
 

--- a/crates/pcb-zen-core/src/diagnostics.rs
+++ b/crates/pcb-zen-core/src/diagnostics.rs
@@ -333,13 +333,6 @@ impl Diagnostic {
         matches!(self.severity, EvalSeverity::Error)
     }
 
-    pub fn categorized_kind(&self) -> Option<&str> {
-        use crate::lang::error::CategorizedDiagnostic;
-        self.innermost()
-            .downcast_error_ref::<CategorizedDiagnostic>()
-            .map(|categorized| categorized.kind.as_str())
-    }
-
     /// Return `true` when two diagnostics represent the same underlying issue.
     /// This compares the innermost diagnostic identity so wrapped child diagnostics
     /// deduplicate cleanly against flat diagnostics.
@@ -347,7 +340,6 @@ impl Diagnostic {
         let a = self.innermost();
         let b = other.innermost();
         std::mem::discriminant(&a.severity) == std::mem::discriminant(&b.severity)
-            && a.categorized_kind() == b.categorized_kind()
             && a.path == b.path
             && a.span == b.span
             && a.body == b.body

--- a/crates/pcb-zen-core/src/erc.rs
+++ b/crates/pcb-zen-core/src/erc.rs
@@ -1,0 +1,197 @@
+use std::collections::{BTreeSet, HashMap};
+
+use pcb_sch::Schematic;
+use starlark::codemap::ResolvedSpan;
+use starlark::errors::EvalSeverity;
+use starlark::values::ValueLike;
+
+use crate::lang::pin_erc::{
+    pin_no_connect_body, pin_types_are_only_no_connect, signal_pin_type_candidates,
+};
+use crate::lang::symbol::SymbolValue;
+use crate::{Diagnostic, Diagnostics, EvalOutput, FrozenNetValue, ModulePath};
+
+#[derive(Clone)]
+struct NetMetadata {
+    display_name: String,
+    path: String,
+    span: Option<ResolvedSpan>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ComponentSignalKey {
+    component_path: String,
+    signal_name: String,
+}
+
+#[derive(Clone)]
+struct NetPinAttachment {
+    component_name: String,
+    signal_name: String,
+    pin_types: Vec<String>,
+}
+
+#[derive(Clone)]
+struct ErcNet<'a> {
+    net: &'a pcb_sch::Net,
+    metadata: Option<NetMetadata>,
+    pin_attachments: Vec<NetPinAttachment>,
+}
+
+struct SchematicErcContext<'a> {
+    nets: Vec<ErcNet<'a>>,
+}
+
+trait SchematicErcPass {
+    fn run(&self, ctx: &SchematicErcContext<'_>, diagnostics: &mut Diagnostics);
+}
+
+struct PinNoConnectPass;
+
+fn component_path(module_path: &ModulePath, component_name: &str) -> String {
+    if module_path.is_root() {
+        component_name.to_string()
+    } else {
+        format!("{module_path}.{component_name}")
+    }
+}
+
+fn signal_names(symbol: &SymbolValue) -> BTreeSet<&str> {
+    symbol
+        .pad_to_signal
+        .values()
+        .map(|value| value.as_str())
+        .collect()
+}
+
+impl<'a> SchematicErcContext<'a> {
+    fn build(eval_output: &EvalOutput, schematic: &'a Schematic) -> Self {
+        let mut pin_types_by_component_signal: HashMap<ComponentSignalKey, Vec<String>> =
+            HashMap::new();
+        let mut net_metadata: HashMap<u64, NetMetadata> = HashMap::new();
+
+        for (module_path, module) in eval_output.module_tree() {
+            for component in module.components() {
+                let component_path = component_path(&module_path, component.name());
+
+                if let Some(symbol) = component.symbol().downcast_ref::<SymbolValue>() {
+                    for signal_name in signal_names(symbol) {
+                        let candidates = signal_pin_type_candidates(symbol, signal_name);
+                        if !candidates.is_empty() {
+                            pin_types_by_component_signal.insert(
+                                ComponentSignalKey {
+                                    component_path: component_path.clone(),
+                                    signal_name: signal_name.to_string(),
+                                },
+                                candidates,
+                            );
+                        }
+                    }
+                }
+
+                for net_value in component.connections().values() {
+                    if let Some(net) = net_value.downcast_ref::<FrozenNetValue>() {
+                        net_metadata.entry(net.id()).or_insert_with(|| NetMetadata {
+                            display_name: net.name().to_string(),
+                            path: net.declaration_path().unwrap_or_default().to_string(),
+                            span: net.declaration_span(),
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut nets = Vec::new();
+        for net in schematic.nets.values() {
+            let mut pin_attachments = Vec::new();
+
+            for port_ref in &net.ports {
+                let Some((component_ref, signal_name)) =
+                    schematic.component_ref_and_pin_for_port(port_ref)
+                else {
+                    continue;
+                };
+
+                let component_path = component_ref.instance_path.join(".");
+                let Some(pin_types) = pin_types_by_component_signal.get(&ComponentSignalKey {
+                    component_path: component_path.clone(),
+                    signal_name: signal_name.to_string(),
+                }) else {
+                    continue;
+                };
+
+                let component_name = component_ref
+                    .instance_path
+                    .last()
+                    .map(String::as_str)
+                    .unwrap_or("<component>")
+                    .to_string();
+
+                pin_attachments.push(NetPinAttachment {
+                    component_name,
+                    signal_name: signal_name.to_string(),
+                    pin_types: pin_types.clone(),
+                });
+            }
+
+            nets.push(ErcNet {
+                net,
+                metadata: net_metadata.get(&net.id).cloned(),
+                pin_attachments,
+            });
+        }
+
+        Self { nets }
+    }
+}
+
+impl SchematicErcPass for PinNoConnectPass {
+    fn run(&self, ctx: &SchematicErcContext<'_>, diagnostics: &mut Diagnostics) {
+        for net in &ctx.nets {
+            let net_kind = net.net.kind.as_str();
+
+            if net_kind == "NotConnected" {
+                continue;
+            }
+
+            for attachment in &net.pin_attachments {
+                if !pin_types_are_only_no_connect(&attachment.pin_types) {
+                    continue;
+                }
+
+                let body = pin_no_connect_body(
+                    &attachment.component_name,
+                    &attachment.signal_name,
+                    net_kind,
+                    net.metadata
+                        .as_ref()
+                        .map(|metadata| metadata.display_name.as_str())
+                        .unwrap_or(net.net.name.as_str()),
+                );
+                let path = net
+                    .metadata
+                    .as_ref()
+                    .map(|metadata| metadata.path.clone())
+                    .unwrap_or_default();
+                let span = net.metadata.as_ref().and_then(|metadata| metadata.span);
+
+                diagnostics.diagnostics.push(
+                    Diagnostic::categorized(&path, &body, "pin.no_connect", EvalSeverity::Warning)
+                        .with_span(span),
+                );
+            }
+        }
+    }
+}
+
+pub fn run_schematic_erc(eval_output: &EvalOutput, schematic: &Schematic) -> Diagnostics {
+    let ctx = SchematicErcContext::build(eval_output, schematic);
+    let mut diagnostics = Diagnostics::default();
+    let passes: [&dyn SchematicErcPass; 1] = [&PinNoConnectPass];
+
+    for pass in passes {
+        pass.run(&ctx, &mut diagnostics);
+    }
+
+    diagnostics
+}

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -25,6 +25,7 @@ use crate::{
     config::ManifestPart,
     lang::{
         evaluator_ext::EvaluatorExt,
+        pin_erc::{pin_no_connect_body, pin_types_are_only_no_connect, signal_pin_type_candidates},
         spice_model::{SpiceModelValue, resolve_spice_subcircuit, validate_spice_model},
     },
 };
@@ -740,34 +741,23 @@ fn net_kind_and_name<'v>(value: Value<'v>) -> Option<(&'v str, &'v str)> {
         })
 }
 
-fn signal_pin_type_candidates<'a>(symbol: &'a SymbolValue, signal_name: &str) -> Vec<&'a str> {
-    let pad_numbers: BTreeSet<&str> = symbol
-        .pad_to_signal()
-        .iter()
-        .filter_map(|(pad, signal)| (signal == signal_name).then_some(pad.as_str()))
-        .collect();
-
-    if pad_numbers.is_empty() {
-        return Vec::new();
-    }
-
-    let mut candidates = BTreeSet::new();
-    for pin in symbol
-        .pins()
-        .iter()
-        .filter(|pin| pad_numbers.contains(pin.number.as_str()))
+fn net_diagnostic_location<'v>(
+    eval: &Evaluator<'v, '_, '_>,
+    value: Value<'v>,
+) -> (String, Option<starlark::codemap::ResolvedSpan>) {
+    if let Some(net) = value.downcast_ref::<NetValue>()
+        && let Some(path) = net.declaration_path()
     {
-        if let Some(pin_type) = pin.electrical_type.as_deref() {
-            candidates.insert(pin_type);
-        }
-        for alternate in &pin.alternates {
-            if let Some(pin_type) = alternate.electrical_type.as_deref() {
-                candidates.insert(pin_type);
-            }
-        }
+        return (path.to_string(), net.declaration_span());
     }
 
-    candidates.into_iter().collect()
+    if let Some(net) = value.downcast_ref::<FrozenNetValue>()
+        && let Some(path) = net.declaration_path()
+    {
+        return (path.to_string(), net.declaration_span());
+    }
+
+    diagnostic_location(eval)
 }
 
 fn pin_type_accepts_net_kind(pin_type: &str, net_kind: &str) -> bool {
@@ -778,11 +768,11 @@ fn pin_type_accepts_net_kind(pin_type: &str, net_kind: &str) -> bool {
     }
 }
 
-fn pin_types_are_only_no_connect(pin_types: &[&str]) -> bool {
-    !pin_types.is_empty() && pin_types.iter().all(|pin_type| *pin_type == "no_connect")
-}
-
-fn alloc_not_connected<'v>(heap: &'v Heap) -> Value<'v> {
+fn alloc_not_connected<'v>(
+    heap: &'v Heap,
+    declaration_path: String,
+    declaration_span: Option<starlark::codemap::ResolvedSpan>,
+) -> Value<'v> {
     heap.alloc(NetValue {
         net_id: generate_net_id(),
         name: String::new(),
@@ -791,6 +781,8 @@ fn alloc_not_connected<'v>(heap: &'v Heap) -> Value<'v> {
         assignment_inferable: false,
         inferred_name: std::sync::OnceLock::new(),
         inferred_original_name: std::sync::OnceLock::new(),
+        declaration_path,
+        declaration_span,
         type_name: "NotConnected".to_string(),
         properties: SmallMap::new(),
     })
@@ -815,9 +807,7 @@ fn warn_pin_net_compatibility<'v>(
     let (kind, message) = if pin_types_are_only_no_connect(&pin_types) {
         (
             "pin.no_connect",
-            format!(
-                "Pin '{signal_name}' on component '{component_name}' is marked no_connect but was explicitly connected to {net_kind} net '{net_name}'; omit it from `pins` and Component() will wire NotConnected() automatically"
-            ),
+            pin_no_connect_body(component_name, signal_name, net_kind, net_name),
         )
     } else if pin_types
         .iter()
@@ -827,7 +817,7 @@ fn warn_pin_net_compatibility<'v>(
     } else if net_kind == "Net"
         && pin_types
             .iter()
-            .any(|pin_type| matches!(*pin_type, "power_in" | "power_out"))
+            .any(|pin_type| matches!(pin_type.as_str(), "power_in" | "power_out"))
     {
         (
             "pin.power_net",
@@ -839,7 +829,7 @@ fn warn_pin_net_compatibility<'v>(
         return;
     };
 
-    let (path, span) = diagnostic_location(eval);
+    let (path, span) = net_diagnostic_location(eval, net);
 
     eval.add_diagnostic(
         crate::Diagnostic::categorized(&path, &message, kind, EvalSeverity::Warning)
@@ -1860,9 +1850,10 @@ where
 
                     let pin_types = signal_pin_type_candidates(&final_symbol, signal_name);
                     if pin_types_are_only_no_connect(&pin_types) {
+                        let (path, span) = diagnostic_location(eval_ctx);
                         connections.insert(
                             (*signal_name).to_owned(),
-                            alloc_not_connected(eval_ctx.heap()),
+                            alloc_not_connected(eval_ctx.heap(), path, span),
                         );
                         false
                     } else {

--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -151,6 +151,8 @@ fn clone_net_template<'v>(
         assignment_inferable: prefix.assignment_inferable,
         inferred_name: OnceLock::new(),
         inferred_original_name: OnceLock::new(),
+        declaration_path: new_net.declaration_path().unwrap_or_default().to_string(),
+        declaration_span: new_net.declaration_span(),
         type_name: new_net.type_name.clone(),
         properties: new_net.properties().clone(),
     }))

--- a/crates/pcb-zen-core/src/lang/mod.rs
+++ b/crates/pcb-zen-core/src/lang/mod.rs
@@ -13,6 +13,7 @@ pub mod net;
 pub(crate) mod param_decl;
 pub mod part;
 pub(crate) mod path;
+pub(crate) mod pin_erc;
 pub mod spice_model;
 pub mod stackup;
 pub mod symbol;

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -109,6 +109,15 @@ pub struct NetValueGen<V> {
     #[trace(unsafe_ignore)]
     #[allocative(skip)]
     pub(crate) inferred_original_name: OnceLock<Option<String>>,
+    /// Source file path where this net was created.
+    #[serde(skip, default)]
+    pub(crate) declaration_path: String,
+    /// Source span where this net was created.
+    #[serde(skip, default)]
+    #[freeze(identity)]
+    #[trace(unsafe_ignore)]
+    #[allocative(skip)]
+    pub(crate) declaration_span: Option<starlark::codemap::ResolvedSpan>,
     /// The type name (e.g., "Net", "Power", "Ground")
     pub(crate) type_name: String,
     /// Properties (including symbol, voltage, impedance, etc. if provided)
@@ -239,6 +248,8 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
             assignment_inferable: self.assignment_inferable,
             inferred_name: Self::clone_once_lock(&self.inferred_name),
             inferred_original_name: Self::clone_once_lock(&self.inferred_original_name),
+            declaration_path: self.declaration_path.clone(),
+            declaration_span: self.declaration_span,
             type_name,
             properties,
         })
@@ -275,6 +286,8 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
             assignment_inferable: false,
             inferred_name: OnceLock::new(),
             inferred_original_name: OnceLock::new(),
+            declaration_path: String::new(),
+            declaration_span: None,
             type_name: "Net".to_string(),
             properties,
         }
@@ -309,6 +322,14 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
     /// Return the properties map of this net instance.
     pub fn properties(&self) -> &SmallMap<String, V> {
         &self.properties
+    }
+
+    pub fn declaration_path(&self) -> Option<&str> {
+        (!self.declaration_path.is_empty()).then_some(self.declaration_path.as_str())
+    }
+
+    pub fn declaration_span(&self) -> Option<starlark::codemap::ResolvedSpan> {
+        self.declaration_span
     }
 
     /// Return the original name as Option (None if auto-generated)
@@ -466,6 +487,10 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> starlark::Result<Value<'v>> {
         let heap = eval.heap();
+        let (declaration_path, declaration_span) = eval
+            .call_stack_top_location()
+            .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
+            .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
 
         let requested_name = explicit_name
             .clone()
@@ -584,6 +609,8 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
             assignment_inferable: options.assignment_inferable,
             inferred_name: OnceLock::new(),
             inferred_original_name: OnceLock::new(),
+            declaration_path,
+            declaration_span,
             type_name: self.type_name.clone(),
             properties,
         }))

--- a/crates/pcb-zen-core/src/lang/pin_erc.rs
+++ b/crates/pcb-zen-core/src/lang/pin_erc.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeSet;
+
+use crate::lang::symbol::SymbolValue;
+
+pub(crate) fn signal_pin_type_candidates(symbol: &SymbolValue, signal_name: &str) -> Vec<String> {
+    let pad_numbers: BTreeSet<&str> = symbol
+        .pad_to_signal()
+        .iter()
+        .filter_map(|(pad, signal)| (signal == signal_name).then_some(pad.as_str()))
+        .collect();
+
+    if pad_numbers.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates = BTreeSet::new();
+    for pin in symbol
+        .pins()
+        .iter()
+        .filter(|pin| pad_numbers.contains(pin.number.as_str()))
+    {
+        if let Some(pin_type) = pin.electrical_type.as_deref() {
+            candidates.insert(pin_type.to_string());
+        }
+        for alternate in &pin.alternates {
+            if let Some(pin_type) = alternate.electrical_type.as_deref() {
+                candidates.insert(pin_type.to_string());
+            }
+        }
+    }
+
+    candidates.into_iter().collect()
+}
+
+pub(crate) fn pin_types_are_only_no_connect(pin_types: &[String]) -> bool {
+    !pin_types.is_empty() && pin_types.iter().all(|pin_type| pin_type == "no_connect")
+}
+
+pub(crate) fn pin_no_connect_body(
+    component_name: &str,
+    signal_name: &str,
+    net_kind: &str,
+    net_name: &str,
+) -> String {
+    format!(
+        "Pin '{signal_name}' on component '{component_name}' is marked no_connect but was explicitly connected to {net_kind} net '{net_name}'; omit it from `pins` and Component() will wire NotConnected() automatically"
+    )
+}

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod convert;
 pub mod diagnostics;
 pub mod embedded_stdlib;
+pub mod erc;
 mod file_provider;
 pub mod graph;
 pub mod kicad_library;
@@ -79,6 +80,7 @@ pub use diagnostics::{
     Diagnostic, DiagnosticError, DiagnosticFrame, DiagnosticReference, DiagnosticReport,
     Diagnostics, DiagnosticsPass, DiagnosticsReport, LoadError, WithDiagnostics,
 };
+pub use erc::run_schematic_erc;
 pub use lang::error::SuppressedDiagnostics;
 pub use lang::eval::{EvalContext, EvalContextConfig, EvalOutput};
 pub use load_spec::LoadSpec;

--- a/crates/pcb-zen-core/src/passes.rs
+++ b/crates/pcb-zen-core/src/passes.rs
@@ -489,4 +489,23 @@ mod tests {
         assert_eq!(diagnostics.diagnostics.len(), 1);
         assert_eq!(diagnostics.diagnostics[0].suppressed_count(), Some(1));
     }
+
+    #[test]
+    fn test_aggregate_pass_deduplicates_multiple_categorized_warnings() {
+        let diag = Diagnostic::categorized(
+            "child.zen",
+            "Pin 'NC' on component 'U1' is marked no_connect but was explicitly connected",
+            "pin.no_connect",
+            EvalSeverity::Warning,
+        );
+
+        let mut diagnostics = Diagnostics {
+            diagnostics: vec![diag.clone(), diag.clone(), diag],
+        };
+
+        AggregatePass.apply(&mut diagnostics);
+
+        assert_eq!(diagnostics.diagnostics.len(), 1);
+        assert_eq!(diagnostics.diagnostics[0].suppressed_count(), Some(2));
+    }
 }

--- a/crates/pcb-zen-core/src/passes.rs
+++ b/crates/pcb-zen-core/src/passes.rs
@@ -88,19 +88,9 @@ impl DiagnosticsPass for AggregatePass {
                 continue;
             }
 
-            let innermost = diagnostic.innermost();
-            let key = (&innermost.body, &innermost.path, &innermost.span);
-
             if let Some(existing) = result.iter_mut().find(|d| {
                 aggregate_severity_key(d.severity) == aggregate_severity_key(diagnostic.severity)
-                    && {
-                        let existing_innermost = d.innermost();
-                        (
-                            &existing_innermost.body,
-                            &existing_innermost.path,
-                            &existing_innermost.span,
-                        ) == key
-                    }
+                    && d.same_identity(diagnostic)
             }) {
                 let suppressed = existing
                     .downcast_error_ref::<SuppressedDiagnostics>()

--- a/crates/pcb/src/build.rs
+++ b/crates/pcb/src/build.rs
@@ -88,6 +88,12 @@ impl BuildEvalState {
             diagnostics
                 .diagnostics
                 .extend(schematic_result.diagnostics.diagnostics);
+            if let Some(ref schematic) = schematic_result.output {
+                let erc_diagnostics = pcb_zen_core::run_schematic_erc(&eval_output, schematic);
+                for diag in erc_diagnostics.diagnostics {
+                    diagnostics.push_unique(diag);
+                }
+            }
             schematic_result.output
         });
 

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -43,6 +43,23 @@ const TEST_KICAD_MOD: &str = r#"(footprint "test"
 )
 "#;
 
+const TEST_NO_CONNECT_SYMBOL: &str = r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "NcPin"
+    (property "Reference" "U")
+    (symbol "NcPin_0_1"
+      (pin no_connect line
+        (at 0 0 0)
+        (length 2.54)
+        (name "NC")
+        (number "1")
+      )
+    )
+  )
+)
+"#;
+
 const SUPPRESSED_WARNINGS_ZEN: &str = r#"
 warn("Regular warning")
 warn("Suppressed warning 1", suppress=True)
@@ -218,6 +235,51 @@ if mode == Mode("TWO"):
     Resistor(name = "R_MODE", value = "3kohm", package = package, P1 = vcc.NET, P2 = gnd.NET)
 "#;
 
+const PIN_NO_CONNECT_REPORTS_AT_NET_ZEN: &str = r#"
+sig = Net("SIG")
+
+Component(
+    name = "U1",
+    footprint = File("test.kicad_mod"),
+    symbol = Symbol(library = "nc_pin.kicad_sym"),
+    pins = {
+        "NC": sig,
+    },
+)
+"#;
+
+const PIN_NO_CONNECT_SUPPRESSES_AT_NET_ZEN: &str = r#"
+sig = Net("SIG")  # suppress: pin.no_connect
+
+Component(
+    name = "U1",
+    footprint = File("test.kicad_mod"),
+    symbol = Symbol(library = "nc_pin.kicad_sym"),
+    pins = {
+        "NC": sig,
+    },
+)
+"#;
+
+const PIN_NO_CONNECT_NESTED_MODULE_DEDUPS_ZEN: &str = r#"
+Child = Module("child.zen")
+
+Child(name = "X1")
+"#;
+
+const PIN_NO_CONNECT_NESTED_CHILD_ZEN: &str = r#"
+sig = Net("SIG")
+
+Component(
+    name = "U1",
+    footprint = File("test.kicad_mod"),
+    symbol = Symbol(library = "nc_pin.kicad_sym"),
+    pins = {
+        "NC": sig,
+    },
+)
+"#;
+
 #[test]
 fn test_warning_and_error_mixed() {
     let mut sandbox = Sandbox::new();
@@ -237,6 +299,42 @@ fn test_warning_and_error_mixed() {
         .write("board.zen", WARNING_AND_ERROR_ZEN)
         .snapshot_run("pcb", ["build", "board.zen"]);
     assert_snapshot!("warning_and_error_mixed", output);
+}
+
+#[test]
+fn test_pin_no_connect_reports_at_net_site() {
+    let mut sandbox = Sandbox::new();
+    let output = sandbox
+        .write("board.zen", PIN_NO_CONNECT_REPORTS_AT_NET_ZEN)
+        .write("test.kicad_mod", TEST_KICAD_MOD)
+        .write("nc_pin.kicad_sym", TEST_NO_CONNECT_SYMBOL)
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert_snapshot!("pin_no_connect_reports_at_net_site", output);
+}
+
+#[test]
+fn test_pin_no_connect_suppresses_at_net_site() {
+    let mut sandbox = Sandbox::new();
+    let output = sandbox
+        .write("board.zen", PIN_NO_CONNECT_SUPPRESSES_AT_NET_ZEN)
+        .write("test.kicad_mod", TEST_KICAD_MOD)
+        .write("nc_pin.kicad_sym", TEST_NO_CONNECT_SYMBOL)
+        .snapshot_run("pcb", ["build", "board.zen"]);
+    assert_snapshot!("pin_no_connect_suppresses_at_net_site", output);
+}
+
+#[test]
+fn test_pin_no_connect_dedups_in_nested_modules() {
+    let mut sandbox = Sandbox::new();
+    let output = sandbox
+        .write("board.zen", PIN_NO_CONNECT_NESTED_MODULE_DEDUPS_ZEN)
+        .write("child.zen", PIN_NO_CONNECT_NESTED_CHILD_ZEN)
+        .write("test.kicad_mod", TEST_KICAD_MOD)
+        .write("nc_pin.kicad_sym", TEST_NO_CONNECT_SYMBOL)
+        .snapshot_run("pcb", ["build", "board.zen"]);
+
+    assert_eq!(output.matches("Warning:").count(), 1, "{output}");
+    assert!(output.contains("net 'SIG'"), "{output}");
 }
 
 #[test]

--- a/crates/pcb/tests/snapshots/build__pin_no_connect_reports_at_net_site.snap
+++ b/crates/pcb/tests/snapshots/build__pin_no_connect_reports_at_net_site.snap
@@ -1,0 +1,16 @@
+---
+source: crates/pcb/tests/build.rs
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+Warning: Pin 'NC' on component 'U1' is marked no_connect but was explicitly connected to Net net 'SIG'; omit it from `pins` and Component() will wire NotConnected() automatically
+   ╭─[ <TEMP_DIR>/board.zen:2:7 ]
+ 2 │sig = Net("SIG")
+   │           ╰───── Pin 'NC' on component 'U1' is marked no_connect but was explicitly connected to Net net 'SIG'; omit it from `pins` and Component() will wire NotConnected() automatically
+
+✓ board.zen (1 components)

--- a/crates/pcb/tests/snapshots/build__pin_no_connect_suppresses_at_net_site.snap
+++ b/crates/pcb/tests/snapshots/build__pin_no_connect_suppresses_at_net_site.snap
@@ -1,0 +1,12 @@
+---
+source: crates/pcb/tests/build.rs
+expression: output
+---
+Command: pcb build board.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+Suppressed 1 warning
+✓ board.zen (1 components)


### PR DESCRIPTION
This is a fairly safe ERC but it establishes all the plumbing we need to build on this (the post-eval hook, the suppression logic, etc.). ERCs will be implemented as passes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new post-eval diagnostics phase and extends net metadata to carry source locations, which can affect warning emission/dedup behavior during `pcb build`. Risk is limited to diagnostics/reporting paths but touches core net creation and aggregation logic.
> 
> **Overview**
> Adds pass-based schematic ERC plumbing and runs it during `pcb build` after schematic generation, emitting `pin.no_connect` warnings when pins typed `no_connect` are connected to non-`NotConnected` nets.
> 
> To support accurate net-site reporting and inline `# suppress:` handling, nets now carry declaration `path`/`span` metadata and this metadata is threaded through net cloning/instantiation (including auto-generated `NotConnected` nets). Diagnostics gain `same_identity` + `push_unique`, and `AggregatePass` now deduplicates using innermost diagnostic identity to avoid duplicates across wrapped/nested module diagnostics; new tests and snapshots cover reporting, suppression, and nested-module dedup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8220c75c747c0529505b13ba6759879b4f2428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
