### PR TITLE
Fix MVS v2 offline vendor manifest loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Added simpler version footprint and separate QR to stdlib.
 
+### Fixed
+
+- MVS v2 offline builds now load dependency manifests from `vendor/` before falling back to the package cache.
+
 ## [0.3.78] - 2026-05-07
 
 ### Fixed

--- a/crates/pcb/src/mod/manifest.rs
+++ b/crates/pcb/src/mod/manifest.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use pcb_zen::cache_index::CacheIndex;
@@ -65,12 +66,12 @@ pub(crate) fn load_manifest_for_module_version(
         return Ok(loaded);
     }
 
-    let pcb_toml_path = if offline {
-        workspace
-            .workspace_cache_dir()
-            .join(module_path)
-            .join(version.to_string())
-            .join("pcb.toml")
+    let vendor_toml_path =
+        package_version_root(workspace.root.join("vendor"), module_path, version).join("pcb.toml");
+    let pcb_toml_path = if vendor_toml_path.exists() {
+        vendor_toml_path
+    } else if offline {
+        package_version_root(workspace.workspace_cache_dir(), module_path, version).join("pcb.toml")
     } else {
         pcb_zen::resolve::ensure_package_manifest_in_cache(module_path, version, index)
             .with_context(|| format!("Failed to materialize {}@{}", module_path, version))?
@@ -167,4 +168,49 @@ fn synthetic_kicad_manifest(
         indirect: BTreeMap::new(),
         parts: Vec::new(),
     }))
+}
+
+pub(crate) fn package_version_root(
+    root: impl AsRef<Path>,
+    module_path: &str,
+    version: &Version,
+) -> PathBuf {
+    root.as_ref().join(module_path).join(version.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use pcb_zen::WorkspaceInfo;
+
+    use super::*;
+
+    #[test]
+    fn offline_manifest_load_prefers_vendor_over_workspace_cache() {
+        let temp = tempfile::tempdir().unwrap();
+        let module_path = "github.com/example/vendor-only-package";
+        let version = Version::new(0, 2, 1);
+        let vendor_toml_path =
+            package_version_root(temp.path().join("vendor"), module_path, &version)
+                .join("pcb.toml");
+        std::fs::create_dir_all(vendor_toml_path.parent().unwrap()).unwrap();
+        std::fs::write(&vendor_toml_path, "").unwrap();
+
+        let workspace = WorkspaceInfo {
+            root: temp.path().to_path_buf(),
+            cache_dir: temp.path().join(".pcb/cache"),
+            config: None,
+            packages: BTreeMap::new(),
+            lockfile: None,
+            errors: Vec::new(),
+        };
+
+        let index = CacheIndex::open().unwrap();
+        let loaded =
+            load_manifest_for_module_version(&workspace, &index, module_path, &version, true)
+                .expect("offline load should use vendored manifest");
+
+        assert!(loaded.direct.is_empty());
+    }
 }

--- a/crates/pcb/src/mod/resolve.rs
+++ b/crates/pcb/src/mod/resolve.rs
@@ -20,7 +20,7 @@ use semver::Version;
 use crate::file_walker;
 
 use super::dep_id::{ResolvedDepId, compatibility_lane, parse_lane_qualified_key};
-use super::manifest::ManifestLoader;
+use super::manifest::{ManifestLoader, package_version_root};
 use super::materialize::materialize_selected;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -326,22 +326,15 @@ impl FrozenResolutionBuilder {
         }
 
         let version_str = version.to_string();
-        let vendor_root = self
-            .workspace
-            .root
-            .join("vendor")
-            .join(module_path)
-            .join(&version_str);
+        let vendor_root =
+            package_version_root(self.workspace.root.join("vendor"), module_path, version);
         if vendor_root.exists() {
             self.remote_roots.insert(key, vendor_root.clone());
             return Ok(vendor_root);
         }
 
-        let cache_root = self
-            .workspace
-            .workspace_cache_dir()
-            .join(module_path)
-            .join(&version_str);
+        let cache_root =
+            package_version_root(self.workspace.workspace_cache_dir(), module_path, version);
         let managed_kicad = self.is_managed_kicad_dep(module_path, version);
         if cache_root.join("pcb.toml").exists() || managed_kicad && cache_root.exists() {
             self.remote_roots.insert(key, cache_root.clone());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches dependency/manifest path resolution used by offline builds; incorrect precedence or path handling could cause missing/incorrect dependencies in `--offline` workflows.
> 
> **Overview**
> **Fixes MVS v2 offline dependency manifest loading** by preferring `vendor/<module>/<version>/pcb.toml` when present, and only falling back to the workspace cache (or online materialization when not offline).
> 
> This factors the repeated `<root>/<module>/<version>` path construction into a shared `package_version_root()` helper, reuses it in resolver root selection, and adds a regression test to ensure vendored manifests win over cache during offline loads. The change is documented in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961bc50320fdcec83270a0f08e07179b5ec69dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->