### PR TITLE
Fix rust 1.95 lints

### DIFF
--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1107,47 +1107,44 @@ impl Parser {
         // Parse child elements for material and dielectric properties
         for child in node.children().filter(|n| n.is_element()) {
             match child.tag_name().name() {
-                "General" => {
-                    // Extract material from General type="MATERIAL"
-                    if child.attribute("type") == Some("MATERIAL") {
-                        // Look for Property, ColorTerm, and Color elements
-                        for prop in child.children().filter(|n| n.is_element()) {
-                            match prop.tag_name().name() {
-                                "Property" => {
-                                    if let Some(text) = prop.attribute("text")
-                                        && !text.is_empty()
-                                    {
-                                        let text_sym = self.interner.intern(text);
-                                        // Store all property texts
-                                        properties.push(text_sym);
-                                        // Take the first non-empty material text we find
-                                        if material.is_none() {
-                                            material = Some(text_sym);
-                                        }
+                "General" if child.attribute("type") == Some("MATERIAL") => {
+                    // Look for Property, ColorTerm, and Color elements
+                    for prop in child.children().filter(|n| n.is_element()) {
+                        match prop.tag_name().name() {
+                            "Property" => {
+                                if let Some(text) = prop.attribute("text")
+                                    && !text.is_empty()
+                                {
+                                    let text_sym = self.interner.intern(text);
+                                    // Store all property texts
+                                    properties.push(text_sym);
+                                    // Take the first non-empty material text we find
+                                    if material.is_none() {
+                                        material = Some(text_sym);
                                     }
                                 }
-                                "ColorTerm" => {
-                                    // Parse ColorTerm name attribute (e.g., "GREEN", "WHITE", "BLACK")
-                                    if let Some(color_name) = prop.attribute("name") {
-                                        color_term = Some(self.interner.intern(color_name));
-                                    }
-                                }
-                                "Color" => {
-                                    // Parse Color r, g, b attributes (0-255)
-                                    if let (Some(r_str), Some(g_str), Some(b_str)) = (
-                                        prop.attribute("r"),
-                                        prop.attribute("g"),
-                                        prop.attribute("b"),
-                                    ) && let (Ok(r), Ok(g), Ok(b)) = (
-                                        r_str.parse::<u8>(),
-                                        g_str.parse::<u8>(),
-                                        b_str.parse::<u8>(),
-                                    ) {
-                                        color_rgb = Some((r, g, b));
-                                    }
-                                }
-                                _ => {}
                             }
+                            "ColorTerm" => {
+                                // Parse ColorTerm name attribute (e.g., "GREEN", "WHITE", "BLACK")
+                                if let Some(color_name) = prop.attribute("name") {
+                                    color_term = Some(self.interner.intern(color_name));
+                                }
+                            }
+                            "Color" => {
+                                // Parse Color r, g, b attributes (0-255)
+                                if let (Some(r_str), Some(g_str), Some(b_str)) = (
+                                    prop.attribute("r"),
+                                    prop.attribute("g"),
+                                    prop.attribute("b"),
+                                ) && let (Ok(r), Ok(g), Ok(b)) = (
+                                    r_str.parse::<u8>(),
+                                    g_str.parse::<u8>(),
+                                    b_str.parse::<u8>(),
+                                ) {
+                                    color_rgb = Some((r, g, b));
+                                }
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -1167,19 +1164,16 @@ impl Parser {
                         }
                     }
                 }
-                "Conductor" => {
-                    // Parse copper weight from Conductor type="WEIGHT"
-                    if child.attribute("type") == Some("WEIGHT") {
-                        for prop in child.children().filter(|n| n.is_element()) {
-                            if prop.tag_name().name() == "Property"
-                                && let Some(value_str) = prop.attribute("value")
-                                && let Ok(value) = value_str.parse::<f64>()
-                            {
-                                // Check unit - should be OZ
-                                let unit = prop.attribute("unit").unwrap_or("OZ");
-                                if unit.to_uppercase() == "OZ" {
-                                    copper_weight_oz = Some(value);
-                                }
+                "Conductor" if child.attribute("type") == Some("WEIGHT") => {
+                    for prop in child.children().filter(|n| n.is_element()) {
+                        if prop.tag_name().name() == "Property"
+                            && let Some(value_str) = prop.attribute("value")
+                            && let Ok(value) = value_str.parse::<f64>()
+                        {
+                            // Check unit - should be OZ
+                            let unit = prop.attribute("unit").unwrap_or("OZ");
+                            if unit.to_uppercase() == "OZ" {
+                                copper_weight_oz = Some(value);
                             }
                         }
                     }

--- a/crates/pcb-diode-api/src/registry/tui/app.rs
+++ b/crates/pcb-diode-api/src/registry/tui/app.rs
@@ -1417,7 +1417,7 @@ impl App {
             .filter_map(|cmd| cmd.match_score(query).map(|score| (cmd, score)))
             .collect();
         // Sort by score descending
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         self.command_palette_filtered = scored.into_iter().map(|(cmd, _)| cmd).collect();
         // Reset selection
         self.command_palette_index = 0;

--- a/crates/pcb-docs/src/lib.rs
+++ b/crates/pcb-docs/src/lib.rs
@@ -91,7 +91,7 @@ pub fn find_page(query: &str) -> Result<&'static Page, DocError> {
         })
         .collect();
 
-    scored.sort_by(|a, b| b.1.cmp(&a.1));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
     if scored.is_empty() {
         return Err(DocError::NoMatch {
@@ -158,7 +158,7 @@ pub fn find_section(page: &Page, query: &str) -> Result<&'static Section, DocErr
         })
         .collect();
 
-    scored.sort_by(|a, b| b.1.cmp(&a.1));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
     if scored.is_empty() {
         return Err(DocError::NoMatch {

--- a/crates/pcb-eda/src/kicad/symbol.rs
+++ b/crates/pcb-eda/src/kicad/symbol.rs
@@ -379,15 +379,11 @@ fn parse_property(symbol: &mut KicadSymbol, prop_list: &[Sexpr]) {
             "Datasheet" => symbol.datasheet_url = Some(value.clone()),
             "Manufacturer_Name" => symbol.manufacturer = Some(value.clone()),
             "Manufacturer_Part_Number" => symbol.mpn = Some(value.clone()),
-            "LCSC Part" => {
-                if symbol.mpn.is_none() {
-                    symbol.mpn = Some(value.clone());
-                }
+            "LCSC Part" if symbol.mpn.is_none() => {
+                symbol.mpn = Some(value.clone());
             }
-            "Value" => {
-                if symbol.mpn.is_none() && symbol.name == value.clone() {
-                    symbol.mpn = Some(value.clone());
-                }
+            "Value" if symbol.mpn.is_none() && symbol.name == value => {
+                symbol.mpn = Some(value.clone());
             }
             key if key.ends_with("Part Number") => {
                 let distributor = key.trim_end_matches(" Part Number");

--- a/crates/pcb-eda/src/kicad/symbol_library.rs
+++ b/crates/pcb-eda/src/kicad/symbol_library.rs
@@ -381,21 +381,21 @@ fn merge_symbol_sexprs(parent_sexp: &Sexpr, child_sexp: &Sexpr) -> Sexpr {
                             let mut symbol_items = symbol_items.clone();
                             if let Some(symbol_name_expr) = symbol_items.get_mut(1) {
                                 match &symbol_name_expr.kind {
-                                    SexprKind::Symbol(symbol_name) => {
+                                    SexprKind::Symbol(symbol_name)
+                                        if symbol_name.starts_with(&parent_name) =>
+                                    {
                                         // Replace parent name with child name in sub-symbol name
-                                        if symbol_name.starts_with(&parent_name) {
-                                            let suffix = &symbol_name[parent_name.len()..];
-                                            *symbol_name_expr =
-                                                Sexpr::symbol(format!("{child_name}{suffix}"));
-                                        }
+                                        let suffix = &symbol_name[parent_name.len()..];
+                                        *symbol_name_expr =
+                                            Sexpr::symbol(format!("{child_name}{suffix}"));
                                     }
-                                    SexprKind::String(symbol_name) => {
+                                    SexprKind::String(symbol_name)
+                                        if symbol_name.starts_with(&parent_name) =>
+                                    {
                                         // Replace parent name with child name in sub-symbol name
-                                        if symbol_name.starts_with(&parent_name) {
-                                            let suffix = &symbol_name[parent_name.len()..];
-                                            *symbol_name_expr =
-                                                Sexpr::string(format!("{child_name}{suffix}"));
-                                        }
+                                        let suffix = &symbol_name[parent_name.len()..];
+                                        *symbol_name_expr =
+                                            Sexpr::string(format!("{child_name}{suffix}"));
                                     }
                                     _ => {}
                                 }

--- a/crates/pcb-ipc2581-tools/src/commands/view.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/view.rs
@@ -114,11 +114,12 @@ fn filter_by_mode(xml: &str, mode: ViewMode) -> Result<String> {
                     writer.write_event(Event::Start(e.to_owned()))?;
                 }
             }
-            Event::Empty(ref e) if skip_depth == 0 => {
-                if !should_exclude(e.name().as_ref(), excluded) {
-                    writer.write_event(Event::Empty(e.to_owned()))?;
-                }
+            Event::Empty(ref e)
+                if skip_depth == 0 && !should_exclude(e.name().as_ref(), excluded) =>
+            {
+                writer.write_event(Event::Empty(e.to_owned()))?;
             }
+            Event::Empty(_) if skip_depth == 0 => {}
             Event::Start(_) if skip_depth > 0 => skip_depth += 1,
             Event::End(_) if skip_depth > 0 => skip_depth -= 1,
             event if skip_depth == 0 => writer.write_event(event)?,

--- a/crates/pcb-sch/src/kicad_netlist.rs
+++ b/crates/pcb-sch/src/kicad_netlist.rs
@@ -330,10 +330,8 @@ pub fn to_kicad_netlist(sch: &Schematic) -> String {
     writeln!(out, "  (nets").unwrap();
     let mut net_vec: Vec<_> = nets.into_iter().collect();
     net_vec.sort_by(|a, b| a.0.cmp(&b.0));
-    let mut code: u32 = 1;
-    for (_name, info) in &mut net_vec {
+    for (code, (_name, info)) in (1_u32..).zip(net_vec.iter_mut()) {
         info.code = code;
-        code += 1;
     }
     for (_name, info) in net_vec {
         // Sort nodes for deterministic ordering.

--- a/crates/pcb-starlark-lsp/src/inspect.rs
+++ b/crates/pcb-starlark-lsp/src/inspect.rs
@@ -184,10 +184,10 @@ impl AstModuleInspect for AstModule {
                             continue;
                         }
                         match &arg.node {
-                            ParameterP::Normal(_, Some(type_), None) => {
-                                if type_.span.contains(position) {
-                                    return Some(AutocompleteType::Type);
-                                }
+                            ParameterP::Normal(_, Some(type_), None)
+                                if type_.span.contains(position) =>
+                            {
+                                return Some(AutocompleteType::Type);
                             }
                             ParameterP::Normal(_, type_, Some(expr)) => {
                                 if let Some(type_) = type_

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -1467,7 +1467,7 @@ impl std::fmt::Display for ComponentValue<'_> {
 
         if !data.properties.is_empty() {
             let mut props: Vec<_> = data.properties.iter().collect();
-            props.sort_by(|(a, _), (b, _)| a.cmp(b));
+            props.sort_by_key(|(key, _)| *key);
             writeln!(f, "Properties:")?;
             for (key, value) in props {
                 writeln!(f, "  {key}: {value:?}")?;
@@ -1489,7 +1489,7 @@ impl std::fmt::Display for FrozenComponentValue {
 
         if !self.data.properties.is_empty() {
             let mut props: Vec<_> = self.data.properties.iter().collect();
-            props.sort_by(|(a, _), (b, _)| a.cmp(b));
+            props.sort_by_key(|(key, _)| *key);
             writeln!(f, "Properties:")?;
             for (key, value) in props {
                 writeln!(f, "  {key}: {value:?}")?;

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -1392,20 +1392,14 @@ fn validate_type<'v>(
     let simple_type = typ.get_type();
 
     match simple_type {
-        "str" | "string" | "String" => {
-            if value.unpack_str().is_some() {
-                return Ok(());
-            }
+        "str" | "string" | "String" if value.unpack_str().is_some() => {
+            return Ok(());
         }
-        "int" | "Int" => {
-            if value.unpack_i32().is_some() {
-                return Ok(());
-            }
+        "int" | "Int" if value.unpack_i32().is_some() => {
+            return Ok(());
         }
-        "float" | "Float" => {
-            if value.downcast_ref::<StarlarkFloat>().is_some() {
-                return Ok(());
-            }
+        "float" | "Float" if value.downcast_ref::<StarlarkFloat>().is_some() => {
+            return Ok(());
         }
         _ => {}
     }

--- a/crates/pcb-zen-core/src/lang/stackup.rs
+++ b/crates/pcb-zen-core/src/lang/stackup.rs
@@ -882,11 +882,8 @@ impl Stackup {
                     "F.SilkS" => {
                         silk_screen_color = Self::extract_string_prop(&layer_data[2..], "color");
                     }
-                    "F.Mask" | "B.Mask" => {
-                        if solder_mask_color.is_none() {
-                            solder_mask_color =
-                                Self::extract_string_prop(&layer_data[2..], "color");
-                        }
+                    "F.Mask" | "B.Mask" if solder_mask_color.is_none() => {
+                        solder_mask_color = Self::extract_string_prop(&layer_data[2..], "color");
                     }
                     name if name.ends_with(".Cu") => {
                         // Copper layer - use actual role from layers section

--- a/crates/pcb-zen-core/src/lang/symbol.rs
+++ b/crates/pcb-zen-core/src/lang/symbol.rs
@@ -152,7 +152,7 @@ impl std::fmt::Display for SymbolValue {
         )?;
 
         let mut pins: Vec<_> = self.pad_to_signal.iter().collect();
-        pins.sort_by(|(a, _), (b, _)| a.cmp(b));
+        pins.sort_by_key(|(key, _)| *key);
 
         let mut first = true;
         for (pad_name, signal_value) in pins {

--- a/crates/pcb-zen/src/ast_utils.rs
+++ b/crates/pcb-zen/src/ast_utils.rs
@@ -104,7 +104,7 @@ pub fn apply_edits(lines: &mut Vec<String>, mut edits: Vec<SourceEdit>) {
         return;
     }
 
-    edits.sort_by(|a, b| (a.0, a.1, a.2, a.3).cmp(&(b.0, b.1, b.2, b.3)));
+    edits.sort_by_key(|edit| (edit.0, edit.1, edit.2, edit.3));
 
     for (start_line, start_col, end_line, end_col, replacement) in edits.into_iter().rev() {
         if start_line == end_line {

--- a/crates/pcb/src/import/portable.rs
+++ b/crates/pcb/src/import/portable.rs
@@ -536,10 +536,10 @@ fn collect_kicad_refs_from_json(value: &Value) -> BTreeSet<String> {
 
 fn collect_refs_recursive(value: &Value, refs: &mut BTreeSet<String>) {
     match value {
-        Value::String(s) => {
-            if extension_of_reference(s).is_some_and(|ext| is_relevant_kicad_extension(&ext)) {
-                refs.insert(s.clone());
-            }
+        Value::String(s)
+            if extension_of_reference(s).is_some_and(|ext| is_relevant_kicad_extension(&ext)) =>
+        {
+            refs.insert(s.clone());
         }
         Value::Array(arr) => {
             for item in arr {

--- a/crates/pcb/src/import/semantic.rs
+++ b/crates/pcb/src/import/semantic.rs
@@ -136,12 +136,11 @@ fn detect_passives(ir: &ImportIr) -> ImportPassiveAnalysis {
             (Some(ImportPassiveKind::Capacitor), Some(ImportPassiveConfidence::Low)) => {
                 summary.capacitor_low += 1;
             }
+            (None, _) if classification.pad_count != Some(2) => {
+                summary.non_two_pad += 1;
+            }
             (None, _) => {
-                if classification.pad_count != Some(2) {
-                    summary.non_two_pad += 1;
-                } else {
-                    summary.unknown += 1;
-                }
+                summary.unknown += 1;
             }
             _ => {
                 summary.unknown += 1;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily mechanical refactors (sorting helpers, match guards, iterator tweaks) with minimal behavior change; low risk aside from small control-flow reshapes in parsing/filters that should be covered by existing tests/fixtures.
> 
> **Overview**
> This PR is a lint-driven cleanup that refactors a handful of `match` arms and sort calls across crates to more idiomatic patterns (e.g., `sort_by_key(Reverse(..))`, match guards, and simpler key sorting) without intended behavioral changes.
> 
> It also makes a few small control-flow rewrites for clarity/determinism, including tightening IPC-2581 `Spec` parsing pattern matches, simplifying KiCad symbol property handling, streamlining net code assignment in KiCad netlist generation, and making XML filtering in `ipc2581-tools view` explicitly handle excluded `Event::Empty` elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e2fdd4a9216f4a3fb6e56cdc9aa8700c962004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->