### PR TITLE
Infer `Component()` spice models from symbol metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Component generation no longer automatically scans datasheets.
 - `pcb new component` and `pcb search` component imports now place datasheet artifacts under each component's `docs/` subdirectory.
 - Layout sync and KiCad netlist export now normalize file- and package-based footprints to library-aware FPIDs.
+- `Component()` now infers `spice_model` from symbol `Sim.*` properties.
 - Module-scoped variable rebinding is now a warning.
 - Removed the 10uF 100V 1210 stdlib house capacitor from generic matching due to severe derating.
 - `Net` and `Power` now expose unset `voltage` as `None`.

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -23,7 +23,10 @@ use tracing::info_span;
 use crate::{
     FrozenSpiceModelValue,
     config::ManifestPart,
-    lang::{evaluator_ext::EvaluatorExt, spice_model::SpiceModelValue},
+    lang::{
+        evaluator_ext::EvaluatorExt,
+        spice_model::{SpiceModelValue, resolve_spice_subcircuit, validate_spice_model},
+    },
 };
 
 use super::net::{FrozenNetValue, NetValue, generate_net_id};
@@ -450,6 +453,259 @@ fn resolve_symbol_datasheet(
             .format_package_uri(&resolved)
             .unwrap_or_else(|| resolved.to_string_lossy().into_owned()),
     ))
