### PR TITLE
feat: support AWS auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added API authentication via AWS credentials.
+
 ## [0.3.74] - 2026-04-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "1.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +470,310 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -737,6 +1083,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +1241,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cmp_any"
@@ -1293,6 +1655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1840,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -2180,7 +2552,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -2283,6 +2655,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +2686,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2315,12 +2707,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2331,8 +2734,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2362,8 +2765,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2378,10 +2781,11 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2397,8 +2801,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -3991,6 +4395,10 @@ dependencies = [
  "anyhow",
  "arboard",
  "atomicwrites",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-runtime-api",
  "base64",
  "chrono",
  "clap",
@@ -4024,8 +4432,11 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.11.0",
  "sqlite-vec",
+ "tempfile",
+ "tokio",
  "toml",
  "url",
  "urlencoding",
@@ -4490,6 +4901,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -5193,6 +5610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5226,8 +5649,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -6074,6 +6497,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6786,6 +7220,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -6793,6 +7228,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -6954,8 +7399,8 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -8170,6 +8615,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,10 @@ anyhow = "1.0"
 atomicwrites = "0.4"
 arboard = { version = "3.4", default-features = false }
 ariadne = { version = "0.6", features = ["auto-color"] }
+aws-config = "1.8.16"
+aws-credential-types = "1.2.14"
+aws-sigv4 = "1.4.3"
+aws-smithy-runtime-api = "1.12.0"
 axoupdater = { version = "0.10", features = ["blocking"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "wrap_help"] }
@@ -76,6 +80,7 @@ serde_json = "1.0"
 tempfile = "3.10.1"
 thiserror = "2"
 toml = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "1.4", features = ["v4", "v5", "js"] }
 walkdir = "2.3"
 deunicode = "1.6"

--- a/crates/pcb-diode-api/Cargo.toml
+++ b/crates/pcb-diode-api/Cargo.toml
@@ -6,11 +6,17 @@ description = "Diode API client for authentication, component search, registry T
 
 [dev-dependencies]
 insta = { workspace = true }
+serial_test = { workspace = true }
+tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
 atomicwrites = { workspace = true }
 arboard = { workspace = true }
+aws-config = { workspace = true }
+aws-credential-types = { workspace = true }
+aws-sigv4 = { workspace = true }
+aws-smithy-runtime-api = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
@@ -46,6 +52,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 sqlite-vec = "0.1"
 toml = { workspace = true }
+tokio = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true }

--- a/crates/pcb-diode-api/src/auth.rs
+++ b/crates/pcb-diode-api/src/auth.rs
@@ -11,6 +11,9 @@ use std::net::TcpListener;
 use std::path::PathBuf;
 
 use crate::WorkspaceContext;
