### PR TITLE
Make `pcb info`, dirty detection much faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Removed the hidden `pcb mcp` command and deleted the `pcb-mcp` / `rquickjs` integration from the workspace.
 - Board releases no longer generate GLB model files.
 - ODB++ release exports now use precision 4.
+- `pcb info` now computes package dirty status from git metadata more efficiently.
 
 ### Fixed
 

--- a/crates/pcb-docgen/src/lib.rs
+++ b/crates/pcb-docgen/src/lib.rs
@@ -33,7 +33,7 @@ pub fn generate_docs(
         .unwrap_or_else(|_| package_root.to_path_buf());
     let zen_files = collect_zen_files(&package_root, filter)?;
     let file_provider = DefaultFileProvider::new();
-    let mut workspace_info = pcb_zen::get_workspace_info(&file_provider, &package_root, true)
+    let mut workspace_info = pcb_zen::get_workspace_info(&file_provider, &package_root)
         .with_context(|| {
             format!(
                 "Failed to load workspace info for {}",

--- a/crates/pcb-layout/tests/fpid_change.rs
+++ b/crates/pcb-layout/tests/fpid_change.rs
@@ -34,8 +34,7 @@ fn test_fpid_change_replaces_footprint_geometry() -> Result<()> {
     let zen_file = temp.path().join("Board.zen");
     assert!(zen_file.exists(), "Board.zen should exist");
 
-    let mut workspace_info =
-        pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path(), true)?;
+    let mut workspace_info = pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path())?;
     let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)?;
 
     let (output, diagnostics) = pcb_zen::run(&zen_file, res.clone(), Default::default()).unpack();
@@ -184,8 +183,7 @@ fn test_fpid_change_preserves_position() -> Result<()> {
     // --- Step 1: Initial layout with 0402 package ---
     let zen_file = temp.path().join("Board.zen");
 
-    let mut workspace_info =
-        pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path(), true)?;
+    let mut workspace_info = pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path())?;
     let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)?;
 
     let (output, _) = pcb_zen::run(&zen_file, res.clone(), Default::default()).unpack();

--- a/crates/pcb-layout/tests/layout_generation.rs
+++ b/crates/pcb-layout/tests/layout_generation.rs
@@ -28,7 +28,7 @@ macro_rules! layout_test {
                 let zen_file = temp.path().join(format!("{}.zen", $board_name));
                 assert!(zen_file.exists(), "{}.zen should exist", $board_name);
 
-                let mut workspace_info = pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path(), true)?;
+                let mut workspace_info = pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path())?;
                 let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)?;
                 let model_dirs = res.kicad_model_dirs();
 

--- a/crates/pcb-layout/tests/moved.rs
+++ b/crates/pcb-layout/tests/moved.rs
@@ -27,8 +27,7 @@ fn test_moved_renames_path_and_preserves_position() -> Result<()> {
     let zen_file = temp.path().join("Board.zen");
     assert!(zen_file.exists(), "Board.zen should exist");
 
-    let mut workspace_info =
-        pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path(), true)?;
+    let mut workspace_info = pcb_zen::get_workspace_info(&DefaultFileProvider::new(), temp.path())?;
     let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)?;
     let model_dirs = res.kicad_model_dirs();
 

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -12,7 +12,6 @@ use tar::Archive;
 
 #[derive(Debug, Clone)]
 pub struct TagMetadata {
-    pub target: String,
     pub timestamp: String,
 }
 
@@ -305,8 +304,7 @@ fn parse_cat_file_tag_metadata(mut bytes: &[u8], tags: &[String]) -> HashMap<Str
         };
         let header = String::from_utf8_lossy(&bytes[..header_end]);
         let mut header_fields = header.split_whitespace();
-        let oid = header_fields.next().unwrap_or_default();
-        let object_type = header_fields.next();
+        let object_type = header_fields.nth(1);
         let size = header_fields
             .next()
             .and_then(|s| s.parse::<usize>().ok())
@@ -324,31 +322,25 @@ fn parse_cat_file_tag_metadata(mut bytes: &[u8], tags: &[String]) -> HashMap<Str
 
         let object_text = String::from_utf8_lossy(object);
         let mut tag_name = input_tag.cloned();
-        let mut target = None;
         let mut timestamp = None;
         for line in object_text.lines() {
             if object_type == Some("tag") {
-                if let Some(object) = line.strip_prefix("object ") {
-                    target = Some(object.to_string());
-                } else if let Some(tag) = line.strip_prefix("tag ") {
+                if let Some(tag) = line.strip_prefix("tag ") {
                     tag_name = Some(tag.to_string());
                 } else if let Some(tagger) = line.strip_prefix("tagger ") {
                     timestamp = parse_git_person_timestamp(tagger);
                 }
-            } else {
-                target = Some(oid.to_string());
-                if let Some(committer) = line.strip_prefix("committer ") {
-                    timestamp = parse_git_person_timestamp(committer);
-                }
+            } else if let Some(committer) = line.strip_prefix("committer ") {
+                timestamp = parse_git_person_timestamp(committer);
             }
 
-            if tag_name.is_some() && target.is_some() && timestamp.is_some() {
+            if tag_name.is_some() && timestamp.is_some() {
                 break;
             }
         }
 
-        if let (Some(tag), Some(target), Some(timestamp)) = (tag_name, target, timestamp) {
-            metadata.insert(tag, TagMetadata { target, timestamp });
+        if let (Some(tag), Some(timestamp)) = (tag_name, timestamp) {
+            metadata.insert(tag, TagMetadata { timestamp });
         }
     }
 

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -169,6 +169,46 @@ pub fn log_subjects(repo_root: &Path, range: Option<&str>, pathspec: Option<&Pat
     })
 }
 