+}
+
+fn parse_sim_pins(pins: &str) -> starlark::Result<Vec<(String, String)>> {
+    let mut mappings = Vec::new();
+    let mut seen_symbol_pins = BTreeSet::new();
+
+    for token in pins.split_whitespace() {
+        let Some((symbol_pin, model_pin)) = token.split_once('=') else {
+            return Err(starlark::Error::new_other(anyhow!(
+                "Invalid Sim.Pins token '{token}'; expected '<symbol-pin>=<model-pin>'"
+            )));
+        };
+
+        if symbol_pin.is_empty() || model_pin.is_empty() || model_pin.contains('=') {
+            return Err(starlark::Error::new_other(anyhow!(
+                "Invalid Sim.Pins token '{token}'; expected '<symbol-pin>=<model-pin>'"
+            )));
+        }
+
+        if !seen_symbol_pins.insert(symbol_pin.to_owned()) {
+            return Err(starlark::Error::new_other(anyhow!(
+                "Duplicate symbol pin '{symbol_pin}' in Sim.Pins"
+            )));
+        }
+
+        mappings.push((symbol_pin.to_owned(), model_pin.to_owned()));
+    }
+
+    Ok(mappings)
+}
+
+fn parse_sim_params(params: &str) -> starlark::Result<SmallMap<String, String>> {
+    let mut parsed = SmallMap::new();
+    let chars: Vec<char> = params.chars().collect();
+    let mut index = 0;
+
+    while index < chars.len() {
+        while index < chars.len() && chars[index].is_whitespace() {
+            index += 1;
+        }
+
+        if index >= chars.len() {
+            break;
+        }
+
+        let key_start = index;
+        while index < chars.len() && !chars[index].is_whitespace() && chars[index] != '=' {
+            index += 1;
+        }
+
+        if key_start == index {
+            return Err(starlark::Error::new_other(anyhow!(
+                "Invalid Sim.Params syntax"
+            )));
+        }
+
+        let key: String = chars[key_start..index].iter().collect();
+
+        while index < chars.len() && chars[index].is_whitespace() {
+            index += 1;
+        }
+
+        if index >= chars.len() || chars[index] != '=' {
+            parsed.insert(key, "1".to_owned());
+            continue;
+        }
+
+        index += 1;
+        while index < chars.len() && chars[index].is_whitespace() {
+            index += 1;
+        }
+
+        if index >= chars.len() {
+            return Err(starlark::Error::new_other(anyhow!(
+                "Missing value for Sim.Params key '{}'",
+                key
+            )));
+        }
+
+        let value = if chars[index] == '"' {
+            index += 1;
+            let mut value = String::new();
+            let mut terminated = false;
+
+            while index < chars.len() {
+                match chars[index] {
+                    '"' => {
+                        terminated = true;
+                        index += 1;
+                        break;
+                    }
+                    '\\' if index + 1 < chars.len() && chars[index + 1] == '"' => {
+                        value.push('"');
+                        index += 2;
+                    }
+                    ch => {
+                        value.push(ch);
+                        index += 1;
+                    }
+                }
+            }
+
+            if !terminated {
+                return Err(starlark::Error::new_other(anyhow!(
+                    "Unterminated quoted value in Sim.Params"
+                )));
+            }
+
+            value
+        } else {
+            let value_start = index;
+            while index < chars.len() && !chars[index].is_whitespace() {
+                index += 1;
+            }
+            chars[value_start..index].iter().collect()
+        };
+
+        parsed.insert(key, value);
+    }
+
+    Ok(parsed)
+}
+
+fn resolve_symbol_spice_model<'v>(
+    final_symbol: &SymbolValue,
+    connections: &SmallMap<String, Value<'v>>,
+    eval_ctx: &crate::EvalContext,
+    heap: &'v Heap,
+) -> starlark::Result<Option<Value<'v>>> {
+    let properties = final_symbol.properties();
+    let sim_device = properties
+        .get("Sim.Device")
+        .and_then(|value| pcb_eda::usable_kicad_field_value(value));
+    let sim_library = properties
+        .get("Sim.Library")
+        .and_then(|value| pcb_eda::usable_kicad_field_value(value));
+    let sim_name = properties
+        .get("Sim.Name")
+        .and_then(|value| pcb_eda::usable_kicad_field_value(value));
+    let sim_pins = properties
+        .get("Sim.Pins")
+        .and_then(|value| pcb_eda::usable_kicad_field_value(value));
+    let sim_params = properties
+        .get("Sim.Params")
+        .and_then(|value| pcb_eda::usable_kicad_field_value(value))
+        .unwrap_or("");
+
+    if sim_device.is_none() && sim_library.is_none() && sim_name.is_none() && sim_pins.is_none() {
+        return Ok(None);
+    }
+
+    let Some(sim_device) = sim_device else {
+        return Ok(None);
+    };
+
+    if !sim_device.eq_ignore_ascii_case("SUBCKT") {
+        return Ok(None);
+    }
+
+    let (Some(sim_library), Some(sim_name), Some(sim_pins)) = (sim_library, sim_name, sim_pins)
+    else {
+        return Ok(None);
+    };
+
+    let symbol_source_uri = final_symbol.source_uri().ok_or_else(|| {
+        starlark::Error::new_other(anyhow!(
+            "Symbol-derived spice_model requires `symbol` to be loaded from a file"
+        ))
+    })?;
+    let symbol_source = eval_ctx
+        .resolution()
+        .resolve_package_uri(symbol_source_uri)
+        .map_err(|e| {
+            starlark::Error::new_other(anyhow!(
+                "Failed to resolve symbol library '{}': {}",
+                symbol_source_uri,
+                e
+            ))
+        })?;
+
+    let mappings = parse_sim_pins(sim_pins)?;
+
+    let mut model_pin_to_signal = SmallMap::new();
+    for (symbol_pin, _) in &mappings {
+        if !final_symbol.pad_to_signal().contains_key(symbol_pin) {
+            return Err(starlark::Error::new_other(anyhow!(
+                "Sim.Pins references unknown symbol pin '{}'",
+                symbol_pin
+            )));
+        }
+    }
+
+    for (symbol_pin, model_pin) in &mappings {
+        let signal_name = final_symbol
+            .pad_to_signal()
+            .get(symbol_pin)
+            .expect("validated above");
+
+        if let Some(existing_signal) = model_pin_to_signal.get(model_pin) {
+            if existing_signal != signal_name {
+                return Err(starlark::Error::new_other(anyhow!(
+                    "Sim.Pins maps model pin '{}' to multiple symbol signals: {}, {}",
+                    model_pin,
+                    existing_signal,
+                    signal_name
+                )));
+            }
+            continue;
+        }
+
+        model_pin_to_signal.insert(model_pin.clone(), signal_name.clone());
+    }
+
+    let (definition, circuit) =
+        resolve_spice_subcircuit(eval_ctx, &symbol_source, sim_library, sim_name)?;
+
+    let mut nets = Vec::with_capacity(circuit.nets.len());
+    for model_pin in &circuit.nets {
+        let signal_name = model_pin_to_signal.get(model_pin).ok_or_else(|| {
+            starlark::Error::new_other(anyhow!("Sim.Pins does not map model pin '{}'", model_pin))
+        })?;
+
+        let net = connections
+            .get(signal_name.as_str())
+            .copied()
+            .ok_or_else(|| {
+                starlark::Error::new_other(anyhow!(
+                    "Sim.Pins mapped model pin '{}' to unconnected symbol signal '{}'",
+                    model_pin,
+                    signal_name
+                ))
+            })?;
+        nets.push(net);
+    }
+
+    for model_pin in model_pin_to_signal.keys() {
+        if !circuit.nets.iter().any(|pin| pin == model_pin) {
+            return Err(starlark::Error::new_other(anyhow!(
+                "Sim.Pins references unknown model pin '{}'",
+                model_pin
+            )));
+        }
+    }
+
+    let args = parse_sim_params(sim_params)?;
+    validate_spice_model(&circuit, nets.len(), &args)?;
+
+    Ok(Some(heap.alloc_complex(SpiceModelValue {
+        definition,
+        name: sim_name.to_owned(),
+        nets,
+        args,
+    })))
 }
 
 fn warn_invalid_symbol_datasheet(eval: &Evaluator<'_, '_, '_>, message: &str) {
@@ -1773,6 +2029,12 @@ where
 
             remove_consolidated_component_properties(&mut properties_map);
 
+            let final_spice_model = if spice_model_val.is_some() {
+                spice_model_val
+            } else {
+                resolve_symbol_spice_model(&final_symbol, &connections, ctx, eval_ctx.heap())?
+            };
+
             let component = eval_ctx.heap().alloc_complex(ComponentValue {
                 name,
                 ctype: final_ctype,
@@ -1788,7 +2050,7 @@ where
                 }),
                 source_path: eval_ctx.source_path().unwrap_or_default(),
                 symbol: eval_ctx.heap().alloc_complex(final_symbol),
-                spice_model: spice_model_val,
+                spice_model: final_spice_model,
                 datasheet: final_datasheet,
                 description: final_description,
             });

