### PR TITLE
Fix net field coercion for loaded physical types

### DIFF
--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -339,6 +339,25 @@ pub enum PhysicalUnit {
 }
 
 impl PhysicalUnit {
+    pub fn from_quantity(quantity: &str) -> Option<Self> {
+        match quantity {
+            "Resistance" => Some(PhysicalUnit::Ohms),
+            "Voltage" => Some(PhysicalUnit::Volts),
+            "Current" => Some(PhysicalUnit::Amperes),
+            "Capacitance" => Some(PhysicalUnit::Farads),
+            "Inductance" => Some(PhysicalUnit::Henries),
+            "Frequency" => Some(PhysicalUnit::Hertz),
+            "Time" => Some(PhysicalUnit::Seconds),
+            "Temperature" => Some(PhysicalUnit::Kelvin),
+            "Charge" => Some(PhysicalUnit::Coulombs),
+            "Power" => Some(PhysicalUnit::Watts),
+            "Energy" => Some(PhysicalUnit::Joules),
+            "Conductance" => Some(PhysicalUnit::Siemens),
+            "MagneticFlux" | "Flux" => Some(PhysicalUnit::Webers),
+            _ => None,
+        }
+    }
+
     pub const fn suffix(&self) -> &'static str {
         match self {
             PhysicalUnit::Ohms => "", // This should be "Ohm", but keep as empty for backward compatibility

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -25,7 +25,8 @@ use starlark_map::sorted_map::SortedMap;
 use crate::lang::evaluator_ext::EvaluatorExt;
 use crate::lang::symbol::SymbolValue;
 use crate::lang::type_conversion::{
-    try_implicit_type_conversion, try_physical_conversion_from_default,
+    try_implicit_type_conversion, try_physical_conversion_from_compiled_type,
+    try_physical_conversion_from_default,
 };
 
 use super::context::ContextValue;
@@ -687,6 +688,21 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
     }
 }
 
+fn compile_field_type<'v>(
+    field_spec: Value<'v>,
+    heap: &'v Heap,
+) -> anyhow::Result<TypeCompiled<Value<'v>>> {
+    if let Some(field_gen) = field_spec.downcast_ref::<FieldGen<Value<'v>>>() {
+        Ok(TypeCompiled::from_ty(field_gen.typ().as_ty(), heap))
+    } else if let Some(field_gen) = field_spec.downcast_ref::<FieldGen<FrozenValue>>() {
+        // Loaded modules freeze field(...) specs, but we still want to honor
+        // the original compiled matcher for validation and coercion.
+        Ok(TypeCompiled::from_ty(field_gen.typ().as_ty(), heap))
+    } else {
+        TypeCompiled::new(field_spec, heap)
+    }
+}
+
 /// Process a field specification: validate provided value or apply default.
 ///
 /// This is the single unified function for field validation used by both
@@ -712,11 +728,7 @@ pub(crate) fn validate_field<'v>(
     };
 
     // Extract TypeCompiled from field spec (FieldGen or direct type)