+pub fn decorated_commits(repo_root: &Path) -> Vec<String> {
+    run_lines({
+        let mut cmd = git(repo_root);
+        cmd.args([
+            "log",
+            "--simplify-by-decoration",
+            "--format=%H%x00%D",
+            "HEAD",
+        ]);
+        cmd
+    })
+}
+
+pub fn changed_paths_since_in_repo(repo_root: &Path, base: &str) -> Vec<PathBuf> {
+    let range = format!("{base}..HEAD");
+    let mut cmd = git(repo_root);
+    cmd.args(["diff", "--name-only", "--no-renames", &range]);
+
+    run_lines(cmd).into_iter().map(PathBuf::from).collect()
+}
+
+pub fn status_paths_in_repo(repo_root: &Path) -> Vec<PathBuf> {
+    let mut cmd = git(repo_root);
+    cmd.args(["status", "--porcelain", "-z"]);
+
+    let Some(stdout) = run_stdout_opt(cmd) else {
+        return Vec::new();
+    };
+
+    stdout
+        .split('\0')
+        .filter_map(|record| {
+            if record.len() < 4 {
+                return None;
+            }
+            Some(PathBuf::from(&record[3..]))
+        })
+        .collect()
+}
+
 pub fn tags_pointing_at_head(repo_root: &Path) -> Vec<String> {
     run_lines({
         let mut cmd = git(repo_root);

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -205,9 +205,13 @@ pub fn status_paths_in_repo(repo_root: &Path) -> Vec<PathBuf> {
     let mut cmd = git(repo_root);
     cmd.args(["status", "--porcelain", "-z", "--no-renames"]);
 
-    let Some(stdout) = run_stdout_opt(cmd) else {
+    let Ok(output) = cmd.output() else {
         return Vec::new();
     };
+    if !output.status.success() {
+        return Vec::new();
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
     stdout
         .split('\0')
@@ -638,14 +642,12 @@ pub fn detect_repository_url(repo_root: &Path) -> anyhow::Result<String> {
 }
 
 pub fn get_repo_subpath(workspace_root: &Path) -> anyhow::Result<Option<PathBuf>> {
-    let git_root = get_repo_root(workspace_root)?;
-    let rel = workspace_root
-        .strip_prefix(&git_root)
-        .map_err(|_| anyhow::anyhow!("Workspace not within git repository"))?;
-    if rel == Path::new("") {
+    let prefix = run_output(workspace_root, &["rev-parse", "--show-prefix"])?;
+    let prefix = prefix.trim_end_matches('/');
+    if prefix.is_empty() {
         Ok(None)
     } else {
-        Ok(Some(rel.to_path_buf()))
+        Ok(Some(PathBuf::from(prefix)))
     }
 }
 

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -1,9 +1,20 @@
 use std::collections::HashMap;
 
+use jiff::{
+    Timestamp,
+    tz::{Offset, TimeZone},
+};
 use pcb_zen_core::config::split_repo_and_subpath;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tar::Archive;
+
+#[derive(Debug, Clone)]
+pub struct TagMetadata {
+    pub target: String,
+    pub timestamp: String,
+}
 
 fn git(repo_root: &Path) -> Command {
     let mut cmd = Command::new("git");
@@ -246,66 +257,129 @@ pub fn describe_tags(repo_root: &Path, commit: &str, tag_prefix: Option<&str>) -
     run_output_opt(repo_root, &args)
 }
 
-pub fn get_all_tag_annotations(repo_root: &Path) -> HashMap<String, String> {
-    const RECORD_SEP: &str = "\x1E";
-    const FIELD_SEP: &str = "\x1F";
-    let format = format!("%(refname:short){FIELD_SEP}%(contents){RECORD_SEP}");
+pub fn get_tag_metadata(repo_root: &Path, tags: &[String]) -> HashMap<String, TagMetadata> {
+    if tags.is_empty() {
+        return HashMap::new();
+    }
 
     let mut cmd = git(repo_root);
-    cmd.args(["for-each-ref", &format!("--format={}", format), "refs/tags"]);
+    cmd.arg("cat-file")
+        .arg("--batch")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped());
 
-    let Some(stdout) = run_stdout_opt(cmd) else {
+    let Ok(mut child) = cmd.spawn() else {
         return HashMap::new();
     };
 
-    stdout
-        .split(RECORD_SEP)
-        .filter_map(|record| {
-            let record = record.trim();
-            record
-                .split_once(FIELD_SEP)
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-        })
-        .collect()
+    if let Some(mut stdin) = child.stdin.take() {
+        for tag in tags {
+            if writeln!(stdin, "refs/tags/{tag}").is_err() {
+                return HashMap::new();
+            }
+        }
+    }
+
+    let Ok(output) = child.wait_with_output() else {
+        return HashMap::new();
+    };
+    if !output.status.success() {
+        return HashMap::new();
+    }
+
+    parse_cat_file_tag_metadata(&output.stdout, tags)
 }
 
-pub fn get_all_tag_timestamps(repo_root: &Path) -> HashMap<String, String> {
-    const RECORD_SEP: &str = "\x1E";
-    const FIELD_SEP: &str = "\x1F";
-    let format = format!(
-        "%(refname:short){FIELD_SEP}%(taggerdate:iso8601-strict){FIELD_SEP}%(creatordate:iso8601-strict){RECORD_SEP}"
-    );
+fn parse_cat_file_tag_metadata(mut bytes: &[u8], tags: &[String]) -> HashMap<String, TagMetadata> {
+    let mut metadata = HashMap::new();
+    let mut input_tags = tags.iter();
 
-    let mut cmd = git(repo_root);
-    cmd.args(["for-each-ref", &format!("--format={}", format), "refs/tags"]);
+    while !bytes.is_empty() {
+        let input_tag = input_tags.next();
+        let Some(header_end) = bytes.iter().position(|&b| b == b'\n') else {
+            break;
+        };
+        let header = String::from_utf8_lossy(&bytes[..header_end]);
+        let mut header_fields = header.split_whitespace();
+        let oid = header_fields.next().unwrap_or_default();
+        let object_type = header_fields.next();
+        let size = header_fields
+            .next()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(0);
 
-    let Some(stdout) = run_stdout_opt(cmd) else {
-        return HashMap::new();
-    };
+        bytes = &bytes[header_end + 1..];
+        if bytes.len() < size {
+            break;
+        }
+        let object = &bytes[..size];
+        bytes = &bytes[size..];
+        if bytes.first() == Some(&b'\n') {
+            bytes = &bytes[1..];
+        }
 
-    stdout
-        .split(RECORD_SEP)
-        .filter_map(|record| {
-            let record = record.trim();
-            if record.is_empty() {
-                return None;
+        let object_text = String::from_utf8_lossy(object);
+        let mut tag_name = input_tag.cloned();
+        let mut target = None;
+        let mut timestamp = None;
+        for line in object_text.lines() {
+            if object_type == Some("tag") {
+                if let Some(object) = line.strip_prefix("object ") {
+                    target = Some(object.to_string());
+                } else if let Some(tag) = line.strip_prefix("tag ") {
+                    tag_name = Some(tag.to_string());
+                } else if let Some(tagger) = line.strip_prefix("tagger ") {
+                    timestamp = parse_git_person_timestamp(tagger);
+                }
+            } else {
+                target = Some(oid.to_string());
+                if let Some(committer) = line.strip_prefix("committer ") {
+                    timestamp = parse_git_person_timestamp(committer);
+                }
             }
 
-            let mut fields = record.split(FIELD_SEP);
-            let tag = fields.next()?.trim();
-            let taggerdate = fields.next().unwrap_or("").trim();
-            let creatordate = fields.next().unwrap_or("").trim();
-            let timestamp = if !taggerdate.is_empty() {
-                taggerdate
-            } else if !creatordate.is_empty() {
-                creatordate
-            } else {
-                return None;
-            };
+            if tag_name.is_some() && target.is_some() && timestamp.is_some() {
+                break;
+            }
+        }
 
-            Some((tag.to_string(), timestamp.to_string()))
-        })
-        .collect()
+        if let (Some(tag), Some(target), Some(timestamp)) = (tag_name, target, timestamp) {
+            metadata.insert(tag, TagMetadata { target, timestamp });
+        }
+    }
+
+    metadata
+}
+
+fn parse_git_person_timestamp(line: &str) -> Option<String> {
+    let mut fields = line.rsplitn(3, ' ');
+    let offset = fields.next()?;
+    let seconds = fields.next()?.parse::<i64>().ok()?;
+    let timestamp = Timestamp::from_second(seconds).ok()?;
+    let offset_seconds = parse_git_timezone_offset(offset)?;
+
+    if offset_seconds == 0 {
+        return Some(timestamp.strftime("%Y-%m-%dT%H:%M:%SZ").to_string());
+    }
+
+    let offset = Offset::from_seconds(offset_seconds).ok()?;
+    let zoned = timestamp.to_zoned(TimeZone::fixed(offset));
+    Some(zoned.strftime("%Y-%m-%dT%H:%M:%S%:z").to_string())
+}
+
+fn parse_git_timezone_offset(offset: &str) -> Option<i32> {
+    let bytes = offset.as_bytes();
+    if bytes.len() != 5 {
+        return None;
+    }
+    let sign = match bytes[0] {
+        b'+' => 1,
+        b'-' => -1,
+        _ => return None,
+    };
+    let hour = offset[1..3].parse::<i32>().ok()?;
+    let minute = offset[3..5].parse::<i32>().ok()?;
+    Some(sign * (hour * 3_600 + minute * 60))
 }
 
 fn clone(remote_url: &str, dest_dir: &Path, bare: bool, prompt: bool) -> anyhow::Result<()> {

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -203,7 +203,7 @@ pub fn changed_paths_since_in_repo(repo_root: &Path, base: &str) -> Vec<PathBuf>
 
 pub fn status_paths_in_repo(repo_root: &Path) -> Vec<PathBuf> {
     let mut cmd = git(repo_root);
-    cmd.args(["status", "--porcelain", "-z"]);
+    cmd.args(["status", "--porcelain", "-z", "--no-renames"]);
 
     let Some(stdout) = run_stdout_opt(cmd) else {
         return Vec::new();

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -153,7 +153,7 @@ impl Default for LspEvalContext {
             base: base_provider,
             open_files: open_files.clone(),
         });
-        let resolution = crate::get_workspace_info(&file_provider, &std::env::temp_dir(), true)
+        let resolution = crate::get_workspace_info(&file_provider, &std::env::temp_dir())
             .and_then(|mut ws| crate::resolve_dependencies(&mut ws, false, false))
             .unwrap_or_else(|_| ResolutionResult::empty());
         let inner = EvalContext::new(file_provider.clone(), resolution);
@@ -454,7 +454,7 @@ impl LspEvalContext {
             return cached.clone();
         }
 
-        let mut resolution = crate::get_workspace_info(&self.file_provider, &workspace_root, true)
+        let mut resolution = crate::get_workspace_info(&self.file_provider, &workspace_root)
             .and_then(|mut ws| crate::resolve_dependencies(&mut ws, false, false))
             .unwrap_or_else(|_| ResolutionResult::empty());
         resolution.canonicalize_keys(&*self.file_provider);

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -80,6 +80,7 @@ fn discover_dirty_packages(
     latest_tags: &BTreeMap<String, PackageTagInfo>,
     tag_metadata: &HashMap<String, git::TagMetadata>,
     status_paths: Vec<PathBuf>,
+    workspace_subpath: Option<&Path>,
 ) -> BTreeSet<String> {
     let mut dirty = BTreeSet::new();
     for url in workspace.packages.keys() {
@@ -90,14 +91,14 @@ fn discover_dirty_packages(
 
     if let Some(base) = latest_package_tagged_ref(&workspace.root, latest_tags, tag_metadata) {
         for path in git::changed_paths_since_in_repo(&workspace.root, &base) {
-            if let Some(url) = package_url_for_path(workspace, &path) {
+            if let Some(url) = package_url_for_path(workspace, &path, workspace_subpath) {
                 dirty.insert(url);
             }
         }
     }
 
     for path in status_paths {
-        if let Some(url) = package_url_for_path(workspace, &path) {
+        if let Some(url) = package_url_for_path(workspace, &path, workspace_subpath) {
             dirty.insert(url);
         }
     }
@@ -178,7 +179,9 @@ fn latest_package_tagged_ref(
     }
 
     for line in git::decorated_commits(repo_root) {
-        let (commit, decorations) = line.split_once('\0')?;
+        let Some((commit, decorations)) = line.split_once('\0') else {
+            continue;
+        };
         if decorations.split(',').any(|decoration| {
             decoration
                 .trim()
@@ -192,7 +195,13 @@ fn latest_package_tagged_ref(
     None
 }
 
-fn package_url_for_path(workspace: &WorkspaceInfo, path: &Path) -> Option<String> {
+fn package_url_for_path(
+    workspace: &WorkspaceInfo,
+    path: &Path,
+    workspace_subpath: Option<&Path>,
+) -> Option<String> {
+    let path = workspace_relative_path(path, workspace_subpath)?;
+
     workspace
         .packages
         .iter()
@@ -209,6 +218,16 @@ fn package_url_for_path(workspace: &WorkspaceInfo, path: &Path) -> Option<String
                 .find(|(_, pkg)| pkg.rel_path.as_os_str().is_empty())
                 .map(|(url, _)| url.clone())
         })
+}
+
+fn workspace_relative_path<'a>(
+    path: &'a Path,
+    workspace_subpath: Option<&Path>,
+) -> Option<&'a Path> {
+    match workspace_subpath {
+        Some(prefix) => path.strip_prefix(prefix).ok(),
+        None => Some(path),
+    }
 }
 
 /// Get workspace information with optional git version enrichment (native-only).
@@ -237,6 +256,7 @@ pub fn get_workspace_info<F: FileProvider>(
     // update if we find a tag (don't overwrite with None)
     let all_tags = git::list_tags_merged_into(&info.root, "HEAD");
     let latest_tags = latest_package_tags(&info, &all_tags);
+    let workspace_subpath = git::get_repo_subpath(&info.root).ok().flatten();
 
     let latest_tag_names: Vec<_> = latest_tags.values().map(|info| info.tag.clone()).collect();
     let (tag_metadata, status_paths) = thread::scope(|scope| {
@@ -247,7 +267,13 @@ pub fn get_workspace_info<F: FileProvider>(
             status_paths.join().unwrap_or_default(),
         )
     });
-    let dirty_map = discover_dirty_packages(&info, &latest_tags, &tag_metadata, status_paths);
+    let dirty_map = discover_dirty_packages(
+        &info,
+        &latest_tags,
+        &tag_metadata,
+        status_paths,
+        workspace_subpath.as_deref(),
+    );
 
     if enrich_versions {
         let _span = info_span!("enrich_workspace_versions").entered();

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -5,8 +5,7 @@
 //! that need workspace metadata.
 
 use anyhow::Result;
-use rayon::prelude::*;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use tracing::{info_span, instrument};
 
@@ -21,25 +20,19 @@ pub use pcb_zen_core::workspace::{
 
 use crate::git;
 use crate::tags;
-use pcb_canonical::{compute_content_hash_from_dir, compute_manifest_hash};
 
 /// Why a package is dirty (has unpublished changes)
 #[derive(Debug, Clone)]
 pub enum DirtyReason {
     Unpublished,
     Uncommitted,
-    LegacyTag,
-    Modified {
-        content_hash: String,
-        manifest_hash: String,
-    },
+    Modified,
 }
 
 /// Extension methods for WorkspaceInfo that require native features (git, filesystem)
 pub trait WorkspaceInfoExt {
     fn reload(&mut self) -> Result<()>;
     fn dirty_packages(&self) -> BTreeMap<String, DirtyReason>;
-    fn populate_dirty(&mut self);
     fn board_name_for_zen(&self, zen_path: &Path) -> Option<String>;
     fn board_info_for_zen(&self, zen_path: &Path) -> Option<BoardInfo>;
     fn package_url_for_zen(&self, zen_path: &Path) -> Option<String>;
@@ -60,24 +53,8 @@ impl WorkspaceInfoExt for WorkspaceInfo {
     }
 
     fn dirty_packages(&self) -> BTreeMap<String, DirtyReason> {
-        let tags = git::list_tags_merged_into(&self.root, "HEAD");
-        let tag_annotations = git::get_all_tag_annotations(&self.root);
-        let workspace_path = self.path().map(|s| s.to_string());
-
-        self.packages
-            .par_iter()
-            .filter_map(|(url, pkg)| {
-                is_dirty(pkg, &self.root, &workspace_path, &tags, &tag_annotations)
-                    .map(|reason| (url.clone(), reason))
-            })
-            .collect()
-    }
-
-    fn populate_dirty(&mut self) {
-        let dirty_map = self.dirty_packages();
-        for (url, pkg) in self.packages.iter_mut() {
-            pkg.dirty = dirty_map.contains_key(url);
-        }
+        let all_tags = git::list_tags_merged_into(&self.root, "HEAD");
+        discover_dirty_packages(self, &all_tags)
     }
 
     fn board_name_for_zen(&self, zen_path: &Path) -> Option<String> {
@@ -106,87 +83,95 @@ impl WorkspaceInfoExt for WorkspaceInfo {
     }
 }
 
-/// Check if a package is dirty (native-only, requires git)
-fn is_dirty(
-    pkg: &MemberPackage,
-    workspace_root: &Path,
-    workspace_path: &Option<String>,
-    tags: &[String],
-    tag_annotations: &HashMap<String, String>,
-) -> Option<DirtyReason> {
-    let tag_prefix = tags::compute_tag_prefix(Some(&pkg.rel_path), workspace_path.as_deref());
-
-    let Some(tag_name) = tags::find_latest_tag(tags, &tag_prefix) else {
-        return Some(DirtyReason::Unpublished);
-    };
-
-    if has_uncommitted_changes(workspace_root, &pkg.dir(workspace_root)) {
-        return Some(DirtyReason::Uncommitted);
-    }
-
-    let Some(tagged) = tag_annotations
-        .get(&tag_name)
-        .and_then(|body| parse_hashes_from_tag_body(body))
-    else {
-        return Some(DirtyReason::LegacyTag);
-    };
-
-    let pkg_dir = pkg.dir(workspace_root);
-    let current_content = compute_content_hash_from_dir(&pkg_dir).ok();
-    let current_manifest = std::fs::read_to_string(pkg_dir.join("pcb.toml"))
-        .ok()
-        .map(|content| compute_manifest_hash(&content));
-
-    if current_content != tagged.content_hash || current_manifest != tagged.manifest_hash {
-        Some(DirtyReason::Modified {
-            content_hash: current_content.unwrap_or_default(),
-            manifest_hash: current_manifest.unwrap_or_default(),
-        })
-    } else {
-        None
-    }
-}
-
-fn has_uncommitted_changes(workspace_root: &Path, package_dir: &Path) -> bool {
-    let rel_path = package_dir
-        .strip_prefix(workspace_root)
-        .unwrap_or(package_dir);
-    git::has_uncommitted_changes_in_path(workspace_root, rel_path)
-}
-
-struct TagHashes {
-    content_hash: Option<String>,
-    manifest_hash: Option<String>,
-}
-
-fn parse_hashes_from_tag_body(body: &str) -> Option<TagHashes> {
-    let mut content_hash = None;
-    let mut manifest_hash = None;
-
-    for line in body.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
+fn discover_dirty_packages(
+    workspace: &WorkspaceInfo,
+    all_tags: &[String],
+) -> BTreeMap<String, DirtyReason> {
+    let workspace_path = workspace.path().map(|s| s.to_string());
+    let latest_tags = latest_package_tags(workspace, all_tags, workspace_path.as_deref());
+    let package_tags: BTreeSet<_> = latest_tags.values().cloned().collect();
+    let mut dirty = BTreeMap::new();
+    for url in workspace.packages.keys() {
+        if !latest_tags.contains_key(url) {
+            dirty.insert(url.clone(), DirtyReason::Unpublished);
         }
-        if let Some(hash_start) = line.find(" h1:") {
-            let hash = line[hash_start + 1..].to_string();
-            let before_hash = &line[..hash_start];
-            if before_hash.ends_with("/pcb.toml") {
-                manifest_hash = Some(hash);
-            } else {
-                content_hash = Some(hash);
+    }
+
+    if let Some(base) = latest_package_tagged_ref(&workspace.root, &package_tags) {
+        for path in git::changed_paths_since_in_repo(&workspace.root, &base) {
+            if let Some(url) = package_url_for_path(workspace, &path) {
+                dirty.insert(url, DirtyReason::Modified);
             }
         }
     }
 
-    if content_hash.is_some() && manifest_hash.is_some() {
-        Some(TagHashes {
-            content_hash,
-            manifest_hash,
-        })
-    } else {
-        None
+    for path in git::status_paths_in_repo(&workspace.root) {
+        if let Some(url) = package_url_for_path(workspace, &path) {
+            dirty.insert(url, DirtyReason::Uncommitted);
+        }
     }
+
+    dirty
+}
+
+fn latest_package_tags(
+    workspace: &WorkspaceInfo,
+    all_tags: &[String],
+    workspace_path: Option<&str>,
+) -> BTreeMap<String, String> {
+    workspace
+        .packages
+        .iter()
+        .filter_map(|(url, pkg)| {
+            let tag_prefix = tags::compute_tag_prefix(Some(&pkg.rel_path), workspace_path);
+            tags::find_latest_tag(all_tags, &tag_prefix).map(|tag| (url.clone(), tag))
+        })
+        .collect()
+}
+
+fn latest_package_tagged_ref(repo_root: &Path, package_tags: &BTreeSet<String>) -> Option<String> {
+    if package_tags.is_empty() {
+        return None;
+    }
+
+    if let Some(tag) = git::describe_tags(repo_root, "HEAD", None)
+        && package_tags.contains(&tag)
+    {
+        return Some(tag);
+    }
+
+    for line in git::decorated_commits(repo_root) {
+        let (commit, decorations) = line.split_once('\0')?;
+        if decorations.split(',').any(|decoration| {
+            decoration
+                .trim()
+                .strip_prefix("tag: ")
+                .is_some_and(|tag| package_tags.contains(tag))
+        }) {
+            return Some(commit.to_string());
+        }
+    }
+
+    None
+}
+
+fn package_url_for_path(workspace: &WorkspaceInfo, path: &Path) -> Option<String> {
+    workspace
+        .packages
+        .iter()
+        .filter(|(_, pkg)| {
+            !pkg.rel_path.as_os_str().is_empty()
+                && (path == pkg.rel_path || path.starts_with(&pkg.rel_path))
+        })
+        .max_by_key(|(_, pkg)| pkg.rel_path.as_os_str().len())
+        .map(|(url, _)| url.clone())
+        .or_else(|| {
+            workspace
+                .packages
+                .iter()
+                .find(|(_, pkg)| pkg.rel_path.as_os_str().is_empty())
+                .map(|(url, _)| url.clone())
+        })
 }
 
 /// Get workspace information with optional git version enrichment (native-only).
@@ -213,9 +198,9 @@ pub fn get_workspace_info<F: FileProvider>(
     // Enrich with git tag versions (native-only feature)
     // For forked packages, version is already set from the fork path, so only
     // update if we find a tag (don't overwrite with None)
+    let all_tags = git::list_tags_merged_into(&info.root, "HEAD");
     if enrich_versions {
         let _span = info_span!("enrich_workspace_versions").entered();
-        let all_tags = git::list_tags_merged_into(&info.root, "HEAD");
         let tag_timestamps = git::get_all_tag_timestamps(&info.root);
         let workspace_path = info.path().map(|s| s.to_string());
         for pkg in info.packages.values_mut() {
@@ -229,6 +214,11 @@ pub fn get_workspace_info<F: FileProvider>(
                 pkg.published_at = tag_timestamps.get(&tag_name).cloned();
             }
         }
+    }
+
+    let dirty_map = discover_dirty_packages(&info, &all_tags);
+    for (url, pkg) in info.packages.iter_mut() {
+        pkg.dirty = dirty_map.contains_key(url);
     }
 
     Ok(info)
@@ -294,7 +284,7 @@ fn add_path_patched_forks<F: FileProvider>(
                 version: fork_version, // Use fork path version if available
                 published_at: None,
                 preferred: false,
-                dirty: false, // Will be populated by populate_dirty()
+                dirty: false,
                 entrypoints: Vec::new(),
                 symbol_files: Vec::new(),
             },

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -22,14 +22,6 @@ pub use pcb_zen_core::workspace::{
 use crate::git;
 use crate::tags;
 
-/// Why a package is dirty (has unpublished changes)
-#[derive(Debug, Clone)]
-pub enum DirtyReason {
-    Unpublished,
-    Uncommitted,
-    Modified,
-}
-
 struct PackageTagInfo {
     tag: String,
     version: Version,
@@ -38,7 +30,6 @@ struct PackageTagInfo {
 /// Extension methods for WorkspaceInfo that require native features (git, filesystem)
 pub trait WorkspaceInfoExt {
     fn reload(&mut self) -> Result<()>;
-    fn dirty_packages(&self) -> BTreeMap<String, DirtyReason>;
     fn board_name_for_zen(&self, zen_path: &Path) -> Option<String>;
     fn board_info_for_zen(&self, zen_path: &Path) -> Option<BoardInfo>;
     fn package_url_for_zen(&self, zen_path: &Path) -> Option<String>;
@@ -56,15 +47,6 @@ impl WorkspaceInfoExt for WorkspaceInfo {
             pkg.config = PcbToml::from_file(&file_provider, &pkg_toml_path)?;
         }
         Ok(())
-    }
-
-    fn dirty_packages(&self) -> BTreeMap<String, DirtyReason> {
-        let all_tags = git::list_tags_merged_into(&self.root, "HEAD");
-        let latest_tags = latest_package_tags(self, &all_tags);
-        let latest_tag_names = latest_tag_names(&latest_tags);
-        let tag_metadata = git::get_tag_metadata(&self.root, &latest_tag_names);
-        let status_paths = git::status_paths_in_repo(&self.root);
-        discover_dirty_packages(self, &latest_tags, &tag_metadata, status_paths)
     }
 
     fn board_name_for_zen(&self, zen_path: &Path) -> Option<String> {
@@ -98,33 +80,29 @@ fn discover_dirty_packages(
     latest_tags: &BTreeMap<String, PackageTagInfo>,
     tag_metadata: &HashMap<String, git::TagMetadata>,
     status_paths: Vec<PathBuf>,
-) -> BTreeMap<String, DirtyReason> {
-    let mut dirty = BTreeMap::new();
+) -> BTreeSet<String> {
+    let mut dirty = BTreeSet::new();
     for url in workspace.packages.keys() {
         if !latest_tags.contains_key(url) {
-            dirty.insert(url.clone(), DirtyReason::Unpublished);
+            dirty.insert(url.clone());
         }
     }
 
     if let Some(base) = latest_package_tagged_ref(&workspace.root, latest_tags, tag_metadata) {
         for path in git::changed_paths_since_in_repo(&workspace.root, &base) {
             if let Some(url) = package_url_for_path(workspace, &path) {
-                dirty.insert(url, DirtyReason::Modified);
+                dirty.insert(url);
             }
         }
     }
 
     for path in status_paths {
         if let Some(url) = package_url_for_path(workspace, &path) {
-            dirty.insert(url, DirtyReason::Uncommitted);
+            dirty.insert(url);
         }
     }
 
     dirty
-}
-
-fn latest_tag_names(latest_tags: &BTreeMap<String, PackageTagInfo>) -> Vec<String> {
-    latest_tags.values().map(|info| info.tag.clone()).collect()
 }
 
 fn latest_package_tags(
@@ -236,7 +214,7 @@ fn package_url_for_path(workspace: &WorkspaceInfo, path: &Path) -> Option<String
 /// Get workspace information with optional git version enrichment (native-only).
 ///
 /// Calls core's get_workspace_info, adds path-patched forks as workspace members,
-/// and optionally enriches with git tag versions.
+/// populates dirty status, and optionally enriches with git tag versions.
 #[instrument(name = "get_workspace_info", skip_all)]
 pub fn get_workspace_info<F: FileProvider>(
     file_provider: &F,
@@ -260,7 +238,7 @@ pub fn get_workspace_info<F: FileProvider>(
     let all_tags = git::list_tags_merged_into(&info.root, "HEAD");
     let latest_tags = latest_package_tags(&info, &all_tags);
 
-    let latest_tag_names = latest_tag_names(&latest_tags);
+    let latest_tag_names: Vec<_> = latest_tags.values().map(|info| info.tag.clone()).collect();
     let (tag_metadata, status_paths) = thread::scope(|scope| {
         let tag_metadata = scope.spawn(|| git::get_tag_metadata(&info.root, &latest_tag_names));
         let status_paths = scope.spawn(|| git::status_paths_in_repo(&info.root));
@@ -284,7 +262,7 @@ pub fn get_workspace_info<F: FileProvider>(
     }
 
     for (url, pkg) in info.packages.iter_mut() {
-        pkg.dirty = dirty_map.contains_key(url);
+        pkg.dirty = dirty_map.contains(url);
     }
 
     Ok(info)

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -5,8 +5,9 @@
 //! that need workspace metadata.
 
 use anyhow::Result;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
+use std::thread;
 use tracing::{info_span, instrument};
 
 use pcb_zen_core::config::PcbToml;
@@ -27,6 +28,11 @@ pub enum DirtyReason {
     Unpublished,
     Uncommitted,
     Modified,
+}
+
+struct PackageTagInfo {
+    tag: String,
+    version: Version,
 }
 
 /// Extension methods for WorkspaceInfo that require native features (git, filesystem)
@@ -54,7 +60,11 @@ impl WorkspaceInfoExt for WorkspaceInfo {
 
     fn dirty_packages(&self) -> BTreeMap<String, DirtyReason> {
         let all_tags = git::list_tags_merged_into(&self.root, "HEAD");
-        discover_dirty_packages(self, &all_tags)
+        let latest_tags = latest_package_tags(self, &all_tags);
+        let latest_tag_names = latest_tag_names(&latest_tags);
+        let tag_metadata = git::get_tag_metadata(&self.root, &latest_tag_names);
+        let status_paths = git::status_paths_in_repo(&self.root);
+        discover_dirty_packages(self, &latest_tags, &tag_metadata, status_paths)
     }
 
     fn board_name_for_zen(&self, zen_path: &Path) -> Option<String> {
@@ -85,11 +95,10 @@ impl WorkspaceInfoExt for WorkspaceInfo {
 
 fn discover_dirty_packages(
     workspace: &WorkspaceInfo,
-    all_tags: &[String],
+    latest_tags: &BTreeMap<String, PackageTagInfo>,
+    tag_metadata: &HashMap<String, git::TagMetadata>,
+    status_paths: Vec<PathBuf>,
 ) -> BTreeMap<String, DirtyReason> {
-    let workspace_path = workspace.path().map(|s| s.to_string());
-    let latest_tags = latest_package_tags(workspace, all_tags, workspace_path.as_deref());
-    let package_tags: BTreeSet<_> = latest_tags.values().cloned().collect();
     let mut dirty = BTreeMap::new();
     for url in workspace.packages.keys() {
         if !latest_tags.contains_key(url) {
@@ -97,7 +106,7 @@ fn discover_dirty_packages(
         }
     }
 
-    if let Some(base) = latest_package_tagged_ref(&workspace.root, &package_tags) {
+    if let Some(base) = latest_package_tagged_ref(&workspace.root, latest_tags, tag_metadata) {
         for path in git::changed_paths_since_in_repo(&workspace.root, &base) {
             if let Some(url) = package_url_for_path(workspace, &path) {
                 dirty.insert(url, DirtyReason::Modified);
@@ -105,7 +114,7 @@ fn discover_dirty_packages(
         }
     }
 
-    for path in git::status_paths_in_repo(&workspace.root) {
+    for path in status_paths {
         if let Some(url) = package_url_for_path(workspace, &path) {
             dirty.insert(url, DirtyReason::Uncommitted);
         }
@@ -114,26 +123,76 @@ fn discover_dirty_packages(
     dirty
 }
 
+fn latest_tag_names(latest_tags: &BTreeMap<String, PackageTagInfo>) -> Vec<String> {
+    latest_tags.values().map(|info| info.tag.clone()).collect()
+}
+
 fn latest_package_tags(
     workspace: &WorkspaceInfo,
     all_tags: &[String],
-    workspace_path: Option<&str>,
-) -> BTreeMap<String, String> {
-    workspace
+) -> BTreeMap<String, PackageTagInfo> {
+    let workspace_path = workspace.path();
+    let package_urls_by_tag_path: BTreeMap<_, _> = workspace
         .packages
         .iter()
-        .filter_map(|(url, pkg)| {
-            let tag_prefix = tags::compute_tag_prefix(Some(&pkg.rel_path), workspace_path);
-            tags::find_latest_tag(all_tags, &tag_prefix).map(|tag| (url.clone(), tag))
+        .map(|(url, pkg)| {
+            let tag_path = match (workspace_path, pkg.rel_path.as_os_str().is_empty()) {
+                (Some(path), true) => path.to_string(),
+                (Some(path), false) => format!("{}/{}", path, pkg.rel_path.to_string_lossy()),
+                (None, _) => pkg.rel_path.to_string_lossy().into_owned(),
+            };
+            (tag_path, url.clone())
         })
-        .collect()
+        .collect();
+
+    let mut latest = BTreeMap::new();
+    for tag in all_tags {
+        let parsed = if let Some((tag_path, version)) = tags::parse_tag(tag) {
+            Some((tag_path, version))
+        } else {
+            tags::parse_root_tag(tag).map(|version| (String::new(), version))
+        };
+        let Some((tag_path, version)) = parsed else {
+            continue;
+        };
+        let Some(url) = package_urls_by_tag_path.get(&tag_path) else {
+            continue;
+        };
+        let entry = latest.entry(url.clone()).or_insert_with(|| PackageTagInfo {
+            tag: tag.clone(),
+            version: version.clone(),
+        });
+        if version > entry.version {
+            *entry = PackageTagInfo {
+                tag: tag.clone(),
+                version,
+            };
+        }
+    }
+    latest
 }
 
-fn latest_package_tagged_ref(repo_root: &Path, package_tags: &BTreeSet<String>) -> Option<String> {
-    if package_tags.is_empty() {
+fn latest_package_tagged_ref(
+    repo_root: &Path,
+    latest_tags: &BTreeMap<String, PackageTagInfo>,
+    tag_metadata: &HashMap<String, git::TagMetadata>,
+) -> Option<String> {
+    if latest_tags.is_empty() {
         return None;
     }
 
+    if let Some(head) = git::rev_parse_head(repo_root)
+        && let Some(tag) = latest_tags.values().find_map(|info| {
+            tag_metadata
+                .get(&info.tag)
+                .filter(|metadata| metadata.target == head)
+                .map(|_| info.tag.clone())
+        })
+    {
+        return Some(tag);
+    }
+
+    let package_tags: BTreeSet<_> = latest_tags.values().map(|info| info.tag.clone()).collect();
     if let Some(tag) = git::describe_tags(repo_root, "HEAD", None)
         && package_tags.contains(&tag)
     {
@@ -199,24 +258,31 @@ pub fn get_workspace_info<F: FileProvider>(
     // For forked packages, version is already set from the fork path, so only
     // update if we find a tag (don't overwrite with None)
     let all_tags = git::list_tags_merged_into(&info.root, "HEAD");
+    let latest_tags = latest_package_tags(&info, &all_tags);
+
+    let latest_tag_names = latest_tag_names(&latest_tags);
+    let (tag_metadata, status_paths) = thread::scope(|scope| {
+        let tag_metadata = scope.spawn(|| git::get_tag_metadata(&info.root, &latest_tag_names));
+        let status_paths = scope.spawn(|| git::status_paths_in_repo(&info.root));
+        (
+            tag_metadata.join().unwrap_or_default(),
+            status_paths.join().unwrap_or_default(),
+        )
+    });
+    let dirty_map = discover_dirty_packages(&info, &latest_tags, &tag_metadata, status_paths);
+
     if enrich_versions {
         let _span = info_span!("enrich_workspace_versions").entered();
-        let tag_timestamps = git::get_all_tag_timestamps(&info.root);
-        let workspace_path = info.path().map(|s| s.to_string());
-        for pkg in info.packages.values_mut() {
-            let tag_prefix =
-                tags::compute_tag_prefix(Some(&pkg.rel_path), workspace_path.as_deref());
-            if let Some(tag_name) = tags::find_latest_tag(&all_tags, &tag_prefix) {
-                let version_str = tag_name
-                    .strip_prefix(&tag_prefix)
-                    .expect("find_latest_tag must return a tag with the requested prefix");
-                pkg.version = Some(version_str.to_string());
-                pkg.published_at = tag_timestamps.get(&tag_name).cloned();
+        for (url, pkg) in info.packages.iter_mut() {
+            if let Some(tag_info) = latest_tags.get(url) {
+                pkg.version = Some(tag_info.version.to_string());
+                pkg.published_at = tag_metadata
+                    .get(&tag_info.tag)
+                    .map(|metadata| metadata.timestamp.clone());
             }
         }
     }
 
-    let dirty_map = discover_dirty_packages(&info, &all_tags);
     for (url, pkg) in info.packages.iter_mut() {
         pkg.dirty = dirty_map.contains_key(url);
     }
@@ -292,30 +358,4 @@ fn add_path_patched_forks<F: FileProvider>(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_hashes_from_tag_body() {
-        let body = "github.com/diodeinc/registry/harness v0.1.0 h1:mIGycQL5u80O2Jx/p3sUzJ566E74nA/Qof630p+ojSg=\ngithub.com/diodeinc/registry/harness v0.1.0/pcb.toml h1:rxNJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI=\n";
-
-        let hashes = parse_hashes_from_tag_body(body).expect("should parse hashes");
-        assert_eq!(
-            hashes.content_hash,
-            Some("h1:mIGycQL5u80O2Jx/p3sUzJ566E74nA/Qof630p+ojSg=".to_string())
-        );
-        assert_eq!(
-            hashes.manifest_hash,
-            Some("h1:rxNJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI=".to_string())
-        );
-
-        assert!(parse_hashes_from_tag_body("").is_none());
-        assert!(parse_hashes_from_tag_body("github.com/foo v1.0.0 h1:abc123=\n").is_none());
-        assert!(
-            parse_hashes_from_tag_body("github.com/foo v1.0.0/pcb.toml h1:abc123=\n").is_none()
-        );
-    }
 }

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -5,7 +5,7 @@
 //! that need workspace metadata.
 
 use anyhow::Result;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::thread;
 use tracing::{info_span, instrument};
@@ -25,6 +25,12 @@ use crate::tags;
 struct PackageTagInfo {
     tag: String,
     version: Version,
+}
+
+enum DirtyBase {
+    Found(String),
+    NoPackageTags,
+    Unknown,
 }
 
 /// Extension methods for WorkspaceInfo that require native features (git, filesystem)
@@ -77,24 +83,27 @@ impl WorkspaceInfoExt for WorkspaceInfo {
 
 fn discover_dirty_packages(
     workspace: &WorkspaceInfo,
-    latest_tags: &BTreeMap<String, PackageTagInfo>,
-    tag_metadata: &HashMap<String, git::TagMetadata>,
+    latest_tags: &HashMap<String, PackageTagInfo>,
     status_paths: Vec<PathBuf>,
     workspace_subpath: Option<&Path>,
-) -> BTreeSet<String> {
-    let mut dirty = BTreeSet::new();
+) -> HashSet<String> {
+    let mut dirty = HashSet::new();
     for url in workspace.packages.keys() {
         if !latest_tags.contains_key(url) {
             dirty.insert(url.clone());
         }
     }
 
-    if let Some(base) = latest_package_tagged_ref(&workspace.root, latest_tags, tag_metadata) {
-        for path in git::changed_paths_since_in_repo(&workspace.root, &base) {
-            if let Some(url) = package_url_for_path(workspace, &path, workspace_subpath) {
-                dirty.insert(url);
+    match dirty_base_ref(&workspace.root, latest_tags) {
+        DirtyBase::Found(base) => {
+            for path in git::changed_paths_since_in_repo(&workspace.root, &base) {
+                if let Some(url) = package_url_for_path(workspace, &path, workspace_subpath) {
+                    dirty.insert(url);
+                }
             }
         }
+        DirtyBase::NoPackageTags => {}
+        DirtyBase::Unknown => dirty.extend(latest_tags.keys().cloned()),
     }
 
     for path in status_paths {
@@ -109,9 +118,9 @@ fn discover_dirty_packages(
 fn latest_package_tags(
     workspace: &WorkspaceInfo,
     all_tags: &[String],
-) -> BTreeMap<String, PackageTagInfo> {
+) -> HashMap<String, PackageTagInfo> {
     let workspace_path = workspace.path();
-    let package_urls_by_tag_path: BTreeMap<_, _> = workspace
+    let package_urls_by_tag_path: HashMap<_, _> = workspace
         .packages
         .iter()
         .map(|(url, pkg)| {
@@ -124,14 +133,9 @@ fn latest_package_tags(
         })
         .collect();
 
-    let mut latest = BTreeMap::new();
+    let mut latest = HashMap::new();
     for tag in all_tags {
-        let parsed = if let Some((tag_path, version)) = tags::parse_tag(tag) {
-            Some((tag_path, version))
-        } else {
-            tags::parse_root_tag(tag).map(|version| (String::new(), version))
-        };
-        let Some((tag_path, version)) = parsed else {
+        let Some((tag_path, version)) = parse_package_tag(tag) else {
             continue;
         };
         let Some(url) = package_urls_by_tag_path.get(&tag_path) else {
@@ -151,31 +155,21 @@ fn latest_package_tags(
     latest
 }
 
-fn latest_package_tagged_ref(
-    repo_root: &Path,
-    latest_tags: &BTreeMap<String, PackageTagInfo>,
-    tag_metadata: &HashMap<String, git::TagMetadata>,
-) -> Option<String> {
+fn parse_package_tag(tag: &str) -> Option<(String, Version)> {
+    tags::parse_tag(tag)
+        .or_else(|| tags::parse_root_tag(tag).map(|version| (String::new(), version)))
+}
+
+fn dirty_base_ref(repo_root: &Path, latest_tags: &HashMap<String, PackageTagInfo>) -> DirtyBase {
     if latest_tags.is_empty() {
-        return None;
+        return DirtyBase::NoPackageTags;
     }
 
-    if let Some(head) = git::rev_parse_head(repo_root)
-        && let Some(tag) = latest_tags.values().find_map(|info| {
-            tag_metadata
-                .get(&info.tag)
-                .filter(|metadata| metadata.target == head)
-                .map(|_| info.tag.clone())
-        })
-    {
-        return Some(tag);
-    }
-
-    let package_tags: BTreeSet<_> = latest_tags.values().map(|info| info.tag.clone()).collect();
+    let package_tags: HashSet<_> = latest_tags.values().map(|info| info.tag.as_str()).collect();
     if let Some(tag) = git::describe_tags(repo_root, "HEAD", None)
-        && package_tags.contains(&tag)
+        && package_tags.contains(tag.as_str())
     {
-        return Some(tag);
+        return DirtyBase::Found(tag);
     }
 
     for line in git::decorated_commits(repo_root) {
@@ -188,11 +182,11 @@ fn latest_package_tagged_ref(
                 .strip_prefix("tag: ")
                 .is_some_and(|tag| package_tags.contains(tag))
         }) {
-            return Some(commit.to_string());
+            return DirtyBase::Found(commit.to_string());
         }
     }
 
-    None
+    DirtyBase::Unknown
 }
 
 fn package_url_for_path(
@@ -200,7 +194,10 @@ fn package_url_for_path(
     path: &Path,
     workspace_subpath: Option<&Path>,
 ) -> Option<String> {
-    let path = workspace_relative_path(path, workspace_subpath)?;
+    let path = match workspace_subpath {
+        Some(prefix) => path.strip_prefix(prefix).ok()?,
+        None => path,
+    };
 
     workspace
         .packages
@@ -220,25 +217,14 @@ fn package_url_for_path(
         })
 }
 
-fn workspace_relative_path<'a>(
-    path: &'a Path,
-    workspace_subpath: Option<&Path>,
-) -> Option<&'a Path> {
-    match workspace_subpath {
-        Some(prefix) => path.strip_prefix(prefix).ok(),
-        None => Some(path),
-    }
-}
-
-/// Get workspace information with optional git version enrichment (native-only).
+/// Get workspace information (native-only).
 ///
 /// Calls core's get_workspace_info, adds path-patched forks as workspace members,
-/// populates dirty status, and optionally enriches with git tag versions.
+/// enriches with git tag metadata, and populates dirty status.
 #[instrument(name = "get_workspace_info", skip_all)]
 pub fn get_workspace_info<F: FileProvider>(
     file_provider: &F,
     start_path: &Path,
-    enrich_versions: bool,
 ) -> Result<WorkspaceInfo> {
     let mut info = {
         let _span = info_span!("discover_workspace_members").entered();
@@ -270,12 +256,11 @@ pub fn get_workspace_info<F: FileProvider>(
     let dirty_map = discover_dirty_packages(
         &info,
         &latest_tags,
-        &tag_metadata,
         status_paths,
         workspace_subpath.as_deref(),
     );
 
-    if enrich_versions {
+    {
         let _span = info_span!("enrich_workspace_versions").entered();
         for (url, pkg) in info.packages.iter_mut() {
             if let Some(tag_info) = latest_tags.get(url) {

--- a/crates/pcb-zen/tests/common/mod.rs
+++ b/crates/pcb-zen/tests/common/mod.rs
@@ -116,8 +116,8 @@ impl TestProject {
         let top_path = self.root().join(top_rel_path);
 
         let file_provider = pcb_zen_core::DefaultFileProvider::new();
-        let mut workspace_info = pcb_zen::get_workspace_info(&file_provider, &top_path, true)
-            .expect("get workspace info");
+        let mut workspace_info =
+            pcb_zen::get_workspace_info(&file_provider, &top_path).expect("get workspace info");
         let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)
             .expect("dependency resolution");
 

--- a/crates/pcb-zen/tests/spice_model.rs
+++ b/crates/pcb-zen/tests/spice_model.rs
@@ -10,7 +10,7 @@ macro_rules! sim_snapshot {
 
         let file_provider = pcb_zen_core::DefaultFileProvider::new();
         let mut workspace_info =
-            pcb_zen::get_workspace_info(&file_provider, &top_path, true).expect("get workspace info");
+            pcb_zen::get_workspace_info(&file_provider, &top_path).expect("get workspace info");
         let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)
             .expect("dependency resolution");
 
@@ -408,7 +408,7 @@ builtin.set_sim_setup(content=".tran 1u 10m")
     let top_path = env.root().join("test.zen");
     let file_provider = pcb_zen_core::DefaultFileProvider::new();
     let mut workspace_info =
-        pcb_zen::get_workspace_info(&file_provider, &top_path, true).expect("get workspace info");
+        pcb_zen::get_workspace_info(&file_provider, &top_path).expect("get workspace info");
     let res = pcb_zen::resolve_dependencies(&mut workspace_info, false, false)
         .expect("dependency resolution");
 

--- a/crates/pcb/src/bundle.rs
+++ b/crates/pcb/src/bundle.rs
@@ -392,12 +392,8 @@ pcb-version = "0.3"
             .write("pcb.toml", ROOT_PCB_TOML)
             .write("pcb.sum", "test/package 0.1.0 h1:test\n");
 
-        let mut workspace = get_workspace_info(
-            &DefaultFileProvider::new(),
-            &sb.root_path().join("src"),
-            true,
-        )
-        .unwrap();
+        let mut workspace =
+            get_workspace_info(&DefaultFileProvider::new(), &sb.root_path().join("src")).unwrap();
         let resolution = resolve_dependencies(&mut workspace, false, false).unwrap();
         let staged_src = sb.root_path().join("staged/src");
 

--- a/crates/pcb/src/doc.rs
+++ b/crates/pcb/src/doc.rs
@@ -338,7 +338,7 @@ fn run_docgen_for_package(pkg: &str, list: bool) -> Result<()> {
 fn resolve_local_workspace_package_url(pkg: &str) -> Option<(PathBuf, String, Option<String>)> {
     let cwd = std::env::current_dir().ok()?;
     let file_provider = pcb_zen_core::DefaultFileProvider::new();
-    let workspace_info = pcb_zen::get_workspace_info(&file_provider, &cwd, true).ok()?;
+    let workspace_info = pcb_zen::get_workspace_info(&file_provider, &cwd).ok()?;
 
     workspace_info
         .packages
@@ -535,7 +535,7 @@ fn run_docgen_for_remote_package(
 fn get_local_package_url(dir: &std::path::Path) -> Option<String> {
     let canonical = dir.canonicalize().ok()?;
     let file_provider = pcb_zen_core::DefaultFileProvider::new();
-    let workspace_info = pcb_zen::get_workspace_info(&file_provider, &canonical, true).ok()?;
+    let workspace_info = pcb_zen::get_workspace_info(&file_provider, &canonical).ok()?;
     let repo = workspace_info.repository()?;
 
     let relative = canonical.strip_prefix(&workspace_info.root).ok()?;

--- a/crates/pcb/src/file_walker.rs
+++ b/crates/pcb/src/file_walker.rs
@@ -137,7 +137,7 @@ pub fn resolve_board_target(path: &Path, action: &str) -> Result<BoardTarget> {
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or(Path::new("."));
-    let workspace = get_workspace_info(&file_provider, start_path, true)?;
+    let workspace = get_workspace_info(&file_provider, start_path)?;
 
     if !workspace.errors.is_empty() {
         for err in &workspace.errors {

--- a/crates/pcb/src/info.rs
+++ b/crates/pcb/src/info.rs
@@ -3,9 +3,7 @@ use clap::Args;
 use colored::Colorize as ColoredExt;
 use pcb_eda::kicad::symbol_library::KicadSymbolLibrary;
 use pcb_ui::{Style, StyledText};
-use pcb_zen::workspace::{
-    MemberPackage, SymbolFileInfo, WorkspaceInfo, WorkspaceInfoExt, get_workspace_info,
-};
+use pcb_zen::workspace::{MemberPackage, SymbolFileInfo, WorkspaceInfo, get_workspace_info};
 use pcb_zen_core::DefaultFileProvider;
 use serde::Serialize;
 use std::env;
@@ -42,9 +40,6 @@ pub fn execute(args: InfoArgs) -> Result<()> {
 
     let file_provider = DefaultFileProvider::new();
     let mut workspace_info = get_workspace_info(&file_provider, &start_path, true)?;
-
-    // Populate dirty status for all packages (used by both human and JSON output)
-    workspace_info.populate_dirty();
 
     match args.format {
         OutputFormat::Human => {

--- a/crates/pcb/src/info.rs
+++ b/crates/pcb/src/info.rs
@@ -39,7 +39,7 @@ pub fn execute(args: InfoArgs) -> Result<()> {
     };
 
     let file_provider = DefaultFileProvider::new();
-    let mut workspace_info = get_workspace_info(&file_provider, &start_path, true)?;
+    let mut workspace_info = get_workspace_info(&file_provider, &start_path)?;
 
     match args.format {
         OutputFormat::Human => {

--- a/crates/pcb/src/package.rs
+++ b/crates/pcb/src/package.rs
@@ -260,7 +260,7 @@ fn package_hash_only(target: WorkspaceTarget, args: &PackageArgs) -> Result<Pack
 #[instrument(name = "resolve_package_target", skip_all)]
 fn resolve_target(path: &Path, require_primary_zen: bool) -> Result<WorkspaceTarget> {
     let file_provider = DefaultFileProvider::new();
-    let workspace = get_workspace_info(&file_provider, path, false)?;
+    let workspace = get_workspace_info(&file_provider, path)?;
 
     if !workspace.errors.is_empty() {
         for err in &workspace.errors {

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -696,7 +696,7 @@ fn publish_packages(start_path: &Path, args: &PublishArgs) -> Result<()> {
         preflight_checks(&workspace_root, &remote)?;
     }
 
-    let workspace = get_workspace_info(&file_provider, start_path, true)?;
+    let workspace = get_workspace_info(&file_provider, start_path)?;
 
     // Fail on workspace discovery errors (invalid pcb.toml files)
     if !workspace.errors.is_empty() {
@@ -1441,12 +1441,7 @@ P1 = io(Net)
     }
 
     fn load_workspace(sb: &Sandbox) -> WorkspaceInfo {
-        get_workspace_info(
-            &DefaultFileProvider::new(),
-            &sb.root_path().join("src"),
-            true,
-        )
-        .unwrap()
+        get_workspace_info(&DefaultFileProvider::new(), &sb.root_path().join("src")).unwrap()
     }
 
     fn dirty_urls(urls: &[&str]) -> HashSet<String> {

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -10,7 +10,7 @@ use colored::Colorize;
 use inquire::{Confirm, Select};
 use pcb_zen::workspace::{MemberPackage, WorkspaceInfo, get_workspace_info};
 use pcb_zen::{git, tags};
-use pcb_zen_core::config::{DependencySpec, PcbToml};
+use pcb_zen_core::config::{DependencySpec, PcbToml, find_workspace_root};
 use pcb_zen_core::{DefaultFileProvider, initial_package_version};
 use petgraph::Direction;
 use petgraph::graph::{DiGraph, NodeIndex};
@@ -686,6 +686,16 @@ fn publish_packages(start_path: &Path, args: &PublishArgs) -> Result<()> {
     }
 
     let file_provider = DefaultFileProvider::new();
+    let workspace_root = find_workspace_root(&file_provider, start_path)?;
+    let remote = resolve_remote(&workspace_root, args.force)?;
+
+    eprintln!("Syncing with {}...", remote.cyan());
+    git::fetch_tags(&workspace_root, &remote)?;
+    if !args.force {
+        git::fetch_branch(&workspace_root, &remote, "main")?;
+        preflight_checks(&workspace_root, &remote)?;
+    }
+
     let workspace = get_workspace_info(&file_provider, start_path, true)?;
 
     // Fail on workspace discovery errors (invalid pcb.toml files)
@@ -694,15 +704,6 @@ fn publish_packages(start_path: &Path, args: &PublishArgs) -> Result<()> {
             eprintln!("{}", err.error);
         }
         bail!("Found {} invalid pcb.toml file(s)", workspace.errors.len());
-    }
-
-    let remote = resolve_remote(&workspace.root, args.force)?;
-
-    eprintln!("Syncing with {}...", remote.cyan());
-    git::fetch_tags(&workspace.root, &remote)?;
-    if !args.force {
-        git::fetch_branch(&workspace.root, &remote, "main")?;
-        preflight_checks(&workspace.root, &remote)?;
     }
 
     if !args.no_build {

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, bail};
 use clap::{Args, ValueEnum};
 use colored::Colorize;
 use inquire::{Confirm, Select};
-use pcb_zen::workspace::{MemberPackage, WorkspaceInfo, WorkspaceInfoExt, get_workspace_info};
+use pcb_zen::workspace::{MemberPackage, WorkspaceInfo, get_workspace_info};
 use pcb_zen::{git, tags};
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::{DefaultFileProvider, initial_package_version};
@@ -686,7 +686,7 @@ fn publish_packages(start_path: &Path, args: &PublishArgs) -> Result<()> {
     }
 
     let file_provider = DefaultFileProvider::new();
-    let mut workspace = get_workspace_info(&file_provider, start_path, true)?;
+    let workspace = get_workspace_info(&file_provider, start_path, true)?;
 
     // Fail on workspace discovery errors (invalid pcb.toml files)
     if !workspace.errors.is_empty() {
@@ -715,8 +715,7 @@ fn publish_packages(start_path: &Path, args: &PublishArgs) -> Result<()> {
         }
     }
 
-    // Populate dirty status and get dirty non-board packages
-    workspace.populate_dirty();
+    // Get dirty non-board packages
     let directly_dirty: HashSet<String> = workspace
         .packages
         .iter()

--- a/crates/pcb/src/release.rs
+++ b/crates/pcb/src/release.rs
@@ -719,8 +719,7 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<()> {
 
     // Re-resolve in offline+locked mode. All dependencies (including KiCad
     // library files) are vendored from eval1 by copy_sources.
-    let mut staged_workspace =
-        get_workspace_info(&DefaultFileProvider::new(), &staged_zen_path, true)?;
+    let mut staged_workspace = get_workspace_info(&DefaultFileProvider::new(), &staged_zen_path)?;
     let staged_resolution = pcb_zen::resolve_dependencies(&mut staged_workspace, true, true)?;
 
     // Use build function with offline mode but allow warnings

--- a/crates/pcb/src/resolve.rs
+++ b/crates/pcb/src/resolve.rs
@@ -27,7 +27,7 @@ pub fn resolve(input_path: Option<&Path>, offline: bool, locked: bool) -> Result
             &cwd
         }
     };
-    let mut workspace_info = get_workspace_info(&DefaultFileProvider::new(), path, true)?;
+    let mut workspace_info = get_workspace_info(&DefaultFileProvider::new(), path)?;
 
     // Fail on workspace discovery errors (invalid pcb.toml files)
     if !workspace_info.errors.is_empty() {

--- a/crates/pcb/src/update.rs
+++ b/crates/pcb/src/update.rs
@@ -134,7 +134,7 @@ fn matches_filter(url: &str, filter: &[String]) -> bool {
 
 pub fn execute(args: UpdateArgs) -> Result<()> {
     let start_path = args.path.canonicalize().unwrap_or(args.path.clone());
-    let workspace = get_workspace_info(&DefaultFileProvider::new(), &start_path, true)?;
+    let workspace = get_workspace_info(&DefaultFileProvider::new(), &start_path)?;
 
     println!("{}", "Checking for updates...".cyan());
 

--- a/crates/pcb/src/vendor.rs
+++ b/crates/pcb/src/vendor.rs
@@ -27,7 +27,7 @@ pub fn execute(args: VendorArgs) -> Result<()> {
         .zen_path
         .unwrap_or_else(|| std::env::current_dir().unwrap())
         .canonicalize()?;
-    let mut workspace_info = get_workspace_info(&DefaultFileProvider::new(), &zen_path, true)?;
+    let mut workspace_info = get_workspace_info(&DefaultFileProvider::new(), &zen_path)?;
 
     if !args.all {
         println!(

--- a/crates/pcb/tests/snapshots/info__json_format_with_published_at.snap
+++ b/crates/pcb/tests/snapshots/info__json_format_with_published_at.snap
@@ -30,7 +30,6 @@ Exit Code: 0
       "version": "0.2.0",
       "published_at": "<PUBLISHED_AT>",
       "preferred": false,
-      "dirty": true,
       "entrypoints": [
         "test_board.zen"
       ]


### PR DESCRIPTION
before:
```
pcb info -f json > /dev/null
1.866 s ± 0.140 s
```

after:
```
target/release/pcb info -f json > /dev/null
223.9 ms ± 3.1 ms
```

This also makes publish faster because it relies in info + dirty detection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reworks dirty-package and tag metadata discovery using git log/diff/status and batched tag reads, which could change which packages are flagged dirty/published. Touches `pcb publish` preflight ordering and workspace discovery signature across many commands, so regressions would affect CLI workflows broadly.
> 
> **Overview**
> **Improves `pcb info` and publish performance** by refactoring workspace discovery to always enrich packages with `version`, `published_at`, and `dirty` using *git metadata* instead of per-package content hashing.
> 
> This adds new git helpers (`decorated_commits`, `changed_paths_since_in_repo`, `status_paths_in_repo`) and replaces tag annotation/timestamp parsing with a batched `git cat-file` implementation to fetch tag/commit timestamps efficiently.
> 
> As a result, `get_workspace_info` drops the `enrich_versions` flag and all call sites are updated; `pcb info` no longer separately calls `populate_dirty`, `pcb publish` now fetches remote tags/branch before loading workspace info, and the JSON snapshot updates to reflect the new dirty computation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121a4f407918bd9f72a65a26b78b66017959f3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
