### PR TITLE
Add IPC-2581 layer rendering to `pcb ipc2581 render`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Preserved IPC-2581 `PolyStepCurve` arc geometry when rendering layer SVGs.
+- Applied IPC-2581 slot/cavity cutouts only to affected layers and subtracted them from rendered layer geometry.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,21 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added initial `pcb ipc2581 render` support for rendering a single IPC-2581 layer to SVG.
+- Added PNG output support to `pcb ipc2581 render`.
+- Added Kitty-compatible terminal graphics output for `pcb ipc2581 render` when no output path is provided.
+
+### Fixed
+
+- Preserved IPC-2581 `PolyStepCurve` arc geometry when rendering layer SVGs.
+
 ### Changed
 
 - `pcb new board <name> <repo-url>` now creates a board repository directly, replacing the separate `pcb new workspace` flow.
 - `pcb import` now writes directly into a board repository root instead of creating `boards/<name>/` under a workspace.
+- Increased default `pcb ipc2581 render` PNG resolution.
 
 ## [0.3.81] - 2026-05-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4564,6 +4564,7 @@ dependencies = [
  "comfy-table",
  "ipc2581",
  "jiff",
+ "kurbo",
  "log",
  "minijinja",
  "pcb-diode-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1719,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "debugserver-types"
@@ -2266,6 +2281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2303,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -3016,6 +3060,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,7 +3214,7 @@ dependencies = [
  "hex",
  "md-5",
  "quick-xml",
- "roxmltree",
+ "roxmltree 0.21.1",
  "thiserror 2.0.18",
  "zstd",
 ]
@@ -3382,6 +3432,17 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -3727,6 +3788,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -4487,6 +4557,7 @@ name = "pcb-ipc2581-tools"
 version = "0.3.81"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "clap",
  "colored",
@@ -4499,8 +4570,10 @@ dependencies = [
  "pcb-sch",
  "pcb-ui",
  "quick-xml",
+ "resvg",
  "serde",
  "serde_json",
+ "terminal_size",
  "zstd",
 ]
 
@@ -4884,6 +4957,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -5669,10 +5748,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"
@@ -5716,6 +5815,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "roxmltree"
@@ -6123,6 +6228,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "rustyline"
@@ -6622,6 +6745,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6632,6 +6764,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -6783,6 +6924,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6865,6 +7015,16 @@ name = "supports-hyperlinks"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -7225,6 +7385,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7475,6 +7661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7513,6 +7708,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7534,6 +7747,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7549,6 +7774,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -7620,6 +7851,34 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf8_iter"
@@ -8591,6 +8850,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "y4m"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,6 +2861,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "i_float"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c8fc32799c6cde9c7604188e4ece27acf3ddcb2d40b038113e3f0bc525aac7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+
+[[package]]
+name = "i_overlay"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f8ed01b5f7de7c2e5661d9ac807aacb33ad76f591f973d89b58e998f552c34"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+]
+
+[[package]]
+name = "i_shape"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d12d0501b145b966d1801f90e4fcc20b65b39617055d131efa8699068bb1de1"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4562,6 +4604,7 @@ dependencies = [
  "clap",
  "colored",
  "comfy-table",
+ "i_overlay",
  "ipc2581",
  "jiff",
  "kurbo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ rust_decimal_macros = "1.38"
 comfy-table = { version = "7.2", features = ["custom_styling"] }
 url = "2.5"
 ignore = "0.4"
+i_overlay = "6"
 sha2 = "0.11"
 semver = { version = "1.0", features = ["serde"] }
 quick-xml = "0.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ ignore = "0.4"
 sha2 = "0.11"
 semver = { version = "1.0", features = ["serde"] }
 quick-xml = "0.39"
+resvg = "0.47"
 zstd = "0.13"
 jiff = "0.2"
 blake3 = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ ignore = "0.4"
 sha2 = "0.11"
 semver = { version = "1.0", features = ["serde"] }
 quick-xml = "0.39"
+kurbo = "0.13"
 resvg = "0.47"
 zstd = "0.13"
 jiff = "0.2"

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1603,12 +1603,22 @@ impl Parser {
             .map(|s| self.parse_polarity(s))
             .transpose()?;
 
-        // Parse layer-specific Profile (for rigid-flex)
+        let mut span = None;
         let mut profile = None;
         for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "Profile" {
-                profile = Some(self.parse_profile(&child)?);
-                break;
+            match child.tag_name().name() {
+                "Span" => {
+                    span = Some(ecad::LayerSpan {
+                        from_layer: child
+                            .attribute("fromLayer")
+                            .map(|s| self.interner.intern(s)),
+                        to_layer: child.attribute("toLayer").map(|s| self.interner.intern(s)),
+                    });
+                }
+                "Profile" => {
+                    profile = Some(self.parse_profile(&child)?);
+                }
+                _ => {}
             }
         }
 
@@ -1617,6 +1627,7 @@ impl Parser {
             layer_function,
             side,
             polarity,
+            span,
             profile,
         })
     }
@@ -1984,10 +1995,15 @@ impl Parser {
             SlotShape::Primitive(self.parse_standard_primitive(&primitive_node, units)?)
         };
 
+        let z_axis_dim = node.children().any(|child| {
+            child.is_element() && matches!(child.tag_name().name(), "MaterialCut" | "MaterialLeft")
+        });
+
         Ok(Slot {
             name,
             shape,
             plating_status,
+            z_axis_dim,
             x,
             y,
         })

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1995,9 +1995,7 @@ impl Parser {
             SlotShape::Primitive(self.parse_standard_primitive(&primitive_node, units)?)
         };
 
-        let z_axis_dim = node.children().any(|child| {
-            child.is_element() && matches!(child.tag_name().name(), "MaterialCut" | "MaterialLeft")
-        });
+        let z_axis_dim = has_z_axis_dim(node);
 
         Ok(Slot {
             name,
@@ -2583,6 +2581,46 @@ impl Parser {
             mirror,
             scale,
         }
+    }
+}
+
+fn has_z_axis_dim(node: &Node) -> bool {
+    node.children()
+        .filter(|child| child.is_element())
+        .any(|child| {
+            matches!(child.tag_name().name(), "MaterialCut" | "MaterialLeft")
+                || (matches!(child.tag_name().name(), "Z_AxisDim" | "ZAxisDim")
+                    && child
+                        .children()
+                        .filter(|grandchild| grandchild.is_element())
+                        .any(|grandchild| {
+                            matches!(grandchild.tag_name().name(), "MaterialCut" | "MaterialLeft")
+                        }))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_slot_cavity_z_axis_substitution_children() {
+        let doc = Document::parse(
+            r#"<SlotCavity><Location x="0" y="0"/><MaterialCut depth="0.1"/></SlotCavity>"#,
+        )
+        .unwrap();
+
+        assert!(has_z_axis_dim(&doc.root_element()));
+    }
+
+    #[test]
+    fn detects_wrapped_slot_cavity_z_axis_dimensions() {
+        let doc = Document::parse(
+            r#"<SlotCavity><Location x="0" y="0"/><ZAxisDim><MaterialLeft thickness="0.1"/></ZAxisDim></SlotCavity>"#,
+        )
+        .unwrap();
+
+        assert!(has_z_axis_dim(&doc.root_element()));
     }
 }
 

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -199,7 +199,14 @@ pub struct Layer {
     pub layer_function: LayerFunction,
     pub side: Option<Side>,
     pub polarity: Option<Polarity>,
+    pub span: Option<LayerSpan>,
     pub profile: Option<Profile>, // Layer-specific outline (for rigid-flex)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LayerSpan {
+    pub from_layer: Option<Symbol>,
+    pub to_layer: Option<Symbol>,
 }
 
 /// LayerFeature contains features on a layer
@@ -272,6 +279,7 @@ pub struct Slot {
     pub name: Option<Symbol>,
     pub shape: SlotShape,
     pub plating_status: PlatingStatus,
+    pub z_axis_dim: bool,
     pub x: f64,
     pub y: f64,
 }

--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -15,6 +15,7 @@ colored = { workspace = true }
 comfy-table = { workspace = true }
 ipc2581 = { workspace = true }
 jiff = { workspace = true }
+kurbo = { workspace = true }
 log = { workspace = true }
 minijinja = { workspace = true }
 pcb-sch = { workspace = true, features = ["table"] }

--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
 comfy-table = { workspace = true }
+i_overlay = { workspace = true }
 ipc2581 = { workspace = true }
 jiff = { workspace = true }
 kurbo = { workspace = true }

--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
@@ -20,6 +21,8 @@ pcb-sch = { workspace = true, features = ["table"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 quick-xml = { workspace = true }
+resvg = { workspace = true }
+terminal_size = { workspace = true }
 zstd = { workspace = true }
 pcb-diode-api = { workspace = true, optional = true }
 pcb-ui = { workspace = true, optional = true }

--- a/crates/pcb-ipc2581-tools/src/commands/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod bom;
 pub mod bom_edit;
 pub mod html_export;
 pub mod info;
+pub mod render;
 pub mod view;

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -1,0 +1,115 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::geometry;
+use crate::utils::file as file_utils;
+use crate::{RenderFormat, ipc2581};
+
+/// Options for rendering processed geometry from a single IPC-2581 layer.
+#[derive(Debug, Clone)]
+pub struct RenderOptions {
+    pub layer: String,
+    pub output: Option<PathBuf>,
+    pub format: RenderFormat,
+}
+
+/// Render processed geometry for one IPC-2581 layer.
+pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
+    let target = resolve_target(options)?;
+    let content = file_utils::load_ipc_file(input_file)?;
+    let ipc = ipc2581::Ipc2581::parse(&content)?;
+    let geometry = geometry::extract_layer(&ipc, &options.layer)?;
+
+    match target {
+        RenderTarget::Svg => render_svg(&geometry, options)?,
+        RenderTarget::Png => render_png(&geometry, options)?,
+        RenderTarget::Terminal => geometry::terminal::render_layer_to_terminal(&geometry, 0)?,
+    }
+
+    for diagnostic in &geometry.diagnostics {
+        eprintln!("warning: {}", diagnostic.message);
+    }
+
+    Ok(())
+}
+
+enum RenderTarget {
+    Svg,
+    Png,
+    Terminal,
+}
+
+fn resolve_target(options: &RenderOptions) -> Result<RenderTarget> {
+    match options.format {
+        RenderFormat::Auto => {
+            if let Some(output) = &options.output {
+                infer_format_from_output(output)
+            } else if geometry::terminal::can_render_to_terminal() {
+                Ok(RenderTarget::Terminal)
+            } else {
+                bail!(
+                    "Could not render IPC-2581 layer to stdout; run from an interactive terminal or pass --output <path>.svg or <path>.png"
+                )
+            }
+        }
+        RenderFormat::Svg => Ok(RenderTarget::Svg),
+        RenderFormat::Png => Ok(RenderTarget::Png),
+    }
+}
+
+fn infer_format_from_output(output: &Path) -> Result<RenderTarget> {
+    match output
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("svg") => Ok(RenderTarget::Svg),
+        Some("png") => Ok(RenderTarget::Png),
+        _ => bail!(
+            "Could not infer IPC-2581 render format from {}; pass --format svg or --format png",
+            output.display()
+        ),
+    }
+}
+
+fn render_svg(geometry: &geometry::ir::GeometryDocument, options: &RenderOptions) -> Result<()> {
+    let svg = geometry::svg::render_layer_svg(geometry, 0);
+
+    if let Some(output) = &options.output {
+        std::fs::write(output, svg)
+            .with_context(|| format!("Failed to write SVG to {}", output.display()))?;
+        println!(
+            "✓ IPC-2581 layer '{}' rendered to {}",
+            options.layer,
+            output.display()
+        );
+    } else {
+        print!("{svg}");
+    }
+
+    Ok(())
+}
+
+fn render_png(geometry: &geometry::ir::GeometryDocument, options: &RenderOptions) -> Result<()> {
+    let png = geometry::raster::render_layer_png(geometry, 0)?;
+
+    if let Some(output) = &options.output {
+        std::fs::write(output, png)
+            .with_context(|| format!("Failed to write PNG to {}", output.display()))?;
+        println!(
+            "✓ IPC-2581 layer '{}' rendered to {}",
+            options.layer,
+            output.display()
+        );
+    } else {
+        std::io::stdout()
+            .lock()
+            .write_all(&png)
+            .context("Failed to write PNG to stdout")?;
+    }
+
+    Ok(())
+}

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -20,7 +20,8 @@ pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
     let target = resolve_target(options)?;
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
-    let geometry = geometry::extract_layer(&ipc, &options.layer)?;
+    let mut geometry = geometry::extract_layer(&ipc, &options.layer)?;
+    geometry::process::process_document(&mut geometry);
 
     match target {
         RenderTarget::Svg => render_svg(&geometry, options)?,

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -740,15 +740,15 @@ fn push_rounded_rect_path(
     let mut cmds = Vec::new();
 
     cmds.push(PathCmd::move_to(Point::new(
-        -hw + if upper_left { r } else { 0.0 },
+        -hw + if lower_left { r } else { 0.0 },
         -hh,
     )));
 
     cmds.push(PathCmd::line_to(Point::new(
-        hw - if upper_right { r } else { 0.0 },
+        hw - if lower_right { r } else { 0.0 },
         -hh,
     )));
-    if upper_right {
+    if lower_right {
         cmds.push(PathCmd::cubic_to(
             Point::new(hw - r + k * r, -hh),
             Point::new(hw, -hh + r - k * r),
@@ -758,9 +758,9 @@ fn push_rounded_rect_path(
 
     cmds.push(PathCmd::line_to(Point::new(
         hw,
-        hh - if lower_right { r } else { 0.0 },
+        hh - if upper_right { r } else { 0.0 },
     )));
-    if lower_right {
+    if upper_right {
         cmds.push(PathCmd::cubic_to(
             Point::new(hw, hh - r + k * r),
             Point::new(hw - r + k * r, hh),
@@ -769,10 +769,10 @@ fn push_rounded_rect_path(
     }
 
     cmds.push(PathCmd::line_to(Point::new(
-        -hw + if lower_left { r } else { 0.0 },
+        -hw + if upper_left { r } else { 0.0 },
         hh,
     )));
-    if lower_left {
+    if upper_left {
         cmds.push(PathCmd::cubic_to(
             Point::new(-hw + r - k * r, hh),
             Point::new(-hw, hh - r + k * r),
@@ -782,9 +782,9 @@ fn push_rounded_rect_path(
 
     cmds.push(PathCmd::line_to(Point::new(
         -hw,
-        -hh + if upper_left { r } else { 0.0 },
+        -hh + if lower_left { r } else { 0.0 },
     )));
-    if upper_left {
+    if lower_left {
         cmds.push(PathCmd::cubic_to(
             Point::new(-hw, -hh + r - k * r),
             Point::new(-hw + r - k * r, -hh),
@@ -820,24 +820,24 @@ fn push_chamfered_rect_path(
     let [upper_right, lower_right, lower_left, upper_left] = corners;
     let mut points = Vec::with_capacity(8);
 
-    points.push(Point::new(-hw + if upper_left { c } else { 0.0 }, -hh));
+    points.push(Point::new(-hw + if lower_left { c } else { 0.0 }, -hh));
 
-    points.push(Point::new(hw - if upper_right { c } else { 0.0 }, -hh));
-    if upper_right {
+    points.push(Point::new(hw - if lower_right { c } else { 0.0 }, -hh));
+    if lower_right {
         points.push(Point::new(hw, -hh + c));
     }
 
-    points.push(Point::new(hw, hh - if lower_right { c } else { 0.0 }));
-    if lower_right {
+    points.push(Point::new(hw, hh - if upper_right { c } else { 0.0 }));
+    if upper_right {
         points.push(Point::new(hw - c, hh));
     }
 
-    points.push(Point::new(-hw + if lower_left { c } else { 0.0 }, hh));
-    if lower_left {
+    points.push(Point::new(-hw + if upper_left { c } else { 0.0 }, hh));
+    if upper_left {
         points.push(Point::new(-hw, hh - c));
     }
 
-    points.push(Point::new(-hw, -hh + if upper_left { c } else { 0.0 }));
+    points.push(Point::new(-hw, -hh + if lower_left { c } else { 0.0 }));
 
     push_closed_points_path(doc, transform, points, FillRule::NonZero);
 }
@@ -1096,10 +1096,10 @@ mod tests {
         let cmds = &doc.path_cmds
             [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize];
 
-        assert!(cmds.iter().any(|cmd| cmd.p0 == Point::new(4.0, -3.0)));
-        assert!(cmds.iter().any(|cmd| cmd.p0 == Point::new(5.0, -2.0)));
-        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(5.0, 2.0)));
-        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(4.0, 3.0)));
+        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(4.0, -3.0)));
+        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(5.0, -2.0)));
+        assert!(cmds.iter().any(|cmd| cmd.p0 == Point::new(5.0, 2.0)));
+        assert!(cmds.iter().any(|cmd| cmd.p0 == Point::new(4.0, 3.0)));
         assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-4.0, 3.0)));
         assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-5.0, 2.0)));
         assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-5.0, -2.0)));

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -582,10 +582,15 @@ fn lower_standard_primitive(
             );
         }
         StandardPrimitive::Contour(contour) => {
-            push_polygon_path(doc, &contour.polygon, transform, FillRule::EvenOdd);
+            let mut contours = Vec::with_capacity(1 + contour.cutouts.len());
+            contours.push(polygon_contour(&contour.polygon, transform));
             for cutout in &contour.cutouts {
-                push_polygon_path(doc, cutout, transform, FillRule::EvenOdd);
+                contours.push(polygon_contour(cutout, transform));
             }
+            doc.push_compound_path(
+                GeometryPath::filled(FillRule::EvenOdd, BBox::empty()),
+                contours,
+            );
         }
         StandardPrimitive::RectRound(rect) => {
             push_rounded_rect_path(
@@ -645,6 +650,11 @@ fn push_polygon_path(
     transform: Affine2,
     fill_rule: FillRule,
 ) {
+    let (bbox, cmds) = polygon_contour(polygon, transform);
+    doc.push_path(GeometryPath::filled(fill_rule, bbox), cmds);
+}
+
+fn polygon_contour(polygon: &ipc2581::types::Polygon, transform: Affine2) -> (BBox, Vec<PathCmd>) {
     let mut cmds = Vec::new();
     let mut current = Point::new(polygon.begin.x, polygon.begin.y);
     let start = transform.transform_point(current);
@@ -677,7 +687,7 @@ fn push_polygon_path(
         }
     }
     cmds.push(PathCmd::close());
-    doc.push_path(GeometryPath::filled(fill_rule, bbox), cmds);
+    (bbox, cmds)
 }
 
 fn push_closed_points_path(
@@ -819,6 +829,11 @@ fn push_regular_polygon_path(
 }
 
 fn push_ellipse_path(doc: &mut GeometryDocument, transform: Affine2, width: f64, height: f64) {
+    let (bbox, cmds) = ellipse_contour(transform, width, height);
+    doc.push_path(GeometryPath::filled(FillRule::NonZero, bbox), cmds);
+}
+
+fn ellipse_contour(transform: Affine2, width: f64, height: f64) -> (BBox, Vec<PathCmd>) {
     let rx = width / 2.0;
     let ry = height / 2.0;
     let k = 0.552_284_749_830_793_6;
@@ -862,7 +877,7 @@ fn push_ellipse_path(doc: &mut GeometryDocument, transform: Affine2, width: f64,
         cmds.push(PathCmd::cubic_to(c1, c2, end));
     }
     cmds.push(PathCmd::close());
-    doc.push_path(GeometryPath::filled(FillRule::NonZero, bbox), cmds);
+    (bbox, cmds)
 }
 
 fn push_oval_path(doc: &mut GeometryDocument, transform: Affine2, width: f64, height: f64) {
@@ -970,12 +985,13 @@ fn push_donut_path(
     outer_diameter: f64,
     inner_diameter: f64,
 ) {
-    let path_start = doc.paths.len();
-    push_ellipse_path(doc, transform, outer_diameter, outer_diameter);
-    push_ellipse_path(doc, transform, inner_diameter, inner_diameter);
-    for path in &mut doc.paths[path_start..] {
-        path.fill_rule = FillRule::EvenOdd;
-    }
+    doc.push_compound_path(
+        GeometryPath::filled(FillRule::EvenOdd, BBox::empty()),
+        [
+            ellipse_contour(transform, outer_diameter, outer_diameter),
+            ellipse_contour(transform, inner_diameter, inner_diameter),
+        ],
+    );
 }
 
 fn push_thermal_path(

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -1010,12 +1010,8 @@ fn push_thermal_path(
         let angle = index as f64 * std::f64::consts::TAU / spoke_count as f64;
         let center_radius = inner_radius + length / 2.0;
         let center = Point::new(center_radius * angle.cos(), center_radius * angle.sin());
-        let spoke_transform = Affine2::placement(
-            transform.transform_point(center),
-            angle.to_degrees(),
-            false,
-            1.0,
-        );
+        let spoke_transform =
+            transform.concat(Affine2::placement(center, angle.to_degrees(), false, 1.0));
         push_rect_path(doc, spoke_transform, length, spoke_width);
     }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use ipc2581::types::{
     FillProperty, LayerFunction, LineEnd, PadUse, PlatingStatus, Polarity, PolyStep, SlotShape,
-    StandardPrimitive, Styled,
+    StandardPrimitive, Styled, ecad::Layer,
 };
 use ipc2581::{Ipc2581, Symbol};
 
@@ -133,10 +133,16 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
     }
 
     for layer_feature in &step.layer_features {
-        let is_drill_layer = ecad.cad_data.layers.iter().any(|candidate| {
-            candidate.name == layer_feature.layer_ref
-                && candidate.layer_function == LayerFunction::Drill
-        });
+        let Some(source_layer) = ecad
+            .cad_data
+            .layers
+            .iter()
+            .find(|candidate| candidate.name == layer_feature.layer_ref)
+        else {
+            continue;
+        };
+        let is_drill_layer = source_layer.layer_function == LayerFunction::Drill;
+        let is_routing_layer = source_layer.layer_function == LayerFunction::Rout;
 
         for (set_index, set) in layer_feature.sets.iter().enumerate() {
             if is_drill_layer {
@@ -154,18 +160,22 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
                 }
             }
 
-            for (feature_index, slot) in set.slots.iter().enumerate() {
-                let feature = extract_slot(
-                    &context,
-                    SourceRef {
-                        set_index: set_index as u32,
-                        feature_index: feature_index as u32,
-                    },
-                    slot,
-                    &mut doc,
-                )?;
-                layer_bbox = layer_bbox.union(feature.bbox);
-                doc.features.push(feature);
+            if is_drill_layer || is_routing_layer {
+                for (feature_index, slot) in set.slots.iter().enumerate() {
+                    if slot_applies_to_layer(source_layer, layer, &ecad.cad_data.layers, slot) {
+                        let feature = extract_slot(
+                            &context,
+                            SourceRef {
+                                set_index: set_index as u32,
+                                feature_index: feature_index as u32,
+                            },
+                            slot,
+                            &mut doc,
+                        )?;
+                        layer_bbox = layer_bbox.union(feature.bbox);
+                        doc.features.push(feature);
+                    }
+                }
             }
         }
     }
@@ -180,6 +190,41 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
     });
 
     Ok(doc)
+}
+
+fn slot_applies_to_layer(
+    source_layer: &Layer,
+    target_layer: &Layer,
+    layers: &[Layer],
+    slot: &ipc2581::types::Slot,
+) -> bool {
+    if slot.z_axis_dim {
+        return source_layer.name == target_layer.name;
+    }
+
+    let Some(span) = source_layer.span else {
+        return true;
+    };
+
+    let Some(target_index) = layer_index(layers, target_layer.name) else {
+        return false;
+    };
+    let from_index = span
+        .from_layer
+        .and_then(|layer| layer_index(layers, layer))
+        .unwrap_or(0);
+    let to_index = span
+        .to_layer
+        .and_then(|layer| layer_index(layers, layer))
+        .unwrap_or(layers.len().saturating_sub(1));
+    let start = from_index.min(to_index);
+    let end = from_index.max(to_index);
+
+    (start..=end).contains(&target_index)
+}
+
+fn layer_index(layers: &[Layer], layer_ref: Symbol) -> Option<usize> {
+    layers.iter().position(|layer| layer.name == layer_ref)
 }
 
 fn extract_pad(
@@ -1104,5 +1149,71 @@ mod tests {
         assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-5.0, 2.0)));
         assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-5.0, -2.0)));
         assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-4.0, -3.0)));
+    }
+
+    #[test]
+    fn slot_cavity_span_controls_target_layers() {
+        let mut interner = ipc2581::Interner::new();
+        let l1 = test_layer(&mut interner, "L1", LayerFunction::Signal, None);
+        let l2 = test_layer(&mut interner, "L2", LayerFunction::Signal, None);
+        let l3 = test_layer(&mut interner, "L3", LayerFunction::Signal, None);
+        let route = test_layer(
+            &mut interner,
+            "ROUT",
+            LayerFunction::Rout,
+            Some(ipc2581::types::ecad::LayerSpan {
+                from_layer: Some(l1.name),
+                to_layer: Some(l2.name),
+            }),
+        );
+        let layers = [l1.clone(), l2.clone(), l3.clone(), route.clone()];
+        let slot = test_slot(false);
+
+        assert!(slot_applies_to_layer(&route, &l1, &layers, &slot));
+        assert!(slot_applies_to_layer(&route, &l2, &layers, &slot));
+        assert!(!slot_applies_to_layer(&route, &l3, &layers, &slot));
+    }
+
+    #[test]
+    fn partial_depth_slot_cavity_does_not_default_to_through_board() {
+        let mut interner = ipc2581::Interner::new();
+        let l1 = test_layer(&mut interner, "L1", LayerFunction::Signal, None);
+        let route = test_layer(&mut interner, "ROUT", LayerFunction::Rout, None);
+        let layers = [l1.clone(), route.clone()];
+        let slot = test_slot(true);
+
+        assert!(!slot_applies_to_layer(&route, &l1, &layers, &slot));
+        assert!(slot_applies_to_layer(&route, &route, &layers, &slot));
+    }
+
+    fn test_layer(
+        interner: &mut ipc2581::Interner,
+        name: &str,
+        layer_function: LayerFunction,
+        span: Option<ipc2581::types::ecad::LayerSpan>,
+    ) -> Layer {
+        Layer {
+            name: interner.intern(name),
+            layer_function,
+            side: None,
+            polarity: None,
+            span,
+            profile: None,
+        }
+    }
+
+    fn test_slot(z_axis_dim: bool) -> ipc2581::types::Slot {
+        ipc2581::types::Slot {
+            name: None,
+            shape: SlotShape::Primitive(StandardPrimitive::Circle(Styled {
+                shape: ipc2581::types::Circle { diameter: 1.0 },
+                fill_property: None,
+                line_desc_ref: None,
+            })),
+            plating_status: PlatingStatus::NonPlated,
+            z_axis_dim,
+            x: 0.0,
+            y: 0.0,
+        }
     }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -672,10 +672,10 @@ fn lower_standard_primitive(
             );
         }
         StandardPrimitive::Butterfly(butterfly) => {
-            push_ellipse_path(doc, transform, butterfly.shape.size, butterfly.shape.size);
+            push_butterfly_path(doc, transform, butterfly.shape.shape, butterfly.shape.size);
         }
         StandardPrimitive::Moire(moire) => {
-            push_ellipse_path(doc, transform, moire.diameter, moire.diameter);
+            push_moire_path(doc, transform, moire);
         }
     }
 
