### PR TITLE
Switch to semantic layout sync checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `pcb layout` now embeds footprint-relative 3D models.
+- `pcb layout --check` and board publish now use a semantic managed-footprint/connectivity check instead of byte-comparing shadow-synced KiCad files.
 
 ## [0.3.77] - 2026-05-07
 

--- a/crates/pcb-layout/src/effective_netlist.rs
+++ b/crates/pcb-layout/src/effective_netlist.rs
@@ -1,0 +1,605 @@
+use anyhow::{Context, Result, bail};
+use pcb_sch::kicad_netlist::try_format_footprint_with_package_roots;
+use pcb_sch::{AttributeValue, InstanceKind, Schematic};
+use pcb_sexpr::Sexpr;
+use pcb_sexpr::board::{extract_keyed_footprints, footprint_name_from_fpid};
+use std::collections::{BTreeMap, BTreeSet};
+use uuid::Uuid;
+
+const UUID_NAMESPACE_URL: Uuid = Uuid::from_u128(0x6ba7b811_9dad_11d1_80b4_00c04fd430c8);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Port {
+    pub component_path: String,
+    pub pad_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveFootprint {
+    pub fpid: String,
+    pub reference: Option<String>,
+    pub pads: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EffectiveNetlist {
+    pub footprints: BTreeMap<String, EffectiveFootprint>,
+    pub nets: BTreeMap<String, BTreeSet<Port>>,
+    pub port_to_net: BTreeMap<Port, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticDiff {
+    pub kind: &'static str,
+    pub severity: DiffSeverity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffSeverity {
+    Warning,
+    Error,
+}
+
+impl SemanticDiff {
+    fn error(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            severity: DiffSeverity::Error,
+            message: message.into(),
+        }
+    }
+
+    fn warning(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            severity: DiffSeverity::Warning,
+            message: message.into(),
+        }
+    }
+}
+
+impl EffectiveNetlist {
+    fn rebuild_nets(&mut self) {
+        let mut grouped: BTreeMap<String, BTreeSet<Port>> = BTreeMap::new();
+        for (port, net_name) in &self.port_to_net {
+            grouped
+                .entry(net_name.clone())
+                .or_default()
+                .insert(port.clone());
+        }
+        self.nets = grouped
+            .into_iter()
+            .filter(|(_, ports)| ports.len() > 1)
+            .collect();
+    }
+}
+
+pub fn source_effective_netlist(schematic: &Schematic) -> Result<EffectiveNetlist> {
+    let mut effective = EffectiveNetlist::default();
+
+    for (instance_ref, instance) in &schematic.instances {
+        if instance.kind != InstanceKind::Component {
+            continue;
+        }
+
+        let component_path = instance_ref.instance_path.join(".");
+        let Some(AttributeValue::String(fp_attr)) = instance.attributes.get("footprint") else {
+            bail!("component `{component_path}` is missing footprint attribute");
+        };
+        let (fpid, _) = try_format_footprint_with_package_roots(fp_attr, &schematic.package_roots)
+            .with_context(|| format!("Failed to resolve footprint path '{fp_attr}'"))?;
+
+        effective.footprints.insert(
+            component_path,
+            EffectiveFootprint {
+                fpid,
+                reference: instance.reference_designator.clone(),
+                pads: BTreeSet::new(),
+            },
+        );
+    }
+
+    for (net_name, net) in &schematic.nets {
+        for port_ref in &net.ports {
+            let Some(component_ref) = schematic.component_ref_for_port(port_ref) else {
+                bail!("missing component owner for netlist port `{port_ref}`");
+            };
+            let component_path = component_ref.instance_path.join(".");
+            let Some(port_instance) = schematic.instances.get(port_ref) else {
+                continue;
+            };
+            let Some(AttributeValue::Array(pads)) = port_instance.attributes.get("pads") else {
+                continue;
+            };
+
+            for pad in pads {
+                let AttributeValue::String(pad_name) = pad else {
+                    continue;
+                };
+                if let Some(fp) = effective.footprints.get_mut(&component_path) {
+                    fp.pads.insert(pad_name.clone());
+                }
+                let port = Port {
+                    component_path: component_path.clone(),
+                    pad_name: pad_name.clone(),
+                };
+                let effective_net_name = if net.kind == "NotConnected" {
+                    format!("unconnected-({component_path}:{pad_name})")
+                } else {
+                    net_name.clone()
+                };
+                if let Some(previous) = effective
+                    .port_to_net
+                    .insert(port.clone(), effective_net_name.clone())
+                    && previous != effective_net_name
+                {
+                    bail!(
+                        "source port {}:{} is assigned to both `{previous}` and `{effective_net_name}`",
+                        port.component_path,
+                        port.pad_name
+                    );
+                }
+            }
+        }
+    }
+
+    effective.rebuild_nets();
+    Ok(effective)
+}
+
+pub fn layout_effective_netlist(
+    board: &Sexpr,
+    expected: &EffectiveNetlist,
+) -> Result<(EffectiveNetlist, Vec<SemanticDiff>)> {
+    let mut effective = EffectiveNetlist::default();
+    let mut diagnostics = Vec::new();
+    let keyed = extract_keyed_footprints(board).map_err(anyhow::Error::msg)?;
+
+    let mut kiid_to_path: BTreeMap<String, String> = BTreeMap::new();
+    for path in expected.footprints.keys() {
+        kiid_to_path.insert(uuid_for_path(path), path.clone());
+    }
+
+    for fp in keyed {
+        let property_path = fp.properties.get("Path").filter(|s| !s.is_empty()).cloned();
+        let component_path = if let Some(path) = property_path.clone() {
+            let expected_kiid = expected_kiid_path(&path);
+            if fp.path != expected_kiid {
+                diagnostics.push(SemanticDiff::warning(
+                    "layout.sync.unmanaged_footprint",
+                    format!(
+                        "Footprint {} ({}:{}) is not managed by sync: expected KIID path {expected_kiid}, found {}",
+                        fp.properties
+                            .get("Reference")
+                            .map(String::as_str)
+                            .unwrap_or("<unknown>"),
+                        path,
+                        fp.fpid.as_deref().unwrap_or(""),
+                        fp.path
+                    ),
+                ));
+                continue;
+            }
+            path
+        } else {
+            let uuid = fp.path.trim_matches('/').rsplit('/').next().unwrap_or("");
+            let Some(path) = kiid_to_path.get(uuid).cloned() else {
+                continue;
+            };
+            path
+        };
+
+        let mut pads = BTreeSet::new();
+        let mut seen_pad_nets: BTreeMap<String, String> = BTreeMap::new();
+        for pad in &fp.pads {
+            if pad.number.is_empty() {
+                continue;
+            }
+            pads.insert(pad.number.clone());
+            let Some(net_name) = pad.net_name.as_ref().filter(|s| !s.is_empty()) else {
+                continue;
+            };
+            if let Some(previous) = seen_pad_nets.insert(pad.number.clone(), net_name.clone())
+                && previous != *net_name
+            {
+                diagnostics.push(SemanticDiff::error(
+                    "layout.sync.pad_assignment",
+                    format!(
+                        "Footprint {component_path} has duplicate physical pad {} assigned to both `{previous}` and `{net_name}`",
+                        pad.number
+                    ),
+                ));
+            }
+        }
+
+        for (pad_name, net_name) in seen_pad_nets {
+            effective.port_to_net.insert(
+                Port {
+                    component_path: component_path.clone(),
+                    pad_name,
+                },
+                net_name,
+            );
+        }
+
+        effective.footprints.insert(
+            component_path,
+            EffectiveFootprint {
+                fpid: fp.fpid.unwrap_or_default(),
+                reference: fp.properties.get("Reference").cloned(),
+                pads,
+            },
+        );
+    }
+
+    effective.rebuild_nets();
+    Ok((effective, diagnostics))
+}
+
+pub fn diff_effective_netlists(
+    expected: &EffectiveNetlist,
+    actual: &EffectiveNetlist,
+) -> Vec<SemanticDiff> {
+    let mut diffs = Vec::new();
+    let mut explained_ports = BTreeSet::new();
+
+    for (path, expected_fp) in &expected.footprints {
+        match actual.footprints.get(path) {
+            None => {
+                diffs.push(SemanticDiff::error(
+                    "layout.sync.missing_footprint",
+                    format!("Managed footprint {path} is missing from layout"),
+                ));
+                mark_ports(path, expected, &mut explained_ports);
+            }
+            Some(actual_fp) => {
+                if comparable_fpid(&expected_fp.fpid) != comparable_fpid(&actual_fp.fpid) {
+                    diffs.push(SemanticDiff::error(
+                        "layout.sync.footprint_fpid",
+                        format!(
+                            "Managed footprint {path} has FPID `{}` in source but `{}` in layout",
+                            expected_fp.fpid, actual_fp.fpid
+                        ),
+                    ));
+                    mark_ports(path, expected, &mut explained_ports);
+                    mark_ports(path, actual, &mut explained_ports);
+                } else if !expected_fp.pads.is_subset(&actual_fp.pads) {
+                    let missing: BTreeSet<_> = expected_fp
+                        .pads
+                        .difference(&actual_fp.pads)
+                        .cloned()
+                        .collect();
+                    diffs.push(SemanticDiff::error(
+                        "layout.sync.pad_inventory",
+                        format!(
+                            "Managed footprint {path} is missing source logical pad(s) in layout: [{}]",
+                            join_strings(&missing)
+                        ),
+                    ));
+                    mark_ports(path, expected, &mut explained_ports);
+                    mark_ports(path, actual, &mut explained_ports);
+                }
+            }
+        }
+    }
+
+    for path in actual.footprints.keys() {
+        if !expected.footprints.contains_key(path) {
+            diffs.push(SemanticDiff::error(
+                "layout.sync.extra_footprint",
+                format!("Layout contains extra managed footprint {path}"),
+            ));
+            mark_ports(path, actual, &mut explained_ports);
+        }
+    }
+
+    let mut consumed_expected = BTreeSet::new();
+    let mut consumed_actual = BTreeSet::new();
+    let expected_sigs = unique_signature_index(&expected.nets);
+    let actual_sigs = unique_signature_index(&actual.nets);
+    for (signature, expected_net) in expected_sigs {
+        if signature.iter().any(|p| explained_ports.contains(p)) {
+            continue;
+        }
+        if let Some(actual_net) = actual_sigs.get(&signature)
+            && expected_net != *actual_net
+        {
+            diffs.push(SemanticDiff::warning(
+                "layout.sync.net_rename",
+                format!(
+                    "Layout net `{actual_net}` has the same connectivity as source net `{expected_net}`"
+                ),
+            ));
+            consumed_expected.insert(expected_net);
+            consumed_actual.insert(actual_net.clone());
+        }
+    }
+
+    let common_ports: BTreeSet<_> = expected
+        .port_to_net
+        .keys()
+        .filter(|p| actual.port_to_net.contains_key(*p) && !explained_ports.contains(*p))
+        .cloned()
+        .collect();
+    let mut by_expected: BTreeMap<String, BTreeMap<String, BTreeSet<Port>>> = BTreeMap::new();
+    let mut by_actual: BTreeMap<String, BTreeMap<String, BTreeSet<Port>>> = BTreeMap::new();
+    for port in &common_ports {
+        let expected_net = expected.port_to_net.get(port).unwrap();
+        let actual_net = actual.port_to_net.get(port).unwrap();
+        if expected_net == actual_net
+            || consumed_expected.contains(expected_net)
+            || consumed_actual.contains(actual_net)
+        {
+            continue;
+        }
+        by_expected
+            .entry(expected_net.clone())
+            .or_default()
+            .entry(actual_net.clone())
+            .or_default()
+            .insert(port.clone());
+        by_actual
+            .entry(actual_net.clone())
+            .or_default()
+            .entry(expected_net.clone())
+            .or_default()
+            .insert(port.clone());
+    }
+
+    for (expected_net, actual_groups) in &by_expected {
+        if actual_groups.len() > 1 {
+            diffs.push(SemanticDiff::error(
+                "layout.sync.net_split",
+                format!(
+                    "Source net `{expected_net}` is split across layout nets: {}",
+                    actual_groups.keys().cloned().collect::<Vec<_>>().join(", ")
+                ),
+            ));
+            consumed_expected.insert(expected_net.clone());
+            consumed_actual.extend(actual_groups.keys().cloned());
+        }
+    }
+    for (actual_net, expected_groups) in &by_actual {
+        if expected_groups.len() > 1 {
+            diffs.push(SemanticDiff::error(
+                "layout.sync.net_merge",
+                format!(
+                    "Layout net `{actual_net}` merges source nets: {}",
+                    expected_groups
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            ));
+            consumed_actual.insert(actual_net.clone());
+            consumed_expected.extend(expected_groups.keys().cloned());
+        }
+    }
+
+    for (net_name, expected_ports) in &expected.nets {
+        if consumed_expected.contains(net_name) {
+            continue;
+        }
+        let actual_ports = actual.nets.get(net_name).cloned().unwrap_or_default();
+        let missing: BTreeSet<_> = expected_ports
+            .difference(&actual_ports)
+            .filter(|p| !explained_ports.contains(*p))
+            .cloned()
+            .collect();
+        if !missing.is_empty() {
+            diffs.push(SemanticDiff::error(
+                "layout.sync.pad_assignment",
+                format!(
+                    "Net `{net_name}` is missing {} pad assignment(s) in layout: {}",
+                    missing.len(),
+                    sample_ports(&missing)
+                ),
+            ));
+        }
+    }
+    for (net_name, actual_ports) in &actual.nets {
+        if consumed_actual.contains(net_name) {
+            continue;
+        }
+        let expected_ports = expected.nets.get(net_name).cloned().unwrap_or_default();
+        let extra: BTreeSet<_> = actual_ports
+            .difference(&expected_ports)
+            .filter(|p| !explained_ports.contains(*p))
+            .cloned()
+            .collect();
+        if !extra.is_empty() {
+            diffs.push(SemanticDiff::error(
+                "layout.sync.pad_assignment",
+                format!(
+                    "Net `{net_name}` has {} extra pad assignment(s) in layout: {}",
+                    extra.len(),
+                    sample_ports(&extra)
+                ),
+            ));
+        }
+    }
+
+    diffs
+}
+
+fn mark_ports(path: &str, netlist: &EffectiveNetlist, explained: &mut BTreeSet<Port>) {
+    for port in netlist.port_to_net.keys() {
+        if port.component_path == path {
+            explained.insert(port.clone());
+        }
+    }
+}
+
+fn unique_signature_index(nets: &BTreeMap<String, BTreeSet<Port>>) -> BTreeMap<Vec<Port>, String> {
+    let mut signatures: BTreeMap<Vec<Port>, Option<String>> = BTreeMap::new();
+    for (net, ports) in nets {
+        let signature: Vec<_> = ports.iter().cloned().collect();
+        signatures
+            .entry(signature)
+            .and_modify(|v| *v = None)
+            .or_insert_with(|| Some(net.clone()));
+    }
+    signatures
+        .into_iter()
+        .filter_map(|(sig, net)| net.map(|n| (sig, n)))
+        .collect()
+}
+
+fn sample_ports(ports: &BTreeSet<Port>) -> String {
+    let mut sample: Vec<_> = ports
+        .iter()
+        .take(5)
+        .map(|p| format!("{}:{}", p.component_path, p.pad_name))
+        .collect();
+    if ports.len() > sample.len() {
+        sample.push(format!("… and {} more", ports.len() - sample.len()));
+    }
+    sample.join(", ")
+}
+
+fn join_strings(values: &BTreeSet<String>) -> String {
+    values.iter().cloned().collect::<Vec<_>>().join(", ")
+}
+
+fn comparable_fpid(fpid: &str) -> String {
+    footprint_name_from_fpid(fpid)
+}
+
+fn uuid_for_path(path: &str) -> String {
+    Uuid::new_v5(&UUID_NAMESPACE_URL, path.as_bytes()).to_string()
+}
+
+fn expected_kiid_path(path: &str) -> String {
+    let uuid = uuid_for_path(path);
+    format!("/{uuid}/{uuid}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn port(component_path: &str, pad_name: &str) -> Port {
+        Port {
+            component_path: component_path.to_string(),
+            pad_name: pad_name.to_string(),
+        }
+    }
+
+    fn netlist(assignments: &[(&str, &str, &str)]) -> EffectiveNetlist {
+        let mut n = EffectiveNetlist::default();
+        for (component_path, pad_name, net_name) in assignments {
+            n.footprints
+                .entry((*component_path).to_string())
+                .or_insert_with(|| EffectiveFootprint {
+                    fpid: "Test:FP".to_string(),
+                    reference: None,
+                    pads: BTreeSet::new(),
+                })
+                .pads
+                .insert((*pad_name).to_string());
+            n.port_to_net
+                .insert(port(component_path, pad_name), (*net_name).to_string());
+        }
+        n.rebuild_nets();
+        n
+    }
+
+    #[test]
+    fn exact_net_rename_is_warning_only() {
+        let expected = netlist(&[("R1", "1", "A"), ("R2", "1", "A")]);
+        let actual = netlist(&[("R1", "1", "B"), ("R2", "1", "B")]);
+
+        let diffs = diff_effective_netlists(&expected, &actual);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].kind, "layout.sync.net_rename");
+        assert_eq!(diffs[0].severity, DiffSeverity::Warning);
+    }
+
+    #[test]
+    fn split_net_is_error() {
+        let expected = netlist(&[("R1", "1", "A"), ("R2", "1", "A"), ("R3", "1", "A")]);
+        let actual = netlist(&[("R1", "1", "B"), ("R2", "1", "C"), ("R3", "1", "C")]);
+
+        let diffs = diff_effective_netlists(&expected, &actual);
+
+        assert!(diffs.iter().any(|d| d.kind == "layout.sync.net_split"));
+    }
+
+    #[test]
+    fn merge_net_is_error() {
+        let expected = netlist(&[
+            ("R1", "1", "A"),
+            ("R2", "1", "A"),
+            ("R3", "1", "B"),
+            ("R4", "1", "B"),
+        ]);
+        let actual = netlist(&[
+            ("R1", "1", "C"),
+            ("R2", "1", "C"),
+            ("R3", "1", "C"),
+            ("R4", "1", "C"),
+        ]);
+
+        let diffs = diff_effective_netlists(&expected, &actual);
+
+        assert!(diffs.iter().any(|d| d.kind == "layout.sync.net_merge"));
+    }
+
+    #[test]
+    fn single_pad_nets_are_ignored() {
+        let expected = netlist(&[("R1", "1", "unconnected-R1-1")]);
+        let actual = netlist(&[("R1", "1", "unconnected-other")]);
+
+        let diffs = diff_effective_netlists(&expected, &actual);
+
+        assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn duplicate_physical_pads_with_same_net_collapse() {
+        let path = "R1";
+        let uuid = uuid_for_path(path);
+        let board = pcb_sexpr::parse(&format!(
+            r#"(kicad_pcb
+              (footprint "Test:FP"
+                (path "/{uuid}/{uuid}")
+                (property "Path" "{path}")
+                (pad "1" smd rect (net 1 "A"))
+                (pad "1" smd rect (net 1 "A"))))"#
+        ))
+        .unwrap();
+        let expected = netlist(&[("R1", "1", "A"), ("R2", "1", "A")]);
+
+        let (actual, diagnostics) = layout_effective_netlist(&board, &expected).unwrap();
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(actual.port_to_net.get(&port("R1", "1")).unwrap(), "A");
+    }
+
+    #[test]
+    fn duplicate_physical_pads_with_conflicting_nets_diagnose() {
+        let path = "R1";
+        let uuid = uuid_for_path(path);
+        let board = pcb_sexpr::parse(&format!(
+            r#"(kicad_pcb
+              (footprint "Test:FP"
+                (path "/{uuid}/{uuid}")
+                (property "Path" "{path}")
+                (pad "1" smd rect (net 1 "A"))
+                (pad "1" smd rect (net 2 "B"))))"#
+        ))
+        .unwrap();
+        let expected = netlist(&[("R1", "1", "A"), ("R2", "1", "A")]);
+
+        let (_actual, diagnostics) = layout_effective_netlist(&board, &expected).unwrap();
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.kind == "layout.sync.pad_assignment")
+        );
+    }
+}

