### PR TITLE
Add Linux arm64 dist target

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,13 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
@@ -26,6 +32,7 @@ x86_64-apple-darwin = "macos-15-large"
 aarch64-apple-darwin = "macos-15-xlarge"
 x86_64-pc-windows-msvc = "diode-windows"
 x86_64-unknown-linux-gnu = "ubicloud-standard-30-ubuntu-2204"
+aarch64-unknown-linux-gnu = "ubicloud-standard-30-arm-ubuntu-2204"
 
 [[dist.extra-artifacts]]
 build = ["sh", "-c", "rustup target add wasm32-wasip2 && cargo build -p pcb-zen-wasm --bin pcb-zen-wasi --target wasm32-wasip2 --release"]


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/release configuration-only change; risk is limited to potential CI/build failures or producing incorrect Linux ARM artifacts if the runner/target setup is misconfigured.
> 
> **Overview**
> Adds Linux ARM64 (`aarch64-unknown-linux-gnu`) to `cargo-dist` release targets and formats the targets list for readability.
> 
> Configures a dedicated GitHub Actions runner (`ubicloud-standard-30-arm-ubuntu-2204`) for the new ARM64 Linux target so releases can build that artifact in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c0244114bf2369bda6f7f7bdee7b52156e50f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->