-    let type_compiled = if let Some(field_gen) = field_spec.downcast_ref::<FieldGen<Value<'v>>>() {
-        Ok(*field_gen.typ())
-    } else {
-        TypeCompiled::new(field_spec, heap)
-    };
+    let type_compiled = compile_field_type(field_spec, heap);
 
     let type_compiled = match type_compiled {
         Ok(t) => t,
@@ -744,7 +756,16 @@ pub(crate) fn validate_field<'v>(
         } else {
             let converted = match try_implicit_type_conversion(provided_val, field_spec, eval)? {
                 Some(converted) => Some(converted),
-                None => try_physical_conversion_from_default(provided_val, default, eval)?,
+                None => {
+                    match try_physical_conversion_from_compiled_type(
+                        provided_val,
+                        &type_compiled,
+                        eval,
+                    )? {
+                        Some(converted) => Some(converted),
+                        None => try_physical_conversion_from_default(provided_val, default, eval)?,
+                    }
+                }
             };
 
             match converted {

--- a/crates/pcb-zen-core/src/lang/type_conversion.rs
+++ b/crates/pcb-zen-core/src/lang/type_conversion.rs
@@ -1,6 +1,7 @@
+use pcb_sch::PhysicalUnit;
 use pcb_sch::physical::{PhysicalUnitDims, PhysicalValue, PhysicalValueType};
 use starlark::eval::Evaluator;
-use starlark::values::{Value, ValueLike, float::StarlarkFloat};
+use starlark::values::{Value, ValueLike, float::StarlarkFloat, typing::TypeCompiled};
 
 use crate::lang::r#enum::{EnumType, EnumValue};
 use crate::lang::net::{FrozenNetType, FrozenNetValue, NetType, NetValue};
@@ -123,6 +124,34 @@ pub(crate) fn try_physical_conversion<'v>(
     }
 
     try_function_conversion(typ, value, eval)
+}
+
+fn physical_unit_from_type_name(type_name: &str) -> Option<PhysicalUnitDims> {
+    PhysicalUnit::from_quantity(type_name).map(PhysicalUnitDims::from)
+}
+
+/// Attempt physical-value conversion by inspecting a compiled field type.
+///
+/// `field(...)` preserves the compiled matcher but not the original constructor
+/// value, so `field(Voltage | None, default=None)` needs this fallback path.
+pub(crate) fn try_physical_conversion_from_compiled_type<'v>(
+    value: Value<'v>,
+    typ: &TypeCompiled<Value<'v>>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Option<Value<'v>>> {
+    for variant in typ.as_ty().iter_union() {
+        let Some(type_name) = variant.as_name() else {
+            continue;
+        };
+        let Some(unit) = physical_unit_from_type_name(type_name) else {
+            continue;
+        };
+        if let Some(converted) = try_physical_conversion_for_unit(value, unit, eval)? {
+            return Ok(Some(converted));
+        }
+    }
+
+    Ok(None)
 }
 
 /// Attempt physical-value conversion by inferring the unit from a typed default.

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -676,3 +676,60 @@ fn net_field_physical_value_coerces_from_string_with_field_default() {
 
     assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
 }
+
+#[test]
+fn net_field_nullable_voltage_coerces_from_string() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+        Power = builtin.net_type("Power", voltage=field(Voltage | None, default=None))
+
+        vcc = Power("VCC", voltage="3.3V")
+        check(vcc.voltage == Voltage("3.3V"), "nullable field(...) voltage string should coerce to Voltage")
+    "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+}
+
+#[test]
+fn net_field_nullable_impedance_coerces_from_string() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+        Net = builtin.net_type("Net", impedance=field(Impedance | None, default=None))
+
+        clk = Net("CLK", impedance="50")
+        check(clk.impedance == Impedance("50"), "nullable field(...) impedance string should coerce to Impedance")
+    "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+}
+
+#[test]
+fn loaded_net_field_nullable_voltage_coerces_from_string() {
+    let result = common::eval_zen(vec![
+        (
+            "lib.zen".to_string(),
+            r#"
+            Power = builtin.net_type("Power", voltage=field(Voltage | None, default=None))
+        "#
+            .to_string(),
+        ),
+        (
+            "test.zen".to_string(),
+            r#"
+            load("lib.zen", "Power")
+
+            vcc = Power("VCC", voltage="3.3V")
+            check(vcc.voltage == Voltage("3.3V"), "loaded nullable field(...) voltage string should coerce to Voltage")
+        "#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+}


### PR DESCRIPTION
Follow up to https://github.com/diodeinc/pcb/pull/698

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core type validation/coercion for net fields; mistakes could change runtime acceptance/rejection of field values, but changes are scoped and covered by new tests.
> 
> **Overview**
> Fixes net field validation/coercion so physical-value fields wrapped in `field(...)` still coerce scalar/string inputs even when the field is *nullable* and/or the net type comes from a loaded (frozen) module.
> 
> This adds `PhysicalUnit::from_quantity()` to map Starlark physical type names (e.g. `Voltage`, `Impedance`) to units, introduces `try_physical_conversion_from_compiled_type()` to infer physical units from a compiled union matcher (e.g. `Voltage | None`), and updates `validate_field()` to use that path before falling back to default-based inference; new tests cover nullable voltage/impedance coercion and the loaded-module case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2179936ed8a5a8f4070acb12900e977f199bcba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
