### PR TITLE
Evaluate and lint referenced KiCad footprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Builds now validate file-backed KiCad footprint S-expressions and embedded model checksums before layout generation.
 - `pcb info -f json` now includes the full transitive external dependency closure using package metadata aligned with workspace packages.
 
 ### Changed
 
 - `pcb layout` now initializes release text variables in KiCad project and board files, using `d10d3c0` as the placeholder git hash.
+- Embedded STEP writers now use KiCad's current MMH3 checksums instead of legacy SHA-256 checksums.
 - `pcb embed-step` is now shown in CLI help.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,7 +4523,6 @@ dependencies = [
  "atomicwrites",
  "base64",
  "dirs",
- "hex",
  "log",
  "pcb-command-runner",
  "pcb-sexpr",
@@ -4531,7 +4530,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.11.0",
  "starlark",
  "tempfile",
  "zstd",
@@ -4545,7 +4543,6 @@ dependencies = [
  "assert_fs",
  "atomicwrites",
  "base64",
- "hex",
  "include_dir",
  "insta",
  "log",
@@ -4560,7 +4557,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.11.0",
  "starlark",
  "tempfile",
  "thiserror 2.0.18",
@@ -4601,8 +4597,12 @@ dependencies = [
 name = "pcb-sexpr"
 version = "0.3.79"
 dependencies = [
+ "base64",
+ "hex",
  "log",
  "serde",
+ "sha2 0.11.0",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/pcb-diode-api/src/snapshots/pcb_diode_api__component__tests__embed_step_in_footprint_basic.snap
+++ b/crates/pcb-diode-api/src/snapshots/pcb_diode_api__component__tests__embed_step_in_footprint_basic.snap
@@ -14,7 +14,7 @@ expression: result
 			(name test.step)
 			(type model)
 			(data |KLUv/SAOcQAAU1RFUCBEQVRBIEhFUkU=|)
-			(checksum "368eafac8da1ec359463c2e25c4a62db836ca6633c73e039aa84ebe38b28c3bb")
+			(checksum "0FC02384A29118F69FFB8F37551022E3")
 		)
 	)
 	(model "kicad-embed://test.step"

--- a/crates/pcb-diode-api/src/snapshots/pcb_diode_api__component__tests__embed_step_in_footprint_preserves_transforms.snap
+++ b/crates/pcb-diode-api/src/snapshots/pcb_diode_api__component__tests__embed_step_in_footprint_preserves_transforms.snap
@@ -14,7 +14,7 @@ expression: result
 			(name new.step)
 			(type model)
 			(data |KLUv/SANaQAATkVXIFNURVAgREFUQQ==|)
-			(checksum "77d27e421d129c030d5426bfd60022a9bbec7e7964cb05b2d459c19d06adf250")
+			(checksum "0FC02384A29118F69FFB8F37551022E3")
 		)
 	)
 	(model "kicad-embed://new.step"

--- a/crates/pcb-kicad/Cargo.toml
+++ b/crates/pcb-kicad/Cargo.toml
@@ -8,7 +8,6 @@ authors = { workspace = true }
 description = "KiCad integration for PCB design tools"
 
 [dependencies]
-hex = { workspace = true }
 anyhow = { workspace = true }
 atomicwrites = { workspace = true }
 base64 = { workspace = true }
@@ -21,6 +20,5 @@ regex = { workspace = true }
 log = { workspace = true }
 pcb-command-runner = { workspace = true }
 pcb-zen-core = { workspace = true }
-sha2 = { workspace = true }
 starlark = { workspace = true }
 zstd = { workspace = true }

--- a/crates/pcb-kicad/src/footprint.rs
+++ b/crates/pcb-kicad/src/footprint.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
 use base64::Engine;
 use pcb_sexpr::formatter::{FormatMode, prettify};
-use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -88,7 +87,7 @@ pub fn embed_step_in_footprint(
     encoder.write_all(&step_bytes)?;
     let compressed = encoder.finish()?;
     let b64 = base64::engine::general_purpose::STANDARD.encode(&compressed);
-    let checksum = hex::encode(Sha256::digest(&step_bytes));
+    let checksum = pcb_sexpr::kicad::footprint::embedded_file_checksum(&step_bytes);
 
     let b64_formatted = b64
         .as_bytes()

--- a/crates/pcb-layout/Cargo.toml
+++ b/crates/pcb-layout/Cargo.toml
@@ -8,7 +8,6 @@ authors = { workspace = true }
 description = "PCB layout generation and management"
 
 [dependencies]
-hex = { workspace = true }
 anyhow = { workspace = true }
 atomicwrites = { workspace = true }
 thiserror = { workspace = true }
@@ -25,7 +24,6 @@ serde = { workspace = true }
 starlark = { workspace = true }
 include_dir = "0.7.4"
 base64 = { workspace = true }
-sha2 = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pcb-layout/src/model_embed_discovery.rs
+++ b/crates/pcb-layout/src/model_embed_discovery.rs
@@ -2,7 +2,6 @@ use anyhow::Context;
 use base64::Engine;
 use pcb_sexpr::formatter::{FormatMode, format_tree};
 use pcb_sexpr::{Sexpr, SexprKind, WalkCtx, find_named_list_index, set_or_insert_named_list};
-use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
@@ -76,7 +75,7 @@ pub(crate) fn embed_models_in_pcb_source(
 
         let bytes = std::fs::read(source_path)
             .with_context(|| format!("Failed to read 3D model {}", source_path.display()))?;
-        let checksum = sha256_hex(&bytes);
+        let checksum = pcb_sexpr::kicad::footprint::embedded_file_checksum(&bytes);
         model_checksums.insert(embed_name.clone(), checksum.clone());
         let data = compress_and_encode(&bytes)?;
         new_file_nodes.push(build_model_file_node(embed_name, &checksum, Some(&data)));
@@ -454,10 +453,6 @@ fn build_model_file_node(name: &str, checksum: &str, data: Option<&str>) -> Sexp
         Sexpr::string(checksum.to_string()),
     ]));
     Sexpr::list(items)
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    hex::encode(Sha256::digest(bytes))
 }
 
 fn compress_and_encode(bytes: &[u8]) -> anyhow::Result<String> {

--- a/crates/pcb-sexpr/Cargo.toml
+++ b/crates/pcb-sexpr/Cargo.toml
@@ -8,8 +8,12 @@ authors = { workspace = true }
 description = "S-expression parser for PCB file formats"
 
 [dependencies]
+base64 = { workspace = true }
+hex = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }
+sha2 = { workspace = true }
+zstd = { workspace = true }
 
 [features]
 default = []

