### PR TITLE
Prefer local workspace package URLs in pcb doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `pcb doc --package <url>` now prefers matching local workspace members for bare package URLs.
 - Suppressed `binding.rebind` warnings for repeated `_` discard targets in top-level assignments.
 - Warn when a BOM-included non-generic component is missing part information.
 

--- a/crates/pcb/src/doc.rs
+++ b/crates/pcb/src/doc.rs
@@ -199,6 +199,17 @@ fn run_docgen_for_package(pkg: &str, list: bool) -> Result<()> {
         return run_docgen(&stdlib_root, Some(pcb_zen_core::STDLIB_MODULE_PATH), filter);
     }
 
+    // When a bare package URL matches the current workspace namespace, prefer the
+    // local workspace member over the published remote package.
+    if !pkg.contains('@')
+        && let Some((package_dir, package_url, filter)) = resolve_local_workspace_package_url(pkg)
+    {
+        if list {
+            return list_package_files(&package_url, &package_dir, filter.as_deref());
+        }
+        return run_docgen(&package_dir, Some(&package_url), filter.as_deref());
+    }
+
     // Handle remote package URLs (github.com/user/repo@version)
     if pkg.starts_with("github.com/") || pkg.starts_with("gitlab.com/") {
         let (display_name, requested_version) = parse_remote_package_spec(pkg)?;
@@ -224,6 +235,29 @@ fn run_docgen_for_package(pkg: &str, list: bool) -> Result<()> {
         return list_package_files(display_name, &package_dir, filter.as_deref());
     }
     run_docgen(&package_dir, url.as_deref(), filter.as_deref())
+}
+
+fn resolve_local_workspace_package_url(pkg: &str) -> Option<(PathBuf, String, Option<String>)> {
+    let cwd = std::env::current_dir().ok()?;
+    let file_provider = pcb_zen_core::DefaultFileProvider::new();
+    let workspace_info = pcb_zen::get_workspace_info(&file_provider, &cwd, true).ok()?;
+
+    workspace_info
+        .packages
+        .iter()
+        .filter(|(package_url, _)| pcb_zen_core::workspace::package_url_covers(package_url, pkg))
+        .max_by_key(|(package_url, _)| package_url.len())
+        .map(|(package_url, member)| {
+            let filter = pkg
+                .strip_prefix(package_url)
+                .and_then(|rest| rest.strip_prefix('/'))
+                .map(str::to_string);
+            (
+                member.dir(&workspace_info.root),
+                package_url.clone(),
+                filter,
+            )
+        })
 }
 
 /// Parse a remote package URL like "github.com/user/repo/pkg@1.0.0".


### PR DESCRIPTION
Model likes doing this in a workspace:
```
pcb doc --package github.com/diodeinc/registry/components/Raspberry_Pi/RP2040
```

when wanting to understand a local package. and it should resolve to the local path rather than last published, especially since this package may not be published.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `pcb doc --package` resolution precedence for bare package URLs, which could cause unexpected local-vs-remote doc sources in some workspaces. Scope is limited to documentation generation and uses existing workspace metadata lookup.
> 
> **Overview**
> `pcb doc --package` now **prefers local workspace members** when given a *bare* package URL (no `@version`) that is covered by the current workspace’s package namespace, so docs render from local code instead of the last published remote package.
> 
> Adds `resolve_local_workspace_package_url()` to pick the best-matching workspace package URL (longest prefix) and to derive an optional subpath filter, and records the behavior change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025649d6f1fb7bbedbdef111553cbbf1b087be28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