@@ -1079,6 +1079,68 @@ fn push_donut_path(
     );
 }
 
+fn push_butterfly_path(
+    doc: &mut GeometryDocument,
+    transform: Affine2,
+    shape: ipc2581::types::ButterflyShape,
+    size: f64,
+) {
+    let radius = size / 2.0;
+    match shape {
+        ipc2581::types::ButterflyShape::Round => doc.push_compound_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            [
+                circular_sector_contour(transform, radius, 90.0, 180.0),
+                circular_sector_contour(transform, radius, 270.0, 360.0),
+            ],
+        ),
+        ipc2581::types::ButterflyShape::Square => doc.push_compound_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            [
+                rect_contour(transform, -radius, 0.0, 0.0, radius),
+                rect_contour(transform, 0.0, -radius, radius, 0.0),
+            ],
+        ),
+    };
+}
+
+fn push_moire_path(doc: &mut GeometryDocument, transform: Affine2, moire: &ipc2581::types::Moire) {
+    for index in 0..moire.ring_number {
+        let outer_diameter = moire.diameter - 2.0 * index as f64 * moire.ring_gap;
+        let inner_diameter = outer_diameter - 2.0 * moire.ring_width;
+        if outer_diameter <= 0.0 {
+            break;
+        }
+
+        if inner_diameter > 0.0 {
+            push_donut_path(doc, transform, outer_diameter, inner_diameter);
+        } else {
+            push_ellipse_path(doc, transform, outer_diameter, outer_diameter);
+        }
+    }
+
+    if let (Some(width), Some(length)) = (moire.line_width, moire.line_length) {
+        let angle = moire.line_angle.unwrap_or(0.0);
+        push_rect_path(
+            doc,
+            transform.concat(Affine2::placement(Point::default(), angle, false, 1.0)),
+            length,
+            width,
+        );
+        push_rect_path(
+            doc,
+            transform.concat(Affine2::placement(
+                Point::default(),
+                angle + 90.0,
+                false,
+                1.0,
+            )),
+            length,
+            width,
+        );
+    }
+}
+
 fn push_thermal_path(
     doc: &mut GeometryDocument,
     transform: Affine2,
@@ -1099,6 +1161,44 @@ fn push_thermal_path(
             transform.concat(Affine2::placement(center, angle.to_degrees(), false, 1.0));
         push_rect_path(doc, spoke_transform, length, spoke_width);
     }
+}
+
+fn circular_sector_contour(
+    transform: Affine2,
+    radius: f64,
+    start_degrees: f64,
+    end_degrees: f64,
+) -> (BBox, Vec<PathCmd>) {
+    let start_angle = start_degrees.to_radians();
+    let end_angle = end_degrees.to_radians();
+    let start = Point::new(radius * start_angle.cos(), radius * start_angle.sin());
+    let end = Point::new(radius * end_angle.cos(), radius * end_angle.sin());
+    let mut bbox = BBox::empty();
+    let cmds = [
+        PathCmd::move_to(Point::default()),
+        PathCmd::line_to(start),
+        PathCmd::arc_to(end, Point::default(), false),
+        PathCmd::close(),
+    ]
+    .into_iter()
+    .map(|cmd| transform_path_cmd(cmd, transform, &mut bbox))
+    .collect();
+    (bbox, cmds)
+}
+
+fn rect_contour(transform: Affine2, x0: f64, y0: f64, x1: f64, y1: f64) -> (BBox, Vec<PathCmd>) {
+    let mut bbox = BBox::empty();
+    let cmds = [
+        PathCmd::move_to(Point::new(x0, y0)),
+        PathCmd::line_to(Point::new(x1, y0)),
+        PathCmd::line_to(Point::new(x1, y1)),
+        PathCmd::line_to(Point::new(x0, y1)),
+        PathCmd::close(),
+    ]
+    .into_iter()
+    .map(|cmd| transform_path_cmd(cmd, transform, &mut bbox))
+    .collect();
+    (bbox, cmds)
 }
 
 fn paths_bbox(doc: &GeometryDocument, path_start: u32, path_count: u32) -> BBox {
@@ -1132,6 +1232,56 @@ fn _styled_is_filled<T>(styled: &Styled<T>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lowers_moire_as_rings_and_crosshair() {
+        let mut doc = GeometryDocument::new("test".to_string());
+
+        push_moire_path(
+            &mut doc,
+            Affine2::identity(),
+            &ipc2581::types::Moire {
+                diameter: 8.0,
+                ring_width: 0.5,
+                ring_gap: 1.0,
+                ring_number: 3,
+                line_width: Some(0.2),
+                line_length: Some(10.0),
+                line_angle: Some(0.0),
+            },
+        );
+
+        assert_eq!(doc.paths.len(), 5);
+        assert_eq!(doc.paths[0].fill_rule, FillRule::EvenOdd);
+        assert_eq!(doc.paths[0].contour_count, 2);
+        assert_eq!(doc.paths[1].contour_count, 2);
+        assert_eq!(doc.paths[2].contour_count, 2);
+        assert_eq!(doc.paths[3].fill_rule, FillRule::NonZero);
+        assert_eq!(doc.paths[4].fill_rule, FillRule::NonZero);
+    }
+
+    #[test]
+    fn lowers_butterfly_with_removed_quadrants() {
+        let mut doc = GeometryDocument::new("test".to_string());
+
+        push_butterfly_path(
+            &mut doc,
+            Affine2::identity(),
+            ipc2581::types::ButterflyShape::Square,
+            4.0,
+        );
+        push_butterfly_path(
+            &mut doc,
+            Affine2::identity(),
+            ipc2581::types::ButterflyShape::Round,
+            4.0,
+        );
+
+        assert_eq!(doc.paths.len(), 2);
+        assert_eq!(doc.paths[0].contour_count, 2);
+        assert_eq!(doc.paths[1].contour_count, 2);
+        assert!(doc.path_cmds.iter().any(|cmd| cmd.op == PathOp::ArcTo));
+    }
 
     #[test]
     fn chamfered_rect_respects_corner_flags() {

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -602,23 +602,18 @@ fn lower_standard_primitive(
             );
         }
         StandardPrimitive::RectCham(rect) => {
-            let hw = rect.shape.size.width / 2.0;
-            let hh = rect.shape.size.height / 2.0;
-            let c = rect.shape.chamfer.min(hw).min(hh);
-            push_closed_points_path(
+            push_chamfered_rect_path(
                 doc,
                 transform,
-                vec![
-                    Point::new(-hw + c, -hh),
-                    Point::new(hw - c, -hh),
-                    Point::new(hw, -hh + c),
-                    Point::new(hw, hh - c),
-                    Point::new(hw - c, hh),
-                    Point::new(-hw + c, hh),
-                    Point::new(-hw, hh - c),
-                    Point::new(-hw, -hh + c),
+                rect.shape.size.width,
+                rect.shape.size.height,
+                rect.shape.chamfer,
+                [
+                    rect.shape.upper_right,
+                    rect.shape.lower_right,
+                    rect.shape.lower_left,
+                    rect.shape.upper_left,
                 ],
-                FillRule::NonZero,
             );
         }
         StandardPrimitive::Butterfly(butterfly) => {
@@ -804,6 +799,47 @@ fn push_rounded_rect_path(
         .map(|cmd| transform_path_cmd(cmd, transform, &mut bbox))
         .collect::<Vec<_>>();
     doc.push_path(GeometryPath::filled(FillRule::NonZero, bbox), cmds);
+}
+
+fn push_chamfered_rect_path(
+    doc: &mut GeometryDocument,
+    transform: Affine2,
+    width: f64,
+    height: f64,
+    chamfer: f64,
+    corners: [bool; 4],
+) {
+    let hw = width / 2.0;
+    let hh = height / 2.0;
+    let c = chamfer.min(hw).min(hh).max(0.0);
+    if c == 0.0 || !corners.iter().any(|corner| *corner) {
+        push_rect_path(doc, transform, width, height);
+        return;
+    }
+
+    let [upper_right, lower_right, lower_left, upper_left] = corners;
+    let mut points = Vec::with_capacity(8);
+
+    points.push(Point::new(-hw + if upper_left { c } else { 0.0 }, -hh));
+
+    points.push(Point::new(hw - if upper_right { c } else { 0.0 }, -hh));
+    if upper_right {
+        points.push(Point::new(hw, -hh + c));
+    }
+
+    points.push(Point::new(hw, hh - if lower_right { c } else { 0.0 }));
+    if lower_right {
+        points.push(Point::new(hw - c, hh));
+    }
+
+    points.push(Point::new(-hw + if lower_left { c } else { 0.0 }, hh));
+    if lower_left {
+        points.push(Point::new(-hw, hh - c));
+    }
+
+    points.push(Point::new(-hw, -hh + if upper_left { c } else { 0.0 }));
+
+    push_closed_points_path(doc, transform, points, FillRule::NonZero);
 }
 
 fn push_regular_polygon_path(
@@ -1036,4 +1072,37 @@ fn _styled_is_filled<T>(styled: &Styled<T>) -> bool {
         styled.fill_property,
         Some(FillProperty::Hollow | FillProperty::Void)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chamfered_rect_respects_corner_flags() {
+        let mut doc = GeometryDocument::new("test".to_string());
+
+        push_chamfered_rect_path(
+            &mut doc,
+            Affine2::identity(),
+            10.0,
+            6.0,
+            1.0,
+            [true, false, false, false],
+        );
+
+        let path = &doc.paths[0];
+        let contour = &doc.contours[path.contour_start as usize];
+        let cmds = &doc.path_cmds
+            [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize];
+
+        assert!(cmds.iter().any(|cmd| cmd.p0 == Point::new(4.0, -3.0)));
+        assert!(cmds.iter().any(|cmd| cmd.p0 == Point::new(5.0, -2.0)));
+        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(5.0, 2.0)));
+        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(4.0, 3.0)));
+        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-4.0, 3.0)));
+        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-5.0, 2.0)));
+        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-5.0, -2.0)));
+        assert!(!cmds.iter().any(|cmd| cmd.p0 == Point::new(-4.0, -3.0)));
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use ipc2581::types::{
     FillProperty, LayerFunction, LineEnd, PadUse, PlatingStatus, Polarity, PolyStep, SlotShape,
-    StandardPrimitive, Styled, ecad::Layer,
+    StandardPrimitive, ecad::Layer,
 };
 use ipc2581::{Ipc2581, Symbol};
 
@@ -14,6 +14,13 @@ struct ExtractContext<'a> {
     padstacks: HashMap<Symbol, &'a ipc2581::types::PadStackDef>,
     line_descs: HashMap<Symbol, ipc2581::types::LineDesc>,
     standard_primitives: HashMap<Symbol, &'a StandardPrimitive>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrimitivePaint {
+    Fill,
+    Hollow,
+    Void,
 }
 
 pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument> {
@@ -304,14 +311,22 @@ fn extract_pad(
     };
 
     let path_start = doc.paths.len() as u32;
-    lower_standard_primitive(context, doc, primitive, transform, bucket)?;
+    let paint = lower_standard_primitive(context, doc, primitive, transform, bucket)?;
     let path_count = doc.paths.len() as u32 - path_start;
     if path_count == 0 {
         return Ok(None);
     }
     let bbox = paths_bbox(doc, path_start, path_count);
 
-    let mut feature = GeometryFeature::new(FeatureKind::Padstack, bucket, polarity);
+    let mut feature = GeometryFeature::new(
+        FeatureKind::Padstack,
+        bucket,
+        if paint == PrimitivePaint::Void {
+            GeometryPolarity::Negative
+        } else {
+            polarity
+        },
+    );
     feature.net = net;
     feature.source = source;
     feature.transform = transform;
@@ -509,7 +524,13 @@ fn extract_slot(
             push_polygon_path(doc, polygon, transform, FillRule::NonZero);
         }
         SlotShape::Primitive(primitive) => {
-            lower_standard_primitive(context, doc, primitive, transform, FeatureBucket::Cutout)?;
+            let _ = lower_standard_primitive(
+                context,
+                doc,
+                primitive,
+                transform,
+                FeatureBucket::Cutout,
+            )?;
         }
     }
 
