### PR TITLE
feat: embed relative-path 3d models in `pcb layout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `pcb layout` now embeds footprint-relative 3D models.
+
 ## [0.3.77] - 2026-05-07
 
 ### Changed

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -536,7 +536,8 @@ pub fn process_layout(
         .with_context(|| format!("Failed to write netlist: {}", paths.netlist.display()))?;
 
     // Write footprint library table
-    utils::write_footprint_library_table(&layout_dir, schematic)?;
+    let footprint_lib_dirs = utils::footprint_library_dirs(schematic)?;
+    utils::write_footprint_library_dirs(&layout_dir, &footprint_lib_dirs)?;
 
     // Write JSON netlist for Python script
     let json_content =
@@ -595,7 +596,12 @@ pub fn process_layout(
             &netclass_assignments,
         )?;
     }
-    patch_pcb_file(&paths.pcb, board_config.as_ref(), kicad_model_dirs)?;
+    patch_pcb_file(
+        &paths.pcb,
+        board_config.as_ref(),
+        kicad_model_dirs,
+        &footprint_lib_dirs,
+    )?;
 
     // Add sync diagnostics from JSON file
     if paths.diagnostics.exists() {
@@ -810,10 +816,9 @@ pub mod utils {
     }
 
     /// Write footprint library table for a layout
-    pub fn write_footprint_library_table(
-        layout_dir: &Path,
+    pub fn footprint_library_dirs(
         schematic: &Schematic,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<HashMap<String, PathBuf>> {
         let mut fp_libs: HashMap<String, PathBuf> = HashMap::new();
 
         for inst in schematic.instances.values() {
@@ -830,17 +835,32 @@ pub mod utils {
             }
         }
 
+        Ok(fp_libs)
+    }
+
+    pub(crate) fn write_footprint_library_dirs(
+        layout_dir: &Path,
+        fp_libs: &HashMap<String, PathBuf>,
+    ) -> anyhow::Result<()> {
         // Canonicalize the layout directory to avoid symlink issues on macOS
         let canonical_layout_dir = layout_dir
             .canonicalize()
             .unwrap_or_else(|_| layout_dir.to_path_buf());
 
         // Write or update the fp-lib-table for this layout directory
-        write_fp_lib_table(&canonical_layout_dir, &fp_libs).with_context(|| {
+        write_fp_lib_table(&canonical_layout_dir, fp_libs).with_context(|| {
             format!("Failed to write fp-lib-table for {}", layout_dir.display())
         })?;
 
         Ok(())
+    }
+
+    pub fn write_footprint_library_table(
+        layout_dir: &Path,
+        schematic: &Schematic,
+    ) -> anyhow::Result<()> {
+        let fp_libs = footprint_library_dirs(schematic)?;
+        write_footprint_library_dirs(layout_dir, &fp_libs)
     }
 }
 
@@ -1001,6 +1021,7 @@ fn patch_pcb_file(
     pcb_path: &Path,
     board_config: Option<&BoardConfig>,
     kicad_model_dirs: &BTreeMap<String, PathBuf>,
+    footprint_lib_dirs: &HashMap<String, PathBuf>,
 ) -> Result<(), LayoutError> {
     let pcb_content = fs::read_to_string(pcb_path).map_err(|e| {
         LayoutError::StackupPatchingError(format!("Failed to read PCB file: {}", e))
@@ -1019,15 +1040,19 @@ fn patch_pcb_file(
         ))
     })?;
     let pcb_dir = pcb_path.parent().unwrap_or_else(|| Path::new("."));
-    let (embedded, discovery, applied) =
-        model_embed_discovery::embed_models_in_pcb_source(&patched, pcb_dir, kicad_model_dirs)
-            .map_err(|e| {
-                LayoutError::StackupPatchingError(format!(
-                    "Failed to prepare embedded 3D models for {}: {}",
-                    pcb_path.display(),
-                    e
-                ))
-            })?;
+    let (embedded, discovery, applied) = model_embed_discovery::embed_models_in_pcb_source(
+        &patched,
+        pcb_dir,
+        kicad_model_dirs,
+        footprint_lib_dirs,
+    )
+    .map_err(|e| {
+        LayoutError::StackupPatchingError(format!(
+            "Failed to prepare embedded 3D models for {}: {}",
+            pcb_path.display(),
+            e
+        ))
+    })?;
     if discovery.unresolved_refs > 0 {
         log::warn!(
             "Unresolved managed 3D model references in {}: {}",

--- a/crates/pcb-layout/src/model_embed_discovery.rs
+++ b/crates/pcb-layout/src/model_embed_discovery.rs
@@ -3,9 +3,9 @@ use base64::Engine;
 use pcb_sexpr::formatter::{FormatMode, format_tree};
 use pcb_sexpr::{Sexpr, SexprKind, WalkCtx, find_named_list_index, set_or_insert_named_list};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ModelEmbedDiscoveryStats {
@@ -37,18 +37,39 @@ enum DiscoveryOutcome {
     Unresolved,
 }
 
+#[derive(Debug, Default)]
+struct EmbedPlan {
+    replacements: BTreeMap<String, ModelReplacement>,
+    files_to_embed: BTreeMap<String, PathBuf>,
+}
+
+#[derive(Debug)]
+enum ModelReplacement {
+    /// The raw model ref has one safe target everywhere it appears.
+    Global(String),
+    /// The raw model ref had mixed outcomes; only rewrite the listed footprint libraries.
+    ByFootprint(BTreeMap<Option<String>, String>),
+}
+
+#[derive(Debug)]
+struct ReplacementOccurrence {
+    footprint_library: Option<String>,
+    replacement: Option<String>,
+}
+
 pub(crate) fn embed_models_in_pcb_source(
     source: &str,
     pcb_dir: &Path,
     kicad_model_dirs: &BTreeMap<String, PathBuf>,
+    footprint_lib_dirs: &HashMap<String, PathBuf>,
 ) -> anyhow::Result<(String, ModelEmbedDiscoveryStats, ModelEmbedApplyStats)> {
     let mut board = pcb_sexpr::parse(source).context("Failed to parse PCB file for model embed")?;
-    let (replacements, files_to_embed, discovery_stats, mut apply_stats) =
-        collect_embed_plan(&board, pcb_dir, kicad_model_dirs);
+    let (plan, discovery_stats, mut apply_stats) =
+        collect_embed_plan(&board, pcb_dir, kicad_model_dirs, footprint_lib_dirs);
 
     let mut model_checksums = existing_embedded_model_checksums(&board);
     let mut new_file_nodes = Vec::new();
-    for (embed_name, source_path) in &files_to_embed {
+    for (embed_name, source_path) in &plan.files_to_embed {
         if model_checksums.contains_key(embed_name) {
             continue;
         }
@@ -73,7 +94,7 @@ pub(crate) fn embed_models_in_pcb_source(
         embedded_files.extend(new_file_nodes);
     }
 
-    rewrite_model_paths(&mut board, &replacements, &mut apply_stats);
+    rewrite_model_paths(&mut board, &plan.replacements, None, &mut apply_stats);
     apply_stats.footprint_metadata_entries =
         upsert_footprint_embedded_model_metadata(&mut board, &model_checksums);
 
@@ -85,10 +106,11 @@ fn is_model_filename(ctx: &WalkCtx<'_>) -> bool {
     ctx.parent_tag() == Some("model") && ctx.index_in_parent == Some(1)
 }
 
-fn resolve_managed_model_reference(
+fn resolve_model_reference(
     model_ref: &str,
     pcb_dir: &Path,
     kicad_model_dirs: &BTreeMap<String, PathBuf>,
+    footprint_lib_dir: Option<&Path>,
 ) -> DiscoveryOutcome {
     if model_ref.starts_with("kicad-embed://") {
         return DiscoveryOutcome::AlreadyEmbedded;
@@ -102,7 +124,10 @@ fn resolve_managed_model_reference(
         let Some(var_root) = kicad_model_dirs.get(var_name) else {
             return DiscoveryOutcome::Unresolved;
         };
-        return to_candidate_or_missing(var_root.join(strip_leading_separators(rest)));
+        let Some(path) = resolve_relative_subpath(var_root, strip_leading_separators(rest)) else {
+            return DiscoveryOutcome::Unmanaged;
+        };
+        return to_candidate_or_missing(path);
     }
 
     if model_ref.starts_with("${") || model_ref.starts_with("$(") {
@@ -111,22 +136,47 @@ fn resolve_managed_model_reference(
 
     let path = Path::new(model_ref);
     if path.is_absolute() {
-        for root in kicad_model_dirs.values() {
-            if path.starts_with(root) {
-                return to_candidate_or_missing(path.to_path_buf());
-            }
+        if is_under_any_root(path, kicad_model_dirs.values()) {
+            return to_candidate_or_missing(path.to_path_buf());
         }
         return DiscoveryOutcome::Unmanaged;
     }
 
+    if let Some(footprint_lib_dir) = footprint_lib_dir {
+        let Some(path) = resolve_relative_subpath(footprint_lib_dir, model_ref) else {
+            return DiscoveryOutcome::Unmanaged;
+        };
+        return to_candidate_or_missing(path);
+    }
+
     let resolved = pcb_dir.join(path);
-    for root in kicad_model_dirs.values() {
-        if resolved.starts_with(root) {
-            return to_candidate_or_missing(resolved);
-        }
+    if is_under_any_root(&resolved, kicad_model_dirs.values()) {
+        return to_candidate_or_missing(resolved);
     }
 
     DiscoveryOutcome::Unmanaged
+}
+
+fn resolve_relative_subpath(root: &Path, reference: &str) -> Option<PathBuf> {
+    if reference.is_empty() || reference.split('\\').any(|part| part == "..") {
+        return None;
+    }
+
+    let path = Path::new(reference);
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return None;
+    }
+
+    Some(root.join(path))
+}
+
+fn is_under_any_root<'a>(path: &Path, roots: impl IntoIterator<Item = &'a PathBuf>) -> bool {
+    roots.into_iter().any(|root| path.starts_with(root))
 }
 
 fn to_candidate_or_missing(managed_path: PathBuf) -> DiscoveryOutcome {
@@ -199,16 +249,12 @@ fn collect_embed_plan(
     board: &Sexpr,
     pcb_dir: &Path,
     kicad_model_dirs: &BTreeMap<String, PathBuf>,
-) -> (
-    BTreeMap<String, String>,
-    BTreeMap<String, PathBuf>,
-    ModelEmbedDiscoveryStats,
-    ModelEmbedApplyStats,
-) {
+    footprint_lib_dirs: &HashMap<String, PathBuf>,
+) -> (EmbedPlan, ModelEmbedDiscoveryStats, ModelEmbedApplyStats) {
     let mut discovery = ModelEmbedDiscoveryStats::default();
     let mut apply = ModelEmbedApplyStats::default();
-    let mut replacements = BTreeMap::<String, String>::new();
     let mut files_to_embed = BTreeMap::<String, PathBuf>::new();
+    let mut replacement_occurrences = BTreeMap::<String, Vec<ReplacementOccurrence>>::new();
 
     board.walk_strings(|value, _span, ctx| {
         if !is_model_filename(&ctx) {
@@ -216,38 +262,147 @@ fn collect_embed_plan(
         }
 
         discovery.total_refs += 1;
-        match resolve_managed_model_reference(value, pcb_dir, kicad_model_dirs) {
+        let footprint_library = footprint_library_name(&ctx).map(str::to_string);
+        let footprint_lib_dir = footprint_library
+            .as_ref()
+            .and_then(|name| footprint_lib_dirs.get(name));
+        match resolve_model_reference(
+            value,
+            pcb_dir,
+            kicad_model_dirs,
+            footprint_lib_dir.map(PathBuf::as_path),
+        ) {
             DiscoveryOutcome::AlreadyEmbedded => discovery.already_embedded += 1,
             DiscoveryOutcome::ManagedCandidate {
                 source_path,
                 embed_name,
             } => {
                 discovery.managed_refs += 1;
-                // Accepted risk: basename collisions are possible (KiCad-style behavior).
-                // For now we keep the first file for a basename and skip conflicting ones.
+                let mut should_rewrite = true;
                 match files_to_embed.get(&embed_name) {
                     Some(existing) if existing != &source_path => {
                         apply.basename_collisions += 1;
+                        should_rewrite = false;
                     }
                     Some(_) => {}
                     None => {
                         files_to_embed.insert(embed_name.clone(), source_path);
                     }
                 }
-                replacements.insert(value.to_string(), format!("kicad-embed://{embed_name}"));
+                if should_rewrite {
+                    let new_value = format!("kicad-embed://{embed_name}");
+                    record_replacement(
+                        &mut replacement_occurrences,
+                        value,
+                        footprint_library,
+                        Some(new_value),
+                    );
+                } else {
+                    record_replacement(
+                        &mut replacement_occurrences,
+                        value,
+                        footprint_library,
+                        None,
+                    );
+                }
             }
             DiscoveryOutcome::ManagedMissing => {
                 discovery.managed_refs += 1;
                 discovery.missing_files += 1;
+                record_replacement(&mut replacement_occurrences, value, footprint_library, None);
             }
-            DiscoveryOutcome::Unmanaged => discovery.unmanaged_refs += 1,
-            DiscoveryOutcome::Unresolved => discovery.unresolved_refs += 1,
+            DiscoveryOutcome::Unmanaged => {
+                discovery.unmanaged_refs += 1;
+                record_replacement(&mut replacement_occurrences, value, footprint_library, None);
+            }
+            DiscoveryOutcome::Unresolved => {
+                discovery.unresolved_refs += 1;
+                record_replacement(&mut replacement_occurrences, value, footprint_library, None);
+            }
         }
     });
 
     apply.candidate_files = files_to_embed.len();
+    let replacements = build_replacements(replacement_occurrences);
 
-    (replacements, files_to_embed, discovery, apply)
+    (
+        EmbedPlan {
+            replacements,
+            files_to_embed,
+        },
+        discovery,
+        apply,
+    )
+}
+
+fn record_replacement(
+    replacement_occurrences: &mut BTreeMap<String, Vec<ReplacementOccurrence>>,
+    model_ref: &str,
+    footprint_library: Option<String>,
+    replacement: Option<String>,
+) {
+    replacement_occurrences
+        .entry(model_ref.to_string())
+        .or_default()
+        .push(ReplacementOccurrence {
+            footprint_library,
+            replacement,
+        });
+}
+
+fn build_replacements(
+    replacement_occurrences: BTreeMap<String, Vec<ReplacementOccurrence>>,
+) -> BTreeMap<String, ModelReplacement> {
+    let mut replacements = BTreeMap::new();
+
+    for (model_ref, occurrences) in replacement_occurrences {
+        let mut global = None::<String>;
+        let mut scoped = BTreeMap::new();
+        let mut can_use_global = true;
+
+        for occurrence in occurrences {
+            let Some(replacement) = occurrence.replacement else {
+                can_use_global = false;
+                continue;
+            };
+            if global.as_ref().is_some_and(|global| global != &replacement) {
+                can_use_global = false;
+            }
+            global.get_or_insert_with(|| replacement.clone());
+            scoped.insert(occurrence.footprint_library, replacement);
+        }
+
+        if scoped.is_empty() {
+            continue;
+        }
+
+        if can_use_global {
+            replacements.insert(model_ref, ModelReplacement::Global(global.unwrap()));
+        } else {
+            replacements.insert(model_ref, ModelReplacement::ByFootprint(scoped));
+        }
+    }
+
+    replacements
+}
+
+fn footprint_library_name<'a>(ctx: &WalkCtx<'a>) -> Option<&'a str> {
+    for ancestor in ctx.ancestors.iter().rev() {
+        let Some(items) = ancestor.as_list() else {
+            continue;
+        };
+        if list_tag(items) != Some("footprint") {
+            continue;
+        }
+        return footprint_library_name_from_items(items);
+    }
+    None
+}
+
+fn footprint_library_name_from_items(items: &[Sexpr]) -> Option<&str> {
+    let footprint_link = items.get(1)?.as_str().or_else(|| items.get(1)?.as_sym())?;
+    let (library, _) = footprint_link.split_once(':')?;
+    Some(library)
 }
 
 fn existing_embedded_model_checksums(board: &Sexpr) -> BTreeMap<String, String> {
@@ -316,14 +471,23 @@ fn compress_and_encode(bytes: &[u8]) -> anyhow::Result<String> {
 
 fn rewrite_model_paths(
     node: &mut Sexpr,
-    replacements: &BTreeMap<String, String>,
+    replacements: &BTreeMap<String, ModelReplacement>,
+    footprint_library: Option<&str>,
     apply: &mut ModelEmbedApplyStats,
 ) {
     let Some(items) = node.as_list_mut() else {
         return;
     };
 
-    if let Some(new_value) = model_path_replacement(items, replacements) {
+    let current_footprint_library = if list_tag(items) == Some("footprint") {
+        footprint_library_name_from_items(items).map(str::to_string)
+    } else {
+        footprint_library.map(str::to_string)
+    };
+
+    if let Some(new_value) =
+        model_path_replacement(items, replacements, current_footprint_library.as_deref())
+    {
         let SexprKind::String(path) = &mut items[1].kind else {
             unreachable!();
         };
@@ -332,13 +496,19 @@ fn rewrite_model_paths(
     }
 
     for child in items.iter_mut() {
-        rewrite_model_paths(child, replacements, apply);
+        rewrite_model_paths(
+            child,
+            replacements,
+            current_footprint_library.as_deref(),
+            apply,
+        );
     }
 }
 
 fn model_path_replacement(
     items: &[Sexpr],
-    replacements: &BTreeMap<String, String>,
+    replacements: &BTreeMap<String, ModelReplacement>,
+    footprint_library: Option<&str>,
 ) -> Option<String> {
     if list_tag(items) != Some("model") {
         return None;
@@ -346,7 +516,12 @@ fn model_path_replacement(
     let SexprKind::String(path) = &items.get(1)?.kind else {
         return None;
     };
-    let new_value = replacements.get(path)?;
+    let new_value = match replacements.get(path)? {
+        ModelReplacement::Global(new_value) => new_value,
+        ModelReplacement::ByFootprint(scoped) => {
+            scoped.get(&footprint_library.map(str::to_string))?
+        }
+    };
     (path != new_value).then(|| new_value.clone())
 }
 
@@ -501,7 +676,7 @@ mod tests {
 
         let dirs = BTreeMap::from([("KICAD9_3DMODEL_DIR".to_string(), model_root.clone())]);
         let (embedded, stats, apply) =
-            embed_models_in_pcb_source(source, temp.path(), &dirs).unwrap();
+            embed_models_in_pcb_source(source, temp.path(), &dirs, &HashMap::new()).unwrap();
 
         assert_eq!(stats.total_refs, 1);
         assert_eq!(stats.managed_refs, 1);
@@ -516,7 +691,7 @@ mod tests {
     }
 
     #[test]
-    fn ignores_embedded_and_unmanaged_and_reports_unresolved() {
+    fn ignores_project_and_reports_unknown_variable_refs() {
         let temp = tempdir().unwrap();
         let source = r#"(kicad_pcb
   (footprint "A" (model "kicad-embed://already.step"))
@@ -525,7 +700,8 @@ mod tests {
 )"#;
 
         let (embedded, stats, apply) =
-            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new()).unwrap();
+            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new(), &HashMap::new())
+                .unwrap();
 
         // Output is always formatted; already-embedded refs trigger footprint metadata upsert.
         assert!(embedded.contains("kicad-embed://already.step"));
@@ -533,10 +709,145 @@ mod tests {
         assert!(embedded.contains("${UNKNOWN_DIR}/part.step"));
         assert_eq!(stats.total_refs, 3);
         assert_eq!(stats.already_embedded, 1);
+        assert_eq!(stats.managed_refs, 0);
+        assert_eq!(stats.missing_files, 0);
         assert_eq!(stats.unmanaged_refs, 1);
         assert_eq!(stats.unresolved_refs, 1);
         assert_eq!(apply.candidate_files, 0);
         assert_eq!(apply.footprint_metadata_entries, 0);
+    }
+
+    #[test]
+    fn does_not_embed_layout_relative_model_refs_without_footprint_library() {
+        let temp = tempdir().unwrap();
+        let model_path = temp.path().join("models/Local.step");
+        std::fs::create_dir_all(model_path.parent().unwrap()).unwrap();
+        std::fs::write(&model_path, b"step").unwrap();
+
+        let source = r#"(kicad_pcb
+  (footprint "U"
+    (model "models/Local.step")
+  )
+)"#;
+
+        let (embedded, stats, apply) =
+            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new(), &HashMap::new())
+                .unwrap();
+
+        assert_eq!(stats.total_refs, 1);
+        assert_eq!(stats.managed_refs, 0);
+        assert_eq!(stats.unmanaged_refs, 1);
+        assert_eq!(apply.candidate_files, 0);
+        assert_eq!(apply.rewritten_refs, 0);
+        assert_eq!(apply.embedded_files_added, 0);
+        assert_eq!(apply.footprint_metadata_entries, 0);
+        assert!(embedded.contains("models/Local.step"));
+        assert!(!embedded.contains("kicad-embed://Local.step"));
+    }
+
+    #[test]
+    fn embeds_footprint_relative_model_refs_from_library_dir() {
+        let temp = tempdir().unwrap();
+        let component_dir = temp.path().join("components/Connector");
+        let model_path = component_dir.join("Connector.step");
+        std::fs::create_dir_all(&component_dir).unwrap();
+        std::fs::write(&model_path, b"step").unwrap();
+        let footprint_lib_dirs =
+            HashMap::from([("LocalConnector".to_string(), component_dir.clone())]);
+
+        let source = r#"(kicad_pcb
+  (footprint "LocalConnector:Connector"
+    (model "Connector.step")
+  )
+)"#;
+
+        let (embedded, stats, apply) =
+            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new(), &footprint_lib_dirs)
+                .unwrap();
+
+        assert_eq!(stats.total_refs, 1);
+        assert_eq!(stats.managed_refs, 1);
+        assert_eq!(stats.missing_files, 0);
+        assert_eq!(apply.candidate_files, 1);
+        assert_eq!(apply.rewritten_refs, 1);
+        assert_eq!(apply.embedded_files_added, 1);
+        assert_eq!(apply.footprint_metadata_entries, 1);
+        assert!(embedded.contains("kicad-embed://Connector.step"));
+        assert_eq!(embedded.matches("(name Connector.step)").count(), 2);
+        assert_eq!(embedded.matches("(data |").count(), 1);
+    }
+
+    #[test]
+    fn scopes_conflicting_footprint_relative_model_refs() {
+        let temp = tempdir().unwrap();
+        let good_dir = temp.path().join("components/Good");
+        let missing_dir = temp.path().join("components/Missing");
+        std::fs::create_dir_all(&good_dir).unwrap();
+        std::fs::create_dir_all(&missing_dir).unwrap();
+        std::fs::write(good_dir.join("Body.step"), b"step").unwrap();
+        let footprint_lib_dirs = HashMap::from([
+            ("Good".to_string(), good_dir),
+            ("Missing".to_string(), missing_dir),
+        ]);
+
+        let source = r#"(kicad_pcb
+  (footprint "Good:Part"
+    (model "Body.step")
+  )
+  (footprint "Missing:Part"
+    (model "Body.step")
+  )
+)"#;
+
+        let (embedded, stats, apply) =
+            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new(), &footprint_lib_dirs)
+                .unwrap();
+
+        assert_eq!(stats.total_refs, 2);
+        assert_eq!(stats.managed_refs, 2);
+        assert_eq!(stats.missing_files, 1);
+        assert_eq!(apply.candidate_files, 1);
+        assert_eq!(apply.rewritten_refs, 1);
+        assert_eq!(apply.embedded_files_added, 1);
+        assert_eq!(apply.footprint_metadata_entries, 1);
+        assert_eq!(
+            embedded
+                .matches("(model \"kicad-embed://Body.step\"")
+                .count(),
+            1
+        );
+        assert_eq!(embedded.matches("(model \"Body.step\"").count(), 1);
+    }
+
+    #[test]
+    fn rejects_footprint_relative_model_refs_that_escape_library_dir() {
+        let temp = tempdir().unwrap();
+        let component_dir = temp.path().join("components/Connector");
+        let escaped_model = temp.path().join("components/Escape.step");
+        std::fs::create_dir_all(&component_dir).unwrap();
+        std::fs::write(&escaped_model, b"step").unwrap();
+        let footprint_lib_dirs =
+            HashMap::from([("LocalConnector".to_string(), component_dir.clone())]);
+
+        let source = r#"(kicad_pcb
+  (footprint "LocalConnector:Connector"
+    (model "../Escape.step")
+  )
+)"#;
+
+        let (embedded, stats, apply) =
+            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new(), &footprint_lib_dirs)
+                .unwrap();
+
+        assert_eq!(stats.total_refs, 1);
+        assert_eq!(stats.managed_refs, 0);
+        assert_eq!(stats.unmanaged_refs, 1);
+        assert_eq!(apply.candidate_files, 0);
+        assert_eq!(apply.rewritten_refs, 0);
+        assert_eq!(apply.embedded_files_added, 0);
+        assert_eq!(apply.footprint_metadata_entries, 0);
+        assert!(embedded.contains("../Escape.step"));
+        assert!(!embedded.contains("kicad-embed://Escape.step"));
     }
 
     #[test]
@@ -557,7 +868,8 @@ mod tests {
 )"#;
 
         let (embedded, stats, apply) =
-            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new()).unwrap();
+            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new(), &HashMap::new())
+                .unwrap();
 
         assert_eq!(stats.total_refs, 1);
         assert_eq!(stats.already_embedded, 1);
@@ -578,7 +890,8 @@ mod tests {
 )"#;
 
         let (embedded, stats, apply) =
-            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new()).unwrap();
+            embed_models_in_pcb_source(source, temp.path(), &BTreeMap::new(), &HashMap::new())
+                .unwrap();
 
         assert_eq!(stats.total_refs, 1);
         assert_eq!(stats.already_embedded, 1);
@@ -604,7 +917,7 @@ mod tests {
 )"#;
         let dirs = BTreeMap::from([("KICAD9_3DMODEL_DIR".to_string(), model_root)]);
         let (embedded, discovery, apply) =
-            embed_models_in_pcb_source(source, temp.path(), &dirs).unwrap();
+            embed_models_in_pcb_source(source, temp.path(), &dirs, &HashMap::new()).unwrap();
 
         assert_eq!(discovery.total_refs, 1);
         assert_eq!(discovery.managed_refs, 1);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how 3D model paths are resolved and rewritten during layout generation, which can alter produced `.kicad_pcb` contents and embedded assets across projects.
> 
> **Overview**
> Fixes `pcb layout` 3D model embedding to also resolve and embed *footprint-relative* model refs (e.g. `Connector.step`) by deriving footprint library directories from the schematic’s footprints and passing them into the embedder.
> 
> The model embedder now validates relative-path safety (rejects `..`/absolute/prefix components), attributes model refs to their containing footprint library, and scopes rewrites when the same raw model reference has mixed outcomes across libraries (avoiding incorrect global rewrites on collisions/missing files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e201761139475410f6e53a7edd2b5f191661ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->