### PR TITLE
Add 15pF Murata house capacitor

### DIFF
--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -160,6 +160,7 @@ HOUSE_CAPS_BY_PKG = {
     "0402": [
         murata_cap("C0G", "50V", "10pF 1%", "GCM1555C1H100FA16", ["D", "J"]),
         murata_cap("C0G", "50V", "12pF 1%", "GCM1555C1H120FA16", ["D", "J"]),
+        murata_cap("C0G", "50V", "15pF 1%", "GCM1555C1H150FA16", ["D", "J"]),
         murata_cap("C0G", "50V", "18pF 1%", "GCM1555C1H180FA16", ["D", "J"]),
         murata_cap("C0G", "50V", "22pF 1%", "GCM1555C1H220FA16", ["D", "J"]),
         murata_cap("C0G", "50V", "30pF 1%", "GCM1555C1H300FA16", ["D", "J"]),


### PR DESCRIPTION
Useful for load caps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single new catalog entry that only affects which MPN can be auto-selected for matching 15pF 0402 capacitors.
> 
> **Overview**
> Adds a new Murata `C0G` `50V` `15pF 1%` 0402 capacitor (`GCM1555C1H150FA16`) to `HOUSE_CAPS_BY_PKG` in `match_generics.zen`, enabling generic capacitor matching to pick this house MPN for 15pF load-cap use cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f15f91641122417361fd0725fd898b9b360f8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
