### PR TITLE
fix: remove GLB export and use ODB export precision 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Removed the hidden `pcb mcp` command and deleted the `pcb-mcp` / `rquickjs` integration from the workspace.
+- Board releases no longer generate GLB model files.
+- ODB++ release exports now use precision 4.
 
 ### Fixed
 

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -187,9 +187,10 @@ const MANUFACTURING_ARTIFACTS: &[ArtifactType] = &[
     ArtifactType::Ipc2581,
     ArtifactType::Step,
     ArtifactType::Vrml,
-    ArtifactType::Glb,
     ArtifactType::Svg,
 ];
+
+const ODB_EXPORT_PRECISION: &str = "4";
 
 const FINALIZATION_TASKS: &[(&str, TaskFn)] = &[
     ("Writing release metadata", write_metadata),
@@ -1099,7 +1100,7 @@ fn generate_odb(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         .arg("--units")
         .arg("mm")
         .arg("--precision")
-        .arg("2")
+        .arg(ODB_EXPORT_PRECISION)
         .arg("--compression")
         .arg("zip")
         .arg(kicad_pcb_path.to_string_lossy())


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes board release artifact outputs by removing GLB generation and altering ODB++ numeric precision, which could affect downstream manufacturing/consumption workflows.
> 
> **Overview**
> Board releases **no longer generate GLB 3D model artifacts**, by removing `ArtifactType::Glb` from the manufacturing artifact pipeline.
> 
> ODB++ exports generated during release now use **precision 4** (via `--precision 4`) instead of the previous lower precision, and the changelog is updated to reflect both output changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf92cd0d79cea652027f9136b00b4073f8a53360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->