### PR TITLE
Improve hydrated dependency resolution performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Capacitors now warn when explicit voltage ratings are below the inferred 1.5x rounded net-voltage requirement.
+- Hydrated MVS v2 builds now reuse cached loads across packages with identical package-local dependency maps.
 
 ### Fixed
 

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -975,7 +975,7 @@ fn infer_kicad_footprint_fallback(
         return Ok(None);
     };
     let Some((symbol_repo, symbol_version, _)) =
-        package_coord_for_path(symbol_source, &eval_ctx.resolution().package_roots())
+        package_coord_for_path(symbol_source, eval_ctx.resolution().package_roots_ref())
     else {
         return Ok(None);
     };

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -42,7 +42,7 @@ use crate::lang::{
     module::{FrozenModuleValue, ModulePath},
 };
 use crate::load_spec::LoadSpec;
-use crate::resolution::{FrozenResolutionMap, FrozenUrlResolution, ResolutionResult};
+use crate::resolution::{PackageScopeKey, PackageUrlResolution, ResolutionResult};
 use crate::{Diagnostic, Diagnostics, WithDiagnostics};
 use crate::{FileProvider, ResolveContext};
 use crate::{convert::ModuleConverter, lang::context::FrozenPendingChild};
@@ -144,7 +144,7 @@ struct CachedModule {
     warnings: Vec<Diagnostic>,
 }
 
-type LoadCacheKey = (Option<String>, PathBuf);
+type LoadCacheKey = (Option<PackageScopeKey>, PathBuf);
 
 /// Output of `parse_and_analyze_file`, preserving both parsed AST and full eval output.
 #[derive(Clone)]
