### PR TITLE
Tighten `pcb-version` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `pcb-version` now requires `major.minor`; auto-deps bumps older workspace minors forward and newer-required minors error out.
+
 ### Fixed
 
 - `pcb doc --package <url>` now prefers matching local workspace members for bare package URLs.

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -73,7 +73,70 @@ fn parse_asset_semver(spec: &AssetDependencySpec) -> Option<Version> {
     Version::parse(raw).ok()
 }
 
+/// Parse a `pcb-version` string into its `(major, minor)` pair.
+///
+/// `pcb-version` is always written and compared as `major.minor`.
+pub fn parse_pcb_version(s: &str) -> Option<(u32, u32)> {
+    let (major, minor) = s.split_once('.')?;
+    if minor.contains('.') {
+        return None;
+    }
+    Some((major.parse().ok()?, minor.parse().ok()?))
+}
+
+fn current_pcb_version() -> (u32, u32) {
+    let version = env!("CARGO_PKG_VERSION");
+    let mut parts = version.split('.');
+    let major = parts
+        .next()
+        .and_then(|part| part.parse().ok())
+        .expect("CARGO_PKG_VERSION must be valid semver");
+    let minor = parts
+        .next()
+        .and_then(|part| part.parse().ok())
+        .expect("CARGO_PKG_VERSION must be valid semver");
+    (major, minor)
+}
+
+/// Format the running pcb binary version as a `major.minor` string.
+pub fn pcb_version_from_cargo() -> String {
+    let (major, minor) = current_pcb_version();
+    format!("{major}.{minor}")
+}
+
+/// Whether `current` is older than `required`, comparing only `major.minor`.
+pub fn pcb_version_is_older(current: &str, required: &str) -> Option<bool> {
+    let current = parse_pcb_version(current)?;
+    let required = parse_pcb_version(required)?;
+    Some(current < required)
+}
+
 impl PcbToml {
+    fn finish_parse(mut self) -> Result<Self> {
+        self.validate_pcb_version()?;
+        self.add_implicit_legacy_asset_dependencies();
+        Ok(self)
+    }
+
+    fn validate_pcb_version(&self) -> Result<()> {
+        let Some(version) = self
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.pcb_version.as_deref())
+        else {
+            return Ok(());
+        };
+
+        if parse_pcb_version(version).is_none() {
+            anyhow::bail!(
+                "invalid `pcb-version`: expected \"major.minor\" like \"0.3\", got \"{}\"",
+                version
+            );
+        }
+
+        Ok(())
+    }
+
     fn add_implicit_legacy_asset_dependencies(&mut self) {
         if self.assets.is_empty() {
             return;
@@ -130,10 +193,10 @@ impl PcbToml {
     /// Returns `false` for legacy V1 manifests (used by `pcb migrate`).
     pub fn is_v2(&self) -> bool {
         if let Some(w) = &self.workspace {
-            // Workspace present: V2 if pcb-version >= 0.3.0
+            // Workspace present: V2 if pcb-version >= 0.3
             if let Some(version_str) = &w.pcb_version {
-                return Self::parse_pcb_version(version_str)
-                    .map(|(major, minor, _)| major > 0 || minor >= 3)
+                return parse_pcb_version(version_str)
+                    .map(|(major, minor)| major > 0 || minor >= 3)
                     .unwrap_or(false);
             }
             // No pcb-version means legacy V1.
@@ -144,31 +207,10 @@ impl PcbToml {
         !self.requires_v1()
     }
 
-    /// Parse pcb-version string into (major, minor, patch) tuple
-    /// Supports formats: "0.3", "0.3.0", "0.3.2"
-    fn parse_pcb_version(s: &str) -> Option<(u32, u32, u32)> {
-        let parts: Vec<&str> = s.split('.').collect();
-        match parts.len() {
-            2 => {
-                let major = parts[0].parse().ok()?;
-                let minor = parts[1].parse().ok()?;
-                Some((major, minor, 0))
-            }
-            3 => {
-                let major = parts[0].parse().ok()?;
-                let minor = parts[1].parse().ok()?;
-                let patch = parts[2].parse().ok()?;
-                Some((major, minor, patch))
-            }
-            _ => None,
-        }
-    }
-
     /// Parse from TOML string
     pub fn parse(content: &str) -> Result<Self> {
-        let mut parsed: Self = toml::from_str(content).map_err(|e| anyhow::anyhow!("{e}"))?;
-        parsed.add_implicit_legacy_asset_dependencies();
-        Ok(parsed)
+        let parsed: Self = toml::from_str(content).map_err(|e| anyhow::anyhow!("{e}"))?;
+        parsed.finish_parse()
     }
 
     /// Parse from file, rendering errors with ariadne-style diagnostics
@@ -189,7 +231,7 @@ impl PcbToml {
 
     /// Parse TOML content with path context for error reporting
     pub fn parse_with_path(content: &str, path: &Path) -> Result<Self> {
-        let mut parsed: Self = toml::from_str(content).map_err(|e| {
+        let parsed: Self = toml::from_str(content).map_err(|e| {
             if let Some(span) = e.span() {
                 let path_str = path.display().to_string();
                 let mut buf = Vec::new();
@@ -210,8 +252,9 @@ impl PcbToml {
                 anyhow::anyhow!("failed to parse {}: {e}", path.display())
             }
         })?;
-        parsed.add_implicit_legacy_asset_dependencies();
-        Ok(parsed)
+        parsed
+            .finish_parse()
+            .map_err(|e| anyhow::anyhow!("failed to parse {}: {e}", path.display()))
     }
 
     /// Extract and parse inline pcb.toml from .zen file content
@@ -327,7 +370,10 @@ pub struct WorkspaceConfig {
     pub kicad_library: Vec<KicadLibraryConfig>,
 
     /// List of board directories/patterns (supports globs)
-    #[serde(default = "default_members")]
+    #[serde(
+        default = "default_members",
+        skip_serializing_if = "is_default_members"
+    )]
     pub members: Vec<String>,
 
     /// Default board name to use
@@ -433,6 +479,10 @@ pub fn stdlib_pinned_kicad_library() -> KicadLibraryConfig {
 
 fn is_default_kicad_library(value: &[KicadLibraryConfig]) -> bool {
     value == default_kicad_library().as_slice()
+}
+
+fn is_default_members(value: &[String]) -> bool {
+    value == default_members().as_slice()
 }
 
 /// Access control configuration (shared by V1 and V2)
@@ -1164,6 +1214,19 @@ name = "TestBoard"
 
         let config = PcbToml::parse(content).unwrap();
         assert!(!config.is_v2());
+    }
+
+    #[test]
+    fn test_parse_rejects_patch_pcb_version() {
+        let err = PcbToml::parse(
+            r#"
+[workspace]
+pcb-version = "0.3.71"
+"#,
+        )
+        .expect_err("expected patch pcb-version to be rejected at parse time");
+
+        assert!(err.to_string().contains("expected \"major.minor\""));
     }
 
     #[test]

--- a/crates/pcb-zen-core/src/workspace.rs
+++ b/crates/pcb-zen-core/src/workspace.rs
@@ -13,7 +13,7 @@ use semver::Version;
 use crate::FileProvider;
 use crate::config::{
     KicadLibraryConfig, Lockfile, PcbToml, WorkspaceConfig, find_workspace_root,
-    stdlib_pinned_kicad_library,
+    pcb_version_from_cargo, pcb_version_is_older, stdlib_pinned_kicad_library,
 };
 use crate::kicad_library::validate_kicad_library_config;
 
@@ -36,6 +36,30 @@ fn build_workspace_base_url(repository: Option<&str>, path: Option<&str>) -> Opt
         (Some(repo), None) => Some(repo.to_string()),
         _ => None,
     }
+}
+
+fn validate_workspace_pcb_version(config: &PcbToml, source: &Path) -> anyhow::Result<()> {
+    let current = pcb_version_from_cargo();
+    let Some(required) = config
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.pcb_version.as_deref())
+    else {
+        return Ok(());
+    };
+
+    if pcb_version_is_older(&current, required) == Some(true) {
+        anyhow::bail!(
+            "Workspace requires pcb-version = \"{}\" but the current pcb is {}\n  \
+             Upgrade pcb before building or updating this workspace.\n  \
+             Manifest: {}",
+            required,
+            current,
+            source.display()
+        );
+    }
+
+    Ok(())
 }
 
 /// A discovered member package in the workspace
@@ -455,6 +479,11 @@ pub fn get_workspace_info<F: FileProvider>(
         return Err(anyhow::anyhow!(msg));
     }
 
+    if let Some(cfg) = &config {
+        let src = config_source.as_deref().unwrap_or(pcb_toml_path.as_path());
+        validate_workspace_pcb_version(cfg, src)?;
+    }
+
     if let Some(cfg) = &config
         && let Some(workspace) = cfg.workspace.as_ref()
     {
@@ -609,7 +638,9 @@ pub fn get_workspace_info<F: FileProvider>(
 mod tests {
     use super::*;
     use crate::InMemoryFileProvider;
-    use crate::config::DEFAULT_KICAD_HTTP_MIRROR_TEMPLATE;
+    use crate::config::{
+        DEFAULT_KICAD_HTTP_MIRROR_TEMPLATE, parse_pcb_version, pcb_version_from_cargo,
+    };
     use std::collections::HashMap;
     use std::path::Path;
 
@@ -813,5 +844,26 @@ preferred = ["components/preferred-part"]
             !info.packages["modules/regular-module"].preferred,
             "non-preferred package should not be annotated"
         );
+    }
+
+    #[test]
+    fn test_workspace_rejects_newer_required_pcb_version() {
+        let (major, minor) = parse_pcb_version(&pcb_version_from_cargo()).unwrap();
+        let required = format!("{}.{}", major, minor + 1);
+        let files = HashMap::from([(
+            "/repo/pcb.toml".to_string(),
+            format!(
+                r#"
+[workspace]
+pcb-version = "{}"
+"#,
+                required
+            ),
+        )]);
+        let provider = InMemoryFileProvider::new(files);
+
+        let err = get_workspace_info(&provider, Path::new("/repo"))
+            .expect_err("expected workspace requiring a newer pcb minor version to fail");
+        assert!(err.to_string().contains(&required));
     }
 }

--- a/crates/pcb-zen/src/auto_deps.rs
+++ b/crates/pcb-zen/src/auto_deps.rs
@@ -113,7 +113,6 @@ fn collect_manifest_paths(
     package_imports: &HashMap<PathBuf, CollectedImports>,
 ) -> BTreeSet<PathBuf> {
     let mut manifests: BTreeSet<PathBuf> = package_imports.keys().cloned().collect();
-
     if packages.is_empty() {
         let root_pcb_toml = workspace_root.join("pcb.toml");
         if root_pcb_toml.exists() {

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -4,7 +4,7 @@ use pcb_eda::kicad::symbol_library::KicadSymbolLibrary;
 use pcb_ui::{Colorize, Spinner, Style, StyledText};
 use pcb_zen_core::config::{
     DependencyDetail, DependencySpec, LockEntry, Lockfile, ManifestPart, PatchSpec, PcbToml,
-    split_repo_and_subpath,
+    pcb_version_from_cargo, pcb_version_is_older, split_repo_and_subpath,
 };
 use pcb_zen_core::kicad_library::{
     KICAD_PARTS_INDEX_FILE, KicadRepoMatch, kicad_http_mirror_template_for_repo,
@@ -310,6 +310,33 @@ fn run_auto_deps(workspace_info: &mut WorkspaceInfo) -> Result<()> {
     Ok(())
 }
 
+fn sync_root_workspace_pcb_version(workspace_info: &mut WorkspaceInfo) -> Result<()> {
+    let Some(config) = workspace_info.config.as_mut() else {
+        return Ok(());
+    };
+    let Some(workspace) = config.workspace.as_mut() else {
+        return Ok(());
+    };
+    let Some(existing) = workspace.pcb_version.as_deref() else {
+        return Ok(());
+    };
+
+    let current = pcb_version_from_cargo();
+    if pcb_version_is_older(existing, &current) != Some(true) {
+        return Ok(());
+    }
+
+    workspace.pcb_version = Some(current);
+    let pcb_toml_path = workspace_info.root.join("pcb.toml");
+    fs::write(&pcb_toml_path, toml::to_string_pretty(&config)?)?;
+    eprintln!(
+        "{} synced workspace pcb-version in {}",
+        "updated:".with_style(Style::Green),
+        pcb_toml_path.display().to_string().bold()
+    );
+    Ok(())
+}
+
 fn is_branch_only_dep(detail: &DependencyDetail) -> bool {
     detail.branch.is_some()
         && detail.rev.is_none()
@@ -523,6 +550,7 @@ pub fn resolve_dependencies(
     // Skip for standalone mode (no pcb.toml to modify)
     // Skip for locked/offline modes (trust the lockfile)
     if !is_standalone && !locked && !offline {
+        sync_root_workspace_pcb_version(workspace_info)?;
         run_auto_deps(workspace_info)?;
     }
 

--- a/crates/pcb/src/migrate/codemods/manifest_v2.rs
+++ b/crates/pcb/src/migrate/codemods/manifest_v2.rs
@@ -2,19 +2,8 @@ use anyhow::{Context, Result};
 use globset::{Glob, GlobSetBuilder};
 use ignore::WalkBuilder;
 use pcb_zen_core::DefaultFileProvider;
-use pcb_zen_core::config::{PcbToml, WorkspaceConfig};
+use pcb_zen_core::config::{PcbToml, WorkspaceConfig, pcb_version_from_cargo};
 use std::path::{Path, PathBuf};
-
-/// Get pcb-version from CARGO_PKG_VERSION (major.minor format)
-pub fn pcb_version_from_cargo() -> String {
-    let version = env!("CARGO_PKG_VERSION");
-    let parts: Vec<&str> = version.split('.').collect();
-    if parts.len() >= 2 {
-        format!("{}.{}", parts[0], parts[1])
-    } else {
-        version.to_string()
-    }
-}
 
 /// Convert all pcb.toml files in workspace to V2
 pub fn convert_workspace_to_v2(

--- a/crates/pcb/src/new.rs
+++ b/crates/pcb/src/new.rs
@@ -5,12 +5,11 @@ use globset::Glob;
 use inquire::{Select, Text};
 use minijinja::{Environment, context};
 use pcb_zen_core::DefaultFileProvider;
-use pcb_zen_core::config::{PcbToml, find_workspace_root};
+use pcb_zen_core::config::{PcbToml, find_workspace_root, pcb_version_from_cargo};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::codegen;
-use crate::migrate::codemods::manifest_v2::pcb_version_from_cargo;
 
 const GITIGNORE_TEMPLATE: &str = include_str!("templates/gitignore");
 const WORKSPACE_PCB_TOML: &str = include_str!("templates/workspace_pcb_toml.jinja");

--- a/crates/pcb/tests/snapshots/auto_deps__auto_deps_branch_dep_pins_rev_and_builds.snap
+++ b/crates/pcb/tests/snapshots/auto_deps__auto_deps_branch_dep_pins_rev_and_builds.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb/tests/auto_deps.rs
-assertion_line: 240
 expression: snapshot
 ---
 Command: pcb build board.zen
@@ -14,13 +13,6 @@ Exit Code: 0
 --- pcb.toml ---
 [workspace]
 pcb-version = "0.3"
-members = [
-    "components/*",
-    "reference/*",
-    "modules/*",
-    "boards/*",
-    "graphics/*",
-]
 
 [dependencies."github.com/mycompany/components/SimpleResistor"]
 branch = "main"

--- a/crates/pcb/tests/snapshots/auto_deps__auto_deps_kicad_dynamic_path_pcb_toml.snap
+++ b/crates/pcb/tests/snapshots/auto_deps__auto_deps_kicad_dynamic_path_pcb_toml.snap
@@ -1,17 +1,9 @@
 ---
 source: crates/pcb/tests/auto_deps.rs
-assertion_line: 165
 expression: pcb_toml_content
 ---
 [workspace]
 pcb-version = "0.3"
-members = [
-    "components/*",
-    "reference/*",
-    "modules/*",
-    "boards/*",
-    "graphics/*",
-]
 
 [dependencies]
 "gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"

--- a/crates/pcb/tests/snapshots/auto_deps__auto_deps_kicad_footprints_pcb_toml.snap
+++ b/crates/pcb/tests/snapshots/auto_deps__auto_deps_kicad_footprints_pcb_toml.snap
@@ -1,17 +1,9 @@
 ---
 source: crates/pcb/tests/auto_deps.rs
-assertion_line: 122
 expression: pcb_toml_content
 ---
 [workspace]
 pcb-version = "0.3"
-members = [
-    "components/*",
-    "reference/*",
-    "modules/*",
-    "boards/*",
-    "graphics/*",
-]
 
 [dependencies]
 "gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"

--- a/crates/pcb/tests/snapshots/auto_deps__auto_deps_kicad_symbols_pcb_toml.snap
+++ b/crates/pcb/tests/snapshots/auto_deps__auto_deps_kicad_symbols_pcb_toml.snap
@@ -1,17 +1,9 @@
 ---
 source: crates/pcb/tests/auto_deps.rs
-assertion_line: 103
 expression: pcb_toml_content
 ---
 [workspace]
 pcb-version = "0.3"
-members = [
-    "components/*",
-    "reference/*",
-    "modules/*",
-    "boards/*",
-    "graphics/*",
-]
 
 [dependencies]
 "gitlab.com/kicad/libraries/kicad-symbols" = "9.0.3"

--- a/crates/pcb/tests/snapshots/auto_deps__auto_deps_multiple_pcb_toml.snap
+++ b/crates/pcb/tests/snapshots/auto_deps__auto_deps_multiple_pcb_toml.snap
@@ -1,17 +1,9 @@
 ---
 source: crates/pcb/tests/auto_deps.rs
-assertion_line: 146
 expression: pcb_toml_content
 ---
 [workspace]
 pcb-version = "0.3"
-members = [
-    "components/*",
-    "reference/*",
-    "modules/*",
-    "boards/*",
-    "graphics/*",
-]
 
 [dependencies]
 "gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"


### PR DESCRIPTION
Auto-dep bumps older workspace minors forward and newer-required minors error out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect manifest parsing and workspace gating, which can hard-fail builds for previously accepted `pcb-version` strings and automatically rewrite root `pcb.toml` during auto-deps.
> 
> **Overview**
> **Tightens `pcb-version` semantics to `major.minor` only** by rejecting patch-form values (e.g. `0.3.71`) at `pcb.toml` parse time and centralizing version helpers in `pcb-zen-core`.
> 
> **Enforces toolchain compatibility at runtime**: workspace discovery now errors when a workspace requires a newer `pcb-version` minor than the running binary, and dependency resolution auto-syncs the root `pcb.toml` to the current `pcb` `major.minor` when it’s behind.
> 
> Also tweaks serialization to omit default `[workspace].members` from generated `pcb.toml` output, updating auto-deps snapshots accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5ddb241449c0fabfe5ef2618b4618c7f4603d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
