### PR TITLE
Round up auto-assigned cap voltage ratings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,51 @@
 # AGENTS.md
 
-This file gives repository-wide instructions to coding agents. Keep it focused on stable, high-value guidance; add a nested `AGENTS.md` only when a subdirectory truly needs different rules.
+## PCB CLI Subcommands
 
-## Project Commands
+- `cargo run -p pcb -- build [PATHS...]` — build and validate Zener designs.
+- `cargo run -p pcb -- test [PATHS...]` — run tests declared in `.zen` files.
+- `cargo run -p pcb -- fmt [PATHS...]` — format `.zen` files.
+- `cargo run -p pcb -- layout --no-open [PATHS...]` — generate/update KiCad layout files without opening KiCad.
 
-- `cargo run -p pcb -- build [PATHS...]` — build and validate `.zen` designs
-- `cargo run -p pcb -- fmt [PATHS...]` — format `.zen` files
-- `cargo run -p pcb -- layout [PATHS...]` — generate layout files
+## Development Workflow
+
+- `cargo test -p <crate>` — run tests for one crate.
+- `cargo fmt` — format Rust code.
+- `uv run pytest crates/pcb-layout/src/scripts/lens/tests/ -v` — run the Python layout-lens tests when changing `crates/pcb-layout/src/scripts/lens/`.
 
 Never run `cargo insta accept` without explicit user approval.
 
-## Repository Map
+## Where to Look
 
-- `crates/pcb` is the main CLI crate.
-- `crates/pcb-zen` and `crates/pcb-zen-core` implement the Zener language runtime and core semantics.
-- `crates/pcb-sch`, `crates/pcb-layout`, and `crates/pcb-kicad` cover schematic, layout, and KiCad integration.
-- `stdlib/` contains the Zener standard library.
-- `examples/` contains runnable example designs.
-- `docs/pages/` contains user-facing documentation, including the language specification in `docs/pages/spec.mdx`.
+- Start with `README.md` for product context and user-facing CLI behavior.
+- `crates/pcb/src/main.rs` declares CLI subcommands; each subcommand usually has a matching file in `crates/pcb/src/` (`build.rs`, `layout.rs`, `fmt.rs`, `test.rs`, etc.).
+- `crates/pcb-zen-core/src/lang/` contains Zener built-ins, core values, type conversion, validation, and evaluation semantics. Check `docs/pages/spec.mdx` when changing user-visible language behavior.
+- `crates/pcb-zen/src/` provides higher-level workspace/dependency resolution, package cache, diagnostics plumbing, and LSP integration around `pcb-zen-core`.
+- `crates/pcb-sch/src/` is the schematic/netlist data model, BOM helpers, KiCad netlist export, and `# pcb:sch` comment handling.
+- `crates/pcb-layout/src/` generates and synchronizes KiCad layouts. The Python lens implementation is in `crates/pcb-layout/src/scripts/lens/`; read `crates/pcb-layout/README.md` before changing sync behavior.
+- `crates/pcb-kicad/src/` wraps KiCad tooling and KiCad-specific checks; `crates/pcb-sexpr/src/` handles low-level S-expression parsing/rewriting for KiCad files.
+- `crates/pcb/src/import/` implements `pcb import`; start with `crates/pcb/src/import/README.md` and `flow.rs` before changing the import pipeline.
+- `crates/pcb-eda/` and `crates/pcb-component-gen/` handle external EDA artifacts and generated Zener component modules.
+- `crates/pcb-diode-api/` contains API/auth/search/BOM-matching client logic.
+- `stdlib/` contains the Zener standard library; `examples/` and `test-workspaces/` are useful runnable designs.
+- Use `docs/pages/packages.mdx` for workspace, dependency, and package behavior.
 
 ## Working Rules
 
-- Prefer the smallest correct change over broad refactors.
-- Match the existing crate and module boundaries unless a structural change is clearly necessary.
-- In `.zen` files, remember that Zener is Starlark-based, not Python: do not use f-strings.
-- Avoid editing generated artifacts, vendored code, or snapshot outputs unless the task specifically requires it.
-- The project depends on a fork of `starlark-rust` (`diodeinc/starlark-rust`); check that fork when language behavior appears to come from upstream Starlark internals rather than this repository.
+- Prefer the smallest correct change and match existing crate/module boundaries.
+- Avoid adding cross-crate abstractions until a boundary is already shared in the existing code.
+- In `.zen` files, remember Zener is Starlark-based, not Python: do not use f-strings.
+- Language behavior may come from the pinned `diodeinc/starlark-rust` fork in `Cargo.toml`; check that fork when local code does not explain Starlark behavior.
 
 ## Documentation Rules
 
