### PR TITLE
Reduce capacitor voltage rating warning noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Capacitor voltage-rating warnings now compare explicit ratings against the connected net voltage difference instead of the inferred 1.5x rounded requirement.
+
 ## [0.3.76] - 2026-05-06
 
 ### Added

--- a/stdlib/generics/Capacitor.zen
+++ b/stdlib/generics/Capacitor.zen
@@ -30,12 +30,11 @@ if exclude_from_bom:
 P1 = io(Net)
 P2 = io(Net)
 
-default_voltage = (
-    capacitor_voltage_rating(Voltage(P1.voltage.diff(P2.voltage) * 1.5)) if P1.voltage and P2.voltage else None
-)
-if voltage and default_voltage and voltage < default_voltage:
+net_voltage_diff = P1.voltage.diff(P2.voltage) if P1.voltage and P2.voltage else None
+default_voltage = capacitor_voltage_rating(Voltage(net_voltage_diff * 1.5)) if net_voltage_diff != None else None
+if voltage and net_voltage_diff != None and voltage < net_voltage_diff:
     warn(
-        "Capacitor voltage rating (%s) should be >= inferred voltage rating (%s)" % (voltage, default_voltage),
+        f"Capacitor voltage rating ({voltage}) should be >= net voltage difference ({net_voltage_diff})",
         kind="capacitor.voltage_rating",
     )
 

--- a/stdlib/generics/test/test_Capacitor.zen
+++ b/stdlib/generics/test/test_Capacitor.zen
@@ -15,6 +15,7 @@ check(capacitor_voltage_rating(Voltage("52.5V")) == Voltage("100V"), "35V is not
 
 v3v3 = Power("V3V3", voltage=Voltage("3.3V"))
 gnd = Ground("GND")
+Capacitor(name="C_EXPLICIT_ABOVE_NET_BELOW_AUTO_VOLTAGE", value="100nF", voltage="5V", P1=v3v3, P2=gnd)
 Capacitor(name="C_EXPLICIT_EQUAL_AUTO_VOLTAGE", value="100nF", voltage="6.3V", P1=v3v3, P2=gnd)
 Capacitor(name="C_EXPLICIT_HIGHER_THAN_AUTO_VOLTAGE", value="100nF", voltage="10V", P1=v3v3, P2=gnd)
 


### PR DESCRIPTION
The registry violates this rule too much. Will reconsider later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to capacitor ERC warning criteria and message; it may alter when/if voltage-rating warnings appear but doesn’t affect netlist/BOM generation.
> 
> **Overview**
> Adjusts `generics/Capacitor.zen` voltage-rating diagnostics to compare *explicit* capacitor voltage ratings against the actual connected net voltage difference (instead of the inferred 1.5x rounded auto-rating), reducing warning noise and updating the warning message accordingly.
> 
> Updates the capacitor generic tests to include a case where an explicit rating is below the previous auto-derived threshold but above the net voltage, and documents the behavior change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b77a629d743e352eccc6727fdfbe7075d6ac5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->