### PR TITLE
Add SOD-882 TVS BOM coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added SOD-882 TVS diodes with capacitance-based BOM matching.
+
 ## [0.3.75] - 2026-05-02
 
 ### Added

--- a/stdlib/bom/helpers.zen
+++ b/stdlib/bom/helpers.zen
@@ -516,16 +516,23 @@ def diodes_inc_datasheet(filename):
 
 
 def tvs(
-    standoff_voltage: str, clamping_voltage: str, peak_pulse_power: str, mpn: str, manufacturer: str, datasheet=None
+    standoff_voltage: str,
+    clamping_voltage: str,
+    peak_pulse_power: str | None,
+    mpn: str,
+    manufacturer: str,
+    datasheet=None,
+    capacitance: str | None = None,
 ) -> dict:
     """Helper to create TVS diode catalog entry.
 
     Args:
         standoff_voltage: Reverse standoff voltage (e.g., "5V" or "5V to 6V")
         clamping_voltage: Clamping voltage @ Ipp (e.g., "9.2V" or "9V to 12V")
-        peak_pulse_power: Peak pulse power (e.g., "200W" or "200W to 400W")
+        peak_pulse_power: Peak pulse power (e.g., "200W" or "200W to 400W") or None
         mpn: Manufacturer part number
         manufacturer: Manufacturer name
+        capacitance: Diode capacitance (e.g., "0.5pF") or None
 
     Returns:
         TVS diode dictionary
@@ -537,12 +544,13 @@ def tvs(
     clamping_val = (
         Voltage(clamping_voltage) if "to" in clamping_voltage else Voltage(clamping_voltage + " to " + clamping_voltage)
     )
-    power_val = Power(peak_pulse_power)
+    power_val = Power(peak_pulse_power) if peak_pulse_power else None
 
     return {
         "standoff_voltage": standoff_val,
         "clamping_voltage": clamping_val,
         "peak_pulse_power": power_val,
+        "capacitance": Capacitance(capacitance) if capacitance else None,
         "mpn": mpn,
         "manufacturer": manufacturer,
         "datasheet": datasheet,

--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -641,6 +641,274 @@ HOUSE_TVS_BY_PKG = {
         vishay_tvs("48V", "77.4V", "6000W", "SMCJ48CA-E3", "88394/smcj.pdf"),
         vishay_tvs("60V", "96.8V", "6000W", "SMCJ60CA-E3", "88394/smcj.pdf"),
     ],
+    ("Unidirectional", "SOD-882"): [
+        tvs(
+            "5V",
+            "7.5V",
+            None,
+            "SP3031-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/tvs-diode-arrays-sp3031-datasheet?assetguid=2f63a461-bb1a-458d-97ab-119532f3b1f4",
+            capacitance="0.8pF",
+        ),
+        tvs(
+            "5V",
+            "12V",
+            None,
+            "SP1003-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sp1003_datasheet.pdf?assetguid=12e91f0b-9a70-47f1-8c30-51aa42e84dd5",
+            capacitance="30pF",
+        ),
+        tvs(
+            "5V",
+            "10V",
+            None,
+            "SP3030-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sp3030_datasheet.pdf?assetguid=477be72d-f135-4b27-a334-de0f49e61bac",
+            capacitance="0.5pF",
+        ),
+        tvs(
+            "5V",
+            "10V",
+            None,
+            "SP1250-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sp1250_datasheet.pdf?assetguid=e52bbf49-0dd7-4706-9776-b2e12ebb5a3a",
+            capacitance="120pF",
+        ),
+        tvs(
+            "7V",
+            "11.8V",
+            None,
+            "SP3530-01ETG",
+            "Littelfuse Inc.",
+            "https://mm.digikey.com/Volume0/opasdata/d220001/medias/docus/2345/SP3530_Series.pdf",
+        ),
+        tvs(
+            "3.3V",
+            "10V",
+            "95W",
+            "VESD03A1C-HD1-GS08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81797/vesd03a1.pdf",
+            capacitance="78pF",
+        ),
+        tvs(
+            "5V",
+            "10V",
+            "80W",
+            "VESD05A1C-HD1-GS08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81798/vesd05a1.pdf",
+            capacitance="63pF",
+        ),
+        tvs(
+            "5V",
+            "12V",
+            "192W",
+            "VESD05A1A-HD1-GS08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81800/vesd05a1.pdf",
+            capacitance="130pF",
+        ),
+        tvs(
+            "3.3V",
+            "9V",
+            "31W",
+            "VESD03A1B-HD1-GS08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81851/vesd03a1.pdf",
+            capacitance="25pF",
+        ),
+        tvs(
+            "5V",
+            "11V",
+            "33W",
+            "VESD05A1B-HD1-GS08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81796/vesd05a1.pdf",
+            capacitance="19pF",
+        ),
+        tvs(
+            "5.5V",
+            "14V",
+            "28W",
+            "VBUS051CD-HD1-G-08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81195/vbus051cd.pdf",
+            capacitance="0.6pF",
+        ),
+    ],
+    ("Bidirectional", "SOD-882"): [
+        tvs(
+            "1V",
+            "8.5V",
+            None,
+            "SP0115-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse-tvs-diode-array-sp0115-01etg-datasheet?assetguid=e612b8e6-e7be-4b03-b9cb-e0e912cf59c1",
+            capacitance="0.85pF",
+        ),
+        tvs(
+            "3.3V",
+            "9V",
+            None,
+            "SC1333-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse-tvs-diode-array-sc1333-01etg-datasheet?assetguid=3f42833b-e7fb-4dbd-925d-18e1fde6e51d",
+            capacitance="8pF",
+        ),
+        tvs(
+            "3.3V",
+            "8.5V",
+            "180W",
+            "SP1233-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sp1233_datasheet.pdf?assetguid=0e864491-f5c5-4123-a4af-5b5f312ccc58",
+            capacitance="35pF",
+        ),
+        tvs(
+            "5V",
+            "14.7V",
+            None,
+            "SP3021-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sp3021_datasheet.pdf?assetguid=02714df5-d4f5-4e09-baec-2bc99a517824",
+        ),
+        tvs(
+            "5V",
+            "11V",
+            None,
+            "SC1210-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse-tvs-diode-array-sc1210-01etg-datasheet?assetguid=69d2080a-f0b0-48bb-a865-7cbf0c1070b5",
+            capacitance="26pF",
+        ),
+        tvs(
+            "5V",
+            "10V",
+            None,
+            "AQ1205-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_aq1205-01etg_datasheet.pdf?assetguid=72e10767-3f7e-4400-818c-12e470836581",
+            capacitance="7pF",
+        ),
+        tvs(
+            "5V",
+            "10V",
+            None,
+            "SC1205-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sc1205-01etg_datasheet.pdf?assetguid=1c78a8be-7e76-4626-a182-63ddf7641a57",
+            capacitance="7pF",
+        ),
+        tvs(
+            "5.3V",
+            "12V",
+            "20W",
+            "SP3022-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse-tvs-diode-array-sp3022-datasheet?assetguid=a27ecccd-9fa4-4223-9a25-f0bb33be4303",
+        ),
+        tvs(
+            "5.3V",
+            "13V",
+            None,
+            "SP3022-01ETG-NM",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse-tvs-diode-array-sp3022-01etg-nm-datasheet?assetguid=60969493-fae9-418a-91ac-bc92d273bb80",
+            capacitance="0.35pF",
+        ),
+        tvs(
+            "6V",
+            "15.6V",
+            None,
+            "SP1005-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sp1005_datasheet.pdf?assetguid=52a245c3-fc07-42d4-9891-4cdd6cceab3f",
+        ),
+        tvs(
+            "6V",
+            "9.2V",
+            None,
+            "SP1007-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sp1007_datasheet.pdf?assetguid=fcbdfc8e-b10b-4d90-ad90-b7da1dfffcb8",
+        ),
+        tvs(
+            "7V",
+            "14.5V",
+            None,
+            "SP3522-01ETG",
+            "Littelfuse Inc.",
+            "https://mm.digikey.com/Volume0/opasdata/d220001/medias/docus/2292/SP3522_Series.pdf",
+        ),
+        tvs(
+            "18V",
+            "38V",
+            None,
+            "SP3118-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse_tvs_diode_array_sp3118_datasheet.pdf?assetguid=049f1614-7668-459d-a6c4-a91a1217584b",
+            capacitance="0.3pF",
+        ),
+        tvs(
+            "28V",
+            "48V",
+            None,
+            "SP3130-01ETG",
+            "Littelfuse Inc.",
+            "https://www.littelfuse.com/assetdocs/littelfuse-tvs-diode-arrays-sp3130-datasheet?assetguid=be94cc20-a863-42b7-82be-41ce11851e36",
+            capacitance="0.3pF",
+        ),
+        tvs(
+            "5.5V",
+            "16V",
+            "56W",
+            "VCUT0505B-HD1-GS08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81852/vcut0505.pdf",
+            capacitance="18pF",
+        ),
+        tvs(
+            "5.5V",
+            "12.5V",
+            "38W",
+            "VCUT05B1-DD1-G-08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81149/vcut05b1dd1.pdf",
+            capacitance="10pF",
+        ),
+        tvs(
+            "5.5V",
+            "17V",
+            "34W",
+            "VBUS05L1-DD1-G-08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81188/vbus05l1.pdf",
+            capacitance="0.33pF",
+        ),
+        tvs(
+            "7V",
+            "15V",
+            "60W",
+            "VCUT07B1-HD1-G4-08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/84137/vcut07b1hd1.pdf",
+            capacitance="14pF",
+        ),
+        tvs(
+            "3.5V",
+            "11.5V",
+            "40W",
+            "VCUT03B1-DD1-G-08",
+            "Vishay General Semiconductor - Diodes Division",
+            "https://www.vishay.com/docs/81148/vcut03b1.pdf",
+            capacitance="12.5pF",
+        ),
+    ],
 }
 
 # House standoff catalog (Würth WA-SMSI series with Sinhoo SMTSO alternatives)
@@ -1186,7 +1454,9 @@ def assign_house_tvs(c, house_tvs_by_pkg):
     req_standoff = prop(c, ["reverse_standoff_voltage", "Reverse_standoff_voltage"])
     req_clamping = prop(c, ["reverse_clamping_voltage", "Reverse_clamping_voltage"])
     req_power = prop(c, ["peak_pulse_power", "Peak_pulse_power"])
+    req_capacitance = prop(c, ["capacitance", "Capacitance"])
     required_power = Power(req_power) if req_power else None
+    required_capacitance = Capacitance(req_capacitance) if req_capacitance else None
 
     parts = house_tvs_by_pkg.get((direction, pkg), [])
     matches = []
@@ -1201,8 +1471,14 @@ def assign_house_tvs(c, house_tvs_by_pkg):
             continue
 
         # Power is a minimum acceptable rating; allow higher-power TVS parts.
-        if required_power and p["peak_pulse_power"] < required_power:
+        if required_power and (not p["peak_pulse_power"] or p["peak_pulse_power"] < required_power):
             continue
+
+        if required_capacitance:
+            if not p["capacitance"]:
+                continue
+            if not p["capacitance"].within(required_capacitance):
+                continue
 
         matches.append(p)
 

--- a/stdlib/generics/Tvs.zen
+++ b/stdlib/generics/Tvs.zen
@@ -1,6 +1,6 @@
 load("../io.zen", "io")
-load("../units.zen", "Voltage", Watts="Power")
-load("../interfaces.zen", "Ground", "Net", "Power")
+load("../units.zen", "Capacitance", "Voltage", Watts="Power")
+load("../interfaces.zen", "Ground", "Net")
 load("../utils.zen", "format_value")
 
 # Package      JEDEC         LxWxH
@@ -8,7 +8,8 @@ load("../utils.zen", "format_value")
 # SMA          DO-214AC      4.6×2.6×2.1
 # SMB          DO-214AA      5.3×3.7×2.5
 # SMC          DO-214AB      7.8×6.8×2.5
-Package = enum("DO-219AB", "DO-214AC", "DO-214AA", "DO-214AB")
+# SOD-882      -             1.0×0.6x0.5
+Package = enum("DO-219AB", "DO-214AC", "DO-214AA", "DO-214AB", "SOD-882")
 Direction = enum("Unidirectional", "Bidirectional")
 
 USB_5V_STANDOFF_VOLTAGE = Voltage("5 to 6V")
@@ -19,12 +20,13 @@ direction = config(Direction, default=Direction("Unidirectional"), help="Unidire
 reverse_standoff_voltage = config(Voltage, default=USB_5V_STANDOFF_VOLTAGE, help="Maximum steady-state reverse voltage")
 reverse_clamping_voltage = config(Voltage, optional=True, help="Clamping voltage at peak pulse current")
 peak_pulse_power = config(Watts, optional=True, help="Peak pulse power rating (8/20μs)")
+capacitance = config(Capacitance, optional=True, help="Diode capacitance C_d at V_R=0V, f=1 MHz")
 mpn = config(str, optional=True, help="Manufacturer Part Number")
 manufacturer = config(str, optional=True, help="Manufacturer")
 
 if direction == Direction("Unidirectional"):
     A = io(Ground)
-    K = io(Power)
+    K = io(Net)
 else:
     A = io(Net)
     K = io(Net)
@@ -56,6 +58,7 @@ def _footprint(package: Package) -> str:
         Package("DO-214AC"): "@kicad-footprints/Diode_SMD.pretty/D_SMA.kicad_mod",
         Package("DO-214AA"): "@kicad-footprints/Diode_SMD.pretty/D_SMB.kicad_mod",
         Package("DO-214AB"): "@kicad-footprints/Diode_SMD.pretty/D_SMC.kicad_mod",
+        Package("SOD-882"): "@kicad-footprints/Diode_SMD.pretty/D_SOD-882.kicad_mod",
     }
     return kicad_footprints[package]
 
@@ -83,6 +86,8 @@ if peak_pulse_power:
     properties["peak_pulse_power"] = peak_pulse_power
 if reverse_clamping_voltage:
     properties["reverse_clamping_voltage"] = reverse_clamping_voltage
+if capacitance:
+    properties["capacitance"] = capacitance
 
 
 def _spice_subcircuit_name(direction: Direction):

--- a/stdlib/generics/test/test_Tvs.zen
+++ b/stdlib/generics/test/test_Tvs.zen
@@ -1,7 +1,6 @@
 """Comprehensive test for TVS Diode component."""
 
-load("../../units.zen", "Power", "Voltage")
-Watts = Power
+load("../../units.zen", "Voltage")
 load("../../interfaces.zen", "Ground", "Net", "Power")
 load("../../bom/match_generics.zen", "assign_house_parts")
 
@@ -107,6 +106,101 @@ _MIN_POWER_CASES = [
     ("Bidirectional", "DO-214AC", "24V", "38.9V", "600W"),
 ]
 
+_SOD882_BOM_MATCH_CASES = [
+    ("Unidirectional", "5V", "7.5V", "0.8pF", None),
+    ("Unidirectional", "5V", "12V", None, None),
+    ("Unidirectional", "5V", "12V", "30pF", None),
+    ("Unidirectional", "5V", "10V", "0.5pF", None),
+    ("Unidirectional", "5V", "10V", "120pF", None),
+    ("Unidirectional", "7V", "11.8V", None, None),
+    ("Unidirectional", "3.3V", "10V", "78pF", "95W"),
+    ("Unidirectional", "5V", "10V", "63pF", "80W"),
+    ("Unidirectional", "5V", "12V", "130pF", "192W"),
+    ("Unidirectional", "3.3V", "9V", "25pF", "31W"),
+    ("Unidirectional", "5V", "11V", "19pF", "33W"),
+    ("Unidirectional", "5.5V", "14V", "0.6pF", "28W"),
+    ("Bidirectional", "1V", "8.5V", "0.85pF", None),
+    ("Bidirectional", "3.3V", "9V", "8pF", None),
+    ("Bidirectional", "3.3V", "8.5V", "35pF", "180W"),
+    ("Bidirectional", "5V", "14.7V", None, None),
+    ("Bidirectional", "5V", "11V", "26pF", None),
+    ("Bidirectional", "5V", "10V", "7pF", None),
+    ("Bidirectional", "5.3V", "12V", None, "20W"),
+    ("Bidirectional", "5.3V", "13V", "0.35pF", None),
+    ("Bidirectional", "6V", "15.6V", None, None),
+    ("Bidirectional", "6V", "9.2V", None, None),
+    ("Bidirectional", "7V", "14.5V", None, None),
+    ("Bidirectional", "18V", "38V", "0.3pF", None),
+    ("Bidirectional", "28V", "48V", "0.3pF", None),
+    ("Bidirectional", "5.5V", "16V", "18pF", "56W"),
+    ("Bidirectional", "5.5V", "12.5V", "10pF", "38W"),
+    ("Bidirectional", "5.5V", "17V", "0.33pF", "34W"),
+    ("Bidirectional", "7V", "15V", "14pF", "60W"),
+    ("Bidirectional", "3.5V", "11.5V", "12.5pF", "40W"),
+]
+
+_SOD882_CAPACITANCE_RANGE_CASES = [
+    # Range requests should accept low-cap parts while rejecting higher capacitance options.
+    ("Bidirectional", "5.3V", "13V", "0.2pF to 0.5pF", None),
+    # Same capacitance range, different voltage constraints, should select the 0.33pF Vishay part.
+    ("Bidirectional", "5.5V", "17V", "0.2pF to 0.5pF", "34W"),
+]
+
+
+def _sod882_tvs(kind, i, direction, standoff, clamp, capacitance, peak_pulse_power):
+    name = "D_TVS_SOD882_" + kind + "_" + str(i)
+    if direction == "Unidirectional":
+        a = gnd
+        k = Net(name + "_K")
+    else:
+        a = Net(name + "_A")
+        k = Net(name + "_K")
+
+    if capacitance and peak_pulse_power:
+        Tvs(
+            name=name,
+            package="SOD-882",
+            direction=direction,
+            reverse_standoff_voltage=standoff,
+            reverse_clamping_voltage=clamp,
+            peak_pulse_power=peak_pulse_power,
+            capacitance=capacitance,
+            A=a,
+            K=k,
+        )
+    elif capacitance:
+        Tvs(
+            name=name,
+            package="SOD-882",
+            direction=direction,
+            reverse_standoff_voltage=standoff,
+            reverse_clamping_voltage=clamp,
+            capacitance=capacitance,
+            A=a,
+            K=k,
+        )
+    elif peak_pulse_power:
+        Tvs(
+            name=name,
+            package="SOD-882",
+            direction=direction,
+            reverse_standoff_voltage=standoff,
+            reverse_clamping_voltage=clamp,
+            peak_pulse_power=peak_pulse_power,
+            A=a,
+            K=k,
+        )
+    else:
+        Tvs(
+            name=name,
+            package="SOD-882",
+            direction=direction,
+            reverse_standoff_voltage=standoff,
+            reverse_clamping_voltage=clamp,
+            A=a,
+            K=k,
+        )
+
 
 for direction, package, standoff, clamp in _HOUSE_PARTS:
     name = _tvs_name("HOUSE", direction, package, standoff)
@@ -120,8 +214,8 @@ for direction, package, standoff, clamp in _HOUSE_PARTS:
         name=name,
         package=package,
         direction=direction,
-        reverse_standoff_voltage=Voltage(standoff),
-        reverse_clamping_voltage=Voltage(clamp),
+        reverse_standoff_voltage=standoff,
+        reverse_clamping_voltage=clamp,
         A=a,
         K=k,
     )
@@ -139,7 +233,7 @@ for i, (direction, package, standoff) in enumerate(_BOM_MATCH_CASES):
         name=name,
         package=package,
         direction=direction,
-        reverse_standoff_voltage=Voltage(standoff),
+        reverse_standoff_voltage=standoff,
         A=a,
         K=k,
     )
@@ -157,11 +251,26 @@ for direction, package, standoff, clamp, peak_pulse_power in _MIN_POWER_CASES:
         name=name,
         package=package,
         direction=direction,
-        reverse_standoff_voltage=Voltage(standoff),
-        reverse_clamping_voltage=Voltage(clamp),
-        peak_pulse_power=Watts(peak_pulse_power),
+        reverse_standoff_voltage=standoff,
+        reverse_clamping_voltage=clamp,
+        peak_pulse_power=peak_pulse_power,
         A=a,
         K=k,
+    )
+
+# Verify SOD-882 ESD diode matching, including capacitance-constrained cases.
+for i, (direction, standoff, clamp, capacitance, peak_pulse_power) in enumerate(_SOD882_BOM_MATCH_CASES):
+    _sod882_tvs("MATCH", i, direction, standoff, clamp, capacitance, peak_pulse_power)
+
+for i, (direction, standoff, clamp, capacitance, peak_pulse_power) in enumerate(_SOD882_CAPACITANCE_RANGE_CASES):
+    _sod882_tvs(
+        "CAP_RANGE",
+        i,
+        direction,
+        standoff,
+        clamp,
+        capacitance,
+        peak_pulse_power,
     )
 
 builtin.add_component_modifier(assign_house_parts)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Extends generic TVS BOM matching logic and schema (new `capacitance` field and `SOD-882` package), which could change part selection behavior for TVS components if properties are present or missing.
> 
> **Overview**
> **Adds SOD-882 TVS diode BOM coverage.** The TVS house-part catalog is extended with multiple `SOD-882` unidirectional/bidirectional entries, and the `Tvs` generic now supports the `SOD-882` package with the correct KiCad footprint.
> 
> **Introduces capacitance-based TVS matching.** The `tvs()` helper and `assign_house_tvs()` now carry an optional `capacitance` attribute and can filter candidates by capacitance ranges; `peak_pulse_power` is also made optional for parts where it’s unspecified.
> 
> **Tests and docs updated.** TVS generic tests add SOD-882 matching cases (including capacitance-range selection), and the changelog notes the new capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27cc3277a0c157938c7563db48c7bbd1023781f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