-- Add at most one `CHANGELOG.md` entry per PR under `Unreleased`, and keep it succinct and minimal while covering the user-visible change set as a whole.
-- If you change Zener language syntax, built-ins, core types, module/import behavior, type rules, or other user-visible language semantics, update `docs/pages/spec.mdx` in the same change.
-- If you change workspace manifests, dependency resolution, or package behavior, update the relevant docs in `docs/pages/`, especially `docs/pages/packages.mdx` when applicable.
-- Keep documentation updates concrete and example-driven; do not leave behavior changes documented only in code.
+- For user-visible changes, add one succinct `CHANGELOG.md` entry under `Unreleased` per logical change.
+- If you change Zener syntax, built-ins, core types, imports/modules, or type rules, update `docs/pages/spec.mdx`.
+- If you change workspace manifests, dependency resolution, or package behavior, update the relevant docs in `docs/pages/`, especially `docs/pages/packages.mdx`.
+- If you change stdlib APIs or examples, prefer a focused docs/example update over broad documentation churn.
 
 ## Verification
 
-- Run the narrowest relevant check first, usually `cargo test -p <crate>` or a focused `cargo run -p pcb -- ...` command.
-- Do not run the full workspace verification suite after every small edit.
-- Before committing or pushing a meaningful batch of changes, run `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo nextest run --no-fail-fast`.
-- If snapshot tests change, call that out clearly in your summary and leave acceptance to the user.
-
-## References
-
-- Start with `README.md` for the product-level overview.
-- Use `docs/pages/spec.mdx` for language semantics.
-- Use `docs/pages/packages.mdx` for workspace, dependency, and package behavior.
+- Run the narrowest relevant check first: usually `cargo test -p <crate>`, a focused `cargo run -p pcb -- ...` command, or the layout-lens pytest command above.
+- Do not run full-workspace checks after every small edit.
+- If snapshot tests change, call that out and leave snapshot acceptance to the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - KiCad CLI discovery now checks `PATH` before platform fallbacks.
 - `pcb search` now refreshes stale local registry and KiCad indexes before non-interactive searches.
 - `pcb layout` no longer fails when KiCad groups contain generated tuning-pattern items.
+- Capacitor auto voltage ratings now round the 1.5x net-voltage requirement up to common capacitor voltage tiers.
 
 ## [0.3.75] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Added SOD-882 TVS diodes with capacitance-based BOM matching.
 
+### Changed
+
+- Capacitors now warn when explicit voltage ratings are below the inferred 1.5x rounded net-voltage requirement.
+
 ### Fixed
 
 - KiCad CLI discovery now checks `PATH` before platform fallbacks.

--- a/stdlib/generics/Capacitor.zen
+++ b/stdlib/generics/Capacitor.zen
@@ -1,7 +1,7 @@
 load("../io.zen", "io")
 load("../interfaces.zen", "Net")
 load("../units.zen", "Capacitance", "Inductance", "Resistance", "Temperature", "Voltage")
-load("../utils.zen", "format_value")
+load("../utils.zen", "capacitor_voltage_rating", "format_value")
 
 Package = enum("01005", "0201", "0402", "0603", "0805", "1206", "1210", "1812", "1825", "2220", "2225", "3640")
 Mount = enum("SMD")
@@ -30,7 +30,11 @@ if exclude_from_bom:
 P1 = io(Net)
 P2 = io(Net)
 