--- a/crates/pcb-sexpr/src/kicad/footprint.rs
+++ b/crates/pcb-sexpr/src/kicad/footprint.rs
@@ -1,0 +1,443 @@
+use std::fmt;
+
+use base64::Engine;
+use sha2::{Digest, Sha256};
+
+use crate::{Sexpr, Span, find_all_child_lists, find_child_list};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FootprintValidationIssue {
+    pub message: String,
+    pub span: Option<Span>,
+}
+
+impl FootprintValidationIssue {
+    fn new(message: impl Into<String>, span: Option<Span>) -> Self {
+        Self {
+            message: message.into(),
+            span,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FootprintValidationError {
+    pub issues: Vec<FootprintValidationIssue>,
+}
+
+impl FootprintValidationError {
+    fn new(issue: impl Into<String>, span: Option<Span>) -> Self {
+        Self {
+            issues: vec![FootprintValidationIssue::new(issue, span)],
+        }
+    }
+}
+
+impl fmt::Display for FootprintValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (idx, issue) in self.issues.iter().enumerate() {
+            if idx > 0 {
+                writeln!(f)?;
+            }
+            write!(f, "{}", issue.message)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for FootprintValidationError {}
+
+/// Validate a KiCad footprint source file.
+///
+/// In addition to basic S-expression shape checks, this verifies KiCad 10
+/// embedded-file checksums. KiCad stores embedded payloads as base64-encoded
+/// zstd data and records a KiCad-specific MMH3 hash of the decompressed original
+/// bytes. Older files may use a SHA-256 hash.
+pub fn validate_footprint_source(source: &str) -> Result<(), FootprintValidationError> {
+    let parsed = crate::parse(source).map_err(|err| {
+        FootprintValidationError::new(format!("Invalid footprint S-expression: {err}"), None)
+    })?;
+    let Some(root) = parsed.as_list() else {
+        return Err(FootprintValidationError::new(
+            "Invalid footprint S-expression: root must be a list",
+            Some(parsed.span),
+        ));
+    };
+    if !matches!(
+        root.first().and_then(Sexpr::as_sym),
+        Some("footprint" | "module")
+    ) {
+        return Err(FootprintValidationError::new(
+            "Invalid footprint S-expression: root list must start with `footprint` or legacy `module`",
+            Some(parsed.span),
+        ));
+    }
+
+    let mut issues = Vec::new();
+    for embedded_files in find_all_child_lists(root, "embedded_files") {
+        for file in find_all_child_lists(embedded_files, "file") {
+            validate_embedded_file(file, &mut issues);
+        }
+    }
+
+    if issues.is_empty() {
+        Ok(())
+    } else {
+        Err(FootprintValidationError { issues })
+    }
+}
+
+fn validate_embedded_file(file: &[Sexpr], issues: &mut Vec<FootprintValidationIssue>) {
+    let file_span = list_span(file);
+    let name = find_child_list(file, "name")
+        .and_then(|list| collect_child_atom_text(list, 1))
+        .unwrap_or_else(|| "<unnamed>".to_string());
+
+    let Some(data_list) = find_child_list(file, "data") else {
+        return;
+    };
+    let Some(encoded) = collect_data_payload(data_list) else {
+        issues.push(FootprintValidationIssue::new(
+            format!("Embedded file `{name}` has an invalid data payload"),
+            list_span(data_list),
+        ));
+        return;
+    };
+    if encoded.is_empty() {
+        return;
+    }
+
+    let Some(checksum_list) = find_child_list(file, "checksum") else {
+        issues.push(FootprintValidationIssue::new(
+            format!("Embedded file `{name}` with data is missing checksum"),
+            file_span,
+        ));
+        return;
+    };
+    let checksum_span = list_span(checksum_list);
+    let data_span = list_span(data_list);
+    let Some(stored_checksum) = checksum_list.get(1).and_then(atom_text) else {
+        issues.push(FootprintValidationIssue::new(
+            format!("Embedded file `{name}` has an invalid checksum field"),
+            checksum_span,
+        ));
+        return;
+    };
+
+    let compressed = match base64::engine::general_purpose::STANDARD.decode(encoded.as_bytes()) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            issues.push(FootprintValidationIssue::new(
+                format!("Embedded file `{name}` has invalid base64 data: {err}"),
+                data_span,
+            ));
+            return;
+        }
+    };
+    let decompressed = match zstd::decode_all(compressed.as_slice()) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            issues.push(FootprintValidationIssue::new(
+                format!("Embedded file `{name}` has invalid zstd data: {err}"),
+                data_span,
+            ));
+            return;
+        }
+    };
+    if !checksum_matches(&stored_checksum, &decompressed) {
+        let mmh3 = embedded_file_checksum(&decompressed);
+        let sha256 = sha256_hash(&decompressed);
+        issues.push(FootprintValidationIssue::new(
+            format!(
+                "Embedded file `{name}` checksum mismatch: stored {stored_checksum}, expected {mmh3} or {sha256}",
+            ),
+            checksum_span,
+        ));
+    }
+}
+
+fn checksum_matches(stored: &str, data: &[u8]) -> bool {
+    if stored.len() == 64 {
+        stored.eq_ignore_ascii_case(&sha256_hash(data))
+    } else {
+        stored.eq_ignore_ascii_case(&embedded_file_checksum(data))
+    }
+}
+
+fn sha256_hash(data: &[u8]) -> String {
+    hex::encode(Sha256::digest(data))
+}
+
+/// Return the checksum KiCad currently writes for embedded file payloads.
+///
+/// This intentionally mirrors KiCad's streaming `MMH3_HASH`, including its
+/// 4-byte tail padding and padded length finalization. That makes 12-15 byte
+/// tails hash like an empty padded tail; odd, but required for byte-for-byte
+/// compatibility with KiCad's embedded-file writer/loader.
+pub fn embedded_file_checksum(data: &[u8]) -> String {
+    const SEED: u64 = 0xABBA_2345;
+    let mut h1 = SEED;
+    let mut h2 = SEED;
+    let mut len = 0usize;
+    let mut block = [0u8; 16];
+
+    let mut chunks = data.chunks_exact(16);
+    for chunk in &mut chunks {
+        block.copy_from_slice(chunk);
+        hash_mmh3_block(&mut h1, &mut h2, &block);
+        len += 16;
+    }
+
+    let tail = chunks.remainder();
+    if !tail.is_empty() {
+        block[..tail.len()].copy_from_slice(tail);
+        let padding = 4 - (tail.len() + 4) % 4;
+        block[tail.len()..tail.len() + padding].fill(0);
+        len += tail.len() + padding;
+    }
+
+    hash_mmh3_tail(&mut h1, &mut h2, &block, len & 15);
+    finish_mmh3(h1, h2, len as u64)
+}
+
+fn hash_mmh3_block(h1: &mut u64, h2: &mut u64, block: &[u8; 16]) {
+    const C1: u64 = 0x87c3_7b91_1142_53d5;
+    const C2: u64 = 0x4cf5_ad43_2745_937f;
+
+    let mut k1 = u64::from_le_bytes(block[0..8].try_into().unwrap());
+    let mut k2 = u64::from_le_bytes(block[8..16].try_into().unwrap());
+
+    k1 = k1.wrapping_mul(C1).rotate_left(31).wrapping_mul(C2);
+    *h1 ^= k1;
+    *h1 = h1
+        .rotate_left(27)
+        .wrapping_add(*h2)
+        .wrapping_mul(5)
+        .wrapping_add(0x52dc_e729);
+
+    k2 = k2.wrapping_mul(C2).rotate_left(33).wrapping_mul(C1);
+    *h2 ^= k2;
+    *h2 = h2
+        .rotate_left(31)
+        .wrapping_add(*h1)
+        .wrapping_mul(5)
+        .wrapping_add(0x3849_5ab5);
+}
+
+fn hash_mmh3_tail(h1: &mut u64, h2: &mut u64, tail: &[u8; 16], len: usize) {
+    const C1: u64 = 0x87c3_7b91_1142_53d5;
+    const C2: u64 = 0x4cf5_ad43_2745_937f;
+
+    let mut k1 = 0u64;
+    let mut k2 = 0u64;
+
+    for (idx, byte) in tail.iter().copied().take(len.min(8)).enumerate() {
+        k1 ^= (byte as u64) << (idx * 8);
+    }
+    for (idx, byte) in tail
+        .iter()
+        .copied()
+        .skip(8)
+        .take(len.saturating_sub(8))
+        .enumerate()
+    {
+        k2 ^= (byte as u64) << (idx * 8);
+    }
+
+    if len > 8 {
+        *h2 ^= k2.wrapping_mul(C2).rotate_left(33).wrapping_mul(C1);
+    }
+    if len > 0 {
+        *h1 ^= k1.wrapping_mul(C1).rotate_left(31).wrapping_mul(C2);
+    }
+}
+
+fn finish_mmh3(mut h1: u64, mut h2: u64, len: u64) -> String {
+    h1 ^= len;
+    h2 ^= len;
+
+    h1 = h1.wrapping_add(h2);
+    h2 = h2.wrapping_add(h1);
+
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+
+    h1 = h1.wrapping_add(h2);
+    h2 = h2.wrapping_add(h1);
+
+    format!("{h1:016X}{h2:016X}")
+}
+
+fn fmix64(mut value: u64) -> u64 {
+    value ^= value >> 33;
+    value = value.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    value ^= value >> 33;
+    value = value.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
+    value ^= value >> 33;
+    value
+}
+
+fn list_span(list: &[Sexpr]) -> Option<Span> {
+    let start = list.first()?.span.start;
+    let end = list.last()?.span.end;
+    Some(Span::new(start, end))
+}
+
+fn collect_data_payload(data_list: &[Sexpr]) -> Option<String> {
+    let raw = collect_child_atom_text(data_list, 1)?;
+    Some(
+        raw.trim()
+            .trim_start_matches('|')
+            .trim_end_matches('|')
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect(),
+    )
+}
+
+fn collect_child_atom_text(list: &[Sexpr], start: usize) -> Option<String> {
+    let mut text = String::new();
+    for node in list.get(start..)? {
+        text.push_str(&atom_text(node)?);
+    }
+    Some(text)
+}
+
+fn atom_text(node: &Sexpr) -> Option<String> {
+    if let Some(raw) = &node.raw_atom {
+        Some(raw.clone())
+    } else {
+        node.as_atom().map(str::to_owned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn embedded_payload(bytes: &[u8]) -> (String, String) {
+        let mut encoder = zstd::Encoder::new(Vec::new(), 17).unwrap();
+        std::io::Write::write_all(&mut encoder, bytes).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let encoded = base64::engine::general_purpose::STANDARD.encode(compressed);
+        let checksum = hex::encode(Sha256::digest(bytes));
+        (encoded, checksum)
+    }
+
+    fn footprint_with_data(data: &str, checksum: &str) -> String {
+        format!(
+            "(footprint \"Test\"\n  (embedded_files\n    (file\n      (name model.step)\n      (type model)\n      (data |{}|)\n      (checksum \"{}\")\n    )\n  )\n)",
+            data, checksum
+        )
+    }
+
+    #[test]
+    fn valid_embedded_file_passes() {
+        let (data, checksum) = embedded_payload(b"step model bytes");
+        validate_footprint_source(&footprint_with_data(&data, &checksum)).unwrap();
+    }
+
+    #[test]
+    fn multiline_embedded_file_passes() {
+        let (data, checksum) = embedded_payload(b"step model bytes");
+        let split = data.len() / 2;
+        let data = format!("{}\n        {}", &data[..split], &data[split..]);
+        validate_footprint_source(&footprint_with_data(&data, &checksum)).unwrap();
+    }
+
+    #[test]
+    fn checksum_mismatch_fails() {
+        let (data, _) = embedded_payload(b"step model bytes");
+        let err = validate_footprint_source(&footprint_with_data(&data, "00")).unwrap_err();
+        assert!(err.to_string().contains("checksum mismatch"));
+        assert!(err.to_string().contains("stored 00"));
+    }
+
+    #[test]
+    fn invalid_base64_fails() {
+        let err = validate_footprint_source(&footprint_with_data("not base64", "00")).unwrap_err();
+        assert!(err.to_string().contains("invalid base64 data"));
+    }
+
+    #[test]
+    fn invalid_zstd_fails() {
+        let data = base64::engine::general_purpose::STANDARD.encode(b"not zstd");
+        let err = validate_footprint_source(&footprint_with_data(&data, "00")).unwrap_err();
+        assert!(err.to_string().contains("invalid zstd data"));
+    }
+
+    #[test]
+    fn footprint_without_embedded_files_passes() {
+        validate_footprint_source("(footprint \"Test\")").unwrap();
+    }
+
+    #[test]
+    fn legacy_module_root_passes() {
+        validate_footprint_source("(module \"Test\")").unwrap();
+    }
+
+    #[test]
+    fn embedded_file_without_data_passes() {
+        validate_footprint_source(
+            "(footprint \"Test\" (embedded_files (file (name model.step) (type model))))",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn embedded_file_with_empty_data_passes() {
+        validate_footprint_source(
+            "(footprint \"Test\" (embedded_files (file (name model.step) (type model) (data))))",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn current_mmh3_checksum_passes() {
+        let (data, _) = embedded_payload(b"step model bytes");
+        let checksum = embedded_file_checksum(b"step model bytes");
+        validate_footprint_source(&footprint_with_data(&data, &checksum)).unwrap();
+    }
+
+    #[test]
+    fn checksum_matches_kicad_padded_tail_output() {
+        assert_eq!(
+            embedded_file_checksum(b"STEP DATA HERE"),
+            "0FC02384A29118F69FFB8F37551022E3"
+        );
+        assert_eq!(
+            embedded_file_checksum(b"NEW STEP DATA"),
+            "0FC02384A29118F69FFB8F37551022E3"
+        );
+    }
+
+    #[test]
+    fn checksum_accepts_kicad_padded_tail_output() {
+        let payload = b"abcdefghijkl";
+        let checksum = embedded_file_checksum(payload);
+        assert_eq!(checksum, "0FC02384A29118F69FFB8F37551022E3");
+
+        let (data, _) = embedded_payload(payload);
+        validate_footprint_source(&footprint_with_data(&data, &checksum)).unwrap();
+    }
+
+    #[test]
+    fn data_without_checksum_fails() {
+        let (data, _) = embedded_payload(b"step model bytes");
+        let footprint = format!(
+            "(footprint \"Test\" (embedded_files (file (name model.step) (type model) (data |{}|))))",
+            data
+        );
+        let err = validate_footprint_source(&footprint).unwrap_err();
+        assert!(err.to_string().contains("with data is missing checksum"));
+    }
+
+    #[test]
+    fn non_footprint_root_fails() {
+        let err = validate_footprint_source("(kicad_pcb)").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("root list must start with `footprint` or legacy `module`")
+        );
+    }
+}

--- a/crates/pcb-sexpr/src/kicad/mod.rs
+++ b/crates/pcb-sexpr/src/kicad/mod.rs
@@ -3,9 +3,11 @@
 //! This module groups KiCad-related parsing utilities in submodules:
 //! - [`props`] - common "property-like" query helpers
 //! - [`netlist`] - KiCad netlist (`kicadsexpr`) helpers
+//! - [`footprint`] - KiCad footprint (`.kicad_mod`) helpers
 //! - [`schematic`] - KiCad schematic (`.kicad_sch`) helpers
 //! - [`symbol`] - KiCad symbol library (`.kicad_sym`) helpers
 
+pub mod footprint;
 pub mod netlist;
 pub mod props;
 pub mod schematic;

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -5,6 +5,7 @@ use pcb_sch::physical::PhysicalValue;
 use semver::Version;
 use starlark::{
     any::ProvidesStaticType,
+    codemap::ResolvedSpan,
     collections::SmallMap,
     environment::GlobalsBuilder,
     errors::EvalSeverity,
@@ -119,6 +120,8 @@ pub struct ComponentGen<V, T> {
     connections: SmallMap<String, V>,
     data: T,
     source_path: String,
+    #[allocative(skip)]
+    declaration_span: Option<ResolvedSpan>,
     symbol: V,
     description: Option<String>,
 }
@@ -166,6 +169,7 @@ impl<'v> Freeze for ComponentValue<'v> {
                 },
             },
             source_path: self.source_path,
+            declaration_span: self.declaration_span,
             symbol: self.symbol.freeze(freezer)?,
             description: self.description,
         })
@@ -1687,6 +1691,10 @@ impl FrozenComponentValue {
         &self.source_path
     }
 
+    pub fn declaration_span(&self) -> Option<ResolvedSpan> {
+        self.declaration_span
+    }
+
     pub fn symbol(&self) -> &FrozenValue {
         &self.symbol
     }
@@ -2120,6 +2128,9 @@ where
                     properties: properties_map,
                 }),
                 source_path: eval_ctx.source_path().unwrap_or_default(),
+                declaration_span: eval_ctx
+                    .call_stack_top_location()
+                    .map(|location| location.resolve_span()),
                 symbol: eval_ctx.heap().alloc_complex(final_symbol),
                 description: final_description,
             });

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -39,6 +39,7 @@ use crate::lang::{
     electrical_check::FrozenElectricalCheck,
     evaluator_ext::EvaluatorExt,
     file::file_globals,
+    footprint::{FootprintCacheKey, footprint_cache_key, validate_footprints},
     module::{FrozenModuleValue, ModulePath},
 };
 use crate::load_spec::LoadSpec;
