### PR TITLE
Fix aarch64-linux build failure

### DIFF
--- a/crates/pcb-diode-api/src/kicad_symbols/mod.rs
+++ b/crates/pcb-diode-api/src/kicad_symbols/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::SearchHit;
 use crate::bom::ComponentKey;
+use crate::ensure_sqlite_vec_registered;
 use crate::registry::{
     ParsedQuery, RrfSearchOutput, build_prefix_fts_query, build_query_embedding,
     collect_deduped_hits_by_url, merge_rrf_hit_lists,
@@ -149,18 +150,7 @@ impl KicadSymbolsClient {
             anyhow::bail!("KiCad symbols database not found at {}.", path.display());
         }
 
-        unsafe {
-            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute::<
-                *const (),
-                unsafe extern "C" fn(
-                    *mut rusqlite::ffi::sqlite3,
-                    *mut *mut i8,
-                    *const rusqlite::ffi::sqlite3_api_routines,
-                ) -> i32,
-            >(
-                sqlite_vec::sqlite3_vec_init as *const (),
-            )));
-        }
+        ensure_sqlite_vec_registered()?;
 
         let conn = Connection::open_with_flags(
             path,

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -1,3 +1,6 @@
+use anyhow::{Context, Result};
+use rusqlite::auto_extension::{RawAutoExtension, register_auto_extension};
+
 pub mod auth;
 pub mod bom;
 pub mod component;
@@ -40,4 +43,15 @@ pub fn get_web_base_url() -> String {
         .unwrap_or_default()
         .web_base_url()
         .to_string()
+}
+
+pub(crate) fn ensure_sqlite_vec_registered() -> Result<()> {
+    unsafe {
+        // SQLite intentionally erases auto-extension entrypoint types to `void(*)(void)`.
+        // Let rusqlite define the target-correct callback signature for us.
+        let init = std::mem::transmute::<unsafe extern "C" fn(), RawAutoExtension>(
+            sqlite_vec::sqlite3_vec_init,
+        );
+        register_auto_extension(init).context("Failed to register sqlite-vec auto-extension")
+    }
 }

--- a/crates/pcb-diode-api/src/registry/mod.rs
+++ b/crates/pcb-diode-api/src/registry/mod.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::bom::ComponentKey;
+use crate::ensure_sqlite_vec_registered;
 
 pub mod download;
 pub mod embeddings;
@@ -503,19 +504,7 @@ impl RegistryClient {
             );
         }
 
