### PR TITLE
Add `bom_profile` support to Simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `pcb new component` and `pcb search` component imports now place datasheet artifacts under each component's `docs/` subdirectory.
 - Layout sync and KiCad netlist export now normalize file- and package-based footprints to library-aware FPIDs.
 - `Component()` now infers `spice_model` from symbol `Sim.*` properties.
+- `Simulation()` now accepts `bom_profile=`.
 - Module-scoped variable rebinding is now a warning.
 - Removed the 10uF 100V 1210 stdlib house capacitor from generic matching due to severe derating.
 - `Net` and `Power` now expose unset `voltage` as `None`.

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -622,6 +622,17 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
 
     /// Add a component modifier function to this module.
     pub fn add_component_modifier(&mut self, modifier_fn: V) {
+        let modifier_value = modifier_fn.to_value();
+
+        // Board()/Layout()/Simulation() can register the same function more than once.
+        if self
+            .component_modifiers
+            .iter()
+            .any(|existing| existing.to_value().ptr_eq(modifier_value))
+        {
+            return;
+        }
+
         self.component_modifiers.push(modifier_fn);
     }
 

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -3,7 +3,33 @@ mod common;
 
 use pcb_zen_core::DiagnosticsPass;
 use pcb_zen_core::SortPass;
+use pcb_zen_core::lang::component::FrozenComponentValue;
 use pcb_zen_core::lang::error::CategorizedDiagnostic;