@@ -172,7 +173,9 @@ impl EvalOutput {
     /// Convert to schematic with diagnostics
     pub fn to_schematic_with_diagnostics(&self) -> crate::WithDiagnostics<pcb_sch::Schematic> {
         let converter = ModuleConverter::new();
-        let mut result = converter.build(self.module_tree());
+        let module_tree = self.module_tree();
+        let footprint_diagnostics = validate_footprints(&module_tree, &self.config, &self.session);
+        let mut result = converter.build(module_tree);
         if let Some(ref mut schematic) = result.output {
             schematic.package_roots = self.config.resolution.package_roots();
             schematic.resolved_paths = self.config.tracked_resolved_paths();
@@ -204,6 +207,7 @@ impl EvalOutput {
                 }
             }
         }
+        result.diagnostics.extend(footprint_diagnostics);
         result
     }
 
@@ -282,6 +286,8 @@ pub struct EvalSession {
     /// root is active. V1 keeps the historical path-only behavior via a `None`
     /// scope.
     load_cache: Arc<RwLock<HashMap<LoadCacheKey, CachedModule>>>,
+    /// Cache of validated footprint files.
+    footprint_cache: Arc<RwLock<HashMap<FootprintCacheKey, Vec<Diagnostic>>>>,
     /// Per-file mapping of `symbol → target path` for "go-to definition".
     symbol_index: Arc<RwLock<HashMap<PathBuf, HashMap<String, PathBuf>>>>,
     /// Per-file mapping of `symbol → parameter list` for signature help.
@@ -782,6 +788,7 @@ impl Default for EvalSession {
         Self {
             file_contents_cache: Arc::new(RwLock::new(HashMap::new())),
             load_cache: Arc::new(RwLock::new(HashMap::new())),
+            footprint_cache: Arc::new(RwLock::new(HashMap::new())),
             symbol_index: Arc::new(RwLock::new(HashMap::new())),
             symbol_params: Arc::new(RwLock::new(HashMap::new())),
             symbol_meta: Arc::new(RwLock::new(HashMap::new())),
@@ -841,10 +848,25 @@ impl EvalSession {
 
     pub fn clear_load_cache(&self) {
         self.load_cache.write().unwrap().clear();
+        self.footprint_cache.write().unwrap().clear();
     }
 
-    fn clear_file_contents(&self, path: &Path) {
+    pub(crate) fn get_cached_footprint(&self, key: &FootprintCacheKey) -> Option<Vec<Diagnostic>> {
+        self.footprint_cache.read().unwrap().get(key).cloned()
+    }
+
+    pub(crate) fn cache_footprint(&self, key: FootprintCacheKey, diagnostics: Vec<Diagnostic>) {
+        self.footprint_cache
+            .write()
+            .unwrap()
+            .insert(key, diagnostics);
+    }
+
+    fn clear_file_contents(&self, path: &Path, footprint_key: Option<FootprintCacheKey>) {
         self.file_contents_cache.write().unwrap().remove(path);
+        if let Some(key) = footprint_key {
+            self.footprint_cache.write().unwrap().remove(&key);
+        }
     }
 
     fn clear_symbol_maps(&self, path: &Path) {
@@ -1628,7 +1650,9 @@ impl EvalContext {
 
     /// Remove file contents from the in-memory cache.
     pub fn clear_file_contents(&self, path: &Path) {
-        self.session.clear_file_contents(path);
+        let footprint_key = (path.extension().and_then(|ext| ext.to_str()) == Some("kicad_mod"))
+            .then(|| footprint_cache_key(path, &self.config));
+        self.session.clear_file_contents(path, footprint_key);
     }
 
     /// Get all symbols for a file
@@ -2197,5 +2221,32 @@ impl FileLoader for EvalContext {
     fn load(&self, path: &str) -> starlark::Result<FrozenModule> {
         let eval_output = self.resolve_and_eval_module(path, None)?;
         Ok(eval_output.star_module)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, sync::Arc};
+
+    use crate::{InMemoryFileProvider, resolution::ResolutionResult};
+
+    use super::*;
+
+    #[test]
+    fn clear_file_contents_invalidates_canonicalized_footprint_cache_key() {
+        let context = EvalContext::new(
+            Arc::new(InMemoryFileProvider::empty()),
+            ResolutionResult::empty(),
+        );
+        let cached_path = Path::new("/dir/bad.kicad_mod");
+        let invalidation_path = Path::new("/dir/../dir/bad.kicad_mod");
+        let key = footprint_cache_key(cached_path, context.config());
+
+        context.session.cache_footprint(key.clone(), Vec::new());
+        assert!(context.session.get_cached_footprint(&key).is_some());
+
+        context.clear_file_contents(invalidation_path);
+
+        assert!(context.session.get_cached_footprint(&key).is_none());
     }
 }

--- a/crates/pcb-zen-core/src/lang/footprint.rs
+++ b/crates/pcb-zen-core/src/lang/footprint.rs
@@ -1,0 +1,134 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use starlark::{
+    codemap::{CodeMap, Pos, ResolvedSpan, Span as StarlarkSpan},
+    errors::EvalSeverity,
+};
+
+use crate::{Diagnostic, FileProviderError};
+
+use super::eval::{EvalContextConfig, EvalSession};
+use super::module::FrozenModuleValue;
+use super::module::ModulePath;
+
+pub(crate) type FootprintCacheKey = (Option<crate::resolution::PackageScopeKey>, PathBuf);
+
+pub(crate) fn validate_footprints(
+    module_tree: &BTreeMap<ModulePath, FrozenModuleValue>,
+    config: &EvalContextConfig,
+    session: &EvalSession,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for module in module_tree.values() {
+        for component in module.components() {
+            let Some(path) = resolve_file_backed_footprint(
+                component.footprint(),
+                std::path::Path::new(component.source_path()),
+                config,
+            ) else {
+                continue;
+            };
+            let key = footprint_cache_key(&path, config);
+            let cached = if let Some(cached) = session.get_cached_footprint(&key) {
+                cached
+            } else {
+                let cached = validate_footprint_file(&path, config);
+                session.cache_footprint(key, cached.clone());
+                cached
+            };
+            diagnostics.extend(cached.into_iter().map(|diagnostic| {
+                Diagnostic::categorized(
+                    component.source_path(),
+                    &format!(
+                        "Component `{}` uses invalid footprint `{}`",
+                        component.name(),
+                        component.footprint()
+                    ),
+                    "footprint.component",
+                    EvalSeverity::Error,
+                )
+                .with_span(component.declaration_span())
+                .with_child(Some(diagnostic.boxed()))
+            }));
+        }
+    }
+
+    diagnostics
+}
+
+fn resolve_file_backed_footprint(
+    footprint: &str,
+    source_path: &std::path::Path,
+    config: &EvalContextConfig,
+) -> Option<PathBuf> {
+    if !footprint.ends_with(".kicad_mod") {
+        return None;
+    }
+    if footprint.starts_with(pcb_sch::PACKAGE_URI_PREFIX) {
+        return config.resolution.resolve_package_uri(footprint).ok();
+    }
+
+    let path = PathBuf::from(footprint);
+    if path.is_absolute() {
+        return Some(path);
+    }
+    source_path.parent().map(|parent| parent.join(path))
+}
+
+pub(crate) fn footprint_cache_key(
+    path: &std::path::Path,
+    config: &EvalContextConfig,
+) -> FootprintCacheKey {
+    let canonical = config
+        .file_provider()
+        .canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf());
+    let scope = config.resolution.load_cache_scope_key_for_file(
+        &canonical,
+        config.mvs_v2_root_package.as_deref(),
+        config.file_provider(),
+    );
+    (scope, canonical)
+}
+
+fn validate_footprint_file(path: &std::path::Path, config: &EvalContextConfig) -> Vec<Diagnostic> {
+    let path_str = path.to_string_lossy().to_string();
+    match config.file_provider().read_file(path) {
+        Ok(source) => match pcb_sexpr::kicad::footprint::validate_footprint_source(&source) {
+            Ok(()) => Vec::new(),
+            Err(err) => err
+                .issues
+                .into_iter()
+                .map(|issue| {
+                    let span = issue
+                        .span
+                        .map(|span| resolved_span_from_byte_span(&path_str, &source, span));
+                    Diagnostic::categorized(
+                        &path_str,
+                        &format!("Invalid KiCad footprint: {}", issue.message),
+                        "footprint.invalid",
+                        EvalSeverity::Error,
+                    )
+                    .with_span(span)
+                })
+                .collect(),
+        },
+        Err(FileProviderError::NotFound(_)) => Vec::new(),
+        Err(err) => vec![Diagnostic::categorized(
+            &path_str,
+            &format!("Failed to read KiCad footprint for validation: {err}"),
+            "footprint.read",
+            EvalSeverity::Error,
+        )],
+    }
+}
+
+fn resolved_span_from_byte_span(path: &str, source: &str, span: pcb_sexpr::Span) -> ResolvedSpan {
+    let codemap = CodeMap::new(path.to_string(), source.to_string());
+    let start = Pos::new(span.start as u32);
+    let end = Pos::new(span.end as u32);
+    codemap
+        .file_span(StarlarkSpan::new(start, end))
+        .resolve_span()
+}

--- a/crates/pcb-zen-core/src/lang/mod.rs
+++ b/crates/pcb-zen-core/src/lang/mod.rs
@@ -6,6 +6,7 @@ pub mod electrical_check;
 pub mod r#enum;
 pub mod eval;
 pub(crate) mod evaluator_ext;
+pub(crate) mod footprint;
 pub(crate) mod interface;
 pub mod io_direction;
 pub mod module;

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -91,6 +91,77 @@ Component(
 }
 
 #[test]
+fn file_backed_footprint_validation_reports_embedded_file_errors() {
+    let result = common::eval_zen(vec![
+        (
+            "bad.kicad_mod".to_string(),
+            r#"
+            (footprint "Bad"
+              (embedded_files
+                (file
+                  (name model.step)
+                  (type model)
+                  (data |not base64|)
+                  (checksum "00")
+                )
+              )
+            )
+            "#
+            .to_string(),
+        ),
+        (
+            "test.zen".to_string(),
+            r#"
+            P1 = Net()
+            P2 = Net()
+            P3 = Net()
+            P4 = Net()
+
+            Component(
+                name = "R1",
+                footprint = "bad.kicad_mod",
+                pin_defs = {"1": "1", "2": "2"},
+                pins = {"1": P1, "2": P2},
+            )
+
+            Component(
+                name = "R2",
+                footprint = "bad.kicad_mod",
+                pin_defs = {"1": "1", "2": "2"},
+                pins = {"1": P3, "2": P4},
+            )
+            "#
+            .to_string(),
+        ),
+    ]);
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+
+    let schematic_result = result
+        .output
+        .expect("expected eval output")
+        .to_schematic_with_diagnostics();
+
+    assert!(schematic_result.diagnostics.has_errors());
+    let footprint_diags = schematic_result
+        .diagnostics
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.body.contains("uses invalid footprint"))
+        .collect::<Vec<_>>();
+    assert_eq!(footprint_diags.len(), 2);
+    let footprint_diag = footprint_diags[0];
+    assert!(footprint_diag.span.is_some());
+    let child = footprint_diag
+        .child
+        .as_ref()
+        .expect("expected inner footprint-file diagnostic");
+    assert!(child.body.contains("Invalid KiCad footprint"), "{child:?}");
+    assert!(child.body.contains("invalid base64 data"), "{child:?}");
+    assert!(child.path.ends_with("bad.kicad_mod"), "{child:?}");
+    assert!(child.span.is_some());
+}
+
+#[test]
 fn component_modifier_part_without_datasheet_clears_stale_part_datasheet() {
     let component = eval_single_root_component(
         r#"


### PR DESCRIPTION
Support sha256 and murmurhash3. Switch to murmurhash3 when pcb embeds steps, it's what kicad defaults to now and its faster. A full registry build goes from ~6s to ~9.4 seconds, which I think is worth it. If we migrate the registry to murmurhash3, we can reclaim some of the performance impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new footprint parsing/validation and a custom KiCad-compatible MMH3 checksum implementation that can now fail builds/schematic generation for previously-accepted footprints. Also changes embedded-model checksum format, which could affect interoperability with existing assets if any edge cases differ from KiCad’s behavior.
> 
> **Overview**
> **Builds now lint referenced `.kicad_mod` footprints** during `EvalContext::to_schematic_with_diagnostics()`, emitting per-component error diagnostics with spans (and caching results keyed by canonicalized path + package scope).
> 
> **Embedded model/STEP checksum handling is updated**: a new `pcb_sexpr::kicad::footprint` module validates embedded payloads (base64+zstd + checksum) and provides `embedded_file_checksum()` matching KiCad’s MMH3 output while still accepting legacy SHA-256; `pcb-kicad` and `pcb-layout` now write MMH3 checksums and drop direct `sha2/hex` usage. Tests/snapshots and the changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7933be1796a4bd7e957768ba160895ac7c062f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->