### PR TITLE
fix: use fallback PDF if fetch doesn't return a PDF

### DIFF
--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -174,6 +174,39 @@ pub fn download_file(url: &str, output_path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn is_valid_pdf_bytes(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"%PDF")
+}
+
+fn write_validated_pdf(bytes: &[u8], output_path: &Path) -> Result<()> {
+    if !is_valid_pdf_bytes(bytes) {
+        anyhow::bail!(
+            "Downloaded file is not a valid PDF: {}",
+            output_path.display()
+        );
+    }
+
+    std::fs::write(output_path, bytes)?;
+    Ok(())
+}
+
+fn download_pdf_file(url: &str, output_path: &Path) -> Result<()> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .user_agent(format!("diode-pcb/{}", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let response = client.get(url).send()?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("File download failed: {} - URL: {}", response.status(), url);
+    }
+
+    let bytes = response.bytes()?;
+    write_validated_pdf(bytes.as_ref(), output_path)
+}
+
 /// Upgrade a .kicad_sym file to the latest version using kicad-cli
 /// Returns Ok(()) if upgrade succeeds or kicad-cli is not available (non-fatal)
 fn upgrade_symbol(symbol_path: &Path) -> Result<()> {
@@ -335,7 +368,7 @@ fn materialize_datasheet_pdf(
     output_path: &Path,
 ) -> Result<()> {
     if datasheet_ref.starts_with("http://") || datasheet_ref.starts_with("https://") {
-        return download_file(datasheet_ref, output_path);
+        return download_pdf_file(datasheet_ref, output_path);
     }
 
     let source_path = {
@@ -351,18 +384,10 @@ fn materialize_datasheet_pdf(
         anyhow::bail!("Datasheet PDF not found: {}", source_path.display());
     }
 
-    if source_path == output_path {
-        return Ok(());
-    }
-
-    fs::copy(&source_path, output_path).with_context(|| {
-        format!(
-            "Failed to copy datasheet PDF {} -> {}",
-            source_path.display(),
-            output_path.display()
-        )
-    })?;
-    Ok(())
+    let bytes = fs::read(&source_path)
+        .with_context(|| format!("Failed to read datasheet PDF {}", source_path.display()))?;
+    write_validated_pdf(&bytes, output_path)
+        .with_context(|| format!("Failed to materialize datasheet {}", source_path.display()))
 }
 
 fn process_component_datasheet(
@@ -404,7 +429,7 @@ fn process_component_datasheet(
         return (DatasheetProcessingOutcome::NotResolved, warnings);
     };
 
-    match download_file(url, output_path) {
+    match download_pdf_file(url, output_path) {
         Ok(()) => (DatasheetProcessingOutcome::FallbackDownloaded, warnings),
         Err(e) => {
             add_symbol_error(&mut warnings);
@@ -2215,6 +2240,37 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("Expected exactly one symbol"));
         assert!(msg.contains("found 2"));
+    }
+
+    #[test]
+    fn test_is_valid_pdf_bytes_requires_pdf_magic_header() {
+        assert!(is_valid_pdf_bytes(b"%PDF-1.7\n"));
+        assert!(!is_valid_pdf_bytes(b"<!doctype html>"));
+        assert!(!is_valid_pdf_bytes(b""));
+    }
+
+    #[test]
+    fn test_materialize_datasheet_pdf_rejects_invalid_local_file() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "pcb-diode-api-test-{}-{}",
+            std::process::id(),
+            nonce
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let source = dir.join("bad.pdf");
+        let output = dir.join("docs").join("copied.pdf");
+        std::fs::write(&source, b"<!doctype html>").unwrap();
+
+        let err = materialize_datasheet_pdf("bad.pdf", Some(&dir), &output).unwrap_err();
+        let _ = std::fs::remove_dir_all(&dir);
+        let message = format!("{err:#}");
+
+        assert!(message.contains("Downloaded file is not a valid PDF"));
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -162,7 +162,7 @@ pub fn download_file(url: &str, output_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn download_bytes(url: &str) -> Result<reqwest::bytes::Bytes> {
+fn download_bytes(url: &str) -> Result<Vec<u8>> {
     let client = Client::builder()
         .timeout(Duration::from_secs(60))
         .redirect(reqwest::redirect::Policy::limited(10))
@@ -175,7 +175,7 @@ fn download_bytes(url: &str) -> Result<reqwest::bytes::Bytes> {
         anyhow::bail!("File download failed: {} - URL: {}", response.status(), url);
     }
 
-    Ok(response.bytes()?)
+    Ok(response.bytes()?.to_vec())
 }
 
 fn is_valid_pdf_bytes(bytes: &[u8]) -> bool {
@@ -196,7 +196,7 @@ fn write_validated_pdf(bytes: &[u8], output_path: &Path) -> Result<()> {
 
 fn download_pdf_file(url: &str, output_path: &Path) -> Result<()> {
     let bytes = download_bytes(url)?;
-    write_validated_pdf(bytes.as_ref(), output_path)
+    write_validated_pdf(&bytes, output_path)
 }
 
 /// Upgrade a .kicad_sym file to the latest version using kicad-cli

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -143,19 +143,7 @@ pub fn download_component(auth_token: &str, component_id: &str) -> Result<Compon
 }
 
 pub fn download_file(url: &str, output_path: &Path) -> Result<()> {
-    let client = Client::builder()
-        .timeout(Duration::from_secs(60))
-        .redirect(reqwest::redirect::Policy::limited(10))
-        .user_agent(format!("diode-pcb/{}", env!("CARGO_PKG_VERSION")))
-        .build()?;
-
-    let response = client.get(url).send()?;
-
-    if !response.status().is_success() {
-        anyhow::bail!("File download failed: {} - URL: {}", response.status(), url);
-    }
-
-    let bytes = response.bytes()?;
+    let bytes = download_bytes(url)?;
 
     // Normalize line endings for text files (KiCad files)
     if let Some(ext) = output_path.extension().and_then(|e| e.to_str())
@@ -172,6 +160,22 @@ pub fn download_file(url: &str, output_path: &Path) -> Result<()> {
 
     std::fs::write(output_path, bytes)?;
     Ok(())
+}
+
+fn download_bytes(url: &str) -> Result<reqwest::bytes::Bytes> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .user_agent(format!("diode-pcb/{}", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let response = client.get(url).send()?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("File download failed: {} - URL: {}", response.status(), url);
+    }
+
+    Ok(response.bytes()?)
 }
 
 fn is_valid_pdf_bytes(bytes: &[u8]) -> bool {
@@ -191,19 +195,7 @@ fn write_validated_pdf(bytes: &[u8], output_path: &Path) -> Result<()> {
 }
 
 fn download_pdf_file(url: &str, output_path: &Path) -> Result<()> {
-    let client = Client::builder()
-        .timeout(Duration::from_secs(60))
-        .redirect(reqwest::redirect::Policy::limited(10))
-        .user_agent(format!("diode-pcb/{}", env!("CARGO_PKG_VERSION")))
-        .build()?;
-
-    let response = client.get(url).send()?;
-
-    if !response.status().is_success() {
-        anyhow::bail!("File download failed: {} - URL: {}", response.status(), url);
-    }
-
-    let bytes = response.bytes()?;
+    let bytes = download_bytes(url)?;
     write_validated_pdf(bytes.as_ref(), output_path)
 }
 

--- a/crates/pcb-zen-core/src/diagnostics.rs
+++ b/crates/pcb-zen-core/src/diagnostics.rs
@@ -784,6 +784,22 @@ impl<T> From<WithDiagnostics<T>> for Result<T, Diagnostics> {
     }
 }
 
+impl<T, D: Into<Diagnostic>> From<D> for WithDiagnostics<T> {
+    fn from(diagnostic: D) -> Self {
+        WithDiagnostics {
+            diagnostics: vec![diagnostic.into()].into(),
+            output: None,
+        }
+    }
+}
+
+/// Trait for implementing diagnostic transformation passes.
+/// Each pass can refine, mutate, or generally make changes to a list of diagnostics.
+pub trait DiagnosticsPass {
+    /// Apply this pass to the given diagnostics, potentially mutating them in-place.
+    fn apply(&self, diagnostics: &mut Diagnostics);
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Diagnostic, Diagnostics};
@@ -829,20 +845,4 @@ mod tests {
 
         assert_eq!(diagnostics.diagnostics.len(), 1);
     }
-}
-
-impl<T, D: Into<Diagnostic>> From<D> for WithDiagnostics<T> {
-    fn from(diagnostic: D) -> Self {
-        WithDiagnostics {
-            diagnostics: vec![diagnostic.into()].into(),
-            output: None,
-        }
-    }
-}
-
-/// Trait for implementing diagnostic transformation passes.
-/// Each pass can refine, mutate, or generally make changes to a list of diagnostics.
-pub trait DiagnosticsPass {
-    /// Apply this pass to the given diagnostics, potentially mutating them in-place.
-    fn apply(&self, diagnostics: &mut Diagnostics);
 }


### PR DESCRIPTION
Some symbols have datasheet URLs that are valid URLs but don't point to a PDF.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes datasheet materialization to reject non-PDF content based on header checks, which could cause previously-accepted (but incorrect) downloads to fail and fall back or error. Risk is otherwise limited to component asset download paths.
> 
> **Overview**
> Ensures datasheet downloads/materialization only write *valid* PDFs by introducing `download_pdf_file`/`write_validated_pdf` (checks for the `%PDF` magic header) and routing both symbol-referenced and fallback datasheet URLs through this validation.
> 
> Refactors generic downloading into `download_bytes` while preserving KiCad text-file newline normalization, and adds tests to verify invalid HTML/empty responses and invalid local “.pdf” files are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8701aa782382968a655c6e17a759231e428a3168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->