### PR TITLE
Add config overrides to layout test and simulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `pcb layout`, `pcb simulate`, and `pcb test` now support repeatable `--config KEY=VALUE` overrides.
 - `pcb-version` now requires `major.minor`; auto-deps bumps older workspace minors forward and newer-required minors error out.
 
 ### Changed

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -5,6 +5,7 @@ use pcb_ui::prelude::*;
 use std::path::PathBuf;
 
 use crate::build::{build, create_diagnostics_passes};
+use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
 use crate::drc;
 
 #[derive(Args, Debug, Default, Clone)]
@@ -13,6 +14,9 @@ pub struct LayoutArgs {
     /// Path to .zen file
     #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
     pub file: PathBuf,
+
+    #[arg(long = "config", value_name = "KEY=VALUE", help = CONFIG_ARG_HELP)]
+    pub config: Vec<String>,
 
     /// Skip opening the layout file after generation
     #[arg(long)]
@@ -44,6 +48,7 @@ pub struct LayoutArgs {
 
 pub fn execute(mut args: LayoutArgs) -> Result<()> {
     crate::file_walker::require_zen_file(&args.file)?;
+    let config_inputs = parse_config_overrides(&args.config)?;
 
     // --check implies --no-open
     if args.check {
@@ -62,7 +67,7 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
 
     let Some(schematic) = build(
         zen_path,
-        Default::default(),
+        config_inputs,
         create_diagnostics_passes(&args.suppress, &[]),
         false,
         &mut false.clone(),

--- a/crates/pcb/src/sim.rs
+++ b/crates/pcb/src/sim.rs
@@ -3,11 +3,14 @@ use clap::Args;
 use colored::Colorize;
 use pcb_sim::{gen_sim, has_sim_setup, run_ngspice_captured};
 use pcb_ui::prelude::*;
+use serde_json::Value as JsonValue;
+use starlark::collections::SmallMap;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
 use crate::build::{build as build_zen, create_diagnostics_passes};
+use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
 use crate::file_walker;
 
 #[derive(Args, Debug)]
@@ -16,6 +19,9 @@ pub struct SimArgs {
     /// .zen file or directory to simulate. Defaults to current directory.
     #[arg(value_name = "PATH", value_hint = clap::ValueHint::AnyPath)]
     pub path: Option<PathBuf>,
+
+    #[arg(long = "config", value_name = "KEY=VALUE", help = CONFIG_ARG_HELP)]
+    pub config: Vec<String>,
 
     /// Setup file (e.g., voltage sources). Only valid when simulating a single file.
     #[arg(long, value_hint = clap::ValueHint::FilePath)]
@@ -46,13 +52,14 @@ pub struct SimArgs {
 fn simulate_one(
     zen_path: &std::path::Path,
     resolution_result: pcb_zen_core::resolution::ResolutionResult,
+    config_inputs: SmallMap<String, JsonValue>,
     args: &SimArgs,
 ) -> Result<bool> {
     let file_name = zen_path.file_name().unwrap().to_string_lossy().to_string();
 
     let Some(schematic) = build_zen(
         zen_path,
-        Default::default(),
+        config_inputs,
         create_diagnostics_passes(&[], &[]),
         false,
         &mut false.clone(),
@@ -140,13 +147,27 @@ fn simulate_one(
 }
 
 pub fn execute(args: SimArgs) -> Result<()> {
+    if !args.config.is_empty() {
+        let Some(path) = args.path.as_deref() else {
+            anyhow::bail!("--config requires a single .zen file target");
+        };
+
+        if path.is_dir() {
+            anyhow::bail!("--config requires a single .zen file target");
+        }
+
+        file_walker::require_zen_file(path)?;
+    }
+
+    let config_inputs = parse_config_overrides(&args.config)?;
+
     // If a specific file is given, run it directly (preserves old single-file behaviour)
     if let Some(path) = &args.path
         && path.is_file()
     {
         file_walker::require_zen_file(path)?;
         let resolution_result = crate::resolve::resolve(Some(path), args.offline, args.locked)?;
-        simulate_one(path, resolution_result, &args)?;
+        simulate_one(path, resolution_result, config_inputs, &args)?;
         return Ok(());
     }
 
@@ -169,7 +190,12 @@ pub fn execute(args: SimArgs) -> Result<()> {
     let mut has_errors = false;
 
     for zen_path in &zen_files {
-        match simulate_one(zen_path, resolution_result.clone(), &args) {
+        match simulate_one(
+            zen_path,
+            resolution_result.clone(),
+            config_inputs.clone(),
+            &args,
+        ) {
             Ok(ran) => {
                 if ran {
                     simulated += 1;

--- a/crates/pcb/src/test.rs
+++ b/crates/pcb/src/test.rs
@@ -5,9 +5,12 @@ use log::debug;
 use pcb_ui::prelude::*;
 use pcb_zen_core::ModulePath;
 use serde::Serialize;
+use serde_json::Value as JsonValue;
+use starlark::collections::SmallMap;
 use std::path::{Path, PathBuf};
 
 use crate::build::create_diagnostics_passes;
+use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
 use crate::file_walker;
 
 #[derive(Args, Debug, Default, Clone)]
@@ -16,6 +19,9 @@ pub struct TestArgs {
     /// .zen file or directory to test. Defaults to current directory.
     #[arg(value_name = "PATH", value_hint = clap::ValueHint::AnyPath)]
     pub path: Option<PathBuf>,
+
+    #[arg(long = "config", value_name = "KEY=VALUE", help = CONFIG_ARG_HELP)]
+    pub config: Vec<String>,
 
     /// Disable network access (offline mode) - only use vendored dependencies
     #[arg(long = "offline")]
@@ -78,6 +84,7 @@ pub fn test(
     zen_path: &Path,
     passes: Vec<Box<dyn pcb_zen_core::DiagnosticsPass>>,
     resolution_result: pcb_zen_core::resolution::ResolutionResult,
+    config_inputs: SmallMap<String, JsonValue>,
 ) -> (Vec<pcb_zen_core::lang::error::BenchTestResult>, bool) {
     let file_name = zen_path.file_name().unwrap().to_string_lossy();
 
@@ -86,7 +93,7 @@ pub fn test(
     let spinner = Spinner::builder(format!("{file_name}: Testing")).start();
 
     // Evaluate the design (use eval() not run() to get EvalOutput and collect TestBenches)
-    let eval_result = pcb_zen::eval(zen_path, resolution_result, Default::default());
+    let eval_result = pcb_zen::eval(zen_path, resolution_result, config_inputs);
 
     let mut diagnostics = eval_result.diagnostics;
 
@@ -223,6 +230,20 @@ fn execute_testbench_checks(
 }
 
 pub fn execute(args: TestArgs) -> Result<()> {
+    if !args.config.is_empty() {
+        let Some(path) = args.path.as_deref() else {
+            anyhow::bail!("--config requires a single .zen file target");
+        };
+
+        if path.is_dir() {
+            anyhow::bail!("--config requires a single .zen file target");
+        }
+
+        file_walker::require_zen_file(path)?;
+    }
+
+    let config_inputs = parse_config_overrides(&args.config)?;
+
     // Resolve dependencies before finding .zen files
     let resolution_result =
         crate::resolve::resolve(args.path.as_deref(), args.offline, args.locked)?;
@@ -242,6 +263,7 @@ pub fn execute(args: TestArgs) -> Result<()> {
             &zen_path,
             create_diagnostics_passes(&args.suppress, &[]),
             resolution_result.clone(),
+            config_inputs.clone(),
         );
         all_test_results.extend(results);
         if had_errors_file {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI surface area and threads config override maps into build/eval paths for `layout`, `simulate`, and `test`, which could change behavior of designs when overrides are provided. Additional argument validation in `simulate`/`test` may reject previously-accepted invocations when `--config` is used with directory/workspace targets.
> 
> **Overview**
> **Adds repeatable `--config KEY=VALUE` overrides** to `pcb layout`, `pcb simulate`, and `pcb test`, parsing overrides via `parse_config_overrides` and passing them into the underlying build/eval calls instead of `Default::default()`.
> 
> For `simulate` and `test`, `--config` is explicitly restricted to **single `.zen` file targets** (errors if omitted or a directory), while workspace/directory runs continue without per-file config variance. `CHANGELOG.md` is updated to document the new flag support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8deb3950505e4a2e64d5a5f8dd7cb52d2f4a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->