### PR TITLE
Generate flat top-level `io()` assignments for component `.zen` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Generated component `.zen` files now declare pins as flat top-level `io(Net)` assignments instead of a `Pins = struct(...)` block.
+
 ## [0.3.72] - 2026-04-27
 
 ### Added

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -245,11 +245,12 @@ mod tests {
         .unwrap();
 
         assert!(zen.contains("Auto-generated using `pcb import`."));
-        assert!(zen.contains("Pins = struct("));
-        assert!(zen.contains("N_INT"));
-        assert!(zen.contains("\"~{INT}\": Pins.N_INT"));
+        assert!(zen.contains("N_INT = io(Net)"));
+        assert!(zen.contains("\"~{INT}\": N_INT"));
         assert!(zen.contains("VCC"));
         assert!(!zen.contains("pin_defs"));
+        assert!(!zen.contains("Pins = struct("));
+        assert!(!zen.contains("Pins."));
     }
 
     #[test]
@@ -355,8 +356,8 @@ mod tests {
         .unwrap();
 
         assert!(zen.contains("name = \"TP_0_75mm_SMD\""));
-        assert!(zen.contains("\"1\": Pins.P1"));
-        assert!(zen.contains("\"2\": Pins.P2"));
+        assert!(zen.contains("\"1\": P1"));
+        assert!(zen.contains("\"2\": P2"));
         assert!(!zen.contains("\"~\":"));
     }
 
@@ -392,8 +393,8 @@ mod tests {
         .unwrap();
 
         // Single io() for the shared signal name
-        assert!(zen.contains("NC = io(\"NC\", Net)"));
-        assert!(zen.contains("\"NC\": Pins.NC"));
+        assert!(zen.contains("NC = io(Net)"));
+        assert!(zen.contains("\"NC\": NC"));
         // No pin_defs needed
         assert!(!zen.contains("pin_defs"));
     }
@@ -437,9 +438,9 @@ mod tests {
         })
         .unwrap();
 
-        assert!(zen.contains("VCC = io(\"VCC\", Net)"));
-        assert!(zen.contains("\"VCC\": Pins.VCC"));
-        assert!(!zen.contains("NC = io(\"NC\", Net)"));
-        assert!(!zen.contains("\"NC\": Pins.NC"));
+        assert!(zen.contains("VCC = io(Net)"));
+        assert!(zen.contains("\"VCC\": VCC"));
+        assert!(!zen.contains("NC = io(Net)"));
+        assert!(!zen.contains("\"NC\": NC"));
     }
 }

--- a/crates/pcb-component-gen/templates/component.zen.jinja
+++ b/crates/pcb-component-gen/templates/component.zen.jinja
@@ -11,12 +11,9 @@ skip_bom = config(bool, default = {{ "True" if skip_bom_default else "False" }})
 skip_pos = config(bool, default = {{ "True" if skip_pos_default else "False" }})
 {% endif %}
 
-Pins = struct(
-{%- for pin in pin_groups %}
-    {{ pin.sanitized_name }} = io("{{ pin.sanitized_name }}", Net){{ "," if not loop.last }}
-{%- endfor %}
-)
-
+{% for pin in pin_groups -%}
+{{ pin.sanitized_name }} = io(Net)
+{% endfor %}
 Component(
     name = "{{ component_name }}",
 {%- if include_skip_bom %}
@@ -28,7 +25,7 @@ Component(
     symbol = Symbol(library = "{{ sym_path }}"),
     pins = {
 {%- for pin in pin_mappings %}
-        "{{ pin.original_name }}": Pins.{{ pin.sanitized_name }}{{ "," if not loop.last }}
+        "{{ pin.original_name }}": {{ pin.sanitized_name }}{{ "," if not loop.last }}
 {%- endfor %}
     },
 )

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -2309,7 +2309,7 @@ mod tests {
 
         // The pins dict should NOT have duplicate "GND" keys
         // Count how many times "GND" appears as a dict key
-        let gnd_key_count = zen_content.matches("\"GND\": Pins.GND").count();
+        let gnd_key_count = zen_content.matches("\"GND\": GND").count();
         assert_eq!(
             gnd_key_count, 1,
             "Expected exactly 1 GND dict entry, found {}. Generated content:\n{}",
@@ -2318,8 +2318,8 @@ mod tests {
 
         // Verify the file is valid Starlark (no duplicate dict keys)
         // The pins dict should only contain unique entries
-        assert!(zen_content.contains("\"VIN\": Pins.VIN"));
-        assert!(zen_content.contains("\"VOUT\": Pins.VOUT"));
+        assert!(zen_content.contains("\"VIN\": VIN"));
+        assert!(zen_content.contains("\"VOUT\": VOUT"));
     }
 
     #[test]


### PR DESCRIPTION
Works better with the new variable name inference support that we have.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated `.zen` component pin API shape from `Pins.<name>` indirections to top-level bindings, which may break any downstream code or tests that relied on the old `Pins = struct(...)` layout.
> 
> **Overview**
> Generated component `.zen` files now emit **flat top-level pin declarations** (e.g. `VCC = io(Net)`) and reference those names directly in `Component(..., pins={...})`, instead of building a `Pins = struct(...)` and using `Pins.<pin>`.
> 
> Updates unit tests in `pcb-component-gen` and `pcb-diode-api` to assert the new output format, and documents the change in the Unreleased changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfff95b2779ceb3692b3aba94ff9a7f04cfdd4b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