--- a/crates/pcb-zen-core/src/lang/spice_model.rs
+++ b/crates/pcb-zen-core/src/lang/spice_model.rs
@@ -2,6 +2,7 @@
 
 use regex::Regex;
 use std::collections::HashSet;
+use std::path::Path;
 
 use allocative::Allocative;
 use starlark::{
@@ -123,7 +124,7 @@ where
                 let name_val: Value = param_parser.next()?;
                 let name = name_val
                     .unpack_str()
-                    .ok_or_else(|| starlark::Error::new_other(anyhow!("`path` must be a string")))?
+                    .ok_or_else(|| starlark::Error::new_other(anyhow!("`name` must be a string")))?
                     .to_owned();
 
                 let inputs_val: Value = param_parser.next()?;
@@ -170,76 +171,12 @@ where
             })?;
 
         let eval_ctx = eval.eval_context().unwrap();
-
         let current_file = eval_ctx
             .source_path()
             .ok_or_else(|| starlark::Error::new_other(anyhow!("No source path available")))?;
-
-        let resolved_path = eval_ctx
-            .get_config()
-            .resolve_path(&path, std::path::Path::new(&current_file))
-            .map_err(|e| {
-                starlark::Error::new_other(anyhow!("Failed to resolve spice model path: {}", e))
-            })?;
-
-        let contents = eval_ctx
-            .file_provider()
-            .read_file(&resolved_path)
-            .map_err(|e| {
-                starlark::Error::new_other(anyhow!(
-                    "Failed to read symbol library '{}': {}",
-                    resolved_path.display(),
-                    e
-                ))
-            })?;
-
-        let circuit = get_sub_circuit(&contents, &name)?;
-
-        // Check missing nets
-        if nets.len() != circuit.nets.len() {
-            return Err(starlark::Error::new_other(anyhow!(
-                "Expected {} nets, {} provided",
-                circuit.nets.len(),
-                nets.len()
-            )));
-        }
-
-        // Check missing arguments
-        let missing: Vec<String> = circuit
-            .params
-            .iter()
-            .filter_map(|param| {
-                if !args.contains_key(param) {
-                    Some(param.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if !missing.is_empty() {
-            return Err(starlark::Error::new_other(anyhow!(
-                "Required argument(s) {:?} not provided",
-                missing
-            )));
-        }
-
-        // Check unexpected arguments
-        let unexpected: Vec<String> = args
-            .iter()
-            .filter_map(|(param, _)| {
-                if !circuit.params.contains(param) {
-                    Some(param.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if !unexpected.is_empty() {
-            return Err(starlark::Error::new_other(anyhow!(
-                "Unexpected argument(s) {:?} ",
-                unexpected
-            )));
-        }
+        let (contents, circuit) =
+            resolve_spice_subcircuit(eval_ctx, Path::new(&current_file), &path, &name)?;
+        validate_spice_model(&circuit, nets.len(), &args)?;
 
         Ok(eval.heap().alloc_complex(SpiceModelValue {
             definition: contents,
@@ -255,9 +192,88 @@ where
 }
 
 #[derive(Debug)]
-struct SubCircuit {
-    nets: Vec<String>,
-    params: HashSet<String>,
+pub(crate) struct SubCircuit {
+    pub(crate) nets: Vec<String>,
+    pub(crate) params: HashSet<String>,
+}
+
+pub(crate) fn resolve_spice_subcircuit(
+    eval_ctx: &crate::EvalContext,
+    resolve_from: &Path,
+    path: &str,
+    name: &str,
+) -> starlark::Result<(String, SubCircuit)> {
+    let resolved_path = eval_ctx
+        .get_config()
+        .resolve_path(path, resolve_from)
+        .map_err(|e| {
+            starlark::Error::new_other(anyhow!("Failed to resolve spice model path: {}", e))
+        })?;
+
+    let contents = eval_ctx
+        .file_provider()
+        .read_file(&resolved_path)
+        .map_err(|e| {
+            starlark::Error::new_other(anyhow!(
+                "Failed to read spice model file '{}': {}",
+                resolved_path.display(),
+                e
+            ))
+        })?;
+
+    let circuit = get_sub_circuit(&contents, name)?;
+    Ok((contents, circuit))
+}
+
+pub(crate) fn validate_spice_model(
+    circuit: &SubCircuit,
+    nets_len: usize,
+    args: &SmallMap<String, String>,
+) -> starlark::Result<()> {
+    if nets_len != circuit.nets.len() {
+        return Err(starlark::Error::new_other(anyhow!(
+            "Expected {} nets, {} provided",
+            circuit.nets.len(),
+            nets_len
+        )));
+    }
+
+    let missing: Vec<String> = circuit
+        .params
+        .iter()
+        .filter_map(|param| {
+            if !args.contains_key(param) {
+                Some(param.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    if !missing.is_empty() {
+        return Err(starlark::Error::new_other(anyhow!(
+            "Required argument(s) {:?} not provided",
+            missing
+        )));
+    }
+
+    let unexpected: Vec<String> = args
+        .iter()
+        .filter_map(|(param, _)| {
+            if !circuit.params.contains(param) {
+                Some(param.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    if !unexpected.is_empty() {
+        return Err(starlark::Error::new_other(anyhow!(
+            "Unexpected argument(s) {:?} ",
+            unexpected
+        )));
+    }
+
+    Ok(())
 }
 
 fn parse_params(s: &str, circuit: &mut SubCircuit) {

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -72,6 +72,124 @@ snapshot_eval!(component_with_symbol, {
     "#
 });
 
+snapshot_eval!(component_infers_spice_model_from_symbol, {
+    "my_model.lib" => r#"
+.SUBCKT my_resistor p n PARAMS: RVAL=1k
+R1 p n {RVAL}
+.ENDS my_resistor
+"#,
+    "test_sim_symbol.kicad_sym" => r#"(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
+  (symbol "TestSim" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
+    (property "Reference" "R" (id 0) (at 0 0 0))
+    (property "Sim.Library" "my_model.lib" (id 1) (at 0 0 0))
+    (property "Sim.Name" "my_resistor" (id 2) (at 0 0 0))
+    (property "Sim.Device" "SUBCKT" (id 3) (at 0 0 0))
+    (property "Sim.Pins" "2=p 1=n" (id 4) (at 0 0 0))
+    (property "Sim.Params" "RVAL=2200" (id 5) (at 0 0 0))
+    (symbol "TestSim_0_1"
+      (rectangle (start -10.16 10.16) (end 10.16 -10.16))
+    )
+    (symbol "TestSim_1_1"
+      (pin passive line (at -12.7 2.54 0) (length 2.54)
+        (name "P1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+      (pin passive line (at -12.7 -2.54 0) (length 2.54)
+        (name "P2" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)"#,
+    "test.zen" => r#"
+        Component(
+            name = "R1",
+            footprint = "0603",
+            symbol = Symbol(library = "./test_sim_symbol.kicad_sym"),
+            pins = {
+                "P1": Net("A"),
+                "P2": Net("B"),
+            },
+        )
+    "#
+});
+
+snapshot_eval!(component_ignores_non_subckt_symbol_spice_model, {
+    "my_model.lib" => r#"
+.SUBCKT my_resistor p n
+R1 p n 1k
+.ENDS my_resistor
+"#,
+    "test_invalid_sim_symbol.kicad_sym" => r#"(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
+  (symbol "TestSim" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
+    (property "Reference" "R" (id 0) (at 0 0 0))
+    (property "Sim.Library" "my_model.lib" (id 1) (at 0 0 0))
+    (property "Sim.Name" "my_resistor" (id 2) (at 0 0 0))
+    (property "Sim.Device" "R" (id 3) (at 0 0 0))
+    (property "Sim.Pins" "1=p 2=n" (id 4) (at 0 0 0))
+    (symbol "TestSim_0_1"
+      (rectangle (start -10.16 10.16) (end 10.16 -10.16))
+    )
+    (symbol "TestSim_1_1"
+      (pin passive line (at -12.7 2.54 0) (length 2.54)
+        (name "P1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+      (pin passive line (at -12.7 -2.54 0) (length 2.54)
+        (name "P2" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)"#,
+    "test.zen" => r#"
+        Component(
+            name = "R1",
+            footprint = "0603",
+            symbol = Symbol(library = "./test_invalid_sim_symbol.kicad_sym"),
+            pins = {
+                "P1": Net("A"),
+                "P2": Net("B"),
+            },
+        )
+    "#
+});
+
+snapshot_eval!(component_ignores_incomplete_subckt_symbol_spice_model, {
+    "test_incomplete_sim_symbol.kicad_sym" => r#"(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
+  (symbol "TestSim" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
+    (property "Reference" "R" (id 0) (at 0 0 0))
+    (property "Sim.Name" "my_resistor" (id 1) (at 0 0 0))
+    (property "Sim.Device" "SUBCKT" (id 2) (at 0 0 0))
+    (property "Sim.Pins" "1=p 2=n" (id 3) (at 0 0 0))
+    (symbol "TestSim_0_1"
+      (rectangle (start -10.16 10.16) (end 10.16 -10.16))
+    )
+    (symbol "TestSim_1_1"
+      (pin passive line (at -12.7 2.54 0) (length 2.54)
+        (name "P1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+      (pin passive line (at -12.7 -2.54 0) (length 2.54)
+        (name "P2" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)"#,
+    "test.zen" => r#"
+        Component(
+            name = "R1",
+            footprint = "0603",
+            symbol = Symbol(library = "./test_incomplete_sim_symbol.kicad_sym"),
+            pins = {
+                "P1": Net("A"),
+                "P2": Net("B"),
+            },
+        )
+    "#
+});
+
 snapshot_eval!(component_duplicate_pin_names, {
     "duplicate_pins_symbol.kicad_sym" => r#"(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
   (symbol "TestSymbol" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)

--- a/crates/pcb-zen-core/tests/snapshots/component__component_ignores_incomplete_subckt_symbol_spice_model.snap
+++ b/crates/pcb-zen-core/tests/snapshots/component__component_ignores_incomplete_subckt_symbol_spice_model.snap
@@ -1,0 +1,57 @@
+---
+source: crates/pcb-zen-core/tests/component.rs
+expression: output
+---
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+        children: [
+            FrozenValue(
+                Component {
+                    name: "R1",
+                    footprint: "0603",
+                    prefix: "R",
+                    connections: {
+                        "P1": FrozenValue(
+                            Net {
+                                name: "A",
+                                id: "<ID>",
+                            },
+                        ),
+                        "P2": FrozenValue(
+                            Net {
+                                name: "B",
+                                id: "<ID>",
+                            },
+                        ),
+                    },
+                    properties: {
+                        "symbol_name": FrozenValue(
+                            "TestSim",
+                        ),
+                    },
+                    symbol: FrozenValue(
+                        Symbol {
+                            name: Some(
+                                "TestSim",
+                            ),
+                            source_uri: "package://test/test_incomplete_sim_symbol.kicad_sym",
+                            pins: {
+                                "1": "P1",
+                                "2": "P2",
+                            },
+                            properties: {
+                                "Reference": "R",
+                                "Sim.Device": "SUBCKT",
+                                "Sim.Name": "my_resistor",
+                                "Sim.Pins": "1=p 2=n",
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/component__component_ignores_non_subckt_symbol_spice_model.snap
+++ b/crates/pcb-zen-core/tests/snapshots/component__component_ignores_non_subckt_symbol_spice_model.snap
@@ -1,0 +1,58 @@
+---
+source: crates/pcb-zen-core/tests/component.rs
+expression: output
+---
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+        children: [
+            FrozenValue(
+                Component {
+                    name: "R1",
+                    footprint: "0603",
+                    prefix: "R",
+                    connections: {
+                        "P1": FrozenValue(
+                            Net {
+                                name: "A",
+                                id: "<ID>",
+                            },
+                        ),
+                        "P2": FrozenValue(
+                            Net {
+                                name: "B",
+                                id: "<ID>",
+                            },
+                        ),
+                    },
+                    properties: {
+                        "symbol_name": FrozenValue(
+                            "TestSim",
+                        ),
+                    },
+                    symbol: FrozenValue(
+                        Symbol {
+                            name: Some(
+                                "TestSim",
+                            ),
+                            source_uri: "package://test/test_invalid_sim_symbol.kicad_sym",
+                            pins: {
+                                "1": "P1",
+                                "2": "P2",
+                            },
+                            properties: {
+                                "Reference": "R",
+                                "Sim.Device": "R",
+                                "Sim.Library": "my_model.lib",
+                                "Sim.Name": "my_resistor",
+                                "Sim.Pins": "1=p 2=n",
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+}
+[]

--- a/crates/pcb-zen-core/tests/snapshots/component__component_infers_spice_model_from_symbol.snap
+++ b/crates/pcb-zen-core/tests/snapshots/component__component_infers_spice_model_from_symbol.snap
@@ -1,0 +1,82 @@
+---
+source: crates/pcb-zen-core/tests/component.rs
+expression: output
+---
+{
+    <root>: Module {
+        path: <root>,
+        source: "test.zen",
+        children: [
+            FrozenValue(
+                Component {
+                    name: "R1",
+                    footprint: "0603",
+                    prefix: "R",
+                    connections: {
+                        "P1": FrozenValue(
+                            Net {
+                                name: "A",
+                                id: "<ID>",
+                            },
+                        ),
+                        "P2": FrozenValue(
+                            Net {
+                                name: "B",
+                                id: "<ID>",
+                            },
+                        ),
+                    },
+                    properties: {
+                        "symbol_name": FrozenValue(
+                            "TestSim",
+                        ),
+                    },
+                    symbol: FrozenValue(
+                        Symbol {
+                            name: Some(
+                                "TestSim",
+                            ),
+                            source_uri: "package://test/test_sim_symbol.kicad_sym",
+                            pins: {
+                                "1": "P1",
+                                "2": "P2",
+                            },
+                            properties: {
+                                "Reference": "R",
+                                "Sim.Device": "SUBCKT",
+                                "Sim.Library": "my_model.lib",
+                                "Sim.Name": "my_resistor",
+                                "Sim.Params": "RVAL=2200",
+                                "Sim.Pins": "2=p 1=n",
+                            },
+                        },
+                    ),
+                    spice_model: FrozenValue(
+                        SpiceModel {
+                            definition: "\n.SUBCKT my_resistor p n PARAMS: RVAL=1k\nR1 p n {RVAL}\n.ENDS my_resistor",
+                            name: "my_resistor",
+                            nets: [
+                                FrozenValue(
+                                    Net {
+                                        name: "B",
+                                        id: "<ID>",
+                                    },
+                                ),
+                                FrozenValue(
+                                    Net {
+                                        name: "A",
+                                        id: "<ID>",
+                                    },
+                                ),
+                            ],
+                            args: {
+                                "RVAL": "2200",
+                            },
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+}
+[]

--- a/crates/pcb-zen/tests/snapshots/spice_model__snapshot_sim_divider_from_symbol_metadata.snap
+++ b/crates/pcb-zen/tests/snapshots/spice_model__snapshot_sim_divider_from_symbol_metadata.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pcb-zen/tests/spice_model.rs
+expression: result
+---
+.SUBCKT my_resistor p n PARAMS: RVAL={0}
+R1 p n {RVAL}
+.ENDS my_resistor
+XR1 vin vout my_resistor RVAL=10000.0
+XR2 vout gnd my_resistor RVAL=10000.0

--- a/crates/pcb-zen/tests/spice_model.rs
+++ b/crates/pcb-zen/tests/spice_model.rs
@@ -222,6 +222,100 @@ builtin.set_sim_setup(content="V1 vin gnd DC 5\n.tran 1u 10m\n.end\n")
 }
 
 #[test]
+fn snapshot_sim_divider_from_symbol_metadata() {
+    let env = TestProject::new();
+
+    env.add_file(
+        "r.lib",
+        r#"
+.SUBCKT my_resistor p n PARAMS: RVAL={0}
+R1 p n {RVAL}
+.ENDS my_resistor
+"#,
+    );
+
+    env.add_file(
+        "myresistor.kicad_sym",
+        r#"(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
+  (symbol "MyResistor" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
+    (property "Reference" "R" (id 0) (at 0 0 0))
+    (property "Sim.Library" "r.lib" (id 1) (at 0 0 0))
+    (property "Sim.Name" "my_resistor" (id 2) (at 0 0 0))
+    (property "Sim.Device" "SUBCKT" (id 3) (at 0 0 0))
+    (property "Sim.Pins" "1=p 2=n" (id 4) (at 0 0 0))
+    (property "Sim.Params" "RVAL=10000.0" (id 5) (at 0 0 0))
+    (symbol "MyResistor_0_1"
+      (rectangle (start -10.16 10.16) (end 10.16 -10.16))
+    )
+    (symbol "MyResistor_1_1"
+      (pin passive line (at -12.7 2.54 0) (length 2.54)
+        (name "P1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+      (pin passive line (at -12.7 -2.54 0) (length 2.54)
+        (name "P2" (effects (font (size 1.27 1.27))))
+        (number "2" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)"#,
+    );
+
+    env.add_file(
+        "myresistor.zen",
+        r#"
+load("@stdlib/config.zen", "config_properties")
+load("@stdlib/units.zen", "Resistance", "Voltage")
+load("@stdlib/utils.zen", "format_value")
+
+Package = enum("0201", "0402", "0603", "0805", "1206", "1210", "2010", "2512")
+
+package = config("package", Package, default = Package("0603"))
+value = config("value", Resistance)
+voltage = config("voltage", Voltage, optional = True)
+
+properties = config_properties({
+    "value": format_value(value, voltage),
+    "package": package,
+    "resistance": value,
+    "voltage": voltage,
+})
+
+P1 = io("P1", Net)
+P2 = io("P2", Net)
+
+Component(
+    name = "R",
+    symbol = Symbol(library = "myresistor.kicad_sym"),
+    footprint = "TEST:0402",
+    prefix = "R",
+    pins = {
+        "P1": P1,
+        "P2": P2,
+    },
+    properties = properties,
+)
+"#,
+    );
+
+    env.add_file(
+        "divider.zen",
+        r#"
+Resistor = Module("myresistor.zen")
+
+vin = io("vin", Power)
+vout = io("vout", Net)
+gnd = io("gnd", Ground)
+
+Resistor(name="R1", value="10kohms", package="0603", P1=vin, P2=vout)
+Resistor(name="R2", value="10kohms", package="0603", P1=vout, P2=gnd)
+"#,
+    );
+
+    sim_snapshot!(env, "divider.zen");
+}
+
+#[test]
 fn snapshot_sim_setup_file() {
     let env = TestProject::new();
 

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -301,6 +301,7 @@ Component(
 | `footprint` | no | PCB footprint path (default: inferred from symbol `Footprint` property) |
 | `type` | no | Component type string |
 | `properties` | no | Additional properties dict |
+| `spice_model` | no | Explicit `SpiceModel`; default: inferred from symbol `Sim.*` properties when present |
 | `dnp` | no | Do Not Populate flag |
 | `skip_bom` | no | Exclude from BOM (default: inverse of symbol `in_bom` flag) |
 | `datasheet` | no | Datasheet path (default: symbol `Datasheet` property; local paths resolved relative to the `.kicad_sym` file) |
@@ -310,6 +311,7 @@ When KiCad symbol pin metadata is available:
 - omitted `no_connect` pins are auto-wired to `NotConnected()`
 - explicit `no_connect` entries warn
 - `power_in` and `power_out` pins warn if connected to plain `Net` instead of `Power` or `Ground`
+- if `spice_model` is omitted and the symbol provides `Sim.Library`, `Sim.Name`, `Sim.Device=SUBCKT`, `Sim.Pins`, and optional `Sim.Params`, `Component()` derives the SPICE model from those symbol properties
 
 ### Part
 


### PR DESCRIPTION
Ref ENG-230

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds implicit SPICE model derivation to `Component()` based on KiCad symbol metadata, which can change simulation behavior and introduce new evaluation-time errors for malformed `Sim.*` fields. Scope is contained to simulation/model parsing paths and covered by new snapshot tests.
> 
> **Overview**
> `Component()` now auto-derives `spice_model` from KiCad symbol `Sim.*` properties (when `Sim.Device=SUBCKT` and required fields are present), including pin mapping via `Sim.Pins` and argument parsing from `Sim.Params`.
> 
> SPICE subcircuit loading/validation logic was refactored into shared helpers (`resolve_spice_subcircuit`, `validate_spice_model`) and reused by both `SpiceModel()` and the new symbol-derived flow, with added tests/snapshots plus spec/changelog updates documenting the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2741d426ed7783c660abb25d13be755b564c434a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
