### PR TITLE
[codex] warn when layout is missing Board macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `pcb new board <name> <repo-url>` now creates a board repository directly, replacing the separate `pcb new workspace` flow.
 - `pcb import` now writes directly into a board repository root instead of creating `boards/<name>/` under a workspace.
 - Increased default `pcb ipc2581 render` PNG resolution.
+- `pcb layout` now warns when a design is missing a `Board` macro and prints a suggested insertion.
 
 ## [0.3.81] - 2026-05-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4402,6 +4402,7 @@ name = "pcb"
 version = "0.3.81"
 dependencies = [
  "anyhow",
+ "ariadne",
  "axoupdater",
  "canon-json",
  "chrono",

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+ariadne = { workspace = true }
 clap = { workspace = true }
 glam = { workspace = true }
 pcb-zen-core = { workspace = true, features = ["table"] }

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -1,12 +1,57 @@
 use anyhow::Result;
+use ariadne::{Label, Report, ReportKind, sources};
 use clap::Args;
 use pcb_layout::process_layout;
+use pcb_sch::{ATTR_LAYOUT_PATH, Schematic};
 use pcb_ui::prelude::*;
 use std::path::PathBuf;
 
 use crate::build::{build, create_diagnostics_passes};
 use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
 use crate::drc;
+
+fn suggested_board_macro(zen_path: &std::path::Path) -> String {
+    let board_name = zen_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("board");
+    format!(r#"Board(name="{board_name}", layers=4, layout_path="layout/{board_name}")"#)
+}
+
+fn render_missing_board_warning(zen_path: &std::path::Path) {
+    let file_name = zen_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("board.zen");
+    let suggestion = suggested_board_macro(zen_path);
+    let source = std::fs::read_to_string(zen_path).unwrap_or_default();
+    let source_id = zen_path.to_string_lossy().to_string();
+    let insertion = source.chars().count();
+
+    let report = Report::build(
+        ReportKind::Warning,
+        (source_id.clone(), insertion..insertion),
+    )
+    .with_message("layout generation needs a root `Board` macro with `layout_path`")
+    .with_label(
+        Label::new((source_id.clone(), insertion..insertion))
+            .with_message("insert the board declaration here"),
+    )
+    .with_help(format!("add this to {file_name}:\n    {suggestion}"));
+
+    let _ = report
+        .finish()
+        .write(sources([(source_id, source)]), &mut std::io::stderr());
+}
+
+fn schematic_has_string_layout_path(schematic: &Schematic) -> bool {
+    schematic
+        .root_ref
+        .as_ref()
+        .and_then(|root| schematic.instances.get(root))
+        .and_then(|root| root.attributes.get(ATTR_LAYOUT_PATH))
+        .is_some_and(|layout_path| layout_path.string().is_some())
+}
 
 #[derive(Args, Debug, Default, Clone)]
 #[command(about = "Generate PCB layout files from a .zen file")]
@@ -100,6 +145,9 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
             anyhow::bail!("Layout sync failed with errors");
         }
 
+        if !schematic_has_string_layout_path(&schematic) {
+            render_missing_board_warning(zen_path);
+        }
         return Ok(());
     };
     let pcb_file = layout_result.pcb_file.clone();

--- a/crates/pcb/tests/layout.rs
+++ b/crates/pcb/tests/layout.rs
@@ -1,0 +1,34 @@
+use pcb_test_utils::assert_snapshot;
+use pcb_test_utils::sandbox::Sandbox;
+
+const BOARD_WITHOUT_LAYOUT_ZEN: &str = r#"
+vin = Power("VIN")
+gnd = Ground("GND")
+signal = Net("SIGNAL")
+"#;
+
+const BOARD_WITH_NON_STRING_LAYOUT_PATH_ZEN: &str = r#"
+add_property("layout_path", 1)
+
+vin = Power("VIN")
+gnd = Ground("GND")
+signal = Net("SIGNAL")
+"#;
+
+#[test]
+fn missing_board_macro_warning() {
+    let mut sb = Sandbox::new();
+    sb.write("boost_5v.zen", BOARD_WITHOUT_LAYOUT_ZEN);
+
+    let output = sb.snapshot_run("pcb", ["layout", "--no-open", "boost_5v.zen"]);
+    assert_snapshot!("missing_board_macro_warning", output);
+}
+
+#[test]
+fn non_string_layout_path_warning() {
+    let mut sb = Sandbox::new();
+    sb.write("bad_layout_path.zen", BOARD_WITH_NON_STRING_LAYOUT_PATH_ZEN);
+
+    let output = sb.snapshot_run("pcb", ["layout", "--no-open", "bad_layout_path.zen"]);
+    assert_snapshot!("non_string_layout_path_warning", output);
+}

--- a/crates/pcb/tests/snapshots/layout__missing_board_macro_warning.snap
+++ b/crates/pcb/tests/snapshots/layout__missing_board_macro_warning.snap
@@ -1,0 +1,21 @@
+---
+source: crates/pcb/tests/layout.rs
+assertion_line: 16
+expression: output
+---
+Command: pcb layout --no-open boost_5v.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+Warning: layout generation needs a root `Board` macro with `layout_path`
+   ╭─[ boost_5v.zen:4:24 ]
+   │
+ 4 │ signal = Net("SIGNAL")
+   │                        │ 
+   │                        ╰─ insert the board declaration here
+   │ 
+   │ Help: add this to boost_5v.zen:
+   │           Board(name="boost_5v", layers=4, layout_path="layout/boost_5v")
+───╯

--- a/crates/pcb/tests/snapshots/layout__non_string_layout_path_warning.snap
+++ b/crates/pcb/tests/snapshots/layout__non_string_layout_path_warning.snap
@@ -1,0 +1,21 @@
+---
+source: crates/pcb/tests/layout.rs
+assertion_line: 33
+expression: output
+---
+Command: pcb layout --no-open bad_layout_path.zen
+Exit Code: 0
+
+--- STDOUT ---
+
+--- STDERR ---
+Warning: layout generation needs a root `Board` macro with `layout_path`
+   ╭─[ bad_layout_path.zen:6:24 ]
+   │
+ 6 │ signal = Net("SIGNAL")
+   │                        │ 
+   │                        ╰─ insert the board declaration here
+   │ 
+   │ Help: add this to bad_layout_path.zen:
+   │           Board(name="bad_layout_path", layers=4, layout_path="layout/bad_layout_path")
+───╯


### PR DESCRIPTION
## Summary

- Warn when `pcb layout` builds a schematic that has no root `Board`/`layout_path`, instead of silently doing nothing.
- Render the warning with Ariadne at the insertion point and include a concrete `Board(...)` suggestion derived from the `.zen` filename.
- Add an integration snapshot test for the warning output.

## Why

Without a root board declaration, layout generation has no destination directory, so `pcb layout` returns successfully without producing files. The new warning explains that requirement and gives the user a directly usable board declaration.

## Validation

- `cargo fmt`
- `cargo test -p pcb --test layout`
- `cargo run -p pcb -- layout --no-open boost_5v.zen` from `examples/os_13_4`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a non-fatal CLI warning path when layout generation produces no output, plus tests; minimal impact on core layout sync behavior.
> 
> **Overview**
> `pcb layout` now emits an Ariadne-rendered warning when layout generation returns no result and the schematic lacks a root `Board` macro with a string `layout_path`, including a suggested `Board(...)` insertion derived from the `.zen` filename.
> 
> Adds `ariadne` as a dependency, updates the changelog entry, and introduces snapshot tests covering missing/invalid `layout_path` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c69899f3cbfc7a7a57f5d00238fd1bb223170f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->