--- a/crates/pcb-layout/src/effective_netlist.rs
+++ b/crates/pcb-layout/src/effective_netlist.rs
@@ -378,11 +378,17 @@ pub fn diff_effective_netlists(
         }
     }
 
+    let expected_ports_by_net = ports_by_net(&expected.port_to_net);
+    let actual_ports_by_net = ports_by_net(&actual.port_to_net);
+
     for (net_name, expected_ports) in &expected.nets {
         if consumed_expected.contains(net_name) {
             continue;
         }
-        let actual_ports = actual.nets.get(net_name).cloned().unwrap_or_default();
+        let actual_ports = actual_ports_by_net
+            .get(net_name)
+            .cloned()
+            .unwrap_or_default();
         let missing: BTreeSet<_> = expected_ports
             .difference(&actual_ports)
             .filter(|p| !explained_ports.contains(*p))
@@ -403,7 +409,10 @@ pub fn diff_effective_netlists(
         if consumed_actual.contains(net_name) {
             continue;
         }
-        let expected_ports = expected.nets.get(net_name).cloned().unwrap_or_default();
+        let expected_ports = expected_ports_by_net
+            .get(net_name)
+            .cloned()
+            .unwrap_or_default();
         let extra: BTreeSet<_> = actual_ports
             .difference(&expected_ports)
             .filter(|p| !explained_ports.contains(*p))
@@ -445,6 +454,17 @@ fn unique_signature_index(nets: &BTreeMap<String, BTreeSet<Port>>) -> BTreeMap<V
         .into_iter()
         .filter_map(|(sig, net)| net.map(|n| (sig, n)))
         .collect()
+}
+
+fn ports_by_net(port_to_net: &BTreeMap<Port, String>) -> BTreeMap<String, BTreeSet<Port>> {
+    let mut by_net = BTreeMap::new();
+    for (port, net_name) in port_to_net {
+        by_net
+            .entry(net_name.clone())
+            .or_insert_with(BTreeSet::new)
+            .insert(port.clone());
+    }
+    by_net
 }
 
 fn sample_ports(ports: &BTreeSet<Port>) -> String {
@@ -556,6 +576,21 @@ mod tests {
         let diffs = diff_effective_netlists(&expected, &actual);
 
         assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn missing_assignment_does_not_overreport_remaining_single_port_net() {
+        let expected = netlist(&[("R1", "1", "A"), ("R2", "1", "A")]);
+        let actual = netlist(&[("R1", "1", "A"), ("R2", "1", "B")]);
+
+        let diffs = diff_effective_netlists(&expected, &actual);
+
+        let missing = diffs
+            .iter()
+            .find(|d| d.message.starts_with("Net `A` is missing"))
+            .unwrap();
+        assert!(missing.message.contains("R2:1"));
+        assert!(!missing.message.contains("R1:1"));
     }
 
     #[test]

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -18,10 +18,14 @@ use include_dir::{Dir, include_dir};
 use pcb_kicad::{PythonScriptBuilder, ensure_board_compatible_with_installed_kicad};
 use pcb_sch::kicad_netlist::{try_format_footprint_with_package_roots, write_fp_lib_table};
 
+mod effective_netlist;
 mod kicad_project_patch;
 mod model_embed_discovery;
 mod moved;
 mod repair_nets;
+use effective_netlist::{
+    DiffSeverity, diff_effective_netlists, layout_effective_netlist, source_effective_netlist,
+};
 pub use moved::compute_moved_paths_patches;
 pub use moved::compute_net_renames_patches;
 
@@ -44,23 +48,12 @@ pub struct LayoutResult {
     pub log_file: PathBuf,
     pub diagnostics_file: PathBuf,
     pub created: bool, // true if new, false if updated
-    pub shadow: Option<ShadowLayoutContext>,
-}
-
-#[derive(Debug)]
-pub struct ShadowLayoutContext {
-    _dir: TempDir,
-    original_pcb_file: PathBuf,
 }
 
 impl LayoutResult {
-    /// Path to show in diagnostics/output. In `--check` mode this is the original PCB path,
-    /// not the shadow-copy PCB.
+    /// Path to show in diagnostics/output.
     pub fn display_pcb_file(&self) -> &Path {
-        self.shadow
-            .as_ref()
-            .map(|s| s.original_pcb_file.as_path())
-            .unwrap_or(self.pcb_file.as_path())
+        self.pcb_file.as_path()
     }
 }
 
@@ -238,14 +231,6 @@ fn render_patches(source: &str, patches: &pcb_sexpr::PatchSet) -> anyhow::Result
     String::from_utf8(out).context("Patched PCB is not valid UTF-8")
 }
 
-fn files_differ(original_path: &Path, generated_path: &Path, what: &str) -> anyhow::Result<bool> {
-    let original_bytes = fs::read(original_path)
-        .with_context(|| format!("Failed to read {what} file: {}", original_path.display()))?;
-    let generated_bytes = fs::read(generated_path)
-        .with_context(|| format!("Failed to read {what} file: {}", generated_path.display()))?;
-    Ok(original_bytes.trim_ascii_end() != generated_bytes.trim_ascii_end())
-}
-
 /// Apply moved() path renames to a PCB file
 fn apply_moved_paths(
     pcb_path: &Path,
@@ -400,50 +385,63 @@ fn run_sync_script(paths: &LayoutPaths, lens_python_path: &Path) -> anyhow::Resu
     builder.log_file(log_file).run()
 }
 
-fn create_shadow_layout_dir(layout_dir: &Path) -> anyhow::Result<TempDir> {
-    let parent = layout_dir.parent().ok_or_else(|| {
-        anyhow::anyhow!("Layout directory has no parent: {}", layout_dir.display())
-    })?;
-    let base_name = layout_dir
-        .file_name()
-        .and_then(|s| s.to_str())
-        .ok_or_else(|| anyhow::anyhow!("Layout directory has invalid UTF-8 name"))?;
-    let temp_dir = tempfile::Builder::new()
-        .prefix(&format!(".{base_name}.pcb-check."))
-        .tempdir_in(parent)
-        .with_context(|| {
-            format!(
-                "Failed to create shadow layout directory near {}",
-                layout_dir.display()
-            )
-        })?;
-    copy_dir_recursive(layout_dir, temp_dir.path())?;
-    Ok(temp_dir)
-}
-
-fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
-    for entry in fs::read_dir(src).with_context(|| format!("Failed to read {}", src.display()))? {
-        let entry = entry?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-        let file_type = entry.file_type()?;
-
-        if file_type.is_dir() {
-            fs::create_dir(&dst_path)
-                .with_context(|| format!("Failed to create {}", dst_path.display()))?;
-            copy_dir_recursive(&src_path, &dst_path)?;
-            continue;
-        }
-
-        fs::copy(&src_path, &dst_path).with_context(|| {
-            format!(
-                "Failed to copy {} to {}",
-                src_path.display(),
-                dst_path.display()
-            )
-        })?;
+/// Check the checked-in KiCad layout against the schematic using a semantic effective-netlist
+/// comparison. This is intentionally read-only: it does not run the Python sync pipeline and
+/// ignores byte-level KiCad serialization churn.
+pub fn check_layout_sync(
+    schematic: &Schematic,
+    diagnostics: &mut pcb_zen_core::Diagnostics,
+) -> Result<Option<LayoutResult>, LayoutError> {
+    let Some(layout_dir) = utils::resolve_layout_dir(schematic)? else {
+        return Ok(None);
+    };
+    let Some(kicad_files) = utils::discover_kicad_files(&layout_dir)? else {
+        return Ok(None);
+    };
+    let pcb_file = kicad_files.kicad_pcb();
+    if !pcb_file.exists() {
+        return Ok(None);
     }
-    Ok(())
+
+    let source_path = schematic
+        .root_ref
+        .as_ref()
+        .map(|r| r.module.source_path.clone())
+        .unwrap_or_default();
+    let paths = utils::get_layout_paths_for_pcb(&layout_dir, pcb_file.clone());
+    let diagnostics_pcb_path = pcb_file.to_string_lossy().to_string();
+
+    let board_content = fs::read_to_string(&pcb_file)
+        .with_context(|| format!("Failed to read PCB file: {}", pcb_file.display()))?;
+    let board = pcb_sexpr::parse(&board_content)
+        .with_context(|| format!("Failed to parse PCB file: {}", pcb_file.display()))?;
+    let expected = source_effective_netlist(schematic)?;
+    let (actual, extraction_diagnostics) = layout_effective_netlist(&board, &expected)?;
+    let mut semantic_diffs = extraction_diagnostics;
+    semantic_diffs.extend(diff_effective_netlists(&expected, &actual));
+
+    for diff in semantic_diffs {
+        diagnostics.diagnostics.push(Diagnostic::categorized(
+            &diagnostics_pcb_path,
+            &diff.message,
+            diff.kind,
+            match diff.severity {
+                DiffSeverity::Warning => EvalSeverity::Warning,
+                DiffSeverity::Error => EvalSeverity::Error,
+            },
+        ));
+    }
+
+    Ok(Some(LayoutResult {
+        source_file: source_path,
+        layout_dir,
+        pcb_file: pcb_file.clone(),
+        netlist_file: paths.netlist,
+        snapshot_file: paths.snapshot,
+        log_file: paths.log,
+        diagnostics_file: paths.diagnostics,
+        created: false,
+    }))
 }
 
 /// Process a schematic and generate/update its layout files
@@ -456,10 +454,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
 /// 5. Create or update the KiCad PCB file
 ///
 /// When `check_mode` is true:
-/// - Requires the real layout to already exist
-/// - Creates a hidden shadow sibling layout directory
-/// - Runs the exact same mutating sync pipeline against the shadow copy
-/// - Returns paths pointing to the shadow copy for downstream DRC
+/// - Runs the pure semantic layout sync check without mutating layout files
 pub fn process_layout(
     schematic: &Schematic,
     kicad_model_dirs: &BTreeMap<String, PathBuf>,
@@ -467,6 +462,10 @@ pub fn process_layout(
     check_mode: bool,
     diagnostics: &mut pcb_zen_core::Diagnostics,
 ) -> Result<Option<LayoutResult>, LayoutError> {
+    if check_mode {
+        return check_layout_sync(schematic, diagnostics);
+    }
+
     // Resolve layout directory
     let resolved_layout_dir = if use_temp_dir {
         // Create a temporary directory and keep it (prevent cleanup on drop)
@@ -488,34 +487,11 @@ pub fn process_layout(
         .map(|r| r.module.source_path.clone())
         .unwrap_or_default();
 
-    let shadow = if check_mode {
-        let Some(existing_files) = utils::discover_kicad_files(&resolved_layout_dir)? else {
-            return Ok(None);
-        };
-        let original_pcb_file = existing_files.kicad_pcb();
-        if !original_pcb_file.exists() {
-            return Ok(None);
-        }
-        let shadow_dir = create_shadow_layout_dir(&resolved_layout_dir)?;
-        Some(ShadowLayoutContext {
-            _dir: shadow_dir,
-            original_pcb_file,
-        })
-    } else {
-        None
-    };
-
-    let layout_dir = shadow
-        .as_ref()
-        .map(|s| s._dir.path().to_path_buf())
-        .unwrap_or_else(|| resolved_layout_dir.clone());
+    let layout_dir = resolved_layout_dir.clone();
 
     let kicad_files = utils::resolve_kicad_files(&layout_dir)?;
     let paths = utils::get_layout_paths_for_pcb(&layout_dir, kicad_files.kicad_pcb());
-    let diagnostics_pcb_path = shadow
-        .as_ref()
-        .map(|s| s.original_pcb_file.to_string_lossy().to_string())
-        .unwrap_or_else(|| paths.pcb.to_string_lossy().to_string());
+    let diagnostics_pcb_path = paths.pcb.to_string_lossy().to_string();
 
     debug!(
         "Generating layout for {} in {}",
@@ -613,25 +589,6 @@ pub fn process_layout(
         }
     }
 
-    // In check mode, fail if the layout would be modified by a sync.
-    //
-    // Since check mode runs the full sync pipeline against a shadow copy, we can compare
-    // the shadow PCB file after sync with the original PCB file in the real layout dir.
-    if check_mode && let Some(ref shadow) = shadow {
-        let pcb_drift = files_differ(&shadow.original_pcb_file, &paths.pcb, "PCB")?;
-        let shadow_pro_file = paths.pcb.with_extension("kicad_pro");
-        let original_pro_file = shadow.original_pcb_file.with_extension("kicad_pro");
-        let project_drift = files_differ(&original_pro_file, &shadow_pro_file, "project")?;
-        if pcb_drift || project_drift {
-            diagnostics.diagnostics.push(Diagnostic::categorized(
-                &diagnostics_pcb_path,
-                "Layout is out of sync (run without --check to apply changes)",
-                "layout.sync",
-                EvalSeverity::Error,
-            ));
-        }
-    }
-
     Ok(Some(LayoutResult {
         source_file: source_path,
         layout_dir,
@@ -641,7 +598,6 @@ pub fn process_layout(
         log_file: paths.log,
         diagnostics_file: paths.diagnostics,
         created: !pcb_exists,
-        shadow,
     }))
 }
 
@@ -870,45 +826,6 @@ mod diff_tests {
     use pcb_sch::{Instance, InstanceRef, ModuleRef, Schematic};
     use serde_json::Value;
     use std::path::PathBuf;
-
-    #[test]
-    fn files_differ_ignores_trailing_whitespace() -> anyhow::Result<()> {
-        let temp = tempfile::tempdir()?;
-        let original = temp.path().join("original.kicad_pcb");
-        let generated = temp.path().join("generated.kicad_pcb");
-
-        fs::write(&original, "(kicad_pcb (version 20240101))\n")?;
-        fs::write(&generated, "(kicad_pcb (version 20240101))\r\n\t")?;
-
-        assert!(!files_differ(&original, &generated, "PCB")?);
-        Ok(())
-    }
-
-    #[test]
-    fn files_differ_detects_leading_whitespace_changes() -> anyhow::Result<()> {
-        let temp = tempfile::tempdir()?;
-        let original = temp.path().join("original.kicad_pcb");
-        let generated = temp.path().join("generated.kicad_pcb");
-
-        fs::write(&original, "(kicad_pcb (version 20240101))\n")?;
-        fs::write(&generated, " (kicad_pcb (version 20240101))\n")?;
-
-        assert!(files_differ(&original, &generated, "PCB")?);
-        Ok(())
-    }
-
-    #[test]
-    fn files_differ_detects_internal_whitespace_changes() -> anyhow::Result<()> {
-        let temp = tempfile::tempdir()?;
-        let original = temp.path().join("original.kicad_pro");
-        let generated = temp.path().join("generated.kicad_pro");
-
-        fs::write(&original, r#"{"a":1,"b":2}"#)?;
-        fs::write(&generated, r#"{"a":1, "b":2}"#)?;
-
-        assert!(files_differ(&original, &generated, "project")?);
-        Ok(())
-    }
 
     #[test]
     fn layout_json_netlist_adds_derived_footprint_fpid() -> anyhow::Result<()> {

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -89,7 +89,7 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
         &schematic,
         &model_dirs,
         args.temp,
-        args.check, // check-mode (shadow copy)
+        args.check,
         &mut diagnostics,
     )?;
     spinner.finish();

--- a/crates/pcb/src/templates/gitignore
+++ b/crates/pcb/src/templates/gitignore
@@ -35,8 +35,5 @@ build/
 # Local pcb cache
 .pcb/
 
-# Temporary layout shadow copies created by `pcb layout --check`
-.*.pcb-check.*
-
 # KiCad layout history directories
 **/.history/


### PR DESCRIPTION
Expecting stable serialization from KiCad is a losing battle at least for now. I identified 4 issues, and by the time I fixed them, 2 more popped up. I can't. We already have a good lens view of the netlist from layout syncing, we can use that to just diff the "effective" netlist, which should hopefully get us most of the value and not much of the noise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `pcb layout --check` from running the full mutating KiCad sync on a shadow copy to a new read-only semantic connectivity/footprint diff, which could miss or newly surface sync issues compared to the prior byte-level drift check.
> 
> **Overview**
> `pcb layout --check` now performs a **read-only semantic sync verification** by extracting an “effective netlist” from the schematic and the checked-in `.kicad_pcb`, then diffing managed footprints, pad inventories, and connectivity (including net rename warnings vs split/merge errors).
> 
> This removes the previous shadow-copy + byte-compare drift detection (`files_differ`, temporary `.pcb-check` dirs, and `LayoutResult.shadow`) and updates diagnostics emission accordingly; the template `.gitignore` drops the shadow-directory ignore rule and the changelog documents the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54136da20c20492f9c23081e458eb7ec4f126908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->