### PR TITLE
feat: warn on component missing part data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Suppressed `binding.rebind` warnings for repeated `_` discard targets in top-level assignments.
+- Warn when a BOM-included non-generic component is missing part information.
+
 ## [0.3.71] - 2026-04-20
 
 ### Added

--- a/crates/pcb-sch/src/bom/core.rs
+++ b/crates/pcb-sch/src/bom/core.rs
@@ -69,6 +69,33 @@ pub struct Alternative {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Part {
+    pub mpn: String,
+    pub manufacturer: String,
+    #[serde(default)]
+    pub qualifications: Vec<String>,
+}
+
+impl Part {
+    pub fn from_attr_value(attr: &crate::AttributeValue) -> Option<Self> {
+        match attr {
+            crate::AttributeValue::Json(json) => serde_json::from_value(json.clone()).ok(),
+            crate::AttributeValue::String(s) => serde_json::from_str(s).ok(),
+            _ => None,
+        }
+    }
+}
+
+impl From<Part> for Alternative {
+    fn from(part: Part) -> Self {
+        Self {
+            mpn: part.mpn,
+            manufacturer: part.manufacturer,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BomEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mpn: Option<String>,

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -604,41 +604,23 @@ impl Instance {
             .unwrap_or_default()
     }
 
-    pub fn alternatives_attr(&self) -> Vec<crate::bom::Alternative> {
-        use crate::bom::Alternative;
+    pub fn part(&self) -> Option<crate::bom::Part> {
+        self.attributes
+            .get("part")
+            .and_then(crate::bom::Part::from_attr_value)
+    }
 
-        let keys = ["alternatives", "__alternatives__"];
-        keys.iter()
-            .filter_map(|&key| self.attributes.get(key))
-            .filter_map(|val| match val {
-                AttributeValue::Array(arr) => Some(arr),
-                _ => None,
+    pub fn alternatives_attr(&self) -> Vec<crate::bom::Alternative> {
+        let Some(AttributeValue::Array(alternatives)) = self.attributes.get("alternatives") else {
+            return Vec::new();
+        };
+
+        alternatives
+            .iter()
+            .filter_map(|alternative| {
+                crate::bom::Part::from_attr_value(alternative).map(Into::into)
             })
-            .map(|arr| {
-                let alternatives: Vec<Alternative> = arr
-                    .iter()
-                    .filter_map(|av| {
-                        // Try to parse as JSON object
-                        if let AttributeValue::Json(json_val) = av {
-                            let mpn = json_val.get("mpn")?.as_str()?.to_string();
-                            let manufacturer = json_val.get("manufacturer")?.as_str()?.to_string();
-                            return Some(Alternative { mpn, manufacturer });
-                        }
-                        // Try to parse JSON string (from Starlark dict serialization)
-                        if let AttributeValue::String(s) = av
-                            && let Ok(json_val) = serde_json::from_str::<serde_json::Value>(s)
-                        {
-                            let mpn = json_val.get("mpn")?.as_str()?.to_string();
-                            let manufacturer = json_val.get("manufacturer")?.as_str()?.to_string();
-                            return Some(Alternative { mpn, manufacturer });
-                        }
-                        None
-                    })
-                    .collect();
-                alternatives
-            })
-            .next()
-            .unwrap_or_default()
+            .collect()
     }
 
     pub fn physical_attr(&self, keys: &[&str]) -> Option<PhysicalValue> {
@@ -653,11 +635,11 @@ impl Instance {
     }
 
     pub fn mpn(&self) -> Option<String> {
-        self.string_attr(&["MPN", "Mpn", "mpn"])
+        self.part().map(|part| part.mpn)
     }
 
     pub fn manufacturer(&self) -> Option<String> {
-        self.string_attr(&["Manufacturer", "manufacturer"])
+        self.part().map(|part| part.manufacturer)
     }
 
     pub fn description(&self) -> Option<String> {

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -424,7 +424,7 @@ impl ModuleConverter {
                 || instance.dnp()
                 || instance.skip_bom()
                 || instance.component_type().is_some()
-                || (instance.mpn().is_some() && instance.manufacturer().is_some())
+                || instance.part().is_some()
             {
                 continue;
             }
@@ -434,7 +434,7 @@ impl ModuleConverter {
                 .as_deref()
                 .unwrap_or(instance.type_ref.module_name.as_ref());
             let body = format!(
-                "Component '{name}' is included in the BOM but is missing complete part information. Specify `part=Part(...)` or both `mpn` and `manufacturer`."
+                "Component '{name}' is included in the BOM but is missing part information. Specify `part=Part(...)`."
             );
             diagnostics.push(Diagnostic::categorized(
                 &instance.type_ref.source_path.to_string_lossy(),

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -338,6 +338,7 @@ impl ModuleConverter {
 
         // These warnings are purely schematic/netlist semantics (not layout-specific),
         // so emit them during schematic conversion rather than in layout sync.
+        self.diagnose_underspecified_bom_components(&mut diagnostics);
         self.diagnose_unused_module_io(&module_tree, &mut diagnostics);
         self.diagnose_not_connected_multi_port(root_module.source_path(), &mut diagnostics);
 
@@ -412,6 +413,33 @@ impl ModuleConverter {
                 root_source_path,
                 &body,
                 "net.notconnected.multi_port",
+                EvalSeverity::Warning,
+            ));
+        }
+    }
+
+    fn diagnose_underspecified_bom_components(&self, diagnostics: &mut Diagnostics) {
+        for instance in self.schematic.instances.values() {
+            if instance.kind != InstanceKind::Component
+                || instance.dnp()
+                || instance.skip_bom()
+                || instance.component_type().is_some()
+                || (instance.mpn().is_some() && instance.manufacturer().is_some())
+            {
+                continue;
+            }
+
+            let name = instance
+                .reference_designator
+                .as_deref()
+                .unwrap_or(instance.type_ref.module_name.as_ref());
+            let body = format!(
+                "Component '{name}' is included in the BOM but is missing complete part information. Specify `part=Part(...)` or both `mpn` and `manufacturer`."
+            );
+            diagnostics.push(Diagnostic::categorized(
+                &instance.type_ref.source_path.to_string_lossy(),
+                &body,
+                "bom.underspecified",
                 EvalSeverity::Warning,
             ));
         }

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -1050,6 +1050,15 @@ fn warns_for_underspecified_non_generic_bom_component() {
                 type = "resistor",
                 properties = {"resistance": "10k", "package": "0402"},
             )
+
+            Component(
+                name = "U2",
+                prefix = "U",
+                footprint = "TEST:QFN",
+                pin_defs = {"VDD": "1", "GND": "2"},
+                pins = {"VDD": vcc, "GND": gnd},
+                part = builtin.Part(mpn = "PART-123", manufacturer = "ACME"),
+            )
         "#
         .to_string(),
     )]);

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -1025,6 +1025,58 @@ fn unused_io_warns_only_for_unconnected_ports() {
     );
 }
 
+#[test]
+fn warns_for_underspecified_non_generic_bom_component() {
+    let eval_result = eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+            vcc = Net("VCC")
+            gnd = Net("GND")
+
+            Component(
+                name = "U1",
+                prefix = "U",
+                footprint = "TEST:QFN",
+                pin_defs = {"VDD": "1", "GND": "2"},
+                pins = {"VDD": vcc, "GND": gnd},
+            )
+
+            Component(
+                name = "R1",
+                prefix = "R",
+                footprint = "TEST:0402",
+                pin_defs = {"1": "1", "2": "2"},
+                pins = {"1": vcc, "2": gnd},
+                type = "resistor",
+                properties = {"resistance": "10k", "package": "0402"},
+            )
+        "#
+        .to_string(),
+    )]);
+
+    assert!(
+        !eval_result.diagnostics.has_errors(),
+        "eval produced unexpected errors: {:?}",
+        eval_result.diagnostics
+    );
+
+    let eval_output = eval_result.output.expect("expected eval output");
+    let mut diagnostics = eval_output.to_schematic_with_diagnostics().diagnostics;
+    SortPass.apply(&mut diagnostics);
+
+    let output = diagnostics
+        .iter()
+        .filter(|diag| {
+            diag.downcast_error_ref::<CategorizedDiagnostic>()
+                .is_some_and(|c| c.kind == "bom.underspecified")
+        })
+        .map(|diag| format!("{}: {}", diag.path, diag.body))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    insta::assert_snapshot!(output);
+}
+
 snapshot_eval!(io_interface_incompatible, {
     "Module.zen" => r#"
         signal = io(Net)

--- a/crates/pcb-zen-core/tests/snapshots/input__warns_for_underspecified_non_generic_bom_component.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__warns_for_underspecified_non_generic_bom_component.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+assertion_line: 1077
+expression: output
+---
+test.zen: Component 'U1' is included in the BOM but is missing complete part information. Specify `part=Part(...)` or both `mpn` and `manufacturer`.

--- a/crates/pcb-zen-core/tests/snapshots/input__warns_for_underspecified_non_generic_bom_component.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__warns_for_underspecified_non_generic_bom_component.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen-core/tests/input.rs
-assertion_line: 1077
+assertion_line: 1086
 expression: output
 ---
-test.zen: Component 'U1' is included in the BOM but is missing complete part information. Specify `part=Part(...)` or both `mpn` and `manufacturer`.
+test.zen: Component 'U1' is included in the BOM but is missing part information. Specify `part=Part(...)`.

--- a/crates/pcb-zen/tests/assert.rs
+++ b/crates/pcb-zen/tests/assert.rs
@@ -30,6 +30,7 @@ check(True, "all good")
 # Dummy component so schematic isn't empty
 Component(
     name = "comp0",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "TEST:0402",
     pin_defs = {"P": "1"},
     pins = {"P": Net("P")},

--- a/crates/pcb-zen/tests/component_properties.rs
+++ b/crates/pcb-zen/tests/component_properties.rs
@@ -19,6 +19,7 @@ fn snapshot_component_properties() {
 # Instantiate with pin connections and a custom property.
 Component(
     name = "NB3N551DG",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     pins = {
         "ICLK": Net("ICLK"),
         "Q1": Net("Q1"),

--- a/crates/pcb-zen/tests/enum_conversion.rs
+++ b/crates/pcb-zen/tests/enum_conversion.rs
@@ -16,6 +16,7 @@ heading = config(Direction)
 # Add a trivial component so that the schematic/netlist is non-empty.
 Component(
     name = "comp0",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "TEST:0402",
     pin_defs = { "V": "1" },
     pins = { "V": Net("VCC") },

--- a/crates/pcb-zen/tests/input.rs
+++ b/crates/pcb-zen/tests/input.rs
@@ -15,6 +15,7 @@ baud = config(int)
 # Tiny component referencing the power net so that the schematic/netlist is non-empty
 Component(
     name = "comp0",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "TEST:0402",
     pin_defs = {"V": "1"},
     pins = {"V": pwr},
@@ -86,6 +87,7 @@ check(baud == None, "baud should be None when omitted")
 # Tiny component referencing the power net so that the schematic/netlist is non-empty
 Component(
     name = "comp0",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "TEST:0402",
     pin_defs = {"V": "1"},
     pins = {"V": Net("INTERNAL_V")},
@@ -213,6 +215,7 @@ signal_if = SingleNet(name="sig")
 # Use the interface correctly by accessing the net field
 Component(
     name = "test_comp",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "test_footprint",
     pin_defs = {"in": "1", "out": "2"},
     pins = {

--- a/crates/pcb-zen/tests/kicad_inference_snapshot.rs
+++ b/crates/pcb-zen/tests/kicad_inference_snapshot.rs
@@ -27,6 +27,7 @@ http_mirror = "https://kicad-mirror.api.diode.computer/{repo_name}-{version}.tar
         r#"
 Component(
     name = "U1",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     symbol = Symbol(library = "@kicad-symbols/Amplifier_Current.kicad_sym", name = "INA240A1D"),
     pins = {
         "+": Net("INP"),

--- a/crates/pcb-zen/tests/module_loading.rs
+++ b/crates/pcb-zen/tests/module_loading.rs
@@ -52,6 +52,7 @@ DummyFunction()
 
 Component(
     name = "TestComponent",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "SMD:0805",
     symbol = Symbol(
         definition = [ 
@@ -164,6 +165,7 @@ INPUT = io(Net)
 OUTPUT = io(Net)
 Component(
     name = "test_component",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "Resistor_SMD:R_0603_1005Metric",
     pin_defs = {"1": "1", "2": "2"},
     pins = {"1": INPUT, "2": OUTPUT},

--- a/crates/pcb-zen/tests/net.rs
+++ b/crates/pcb-zen/tests/net.rs
@@ -39,6 +39,7 @@ INTERNAL = Net()
 Component(
     name = "R1",
     prefix = "R",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "SMD:0402",
     pin_defs = { "P1": "1", "P2": "2" },
     pins = { "P1": VIN_NET, "P2": GND_NET },
@@ -47,6 +48,7 @@ Component(
 Component(
     name = "R2",
     prefix = "R",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "SMD:0402",
     pin_defs = { "P1": "1", "P2": "2" },
     pins = { "P1": INTERNAL, "P2": GND_NET },

--- a/crates/pcb-zen/tests/placeholder.rs
+++ b/crates/pcb-zen/tests/placeholder.rs
@@ -15,6 +15,7 @@ baud = config(int)
 # Very small dummy component that ties to the power net so that the schematic is non-empty.
 Component(
     name = "comp0",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "TEST:0402",
     pin_defs = {
         "V": "1",
@@ -52,6 +53,7 @@ pwr = io(Net, optional = True)
 
 Component(
     name = "comp0",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     footprint = "TEST:0402",
     pin_defs = {"V": "1"},
     pins = {"V": pwr},

--- a/crates/pcb-zen/tests/snapshots/assert__snapshot_check_true_should_pass.snap
+++ b/crates/pcb-zen/tests/snapshots/assert__snapshot_check_true_should_pass.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/assert.rs
-assertion_line: 41
+assertion_line: 42
 expression: snapshot_output
 ---
 (export (version "E")
@@ -10,16 +10,18 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "TEST:0402")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "comp0") (tstamps "4398fe89-a23f-5645-8878-bb2e739a72f1"))
       (tstamps "4398fe89-a23f-5645-8878-bb2e739a72f1")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/component_properties__snapshot_component_properties.snap
+++ b/crates/pcb-zen/tests/snapshots/component_properties__snapshot_component_properties.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pcb-zen/tests/component_properties.rs
-expression: netlist
+assertion_line: 40
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -9,18 +10,20 @@ expression: netlist
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "SMD:0805")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "NB3N551DG") (tstamps "6c73e1fb-8e95-5677-97d9-7dce42ba86d2"))
       (tstamps "6c73e1fb-8e95-5677-97d9-7dce42ba86d2")
       (property (name "Reference") (value "U1"))
       (property (name "CustomProp") (value "Value123"))
       (property (name "datasheet") (value "https://lcsc.com/product-detail/Logic-ICs_ON_NB3N551DG_NB3N551DG_C146731.html"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/enum_conversion__snapshot_enum_config_conversion.snap
+++ b/crates/pcb-zen/tests/snapshots/enum_conversion__snapshot_enum_config_conversion.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pcb-zen/tests/enum_conversion.rs
-expression: netlist
+assertion_line: 38
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -9,16 +10,18 @@ expression: netlist
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "TEST:0402")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "child.comp0") (tstamps "1210f117-19c9-578c-bf69-b70ae9bad0e5"))
       (tstamps "1210f117-19c9-578c-bf69-b70ae9bad0e5")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/input__correct_usage_with_explicit_net_access.snap
+++ b/crates/pcb-zen/tests/snapshots/input__correct_usage_with_explicit_net_access.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-assertion_line: 226
+assertion_line: 229
 expression: snapshot_output
 ---
 (export (version "E")
@@ -10,16 +10,18 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "test_footprint:test_footprint")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "test_comp") (tstamps "12cb098b-bab7-5f52-8c70-58c8f9863fe7"))
       (tstamps "12cb098b-bab7-5f52-8c70-58c8f9863fe7")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_io_and_config_with_values.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_io_and_config_with_values.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-assertion_line: 35
+assertion_line: 36
 expression: snapshot_output
 ---
 (export (version "E")
@@ -10,16 +10,18 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "TEST:0402")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "sub.comp0") (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5"))
       (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/input__snapshot_optional_inputs_return_none.snap
+++ b/crates/pcb-zen/tests/snapshots/input__snapshot_optional_inputs_return_none.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/input.rs
-assertion_line: 105
+assertion_line: 107
 expression: snapshot_output
 ---
 (export (version "E")
@@ -10,16 +10,18 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "TEST:0402")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "sub.comp0") (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5"))
       (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/kicad_inference_snapshot__snapshot_kicad_symbol_footprint_inference.snap
+++ b/crates/pcb-zen/tests/snapshots/kicad_inference_snapshot__snapshot_kicad_symbol_footprint_inference.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-zen/tests/kicad_inference_snapshot.rs
+assertion_line: 45
 expression: snapshot_output
 ---
 (export (version "E")
@@ -9,18 +10,20 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "kicad_libraries_kicad-footprints_Package_SO@9.0.3:SOIC-8_3.9x4.9mm_P1.27mm")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "U1") (tstamps "bb9170a7-68d4-539c-bed9-f036cbc8d7db"))
       (tstamps "bb9170a7-68d4-539c-bed9-f036cbc8d7db")
       (property (name "Reference") (value "U1"))
       (property (name "datasheet") (value "http://www.ti.com/lit/ds/symlink/ina240.pdf"))
       (property (name "description") (value "High- and Low-Side, Bidirectional, Zero-Drift, Current-Sense Amplifier With Enhanced PWM Rejection, 20V/V, SOIC-8"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/module_loading__module_relative_from_subdir.snap
+++ b/crates/pcb-zen/tests/snapshots/module_loading__module_relative_from_subdir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pcb-zen/tests/module_loading.rs
+assertion_line: 198
 expression: snapshot_output
 ---
 (export (version "E")
@@ -9,16 +10,18 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "Resistor_SMD:R_0603_1005Metric")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "M1.test_component") (tstamps "4b7ee67c-33a2-5915-b83b-b6b2a7a545d1"))
       (tstamps "4b7ee67c-33a2-5915-b83b-b6b2a7a545d1")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/module_loading__module_with_nested_directories.snap
+++ b/crates/pcb-zen/tests/snapshots/module_loading__module_with_nested_directories.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pcb-zen/tests/module_loading.rs
-expression: netlist
+assertion_line: 79
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -9,16 +10,18 @@ expression: netlist
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "SMD:0805")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "sub.TestComponent") (tstamps "3e2bd4f8-e122-5324-ba4c-49fa5528be8b"))
       (tstamps "3e2bd4f8-e122-5324-ba4c-49fa5528be8b")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/net__net_scoping_preserves_parent_name_on_cast.snap
+++ b/crates/pcb-zen/tests/snapshots/net__net_scoping_preserves_parent_name_on_cast.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/net.rs
-assertion_line: 82
+assertion_line: 84
 expression: snapshot_output
 ---
 (export (version "E")
@@ -10,24 +10,28 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "R1")
-      (value "?")
+      (value "TEST")
       (footprint "SMD:0402")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "Regulator.R1") (tstamps "a879d39a-b8a0-5473-a37a-6f7cfddd2790"))
       (tstamps "a879d39a-b8a0-5473-a37a-6f7cfddd2790")
       (property (name "Reference") (value "R1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
     (comp (ref "R2")
-      (value "?")
+      (value "TEST")
       (footprint "SMD:0402")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "Regulator.R2") (tstamps "f9a06d42-9647-5330-b3dc-fe00b973cbd6"))
       (tstamps "f9a06d42-9647-5330-b3dc-fe00b973cbd6")
       (property (name "Reference") (value "R2"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/placeholder__snapshot_io_and_config_placeholders.snap
+++ b/crates/pcb-zen/tests/snapshots/placeholder__snapshot_io_and_config_placeholders.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/placeholder.rs
-assertion_line: 40
+assertion_line: 41
 expression: snapshot_output
 ---
 (export (version "E")
@@ -10,16 +10,18 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "TEST:0402")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "sub.comp0") (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5"))
       (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/placeholder__snapshot_undefined_placeholder.snap
+++ b/crates/pcb-zen/tests/snapshots/placeholder__snapshot_undefined_placeholder.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen/tests/placeholder.rs
-assertion_line: 74
+assertion_line: 76
 expression: snapshot_output
 ---
 (export (version "E")
@@ -10,16 +10,18 @@ expression: snapshot_output
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "TEST:0402")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "sub.comp0") (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5"))
       (tstamps "c36451f5-9361-5aad-8949-5d9502853fc5")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/test__nested_components.snap
+++ b/crates/pcb-zen/tests/snapshots/test__nested_components.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pcb-zen/tests/test.rs
-expression: netlist
+assertion_line: 178
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -9,16 +10,18 @@ expression: netlist
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "SMD:0805")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "MyModule.MyComponent.Component") (tstamps "88868ff1-5bd1-55c8-8857-a9182b7af4bf"))
       (tstamps "88868ff1-5bd1-55c8-8857-a9182b7af4bf")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/snapshots/test__net_name_deduplication.snap
+++ b/crates/pcb-zen/tests/snapshots/test__net_name_deduplication.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pcb-zen/tests/test.rs
-expression: netlist
+assertion_line: 209
+expression: snapshot_output
 ---
 (export (version "E")
   (design
@@ -9,32 +10,38 @@ expression: netlist
     (tool "pcb"))
   (components
     (comp (ref "U1")
-      (value "?")
+      (value "TEST")
       (footprint "SMD:0805")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "MyModule1.Component") (tstamps "634986a9-509e-5464-b539-8450f6429931"))
       (tstamps "634986a9-509e-5464-b539-8450f6429931")
       (property (name "Reference") (value "U1"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
     (comp (ref "U2")
-      (value "?")
+      (value "TEST")
       (footprint "SMD:0805")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "MyModule2.Component") (tstamps "49d7b781-9d5f-5d3f-9170-df886b275b2f"))
       (tstamps "49d7b781-9d5f-5d3f-9170-df886b275b2f")
       (property (name "Reference") (value "U2"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
     (comp (ref "U3")
-      (value "?")
+      (value "TEST")
       (footprint "SMD:0805")
-      (libsource (lib "lib") (part "?") (description "unknown"))
+      (libsource (lib "lib") (part "TEST") (description "unknown"))
       (sheetpath (names "MyModule3.Component") (tstamps "38812e2a-4ee1-57b0-9eb7-e9d1dcd3bf43"))
       (tstamps "38812e2a-4ee1-57b0-9eb7-e9d1dcd3bf43")
       (property (name "Reference") (value "U3"))
+      (property (name "manufacturer") (value "TEST"))
+      (property (name "part") (value "{\"manufacturer\":\"TEST\",\"mpn\":\"TEST\",\"qualifications\":[]}"))
     )
   )
   (libparts
-    (libpart (lib "lib") (part "?")
+    (libpart (lib "lib") (part "TEST")
       (description "")
       (docs "~")
       (footprints

--- a/crates/pcb-zen/tests/test.rs
+++ b/crates/pcb-zen/tests/test.rs
@@ -156,6 +156,7 @@ Component(
         "P2": Net("P2"),
     },
     footprint = "SMD:0805",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
 )
 
 # --- Module.zen
@@ -194,6 +195,7 @@ Component(
         "P1": _internal_net,
     },
     footprint = "SMD:0805",
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
 )
 
 # --- Top.zen

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -225,6 +225,7 @@ Component(
     name = "U",
     symbol = Symbol(library = "Part.kicad_sym"),
     pins = {"P1": P1, "P2": P2},
+    skip_bom = True,
 )
 "#;
 
@@ -269,6 +270,7 @@ Component(
     name = "U1",
     footprint = File("test.kicad_mod"),
     symbol = Symbol(library = "nc_pin.kicad_sym"),
+    skip_bom = True,
     pins = {
         "NC": sig,
     },
@@ -282,6 +284,7 @@ Component(
     name = "U1",
     footprint = File("test.kicad_mod"),
     symbol = Symbol(library = "nc_pin.kicad_sym"),
+    skip_bom = True,
     pins = {
         "NC": sig,
     },
@@ -301,6 +304,7 @@ Component(
     name = "U1",
     footprint = File("test.kicad_mod"),
     symbol = Symbol(library = "nc_pin.kicad_sym"),
+    skip_bom = True,
     pins = {
         "NC": sig,
     },
@@ -655,6 +659,7 @@ Component(
     footprint = "TEST:0402",
     pin_defs = {"P1": "1"},
     pins = {"P1": P1},
+    skip_bom = True,
 )
 "#;
 
@@ -680,6 +685,7 @@ Component(
     footprint = "TEST:0402",
     pin_defs = {"P1": "1"},
     pins = {"P1": unnamed},
+    skip_bom = True,
 )
 "#;
 
@@ -706,6 +712,7 @@ Component(
     footprint = File("test.kicad_mod"),
     pin_defs = {"P": "1"},
     pins = {"P": VIN},
+    skip_bom = True,
 )
 "#;
 

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -225,7 +225,7 @@ Component(
     name = "U",
     symbol = Symbol(library = "Part.kicad_sym"),
     pins = {"P1": P1, "P2": P2},
-    skip_bom = True,
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
 )
 "#;
 
@@ -270,7 +270,7 @@ Component(
     name = "U1",
     footprint = File("test.kicad_mod"),
     symbol = Symbol(library = "nc_pin.kicad_sym"),
-    skip_bom = True,
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     pins = {
         "NC": sig,
     },
@@ -284,7 +284,7 @@ Component(
     name = "U1",
     footprint = File("test.kicad_mod"),
     symbol = Symbol(library = "nc_pin.kicad_sym"),
-    skip_bom = True,
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     pins = {
         "NC": sig,
     },
@@ -304,7 +304,7 @@ Component(
     name = "U1",
     footprint = File("test.kicad_mod"),
     symbol = Symbol(library = "nc_pin.kicad_sym"),
-    skip_bom = True,
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
     pins = {
         "NC": sig,
     },
@@ -659,7 +659,7 @@ Component(
     footprint = "TEST:0402",
     pin_defs = {"P1": "1"},
     pins = {"P1": P1},
-    skip_bom = True,
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
 )
 "#;
 
@@ -685,7 +685,7 @@ Component(
     footprint = "TEST:0402",
     pin_defs = {"P1": "1"},
     pins = {"P1": unnamed},
-    skip_bom = True,
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
 )
 "#;
 
@@ -712,7 +712,7 @@ Component(
     footprint = File("test.kicad_mod"),
     pin_defs = {"P": "1"},
     pins = {"P": VIN},
-    skip_bom = True,
+    part = Part(mpn = "TEST", manufacturer = "TEST"),
 )
 "#;
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new schematic-conversion warning and changes how `mpn`/`manufacturer`/`alternatives` are parsed (now via typed `Part`), which can affect BOM output and netlist properties for existing designs that relied on legacy string attributes.
> 
> **Overview**
> Adds a new `bom.underspecified` *warning* during schematic conversion when a component is included in the BOM but has neither `type` (generic) nor `part` metadata.
> 
> Refactors BOM metadata handling to introduce a typed `Part` (with `qualifications`) and to parse `part`/`alternatives` from JSON/string attribute values; `Instance::mpn()`/`manufacturer()` now derive from `part` rather than legacy attributes. Updates/extends tests and snapshots to supply `Part(...)` in fixtures and to cover the new warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c89997bcf1e2fe46fdf96beba5fb39467624056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->