### PR TITLE
Remove unsupported workspace-relative load docs

### DIFF
--- a/crates/pcb-zen-core/src/load_spec.rs
+++ b/crates/pcb-zen-core/src/load_spec.rs
@@ -137,10 +137,6 @@ impl LoadSpec {
     ///   - `"@gitlab/foo/bar/src/lib.zen"` - Simple user/repo without revision (assumes HEAD)
     ///   - `"@gitlab/kicad/libraries/kicad-symbols:main/Device.kicad_sym"` - Nested groups with revision
     ///
-    /// • **Workspace-relative path** – `"//<path>"`.
-    ///   Paths starting with `//` are resolved relative to the workspace root.
-    ///   Example: `"//src/components/resistor.zen"`.
-    ///
     /// • **Package URI** – `"package://<url>/<path>"`.
     ///   A stable, machine-independent reference to a file within a resolved package.
     ///   Example: `"package://github.com/diodeinc/registry/reference/TPS54331/TPS54331.zen"`.


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates Rust doc comments and does not change parsing or runtime behavior.
> 
> **Overview**
> Removes the documentation for `//<path>` *workspace-relative* `load()` specs from `LoadSpec::parse` docs, leaving only the supported package, GitHub/GitLab, `package://`, stdlib URI, and raw path forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054ac3b7abacd8717cf0753ca3feb7be776345b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->