### PR TITLE
fix: supported nested nets in hlabel schematic position parsing

### DIFF
--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -180,6 +180,34 @@ fn wrap(tag: &str, inner: JsonValue) -> JsonValue {
     JsonValue::Object(JsonMap::from_iter([(tag.to_string(), inner)]))
 }
 
+/// Walk a signature parameter's default value (Net or Interface, possibly nested) and return the
+/// path of field names leading to a net whose name equals `target_net_name`. Returns `Some(vec![])`
+/// when the value itself is a matching net.
+fn find_net_field_path(value: FrozenValue, target_net_name: &str) -> Option<Vec<String>> {
+    if let Some(net) = value.downcast_ref::<FrozenNetValue>() {
+        return (net.name() == target_net_name).then(Vec::new);
+    }
+    let interface = value.downcast_ref::<FrozenInterfaceValue>()?;
+    for (field_name, field_value) in interface.fields().iter() {
+        if let Some(mut path) = find_net_field_path(*field_value, target_net_name) {
+            path.insert(0, field_name.clone());
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Resolve a field path (as produced by [`find_net_field_path`]) against a value, returning the
+/// net id at the end of the path. The terminal value must be a [`FrozenNetValue`].
+fn resolve_net_id_along_path(value: FrozenValue, path: &[String]) -> Option<NetId> {
+    let Some((head, tail)) = path.split_first() else {
+        return value.downcast_ref::<FrozenNetValue>().map(|n| n.id());
+    };
+    let interface = value.downcast_ref::<FrozenInterfaceValue>()?;
+    let next_value = *interface.fields().get(head)?;
+    resolve_net_id_along_path(next_value, tail)
+}
+
 impl ModuleConverter {
     pub(crate) fn new() -> Self {
         Self {
@@ -928,44 +956,29 @@ impl ModuleConverter {
             return Some(symbol_key);
         }
 
-        // First try: public io() nets from signature - these need net ID lookup to get actual name
+        // First try: public io() nets from signature - these need net ID lookup to get actual name.
+        // Walks the parameter's default value (Net or Interface, possibly nested) looking for a
+        // net whose name matches `net_part`, then resolves the same field path on the actual
+        // value to get the bound net's id.
         for param in module.signature().iter().filter(|p| !p.is_config) {
-            if let Some(default_net_name) = param.default_value.and_then(|v| {
-                v.downcast_ref::<FrozenNetValue>()
-                    .map(|n| n.name().to_string())
-                    .or_else(|| {
-                        v.downcast_ref::<FrozenInterfaceValue>()?
-                            .fields()
-                            .get("NET")?
-                            .downcast_ref::<FrozenNetValue>()
-                            .map(|n| n.name().to_string())
-                    })
-            }) && default_net_name == net_part
+            let Some(default_value) = param.default_value else {
+                continue;
+            };
+            let Some(field_path) = find_net_field_path(default_value, net_part) else {
+                continue;
+            };
+            let Some(actual_value) = param.actual_value else {
+                continue;
+            };
+            let Some(net_id) = resolve_net_id_along_path(actual_value, &field_path) else {
+                continue;
+            };
+            if let Some(actual_net_name) = self
+                .net_to_info
+                .get(&net_id)
+                .and_then(|info| info.name.clone())
             {
-                // Get the actual net name from the net ID
-                let net_id =
-                    if let Some(net_value) = param.actual_value?.downcast_ref::<FrozenNetValue>() {
-                        net_value.id()
-                    } else if let Some(net_value) = param
-                        .actual_value?
-                        .downcast_ref::<FrozenInterfaceValue>()?
-                        .fields()
-                        .get("NET")?
-                        .downcast_ref::<FrozenNetValue>()
-                    {
-                        net_value.id()
-                    } else {
-                        continue;
-                    };
-
-                // Look up actual net name and construct symbol key
-                if let Some(actual_net_name) = self
-                    .net_to_info
-                    .get(&net_id)
-                    .and_then(|info| info.name.clone())
-                {
-                    return Some(format!("sym:{}#{}", actual_net_name, suffix));
-                }
+                return Some(format!("sym:{}#{}", actual_net_name, suffix));
             }
         }
 

--- a/crates/pcb/tests/netlist.rs
+++ b/crates/pcb/tests/netlist.rs
@@ -204,6 +204,50 @@ fn test_netlist_hierarchical_board_with_positions() {
     assert_snapshot!("netlist_hierarchical_board_with_positions", output);
 }
 
+const I2C_MODULE_ZEN: &str = r#"
+load("@stdlib/interfaces.zen", "I2c")
+
+Resistor = Module("@stdlib/generics/Resistor.zen")
+
+VDD = io(Power)
+GND = io(Ground)
+I2C = io(I2c)
+
+Resistor(name="R_SCL", value="10kohm", package="0402", P1=VDD, P2=I2C.SCL)
+Resistor(name="R_SDA", value="10kohm", package="0402", P1=VDD, P2=I2C.SDA)
+
+# Hierarchical labels on multi-field interface bus (I2c) - SCL and SDA fields.
+# pcb:sch I2C_SCL.0 x=10.0000 y=20.0000 rot=0
+# pcb:sch I2C_SDA.0 x=10.0000 y=30.0000 rot=0
+"#;
+
+const I2C_HIERARCHICAL_BOARD_ZEN: &str = r#"
+load("@stdlib/interfaces.zen", "I2c")
+
+I2cPullups = Module("../modules/I2cPullups.zen")
+
+vdd = Power("VDD_3V3")
+gnd = Ground("GND")
+bus = I2c("I2C_BUS")
+
+I2cPullups(name="PU1", VDD=vdd, GND=gnd, I2C=bus)
+"#;
+
+#[test]
+fn test_netlist_interface_field_positions() {
+    let mut sandbox = Sandbox::new();
+    sandbox
+        .write("pcb.toml", WORKSPACE_PCB_TOML)
+        .write("modules/I2cPullups.zen", I2C_MODULE_ZEN)
+        .write("boards/I2cBoard.zen", I2C_HIERARCHICAL_BOARD_ZEN);
+    let output = snapshot_netlist_positions(
+        &mut sandbox,
+        "pcb",
+        &["build", "boards/I2cBoard.zen", "--netlist"],
+    );
+    assert_snapshot!("netlist_interface_field_positions", output);
+}
+
 #[test]
 fn test_netlist_no_positions() {
     let board_zen = r#"

--- a/crates/pcb/tests/snapshots/netlist__netlist_interface_field_positions.snap
+++ b/crates/pcb/tests/snapshots/netlist__netlist_interface_field_positions.snap
@@ -1,0 +1,21 @@
+---
+source: crates/pcb/tests/netlist.rs
+assertion_line: 248
+expression: output
+---
+{
+  "<TEMP_DIR>/boards/I2cBoard.zen:<root>.PU1": {
+    "symbol_positions": {
+      "sym:I2C_BUS_SCL#0": {
+        "rotation": 0,
+        "x": 10,
+        "y": 20
+      },
+      "sym:I2C_BUS_SDA#0": {
+        "rotation": 0,
+        "x": 10,
+        "y": 30
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates schematic position symbol-key resolution for `io()` nets to recurse through nested `Interface` defaults, which could change how existing hierarchical label positions map to net names. Test coverage was added for a multi-field interface bus (I2C) to reduce regression risk.
> 
> **Overview**
> Fixes schematic/netlist position mapping for hierarchical labels that reference nets nested inside `io()` interface parameters (e.g., `I2C.SCL`/`I2C.SDA`).
> 
> `find_net_symbol_key` now discovers the matching net inside a parameter’s default value via a recursive field-path search and resolves that same path on the actual bound value to look up the correct net id/name. Adds a new netlist snapshot test covering interface-field hlabel positions (I2C pullups) and the expected `sym:<bus>_<field>#<idx>` symbol keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 652b68a9b2405da9f4eee37a1b79973e36437561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->