### PR TITLE
Add IPC-2581 panel SVG export

### DIFF
--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1460,6 +1460,7 @@ impl Parser {
         // Single pass through children
         let mut datum = None;
         let mut profile = None;
+        let mut step_repeats = Vec::new();
         let mut padstack_defs = Vec::new();
         let mut packages = Vec::new();
         let mut components = Vec::new();
@@ -1471,6 +1472,7 @@ impl Parser {
             match child.tag_name().name() {
                 "Datum" => datum = Some(self.parse_datum(&child)?),
                 "Profile" => profile = Some(self.parse_profile(&child)?),
+                "StepRepeat" => step_repeats.push(self.parse_step_repeat(&child)?),
                 "PadStackDef" => padstack_defs.push(self.parse_padstack_def(&child)?),
                 "Package" => packages.push(self.parse_package(&child)?),
                 "Component" => components.push(self.parse_component(&child)?),
@@ -1485,12 +1487,57 @@ impl Parser {
             name,
             datum,
             profile,
+            step_repeats,
             padstack_defs,
             packages,
             components,
             logical_nets,
             phy_net_groups,
             layer_features,
+        })
+    }
+
+    fn parse_step_repeat(&mut self, node: &Node) -> Result<StepRepeat> {
+        // StepRepeat is in ECAD section, use ECAD units.
+        let units = self.ecad_units.unwrap_or(Units::Millimeter);
+
+        let step_ref = self.required_attr(node, "stepRef", "StepRepeat")?;
+        let x = self
+            .parse_optional_f64_attr_with_units(node, "x", units)?
+            .unwrap_or(0.0);
+        let y = self
+            .parse_optional_f64_attr_with_units(node, "y", units)?
+            .unwrap_or(0.0);
+        let nx = self.parse_optional_u32_attr(node, "nx")?.unwrap_or(1);
+        let ny = self.parse_optional_u32_attr(node, "ny")?.unwrap_or(1);
+        let dx = self
+            .parse_optional_f64_attr_with_units(node, "dx", units)?
+            .unwrap_or(0.0);
+        let dy = self
+            .parse_optional_f64_attr_with_units(node, "dy", units)?
+            .unwrap_or(0.0);
+        let angle = self.parse_optional_f64_attr(node, "angle")?.unwrap_or(0.0);
+        let mirror = match node.attribute("mirror") {
+            Some(value) if value.eq_ignore_ascii_case("true") => true,
+            Some(value) if value.eq_ignore_ascii_case("false") => false,
+            Some(_) => {
+                return Err(Ipc2581Error::InvalidAttribute(
+                    "Invalid bool value for mirror".to_string(),
+                ));
+            }
+            None => false,
+        };
+
+        Ok(StepRepeat {
+            step_ref,
+            x,
+            y,
+            nx,
+            ny,
+            dx,
+            dy,
+            angle,
+            mirror,
         })
     }
 

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -81,12 +81,27 @@ pub struct Step {
     pub name: Symbol,
     pub datum: Option<Datum>,
     pub profile: Option<Profile>,
+    pub step_repeats: Vec<StepRepeat>,
     pub padstack_defs: Vec<PadStackDef>,
     pub packages: Vec<Package>,
     pub components: Vec<Component>,
     pub logical_nets: Vec<LogicalNet>,
     pub phy_net_groups: Vec<PhyNetGroup>,
     pub layer_features: Vec<LayerFeature>,
+}
+
+/// StepRepeat places one Step within another Step, usually a board within a panel.
+#[derive(Debug, Clone)]
+pub struct StepRepeat {
+    pub step_ref: Symbol,
+    pub x: f64,
+    pub y: f64,
+    pub nx: u32,
+    pub ny: u32,
+    pub dx: f64,
+    pub dy: f64,
+    pub angle: f64,
+    pub mirror: bool,
 }
 
 /// Datum defines the origin point for a Step

--- a/crates/ipc2581/tests/step_repeat.rs
+++ b/crates/ipc2581/tests/step_repeat.rs
@@ -1,0 +1,61 @@
+use ipc2581::Ipc2581;
+
+fn panel_fixture() -> &'static str {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="panel"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Step name="board" type="BOARD">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="5"/>
+            <PolyStepSegment x="0" y="5"/>
+          </Polygon>
+        </Profile>
+      </Step>
+      <Step name="panel" type="PALLET">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="100" y="0"/>
+            <PolyStepSegment x="100" y="80"/>
+            <PolyStepSegment x="0" y="80"/>
+          </Polygon>
+        </Profile>
+        <StepRepeat stepRef="board" x="7.5" y="9.25" nx="2" ny="3" dx="30" dy="20" angle="90" mirror="true"/>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#
+}
+
+#[test]
+fn parses_step_repeat_on_step() {
+    let doc = Ipc2581::parse(panel_fixture()).expect("synthetic fixture should parse");
+    let ecad = doc.ecad().expect("fixture has ECAD data");
+    let panel = ecad
+        .cad_data
+        .steps
+        .iter()
+        .find(|step| doc.resolve(step.name) == "panel")
+        .expect("fixture has panel step");
+
+    assert_eq!(panel.step_repeats.len(), 1);
+    let repeat = &panel.step_repeats[0];
+    assert_eq!(doc.resolve(repeat.step_ref), "board");
+    assert_eq!(repeat.x, 7.5);
+    assert_eq!(repeat.y, 9.25);
+    assert_eq!(repeat.nx, 2);
+    assert_eq!(repeat.ny, 3);
+    assert_eq!(repeat.dx, 30.0);
+    assert_eq!(repeat.dy, 20.0);
+    assert_eq!(repeat.angle, 90.0);
+    assert!(repeat.mirror);
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use ipc2581::types::{
     FillProperty, LayerFunction, LineEnd, PadUse, PlatingStatus, Polarity, PolyStep, SlotShape,
-    StandardPrimitive, ecad::Layer,
+    StandardPrimitive,
+    ecad::{Layer, Step, StepRepeat},
 };
 use ipc2581::{Ipc2581, Symbol};
 
@@ -25,18 +26,95 @@ enum PrimitivePaint {
 
 pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
-    let step = ecad
-        .cad_data
-        .steps
-        .first()
-        .context("IPC-2581 ECAD section has no Step")?;
     let layer = ecad
         .cad_data
         .layers
         .iter()
         .find(|layer| ipc.resolve(layer.name) == layer_name)
         .with_context(|| format!("IPC-2581 layer '{layer_name}' was not found"))?;
+    let step = primary_step(ipc, &ecad.cad_data.steps)?;
 
+    if !step.step_repeats.is_empty() {
+        return extract_panel_layer(
+            ipc,
+            &ecad.cad_data.steps,
+            &ecad.cad_data.layers,
+            step,
+            layer,
+            layer_name,
+        );
+    }
+
+    extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)
+}
+
+fn primary_step<'a>(ipc: &Ipc2581, steps: &'a [Step]) -> Result<&'a Step> {
+    if let Some(step_ref) = ipc.content().step_refs.first()
+        && let Some(step) = steps.iter().find(|step| step.name == *step_ref)
+    {
+        return Ok(step);
+    }
+
+    steps.first().context("IPC-2581 ECAD section has no Step")
+}
+
+fn extract_panel_layer(
+    ipc: &Ipc2581,
+    steps: &[Step],
+    layers: &[Layer],
+    panel: &Step,
+    layer: &Layer,
+    layer_name: &str,
+) -> Result<GeometryDocument> {
+    let mut doc = GeometryDocument::new(ipc.resolve(panel.name).to_string());
+    let feature_start = doc.features.len() as u32;
+    let mut layer_bbox = BBox::empty();
+
+    for repeat in &panel.step_repeats {
+        let source_step = steps
+            .iter()
+            .find(|step| step.name == repeat.step_ref)
+            .with_context(|| {
+                format!(
+                    "StepRepeat references unknown Step '{}'",
+                    ipc.resolve(repeat.step_ref)
+                )
+            })?;
+        let source_doc = extract_step_layer(ipc, source_step, layers, layer, layer_name)?;
+        doc.diagnostics.extend(source_doc.diagnostics.clone());
+
+        for iy in 0..repeat.ny {
+            for ix in 0..repeat.nx {
+                let transform = step_repeat_transform(repeat, ix, iy);
+                layer_bbox = layer_bbox.union(append_transformed_layer(
+                    &mut doc,
+                    &source_doc,
+                    0,
+                    transform,
+                ));
+            }
+        }
+    }
+
+    let feature_count = doc.features.len() as u32 - feature_start;
+    doc.layers.push(GeometryLayer {
+        name: layer_name.to_string(),
+        source_layer_ref: layer.name,
+        feature_start,
+        feature_count,
+        bbox: layer_bbox,
+    });
+
+    Ok(doc)
+}
+
+fn extract_step_layer(
+    ipc: &Ipc2581,
+    step: &Step,
+    layers: &[Layer],
+    layer: &Layer,
+    layer_name: &str,
+) -> Result<GeometryDocument> {
     let content = ipc.content();
     let context = ExtractContext {
         ipc,
@@ -140,9 +218,7 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
     }
 
     for layer_feature in &step.layer_features {
-        let Some(source_layer) = ecad
-            .cad_data
-            .layers
+        let Some(source_layer) = layers
             .iter()
             .find(|candidate| candidate.name == layer_feature.layer_ref)
         else {
@@ -152,9 +228,7 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
         let is_routing_layer = source_layer.layer_function == LayerFunction::Rout;
 
         for (set_index, set) in layer_feature.sets.iter().enumerate() {
-            if is_drill_layer
-                && layer_span_applies_to_layer(source_layer, layer, &ecad.cad_data.layers)
-            {
+            if is_drill_layer && layer_span_applies_to_layer(source_layer, layer, layers) {
                 for (feature_index, hole) in set.holes.iter().enumerate() {
                     let feature = extract_hole(
                         SourceRef {
@@ -171,7 +245,7 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
 
             if is_drill_layer || is_routing_layer {
                 for (feature_index, slot) in set.slots.iter().enumerate() {
-                    if slot_applies_to_layer(source_layer, layer, &ecad.cad_data.layers, slot) {
+                    if slot_applies_to_layer(source_layer, layer, layers, slot) {
                         let feature = extract_slot(
                             &context,
                             SourceRef {
@@ -199,6 +273,93 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
     });
 
     Ok(doc)
+}
+
+fn step_repeat_transform(repeat: &StepRepeat, ix: u32, iy: u32) -> Affine2 {
+    Affine2::placement(
+        Point::new(
+            repeat.x + ix as f64 * repeat.dx,
+            repeat.y + iy as f64 * repeat.dy,
+        ),
+        repeat.angle,
+        repeat.mirror,
+        1.0,
+    )
+}
+
+fn append_transformed_layer(
+    target: &mut GeometryDocument,
+    source: &GeometryDocument,
+    layer_index: usize,
+    transform: Affine2,
+) -> BBox {
+    let layer = &source.layers[layer_index];
+    let mut layer_bbox = BBox::empty();
+
+    for feature in &source.features
+        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
+    {
+        let path_start = target.paths.len() as u32;
+        for path in &source.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+        {
+            append_transformed_path(target, source, path, transform);
+        }
+        let path_count = target.paths.len() as u32 - path_start;
+        let bbox = paths_bbox(target, path_start, path_count);
+
+        let mut feature = feature.clone();
+        feature.transform = transform.concat(feature.transform);
+        feature.bbox = bbox;
+        feature.path_start = path_start;
+        feature.path_count = path_count;
+        feature.center = transform.transform_point(feature.center);
+        target.features.push(feature);
+        layer_bbox = layer_bbox.union(bbox);
+    }
+
+    layer_bbox
+}
+
+fn append_transformed_path(
+    target: &mut GeometryDocument,
+    source: &GeometryDocument,
+    path: &GeometryPath,
+    transform: Affine2,
+) {
+    let contour_start = target.contours.len() as u32;
+    let mut path_bbox = BBox::empty();
+
+    for contour in &source.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+    {
+        let cmd_start = target.path_cmds.len() as u32;
+        let mut contour_bbox = BBox::empty();
+        for cmd in &source.path_cmds
+            [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+        {
+            target
+                .path_cmds
+                .push(transform_path_cmd(*cmd, transform, &mut contour_bbox));
+        }
+        if path.flags.stroked {
+            contour_bbox = contour_bbox.expand(path.stroke_width / 2.0);
+        }
+
+        let cmd_count = target.path_cmds.len() as u32 - cmd_start;
+        target.contours.push(GeometryContour {
+            cmd_start,
+            cmd_count,
+            bbox: contour_bbox,
+        });
+        path_bbox = path_bbox.union(contour_bbox);
+    }
+
+    let mut path = path.clone();
+    path.contour_start = contour_start;
+    path.contour_count = target.contours.len() as u32 - contour_start;
+    path.bbox = path_bbox;
+    target.paths.push(path);
 }
 
 fn slot_applies_to_layer(
@@ -1448,6 +1609,23 @@ mod tests {
     }
 
     #[test]
+    fn extracts_repeated_panel_layer_instances() {
+        let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
+            .expect("synthetic panel fixture should parse");
+        let doc = extract_layer(&ipc, "TOP").expect("panel layer should extract");
+        let layer = &doc.layers[0];
+        let features = &doc.features
+            [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize];
+
+        assert_eq!(doc.board_name, "panel");
+        assert_eq!(features.len(), 2);
+        assert_eq!(features[0].center, Point::new(12.0, 23.0));
+        assert_eq!(features[1].center, Point::new(27.0, 23.0));
+        assert_eq!(layer.bbox.min, Point::new(11.5, 22.5));
+        assert_eq!(layer.bbox.max, Point::new(27.5, 23.5));
+    }
+
+    #[test]
     fn chamfered_rect_respects_corner_flags() {
         let mut doc = GeometryDocument::new("test".to_string());
 
@@ -1542,5 +1720,44 @@ mod tests {
             x: 0.0,
             y: 0.0,
         }
+    }
+
+    fn panel_layer_fixture() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="panel"/>
+    <LayerRef name="TOP"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="pad">
+        <Circle diameter="1"/>
+      </EntryStandard>
+    </DictionaryStandard>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <PadStackDef name="padstack">
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR">
+            <StandardPrimitiveRef id="pad"/>
+          </PadstackPadDef>
+        </PadStackDef>
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <Pad padstackDefRef="padstack">
+              <Location x="2" y="3"/>
+            </Pad>
+          </Set>
+        </LayerFeature>
+      </Step>
+      <Step name="panel" type="PALLET">
+        <StepRepeat stepRef="board" x="10" y="20" nx="2" ny="1" dx="15" dy="0"/>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#
     }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -69,6 +69,17 @@ fn extract_panel_layer(
     let mut doc = GeometryDocument::new(ipc.resolve(panel.name).to_string());
     let feature_start = doc.features.len() as u32;
     let mut layer_bbox = BBox::empty();
+    let mut append_state = LayerAppendState::default();
+
+    let panel_doc = extract_step_layer(ipc, panel, layers, layer, layer_name)?;
+    doc.diagnostics
+        .extend(panel_doc.diagnostics.iter().cloned());
+    layer_bbox = layer_bbox.union(append_state.append_layer(
+        &mut doc,
+        &panel_doc,
+        0,
+        Affine2::identity(),
+    )?);
 
     for repeat in &panel.step_repeats {
         let source_step = steps
@@ -86,12 +97,12 @@ fn extract_panel_layer(
         for iy in 0..repeat.ny {
             for ix in 0..repeat.nx {
                 let transform = step_repeat_transform(repeat, ix, iy);
-                layer_bbox = layer_bbox.union(append_transformed_layer(
+                layer_bbox = layer_bbox.union(append_state.append_layer(
                     &mut doc,
                     &source_doc,
                     0,
                     transform,
-                ));
+                )?);
             }
         }
     }
@@ -287,18 +298,64 @@ fn step_repeat_transform(repeat: &StepRepeat, ix: u32, iy: u32) -> Affine2 {
     )
 }
 
+#[derive(Debug, Default)]
+struct LayerAppendState {
+    next_source_set_index: u32,
+}
+
+impl LayerAppendState {
+    fn append_layer(
+        &mut self,
+        target: &mut GeometryDocument,
+        source: &GeometryDocument,
+        layer_index: usize,
+        transform: Affine2,
+    ) -> Result<BBox> {
+        let source_set_offset = self.next_source_set_index;
+        let source_set_span = source_layer_set_span(source, layer_index)?;
+        let bbox =
+            append_transformed_layer(target, source, layer_index, transform, source_set_offset)?;
+        self.next_source_set_index = self
+            .next_source_set_index
+            .checked_add(source_set_span)
+            .context("Panel contains too many repeated source feature sets")?;
+        Ok(bbox)
+    }
+}
+
+fn source_layer_set_span(source: &GeometryDocument, layer_index: usize) -> Result<u32> {
+    let layer = &source.layers[layer_index];
+    let mut span = 0;
+    for feature in source_layer_features(source, layer) {
+        let set_end = feature
+            .source
+            .set_index
+            .checked_add(1)
+            .context("Source feature set index overflow")?;
+        span = span.max(set_end);
+    }
+    Ok(span)
+}
+
+fn source_layer_features<'a>(
+    source: &'a GeometryDocument,
+    layer: &GeometryLayer,
+) -> &'a [GeometryFeature] {
+    &source.features
+        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
+}
+
 fn append_transformed_layer(
     target: &mut GeometryDocument,
     source: &GeometryDocument,
     layer_index: usize,
     transform: Affine2,
-) -> BBox {
+    source_set_offset: u32,
+) -> Result<BBox> {
     let layer = &source.layers[layer_index];
     let mut layer_bbox = BBox::empty();
 
-    for feature in &source.features
-        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
-    {
+    for feature in source_layer_features(source, layer) {
         let path_start = target.paths.len() as u32;
         for path in &source.paths
             [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
@@ -314,11 +371,16 @@ fn append_transformed_layer(
         feature.path_start = path_start;
         feature.path_count = path_count;
         feature.center = transform.transform_point(feature.center);
+        feature.source.set_index = feature
+            .source
+            .set_index
+            .checked_add(source_set_offset)
+            .context("Panel source feature set index overflow")?;
         target.features.push(feature);
         layer_bbox = layer_bbox.union(bbox);
     }
 
-    layer_bbox
+    Ok(layer_bbox)
 }
 
 fn append_transformed_path(
@@ -1609,7 +1671,7 @@ mod tests {
     }
 
     #[test]
-    fn extracts_repeated_panel_layer_instances() {
+    fn extracts_panel_and_repeated_layer_instances() {
         let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
             .expect("synthetic panel fixture should parse");
         let doc = extract_layer(&ipc, "TOP").expect("panel layer should extract");
@@ -1618,11 +1680,35 @@ mod tests {
             [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize];
 
         assert_eq!(doc.board_name, "panel");
-        assert_eq!(features.len(), 2);
-        assert_eq!(features[0].center, Point::new(12.0, 23.0));
-        assert_eq!(features[1].center, Point::new(27.0, 23.0));
-        assert_eq!(layer.bbox.min, Point::new(11.5, 22.5));
-        assert_eq!(layer.bbox.max, Point::new(27.5, 23.5));
+        assert_eq!(features.len(), 3);
+        assert_eq!(features[0].center, Point::new(40.0, 5.0));
+        assert_eq!(features[1].center, Point::new(12.0, 23.0));
+        assert_eq!(features[2].center, Point::new(27.0, 23.0));
+        assert_eq!(features[0].source.set_index, 0);
+        assert_eq!(features[1].source.set_index, 1);
+        assert_eq!(features[2].source.set_index, 2);
+        assert_eq!(layer.bbox.min, Point::new(11.5, 4.5));
+        assert_eq!(layer.bbox.max, Point::new(40.5, 23.5));
+    }
+
+    #[test]
+    fn repeated_panel_traces_keep_distinct_source_sets_after_processing() {
+        let ipc = ipc2581::Ipc2581::parse(panel_trace_fixture())
+            .expect("synthetic panel fixture should parse");
+        let mut doc = extract_layer(&ipc, "TOP").expect("panel layer should extract");
+        crate::geometry::process::process_document(&mut doc);
+
+        let layer = &doc.layers[0];
+        let traces = doc.features
+            [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
+            .iter()
+            .filter(|feature| feature.bucket == FeatureBucket::Trace)
+            .collect::<Vec<_>>();
+
+        assert_eq!(traces.len(), 2);
+        assert!(traces.iter().all(|feature| feature.path_count > 0));
+        assert_eq!(traces[0].source.set_index, 0);
+        assert_eq!(traces[1].source.set_index, 1);
     }
 
     #[test]
@@ -1754,7 +1840,54 @@ mod tests {
         </LayerFeature>
       </Step>
       <Step name="panel" type="PALLET">
+        <PadStackDef name="panel_padstack">
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR">
+            <StandardPrimitiveRef id="pad"/>
+          </PadstackPadDef>
+        </PadStackDef>
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <Pad padstackDefRef="panel_padstack">
+              <Location x="40" y="5"/>
+            </Pad>
+          </Set>
+        </LayerFeature>
         <StepRepeat stepRef="board" x="10" y="20" nx="2" ny="1" dx="15" dy="0"/>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#
+    }
+
+    fn panel_trace_fixture() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="panel"/>
+    <LayerRef name="TOP"/>
+    <DictionaryLineDesc units="MILLIMETER">
+      <EntryLineDesc id="trace">
+        <LineDesc lineWidth="1" lineEnd="ROUND"/>
+      </EntryLineDesc>
+    </DictionaryLineDesc>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <LayerFeature layerRef="TOP">
+          <Set net="N1">
+            <Polyline lineDescRef="trace">
+              <PolyBegin x="0" y="0"/>
+              <PolyStepSegment x="10" y="0"/>
+            </Polyline>
+          </Set>
+        </LayerFeature>
+      </Step>
+      <Step name="panel" type="PALLET">
+        <StepRepeat stepRef="board" x="0" y="0" nx="2" ny="1" dx="20" dy="0"/>
       </Step>
     </CadData>
   </Ecad>


### PR DESCRIPTION
## Summary
- parse IPC-2581 StepRepeat entries into the typed ECAD model
- make the current pcb-ipc2581-tools layer renderer honor panel StepRepeat instances
- add synthetic parser and renderer coverage for repeated panel layers

## Testing
- cargo test -p ipc2581 -p pcb-ipc2581-tools
- git diff --check origin/main...HEAD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds panelization support by parsing `StepRepeat` and duplicating/translating/rotating geometry during layer extraction, which can affect downstream geometry output and feature indexing. Risk is moderate due to new transformation/append logic and potential edge cases with repeats, mirroring, and set-index overflow handling.
> 
> **Overview**
> Adds `StepRepeat` to the IPC-2581 typed ECAD model and parser, including unit-converted placement (`x`,`y`,`dx`,`dy`), repetition counts (`nx`,`ny`), rotation (`angle`), and `mirror` handling.
> 
> Updates `pcb-ipc2581-tools` layer extraction to choose the primary `Step` from `Content.StepRef`, and when that step contains repeats, builds a panel layer by extracting the panel’s own features plus transformed copies of the referenced step’s features. This includes new logic to append transformed paths/features while offsetting `source.set_index` to keep repeated instances distinct, with new synthetic tests covering parser and renderer behavior for repeated pads/traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2abb171c1be1b2baf85d342d8fe4de287001a50a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->