@@ -535,7 +556,8 @@ fn lower_standard_primitive(
     primitive: &StandardPrimitive,
     transform: Affine2,
     bucket: FeatureBucket,
-) -> Result<()> {
+) -> Result<PrimitivePaint> {
+    let path_start = doc.paths.len() as u32;
     match primitive {
         StandardPrimitive::Circle(circle) => {
             push_ellipse_path(doc, transform, circle.shape.diameter, circle.shape.diameter);
@@ -686,8 +708,26 @@ fn lower_standard_primitive(
         // just here to make the bucket dependency explicit for future styling.
     }
 
-    let _ = context;
-    Ok(())
+    let paint = primitive_paint(primitive);
+    match paint {
+        PrimitivePaint::Fill => {}
+        PrimitivePaint::Hollow => {
+            let Some(line_desc) = primitive_line_desc(context, primitive) else {
+                doc.warn("Skipping hollow primitive without LineDescRef");
+                make_paths_unpainted(doc, path_start);
+                return Ok(paint);
+            };
+            make_paths_stroked(
+                doc,
+                path_start,
+                line_desc.line_width,
+                map_line_cap(line_desc.line_end),
+            );
+        }
+        PrimitivePaint::Void => {}
+    }
+
+    Ok(paint)
 }
 
 fn push_polygon_path(
@@ -698,6 +738,75 @@ fn push_polygon_path(
 ) {
     let (bbox, cmds) = polygon_contour(polygon, transform);
     doc.push_path(GeometryPath::filled(fill_rule, bbox), cmds);
+}
+
+fn primitive_paint(primitive: &StandardPrimitive) -> PrimitivePaint {
+    match primitive_fill_property(primitive) {
+        Some(FillProperty::Hollow) => PrimitivePaint::Hollow,
+        Some(FillProperty::Void) => PrimitivePaint::Void,
+        _ => PrimitivePaint::Fill,
+    }
+}
+
+fn primitive_fill_property(primitive: &StandardPrimitive) -> Option<FillProperty> {
+    match primitive {
+        StandardPrimitive::Circle(styled) => styled.fill_property,
+        StandardPrimitive::RectCenter(styled) => styled.fill_property,
+        StandardPrimitive::RectRound(styled) => styled.fill_property,
+        StandardPrimitive::RectCham(styled) => styled.fill_property,
+        StandardPrimitive::RectCorner(styled) => styled.fill_property,
+        StandardPrimitive::Oval(styled) => styled.fill_property,
+        StandardPrimitive::Butterfly(styled) => styled.fill_property,
+        StandardPrimitive::Diamond(styled) => styled.fill_property,
+        StandardPrimitive::Donut(styled) => styled.fill_property,
+        StandardPrimitive::Ellipse(styled) => styled.fill_property,
+        StandardPrimitive::Hexagon(styled) => styled.fill_property,
+        StandardPrimitive::Octagon(styled) => styled.fill_property,
+        StandardPrimitive::Thermal(styled) => styled.fill_property,
+        StandardPrimitive::Triangle(styled) => styled.fill_property,
+        StandardPrimitive::Moire(_) | StandardPrimitive::Contour(_) => None,
+    }
+}
+
+fn primitive_line_desc(
+    context: &ExtractContext<'_>,
+    primitive: &StandardPrimitive,
+) -> Option<ipc2581::types::LineDesc> {
+    let line_desc_ref = match primitive {
+        StandardPrimitive::Circle(styled) => styled.line_desc_ref,
+        StandardPrimitive::RectCenter(styled) => styled.line_desc_ref,
+        StandardPrimitive::RectRound(styled) => styled.line_desc_ref,
+        StandardPrimitive::RectCham(styled) => styled.line_desc_ref,
+        StandardPrimitive::RectCorner(styled) => styled.line_desc_ref,
+        StandardPrimitive::Oval(styled) => styled.line_desc_ref,
+        StandardPrimitive::Butterfly(styled) => styled.line_desc_ref,
+        StandardPrimitive::Diamond(styled) => styled.line_desc_ref,
+        StandardPrimitive::Donut(styled) => styled.line_desc_ref,
+        StandardPrimitive::Ellipse(styled) => styled.line_desc_ref,
+        StandardPrimitive::Hexagon(styled) => styled.line_desc_ref,
+        StandardPrimitive::Octagon(styled) => styled.line_desc_ref,
+        StandardPrimitive::Thermal(styled) => styled.line_desc_ref,
+        StandardPrimitive::Triangle(styled) => styled.line_desc_ref,
+        StandardPrimitive::Moire(_) | StandardPrimitive::Contour(_) => None,
+    }?;
+    context.line_descs.get(&line_desc_ref).copied()
+}
+
+fn make_paths_stroked(doc: &mut GeometryDocument, path_start: u32, width: f64, line_cap: LineCap) {
+    for path in &mut doc.paths[path_start as usize..] {
+        path.flags.filled = false;
+        path.flags.stroked = true;
+        path.fill_rule = FillRule::NonZero;
+        path.stroke_width = width;
+        path.line_cap = line_cap;
+    }
+}
+
+fn make_paths_unpainted(doc: &mut GeometryDocument, path_start: u32) {
+    for path in &mut doc.paths[path_start as usize..] {
+        path.flags.filled = false;
+        path.flags.stroked = false;
+    }
 }
 
 fn polygon_contour(polygon: &ipc2581::types::Polygon, transform: Affine2) -> (BBox, Vec<PathCmd>) {
@@ -1108,8 +1217,9 @@ fn push_butterfly_path(
 
 fn push_moire_path(doc: &mut GeometryDocument, transform: Affine2, moire: &ipc2581::types::Moire) {
     for index in 0..moire.ring_number {
-        let outer_diameter = moire.diameter - 2.0 * index as f64 * moire.ring_gap;
-        let inner_diameter = outer_diameter - 2.0 * moire.ring_width;
+        let centerline_diameter = moire.diameter - 2.0 * index as f64 * moire.ring_gap;
+        let outer_diameter = centerline_diameter + moire.ring_width;
+        let inner_diameter = centerline_diameter - moire.ring_width;
         if outer_diameter <= 0.0 {
             break;
         }
@@ -1230,13 +1340,6 @@ fn map_line_cap(line_end: LineEnd) -> LineCap {
     }
 }
 
-fn _styled_is_filled<T>(styled: &Styled<T>) -> bool {
-    !matches!(
-        styled.fill_property,
-        Some(FillProperty::Hollow | FillProperty::Void)
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1266,8 +1369,32 @@ mod tests {
         assert_eq!(doc.paths[2].contour_count, 2);
         assert_eq!(doc.paths[3].fill_rule, FillRule::NonZero);
         assert_eq!(doc.paths[4].fill_rule, FillRule::NonZero);
-        assert_eq!(doc.paths[1].bbox.min, Point::new(-3.0, -3.0));
-        assert_eq!(doc.paths[1].bbox.max, Point::new(3.0, 3.0));
+        assert_eq!(doc.paths[0].bbox.min, Point::new(-4.25, -4.25));
+        assert_eq!(doc.paths[0].bbox.max, Point::new(4.25, 4.25));
+        assert_eq!(doc.paths[1].bbox.min, Point::new(-3.25, -3.25));
+        assert_eq!(doc.paths[1].bbox.max, Point::new(3.25, 3.25));
+    }
+
+    #[test]
+    fn reads_standard_primitive_fill_properties() {
+        let circle = ipc2581::types::StandardPrimitive::Circle(ipc2581::types::Styled {
+            shape: ipc2581::types::Circle { diameter: 1.0 },
+            fill_property: Some(FillProperty::Hollow),
+            line_desc_ref: None,
+        });
+        let rect = ipc2581::types::StandardPrimitive::RectCenter(ipc2581::types::Styled {
+            shape: ipc2581::types::RectCenter {
+                size: ipc2581::types::Size {
+                    width: 1.0,
+                    height: 1.0,
+                },
+            },
+            fill_property: Some(FillProperty::Void),
+            line_desc_ref: None,
+        });
+
+        assert_eq!(primitive_paint(&circle), PrimitivePaint::Hollow);
+        assert_eq!(primitive_paint(&rect), PrimitivePaint::Void);
     }
 
     #[test]
@@ -1405,7 +1532,7 @@ mod tests {
     fn test_slot(z_axis_dim: bool) -> ipc2581::types::Slot {
         ipc2581::types::Slot {
             name: None,
-            shape: SlotShape::Primitive(StandardPrimitive::Circle(Styled {
+            shape: SlotShape::Primitive(StandardPrimitive::Circle(ipc2581::types::Styled {
                 shape: ipc2581::types::Circle { diameter: 1.0 },
                 fill_property: None,
                 line_desc_ref: None,

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -620,14 +620,16 @@ fn lower_standard_primitive(
             let spoke_width = thermal
                 .shape
                 .spoke_width
-                .unwrap_or(thermal.shape.outer_diameter * 0.15);
+                .unwrap_or(thermal.shape.outer_diameter - thermal.shape.inner_diameter)
+                .max(0.0);
             push_thermal_path(
                 doc,
                 transform,
                 thermal.shape.outer_diameter,
                 thermal.shape.inner_diameter,
                 spoke_width,
-                thermal.shape.spoke_count.max(1),
+                thermal.shape.spoke_count,
+                thermal.shape.spoke_start_angle.unwrap_or(45.0),
             );
         }
         StandardPrimitive::Contour(contour) => {
@@ -1148,13 +1150,19 @@ fn push_thermal_path(
     inner_diameter: f64,
     spoke_width: f64,
     spoke_count: u32,
+    spoke_start_angle: f64,
 ) {
-    push_donut_path(doc, transform, outer_diameter, inner_diameter);
+    if spoke_count == 0 {
+        push_donut_path(doc, transform, outer_diameter, inner_diameter);
+        return;
+    }
+
     let outer_radius = outer_diameter / 2.0;
     let inner_radius = inner_diameter / 2.0;
     let length = (outer_radius - inner_radius).max(0.0);
     for index in 0..spoke_count {
-        let angle = index as f64 * std::f64::consts::TAU / spoke_count as f64;
+        let angle = spoke_start_angle.to_radians()
+            + index as f64 * std::f64::consts::TAU / spoke_count as f64;
         let center_radius = inner_radius + length / 2.0;
         let center = Point::new(center_radius * angle.cos(), center_radius * angle.sin());
         let spoke_transform =
@@ -1258,6 +1266,8 @@ mod tests {
         assert_eq!(doc.paths[2].contour_count, 2);
         assert_eq!(doc.paths[3].fill_rule, FillRule::NonZero);
         assert_eq!(doc.paths[4].fill_rule, FillRule::NonZero);
+        assert_eq!(doc.paths[1].bbox.min, Point::new(-3.0, -3.0));
+        assert_eq!(doc.paths[1].bbox.max, Point::new(3.0, 3.0));
     }
 
     #[test]
@@ -1281,6 +1291,33 @@ mod tests {
         assert_eq!(doc.paths[0].contour_count, 2);
         assert_eq!(doc.paths[1].contour_count, 2);
         assert!(doc.path_cmds.iter().any(|cmd| cmd.op == PathOp::ArcTo));
+    }
+
+    #[test]
+    fn lowers_thermal_as_spokes_without_redundant_ring() {
+        let mut doc = GeometryDocument::new("test".to_string());
+
+        push_thermal_path(&mut doc, Affine2::identity(), 10.0, 6.0, 2.0, 4, 0.0);
+
+        assert_eq!(doc.paths.len(), 4);
+        assert!(
+            doc.paths
+                .iter()
+                .all(|path| path.fill_rule == FillRule::NonZero && path.contour_count == 1)
+        );
+        assert_eq!(doc.paths[0].bbox.min, Point::new(3.0, -1.0));
+        assert_eq!(doc.paths[0].bbox.max, Point::new(5.0, 1.0));
+    }
+
+    #[test]
+    fn lowers_spokeless_thermal_as_donut() {
+        let mut doc = GeometryDocument::new("test".to_string());
+
+        push_thermal_path(&mut doc, Affine2::identity(), 10.0, 6.0, 2.0, 0, 0.0);
+
+        assert_eq!(doc.paths.len(), 1);
+        assert_eq!(doc.paths[0].fill_rule, FillRule::EvenOdd);
+        assert_eq!(doc.paths[0].contour_count, 2);
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -323,8 +323,6 @@ fn extract_trace(
         .collect();
     Some(push_stroked_polyline(
         doc,
-        FeatureKind::Trace,
-        FeatureBucket::Trace,
         net,
         polarity,
         source,
@@ -343,8 +341,6 @@ fn extract_line(
 ) -> GeometryFeature {
     push_stroked_polyline(
         doc,
-        FeatureKind::Trace,
-        FeatureBucket::Trace,
         net,
         polarity,
         source,
@@ -380,8 +376,6 @@ fn extract_polygon(
 
 fn push_stroked_polyline(
     doc: &mut GeometryDocument,
-    kind: FeatureKind,
-    bucket: FeatureBucket,
     net: Option<Symbol>,
     polarity: GeometryPolarity,
     source: SourceRef,
@@ -404,7 +398,7 @@ fn push_stroked_polyline(
     let path_start = doc.paths.len() as u32;
     doc.push_path(GeometryPath::stroked(width, line_cap, bbox), cmds);
 
-    let mut feature = GeometryFeature::new(kind, bucket, polarity);
+    let mut feature = GeometryFeature::new(FeatureKind::Trace, FeatureBucket::Trace, polarity);
     feature.net = net;
     feature.source = source;
     feature.bbox = bbox;

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -145,7 +145,9 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
         let is_routing_layer = source_layer.layer_function == LayerFunction::Rout;
 
         for (set_index, set) in layer_feature.sets.iter().enumerate() {
-            if is_drill_layer {
+            if is_drill_layer
+                && layer_span_applies_to_layer(source_layer, layer, &ecad.cad_data.layers)
+            {
                 for (feature_index, hole) in set.holes.iter().enumerate() {
                     let feature = extract_hole(
                         SourceRef {
@@ -202,6 +204,14 @@ fn slot_applies_to_layer(
         return source_layer.name == target_layer.name;
     }
 
+    layer_span_applies_to_layer(source_layer, target_layer, layers)
+}
+
+fn layer_span_applies_to_layer(
+    source_layer: &Layer,
+    target_layer: &Layer,
+    layers: &[Layer],
+) -> bool {
     let Some(span) = source_layer.span else {
         return true;
     };
@@ -1172,6 +1182,9 @@ mod tests {
         assert!(slot_applies_to_layer(&route, &l1, &layers, &slot));
         assert!(slot_applies_to_layer(&route, &l2, &layers, &slot));
         assert!(!slot_applies_to_layer(&route, &l3, &layers, &slot));
+        assert!(layer_span_applies_to_layer(&route, &l1, &layers));
+        assert!(layer_span_applies_to_layer(&route, &l2, &layers));
+        assert!(!layer_span_applies_to_layer(&route, &l3, &layers));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -1,0 +1,1033 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use ipc2581::types::{
+    FillProperty, LayerFunction, LineEnd, PadUse, PlatingStatus, Polarity, PolyStep, SlotShape,
+    StandardPrimitive, Styled,
+};
+use ipc2581::{Ipc2581, Symbol};
+
+use super::ir::*;
+
+struct ExtractContext<'a> {
+    ipc: &'a Ipc2581,
+    padstacks: HashMap<Symbol, &'a ipc2581::types::PadStackDef>,
+    line_descs: HashMap<Symbol, ipc2581::types::LineDesc>,
+    standard_primitives: HashMap<Symbol, &'a StandardPrimitive>,
+}
+
+pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument> {
+    let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
+    let step = ecad
+        .cad_data
+        .steps
+        .first()
+        .context("IPC-2581 ECAD section has no Step")?;
+    let layer = ecad
+        .cad_data
+        .layers
+        .iter()
+        .find(|layer| ipc.resolve(layer.name) == layer_name)
+        .with_context(|| format!("IPC-2581 layer '{layer_name}' was not found"))?;
+
+    let content = ipc.content();
+    let context = ExtractContext {
+        ipc,
+        padstacks: step
+            .padstack_defs
+            .iter()
+            .map(|padstack| (padstack.name, padstack))
+            .collect(),
+        line_descs: content
+            .dictionary_line_desc
+            .entries
+            .iter()
+            .map(|entry| (entry.id, entry.line_desc))
+            .collect(),
+        standard_primitives: content
+            .dictionary_standard
+            .entries
+            .iter()
+            .map(|entry| (entry.id, &entry.primitive))
+            .collect(),
+    };
+
+    let mut doc = GeometryDocument::new(ipc.resolve(step.name).to_string());
+    let feature_start = doc.features.len() as u32;
+    let mut layer_bbox = BBox::empty();
+    let layer_polarity = map_polarity(layer.polarity.unwrap_or(Polarity::Positive));
+
+    for layer_feature in step
+        .layer_features
+        .iter()
+        .filter(|feature| feature.layer_ref == layer.name)
+    {
+        for (set_index, set) in layer_feature.sets.iter().enumerate() {
+            let polarity = set.polarity.map(map_polarity).unwrap_or(layer_polarity);
+
+            for (feature_index, pad) in set.pads.iter().enumerate() {
+                if let Some(feature) = extract_pad(
+                    &context,
+                    layer.name,
+                    set.net,
+                    polarity,
+                    SourceRef {
+                        set_index: set_index as u32,
+                        feature_index: feature_index as u32,
+                    },
+                    pad,
+                    &mut doc,
+                )? {
+                    layer_bbox = layer_bbox.union(feature.bbox);
+                    doc.features.push(feature);
+                }
+            }
+
+            for (feature_index, trace) in set.traces.iter().enumerate() {
+                if let Some(feature) = extract_trace(
+                    &context,
+                    set.net,
+                    polarity,
+                    SourceRef {
+                        set_index: set_index as u32,
+                        feature_index: feature_index as u32,
+                    },
+                    trace,
+                    &mut doc,
+                ) {
+                    layer_bbox = layer_bbox.union(feature.bbox);
+                    doc.features.push(feature);
+                }
+            }
+
+            for (feature_index, polygon) in set.polygons.iter().enumerate() {
+                let feature = extract_polygon(
+                    set.net,
+                    polarity,
+                    SourceRef {
+                        set_index: set_index as u32,
+                        feature_index: feature_index as u32,
+                    },
+                    polygon,
+                    &mut doc,
+                );
+                layer_bbox = layer_bbox.union(feature.bbox);
+                doc.features.push(feature);
+            }
+
+            for (feature_index, line) in set.lines.iter().enumerate() {
+                let feature = extract_line(
+                    set.net,
+                    polarity,
+                    SourceRef {
+                        set_index: set_index as u32,
+                        feature_index: feature_index as u32,
+                    },
+                    line,
+                    &mut doc,
+                );
+                layer_bbox = layer_bbox.union(feature.bbox);
+                doc.features.push(feature);
+            }
+        }
+    }
+
+    for layer_feature in &step.layer_features {
+        let is_drill_layer = ecad.cad_data.layers.iter().any(|candidate| {
+            candidate.name == layer_feature.layer_ref
+                && candidate.layer_function == LayerFunction::Drill
+        });
+
+        for (set_index, set) in layer_feature.sets.iter().enumerate() {
+            if is_drill_layer {
+                for (feature_index, hole) in set.holes.iter().enumerate() {
+                    let feature = extract_hole(
+                        SourceRef {
+                            set_index: set_index as u32,
+                            feature_index: feature_index as u32,
+                        },
+                        hole,
+                        &mut doc,
+                    );
+                    layer_bbox = layer_bbox.union(feature.bbox);
+                    doc.features.push(feature);
+                }
+            }
+
+            for (feature_index, slot) in set.slots.iter().enumerate() {
+                let feature = extract_slot(
+                    &context,
+                    SourceRef {
+                        set_index: set_index as u32,
+                        feature_index: feature_index as u32,
+                    },
+                    slot,
+                    &mut doc,
+                )?;
+                layer_bbox = layer_bbox.union(feature.bbox);
+                doc.features.push(feature);
+            }
+        }
+    }
+
+    let feature_count = doc.features.len() as u32 - feature_start;
+    doc.layers.push(GeometryLayer {
+        name: layer_name.to_string(),
+        source_layer_ref: layer.name,
+        feature_start,
+        feature_count,
+        bbox: layer_bbox,
+    });
+
+    Ok(doc)
+}
+
+fn extract_pad(
+    context: &ExtractContext<'_>,
+    layer_ref: Symbol,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    pad: &ipc2581::types::Pad,
+    doc: &mut GeometryDocument,
+) -> Result<Option<GeometryFeature>> {
+    let Some(padstack_ref) = pad.padstack_def_ref else {
+        doc.warn("Skipping pad without PadStackDefRef");
+        return Ok(None);
+    };
+    let Some(x) = pad.x else {
+        doc.warn("Skipping pad without x coordinate");
+        return Ok(None);
+    };
+    let Some(y) = pad.y else {
+        doc.warn("Skipping pad without y coordinate");
+        return Ok(None);
+    };
+    let Some(padstack) = context.padstacks.get(&padstack_ref).copied() else {
+        doc.warn(format!(
+            "Skipping pad referencing missing padstack '{}'",
+            context.ipc.resolve(padstack_ref)
+        ));
+        return Ok(None);
+    };
+
+    let bucket = match padstack.hole_def.as_ref().map(|hole| hole.plating_status) {
+        Some(PlatingStatus::Via) => FeatureBucket::Via,
+        Some(PlatingStatus::Plated) => FeatureBucket::Pth,
+        Some(PlatingStatus::NonPlated) => return Ok(None),
+        None => FeatureBucket::Smd,
+    };
+
+    let xform = pad.xform.unwrap_or_default();
+    let offset = Affine2::transform_vector(
+        xform.rotation,
+        xform.mirror,
+        xform.scale,
+        Point::new(xform.x_offset, xform.y_offset),
+    );
+    let center = Point::new(x + offset.x, y + offset.y);
+    let transform = Affine2::placement(center, xform.rotation, xform.mirror, xform.scale);
+
+    let primitive_ref = pad
+        .standard_primitive_ref
+        .or_else(|| find_pad_primitive_ref(padstack, layer_ref));
+    let Some(primitive_ref) = primitive_ref else {
+        doc.warn(format!(
+            "Skipping padstack '{}' because it has no regular primitive for layer '{}'",
+            context.ipc.resolve(padstack.name),
+            context.ipc.resolve(layer_ref)
+        ));
+        return Ok(None);
+    };
+    let Some(primitive) = context.standard_primitives.get(&primitive_ref).copied() else {
+        doc.warn(format!(
+            "Skipping padstack '{}' because primitive '{}' is missing",
+            context.ipc.resolve(padstack.name),
+            context.ipc.resolve(primitive_ref)
+        ));
+        return Ok(None);
+    };
+
+    let path_start = doc.paths.len() as u32;
+    lower_standard_primitive(context, doc, primitive, transform, bucket)?;
+    let path_count = doc.paths.len() as u32 - path_start;
+    if path_count == 0 {
+        return Ok(None);
+    }
+    let bbox = paths_bbox(doc, path_start, path_count);
+
+    let mut feature = GeometryFeature::new(FeatureKind::Padstack, bucket, polarity);
+    feature.net = net;
+    feature.source = source;
+    feature.transform = transform;
+    feature.bbox = bbox;
+    feature.path_start = path_start;
+    feature.path_count = path_count;
+    feature.center = center;
+    feature.rotation_degrees = xform.rotation;
+    feature.scale = xform.scale;
+    feature.padstack_ref = Some(padstack_ref);
+    feature.primitive_ref = Some(primitive_ref);
+    feature.flags.expanded_padstack = true;
+    feature.flags.lowered_to_paths = true;
+
+    Ok(Some(feature))
+}
+
+fn find_pad_primitive_ref(
+    padstack: &ipc2581::types::PadStackDef,
+    layer_ref: Symbol,
+) -> Option<Symbol> {
+    padstack
+        .pad_defs
+        .iter()
+        .find(|pad_def| pad_def.layer_ref == layer_ref && pad_def.pad_use == PadUse::Regular)
+        .or_else(|| {
+            padstack.pad_defs.iter().find(|pad_def| {
+                pad_def.layer_ref == layer_ref && pad_def.pad_use == PadUse::Thermal
+            })
+        })
+        .and_then(|pad_def| pad_def.standard_primitive_ref)
+}
+
+fn extract_trace(
+    context: &ExtractContext<'_>,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    trace: &ipc2581::types::Trace,
+    doc: &mut GeometryDocument,
+) -> Option<GeometryFeature> {
+    if trace.points.is_empty() {
+        return None;
+    }
+    let line_desc_ref = match trace.line_desc_ref {
+        Some(line_desc_ref) => line_desc_ref,
+        None => {
+            doc.warn("Skipping trace without LineDescRef");
+            return None;
+        }
+    };
+    let Some(line_desc) = context.line_descs.get(&line_desc_ref).copied() else {
+        doc.warn(format!(
+            "Skipping trace referencing missing LineDesc '{}'",
+            context.ipc.resolve(line_desc_ref)
+        ));
+        return None;
+    };
+
+    let points: Vec<Point> = trace
+        .points
+        .iter()
+        .map(|point| Point::new(point.x, point.y))
+        .collect();
+    Some(push_stroked_polyline(
+        doc,
+        FeatureKind::Trace,
+        FeatureBucket::Trace,
+        net,
+        polarity,
+        source,
+        points,
+        line_desc.line_width,
+        map_line_cap(line_desc.line_end),
+    ))
+}
+
+fn extract_line(
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    line: &ipc2581::types::ecad::Line,
+    doc: &mut GeometryDocument,
+) -> GeometryFeature {
+    push_stroked_polyline(
+        doc,
+        FeatureKind::Trace,
+        FeatureBucket::Trace,
+        net,
+        polarity,
+        source,
+        vec![
+            Point::new(line.start_x, line.start_y),
+            Point::new(line.end_x, line.end_y),
+        ],
+        line.line_width,
+        line.line_end.map(map_line_cap).unwrap_or(LineCap::Round),
+    )
+}
+
+fn extract_polygon(
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    polygon: &ipc2581::types::Polygon,
+    doc: &mut GeometryDocument,
+) -> GeometryFeature {
+    let path_start = doc.paths.len() as u32;
+    push_polygon_path(doc, polygon, Affine2::identity(), FillRule::NonZero);
+    let path_count = doc.paths.len() as u32 - path_start;
+
+    let mut feature = GeometryFeature::new(FeatureKind::Polygon, FeatureBucket::Fill, polarity);
+    feature.net = net;
+    feature.source = source;
+    feature.bbox = paths_bbox(doc, path_start, path_count);
+    feature.path_start = path_start;
+    feature.path_count = path_count;
+    feature.flags.lowered_to_paths = true;
+    feature
+}
+
+fn push_stroked_polyline(
+    doc: &mut GeometryDocument,
+    kind: FeatureKind,
+    bucket: FeatureBucket,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    points: Vec<Point>,
+    width: f64,
+    line_cap: LineCap,
+) -> GeometryFeature {
+    let mut bbox = BBox::empty();
+    let mut cmds = Vec::new();
+    for (index, point) in points.iter().copied().enumerate() {
+        bbox.include_point(point);
+        cmds.push(if index == 0 {
+            PathCmd::move_to(point)
+        } else {
+            PathCmd::line_to(point)
+        });
+    }
+    bbox = bbox.expand(width / 2.0);
+
+    let path_start = doc.paths.len() as u32;
+    doc.push_path(GeometryPath::stroked(width, line_cap, bbox), cmds);
+
+    let mut feature = GeometryFeature::new(kind, bucket, polarity);
+    feature.net = net;
+    feature.source = source;
+    feature.bbox = bbox;
+    feature.path_start = path_start;
+    feature.path_count = 1;
+    feature.stroke_width = width;
+    feature.line_cap = line_cap;
+    feature.flags.lowered_to_paths = true;
+    feature
+}
+
+fn extract_hole(
+    source: SourceRef,
+    hole: &ipc2581::types::Hole,
+    doc: &mut GeometryDocument,
+) -> GeometryFeature {
+    let path_start = doc.paths.len() as u32;
+    let center = Point::new(hole.x, hole.y);
+    push_ellipse_path(
+        doc,
+        Affine2::placement(center, 0.0, false, 1.0),
+        hole.diameter,
+        hole.diameter,
+    );
+    let path_count = doc.paths.len() as u32 - path_start;
+
+    let mut feature = GeometryFeature::new(
+        FeatureKind::Hole,
+        FeatureBucket::Cutout,
+        GeometryPolarity::Positive,
+    );
+    feature.source = source;
+    feature.bbox = paths_bbox(doc, path_start, path_count);
+    feature.path_start = path_start;
+    feature.path_count = path_count;
+    feature.center = center;
+    feature.outer_diameter = hole.diameter;
+    feature.flags.lowered_to_paths = true;
+    feature
+}
+
+fn extract_slot(
+    context: &ExtractContext<'_>,
+    source: SourceRef,
+    slot: &ipc2581::types::Slot,
+    doc: &mut GeometryDocument,
+) -> Result<GeometryFeature> {
+    let transform = Affine2::placement(Point::new(slot.x, slot.y), 0.0, false, 1.0);
+    let path_start = doc.paths.len() as u32;
+
+    match &slot.shape {
+        SlotShape::Outline(polygon) => {
+            push_polygon_path(doc, polygon, transform, FillRule::NonZero);
+        }
+        SlotShape::Primitive(primitive) => {
+            lower_standard_primitive(context, doc, primitive, transform, FeatureBucket::Cutout)?;
+        }
+    }
+
+    let path_count = doc.paths.len() as u32 - path_start;
+    let mut feature = GeometryFeature::new(
+        FeatureKind::Slot,
+        FeatureBucket::Cutout,
+        GeometryPolarity::Positive,
+    );
+    feature.source = source;
+    feature.transform = transform;
+    feature.bbox = paths_bbox(doc, path_start, path_count);
+    feature.path_start = path_start;
+    feature.path_count = path_count;
+    feature.center = Point::new(slot.x, slot.y);
+    feature.flags.lowered_to_paths = true;
+    Ok(feature)
+}
+
+fn lower_standard_primitive(
+    context: &ExtractContext<'_>,
+    doc: &mut GeometryDocument,
+    primitive: &StandardPrimitive,
+    transform: Affine2,
+    bucket: FeatureBucket,
+) -> Result<()> {
+    match primitive {
+        StandardPrimitive::Circle(circle) => {
+            push_ellipse_path(doc, transform, circle.shape.diameter, circle.shape.diameter);
+        }
+        StandardPrimitive::Ellipse(ellipse) => {
+            push_ellipse_path(
+                doc,
+                transform,
+                ellipse.shape.size.width,
+                ellipse.shape.size.height,
+            );
+        }
+        StandardPrimitive::Oval(oval) => {
+            push_oval_path(
+                doc,
+                transform,
+                oval.shape.size.width,
+                oval.shape.size.height,
+            );
+        }
+        StandardPrimitive::RectCenter(rect) => {
+            push_rect_path(
+                doc,
+                transform,
+                rect.shape.size.width,
+                rect.shape.size.height,
+            );
+        }
+        StandardPrimitive::RectCorner(rect) => {
+            let points = vec![
+                Point::new(rect.shape.lower_left.x, rect.shape.lower_left.y),
+                Point::new(rect.shape.upper_right.x, rect.shape.lower_left.y),
+                Point::new(rect.shape.upper_right.x, rect.shape.upper_right.y),
+                Point::new(rect.shape.lower_left.x, rect.shape.upper_right.y),
+            ];
+            push_closed_points_path(doc, transform, points, FillRule::NonZero);
+        }
+        StandardPrimitive::Diamond(diamond) => {
+            let hw = diamond.shape.size.width / 2.0;
+            let hh = diamond.shape.size.height / 2.0;
+            push_closed_points_path(
+                doc,
+                transform,
+                vec![
+                    Point::new(0.0, -hh),
+                    Point::new(hw, 0.0),
+                    Point::new(0.0, hh),
+                    Point::new(-hw, 0.0),
+                ],
+                FillRule::NonZero,
+            );
+        }
+        StandardPrimitive::Hexagon(hexagon) => {
+            push_regular_polygon_path(doc, transform, 6, hexagon.shape.point_to_point / 2.0);
+        }
+        StandardPrimitive::Octagon(octagon) => {
+            push_regular_polygon_path(doc, transform, 8, octagon.shape.point_to_point / 2.0);
+        }
+        StandardPrimitive::Triangle(triangle) => {
+            let hw = triangle.shape.base / 2.0;
+            let hh = triangle.shape.height / 2.0;
+            push_closed_points_path(
+                doc,
+                transform,
+                vec![
+                    Point::new(0.0, -hh),
+                    Point::new(hw, hh),
+                    Point::new(-hw, hh),
+                ],
+                FillRule::NonZero,
+            );
+        }
+        StandardPrimitive::Donut(donut) => {
+            push_donut_path(
+                doc,
+                transform,
+                donut.shape.outer_diameter,
+                donut.shape.inner_diameter,
+            );
+        }
+        StandardPrimitive::Thermal(thermal) => {
+            let spoke_width = thermal
+                .shape
+                .spoke_width
+                .unwrap_or(thermal.shape.outer_diameter * 0.15);
+            push_thermal_path(
+                doc,
+                transform,
+                thermal.shape.outer_diameter,
+                thermal.shape.inner_diameter,
+                spoke_width,
+                thermal.shape.spoke_count.max(1),
+            );
+        }
+        StandardPrimitive::Contour(contour) => {
+            push_polygon_path(doc, &contour.polygon, transform, FillRule::EvenOdd);
+            for cutout in &contour.cutouts {
+                push_polygon_path(doc, cutout, transform, FillRule::EvenOdd);
+            }
+        }
+        StandardPrimitive::RectRound(rect) => {
+            push_rounded_rect_path(
+                doc,
+                transform,
+                rect.shape.size.width,
+                rect.shape.size.height,
+                rect.shape.radius,
+                [
+                    rect.shape.upper_right,
+                    rect.shape.lower_right,
+                    rect.shape.lower_left,
+                    rect.shape.upper_left,
+                ],
+            );
+        }
+        StandardPrimitive::RectCham(rect) => {
+            let hw = rect.shape.size.width / 2.0;
+            let hh = rect.shape.size.height / 2.0;
+            let c = rect.shape.chamfer.min(hw).min(hh);
+            push_closed_points_path(
+                doc,
+                transform,
+                vec![
+                    Point::new(-hw + c, -hh),
+                    Point::new(hw - c, -hh),
+                    Point::new(hw, -hh + c),
+                    Point::new(hw, hh - c),
+                    Point::new(hw - c, hh),
+                    Point::new(-hw + c, hh),
+                    Point::new(-hw, hh - c),
+                    Point::new(-hw, -hh + c),
+                ],
+                FillRule::NonZero,
+            );
+        }
+        StandardPrimitive::Butterfly(butterfly) => {
+            push_ellipse_path(doc, transform, butterfly.shape.size, butterfly.shape.size);
+        }
+        StandardPrimitive::Moire(moire) => {
+            push_ellipse_path(doc, transform, moire.diameter, moire.diameter);
+        }
+    }
+
+    if matches!(bucket, FeatureBucket::Thermal) {
+        // Thermal pads are already represented by their primitive. This branch is
+        // just here to make the bucket dependency explicit for future styling.
+    }
+
+    let _ = context;
+    Ok(())
+}
+
+fn push_polygon_path(
+    doc: &mut GeometryDocument,
+    polygon: &ipc2581::types::Polygon,
+    transform: Affine2,
+    fill_rule: FillRule,
+) {
+    let mut cmds = Vec::new();
+    let mut current = Point::new(polygon.begin.x, polygon.begin.y);
+    let start = transform.transform_point(current);
+    let mut bbox = BBox::from_point(start);
+    cmds.push(PathCmd::move_to(start));
+
+    for step in &polygon.steps {
+        match step {
+            PolyStep::Segment(segment) => {
+                current = Point::new(segment.point.x, segment.point.y);
+                let p = transform.transform_point(current);
+                bbox.include_point(p);
+                cmds.push(PathCmd::line_to(p));
+            }
+            PolyStep::Curve(curve) => {
+                let end = Point::new(curve.point.x, curve.point.y);
+                let center = Point::new(curve.center.x, curve.center.y);
+                let start = transform.transform_point(current);
+                let end = transform.transform_point(end);
+                let center = transform.transform_point(center);
+                let clockwise = if transform.determinant() < 0.0 {
+                    !curve.clockwise
+                } else {
+                    curve.clockwise
+                };
+                bbox.include_circular_arc(start, end, center, clockwise);
+                cmds.push(PathCmd::arc_to(end, center, clockwise));
+                current = Point::new(curve.point.x, curve.point.y);
+            }
+        }
+    }
+    cmds.push(PathCmd::close());
+    doc.push_path(GeometryPath::filled(fill_rule, bbox), cmds);
+}
+
+fn push_closed_points_path(
+    doc: &mut GeometryDocument,
+    transform: Affine2,
+    points: Vec<Point>,
+    fill_rule: FillRule,
+) {
+    if points.is_empty() {
+        return;
+    }
+    let mut bbox = BBox::empty();
+    let mut cmds = Vec::with_capacity(points.len() + 1);
+    for (index, point) in points.into_iter().enumerate() {
+        let p = transform.transform_point(point);
+        bbox.include_point(p);
+        cmds.push(if index == 0 {
+            PathCmd::move_to(p)
+        } else {
+            PathCmd::line_to(p)
+        });
+    }
+    cmds.push(PathCmd::close());
+    doc.push_path(GeometryPath::filled(fill_rule, bbox), cmds);
+}
+
+fn push_rect_path(doc: &mut GeometryDocument, transform: Affine2, width: f64, height: f64) {
+    let hw = width / 2.0;
+    let hh = height / 2.0;
+    push_closed_points_path(
+        doc,
+        transform,
+        vec![
+            Point::new(-hw, -hh),
+            Point::new(hw, -hh),
+            Point::new(hw, hh),
+            Point::new(-hw, hh),
+        ],
+        FillRule::NonZero,
+    );
+}
+
+fn push_rounded_rect_path(
+    doc: &mut GeometryDocument,
+    transform: Affine2,
+    width: f64,
+    height: f64,
+    radius: f64,
+    corners: [bool; 4],
+) {
+    let hw = width / 2.0;
+    let hh = height / 2.0;
+    let r = radius.min(hw).min(hh).max(0.0);
+    if r == 0.0 || !corners.iter().any(|corner| *corner) {
+        push_rect_path(doc, transform, width, height);
+        return;
+    }
+
+    let k = 0.552_284_749_830_793_6;
+    let [upper_right, lower_right, lower_left, upper_left] = corners;
+    let mut cmds = Vec::new();
+
+    cmds.push(PathCmd::move_to(Point::new(
+        -hw + if upper_left { r } else { 0.0 },
+        -hh,
+    )));
+
+    cmds.push(PathCmd::line_to(Point::new(
+        hw - if upper_right { r } else { 0.0 },
+        -hh,
+    )));
+    if upper_right {
+        cmds.push(PathCmd::cubic_to(
+            Point::new(hw - r + k * r, -hh),
+            Point::new(hw, -hh + r - k * r),
+            Point::new(hw, -hh + r),
+        ));
+    }
+
+    cmds.push(PathCmd::line_to(Point::new(
+        hw,
+        hh - if lower_right { r } else { 0.0 },
+    )));
+    if lower_right {
+        cmds.push(PathCmd::cubic_to(
+            Point::new(hw, hh - r + k * r),
+            Point::new(hw - r + k * r, hh),
+            Point::new(hw - r, hh),
+        ));
+    }
+
+    cmds.push(PathCmd::line_to(Point::new(
+        -hw + if lower_left { r } else { 0.0 },
+        hh,
+    )));
+    if lower_left {
+        cmds.push(PathCmd::cubic_to(
+            Point::new(-hw + r - k * r, hh),
+            Point::new(-hw, hh - r + k * r),
+            Point::new(-hw, hh - r),
+        ));
+    }
+
+    cmds.push(PathCmd::line_to(Point::new(
+        -hw,
+        -hh + if upper_left { r } else { 0.0 },
+    )));
+    if upper_left {
+        cmds.push(PathCmd::cubic_to(
+            Point::new(-hw, -hh + r - k * r),
+            Point::new(-hw + r - k * r, -hh),
+            Point::new(-hw + r, -hh),
+        ));
+    }
+    cmds.push(PathCmd::close());
+
+    let mut bbox = BBox::empty();
+    let cmds = cmds
+        .into_iter()
+        .map(|cmd| transform_path_cmd(cmd, transform, &mut bbox))
+        .collect::<Vec<_>>();
+    doc.push_path(GeometryPath::filled(FillRule::NonZero, bbox), cmds);
+}
+
+fn push_regular_polygon_path(
+    doc: &mut GeometryDocument,
+    transform: Affine2,
+    sides: usize,
+    radius: f64,
+) {
+    let points = (0..sides)
+        .map(|index| {
+            let angle = -std::f64::consts::FRAC_PI_2
+                + (index as f64 * std::f64::consts::TAU / sides as f64);
+            Point::new(radius * angle.cos(), radius * angle.sin())
+        })
+        .collect();
+    push_closed_points_path(doc, transform, points, FillRule::NonZero);
+}
+
+fn push_ellipse_path(doc: &mut GeometryDocument, transform: Affine2, width: f64, height: f64) {
+    let rx = width / 2.0;
+    let ry = height / 2.0;
+    let k = 0.552_284_749_830_793_6;
+    let local = [
+        (
+            Point::new(rx, 0.0),
+            Point::new(rx, k * ry),
+            Point::new(k * rx, ry),
+            Point::new(0.0, ry),
+        ),
+        (
+            Point::new(0.0, ry),
+            Point::new(-k * rx, ry),
+            Point::new(-rx, k * ry),
+            Point::new(-rx, 0.0),
+        ),
+        (
+            Point::new(-rx, 0.0),
+            Point::new(-rx, -k * ry),
+            Point::new(-k * rx, -ry),
+            Point::new(0.0, -ry),
+        ),
+        (
+            Point::new(0.0, -ry),
+            Point::new(k * rx, -ry),
+            Point::new(rx, -k * ry),
+            Point::new(rx, 0.0),
+        ),
+    ];
+
+    let start = transform.transform_point(local[0].0);
+    let mut bbox = BBox::from_point(start);
+    let mut cmds = vec![PathCmd::move_to(start)];
+    for (_, c1, c2, end) in local {
+        let c1 = transform.transform_point(c1);
+        let c2 = transform.transform_point(c2);
+        let end = transform.transform_point(end);
+        bbox.include_point(c1);
+        bbox.include_point(c2);
+        bbox.include_point(end);
+        cmds.push(PathCmd::cubic_to(c1, c2, end));
+    }
+    cmds.push(PathCmd::close());
+    doc.push_path(GeometryPath::filled(FillRule::NonZero, bbox), cmds);
+}
+
+fn push_oval_path(doc: &mut GeometryDocument, transform: Affine2, width: f64, height: f64) {
+    if (width - height).abs() < 1e-9 {
+        push_ellipse_path(doc, transform, width, height);
+        return;
+    }
+
+    let k = 0.552_284_749_830_793_6;
+    let mut local_cmds = Vec::new();
+    if width > height {
+        let r = height / 2.0;
+        let a = (width - height) / 2.0;
+        local_cmds.push(PathCmd::move_to(Point::new(a, -r)));
+        local_cmds.push(PathCmd::line_to(Point::new(-a, -r)));
+        local_cmds.push(PathCmd::cubic_to(
+            Point::new(-a - k * r, -r),
+            Point::new(-a - r, -k * r),
+            Point::new(-a - r, 0.0),
+        ));
+        local_cmds.push(PathCmd::cubic_to(
+            Point::new(-a - r, k * r),
+            Point::new(-a - k * r, r),
+            Point::new(-a, r),
+        ));
+        local_cmds.push(PathCmd::line_to(Point::new(a, r)));
+        local_cmds.push(PathCmd::cubic_to(
+            Point::new(a + k * r, r),
+            Point::new(a + r, k * r),
+            Point::new(a + r, 0.0),
+        ));
+        local_cmds.push(PathCmd::cubic_to(
+            Point::new(a + r, -k * r),
+            Point::new(a + k * r, -r),
+            Point::new(a, -r),
+        ));
+    } else {
+        let r = width / 2.0;
+        let a = (height - width) / 2.0;
+        local_cmds.push(PathCmd::move_to(Point::new(r, -a)));
+        local_cmds.push(PathCmd::line_to(Point::new(r, a)));
+        local_cmds.push(PathCmd::cubic_to(
+            Point::new(r, a + k * r),
+            Point::new(k * r, a + r),
+            Point::new(0.0, a + r),
+        ));
+        local_cmds.push(PathCmd::cubic_to(
+            Point::new(-k * r, a + r),
+            Point::new(-r, a + k * r),
+            Point::new(-r, a),
+        ));
+        local_cmds.push(PathCmd::line_to(Point::new(-r, -a)));
+        local_cmds.push(PathCmd::cubic_to(
+            Point::new(-r, -a - k * r),
+            Point::new(-k * r, -a - r),
+            Point::new(0.0, -a - r),
+        ));
+        local_cmds.push(PathCmd::cubic_to(
+            Point::new(k * r, -a - r),
+            Point::new(r, -a - k * r),
+            Point::new(r, -a),
+        ));
+    }
+    local_cmds.push(PathCmd::close());
+
+    let mut bbox = BBox::empty();
+    let cmds = local_cmds
+        .into_iter()
+        .map(|cmd| transform_path_cmd(cmd, transform, &mut bbox))
+        .collect::<Vec<_>>();
+    doc.push_path(GeometryPath::filled(FillRule::NonZero, bbox), cmds);
+}
+
+fn transform_path_cmd(cmd: PathCmd, transform: Affine2, bbox: &mut BBox) -> PathCmd {
+    let mut transformed = cmd;
+    transformed.p0 = transform.transform_point(cmd.p0);
+    transformed.p1 = transform.transform_point(cmd.p1);
+    if cmd.op != PathOp::ArcTo {
+        transformed.p2 = transform.transform_point(cmd.p2);
+    } else if transform.determinant() < 0.0 {
+        transformed.clockwise = !cmd.clockwise;
+    }
+    transformed.p3 = transform.transform_point(cmd.p3);
+
+    match cmd.op {
+        PathOp::MoveTo | PathOp::LineTo => bbox.include_point(transformed.p0),
+        PathOp::ArcTo => {
+            bbox.include_point(transformed.p0);
+            bbox.include_point(transformed.p1);
+        }
+        PathOp::CubicTo => {
+            bbox.include_point(transformed.p0);
+            bbox.include_point(transformed.p1);
+            bbox.include_point(transformed.p2);
+        }
+        PathOp::Close => {}
+    }
+
+    transformed
+}
+
+fn push_donut_path(
+    doc: &mut GeometryDocument,
+    transform: Affine2,
+    outer_diameter: f64,
+    inner_diameter: f64,
+) {
+    let path_start = doc.paths.len();
+    push_ellipse_path(doc, transform, outer_diameter, outer_diameter);
+    push_ellipse_path(doc, transform, inner_diameter, inner_diameter);
+    for path in &mut doc.paths[path_start..] {
+        path.fill_rule = FillRule::EvenOdd;
+    }
+}
+
+fn push_thermal_path(
+    doc: &mut GeometryDocument,
+    transform: Affine2,
+    outer_diameter: f64,
+    inner_diameter: f64,
+    spoke_width: f64,
+    spoke_count: u32,
+) {
+    push_donut_path(doc, transform, outer_diameter, inner_diameter);
+    let outer_radius = outer_diameter / 2.0;
+    let inner_radius = inner_diameter / 2.0;
+    let length = (outer_radius - inner_radius).max(0.0);
+    for index in 0..spoke_count {
+        let angle = index as f64 * std::f64::consts::TAU / spoke_count as f64;
+        let center_radius = inner_radius + length / 2.0;
+        let center = Point::new(center_radius * angle.cos(), center_radius * angle.sin());
+        let spoke_transform = Affine2::placement(
+            transform.transform_point(center),
+            angle.to_degrees(),
+            false,
+            1.0,
+        );
+        push_rect_path(doc, spoke_transform, length, spoke_width);
+    }
+}
+
+fn paths_bbox(doc: &GeometryDocument, path_start: u32, path_count: u32) -> BBox {
+    doc.paths[path_start as usize..(path_start + path_count) as usize]
+        .iter()
+        .fold(BBox::empty(), |bbox, path| bbox.union(path.bbox))
+}
+
+fn map_polarity(polarity: Polarity) -> GeometryPolarity {
+    match polarity {
+        Polarity::Positive => GeometryPolarity::Positive,
+        Polarity::Negative => GeometryPolarity::Negative,
+    }
+}
+
+fn map_line_cap(line_end: LineEnd) -> LineCap {
+    match line_end {
+        LineEnd::Round => LineCap::Round,
+        LineEnd::Square => LineCap::Square,
+        LineEnd::Flat => LineCap::Butt,
+    }
+}
+
+fn _styled_is_filled<T>(styled: &Styled<T>) -> bool {
+    !matches!(
+        styled.fill_property,
+        Some(FillProperty::Hollow | FillProperty::Void)
+    )
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -1,0 +1,492 @@
+use ipc2581::Symbol;
+
+#[derive(Debug, Clone)]
+pub struct GeometryDocument {
+    pub board_name: String,
+    pub layers: Vec<GeometryLayer>,
+    pub features: Vec<GeometryFeature>,
+    pub paths: Vec<GeometryPath>,
+    pub path_cmds: Vec<PathCmd>,
+    pub diagnostics: Vec<GeometryDiagnostic>,
+}
+
+impl GeometryDocument {
+    pub fn new(board_name: String) -> Self {
+        Self {
+            board_name,
+            layers: Vec::new(),
+            features: Vec::new(),
+            paths: Vec::new(),
+            path_cmds: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    pub fn push_path(
+        &mut self,
+        path: GeometryPath,
+        cmds: impl IntoIterator<Item = PathCmd>,
+    ) -> u32 {
+        let cmd_start = self.path_cmds.len() as u32;
+        self.path_cmds.extend(cmds);
+        let cmd_count = self.path_cmds.len() as u32 - cmd_start;
+
+        let mut path = path;
+        path.cmd_start = cmd_start;
+        path.cmd_count = cmd_count;
+
+        let path_id = self.paths.len() as u32;
+        self.paths.push(path);
+        path_id
+    }
+
+    pub fn warn(&mut self, message: impl Into<String>) {
+        self.diagnostics.push(GeometryDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            message: message.into(),
+        });
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryLayer {
+    pub name: String,
+    pub source_layer_ref: Symbol,
+    pub feature_start: u32,
+    pub feature_count: u32,
+    pub bbox: BBox,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryFeature {
+    pub kind: FeatureKind,
+    pub bucket: FeatureBucket,
+    pub polarity: GeometryPolarity,
+    pub net: Option<Symbol>,
+    pub source: SourceRef,
+    pub transform: Affine2,
+    pub bbox: BBox,
+    pub path_start: u32,
+    pub path_count: u32,
+
+    pub center: Point,
+    pub width: f64,
+    pub height: f64,
+    pub radius: f64,
+    pub outer_diameter: f64,
+    pub inner_diameter: f64,
+    pub stroke_width: f64,
+    pub rotation_degrees: f64,
+    pub scale: f64,
+
+    pub line_cap: LineCap,
+    pub fill_rule: FillRule,
+    pub padstack_ref: Option<Symbol>,
+    pub primitive_ref: Option<Symbol>,
+    pub flags: FeatureFlags,
+}
+
+impl GeometryFeature {
+    pub fn new(kind: FeatureKind, bucket: FeatureBucket, polarity: GeometryPolarity) -> Self {
+        Self {
+            kind,
+            bucket,
+            polarity,
+            net: None,
+            source: SourceRef::default(),
+            transform: Affine2::identity(),
+            bbox: BBox::empty(),
+            path_start: 0,
+            path_count: 0,
+            center: Point::default(),
+            width: 0.0,
+            height: 0.0,
+            radius: 0.0,
+            outer_diameter: 0.0,
+            inner_diameter: 0.0,
+            stroke_width: 0.0,
+            rotation_degrees: 0.0,
+            scale: 1.0,
+            line_cap: LineCap::Round,
+            fill_rule: FillRule::NonZero,
+            padstack_ref: None,
+            primitive_ref: None,
+            flags: FeatureFlags::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryPath {
+    pub cmd_start: u32,
+    pub cmd_count: u32,
+    pub bbox: BBox,
+    pub fill_rule: FillRule,
+    pub stroke_width: f64,
+    pub line_cap: LineCap,
+    pub flags: PathFlags,
+}
+
+impl GeometryPath {
+    pub fn filled(fill_rule: FillRule, bbox: BBox) -> Self {
+        Self {
+            cmd_start: 0,
+            cmd_count: 0,
+            bbox,
+            fill_rule,
+            stroke_width: 0.0,
+            line_cap: LineCap::Round,
+            flags: PathFlags {
+                filled: true,
+                stroked: false,
+            },
+        }
+    }
+
+    pub fn stroked(width: f64, line_cap: LineCap, bbox: BBox) -> Self {
+        Self {
+            cmd_start: 0,
+            cmd_count: 0,
+            bbox,
+            fill_rule: FillRule::NonZero,
+            stroke_width: width,
+            line_cap,
+            flags: PathFlags {
+                filled: false,
+                stroked: true,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PathCmd {
+    pub op: PathOp,
+    pub p0: Point,
+    pub p1: Point,
+    pub p2: Point,
+    pub p3: Point,
+    pub clockwise: bool,
+}
+
+impl PathCmd {
+    pub fn move_to(p: Point) -> Self {
+        Self {
+            op: PathOp::MoveTo,
+            p0: p,
+            ..Self::default()
+        }
+    }
+
+    pub fn line_to(p: Point) -> Self {
+        Self {
+            op: PathOp::LineTo,
+            p0: p,
+            ..Self::default()
+        }
+    }
+
+    pub fn cubic_to(p1: Point, p2: Point, p3: Point) -> Self {
+        Self {
+            op: PathOp::CubicTo,
+            p0: p1,
+            p1: p2,
+            p2: p3,
+            ..Self::default()
+        }
+    }
+
+    pub fn arc_to(end: Point, center: Point, clockwise: bool) -> Self {
+        Self {
+            op: PathOp::ArcTo,
+            p0: end,
+            p1: center,
+            clockwise,
+            ..Self::default()
+        }
+    }
+
+    pub fn close() -> Self {
+        Self {
+            op: PathOp::Close,
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PathOp {
+    #[default]
+    MoveTo,
+    LineTo,
+    ArcTo,
+    CubicTo,
+    Close,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureKind {
+    Hole,
+    Padstack,
+    Primitive,
+    Polygon,
+    Slot,
+    Trace,
+    FlattenedBucket,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureBucket {
+    Smd,
+    Pth,
+    Via,
+    Trace,
+    Fill,
+    Cutout,
+    Thermal,
+    Antipad,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeometryPolarity {
+    Positive,
+    Negative,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineCap {
+    Round,
+    Square,
+    Butt,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FillRule {
+    NonZero,
+    EvenOdd,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FeatureFlags {
+    pub expanded_padstack: bool,
+    pub lowered_to_paths: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PathFlags {
+    pub filled: bool,
+    pub stroked: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SourceRef {
+    pub set_index: u32,
+    pub feature_index: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticSeverity {
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Point {
+    pub fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+
+    pub fn distance_to(self, other: Point) -> f64 {
+        ((self.x - other.x).powi(2) + (self.y - other.y).powi(2)).sqrt()
+    }
+
+    pub fn angle_from(self, center: Point) -> f64 {
+        (self.y - center.y).atan2(self.x - center.x)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BBox {
+    pub min: Point,
+    pub max: Point,
+}
+
+impl BBox {
+    pub fn empty() -> Self {
+        Self {
+            min: Point::new(f64::INFINITY, f64::INFINITY),
+            max: Point::new(f64::NEG_INFINITY, f64::NEG_INFINITY),
+        }
+    }
+
+    pub fn from_point(p: Point) -> Self {
+        Self { min: p, max: p }
+    }
+
+    pub fn include_point(&mut self, p: Point) {
+        self.min.x = self.min.x.min(p.x);
+        self.min.y = self.min.y.min(p.y);
+        self.max.x = self.max.x.max(p.x);
+        self.max.y = self.max.y.max(p.y);
+    }
+
+    pub fn include_circular_arc(
+        &mut self,
+        start: Point,
+        end: Point,
+        center: Point,
+        clockwise: bool,
+    ) {
+        self.include_point(start);
+        self.include_point(end);
+
+        let radius = start.distance_to(center).max(end.distance_to(center));
+        if radius <= 0.0 {
+            return;
+        }
+
+        let start_angle = start.angle_from(center);
+        let end_angle = end.angle_from(center);
+        for angle in [
+            0.0,
+            std::f64::consts::FRAC_PI_2,
+            std::f64::consts::PI,
+            std::f64::consts::PI * 1.5,
+        ] {
+            if angle_is_on_arc(start_angle, end_angle, angle, clockwise) {
+                self.include_point(Point::new(
+                    center.x + radius * angle.cos(),
+                    center.y + radius * angle.sin(),
+                ));
+            }
+        }
+    }
+
+    pub fn union(mut self, other: BBox) -> Self {
+        if other.is_empty() {
+            return self;
+        }
+        self.include_point(other.min);
+        self.include_point(other.max);
+        self
+    }
+
+    pub fn expand(self, amount: f64) -> Self {
+        if self.is_empty() {
+            return self;
+        }
+        Self {
+            min: Point::new(self.min.x - amount, self.min.y - amount),
+            max: Point::new(self.max.x + amount, self.max.y + amount),
+        }
+    }
+
+    pub fn width(&self) -> f64 {
+        self.max.x - self.min.x
+    }
+
+    pub fn height(&self) -> f64 {
+        self.max.y - self.min.y
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.min.x.is_infinite() || self.min.y.is_infinite()
+    }
+}
+
+impl Default for BBox {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+pub fn arc_sweep_radians(start: Point, end: Point, center: Point, clockwise: bool) -> f64 {
+    let start_angle = start.angle_from(center);
+    let end_angle = end.angle_from(center);
+    if clockwise {
+        normalize_angle(start_angle - end_angle)
+    } else {
+        normalize_angle(end_angle - start_angle)
+    }
+}
+
+fn angle_is_on_arc(start: f64, end: f64, angle: f64, clockwise: bool) -> bool {
+    if clockwise {
+        normalize_angle(start - angle) <= normalize_angle(start - end) + 1e-12
+    } else {
+        normalize_angle(angle - start) <= normalize_angle(end - start) + 1e-12
+    }
+}
+
+fn normalize_angle(angle: f64) -> f64 {
+    angle.rem_euclid(std::f64::consts::TAU)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Affine2 {
+    pub m00: f64,
+    pub m01: f64,
+    pub m02: f64,
+    pub m10: f64,
+    pub m11: f64,
+    pub m12: f64,
+}
+
+impl Affine2 {
+    pub fn identity() -> Self {
+        Self {
+            m00: 1.0,
+            m01: 0.0,
+            m02: 0.0,
+            m10: 0.0,
+            m11: 1.0,
+            m12: 0.0,
+        }
+    }
+
+    pub fn placement(center: Point, rotation_degrees: f64, mirror: bool, scale: f64) -> Self {
+        let mirror_scale = if mirror { -scale } else { scale };
+        let radians = rotation_degrees.to_radians();
+        let cos = radians.cos();
+        let sin = radians.sin();
+
+        Self {
+            m00: cos * mirror_scale,
+            m01: -sin * scale,
+            m02: center.x,
+            m10: sin * mirror_scale,
+            m11: cos * scale,
+            m12: center.y,
+        }
+    }
+
+    pub fn transform_point(&self, p: Point) -> Point {
+        Point::new(
+            self.m00 * p.x + self.m01 * p.y + self.m02,
+            self.m10 * p.x + self.m11 * p.y + self.m12,
+        )
+    }
+
+    pub fn determinant(&self) -> f64 {
+        self.m00 * self.m11 - self.m01 * self.m10
+    }
+
+    pub fn transform_vector(rotation_degrees: f64, mirror: bool, scale: f64, p: Point) -> Point {
+        let tx = if mirror { -p.x * scale } else { p.x * scale };
+        let ty = p.y * scale;
+        let radians = rotation_degrees.to_radians();
+        let cos = radians.cos();
+        let sin = radians.sin();
+        Point::new(tx * cos - ty * sin, tx * sin + ty * cos)
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -6,6 +6,7 @@ pub struct GeometryDocument {
     pub layers: Vec<GeometryLayer>,
     pub features: Vec<GeometryFeature>,
     pub paths: Vec<GeometryPath>,
+    pub contours: Vec<GeometryContour>,
     pub path_cmds: Vec<PathCmd>,
     pub diagnostics: Vec<GeometryDiagnostic>,
 }
@@ -17,6 +18,7 @@ impl GeometryDocument {
             layers: Vec::new(),
             features: Vec::new(),
             paths: Vec::new(),
+            contours: Vec::new(),
             path_cmds: Vec::new(),
             diagnostics: Vec::new(),
         }
@@ -27,17 +29,53 @@ impl GeometryDocument {
         path: GeometryPath,
         cmds: impl IntoIterator<Item = PathCmd>,
     ) -> u32 {
-        let cmd_start = self.path_cmds.len() as u32;
-        self.path_cmds.extend(cmds);
-        let cmd_count = self.path_cmds.len() as u32 - cmd_start;
+        let contour_start = self.contours.len() as u32;
+        let bbox = path.bbox;
+        self.push_contour(bbox, cmds);
 
         let mut path = path;
-        path.cmd_start = cmd_start;
-        path.cmd_count = cmd_count;
+        path.contour_start = contour_start;
+        path.contour_count = 1;
 
         let path_id = self.paths.len() as u32;
         self.paths.push(path);
         path_id
+    }
+
+    pub fn push_compound_path(
+        &mut self,
+        mut path: GeometryPath,
+        contours: impl IntoIterator<Item = (BBox, Vec<PathCmd>)>,
+    ) -> u32 {
+        let contour_start = self.contours.len() as u32;
+        let mut path_bbox = BBox::empty();
+        for (bbox, cmds) in contours {
+            path_bbox = path_bbox.union(bbox);
+            self.push_contour(bbox, cmds);
+        }
+        let contour_count = self.contours.len() as u32 - contour_start;
+
+        path.contour_start = contour_start;
+        path.contour_count = contour_count;
+        path.bbox = path_bbox;
+
+        let path_id = self.paths.len() as u32;
+        self.paths.push(path);
+        path_id
+    }
+
+    fn push_contour(&mut self, bbox: BBox, cmds: impl IntoIterator<Item = PathCmd>) -> u32 {
+        let cmd_start = self.path_cmds.len() as u32;
+        self.path_cmds.extend(cmds);
+        let cmd_count = self.path_cmds.len() as u32 - cmd_start;
+
+        let contour_id = self.contours.len() as u32;
+        self.contours.push(GeometryContour {
+            cmd_start,
+            cmd_count,
+            bbox,
+        });
+        contour_id
     }
 
     pub fn warn(&mut self, message: impl Into<String>) {
@@ -118,8 +156,8 @@ impl GeometryFeature {
 
 #[derive(Debug, Clone)]
 pub struct GeometryPath {
-    pub cmd_start: u32,
-    pub cmd_count: u32,
+    pub contour_start: u32,
+    pub contour_count: u32,
     pub bbox: BBox,
     pub fill_rule: FillRule,
     pub stroke_width: f64,
@@ -130,8 +168,8 @@ pub struct GeometryPath {
 impl GeometryPath {
     pub fn filled(fill_rule: FillRule, bbox: BBox) -> Self {
         Self {
-            cmd_start: 0,
-            cmd_count: 0,
+            contour_start: 0,
+            contour_count: 0,
             bbox,
             fill_rule,
             stroke_width: 0.0,
@@ -145,8 +183,8 @@ impl GeometryPath {
 
     pub fn stroked(width: f64, line_cap: LineCap, bbox: BBox) -> Self {
         Self {
-            cmd_start: 0,
-            cmd_count: 0,
+            contour_start: 0,
+            contour_count: 0,
             bbox,
             fill_rule: FillRule::NonZero,
             stroke_width: width,
@@ -157,6 +195,13 @@ impl GeometryPath {
             },
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryContour {
+    pub cmd_start: u32,
+    pub cmd_count: u32,
+    pub bbox: BBox,
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -522,6 +522,17 @@ impl Affine2 {
         )
     }
 
+    pub fn concat(&self, child: Self) -> Self {
+        Self {
+            m00: self.m00 * child.m00 + self.m01 * child.m10,
+            m01: self.m00 * child.m01 + self.m01 * child.m11,
+            m02: self.m00 * child.m02 + self.m01 * child.m12 + self.m02,
+            m10: self.m10 * child.m00 + self.m11 * child.m10,
+            m11: self.m10 * child.m01 + self.m11 * child.m11,
+            m12: self.m10 * child.m02 + self.m11 * child.m12 + self.m12,
+        }
+    }
+
     pub fn determinant(&self) -> f64 {
         self.m00 * self.m11 - self.m01 * self.m10
     }

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -456,6 +456,10 @@ impl Default for BBox {
 }
 
 pub fn arc_sweep_radians(start: Point, end: Point, center: Point, clockwise: bool) -> f64 {
+    if start.distance_to(end) <= 1e-9 && start.distance_to(center) > 1e-9 {
+        return std::f64::consts::TAU;
+    }
+
     let start_angle = start.angle_from(center);
     let end_angle = end.angle_from(center);
     if clockwise {
@@ -466,6 +470,10 @@ pub fn arc_sweep_radians(start: Point, end: Point, center: Point, clockwise: boo
 }
 
 fn angle_is_on_arc(start: f64, end: f64, angle: f64, clockwise: bool) -> bool {
+    if normalize_angle(end - start) <= 1e-12 {
+        return true;
+    }
+
     if clockwise {
         normalize_angle(start - angle) <= normalize_angle(start - end) + 1e-12
     } else {

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -292,7 +292,7 @@ pub enum FeatureBucket {
     Antipad,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GeometryPolarity {
     Positive,
     Negative,
@@ -305,7 +305,7 @@ pub enum LineCap {
     Butt,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FillRule {
     NonZero,
     EvenOdd,

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -1,0 +1,7 @@
+mod extract;
+pub mod ir;
+pub mod raster;
+pub mod svg;
+pub mod terminal;
+
+pub use extract::extract_layer;

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -1,5 +1,6 @@
 mod extract;
 pub mod ir;
+pub mod process;
 pub mod raster;
 pub mod svg;
 pub mod terminal;

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -1,12 +1,16 @@
 use super::ir::*;
+use i_overlay::core::fill_rule::FillRule as OverlayFillRule;
+use i_overlay::float::simplify::SimplifyShape;
 use kurbo::{BezPath, Cap, Join, PathEl, Stroke, StrokeOpts};
 
 type ContourPayload = (BBox, Vec<PathCmd>);
+type PolygonContour = Vec<[f64; 2]>;
 
 pub fn process_document(doc: &mut GeometryDocument) {
     normalize_bounds(doc);
     compose_feature_paths(doc);
     outline_stroked_paths(doc);
+    union_feature_filled_paths(doc);
     normalize_bounds(doc);
 }
 
@@ -70,6 +74,10 @@ pub fn outline_stroked_paths(doc: &mut GeometryDocument) {
     let feature_count = doc.features.len();
     for feature_index in 0..feature_count {
         let feature = doc.features[feature_index].clone();
+        if feature.bucket != FeatureBucket::Trace {
+            continue;
+        }
+
         let paths = &doc.paths
             [feature.path_start as usize..(feature.path_start + feature.path_count) as usize];
         if !paths.iter().any(|path| path.flags.stroked) {
@@ -91,6 +99,48 @@ pub fn outline_stroked_paths(doc: &mut GeometryDocument) {
         let feature = &mut doc.features[feature_index];
         feature.path_start = path_start;
         feature.path_count = doc.paths.len() as u32 - path_start;
+    }
+}
+
+pub fn union_feature_filled_paths(doc: &mut GeometryDocument) {
+    let feature_count = doc.features.len();
+    for feature_index in 0..feature_count {
+        let feature = doc.features[feature_index].clone();
+        if feature.bucket != FeatureBucket::Trace {
+            continue;
+        }
+
+        let paths = &doc.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize];
+        if paths.is_empty() || !paths.iter().all(|path| path.flags.filled) {
+            continue;
+        }
+
+        let mut contours = Vec::new();
+        let mut supported = true;
+        for path in paths {
+            if !path_to_polygon_contours(doc, path, &mut contours) {
+                supported = false;
+                break;
+            }
+        }
+        if !supported || contours.len() < 2 {
+            continue;
+        }
+
+        let result = contours.simplify_shape(OverlayFillRule::NonZero);
+        let contours = polygon_shapes_to_contours(result);
+        if contours.is_empty() {
+            continue;
+        }
+
+        let path_id = doc.push_compound_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            contours,
+        );
+        let feature = &mut doc.features[feature_index];
+        feature.path_start = path_id;
+        feature.path_count = 1;
     }
 }
 
@@ -300,6 +350,68 @@ fn ir_point(point: kurbo::Point) -> Point {
     Point::new(point.x, point.y)
 }
 
+fn path_to_polygon_contours(
+    doc: &GeometryDocument,
+    path: &GeometryPath,
+    out: &mut Vec<PolygonContour>,
+) -> bool {
+    let bez_path = path_to_kurbo(doc, path);
+    let mut current = Vec::new();
+    kurbo::flatten(bez_path, 0.005, |element| match element {
+        PathEl::MoveTo(point) => {
+            push_polygon_contour(out, &mut current);
+            current.push([point.x, point.y]);
+        }
+        PathEl::LineTo(point) => current.push([point.x, point.y]),
+        PathEl::ClosePath => push_polygon_contour(out, &mut current),
+        PathEl::QuadTo(..) | PathEl::CurveTo(..) => unreachable!("kurbo::flatten emits lines"),
+    });
+    push_polygon_contour(out, &mut current);
+    true
+}
+
+fn push_polygon_contour(out: &mut Vec<PolygonContour>, contour: &mut PolygonContour) {
+    if contour.len() < 3 {
+        contour.clear();
+        return;
+    }
+
+    if contour.first() == contour.last() {
+        contour.pop();
+    }
+    if contour.len() >= 3 {
+        out.push(std::mem::take(contour));
+    } else {
+        contour.clear();
+    }
+}
+
+fn polygon_shapes_to_contours(shapes: Vec<Vec<PolygonContour>>) -> Vec<ContourPayload> {
+    let mut contours = Vec::new();
+    for shape in shapes {
+        for contour in shape {
+            if contour.len() < 3 {
+                continue;
+            }
+
+            let mut bbox = BBox::empty();
+            let mut cmds = Vec::with_capacity(contour.len() + 2);
+            for (index, [x, y]) in contour.into_iter().enumerate() {
+                let point = Point::new(x, y);
+                bbox.include_point(point);
+                if index == 0 {
+                    cmds.push(PathCmd::move_to(point));
+                } else {
+                    cmds.push(PathCmd::line_to(point));
+                }
+            }
+            cmds.push(PathCmd::close());
+            contours.push((bbox, cmds));
+        }
+    }
+    contours
+}
+
 fn contour_bbox(doc: &GeometryDocument, contour_index: usize) -> BBox {
     let contour = &doc.contours[contour_index];
     let mut bbox = BBox::empty();
@@ -428,5 +540,45 @@ mod tests {
 
         assert_eq!(doc.features[0].path_start, 0);
         assert_eq!(doc.features[0].path_count, 2);
+    }
+
+    #[test]
+    fn unions_filled_trace_geometry_inside_one_feature() {
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(0.0, 0.0, 2.0, 1.0),
+        );
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 0.0, 3.0, 1.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 2,
+            ..GeometryFeature::new(
+                FeatureKind::Trace,
+                FeatureBucket::Trace,
+                GeometryPolarity::Positive,
+            )
+        });
+
+        process_document(&mut doc);
+
+        assert_eq!(doc.features[0].path_count, 1);
+        let path = &doc.paths[doc.features[0].path_start as usize];
+        assert!(path.flags.filled);
+        assert_eq!(path.contour_count, 1);
+        assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(path.bbox.max, Point::new(3.0, 1.0));
+    }
+
+    fn rect_cmds(x0: f64, y0: f64, x1: f64, y1: f64) -> [PathCmd; 5] {
+        [
+            PathCmd::move_to(Point::new(x0, y0)),
+            PathCmd::line_to(Point::new(x1, y0)),
+            PathCmd::line_to(Point::new(x1, y1)),
+            PathCmd::line_to(Point::new(x0, y1)),
+            PathCmd::close(),
+        ]
     }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -12,8 +12,8 @@ pub fn process_document(doc: &mut GeometryDocument) {
     normalize_bounds(doc);
     compose_feature_paths(doc);
     outline_stroked_paths(doc);
-    subtract_layer_cutouts(doc);
     union_feature_filled_paths(doc);
+    subtract_layer_cutouts(doc);
     normalize_bounds(doc);
 }
 

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -1,6 +1,8 @@
 use super::ir::*;
 use i_overlay::core::fill_rule::FillRule as OverlayFillRule;
+use i_overlay::core::overlay_rule::OverlayRule;
 use i_overlay::float::simplify::SimplifyShape;
+use i_overlay::float::single::SingleFloatOverlay;
 use kurbo::{BezPath, Cap, Join, PathEl, Stroke, StrokeOpts};
 
 type ContourPayload = (BBox, Vec<PathCmd>);
@@ -10,6 +12,7 @@ pub fn process_document(doc: &mut GeometryDocument) {
     normalize_bounds(doc);
     compose_feature_paths(doc);
     outline_stroked_paths(doc);
+    subtract_layer_cutouts(doc);
     union_feature_filled_paths(doc);
     normalize_bounds(doc);
 }
@@ -117,14 +120,10 @@ pub fn union_feature_filled_paths(doc: &mut GeometryDocument) {
         }
 
         let mut contours = Vec::new();
-        let mut supported = true;
         for path in paths {
-            if !path_to_polygon_contours(doc, path, &mut contours) {
-                supported = false;
-                break;
-            }
+            path_to_polygon_contours(doc, path, &mut contours);
         }
-        if !supported || contours.len() < 2 {
+        if contours.len() < 2 {
             continue;
         }
 
@@ -141,6 +140,63 @@ pub fn union_feature_filled_paths(doc: &mut GeometryDocument) {
         let feature = &mut doc.features[feature_index];
         feature.path_start = path_id;
         feature.path_count = 1;
+    }
+}
+
+pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
+    for layer_index in 0..doc.layers.len() {
+        let layer = doc.layers[layer_index].clone();
+        let features = &doc.features
+            [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize];
+        let mut cutouts = Vec::new();
+        for feature in features {
+            if feature.bucket == FeatureBucket::Cutout {
+                for path in &doc.paths[feature.path_start as usize
+                    ..(feature.path_start + feature.path_count) as usize]
+                {
+                    path_to_polygon_contours(doc, path, &mut cutouts);
+                }
+            }
+        }
+        if cutouts.is_empty() {
+            continue;
+        }
+
+        for feature_index in layer.feature_start..layer.feature_start + layer.feature_count {
+            let feature = doc.features[feature_index as usize].clone();
+            if feature.bucket == FeatureBucket::Cutout {
+                continue;
+            }
+
+            let paths = &doc.paths
+                [feature.path_start as usize..(feature.path_start + feature.path_count) as usize];
+            if paths.is_empty() || !paths.iter().all(|path| path.flags.filled) {
+                continue;
+            }
+
+            let mut subject = Vec::new();
+            for path in paths {
+                path_to_polygon_contours(doc, path, &mut subject);
+            }
+            if subject.is_empty() {
+                continue;
+            }
+
+            let result =
+                subject.overlay(&cutouts, OverlayRule::Difference, OverlayFillRule::NonZero);
+            let contours = polygon_shapes_to_contours(result);
+            if contours.is_empty() {
+                continue;
+            }
+
+            let path_id = doc.push_compound_path(
+                GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+                contours,
+            );
+            let feature = &mut doc.features[feature_index as usize];
+            feature.path_start = path_id;
+            feature.path_count = 1;
+        }
     }
 }
 
@@ -354,7 +410,7 @@ fn path_to_polygon_contours(
     doc: &GeometryDocument,
     path: &GeometryPath,
     out: &mut Vec<PolygonContour>,
-) -> bool {
+) {
     let bez_path = path_to_kurbo(doc, path);
     let mut current = Vec::new();
     kurbo::flatten(bez_path, 0.005, |element| match element {
@@ -367,7 +423,6 @@ fn path_to_polygon_contours(
         PathEl::QuadTo(..) | PathEl::CurveTo(..) => unreachable!("kurbo::flatten emits lines"),
     });
     push_polygon_contour(out, &mut current);
-    true
 }
 
 fn push_polygon_contour(out: &mut Vec<PolygonContour>, contour: &mut PolygonContour) {
@@ -570,6 +625,53 @@ mod tests {
         assert_eq!(path.contour_count, 1);
         assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
         assert_eq!(path.bbox.max, Point::new(3.0, 1.0));
+    }
+
+    #[test]
+    fn subtracts_cutouts_from_filled_layer_geometry() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(0.0, 0.0, 4.0, 4.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 1.0, 3.0, 3.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Slot,
+                FeatureBucket::Cutout,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 2,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        let feature = &doc.features[0];
+        let path = &doc.paths[feature.path_start as usize];
+        assert_eq!(feature.path_count, 1);
+        assert!(path.contour_count > 1);
+        assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(path.bbox.max, Point::new(4.0, 4.0));
     }
 
     fn rect_cmds(x0: f64, y0: f64, x1: f64, y1: f64) -> [PathCmd; 5] {

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -186,6 +186,9 @@ pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
                 subject.overlay(&cutouts, OverlayRule::Difference, OverlayFillRule::NonZero);
             let contours = polygon_shapes_to_contours(result);
             if contours.is_empty() {
+                let feature = &mut doc.features[feature_index as usize];
+                feature.path_start = doc.paths.len() as u32;
+                feature.path_count = 0;
                 continue;
             }
 
@@ -672,6 +675,99 @@ mod tests {
         assert!(path.contour_count > 1);
         assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
         assert_eq!(path.bbox.max, Point::new(4.0, 4.0));
+    }
+
+    #[test]
+    fn subtracts_cutouts_after_trace_union() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::stroked(1.0, LineCap::Round, BBox::empty()),
+            [
+                PathCmd::move_to(Point::new(0.0, 2.0)),
+                PathCmd::line_to(Point::new(4.0, 2.0)),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Trace,
+                FeatureBucket::Trace,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.5, 1.0, 2.5, 3.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Slot,
+                FeatureBucket::Cutout,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 2,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        let trace = &doc.features[0];
+        let path = &doc.paths[trace.path_start as usize];
+        assert!(path.flags.filled);
+        assert!(path.contour_count >= 2);
+        assert_eq!(path.bbox.min.x, -0.5);
+        assert_eq!(path.bbox.max.x, 4.5);
+    }
+
+    #[test]
+    fn removes_features_fully_inside_cutouts() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 1.0, 2.0, 2.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(0.0, 0.0, 3.0, 3.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Slot,
+                FeatureBucket::Cutout,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 2,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        assert_eq!(doc.features[0].path_count, 0);
+        assert!(doc.features[0].bbox.is_empty());
     }
 
     fn rect_cmds(x0: f64, y0: f64, x1: f64, y1: f64) -> [PathCmd; 5] {

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -52,24 +52,14 @@ pub fn compose_feature_paths(doc: &mut GeometryDocument) {
             continue;
         }
 
-        let mut contours = Vec::new();
-        for path in paths {
-            for contour in &doc.contours
-                [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
-            {
-                let cmds = doc.path_cmds
-                    [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
-                    .to_vec();
-                contours.push((contour.bbox, cmds));
-            }
-        }
+        let contours = paths
+            .iter()
+            .flat_map(|path| path_contours(doc, path))
+            .collect::<Vec<_>>();
 
         let mut path = first.clone();
         path.bbox = BBox::empty();
-        let path_id = doc.push_compound_path(path, contours);
-        let feature = &mut doc.features[feature_index];
-        feature.path_start = path_id;
-        feature.path_count = 1;
+        replace_feature_with_compound_path(doc, feature_index, path, contours);
     }
 }
 
@@ -88,7 +78,7 @@ pub fn outline_stroked_paths(doc: &mut GeometryDocument) {
         }
 
         let paths = paths.to_vec();
-        let path_start = doc.paths.len() as u32;
+        let new_path_start = doc.paths.len() as u32;
         for path in paths {
             if path.flags.stroked {
                 if let Some((path, contours)) = stroked_path_outline(doc, &path) {
@@ -100,8 +90,8 @@ pub fn outline_stroked_paths(doc: &mut GeometryDocument) {
         }
 
         let feature = &mut doc.features[feature_index];
-        feature.path_start = path_start;
-        feature.path_count = doc.paths.len() as u32 - path_start;
+        feature.path_start = new_path_start;
+        feature.path_count = doc.paths.len() as u32 - new_path_start;
     }
 }
 
@@ -119,10 +109,7 @@ pub fn union_feature_filled_paths(doc: &mut GeometryDocument) {
             continue;
         }
 
-        let mut contours = Vec::new();
-        for path in paths {
-            path_to_polygon_contours(doc, path, &mut contours);
-        }
+        let contours = feature_polygon_contours(doc, &feature);
         if contours.len() < 2 {
             continue;
         }
@@ -133,31 +120,19 @@ pub fn union_feature_filled_paths(doc: &mut GeometryDocument) {
             continue;
         }
 
-        let path_id = doc.push_compound_path(
+        replace_feature_with_compound_path(
+            doc,
+            feature_index,
             GeometryPath::filled(FillRule::NonZero, BBox::empty()),
             contours,
         );
-        let feature = &mut doc.features[feature_index];
-        feature.path_start = path_id;
-        feature.path_count = 1;
     }
 }
 
 pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
     for layer_index in 0..doc.layers.len() {
         let layer = doc.layers[layer_index].clone();
-        let features = &doc.features
-            [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize];
-        let mut cutouts = Vec::new();
-        for feature in features {
-            if feature.bucket == FeatureBucket::Cutout {
-                for path in &doc.paths[feature.path_start as usize
-                    ..(feature.path_start + feature.path_count) as usize]
-                {
-                    path_to_polygon_contours(doc, path, &mut cutouts);
-                }
-            }
-        }
+        let cutouts = layer_cutout_contours(doc, &layer);
         if cutouts.is_empty() {
             continue;
         }
@@ -174,10 +149,7 @@ pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
                 continue;
             }
 
-            let mut subject = Vec::new();
-            for path in paths {
-                path_to_polygon_contours(doc, path, &mut subject);
-            }
+            let subject = feature_polygon_contours(doc, &feature);
             if subject.is_empty() {
                 continue;
             }
@@ -186,19 +158,16 @@ pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
                 subject.overlay(&cutouts, OverlayRule::Difference, OverlayFillRule::NonZero);
             let contours = polygon_shapes_to_contours(result);
             if contours.is_empty() {
-                let feature = &mut doc.features[feature_index as usize];
-                feature.path_start = doc.paths.len() as u32;
-                feature.path_count = 0;
+                clear_feature_paths(doc, feature_index as usize);
                 continue;
             }
 
-            let path_id = doc.push_compound_path(
+            replace_feature_with_compound_path(
+                doc,
+                feature_index as usize,
                 GeometryPath::filled(FillRule::NonZero, BBox::empty()),
                 contours,
             );
-            let feature = &mut doc.features[feature_index as usize];
-            feature.path_start = path_id;
-            feature.path_count = 1;
         }
     }
 }
@@ -211,8 +180,29 @@ fn compatible_paths(a: &GeometryPath, b: &GeometryPath) -> bool {
 }
 
 fn copy_path(doc: &mut GeometryDocument, path: &GeometryPath) -> u32 {
-    let contours = doc.contours
-        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+    doc.push_compound_path(path.clone(), path_contours(doc, path))
+}
+
+fn replace_feature_with_compound_path(
+    doc: &mut GeometryDocument,
+    feature_index: usize,
+    path: GeometryPath,
+    contours: Vec<ContourPayload>,
+) {
+    let path_id = doc.push_compound_path(path, contours);
+    let feature = &mut doc.features[feature_index];
+    feature.path_start = path_id;
+    feature.path_count = 1;
+}
+
+fn clear_feature_paths(doc: &mut GeometryDocument, feature_index: usize) {
+    let feature = &mut doc.features[feature_index];
+    feature.path_start = doc.paths.len() as u32;
+    feature.path_count = 0;
+}
+
+fn path_contours(doc: &GeometryDocument, path: &GeometryPath) -> Vec<ContourPayload> {
+    doc.contours[path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
         .iter()
         .map(|contour| {
             let cmds = doc.path_cmds
@@ -220,8 +210,25 @@ fn copy_path(doc: &mut GeometryDocument, path: &GeometryPath) -> u32 {
                 .to_vec();
             (contour.bbox, cmds)
         })
-        .collect::<Vec<_>>();
-    doc.push_compound_path(path.clone(), contours)
+        .collect()
+}
+
+fn layer_cutout_contours(doc: &GeometryDocument, layer: &GeometryLayer) -> Vec<PolygonContour> {
+    doc.features[layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
+        .iter()
+        .filter(|feature| feature.bucket == FeatureBucket::Cutout)
+        .flat_map(|feature| feature_polygon_contours(doc, feature))
+        .collect()
+}
+
+fn feature_polygon_contours(
+    doc: &GeometryDocument,
+    feature: &GeometryFeature,
+) -> Vec<PolygonContour> {
+    doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+        .iter()
+        .flat_map(|path| path_polygon_contours(doc, path))
+        .collect()
 }
 
 fn stroked_path_outline(
@@ -426,6 +433,12 @@ fn path_to_polygon_contours(
         PathEl::QuadTo(..) | PathEl::CurveTo(..) => unreachable!("kurbo::flatten emits lines"),
     });
     push_polygon_contour(out, &mut current);
+}
+
+fn path_polygon_contours(doc: &GeometryDocument, path: &GeometryPath) -> Vec<PolygonContour> {
+    let mut contours = Vec::new();
+    path_to_polygon_contours(doc, path, &mut contours);
+    contours
 }
 
 fn push_polygon_contour(out: &mut Vec<PolygonContour>, contour: &mut PolygonContour) {

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::ir::*;
 use i_overlay::core::fill_rule::FillRule as OverlayFillRule;
 use i_overlay::core::overlay_rule::OverlayRule;
@@ -8,11 +10,20 @@ use kurbo::{BezPath, Cap, Join, PathEl, Stroke, StrokeOpts};
 type ContourPayload = (BBox, Vec<PathCmd>);
 type PolygonContour = Vec<[f64; 2]>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct TraceGroupKey {
+    net: Option<ipc2581::Symbol>,
+    set_index: u32,
+    polarity: GeometryPolarity,
+    fill_rule: FillRule,
+}
+
 pub fn process_document(doc: &mut GeometryDocument) {
     normalize_bounds(doc);
     compose_feature_paths(doc);
     outline_stroked_paths(doc);
     union_feature_filled_paths(doc);
+    coalesce_related_trace_features(doc);
     subtract_layer_cutouts(doc);
     normalize_bounds(doc);
 }
@@ -108,13 +119,16 @@ pub fn union_feature_filled_paths(doc: &mut GeometryDocument) {
         if paths.is_empty() || !paths.iter().all(|path| path.flags.filled) {
             continue;
         }
+        let Some(fill_rule) = feature_fill_rule(paths) else {
+            continue;
+        };
 
         let contours = feature_polygon_contours(doc, &feature);
         if contours.len() < 2 {
             continue;
         }
 
-        let result = contours.simplify_shape(OverlayFillRule::NonZero);
+        let result = contours.simplify_shape(overlay_fill_rule(fill_rule));
         let contours = polygon_shapes_to_contours(result);
         if contours.is_empty() {
             continue;
@@ -123,9 +137,77 @@ pub fn union_feature_filled_paths(doc: &mut GeometryDocument) {
         replace_feature_with_compound_path(
             doc,
             feature_index,
-            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            GeometryPath::filled(fill_rule, BBox::empty()),
             contours,
         );
+    }
+}
+
+pub fn coalesce_related_trace_features(doc: &mut GeometryDocument) {
+    for layer_index in 0..doc.layers.len() {
+        let layer = doc.layers[layer_index].clone();
+        let mut groups: HashMap<TraceGroupKey, Vec<usize>> = HashMap::new();
+
+        for feature_index in layer.feature_start..layer.feature_start + layer.feature_count {
+            let feature_index = feature_index as usize;
+            let feature = &doc.features[feature_index];
+            if feature.bucket != FeatureBucket::Trace
+                || feature.polarity != GeometryPolarity::Positive
+            {
+                continue;
+            }
+
+            let paths = &doc.paths
+                [feature.path_start as usize..(feature.path_start + feature.path_count) as usize];
+            if paths.is_empty() || !paths.iter().all(|path| path.flags.filled) {
+                continue;
+            }
+
+            let Some(fill_rule) = feature_fill_rule(paths) else {
+                continue;
+            };
+            groups
+                .entry(TraceGroupKey {
+                    net: feature.net,
+                    set_index: feature.source.set_index,
+                    polarity: feature.polarity,
+                    fill_rule,
+                })
+                .or_default()
+                .push(feature_index);
+        }
+
+        for (key, group) in groups {
+            if group.len() < 2 {
+                continue;
+            }
+
+            let contours = group
+                .iter()
+                .flat_map(|&feature_index| {
+                    feature_polygon_contours(doc, &doc.features[feature_index])
+                })
+                .collect::<Vec<_>>();
+            if contours.len() < 2 {
+                continue;
+            }
+
+            let result = contours.simplify_shape(overlay_fill_rule(key.fill_rule));
+            let contours = polygon_shapes_to_contours(result);
+            if contours.is_empty() {
+                continue;
+            }
+
+            replace_feature_with_compound_path(
+                doc,
+                group[0],
+                GeometryPath::filled(key.fill_rule, BBox::empty()),
+                contours,
+            );
+            for &feature_index in &group[1..] {
+                clear_feature_paths(doc, feature_index);
+            }
+        }
     }
 }
 
@@ -148,16 +230,13 @@ pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
             if paths.is_empty() || !paths.iter().all(|path| path.flags.filled) {
                 continue;
             }
-            let Some(fill_rule) = feature_fill_rule(paths) else {
-                continue;
-            };
-
-            let subject = feature_polygon_contours(doc, &feature);
+            let subject = feature_filled_contours(doc, &feature);
             if subject.is_empty() {
                 continue;
             }
 
-            let result = subject.overlay(&cutouts, OverlayRule::Difference, fill_rule);
+            let result =
+                subject.overlay(&cutouts, OverlayRule::Difference, OverlayFillRule::NonZero);
             let contours = polygon_shapes_to_contours(result);
             if contours.is_empty() {
                 clear_feature_paths(doc, feature_index as usize);
@@ -181,12 +260,12 @@ fn compatible_paths(a: &GeometryPath, b: &GeometryPath) -> bool {
         && (!a.flags.stroked || (a.stroke_width == b.stroke_width && a.line_cap == b.line_cap))
 }
 
-fn feature_fill_rule(paths: &[GeometryPath]) -> Option<OverlayFillRule> {
+fn feature_fill_rule(paths: &[GeometryPath]) -> Option<FillRule> {
     let fill_rule = paths.first()?.fill_rule;
     paths
         .iter()
         .all(|path| path.fill_rule == fill_rule)
-        .then_some(overlay_fill_rule(fill_rule))
+        .then_some(fill_rule)
 }
 
 fn overlay_fill_rule(fill_rule: FillRule) -> OverlayFillRule {
@@ -234,8 +313,34 @@ fn layer_cutout_contours(doc: &GeometryDocument, layer: &GeometryLayer) -> Vec<P
     doc.features[layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
         .iter()
         .filter(|feature| feature.bucket == FeatureBucket::Cutout)
-        .flat_map(|feature| feature_polygon_contours(doc, feature))
+        .flat_map(|feature| feature_filled_contours(doc, feature))
         .collect()
+}
+
+fn feature_filled_contours(
+    doc: &GeometryDocument,
+    feature: &GeometryFeature,
+) -> Vec<PolygonContour> {
+    let mut groups: HashMap<FillRule, Vec<PolygonContour>> = HashMap::new();
+    for path in
+        &doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+    {
+        if path.flags.filled {
+            groups
+                .entry(path.fill_rule)
+                .or_default()
+                .extend(path_polygon_contours(doc, path));
+        }
+    }
+
+    let mut contours = groups
+        .into_iter()
+        .flat_map(|(fill_rule, contours)| simplify_polygon_contours(contours, fill_rule))
+        .collect::<Vec<_>>();
+    if contours.len() > 1 {
+        contours = simplify_polygon_contours(contours, FillRule::NonZero);
+    }
+    contours
 }
 
 fn feature_polygon_contours(
@@ -474,6 +579,17 @@ fn push_polygon_contour(out: &mut Vec<PolygonContour>, contour: &mut PolygonCont
     }
 }
 
+fn simplify_polygon_contours(
+    contours: Vec<PolygonContour>,
+    fill_rule: FillRule,
+) -> Vec<PolygonContour> {
+    polygon_shapes_to_polygon_contours(contours.simplify_shape(overlay_fill_rule(fill_rule)))
+}
+
+fn polygon_shapes_to_polygon_contours(shapes: Vec<Vec<PolygonContour>>) -> Vec<PolygonContour> {
+    shapes.into_iter().flatten().collect()
+}
+
 fn polygon_shapes_to_contours(shapes: Vec<Vec<PolygonContour>>) -> Vec<ContourPayload> {
     let mut contours = Vec::new();
     for shape in shapes {
@@ -655,6 +771,83 @@ mod tests {
         assert_eq!(doc.features[0].path_count, 1);
         let path = &doc.paths[doc.features[0].path_start as usize];
         assert!(path.flags.filled);
+        assert_eq!(path.contour_count, 1);
+        assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(path.bbox.max, Point::new(3.0, 1.0));
+    }
+
+    #[test]
+    fn coalesces_related_trace_features_inside_one_source_set() {
+        let mut interner = ipc2581::Interner::new();
+        let net = interner.intern("N1");
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(0.0, 0.0, 2.0, 1.0),
+        );
+        doc.features.push(GeometryFeature {
+            net: Some(net),
+            source: SourceRef {
+                set_index: 7,
+                feature_index: 0,
+            },
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Trace,
+                FeatureBucket::Trace,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 0.0, 3.0, 1.0),
+        );
+        doc.features.push(GeometryFeature {
+            net: Some(net),
+            source: SourceRef {
+                set_index: 7,
+                feature_index: 1,
+            },
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Trace,
+                FeatureBucket::Trace,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(10.0, 0.0, 11.0, 1.0),
+        );
+        doc.features.push(GeometryFeature {
+            net: Some(net),
+            source: SourceRef {
+                set_index: 8,
+                feature_index: 0,
+            },
+            path_start: 2,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Trace,
+                FeatureBucket::Trace,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 3,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        assert_eq!(doc.features[0].path_count, 1);
+        assert_eq!(doc.features[1].path_count, 0);
+        assert_eq!(doc.features[2].path_count, 1);
+        let path = &doc.paths[doc.features[0].path_start as usize];
         assert_eq!(path.contour_count, 1);
         assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
         assert_eq!(path.bbox.max, Point::new(3.0, 1.0));
@@ -848,6 +1041,59 @@ mod tests {
         assert_eq!(path.contour_count, 2);
         assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
         assert_eq!(path.bbox.max, Point::new(4.0, 4.0));
+    }
+
+    #[test]
+    fn subtracts_cutouts_from_mixed_fill_rule_features() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_compound_path(
+            GeometryPath::filled(FillRule::EvenOdd, BBox::empty()),
+            vec![
+                (BBox::empty(), rect_cmds(0.0, 0.0, 4.0, 4.0).to_vec()),
+                (BBox::empty(), rect_cmds(1.0, 1.0, 3.0, 3.0).to_vec()),
+            ],
+        );
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(2.0, 1.5, 4.5, 2.5),
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 2,
+            ..GeometryFeature::new(
+                FeatureKind::Padstack,
+                FeatureBucket::Thermal,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(3.5, 0.0, 5.0, 4.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_start: 2,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Slot,
+                FeatureBucket::Cutout,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 2,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        let feature = &doc.features[0];
+        assert_eq!(feature.path_count, 1);
+        let path = &doc.paths[feature.path_start as usize];
+        assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(path.bbox.max, Point::new(3.5, 4.0));
     }
 
     fn rect_cmds(x0: f64, y0: f64, x1: f64, y1: f64) -> [PathCmd; 5] {

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -1,8 +1,12 @@
 use super::ir::*;
+use kurbo::{BezPath, Cap, Join, PathEl, Stroke, StrokeOpts};
+
+type ContourPayload = (BBox, Vec<PathCmd>);
 
 pub fn process_document(doc: &mut GeometryDocument) {
     normalize_bounds(doc);
     compose_feature_paths(doc);
+    outline_stroked_paths(doc);
     normalize_bounds(doc);
 }
 
@@ -62,11 +66,238 @@ pub fn compose_feature_paths(doc: &mut GeometryDocument) {
     }
 }
 
+pub fn outline_stroked_paths(doc: &mut GeometryDocument) {
+    let feature_count = doc.features.len();
+    for feature_index in 0..feature_count {
+        let feature = doc.features[feature_index].clone();
+        let paths = &doc.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize];
+        if !paths.iter().any(|path| path.flags.stroked) {
+            continue;
+        }
+
+        let paths = paths.to_vec();
+        let path_start = doc.paths.len() as u32;
+        for path in paths {
+            if path.flags.stroked {
+                if let Some((path, contours)) = stroked_path_outline(doc, &path) {
+                    doc.push_compound_path(path, contours);
+                }
+            } else {
+                copy_path(doc, &path);
+            }
+        }
+
+        let feature = &mut doc.features[feature_index];
+        feature.path_start = path_start;
+        feature.path_count = doc.paths.len() as u32 - path_start;
+    }
+}
+
 fn compatible_paths(a: &GeometryPath, b: &GeometryPath) -> bool {
     a.flags.filled == b.flags.filled
         && a.flags.stroked == b.flags.stroked
         && (!a.flags.filled || a.fill_rule == b.fill_rule)
         && (!a.flags.stroked || (a.stroke_width == b.stroke_width && a.line_cap == b.line_cap))
+}
+
+fn copy_path(doc: &mut GeometryDocument, path: &GeometryPath) -> u32 {
+    let contours = doc.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+        .iter()
+        .map(|contour| {
+            let cmds = doc.path_cmds
+                [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+                .to_vec();
+            (contour.bbox, cmds)
+        })
+        .collect::<Vec<_>>();
+    doc.push_compound_path(path.clone(), contours)
+}
+
+fn stroked_path_outline(
+    doc: &GeometryDocument,
+    path: &GeometryPath,
+) -> Option<(GeometryPath, Vec<ContourPayload>)> {
+    let source = path_to_kurbo(doc, path);
+    if source.elements().is_empty() {
+        return None;
+    }
+
+    let stroke = Stroke::new(path.stroke_width)
+        .with_join(Join::Round)
+        .with_caps(kurbo_cap(path.line_cap));
+    let outline = kurbo::stroke(source, &stroke, &StrokeOpts::default(), 0.01);
+    let contours = kurbo_path_to_contours(&outline);
+    if contours.is_empty() {
+        return None;
+    }
+
+    Some((
+        GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+        contours,
+    ))
+}
+
+fn path_to_kurbo(doc: &GeometryDocument, path: &GeometryPath) -> BezPath {
+    let mut out = BezPath::new();
+    for contour in &doc.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+    {
+        let mut current = Point::default();
+        for cmd in &doc.path_cmds
+            [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+        {
+            match cmd.op {
+                PathOp::MoveTo => {
+                    current = cmd.p0;
+                    out.move_to(kurbo_point(cmd.p0));
+                }
+                PathOp::LineTo => {
+                    current = cmd.p0;
+                    out.line_to(kurbo_point(cmd.p0));
+                }
+                PathOp::ArcTo => {
+                    append_arc_to_kurbo(&mut out, current, cmd.p0, cmd.p1, cmd.clockwise);
+                    current = cmd.p0;
+                }
+                PathOp::CubicTo => {
+                    current = cmd.p2;
+                    out.curve_to(
+                        kurbo_point(cmd.p0),
+                        kurbo_point(cmd.p1),
+                        kurbo_point(cmd.p2),
+                    );
+                }
+                PathOp::Close => out.close_path(),
+            }
+        }
+    }
+    out
+}
+
+fn append_arc_to_kurbo(
+    out: &mut BezPath,
+    start: Point,
+    end: Point,
+    center: Point,
+    clockwise: bool,
+) {
+    let radius = start.distance_to(center);
+    if radius == 0.0 {
+        out.line_to(kurbo_point(end));
+        return;
+    }
+
+    let sweep = arc_sweep_radians(start, end, center, clockwise);
+    let signed_sweep = if clockwise { -sweep } else { sweep };
+    let segment_count = (signed_sweep.abs() / std::f64::consts::FRAC_PI_2).ceil() as usize;
+    let delta = signed_sweep / segment_count.max(1) as f64;
+    let mut angle = start.angle_from(center);
+
+    for _ in 0..segment_count.max(1) {
+        let next_angle = angle + delta;
+        let k = 4.0 / 3.0 * (delta / 4.0).tan();
+        let p0 = Point::new(
+            center.x + radius * angle.cos(),
+            center.y + radius * angle.sin(),
+        );
+        let p3 = Point::new(
+            center.x + radius * next_angle.cos(),
+            center.y + radius * next_angle.sin(),
+        );
+        let c1 = Point::new(
+            p0.x - radius * angle.sin() * k,
+            p0.y + radius * angle.cos() * k,
+        );
+        let c2 = Point::new(
+            p3.x + radius * next_angle.sin() * k,
+            p3.y - radius * next_angle.cos() * k,
+        );
+        out.curve_to(kurbo_point(c1), kurbo_point(c2), kurbo_point(p3));
+        angle = next_angle;
+    }
+}
+
+fn kurbo_path_to_contours(path: &BezPath) -> Vec<(BBox, Vec<PathCmd>)> {
+    let mut contours = Vec::new();
+    let mut cmds = Vec::new();
+    let mut bbox = BBox::empty();
+    let mut current = Point::default();
+
+    for element in path.iter() {
+        match element {
+            PathEl::MoveTo(point) => {
+                push_kurbo_contour(&mut contours, &mut bbox, &mut cmds);
+                current = ir_point(point);
+                bbox.include_point(current);
+                cmds.push(PathCmd::move_to(current));
+            }
+            PathEl::LineTo(point) => {
+                current = ir_point(point);
+                bbox.include_point(current);
+                cmds.push(PathCmd::line_to(current));
+            }
+            PathEl::QuadTo(p1, p2) => {
+                let p1 = ir_point(p1);
+                let p2 = ir_point(p2);
+                let c1 = Point::new(
+                    current.x + (p1.x - current.x) * 2.0 / 3.0,
+                    current.y + (p1.y - current.y) * 2.0 / 3.0,
+                );
+                let c2 = Point::new(
+                    p2.x + (p1.x - p2.x) * 2.0 / 3.0,
+                    p2.y + (p1.y - p2.y) * 2.0 / 3.0,
+                );
+                bbox.include_point(c1);
+                bbox.include_point(c2);
+                bbox.include_point(p2);
+                cmds.push(PathCmd::cubic_to(c1, c2, p2));
+                current = p2;
+            }
+            PathEl::CurveTo(p1, p2, p3) => {
+                let p1 = ir_point(p1);
+                let p2 = ir_point(p2);
+                let p3 = ir_point(p3);
+                bbox.include_point(p1);
+                bbox.include_point(p2);
+                bbox.include_point(p3);
+                cmds.push(PathCmd::cubic_to(p1, p2, p3));
+                current = p3;
+            }
+            PathEl::ClosePath => cmds.push(PathCmd::close()),
+        }
+    }
+    push_kurbo_contour(&mut contours, &mut bbox, &mut cmds);
+    contours
+}
+
+fn push_kurbo_contour(
+    contours: &mut Vec<(BBox, Vec<PathCmd>)>,
+    bbox: &mut BBox,
+    cmds: &mut Vec<PathCmd>,
+) {
+    if cmds.is_empty() {
+        return;
+    }
+    contours.push((*bbox, std::mem::take(cmds)));
+    *bbox = BBox::empty();
+}
+
+fn kurbo_cap(line_cap: LineCap) -> Cap {
+    match line_cap {
+        LineCap::Round => Cap::Round,
+        LineCap::Square => Cap::Square,
+        LineCap::Butt => Cap::Butt,
+    }
+}
+
+fn kurbo_point(point: Point) -> kurbo::Point {
+    kurbo::Point::new(point.x, point.y)
+}
+
+fn ir_point(point: kurbo::Point) -> Point {
+    Point::new(point.x, point.y)
 }
 
 fn contour_bbox(doc: &GeometryDocument, contour_index: usize) -> BBox {
@@ -163,7 +394,8 @@ mod tests {
 
         assert_eq!(doc.features[0].path_count, 1);
         let path = &doc.paths[doc.features[0].path_start as usize];
-        assert_eq!(path.contour_count, 2);
+        assert!(path.flags.filled);
+        assert!(!path.flags.stroked);
         assert_eq!(path.bbox.min, Point::new(-1.0, -1.0));
         assert_eq!(path.bbox.max, Point::new(11.0, 1.0));
     }

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -148,14 +148,16 @@ pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
             if paths.is_empty() || !paths.iter().all(|path| path.flags.filled) {
                 continue;
             }
+            let Some(fill_rule) = feature_fill_rule(paths) else {
+                continue;
+            };
 
             let subject = feature_polygon_contours(doc, &feature);
             if subject.is_empty() {
                 continue;
             }
 
-            let result =
-                subject.overlay(&cutouts, OverlayRule::Difference, OverlayFillRule::NonZero);
+            let result = subject.overlay(&cutouts, OverlayRule::Difference, fill_rule);
             let contours = polygon_shapes_to_contours(result);
             if contours.is_empty() {
                 clear_feature_paths(doc, feature_index as usize);
@@ -177,6 +179,21 @@ fn compatible_paths(a: &GeometryPath, b: &GeometryPath) -> bool {
         && a.flags.stroked == b.flags.stroked
         && (!a.flags.filled || a.fill_rule == b.fill_rule)
         && (!a.flags.stroked || (a.stroke_width == b.stroke_width && a.line_cap == b.line_cap))
+}
+
+fn feature_fill_rule(paths: &[GeometryPath]) -> Option<OverlayFillRule> {
+    let fill_rule = paths.first()?.fill_rule;
+    paths
+        .iter()
+        .all(|path| path.fill_rule == fill_rule)
+        .then_some(overlay_fill_rule(fill_rule))
+}
+
+fn overlay_fill_rule(fill_rule: FillRule) -> OverlayFillRule {
+    match fill_rule {
+        FillRule::EvenOdd => OverlayFillRule::EvenOdd,
+        FillRule::NonZero => OverlayFillRule::NonZero,
+    }
 }
 
 fn copy_path(doc: &mut GeometryDocument, path: &GeometryPath) -> u32 {
@@ -781,6 +798,56 @@ mod tests {
 
         assert_eq!(doc.features[0].path_count, 0);
         assert!(doc.features[0].bbox.is_empty());
+    }
+
+    #[test]
+    fn subtracts_cutouts_with_even_odd_subject_fill_rule() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_compound_path(
+            GeometryPath::filled(FillRule::EvenOdd, BBox::empty()),
+            vec![
+                (BBox::empty(), rect_cmds(0.0, 0.0, 4.0, 4.0).to_vec()),
+                (BBox::empty(), rect_cmds(1.0, 1.0, 3.0, 3.0).to_vec()),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Padstack,
+                FeatureBucket::Pth,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.5, 1.5, 2.5, 2.5),
+        );
+        doc.features.push(GeometryFeature {
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Hole,
+                FeatureBucket::Cutout,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 2,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        let feature = &doc.features[0];
+        assert_eq!(feature.path_count, 1);
+        let path = &doc.paths[feature.path_start as usize];
+        assert_eq!(path.contour_count, 2);
+        assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(path.bbox.max, Point::new(4.0, 4.0));
     }
 
     fn rect_cmds(x0: f64, y0: f64, x1: f64, y1: f64) -> [PathCmd; 5] {

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -1,0 +1,200 @@
+use super::ir::*;
+
+pub fn process_document(doc: &mut GeometryDocument) {
+    normalize_bounds(doc);
+    compose_feature_paths(doc);
+    normalize_bounds(doc);
+}
+
+pub fn normalize_bounds(doc: &mut GeometryDocument) {
+    for contour_index in 0..doc.contours.len() {
+        doc.contours[contour_index].bbox = contour_bbox(doc, contour_index);
+    }
+
+    for path_index in 0..doc.paths.len() {
+        doc.paths[path_index].bbox = path_bbox(doc, path_index);
+    }
+
+    for feature_index in 0..doc.features.len() {
+        doc.features[feature_index].bbox = feature_bbox(doc, feature_index);
+    }
+
+    for layer_index in 0..doc.layers.len() {
+        doc.layers[layer_index].bbox = layer_bbox(doc, layer_index);
+    }
+}
+
+pub fn compose_feature_paths(doc: &mut GeometryDocument) {
+    let feature_count = doc.features.len();
+    for feature_index in 0..feature_count {
+        let feature = doc.features[feature_index].clone();
+        if feature.path_count < 2 {
+            continue;
+        }
+
+        let paths = &doc.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize];
+        let Some(first) = paths.first() else {
+            continue;
+        };
+        if !paths.iter().all(|path| compatible_paths(first, path)) {
+            continue;
+        }
+
+        let mut contours = Vec::new();
+        for path in paths {
+            for contour in &doc.contours
+                [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+            {
+                let cmds = doc.path_cmds
+                    [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+                    .to_vec();
+                contours.push((contour.bbox, cmds));
+            }
+        }
+
+        let mut path = first.clone();
+        path.bbox = BBox::empty();
+        let path_id = doc.push_compound_path(path, contours);
+        let feature = &mut doc.features[feature_index];
+        feature.path_start = path_id;
+        feature.path_count = 1;
+    }
+}
+
+fn compatible_paths(a: &GeometryPath, b: &GeometryPath) -> bool {
+    a.flags.filled == b.flags.filled
+        && a.flags.stroked == b.flags.stroked
+        && (!a.flags.filled || a.fill_rule == b.fill_rule)
+        && (!a.flags.stroked || (a.stroke_width == b.stroke_width && a.line_cap == b.line_cap))
+}
+
+fn contour_bbox(doc: &GeometryDocument, contour_index: usize) -> BBox {
+    let contour = &doc.contours[contour_index];
+    let mut bbox = BBox::empty();
+    let mut current = Point::default();
+    for cmd in
+        &doc.path_cmds[contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+    {
+        match cmd.op {
+            PathOp::MoveTo | PathOp::LineTo => {
+                current = cmd.p0;
+                bbox.include_point(cmd.p0);
+            }
+            PathOp::ArcTo => {
+                bbox.include_circular_arc(current, cmd.p0, cmd.p1, cmd.clockwise);
+                current = cmd.p0;
+            }
+            PathOp::CubicTo => {
+                bbox.include_point(cmd.p0);
+                bbox.include_point(cmd.p1);
+                bbox.include_point(cmd.p2);
+                current = cmd.p2;
+            }
+            PathOp::Close => {}
+        }
+    }
+    bbox
+}
+
+fn path_bbox(doc: &GeometryDocument, path_index: usize) -> BBox {
+    let path = &doc.paths[path_index];
+    let bbox = doc.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+        .iter()
+        .fold(BBox::empty(), |bbox, contour| bbox.union(contour.bbox));
+
+    if path.flags.stroked {
+        bbox.expand(path.stroke_width / 2.0)
+    } else {
+        bbox
+    }
+}
+
+fn feature_bbox(doc: &GeometryDocument, feature_index: usize) -> BBox {
+    let feature = &doc.features[feature_index];
+    doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+        .iter()
+        .fold(BBox::empty(), |bbox, path| bbox.union(path.bbox))
+}
+
+fn layer_bbox(doc: &GeometryDocument, layer_index: usize) -> BBox {
+    let layer = &doc.layers[layer_index];
+    doc.features[layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
+        .iter()
+        .fold(BBox::empty(), |bbox, feature| bbox.union(feature.bbox))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composes_compatible_stroked_feature_paths() {
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(10.0, 0.0),
+        };
+        doc.push_path(
+            GeometryPath::stroked(2.0, LineCap::Round, bbox),
+            [
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(5.0, 0.0)),
+            ],
+        );
+        doc.push_path(
+            GeometryPath::stroked(2.0, LineCap::Round, bbox),
+            [
+                PathCmd::move_to(Point::new(5.0, 0.0)),
+                PathCmd::line_to(Point::new(10.0, 0.0)),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 2,
+            ..GeometryFeature::new(
+                FeatureKind::Trace,
+                FeatureBucket::Trace,
+                GeometryPolarity::Positive,
+            )
+        });
+
+        process_document(&mut doc);
+
+        assert_eq!(doc.features[0].path_count, 1);
+        let path = &doc.paths[doc.features[0].path_start as usize];
+        assert_eq!(path.contour_count, 2);
+        assert_eq!(path.bbox.min, Point::new(-1.0, -1.0));
+        assert_eq!(path.bbox.max, Point::new(11.0, 1.0));
+    }
+
+    #[test]
+    fn leaves_incompatible_feature_paths_separate() {
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(1.0, 1.0),
+        };
+        doc.push_path(
+            GeometryPath::filled(FillRule::EvenOdd, bbox),
+            [PathCmd::move_to(Point::new(0.0, 0.0)), PathCmd::close()],
+        );
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, bbox),
+            [PathCmd::move_to(Point::new(1.0, 1.0)), PathCmd::close()],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 2,
+            ..GeometryFeature::new(
+                FeatureKind::Padstack,
+                FeatureBucket::Thermal,
+                GeometryPolarity::Positive,
+            )
+        });
+
+        process_document(&mut doc);
+
+        assert_eq!(doc.features[0].path_start, 0);
+        assert_eq!(doc.features[0].path_count, 2);
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -24,6 +24,7 @@ pub fn process_document(doc: &mut GeometryDocument) {
     outline_stroked_paths(doc);
     union_feature_filled_paths(doc);
     coalesce_related_trace_features(doc);
+    resolve_negative_polarity(doc);
     subtract_layer_cutouts(doc);
     normalize_bounds(doc);
 }
@@ -211,6 +212,42 @@ pub fn coalesce_related_trace_features(doc: &mut GeometryDocument) {
     }
 }
 
+pub fn resolve_negative_polarity(doc: &mut GeometryDocument) {
+    for layer_index in 0..doc.layers.len() {
+        let layer = doc.layers[layer_index].clone();
+        let negative_features = layer_features(&layer)
+            .filter(|&feature_index| {
+                let feature = &doc.features[feature_index];
+                feature.bucket != FeatureBucket::Cutout
+                    && feature.polarity == GeometryPolarity::Negative
+            })
+            .collect::<Vec<_>>();
+        let mut cutters = negative_features
+            .iter()
+            .flat_map(|&feature_index| feature_filled_contours(doc, &doc.features[feature_index]))
+            .collect::<Vec<_>>();
+        if cutters.is_empty() {
+            continue;
+        }
+        if cutters.len() > 1 {
+            cutters = simplify_polygon_contours(cutters, FillRule::NonZero);
+        }
+
+        for feature_index in layer_features(&layer).collect::<Vec<_>>() {
+            let feature = &doc.features[feature_index];
+            if feature.bucket != FeatureBucket::Cutout
+                && feature.polarity == GeometryPolarity::Positive
+            {
+                subtract_contours_from_feature(doc, feature_index, &cutters);
+            }
+        }
+
+        for feature_index in negative_features {
+            clear_feature_paths(doc, feature_index);
+        }
+    }
+}
+
 pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
     for layer_index in 0..doc.layers.len() {
         let layer = doc.layers[layer_index].clone();
@@ -225,32 +262,38 @@ pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
                 continue;
             }
 
-            let paths = &doc.paths
-                [feature.path_start as usize..(feature.path_start + feature.path_count) as usize];
-            if paths.is_empty() || !paths.iter().all(|path| path.flags.filled) {
-                continue;
-            }
-            let subject = feature_filled_contours(doc, &feature);
-            if subject.is_empty() {
-                continue;
-            }
-
-            let result =
-                subject.overlay(&cutouts, OverlayRule::Difference, OverlayFillRule::NonZero);
-            let contours = polygon_shapes_to_contours(result);
-            if contours.is_empty() {
-                clear_feature_paths(doc, feature_index as usize);
-                continue;
-            }
-
-            replace_feature_with_compound_path(
-                doc,
-                feature_index as usize,
-                GeometryPath::filled(FillRule::NonZero, BBox::empty()),
-                contours,
-            );
+            subtract_contours_from_feature(doc, feature_index as usize, &cutouts);
         }
     }
+}
+
+fn subtract_contours_from_feature(
+    doc: &mut GeometryDocument,
+    feature_index: usize,
+    cutters: &Vec<PolygonContour>,
+) {
+    let subject = feature_filled_contours(doc, &doc.features[feature_index]);
+    if subject.is_empty() {
+        return;
+    }
+
+    let result = subject.overlay(cutters, OverlayRule::Difference, OverlayFillRule::NonZero);
+    let contours = polygon_shapes_to_contours(result);
+    if contours.is_empty() {
+        clear_feature_paths(doc, feature_index);
+        return;
+    }
+
+    replace_feature_with_compound_path(
+        doc,
+        feature_index,
+        GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+        contours,
+    );
+}
+
+fn layer_features(layer: &GeometryLayer) -> impl Iterator<Item = usize> + '_ {
+    (layer.feature_start..layer.feature_start + layer.feature_count).map(|index| index as usize)
 }
 
 fn compatible_paths(a: &GeometryPath, b: &GeometryPath) -> bool {
@@ -851,6 +894,73 @@ mod tests {
         assert_eq!(path.contour_count, 1);
         assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
         assert_eq!(path.bbox.max, Point::new(3.0, 1.0));
+    }
+
+    #[test]
+    fn resolves_negative_polarity_as_layer_subtraction() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(0.0, 0.0, 4.0, 4.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 1.0, 3.0, 3.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Negative,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 2,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        let feature = &doc.features[0];
+        let path = &doc.paths[feature.path_start as usize];
+        assert_eq!(feature.path_count, 1);
+        assert!(path.contour_count > 1);
+        assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(path.bbox.max, Point::new(4.0, 4.0));
+        assert_eq!(doc.features[1].path_count, 0);
+        assert!(doc.features[1].bbox.is_empty());
+    }
+
+    #[test]
+    fn converts_full_circle_arc_to_polygon_contours() {
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            [
+                PathCmd::move_to(Point::new(1.0, 0.0)),
+                PathCmd::arc_to(Point::new(1.0, 0.0), Point::new(0.0, 0.0), false),
+                PathCmd::close(),
+            ],
+        );
+
+        let contours = path_polygon_contours(&doc, &doc.paths[0]);
+
+        assert_eq!(contours.len(), 1);
+        assert!(contours[0].len() > 8);
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/raster.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/raster.rs
@@ -1,0 +1,78 @@
+use anyhow::{Context, Result};
+use resvg::{tiny_skia, usvg};
+
+use super::ir::GeometryDocument;
+
+const DEFAULT_MAX_DIMENSION_PX: u32 = 3200;
+
+pub fn render_layer_png(doc: &GeometryDocument, layer_index: usize) -> Result<Vec<u8>> {
+    render_layer_png_with_max_dimension(doc, layer_index, DEFAULT_MAX_DIMENSION_PX)
+}
+
+pub fn render_layer_png_with_max_dimension(
+    doc: &GeometryDocument,
+    layer_index: usize,
+    max_dimension_px: u32,
+) -> Result<Vec<u8>> {
+    let (width_px, height_px) = pixel_size_for_layer(doc, layer_index, max_dimension_px);
+    let svg = super::svg::render_layer_svg_sized(doc, layer_index, width_px, height_px);
+    svg_to_png(&svg)
+}
+
+fn svg_to_png(svg: &str) -> Result<Vec<u8>> {
+    let options = usvg::Options::default();
+    let tree = usvg::Tree::from_data(svg.as_bytes(), &options).context("Failed to parse SVG")?;
+    let size = tree.size();
+    let width = size.width().ceil().max(1.0) as u32;
+    let height = size.height().ceil().max(1.0) as u32;
+    let mut pixmap = tiny_skia::Pixmap::new(width, height)
+        .with_context(|| format!("Failed to allocate {width}x{height} PNG raster"))?;
+
+    resvg::render(
+        &tree,
+        tiny_skia::Transform::identity(),
+        &mut pixmap.as_mut(),
+    );
+
+    pixmap.encode_png().context("Failed to encode PNG")
+}
+
+fn pixel_size_for_layer(
+    doc: &GeometryDocument,
+    layer_index: usize,
+    max_dimension_px: u32,
+) -> (u32, u32) {
+    let bbox = doc.layers[layer_index].bbox;
+    if bbox.is_empty() || bbox.width() <= 0.0 || bbox.height() <= 0.0 {
+        return (max_dimension_px, max_dimension_px);
+    }
+
+    let scale = max_dimension_px as f64 / bbox.width().max(bbox.height());
+    let width = (bbox.width() * scale).ceil().max(1.0) as u32;
+    let height = (bbox.height() * scale).ceil().max(1.0) as u32;
+    (width, height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geometry::ir::{BBox, GeometryLayer, Point};
+
+    #[test]
+    fn preserves_layer_aspect_ratio_for_png_size() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 0,
+            bbox: BBox {
+                min: Point::new(10.0, 20.0),
+                max: Point::new(50.0, 40.0),
+            },
+        });
+
+        assert_eq!(pixel_size_for_layer(&doc, 0, 1600), (1600, 800));
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -56,15 +56,6 @@ fn render_layer_svg_with_size(
     writeln!(svg, "  <title>{}</title>", escape_xml(&doc.board_name)).unwrap();
     writeln!(
         svg,
-        "  <rect x='{}' y='{}' width='{}' height='{}' fill='black'/>",
-        fmt_num(geometry_bbox.min.x),
-        fmt_num(viewbox_y),
-        fmt_num(geometry_bbox.width()),
-        fmt_num(geometry_bbox.height())
-    )
-    .unwrap();
-    writeln!(
-        svg,
         "  <g data-layer='{}' transform='scale(1 -1)'>",
         escape_xml(&layer.name)
     )
@@ -73,20 +64,35 @@ fn render_layer_svg_with_size(
     for feature in &doc.features
         [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
     {
-        if feature.bucket == FeatureBucket::Cutout {
-            continue;
-        }
+        write_feature_paths(&mut svg, doc, feature, false);
+    }
 
-        for path in &doc.paths
-            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
-        {
-            write_path(&mut svg, doc, feature, path);
-        }
+    for feature in &doc.features
+        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
+    {
+        write_feature_paths(&mut svg, doc, feature, true);
     }
 
     writeln!(svg, "  </g>").unwrap();
     writeln!(svg, "</svg>").unwrap();
     svg
+}
+
+fn write_feature_paths(
+    svg: &mut String,
+    doc: &GeometryDocument,
+    feature: &GeometryFeature,
+    cutouts: bool,
+) {
+    if (feature.bucket == FeatureBucket::Cutout) != cutouts {
+        return;
+    }
+
+    for path in
+        &doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+    {
+        write_path(svg, doc, feature, path);
+    }
 }
 
 fn write_path(
@@ -352,7 +358,7 @@ mod tests {
     }
 
     #[test]
-    fn does_not_render_cutout_features_as_positive_geometry() {
+    fn renders_cutout_features_after_positive_geometry() {
         let mut interner = ipc2581::Interner::new();
         let mut doc = GeometryDocument::new("test".to_string());
         let bbox = BBox {
@@ -372,6 +378,25 @@ mod tests {
             path_count: 1,
             bbox,
             ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, bbox),
+            [
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(1.0, 0.0)),
+                PathCmd::line_to(Point::new(1.0, 1.0)),
+                PathCmd::close(),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_start: 1,
+            path_count: 1,
+            bbox,
+            ..GeometryFeature::new(
                 FeatureKind::Hole,
                 FeatureBucket::Cutout,
                 GeometryPolarity::Positive,
@@ -381,12 +406,13 @@ mod tests {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
             feature_start: 0,
-            feature_count: 1,
+            feature_count: 2,
             bbox,
         });
 
         let svg = render_layer_svg(&doc, 0);
 
-        assert_eq!(svg.matches("<path d='").count(), 0);
+        assert_eq!(svg.matches("<path d='").count(), 2);
+        assert!(svg.find("fill='#2f9e44'").unwrap() < svg.find("fill='#64748b'").unwrap());
     }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -120,7 +120,7 @@ fn write_path(
             line_cap(path.line_cap)
         )
         .unwrap();
-    } else {
+    } else if path.flags.filled {
         writeln!(
             svg,
             "    <path d='{}' fill='{}' fill-opacity='{}' fill-rule='{}'/>",

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -1,0 +1,279 @@
+use std::fmt::Write;
+
+use super::ir::*;
+
+pub fn render_layer_svg(doc: &GeometryDocument, layer_index: usize) -> String {
+    render_layer_svg_with_size(doc, layer_index, None)
+}
+
+pub fn render_layer_svg_sized(
+    doc: &GeometryDocument,
+    layer_index: usize,
+    width_px: u32,
+    height_px: u32,
+) -> String {
+    render_layer_svg_with_size(doc, layer_index, Some((width_px, height_px)))
+}
+
+fn render_layer_svg_with_size(
+    doc: &GeometryDocument,
+    layer_index: usize,
+    pixel_size: Option<(u32, u32)>,
+) -> String {
+    let layer = &doc.layers[layer_index];
+    let geometry_bbox = if layer.bbox.is_empty() {
+        BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(100.0, 100.0),
+        }
+    } else {
+        layer.bbox
+    };
+    let viewbox_y = -geometry_bbox.max.y;
+
+    let mut svg = String::new();
+    if let Some((width_px, height_px)) = pixel_size {
+        writeln!(
+            svg,
+            "<svg xmlns='http://www.w3.org/2000/svg' width='{width_px}' height='{height_px}' viewBox='{} {} {} {}'>",
+            fmt_num(geometry_bbox.min.x),
+            fmt_num(viewbox_y),
+            fmt_num(geometry_bbox.width()),
+            fmt_num(geometry_bbox.height())
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            svg,
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='{} {} {} {}'>",
+            fmt_num(geometry_bbox.min.x),
+            fmt_num(viewbox_y),
+            fmt_num(geometry_bbox.width()),
+            fmt_num(geometry_bbox.height())
+        )
+        .unwrap();
+    }
+    writeln!(svg, "  <title>{}</title>", escape_xml(&doc.board_name)).unwrap();
+    writeln!(
+        svg,
+        "  <rect x='{}' y='{}' width='{}' height='{}' fill='black'/>",
+        fmt_num(geometry_bbox.min.x),
+        fmt_num(viewbox_y),
+        fmt_num(geometry_bbox.width()),
+        fmt_num(geometry_bbox.height())
+    )
+    .unwrap();
+    writeln!(
+        svg,
+        "  <g data-layer='{}' transform='scale(1 -1)'>",
+        escape_xml(&layer.name)
+    )
+    .unwrap();
+
+    for feature in &doc.features
+        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
+    {
+        for path in &doc.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+        {
+            write_path(&mut svg, doc, feature, path);
+        }
+    }
+
+    writeln!(svg, "  </g>").unwrap();
+    writeln!(svg, "</svg>").unwrap();
+    svg
+}
+
+fn write_path(
+    svg: &mut String,
+    doc: &GeometryDocument,
+    feature: &GeometryFeature,
+    path: &GeometryPath,
+) {
+    let d = path_data(doc, path);
+    let color = color_for_bucket(feature.bucket, feature.polarity);
+    let opacity = opacity_for_bucket(feature.bucket, feature.polarity);
+    let fill_rule = match path.fill_rule {
+        FillRule::NonZero => "nonzero",
+        FillRule::EvenOdd => "evenodd",
+    };
+
+    if path.flags.stroked {
+        writeln!(
+            svg,
+            "    <path d='{}' fill='none' stroke='{}' stroke-opacity='{}' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='round'/>",
+            d,
+            color,
+            fmt_num(opacity),
+            fmt_num(path.stroke_width),
+            line_cap(path.line_cap)
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            svg,
+            "    <path d='{}' fill='{}' fill-opacity='{}' fill-rule='{}'/>",
+            d,
+            color,
+            fmt_num(opacity),
+            fill_rule
+        )
+        .unwrap();
+    }
+}
+
+fn path_data(doc: &GeometryDocument, path: &GeometryPath) -> String {
+    let mut data = String::new();
+    let mut current = Point::default();
+    for cmd in &doc.path_cmds[path.cmd_start as usize..(path.cmd_start + path.cmd_count) as usize] {
+        match cmd.op {
+            PathOp::MoveTo => {
+                current = cmd.p0;
+                write!(data, "M{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap()
+            }
+            PathOp::LineTo => {
+                current = cmd.p0;
+                write!(data, " L{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap()
+            }
+            PathOp::ArcTo => {
+                let radius = current.distance_to(cmd.p1);
+                let large_arc = u8::from(
+                    arc_sweep_radians(current, cmd.p0, cmd.p1, cmd.clockwise)
+                        > std::f64::consts::PI,
+                );
+                let sweep = if cmd.clockwise { 0 } else { 1 };
+                current = cmd.p0;
+                write!(
+                    data,
+                    " A{} {} 0 {} {} {} {}",
+                    fmt_num(radius),
+                    fmt_num(radius),
+                    large_arc,
+                    sweep,
+                    fmt_num(cmd.p0.x),
+                    fmt_num(cmd.p0.y)
+                )
+                .unwrap()
+            }
+            PathOp::CubicTo => write!(
+                data,
+                " C{} {},{} {},{} {}",
+                fmt_num(cmd.p0.x),
+                fmt_num(cmd.p0.y),
+                fmt_num(cmd.p1.x),
+                fmt_num(cmd.p1.y),
+                fmt_num(cmd.p2.x),
+                fmt_num(cmd.p2.y)
+            )
+            .map(|_| current = cmd.p2)
+            .unwrap(),
+            PathOp::Close => data.push_str(" Z"),
+        }
+    }
+    data
+}
+
+fn color_for_bucket(bucket: FeatureBucket, polarity: GeometryPolarity) -> &'static str {
+    if polarity == GeometryPolarity::Negative {
+        return "#111827";
+    }
+
+    match bucket {
+        FeatureBucket::Smd => "#d97706",
+        FeatureBucket::Pth => "#7c3aed",
+        FeatureBucket::Via => "#2563eb",
+        FeatureBucket::Trace => "#c2410c",
+        FeatureBucket::Fill => "#2f9e44",
+        FeatureBucket::Cutout => "#64748b",
+        FeatureBucket::Thermal => "#ca8a04",
+        FeatureBucket::Antipad => "#64748b",
+    }
+}
+
+fn opacity_for_bucket(bucket: FeatureBucket, polarity: GeometryPolarity) -> f64 {
+    if polarity == GeometryPolarity::Negative {
+        return 0.8;
+    }
+
+    match bucket {
+        FeatureBucket::Fill => 0.82,
+        FeatureBucket::Trace => 0.95,
+        FeatureBucket::Smd | FeatureBucket::Pth => 0.95,
+        FeatureBucket::Via => 0.9,
+        FeatureBucket::Cutout | FeatureBucket::Antipad => 0.85,
+        FeatureBucket::Thermal => 0.92,
+    }
+}
+
+fn line_cap(line_cap: LineCap) -> &'static str {
+    match line_cap {
+        LineCap::Round => "round",
+        LineCap::Square => "square",
+        LineCap::Butt => "butt",
+    }
+}
+
+fn fmt_num(value: f64) -> String {
+    let value = if value.abs() < 0.000_000_5 {
+        0.0
+    } else {
+        value
+    };
+    format!("{value:.6}")
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_string()
+}
+
+fn escape_xml(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_arc_path_command_without_flattening() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let mut bbox = BBox::empty();
+        bbox.include_point(Point::new(-1.0, 0.0));
+        bbox.include_point(Point::new(1.0, 0.0));
+        bbox.include_point(Point::new(0.0, -1.0));
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, bbox),
+            [
+                PathCmd::move_to(Point::new(1.0, 0.0)),
+                PathCmd::arc_to(Point::new(-1.0, 0.0), Point::new(0.0, 0.0), true),
+                PathCmd::close(),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            bbox,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 1,
+            bbox,
+        });
+
+        let svg = render_layer_svg(&doc, 0);
+
+        assert!(svg.contains(" A1 1 0 0 0 -1 0"));
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -156,11 +156,33 @@ fn path_data(doc: &GeometryDocument, path: &GeometryPath) -> String {
                 }
                 PathOp::ArcTo => {
                     let radius = current.distance_to(cmd.p1);
+                    let sweep = if cmd.clockwise { 0 } else { 1 };
+                    if current.distance_to(cmd.p0) <= 1e-9 && radius > 0.0 {
+                        let mid =
+                            Point::new(2.0 * cmd.p1.x - current.x, 2.0 * cmd.p1.y - current.y);
+                        write!(
+                            data,
+                            " A{} {} 0 0 {} {} {} A{} {} 0 0 {} {} {}",
+                            fmt_num(radius),
+                            fmt_num(radius),
+                            sweep,
+                            fmt_num(mid.x),
+                            fmt_num(mid.y),
+                            fmt_num(radius),
+                            fmt_num(radius),
+                            sweep,
+                            fmt_num(cmd.p0.x),
+                            fmt_num(cmd.p0.y)
+                        )
+                        .unwrap();
+                        current = cmd.p0;
+                        continue;
+                    }
+
                     let large_arc = u8::from(
                         arc_sweep_radians(current, cmd.p0, cmd.p1, cmd.clockwise)
                             > std::f64::consts::PI,
                     );
-                    let sweep = if cmd.clockwise { 0 } else { 1 };
                     current = cmd.p0;
                     write!(
                         data,
@@ -294,6 +316,44 @@ mod tests {
         let svg = render_layer_svg(&doc, 0);
 
         assert!(svg.contains(" A1 1 0 0 0 -1 0"));
+    }
+
+    #[test]
+    fn renders_full_circle_arc_as_two_svg_arcs() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(-1.0, -1.0),
+            max: Point::new(1.0, 1.0),
+        };
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, bbox),
+            [
+                PathCmd::move_to(Point::new(1.0, 0.0)),
+                PathCmd::arc_to(Point::new(1.0, 0.0), Point::new(0.0, 0.0), false),
+                PathCmd::close(),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            bbox,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 1,
+            bbox,
+        });
+
+        let svg = render_layer_svg(&doc, 0);
+
+        assert!(svg.contains(" A1 1 0 0 1 -1 0 A1 1 0 0 1 1 0"));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -125,50 +125,59 @@ fn write_path(
 
 fn path_data(doc: &GeometryDocument, path: &GeometryPath) -> String {
     let mut data = String::new();
-    let mut current = Point::default();
-    for cmd in &doc.path_cmds[path.cmd_start as usize..(path.cmd_start + path.cmd_count) as usize] {
-        match cmd.op {
-            PathOp::MoveTo => {
-                current = cmd.p0;
-                write!(data, "M{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap()
-            }
-            PathOp::LineTo => {
-                current = cmd.p0;
-                write!(data, " L{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap()
-            }
-            PathOp::ArcTo => {
-                let radius = current.distance_to(cmd.p1);
-                let large_arc = u8::from(
-                    arc_sweep_radians(current, cmd.p0, cmd.p1, cmd.clockwise)
-                        > std::f64::consts::PI,
-                );
-                let sweep = if cmd.clockwise { 0 } else { 1 };
-                current = cmd.p0;
-                write!(
+    for contour in &doc.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+    {
+        let mut current = Point::default();
+        for cmd in &doc.path_cmds
+            [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+        {
+            match cmd.op {
+                PathOp::MoveTo => {
+                    current = cmd.p0;
+                    if !data.is_empty() {
+                        data.push(' ');
+                    }
+                    write!(data, "M{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap()
+                }
+                PathOp::LineTo => {
+                    current = cmd.p0;
+                    write!(data, " L{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap()
+                }
+                PathOp::ArcTo => {
+                    let radius = current.distance_to(cmd.p1);
+                    let large_arc = u8::from(
+                        arc_sweep_radians(current, cmd.p0, cmd.p1, cmd.clockwise)
+                            > std::f64::consts::PI,
+                    );
+                    let sweep = if cmd.clockwise { 0 } else { 1 };
+                    current = cmd.p0;
+                    write!(
+                        data,
+                        " A{} {} 0 {} {} {} {}",
+                        fmt_num(radius),
+                        fmt_num(radius),
+                        large_arc,
+                        sweep,
+                        fmt_num(cmd.p0.x),
+                        fmt_num(cmd.p0.y)
+                    )
+                    .unwrap()
+                }
+                PathOp::CubicTo => write!(
                     data,
-                    " A{} {} 0 {} {} {} {}",
-                    fmt_num(radius),
-                    fmt_num(radius),
-                    large_arc,
-                    sweep,
+                    " C{} {},{} {},{} {}",
                     fmt_num(cmd.p0.x),
-                    fmt_num(cmd.p0.y)
+                    fmt_num(cmd.p0.y),
+                    fmt_num(cmd.p1.x),
+                    fmt_num(cmd.p1.y),
+                    fmt_num(cmd.p2.x),
+                    fmt_num(cmd.p2.y)
                 )
-                .unwrap()
+                .map(|_| current = cmd.p2)
+                .unwrap(),
+                PathOp::Close => data.push_str(" Z"),
             }
-            PathOp::CubicTo => write!(
-                data,
-                " C{} {},{} {},{} {}",
-                fmt_num(cmd.p0.x),
-                fmt_num(cmd.p0.y),
-                fmt_num(cmd.p1.x),
-                fmt_num(cmd.p1.y),
-                fmt_num(cmd.p2.x),
-                fmt_num(cmd.p2.y)
-            )
-            .map(|_| current = cmd.p2)
-            .unwrap(),
-            PathOp::Close => data.push_str(" Z"),
         }
     }
     data
@@ -275,5 +284,66 @@ mod tests {
         let svg = render_layer_svg(&doc, 0);
 
         assert!(svg.contains(" A1 1 0 0 0 -1 0"));
+    }
+
+    #[test]
+    fn renders_compound_path_contours_as_one_svg_path() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let outer = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(10.0, 10.0),
+        };
+        let inner = BBox {
+            min: Point::new(2.0, 2.0),
+            max: Point::new(4.0, 4.0),
+        };
+        doc.push_compound_path(
+            GeometryPath::filled(FillRule::EvenOdd, BBox::empty()),
+            [
+                (
+                    outer,
+                    vec![
+                        PathCmd::move_to(Point::new(0.0, 0.0)),
+                        PathCmd::line_to(Point::new(10.0, 0.0)),
+                        PathCmd::line_to(Point::new(10.0, 10.0)),
+                        PathCmd::line_to(Point::new(0.0, 10.0)),
+                        PathCmd::close(),
+                    ],
+                ),
+                (
+                    inner,
+                    vec![
+                        PathCmd::move_to(Point::new(2.0, 2.0)),
+                        PathCmd::line_to(Point::new(4.0, 2.0)),
+                        PathCmd::line_to(Point::new(4.0, 4.0)),
+                        PathCmd::line_to(Point::new(2.0, 4.0)),
+                        PathCmd::close(),
+                    ],
+                ),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            bbox: outer,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 1,
+            bbox: outer,
+        });
+
+        let svg = render_layer_svg(&doc, 0);
+
+        assert_eq!(svg.matches("<path d='").count(), 1);
+        assert!(svg.contains(" Z M2 2"));
+        assert!(svg.contains("fill-rule='evenodd'"));
     }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -73,6 +73,10 @@ fn render_layer_svg_with_size(
     for feature in &doc.features
         [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
     {
+        if feature.bucket == FeatureBucket::Cutout {
+            continue;
+        }
+
         for path in &doc.paths
             [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
         {
@@ -345,5 +349,44 @@ mod tests {
         assert_eq!(svg.matches("<path d='").count(), 1);
         assert!(svg.contains(" Z M2 2"));
         assert!(svg.contains("fill-rule='evenodd'"));
+    }
+
+    #[test]
+    fn does_not_render_cutout_features_as_positive_geometry() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(1.0, 1.0),
+        };
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, bbox),
+            [
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(1.0, 0.0)),
+                PathCmd::line_to(Point::new(1.0, 1.0)),
+                PathCmd::close(),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            bbox,
+            ..GeometryFeature::new(
+                FeatureKind::Hole,
+                FeatureBucket::Cutout,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 1,
+            bbox,
+        });
+
+        let svg = render_layer_svg(&doc, 0);
+
+        assert_eq!(svg.matches("<path d='").count(), 0);
     }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/terminal.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/terminal.rs
@@ -37,8 +37,7 @@ fn terminal_max_dimension_px() -> u32 {
 
     u32::from(columns)
         .saturating_mul(12)
-        .max(1)
-        .min(MAX_TERMINAL_DIMENSION_PX)
+        .clamp(1, MAX_TERMINAL_DIMENSION_PX)
 }
 
 fn write_kitty_png<W: Write>(writer: &mut W, png: &[u8]) -> io::Result<()> {

--- a/crates/pcb-ipc2581-tools/src/geometry/terminal.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/terminal.rs
@@ -1,0 +1,80 @@
+use std::io::{self, IsTerminal, Write};
+
+use anyhow::{Result, bail};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use terminal_size::{Width, terminal_size};
+
+use super::ir::GeometryDocument;
+
+const KITTY_CHUNK_SIZE: usize = 4096;
+const MAX_TERMINAL_DIMENSION_PX: u32 = 1200;
+
+pub fn can_render_to_terminal() -> bool {
+    io::stdout().is_terminal()
+}
+
+pub fn render_layer_to_terminal(doc: &GeometryDocument, layer_index: usize) -> Result<()> {
+    if !io::stdout().is_terminal() {
+        bail!("stdout is not an interactive terminal; pass --output <path>.svg or <path>.png");
+    }
+
+    let png = super::raster::render_layer_png_with_max_dimension(
+        doc,
+        layer_index,
+        terminal_max_dimension_px(),
+    )?;
+    let mut stdout = io::stdout().lock();
+    write_kitty_png(&mut stdout, &png)?;
+    stdout.write_all(b"\n")?;
+    Ok(())
+}
+
+fn terminal_max_dimension_px() -> u32 {
+    let Some((Width(columns), _)) = terminal_size() else {
+        return MAX_TERMINAL_DIMENSION_PX;
+    };
+
+    u32::from(columns)
+        .saturating_mul(12)
+        .max(1)
+        .min(MAX_TERMINAL_DIMENSION_PX)
+}
+
+fn write_kitty_png<W: Write>(writer: &mut W, png: &[u8]) -> io::Result<()> {
+    let encoded = STANDARD.encode(png);
+    let mut chunks = encoded.as_bytes().chunks(KITTY_CHUNK_SIZE).peekable();
+    let mut first = true;
+
+    while let Some(chunk) = chunks.next() {
+        let more = u8::from(chunks.peek().is_some());
+        if first {
+            write!(writer, "\x1b_Ga=T,f=100,m={more};")?;
+            first = false;
+        } else {
+            write!(writer, "\x1b_Gm={more};")?;
+        }
+        writer.write_all(chunk)?;
+        writer.write_all(b"\x1b\\")?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kitty_png_writer_chunks_payload() {
+        let mut out = Vec::new();
+        let png = vec![0u8; KITTY_CHUNK_SIZE];
+
+        write_kitty_png(&mut out, &png).unwrap();
+
+        let out = String::from_utf8(out).unwrap();
+        assert!(out.starts_with("\x1b_Ga=T,f=100,m=1;"));
+        assert!(out.contains("\x1b_Gm=0;"));
+        assert!(out.ends_with("\x1b\\"));
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 
 pub mod accessors;
 pub mod commands;
+pub mod geometry;
 pub mod utils;
 
 // Re-export ipc2581 for external use
@@ -11,6 +12,13 @@ pub use ipc2581;
 pub enum OutputFormat {
     Text,
     Json,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy)]
+pub enum RenderFormat {
+    Auto,
+    Svg,
+    Png,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]

--- a/crates/pcb/src/ipc2581.rs
+++ b/crates/pcb/src/ipc2581.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
-use pcb_ipc2581_tools::{OutputFormat, UnitFormat, ViewMode, commands, utils};
+use pcb_ipc2581_tools::{OutputFormat, RenderFormat, UnitFormat, ViewMode, commands, utils};
 
 #[derive(Args)]
 pub struct Ipc2581Args {
@@ -59,6 +59,21 @@ enum Commands {
         /// Unit format for dimensions
         #[arg(short, long, default_value = "mm")]
         units: UnitFormat,
+    },
+    /// Render processed geometry for a single IPC-2581 layer
+    Render {
+        /// IPC-2581 XML file to render from
+        #[arg(value_hint = clap::ValueHint::FilePath)]
+        file: PathBuf,
+        /// Layer name to render, for example TOP or BOTTOM
+        #[arg(short, long)]
+        layer: String,
+        /// Output file path. If omitted, auto renders to the terminal when possible.
+        #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
+        output: Option<PathBuf>,
+        /// Render format. Auto infers SVG/PNG from the output extension or uses terminal graphics.
+        #[arg(short, long, default_value = "auto")]
+        format: RenderFormat,
     },
 }
 
@@ -120,5 +135,18 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             output,
             units,
         } => commands::html_export::execute(&file, output.as_deref(), units),
+        Commands::Render {
+            file,
+            layer,
+            output,
+            format,
+        } => commands::render::execute(
+            &file,
+            &commands::render::RenderOptions {
+                layer,
+                output,
+                format,
+            },
+        ),
     }
 }


### PR DESCRIPTION
Usage:
`pcb ipc2581 render --layer F.Cu <path to icp2581 xml>`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new IPC-2581 geometry extraction/rendering pipeline plus new parsing fields (`LayerSpan`, slot `z_axis_dim`), which could affect layer/slot interpretation and introduces new rendering/overlay dependencies.
> 
> **Overview**
> Adds a new `pcb ipc2581 render` subcommand that extracts a single IPC-2581 layer, processes its geometry (trace stroking/union, polarity resolution, and layer cutout subtraction), and renders it as **SVG**, **PNG**, or Kitty terminal graphics when no output path is provided.
> 
> Extends the IPC-2581 parser/types to capture per-layer `Span` (`LayerSpan`) and detect slot/cavity Z-axis depth (`z_axis_dim`) so cutouts are only applied to the appropriate layers; also preserves `PolyStepCurve` arc geometry when emitting SVG paths and increases the default PNG render resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f82484838621d2f5b7c97645a6e45607c1883a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->