@@ -277,9 +277,10 @@ pub struct EvalSession {
     file_contents_cache: Arc<RwLock<HashMap<PathBuf, String>>>,
     /// Dedicated load cache - frequently accessed during parallel module evaluation.
     ///
-    /// MVS v2 resolution is root-package scoped, so cached modules are keyed by
-    /// root package when a frozen root is active. V1 keeps the historical
-    /// path-only behavior via a `None` root key.
+    /// MVS v2 resolution is package-local, so cached modules are keyed by the
+    /// loaded file's package identity and resolved dependency map when a frozen
+    /// root is active. V1 keeps the historical path-only behavior via a `None`
+    /// scope.
     load_cache: Arc<RwLock<HashMap<LoadCacheKey, CachedModule>>>,
     /// Per-file mapping of `symbol → target path` for "go-to definition".
     symbol_index: Arc<RwLock<HashMap<PathBuf, HashMap<String, PathBuf>>>>,
@@ -509,10 +510,15 @@ impl EvalContextConfig {
         paths
     }
 
-    fn active_mvs_v2_resolution(&self) -> Option<&FrozenResolutionMap> {
-        self.mvs_v2_root_package
-            .as_deref()
-            .and_then(|package_url| self.resolution.mvs_v2_root(package_url))
+    fn package_scope_for_file(
+        &self,
+        path: &Path,
+    ) -> Option<crate::resolution::ResolvedPackageScope<'_>> {
+        self.resolution.package_scope_for_file(
+            path,
+            self.mvs_v2_root_package.as_deref(),
+            self.file_provider(),
+        )
     }
 
     /// Manually track a file. Useful for entrypoints.
@@ -557,86 +563,23 @@ impl EvalContextConfig {
         self.resolve(&mut context)
     }
 
-    /// Find the package root for a given file by walking up directories.
-    /// Expects a canonical (absolute, normalized) path.
-    fn find_package_root_for_file(&self, file: &Path) -> anyhow::Result<PathBuf> {
-        let mut current = file.parent();
-        while let Some(dir) = current {
-            if self.resolution.package_resolutions.contains_key(dir) {
-                return Ok(dir.to_path_buf());
-            }
-            let pcb_toml = dir.join("pcb.toml");
-            if self.file_provider.exists(&pcb_toml) {
-                return Ok(dir.to_path_buf());
-            }
-            current = dir.parent();
-        }
-        anyhow::bail!(
-            "Internal error: current file not in any package: {}",
-            file.display()
-        )
-    }
-
-    fn find_alias_in_map(resolved_map: &BTreeMap<String, PathBuf>, alias: &str) -> Option<String> {
-        for url in resolved_map.keys() {
-            if let Some(last_segment) = url.rsplit('/').next()
-                && last_segment == alias
-            {
-                return Some(url.clone());
-            }
-        }
-        None
-    }
-
-    fn current_mvs_v2_package<'a>(
-        resolution: &'a FrozenResolutionMap,
+    fn current_package_scope(
+        &self,
         file: &Path,
-    ) -> anyhow::Result<(&'a PathBuf, &'a crate::resolution::FrozenPackage)> {
-        resolution.package_for_file(file).ok_or_else(|| {
+    ) -> anyhow::Result<crate::resolution::ResolvedPackageScope<'_>> {
+        self.package_scope_for_file(file).ok_or_else(|| {
             anyhow::anyhow!(
-                "Internal error: current file not in MVS v2 resolution map: {}",
+                "Internal error: current file not in any package: {}",
                 file.display()
             )
         })
     }
 
-    fn expand_alias_v2(
-        &self,
-        context: &ResolveContext,
-        alias: &str,
-        resolution: &FrozenResolutionMap,
-    ) -> Result<String, anyhow::Error> {
-        let (_, package) = Self::current_mvs_v2_package(resolution, &context.current_file)?;
-        if let Some(url) = Self::find_alias_in_map(&package.deps, alias) {
-            return Ok(url);
-        }
-
-        anyhow::bail!("Unknown alias '@{}'", alias)
-    }
-
-    fn find_best_dep_match<'a>(
-        resolved_map: &'a BTreeMap<String, PathBuf>,
-        full_url: &str,
-    ) -> Option<(&'a String, &'a PathBuf)> {
-        resolved_map
-            .iter()
-            .rev()
-            .find(|(dep_url, _)| Self::url_matches_prefix(dep_url, full_url))
-    }
-
-    fn url_matches_prefix(prefix: &str, full_url: &str) -> bool {
-        full_url.starts_with(prefix)
-            && (full_url.len() == prefix.len()
-                || full_url.as_bytes().get(prefix.len()) == Some(&b'/'))
-    }
-
     /// Expand alias using the resolution map.
     fn expand_alias(&self, context: &ResolveContext, alias: &str) -> Result<String, anyhow::Error> {
-        let package_root = self.find_package_root_for_file(&context.current_file)?;
-        if let Some(resolved_map) = self.resolution.package_resolutions.get(&package_root)
-            && let Some(url) = Self::find_alias_in_map(resolved_map, alias)
-        {
-            return Ok(url);
+        let scope = self.current_package_scope(&context.current_file)?;
+        if let Some(url) = scope.expand_alias(alias) {
+            return Ok(url.to_string());
         }
 
         anyhow::bail!("Unknown alias '@{}'", alias)
@@ -646,7 +589,7 @@ impl EvalContextConfig {
     fn try_resolve_workspace(
         &self,
         context: &ResolveContext,
-        package_root: &Path,
+        scope: &crate::resolution::ResolvedPackageScope<'_>,
     ) -> Result<PathBuf, anyhow::Error> {
         let full_url = if let LoadSpec::Stdlib { path } = context.latest_spec() {
             let stdlib_root = self.resolution.workspace_info.workspace_stdlib_dir();
@@ -662,47 +605,28 @@ impl EvalContextConfig {
                 .expect("try_resolve_workspace called with non-URL spec")
         };
 
-        let canonical_root = self.file_provider.canonicalize(package_root)?;
-        if let Some(package_url) = self.find_url_for_package_root(&canonical_root)
-            && {
-                let package_roots = self.resolution.package_roots();
-                Self::find_best_dep_match(&package_roots, &full_url)
-                    .is_some_and(|(matched_url, _)| matched_url == &package_url)
-            }
-        {
-            anyhow::bail!(
+        let (matched_dep, root_path) = match scope.resolve_package_url(&full_url) {
+            Some(PackageUrlResolution::OwnPackage) => anyhow::bail!(
                 "{} uses package URL '{}' that points into its own package '{}'; use a relative path instead",
                 context.current_file.display(),
                 full_url,
-                package_url
-            );
-        }
-
-        let resolved_map = self.resolution.package_resolutions.get(package_root);
-        let best_match = resolved_map.and_then(|map| Self::find_best_dep_match(map, &full_url));
-
-        let Some((matched_dep, root_path)) = best_match else {
-            if resolved_map.is_none() {
-                anyhow::bail!(
-                    "Dependency map not loaded for package '{}'",
-                    package_root.display()
-                );
-            }
-
-            anyhow::bail!(
+                scope.display()
+            ),
+            Some(PackageUrlResolution::Dependency { dep_url, root }) => (dep_url, root),
+            None => anyhow::bail!(
                 "No declared dependency matches '{}'\n  \
                 Add a dependency to [dependencies] in pcb.toml that covers this path",
                 full_url
-            );
+            ),
         };
 
         let relative_path = full_url
-            .strip_prefix(matched_dep.as_str())
+            .strip_prefix(matched_dep)
             .and_then(|s| s.strip_prefix('/'))
             .unwrap_or("");
 
         let full_path = if relative_path.is_empty() {
-            root_path.clone()
+            root_path.to_path_buf()
         } else {
             root_path.join(relative_path)
         };
@@ -719,77 +643,10 @@ impl EvalContextConfig {
         Ok(full_path)
     }
 
-    fn try_resolve_workspace_v2(
-        &self,
-        context: &ResolveContext,
-        resolution: &FrozenResolutionMap,
-    ) -> Result<PathBuf, anyhow::Error> {
-        let full_url = if let LoadSpec::Stdlib { path } = context.latest_spec() {
-            let stdlib_root = self.resolution.workspace_info.workspace_stdlib_dir();
-            return Ok(if path.as_os_str().is_empty() {
-                stdlib_root
-            } else {
-                stdlib_root.join(path)
-            });
-        } else {
-            context
-                .latest_spec()
-                .to_full_url()
-                .expect("try_resolve_workspace_v2 called with non-URL spec")
-        };
-
-        let (_, package) = Self::current_mvs_v2_package(resolution, &context.current_file)?;
-        let (matched_dep, root_path) = match resolution.resolve_package_url(package, &full_url) {
-            Some(FrozenUrlResolution::OwnPackage) => anyhow::bail!(
-                "{} uses package URL '{}' that points into its own package '{}'; use a relative path instead",
-                context.current_file.display(),
-                full_url,
-                package.identity.display()
-            ),
-            Some(FrozenUrlResolution::Dependency { dep_url, root }) => (dep_url, root),
-            None => anyhow::bail!(
-                "No declared dependency matches '{}'\n  \
-                Add a dependency to [dependencies] in pcb.toml that covers this path",
-                full_url
-            ),
-        };
-
-        let relative_path = full_url
-            .strip_prefix(matched_dep)
-            .and_then(|s| s.strip_prefix('/'))
-            .unwrap_or("");
-
-        let full_path = root_path.join(relative_path);
-
-        if !self.file_provider.exists(&full_path) {
-            anyhow::bail!(
-                "File not found: {} (resolved to: {}, dep root: {})",
-                relative_path,
-                full_path.display(),
-                root_path.display()
-            );
-        }
-
-        Ok(full_path)
-    }
-
     /// URL resolution: translate canonical URL to cache path using resolution map.
     fn resolve_url(&self, context: &mut ResolveContext) -> Result<PathBuf, anyhow::Error> {
-        let package_root = self.find_package_root_for_file(&context.current_file)?;
-        self.try_resolve_workspace(context, &package_root)
-    }
-
-    /// Find the package URL for a given canonical package root path by scanning
-    /// known package roots.
-    // TODO: if this becomes a bottleneck, pre-build a reverse map (PathBuf -> URL) at init time.
-    fn find_url_for_package_root(&self, canonical_root: &Path) -> Option<String> {
-        for (url, root) in self.resolution.package_roots() {
-            let canonical = self.file_provider.canonicalize(&root).unwrap_or(root);
-            if canonical == canonical_root {
-                return Some(url);
-            }
-        }
-        None
+        let scope = self.current_package_scope(&context.current_file)?;
+        self.try_resolve_workspace(context, &scope)
     }
 
     /// Compute the canonical URL for a file being evaluated.
@@ -805,59 +662,15 @@ impl EvalContextConfig {
             return Ok(url);
         }
 
-        // Slow path: scan workspace members and resolution maps to find the URL
-        let pkg_root = self.find_package_root_for_file(file_path)?;
-        let canonical_root = self.file_provider.canonicalize(&pkg_root)?;
-
-        let pkg_url = self
-            .find_url_for_package_root(&canonical_root)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Cannot determine package URL for '{}' (package root: '{}')",
-                    file_path.display(),
-                    pkg_root.display()
-                )
-            })?;
-
-        let rel = file_path
-            .strip_prefix(&canonical_root)
-            .or_else(|_| file_path.strip_prefix(&pkg_root))
-            .unwrap_or(Path::new(""));
-
-        if rel.as_os_str().is_empty() {
-            Ok(pkg_url.clone())
-        } else {
-            Ok(format!("{}/{}", pkg_url, rel.display()))
-        }
-    }
-
-    fn file_url_v2(
-        &self,
-        file_path: &Path,
-        resolution: &FrozenResolutionMap,
-    ) -> anyhow::Result<String> {
-        if let Some(spec) = self.get_load_spec(file_path)
-            && let Some(url) = spec.to_full_url()
-        {
-            return Ok(url);
-        }
-
-        let (pkg_root, package) = Self::current_mvs_v2_package(resolution, file_path)?;
-        let pkg_url = package.identity.package_url().ok_or_else(|| {
-            anyhow::anyhow!(
-                "Cannot determine package URL for '{}' (package root: '{}')",
-                file_path.display(),
-                pkg_root.display()
+        self.resolution
+            .package_url_for_file(
+                file_path,
+                self.mvs_v2_root_package.as_deref(),
+                self.file_provider(),
             )
-        })?;
-
-        let rel = file_path.strip_prefix(pkg_root).unwrap_or(Path::new(""));
-
-        if rel.as_os_str().is_empty() {
-            Ok(pkg_url.to_string())
-        } else {
-            Ok(format!("{}/{}", pkg_url, rel.display()))
-        }
+            .ok_or_else(|| {
+                anyhow::anyhow!("Cannot determine package URL for '{}'", file_path.display())
+            })
     }
 
     /// Relative path resolution: resolve relative to current file with boundary enforcement.
@@ -867,7 +680,9 @@ impl EvalContextConfig {
         };
         let path = path.clone();
 
-        let package_root = self.find_package_root_for_file(&context.current_file)?;
+        let scope = self.current_package_scope(&context.current_file)?;
+        let package_root = scope.root().to_path_buf();
+        let enforce_nested_package_boundary = scope.enforces_nested_package_boundaries();
 
         let current_dir = context
             .current_file
@@ -879,7 +694,19 @@ impl EvalContextConfig {
         let canonical_resolved = context.file_provider.canonicalize(&resolved_path)?;
         let canonical_root = context.file_provider.canonicalize(&package_root)?;
 
-        if !canonical_resolved.starts_with(&canonical_root) {
+        let mut crosses_package_boundary = !canonical_resolved.starts_with(&canonical_root);
+        if !crosses_package_boundary
+            && enforce_nested_package_boundary
+            && let Some(target_scope) = self.package_scope_for_file(&canonical_resolved)
+        {
+            let target_root = context
+                .file_provider
+                .canonicalize(target_scope.root())
+                .unwrap_or_else(|_| target_scope.root().to_path_buf());
+            crosses_package_boundary = target_root != canonical_root;
+        }
+
+        if crosses_package_boundary {
             // Escaped package boundary — resolve via URL arithmetic
             let current_url = self.file_url(&context.current_file)?;
             let current_dir_url = current_url
@@ -903,77 +730,6 @@ impl EvalContextConfig {
         crate::validate_path_case_with_canonical(&path, &canonical_resolved)?;
 
         Ok(canonical_resolved)
-    }
-
-    fn resolve_relative_v2(
-        &self,
-        context: &mut ResolveContext,
-        resolution: &FrozenResolutionMap,
-    ) -> Result<PathBuf, anyhow::Error> {
-        let LoadSpec::Path { path, .. } = context.latest_spec() else {
-            unreachable!("resolve_relative_v2 called on non-Path spec");
-        };
-        let path = path.clone();
-
-        let (package_root, _) = Self::current_mvs_v2_package(resolution, &context.current_file)?;
-        let current_dir = context
-            .current_file
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Current file has no parent directory"))?;
-        let resolved_path = current_dir.join(&path);
-        let canonical_resolved = context.file_provider.canonicalize(&resolved_path)?;
-        let canonical_root = context.file_provider.canonicalize(package_root)?;
-        let target_package_root = resolution
-            .package_for_file(&canonical_resolved)
-            .map(|(root, _)| root);
-
-        if !canonical_resolved.starts_with(&canonical_root)
-            || target_package_root.is_some_and(|root| root != package_root)
-        {
-            let current_url = self.file_url_v2(&context.current_file, resolution)?;
-            let current_dir_url = current_url
-                .rsplit_once('/')
-                .map(|(dir, _)| dir)
-                .unwrap_or(&current_url);
-            let target_url = crate::normalize_url_path(&format!(
-                "{}/{}",
-                current_dir_url,
-                path.to_string_lossy().replace('\\', "/")
-            ))?;
-
-            let new_spec = LoadSpec::Package {
-                package: target_url,
-                path: PathBuf::new(),
-            };
-            context.push_spec(new_spec)?;
-            return self.try_resolve_workspace_v2(context, resolution);
-        }
-
-        crate::validate_path_case_with_canonical(&path, &canonical_resolved)?;
-
-        Ok(canonical_resolved)
-    }
-
-    fn resolve_v2(
-        &self,
-        context: &mut ResolveContext,
-        resolution: &FrozenResolutionMap,
-    ) -> Result<PathBuf, anyhow::Error> {
-        if let LoadSpec::Package { package, path, .. } = context.latest_spec() {
-            let expanded_url = self.expand_alias_v2(context, package, resolution)?;
-            let expanded_spec = LoadSpec::Package {
-                package: expanded_url,
-                path: path.clone(),
-            };
-            if &expanded_spec != context.latest_spec() {
-                context.push_spec(expanded_spec)?;
-            }
-        }
-
-        match context.latest_spec() {
-            LoadSpec::Path { .. } => self.resolve_relative_v2(context, resolution),
-            _ => self.try_resolve_workspace_v2(context, resolution),
-        }
     }
 
     fn finish_resolve(
@@ -1000,11 +756,6 @@ impl EvalContextConfig {
 
     /// Resolve a load path. Supports aliases, URLs, and relative paths.
     pub(crate) fn resolve(&self, context: &mut ResolveContext) -> Result<PathBuf, anyhow::Error> {
-        if let Some(resolution) = self.active_mvs_v2_resolution() {
-            let resolved_path = self.resolve_v2(context, resolution)?;
-            return self.finish_resolve(context, resolved_path);
-        }
-
         // Expand aliases
         if let LoadSpec::Package { package, path, .. } = context.latest_spec() {
             let expanded_url = self.expand_alias(context, package)?;
@@ -1074,13 +825,17 @@ impl EvalSession {
 
     // --- Load cache ---
 
-    fn get_cached_module(&self, root_package: Option<&str>, path: &Path) -> Option<CachedModule> {
-        let key = (root_package.map(str::to_string), path.to_path_buf());
+    fn get_cached_module(
+        &self,
+        scope: Option<PackageScopeKey>,
+        path: &Path,
+    ) -> Option<CachedModule> {
+        let key = (scope, path.to_path_buf());
         self.load_cache.read().unwrap().get(&key).cloned()
     }
 
-    fn cache_module(&self, root_package: Option<&str>, path: PathBuf, module: CachedModule) {
-        let key = (root_package.map(str::to_string), path);
+    fn cache_module(&self, scope: Option<PackageScopeKey>, path: PathBuf, module: CachedModule) {
+        let key = (scope, path);
         self.load_cache.write().unwrap().insert(key, module);
     }
 
@@ -1404,14 +1159,22 @@ impl EvalContext {
         self.session.record_module_dependency(from, to);
     }
 
+    fn load_cache_scope(&self, path: &Path) -> Option<PackageScopeKey> {
+        self.config.resolution.load_cache_scope_key_for_file(
+            path,
+            self.config.mvs_v2_root_package.as_deref(),
+            self.file_provider(),
+        )
+    }
+
     fn get_cached_module(&self, path: &Path) -> Option<CachedModule> {
         self.session
-            .get_cached_module(self.config.mvs_v2_root_package.as_deref(), path)
+            .get_cached_module(self.load_cache_scope(path), path)
     }
 
     fn cache_module(&self, path: PathBuf, module: CachedModule) {
-        self.session
-            .cache_module(self.config.mvs_v2_root_package.as_deref(), path, module);
+        let scope = self.load_cache_scope(&path);
+        self.session.cache_module(scope, path, module);
     }
 
     /// Check if there is a module dependency between two files

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -140,40 +140,35 @@ impl<'a> ResolvedPackageScope<'a> {
         &'scope self,
         full_url: &str,
     ) -> Option<PackageUrlResolution<'scope>> {
-        resolve_package_url_parts(self.package_url(), self.deps.as_ref(), full_url)
+        let own_url = self
+            .package_url()
+            .filter(|url| package_url_covers(url, full_url));
+        let dep = self
+            .deps
+            .iter()
+            .filter(|(dep_url, _)| package_url_covers(dep_url, full_url))
+            .max_by_key(|(dep_url, _)| dep_url.len());
+
+        match (own_url, dep) {
+            (Some(own_url), Some((dep_url, root))) if dep_url.len() > own_url.len() => {
+                Some(PackageUrlResolution::Dependency {
+                    dep_url: dep_url.as_str(),
+                    root: root.as_path(),
+                })
+            }
+            (Some(_), _) => Some(PackageUrlResolution::OwnPackage),
+            (None, Some((dep_url, root))) => Some(PackageUrlResolution::Dependency {
+                dep_url: dep_url.as_str(),
+                root: root.as_path(),
+            }),
+            (None, None) => None,
+        }
     }
 }
 
 pub(crate) enum PackageUrlResolution<'a> {
     OwnPackage,
     Dependency { dep_url: &'a str, root: &'a Path },
-}
-
-fn resolve_package_url_parts<'a>(
-    package_url: Option<&'a str>,
-    deps: &'a BTreeMap<String, PathBuf>,
-    full_url: &str,
-) -> Option<PackageUrlResolution<'a>> {
-    let own_url = package_url.filter(|url| package_url_covers(url, full_url));
-    let dep = deps
-        .iter()
-        .filter(|(dep_url, _)| package_url_covers(dep_url, full_url))
-        .max_by_key(|(dep_url, _)| dep_url.len());
-
-    match (own_url, dep) {
-        (Some(own_url), Some((dep_url, root))) if dep_url.len() > own_url.len() => {
-            Some(PackageUrlResolution::Dependency {
-                dep_url: dep_url.as_str(),
-                root: root.as_path(),
-            })
-        }
-        (Some(_), _) => Some(PackageUrlResolution::OwnPackage),
-        (None, Some((dep_url, root))) => Some(PackageUrlResolution::Dependency {
-            dep_url: dep_url.as_str(),
-            root: root.as_path(),
-        }),
-        (None, None) => None,
-    }
 }
 
 /// Compute the semver family for a version.
@@ -324,7 +319,11 @@ fn resolution_package_roots(
 ) -> BTreeMap<String, PathBuf> {
     let mut roots = build_package_roots(workspace_info, package_resolutions);
     if let Some(resolution) = mvs_v2_resolution {
-        roots.extend(resolution.package_roots());
+        roots.extend(
+            resolution
+                .values()
+                .flat_map(FrozenResolutionMap::package_roots),
+        );
     }
     roots
 }
@@ -567,36 +566,7 @@ impl PackagePathResolver for NativePathResolver {
 }
 
 /// MVS v2 resolution maps keyed by root package URL.
-#[derive(Debug, Clone, Default)]
-pub struct FrozenResolutionSet {
-    pub root_packages: BTreeMap<String, FrozenResolutionMap>,
-}
-
-impl FrozenResolutionSet {
-    pub fn get(&self, package_url: &str) -> Option<&FrozenResolutionMap> {
-        self.root_packages.get(package_url)
-    }
-
-    pub fn package_roots(&self) -> BTreeMap<String, PathBuf> {
-        self.root_packages
-            .values()
-            .flat_map(FrozenResolutionMap::package_roots)
-            .collect()
-    }
-
-    pub fn kicad_model_dirs(&self, workspace_info: &WorkspaceInfo) -> BTreeMap<String, PathBuf> {
-        self.root_packages
-            .values()
-            .flat_map(|resolution| resolution.kicad_model_dirs(workspace_info))
-            .collect()
-    }
-
-    fn canonicalize_keys(&mut self, file_provider: &dyn crate::FileProvider) {
-        for resolution in self.root_packages.values_mut() {
-            resolution.canonicalize_keys(file_provider);
-        }
-    }
-}
+pub type FrozenResolutionSet = BTreeMap<String, FrozenResolutionMap>;
 
 /// Frozen package-local resolution table for one root package.
 #[derive(Debug, Clone)]
@@ -756,7 +726,7 @@ pub struct ResolutionResult {
 }
 
 impl ResolutionResult {
-    pub fn new(
+    fn new(
         workspace_info: WorkspaceInfo,
         package_resolutions: HashMap<PathBuf, BTreeMap<String, PathBuf>>,
         closure: HashMap<ModuleLine, Version>,
@@ -850,31 +820,13 @@ impl ResolutionResult {
                 .map(|(root, package)| ResolvedPackageScope::frozen(root, package));
         }
 
-        if let Some((root, deps)) = self.native_resolution_for_file(file) {
-            let package_url = self.package_url_for_package_root(root, file_provider);
-            return Some(ResolvedPackageScope::native(root, deps, package_url));
-        }
-
-        self.native_manifest_scope_for_file(file, file_provider)
-    }
-
-    fn native_resolution_for_file(
-        &self,
-        file: &Path,
-    ) -> Option<(&PathBuf, &BTreeMap<String, PathBuf>)> {
-        self.package_resolutions
-            .iter()
-            .filter(|(root, _)| file.starts_with(root))
-            .max_by_key(|(root, _)| root.as_os_str().len())
-    }
-
-    fn native_manifest_scope_for_file<'a>(
-        &'a self,
-        file: &Path,
-        file_provider: &dyn FileProvider,
-    ) -> Option<ResolvedPackageScope<'a>> {
         let mut current = file.parent();
         while let Some(dir) = current {
+            if let Some((root, deps)) = self.package_resolutions.get_key_value(dir) {
+                let package_url = self.package_url_for_package_root(root, file_provider);
+                return Some(ResolvedPackageScope::native(root, deps, package_url));
+            }
+
             if file_provider.exists(&dir.join("pcb.toml")) {
                 let root = dir.to_path_buf();
                 let package_url = self.package_url_for_package_root(&root, file_provider);
@@ -989,8 +941,10 @@ impl ResolutionResult {
                 (canon, deps.clone())
             })
             .collect();
-        if let Some(resolution) = &mut self.mvs_v2_resolution {
-            resolution.canonicalize_keys(file_provider);
+        if let Some(resolution_set) = &mut self.mvs_v2_resolution {
+            for resolution in resolution_set.values_mut() {
+                resolution.canonicalize_keys(file_provider);
+            }
         }
         self.refresh_package_roots();
     }
@@ -1034,7 +988,7 @@ impl ResolutionResult {
             .iter()
             .filter_map(|(url, package)| {
                 let root = package.dir(&self.workspace_info.root);
-                (file.starts_with(&root) && resolution.get(url).is_some())
+                (file.starts_with(&root) && resolution.contains_key(url))
                     .then_some((url, root.as_os_str().len()))
             })
             .max_by_key(|(_, root_len)| *root_len)
@@ -1065,8 +1019,10 @@ impl ResolutionResult {
                 }
             }
         }
-        if let Some(resolution) = &self.mvs_v2_resolution {
-            model_dirs.extend(resolution.kicad_model_dirs(&self.workspace_info));
+        if let Some(resolution_set) = &self.mvs_v2_resolution {
+            for resolution in resolution_set.values() {
+                model_dirs.extend(resolution.kicad_model_dirs(&self.workspace_info));
+            }
         }
         model_dirs
     }
@@ -1199,28 +1155,26 @@ mod tests {
 
         assert!(!result.package_roots().contains_key(dep_coord));
 
-        result.set_mvs_v2_resolution(FrozenResolutionSet {
-            root_packages: BTreeMap::from([(
-                "github.com/acme/root".into(),
-                FrozenResolutionMap {
-                    selected_remote: BTreeMap::new(),
-                    packages: BTreeMap::from([(
-                        dep_root.clone(),
-                        FrozenPackage {
-                            identity: FrozenPackageIdentity::Remote {
-                                dep_id: FrozenDepId {
-                                    path: "github.com/acme/dep".into(),
-                                    lane: "v1".into(),
-                                },
-                                version: Version::parse("1.2.3").unwrap(),
+        result.set_mvs_v2_resolution(BTreeMap::from([(
+            "github.com/acme/root".into(),
+            FrozenResolutionMap {
+                selected_remote: BTreeMap::new(),
+                packages: BTreeMap::from([(
+                    dep_root.clone(),
+                    FrozenPackage {
+                        identity: FrozenPackageIdentity::Remote {
+                            dep_id: FrozenDepId {
+                                path: "github.com/acme/dep".into(),
+                                lane: "v1".into(),
                             },
-                            deps: BTreeMap::new(),
-                            parts: Vec::new(),
+                            version: Version::parse("1.2.3").unwrap(),
                         },
-                    )]),
-                },
-            )]),
-        });
+                        deps: BTreeMap::new(),
+                        parts: Vec::new(),
+                    },
+                )]),
+            },
+        )]));
 
         assert_eq!(result.package_roots().get(dep_coord), Some(&dep_root));
     }
@@ -1251,30 +1205,22 @@ mod tests {
                 lockfile: None,
                 errors: vec![],
             },
-            FrozenResolutionSet {
-                root_packages: BTreeMap::from([
-                    (
-                        "github.com/acme/root-a".into(),
-                        FrozenResolutionMap {
-                            selected_remote: BTreeMap::new(),
-                            packages: BTreeMap::from([(
-                                shared_root.clone(),
-                                shared_package.clone(),
-                            )]),
-                        },
-                    ),
-                    (
-                        "github.com/acme/root-b".into(),
-                        FrozenResolutionMap {
-                            selected_remote: BTreeMap::new(),
-                            packages: BTreeMap::from([(
-                                shared_root.clone(),
-                                shared_package.clone(),
-                            )]),
-                        },
-                    ),
-                ]),
-            },
+            BTreeMap::from([
+                (
+                    "github.com/acme/root-a".into(),
+                    FrozenResolutionMap {
+                        selected_remote: BTreeMap::new(),
+                        packages: BTreeMap::from([(shared_root.clone(), shared_package.clone())]),
+                    },
+                ),
+                (
+                    "github.com/acme/root-b".into(),
+                    FrozenResolutionMap {
+                        selected_remote: BTreeMap::new(),
+                        packages: BTreeMap::from([(shared_root.clone(), shared_package.clone())]),
+                    },
+                ),
+            ]),
             HashMap::new(),
         );
         let provider = InMemoryFileProvider::new(HashMap::new());
@@ -1317,30 +1263,28 @@ mod tests {
                 lockfile: None,
                 errors: vec![],
             },
-            FrozenResolutionSet {
-                root_packages: BTreeMap::from([
-                    (
-                        "github.com/acme/root-a".into(),
-                        FrozenResolutionMap {
-                            selected_remote: BTreeMap::new(),
-                            packages: BTreeMap::from([(
-                                shared_root.clone(),
-                                package_with_dep("/cache/github.com/acme/base/1.0.0"),
-                            )]),
-                        },
-                    ),
-                    (
-                        "github.com/acme/root-b".into(),
-                        FrozenResolutionMap {
-                            selected_remote: BTreeMap::new(),
-                            packages: BTreeMap::from([(
-                                shared_root.clone(),
-                                package_with_dep("/cache/github.com/acme/base/2.0.0"),
-                            )]),
-                        },
-                    ),
-                ]),
-            },
+            BTreeMap::from([
+                (
+                    "github.com/acme/root-a".into(),
+                    FrozenResolutionMap {
+                        selected_remote: BTreeMap::new(),
+                        packages: BTreeMap::from([(
+                            shared_root.clone(),
+                            package_with_dep("/cache/github.com/acme/base/1.0.0"),
+                        )]),
+                    },
+                ),
+                (
+                    "github.com/acme/root-b".into(),
+                    FrozenResolutionMap {
+                        selected_remote: BTreeMap::new(),
+                        packages: BTreeMap::from([(
+                            shared_root.clone(),
+                            package_with_dep("/cache/github.com/acme/base/2.0.0"),
+                        )]),
+                    },
+                ),
+            ]),
             HashMap::new(),
         );
         let provider = InMemoryFileProvider::new(HashMap::new());
@@ -1392,6 +1336,45 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn native_scope_walks_to_nearest_package_boundary() {
+        let resolution = ResolutionResult::native(
+            WorkspaceInfo {
+                root: PathBuf::from("/workspace"),
+                cache_dir: PathBuf::new(),
+                config: None,
+                packages: BTreeMap::new(),
+                lockfile: None,
+                errors: vec![],
+            },
+            HashMap::from([(
+                PathBuf::from("/workspace/pkg"),
+                BTreeMap::from([(
+                    "github.com/acme/outer".into(),
+                    PathBuf::from("/cache/github.com/acme/outer/1.0.0"),
+                )]),
+            )]),
+            HashMap::new(),
+            false,
+            HashMap::new(),
+        );
+        let provider = InMemoryFileProvider::new(HashMap::from([(
+            "/workspace/pkg/nested/pcb.toml".to_string(),
+            "[board]\nname = \"nested\"\npath = \"src/lib.zen\"\n".to_string(),
+        )]));
+
+        let scope = resolution
+            .package_scope_for_file(
+                Path::new("/workspace/pkg/nested/src/lib.zen"),
+                None,
+                &provider,
+            )
+            .expect("expected nested package scope");
+
+        assert_eq!(scope.root(), Path::new("/workspace/pkg/nested"));
+        assert_eq!(scope.expand_alias("outer"), None);
     }
 
     #[test]

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -8,8 +8,10 @@
 //! - Native: checks patches, vendor/, then ~/.pcb/cache
 //! - WASM: only checks vendor/ (everything must be pre-vendored)
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use semver::Version;
 
@@ -18,6 +20,161 @@ use crate::STDLIB_MODULE_PATH;
 use crate::config::{DependencyDetail, DependencySpec, Lockfile, ManifestPart, PcbToml};
 use crate::kicad_library::effective_kicad_library_for_repo;
 use crate::workspace::{LOCAL_WORKSPACE_ROOT_URL, WorkspaceInfo, package_url_covers};
+
+/// Stable identity for package-local evaluation state.
+///
+/// Frozen MVS v2 resolution is package-local: the same file path can be loaded
+/// under different dependency environments. This key captures the loaded
+/// package's semantic resolution scope so eval caches can share modules only
+/// when the package identity and its resolved deps match.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct PackageScopeKey {
+    package_identity: String,
+    deps: Vec<(String, PathBuf)>,
+}
+
+impl PackageScopeKey {
+    fn frozen(package: &FrozenPackage) -> Self {
+        Self {
+            package_identity: package.identity.display(),
+            deps: package
+                .deps
+                .iter()
+                .map(|(dep, path)| (dep.clone(), path.clone()))
+                .collect(),
+        }
+    }
+}
+
+/// Resolved package-local dependency environment for a file.
+///
+/// This is a read-only view over the existing native v1 and frozen MVS v2
+/// resolution data. Eval code should consume this abstraction rather than
+/// branching on the underlying representation.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedPackageScope<'a> {
+    root: Cow<'a, Path>,
+    package_url: Option<Cow<'a, str>>,
+    display: Cow<'a, str>,
+    deps: Cow<'a, BTreeMap<String, PathBuf>>,
+    cache_key: Option<PackageScopeKey>,
+    enforce_nested_package_boundaries: bool,
+}
+
+impl<'a> ResolvedPackageScope<'a> {
+    fn native(
+        root: &'a Path,
+        deps: &'a BTreeMap<String, PathBuf>,
+        package_url: Option<String>,
+    ) -> Self {
+        let display = package_url
+            .as_deref()
+            .map(|url| Cow::Owned(url.to_string()))
+            .unwrap_or_else(|| Cow::Owned(root.display().to_string()));
+        Self {
+            root: Cow::Borrowed(root),
+            package_url: package_url.map(Cow::Owned),
+            display,
+            deps: Cow::Borrowed(deps),
+            cache_key: None,
+            enforce_nested_package_boundaries: false,
+        }
+    }
+
+    fn native_empty(root: PathBuf, package_url: Option<String>) -> Self {
+        let display = package_url
+            .as_deref()
+            .map(|url| Cow::Owned(url.to_string()))
+            .unwrap_or_else(|| Cow::Owned(root.display().to_string()));
+        Self {
+            root: Cow::Owned(root),
+            package_url: package_url.map(Cow::Owned),
+            display,
+            deps: Cow::Owned(BTreeMap::new()),
+            cache_key: None,
+            enforce_nested_package_boundaries: false,
+        }
+    }
+
+    fn frozen(root: &'a Path, package: &'a FrozenPackage) -> Self {
+        Self {
+            root: Cow::Borrowed(root),
+            package_url: package.identity.package_url().map(Cow::Borrowed),
+            display: Cow::Owned(package.identity.display()),
+            deps: Cow::Borrowed(&package.deps),
+            cache_key: Some(PackageScopeKey::frozen(package)),
+            enforce_nested_package_boundaries: true,
+        }
+    }
+
+    pub(crate) fn enforces_nested_package_boundaries(&self) -> bool {
+        self.enforce_nested_package_boundaries
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        self.root.as_ref()
+    }
+
+    pub(crate) fn package_url(&self) -> Option<&str> {
+        self.package_url.as_deref()
+    }
+
+    pub(crate) fn display(&self) -> &str {
+        self.display.as_ref()
+    }
+
+    pub(crate) fn load_cache_key(&self) -> Option<PackageScopeKey> {
+        self.cache_key.clone()
+    }
+
+    pub(crate) fn expand_alias(&self, alias: &str) -> Option<&str> {
+        self.deps.keys().find_map(|url| {
+            url.rsplit('/')
+                .next()
+                .filter(|last_segment| *last_segment == alias)
+                .map(|_| url.as_str())
+        })
+    }
+
+    pub(crate) fn resolve_package_url<'scope>(
+        &'scope self,
+        full_url: &str,
+    ) -> Option<PackageUrlResolution<'scope>> {
+        resolve_package_url_parts(self.package_url(), self.deps.as_ref(), full_url)
+    }
+}
+
+pub(crate) enum PackageUrlResolution<'a> {
+    OwnPackage,
+    Dependency { dep_url: &'a str, root: &'a Path },
+}
+
+fn resolve_package_url_parts<'a>(
+    package_url: Option<&'a str>,
+    deps: &'a BTreeMap<String, PathBuf>,
+    full_url: &str,
+) -> Option<PackageUrlResolution<'a>> {
+    let own_url = package_url.filter(|url| package_url_covers(url, full_url));
+    let dep = deps
+        .iter()
+        .filter(|(dep_url, _)| package_url_covers(dep_url, full_url))
+        .max_by_key(|(dep_url, _)| dep_url.len());
+
+    match (own_url, dep) {
+        (Some(own_url), Some((dep_url, root))) if dep_url.len() > own_url.len() => {
+            Some(PackageUrlResolution::Dependency {
+                dep_url: dep_url.as_str(),
+                root: root.as_path(),
+            })
+        }
+        (Some(_), _) => Some(PackageUrlResolution::OwnPackage),
+        (None, Some((dep_url, root))) => Some(PackageUrlResolution::Dependency {
+            dep_url: dep_url.as_str(),
+            root: root.as_path(),
+        }),
+        (None, None) => None,
+    }
+}
 
 /// Compute the semver family for a version.
 ///
@@ -476,37 +633,6 @@ impl FrozenResolutionMap {
             .max_by_key(|(root, _)| root.as_os_str().len())
     }
 
-    pub fn resolve_package_url<'a>(
-        &'a self,
-        package: &'a FrozenPackage,
-        full_url: &str,
-    ) -> Option<FrozenUrlResolution<'a>> {
-        let own_url = package
-            .identity
-            .package_url()
-            .filter(|url| package_url_covers(url, full_url));
-        let dep = package
-            .deps
-            .iter()
-            .filter(|(dep_url, _)| package_url_covers(dep_url, full_url))
-            .max_by_key(|(dep_url, _)| dep_url.len());
-
-        match (own_url, dep) {
-            (Some(own_url), Some((dep_url, root))) if dep_url.len() > own_url.len() => {
-                Some(FrozenUrlResolution::Dependency {
-                    dep_url: dep_url.as_str(),
-                    root: root.as_path(),
-                })
-            }
-            (Some(_), _) => Some(FrozenUrlResolution::OwnPackage),
-            (None, Some((dep_url, root))) => Some(FrozenUrlResolution::Dependency {
-                dep_url: dep_url.as_str(),
-                root: root.as_path(),
-            }),
-            (None, None) => None,
-        }
-    }
-
     fn canonicalize_keys(&mut self, file_provider: &dyn crate::FileProvider) {
         self.packages = self
             .packages
@@ -536,11 +662,6 @@ impl FrozenResolutionMap {
             })
             .collect();
     }
