### PR TITLE
Add stdlib power inductor BOM matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added scoped multi-registry search for registry-backed `pcb search`.
 - Builds now validate file-backed KiCad footprint S-expressions and embedded model checksums before layout generation.
 - `pcb info -f json` now includes the full transitive external dependency closure using package metadata aligned with workspace packages.
+- Added stdlib BOM matching for 0603 and 0805 Würth Elektronik WE-PMI and WE-PMCI power inductors.
 
 ### Changed
 

--- a/stdlib/bom/helpers.zen
+++ b/stdlib/bom/helpers.zen
@@ -7,6 +7,7 @@ load(
     "Voltage",
     "Power",
     "Capacitance",
+    "Inductance",
     "Impedance",
     "Current",
     "Frequency",
@@ -517,6 +518,29 @@ def ferrite_bead(
     return {
         "impedance": Impedance(impedance),
         "frequency": Frequency(frequency),
+        "current": Current(current),
+        "dcr": Resistance(dcr),
+        "mpn": mpn,
+        "manufacturer": manufacturer,
+        "datasheet": datasheet,
+    }
+
+
+def power_inductor(inductance: str, current: str, dcr: str, mpn: str, manufacturer: str, datasheet=None) -> dict:
+    """Helper to create power inductor catalog entry.
+
+    Args:
+        inductance: Inductance with tolerance (e.g., "10uH 20%")
+        current: Rated current (e.g., "1.2A")
+        dcr: DC resistance max (e.g., "250mOhm")
+        mpn: Manufacturer part number
+        manufacturer: Manufacturer name
+
+    Returns:
+        Power inductor dictionary
+    """
+    return {
+        "inductance": Inductance(inductance),
         "current": Current(current),
         "dcr": Resistance(dcr),
         "mpn": mpn,

--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -9,6 +9,7 @@ load(
     "Voltage",
     "Resistance",
     "Capacitance",
+    "Inductance",
     "Power",
     "Current",
     "Frequency",
@@ -41,6 +42,7 @@ load(
     "ecs_crystal",
     "led",
     "ferrite_bead",
+    "power_inductor",
     "tvs",
     "rectifier",
     "zener",
@@ -338,6 +340,113 @@ HOUSE_FB_BY_PKG = {
     "0805": [
         ferrite_bead("220Ohm 25%", "100MHz", "2A", "45mOhm", "BLM21PG221SN1D", "Murata Electronics"),
         ferrite_bead("220Ohm 25%", "100MHz", "3A", "40mOhm", "MPZ2012S221AT000", "TDK Corporation"),
+    ],
+}
+
+# House power inductor catalog by package.
+HOUSE_POWER_INDUCTORS_BY_PKG = {
+    "0603": [
+        # Würth Elektronik WE-PMCI, 0603 (1608 Metric), shielded molded power inductors.
+        power_inductor(
+            "470nH 20%",
+            "3.95A",
+            "75mOhm",
+            "74479262147",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479262147.pdf",
+        ),
+        power_inductor(
+            "1uH 20%",
+            "2.6A",
+            "115mOhm",
+            "74479262210",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479262210.pdf",
+        ),
+    ],
+    "0805": [
+        # Würth Elektronik WE-PMCI, 0805 (2012 Metric), shielded molded power inductors.
+        power_inductor(
+            "470nH 20%",
+            "4.3A",
+            "44mOhm",
+            "74479275147",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479275147.pdf",
+        ),
+        power_inductor(
+            "1uH 20%",
+            "3.3A",
+            "75mOhm",
+            "74479275210",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479275210.pdf",
+        ),
+        power_inductor(
+            "2.2uH 20%",
+            "2A",
+            "190mOhm",
+            "74479275222",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479275222.pdf",
+        ),
+        # Würth Elektronik WE-PMI, 0805 (2012 Metric), shielded multilayer power inductors.
+        power_inductor(
+            "470nH 20%",
+            "1.4A",
+            "100mOhm",
+            "74479775147A",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479775147A.pdf",
+        ),
+        power_inductor(
+            "1uH 20%",
+            "1.1A",
+            "190mOhm",
+            "74479774210",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479774210.pdf",
+        ),
+        power_inductor(
+            "2.2uH 20%",
+            "700mA",
+            "340mOhm",
+            "74479774222",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479774222.pdf",
+        ),
+        power_inductor(
+            "4.7uH 20%",
+            "850mA",
+            "312.5mOhm",
+            "74479775247",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479775247.pdf",
+        ),
+        power_inductor(
+            "6.8uH 20%",
+            "900mA",
+            "375mOhm",
+            "74479777268",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479777268.pdf",
+        ),
+        power_inductor(
+            "10uH 20%",
+            "900mA",
+            "375mOhm",
+            "74479777310A",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479777310A.pdf",
+        ),
+        power_inductor(
+            "10uH 20%",
+            "650mA",
+            "625mOhm",
+            "74479777310",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479777310.pdf",
+        ),
     ],
 }
 
@@ -1419,6 +1528,47 @@ def assign_house_ferrite_bead(c, house_fb_by_pkg):
     _no_match_warn("ferrite bead", c, pkg)
 
 
+def assign_house_inductor(c, house_inductors_by_pkg):
+    """Assign house power inductor MPNs."""
+    pkg = prop(c, ["package", "Package"])
+    if pkg not in house_inductors_by_pkg:
+        return
+
+    inductance_req = Inductance(prop(c, ["inductance", "Inductance"]))
+    current_constraint = prop(c, ["current", "Current"])
+    dcr_constraint = prop(c, ["dcr", "Dcr"])
+
+    if inductance_req.tolerance == 0.0:
+        inductance_req = inductance_req.with_tolerance(0.20)
+
+    parts = house_inductors_by_pkg.get(pkg, [])
+    matches = []
+
+    for p in parts:
+        if not p["inductance"].within(inductance_req):
+            continue
+
+        # Current: part's current must be >= required (higher is better)
+        if current_constraint and p["current"] < current_constraint:
+            continue
+
+        # DCR: part's DCR must be <= required (lower is better)
+        if dcr_constraint and p["dcr"] > dcr_constraint:
+            continue
+
+        err = p["inductance"].diff(inductance_req) / inductance_req
+        score = (err, p["current"] * -1, p["dcr"])
+        matches.append((score, p))
+
+    if matches:
+        sorted_matches = sorted(matches, key=lambda x: x[0])
+        set_from_matches(c, [p for score, p in sorted_matches])
+        c.matcher = "assign_house_inductor"
+        return
+
+    _no_match_warn("power inductor", c, pkg)
+
+
 def assign_house_pin_header(c, house_ph):
     """Assign house pin header MPNs."""
     pins_req = prop(c, ["pins", "Pins"])
@@ -1663,6 +1813,8 @@ def assign_house_parts(c):
         assign_house_led(c, HOUSE_LEDS_BY_PKG)
     elif c.type == "ferrite_bead":
         assign_house_ferrite_bead(c, HOUSE_FB_BY_PKG)
+    elif c.type == "inductor":
+        assign_house_inductor(c, HOUSE_POWER_INDUCTORS_BY_PKG)
     elif c.type == "rectifier":
         assign_house_rectifier(c, HOUSE_RECTIFIERS_BY_PKG)
     elif c.type == "zener":

--- a/stdlib/generics/test/test_Inductor.zen
+++ b/stdlib/generics/test/test_Inductor.zen
@@ -2,29 +2,97 @@
 
 load("../../interfaces.zen", "Net")
 load("../../properties.zen", "Layout")
+load("../../bom/match_generics.zen", "HOUSE_POWER_INDUCTORS_BY_PKG", "assign_house_parts")
 
 Inductor = Module("../Inductor.zen")
 
-# Test all Package values
+
+def _sanitize(s):
+    return str(s).replace(" ", "").replace(".", "p").replace("%", "pct")
+
+
+# Test all standard Package values. KICAD is deprecated and intentionally not
+# exercised here.
 for package in Inductor.Package.values():
+    if package == Inductor.Package("KICAD"):
+        continue
+
     name = "L_" + str(package)
     Inductor(
         name=name,
         value="10uH",
         current="1A",
+        mpn="TEST-" + name,
+        manufacturer="Test",
         package=package,
         P1=Net(name + "_P1"),
         P2=Net(name + "_P2"),
     )
 
-# Test KICAD
-Inductor(
-    name="L_KICAD",
-    value="10uH",
-    current="1A",
-    package=Inductor.Package("KICAD"),
-    kicad_library="Inductor_SMD",
-    kicad_package="L_0603_1608Metric",
-    P1=Net("L_KICAD_P1"),
-    P2=Net("L_KICAD_P2"),
-)
+# Every house power inductor entry should build through the house inductor matcher.
+for package, parts in HOUSE_POWER_INDUCTORS_BY_PKG.items():
+    for i, p in enumerate(parts):
+        name = "L_MATCH_" + package + "_" + str(i) + "_" + _sanitize(p["inductance"])
+        Inductor(
+            name=name,
+            value=p["inductance"],
+            current=p["current"],
+            dcr=p["dcr"],
+            package=Inductor.Package(package),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+
+
+_MATCH_CONSTRAINT_CASES = [
+    # Unconstrained value should match using the default 20% inductance tolerance.
+    ("DEFAULT_TOL", "1uH", None, None),
+    # Current and DCR are constraints: house part current must be >= requested,
+    # and house part DCR must be <= requested.
+    ("CURRENT_MIN", "1uH", "3A", None),
+    ("DCR_MAX", "1uH", None, "100mOhm"),
+    ("CURRENT_AND_DCR", "2.2uH", "1.5A", "250mOhm"),
+    # 10uH is only present in the WE-PMI series in the current 0805 catalog.
+    ("PMI_10UH", "10uH", "700mA", "500mOhm"),
+]
+
+for kind, value, current, dcr in _MATCH_CONSTRAINT_CASES:
+    name = "L_MATCH_0805_" + kind
+    if current and dcr:
+        Inductor(
+            name=name,
+            value=value,
+            current=current,
+            dcr=dcr,
+            package=Inductor.Package("0805"),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+    elif current:
+        Inductor(
+            name=name,
+            value=value,
+            current=current,
+            package=Inductor.Package("0805"),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+    elif dcr:
+        Inductor(
+            name=name,
+            value=value,
+            dcr=dcr,
+            package=Inductor.Package("0805"),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+    else:
+        Inductor(
+            name=name,
+            value=value,
+            package=Inductor.Package("0805"),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+
+builtin.add_component_modifier(assign_house_parts)


### PR DESCRIPTION
Added the wurth model chip inductors.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new generic BOM auto-matching logic for `inductor` components, which can change selected MPNs and alternatives in generated BOMs. Risk is limited to stdlib matching/catalog data but could impact sourcing if the heuristic or constraints behave unexpectedly.
> 
> **Overview**
> Adds stdlib *house-part BOM matching* for power inductors: introduces a `power_inductor()` helper and a new `HOUSE_POWER_INDUCTORS_BY_PKG` catalog (0603/0805 Würth Elektronik WE-PMI/WE-PMCI) and wires it into generic matching via `assign_house_inductor` and the `assign_house_parts` dispatcher.
> 
> Updates `test_Inductor.zen` to exercise all non-`KICAD` packages and to validate that each catalog entry (plus several constraint scenarios for inductance/current/DCR) successfully builds through the new matcher, and documents the feature in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c4d9873f5bc3d262d87109ed0661896921c933c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->