### PR TITLE
Fix Windows workspace cache setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Avoid collisions in generated footprint library names.
+- Fixed Windows workspace cache setup so `pcb build` and `pcb layout` do not require symlink privileges.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,6 +2975,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4429,6 +4439,7 @@ dependencies = [
  "insta",
  "itertools 0.13.0",
  "jiff",
+ "junction",
  "log",
  "lsp-server",
  "lsp-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ natord = "1.0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 json-patch = "3.0"
+junction = "1.4.2"
 tempfile = "3.10.1"
 thiserror = "1.0"
 toml = "0.8"

--- a/crates/pcb-zen/Cargo.toml
+++ b/crates/pcb-zen/Cargo.toml
@@ -74,6 +74,9 @@ termtree = { workspace = true }
 [lib]
 path = "src/lib.rs"
 
+[target.'cfg(windows)'.dependencies]
+junction = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 insta = { workspace = true }

--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -306,9 +306,11 @@ pub fn ensure_stdlib_materialized(workspace_root: &std::path::Path) -> Result<Pa
     Ok(target)
 }
 
-/// Ensure the workspace cache symlink exists.
+/// Ensure the workspace cache link exists.
 ///
 /// Creates <workspace_root>/.pcb/cache as a symlink to ~/.pcb/cache.
+/// On Windows, falls back to a junction when symlink creation requires
+/// privileges that the current process does not have.
 /// This provides stable workspace-relative paths in generated files.
 pub fn ensure_workspace_cache_symlink(workspace_root: &std::path::Path) -> Result<()> {
     let home_dir = dirs::home_dir().expect("Cannot determine home directory");
@@ -325,24 +327,99 @@ pub fn ensure_workspace_cache_symlink(workspace_root: &std::path::Path) -> Resul
     std::fs::create_dir_all(workspace_root.join(".pcb"))?;
     std::fs::create_dir_all(&home_cache)?;
 
-    // Check if already a correct symlink
-    if let Ok(target) = std::fs::read_link(&workspace_cache)
-        && target == home_cache
-    {
+    // Check if already a correct symlink or Windows junction.
+    if cache_link_points_to(&workspace_cache, &home_cache) {
         return Ok(());
     }
 
     // Remove whatever exists at the path
-    let _ = std::fs::remove_file(&workspace_cache);
-    let _ = std::fs::remove_dir_all(&workspace_cache);
+    remove_workspace_cache_entry(&workspace_cache)?;
 
-    // Create symlink
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(&home_cache, &workspace_cache)?;
-    #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(&home_cache, &workspace_cache)?;
+    create_workspace_cache_link(&home_cache, &workspace_cache)?;
 
     Ok(())
+}
+
+fn paths_equal(left: &std::path::Path, right: &std::path::Path) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn cache_link_points_to(workspace_cache: &std::path::Path, home_cache: &std::path::Path) -> bool {
+    if let Ok(target) = std::fs::read_link(workspace_cache)
+        && paths_equal(&target, home_cache)
+    {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        if junction::exists(workspace_cache).unwrap_or(false)
+            && let Ok(target) = junction::get_target(workspace_cache)
+        {
+            return paths_equal(&target, home_cache);
+        }
+    }
+
+    false
+}
+
+fn remove_workspace_cache_entry(workspace_cache: &std::path::Path) -> std::io::Result<()> {
+    let metadata = match std::fs::symlink_metadata(workspace_cache) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+
+    #[cfg(windows)]
+    {
+        if junction::exists(workspace_cache).unwrap_or(false) {
+            return junction::delete(workspace_cache);
+        }
+    }
+
+    if metadata.file_type().is_symlink() {
+        return std::fs::remove_file(workspace_cache)
+            .or_else(|_| std::fs::remove_dir(workspace_cache));
+    }
+
+    if metadata.is_dir() {
+        std::fs::remove_dir_all(workspace_cache)
+    } else {
+        std::fs::remove_file(workspace_cache)
+    }
+}
+
+#[cfg(unix)]
+fn create_workspace_cache_link(
+    home_cache: &std::path::Path,
+    workspace_cache: &std::path::Path,
+) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(home_cache, workspace_cache)
+}
+
+#[cfg(windows)]
+fn create_workspace_cache_link(
+    home_cache: &std::path::Path,
+    workspace_cache: &std::path::Path,
+) -> std::io::Result<()> {
+    match std::os::windows::fs::symlink_dir(home_cache, workspace_cache) {
+        Ok(()) => Ok(()),
+        Err(err)
+            if err.raw_os_error() == Some(1314)
+                || err.kind() == std::io::ErrorKind::PermissionDenied =>
+        {
+            let _ = remove_workspace_cache_entry(workspace_cache);
+            junction::create(home_cache, workspace_cache)
+        }
+        Err(err) => Err(err),
+    }
 }
 
 pub fn ensure_bare_repo(repo_url: &str) -> Result<PathBuf> {

--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -380,7 +380,14 @@ fn remove_workspace_cache_entry(workspace_cache: &std::path::Path) -> std::io::R
     #[cfg(windows)]
     {
         if junction::exists(workspace_cache).unwrap_or(false) {
-            return junction::delete(workspace_cache);
+            junction::delete(workspace_cache)?;
+            return std::fs::remove_dir(workspace_cache).or_else(|err| {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    Ok(())
+                } else {
+                    Err(err)
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes a Windows startup failure in `pcb build` / `pcb layout` when creating `<workspace>/.pcb/cache`.

Windows can reject directory symlink creation with `os error 1314` unless Developer Mode or elevated privileges are enabled. This keeps the existing symlink path when available, and falls back to an NTFS junction for normal non-admin Windows users.

Also handles replacing stale `.pcb/cache` junctions safely.

## Tests
- `cargo fmt --check`
- `cargo check -p pcb-zen`
- `cargo test -p pcb-zen --lib`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes filesystem link creation/removal behavior for the workspace cache on Windows, which could affect startup and path stability if edge cases are missed.
> 
> **Overview**
> Fixes Windows failures creating `<workspace>/.pcb/cache` by **falling back from directory symlinks to NTFS junctions** when symlink creation is denied (e.g., `os error 1314`).
> 
> Refactors `ensure_workspace_cache_symlink` to detect whether the existing cache entry already targets `~/.pcb/cache` (symlink *or* junction), safely replace stale entries, and only add the `junction` dependency on Windows. Updates the changelog to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88e9fe291074c7b8f8df2c2935e7c2b60fa9d3f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->