-}
-
-pub enum FrozenUrlResolution<'a> {
-    OwnPackage,
-    Dependency { dep_url: &'a str, root: &'a Path },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -619,13 +740,65 @@ pub struct ResolutionResult {
     /// Keys are `package://` URIs for `.kicad_sym` files. Values are ordered lists
     /// of parts declared for that symbol (preserving manifest order).
     pub symbol_parts: HashMap<String, Vec<ManifestPart>>,
+    package_roots_cache: OnceLock<BTreeMap<String, PathBuf>>,
 }
 
 impl ResolutionResult {
+    pub fn new(
+        workspace_info: WorkspaceInfo,
+        package_resolutions: HashMap<PathBuf, BTreeMap<String, PathBuf>>,
+        closure: HashMap<ModuleLine, Version>,
+        mvs_v2_resolution: Option<FrozenResolutionSet>,
+        lockfile_changed: bool,
+        symbol_parts: HashMap<String, Vec<ManifestPart>>,
+    ) -> Self {
+        Self {
+            workspace_info,
+            package_resolutions,
+            closure,
+            mvs_v2_resolution,
+            lockfile_changed,
+            symbol_parts,
+            package_roots_cache: OnceLock::new(),
+        }
+    }
+
+    pub fn native(
+        workspace_info: WorkspaceInfo,
+        package_resolutions: HashMap<PathBuf, BTreeMap<String, PathBuf>>,
+        closure: HashMap<ModuleLine, Version>,
+        lockfile_changed: bool,
+        symbol_parts: HashMap<String, Vec<ManifestPart>>,
+    ) -> Self {
+        Self::new(
+            workspace_info,
+            package_resolutions,
+            closure,
+            None,
+            lockfile_changed,
+            symbol_parts,
+        )
+    }
+
+    pub fn frozen(
+        workspace_info: WorkspaceInfo,
+        resolution: FrozenResolutionSet,
+        symbol_parts: HashMap<String, Vec<ManifestPart>>,
+    ) -> Self {
+        Self::new(
+            workspace_info,
+            HashMap::new(),
+            HashMap::new(),
+            Some(resolution),
+            false,
+            symbol_parts,
+        )
+    }
+
     /// Create an empty resolution result with no dependencies.
     pub fn empty() -> Self {
-        Self {
-            workspace_info: WorkspaceInfo {
+        Self::new(
+            WorkspaceInfo {
                 root: PathBuf::new(),
                 cache_dir: PathBuf::new(),
                 config: None,
@@ -633,12 +806,153 @@ impl ResolutionResult {
                 lockfile: None,
                 errors: vec![],
             },
-            package_resolutions: HashMap::new(),
-            closure: HashMap::new(),
-            mvs_v2_resolution: None,
-            lockfile_changed: false,
-            symbol_parts: HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            None,
+            false,
+            HashMap::new(),
+        )
+    }
+
+    /// Resolve the package-local dependency scope for a file.
+    ///
+    /// When `active_mvs_v2_root` is present, lookup is intentionally scoped to
+    /// that frozen root package. The same physical package root can appear in
+    /// multiple v2 dependency environments, so callers must not use a global
+    /// file → scope lookup for frozen resolution.
+    pub(crate) fn package_scope_for_file<'a>(
+        &'a self,
+        file: &Path,
+        active_mvs_v2_root: Option<&str>,
+        file_provider: &dyn FileProvider,
+    ) -> Option<ResolvedPackageScope<'a>> {
+        if let Some(root_package) = active_mvs_v2_root {
+            return self
+                .mvs_v2_root(root_package)
+                .and_then(|resolution| resolution.package_for_file(file))
+                .map(|(root, package)| ResolvedPackageScope::frozen(root, package));
         }
+
+        if let Some((root, deps)) = self.native_resolution_for_file(file) {
+            let package_url = self.package_url_for_package_root(root, file_provider);
+            return Some(ResolvedPackageScope::native(root, deps, package_url));
+        }
+
+        self.native_manifest_scope_for_file(file, file_provider)
+    }
+
+    fn native_resolution_for_file(
+        &self,
+        file: &Path,
+    ) -> Option<(&PathBuf, &BTreeMap<String, PathBuf>)> {
+        self.package_resolutions
+            .iter()
+            .filter(|(root, _)| file.starts_with(root))
+            .max_by_key(|(root, _)| root.as_os_str().len())
+    }
+
+    fn native_manifest_scope_for_file<'a>(
+        &'a self,
+        file: &Path,
+        file_provider: &dyn FileProvider,
+    ) -> Option<ResolvedPackageScope<'a>> {
+        let mut current = file.parent();
+        while let Some(dir) = current {
+            if file_provider.exists(&dir.join("pcb.toml")) {
+                let root = dir.to_path_buf();
+                let package_url = self.package_url_for_package_root(&root, file_provider);
+                return Some(ResolvedPackageScope::native_empty(root, package_url));
+            }
+            current = dir.parent();
+        }
+        None
+    }
+
+    pub fn package_url_for_package_root(
+        &self,
+        root: &Path,
+        file_provider: &dyn FileProvider,
+    ) -> Option<String> {
+        let canonical_root = file_provider
+            .canonicalize(root)
+            .unwrap_or_else(|_| root.to_path_buf());
+
+        let stdlib_root = self.workspace_info.workspace_stdlib_dir();
+        let canonical_stdlib = file_provider
+            .canonicalize(&stdlib_root)
+            .unwrap_or(stdlib_root);
+        if canonical_root == canonical_stdlib {
+            return Some(STDLIB_MODULE_PATH.to_string());
+        }
+
+        for (url, package) in &self.workspace_info.packages {
+            let package_root = package.dir(&self.workspace_info.root);
+            let canonical_package = file_provider
+                .canonicalize(&package_root)
+                .unwrap_or(package_root);
+            if canonical_root == canonical_package {
+                return Some(url.clone());
+            }
+        }
+
+        let has_root_package = self
+            .workspace_info
+            .packages
+            .values()
+            .any(|pkg| pkg.rel_path.as_os_str().is_empty());
+        if !has_root_package {
+            let workspace_root = self.workspace_info.root.clone();
+            let canonical_workspace = file_provider
+                .canonicalize(&workspace_root)
+                .unwrap_or(workspace_root);
+            if canonical_root == canonical_workspace {
+                return Some(LOCAL_WORKSPACE_ROOT_URL.to_string());
+            }
+        }
+
+        self.package_resolutions
+            .values()
+            .flat_map(|deps| deps.iter())
+            .filter_map(|(dep_url, dep_root)| {
+                let canonical_dep = file_provider
+                    .canonicalize(dep_root)
+                    .unwrap_or_else(|_| dep_root.clone());
+                (canonical_root == canonical_dep).then_some(dep_url.clone())
+            })
+            .max_by_key(|dep_url| dep_url.len())
+    }
+
+    pub(crate) fn package_url_for_file(
+        &self,
+        file: &Path,
+        active_mvs_v2_root: Option<&str>,
+        file_provider: &dyn FileProvider,
+    ) -> Option<String> {
+        let scope = self.package_scope_for_file(file, active_mvs_v2_root, file_provider)?;
+        let package_url = scope.package_url()?.to_string();
+        let canonical_root = file_provider
+            .canonicalize(scope.root())
+            .unwrap_or_else(|_| scope.root().to_path_buf());
+        let rel = file
+            .strip_prefix(&canonical_root)
+            .or_else(|_| file.strip_prefix(scope.root()))
+            .unwrap_or(Path::new(""));
+
+        if rel.as_os_str().is_empty() {
+            Some(package_url)
+        } else {
+            Some(format!("{}/{}", package_url, rel.display()))
+        }
+    }
+
+    pub(crate) fn load_cache_scope_key_for_file(
+        &self,
+        file: &Path,
+        active_mvs_v2_root: Option<&str>,
+        file_provider: &dyn FileProvider,
+    ) -> Option<PackageScopeKey> {
+        self.package_scope_for_file(file, active_mvs_v2_root, file_provider)
+            .and_then(|scope| scope.load_cache_key())
     }
 
     /// Canonicalize `package_resolutions` keys using the given file provider.
