### PR TITLE
Warn on deprecated `NET=` net casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ Warning: Pin 'VDD' on component 'LIS3DH' is a power pin but is connected to plai
 - Module-scoped variable rebinding is now a warning.
 - Removed the 10uF 100V 1210 stdlib house capacitor from generic matching due to severe derating.
 - `Net` and `Power` now expose unset `voltage` as `None`.
+- Deprecated `NET=` net casts now warn; use positional forms like `Power(other_net)`.
 
 ### Fixed
 

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -885,6 +885,30 @@ pub(crate) fn instantiate_generated_net<'v>(
     .into())
 }
 
+fn emit_net_keyword_deprecation<'v>(eval: &Evaluator<'v, '_, '_>, type_name: &str) {
+    let message = format!(
+        "{type_name}() keyword argument `NET=` is deprecated; use the positional form `{type_name}(other_net)` instead"
+    );
+    let (path, span) = match eval.call_stack_top_location() {
+        Some(location) => (
+            location.filename().to_owned(),
+            Some(location.resolve_span()),
+        ),
+        None => (eval.source_path().unwrap_or_default(), None),
+    };
+
+    eval.add_diagnostic(
+        crate::Diagnostic::categorized(
+            &path,
+            &message,
+            "deprecated.net_constructor_kwarg",
+            starlark::errors::EvalSeverity::Warning,
+        )
+        .with_span(span)
+        .with_call_stack(Some(eval.call_stack())),
+    );
+}
+
 #[starlark_value(type = "NetType")]
 impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for NetTypeGen<V>
 where
@@ -967,6 +991,7 @@ where
                         .into());
                     }
                     base_net = Some(nv);
+                    emit_net_keyword_deprecation(eval, &type_name);
                 }
 
                 // Choose requested name: name= overrides positional string, which overrides base net's original name

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -175,7 +175,7 @@ fn io_derived_template_skips_implicit_checks() {
             r#"
                 Mod = Module("Module.zen")
                 vin = Mod.Power("VIN", voltage="3.3V")
-                en = Mod.Power("ENABLE", voltage="5V").NET
+                en = Mod.Power("ENABLE", voltage="5V")
                 Mod(name = "child", VIN = vin, EN = en)
             "#
             .to_string(),

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 mod common;
 
+use crate::common::eval_zen;
+use pcb_zen_core::lang::error::CategorizedDiagnostic;
+
 snapshot_eval!(net_with_symbol, {
     "test.zen" => r#"
         # Create a symbol
@@ -225,7 +228,7 @@ snapshot_eval!(net_cast_base_attrs, {
         Signal = builtin.net_type("Signal")
 
         sig = Signal("SIG")
-        base = sig.NET
+        base = Net(sig)
 
         print("has voltage:", hasattr(base, "voltage"))
         print("has impedance:", hasattr(base, "impedance"))
@@ -732,4 +735,76 @@ fn loaded_net_field_nullable_voltage_coerces_from_string() {
     ]);
 
     assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+}
+
+#[test]
+fn net_constructor_net_keyword_warns_and_preserves_behavior() {
+    let result = eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            Power = builtin.net_type("Power")
+
+            other_net = Net("SIG")
+            power = Power(NET=other_net)
+
+            check(power.name == "SIG", "NET= cast should preserve the base net name")
+        "#
+        .to_string(),
+    )]);
+
+    assert!(
+        !result.diagnostics.has_errors(),
+        "did not expect errors, got: {:?}",
+        result.diagnostics
+    );
+
+    let warnings = result.diagnostics.warnings();
+    let warning = warnings
+        .iter()
+        .find(|diag| {
+            diag.downcast_error_ref::<CategorizedDiagnostic>()
+                .is_some_and(|c| c.kind == "deprecated.net_constructor_kwarg")
+        })
+        .expect("expected NET= deprecation warning");
+
+    assert_eq!(
+        warning.body,
+        "Power() keyword argument `NET=` is deprecated; use the positional form `Power(other_net)` instead"
+    );
+    assert_eq!(warning.path, "test.zen");
+    assert!(
+        warning.span.is_some(),
+        "expected NET= deprecation warning to include a source span, got: {:?}",
+        warning
+    );
+}
+
+#[test]
+fn net_constructor_positional_cast_does_not_warn() {
+    let result = eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            Power = builtin.net_type("Power")
+
+            other_net = Net("SIG")
+            power = Power(other_net)
+
+            check(power.name == "SIG", "positional cast should preserve the base net name")
+        "#
+        .to_string(),
+    )]);
+
+    assert!(
+        !result.diagnostics.has_errors(),
+        "did not expect errors, got: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !result.diagnostics.warnings().iter().any(|diag| {
+            diag.downcast_error_ref::<CategorizedDiagnostic>()
+                .is_some_and(|c| c.kind == "deprecated.net_constructor_kwarg")
+        }),
+        "did not expect NET= deprecation warning, got: {:?}",
+        result.diagnostics.warnings()
+    );
 }

