### PR TITLE
Refresh local search indexes before CLI search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Added SOD-882 TVS diodes with capacitance-based BOM matching.
 
+### Fixed
+
+- `pcb search` now refreshes stale local registry and KiCad indexes before non-interactive searches.
+
 ## [0.3.75] - 2026-05-02
 
 ### Added

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -1348,12 +1348,33 @@ fn execute_search(
         None => SearchMode::WebComponents,
     };
 
+    refresh_search_index_if_stale(effective_mode, registry_index);
+
     match effective_mode {
         SearchMode::RegistryModules | SearchMode::RegistryComponents => {
             execute_registry_search_filtered(query, json, effective_mode, registry_index)
         }
         SearchMode::KicadSymbols => execute_kicad_symbols_search(query, json),
         SearchMode::WebComponents => execute_web_search(query, json),
+    }
+}
+
+fn refresh_search_index_if_stale(
+    mode: crate::registry::tui::SearchMode,
+    registry_index: Option<&Path>,
+) {
+    use crate::registry::tui::SearchMode;
+
+    match mode {
+        SearchMode::RegistryModules | SearchMode::RegistryComponents => {
+            if registry_index.is_none() {
+                let _ = crate::RegistryClient::refresh_if_stale();
+            }
+        }
+        SearchMode::KicadSymbols => {
+            let _ = crate::KicadSymbolsClient::refresh_if_stale();
+        }
+        SearchMode::WebComponents => {}
     }
 }
 

--- a/crates/pcb-diode-api/src/download_support.rs
+++ b/crates/pcb-diode-api/src/download_support.rs
@@ -129,6 +129,15 @@ pub(crate) fn save_local_version(db_path: &Path, version: &str, label: &str) -> 
     Ok(())
 }
 
