### PR TITLE
Skip `no_connect` pins in generated component wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed `io` prelude handling for `generics/Rectifier.zen` and `generics/Zener.zen`.
+- Generated component .zen files now omit KiCad `no_connect` pins from `io()` and `Component(..., pins=...)`.
 
 ## [0.3.68] - 2026-04-17
 

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -131,13 +131,9 @@ fn signal_is_only_no_connect(metadata: &SignalPinMetadata) -> bool {
     metadata.saw_pin_type && !metadata.saw_non_no_connect
 }
 
-pub fn generate_component_zen(args: GenerateComponentZenArgs<'_>) -> Result<String> {
-    let component_name = sanitize_mpn_for_path(args.component_name);
-
-    // Track unique signals and their electrical-type metadata so wrapper generation can
-    // omit signals that KiCad marks as no_connect.
+pub fn generated_signal_io_names(symbol: &Symbol) -> BTreeMap<String, String> {
     let mut signals: BTreeMap<String, SignalPinMetadata> = BTreeMap::new();
-    for pin in &args.symbol.pins {
+    for pin in &symbol.pins {
         let signal_name = pin.signal_name().to_string();
         let metadata = signals
             .entry(signal_name)
@@ -148,34 +144,32 @@ pub fn generate_component_zen(args: GenerateComponentZenArgs<'_>) -> Result<Stri
         update_signal_pin_metadata(metadata, pin);
     }
 
-    // Group by sanitized io name; duplicate signal names (e.g. multiple pads for the same
-    // net) naturally merge into one io() declaration. Signals that are unambiguously
-    // no_connect are skipped entirely so generated wrappers match Component() expectations.
-    let mut pin_groups: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
-    for (signal_name, metadata) in signals {
-        if signal_is_only_no_connect(&metadata) {
-            continue;
-        }
+    signals
+        .into_iter()
+        .filter_map(|(signal_name, metadata)| {
+            (!signal_is_only_no_connect(&metadata))
+                .then_some((signal_name, metadata.sanitized_name))
+        })
+        .collect()
+}
 
-        pin_groups
-            .entry(metadata.sanitized_name)
-            .or_default()
-            .insert(signal_name);
-    }
+pub fn generate_component_zen(args: GenerateComponentZenArgs<'_>) -> Result<String> {
+    let component_name = sanitize_mpn_for_path(args.component_name);
+    let signal_io_names = generated_signal_io_names(args.symbol);
 
-    let pin_groups_vec: Vec<_> = pin_groups
-        .keys()
+    let pin_groups_vec: Vec<_> = signal_io_names
+        .values()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
         .map(|name| serde_json::json!({"sanitized_name": name}))
         .collect();
 
-    let pin_mappings: Vec<_> = pin_groups
+    let pin_mappings: Vec<_> = signal_io_names
         .iter()
-        .flat_map(|(sanitized, originals)| {
-            originals.iter().map(move |orig| {
-                serde_json::json!({
-                    "original_name": orig,
-                    "sanitized_name": sanitized
-                })
+        .map(|(signal_name, io_name)| {
+            serde_json::json!({
+                "original_name": signal_name,
+                "sanitized_name": io_name
             })
         })
         .collect();

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use deunicode::deunicode;
 use minijinja::Environment;
-use pcb_eda::Symbol;
+use pcb_eda::{Pin, Symbol};
 use std::collections::{BTreeMap, BTreeSet};
 
 const COMPONENT_ZEN_TEMPLATE: &str = include_str!("../templates/component.zen.jinja");
@@ -103,16 +103,62 @@ pub struct GenerateComponentZenArgs<'a> {
     pub skip_pos_default: bool,
 }
 
+#[derive(Debug, Default)]
+struct SignalPinMetadata {
+    sanitized_name: String,
+    saw_pin_type: bool,
+    saw_non_no_connect: bool,
+}
+
+fn pin_type_candidates(pin: &Pin) -> impl Iterator<Item = &str> {
+    pin.electrical_type.as_deref().into_iter().chain(
+        pin.alternates
+            .iter()
+            .filter_map(|alt| alt.electrical_type.as_deref()),
+    )
+}
+
+fn update_signal_pin_metadata(metadata: &mut SignalPinMetadata, pin: &Pin) {
+    for pin_type in pin_type_candidates(pin) {
+        metadata.saw_pin_type = true;
+        if pin_type != "no_connect" {
+            metadata.saw_non_no_connect = true;
+        }
+    }
+}
+
+fn signal_is_only_no_connect(metadata: &SignalPinMetadata) -> bool {
+    metadata.saw_pin_type && !metadata.saw_non_no_connect
+}
+
 pub fn generate_component_zen(args: GenerateComponentZenArgs<'_>) -> Result<String> {
     let component_name = sanitize_mpn_for_path(args.component_name);
 
-    // Group pins by sanitized name; duplicate signal names (e.g. multiple "NC" pads)
-    // naturally merge into one io() declaration.
-    let mut pin_groups: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    // Track unique signals and their electrical-type metadata so wrapper generation can
+    // omit signals that KiCad marks as no_connect.
+    let mut signals: BTreeMap<String, SignalPinMetadata> = BTreeMap::new();
     for pin in &args.symbol.pins {
         let signal_name = pin.signal_name().to_string();
+        let metadata = signals
+            .entry(signal_name)
+            .or_insert_with_key(|signal_name| SignalPinMetadata {
+                sanitized_name: sanitize_pin_name(signal_name),
+                ..Default::default()
+            });
+        update_signal_pin_metadata(metadata, pin);
+    }
+
+    // Group by sanitized io name; duplicate signal names (e.g. multiple pads for the same
+    // net) naturally merge into one io() declaration. Signals that are unambiguously
+    // no_connect are skipped entirely so generated wrappers match Component() expectations.
+    let mut pin_groups: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (signal_name, metadata) in signals {
+        if signal_is_only_no_connect(&metadata) {
+            continue;
+        }
+
         pin_groups
-            .entry(sanitize_pin_name(&signal_name))
+            .entry(metadata.sanitized_name)
             .or_default()
             .insert(signal_name);
     }
@@ -356,5 +402,50 @@ mod tests {
         assert!(zen.contains("\"NC\": Pins.NC"));
         // No pin_defs needed
         assert!(!zen.contains("pin_defs"));
+    }
+
+    #[test]
+    fn skips_no_connect_pins_entirely() {
+        let symbol = pcb_eda::Symbol {
+            name: "X".to_string(),
+            pins: vec![
+                pcb_eda::Pin {
+                    name: "NC".to_string(),
+                    number: "1".to_string(),
+                    electrical_type: Some("no_connect".to_string()),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "NC".to_string(),
+                    number: "2".to_string(),
+                    electrical_type: Some("no_connect".to_string()),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "VCC".to_string(),
+                    number: "3".to_string(),
+                    electrical_type: Some("power_in".to_string()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let zen = generate_component_zen(GenerateComponentZenArgs {
+            component_name: "MPN1",
+            symbol: &symbol,
+            symbol_filename: "MPN1.kicad_sym",
+            generated_by: "pcb import",
+            include_skip_bom: false,
+            include_skip_pos: false,
+            skip_bom_default: false,
+            skip_pos_default: false,
+        })
+        .unwrap();
+
+        assert!(zen.contains("VCC = io(\"VCC\", Net)"));
+        assert!(zen.contains("\"VCC\": Pins.VCC"));
+        assert!(!zen.contains("NC = io(\"NC\", Net)"));
+        assert!(!zen.contains("\"NC\": Pins.NC"));
     }
 }

--- a/crates/pcb/src/import/generate.rs
+++ b/crates/pcb/src/import/generate.rs
@@ -2057,11 +2057,18 @@ fn render_component_zen(
     symbol_filename: &str,
     flags: ImportPartFlags,
 ) -> Result<RenderedComponentZen> {
+    let generated_io_names = component_gen::generated_signal_io_names(symbol);
     let mut io_pins: BTreeMap<String, BTreeSet<KiCadPinNumber>> = BTreeMap::new();
     for pin in &symbol.pins {
+        let signal_name = pin.signal_name().to_string();
+        let Some(io_name) = generated_io_names.get(&signal_name) else {
+            continue;
+        };
         let pin_number = KiCadPinNumber::from(pin.number.clone());
-        let io_name = component_gen::sanitize_pin_name(pin.signal_name());
-        io_pins.entry(io_name).or_default().insert(pin_number);
+        io_pins
+            .entry(io_name.clone())
+            .or_default()
+            .insert(pin_number);
     }
 
     let zen_content =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Affects generated pin maps for imported components; incorrect filtering could drop real signals or change IO naming, impacting connectivity in downstream builds.
> 
> **Overview**
> Generated component `.zen` wrappers now **skip KiCad pins whose electrical type is `no_connect`**, so they are not emitted as `io()` declarations and are not included in `Component(..., pins=...)` mappings.
> 
> This refactors pin grouping into a shared `generated_signal_io_names()` helper (used by both `.zen` rendering and `pcb import`’s `io_pins` mapping) and adds a unit test asserting `no_connect` signals are omitted. The changelog is updated to document the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d871b395e83a76b5262cbaced1d3a29eeb344d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