--- a/crates/pcb-zen/tests/spice_model.rs
+++ b/crates/pcb-zen/tests/spice_model.rs
@@ -137,8 +137,8 @@ vout = io(Analog)
 gnd = io(Ground)
 
 # Create the voltage divider
-Resistor(name="R1", value=r1_value, package="0603", P1=vin.NET, P2=vout.NET)
-Resistor(name="R2", value=r2_value, package="0603", P1=vout.NET, P2=gnd.NET)
+Resistor(name="R1", value=r1_value, package="0603", P1=vin, P2=vout)
+Resistor(name="R2", value=r2_value, package="0603", P1=vout, P2=gnd)
 "#,
     );
 
@@ -211,8 +211,8 @@ vin = io(Power)
 vout = io(Analog)
 gnd = io(Ground)
 
-Resistor(name="R1", value=r1_value, package="0603", P1=vin.NET, P2=vout.NET)
-Resistor(name="R2", value=r2_value, package="0603", P1=vout.NET, P2=gnd.NET)
+Resistor(name="R1", value=r1_value, package="0603", P1=vin, P2=vout)
+Resistor(name="R2", value=r2_value, package="0603", P1=vout, P2=gnd)
 
 builtin.set_sim_setup(content="V1 vin gnd DC 5\n.tran 1u 10m\n.end\n")
 "#,
@@ -383,8 +383,8 @@ vin = io(Power)
 vout = io(Analog)
 gnd = io(Ground)
 
-Resistor(name="R1", value=r1_value, package="0603", P1=vin.NET, P2=vout.NET)
-Resistor(name="R2", value=r2_value, package="0603", P1=vout.NET, P2=gnd.NET)
+Resistor(name="R1", value=r1_value, package="0603", P1=vin, P2=vout)
+Resistor(name="R2", value=r2_value, package="0603", P1=vout, P2=gnd)
 
 builtin.set_sim_setup(file="setup.spice")
 "#,

--- a/crates/pcb/tests/bom.rs
+++ b/crates/pcb/tests/bom.rs
@@ -20,8 +20,8 @@ CTRL = io(Gpio)
 
 led_anode = Net("LED_ANODE")
 
-Resistor(name = "R1", value = r_value, package = package, P1 = VCC.NET, P2 = led_anode)
-Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.NET)
+Resistor(name = "R1", value = r_value, package = package, P1 = VCC, P2 = led_anode)
+Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL)
 "#;
 
 const TEST_BOARD_ZEN: &str = r#"
@@ -38,18 +38,18 @@ led_ctrl = Gpio("LED_CTRL")
 osc_xi = Gpio("OSC_XI")
 osc_xo = Gpio("OSC_XO")
 
-Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
-Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3, P2 = gnd)
+Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3, P2 = gnd)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
-LedModule(name = "LED2", led_color = "red", VCC = vcc_3v3, GND = gnd, CTRL = Gpio(NET = gnd.NET))
+LedModule(name = "LED2", led_color = "red", VCC = vcc_3v3, GND = gnd, CTRL = Gpio(gnd))
 
