### PR TITLE
Fix stdlib diode io prelude handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [0.3.69] - 2026-04-17
 
+### Fixed
+
+- Fixed `io` prelude handling for `generics/Rectifier.zen` and `generics/Zener.zen`.
+
 ## [0.3.68] - 2026-04-17
 
 ### Migration Guide

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -381,6 +381,8 @@ impl EvalContextConfig {
 
     /// Set the source path of the module we are evaluating.
     pub fn set_source_path(mut self, path: PathBuf) -> Self {
+        let stdlib_dir = self.resolution.workspace_info.workspace_stdlib_dir();
+        self.inject_prelude = self.inject_prelude && !path.starts_with(&stdlib_dir);
         self.source_path = Some(path);
         self
     }
@@ -423,10 +425,6 @@ impl EvalContextConfig {
             child_load_chain.insert(source.clone());
         }
 
-        // Disable prelude for stdlib modules to avoid circular deps.
-        let stdlib_dir = self.resolution.workspace_info.workspace_stdlib_dir();
-        let inject_prelude = self.inject_prelude && !target_path.starts_with(&stdlib_dir);
-
         Self {
             builtin_docs: self.builtin_docs.clone(),
             file_provider: self.file_provider.clone(),
@@ -434,13 +432,14 @@ impl EvalContextConfig {
             path_to_spec: self.path_to_spec.clone(),
             module_path: child_module_path,
             load_chain: child_load_chain,
-            source_path: Some(target_path),
+            source_path: None,
             contents: None,
             strict_io_config: false,
             build_circuit: false,
             eager: self.eager,
-            inject_prelude,
+            inject_prelude: self.inject_prelude,
         }
+        .set_source_path(target_path)
     }
 
     /// Check if loading the given path would create a cycle.
@@ -1231,7 +1230,7 @@ impl EvalContext {
 
     /// Set the source path of the module we are evaluating.
     pub fn set_source_path(mut self, path: PathBuf) -> Self {
-        self.config.source_path = Some(path);
+        self.config = self.config.set_source_path(path);
         self
     }
 

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -60,6 +60,33 @@ const TEST_NO_CONNECT_SYMBOL: &str = r#"(kicad_symbol_lib
 )
 "#;
 
+const DIODES_ZEN: &str = r#"
+Rectifier = Module("@stdlib/generics/Rectifier.zen")
+Zener = Module("@stdlib/generics/Zener.zen")
+
+vin = Power("VIN")
+gnd = Ground("GND")
+protected = Net("PROTECTED")
+
+Rectifier(
+    name = "D1",
+    package = "DO-214AC",
+    reverse_voltage = "40V",
+    forward_current = "1A",
+    A = vin,
+    K = protected,
+)
+
+Zener(
+    name = "D2",
+    package = "SOD-123",
+    zener_voltage = "5.1V",
+    power = "500mW",
+    A = gnd,
+    K = protected,
+)
+"#;
+
 const SUPPRESSED_WARNINGS_ZEN: &str = r#"
 warn("Regular warning")
 warn("Suppressed warning 1", suppress=True)
@@ -359,6 +386,15 @@ fn test_build_with_config_overrides() {
 
     assert!(output.contains("Exit Code: 0"), "{output}");
     assert!(output.contains("(4 components)"), "{output}");
+}
+
+#[test]
+fn test_diodes_build() {
+    let output = Sandbox::new()
+        .write("diodes.zen", DIODES_ZEN)
+        .snapshot_run("pcb", ["build", "diodes.zen"]);
+
+    assert!(output.contains("Exit Code: 0"), "{output}");
 }
 
 #[test]

--- a/stdlib/generics/Rectifier.zen
+++ b/stdlib/generics/Rectifier.zen
@@ -4,6 +4,7 @@ Generic rectifier diode.
 This module covers both small-signal / signaling diodes and power rectifiers.
 """
 
+load("../io.zen", "io")
 load("../interfaces.zen", "Net")
 load("../units.zen", "Current", "Voltage")
 load("../utils.zen", "format_value")

--- a/stdlib/generics/Zener.zen
+++ b/stdlib/generics/Zener.zen
@@ -5,6 +5,7 @@ This module covers both small-signal zener diodes and higher-power zener
 diodes used for regulation and protection.
 """
 
+load("../io.zen", "io")
 load("../interfaces.zen", "Net")
 load("../units.zen", "Power", "Voltage")
 Watts = Power


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core evaluation/module-loading configuration (`inject_prelude`) and could affect how any loaded modules resolve implicit stdlib symbols, though changes are narrow and covered by a new build regression test.
> 
> **Overview**
> Fixes stdlib prelude injection so it is automatically **disabled for modules under the bundled stdlib**, preventing circular/incorrect prelude behavior when evaluating loaded stdlib files.
> 
> Updates the stdlib `generics/Rectifier.zen` and `generics/Zener.zen` modules to explicitly `load("../io.zen", "io")` (so they don’t rely on the prelude), and adds a regression test that builds a small diode design using those modules. Changelog is updated for `0.3.69` to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334a7df4050923f5b1ba726408f82e30132ddff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->