### PR TITLE
Avoid re-execing pcb for self-update changelog

### DIFF
--- a/crates/pcb/src/changelog.rs
+++ b/crates/pcb/src/changelog.rs
@@ -9,7 +9,7 @@ const CHANGELOG_URL: &str =
 pub struct ChangelogArgs {
     /// Version selector: latest, unreleased, 0.3.80, or 0.3.78..0.3.80
     #[arg(default_value = "")]
-    selector: String,
+    pub(crate) selector: String,
 }
 
 pub fn execute(args: ChangelogArgs) -> Result<()> {

--- a/crates/pcb/src/self_update.rs
+++ b/crates/pcb/src/self_update.rs
@@ -30,14 +30,11 @@ pub fn execute(args: SelfUpdateArgs) -> anyhow::Result<()> {
 
             match updater.run_sync()? {
                 Some(result) => {
-                    // Update was performed - print changelog from the NEW binary.
+                    // Update was performed - print changelog for the version range.
                     println!();
                     let selector =
                         changelog_selector(result.old_version.as_ref(), &result.new_version);
-                    let _ = std::process::Command::new("pcb")
-                        .arg("changelog")
-                        .arg(selector)
-                        .status();
+                    let _ = crate::changelog::execute(crate::changelog::ChangelogArgs { selector });
 
                     // Print a random fortune
                     let fortunes: Vec<&str> = FORTUNES.lines().filter(|l| !l.is_empty()).collect();


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces a post-update subprocess call with an in-process call and slightly widens `ChangelogArgs` visibility; behavior should be equivalent aside from avoiding process-spawn edge cases.
> 
> **Overview**
> After a successful self-update, `pcb` now renders the changelog **in-process** by calling `crate::changelog::execute(...)` instead of spawning a new `pcb changelog` subprocess.
> 
> To support this, `ChangelogArgs.selector` is widened to `pub(crate)` so `self_update` can construct the args directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0df2aaf9dc98abe43e200d4ba8ad0f962b6a8ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->