-Crystal(name = "X1", frequency = "16MHz", load_capacitance = "18pF", package = "5032_2Pin", XIN = osc_xi.NET, XOUT = osc_xo.NET)
+Crystal(name = "X1", frequency = "16MHz", load_capacitance = "18pF", package = "5032_2Pin", XIN = osc_xi, XOUT = osc_xo)
 
-Capacitor(name = "C3", value = "22pF", package = "0402", P1 = osc_xi.NET, P2 = gnd.NET)
-Capacitor(name = "C4", value = "22pF", package = "0402", P1 = osc_xo.NET, P2 = gnd.NET)
+Capacitor(name = "C3", value = "22pF", package = "0402", P1 = osc_xi, P2 = gnd)
+Capacitor(name = "C4", value = "22pF", package = "0402", P1 = osc_xo, P2 = gnd)
 
-Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 "#;
 
 const SIMPLE_RESISTOR_BOARD_ZEN: &str = r#"
@@ -63,9 +63,9 @@ Resistor = Module("@stdlib/generics/Resistor.zen")
 vcc = Power("VCC")
 gnd = Ground("GND")
 
-Resistor(name = "R1", value = "1kOhm", package = "0603", P1 = vcc.NET, P2 = gnd.NET)
-Resistor(name = "R2", value = "1kOhm", package = "0603", P1 = vcc.NET, P2 = gnd.NET)
-Resistor(name = "R3", value = "4.7kOhm", package = "0402", P1 = vcc.NET, P2 = gnd.NET)
+Resistor(name = "R1", value = "1kOhm", package = "0603", P1 = vcc, P2 = gnd)
+Resistor(name = "R2", value = "1kOhm", package = "0603", P1 = vcc, P2 = gnd)
+Resistor(name = "R3", value = "4.7kOhm", package = "0402", P1 = vcc, P2 = gnd)
 "#;
 
 const CAPACITOR_BOARD_ZEN: &str = r#"
@@ -79,9 +79,9 @@ Capacitor = Module("@stdlib/generics/Capacitor.zen")
 vcc = Power("VCC")
 gnd = Ground("GND")
 
-Capacitor(name = "C1", value = "100nF", package = "0402", voltage = "16V", dielectric = "X7R", P1 = vcc.NET, P2 = gnd.NET)
-Capacitor(name = "C2", value = "10uF", package = "0805", voltage = "25V", dielectric = "X5R", P1 = vcc.NET, P2 = gnd.NET)
-Capacitor(name = "C3", value = "1uF", package = "0603", P1 = vcc.NET, P2 = gnd.NET)
+Capacitor(name = "C1", value = "100nF", package = "0402", voltage = "16V", dielectric = "X7R", P1 = vcc, P2 = gnd)
+Capacitor(name = "C2", value = "10uF", package = "0805", voltage = "25V", dielectric = "X5R", P1 = vcc, P2 = gnd)
+Capacitor(name = "C3", value = "1uF", package = "0603", P1 = vcc, P2 = gnd)
 "#;
 
 const SKIP_BOM_BOARD_ZEN: &str = r#"
@@ -199,14 +199,14 @@ vcc = Power("VCC")
 gnd = Ground("GND")
 
 # Normal module - components should NOT be DNP
-Resistor(name = "R1", value = "1kOhm", package = "0603", P1 = vcc.NET, P2 = gnd.NET)
+Resistor(name = "R1", value = "1kOhm", package = "0603", P1 = vcc, P2 = gnd)
 
 # Module with dnp=True - all child components should be DNP
-Resistor(name = "R2_DNP", value = "10kOhm", package = "0603", P1 = vcc.NET, P2 = gnd.NET, dnp = True)
-Capacitor(name = "C1_DNP", value = "100nF", package = "0402", P1 = vcc.NET, P2 = gnd.NET, dnp = True)
+Resistor(name = "R2_DNP", value = "10kOhm", package = "0603", P1 = vcc, P2 = gnd, dnp = True)
+Capacitor(name = "C1_DNP", value = "100nF", package = "0402", P1 = vcc, P2 = gnd, dnp = True)
 
 # Normal module again - should NOT be DNP
-Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc.NET, P2 = gnd.NET)
+Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc, P2 = gnd)
 "#;
 
 const WORKSPACE_TOML: &str = r#"

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -224,15 +224,15 @@ for i in range(count):
         name = "R{}".format(i + 1),
         value = "1kohm",
         package = package,
-        P1 = vcc.NET,
-        P2 = gnd.NET,
+        P1 = vcc,
+        P2 = gnd,
     )
 
 if enable_extra:
-    Resistor(name = "R_EXTRA", value = "2kohm", package = package, P1 = vcc.NET, P2 = gnd.NET)
+    Resistor(name = "R_EXTRA", value = "2kohm", package = package, P1 = vcc, P2 = gnd)
 
 if mode == Mode("TWO"):
-    Resistor(name = "R_MODE", value = "3kohm", package = package, P1 = vcc.NET, P2 = gnd.NET)
+    Resistor(name = "R_MODE", value = "3kohm", package = package, P1 = vcc, P2 = gnd)
 "#;
 
 const PIN_NO_CONNECT_REPORTS_AT_NET_ZEN: &str = r#"

--- a/crates/pcb/tests/netlist.rs
+++ b/crates/pcb/tests/netlist.rs
@@ -98,8 +98,8 @@ LedModule = Module("../modules/LedModule.zen")
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
 
-LedModule(name="LED1", led_color="green", VCC=vcc_3v3, GND=gnd, CTRL=Gpio(NET=Net("LED_CTRL")))
-LedModule(name="LED2", led_color="red", VCC=vcc_3v3, GND=gnd, CTRL=Gpio(NET=Net("LED_CTRL2")))
+LedModule(name="LED1", led_color="green", VCC=vcc_3v3, GND=gnd, CTRL=Gpio("LED_CTRL"))
+LedModule(name="LED2", led_color="red", VCC=vcc_3v3, GND=gnd, CTRL=Gpio("LED_CTRL2"))
 
 # Position comments for hierarchical design
 # pcb:sch LED1.R1 x=100.0000 y=100.0000 rot=0
@@ -316,7 +316,7 @@ Component(
     name = "R1",
     footprint = "TEST:0402",
     pin_defs = {"1": "1"},
-    pins = {"1": vcc.NET},
+    pins = {"1": vcc},
 )
 "#;
 

--- a/crates/pcb/tests/release.rs
+++ b/crates/pcb/tests/release.rs
@@ -22,8 +22,8 @@ CTRL = io(Gpio)
 
 led_anode = Net("LED_ANODE")
 
-Resistor(name = "R1", value = r_value, package = package, P1 = VCC.NET, P2 = led_anode)
-Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.NET)
+Resistor(name = "R1", value = r_value, package = package, P1 = VCC, P2 = led_anode)
+Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL)
 "#;
 
 const TEST_BOARD_ZEN: &str = r#"
@@ -39,12 +39,12 @@ vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
 led_ctrl = Gpio("LED_CTRL")
 
-Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
-Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3, P2 = gnd)
+Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3, P2 = gnd)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
 
-Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 "#;
 
 const PCB_TOML: &str = r#"

--- a/crates/pcb/tests/simple.rs
+++ b/crates/pcb/tests/simple.rs
@@ -17,8 +17,8 @@ CTRL = io(Gpio)
 
 led_anode = Net("LED_ANODE")
 
-Resistor(name = "R1", value = r_value, package = package, P1 = VCC.NET, P2 = led_anode)
-Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.NET)
+Resistor(name = "R1", value = r_value, package = package, P1 = VCC, P2 = led_anode)
+Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL)
 "#;
 
 const TEST_BOARD_ZEN: &str = r#"
@@ -37,18 +37,18 @@ led_ctrl = Gpio("LED_CTRL")
 osc_xi = Gpio("OSC_XI")
 osc_xo = Gpio("OSC_XO")
 
-Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
-Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3, P2 = gnd)
+Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3, P2 = gnd)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
-LedModule(name = "LED2", led_color = "red", VCC = vcc_3v3, GND = gnd, CTRL = Gpio(NET = gnd.NET))
+LedModule(name = "LED2", led_color = "red", VCC = vcc_3v3, GND = gnd, CTRL = Gpio(gnd))
 
-Crystal(name = "X1", frequency = "16MHz", load_capacitance = "18pF", package = "5032_2Pin", XIN = osc_xi.NET, XOUT = osc_xo.NET)
+Crystal(name = "X1", frequency = "16MHz", load_capacitance = "18pF", package = "5032_2Pin", XIN = osc_xi, XOUT = osc_xo)
 
-Capacitor(name = "C3", value = "22pF", package = "0402", P1 = osc_xi.NET, P2 = gnd.NET)
-Capacitor(name = "C4", value = "22pF", package = "0402", P1 = osc_xo.NET, P2 = gnd.NET)
+Capacitor(name = "C3", value = "22pF", package = "0402", P1 = osc_xi, P2 = gnd)
+Capacitor(name = "C4", value = "22pF", package = "0402", P1 = osc_xo, P2 = gnd)
 
-Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 "#;
 
 const SIMPLE_BOARD_ZEN: &str = r#"
@@ -65,7 +65,6 @@ load("github.com/nonexistent/repo:main/interfaces.zen", "Gpio", "Ground", "Power
 
 vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
-vcc_3v3.NET = Net("VCC_3V3")
 "#;
 
 const SIMPLE_RESISTOR_ZEN: &str = r#"

--- a/crates/pcb/tests/snapshots/release__publish_full.snap
+++ b/crates/pcb/tests/snapshots/release__publish_full.snap
@@ -133,12 +133,12 @@ vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
 led_ctrl = Gpio("LED_CTRL")
 
-Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
-Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3, P2 = gnd)
+Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3, P2 = gnd)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
 
-Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 === src/boards/modules/LedModule.zen
 
 load("@stdlib/interfaces.zen", "Gpio")
@@ -156,8 +156,8 @@ CTRL = io(Gpio)
 
 led_anode = Net("LED_ANODE")
 
-Resistor(name = "R1", value = r_value, package = package, P1 = VCC.NET, P2 = led_anode)
-Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.NET)
+Resistor(name = "R1", value = r_value, package = package, P1 = VCC, P2 = led_anode)
+Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL)
 === src/boards/pcb.toml
 
 [board]

--- a/crates/pcb/tests/snapshots/release__publish_source_only.snap
+++ b/crates/pcb/tests/snapshots/release__publish_source_only.snap
@@ -59,12 +59,12 @@ vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
 led_ctrl = Gpio("LED_CTRL")
 
-Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
-Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3, P2 = gnd)
+Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3, P2 = gnd)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
 
-Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 === src/boards/modules/LedModule.zen
 
 load("@stdlib/interfaces.zen", "Gpio")
@@ -82,8 +82,8 @@ CTRL = io(Gpio)
 
 led_anode = Net("LED_ANODE")
 
-Resistor(name = "R1", value = r_value, package = package, P1 = VCC.NET, P2 = led_anode)
-Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.NET)
+Resistor(name = "R1", value = r_value, package = package, P1 = VCC, P2 = led_anode)
+Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL)
 === src/boards/pcb.toml
 
 [board]

--- a/crates/pcb/tests/snapshots/release__publish_with_description.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_description.snap
@@ -60,12 +60,12 @@ vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
 led_ctrl = Gpio("LED_CTRL")
 
-Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
-Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3, P2 = gnd)
+Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3, P2 = gnd)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
 
-Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 === src/boards/modules/LedModule.zen
 
 load("@stdlib/interfaces.zen", "Gpio")
@@ -83,8 +83,8 @@ CTRL = io(Gpio)
 
 led_anode = Net("LED_ANODE")
 
