### PR TITLE
Fix package-aware footprint library naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid collisions in generated footprint library names.
+
 ## [0.3.70] - 2026-04-17
 
 ### Fixed

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -922,7 +922,7 @@ mod diff_tests {
         );
         assert_eq!(
             instance["footprint_fpid"],
-            "Resistor_SMD@10.0.0:R_0603_1608Metric"
+            "kicad_libraries_kicad-footprints_Resistor_SMD@10.0.0:R_0603_1608Metric"
         );
 
         Ok(())

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -255,15 +255,10 @@ class JsonNetlistParser:
             # Get footprint
             footprint = instance.get("footprint_fpid", "")
             if not footprint:
-                footprint_path = (
-                    instance["attributes"].get("footprint", {}).get("String", "")
+                raise ValueError(
+                    f"Component instance {instance_ref!r} is missing required "
+                    "'footprint_fpid'; regenerate the layout netlist with a current pcb tool."
                 )
-                if footprint_path:
-                    # Backward-compatible fallback for older JSON netlists that do not
-                    # include the derived footprint_fpid field yet.
-                    footprint = format_footprint(footprint_path, parser.package_roots)
-                else:
-                    footprint = "unknown:unknown"
 
             # Build hierarchical path - this needs to match the Rust implementation
             # Extract the instance path after the root module
@@ -417,120 +412,6 @@ class JsonNetlistParser:
 
 
 ####################################################################################################
-# Footprint formatting helper
-####################################################################################################
-
-
-def is_kicad_lib_fp(s):
-    """Determine whether a given string is a KiCad lib:footprint reference rather than a file path."""
-    if ":" not in s:
-        return False
-
-    lib, fp = s.split(":", 1)
-
-    # Filter out Windows drive prefixes like "C:"
-    if len(lib) == 1 and lib.isalpha():
-        return False
-
-    # Any path separator indicates this is still a filesystem path
-    if "/" in lib or "\\" in lib or "/" in fp or "\\" in fp:
-        return False
-
-    return True
-
-
-def _path_under_root(path_obj, root_obj):
-    try:
-        path_obj.relative_to(root_obj)
-        return True
-    except ValueError:
-        return False
-
-
-def _package_coord_for_path(fp_path, package_roots):
-    if not package_roots:
-        return None
-
-    best_match = None
-    for coord, root in package_roots.items():
-        root_path = Path(root)
-        if not _path_under_root(fp_path, root_path):
-            continue
-
-        depth = len(root_path.parts)
-        if best_match is None or depth > best_match[0]:
-            best_match = (depth, coord.rsplit("/", 1)[-1], root_path)
-
-    if best_match is None:
-        return None
-
-    _, package_name, root_path = best_match
-    return package_name, root_path
-
-
-def _package_library_name(fp_path, package_match):
-    if not package_match:
-        return None
-
-    package_name, root_path = package_match
-    if fp_path.parent != root_path:
-        return None
-
-    return package_name
-
-
-def _pretty_library_name(parent, package_name=None):
-    if parent.suffix != ".pretty":
-        return None
-
-    pretty_name = parent.stem or parent.name
-    if not pretty_name:
-        return None
-
-    if package_name and package_name.startswith("kicad-footprints@"):
-        version = package_name.removeprefix("kicad-footprints@")
-        if version:
-            return f"{pretty_name}@{version}"
-
-    return pretty_name
-
-
-def format_footprint(fp_str, package_roots=None):
-    """Convert footprint strings that may point to a .kicad_mod file into a KiCad lib:fp identifier.
-
-    This matches the Rust implementation in kicad_netlist.rs
-    """
-    if is_kicad_lib_fp(fp_str):
-        return fp_str
-
-    # Extract the footprint name from the file path
-    if fp_str.startswith("package://") and package_roots:
-        try:
-            fp_path = resolve_package_uri(fp_str, package_roots)
-        except ValueError:
-            fp_path = Path(fp_str)
-    else:
-        fp_path = Path(fp_str)
-    stem = fp_path.stem
-    if not stem:
-        return "UNKNOWN:UNKNOWN"
-
-    parent = fp_path.parent
-    package_roots = package_roots or {}
-    package_match = _package_coord_for_path(fp_path, package_roots)
-    package_name = package_match[0] if package_match else None
-    lib_name = _pretty_library_name(parent, package_name)
-
-    if not lib_name:
-        lib_name = _package_library_name(fp_path, package_match)
-
-    if not lib_name:
-        lib_name = parent.name or stem
-
-    return f"{lib_name}:{stem}"
-
-
-####################################################################################################
 # Data Structures + Utility Functions
 #
 # Here we define some data structures that represent the footprints and layouts we'll be working
@@ -606,7 +487,7 @@ class SyncState:
 
 # Import the lens module (extracted to temp dir by Rust and added to PYTHONPATH)
 from lens import run_lens_sync  # noqa: E402
-from lens.kicad_adapter import get_footprint_field, resolve_package_uri  # noqa: E402
+from lens.kicad_adapter import get_footprint_field  # noqa: E402
 
 
 class ImportNetlist(Step):

--- a/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step1.log.snap
+++ b/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step1.log.snap
@@ -13,12 +13,12 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu
 INFO: Added footprint: R1.R
 INFO: HierPlace: placed 1 items
-INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0402_1005Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG PLACE_FP path=R1.R x=147545000 y=104505000 w=1910000 h=990000

--- a/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step2.log.snap
+++ b/crates/pcb-layout/tests/snapshots/fpid_change__fpid_change_step2.log.snap
@@ -11,19 +11,19 @@ INFO: Starting ImportNetlist...
 INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
-INFO: OLD FPV path=R1.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: OLD FPV path=R1.R ref=R1 value=10k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0402_1005Metric fields=["Package=0402", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: OLD FPC path=R1.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103830000 val_x=148500000 val_y=106170000
 INFO: Changes: +1 -1 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_REMOVE path=R1.R fpid=Resistor_SMD@9.0.3:R_0402_1005Metric x=148500000 y=105000000 orient=0.0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_REMOVE path=R1.R fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0402_1005Metric x=148500000 y=105000000 orient=0.0 layer=F.Cu
 INFO: Removed footprint: R1.R
 INFO: Added footprint: R1.R
 INFO: HierPlace: placed 1 items
 INFO: OPLOG FP_REMOVE path=R1.R
-INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG PLACE_FP_INHERIT path=R1.R x=148500000 y=105000000 old_fpid=Resistor_SMD@9.0.3:R_0402_1005Metric new_fpid=Resistor_SMD@9.0.3:R_0603_1608Metric
+INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG PLACE_FP_INHERIT path=R1.R x=148500000 y=105000000 old_fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0402_1005Metric new_fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric
 INFO: Sync completed in X.XXXs
 INFO: Lens sync complete: +1 -1 footprints
 INFO: Completed ImportNetlist in X.XXX seconds

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -1012,7 +1012,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -1263,7 +1263,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -1514,7 +1514,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -1765,7 +1765,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__complex.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__complex.log.snap
@@ -26,14 +26,14 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 8 footprints, 6 groups, 4 nets
 INFO: Changes: +8 -0 footprints
-INFO: NEW FPV path=M1.S1.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S1.R2.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S2.R1.R ref=R3 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.S2.R2.R ref=R4 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S1.R1.R ref=R5 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S1.R2.R ref=R6 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S2.R1.R ref=R7 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.S2.R2.R ref=R8 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S1.R1.R ref=R1 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S1.R2.R ref=R2 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S2.R1.R ref=R3 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.S2.R2.R ref=R4 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.S1.R1.R ref=R5 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.S1.R2.R ref=R6 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.S2.R1.R ref=R7 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.S2.R2.R ref=R8 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=M1 members=[M1.S1.R1.R, M1.S1.R2.R, M1.S2.R1.R, M1.S2.R2.R] layout=module
 INFO: NEW GRV path=M1.S1 members=[M1.S1.R1.R, M1.S1.R2.R] layout=submodule
 INFO: NEW GRV path=M1.S2 members=[M1.S2.R1.R, M1.S2.R2.R] layout=submodule
@@ -48,14 +48,14 @@ INFO: NEW FPC path=M2.S1.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.S1.R2.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.S2.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.S2.R2.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.S1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.S1.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.S2.R1.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.S2.R2.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.S1.R1.R ref=R5 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.S1.R2.R ref=R6 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.S2.R1.R ref=R7 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.S2.R2.R ref=R8 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.S1.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.S1.R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.S2.R1.R ref=R3 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.S2.R2.R ref=R4 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.S1.R1.R ref=R5 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.S1.R2.R ref=R6 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.S2.R1.R ref=R7 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.S2.R2.R ref=R8 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=M1 members=4 fragment=true
 INFO: CHANGESET GR_ADD path=M1.S1 members=2 fragment=true
 INFO: CHANGESET GR_ADD path=M1.S2 members=2 fragment=true
@@ -84,14 +84,14 @@ INFO: Authoritative fragments: ['M1', 'M2']
 INFO: Applied fragment routing to M1: 23 tracks, 4 vias, 2 zones, 10 graphics
 INFO: Applied fragment routing to M2: 23 tracks, 4 vias, 2 zones, 10 graphics
 INFO: HierPlace: placed 10 items
-INFO: OPLOG FP_ADD path=M1.S1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M1.S1.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M1.S2.R1.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M1.S2.R2.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.S1.R1.R ref=R5 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.S1.R2.R ref=R6 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.S2.R1.R ref=R7 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.S2.R2.R ref=R8 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.S1.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.S1.R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.S2.R1.R ref=R3 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.S2.R2.R ref=R4 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.S1.R1.R ref=R5 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.S1.R2.R ref=R6 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.S2.R1.R ref=R7 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.S2.R2.R ref=R8 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=M1
 INFO: OPLOG GR_ADD path=M1.S1
 INFO: OPLOG GR_ADD path=M1.S2

--- a/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__component_side_sync.log.snap
@@ -17,19 +17,19 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 1 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R3.R ref=R3 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R4.R ref=R4 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R3.R ref=R3 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R4.R ref=R4 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=MyModule members=[MyModule.R1.R, MyModule.R2.R, MyModule.R3.R, MyModule.R4.R] layout=module
 INFO: NEW FPC path=MyModule.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R2.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R3.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R4.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R3.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R4.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R3.R ref=R3 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R4.R ref=R4 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=MyModule members=4 fragment=true
 INFO: Added footprint: MyModule.R1.R
 INFO: Added footprint: MyModule.R2.R
@@ -38,10 +38,10 @@ INFO: Added footprint: MyModule.R4.R
 INFO: Added group: MyModule
 INFO: Authoritative fragments: ['MyModule']
 INFO: HierPlace: placed 5 items
-INFO: OPLOG FP_ADD path=MyModule.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MyModule.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MyModule.R3.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MyModule.R4.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R3.R ref=R3 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R4.R ref=R4 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=MyModule
 INFO: OPLOG NET_ADD name=MyModule.P1
 INFO: OPLOG NET_ADD name=MyModule.P2

--- a/crates/pcb-layout/tests/snapshots/layout_generation__dnp.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__dnp.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": true,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": true,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__dnp.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__dnp.log.snap
@@ -16,27 +16,27 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 0 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=dnp.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric dnp=true fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=exclude_from_bom.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=exclude_from_bom_and_dnp.R ref=R3 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric dnp=true bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=normal.R ref=R4 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=dnp.R ref=R1 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric dnp=true fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=exclude_from_bom.R ref=R2 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=exclude_from_bom_and_dnp.R ref=R3 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric dnp=true bom=false fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=normal.R ref=R4 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW FPC path=dnp.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=exclude_from_bom.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=exclude_from_bom_and_dnp.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=normal.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=dnp.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=exclude_from_bom.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=exclude_from_bom_and_dnp.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=normal.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=dnp.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=exclude_from_bom.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=exclude_from_bom_and_dnp.R ref=R3 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=normal.R ref=R4 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: Added footprint: dnp.R
 INFO: Added footprint: exclude_from_bom.R
 INFO: Added footprint: exclude_from_bom_and_dnp.R
 INFO: Added footprint: normal.R
 INFO: HierPlace: placed 4 items
-INFO: OPLOG FP_ADD path=dnp.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=exclude_from_bom.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=exclude_from_bom_and_dnp.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=normal.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=dnp.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=exclude_from_bom.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=exclude_from_bom_and_dnp.R ref=R3 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=normal.R ref=R4 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=P1
 INFO: OPLOG NET_ADD name=P2
 INFO: OPLOG PLACE_FP path=dnp.R x=146995000 y=104245000 w=3010000 h=1510000

--- a/crates/pcb-layout/tests/snapshots/layout_generation__graphics.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__graphics.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__graphics.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__graphics.log.snap
@@ -16,14 +16,14 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 2 groups, 2 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=G1.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=G2.R1.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=G1.R1.R ref=R1 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=G2.R1.R ref=R2 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=G1 members=[G1.R1.R] layout=module
 INFO: NEW GRV path=G2 members=[G2.R1.R] layout=module
 INFO: NEW FPC path=G1.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=G2.R1.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=G1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=G2.R1.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=G1.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=G2.R1.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=G1 members=1 fragment=true
 INFO: CHANGESET GR_ADD path=G2 members=1 fragment=true
 INFO: Added footprint: G1.R1.R
@@ -34,8 +34,8 @@ INFO: Authoritative fragments: ['G1', 'G2']
 INFO: Applied fragment routing to G1: 0 tracks, 0 vias, 0 zones, 2 graphics
 INFO: Applied fragment routing to G2: 0 tracks, 0 vias, 0 zones, 2 graphics
 INFO: HierPlace: placed 4 items
-INFO: OPLOG FP_ADD path=G1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=G2.R1.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=G1.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=G2.R1.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=G1
 INFO: OPLOG GR_ADD path=G2
 INFO: OPLOG NET_ADD name=BOARD_ONE

--- a/crates/pcb-layout/tests/snapshots/layout_generation__module_layout.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__module_layout.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Capacitor_SMD@9.0.3:C_0402_1005Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Capacitor_SMD@9.0.3:C_0402_1005Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Capacitor_SMD@9.0.3:C_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Capacitor_SMD@9.0.3:C_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__module_layout.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__module_layout.log.snap
@@ -18,20 +18,20 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 2 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=MODULE1.C1.C ref=C1 value=0F fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=MODULE1.C2.C ref=C2 value=0F fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=MODULE2.C1.C ref=C3 value=0F fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=MODULE2.C2.C ref=C4 value=0F fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=MODULE1.C1.C ref=C1 value=0F fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=MODULE1.C2.C ref=C2 value=0F fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=MODULE2.C1.C ref=C3 value=0F fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=MODULE2.C2.C ref=C4 value=0F fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
 INFO: NEW GRV path=MODULE1 members=[MODULE1.C1.C, MODULE1.C2.C] layout=module_layout
 INFO: NEW GRV path=MODULE2 members=[MODULE2.C1.C, MODULE2.C2.C] layout=module_layout
 INFO: NEW FPC path=MODULE1.C1.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MODULE1.C2.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MODULE2.C1.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MODULE2.C2.C x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MODULE1.C1.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MODULE1.C2.C ref=C2 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MODULE2.C1.C ref=C3 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MODULE2.C2.C ref=C4 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MODULE1.C1.C ref=C1 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MODULE1.C2.C ref=C2 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MODULE2.C1.C ref=C3 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MODULE2.C2.C ref=C4 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=MODULE1 members=2 fragment=true
 INFO: CHANGESET GR_ADD path=MODULE2 members=2 fragment=true
 INFO: Added footprint: MODULE1.C1.C
@@ -43,10 +43,10 @@ INFO: Added group: MODULE2
 WARNING: Fragment package://workspace/build/module_layout not found, using HierPlace: Layout fragment not found: <TEMP_DIR>
 WARNING: Fragment package://workspace/build/module_layout not found, using HierPlace: Layout fragment not found: <TEMP_DIR>
 INFO: HierPlace: placed 4 items
-INFO: OPLOG FP_ADD path=MODULE1.C1.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MODULE1.C2.C ref=C2 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MODULE2.C1.C ref=C3 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MODULE2.C2.C ref=C4 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MODULE1.C1.C ref=C1 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MODULE1.C2.C ref=C2 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MODULE2.C1.C ref=C3 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MODULE2.C2.C ref=C4 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=MODULE1
 INFO: OPLOG GR_ADD path=MODULE2
 INFO: OPLOG NET_ADD name=MAIN_GND

--- a/crates/pcb-layout/tests/snapshots/layout_generation__multi_pads.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__multi_pads.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
+      "footprint": "kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
       "graphical_items": [
         {
           "angle": null,
@@ -851,7 +851,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
+      "footprint": "kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__multi_pads.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__multi_pads.log.snap
@@ -12,17 +12,17 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 0 groups, 4 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=C0 ref=U1 value=? fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
-INFO: NEW FPV path=C1 ref=U2 value=? fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
+INFO: NEW FPV path=C0 ref=U1 value=? fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
+INFO: NEW FPV path=C1 ref=U2 value=? fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
 INFO: NEW FPC path=C0 x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=C1 x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=C0 ref=U1 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=C1 ref=U2 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=C0 ref=U1 fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=C1 ref=U2 fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
 INFO: Added footprint: C0
 INFO: Added footprint: C1
 INFO: HierPlace: placed 2 items
-INFO: OPLOG FP_ADD path=C0 ref=U1 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
-INFO: OPLOG FP_ADD path=C1 ref=U2 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
+INFO: OPLOG FP_ADD path=C0 ref=U1 fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
+INFO: OPLOG FP_ADD path=C1 ref=U2 fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
 INFO: OPLOG NET_ADD name=A
 INFO: OPLOG NET_ADD name=B
 INFO: OPLOG NET_ADD name=IN

--- a/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Capacitor_SMD@9.0.3:C_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical",
+      "footprint": "kicad_libraries_kicad-footprints_Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical",
       "graphical_items": [
         {
           "angle": null,
@@ -602,7 +602,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical",
+      "footprint": "kicad_libraries_kicad-footprints_Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical",
       "graphical_items": [
         {
           "angle": null,
@@ -1057,7 +1057,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__netclass_assignment.log.snap
@@ -16,27 +16,27 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 0 groups, 11 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=HDMI_MOD.C_DIFFPAIR.C ref=C1 value=0F fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=U1 ref=U1 value=? fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical fields=["Prefix=U"]
-INFO: NEW FPV path=U2 ref=U2 value=? fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical fields=["Prefix=U"]
-INFO: NEW FPV path=USB_MOD.R_USB.R ref=R1 value="0" fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=0", "Type=resistor"]
+INFO: NEW FPV path=HDMI_MOD.C_DIFFPAIR.C ref=C1 value=0F fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric fields=["Capacitance=0F", "Package=0603", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=U1 ref=U1 value=? fpid=kicad_libraries_kicad-footprints_Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical fields=["Prefix=U"]
+INFO: NEW FPV path=U2 ref=U2 value=? fpid=kicad_libraries_kicad-footprints_Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical fields=["Prefix=U"]
+INFO: NEW FPV path=USB_MOD.R_USB.R ref=R1 value="0" fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=0", "Type=resistor"]
 INFO: NEW FPC path=HDMI_MOD.C_DIFFPAIR.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=U1 x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=U2 x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=USB_MOD.R_USB.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=U2 ref=U2 fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=kicad_libraries_kicad-footprints_Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=U2 ref=U2 fpid=kicad_libraries_kicad-footprints_Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu
 INFO: Added footprint: HDMI_MOD.C_DIFFPAIR.C
 INFO: Added footprint: U1
 INFO: Added footprint: U2
 INFO: Added footprint: USB_MOD.R_USB.R
 INFO: HierPlace: placed 4 items
-INFO: OPLOG FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=10
-INFO: OPLOG FP_ADD path=U2 ref=U2 fpid=Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=1
-INFO: OPLOG FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=HDMI_MOD.C_DIFFPAIR.C ref=C1 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0603_1608Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=kicad_libraries_kicad-footprints_Connector_PinHeader_2.54mm@9.0.3:PinHeader_2x05_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=10
+INFO: OPLOG FP_ADD path=U2 ref=U2 fpid=kicad_libraries_kicad-footprints_Connector_PinHeader_2.54mm@9.0.3:PinHeader_1x01_P2.54mm_Vertical value=? x=0 y=0 layer=F.Cu pads=1
+INFO: OPLOG FP_ADD path=USB_MOD.R_USB.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value="0" x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=HDMI_N
 INFO: OPLOG NET_ADD name=HDMI_P
 INFO: OPLOG NET_ADD name=CLK_50

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
@@ -14,17 +14,17 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 0 groups, 3 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
-INFO: NEW FPV path=R2.R ref=R2 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R1.R ref=R1 value=10k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=R2.R ref=R2 value=10k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=R2.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
 INFO: Added footprint: R1.R
 INFO: Added footprint: R2.R
 INFO: HierPlace: placed 2 items
-INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=NC_PIN
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG NET_ADD name=GND

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
+      "footprint": "kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected_single_pin_multi_pad.log.snap
@@ -12,12 +12,12 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
-INFO: NEW FPV path=U1 ref=U1 value=? fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
+INFO: NEW FPV path=U1 ref=U1 value=? fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias fields=["Prefix=U"]
 INFO: NEW FPC path=U1 x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=U1 ref=U1 fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu
 INFO: Added footprint: U1
 INFO: HierPlace: placed 1 items
-INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
+INFO: OPLOG FP_ADD path=U1 ref=U1 fpid=kicad_libraries_kicad-footprints_Package_DFN_QFN@9.0.3:QFN-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm_ThermalVias value=? x=0 y=0 layer=F.Cu pads=26
 INFO: OPLOG NET_ADD name=unconnected-(U1:5)
 INFO: OPLOG NET_ADD name=unconnected-(U1:17)
 INFO: OPLOG PLACE_FP path=U1 x=146345000 y=102845000 w=4310000 h=4310000

--- a/crates/pcb-layout/tests/snapshots/layout_generation__simple.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__simple.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Capacitor_SMD@9.0.3:C_0402_1005Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "eda:BMI270",
+      "footprint": "workspace_eda:BMI270",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__simple.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__simple.log.snap
@@ -14,20 +14,20 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 1 groups, 10 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=BMI270.C.C ref=C1 value=0F fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
-INFO: NEW FPV path=BMI270.IC ref=IC1 value=BMI270 fpid=eda:BMI270 fields=["Manufacturer=BOSCH", "Mpn=BMI270", "Prefix=IC"]
+INFO: NEW FPV path=BMI270.C.C ref=C1 value=0F fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric fields=["Capacitance=0F", "Package=0402", "Prefix=C", "Type=capacitor"]
+INFO: NEW FPV path=BMI270.IC ref=IC1 value=BMI270 fpid=workspace_eda:BMI270 fields=["Manufacturer=BOSCH", "Mpn=BMI270", "Prefix=IC"]
 INFO: NEW GRV path=BMI270 members=[BMI270.C.C, BMI270.IC]
 INFO: NEW FPC path=BMI270.C.C x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=BMI270.IC x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=BMI270.C.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=BMI270.IC ref=IC1 fpid=eda:BMI270 value=BMI270 x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=BMI270.C.C ref=C1 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=BMI270.IC ref=IC1 fpid=workspace_eda:BMI270 value=BMI270 x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=BMI270 members=2
 INFO: Added footprint: BMI270.C.C
 INFO: Added footprint: BMI270.IC
 INFO: Added group: BMI270
 INFO: HierPlace: placed 2 items
-INFO: OPLOG FP_ADD path=BMI270.C.C ref=C1 fpid=Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=BMI270.IC ref=IC1 fpid=eda:BMI270 value=BMI270 x=0 y=0 layer=F.Cu pads=14
+INFO: OPLOG FP_ADD path=BMI270.C.C ref=C1 fpid=kicad_libraries_kicad-footprints_Capacitor_SMD@9.0.3:C_0402_1005Metric value=0F x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=BMI270.IC ref=IC1 fpid=workspace_eda:BMI270 value=BMI270 x=0 y=0 layer=F.Cu pads=14
 INFO: OPLOG GR_ADD path=BMI270
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG NET_ADD name=POWER

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -510,7 +510,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -761,7 +761,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__tracks.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__tracks.log.snap
@@ -18,20 +18,20 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 4 footprints, 2 groups, 2 nets
 INFO: Changes: +4 -0 footprints
-INFO: NEW FPV path=M1.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M1.R2.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.R1.R ref=R3 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=M2.R2.R ref=R4 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.R1.R ref=R1 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M1.R2.R ref=R2 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.R1.R ref=R3 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=M2.R2.R ref=R4 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=M1 members=[M1.R1.R, M1.R2.R] layout=module
 INFO: NEW GRV path=M2 members=[M2.R1.R, M2.R2.R] layout=module
 INFO: NEW FPC path=M1.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M1.R2.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=M2.R2.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M1.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.R1.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=M2.R2.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M1.R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.R1.R ref=R3 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=M2.R2.R ref=R4 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=M1 members=2 fragment=true
 INFO: CHANGESET GR_ADD path=M2 members=2 fragment=true
 INFO: Added footprint: M1.R1.R
@@ -44,10 +44,10 @@ INFO: Authoritative fragments: ['M1', 'M2']
 INFO: Applied fragment routing to M1: 12 tracks, 2 vias, 0 zones, 0 graphics
 INFO: Applied fragment routing to M2: 12 tracks, 2 vias, 0 zones, 0 graphics
 INFO: HierPlace: placed 6 items
-INFO: OPLOG FP_ADD path=M1.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M1.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.R1.R ref=R3 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=M2.R2.R ref=R4 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M1.R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.R1.R ref=R3 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=M2.R2.R ref=R4 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=M1
 INFO: OPLOG GR_ADD path=M2
 INFO: OPLOG NET_ADD name=BOARD_ONE

--- a/crates/pcb-layout/tests/snapshots/layout_generation__zones.layout.json.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__zones.layout.json.snap
@@ -8,7 +8,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,
@@ -259,7 +259,7 @@ expression: content
       "dnp": false,
       "exclude_from_bom": false,
       "exclude_from_pos_files": false,
-      "footprint": "Resistor_SMD@9.0.3:R_0603_1608Metric",
+      "footprint": "kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric",
       "graphical_items": [
         {
           "angle": null,

--- a/crates/pcb-layout/tests/snapshots/layout_generation__zones.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__zones.log.snap
@@ -15,13 +15,13 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 2 footprints, 1 groups, 2 nets
 INFO: Changes: +2 -0 footprints
-INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
-INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R1.R ref=R1 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
+INFO: NEW FPV path=MyModule.R2.R ref=R2 value=1k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=1k", "Type=resistor"]
 INFO: NEW GRV path=MyModule members=[MyModule.R1.R, MyModule.R2.R] layout=module
 INFO: NEW FPC path=MyModule.R1.R x=0 y=0 orient=0.0 layer=F.Cu
 INFO: NEW FPC path=MyModule.R2.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=MyModule.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=MyModule.R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu
 INFO: CHANGESET GR_ADD path=MyModule members=2 fragment=true
 INFO: Added footprint: MyModule.R1.R
 INFO: Added footprint: MyModule.R2.R
@@ -29,8 +29,8 @@ INFO: Added group: MyModule
 INFO: Authoritative fragments: ['MyModule']
 INFO: Applied fragment routing to MyModule: 0 tracks, 0 vias, 1 zones, 0 graphics
 INFO: HierPlace: placed 3 items
-INFO: OPLOG FP_ADD path=MyModule.R1.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG FP_ADD path=MyModule.R2.R ref=R2 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R1.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=MyModule.R2.R ref=R2 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=1k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG GR_ADD path=MyModule
 INFO: OPLOG NET_ADD name=BOARD_ONE
 INFO: OPLOG NET_ADD name=BOARD_TWO

--- a/crates/pcb-layout/tests/snapshots/moved__moved_step1.log.snap
+++ b/crates/pcb-layout/tests/snapshots/moved__moved_step1.log.snap
@@ -13,12 +13,12 @@ INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
 INFO: Changes: +1 -0 footprints
-INFO: NEW FPV path=OldModule.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=OldModule.R ref=R1 value=10k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=OldModule.R x=0 y=0 orient=0.0 layer=F.Cu
-INFO: CHANGESET FP_ADD path=OldModule.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
+INFO: CHANGESET FP_ADD path=OldModule.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu
 INFO: Added footprint: OldModule.R
 INFO: HierPlace: placed 1 items
-INFO: OPLOG FP_ADD path=OldModule.R ref=R1 fpid=Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
+INFO: OPLOG FP_ADD path=OldModule.R ref=R1 fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG PLACE_FP path=OldModule.R x=146995000 y=104245000 w=3010000 h=1510000

--- a/crates/pcb-layout/tests/snapshots/moved__moved_step2.log.snap
+++ b/crates/pcb-layout/tests/snapshots/moved__moved_step2.log.snap
@@ -11,10 +11,10 @@ INFO: Starting ImportNetlist...
 INFO: Running lens-based netlist sync
 INFO: Starting lens-based layout sync
 INFO: Source: 1 footprints, 0 groups, 2 nets
-INFO: OLD FPV path=NewModule.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: OLD FPV path=NewModule.R ref=R1 value=10k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: OLD FPC path=NewModule.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103570000 val_x=148500000 val_y=106430000
 INFO: Changes: +0 -0 footprints
-INFO: NEW FPV path=NewModule.R ref=R1 value=10k fpid=Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
+INFO: NEW FPV path=NewModule.R ref=R1 value=10k fpid=kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0603_1608Metric fields=["Package=0603", "Prefix=R", "Resistance=10k", "Type=resistor"]
 INFO: NEW FPC path=NewModule.R x=148500000 y=105000000 orient=0.0 layer=F.Cu ref_x=148500000 ref_y=103570000 val_x=148500000 val_y=106430000
 INFO: Sync completed in X.XXXs
 INFO: Lens sync complete: +0 -0 footprints

--- a/crates/pcb-sch/src/kicad_netlist.rs
+++ b/crates/pcb-sch/src/kicad_netlist.rs
@@ -474,48 +474,130 @@ fn format_resolved_footprint_path(
 
 fn footprint_library_name(p: &Path, package_roots: &BTreeMap<String, PathBuf>) -> Option<String> {
     let parent = p.parent()?;
-    let package_match = package_coord_for_path(p, package_roots);
-
-    if let Some(pretty_name) = pretty_library_name(
-        parent,
-        package_match
-            .as_ref()
-            .map(|(package_name, _)| package_name.as_str()),
-    ) {
-        return Some(pretty_name);
-    }
-
-    if let Some((package_name, package_root)) = package_match
-        && parent == package_root
+    if let Some((package_coord, package_root)) = package_coord_for_path(p, package_roots)
+        && let Ok(rel_dir) = parent.strip_prefix(&package_root)
+        && let Some(package_name) = package_library_name(&package_coord, rel_dir)
     {
         return Some(package_name);
+    }
+
+    fallback_library_name(parent)
+}
+
+/// Derive a deterministic KiCad library nickname from package identity and
+/// the library directory relative to that package root.
+///
+/// Rules:
+/// - Strip only the hostname from the package coordinate.
+/// - Strip only the final `.pretty` suffix from the relative library path.
+/// - Sanitize path segments with underscores.
+/// - If the package coordinate ends with `@version`, move that version suffix
+///   to the end of the full rendered nickname.
+fn package_library_name(package_coord: &str, rel_dir: &Path) -> Option<String> {
+    let (package_path, version) = split_package_version(strip_package_host(package_coord));
+    let mut parts = package_path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .map(sanitize_nickname_segment)
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+
+    parts.extend(
+        relative_library_segments(rel_dir)
+            .into_iter()
+            .map(|segment| sanitize_nickname_segment(&segment))
+            .filter(|segment| !segment.is_empty()),
+    );
+
+    let mut nickname = parts.join("_");
+
+    if nickname.is_empty() {
+        return None;
+    }
+
+    if let Some(version) = version {
+        let version = sanitize_nickname_segment(version);
+
+        if !version.is_empty() {
+            nickname.push('@');
+            nickname.push_str(&version);
+        }
+    }
+
+    Some(nickname)
+}
+
+fn split_package_version(package_coord: &str) -> (&str, Option<&str>) {
+    let Some((head, tail)) = package_coord.rsplit_once('/') else {
+        return split_final_version_suffix(package_coord);
+    };
+
+    let (last, version) = split_final_version_suffix(tail);
+
+    let Some(version) = version else {
+        return (package_coord, None);
+    };
+
+    if head.is_empty() {
+        (last, Some(version))
+    } else {
+        let package_path = &package_coord[..head.len() + 1 + last.len()];
+        (package_path, Some(version))
+    }
+}
+
+fn relative_library_segments(rel_dir: &Path) -> Vec<String> {
+    let mut segments: Vec<String> = rel_dir
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(name) => Some(name.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect();
+
+    if let Some(last) = segments.last_mut() {
+        *last = strip_final_pretty_suffix(last).to_owned();
+    }
+
+    segments
+}
+
+fn sanitize_nickname_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|ch| match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '-' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
+fn strip_package_host(package_coord: &str) -> &str {
+    if let Some((host, rest)) = package_coord.split_once('/')
+        && host.contains('.')
+        && !rest.is_empty()
+    {
+        return rest;
+    }
+
+    package_coord
+}
+
+fn fallback_library_name(parent: &Path) -> Option<String> {
+    if let Some(pretty_name) = parent
+        .file_stem()
+        .filter(|_| parent.extension().is_some_and(|ext| ext == "pretty"))
+        .map(|stem| stem.to_string_lossy().to_string())
+        .map(|name| strip_final_pretty_suffix(&name).to_owned())
+        .filter(|name| !name.is_empty())
+    {
+        return Some(pretty_name);
     }
 
     parent
         .file_name()
         .map(|name| name.to_string_lossy().to_string())
         .filter(|name| !name.is_empty())
-}
-
-fn pretty_library_name(parent: &Path, package_name: Option<&str>) -> Option<String> {
-    let pretty_name = parent
-        .file_stem()
-        .filter(|_| parent.extension().is_some_and(|ext| ext == "pretty"))?
-        .to_string_lossy();
-
-    let version = package_name
-        .and_then(|package_name| package_name.strip_prefix("kicad-footprints@"))
-        .filter(|version| !version.is_empty());
-
-    if let Some(version) = version {
-        return Some(format!("{pretty_name}@{version}"));
-    }
-
-    if pretty_name.is_empty() {
-        None
-    } else {
-        Some(pretty_name.into_owned())
-    }
 }
 
 fn package_coord_for_path(
@@ -528,15 +610,21 @@ fn package_coord_for_path(
             if !path.starts_with(root) {
                 return None;
             }
-            let package_name = coord.rsplit('/').next().unwrap_or(coord);
-            Some((
-                root.components().count(),
-                package_name.to_string(),
-                root.clone(),
-            ))
+            Some((root.components().count(), coord.clone(), root.clone()))
         })
         .max_by_key(|(depth, _, _)| *depth)
-        .map(|(_, package_name, root)| (package_name, root))
+        .map(|(_, package_coord, root)| (package_coord, root))
+}
+
+fn split_final_version_suffix(segment: &str) -> (&str, Option<&str>) {
+    match segment.rsplit_once('@') {
+        Some((name, version)) if !name.is_empty() && !version.is_empty() => (name, Some(version)),
+        _ => (segment, None),
+    }
+}
+
+fn strip_final_pretty_suffix(name: &str) -> &str {
+    name.strip_suffix(".pretty").unwrap_or(name)
 }
 
 /// Determine whether a given string is a KiCad `lib:footprint` reference rather than a file path.
@@ -738,18 +826,18 @@ mod tests {
     fn test_format_footprint_for_kicad_pretty_package_root_uri() {
         let mut package_roots = BTreeMap::new();
         package_roots.insert(
-            "gitlab.com/kicad/libraries/kicad-footprints@10.0.0".to_string(),
-            PathBuf::from("/tmp/vendor/gitlab.com/kicad/libraries/kicad-footprints/10.0.0"),
+            "gitlab.com/example/libs/footprints@10.0.0".to_string(),
+            PathBuf::from("/tmp/vendor/gitlab.com/example/libs/footprints/10.0.0"),
         );
 
         assert_formatted_footprint(
             format_footprint_with_package_roots(
-                "package://gitlab.com/kicad/libraries/kicad-footprints@10.0.0/Capacitor_SMD.pretty/C_0402_1005Metric.kicad_mod",
+                "package://gitlab.com/example/libs/footprints@10.0.0/Capacitor_SMD.pretty/C_0402_1005Metric.kicad_mod",
                 &package_roots,
             ),
-            "Capacitor_SMD@10.0.0:C_0402_1005Metric",
-            "Capacitor_SMD@10.0.0",
-            "/tmp/vendor/gitlab.com/kicad/libraries/kicad-footprints/10.0.0/Capacitor_SMD.pretty",
+            "example_libs_footprints_Capacitor_SMD@10.0.0:C_0402_1005Metric",
+            "example_libs_footprints_Capacitor_SMD@10.0.0",
+            "/tmp/vendor/gitlab.com/example/libs/footprints/10.0.0/Capacitor_SMD.pretty",
         );
     }
 
@@ -777,18 +865,18 @@ mod tests {
     fn test_format_footprint_for_versioned_package_root_uri() {
         let mut package_roots = BTreeMap::new();
         package_roots.insert(
-            "github.com/diodeinc/registry/components/BSS138-7-F@0.3.2".to_string(),
-            PathBuf::from("/tmp/vendor/github.com/diodeinc/registry/components/BSS138-7-F/0.3.2"),
+            "github.com/example/registry/components/ExamplePart@0.3.2".to_string(),
+            PathBuf::from("/tmp/vendor/github.com/example/registry/components/ExamplePart/0.3.2"),
         );
 
         assert_formatted_footprint(
             format_footprint_with_package_roots(
-                "package://github.com/diodeinc/registry/components/BSS138-7-F@0.3.2/SOT96P240X115-3N.kicad_mod",
+                "package://github.com/example/registry/components/ExamplePart@0.3.2/SOT96P240X115-3N.kicad_mod",
                 &package_roots,
             ),
-            "BSS138-7-F@0.3.2:SOT96P240X115-3N",
-            "BSS138-7-F@0.3.2",
-            "/tmp/vendor/github.com/diodeinc/registry/components/BSS138-7-F/0.3.2",
+            "example_registry_components_ExamplePart@0.3.2:SOT96P240X115-3N",
+            "example_registry_components_ExamplePart@0.3.2",
+            "/tmp/vendor/github.com/example/registry/components/ExamplePart/0.3.2",
         );
     }
 
@@ -805,9 +893,50 @@ mod tests {
                 "/tmp/workspace/components/MyPart/Thing.kicad_mod",
                 &package_roots,
             ),
-            "MyPart:Thing",
-            "MyPart",
+            "workspace_components_MyPart:Thing",
+            "workspace_components_MyPart",
             "/tmp/workspace/components/MyPart",
+        );
+    }
+
+    #[test]
+    fn test_package_library_name_cases() {
+        assert_eq!(
+            package_library_name(
+                "github.com/example/workspace/boards/DemoBoard",
+                Path::new("components/1u.pretty"),
+            ),
+            Some("example_workspace_boards_DemoBoard_components_1u".to_string())
+        );
+        assert_eq!(
+            package_library_name("boards/DemoBoard", Path::new("components/1u")),
+            Some("boards_DemoBoard_components_1u".to_string())
+        );
+        assert_eq!(
+            package_library_name(
+                "github.com/example/workspace/boards/DemoBoard",
+                Path::new("components/Murata/1u"),
+            ),
+            Some("example_workspace_boards_DemoBoard_components_Murata_1u".to_string())
+        );
+        assert_eq!(
+            sanitize_nickname_segment("name_with_underscore"),
+            "name_with_underscore"
+        );
+        assert_eq!(
+            sanitize_nickname_segment("name with space"),
+            "name_with_space"
+        );
+        assert_eq!(
+            sanitize_nickname_segment("name=with=equals"),
+            "name_with_equals"
+        );
+        assert_eq!(
+            package_library_name(
+                "github.com/example/libs/footprints@9.0.3",
+                Path::new("Resistor_SMD.pretty"),
+            ),
+            Some("example_libs_footprints_Resistor_SMD@9.0.3".to_string())
         );
     }
 

--- a/crates/pcb-zen/tests/snapshots/kicad_inference_snapshot__snapshot_kicad_symbol_footprint_inference.snap
+++ b/crates/pcb-zen/tests/snapshots/kicad_inference_snapshot__snapshot_kicad_symbol_footprint_inference.snap
@@ -10,7 +10,7 @@ expression: snapshot_output
   (components
     (comp (ref "U1")
       (value "?")
-      (footprint "Package_SO@9.0.3:SOIC-8_3.9x4.9mm_P1.27mm")
+      (footprint "kicad_libraries_kicad-footprints_Package_SO@9.0.3:SOIC-8_3.9x4.9mm_P1.27mm")
       (libsource (lib "lib") (part "?") (description "unknown"))
       (sheetpath (names "U1") (tstamps "bb9170a7-68d4-539c-bed9-f036cbc8d7db"))
       (tstamps "bb9170a7-68d4-539c-bed9-f036cbc8d7db")

--- a/stdlib/bom/house_cap_coverage.py
+++ b/stdlib/bom/house_cap_coverage.py
@@ -2,7 +2,6 @@
 """Visualize house capacitor catalog"""
 
 import matplotlib.pyplot as plt
-import numpy as np
 
 # Data extracted from HOUSE_CAPS_BY_PKG (package, dielectric)
 caps_data = {


### PR DESCRIPTION
Our footprint library naming has always been susceptible to collisions. We used to use `<footprint name>:<footprint name>`, but this assumed the same footprint name wouldn't be used in multiple packages. We then used the parent dir name as lib name: `<footprint dir name>:<footprint name>` as this is what typical KiCad projects do, but this is also susceptible to collisions. Now, we use sanitized full package uris as this effectively eliminates the likelihood of collisions.

Before:
```
Resistor_SMD@9.0.3:R_0402_1005Metric
```

After:
```
kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:R_0402_1005Metric
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated KiCad footprint library nicknames/FPIDs across layout/netlist flows, which can cause churn in existing layouts and fp-lib-table resolution if any downstream tooling assumes the old names.
> 
> **Overview**
> **Eliminates KiCad footprint library nickname collisions** by deriving the FPID library portion from a sanitized package coordinate + relative library path (e.g. `kicad_libraries_kicad-footprints_Resistor_SMD@9.0.3:...`) instead of relying on the `.pretty` directory name alone.
> 
> The layout sync pipeline now treats `footprint_fpid` as required in the JSON netlist (dropping the backward-compatible Python fallback that re-derived it), and updates tests/snapshots to the new FPIDs. Documentation is updated in `CHANGELOG.md`, and an unused `numpy` import is removed from `house_cap_coverage.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff9b6cac9fbb97df21628115e44e53ca75cc493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