+pub(crate) fn sha256_version_token(sha256: &str, label: &str) -> Result<String> {
+    let sha256 = sha256.trim();
+    if !sha256.is_empty() {
+        return Ok(sha256.to_string());
+    }
+
+    anyhow::bail!("{label} metadata missing sha256")
+}
+
 pub(crate) fn ensure_parent_dir(dest_path: &Path, label: &str) -> Result<()> {
     if let Some(parent) = dest_path.parent() {
         fs::create_dir_all(parent)

--- a/crates/pcb-diode-api/src/kicad_symbols/download.rs
+++ b/crates/pcb-diode-api/src/kicad_symbols/download.rs
@@ -26,12 +26,7 @@ pub struct KicadSymbolsIndexMetadata {
 impl KicadSymbolsIndexMetadata {
     /// Stable token for local freshness checks.
     pub fn version_token(&self) -> Result<String> {
-        let sha256 = self.sha256.trim();
-        if !sha256.is_empty() {
-            return Ok(sha256.to_string());
-        }
-
-        anyhow::bail!("KiCad symbols index metadata missing sha256")
+        crate::download_support::sha256_version_token(&self.sha256, "KiCad symbols index")
     }
 }
 

--- a/crates/pcb-diode-api/src/registry/download.rs
+++ b/crates/pcb-diode-api/src/registry/download.rs
@@ -10,6 +10,8 @@ use serde::Deserialize;
 use std::path::Path;
 use std::sync::mpsc::Sender;
 
+const REGISTRY_INDEX_ROUTE: &str = "/api/registry/index";
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct RegistryIndexMetadata {
     pub url: String,
@@ -19,6 +21,13 @@ pub struct RegistryIndexMetadata {
     #[serde(rename = "expiresAt")]
     #[allow(dead_code)]
     pub expires_at: String,
+}
+
+impl RegistryIndexMetadata {
+    /// Stable token for local freshness checks.
+    pub fn version_token(&self) -> Result<String> {
+        crate::download_support::sha256_version_token(&self.sha256, "registry index")
+    }
 }
 
 pub fn load_local_version(db_path: &Path) -> Option<String> {
@@ -34,18 +43,30 @@ pub fn fetch_registry_index_metadata() -> Result<RegistryIndexMetadata> {
     let token = crate::auth::get_valid_token().context("Auth failed")?;
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
-    let url = format!("{}/api/registry/index", api_url);
+    let url = format!("{api_url}{REGISTRY_INDEX_ROUTE}");
 
     let resp = client
         .get(&url)
         .bearer_auth(&token)
         .send()
-        .with_context(|| format!("Request to {} failed", url))?
+        .with_context(|| format!("Request to {url} failed"))?
         .error_for_status()
-        .with_context(|| format!("API error from {}", url))?;
+        .with_context(|| format!("API error from {url}"))?;
 
     resp.json()
         .context("Failed to parse registry index metadata")
+}
+
+fn download_index_response(
+    client: &reqwest::blocking::Client,
+    index_url: &str,
+) -> Result<reqwest::blocking::Response> {
+    client
+        .get(index_url)
+        .send()
+        .context("Failed to download registry index")?
+        .error_for_status()
+        .context("S3 returned error when downloading registry index")
 }
 
 /// Result of checking registry access
@@ -63,13 +84,13 @@ pub fn check_registry_access() -> Result<RegistryAccessResult> {
         .context("Authentication required. Run `pcb auth` to log in.")?;
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
-    let url = format!("{}/api/registry/index", api_url);
+    let url = format!("{api_url}{REGISTRY_INDEX_ROUTE}");
 
     let resp = client
         .get(&url)
         .bearer_auth(&token)
         .send()
-        .with_context(|| format!("Request to {} failed", url))?;
+        .with_context(|| format!("Request to {url} failed"))?;
 
     match resp.status() {
         reqwest::StatusCode::FORBIDDEN => Ok(RegistryAccessResult::Forbidden),
@@ -84,7 +105,7 @@ pub fn check_registry_access() -> Result<RegistryAccessResult> {
         }
         _ => {
             resp.error_for_status()
-                .with_context(|| format!("API error from {}", url))?;
+                .with_context(|| format!("API error from {url}"))?;
             unreachable!()
         }
     }
@@ -113,52 +134,22 @@ pub fn download_registry_index_with_progress(
 
     let client = http_client()?;
 
-    // Use pre-fetched metadata or fetch from API
-    let index_metadata: RegistryIndexMetadata = if let Some(meta) = prefetched_metadata {
+    let index_metadata = if let Some(meta) = prefetched_metadata {
         meta.clone()
     } else {
-        let token = match crate::auth::get_valid_token() {
-            Ok(t) => t,
-            Err(e) => {
-                let msg = format!("Auth required: {}", e);
-                send_progress(None, true, Some(msg.clone()));
-                anyhow::bail!(msg);
-            }
-        };
-
-        let api_url = crate::get_api_base_url();
-        match client
-            .get(format!("{}/api/registry/index", api_url))
-            .bearer_auth(&token)
-            .send()
-            .and_then(|r| r.error_for_status())
-        {
-            Ok(resp) => match resp.json() {
-                Ok(j) => j,
-                Err(e) => {
-                    let msg = format!("Failed to parse index response: {}", e);
-                    send_progress(None, true, Some(msg.clone()));
-                    anyhow::bail!(msg);
-                }
-            },
-            Err(e) => {
-                let msg = format!("Failed to fetch index URL: {}", e);
-                send_progress(None, true, Some(msg.clone()));
-                anyhow::bail!(msg);
-            }
-        }
+        fetch_registry_index_metadata().map_err(|e| {
+            let msg = format!("Failed to fetch registry index URL: {e}");
+            send_progress(None, true, Some(msg.clone()));
+            anyhow::anyhow!(msg)
+        })?
     };
 
     ensure_parent_dir(dest_path, "registry")?;
 
-    let response = match client
-        .get(&index_metadata.url)
-        .send()
-        .and_then(|r| r.error_for_status())
-    {
+    let response = match download_index_response(&client, &index_metadata.url) {
         Ok(r) => r,
         Err(e) => {
-            let msg = format!("Failed to download from S3: {}", e);
+            let msg = format!("Failed to download registry index: {e}");
             send_progress(None, true, Some(msg.clone()));
             anyhow::bail!(msg);
         }
@@ -170,7 +161,8 @@ pub fn download_registry_index_with_progress(
     let progress_reader = ProgressReader::new(response, total_size, &send_progress);
     write_decoded_index(dest_path, progress_reader, "registry index")?;
 
-    let _ = save_local_version(dest_path, &index_metadata.sha256);
+    let version_token = index_metadata.version_token()?;
+    let _ = save_local_version(dest_path, &version_token);
 
     send_progress(Some(100), true, None);
     Ok(())
@@ -183,10 +175,11 @@ pub fn download_registry_index(dest_path: &Path) -> Result<()> {
 
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
+    let url = format!("{api_url}{REGISTRY_INDEX_ROUTE}");
 
     eprintln!("Fetching registry index URL...");
     let index_metadata: RegistryIndexMetadata = client
-        .get(format!("{}/api/registry/index", api_url))
+        .get(&url)
         .bearer_auth(&token)
         .send()
         .context("Failed to fetch registry index URL")?
@@ -198,12 +191,7 @@ pub fn download_registry_index(dest_path: &Path) -> Result<()> {
     ensure_parent_dir(dest_path, "registry")?;
 
     eprintln!("Downloading parts.db.zst...");
-    let response = client
-        .get(&index_metadata.url)
-        .send()
-        .context("Failed to download registry index from S3")?
-        .error_for_status()
-        .context("S3 returned error when downloading registry index")?;
+    let response = download_index_response(&client, &index_metadata.url)?;
 
     let total_size = response.content_length();
 
@@ -212,6 +200,31 @@ pub fn download_registry_index(dest_path: &Path) -> Result<()> {
     write_decoded_index(dest_path, progress_reader, "registry index")?;
     eprintln!();
 
+    let version_token = index_metadata.version_token()?;
+    save_local_version(dest_path, &version_token)?;
+
     eprintln!("Registry index downloaded successfully.");
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshResult {
+    UpToDate,
+    Downloaded,
+}
+
+/// Refresh the local registry index when the server-side version changes.
+pub fn refresh_registry_index_if_stale(dest_path: &Path) -> Result<RefreshResult> {
+    let meta = fetch_registry_index_metadata()?;
+    let remote_version = meta.version_token()?;
+    let local_version = load_local_version(dest_path);
+
+    if dest_path.exists() && local_version.as_deref() == Some(remote_version.as_str()) {
+        return Ok(RefreshResult::UpToDate);
+    }
+
+    let (progress_tx, progress_rx) = std::sync::mpsc::channel();
+    let _ = progress_rx;
+    download_registry_index_with_progress(dest_path, &progress_tx, true, Some(&meta))?;
+    Ok(RefreshResult::Downloaded)
 }

--- a/crates/pcb-diode-api/src/registry/mod.rs
+++ b/crates/pcb-diode-api/src/registry/mod.rs
@@ -425,6 +425,12 @@ impl RegistryClient {
         Ok(home.join(".pcb").join("registry").join("packages.db"))
     }
 
+    /// Refresh the default registry index when the server-side version changes.
+    pub fn refresh_if_stale() -> Result<download::RefreshResult> {
+        let path = Self::default_db_path()?;
+        download::refresh_registry_index_if_stale(&path)
+    }
+
     pub fn open() -> Result<Self> {
         let path = Self::default_db_path()?;
         if !path.exists() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds automatic pre-search refresh behavior that can trigger network calls and index downloads, which may affect CLI latency and error modes in non-interactive flows.
> 
> **Overview**
> Non-interactive `pcb search` now proactively refreshes the local registry and KiCad symbol indexes when they’re stale (skipping refresh when `--registry-index` is provided).
> 
> Registry index download logic is refactored to share a SHA-based version token helper, centralize the index route constant, and add `refresh_registry_index_if_stale()`/`RegistryClient::refresh_if_stale()` for on-demand freshness checks; changelog updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b94f6695d4e161c6cd1a8991fdb7a89e900673d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->