+use crate::aws_auth::{self, AwsDiodeToken};
+
+const NOT_AUTHENTICATED_MESSAGE: &str = "Not authenticated. Run `pcb auth login` to authenticate.";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthTokens {
@@ -183,15 +186,36 @@ pub fn refresh_tokens() -> Result<AuthTokens> {
 }
 
 pub fn get_valid_token_with_context(ctx: &WorkspaceContext) -> Result<String> {
-    let tokens = load_tokens_with_context(ctx)?
-        .context("Not authenticated. Run `pcb auth login` to authenticate.")?;
+    get_valid_token_with_sources(
+        ctx,
+        aws_auth::get_service_token,
+        refresh_tokens_with_context,
+    )
+}
 
-    if tokens.is_expired() {
-        let new_tokens = refresh_tokens_with_context(ctx)?;
-        return Ok(new_tokens.access_token);
+fn get_valid_token_with_sources(
+    ctx: &WorkspaceContext,
+    aws_service_token: impl Fn(&WorkspaceContext) -> Result<AwsDiodeToken>,
+    refresh_tokens: impl Fn(&WorkspaceContext) -> Result<AuthTokens>,
+) -> Result<String> {
+    let aws_token = || {
+        aws_service_token(ctx)
+            .map(|token| token.access_token)
+            .map_err(|_| anyhow::anyhow!(NOT_AUTHENTICATED_MESSAGE))
+    };
+
+    let Some(tokens) = load_tokens_with_context(ctx)? else {
+        return aws_token();
+    };
+
+    if !tokens.is_expired() {
+        return Ok(tokens.access_token);
     }
 
-    Ok(tokens.access_token)
+    match refresh_tokens(ctx) {
+        Ok(new_tokens) => Ok(new_tokens.access_token),
+        Err(_) => aws_token(),
+    }
 }
 
 pub fn get_valid_token() -> Result<String> {
@@ -264,6 +288,7 @@ pub fn login() -> Result<()> {
 
 pub fn logout_with_context(ctx: &WorkspaceContext) -> Result<()> {
     clear_tokens_with_context(ctx)?;
+    aws_auth::clear_service_token(ctx)?;
     println!("✓ Logged out successfully");
     Ok(())
 }
@@ -393,5 +418,177 @@ pub fn execute(args: AuthArgs, ctx: &WorkspaceContext) -> Result<()> {
         Some(AuthCommand::Status) => status_with_context(ctx),
         Some(AuthCommand::Refresh) => refresh_with_context(ctx),
         Some(AuthCommand::Token) => token_with_context(ctx),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::cell::Cell;
+    use std::ffi::OsString;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &std::path::Path) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    std::env::set_var(self.key, previous);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
+    fn unix_now() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+
+    fn isolated_context() -> (tempfile::TempDir, EnvGuard, WorkspaceContext) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let guard = EnvGuard::set("PCB_CONFIG_DIR", tempdir.path());
+        (tempdir, guard, WorkspaceContext::default())
+    }
+
+    fn service_token(access_token: &str) -> AwsDiodeToken {
+        AwsDiodeToken {
+            access_token: access_token.to_string(),
+            expires_at: unix_now() + 3600,
+            aws_principal_arn: None,
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn no_auth_file_and_aws_exchange_success_returns_service_token() {
+        let (_tempdir, _guard, ctx) = isolated_context();
+        let aws_calls = Cell::new(0);
+        let refresh_calls = Cell::new(0);
+
+        let token = get_valid_token_with_sources(
+            &ctx,
+            |_| {
+                aws_calls.set(aws_calls.get() + 1);
+                Ok(service_token("aws-service-token"))
+            },
+            |_| {
+                refresh_calls.set(refresh_calls.get() + 1);
+                anyhow::bail!("refresh should not be called")
+            },
+        )
+        .unwrap();
+
+        assert_eq!(token, "aws-service-token");
+        assert_eq!(refresh_calls.get(), 0);
+        assert_eq!(aws_calls.get(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn expired_auth_file_refresh_failure_falls_back_to_aws_exchange() {
+        let (_tempdir, _guard, ctx) = isolated_context();
+        save_tokens(
+            &ctx,
+            "expired-token",
+            "refresh-token",
+            unix_now() - 3600,
+            Some("user@example.com"),
+        )
+        .unwrap();
+        let aws_calls = Cell::new(0);
+        let refresh_calls = Cell::new(0);
+
+        let token = get_valid_token_with_sources(
+            &ctx,
+            |_| {
+                aws_calls.set(aws_calls.get() + 1);
+                Ok(service_token("aws-service-token"))
+            },
+            |_| {
+                refresh_calls.set(refresh_calls.get() + 1);
+                anyhow::bail!("refresh failed")
+            },
+        )
+        .unwrap();
+
+        assert_eq!(token, "aws-service-token");
+        assert_eq!(refresh_calls.get(), 1);
+        assert_eq!(aws_calls.get(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn no_auth_file_and_aws_unavailable_returns_existing_error() {
+        let (_tempdir, _guard, ctx) = isolated_context();
+        let aws_calls = Cell::new(0);
+        let refresh_calls = Cell::new(0);
+
+        let err = get_valid_token_with_sources(
+            &ctx,
+            |_| {
+                aws_calls.set(aws_calls.get() + 1);
+                anyhow::bail!("aws unavailable")
+            },
+            |_| {
+                refresh_calls.set(refresh_calls.get() + 1);
+                anyhow::bail!("refresh should not be called")
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), NOT_AUTHENTICATED_MESSAGE);
+        assert_eq!(refresh_calls.get(), 0);
+        assert_eq!(aws_calls.get(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn valid_auth_file_does_not_call_aws_exchange() {
+        let (_tempdir, _guard, ctx) = isolated_context();
+        save_tokens(
+            &ctx,
+            "local-token",
+            "refresh-token",
+            unix_now() + 3600,
+            Some("user@example.com"),
+        )
+        .unwrap();
+        let aws_calls = Cell::new(0);
+        let refresh_calls = Cell::new(0);
+
+        let token = get_valid_token_with_sources(
+            &ctx,
+            |_| {
+                aws_calls.set(aws_calls.get() + 1);
+                anyhow::bail!("aws should not be called")
+            },
+            |_| {
+                refresh_calls.set(refresh_calls.get() + 1);
+                anyhow::bail!("refresh should not be called")
+            },
+        )
+        .unwrap();
+
+        assert_eq!(token, "local-token");
+        assert_eq!(refresh_calls.get(), 0);
+        assert_eq!(aws_calls.get(), 0);
     }
 }

--- a/crates/pcb-diode-api/src/auth.rs
+++ b/crates/pcb-diode-api/src/auth.rs
@@ -33,21 +33,25 @@ impl AuthTokens {
     }
 
     pub fn time_until_expiry(&self) -> String {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-        let remaining = self.expires_at - now;
+        time_until_expiry(self.expires_at)
+    }
+}
 
-        if remaining <= 0 {
-            "expired".to_string()
-        } else if remaining < 3600 {
-            format!("{} minutes", remaining / 60)
-        } else if remaining < 86400 {
-            format!("{} hours", remaining / 3600)
-        } else {
-            format!("{} days", remaining / 86400)
-        }
+fn time_until_expiry(expires_at: i64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let remaining = expires_at - now;
+
+    if remaining <= 0 {
+        "expired".to_string()
+    } else if remaining < 3600 {
+        format!("{} minutes", remaining / 60)
+    } else if remaining < 86400 {
+        format!("{} hours", remaining / 3600)
+    } else {
+        format!("{} days", remaining / 86400)
     }
 }
 
@@ -299,9 +303,9 @@ pub fn logout() -> Result<()> {
 }
 
 pub fn status_with_context(ctx: &WorkspaceContext) -> Result<()> {
+    println!("Authentication Status:");
     match load_tokens_with_context(ctx)? {
         Some(tokens) => {
-            println!("Authentication Status:");
             println!("  Status: Logged in");
             if let Some(email) = &tokens.email {
                 println!("  Email: {}", email);
@@ -313,11 +317,23 @@ pub fn status_with_context(ctx: &WorkspaceContext) -> Result<()> {
                 println!("  Token expires in: {}", tokens.time_until_expiry());
             }
         }
-        None => {
-            println!("Authentication Status:");
-            println!("  Status: Not logged in");
-            println!("\nRun `pcb auth login` to authenticate.");
-        }
+        None => match aws_auth::get_service_token(ctx) {
+            Ok(token) => {
+                println!("  Status: Logged in");
+                println!("  Method: AWS credentials");
+                if let Some(aws_principal_arn) = &token.aws_principal_arn {
+                    println!("  AWS principal: {}", aws_principal_arn);
+                }
+                println!(
+                    "  Token expires in: {}",
+                    time_until_expiry(token.expires_at)
+                );
+            }
+            Err(_) => {
+                println!("  Status: Not logged in");
+                println!("\nRun `pcb auth login` to authenticate.");
+            }
+        },
     }
     Ok(())
 }

--- a/crates/pcb-diode-api/src/aws_auth.rs
+++ b/crates/pcb-diode-api/src/aws_auth.rs
@@ -21,6 +21,8 @@ use std::time::SystemTime;
 use crate::WorkspaceContext;
 
 const SERVICE_TOKEN_EXPIRY_SKEW_SECONDS: i64 = 120;
+const AWS_AUTH_AUDIENCE_HEADER: &str = "x-diode-audience";
+const AWS_AUTH_AUDIENCE: &str = "diode-api/aws-auth/v1";
 
 #[derive(Debug, Clone)]
 pub(crate) struct AwsDiodeToken {
@@ -267,10 +269,16 @@ fn build_identity_proof() -> Result<AwsIdentityProofWithCacheKey> {
             .into();
 
         let mut url = sts_get_caller_identity_url(region);
+        let proof_headers = [(
+            AWS_AUTH_AUDIENCE_HEADER.to_string(),
+            AWS_AUTH_AUDIENCE.to_string(),
+        )];
         let signable_request = SignableRequest::new(
             "GET",
             url.as_str(),
-            std::iter::empty(),
+            proof_headers
+                .iter()
+                .map(|(name, value)| (name.as_str(), value.as_str())),
             SignableBody::empty(),
         )
         .context("Failed to build signable STS request")?;
@@ -286,7 +294,7 @@ fn build_identity_proof() -> Result<AwsIdentityProofWithCacheKey> {
             proof: AwsIdentityProof {
                 method: "GET".to_string(),
                 url: url.to_string(),
-                headers: HashMap::new(),
+                headers: proof_headers.into_iter().collect(),
                 body: String::new(),
             },
             cache_discriminator,

--- a/crates/pcb-diode-api/src/aws_auth.rs
+++ b/crates/pcb-diode-api/src/aws_auth.rs
@@ -146,7 +146,7 @@ pub(crate) fn clear_service_token(ctx: &WorkspaceContext) -> Result<()> {
         cache.retain(|key, _| !key.starts_with(&cache_prefix));
     }
 
-    let service_auth_dir = service_auth_dir()?;
+    let service_auth_dir = service_auth_dir_path()?;
     if !service_auth_dir.exists() {
         return Ok(());
     }
@@ -180,14 +180,18 @@ fn cache_token(cache_key: String, token: AwsDiodeToken) {
     }
 }
 
-fn service_auth_dir() -> Result<PathBuf> {
+fn service_auth_dir_path() -> Result<PathBuf> {
     let pcb_dir = if let Ok(config_dir) = std::env::var("PCB_CONFIG_DIR") {
         PathBuf::from(config_dir)
     } else {
         let home_dir = dirs::home_dir().context("Failed to get home directory")?;
         home_dir.join(".pcb")
     };
-    let service_auth_dir = pcb_dir.join("service-auth");
+    Ok(pcb_dir.join("service-auth"))
+}
+
+fn service_auth_dir() -> Result<PathBuf> {
+    let service_auth_dir = service_auth_dir_path()?;
     fs::create_dir_all(&service_auth_dir)?;
     Ok(service_auth_dir)
 }

--- a/crates/pcb-diode-api/src/aws_auth.rs
+++ b/crates/pcb-diode-api/src/aws_auth.rs
@@ -1,0 +1,429 @@
+use anyhow::{Context, Result};
+use aws_config::BehaviorVersion;
+use aws_config::meta::region::RegionProviderChain;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_sigv4::http_request::{
+    SignableBody, SignableRequest, SignatureLocation, SigningSettings, sign,
+};
+use aws_sigv4::sign::v4;
+use aws_smithy_runtime_api::client::identity::Identity;
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+use std::time::SystemTime;
+
+use crate::WorkspaceContext;
+
+const SERVICE_TOKEN_EXPIRY_SKEW_SECONDS: i64 = 120;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AwsDiodeToken {
+    pub access_token: String,
+    pub expires_at: i64,
+    pub aws_principal_arn: Option<String>,
+}
+
+impl AwsDiodeToken {
+    pub fn is_valid_for_use(&self) -> bool {
+        self.expires_at - unix_now() > SERVICE_TOKEN_EXPIRY_SKEW_SECONDS
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AwsIdentityProof {
+    method: String,
+    url: String,
+    headers: HashMap<String, String>,
+    body: String,
+}
+
+struct AwsIdentityProofWithCacheKey {
+    proof: AwsIdentityProof,
+    cache_discriminator: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AwsExchangeResponse {
+    access_token: String,
+    expires_at: i64,
+    aws_principal_arn: Option<String>,
+    principal: Option<AwsExchangePrincipal>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AwsExchangePrincipal {
+    arn: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedAwsDiodeToken {
+    access_token: String,
+    expires_at: i64,
+    source: String,
+    aws_principal_arn: Option<String>,
+}
+
+impl From<&AwsDiodeToken> for CachedAwsDiodeToken {
+    fn from(token: &AwsDiodeToken) -> Self {
+        Self {
+            access_token: token.access_token.clone(),
+            expires_at: token.expires_at,
+            source: "aws".to_string(),
+            aws_principal_arn: token.aws_principal_arn.clone(),
+        }
+    }
+}
+
+impl TryFrom<CachedAwsDiodeToken> for AwsDiodeToken {
+    type Error = anyhow::Error;
+
+    fn try_from(token: CachedAwsDiodeToken) -> Result<Self> {
+        anyhow::ensure!(
+            token.source == "aws",
+            "service token cache source is not AWS"
+        );
+        Ok(Self {
+            access_token: token.access_token,
+            expires_at: token.expires_at,
+            aws_principal_arn: token.aws_principal_arn,
+        })
+    }
+}
+
+static TOKEN_CACHE: OnceLock<Mutex<HashMap<String, AwsDiodeToken>>> = OnceLock::new();
+
+pub(crate) fn get_service_token(ctx: &WorkspaceContext) -> Result<AwsDiodeToken> {
+    let proof = build_identity_proof()?;
+    let cache_key = format!("{}:{}", ctx.api_base_url(), proof.cache_discriminator);
+    if let Some(token) = cached_token(&cache_key) {
+        return Ok(token);
+    }
+
+    if let Some(token) = load_cached_service_token(ctx, &proof.cache_discriminator)? {
+        cache_token(cache_key, token.clone());
+        return Ok(token);
+    }
+
+    let url = format!("{}/api/auth/aws/exchange", ctx.api_base_url());
+    let response = Client::new()
+        .post(&url)
+        .json(&proof.proof)
+        .send()
+        .context("Failed to exchange AWS identity proof")?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("AWS identity exchange failed: {}", response.status());
+    }
+
+    let response: AwsExchangeResponse = response
+        .json()
+        .context("Failed to decode AWS identity exchange response")?;
+    let token = AwsDiodeToken {
+        access_token: response.access_token,
+        expires_at: response.expires_at,
+        aws_principal_arn: response
+            .aws_principal_arn
+            .or_else(|| response.principal.map(|principal| principal.arn)),
+    };
+    save_cached_service_token(ctx, &proof.cache_discriminator, &token)?;
+    cache_token(cache_key, token.clone());
+    Ok(token)
+}
+
+pub(crate) fn clear_service_token(ctx: &WorkspaceContext) -> Result<()> {
+    let api_slug = crate::endpoint::auth_scope_slug(ctx.api_base_url());
+    if let Ok(mut cache) = TOKEN_CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+    {
+        let cache_prefix = format!("{}:", ctx.api_base_url());
+        cache.retain(|key, _| !key.starts_with(&cache_prefix));
+    }
+
+    let service_auth_dir = service_auth_dir()?;
+    if !service_auth_dir.exists() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(service_auth_dir)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if file_name == format!("{api_slug}.toml")
+            || (file_name.starts_with(&format!("{api_slug}-")) && file_name.ends_with(".toml"))
+        {
+            fs::remove_file(entry.path())?;
+        }
+    }
+
+    Ok(())
+}
+
+fn cached_token(cache_key: &str) -> Option<AwsDiodeToken> {
+    let cache = TOKEN_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let token = cache.lock().ok()?.get(cache_key).cloned()?;
+    token.is_valid_for_use().then_some(token)
+}
+
+fn cache_token(cache_key: String, token: AwsDiodeToken) {
+    if let Ok(mut cache) = TOKEN_CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+    {
+        cache.insert(cache_key, token);
+    }
+}
+
+fn service_auth_dir() -> Result<PathBuf> {
+    let pcb_dir = if let Ok(config_dir) = std::env::var("PCB_CONFIG_DIR") {
+        PathBuf::from(config_dir)
+    } else {
+        let home_dir = dirs::home_dir().context("Failed to get home directory")?;
+        home_dir.join(".pcb")
+    };
+    let service_auth_dir = pcb_dir.join("service-auth");
+    fs::create_dir_all(&service_auth_dir)?;
+    Ok(service_auth_dir)
+}
+
+fn service_auth_file_path(ctx: &WorkspaceContext, cache_discriminator: &str) -> Result<PathBuf> {
+    let slug = crate::endpoint::auth_scope_slug(ctx.api_base_url());
+    Ok(service_auth_dir()?.join(format!("{slug}-{cache_discriminator}.toml")))
+}
+
+fn load_cached_service_token(
+    ctx: &WorkspaceContext,
+    cache_discriminator: &str,
+) -> Result<Option<AwsDiodeToken>> {
+    let path = service_auth_file_path(ctx, cache_discriminator)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let contents = fs::read_to_string(&path)?;
+    let token = AwsDiodeToken::try_from(toml::from_str::<CachedAwsDiodeToken>(&contents)?)?;
+    Ok(token.is_valid_for_use().then_some(token))
+}
+
+fn save_cached_service_token(
+    ctx: &WorkspaceContext,
+    cache_discriminator: &str,
+    token: &AwsDiodeToken,
+) -> Result<()> {
+    let path = service_auth_file_path(ctx, cache_discriminator)?;
+    let contents = toml::to_string(&CachedAwsDiodeToken::from(token))?;
+    atomicwrites::AtomicFile::new(&path, atomicwrites::OverwriteBehavior::AllowOverwrite)
+        .write(|f| {
+            f.write_all(contents.as_bytes())?;
+            f.flush()
+        })
+        .map_err(|err| anyhow::anyhow!("Failed to write AWS service auth token: {err}"))?;
+    Ok(())
+}
+
+fn build_identity_proof() -> Result<AwsIdentityProofWithCacheKey> {
+    let runtime = tokio::runtime::Runtime::new().context("Failed to create AWS auth runtime")?;
+    runtime.block_on(async {
+        let region_provider = RegionProviderChain::default_provider().or_else("us-west-2");
+        let config = aws_config::defaults(BehaviorVersion::latest())
+            .region(region_provider)
+            .load()
+            .await;
+        let credentials = config
+            .credentials_provider()
+            .context("AWS credentials are unavailable")?
+            .provide_credentials()
+            .await
+            .context("AWS credentials are unavailable")?;
+        let cache_discriminator = aws_cache_discriminator(credentials.access_key_id());
+        let identity: Identity = credentials.into();
+        let region = config
+            .region()
+            .map(|region| region.as_ref())
+            .unwrap_or("us-west-2");
+
+        let mut signing_settings = SigningSettings::default();
+        signing_settings.signature_location = SignatureLocation::QueryParams;
+        signing_settings.expires_in = Some(Duration::from_secs(60));
+
+        let signing_params = v4::SigningParams::builder()
+            .identity(&identity)
+            .region(region)
+            .name("sts")
+            .time(SystemTime::now())
+            .settings(signing_settings)
+            .build()
+            .context("Failed to build STS signing parameters")?
+            .into();
+
+        let mut url = sts_get_caller_identity_url(region);
+        let signable_request = SignableRequest::new(
+            "GET",
+            url.as_str(),
+            std::iter::empty(),
+            SignableBody::empty(),
+        )
+        .context("Failed to build signable STS request")?;
+        let (signing_instructions, _signature) = sign(signable_request, &signing_params)
+            .context("Failed to create presigned STS GetCallerIdentity proof")?
+            .into_parts();
+
+        for (name, value) in signing_instructions.into_parts().1 {
+            url.query_pairs_mut().append_pair(name, &value);
+        }
+
+        Ok(AwsIdentityProofWithCacheKey {
+            proof: AwsIdentityProof {
+                method: "GET".to_string(),
+                url: url.to_string(),
+                headers: HashMap::new(),
+                body: String::new(),
+            },
+            cache_discriminator,
+        })
+    })
+}
+
+fn aws_cache_discriminator(access_key_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(access_key_id.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn sts_get_caller_identity_url(region: &str) -> url::Url {
+    let mut url =
+        url::Url::parse(&format!("https://sts.{region}.amazonaws.com/")).expect("STS URL is valid");
+    url.query_pairs_mut()
+        .append_pair("Action", "GetCallerIdentity")
+        .append_pair("Version", "2011-06-15");
+    url
+}
+
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::ffi::OsString;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &std::path::Path) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    std::env::set_var(self.key, previous);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
+    fn isolated_context() -> (tempfile::TempDir, EnvGuard, WorkspaceContext) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let guard = EnvGuard::set("PCB_CONFIG_DIR", tempdir.path());
+        (tempdir, guard, WorkspaceContext::default())
+    }
+
+    fn test_token(expires_at: i64) -> AwsDiodeToken {
+        AwsDiodeToken {
+            access_token: "cached-service-token".to_string(),
+            expires_at,
+            aws_principal_arn: Some(
+                "arn:aws:sts::123456789012:assumed-role/example/session".to_string(),
+            ),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn service_token_cache_round_trips_under_service_auth_dir() {
+        let (tempdir, _guard, ctx) = isolated_context();
+        let token = test_token(unix_now() + 3600);
+        let cache_discriminator = "aws-principal-a";
+
+        save_cached_service_token(&ctx, cache_discriminator, &token).unwrap();
+        let loaded = load_cached_service_token(&ctx, cache_discriminator)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(loaded.access_token, token.access_token);
+        assert_eq!(loaded.aws_principal_arn, token.aws_principal_arn);
+        assert!(
+            service_auth_file_path(&ctx, cache_discriminator)
+                .unwrap()
+                .starts_with(tempdir.path().join("service-auth"))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn service_token_cache_ignores_tokens_near_expiry() {
+        let (_tempdir, _guard, ctx) = isolated_context();
+        let cache_discriminator = "aws-principal-a";
+        save_cached_service_token(&ctx, cache_discriminator, &test_token(unix_now() + 60)).unwrap();
+
+        assert!(
+            load_cached_service_token(&ctx, cache_discriminator)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn service_token_cache_is_scoped_by_aws_cache_discriminator() {
+        let (_tempdir, _guard, ctx) = isolated_context();
+        let token = test_token(unix_now() + 3600);
+
+        save_cached_service_token(&ctx, "aws-principal-a", &token).unwrap();
+
+        assert!(
+            load_cached_service_token(&ctx, "aws-principal-b")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn clear_service_token_removes_service_auth_cache_for_api_scope() {
+        let (_tempdir, _guard, ctx) = isolated_context();
+        let token = test_token(unix_now() + 3600);
+
+        save_cached_service_token(&ctx, "aws-principal-a", &token).unwrap();
+        clear_service_token(&ctx).unwrap();
+
+        assert!(
+            load_cached_service_token(&ctx, "aws-principal-a")
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use rusqlite::auto_extension::{RawAutoExtension, register_auto_extension};
 
 pub mod auth;
+mod aws_auth;
 pub mod bom;
 pub mod component;
 pub mod datasheet;


### PR DESCRIPTION
Support service API authentication by exchanging a presigned GetCallerIdentity request for a JWT from the server.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new AWS SigV4-based auth path and token caching/fallback logic, changing how API access tokens are obtained and stored. This touches authentication flows and introduces new dependencies/runtime behavior (Tokio + AWS SDK), so regressions could block access or leak/scoped tokens incorrectly.
> 
> **Overview**
> Adds **AWS-credential-based API authentication** by generating a presigned STS `GetCallerIdentity` proof and exchanging it for a Diode JWT (`/api/auth/aws/exchange`), with on-disk + in-memory caching scoped per API endpoint and AWS access key.
> 
> Updates existing auth token retrieval to **prefer stored CLI tokens when valid**, refresh when expired, and **fall back to AWS auth** when no tokens exist or refresh fails; `pcb auth status` and `logout` now reflect/clear AWS-based auth as well. Workspace dependencies are expanded to include AWS SDK/SigV4 crates and `tokio`, and unit tests were added around the new selection and caching behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80ec8054d5199509dd3c92a553d4a55e9737b259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->