-Resistor(name = "R1", value = r_value, package = package, P1 = VCC.NET, P2 = led_anode)
-Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.NET)
+Resistor(name = "R1", value = r_value, package = package, P1 = VCC, P2 = led_anode)
+Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL)
 === src/boards/pcb.toml
 
 [board]

--- a/crates/pcb/tests/snapshots/release__publish_with_version.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_version.snap
@@ -59,12 +59,12 @@ vcc_3v3 = Power("VCC_3V3")
 gnd = Ground("GND")
 led_ctrl = Gpio("LED_CTRL")
 
-Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3.NET, P2 = gnd.NET)
-Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3.NET, P2 = gnd.NET)
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = vcc_3v3, P2 = gnd)
+Capacitor(name = "C2", value = "10uF", package = "0805", P1 = vcc_3v3, P2 = gnd)
 
 LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = led_ctrl)
 
-Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3.NET, P2 = led_ctrl.NET)
+Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 === src/boards/modules/LedModule.zen
 
 load("@stdlib/interfaces.zen", "Gpio")
@@ -82,8 +82,8 @@ CTRL = io(Gpio)
 
 led_anode = Net("LED_ANODE")
 
-Resistor(name = "R1", value = r_value, package = package, P1 = VCC.NET, P2 = led_anode)
-Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL.NET)
+Resistor(name = "R1", value = r_value, package = package, P1 = VCC, P2 = led_anode)
+Led(name = "D1", color = led_color, package = package, A = led_anode, K = CTRL)
 === src/boards/pcb.toml
 
 [board]

--- a/stdlib/amplifiers.zen
+++ b/stdlib/amplifiers.zen
@@ -44,7 +44,7 @@ def inverting_sum(
 
     Resistor(name=name + "_R_F", value=RG, package=package, voltage=V, P1=IN_N, P2=OUT)
 
-    return Opamp(name=name, IN_P=GND.NET, IN_N=IN_N, OUT=OUT)
+    return Opamp(name=name, IN_P=GND, IN_N=IN_N, OUT=OUT)
 
 
 def noninverting_sum(

--- a/stdlib/checks.zen
+++ b/stdlib/checks.zen
@@ -16,11 +16,11 @@ def voltage_within(
 
     def check_gen(actual, severity: Severity = severity, name: str = name):
         if hasattr(actual, "NET"):
-            check_name = actual.NET.name + "_" + name
+            check_name = actual.name + "_" + name
             if not actual.voltage:
                 return
             voltage = actual.voltage
-            net_name = actual.NET.name
+            net_name = actual.name
         else:
             voltage = Voltage(actual)
             net_name = name

--- a/stdlib/simulation/test/test_LevelShifter.zen
+++ b/stdlib/simulation/test/test_LevelShifter.zen
@@ -24,7 +24,7 @@ OPA1, OPA2 = level_shifter(
 )
 
 # 1V offset for level shifting
-Resistor(name="R1", value="110kOhm", package="0603", P1=VP.NET, P2=VOFFSET)
+Resistor(name="R1", value="110kOhm", package="0603", P1=VP, P2=VOFFSET)
 Resistor(name="R2", value="10kOhm", package="0603", P1=VOFFSET, P2=GND)
 
 OperationalAmplifier(


### PR DESCRIPTION
Also remove unnecessary `.NET` casts from examples, test code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is preserved and the runtime change is limited to emitting a new warning diagnostic when the deprecated `NET=` kwarg is used, though it may surface new warnings in existing projects.
> 
> **Overview**
> Adds a new deprecation warning (`deprecated.net_constructor_kwarg`) when typed-net constructors are called with the legacy `NET=` keyword (e.g. `Power(NET=other_net)`), guiding users to the positional cast form.
> 
> Updates stdlib/examples/tests/snapshots to remove redundant `.NET` casts and migrate call sites to positional net passing/casting (e.g. `Power(other_net)`, `Net(sig)`, and passing `io()` nets directly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcfef69573ad2bb19df2ec0976a1d19e6e72fc6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->