### PR TITLE
Fix rebinding warning for discard targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Suppressed `binding.rebind` warnings for repeated `_` discard targets in top-level assignments.
+
 ## [0.3.71] - 2026-04-20
 
 ### Added

--- a/crates/pcb-zen-core/src/lang/binding.rs
+++ b/crates/pcb-zen-core/src/lang/binding.rs
@@ -53,6 +53,12 @@ impl<'a> BindingChecker<'a> {
     }
 
     fn bind_name(&mut self, state: &mut ScopeState, name: &str, span: Span) {
+        // `_` is conventionally used as a discard target, so repeated uses should
+        // not participate in same-scope rebinding diagnostics.
+        if name == "_" {
+            return;
+        }
+
         if let Some(previous) = state.maybe_bound.get(name).copied() {
             let previous = self.codemap.file_span(previous).resolve_span();
             let message = format!("Rebinding '{name}' in the same scope");

--- a/crates/pcb-zen-core/tests/binding.rs
+++ b/crates/pcb-zen-core/tests/binding.rs
@@ -112,6 +112,22 @@ fn binding_after_mutually_exclusive_assignment_warns() {
 }
 
 #[test]
+fn discard_bindings_do_not_emit_warning() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            left, _ = ("A", "discard")
+            right, _ = ("B", "discard")
+            _, _ = ("C", "D")
+        "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success());
+    assert!(binding_kinds(&result).is_empty());
+}
+
+#[test]
 fn for_loop_bindings_do_not_emit_warning() {
     let result = common::eval_zen(vec![(
         "test.zen".to_string(),


### PR DESCRIPTION
Fixes:

```
Warning: Rebinding '_' in the same scope
     ╭─[ /Users/akhilles/src/diodehub/keysight/reference/LTM8078x/LTM8078x.zen:275:94 ]
 275 │cout1_value, cout1_2_value, cout1_package, cout1_voltage, cout1_dielectric, cin1_package, _, _ = table1_values(voltage1)
     │                                                                                             ╰─ Rebinding '_' in the same scope

Warning: Rebinding '_' in the same scope
     ╭─[ /Users/akhilles/src/diodehub/keysight/reference/LTM8078x/LTM8078x.zen:276:91 ]
 276 │cout2_value, cout2_2_value, cout2_package, cout2_voltage, cout2_dielectric, cin2_package, _, _ = table1_values(voltage2)
     │                                                                                          ╰─ Rebinding '_' in the same scope

Warning: Rebinding '_' in the same scope
     ╭─[ /Users/akhilles/src/diodehub/keysight/reference/LTM8078x/LTM8078x.zen:276:94 ]
 276 │cout2_value, cout2_2_value, cout2_package, cout2_voltage, cout2_dielectric, cin2_package, _, _ = table1_values(voltage2)
     │                                                                                             ╰─ Rebinding '_' in the same scope
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to warning emission logic for top-level bindings, with a focused regression test added to prevent accidental behavior changes.
> 
> **Overview**
> Suppresses `binding.rebind` warnings when the rebound name is `_`, treating it as a conventional discard target during top-level tuple/unpack assignments.
> 
> Adds a new test ensuring repeated `_` bindings (including multiple `_` in a single assignment) no longer produce rebinding warnings, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52109e5740c4c076c8ab1a125f49095b4e3b493a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->