### PR TITLE
Keep MVS v2 package roots workspace-relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed 4-digit resistor R-notation for generic BOM matching of sub-10Ω E96 values.
+- MVS v2 layout generation now keeps cache-backed footprint library paths workspace-relative.
 
 ## [0.3.79] - 2026-05-08
 

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -968,7 +968,10 @@ impl ResolutionResult {
     /// are discovered from `package_resolutions` values (already resolved by the
     /// resolver through patches → vendor → cache).
     pub fn package_roots(&self) -> BTreeMap<String, PathBuf> {
-        self.package_roots.as_ref().clone()
+        self.package_roots
+            .iter()
+            .map(|(coord, root)| (coord.clone(), self.workspace_cache_path(root)))
+            .collect()
     }
 
     pub(crate) fn package_roots_ref(&self) -> &BTreeMap<String, PathBuf> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches dependency resolution output used to build `package://` URI mappings, so incorrect rewriting could break layout/netlist path resolution or bundling for MVS v2 builds. Scope is small and localized but affects core path mapping behavior.
> 
> **Overview**
> Ensures `ResolutionResult::package_roots()` returns workspace-relative paths for cache-backed dependencies by rewriting roots through `workspace_cache_path()` instead of returning the stored absolute cache paths.
> 
> Updates the changelog to note the fix for MVS v2 layout generation keeping footprint library paths workspace-relative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba439b4d7bc35eb344cc4f95197f9d67d2c87ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->