-effective_voltage = Voltage(P1.voltage.diff(P2.voltage) * 1.5) if not voltage and P1.voltage and P2.voltage else voltage
+effective_voltage = (
+    capacitor_voltage_rating(Voltage(P1.voltage.diff(P2.voltage) * 1.5))
+    if not voltage and P1.voltage and P2.voltage
+    else voltage
+)
 
 # Properties
 properties = {

--- a/stdlib/generics/Capacitor.zen
+++ b/stdlib/generics/Capacitor.zen
@@ -30,11 +30,16 @@ if exclude_from_bom:
 P1 = io(Net)
 P2 = io(Net)
 
-effective_voltage = (
-    capacitor_voltage_rating(Voltage(P1.voltage.diff(P2.voltage) * 1.5))
-    if not voltage and P1.voltage and P2.voltage
-    else voltage
+default_voltage = (
+    capacitor_voltage_rating(Voltage(P1.voltage.diff(P2.voltage) * 1.5)) if P1.voltage and P2.voltage else None
 )
+if voltage and default_voltage and voltage < default_voltage:
+    warn(
+        "Capacitor voltage rating (%s) should be >= inferred voltage rating (%s)" % (voltage, default_voltage),
+        kind="capacitor.voltage_rating",
+    )
+
+effective_voltage = voltage if voltage else default_voltage
 
 # Properties
 properties = {

--- a/stdlib/generics/test/test_Capacitor.zen
+++ b/stdlib/generics/test/test_Capacitor.zen
@@ -2,9 +2,16 @@
 
 load("../../interfaces.zen", "Net")
 load("../../properties.zen", "Layout")
+load("../../units.zen", "Voltage")
+load("../../utils.zen", "capacitor_voltage_rating")
 load("../../bom/match_generics.zen", "HOUSE_CAPS_BY_PKG", "assign_house_parts")
 
 Capacitor = Module("../Capacitor.zen")
+
+check(capacitor_voltage_rating(Voltage("4.95V")) == Voltage("6.3V"), "3.3V rail cap should round to 6.3V")
+check(capacitor_voltage_rating(Voltage("7.5V")) == Voltage("10V"), "5V rail cap should round to 10V")
+check(capacitor_voltage_rating(Voltage("36V")) == Voltage("50V"), "24V rail cap should round to 50V")
+check(capacitor_voltage_rating(Voltage("52.5V")) == Voltage("100V"), "35V is not a capacitor rating tier")
 
 # Capacitors
 for package in Capacitor.Package.values():

--- a/stdlib/generics/test/test_Capacitor.zen
+++ b/stdlib/generics/test/test_Capacitor.zen
@@ -1,6 +1,6 @@
 """Comprehensive test for all generic components."""
 
-load("../../interfaces.zen", "Net")
+load("../../interfaces.zen", "Ground", "Net", "Power")
 load("../../properties.zen", "Layout")
 load("../../units.zen", "Voltage")
 load("../../utils.zen", "capacitor_voltage_rating")
@@ -12,6 +12,11 @@ check(capacitor_voltage_rating(Voltage("4.95V")) == Voltage("6.3V"), "3.3V rail 
 check(capacitor_voltage_rating(Voltage("7.5V")) == Voltage("10V"), "5V rail cap should round to 10V")
 check(capacitor_voltage_rating(Voltage("36V")) == Voltage("50V"), "24V rail cap should round to 50V")
 check(capacitor_voltage_rating(Voltage("52.5V")) == Voltage("100V"), "35V is not a capacitor rating tier")
+
+v3v3 = Power("V3V3", voltage=Voltage("3.3V"))
+gnd = Ground("GND")
+Capacitor(name="C_EXPLICIT_EQUAL_AUTO_VOLTAGE", value="100nF", voltage="6.3V", P1=v3v3, P2=gnd)
+Capacitor(name="C_EXPLICIT_HIGHER_THAN_AUTO_VOLTAGE", value="100nF", voltage="10V", P1=v3v3, P2=gnd)
 
 # Capacitors
 for package in Capacitor.Package.values():

--- a/stdlib/utils.zen
+++ b/stdlib/utils.zen
@@ -128,6 +128,20 @@ def e192(physical_value):
     return _e_series(physical_value, E_SERIES["E192"])
 
 
+CAPACITOR_VOLTAGE_RATINGS = [6.3, 10.0, 16.0, 25.0, 50.0, 100.0, 200.0, 250.0, 500.0, 1000.0]
+
+
+def capacitor_voltage_rating(voltage):
+    """Round voltage up to a common capacitor voltage rating."""
+    required = voltage.with_value(voltage.max)
+
+    for rating in CAPACITOR_VOLTAGE_RATINGS:
+        if required.value <= rating:
+            return voltage.with_value(rating)
+
+    return required
+
+
 def format_value(*args):
     strings = []
     for arg in args:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes stdlib capacitor voltage inference and adds new warnings, which can affect generated properties/BOM matching and may surface new diagnostics in existing designs.
> 
> **Overview**
> **Capacitor voltage auto-rating is now rounded up to common capacitor voltage tiers** via a new `utils.zen` helper (`capacitor_voltage_rating`) and is used when `generics/Capacitor.zen` infers voltage from net voltage (still based on a 1.5× factor).
> 
> If a user specifies an explicit `voltage` below the inferred rounded requirement, the capacitor generic now emits a `capacitor.voltage_rating` warning; tests were updated to cover the rounding behavior and explicit-vs-inferred cases, and `CHANGELOG.md` documents both the rounding fix and the new warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d950888d83d7db62204589192af3b7c4eb81b962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->