### PR TITLE
Show `embed-step` in CLI help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `pcb embed-step` is now shown in CLI help.
+
 ### Fixed
 
 - Fixed 4-digit resistor R-notation for generic BOM matching of sub-10Ω E96 values.

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -146,7 +146,6 @@ enum Commands {
     Fork,
 
     /// Embed a STEP model into a KiCad footprint
-    #[command(hide = true)]
     EmbedStep(embed_step::EmbedStepArgs),
 
     /// Scan datasheets from local PDFs or URLs

--- a/crates/pcb/tests/snapshots/simple__help.snap
+++ b/crates/pcb/tests/snapshots/simple__help.snap
@@ -11,32 +11,33 @@ PCB tool with build and layout capabilities
 Usage: pcb <COMMAND>
 
 Commands:
-  auth      Manage authentication
-  build     Build PCB projects
-  test      Run tests in .zen files
-  migrate   Migrate PCB projects
-  mod       Manage package dependency manifests
-  add       Add or update a direct dependency
-  sync      Reconcile source imports and hydrate package dependency manifests
-  new       Create a new workspace, board, package, or component
-  update    Update dependencies to latest compatible versions
-  self      Update the pcb tool itself
-  bom       Generate Bill of Materials (BOM)
-  info      Display workspace and board information
-  import    Import KiCad projects into a Zener workspace
-  doc       View embedded Zener documentation
-  layout    Layout PCB designs
-  fmt       Format .zen files
-  open      Open PCB layout files
-  publish   Publish packages and boards by creating version tags
-  preview   Build and upload a preview release for a board
-  vendor    Vendor external dependencies
-  fork      Reserved subcommand for future use
-  scan      Scan datasheets from local PDFs or URLs
-  search    Search for electronic components
-  simulate  Run SPICE simulations
-  ipc2581   IPC-2581 parser and inspection tool
-  help      Print this message or the help of the given subcommand(s)
+  auth        Manage authentication
+  build       Build PCB projects
+  test        Run tests in .zen files
+  migrate     Migrate PCB projects
+  mod         Manage package dependency manifests
+  add         Add or update a direct dependency
+  sync        Reconcile source imports and hydrate package dependency manifests
+  new         Create a new workspace, board, package, or component
+  update      Update dependencies to latest compatible versions
+  self        Update the pcb tool itself
+  bom         Generate Bill of Materials (BOM)
+  info        Display workspace and board information
+  import      Import KiCad projects into a Zener workspace
+  doc         View embedded Zener documentation
+  layout      Layout PCB designs
+  fmt         Format .zen files
+  open        Open PCB layout files
+  publish     Publish packages and boards by creating version tags
+  preview     Build and upload a preview release for a board
+  vendor      Vendor external dependencies
+  fork        Reserved subcommand for future use
+  embed-step  Embed a STEP model into a KiCad footprint
+  scan        Scan datasheets from local PDFs or URLs
+  search      Search for electronic components
+  simulate    Run SPICE simulations
+  ipc2581     IPC-2581 parser and inspection tool
+  help        Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help


### PR DESCRIPTION
It's useful enough to not hide it.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 68c3cc05eb723d361a4c40c4de65bf5ce181a244. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->