### PR TITLE
Extend Schottky and TVS house ladders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Extended house Schottky and TVS BOM ladders with additional higher-voltage entries.
+
 ### Fixed
 
 - Avoid collisions in generated footprint library names.

--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -389,8 +389,12 @@ HOUSE_RECTIFIERS_BY_PKG = {
         rectifier("Schottky", "20V", "1A", "0.34V", "MBR120VLSFT1G", "onsemi"),
         rectifier("Schottky", "30V", "1A", "0.45V", "NRVB130LSFT1G", "onsemi"),
         rectifier("Schottky", "40V", "1A", "0.56V", "NRVB140ESFT1G", "onsemi"),
+        rectifier("Schottky", "100V", "1A", "0.76V", "NRVB1H100SFT3G", "onsemi"),
     ],
     ("Schottky", "SOD-123"): [
+        rectifier("Schottky", "40V", "100mA", "0.9V", "SD101CW", "Vishay General Semiconductor - Diodes Division"),
+        rectifier("Schottky", "50V", "100mA", "1V", "SD101BW", "Vishay General Semiconductor - Diodes Division"),
+        rectifier("Schottky", "60V", "100mA", "1V", "SD101AW", "Vishay General Semiconductor - Diodes Division"),
         rectifier("Schottky", "20V", "350mA", "0.6V", "SD103CW", "Vishay General Semiconductor - Diodes Division"),
         rectifier("Schottky", "30V", "350mA", "0.6V", "SD103BW", "Vishay General Semiconductor - Diodes Division"),
         rectifier("Schottky", "40V", "350mA", "0.6V", "SD103AW", "Vishay General Semiconductor - Diodes Division"),
@@ -479,6 +483,7 @@ HOUSE_TVS_BY_PKG = {
         tvs("20V", "32.4V", "2000W", "SMAJ20A-E3", "Vishay General Semiconductor - Diodes Division"),
         tvs("24V", "38.9V", "2000W", "SMAJ24A-E3", "Vishay General Semiconductor - Diodes Division"),
         tvs("33V", "53.3V", "2000W", "SMAJ33A-E3", "Vishay General Semiconductor - Diodes Division"),
+        tvs("60V", "96.8V", "2000W", "SMAJ60A-E3", "Vishay General Semiconductor - Diodes Division"),
     ],
     ("Unidirectional", "DO-214AA"): [
         # Vishay SMBJ A series
@@ -488,6 +493,7 @@ HOUSE_TVS_BY_PKG = {
         tvs("24V", "38.9V", "3000W", "SMBJ24A-E3", "Vishay General Semiconductor - Diodes Division"),
         tvs("28V", "45.5V", "3000W", "SMBJ28A-E3", "Vishay General Semiconductor - Diodes Division"),
         tvs("33V", "53.3V", "3000W", "SMBJ33A-E3", "Vishay General Semiconductor - Diodes Division"),
+        tvs("78V", "126V", "3000W", "SMBJ78A-E3", "Vishay General Semiconductor - Diodes Division"),
     ],
     ("Unidirectional", "DO-214AB"): [
         # Vishay SMCJ A series
@@ -497,7 +503,9 @@ HOUSE_TVS_BY_PKG = {
         tvs("24V", "38.9V", "6000W", "SMCJ24A-E3", "Vishay General Semiconductor - Diodes Division"),
         tvs("33V", "53.3V", "6000W", "SMCJ33A-E3", "Vishay General Semiconductor - Diodes Division"),
         tvs("48V", "77.4V", "6000W", "SMCJ48A-E3", "Vishay General Semiconductor - Diodes Division"),
+        tvs("58V", "93.6V", "6000W", "SMCJ58A-E3", "Vishay General Semiconductor - Diodes Division"),
         tvs("60V", "96.8V", "6000W", "SMCJ60A-E3", "Vishay General Semiconductor - Diodes Division"),
+        tvs("85V", "137V", "6000W", "SMCJ85A-E3", "Vishay General Semiconductor - Diodes Division"),
     ],
     ("Bidirectional", "DO-214AC"): [
         # Vishay SMAJ CA series
@@ -1058,6 +1066,7 @@ def assign_house_tvs(c, house_tvs_by_pkg):
     req_standoff = prop(c, ["reverse_standoff_voltage", "Reverse_standoff_voltage"])
     req_clamping = prop(c, ["reverse_clamping_voltage", "Reverse_clamping_voltage"])
     req_power = prop(c, ["peak_pulse_power", "Peak_pulse_power"])
+    required_power = Power(req_power) if req_power else None
 
     parts = house_tvs_by_pkg.get((direction, pkg), [])
     matches = []
@@ -1071,8 +1080,8 @@ def assign_house_tvs(c, house_tvs_by_pkg):
         if req_clamping and p["clamping_voltage"] not in req_clamping:
             continue
 
-        # Power: part must be within the requirement
-        if req_power and p["peak_pulse_power"] not in req_power:
+        # Power is a minimum acceptable rating; allow higher-power TVS parts.
+        if required_power and p["peak_pulse_power"] < required_power:
             continue
 
         matches.append(p)

--- a/stdlib/generics/test/test_Rectifier.zen
+++ b/stdlib/generics/test/test_Rectifier.zen
@@ -65,6 +65,10 @@ _HOUSE_PARTS = [
     ("Schottky", "SOD-123FL", "20V", "1A"),
     ("Schottky", "SOD-123FL", "30V", "1A"),
     ("Schottky", "SOD-123FL", "40V", "1A"),
+    ("Schottky", "SOD-123FL", "100V", "1A"),
+    ("Schottky", "SOD-123", "40V", "100mA"),
+    ("Schottky", "SOD-123", "50V", "100mA"),
+    ("Schottky", "SOD-123", "60V", "100mA"),
     ("Schottky", "SOD-123", "20V", "350mA"),
     ("Schottky", "SOD-123", "30V", "350mA"),
     ("Schottky", "SOD-123", "40V", "350mA"),
@@ -81,8 +85,21 @@ def _sanitize(s):
     return s.replace("-", "_").replace(".", "p")
 
 
+def _rect_name(technology, package, reverse_voltage, forward_current):
+    return "_".join(
+        [
+            "D",
+            "RECT",
+            _sanitize(technology),
+            _sanitize(package),
+            _sanitize(reverse_voltage),
+            _sanitize(forward_current),
+        ]
+    )
+
+
 for technology, package, reverse_voltage, forward_current in _HOUSE_PARTS:
-    name = "D_RECT_" + _sanitize(technology) + "_" + _sanitize(package) + "_" + _sanitize(reverse_voltage)
+    name = _rect_name(technology, package, reverse_voltage, forward_current)
     Rectifier(
         name=name,
         package=package,

--- a/stdlib/generics/test/test_Tvs.zen
+++ b/stdlib/generics/test/test_Tvs.zen
@@ -9,34 +9,50 @@ Tvs = Module("../Tvs.zen")
 
 gnd = Ground("GND")
 
-# Unidirectional house parts: (package, standoff, clamping)
-_UNI_PARTS = [
-    # DO-219AB
-    ("DO-219AB", "3.3V", "8.9V"),
-    ("DO-219AB", "5V", "9.2V"),
-    ("DO-219AB", "20V", "32.4V"),
-    ("DO-219AB", "24V", "38.9V"),
-    # DO-214AC
-    ("DO-214AC", "5V", "9.2V"),
-    ("DO-214AC", "12V", "19.9V"),
-    ("DO-214AC", "20V", "32.4V"),
-    ("DO-214AC", "24V", "38.9V"),
-    ("DO-214AC", "33V", "53.3V"),
-    # DO-214AA
-    ("DO-214AA", "5V", "9.2V"),
-    ("DO-214AA", "12V", "19.9V"),
-    ("DO-214AA", "20V", "32.4V"),
-    ("DO-214AA", "24V", "38.9V"),
-    ("DO-214AA", "28V", "45.5V"),
-    ("DO-214AA", "33V", "53.3V"),
-    # DO-214AB
-    ("DO-214AB", "5V", "9.2V"),
-    ("DO-214AB", "12V", "19.9V"),
-    ("DO-214AB", "20V", "32.4V"),
-    ("DO-214AB", "24V", "38.9V"),
-    ("DO-214AB", "33V", "53.3V"),
-    ("DO-214AB", "48V", "77.4V"),
-    ("DO-214AB", "60V", "96.8V"),
+_HOUSE_PARTS = [
+    ("Unidirectional", "DO-219AB", "3.3V", "8.9V"),
+    ("Unidirectional", "DO-219AB", "5V", "9.2V"),
+    ("Unidirectional", "DO-219AB", "20V", "32.4V"),
+    ("Unidirectional", "DO-219AB", "24V", "38.9V"),
+    ("Unidirectional", "DO-214AC", "5V", "9.2V"),
+    ("Unidirectional", "DO-214AC", "12V", "19.9V"),
+    ("Unidirectional", "DO-214AC", "20V", "32.4V"),
+    ("Unidirectional", "DO-214AC", "24V", "38.9V"),
+    ("Unidirectional", "DO-214AC", "33V", "53.3V"),
+    ("Unidirectional", "DO-214AC", "60V", "96.8V"),
+    ("Unidirectional", "DO-214AA", "5V", "9.2V"),
+    ("Unidirectional", "DO-214AA", "12V", "19.9V"),
+    ("Unidirectional", "DO-214AA", "20V", "32.4V"),
+    ("Unidirectional", "DO-214AA", "24V", "38.9V"),
+    ("Unidirectional", "DO-214AA", "28V", "45.5V"),
+    ("Unidirectional", "DO-214AA", "33V", "53.3V"),
+    ("Unidirectional", "DO-214AA", "78V", "126V"),
+    ("Unidirectional", "DO-214AB", "5V", "9.2V"),
+    ("Unidirectional", "DO-214AB", "12V", "19.9V"),
+    ("Unidirectional", "DO-214AB", "20V", "32.4V"),
+    ("Unidirectional", "DO-214AB", "24V", "38.9V"),
+    ("Unidirectional", "DO-214AB", "33V", "53.3V"),
+    ("Unidirectional", "DO-214AB", "48V", "77.4V"),
+    ("Unidirectional", "DO-214AB", "58V", "93.6V"),
+    ("Unidirectional", "DO-214AB", "60V", "96.8V"),
+    ("Unidirectional", "DO-214AB", "85V", "137V"),
+    ("Bidirectional", "DO-214AC", "5V", "9.2V"),
+    ("Bidirectional", "DO-214AC", "12V", "19.9V"),
+    ("Bidirectional", "DO-214AC", "15V", "24.4V"),
+    ("Bidirectional", "DO-214AC", "24V", "38.9V"),
+    ("Bidirectional", "DO-214AC", "33V", "53.3V"),
+    ("Bidirectional", "DO-214AC", "60V", "96.8V"),
+    ("Bidirectional", "DO-214AA", "5V", "9.2V"),
+    ("Bidirectional", "DO-214AA", "12V", "19.9V"),
+    ("Bidirectional", "DO-214AA", "24V", "38.9V"),
+    ("Bidirectional", "DO-214AA", "33V", "53.3V"),
+    ("Bidirectional", "DO-214AA", "40V", "64.5V"),
+    ("Bidirectional", "DO-214AB", "5V", "9.2V"),
+    ("Bidirectional", "DO-214AB", "12V", "19.9V"),
+    ("Bidirectional", "DO-214AB", "24V", "38.9V"),
+    ("Bidirectional", "DO-214AB", "33V", "53.3V"),
+    ("Bidirectional", "DO-214AB", "48V", "77.4V"),
+    ("Bidirectional", "DO-214AB", "60V", "96.8V"),
 ]
 
 
@@ -44,42 +60,22 @@ def _sanitize(s):
     return s.replace("-", "_").replace(".", "p")
 
 
-for pkg, standoff, clamp in _UNI_PARTS:
-    name = "D_TVS_UNI_" + _sanitize(pkg) + "_" + _sanitize(standoff)
-    vcc = Power(name + "_VCC", voltage=Voltage(standoff))
-    Tvs(
-        name=name,
-        package=pkg,
-        direction="Unidirectional",
-        reverse_standoff_voltage=Voltage(standoff),
-        reverse_clamping_voltage=Voltage(clamp),
-        A=gnd,
-        K=vcc,
+def _power_net(name, voltage):
+    return Power(name + "_VCC", voltage=Voltage(voltage))
+
+
+def _tvs_name(kind, direction, package, standoff):
+    return "_".join(
+        [
+            "D",
+            "TVS",
+            kind,
+            _sanitize(direction),
+            _sanitize(package),
+            _sanitize(standoff),
+        ]
     )
 
-# Bidirectional house parts: (package, standoff, clamping)
-_BI_PARTS = [
-    # DO-214AC
-    ("DO-214AC", "5V", "9.2V"),
-    ("DO-214AC", "12V", "19.9V"),
-    ("DO-214AC", "15V", "24.4V"),
-    ("DO-214AC", "24V", "38.9V"),
-    ("DO-214AC", "33V", "53.3V"),
-    ("DO-214AC", "60V", "96.8V"),
-    # DO-214AA
-    ("DO-214AA", "5V", "9.2V"),
-    ("DO-214AA", "12V", "19.9V"),
-    ("DO-214AA", "24V", "38.9V"),
-    ("DO-214AA", "33V", "53.3V"),
-    ("DO-214AA", "40V", "64.5V"),
-    # DO-214AB
-    ("DO-214AB", "5V", "9.2V"),
-    ("DO-214AB", "12V", "19.9V"),
-    ("DO-214AB", "24V", "38.9V"),
-    ("DO-214AB", "33V", "53.3V"),
-    ("DO-214AB", "48V", "77.4V"),
-    ("DO-214AB", "60V", "96.8V"),
-]
 
 # Matcher-only cases ported from stdlib/bom/test/test_match_Tvs.zen.
 # These verify house-part selection using only the minimum required BOM-facing
@@ -91,8 +87,12 @@ _BOM_MATCH_CASES = [
     ("Unidirectional", "DO-219AB", "24V"),
     ("Unidirectional", "DO-214AC", "20V"),
     ("Unidirectional", "DO-214AC", "24V"),
+    ("Unidirectional", "DO-214AC", "60V"),
     ("Unidirectional", "DO-214AA", "28V"),
     ("Unidirectional", "DO-214AA", "33V"),
+    ("Unidirectional", "DO-214AA", "78V"),
+    ("Unidirectional", "DO-214AB", "58V"),
+    ("Unidirectional", "DO-214AB", "85V"),
     ("Bidirectional", "DO-214AC", "15V"),
     ("Bidirectional", "DO-214AC", "33V"),
     ("Bidirectional", "DO-214AC", "60V"),
@@ -100,50 +100,68 @@ _BOM_MATCH_CASES = [
     ("Bidirectional", "DO-214AB", "24V"),
 ]
 
-for pkg, standoff, clamp in _BI_PARTS:
-    name = "D_TVS_BI_" + _sanitize(pkg) + "_" + _sanitize(standoff)
+_MIN_POWER_CASES = [
+    ("Unidirectional", "DO-214AC", "24V", "38.9V", "600W"),
+    ("Unidirectional", "DO-214AA", "24V", "38.9V", "600W"),
+    ("Unidirectional", "DO-214AB", "24V", "38.9V", "600W"),
+    ("Bidirectional", "DO-214AC", "24V", "38.9V", "600W"),
+]
+
+
+for direction, package, standoff, clamp in _HOUSE_PARTS:
+    name = _tvs_name("HOUSE", direction, package, standoff)
+    if direction == "Unidirectional":
+        a = gnd
+        k = _power_net(name, standoff)
+    else:
+        a = Net(name + "_A")
+        k = Net(name + "_K")
     Tvs(
         name=name,
-        package=pkg,
-        direction="Bidirectional",
+        package=package,
+        direction=direction,
         reverse_standoff_voltage=Voltage(standoff),
         reverse_clamping_voltage=Voltage(clamp),
-        A=Net(name + "_A"),
-        K=Net(name + "_K"),
+        A=a,
+        K=k,
     )
+
 
 for i, (direction, package, standoff) in enumerate(_BOM_MATCH_CASES):
     name = "D_TVS_MATCH_" + str(i)
     if direction == "Unidirectional":
-        Tvs(
-            name=name,
-            direction=direction,
-            package=package,
-            reverse_standoff_voltage=Voltage(standoff),
-            A=gnd,
-            K=Power(name + "_VCC", voltage=Voltage("3.3V")),
-        )
+        a = gnd
+        k = _power_net(name, "3.3V")
     else:
-        Tvs(
-            name=name,
-            direction=direction,
-            package=package,
-            reverse_standoff_voltage=Voltage(standoff),
-            A=Net(name + "_A"),
-            K=Net(name + "_K"),
-        )
+        a = Net(name + "_A")
+        k = Net(name + "_K")
+    Tvs(
+        name=name,
+        package=package,
+        direction=direction,
+        reverse_standoff_voltage=Voltage(standoff),
+        A=a,
+        K=k,
+    )
 
-Tvs(
-    name="D_TVS_EXPLICIT_DO214AA_24V",
-    package="DO-214AA",
-    direction="Unidirectional",
-    reverse_standoff_voltage=Voltage("24V"),
-    reverse_clamping_voltage=Voltage("38.9V"),
-    peak_pulse_power=Watts("3000W"),
-    mpn="SMBJ24A-E3",
-    manufacturer="Vishay General Semiconductor - Diodes Division",
-    A=gnd,
-    K=Power("D_TVS_EXPLICIT_DO214AA_24V_VCC", voltage=Voltage("24V")),
-)
+# Verify TVS matching treats peak pulse power as a minimum required rating.
+for direction, package, standoff, clamp, peak_pulse_power in _MIN_POWER_CASES:
+    name = _tvs_name("MIN_POWER", direction, package, standoff)
+    if direction == "Unidirectional":
+        a = gnd
+        k = _power_net(name, standoff)
+    else:
+        a = Net(name + "_A")
+        k = Net(name + "_K")
+    Tvs(
+        name=name,
+        package=package,
+        direction=direction,
+        reverse_standoff_voltage=Voltage(standoff),
+        reverse_clamping_voltage=Voltage(clamp),
+        peak_pulse_power=Watts(peak_pulse_power),
+        A=a,
+        K=k,
+    )
 
 builtin.add_component_modifier(assign_house_parts)


### PR DESCRIPTION
This is enough to cover registry fully and the ~8 board repos I spot checked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes TVS house-part selection semantics (treating `peak_pulse_power` as a minimum), which can alter chosen MPNs in BOM generation, in addition to expanding the catalog entries.
> 
> **Overview**
> **House BOM coverage is expanded** by adding higher-voltage Schottky entries (including new `SOD-123` 100mA options and a 100V `SOD-123FL`) and additional higher-voltage TVS MPNs across SMAJ/SMBJ/SMCJ packages.
> 
> **TVS matching behavior changes**: `assign_house_tvs` now treats `peak_pulse_power` as a *minimum required rating* (allowing higher-power parts) instead of requiring exact inclusion, and tests were refactored/extended to cover the new ladders and the new minimum-power behavior. The changelog documents the ladder extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ebcbd00a484876a7eb60d7823980bbd5366b3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