-        // Register sqlite-vec extension BEFORE opening connection
-        unsafe {
-            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute::<
-                *const (),
-                unsafe extern "C" fn(
-                    *mut rusqlite::ffi::sqlite3,
-                    *mut *mut i8,
-                    *const rusqlite::ffi::sqlite3_api_routines,
-                ) -> i32,
-            >(
-                sqlite_vec::sqlite3_vec_init as *const (),
-            )));
-        }
+        ensure_sqlite_vec_registered()?;
 
         let conn = Connection::open_with_flags(
             path,

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -90,24 +90,6 @@ struct UnresolvedDep {
     spec: DependencySpec,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RequirementSource {
-    LockfileSeed,
-    Dependency,
-}
-
-impl RequirementSource {
-    fn is_stronger_than(self, other: Self) -> bool {
-        matches!(
-            (self, other),
-            (
-                RequirementSource::Dependency,
-                RequirementSource::LockfileSeed
-            )
-        )
-    }
-}
-
 fn missing_workspace_member_error(workspace_info: &WorkspaceInfo, url: &str) -> anyhow::Error {
     let missing_manifest_hint = workspace_info
         .workspace_base_url()
@@ -582,13 +564,12 @@ pub fn resolve_dependencies(
 
     // MVS state
     let mut selected: HashMap<ModuleLine, Version> = HashMap::new();
-    let mut selected_sources: HashMap<ModuleLine, RequirementSource> = HashMap::new();
     let mut work_queue: VecDeque<ModuleLine> = VecDeque::new();
     let mut manifest_cache: HashMap<(ModuleLine, Version), PcbToml> = HashMap::new();
 
-    // Preseed from lockfile (opportunistic frontloading)
-    // This allows Wave 1 to start fetching known deps immediately
-    if let Some(lockfile) = &workspace_info.lockfile {
+    // Offline resolution needs lockfile-selected versions up front because only
+    // previously resolved packages can be fetched from vendor/.
+    if offline && let Some(lockfile) = &workspace_info.lockfile {
         for entry in lockfile.iter() {
             // Skip non-package lock entries (manifest hash is package-only).
             if entry.manifest_hash.is_none() {
@@ -614,10 +595,8 @@ pub fn resolve_dependencies(
                 entry.module_path.clone(),
                 version,
                 &mut selected,
-                &mut selected_sources,
                 &mut work_queue,
                 &patches,
-                RequirementSource::LockfileSeed,
             );
         }
     }
@@ -704,25 +683,15 @@ pub fn resolve_dependencies(
                 dep.url.clone(),
                 version,
                 &mut selected,
-                &mut selected_sources,
                 &mut work_queue,
                 &patches,
-                RequirementSource::Dependency,
             );
         }
     }
 
     // Seed MVS with implicit stdlib asset requirements from workspace configuration.
     for (repo, version) in workspace_info.stdlib_asset_dep_versions() {
-        add_requirement(
-            repo,
-            version,
-            &mut selected,
-            &mut selected_sources,
-            &mut work_queue,
-            &patches,
-            RequirementSource::Dependency,
-        );
+        add_requirement(repo, version, &mut selected, &mut work_queue, &patches);
     }
 
     let fetch_pool = build_fetch_pool()?;
@@ -831,10 +800,8 @@ pub fn resolve_dependencies(
                     dep_path.clone(),
                     dep_version,
                     &mut selected,
-                    &mut selected_sources,
                     &mut work_queue,
                     &patches,
-                    RequirementSource::Dependency,
                 );
                 if work_queue.len() > before {
                     new_deps += 1;
@@ -2162,16 +2129,16 @@ impl PseudoVersionContext {
 
 /// Add a requirement to the MVS state.
 ///
-/// Lockfile-preseeded versions are weak hints; dependency-derived versions are authoritative.
-/// Patches are checked here - they override version selection with ultimate authority.
+/// Selection is monotonic within a module line: unseen versions are added and
+/// newer versions upgrade the current selection. Lower versions are ignored.
+/// Patches are checked here - they override version selection with ultimate
+/// authority.
 fn add_requirement(
     path: String,
     version: Version,
     selected: &mut HashMap<ModuleLine, Version>,
-    selected_sources: &mut HashMap<ModuleLine, RequirementSource>,
     work_queue: &mut VecDeque<ModuleLine>,
     patches: &BTreeMap<String, pcb_zen_core::config::PatchSpec>,
-    source: RequirementSource,
 ) {
     if is_stdlib_module_path(&path) {
         return;
@@ -2189,32 +2156,20 @@ fn add_requirement(
 
     let line = ModuleLine::new(path.clone(), &final_version);
     let current_version = selected.get(&line);
-    let current_source = selected_sources.get(&line).copied();
-    let needs_update = match (current_version, current_source) {
-        (None, _) => true,
-        (Some(_), Some(existing_source)) if source.is_stronger_than(existing_source) => true,
-        (Some(_), Some(existing_source)) if existing_source.is_stronger_than(source) => false,
-        (Some(current), _) => final_version > *current,
-    };
-
-    if needs_update {
-        let version_changed = current_version != Some(&final_version);
-        let action = match current_version {
-            None => "Adding",
-            Some(current) if final_version > *current => "Upgrading",
-            Some(_) => "Selecting",
-        };
-        let suffix = if is_patched { " (patched)" } else { "" };
-        if version_changed {
-            log::debug!("  → {} {}@v{}{}", action, path, final_version, suffix);
-        }
-
-        selected.insert(line.clone(), final_version);
-        selected_sources.insert(line.clone(), source);
-        if version_changed {
-            work_queue.push_back(line);
-        }
+    if current_version.is_some_and(|current| final_version <= *current) {
+        return;
     }
+
+    let action = if current_version.is_some() {
+        "Upgrading"
+    } else {
+        "Adding"
+    };
+    let suffix = if is_patched { " (patched)" } else { "" };
+    log::debug!("  → {} {}@v{}{}", action, path, final_version, suffix);
+
+    selected.insert(line.clone(), final_version);
+    work_queue.push_back(line);
 }
 
 /// Verify computed hashes match the expected hashes from the git tag annotation
@@ -3005,46 +2960,5 @@ mod tests {
         .expect("expected matching locked pseudo-version");
 
         assert_eq!(version, pseudo);
-    }
-
-    #[test]
-    fn test_dependency_requirement_overrides_lockfile_seed_for_same_line() {
-        let dep = "github.com/mycompany/components/SimpleResistor".to_string();
-        let lockfile_seed =
-            Version::parse("0.1.1-0.20260101000000-f000000000000000000000000000000000000000")
-                .unwrap();
-        let resolved_dep =
-            Version::parse("0.1.1-0.20260101000000-1000000000000000000000000000000000000000")
-                .unwrap();
-        let line = ModuleLine::new(dep.clone(), &lockfile_seed);
-        let mut selected = HashMap::new();
-        let mut selected_sources = HashMap::new();
-        let mut work_queue = VecDeque::new();
-        let patches = BTreeMap::new();
-
-        add_requirement(
-            dep.clone(),
-            lockfile_seed,
-            &mut selected,
-            &mut selected_sources,
-            &mut work_queue,
-            &patches,
-            RequirementSource::LockfileSeed,
-        );
-        add_requirement(
-            dep,
-            resolved_dep.clone(),
-            &mut selected,
-            &mut selected_sources,
-            &mut work_queue,
-            &patches,
-            RequirementSource::Dependency,
-        );
-
-        assert_eq!(selected.get(&line), Some(&resolved_dep));
-        assert_eq!(
-            selected_sources.get(&line),
-            Some(&RequirementSource::Dependency)
-        );
     }
 }


### PR DESCRIPTION
https://github.com/diodeinc/pcb/actions/runs/24576696378/job/71863905130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQLite extension registration and dependency resolution behavior in offline mode; mistakes could break search DB startup or change resolved dependency sets, but changes are localized and straightforward.
> 
> **Overview**
> Fixes SQLite `sqlite-vec` extension registration by centralizing it in `pcb-diode-api` (`ensure_sqlite_vec_registered`) and switching both registry and KiCad-symbol DB open paths to use rusqlite’s `register_auto_extension` (avoiding the previous manual `sqlite3_auto_extension` transmute that was failing on aarch64).
> 
> Adjusts `pcb-zen` dependency resolution so lockfile preseeding only happens in `--offline` mode, and simplifies MVS requirement selection to **monotonic upgrades only** (removing the lockfile-vs-dependency “strength” tracking and the associated unit test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71827d1b5dc6b5ef5cc825b78d1c34fc86f6aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