+
+fn eval_single_root_component(source: &str) -> FrozenComponentValue {
+    let result = common::eval_zen(vec![("test.zen".to_string(), source.to_string())]);
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+
+    let output = result.output.expect("expected eval output");
+    let module_tree = output.module_tree();
+    let root_module = module_tree
+        .values()
+        .find(|module| module.path().is_root())
+        .expect("expected root module");
+
+    let components: Vec<_> = root_module.components().cloned().collect();
+    assert_eq!(
+        components.len(),
+        1,
+        "expected exactly one root component, got {}",
+        components.len()
+    );
+
+    components
+        .into_iter()
+        .next()
+        .expect("expected one component")
+}
 
 snapshot_eval!(component_properties, {
     "C146731.kicad_sym" => include_str!("resources/C146731.kicad_sym"),
@@ -391,6 +417,102 @@ snapshot_eval!(component_inherits_reference_prefix, {
 // ============================================================================
 // Note: Component() now returns None (like Module()), so direct mutation
 // outside of modifiers is not allowed. Mutation must happen in modifier functions.
+
+#[test]
+fn simulation_uses_default_bom_profile() {
+    let component = eval_single_root_component(
+        r#"
+        load("@stdlib/properties.zen", "Simulation")
+
+        Component(
+            name = "R1",
+            prefix = "R",
+            footprint = "0603",
+            pin_defs = {"1": "1", "2": "2"},
+            pins = {"1": Net("A"), "2": Net("B")},
+            properties = {"package": "0603", "resistance": "10k"},
+            type = "resistor",
+        )
+
+        Simulation(
+            name = "sim",
+            setup = "* noop",
+        )
+    "#,
+    );
+
+    assert!(
+        component.mpn().is_some(),
+        "expected default simulation BOM profile to assign a house part"
+    );
+    assert!(
+        component.manufacturer().is_some(),
+        "expected default simulation BOM profile to assign a manufacturer"
+    );
+}
+
+#[test]
+fn simulation_can_disable_bom_profile() {
+    let component = eval_single_root_component(
+        r#"
+        load("@stdlib/properties.zen", "Simulation")
+
+        Component(
+            name = "R1",
+            prefix = "R",
+            footprint = "0603",
+            pin_defs = {"1": "1", "2": "2"},
+            pins = {"1": Net("A"), "2": Net("B")},
+            properties = {"package": "0603", "resistance": "10k"},
+            type = "resistor",
+        )
+
+        Simulation(
+            name = "sim",
+            setup = "* noop",
+            bom_profile = None,
+        )
+    "#,
+    );
+
+    assert_eq!(
+        component.mpn(),
+        None,
+        "expected bom_profile=None to skip simulation-time house matching"
+    );
+}
+
+#[test]
+fn simulation_modifiers_run_before_bom_profile() {
+    let component = eval_single_root_component(
+        r#"
+        load("@stdlib/properties.zen", "Simulation")
+
+        def assign_custom_part(component):
+            if hasattr(component, "resistance"):
+                component.part = builtin.Part(mpn = "CUSTOM_MPN", manufacturer = "ACME")
+
+        Component(
+            name = "R1",
+            prefix = "R",
+            footprint = "0603",
+            pin_defs = {"1": "1", "2": "2"},
+            pins = {"1": Net("A"), "2": Net("B")},
+            properties = {"package": "0603", "resistance": "10k"},
+            type = "resistor",
+        )
+
+        Simulation(
+            name = "sim",
+            setup = "* noop",
+            modifiers = [assign_custom_part],
+        )
+    "#,
+    );
+
+    assert_eq!(component.mpn(), Some("CUSTOM_MPN"));
+    assert_eq!(component.manufacturer(), Some("ACME"));
+}
 
 snapshot_eval!(component_modifier_basic, {
     "test.zen" => r#"

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -565,6 +565,10 @@ When `layers` is provided, `Board()` selects an appropriate default stackup, net
 
 `Layout()` defines reusable layout blocks for modules. When writing a module, use `Layout(name, path)` to associate a PCB layout with the subcircuit. See `@stdlib/properties.zen`.
 
+**`Simulation(name, setup=None, modifiers=None, bom_profile=...)`** — Attach inline simulation setup and component modifiers to the current module.
+
+`Simulation()` uses the same BOM-profile hook as `Layout()`: by default it registers the standard house-part matcher, `modifiers` run before `bom_profile`, and `bom_profile=None` disables automatic house matching for simulation-only evals.
+
 ### File and Path
 
 **`File(path)`** — Resolve a path relative to the current `.zen` file. Raises an error if it doesn't exist.

--- a/stdlib/properties.zen
+++ b/stdlib/properties.zen
@@ -58,12 +58,11 @@ def Layout(
 
     # Only register at root
     if len(builtin.current_module_path()) == 0:
-        # Register user modifiers first (so they run before BOM matching)
+        # Register user modifiers first so they can override the BOM profile.
         if modifiers:
             for modifier in modifiers:
                 builtin.add_component_modifier(modifier)
 
-        # Register BOM profile modifier
         if bom_profile:
             builtin.add_component_modifier(bom_profile)
 
@@ -85,13 +84,22 @@ def Schematics(name: str, collapse: bool | None = None) -> None:
         add_property("collapse", collapse)
 
 
-def Simulation(name: str, setup: str | None = None, modifiers: list | None = None) -> None:
+def Simulation(
+    name: str,
+    setup: str | None = None,
+    modifiers: list | None = None,
+    bom_profile=assign_house_parts,
+) -> None:
     """Helper function to create a simulations object"""
 
     # `name` is explicitly not used, but kept for consistency and future compatibility
 
     builtin.set_sim_setup(content=setup)
 
+    # Register user modifiers first so they can override the BOM profile.
     if modifiers:
         for modifier in modifiers:
             builtin.add_component_modifier(modifier)
+
+    if bom_profile:
+        builtin.add_component_modifier(bom_profile)

--- a/stdlib/properties.zen
+++ b/stdlib/properties.zen
@@ -96,10 +96,12 @@ def Simulation(
 
     builtin.set_sim_setup(content=setup)
 
-    # Register user modifiers first so they can override the BOM profile.
-    if modifiers:
-        for modifier in modifiers:
-            builtin.add_component_modifier(modifier)
+    # Only register at root, matching Layout().
+    if len(builtin.current_module_path()) == 0:
+        # Register user modifiers first so they can override the BOM profile.
+        if modifiers:
+            for modifier in modifiers:
+                builtin.add_component_modifier(modifier)
 
-    if bom_profile:
-        builtin.add_component_modifier(bom_profile)
+        if bom_profile:
+            builtin.add_component_modifier(bom_profile)


### PR DESCRIPTION
cc @hexdae 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how simulation-time component modifiers/BOM matching are registered (including new default house-part matching and deduping duplicate modifier functions), which could subtly affect evaluated component part assignment order or results.
> 
> **Overview**
> **`Simulation()` now supports `bom_profile=`** (defaulting to the standard house-part matcher) and applies `modifiers` *before* the BOM profile, with `bom_profile=None` disabling automatic house matching for simulation-only evals.
> 
> To support this, the core module system now **deduplicates repeated component-modifier registrations** (avoiding double-application when helpers register the same function multiple times), and tests/docs/changelog are updated to lock in the new simulation BOM-profile behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc3677e0c7afba963734f3b19410d69ad72e6b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
