### PR TITLE
fix `pcb layout` crash with tuning patterns in groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `pcb search` now refreshes stale local registry and KiCad indexes before non-interactive searches.
+- `pcb layout` no longer fails when KiCad groups contain generated tuning-pattern items.
 
 ## [0.3.75] - 2026-05-02
 

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -111,6 +111,13 @@ def get_group_items(group: Any) -> List[Any]:
     return items
 
 
+def get_group_items_for_detach(group: Any) -> List[Any]:
+    """Return every raw group item that can be passed to PCB_GROUP.RemoveItem."""
+    if not hasattr(group, "GetItemsDeque"):
+        return list(group.GetItems())
+    return list(group.GetItemsDeque())
+
+
 def _discover_kicad_pcb_file(layout_dir: Path) -> Path:
     """Discover the KiCad PCB file inside a layout directory.
 
@@ -783,7 +790,7 @@ def apply_changeset(
         # Detach all members first. Deleting a group directly can leave stale
         # parent-group pointers on BOARD_ITEMs, which later crashes KiCad in
         # BOARD_ITEM::IsLocked() during SaveBoard.
-        for item in get_group_items(group):
+        for item in get_group_items_for_detach(group):
             group.RemoveItem(item)
 
         kicad_board.Delete(group)

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -56,6 +56,12 @@ logger = logging.getLogger("pcb.lens.kicad")
 PACKAGE_URI_PREFIX = "package://"
 FRAGMENT_ZONE_PRIORITY_BIAS = 1
 
+# KiCad 10 length-tuning patterns are serialized as PCB_GENERATOR board items.
+# pcbnew's Python wrapper cannot Cast() them, and the lens does not model the
+# generator controller itself; the generated tracks/vias remain separate board
+# items and are handled through the normal routing paths.
+_UNCASTABLE_GROUP_ITEM_CLASSES = {"PCB_GENERATOR"}
+
 
 def resolve_package_uri(uri: str, package_roots: Dict[str, str]) -> Path:
     """Resolve a package:// URI to an absolute filesystem path.
@@ -89,6 +95,20 @@ def get_footprint_field(fp: Any, name: str) -> Optional[Any]:
     if hasattr(fp, "HasField") and fp.HasField(name):
         return fp.GetField(name)
     return None
+
+
+def get_group_items(group: Any) -> List[Any]:
+    """Return group items, skipping KiCad item classes the Python wrapper cannot cast."""
+    if not hasattr(group, "GetItemsDeque"):
+        return list(group.GetItems())
+
+    items: List[Any] = []
+    for item in group.GetItemsDeque():
+        item_class = str(item.GetClass()).upper() if hasattr(item, "GetClass") else ""
+        if item_class in _UNCASTABLE_GROUP_ITEM_CLASSES:
+            continue
+        items.append(item.Cast() if hasattr(item, "Cast") else item)
+    return items
 
 
 def _discover_kicad_pcb_file(layout_dir: Path) -> Path:
@@ -240,7 +260,7 @@ def _move_group_to(
 
     Returns (dx, dy) applied to all items, or None if move failed.
     """
-    items = list(group.GetItems())
+    items = get_group_items(group)
     bbox = _compute_items_bbox(items, pcbnew)
     if not bbox:
         return None
@@ -527,7 +547,7 @@ def _get_group_bbox_size(group: Any, pcbnew: Any) -> Tuple[int, int]:
     """Get the bounding box size of a KiCad group."""
     if not group:
         return (0, 0)
-    bbox = _compute_items_bbox(list(group.GetItems()), pcbnew)
+    bbox = _compute_items_bbox(get_group_items(group), pcbnew)
     return (bbox[2], bbox[3]) if bbox else (0, 0)
 
 
@@ -763,7 +783,7 @@ def apply_changeset(
         # Detach all members first. Deleting a group directly can leave stale
         # parent-group pointers on BOARD_ITEMs, which later crashes KiCad in
         # BOARD_ITEM::IsLocked() during SaveBoard.
-        for item in list(group.GetItems()):
+        for item in get_group_items(group):
             group.RemoveItem(item)
 
         kicad_board.Delete(group)
@@ -874,7 +894,7 @@ def apply_changeset(
 
         # Clear only lens-owned membership (footprints and child groups)
         # Routing items (tracks, vias, zones, graphics) are board-authored and preserved
-        for item in list(group.GetItems()):
+        for item in get_group_items(group):
             is_footprint = hasattr(pcbnew, "FOOTPRINT") and isinstance(
                 item, pcbnew.FOOTPRINT
             )

--- a/crates/pcb-layout/src/scripts/lens/lens.py
+++ b/crates/pcb-layout/src/scripts/lens/lens.py
@@ -47,7 +47,11 @@ from .types import (
     default_footprint_complement,
     default_group_complement,
 )
-from .kicad_adapter import extract_zone_outline_positions, get_footprint_field
+from .kicad_adapter import (
+    extract_zone_outline_positions,
+    get_footprint_field,
+    get_group_items,
+)
 
 logger = logging.getLogger("pcb.lens")
 
@@ -454,7 +458,7 @@ def extract(
         vias: List[ViaComplement] = []
         zones: List[ZoneComplement] = []
 
-        for item in group.GetItems():
+        for item in get_group_items(group):
             item_class = item.GetClass().upper()
             item_uuid = str(item.m_Uuid.AsString())
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, targeted compatibility fix in the KiCad adapter to avoid crashes when iterating group items; main behavioral change is skipping uncastable generator controller items during bbox/membership processing.
> 
> **Overview**
> Prevents `pcb layout` from failing on KiCad 10 boards where length-tuning patterns inside groups are serialized as uncastable `PCB_GENERATOR` items.
> 
> This introduces `get_group_items()` (and a detach-safe variant) to filter/handle group members consistently, updates group bbox/move, group removal, membership rebuild, and lens group complement extraction to use the new helpers, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfe8c3e70a3c8b2e5a7a35e7062326475f507da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->