### PR TITLE
Add 2520 crystal house parts

### DIFF
--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -270,6 +270,17 @@ HOUSE_CRYSTALS_BY_PKG = {
         crystal("25MHz", "12pF", "ABM8AIG-25.000MHZ-12-2Z-T3", "Abracon LLC"),
         crystal("25MHz", "12pF", "X322525MOB4SI", "YXC Crystal Oscillators"),
     ],
+    "2520_4Pin": [
+        crystal("12MHz", "10pF", "ECS-120-10-36Q-AES-TR", "ECS Inc."),
+        crystal("12MHz", "10pF", "ABM10AIG-12.000MHZ-4Z-T3", "Abracon LLC"),
+        crystal("12MHz", "10pF", "TXM12M0004252DBCEO00T", "Yajingxin"),
+        crystal("16MHz", "10pF", "ECS-160-10-36Q-ES-TR", "ECS Inc."),
+        crystal("16MHz", "10pF", "ABM10AIG-16.000MHZ-4Z-T3", "Abracon LLC"),
+        crystal("16MHz", "10pF", "TXM16M0004252DBCEO00T", "Yajingxin"),
+        crystal("25MHz", "10pF", "ECS-250-10-36Q-ES-TR", "ECS Inc."),
+        crystal("25MHz", "10pF", "ABM10AIG-25.000MHZ-4Z-T3", "Abracon LLC"),
+        crystal("25MHz", "10pF", "TXM25M0004252DBCEO00T", "Yajingxin"),
+    ],
 }
 
 # House pin header catalog (Würth Elektronik WR-PHD series)

--- a/stdlib/generics/test/test_Crystal.zen
+++ b/stdlib/generics/test/test_Crystal.zen
@@ -46,6 +46,9 @@ CRYSTAL_MATCH_CASES = [
     ("3225_4Pin", "12MHz", "12pF"),
     ("3225_4Pin", "16MHz", "12pF"),
     ("3225_4Pin", "25MHz", "12pF"),
+    ("2520_4Pin", "12MHz", "10pF"),
+    ("2520_4Pin", "16MHz", "10pF"),
+    ("2520_4Pin", "25MHz", "10pF"),
 ]
 
 for i, (package, frequency, load_capacitance) in enumerate(CRYSTAL_MATCH_CASES):


### PR DESCRIPTION
Useful for more compact designs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new house-part entries and expands an existing matcher test matrix, without changing matching logic or APIs.
> 
> **Overview**
> Adds a new `2520_4Pin` entry to `HOUSE_CRYSTALS_BY_PKG` so the generic BOM matcher can auto-assign house MPNs for compact 2.5×2.0mm 4‑pin crystals (12/16/25MHz, 10pF load capacitance).
> 
> Updates `test_Crystal.zen` to include these new package/frequency/load-cap match cases to ensure `assign_house_parts` selects the expected crystal parts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741b24643ac274290105211c28a49fdc783fe545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
