### PR TITLE
fix: update registry api endpoints

### DIFF
--- a/crates/pcb-diode-api/src/registry/download.rs
+++ b/crates/pcb-diode-api/src/registry/download.rs
@@ -14,8 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::Sender;
 use std::thread;
 
-const REGISTRY_INDEX_ROUTE: &str = "/api/registry/index";
-const REGISTRIES_ROUTE: &str = "/api/registry/registries";
+const REGISTRIES_ROUTE: &str = "/api/registries";
 pub const DEFAULT_REGISTRY_URL: &str = "github.com/diodeinc/registry";
 
 #[derive(Debug, Clone, Deserialize, serde::Serialize, PartialEq, Eq)]
@@ -520,14 +519,17 @@ fn registry_url_from_package_url(url: &str) -> Option<String> {
     None
 }
 
+fn registry_index_route(registry: &RegistryInfo) -> String {
+    format!("/api/registries/{}/index", registry.id)
+}
+
 /// Fetch registry index metadata without downloading the file.
-pub fn fetch_registry_index_metadata(registry_id: &str) -> Result<RegistryIndexMetadata> {
+pub fn fetch_registry_index_metadata(registry: &RegistryInfo) -> Result<RegistryIndexMetadata> {
     let token = crate::auth::get_valid_token().context("Auth failed")?;
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
-    let mut url = reqwest::Url::parse(&format!("{api_url}{REGISTRY_INDEX_ROUTE}"))
+    let url = reqwest::Url::parse(&format!("{api_url}{}", registry_index_route(registry)))
         .context("Invalid registry index URL")?;
-    url.query_pairs_mut().append_pair("registryId", registry_id);
 
     let resp = client
         .get(url.clone())
@@ -578,7 +580,7 @@ fn registry_cache_dir_name(registry_id: &str) -> String {
 
 pub fn ensure_registry_index(registry: &RegistryInfo, force: bool) -> Result<RegistryIndexFile> {
     let path = registry_db_path(registry)?;
-    let metadata = match fetch_registry_index_metadata(&registry.id) {
+    let metadata = match fetch_registry_index_metadata(registry) {
         Ok(metadata) => metadata,
         Err(err) if !force && path.exists() => {
             log::debug!(

--- a/crates/pcb-diode-api/src/registry/tui/image.rs
+++ b/crates/pcb-diode-api/src/registry/tui/image.rs
@@ -263,7 +263,10 @@ fn resolve_registry_image_url(
     token: &str,
     sha256: &str,
 ) -> Result<Option<String>> {
-    let endpoint = format!("{}/api/registry/images/{sha256}", crate::get_api_base_url());
+    let endpoint = format!(
+        "{}/api/registries/images/{sha256}",
+        crate::get_api_base_url()
+    );
     let response = client
         .get(endpoint)
         .bearer_auth(token)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes client-side registry API paths (index metadata and image URL resolution), which will break registry downloads/images if the server routes or IDs don’t match the new contract.
> 
> **Overview**
> Updates the registry client to use the new `registries` API namespace.
> 
> Registry discovery now calls `GET /api/registries`, registry index metadata is fetched via a per-registry path (`/api/registries/{id}/index`) instead of a query param, and TUI image URL resolution moves to `GET /api/registries/images/{sha256}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5044ad9a3cbd8274d2356791b9e846823d233c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->