### PR TITLE
`voltage_within` now accepts `Voltage`, not just nets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Warning: Pin 'VDD' on component 'LIS3DH' is a power pin but is connected to plai
 - Component generation no longer automatically scans datasheets.
 - Component modifiers can now override `spice_model`.
 - House Murata caps now use vendor MLCC models when available.
+- `voltage_within()` now accepts nets with voltage metadata or direct `Voltage` values.
 - `pcb new component` and `pcb search` component imports now place datasheet artifacts under each component's `docs/` subdirectory.
 - Layout sync and KiCad netlist export now normalize file- and package-based footprints to library-aware FPIDs.
 - `Component()` now infers `spice_model` from symbol `Sim.*` properties.

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -609,11 +609,11 @@ warn("Using deprecated parameter")
 
 ### Electrical Checks
 
-`@stdlib/checks.zen` provides reusable check functions for `io()` boundaries. For example, `voltage_within(range)` validates that a Power net's voltage falls within a specified range:
+`@stdlib/checks.zen` provides reusable check functions for typed inputs. For example, `voltage_within(range)` validates that a net with voltage metadata, or a direct `Voltage` value, falls within a specified range:
 
 ```python
 load("@stdlib/checks.zen", "voltage_within")
-VCC = io(Power, checks=voltage_within("1.1–3.6V"))
+vref = config(Voltage, checks=voltage_within("1.1–3.6V"))
 ```
 
 Template-first `io()` can also contribute implicit checks. A typed net template with a meaningful `voltage` property enforces the same containment rule automatically:

--- a/stdlib/checks.zen
+++ b/stdlib/checks.zen
@@ -1,5 +1,4 @@
 load("units.zen", "Voltage")
-load("interfaces.zen", "Power")
 
 Severity = enum("error", "warning", "advice")
 
@@ -15,14 +14,21 @@ def voltage_within(
         err_msg = "Voltage range " + str(voltage) + " of " + net_name + " is not within " + str(within)
         check(voltage in within, err_msg)
 
-    def check_gen(power: Power, severity: Severity = severity, name: str = name):
-        check_name = power.NET.name + "_" + name
-        if not power.voltage:
-            return
+    def check_gen(actual, severity: Severity = severity, name: str = name):
+        if hasattr(actual, "NET"):
+            check_name = actual.NET.name + "_" + name
+            if not actual.voltage:
+                return
+            voltage = actual.voltage
+            net_name = actual.NET.name
+        else:
+            voltage = Voltage(actual)
+            net_name = name
+            check_name = name
         builtin.add_electrical_check(
             name=check_name,
             check_fn=ensure_voltage_within,
-            inputs={"voltage": power.voltage, "within": within, "net_name": power.NET.name},
+            inputs={"voltage": voltage, "within": within, "net_name": net_name},
             severity=severity.value,
         )
 

--- a/stdlib/test/test_checks.zen
+++ b/stdlib/test/test_checks.zen
@@ -1,5 +1,5 @@
 load("../checks.zen", "voltage_within")
-load("../interfaces.zen", "Power")
+load("../interfaces.zen", "Net", "Power")
 load("../units.zen", "Voltage")
 
 # Test 3.3V rail with tolerance
@@ -23,3 +23,12 @@ check_1v8(v1v8)
 v_unknown = Power("UNKNOWN")
 check_unknown = voltage_within("5V 10%")
 check_unknown(v_unknown)
+
+# Test generic net with voltage metadata
+vref = Net("VREF", voltage=Voltage("1.2V 1%"))
+check_vref = voltage_within("1.2V 5%")
+check_vref(vref)
+
+# Test direct voltage input with fallback naming
+check_direct = voltage_within("2.5V 5%", name="direct_voltage")
+check_direct(Voltage("2.5V 1%"))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to a stdlib check helper plus documentation/tests; main risk is minor behavior differences for existing callers due to broader accepted input types and naming.
> 
> **Overview**
> **`voltage_within()` is generalized beyond `Power` nets** to accept any net-like object with `.NET`/`.voltage` *or* a direct `Voltage`/string coercible to `Voltage`, and uses a fallback check name when validating a standalone value.
> 
> Docs and release notes are updated to reflect the new typed-input usage pattern, and stdlib tests add coverage for generic `Net` voltage metadata and direct `Voltage` inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24165fa7d8d2c75338425bc0264c3d9d91327909. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
