### PR TITLE
Drop `flake-utils`, bump crane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,44 +2,26 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1770419512,
-        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
+        "lastModified": 1776635034,
+        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
+        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770537093,
-        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -52,23 +34,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,106 +1,113 @@
 {
+  description = "Nix flake for the pcb CLI";
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      crane,
-      flake-utils,
-      ...
-    }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
+    { self, nixpkgs, crane, ... }:
+    let
+      lib = nixpkgs.lib;
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = lib.genAttrs systems;
+      workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
 
-        inherit (pkgs) lib;
+      packageFor =
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          craneLib = crane.mkLib pkgs;
 
-        craneLib = crane.mkLib pkgs;
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              (craneLib.fileset.commonCargoSources ./.)
+              ./crates/pcb/src/fortune.txt
+              ./crates/pcb/src/templates
+              ./crates/pcb-component-gen/templates
+              ./crates/pcb-ipc2581-tools/src/commands/html_template.html.jinja
+              ./crates/pcb-ipc2581-tools/src/commands/style.css
+              ./crates/pcb-layout/src/scripts
+              ./docs/pages
+              ./stdlib
+            ];
+          };
 
-        unfilteredRoot = ./.; # The original, unfiltered source
+          commonArgs = {
+            pname = "pcb";
+            version = workspaceCargo.workspace.package.version;
+            inherit src;
+            strictDeps = true;
+            doCheck = false;
+            cargoExtraArgs = "-p pcb";
 
-        src = lib.fileset.toSource {
-          root = unfilteredRoot;
-          fileset = lib.fileset.unions [
-            # Default files from crane (Rust and cargo files)
-            (craneLib.fileset.commonCargoSources unfilteredRoot)
+            nativeBuildInputs = with pkgs; [
+              makeWrapper
+              pkg-config
+            ];
 
-            # Also keep any jinja template files
-            (lib.fileset.fileFilter (file: file.hasExt "jinja") unfilteredRoot)
-            # Also keep any python files
-            (lib.fileset.fileFilter (file: file.hasExt "py") unfilteredRoot)
+            buildInputs = with pkgs; [
+              python312
+              python312Packages.kicad
+            ];
+          };
 
-            # Also keep any kicad_sym files (testing)
-            (lib.fileset.fileFilter (file: file.hasExt "kicad_sym") unfilteredRoot)
-
-            # keep web files
-            (lib.fileset.fileFilter (file: file.hasExt "css") unfilteredRoot)
-
-            # skills
-            (lib.fileset.fileFilter (file: file.hasExt "md") unfilteredRoot)
-            (lib.fileset.fileFilter (file: file.hasExt "mdx") unfilteredRoot)
-            (lib.fileset.fileFilter (file: file.hasExt "txt") unfilteredRoot)
-
-            # mcp
-            (lib.fileset.fileFilter (file: file.hasExt "json") unfilteredRoot)
-
-            # gitignore kicad template
-            (lib.fileset.fileFilter ({ name, ... }: name == "gitignore") unfilteredRoot)
-
-          ];
-        };
-
-        commonArgs = {
-          pname = "pcb";
-          inherit src;
-          strictDeps = true;
-          doCheck = false;
-
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-            openssl.dev
-            makeWrapper
-          ];
-
-          buildInputs = with pkgs; [
-            pkg-config
-            openssl
-            python312
-            python312Packages.kicad
-          ];
-        };
-
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
-        pcb = craneLib.buildPackage (
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+        in
+        craneLib.buildPackage (
           commonArgs
           // {
             inherit cargoArtifacts;
-            inherit (craneLib.crateNameFromCargoToml { inherit src; }) version;
-
-            doCheck = false;
 
             postFixup = ''
               wrapProgram $out/bin/pcb \
                 --set KICAD_PYTHON_SITE_PACKAGES "${pkgs.python312Packages.kicad}/${pkgs.python312.sitePackages}" \
                 --set KICAD_PYTHON_INTERPRETER "${pkgs.python312}/bin/python"
             '';
+
+            meta = with lib; {
+              description = "CLI for circuit board design";
+              homepage = "https://github.com/diodeinc/pcb";
+              license = licenses.mit;
+              mainProgram = "pcb";
+              platforms = platforms.unix;
+            };
           }
         );
-      in
-      {
-        packages = {
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pcb = packageFor system;
+        in
+        {
           default = pcb;
-        };
+          inherit pcb;
+        }
+      );
 
-        apps = {
-          default = flake-utils.lib.mkApp { drv = pcb; };
-        };
-      }
-    );
+      apps = forAllSystems (
+        system:
+        let
+          pcb = self.packages.${system}.pcb;
+        in
+        {
+          default = {
+            type = "app";
+            program = "${pcb}/bin/pcb";
+          };
+          pcb = {
+            type = "app";
+            program = "${pcb}/bin/pcb";
+          };
+        }
+      );
+    };
 }


### PR DESCRIPTION
I'm a `flake-utils` hater. Also, drop `openssl` since we don't need it anymore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Nix build/packaging definition (systems matrix, source fileset, build inputs), which can break CI/builds across platforms. No runtime app logic is modified.
> 
> **Overview**
> Simplifies the Nix flake by **removing `flake-utils`** and replacing `eachDefaultSystem` with an explicit `systems` list and `genAttrs`-based `packages`/`apps` outputs.
> 
> Updates pinned dependencies in `flake.lock` (**bumps `crane` and `nixpkgs`**) and adjusts the build definition to pull the workspace version from `Cargo.toml`, explicitly include required non-Rust assets in the `src` fileset, and **drop OpenSSL-related build inputs** while keeping the KiCad Python wrapping in `postFixup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f2c074c26520e1368e7287c6298c1f2d186091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
