### PR TITLE
Add 0201 resistor generic matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added scoped multi-registry search for registry-backed `pcb search`.
 - Builds now validate file-backed KiCad footprint S-expressions and embedded model checksums before layout generation.
 - `pcb info -f json` now includes the full transitive external dependency closure using package metadata aligned with workspace packages.
+- Added stdlib BOM matching for 0603 and 0805 Würth Elektronik WE-PMI and WE-PMCI power inductors.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Builds now validate file-backed KiCad footprint S-expressions and embedded model checksums before layout generation.
 - `pcb info -f json` now includes the full transitive external dependency closure using package metadata aligned with workspace packages.
 - Added stdlib BOM matching for 0603 and 0805 Würth Elektronik WE-PMI and WE-PMCI power inductors.
+- Added stdlib BOM matching for Panasonic ERJ-1GJF and ERJ-1GNF 0201 resistors.
 
 ### Changed
 

--- a/stdlib/bom/helpers.zen
+++ b/stdlib/bom/helpers.zen
@@ -7,6 +7,7 @@ load(
     "Voltage",
     "Power",
     "Capacitance",
+    "Inductance",
     "Impedance",
     "Current",
     "Frequency",
@@ -517,6 +518,29 @@ def ferrite_bead(
     return {
         "impedance": Impedance(impedance),
         "frequency": Frequency(frequency),
+        "current": Current(current),
+        "dcr": Resistance(dcr),
+        "mpn": mpn,
+        "manufacturer": manufacturer,
+        "datasheet": datasheet,
+    }
+
+
+def power_inductor(inductance: str, current: str, dcr: str, mpn: str, manufacturer: str, datasheet=None) -> dict:
+    """Helper to create power inductor catalog entry.
+
+    Args:
+        inductance: Inductance with tolerance (e.g., "10uH 20%")
+        current: Rated current (e.g., "1.2A")
+        dcr: DC resistance max (e.g., "250mOhm")
+        mpn: Manufacturer part number
+        manufacturer: Manufacturer name
+
+    Returns:
+        Power inductor dictionary
+    """
+    return {
+        "inductance": Inductance(inductance),
         "current": Current(current),
         "dcr": Resistance(dcr),
         "mpn": mpn,

--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -9,6 +9,7 @@ load(
     "Voltage",
     "Resistance",
     "Capacitance",
+    "Inductance",
     "Power",
     "Current",
     "Frequency",
@@ -41,6 +42,7 @@ load(
     "ecs_crystal",
     "led",
     "ferrite_bead",
+    "power_inductor",
     "tvs",
     "rectifier",
     "zener",
@@ -338,6 +340,113 @@ HOUSE_FB_BY_PKG = {
     "0805": [
         ferrite_bead("220Ohm 25%", "100MHz", "2A", "45mOhm", "BLM21PG221SN1D", "Murata Electronics"),
         ferrite_bead("220Ohm 25%", "100MHz", "3A", "40mOhm", "MPZ2012S221AT000", "TDK Corporation"),
+    ],
+}
+
+# House power inductor catalog by package.
+HOUSE_POWER_INDUCTORS_BY_PKG = {
+    "0603": [
+        # Würth Elektronik WE-PMCI, 0603 (1608 Metric), shielded molded power inductors.
+        power_inductor(
+            "470nH 20%",
+            "3.95A",
+            "75mOhm",
+            "74479262147",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479262147.pdf",
+        ),
+        power_inductor(
+            "1uH 20%",
+            "2.6A",
+            "115mOhm",
+            "74479262210",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479262210.pdf",
+        ),
+    ],
+    "0805": [
+        # Würth Elektronik WE-PMCI, 0805 (2012 Metric), shielded molded power inductors.
+        power_inductor(
+            "470nH 20%",
+            "4.3A",
+            "44mOhm",
+            "74479275147",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479275147.pdf",
+        ),
+        power_inductor(
+            "1uH 20%",
+            "3.3A",
+            "75mOhm",
+            "74479275210",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479275210.pdf",
+        ),
+        power_inductor(
+            "2.2uH 20%",
+            "2A",
+            "190mOhm",
+            "74479275222",
+            "Würth Elektronik",
+            "https://www.we-online.com/catalog/datasheet/74479275222.pdf",
+        ),
+        # Würth Elektronik WE-PMI, 0805 (2012 Metric), shielded multilayer power inductors.
+        power_inductor(
+            "470nH 20%",
+            "1.4A",
+            "100mOhm",
+            "74479775147A",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479775147A.pdf",
+        ),
+        power_inductor(
+            "1uH 20%",
+            "1.1A",
+            "190mOhm",
+            "74479774210",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479774210.pdf",
+        ),
+        power_inductor(
+            "2.2uH 20%",
+            "700mA",
+            "340mOhm",
+            "74479774222",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479774222.pdf",
+        ),
+        power_inductor(
+            "4.7uH 20%",
+            "850mA",
+            "312.5mOhm",
+            "74479775247",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479775247.pdf",
+        ),
+        power_inductor(
+            "6.8uH 20%",
+            "900mA",
+            "375mOhm",
+            "74479777268",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479777268.pdf",
+        ),
+        power_inductor(
+            "10uH 20%",
+            "900mA",
+            "375mOhm",
+            "74479777310A",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479777310A.pdf",
+        ),
+        power_inductor(
+            "10uH 20%",
+            "650mA",
+            "625mOhm",
+            "74479777310",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479777310.pdf",
+        ),
     ],
 }
 
@@ -1419,6 +1528,47 @@ def assign_house_ferrite_bead(c, house_fb_by_pkg):
     _no_match_warn("ferrite bead", c, pkg)
 
 
+def assign_house_inductor(c, house_inductors_by_pkg):
+    """Assign house power inductor MPNs."""
+    pkg = prop(c, ["package", "Package"])
+    if pkg not in house_inductors_by_pkg:
+        return
+
+    inductance_req = Inductance(prop(c, ["inductance", "Inductance"]))
+    current_constraint = prop(c, ["current", "Current"])
+    dcr_constraint = prop(c, ["dcr", "Dcr"])
+
+    if inductance_req.tolerance == 0.0:
+        inductance_req = inductance_req.with_tolerance(0.20)
+
+    parts = house_inductors_by_pkg.get(pkg, [])
+    matches = []
+
+    for p in parts:
+        if not p["inductance"].within(inductance_req):
+            continue
+
+        # Current: part's current must be >= required (higher is better)
+        if current_constraint and p["current"] < current_constraint:
+            continue
+
+        # DCR: part's DCR must be <= required (lower is better)
+        if dcr_constraint and p["dcr"] > dcr_constraint:
+            continue
+
+        err = p["inductance"].diff(inductance_req) / inductance_req
+        score = (err, p["current"] * -1, p["dcr"])
+        matches.append((score, p))
+
+    if matches:
+        sorted_matches = sorted(matches, key=lambda x: x[0])
+        set_from_matches(c, [p for score, p in sorted_matches])
+        c.matcher = "assign_house_inductor"
+        return
+
+    _no_match_warn("power inductor", c, pkg)
+
+
 def assign_house_pin_header(c, house_ph):
     """Assign house pin header MPNs."""
     pins_req = prop(c, ["pins", "Pins"])
@@ -1663,6 +1813,8 @@ def assign_house_parts(c):
         assign_house_led(c, HOUSE_LEDS_BY_PKG)
     elif c.type == "ferrite_bead":
         assign_house_ferrite_bead(c, HOUSE_FB_BY_PKG)
+    elif c.type == "inductor":
+        assign_house_inductor(c, HOUSE_POWER_INDUCTORS_BY_PKG)
     elif c.type == "rectifier":
         assign_house_rectifier(c, HOUSE_RECTIFIERS_BY_PKG)
     elif c.type == "zener":

--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -98,6 +98,28 @@ SERIES_BY_PKG = {
             [("0Ohm", "RC0201FR-070RL")],
             yageo_asset_datasheet("PYU-RC_GROUP_51_ROHS_L"),
         ),
+        panasonic_erj(
+            "ERJ-1GJF",
+            "10Ohm – 1MOhm",
+            "25V",
+            "0.05W",
+            "1%",
+            ["e96", "e24"],
+            "C",
+            iec60062_4digit,
+            "RDA0000/AOA0000C304.pdf",
+        ),
+        panasonic_erj(
+            "ERJ-1GNF",
+            "10Ohm – 1MOhm",
+            "25V",
+            "0.05W",
+            "1%",
+            ["e96", "e24"],
+            "C",
+            iec60062_4digit,
+            "RDA0000/AOA0000C304.pdf",
+        ),
     ],
     "0402": [
         # 0 ohm jumpers (checked first for exact 0 ohm match)

--- a/stdlib/generics/test/test_Inductor.zen
+++ b/stdlib/generics/test/test_Inductor.zen
@@ -2,29 +2,97 @@
 
 load("../../interfaces.zen", "Net")
 load("../../properties.zen", "Layout")
+load("../../bom/match_generics.zen", "HOUSE_POWER_INDUCTORS_BY_PKG", "assign_house_parts")
 
 Inductor = Module("../Inductor.zen")
 
-# Test all Package values
+
+def _sanitize(s):
+    return str(s).replace(" ", "").replace(".", "p").replace("%", "pct")
+
+
+# Test all standard Package values. KICAD is deprecated and intentionally not
+# exercised here.
 for package in Inductor.Package.values():
+    if package == Inductor.Package("KICAD"):
+        continue
+
     name = "L_" + str(package)
     Inductor(
         name=name,
         value="10uH",
         current="1A",
+        mpn="TEST-" + name,
+        manufacturer="Test",
         package=package,
         P1=Net(name + "_P1"),
         P2=Net(name + "_P2"),
     )
 
-# Test KICAD
-Inductor(
-    name="L_KICAD",
-    value="10uH",
-    current="1A",
-    package=Inductor.Package("KICAD"),
-    kicad_library="Inductor_SMD",
-    kicad_package="L_0603_1608Metric",
-    P1=Net("L_KICAD_P1"),
-    P2=Net("L_KICAD_P2"),
-)
+# Every house power inductor entry should build through the house inductor matcher.
+for package, parts in HOUSE_POWER_INDUCTORS_BY_PKG.items():
+    for i, p in enumerate(parts):
+        name = "L_MATCH_" + package + "_" + str(i) + "_" + _sanitize(p["inductance"])
+        Inductor(
+            name=name,
+            value=p["inductance"],
+            current=p["current"],
+            dcr=p["dcr"],
+            package=Inductor.Package(package),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+
+
+_MATCH_CONSTRAINT_CASES = [
+    # Unconstrained value should match using the default 20% inductance tolerance.
+    ("DEFAULT_TOL", "1uH", None, None),
+    # Current and DCR are constraints: house part current must be >= requested,
+    # and house part DCR must be <= requested.
+    ("CURRENT_MIN", "1uH", "3A", None),
+    ("DCR_MAX", "1uH", None, "100mOhm"),
+    ("CURRENT_AND_DCR", "2.2uH", "1.5A", "250mOhm"),
+    # 10uH is only present in the WE-PMI series in the current 0805 catalog.
+    ("PMI_10UH", "10uH", "700mA", "500mOhm"),
+]
+
+for kind, value, current, dcr in _MATCH_CONSTRAINT_CASES:
+    name = "L_MATCH_0805_" + kind
+    if current and dcr:
+        Inductor(
+            name=name,
+            value=value,
+            current=current,
+            dcr=dcr,
+            package=Inductor.Package("0805"),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+    elif current:
+        Inductor(
+            name=name,
+            value=value,
+            current=current,
+            package=Inductor.Package("0805"),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+    elif dcr:
+        Inductor(
+            name=name,
+            value=value,
+            dcr=dcr,
+            package=Inductor.Package("0805"),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+    else:
+        Inductor(
+            name=name,
+            value=value,
+            package=Inductor.Package("0805"),
+            P1=Net(name + "_P1"),
+            P2=Net(name + "_P2"),
+        )
+
+builtin.add_component_modifier(assign_house_parts)

--- a/stdlib/generics/test/test_Resistor.zen
+++ b/stdlib/generics/test/test_Resistor.zen
@@ -2,6 +2,7 @@
 
 load("../../interfaces.zen", "Net")
 load("../../properties.zen", "Layout")
+load("../../bom/match_generics.zen", "assign_house_parts")
 
 Resistor = Module("../Resistor.zen")
 
@@ -13,6 +14,8 @@ for package in Resistor.Package.values():
         value="10kOhm",
         voltage="50V",
         package=package,
+        mpn="TEST-" + name,
+        manufacturer="Test",
         P1=Net(name + "_P1"),
         P2=Net(name + "_P2"),
     )
@@ -24,6 +27,21 @@ Resistor(
     voltage="50V",
     package="0603",
     use_us_symbol=True,
+    mpn="TEST-" + name,
+    manufacturer="Test",
     P1=Net(name + "_P1"),
     P2=Net(name + "_P2"),
 )
+
+for value in ["10kOhm", "47kOhm", "100kOhm"]:
+    name = "R_0201_MATCH_" + value
+    Resistor(
+        name=name,
+        value=value,
+        voltage="25V",
+        package="0201",
+        P1=Net(name + "_P1"),
+        P2=Net(name + "_P2"),
+    )
+
+builtin.add_component_modifier(assign_house_parts)


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends generic BOM auto-matching logic and catalogs; incorrect matching/scoring or constraints could change selected MPNs in generated BOMs for resistors/inductors.
> 
> **Overview**
> Adds new stdlib house-part catalogs and matching for **Panasonic ERJ-1GJF/ERJ-1GNF 0201 resistors** and **Würth WE-PMI/WE-PMCI 0603/0805 power inductors**, and documents these additions in the changelog.
> 
> Introduces a `power_inductor()` catalog helper plus a new `assign_house_inductor` matcher (inductance tolerance defaulting to 20%, with current-min and DCR-max constraints) and wires it into `assign_house_parts` dispatch.
> 
> Expands generic tests to exercise the new matching paths: resistor tests now run house matching for several 0201 values, and inductor tests add matcher coverage for the full inductor catalog and constraint-based selection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65965a26f5713cda1684c867c899a4ddf5fe1d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->