@@ -661,6 +975,7 @@ impl ResolutionResult {
         if let Some(resolution) = &mut self.mvs_v2_resolution {
             resolution.canonicalize_keys(file_provider);
         }
+        self.package_roots_cache = OnceLock::new();
     }
 
     /// Build the package coordinate → absolute root directory mapping.
@@ -669,11 +984,17 @@ impl ResolutionResult {
     /// are discovered from `package_resolutions` values (already resolved by the
     /// resolver through patches → vendor → cache).
     pub fn package_roots(&self) -> BTreeMap<String, PathBuf> {
-        let mut roots = build_package_roots(&self.workspace_info, &self.package_resolutions);
-        if let Some(resolution) = &self.mvs_v2_resolution {
-            roots.extend(resolution.package_roots());
-        }
-        roots
+        self.package_roots_cached().clone()
+    }
+
+    fn package_roots_cached(&self) -> &BTreeMap<String, PathBuf> {
+        self.package_roots_cache.get_or_init(|| {
+            let mut roots = build_package_roots(&self.workspace_info, &self.package_resolutions);
+            if let Some(resolution) = &self.mvs_v2_resolution {
+                roots.extend(resolution.package_roots());
+            }
+            roots
+        })
     }
 
     pub fn mvs_v2_root(&self, package_url: &str) -> Option<&FrozenResolutionMap> {
@@ -728,7 +1049,7 @@ impl ResolutionResult {
 
     /// Resolve a package URI (`package://…`) to an absolute filesystem path.
     pub fn resolve_package_uri(&self, uri: &str) -> anyhow::Result<PathBuf> {
-        pcb_sch::resolve_package_uri(uri, &self.package_roots())
+        pcb_sch::resolve_package_uri(uri, self.package_roots_cached())
     }
 
     fn workspace_cache_path(&self, path: &Path) -> PathBuf {
@@ -746,9 +1067,9 @@ impl ResolutionResult {
     pub fn format_package_uri(&self, abs: &Path) -> Option<String> {
         let effective_abs = self.workspace_cache_path(abs);
         let package_roots = self
-            .package_roots()
-            .into_iter()
-            .map(|(coord, root)| (coord, self.workspace_cache_path(&root)))
+            .package_roots_cached()
+            .iter()
+            .map(|(coord, root)| (coord.clone(), self.workspace_cache_path(root)))
             .collect();
         pcb_sch::format_package_uri(&effective_abs, &package_roots)
     }
@@ -815,28 +1136,191 @@ mod tests {
             )]),
             parts: Vec::new(),
         };
-        let resolution = FrozenResolutionMap {
-            selected_remote: BTreeMap::new(),
-            packages: BTreeMap::new(),
-        };
+        let scope = ResolvedPackageScope::frozen(Path::new("/workspace/boards/demo"), &package);
 
-        let resolved = resolution.resolve_package_url(
-            &package,
-            "github.com/acme/repo/boards/demo/modules/usb/Usb.zen",
-        );
+        let resolved =
+            scope.resolve_package_url("github.com/acme/repo/boards/demo/modules/usb/Usb.zen");
 
         match resolved {
-            Some(FrozenUrlResolution::Dependency { dep_url, root }) => {
+            Some(PackageUrlResolution::Dependency { dep_url, root }) => {
                 assert_eq!(dep_url, "github.com/acme/repo/boards/demo/modules/usb");
                 assert_eq!(root, nested_root.as_path());
             }
             _ => panic!("expected nested dependency resolution"),
         }
 
-        let resolved = resolution
-            .resolve_package_url(&package, "github.com/acme/repo/boards/demo/src/Main.zen");
+        let resolved = scope.resolve_package_url("github.com/acme/repo/boards/demo/src/Main.zen");
 
-        assert!(matches!(resolved, Some(FrozenUrlResolution::OwnPackage)));
+        assert!(matches!(resolved, Some(PackageUrlResolution::OwnPackage)));
+    }
+
+    #[test]
+    fn frozen_scope_cache_key_is_package_local() {
+        let shared_root = PathBuf::from("/cache/github.com/acme/shared/1.0.0");
+        let shared_package = FrozenPackage {
+            identity: FrozenPackageIdentity::Remote {
+                dep_id: FrozenDepId {
+                    path: "github.com/acme/shared".into(),
+                    lane: "v1".into(),
+                },
+                version: Version::parse("1.0.0").unwrap(),
+            },
+            deps: BTreeMap::from([(
+                "github.com/acme/base".into(),
+                PathBuf::from("/cache/github.com/acme/base/1.0.0"),
+            )]),
+            parts: Vec::new(),
+        };
+        let resolution = ResolutionResult::frozen(
+            WorkspaceInfo {
+                root: PathBuf::from("/workspace"),
+                cache_dir: PathBuf::new(),
+                config: None,
+                packages: BTreeMap::new(),
+                lockfile: None,
+                errors: vec![],
+            },
+            FrozenResolutionSet {
+                root_packages: BTreeMap::from([
+                    (
+                        "github.com/acme/root-a".into(),
+                        FrozenResolutionMap {
+                            selected_remote: BTreeMap::new(),
+                            packages: BTreeMap::from([(
+                                shared_root.clone(),
+                                shared_package.clone(),
+                            )]),
+                        },
+                    ),
+                    (
+                        "github.com/acme/root-b".into(),
+                        FrozenResolutionMap {
+                            selected_remote: BTreeMap::new(),
+                            packages: BTreeMap::from([(
+                                shared_root.clone(),
+                                shared_package.clone(),
+                            )]),
+                        },
+                    ),
+                ]),
+            },
+            HashMap::new(),
+        );
+        let provider = InMemoryFileProvider::new(HashMap::new());
+        let file = shared_root.join("lib.zen");
+
+        assert_eq!(
+            resolution.load_cache_scope_key_for_file(
+                &file,
+                Some("github.com/acme/root-a"),
+                &provider,
+            ),
+            resolution.load_cache_scope_key_for_file(
+                &file,
+                Some("github.com/acme/root-b"),
+                &provider,
+            )
+        );
+    }
+
+    #[test]
+    fn frozen_scope_cache_key_changes_with_package_deps() {
+        let shared_root = PathBuf::from("/cache/github.com/acme/shared/1.0.0");
+        let package_with_dep = |dep_root: &str| FrozenPackage {
+            identity: FrozenPackageIdentity::Remote {
+                dep_id: FrozenDepId {
+                    path: "github.com/acme/shared".into(),
+                    lane: "v1".into(),
+                },
+                version: Version::parse("1.0.0").unwrap(),
+            },
+            deps: BTreeMap::from([("github.com/acme/base".into(), PathBuf::from(dep_root))]),
+            parts: Vec::new(),
+        };
+        let resolution = ResolutionResult::frozen(
+            WorkspaceInfo {
+                root: PathBuf::from("/workspace"),
+                cache_dir: PathBuf::new(),
+                config: None,
+                packages: BTreeMap::new(),
+                lockfile: None,
+                errors: vec![],
+            },
+            FrozenResolutionSet {
+                root_packages: BTreeMap::from([
+                    (
+                        "github.com/acme/root-a".into(),
+                        FrozenResolutionMap {
+                            selected_remote: BTreeMap::new(),
+                            packages: BTreeMap::from([(
+                                shared_root.clone(),
+                                package_with_dep("/cache/github.com/acme/base/1.0.0"),
+                            )]),
+                        },
+                    ),
+                    (
+                        "github.com/acme/root-b".into(),
+                        FrozenResolutionMap {
+                            selected_remote: BTreeMap::new(),
+                            packages: BTreeMap::from([(
+                                shared_root.clone(),
+                                package_with_dep("/cache/github.com/acme/base/2.0.0"),
+                            )]),
+                        },
+                    ),
+                ]),
+            },
+            HashMap::new(),
+        );
+        let provider = InMemoryFileProvider::new(HashMap::new());
+        let file = shared_root.join("lib.zen");
+
+        assert_ne!(
+            resolution.load_cache_scope_key_for_file(
+                &file,
+                Some("github.com/acme/root-a"),
+                &provider,
+            ),
+            resolution.load_cache_scope_key_for_file(
+                &file,
+                Some("github.com/acme/root-b"),
+                &provider,
+            )
+        );
+    }
+
+    #[test]
+    fn native_scope_cache_key_remains_path_only() {
+        let resolution = ResolutionResult::native(
+            WorkspaceInfo {
+                root: PathBuf::from("/workspace"),
+                cache_dir: PathBuf::new(),
+                config: None,
+                packages: BTreeMap::new(),
+                lockfile: None,
+                errors: vec![],
+            },
+            HashMap::from([(
+                PathBuf::from("/workspace/pkg"),
+                BTreeMap::from([(
+                    "github.com/acme/dep".into(),
+                    PathBuf::from("/cache/github.com/acme/dep/1.0.0"),
+                )]),
+            )]),
+            HashMap::new(),
+            false,
+            HashMap::new(),
+        );
+        let provider = InMemoryFileProvider::new(HashMap::new());
+
+        assert_eq!(
+            resolution.load_cache_scope_key_for_file(
+                Path::new("/workspace/pkg/lib.zen"),
+                None,
+                &provider,
+            ),
+            None
+        );
     }
 
     #[test]
@@ -896,14 +1380,13 @@ mod tests {
             errors: vec![],
         };
 
-        let result = ResolutionResult {
-            workspace_info: workspace,
-            package_resolutions: HashMap::new(),
-            closure: HashMap::new(),
-            mvs_v2_resolution: None,
-            lockfile_changed: false,
-            symbol_parts: HashMap::new(),
-        };
+        let result = ResolutionResult::native(
+            workspace,
+            HashMap::new(),
+            HashMap::new(),
+            false,
+            HashMap::new(),
+        );
 
         let abs = workspace_root
             .join(".pcb")
@@ -916,8 +1399,8 @@ mod tests {
     #[test]
     fn test_package_roots_include_workspace_fallback_for_standalone_files() {
         let workspace_root = PathBuf::from("/workspace");
-        let result = ResolutionResult {
-            workspace_info: WorkspaceInfo {
+        let result = ResolutionResult::native(
+            WorkspaceInfo {
                 root: workspace_root.clone(),
                 cache_dir: PathBuf::new(),
                 config: None,
@@ -925,12 +1408,11 @@ mod tests {
                 lockfile: None,
                 errors: vec![],
             },
-            package_resolutions: HashMap::new(),
-            closure: HashMap::new(),
-            mvs_v2_resolution: None,
-            lockfile_changed: false,
-            symbol_parts: HashMap::new(),
-        };
+            HashMap::new(),
+            HashMap::new(),
+            false,
+            HashMap::new(),
+        );
 
         let abs = workspace_root.join("lib.kicad_sym");
         let uri = result.format_package_uri(&abs);
@@ -1155,8 +1637,8 @@ mod tests {
     fn test_kicad_model_dirs_use_selected_builtin_family() {
         let version = "10.0.0";
         let models = "gitlab.com/kicad/libraries/kicad-packages3D".to_string();
-        let result = ResolutionResult {
-            workspace_info: WorkspaceInfo {
+        let result = ResolutionResult::native(
+            WorkspaceInfo {
                 root: PathBuf::from("/workspace"),
                 cache_dir: PathBuf::new(),
                 config: None,
@@ -1164,18 +1646,17 @@ mod tests {
                 lockfile: None,
                 errors: vec![],
             },
-            package_resolutions: HashMap::from([(
+            HashMap::from([(
                 PathBuf::from("/workspace"),
                 BTreeMap::from([(
                     models.clone(),
                     PathBuf::from(format!("/cache/{models}/{version}")),
                 )]),
             )]),
-            closure: HashMap::new(),
-            mvs_v2_resolution: None,
-            lockfile_changed: false,
-            symbol_parts: HashMap::new(),
-        };
+            HashMap::new(),
+            false,
+            HashMap::new(),
+        );
 
         assert_eq!(
             result.kicad_model_dirs(),

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -11,7 +11,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::Arc;
 
 use semver::Version;
 
@@ -314,6 +314,18 @@ pub fn build_package_roots(
         }
     }
 
+    roots
+}
+
+fn resolution_package_roots(
+    workspace_info: &WorkspaceInfo,
+    package_resolutions: &HashMap<PathBuf, BTreeMap<String, PathBuf>>,
+    mvs_v2_resolution: Option<&FrozenResolutionSet>,
+) -> BTreeMap<String, PathBuf> {
+    let mut roots = build_package_roots(workspace_info, package_resolutions);
+    if let Some(resolution) = mvs_v2_resolution {
+        roots.extend(resolution.package_roots());
+    }
     roots
 }
 
@@ -732,7 +744,7 @@ pub struct ResolutionResult {
     ///
     /// Native CLI resolution populates this for hydrated package scopes, and eval
     /// uses it as the authoritative package lookup table for those invocations.
-    pub mvs_v2_resolution: Option<FrozenResolutionSet>,
+    mvs_v2_resolution: Option<FrozenResolutionSet>,
     /// Whether the lockfile (pcb.sum) was updated during resolution
     pub lockfile_changed: bool,
     /// Symbol-to-parts mapping built from `[parts]` sections across all manifests.
@@ -740,7 +752,7 @@ pub struct ResolutionResult {
     /// Keys are `package://` URIs for `.kicad_sym` files. Values are ordered lists
     /// of parts declared for that symbol (preserving manifest order).
     pub symbol_parts: HashMap<String, Vec<ManifestPart>>,
-    package_roots_cache: OnceLock<BTreeMap<String, PathBuf>>,
+    package_roots: Arc<BTreeMap<String, PathBuf>>,
 }
 
 impl ResolutionResult {
@@ -752,6 +764,11 @@ impl ResolutionResult {
         lockfile_changed: bool,
         symbol_parts: HashMap<String, Vec<ManifestPart>>,
     ) -> Self {
+        let package_roots = Arc::new(resolution_package_roots(
+            &workspace_info,
+            &package_resolutions,
+            mvs_v2_resolution.as_ref(),
+        ));
         Self {
             workspace_info,
             package_resolutions,
@@ -759,7 +776,7 @@ impl ResolutionResult {
             mvs_v2_resolution,
             lockfile_changed,
             symbol_parts,
-            package_roots_cache: OnceLock::new(),
+            package_roots,
         }
     }
 
@@ -975,7 +992,20 @@ impl ResolutionResult {
         if let Some(resolution) = &mut self.mvs_v2_resolution {
             resolution.canonicalize_keys(file_provider);
         }
-        self.package_roots_cache = OnceLock::new();
+        self.refresh_package_roots();
+    }
+
+    fn refresh_package_roots(&mut self) {
+        self.package_roots = Arc::new(resolution_package_roots(
+            &self.workspace_info,
+            &self.package_resolutions,
+            self.mvs_v2_resolution.as_ref(),
+        ));
+    }
+
+    pub fn set_mvs_v2_resolution(&mut self, resolution: FrozenResolutionSet) {
+        self.mvs_v2_resolution = Some(resolution);
+        self.refresh_package_roots();
     }
 
     /// Build the package coordinate → absolute root directory mapping.
@@ -984,17 +1014,11 @@ impl ResolutionResult {
     /// are discovered from `package_resolutions` values (already resolved by the
     /// resolver through patches → vendor → cache).
     pub fn package_roots(&self) -> BTreeMap<String, PathBuf> {
-        self.package_roots_cached().clone()
+        self.package_roots.as_ref().clone()
     }
 
-    fn package_roots_cached(&self) -> &BTreeMap<String, PathBuf> {
-        self.package_roots_cache.get_or_init(|| {
-            let mut roots = build_package_roots(&self.workspace_info, &self.package_resolutions);
-            if let Some(resolution) = &self.mvs_v2_resolution {
-                roots.extend(resolution.package_roots());
-            }
-            roots
-        })
+    pub(crate) fn package_roots_ref(&self) -> &BTreeMap<String, PathBuf> {
+        self.package_roots.as_ref()
     }
 
     pub fn mvs_v2_root(&self, package_url: &str) -> Option<&FrozenResolutionMap> {
@@ -1049,7 +1073,7 @@ impl ResolutionResult {
 
     /// Resolve a package URI (`package://…`) to an absolute filesystem path.
     pub fn resolve_package_uri(&self, uri: &str) -> anyhow::Result<PathBuf> {
-        pcb_sch::resolve_package_uri(uri, self.package_roots_cached())
+        pcb_sch::resolve_package_uri(uri, self.package_roots.as_ref())
     }
 
     fn workspace_cache_path(&self, path: &Path) -> PathBuf {
@@ -1067,7 +1091,7 @@ impl ResolutionResult {
     pub fn format_package_uri(&self, abs: &Path) -> Option<String> {
         let effective_abs = self.workspace_cache_path(abs);
         let package_roots = self
-            .package_roots_cached()
+            .package_roots
             .iter()
             .map(|(coord, root)| (coord.clone(), self.workspace_cache_path(root)))
             .collect();
@@ -1152,6 +1176,53 @@ mod tests {
         let resolved = scope.resolve_package_url("github.com/acme/repo/boards/demo/src/Main.zen");
 
         assert!(matches!(resolved, Some(PackageUrlResolution::OwnPackage)));
+    }
+
+    #[test]
+    fn package_roots_reflect_attached_mvs_v2_resolution() {
+        let mut result = ResolutionResult::native(
+            WorkspaceInfo {
+                root: PathBuf::from("/workspace"),
+                cache_dir: PathBuf::new(),
+                config: None,
+                packages: BTreeMap::new(),
+                lockfile: None,
+                errors: vec![],
+            },
+            HashMap::new(),
+            HashMap::new(),
+            false,
+            HashMap::new(),
+        );
+        let dep_root = PathBuf::from("/cache/github.com/acme/dep/1.2.3");
+        let dep_coord = "github.com/acme/dep@1.2.3";
+
+        assert!(!result.package_roots().contains_key(dep_coord));
+
+        result.set_mvs_v2_resolution(FrozenResolutionSet {
+            root_packages: BTreeMap::from([(
+                "github.com/acme/root".into(),
+                FrozenResolutionMap {
+                    selected_remote: BTreeMap::new(),
+                    packages: BTreeMap::from([(
+                        dep_root.clone(),
+                        FrozenPackage {
+                            identity: FrozenPackageIdentity::Remote {
+                                dep_id: FrozenDepId {
+                                    path: "github.com/acme/dep".into(),
+                                    lane: "v1".into(),
+                                },
+                                version: Version::parse("1.2.3").unwrap(),
+                            },
+                            deps: BTreeMap::new(),
+                            parts: Vec::new(),
+                        },
+                    )]),
+                },
+            )]),
+        });
+
+        assert_eq!(result.package_roots().get(dep_coord), Some(&dep_root));
     }
 
     #[test]

--- a/crates/pcb-zen-core/tests/cross_package_load.rs
+++ b/crates/pcb-zen-core/tests/cross_package_load.rs
@@ -130,14 +130,13 @@ check(LedValue == "hello from Led", "should load from Led")
     // Workspace root resolution map
     package_resolutions.insert(workspace_root, common::default_test_kicad_resolution_map());
 
-    let resolution = ResolutionResult {
+    let resolution = ResolutionResult::native(
         workspace_info,
         package_resolutions,
-        closure: HashMap::new(),
-        mvs_v2_resolution: None,
-        lockfile_changed: false,
-        symbol_parts: HashMap::new(),
-    };
+        HashMap::new(),
+        false,
+        HashMap::new(),
+    );
 
     let main_path = PathBuf::from("/workspace/boards/Main/Main.zen");
     (file_provider, resolution, main_path)

--- a/crates/pcb-zen-wasm/src/lib.rs
+++ b/crates/pcb-zen-wasm/src/lib.rs
@@ -606,14 +606,13 @@ fn resolve_packages<F: FileProvider + Clone>(
 
     let package_resolutions =
         build_resolution_map(&file_provider, &resolver, &workspace, resolver.closure());
-    Ok(pcb_zen_core::resolution::ResolutionResult {
-        workspace_info: workspace,
+    Ok(pcb_zen_core::resolution::ResolutionResult::native(
+        workspace,
         package_resolutions,
-        closure: HashMap::new(),
-        mvs_v2_resolution: None,
-        lockfile_changed: false,
-        symbol_parts: HashMap::new(),
-    })
+        HashMap::new(),
+        false,
+        HashMap::new(),
+    ))
 }
 
 fn diagnostic_to_json(diag: &pcb_zen_core::Diagnostic) -> DiagnosticInfo {

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -878,14 +878,13 @@ pub fn resolve_dependencies(
         &package_resolutions,
     )?;
 
-    Ok(ResolutionResult {
-        workspace_info: workspace_info.clone(),
+    Ok(ResolutionResult::native(
+        workspace_info.clone(),
         package_resolutions,
         closure,
-        mvs_v2_resolution: None,
         lockfile_changed,
         symbol_parts,
-    })
+    ))
 }
 
 /// Vendor dependencies from cache to vendor directory

--- a/crates/pcb/src/mod/mod.rs
+++ b/crates/pcb/src/mod/mod.rs
@@ -26,9 +26,7 @@ use std::path::{Path, PathBuf};
 use self::materialize::{materialize_selected, vendor_selected};
 use self::mvs::{DepGraph, DepGraphNode, PackageResolver};
 use self::request::resolve_direct_dependency_request;
-pub(crate) use self::resolve::{
-    build_frozen_resolution_map, build_frozen_resolution_maps, target_package_urls_for_path,
-};
+pub(crate) use self::resolve::{build_frozen_resolution_maps, target_package_urls_for_path};
 use self::target::{AddTarget, discover_add_targets};
 use self::writeback::write_package_manifest;
 
@@ -137,10 +135,10 @@ pub fn execute_mod_download(args: ModDownloadArgs) -> Result<()> {
         return Ok(());
     }
 
-    let targets = discover_add_targets(&workspace, &cwd)?;
-    for target in targets {
-        build_frozen_resolution_map(&workspace, &target.package_url, false)?;
-    }
+    let package_urls = discover_add_targets(&workspace, &cwd)?
+        .into_iter()
+        .map(|target| target.package_url);
+    build_frozen_resolution_maps(&workspace, package_urls, false)?;
     Ok(())
 }
 
@@ -179,12 +177,15 @@ pub fn execute_mod_resolve(args: ModResolveArgs) -> Result<()> {
     validate_workspace(&workspace)?;
 
     let package_urls = target_package_urls_for_path(&workspace, path)?;
+    let resolutions = build_frozen_resolution_maps(&workspace, package_urls.clone(), false)?;
     for (idx, package_url) in package_urls.iter().enumerate() {
         if idx > 0 {
             println!();
         }
-        let resolution = build_frozen_resolution_map(&workspace, package_url, false)?;
-        print_frozen_resolution(&workspace, package_url, &resolution);
+        let resolution = resolutions
+            .get(package_url)
+            .expect("frozen resolution was built for requested package");
+        print_frozen_resolution(&workspace, package_url, resolution);
     }
 
     Ok(())

--- a/crates/pcb/src/mod/mod.rs
+++ b/crates/pcb/src/mod/mod.rs
@@ -26,7 +26,9 @@ use std::path::{Path, PathBuf};
 use self::materialize::{materialize_selected, vendor_selected};
 use self::mvs::{DepGraph, DepGraphNode, PackageResolver};
 use self::request::resolve_direct_dependency_request;
-pub(crate) use self::resolve::{build_frozen_resolution_map, target_package_urls_for_path};
+pub(crate) use self::resolve::{
+    build_frozen_resolution_map, build_frozen_resolution_maps, target_package_urls_for_path,
+};
 use self::target::{AddTarget, discover_add_targets};
 use self::writeback::write_package_manifest;
 

--- a/crates/pcb/src/mod/resolve.rs
+++ b/crates/pcb/src/mod/resolve.rs
@@ -60,7 +60,9 @@ pub(crate) fn build_frozen_resolution_maps(
     let mut builder = FrozenResolutionBuilder::new(workspace.clone(), offline)?;
     let mut resolutions = BTreeMap::new();
     for package_url in package_urls {
-        let resolution = builder.build(&package_url)?;
+        let resolution = builder
+            .build(&package_url)
+            .with_context(|| format!("while resolving dependencies for {package_url}"))?;
         resolutions.insert(package_url, resolution);
     }
     Ok(resolutions)
@@ -375,7 +377,7 @@ impl FrozenResolutionBuilder {
         let (_, config) = self.workspace_manifest(package_url)?;
         if config.dependencies.indirect.is_empty() {
             bail!(
-                "{} does not contain a hydrated MVS v2 dependency closure; run `pcb mod sync` first",
+                "{} is missing resolved dependency entries; run `pcb sync` first",
                 package_url
             );
         }
@@ -454,7 +456,7 @@ fn exact_spec_version(dep_url: &str, spec: &DependencySpec) -> Result<Version> {
         }
         DependencySpec::Detailed(_) => {
             bail!(
-                "Dependency {} must have an exact version for frozen MVS v2 resolution",
+                "Dependency {} must specify an exact version; run `pcb sync` to update dependency versions",
                 dep_url
             );
         }

--- a/crates/pcb/src/mod/resolve.rs
+++ b/crates/pcb/src/mod/resolve.rs
@@ -52,14 +52,6 @@ pub(crate) fn target_package_urls_for_path(
     Ok(package_urls.into_iter().collect())
 }
 
-pub(crate) fn build_frozen_resolution_map(
-    workspace: &WorkspaceInfo,
-    package_url: &str,
-    offline: bool,
-) -> Result<FrozenResolutionMap> {
-    FrozenResolutionBuilder::new(workspace.clone(), offline)?.build(package_url)
-}
-
 pub(crate) fn build_frozen_resolution_maps(
     workspace: &WorkspaceInfo,
     package_urls: impl IntoIterator<Item = String>,

--- a/crates/pcb/src/mod/resolve.rs
+++ b/crates/pcb/src/mod/resolve.rs
@@ -60,12 +60,28 @@ pub(crate) fn build_frozen_resolution_map(
     FrozenResolutionBuilder::new(workspace.clone(), offline)?.build(package_url)
 }
 
+pub(crate) fn build_frozen_resolution_maps(
+    workspace: &WorkspaceInfo,
+    package_urls: impl IntoIterator<Item = String>,
+    offline: bool,
+) -> Result<BTreeMap<String, FrozenResolutionMap>> {
+    let mut builder = FrozenResolutionBuilder::new(workspace.clone(), offline)?;
+    let mut resolutions = BTreeMap::new();
+    for package_url in package_urls {
+        let resolution = builder.build(&package_url)?;
+        resolutions.insert(package_url, resolution);
+    }
+    Ok(resolutions)
+}
+
 struct FrozenResolutionBuilder {
     workspace: WorkspaceInfo,
     offline: bool,
     cache_index: CacheIndex,
     manifest_loader: ManifestLoader,
     selected_remote: BTreeMap<ResolvedDepId, Version>,
+    materialized_remote: BTreeSet<(ResolvedDepId, Version)>,
+    remote_roots: BTreeMap<(String, Version), PathBuf>,
     packages: BTreeMap<PathBuf, FrozenPackage>,
 }
 
@@ -78,16 +94,19 @@ impl FrozenResolutionBuilder {
             workspace,
             offline,
             selected_remote: BTreeMap::new(),
+            materialized_remote: BTreeSet::new(),
+            remote_roots: BTreeMap::new(),
             packages: BTreeMap::new(),
         })
     }
 
-    fn build(mut self, package_url: &str) -> Result<FrozenResolutionMap> {
+    fn build(&mut self, package_url: &str) -> Result<FrozenResolutionMap> {
         self.selected_remote = self
             .selected_remote_from_root_manifest(package_url)
             .with_context(|| format!("while reading resolved closure for {}", package_url))?;
 
-        materialize_selected(&self.workspace, &self.selected_remote, self.offline)?;
+        self.materialize_selected_remote()?;
+        self.packages.clear();
 
         let mut queue = VecDeque::from([PackageNode::Workspace(package_url.to_string())]);
         let mut seen = BTreeSet::new();
@@ -102,11 +121,33 @@ impl FrozenResolutionBuilder {
         Ok(FrozenResolutionMap {
             selected_remote: self
                 .selected_remote
+                .clone()
                 .into_iter()
                 .map(|(dep_id, version)| (frozen_dep_id(dep_id), version))
                 .collect(),
-            packages: self.packages,
+            packages: std::mem::take(&mut self.packages),
         })
+    }
+
+    fn materialize_selected_remote(&mut self) -> Result<()> {
+        let pending: BTreeMap<_, _> = self
+            .selected_remote
+            .iter()
+            .filter(|(dep_id, version)| {
+                !self
+                    .materialized_remote
+                    .contains(&((*dep_id).clone(), (*version).clone()))
+            })
+            .map(|(dep_id, version)| (dep_id.clone(), version.clone()))
+            .collect();
+
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        materialize_selected(&self.workspace, &pending, self.offline)?;
+        self.materialized_remote.extend(pending);
+        Ok(())
     }
 
     fn resolve_package_node(
@@ -285,6 +326,11 @@ impl FrozenResolutionBuilder {
     }
 
     fn remote_package_root(&mut self, module_path: &str, version: &Version) -> Result<PathBuf> {
+        let key = (module_path.to_string(), version.clone());
+        if let Some(root) = self.remote_roots.get(&key) {
+            return Ok(root.clone());
+        }
+
         let version_str = version.to_string();
         let vendor_root = self
             .workspace
@@ -293,6 +339,7 @@ impl FrozenResolutionBuilder {
             .join(module_path)
             .join(&version_str);
         if vendor_root.exists() {
+            self.remote_roots.insert(key, vendor_root.clone());
             return Ok(vendor_root);
         }
 
@@ -303,6 +350,7 @@ impl FrozenResolutionBuilder {
             .join(&version_str);
         let managed_kicad = self.is_managed_kicad_dep(module_path, version);
         if cache_root.join("pcb.toml").exists() || managed_kicad && cache_root.exists() {
+            self.remote_roots.insert(key, cache_root.clone());
             return Ok(cache_root);
         }
 
@@ -317,6 +365,7 @@ impl FrozenResolutionBuilder {
         if !managed_kicad {
             ensure_package_manifest_in_cache(module_path, version, &self.cache_index)?;
         }
+        self.remote_roots.insert(key, cache_root.clone());
         Ok(cache_root)
     }
 

--- a/crates/pcb/src/resolve.rs
+++ b/crates/pcb/src/resolve.rs
@@ -83,9 +83,9 @@ fn resolve_mvs_v2(
     let mut resolution_set = FrozenResolutionSet::default();
     let mut symbol_parts = HashMap::new();
 
-    for package_url in package_urls {
-        let resolution =
-            crate::pcb_mod::build_frozen_resolution_map(&workspace_info, &package_url, offline)?;
+    for (package_url, resolution) in
+        crate::pcb_mod::build_frozen_resolution_maps(&workspace_info, package_urls, offline)?
+    {
         symbol_parts.extend(pcb_zen::resolve::build_frozen_symbol_parts(
             &workspace_info,
             &resolution,
@@ -93,14 +93,11 @@ fn resolve_mvs_v2(
         resolution_set.root_packages.insert(package_url, resolution);
     }
 
-    Ok(ResolutionResult {
+    Ok(ResolutionResult::frozen(
         workspace_info,
-        package_resolutions: HashMap::new(),
-        closure: HashMap::new(),
-        mvs_v2_resolution: Some(resolution_set),
-        lockfile_changed: false,
+        resolution_set,
         symbol_parts,
-    })
+    ))
 }
 
 pub(crate) fn attach_mvs_v2_resolution_for_packages(

--- a/crates/pcb/src/resolve.rs
+++ b/crates/pcb/src/resolve.rs
@@ -128,7 +128,7 @@ pub(crate) fn attach_mvs_v2_resolution_for_packages(
     }
 
     if !resolution_set.root_packages.is_empty() {
-        res.mvs_v2_resolution = Some(resolution_set);
+        res.set_mvs_v2_resolution(resolution_set);
     }
 }
 

--- a/crates/pcb/src/resolve.rs
+++ b/crates/pcb/src/resolve.rs
@@ -90,7 +90,7 @@ fn resolve_mvs_v2(
             &workspace_info,
             &resolution,
         )?);
-        resolution_set.root_packages.insert(package_url, resolution);
+        resolution_set.insert(package_url, resolution);
     }
 
     Ok(ResolutionResult::frozen(
@@ -105,30 +105,17 @@ pub(crate) fn attach_mvs_v2_resolution_for_packages(
     package_urls: impl IntoIterator<Item = String>,
     offline: bool,
 ) {
-    let mut resolution_set = FrozenResolutionSet::default();
-
-    for package_url in package_urls {
-        if !package_has_indirect(&res.workspace_info, &package_url) {
-            continue;
-        }
-        match crate::pcb_mod::build_frozen_resolution_map(
-            &res.workspace_info,
-            &package_url,
-            offline,
-        ) {
-            Ok(resolution) => {
-                resolution_set
-                    .root_packages
-                    .insert(package_url.to_string(), resolution);
-            }
-            Err(err) => {
-                log::debug!("Skipping shadow MVS v2 resolution for {package_url}: {err:#}");
-            }
-        }
+    let package_urls: Vec<_> = package_urls
+        .into_iter()
+        .filter(|package_url| package_has_indirect(&res.workspace_info, package_url))
+        .collect();
+    if package_urls.is_empty() {
+        return;
     }
 
-    if !resolution_set.root_packages.is_empty() {
-        res.set_mvs_v2_resolution(resolution_set);
+    match crate::pcb_mod::build_frozen_resolution_maps(&res.workspace_info, package_urls, offline) {
+        Ok(resolution) => res.set_mvs_v2_resolution(resolution),
+        Err(err) => log::debug!("Skipping shadow MVS v2 resolution: {err:#}"),
     }
 }
 


### PR DESCRIPTION
| Mode | State | Command shape | Time |
| --- | --- | --- | ---: |
| v1 | clean/non-hydrated temp worktree | `pcb build .` | ~9.36s |
| v2 | hydrated worktree after `pcb sync` | `pcb build .` | ~5.18s |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dependency resolution and module-loading cache keys; mistakes could cause incorrect module reuse across differing dependency environments or regress URL/path resolution behavior.
> 
> **Overview**
> Improves performance for hydrated (MVS v2) builds by making Starlark module load caching **package-local**: cached modules are now keyed by a stable `PackageScopeKey` (package identity + resolved dep map) so identical package scopes can reuse loads across packages.
> 
> Refactors resolution to expose a unified `ResolvedPackageScope` abstraction and centralizes package/root URL lookups (`package_scope_for_file`, `package_url_for_file`, cached `package_roots`), removing separate v2-specific resolution branches in the evaluator and tightening nested-package boundary enforcement for relative loads.
> 
> Updates `pcb mod`/build flows to build **multiple** frozen resolution maps in one pass (shared materialization + cached remote roots) and adjusts constructors/callers/tests accordingly, with clearer guidance to run `pcb sync` when resolved dependency entries are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3863645d8d0ac54df9dbfcb286f6c2ea5fa267d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->