### PR TITLE
IPC-2581 geometry rendering is now much more spec-faithful

### DIFF
--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -391,6 +391,63 @@ mod tests {
     }
 
     #[test]
+    fn parses_user_special_contours_lines_polylines_and_line_desc_refs() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+    <DictionaryUser units="MILLIMETER">
+      <EntryUser id="U1">
+        <UserSpecial>
+          <Contour>
+            <Polygon>
+              <PolyBegin x="0" y="0"/>
+              <PolyStepSegment x="1" y="0"/>
+              <PolyStepSegment x="0" y="0"/>
+              <LineDescRef id="fine"/>
+              <FillDesc fillProperty="HOLLOW"/>
+            </Polygon>
+          </Contour>
+          <Line startX="0" startY="0" endX="1" endY="0">
+            <LineDescRef id="fine"/>
+          </Line>
+          <Polyline>
+            <PolyBegin x="1" y="0"/>
+            <PolyStepCurve x="0" y="1" centerX="0" centerY="0" clockwise="false"/>
+            <LineDescRef id="fine"/>
+          </Polyline>
+        </UserSpecial>
+      </EntryUser>
+    </DictionaryUser>
+  </Content>
+</IPC-2581>"#;
+
+        let doc = Ipc2581::parse(xml).expect("parse IPC-2581");
+        let primitive = &doc.content().dictionary_user.entries[0].primitive;
+        let UserPrimitive::UserSpecial(user_special) = primitive;
+
+        assert_eq!(user_special.shapes.len(), 3);
+        assert!(matches!(
+            user_special.shapes[0].shape,
+            UserShapeType::Polygon(_)
+        ));
+        assert_eq!(
+            user_special.shapes[0]
+                .line_desc_ref
+                .map(|symbol| doc.resolve(symbol)),
+            Some("fine")
+        );
+        assert!(matches!(
+            user_special.shapes[1].shape,
+            UserShapeType::Line(_)
+        ));
+        assert!(matches!(
+            user_special.shapes[2].shape,
+            UserShapeType::Polyline(_)
+        ));
+    }
+
+    #[test]
     fn parse_document_with_avl() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -349,6 +349,48 @@ mod tests {
     }
 
     #[test]
+    fn preserves_feature_polyline_curves() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="F.SilkS" layerFunction="LEGEND"/>
+      <Step name="Board">
+        <LayerFeature layerRef="F.SilkS">
+          <Set>
+            <Features>
+              <Location x="10" y="20"/>
+              <Polyline>
+                <PolyBegin x="1" y="0"/>
+                <PolyStepCurve x="0" y="1" centerX="0" centerY="0" clockwise="false"/>
+                <LineDescRef id="fine"/>
+              </Polyline>
+            </Features>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+        let doc = Ipc2581::parse(xml).expect("parse IPC-2581");
+        let set = &doc.ecad().unwrap().cad_data.steps[0].layer_features[0].sets[0];
+
+        assert_eq!(set.features.len(), 1);
+        let ecad::SetFeature::Polyline(polyline) = &set.features[0] else {
+            panic!("expected feature polyline");
+        };
+        assert_eq!(polyline.begin, Point { x: 11.0, y: 20.0 });
+        assert!(matches!(polyline.steps[0], PolyStep::Curve(_)));
+        assert_eq!(set.polylines.len(), 1);
+        assert!(set.lines.is_empty());
+    }
+
+    #[test]
     fn parse_document_with_avl() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -290,6 +290,65 @@ mod tests {
     }
 
     #[test]
+    fn preserves_set_feature_source_order() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="F.Cu" layerFunction="SIGNAL"/>
+      <Step name="Board">
+        <LayerFeature layerRef="F.Cu">
+          <Set>
+            <Polyline>
+              <PolyBegin x="0" y="0"/>
+              <PolyStepSegment x="1" y="0"/>
+              <LineDescRef id="trace"/>
+            </Polyline>
+            <Features>
+              <Polygon>
+                <PolyBegin x="0" y="0"/>
+                <PolyStepSegment x="1" y="0"/>
+                <PolyStepSegment x="1" y="1"/>
+                <PolyStepSegment x="0" y="0"/>
+              </Polygon>
+              <UserSpecial>
+                <Line startX="0" startY="0" endX="0" endY="1">
+                  <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
+                </Line>
+              </UserSpecial>
+            </Features>
+            <Polyline>
+              <PolyBegin x="2" y="0"/>
+              <PolyStepCurve x="3" y="1" centerX="2" centerY="1" clockwise="true"/>
+              <LineDescRef id="trace"/>
+            </Polyline>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+        let doc = Ipc2581::parse(xml).expect("parse IPC-2581");
+        let set = &doc.ecad().unwrap().cad_data.steps[0].layer_features[0].sets[0];
+
+        assert_eq!(set.features.len(), 4);
+        assert!(matches!(set.features[0], ecad::SetFeature::Trace(_)));
+        assert!(matches!(set.features[1], ecad::SetFeature::Polygon(_)));
+        assert!(matches!(set.features[2], ecad::SetFeature::Line(_)));
+        assert!(matches!(set.features[3], ecad::SetFeature::Trace(_)));
+
+        assert_eq!(set.traces.len(), 2);
+        assert!(matches!(set.traces[1].steps[0], PolyStep::Curve(_)));
+        assert_eq!(set.polygons.len(), 1);
+        assert_eq!(set.lines.len(), 1);
+    }
+
+    #[test]
     fn parse_document_with_avl() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -391,6 +391,60 @@ mod tests {
     }
 
     #[test]
+    fn applies_features_location_to_polygons() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="F.SilkS" layerFunction="LEGEND"/>
+      <Step name="Board">
+        <LayerFeature layerRef="F.SilkS">
+          <Set>
+            <Features>
+              <Location x="10" y="20"/>
+              <Polygon>
+                <PolyBegin x="0" y="0"/>
+                <PolyStepSegment x="1" y="0"/>
+                <PolyStepCurve x="0" y="1" centerX="0" centerY="0" clockwise="false"/>
+                <PolyStepSegment x="0" y="0"/>
+              </Polygon>
+              <UserSpecial>
+                <Contour>
+                  <Polygon>
+                    <PolyBegin x="2" y="0"/>
+                    <PolyStepSegment x="3" y="0"/>
+                    <PolyStepSegment x="2" y="0"/>
+                  </Polygon>
+                </Contour>
+              </UserSpecial>
+            </Features>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+        let doc = Ipc2581::parse(xml).expect("parse IPC-2581");
+        let set = &doc.ecad().unwrap().cad_data.steps[0].layer_features[0].sets[0];
+
+        assert_eq!(set.polygons.len(), 2);
+        assert_eq!(set.polygons[0].begin, Point { x: 10.0, y: 20.0 });
+        assert!(matches!(
+            set.polygons[0].steps[1],
+            PolyStep::Curve(PolyStepCurve {
+                center: Point { x: 10.0, y: 20.0 },
+                ..
+            })
+        ));
+        assert_eq!(set.polygons[1].begin, Point { x: 12.0, y: 20.0 });
+    }
+
+    #[test]
     fn parses_user_special_contours_lines_polylines_and_line_desc_refs() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -780,6 +780,12 @@ impl<'a> Parser<'a> {
 
             // Parse shape based on tag name
             let shape_type = match tag_name {
+                "Contour" => self
+                    .element_children(&child)
+                    .find(|n| self.name(n) == "Polygon")
+                    .map(|polygon| self.parse_polygon(&polygon, units))
+                    .transpose()?
+                    .map(UserShapeType::Polygon),
                 "Circle" => Some(UserShapeType::Circle(Circle {
                     diameter: self
                         .parse_f64_attr_with_units(&child, "diameter", "Circle", units)?,
@@ -807,32 +813,117 @@ impl<'a> Parser<'a> {
                     },
                 })),
                 "Polygon" => Some(UserShapeType::Polygon(self.parse_polygon(&child, units)?)),
+                "Line" => Some(UserShapeType::Line(crate::types::primitives::Line {
+                    start: Point {
+                        x: self.parse_f64_attr_with_units(&child, "startX", "Line", units)?,
+                        y: self.parse_f64_attr_with_units(&child, "startY", "Line", units)?,
+                    },
+                    end: Point {
+                        x: self.parse_f64_attr_with_units(&child, "endX", "Line", units)?,
+                        y: self.parse_f64_attr_with_units(&child, "endY", "Line", units)?,
+                    },
+                })),
+                "Polyline" => Some(UserShapeType::Polyline(
+                    self.parse_user_polyline(&child, units)?,
+                )),
                 _ => None,
             };
 
             if let Some(shape_type) = shape_type {
-                // Parse optional LineDesc and FillDesc children
-                let line_desc = self
-                    .element_children(&child)
-                    .find(|n| self.name(n) == "LineDesc")
-                    .map(|n| self.parse_line_desc(&n, units))
-                    .transpose()?;
-
-                let fill_desc = self
-                    .element_children(&child)
-                    .find(|n| self.name(n) == "FillDesc")
-                    .map(|n| self.parse_fill_desc(&n))
-                    .transpose()?;
+                let style_node = if tag_name == "Contour" {
+                    self.element_children(&child)
+                        .find(|n| self.name(n) == "Polygon")
+                        .unwrap_or(child)
+                } else {
+                    child
+                };
+                let (line_desc, line_desc_ref, fill_desc) =
+                    self.parse_user_shape_style(&style_node, units)?;
 
                 shapes.push(UserShape {
                     shape: shape_type,
                     line_desc,
+                    line_desc_ref,
                     fill_desc,
                 });
             }
         }
 
         Ok(UserPrimitive::UserSpecial(UserSpecial { shapes }))
+    }
+
+    fn parse_user_shape_style(
+        &mut self,
+        node: &Node,
+        units: Units,
+    ) -> Result<(Option<LineDesc>, Option<Symbol>, Option<FillDesc>)> {
+        let mut line_desc = None;
+        let mut line_desc_ref = None;
+        let mut fill_desc = None;
+
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "LineDesc" => line_desc = Some(self.parse_line_desc(&child, units)?),
+                "LineDescRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        line_desc_ref = Some(self.interner.intern(id));
+                    }
+                }
+                "FillDesc" => fill_desc = Some(self.parse_fill_desc(&child)?),
+                _ => {}
+            }
+        }
+
+        Ok((line_desc, line_desc_ref, fill_desc))
+    }
+
+    fn parse_user_polyline(&mut self, node: &Node, units: Units) -> Result<Polyline> {
+        let mut begin = None;
+        let mut steps = Vec::new();
+
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "PolyBegin" => {
+                    begin = Some(Point {
+                        x: self.parse_f64_attr_with_units(&child, "x", "PolyBegin", units)?,
+                        y: self.parse_f64_attr_with_units(&child, "y", "PolyBegin", units)?,
+                    });
+                }
+                "PolyStepSegment" => steps.push(PolyStep::Segment(PolyStepSegment {
+                    point: Point {
+                        x: self.parse_f64_attr_with_units(&child, "x", "PolyStepSegment", units)?,
+                        y: self.parse_f64_attr_with_units(&child, "y", "PolyStepSegment", units)?,
+                    },
+                })),
+                "PolyStepCurve" => steps.push(PolyStep::Curve(PolyStepCurve {
+                    point: Point {
+                        x: self.parse_f64_attr_with_units(&child, "x", "PolyStepCurve", units)?,
+                        y: self.parse_f64_attr_with_units(&child, "y", "PolyStepCurve", units)?,
+                    },
+                    center: Point {
+                        x: self.parse_f64_attr_with_units(
+                            &child,
+                            "centerX",
+                            "PolyStepCurve",
+                            units,
+                        )?,
+                        y: self.parse_f64_attr_with_units(
+                            &child,
+                            "centerY",
+                            "PolyStepCurve",
+                            units,
+                        )?,
+                    },
+                    clockwise: self.parse_bool_attr(&child, "clockwise")?,
+                })),
+                _ => {}
+            }
+        }
+
+        Ok(Polyline {
+            begin: begin.ok_or(Ipc2581Error::MissingElement("PolyBegin in Polyline"))?,
+            steps,
+        })
     }
 
     fn parse_logistic_header(&mut self, node: &Node) -> Result<LogisticHeader> {
@@ -1793,6 +1884,8 @@ impl<'a> Parser<'a> {
                             ecad::SetFeature::Polyline(polyline) => {
                                 polylines.push(polyline.clone())
                             }
+                            ecad::SetFeature::StandardPrimitiveRef(_)
+                            | ecad::SetFeature::UserPrimitiveRef(_) => {}
                             _ => {}
                         }
                         features.push(feature);
@@ -1899,6 +1992,28 @@ impl<'a> Parser<'a> {
                             }
                             _ => {}
                         }
+                    }
+                }
+                "StandardPrimitiveRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        features.push(ecad::SetFeature::StandardPrimitiveRef(
+                            ecad::FeaturePrimitiveRef {
+                                id: self.interner.intern(id),
+                                x: offset_x,
+                                y: offset_y,
+                            },
+                        ));
+                    }
+                }
+                "UserPrimitiveRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        features.push(ecad::SetFeature::UserPrimitiveRef(
+                            ecad::FeaturePrimitiveRef {
+                                id: self.interner.intern(id),
+                                x: offset_x,
+                                y: offset_y,
+                            },
+                        ));
                     }
                 }
                 _ => {}

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1759,6 +1759,7 @@ impl<'a> Parser<'a> {
         let mut traces = Vec::new();
         let mut polygons = Vec::new();
         let mut lines = Vec::new();
+        let mut polylines = Vec::new();
         let mut features = Vec::new();
         let mut nonstandard_attributes = Vec::new();
 
@@ -1789,6 +1790,9 @@ impl<'a> Parser<'a> {
                         match &feature {
                             ecad::SetFeature::Polygon(polygon) => polygons.push(polygon.clone()),
                             ecad::SetFeature::Line(line) => lines.push(line.clone()),
+                            ecad::SetFeature::Polyline(polyline) => {
+                                polylines.push(polyline.clone())
+                            }
                             _ => {}
                         }
                         features.push(feature);
@@ -1814,6 +1818,7 @@ impl<'a> Parser<'a> {
             traces,
             polygons,
             lines,
+            polylines,
             nonstandard_attributes,
         })
     }
@@ -1861,15 +1866,14 @@ impl<'a> Parser<'a> {
                     }
                 }
                 "Polyline" => {
-                    // Polyline traces in Features
-                    features.extend(
-                        self.parse_polyline_to_lines(&child, units, offset_x, offset_y)
-                            .into_iter()
-                            .map(ecad::SetFeature::Line),
-                    );
+                    if let Ok(polyline) =
+                        self.parse_feature_polyline(&child, units, offset_x, offset_y)
+                    {
+                        features.push(ecad::SetFeature::Polyline(polyline));
+                    }
                 }
                 "UserSpecial" => {
-                    // UserSpecial contains Contour > Polygon OR Line
+                    // UserSpecial contains Contour > Polygon, Line, or Polyline.
                     for inner in self.element_children(&child) {
                         match self.name(&inner) {
                             "Contour" => {
@@ -1884,6 +1888,13 @@ impl<'a> Parser<'a> {
                             "Line" => {
                                 if let Ok(line) = self.parse_line(&inner, units) {
                                     features.push(ecad::SetFeature::Line(line));
+                                }
+                            }
+                            "Polyline" => {
+                                if let Ok(polyline) =
+                                    self.parse_feature_polyline(&inner, units, offset_x, offset_y)
+                                {
+                                    features.push(ecad::SetFeature::Polyline(polyline));
                                 }
                             }
                             _ => {}
@@ -1942,83 +1953,79 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_polyline_to_lines(
+    fn parse_feature_polyline(
         &mut self,
         node: &Node,
         units: Units,
         offset_x: f64,
         offset_y: f64,
-    ) -> Vec<ecad::Line> {
-        let mut out = Vec::new();
-        let mut current_x = offset_x;
-        let mut current_y = offset_y;
+    ) -> Result<ecad::FeaturePolyline> {
+        let mut begin = None;
+        let mut steps = Vec::new();
         let mut line_width = 0.25;
         let mut line_end = None;
         let mut line_desc_ref = None;
 
-        // Parse points and LineDesc, tessellating curves
         for child in self.element_children(node) {
             match self.name(&child) {
                 "PolyBegin" => {
-                    current_x = self
-                        .parse_f64_attr_with_units(&child, "x", "PolyBegin", units)
-                        .unwrap_or(0.0)
-                        + offset_x;
-                    current_y = self
-                        .parse_f64_attr_with_units(&child, "y", "PolyBegin", units)
-                        .unwrap_or(0.0)
-                        + offset_y;
+                    begin = Some(Point {
+                        x: self.parse_f64_attr_with_units(&child, "x", "PolyBegin", units)?
+                            + offset_x,
+                        y: self.parse_f64_attr_with_units(&child, "y", "PolyBegin", units)?
+                            + offset_y,
+                    });
                 }
                 "PolyStepSegment" => {
-                    let x = self
-                        .parse_f64_attr_with_units(&child, "x", "PolyStepSegment", units)
-                        .unwrap_or(0.0)
-                        + offset_x;
-                    let y = self
-                        .parse_f64_attr_with_units(&child, "y", "PolyStepSegment", units)
-                        .unwrap_or(0.0)
-                        + offset_y;
-
-                    out.push(ecad::Line {
-                        start_x: current_x,
-                        start_y: current_y,
-                        end_x: x,
-                        end_y: y,
-                        line_desc_ref,
-                        line_width,
-                        line_end,
-                    });
-
-                    current_x = x;
-                    current_y = y;
+                    steps.push(PolyStep::Segment(PolyStepSegment {
+                        point: Point {
+                            x: self.parse_f64_attr_with_units(
+                                &child,
+                                "x",
+                                "PolyStepSegment",
+                                units,
+                            )? + offset_x,
+                            y: self.parse_f64_attr_with_units(
+                                &child,
+                                "y",
+                                "PolyStepSegment",
+                                units,
+                            )? + offset_y,
+                        },
+                    }));
                 }
                 "PolyStepCurve" => {
-                    // TODO: Properly handle arcs in UserSpecial
-                    // Currently we skip arcs to keep parser pure (no tessellation dependencies)
-                    // This should store raw Arc data and let downstream code handle tessellation
-                    let end_x = self
-                        .parse_f64_attr_with_units(&child, "x", "PolyStepCurve", units)
-                        .unwrap_or(0.0)
-                        + offset_x;
-                    let end_y = self
-                        .parse_f64_attr_with_units(&child, "y", "PolyStepCurve", units)
-                        .unwrap_or(0.0)
-                        + offset_y;
-
-                    // For now, create straight line from current to end point
-                    // Proper fix: store Arc data in UserSpecial and tessellate in ipc2581-tools
-                    out.push(ecad::Line {
-                        start_x: current_x,
-                        start_y: current_y,
-                        end_x,
-                        end_y,
-                        line_desc_ref,
-                        line_width,
-                        line_end,
-                    });
-
-                    current_x = end_x;
-                    current_y = end_y;
+                    steps.push(PolyStep::Curve(PolyStepCurve {
+                        point: Point {
+                            x: self.parse_f64_attr_with_units(
+                                &child,
+                                "x",
+                                "PolyStepCurve",
+                                units,
+                            )? + offset_x,
+                            y: self.parse_f64_attr_with_units(
+                                &child,
+                                "y",
+                                "PolyStepCurve",
+                                units,
+                            )? + offset_y,
+                        },
+                        center: Point {
+                            x: self.parse_f64_attr_with_units(
+                                &child,
+                                "centerX",
+                                "PolyStepCurve",
+                                units,
+                            )? + offset_x,
+                            y: self.parse_f64_attr_with_units(
+                                &child,
+                                "centerY",
+                                "PolyStepCurve",
+                                units,
+                            )? + offset_y,
+                        },
+                        clockwise: self.parse_bool_attr(&child, "clockwise")?,
+                    }));
                 }
                 "LineDesc" => {
                     line_width = self
@@ -2042,7 +2049,13 @@ impl<'a> Parser<'a> {
             }
         }
 
-        out
+        Ok(ecad::FeaturePolyline {
+            begin: begin.ok_or(Ipc2581Error::MissingElement("PolyBegin in Polyline"))?,
+            steps,
+            line_desc_ref,
+            line_width,
+            line_end,
+        })
     }
 
     fn parse_hole(&mut self, node: &Node) -> Result<Hole> {

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -854,8 +854,8 @@ impl<'a> Parser<'a> {
                 "Polyline" => Some(UserShapeType::Polyline(
                     self.parse_user_polyline(&child, units)?,
                 )),
-                "UserPrimitiveRef" => child
-                    .attribute("id")
+                "UserPrimitiveRef" => self
+                    .attr(&child, "id")
                     .map(|id| UserShapeType::UserPrimitiveRef(self.interner.intern(id))),
                 _ => None,
             };
@@ -2059,7 +2059,7 @@ impl<'a> Parser<'a> {
                                 }
                             }
                             "UserPrimitiveRef" => {
-                                if let Some(id) = inner.attribute("id") {
+                                if let Some(id) = self.attr(&inner, "id") {
                                     features.push(ecad::SetFeature::UserPrimitiveRef(
                                         ecad::FeaturePrimitiveRef {
                                             id: self.interner.intern(id),
@@ -2165,15 +2165,15 @@ impl<'a> Parser<'a> {
         let mut line_end = None;
         let mut line_desc_ref = None;
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "LineDesc" => {
-                    line_width = child
-                        .attribute("lineWidth")
+                    line_width = self
+                        .attr(&child, "lineWidth")
                         .and_then(|s| s.parse::<f64>().ok())
                         .map(|v| crate::units::to_mm(v, units))
                         .unwrap_or(0.25);
-                    line_end = child.attribute("lineEnd").and_then(|s| match s {
+                    line_end = self.attr(&child, "lineEnd").and_then(|s| match s {
                         "ROUND" => Some(LineEnd::Round),
                         "SQUARE" => Some(LineEnd::Square),
                         "FLAT" => Some(LineEnd::Flat),
@@ -2181,7 +2181,7 @@ impl<'a> Parser<'a> {
                     });
                 }
                 "LineDescRef" => {
-                    if let Some(id) = child.attribute("id") {
+                    if let Some(id) = self.attr(&child, "id") {
                         line_desc_ref = Some(self.interner.intern(id));
                     }
                 }
@@ -2511,10 +2511,7 @@ impl<'a> Parser<'a> {
                         self.parse_f64_attr_with_units(&child, "centerX", "PolyStepCurve", units)?;
                     let center_y =
                         self.parse_f64_attr_with_units(&child, "centerY", "PolyStepCurve", units)?;
-                    let clockwise = self
-                        .attr(&child, "clockwise")
-                        .map(|value| value == "true" || value == "1")
-                        .unwrap_or(false);
+                    let clockwise = self.parse_bool_attr(&child, "clockwise")?;
                     points.push(TracePoint { x, y });
                     steps.push(PolyStep::Curve(PolyStepCurve {
                         point: Point { x, y },

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1700,7 +1700,7 @@ impl<'a> Parser<'a> {
             .parse_optional_f64_attr_with_units(node, "dy", units)?
             .unwrap_or(0.0);
         let angle = self.parse_optional_f64_attr(node, "angle")?.unwrap_or(0.0);
-        let mirror = match node.attribute("mirror") {
+        let mirror = match self.attr(node, "mirror") {
             Some(value) if value.eq_ignore_ascii_case("true") => true,
             Some(value) if value.eq_ignore_ascii_case("false") => false,
             Some(_) => {

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1759,19 +1759,40 @@ impl<'a> Parser<'a> {
         let mut traces = Vec::new();
         let mut polygons = Vec::new();
         let mut lines = Vec::new();
+        let mut features = Vec::new();
         let mut nonstandard_attributes = Vec::new();
 
         for child in self.element_children(node) {
             match self.name(&child) {
-                "Hole" => holes.push(self.parse_hole(&child)?),
-                "SlotCavity" => slots.push(self.parse_slot_cavity(&child)?),
-                "Pad" => pads.push(self.parse_pad(&child)?),
-                "Polyline" => traces.push(self.parse_trace(&child)?),
+                "Hole" => {
+                    let hole = self.parse_hole(&child)?;
+                    features.push(ecad::SetFeature::Hole(hole.clone()));
+                    holes.push(hole);
+                }
+                "SlotCavity" => {
+                    let slot = self.parse_slot_cavity(&child)?;
+                    features.push(ecad::SetFeature::Slot(slot.clone()));
+                    slots.push(slot);
+                }
+                "Pad" => {
+                    let pad = self.parse_pad(&child)?;
+                    features.push(ecad::SetFeature::Pad(pad.clone()));
+                    pads.push(pad);
+                }
+                "Polyline" => {
+                    let trace = self.parse_trace(&child)?;
+                    features.push(ecad::SetFeature::Trace(trace.clone()));
+                    traces.push(trace);
+                }
                 "Features" => {
-                    // Parse polygons and lines from Features
-                    let (feat_polygons, feat_lines) = self.parse_features(&child);
-                    polygons.extend(feat_polygons);
-                    lines.extend(feat_lines);
+                    for feature in self.parse_features(&child) {
+                        match &feature {
+                            ecad::SetFeature::Polygon(polygon) => polygons.push(polygon.clone()),
+                            ecad::SetFeature::Line(line) => lines.push(line.clone()),
+                            _ => {}
+                        }
+                        features.push(feature);
+                    }
                 }
                 "NonstandardAttribute" => {
                     if let Ok(attr) = self.parse_nonstandard_attribute(&child) {
@@ -1786,6 +1807,7 @@ impl<'a> Parser<'a> {
             net,
             geometry,
             polarity,
+            features,
             holes,
             slots,
             pads,
@@ -1808,9 +1830,8 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_features(&mut self, features_node: &Node) -> (Vec<Polygon>, Vec<ecad::Line>) {
-        let mut polygons = Vec::new();
-        let mut lines = Vec::new();
+    fn parse_features(&mut self, features_node: &Node) -> Vec<ecad::SetFeature> {
+        let mut features = Vec::new();
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
 
         // Check for Location offset (applies to all geometry in Features)
@@ -1836,12 +1857,16 @@ impl<'a> Parser<'a> {
             match self.name(&child) {
                 "Polygon" => {
                     if let Ok(poly) = self.parse_polygon(&child, units) {
-                        polygons.push(poly);
+                        features.push(ecad::SetFeature::Polygon(poly));
                     }
                 }
                 "Polyline" => {
                     // Polyline traces in Features
-                    lines.extend(self.parse_polyline_to_lines(&child, units, offset_x, offset_y));
+                    features.extend(
+                        self.parse_polyline_to_lines(&child, units, offset_x, offset_y)
+                            .into_iter()
+                            .map(ecad::SetFeature::Line),
+                    );
                 }
                 "UserSpecial" => {
                     // UserSpecial contains Contour > Polygon OR Line
@@ -1852,13 +1877,13 @@ impl<'a> Parser<'a> {
                                     if self.name(&poly_node) == "Polygon"
                                         && let Ok(poly) = self.parse_polygon(&poly_node, units)
                                     {
-                                        polygons.push(poly);
+                                        features.push(ecad::SetFeature::Polygon(poly));
                                     }
                                 }
                             }
                             "Line" => {
                                 if let Ok(line) = self.parse_line(&inner, units) {
-                                    lines.push(line);
+                                    features.push(ecad::SetFeature::Line(line));
                                 }
                             }
                             _ => {}
@@ -1869,7 +1894,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        (polygons, lines)
+        features
     }
 
     fn parse_line(&mut self, node: &Node, units: Units) -> Result<ecad::Line> {
@@ -2180,12 +2205,41 @@ impl<'a> Parser<'a> {
             .map(|s| self.interner.intern(s));
 
         let mut points = Vec::new();
+        let mut steps = Vec::new();
         for child in self.element_children(node) {
             match self.name(&child) {
-                "PolyBegin" | "PolyStepSegment" => {
+                "PolyBegin" => {
                     let x = self.parse_f64_attr_with_units(&child, "x", "TracePoint", units)?;
                     let y = self.parse_f64_attr_with_units(&child, "y", "TracePoint", units)?;
                     points.push(TracePoint { x, y });
+                }
+                "PolyStepSegment" => {
+                    let x = self.parse_f64_attr_with_units(&child, "x", "TracePoint", units)?;
+                    let y = self.parse_f64_attr_with_units(&child, "y", "TracePoint", units)?;
+                    let point = Point { x, y };
+                    points.push(TracePoint { x, y });
+                    steps.push(PolyStep::Segment(PolyStepSegment { point }));
+                }
+                "PolyStepCurve" => {
+                    let x = self.parse_f64_attr_with_units(&child, "x", "TracePoint", units)?;
+                    let y = self.parse_f64_attr_with_units(&child, "y", "TracePoint", units)?;
+                    let center_x =
+                        self.parse_f64_attr_with_units(&child, "centerX", "PolyStepCurve", units)?;
+                    let center_y =
+                        self.parse_f64_attr_with_units(&child, "centerY", "PolyStepCurve", units)?;
+                    let clockwise = self
+                        .attr(&child, "clockwise")
+                        .map(|value| value == "true" || value == "1")
+                        .unwrap_or(false);
+                    points.push(TracePoint { x, y });
+                    steps.push(PolyStep::Curve(PolyStepCurve {
+                        point: Point { x, y },
+                        center: Point {
+                            x: center_x,
+                            y: center_y,
+                        },
+                        clockwise,
+                    }));
                 }
                 "LineDescRef" => {
                     if let Some(id) = self.attr(&child, "id") {
@@ -2199,6 +2253,7 @@ impl<'a> Parser<'a> {
         Ok(Trace {
             line_desc_ref,
             points,
+            steps,
         })
     }
 

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1981,47 +1981,29 @@ impl<'a> Parser<'a> {
     fn parse_features(&mut self, features_node: &Node) -> Vec<ecad::SetFeature> {
         let mut features = Vec::new();
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
-
-        // Check for Location offset (applies to all geometry in Features)
-        let mut offset_x = 0.0;
-        let mut offset_y = 0.0;
-        for child in self.element_children(features_node) {
-            if self.name(&child) == "Location" {
-                offset_x = self
-                    .attr(&child, "x")
-                    .and_then(|s| s.parse::<f64>().ok())
-                    .map(|v| crate::units::to_mm(v, units))
-                    .unwrap_or(0.0);
-                offset_y = self
-                    .attr(&child, "y")
-                    .and_then(|s| s.parse::<f64>().ok())
-                    .map(|v| crate::units::to_mm(v, units))
-                    .unwrap_or(0.0);
-                break;
-            }
-        }
+        let offset = self.parse_features_location(features_node, units);
 
         for child in self.element_children(features_node) {
             match self.name(&child) {
                 "Polygon" => {
-                    if let Ok(poly) = self.parse_polygon(&child, units) {
-                        features.push(ecad::SetFeature::Polygon(poly));
+                    if let Some(feature) = self.parse_feature_polygon(&child, units, offset) {
+                        features.push(feature);
                     }
                 }
                 "Polyline" => {
                     if let Ok(polyline) =
-                        self.parse_feature_polyline(&child, units, offset_x, offset_y)
+                        self.parse_feature_polyline(&child, units, offset.x, offset.y)
                     {
                         features.push(ecad::SetFeature::Polyline(polyline));
                     }
                 }
                 "Line" => {
-                    if let Ok(line) = self.parse_line(&child, units, offset_x, offset_y) {
+                    if let Ok(line) = self.parse_line(&child, units, offset.x, offset.y) {
                         features.push(ecad::SetFeature::Line(line));
                     }
                 }
                 "Arc" => {
-                    if let Ok(arc) = self.parse_feature_arc(&child, units, offset_x, offset_y) {
+                    if let Ok(arc) = self.parse_feature_arc(&child, units, offset.x, offset.y) {
                         features.push(ecad::SetFeature::Arc(arc));
                     }
                 }
@@ -2032,28 +2014,29 @@ impl<'a> Parser<'a> {
                             "Contour" => {
                                 for poly_node in self.element_children(&inner) {
                                     if self.name(&poly_node) == "Polygon"
-                                        && let Ok(poly) = self.parse_polygon(&poly_node, units)
+                                        && let Some(feature) =
+                                            self.parse_feature_polygon(&poly_node, units, offset)
                                     {
-                                        features.push(ecad::SetFeature::Polygon(poly));
+                                        features.push(feature);
                                     }
                                 }
                             }
                             "Line" => {
-                                if let Ok(line) = self.parse_line(&inner, units, offset_x, offset_y)
+                                if let Ok(line) = self.parse_line(&inner, units, offset.x, offset.y)
                                 {
                                     features.push(ecad::SetFeature::Line(line));
                                 }
                             }
                             "Arc" => {
                                 if let Ok(arc) =
-                                    self.parse_feature_arc(&inner, units, offset_x, offset_y)
+                                    self.parse_feature_arc(&inner, units, offset.x, offset.y)
                                 {
                                     features.push(ecad::SetFeature::Arc(arc));
                                 }
                             }
                             "Polyline" => {
                                 if let Ok(polyline) =
-                                    self.parse_feature_polyline(&inner, units, offset_x, offset_y)
+                                    self.parse_feature_polyline(&inner, units, offset.x, offset.y)
                                 {
                                     features.push(ecad::SetFeature::Polyline(polyline));
                                 }
@@ -2063,8 +2046,8 @@ impl<'a> Parser<'a> {
                                     features.push(ecad::SetFeature::UserPrimitiveRef(
                                         ecad::FeaturePrimitiveRef {
                                             id: self.interner.intern(id),
-                                            x: offset_x,
-                                            y: offset_y,
+                                            x: offset.x,
+                                            y: offset.y,
                                         },
                                     ));
                                 }
@@ -2078,8 +2061,8 @@ impl<'a> Parser<'a> {
                         features.push(ecad::SetFeature::StandardPrimitiveRef(
                             ecad::FeaturePrimitiveRef {
                                 id: self.interner.intern(id),
-                                x: offset_x,
-                                y: offset_y,
+                                x: offset.x,
+                                y: offset.y,
                             },
                         ));
                     }
@@ -2089,8 +2072,8 @@ impl<'a> Parser<'a> {
                         features.push(ecad::SetFeature::UserPrimitiveRef(
                             ecad::FeaturePrimitiveRef {
                                 id: self.interner.intern(id),
-                                x: offset_x,
-                                y: offset_y,
+                                x: offset.x,
+                                y: offset.y,
                             },
                         ));
                     }
@@ -2100,6 +2083,56 @@ impl<'a> Parser<'a> {
         }
 
         features
+    }
+
+    fn parse_features_location(&self, features_node: &Node, units: Units) -> Point {
+        self.element_children(features_node)
+            .find(|child| self.name(child) == "Location")
+            .map(|location| Point {
+                x: self
+                    .attr(&location, "x")
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .map(|v| crate::units::to_mm(v, units))
+                    .unwrap_or(0.0),
+                y: self
+                    .attr(&location, "y")
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .map(|v| crate::units::to_mm(v, units))
+                    .unwrap_or(0.0),
+            })
+            .unwrap_or(Point { x: 0.0, y: 0.0 })
+    }
+
+    fn parse_feature_polygon(
+        &mut self,
+        node: &Node,
+        units: Units,
+        offset: Point,
+    ) -> Option<ecad::SetFeature> {
+        self.parse_polygon(node, units)
+            .ok()
+            .map(|polygon| ecad::SetFeature::Polygon(Self::translate_polygon(polygon, offset)))
+    }
+
+    fn translate_polygon(mut polygon: Polygon, offset: Point) -> Polygon {
+        Self::translate_point(&mut polygon.begin, offset);
+        for step in &mut polygon.steps {
+            match step {
+                PolyStep::Segment(segment) => {
+                    Self::translate_point(&mut segment.point, offset);
+                }
+                PolyStep::Curve(curve) => {
+                    Self::translate_point(&mut curve.point, offset);
+                    Self::translate_point(&mut curve.center, offset);
+                }
+            }
+        }
+        polygon
+    }
+
+    fn translate_point(point: &mut Point, offset: Point) {
+        point.x += offset.x;
+        point.y += offset.y;
     }
 
     fn parse_line(

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -778,6 +778,12 @@ impl<'a> Parser<'a> {
         for child in self.element_children(node) {
             let tag_name = self.name(&child);
 
+            if tag_name == "UserSpecial" {
+                let UserPrimitive::UserSpecial(nested) = self.parse_user_special(&child, units)?;
+                shapes.extend(nested.shapes);
+                continue;
+            }
+
             // Parse shape based on tag name
             let shape_type = match tag_name {
                 "Contour" => self
@@ -812,6 +818,27 @@ impl<'a> Parser<'a> {
                         height: self.parse_f64_attr_with_units(&child, "height", "Oval", units)?,
                     },
                 })),
+                "RectRound" => Some(UserShapeType::RectRound(RectRound {
+                    size: Size {
+                        width: self.parse_f64_attr_with_units(
+                            &child,
+                            "width",
+                            "RectRound",
+                            units,
+                        )?,
+                        height: self.parse_f64_attr_with_units(
+                            &child,
+                            "height",
+                            "RectRound",
+                            units,
+                        )?,
+                    },
+                    radius: self.parse_f64_attr_with_units(&child, "radius", "RectRound", units)?,
+                    upper_right: self.parse_bool_attr(&child, "upperRight").unwrap_or(false),
+                    upper_left: self.parse_bool_attr(&child, "upperLeft").unwrap_or(false),
+                    lower_right: self.parse_bool_attr(&child, "lowerRight").unwrap_or(false),
+                    lower_left: self.parse_bool_attr(&child, "lowerLeft").unwrap_or(false),
+                })),
                 "Polygon" => Some(UserShapeType::Polygon(self.parse_polygon(&child, units)?)),
                 "Line" => Some(UserShapeType::Line(crate::types::primitives::Line {
                     start: Point {
@@ -823,9 +850,13 @@ impl<'a> Parser<'a> {
                         y: self.parse_f64_attr_with_units(&child, "endY", "Line", units)?,
                     },
                 })),
+                "Arc" => Some(UserShapeType::Arc(self.parse_user_arc(&child, units)?)),
                 "Polyline" => Some(UserShapeType::Polyline(
                     self.parse_user_polyline(&child, units)?,
                 )),
+                "UserPrimitiveRef" => child
+                    .attribute("id")
+                    .map(|id| UserShapeType::UserPrimitiveRef(self.interner.intern(id))),
                 _ => None,
             };
 
@@ -923,6 +954,24 @@ impl<'a> Parser<'a> {
         Ok(Polyline {
             begin: begin.ok_or(Ipc2581Error::MissingElement("PolyBegin in Polyline"))?,
             steps,
+        })
+    }
+
+    fn parse_user_arc(&mut self, node: &Node, units: Units) -> Result<Arc> {
+        Ok(Arc {
+            start: Point {
+                x: self.parse_f64_attr_with_units(node, "startX", "Arc", units)?,
+                y: self.parse_f64_attr_with_units(node, "startY", "Arc", units)?,
+            },
+            end: Point {
+                x: self.parse_f64_attr_with_units(node, "endX", "Arc", units)?,
+                y: self.parse_f64_attr_with_units(node, "endY", "Arc", units)?,
+            },
+            center: Point {
+                x: self.parse_f64_attr_with_units(node, "centerX", "Arc", units)?,
+                y: self.parse_f64_attr_with_units(node, "centerY", "Arc", units)?,
+            },
+            clockwise: self.parse_bool_attr(node, "clockwise")?,
         })
     }
 
@@ -1884,7 +1933,8 @@ impl<'a> Parser<'a> {
                             ecad::SetFeature::Polyline(polyline) => {
                                 polylines.push(polyline.clone())
                             }
-                            ecad::SetFeature::StandardPrimitiveRef(_)
+                            ecad::SetFeature::Arc(_)
+                            | ecad::SetFeature::StandardPrimitiveRef(_)
                             | ecad::SetFeature::UserPrimitiveRef(_) => {}
                             _ => {}
                         }
@@ -1965,6 +2015,16 @@ impl<'a> Parser<'a> {
                         features.push(ecad::SetFeature::Polyline(polyline));
                     }
                 }
+                "Line" => {
+                    if let Ok(line) = self.parse_line(&child, units, offset_x, offset_y) {
+                        features.push(ecad::SetFeature::Line(line));
+                    }
+                }
+                "Arc" => {
+                    if let Ok(arc) = self.parse_feature_arc(&child, units, offset_x, offset_y) {
+                        features.push(ecad::SetFeature::Arc(arc));
+                    }
+                }
                 "UserSpecial" => {
                     // UserSpecial contains Contour > Polygon, Line, or Polyline.
                     for inner in self.element_children(&child) {
@@ -1979,8 +2039,16 @@ impl<'a> Parser<'a> {
                                 }
                             }
                             "Line" => {
-                                if let Ok(line) = self.parse_line(&inner, units) {
+                                if let Ok(line) = self.parse_line(&inner, units, offset_x, offset_y)
+                                {
                                     features.push(ecad::SetFeature::Line(line));
+                                }
+                            }
+                            "Arc" => {
+                                if let Ok(arc) =
+                                    self.parse_feature_arc(&inner, units, offset_x, offset_y)
+                                {
+                                    features.push(ecad::SetFeature::Arc(arc));
                                 }
                             }
                             "Polyline" => {
@@ -1988,6 +2056,17 @@ impl<'a> Parser<'a> {
                                     self.parse_feature_polyline(&inner, units, offset_x, offset_y)
                                 {
                                     features.push(ecad::SetFeature::Polyline(polyline));
+                                }
+                            }
+                            "UserPrimitiveRef" => {
+                                if let Some(id) = inner.attribute("id") {
+                                    features.push(ecad::SetFeature::UserPrimitiveRef(
+                                        ecad::FeaturePrimitiveRef {
+                                            id: self.interner.intern(id),
+                                            x: offset_x,
+                                            y: offset_y,
+                                        },
+                                    ));
                                 }
                             }
                             _ => {}
@@ -2023,11 +2102,17 @@ impl<'a> Parser<'a> {
         features
     }
 
-    fn parse_line(&mut self, node: &Node, units: Units) -> Result<ecad::Line> {
-        let start_x = self.parse_f64_attr_with_units(node, "startX", "Line", units)?;
-        let start_y = self.parse_f64_attr_with_units(node, "startY", "Line", units)?;
-        let end_x = self.parse_f64_attr_with_units(node, "endX", "Line", units)?;
-        let end_y = self.parse_f64_attr_with_units(node, "endY", "Line", units)?;
+    fn parse_line(
+        &mut self,
+        node: &Node,
+        units: Units,
+        offset_x: f64,
+        offset_y: f64,
+    ) -> Result<ecad::Line> {
+        let start_x = self.parse_f64_attr_with_units(node, "startX", "Line", units)? + offset_x;
+        let start_y = self.parse_f64_attr_with_units(node, "startY", "Line", units)? + offset_y;
+        let end_x = self.parse_f64_attr_with_units(node, "endX", "Line", units)? + offset_x;
+        let end_y = self.parse_f64_attr_with_units(node, "endY", "Line", units)? + offset_y;
 
         let mut line_width = 0.25;
         let mut line_end = None;
@@ -2062,6 +2147,62 @@ impl<'a> Parser<'a> {
             start_y,
             end_x,
             end_y,
+            line_desc_ref,
+            line_width,
+            line_end,
+        })
+    }
+
+    fn parse_feature_arc(
+        &mut self,
+        node: &Node,
+        units: Units,
+        offset_x: f64,
+        offset_y: f64,
+    ) -> Result<ecad::FeatureArc> {
+        let arc = self.parse_user_arc(node, units)?;
+        let mut line_width = 0.25;
+        let mut line_end = None;
+        let mut line_desc_ref = None;
+
+        for child in node.children().filter(|n| n.is_element()) {
+            match child.tag_name().name() {
+                "LineDesc" => {
+                    line_width = child
+                        .attribute("lineWidth")
+                        .and_then(|s| s.parse::<f64>().ok())
+                        .map(|v| crate::units::to_mm(v, units))
+                        .unwrap_or(0.25);
+                    line_end = child.attribute("lineEnd").and_then(|s| match s {
+                        "ROUND" => Some(LineEnd::Round),
+                        "SQUARE" => Some(LineEnd::Square),
+                        "FLAT" => Some(LineEnd::Flat),
+                        _ => None,
+                    });
+                }
+                "LineDescRef" => {
+                    if let Some(id) = child.attribute("id") {
+                        line_desc_ref = Some(self.interner.intern(id));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(ecad::FeatureArc {
+            start: Point {
+                x: arc.start.x + offset_x,
+                y: arc.start.y + offset_y,
+            },
+            end: Point {
+                x: arc.end.x + offset_x,
+                y: arc.end.y + offset_y,
+            },
+            center: Point {
+                x: arc.center.x + offset_x,
+                y: arc.center.y + offset_y,
+            },
+            clockwise: arc.clockwise,
             line_desc_ref,
             line_width,
             line_end,

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1905,23 +1905,29 @@ impl<'a> Parser<'a> {
 
         let mut line_width = 0.25;
         let mut line_end = None;
+        let mut line_desc_ref = None;
 
-        // Look for LineDesc child
         for child in self.element_children(node) {
-            if self.name(&child) == "LineDesc" {
-                line_width = self
-                    .attr(&child, "lineWidth")
-                    .and_then(|s| s.parse::<f64>().ok())
-                    .map(|v| crate::units::to_mm(v, units))
-                    .unwrap_or(0.25);
-
-                line_end = self.attr(&child, "lineEnd").and_then(|s| match s {
-                    "ROUND" => Some(LineEnd::Round),
-                    "SQUARE" => Some(LineEnd::Square),
-                    "FLAT" => Some(LineEnd::Flat),
-                    _ => None,
-                });
-                break;
+            match self.name(&child) {
+                "LineDesc" => {
+                    line_width = self
+                        .attr(&child, "lineWidth")
+                        .and_then(|s| s.parse::<f64>().ok())
+                        .map(|v| crate::units::to_mm(v, units))
+                        .unwrap_or(0.25);
+                    line_end = self.attr(&child, "lineEnd").and_then(|s| match s {
+                        "ROUND" => Some(LineEnd::Round),
+                        "SQUARE" => Some(LineEnd::Square),
+                        "FLAT" => Some(LineEnd::Flat),
+                        _ => None,
+                    });
+                }
+                "LineDescRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        line_desc_ref = Some(self.interner.intern(id));
+                    }
+                }
+                _ => {}
             }
         }
 
@@ -1930,6 +1936,7 @@ impl<'a> Parser<'a> {
             start_y,
             end_x,
             end_y,
+            line_desc_ref,
             line_width,
             line_end,
         })
@@ -1947,6 +1954,7 @@ impl<'a> Parser<'a> {
         let mut current_y = offset_y;
         let mut line_width = 0.25;
         let mut line_end = None;
+        let mut line_desc_ref = None;
 
         // Parse points and LineDesc, tessellating curves
         for child in self.element_children(node) {
@@ -1976,6 +1984,7 @@ impl<'a> Parser<'a> {
                         start_y: current_y,
                         end_x: x,
                         end_y: y,
+                        line_desc_ref,
                         line_width,
                         line_end,
                     });
@@ -2003,6 +2012,7 @@ impl<'a> Parser<'a> {
                         start_y: current_y,
                         end_x,
                         end_y,
+                        line_desc_ref,
                         line_width,
                         line_end,
                     });
@@ -2022,6 +2032,11 @@ impl<'a> Parser<'a> {
                         "FLAT" => Some(LineEnd::Flat),
                         _ => None,
                     });
+                }
+                "LineDescRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        line_desc_ref = Some(self.interner.intern(id));
+                    }
                 }
                 _ => {}
             }

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -237,6 +237,7 @@ pub struct FeatureSet {
     pub net: Option<Symbol>,      // Net name from Set element
     pub geometry: Option<Symbol>, // Reference to PadStackDef or other geometry definition
     pub polarity: Option<Polarity>,
+    pub features: Vec<SetFeature>,
     pub holes: Vec<Hole>,
     pub slots: Vec<Slot>,
     pub pads: Vec<Pad>,
@@ -244,6 +245,17 @@ pub struct FeatureSet {
     pub polygons: Vec<super::Polygon>, // Copper pours from Features
     pub lines: Vec<Line>,              // Trace lines from Features > UserSpecial > Line
     pub nonstandard_attributes: Vec<NonstandardAttribute>,
+}
+
+/// Geometry-bearing children of a Set in source document order.
+#[derive(Debug, Clone)]
+pub enum SetFeature {
+    Hole(Hole),
+    Slot(Slot),
+    Pad(Pad),
+    Trace(Trace),
+    Polygon(super::Polygon),
+    Line(Line),
 }
 
 /// NonstandardAttribute from Set elements
@@ -317,6 +329,7 @@ pub struct Pad {
 pub struct Trace {
     pub line_desc_ref: Option<Symbol>,
     pub points: Vec<TracePoint>,
+    pub steps: Vec<super::PolyStep>,
 }
 
 /// Point in a trace

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -258,6 +258,8 @@ pub enum SetFeature {
     Polygon(super::Polygon),
     Line(Line),
     Polyline(FeaturePolyline),
+    StandardPrimitiveRef(FeaturePrimitiveRef),
+    UserPrimitiveRef(FeaturePrimitiveRef),
 }
 
 /// NonstandardAttribute from Set elements
@@ -288,6 +290,14 @@ pub struct FeaturePolyline {
     pub line_desc_ref: Option<Symbol>,
     pub line_width: f64,
     pub line_end: Option<super::LineEnd>,
+}
+
+/// Primitive reference used directly as feature geometry.
+#[derive(Debug, Clone)]
+pub struct FeaturePrimitiveRef {
+    pub id: Symbol,
+    pub x: f64,
+    pub y: f64,
 }
 
 /// Hole represents a drilled hole instance

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -257,6 +257,7 @@ pub enum SetFeature {
     Trace(Trace),
     Polygon(super::Polygon),
     Line(Line),
+    Arc(FeatureArc),
     Polyline(FeaturePolyline),
     StandardPrimitiveRef(FeaturePrimitiveRef),
     UserPrimitiveRef(FeaturePrimitiveRef),
@@ -287,6 +288,18 @@ pub struct Line {
 pub struct FeaturePolyline {
     pub begin: super::Point,
     pub steps: Vec<super::PolyStep>,
+    pub line_desc_ref: Option<Symbol>,
+    pub line_width: f64,
+    pub line_end: Option<super::LineEnd>,
+}
+
+/// Arc feature preserving center and direction.
+#[derive(Debug, Clone)]
+pub struct FeatureArc {
+    pub start: super::Point,
+    pub end: super::Point,
+    pub center: super::Point,
+    pub clockwise: bool,
     pub line_desc_ref: Option<Symbol>,
     pub line_width: f64,
     pub line_end: Option<super::LineEnd>,

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -244,6 +244,7 @@ pub struct FeatureSet {
     pub traces: Vec<Trace>,
     pub polygons: Vec<super::Polygon>, // Copper pours from Features
     pub lines: Vec<Line>,              // Trace lines from Features > UserSpecial > Line
+    pub polylines: Vec<FeaturePolyline>,
     pub nonstandard_attributes: Vec<NonstandardAttribute>,
 }
 
@@ -256,6 +257,7 @@ pub enum SetFeature {
     Trace(Trace),
     Polygon(super::Polygon),
     Line(Line),
+    Polyline(FeaturePolyline),
 }
 
 /// NonstandardAttribute from Set elements
@@ -273,6 +275,16 @@ pub struct Line {
     pub start_y: f64,
     pub end_x: f64,
     pub end_y: f64,
+    pub line_desc_ref: Option<Symbol>,
+    pub line_width: f64,
+    pub line_end: Option<super::LineEnd>,
+}
+
+/// Open polyline feature preserving straight and curved PolyStep order.
+#[derive(Debug, Clone)]
+pub struct FeaturePolyline {
+    pub begin: super::Point,
+    pub steps: Vec<super::PolyStep>,
     pub line_desc_ref: Option<Symbol>,
     pub line_width: f64,
     pub line_end: Option<super::LineEnd>,

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -273,6 +273,7 @@ pub struct Line {
     pub start_y: f64,
     pub end_x: f64,
     pub end_y: f64,
+    pub line_desc_ref: Option<Symbol>,
     pub line_width: f64,
     pub line_end: Option<super::LineEnd>,
 }

--- a/crates/ipc2581/src/types/primitives.rs
+++ b/crates/ipc2581/src/types/primitives.rs
@@ -307,6 +307,7 @@ pub struct UserSpecial {
 pub struct UserShape {
     pub shape: UserShapeType,
     pub line_desc: Option<LineDesc>,
+    pub line_desc_ref: Option<Symbol>,
     pub fill_desc: Option<FillDesc>,
 }
 
@@ -317,7 +318,8 @@ pub enum UserShapeType {
     RectCenter(RectCenter),
     Oval(Oval),
     Polygon(Polygon),
-    // Other standard shapes as needed (e.g., Polyline)
+    Line(Line),
+    Polyline(Polyline),
 }
 
 // FromStr implementations for shape enums

--- a/crates/ipc2581/src/types/primitives.rs
+++ b/crates/ipc2581/src/types/primitives.rs
@@ -317,9 +317,12 @@ pub enum UserShapeType {
     Circle(Circle),
     RectCenter(RectCenter),
     Oval(Oval),
+    RectRound(RectRound),
     Polygon(Polygon),
     Line(Line),
+    Arc(Arc),
     Polyline(Polyline),
+    UserPrimitiveRef(Symbol),
 }
 
 // FromStr implementations for shape enums

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use ipc2581::types::{
     FillProperty, LayerFunction, LineEnd, PadUse, PlatingStatus, Polarity, PolyStep, SlotShape,
     StandardPrimitive,
-    ecad::{Layer, Step, StepRepeat},
+    ecad::{Layer, SetFeature, Step, StepRepeat},
 };
 use ipc2581::{Ipc2581, Symbol};
 
@@ -161,69 +161,31 @@ fn extract_step_layer(
         for (set_index, set) in layer_feature.sets.iter().enumerate() {
             let polarity = set.polarity.map(map_polarity).unwrap_or(layer_polarity);
 
-            for (feature_index, pad) in set.pads.iter().enumerate() {
-                if let Some(feature) = extract_pad(
-                    &context,
-                    layer.name,
-                    set.net,
-                    polarity,
-                    SourceRef {
-                        set_index: set_index as u32,
-                        feature_index: feature_index as u32,
-                    },
-                    pad,
-                    &mut doc,
-                )? {
+            for (feature_index, set_feature) in set.features.iter().enumerate() {
+                let source = SourceRef {
+                    set_index: set_index as u32,
+                    feature_index: feature_index as u32,
+                };
+                let feature = match set_feature {
+                    SetFeature::Pad(pad) => extract_pad(
+                        &context, layer.name, set.net, polarity, source, pad, &mut doc,
+                    )?,
+                    SetFeature::Trace(trace) => {
+                        extract_trace(&context, set.net, polarity, source, trace, &mut doc)
+                    }
+                    SetFeature::Polygon(polygon) => Some(extract_polygon(
+                        set.net, polarity, source, polygon, &mut doc,
+                    )),
+                    SetFeature::Line(line) => {
+                        Some(extract_line(set.net, polarity, source, line, &mut doc))
+                    }
+                    SetFeature::Hole(_) | SetFeature::Slot(_) => None,
+                };
+
+                if let Some(feature) = feature {
                     layer_bbox = layer_bbox.union(feature.bbox);
                     doc.features.push(feature);
                 }
-            }
-
-            for (feature_index, trace) in set.traces.iter().enumerate() {
-                if let Some(feature) = extract_trace(
-                    &context,
-                    set.net,
-                    polarity,
-                    SourceRef {
-                        set_index: set_index as u32,
-                        feature_index: feature_index as u32,
-                    },
-                    trace,
-                    &mut doc,
-                ) {
-                    layer_bbox = layer_bbox.union(feature.bbox);
-                    doc.features.push(feature);
-                }
-            }
-
-            for (feature_index, polygon) in set.polygons.iter().enumerate() {
-                let feature = extract_polygon(
-                    set.net,
-                    polarity,
-                    SourceRef {
-                        set_index: set_index as u32,
-                        feature_index: feature_index as u32,
-                    },
-                    polygon,
-                    &mut doc,
-                );
-                layer_bbox = layer_bbox.union(feature.bbox);
-                doc.features.push(feature);
-            }
-
-            for (feature_index, line) in set.lines.iter().enumerate() {
-                let feature = extract_line(
-                    set.net,
-                    polarity,
-                    SourceRef {
-                        set_index: set_index as u32,
-                        feature_index: feature_index as u32,
-                    },
-                    line,
-                    &mut doc,
-                );
-                layer_bbox = layer_bbox.union(feature.bbox);
-                doc.features.push(feature);
             }
         }
     }
@@ -240,23 +202,27 @@ fn extract_step_layer(
 
         for (set_index, set) in layer_feature.sets.iter().enumerate() {
             if is_drill_layer && layer_span_applies_to_layer(source_layer, layer, layers) {
-                for (feature_index, hole) in set.holes.iter().enumerate() {
-                    let feature = extract_hole(
-                        SourceRef {
-                            set_index: set_index as u32,
-                            feature_index: feature_index as u32,
-                        },
-                        hole,
-                        &mut doc,
-                    );
-                    layer_bbox = layer_bbox.union(feature.bbox);
-                    doc.features.push(feature);
+                for (feature_index, set_feature) in set.features.iter().enumerate() {
+                    if let SetFeature::Hole(hole) = set_feature {
+                        let feature = extract_hole(
+                            SourceRef {
+                                set_index: set_index as u32,
+                                feature_index: feature_index as u32,
+                            },
+                            hole,
+                            &mut doc,
+                        );
+                        layer_bbox = layer_bbox.union(feature.bbox);
+                        doc.features.push(feature);
+                    }
                 }
             }
 
             if is_drill_layer || is_routing_layer {
-                for (feature_index, slot) in set.slots.iter().enumerate() {
-                    if slot_applies_to_layer(source_layer, layer, layers, slot) {
+                for (feature_index, set_feature) in set.features.iter().enumerate() {
+                    if let SetFeature::Slot(slot) = set_feature
+                        && slot_applies_to_layer(source_layer, layer, layers, slot)
+                    {
                         let feature = extract_slot(
                             &context,
                             SourceRef {
@@ -610,17 +576,12 @@ fn extract_trace(
         return None;
     };
 
-    let points: Vec<Point> = trace
-        .points
-        .iter()
-        .map(|point| Point::new(point.x, point.y))
-        .collect();
-    Some(push_stroked_polyline(
+    Some(push_stroked_trace(
         doc,
         net,
         polarity,
         source,
-        points,
+        trace,
         line_desc.line_width,
         map_line_cap(line_desc.line_end),
     ))
@@ -686,6 +647,60 @@ fn push_stroked_polyline(
         } else {
             PathCmd::line_to(point)
         });
+    }
+    bbox = bbox.expand(width / 2.0);
+
+    let path_start = doc.paths.len() as u32;
+    doc.push_path(GeometryPath::stroked(width, line_cap, bbox), cmds);
+
+    let mut feature = GeometryFeature::new(FeatureKind::Trace, FeatureBucket::Trace, polarity);
+    feature.net = net;
+    feature.source = source;
+    feature.bbox = bbox;
+    feature.path_start = path_start;
+    feature.path_count = 1;
+    feature.stroke_width = width;
+    feature.line_cap = line_cap;
+    feature.flags.lowered_to_paths = true;
+    feature
+}
+
+fn push_stroked_trace(
+    doc: &mut GeometryDocument,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    trace: &ipc2581::types::Trace,
+    width: f64,
+    line_cap: LineCap,
+) -> GeometryFeature {
+    if trace.steps.is_empty() {
+        let points = trace
+            .points
+            .iter()
+            .map(|point| Point::new(point.x, point.y))
+            .collect();
+        return push_stroked_polyline(doc, net, polarity, source, points, width, line_cap);
+    }
+
+    let mut current = Point::new(trace.points[0].x, trace.points[0].y);
+    let mut bbox = BBox::from_point(current);
+    let mut cmds = vec![PathCmd::move_to(current)];
+    for step in &trace.steps {
+        match step {
+            PolyStep::Segment(segment) => {
+                current = Point::new(segment.point.x, segment.point.y);
+                bbox.include_point(current);
+                cmds.push(PathCmd::line_to(current));
+            }
+            PolyStep::Curve(curve) => {
+                let end = Point::new(curve.point.x, curve.point.y);
+                let center = Point::new(curve.center.x, curve.center.y);
+                bbox.include_circular_arc(current, end, center, curve.clockwise);
+                cmds.push(PathCmd::arc_to(end, center, curve.clockwise));
+                current = end;
+            }
+        }
     }
     bbox = bbox.expand(width / 2.0);
 
@@ -1619,6 +1634,38 @@ mod tests {
 
         assert_eq!(primitive_paint(&circle), PrimitivePaint::Hollow);
         assert_eq!(primitive_paint(&rect), PrimitivePaint::Void);
+    }
+
+    #[test]
+    fn lowers_trace_poly_step_curves_as_arcs() {
+        let mut doc = GeometryDocument::new("test".to_string());
+        let trace = ipc2581::types::Trace {
+            line_desc_ref: None,
+            points: vec![
+                ipc2581::types::ecad::TracePoint { x: 1.0, y: 0.0 },
+                ipc2581::types::ecad::TracePoint { x: 0.0, y: 1.0 },
+            ],
+            steps: vec![PolyStep::Curve(ipc2581::types::PolyStepCurve {
+                point: ipc2581::types::Point { x: 0.0, y: 1.0 },
+                center: ipc2581::types::Point { x: 0.0, y: 0.0 },
+                clockwise: false,
+            })],
+        };
+
+        let feature = push_stroked_trace(
+            &mut doc,
+            None,
+            GeometryPolarity::Positive,
+            SourceRef::default(),
+            &trace,
+            0.2,
+            LineCap::Round,
+        );
+
+        assert_eq!(feature.path_count, 1);
+        assert_eq!(doc.paths[0].bbox.min, Point::new(-0.1, -0.1));
+        assert_eq!(doc.paths[0].bbox.max, Point::new(1.1, 1.1));
+        assert!(doc.path_cmds.iter().any(|cmd| cmd.op == PathOp::ArcTo));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -195,6 +195,24 @@ fn extract_step_layer(
                     SetFeature::Polyline(polyline) => Some(extract_feature_polyline(
                         &context, set.net, polarity, source, polyline, &mut doc,
                     )),
+                    SetFeature::StandardPrimitiveRef(primitive_ref) => extract_feature_primitive(
+                        &context,
+                        set.net,
+                        polarity,
+                        source,
+                        primitive_ref,
+                        FeaturePrimitiveKind::Standard,
+                        &mut doc,
+                    )?,
+                    SetFeature::UserPrimitiveRef(primitive_ref) => extract_feature_primitive(
+                        &context,
+                        set.net,
+                        polarity,
+                        source,
+                        primitive_ref,
+                        FeaturePrimitiveKind::User,
+                        &mut doc,
+                    )?,
                     SetFeature::Hole(_) | SetFeature::Slot(_) => None,
                 };
 
@@ -527,7 +545,7 @@ fn extract_pad(
                 ));
                 return Ok(None);
             };
-            lower_user_primitive(doc, primitive, transform)
+            lower_user_primitive(context, doc, primitive, transform)
         }
     };
     let path_count = doc.paths.len() as u32 - path_start;
@@ -597,6 +615,76 @@ fn find_pad_primitive_ref(
                 .map(PadPrimitiveRef::Standard)
                 .or_else(|| pad_def.user_primitive_ref.map(PadPrimitiveRef::User))
         })
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FeaturePrimitiveKind {
+    Standard,
+    User,
+}
+
+fn extract_feature_primitive(
+    context: &ExtractContext<'_>,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    primitive_ref: &ipc2581::types::ecad::FeaturePrimitiveRef,
+    primitive_kind: FeaturePrimitiveKind,
+    doc: &mut GeometryDocument,
+) -> Result<Option<GeometryFeature>> {
+    let transform = Affine2::placement(
+        Point::new(primitive_ref.x, primitive_ref.y),
+        0.0,
+        false,
+        1.0,
+    );
+    let path_start = doc.paths.len() as u32;
+    let paint = match primitive_kind {
+        FeaturePrimitiveKind::Standard => {
+            let Some(primitive) = context.standard_primitives.get(&primitive_ref.id).copied()
+            else {
+                doc.warn(format!(
+                    "Skipping feature because standard primitive '{}' is missing",
+                    context.ipc.resolve(primitive_ref.id)
+                ));
+                return Ok(None);
+            };
+            lower_standard_primitive(context, doc, primitive, transform, FeatureBucket::Fill)?
+        }
+        FeaturePrimitiveKind::User => {
+            let Some(primitive) = context.user_primitives.get(&primitive_ref.id).copied() else {
+                doc.warn(format!(
+                    "Skipping feature because user primitive '{}' is missing",
+                    context.ipc.resolve(primitive_ref.id)
+                ));
+                return Ok(None);
+            };
+            lower_user_primitive(context, doc, primitive, transform)
+        }
+    };
+
+    let path_count = doc.paths.len() as u32 - path_start;
+    if path_count == 0 {
+        return Ok(None);
+    }
+
+    let mut feature = GeometryFeature::new(
+        FeatureKind::Primitive,
+        FeatureBucket::Fill,
+        if paint == PrimitivePaint::Void {
+            GeometryPolarity::Negative
+        } else {
+            polarity
+        },
+    );
+    feature.net = net;
+    feature.source = source;
+    feature.transform = transform;
+    feature.bbox = paths_bbox(doc, path_start, path_count);
+    feature.path_start = path_start;
+    feature.path_count = path_count;
+    feature.flags.lowered_to_paths = true;
+    Ok(Some(feature))
 }
 
 fn extract_trace(
@@ -1084,6 +1172,7 @@ fn lower_standard_primitive(
 }
 
 fn lower_user_primitive(
+    context: &ExtractContext<'_>,
     doc: &mut GeometryDocument,
     primitive: &UserPrimitive,
     transform: Affine2,
@@ -1106,11 +1195,19 @@ fn lower_user_primitive(
                     UserShapeType::Polygon(polygon) => {
                         push_polygon_path(doc, polygon, transform, FillRule::NonZero);
                     }
+                    UserShapeType::Line(line) => {
+                        let line_desc = user_shape_line_desc(context, shape);
+                        push_user_line_path(doc, line, transform, line_desc);
+                    }
+                    UserShapeType::Polyline(polyline) => {
+                        let line_desc = user_shape_line_desc(context, shape);
+                        push_user_polyline_path(doc, polyline, transform, line_desc);
+                    }
                 }
 
                 match shape.fill_desc.map(|desc| desc.fill_property) {
                     Some(FillProperty::Hollow) => {
-                        if let Some(line_desc) = shape.line_desc {
+                        if let Some(line_desc) = user_shape_line_desc(context, shape) {
                             make_paths_stroked(
                                 doc,
                                 path_start,
@@ -1134,6 +1231,83 @@ fn lower_user_primitive(
             paint
         }
     }
+}
+
+fn user_shape_line_desc(
+    context: &ExtractContext<'_>,
+    shape: &ipc2581::types::UserShape,
+) -> Option<ipc2581::types::LineDesc> {
+    shape.line_desc.or_else(|| {
+        shape
+            .line_desc_ref
+            .and_then(|line_desc_ref| context.line_descs.get(&line_desc_ref).copied())
+    })
+}
+
+fn push_user_line_path(
+    doc: &mut GeometryDocument,
+    line: &ipc2581::types::primitives::Line,
+    transform: Affine2,
+    line_desc: Option<ipc2581::types::LineDesc>,
+) {
+    let start = transform.transform_point(Point::new(line.start.x, line.start.y));
+    let end = transform.transform_point(Point::new(line.end.x, line.end.y));
+    let width = line_desc.map(|desc| desc.line_width).unwrap_or(0.25);
+    let line_cap = line_desc
+        .map(|desc| map_line_cap(desc.line_end))
+        .unwrap_or(LineCap::Round);
+    let bbox = BBox::from_point(start)
+        .union(BBox::from_point(end))
+        .expand(width / 2.0);
+    doc.push_path(
+        GeometryPath::stroked(width, line_cap, bbox),
+        vec![PathCmd::move_to(start), PathCmd::line_to(end)],
+    );
+}
+
+fn push_user_polyline_path(
+    doc: &mut GeometryDocument,
+    polyline: &ipc2581::types::Polyline,
+    transform: Affine2,
+    line_desc: Option<ipc2581::types::LineDesc>,
+) {
+    let width = line_desc.map(|desc| desc.line_width).unwrap_or(0.25);
+    let line_cap = line_desc
+        .map(|desc| map_line_cap(desc.line_end))
+        .unwrap_or(LineCap::Round);
+    let mut current = Point::new(polyline.begin.x, polyline.begin.y);
+    let start = transform.transform_point(current);
+    let mut bbox = BBox::from_point(start);
+    let mut cmds = vec![PathCmd::move_to(start)];
+
+    for step in &polyline.steps {
+        match step {
+            PolyStep::Segment(segment) => {
+                current = Point::new(segment.point.x, segment.point.y);
+                let point = transform.transform_point(current);
+                bbox.include_point(point);
+                cmds.push(PathCmd::line_to(point));
+            }
+            PolyStep::Curve(curve) => {
+                let end = Point::new(curve.point.x, curve.point.y);
+                let center = Point::new(curve.center.x, curve.center.y);
+                let start = transform.transform_point(current);
+                let end = transform.transform_point(end);
+                let center = transform.transform_point(center);
+                let clockwise = if transform.determinant() < 0.0 {
+                    !curve.clockwise
+                } else {
+                    curve.clockwise
+                };
+                bbox.include_circular_arc(start, end, center, clockwise);
+                cmds.push(PathCmd::arc_to(end, center, clockwise));
+                current = Point::new(curve.point.x, curve.point.y);
+            }
+        }
+    }
+
+    bbox = bbox.expand(width / 2.0);
+    doc.push_path(GeometryPath::stroked(width, line_cap, bbox), cmds);
 }
 
 fn push_polygon_path(
@@ -1885,6 +2059,7 @@ mod tests {
                     line_end: LineEnd::Round,
                     line_property: None,
                 }),
+                line_desc_ref: None,
                 fill_desc: Some(ipc2581::types::FillDesc {
                     fill_property: FillProperty::Hollow,
                     angle1: None,
@@ -1893,7 +2068,18 @@ mod tests {
             }],
         });
 
-        let paint = lower_user_primitive(&mut doc, &primitive, Affine2::identity());
+        let ipc = Ipc2581::parse(
+            r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581"><Content roleRef="Owner"><FunctionMode mode="FABRICATION"/></Content></IPC-2581>"#,
+        )
+        .unwrap();
+        let context = ExtractContext {
+            ipc: &ipc,
+            padstacks: HashMap::new(),
+            line_descs: HashMap::new(),
+            standard_primitives: HashMap::new(),
+            user_primitives: HashMap::new(),
+        };
+        let paint = lower_user_primitive(&context, &mut doc, &primitive, Affine2::identity());
 
         assert_eq!(paint, PrimitivePaint::Hollow);
         assert_eq!(doc.paths.len(), 1);
@@ -1902,6 +2088,66 @@ mod tests {
         assert_eq!(doc.paths[0].stroke_width, 0.1);
         assert_eq!(doc.paths[0].bbox.min, Point::new(-0.7, -0.7));
         assert_eq!(doc.paths[0].bbox.max, Point::new(0.7, 0.7));
+    }
+
+    #[test]
+    fn lowers_user_special_lines_polylines_and_line_desc_refs() {
+        let ipc = Ipc2581::parse(
+            r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+    <DictionaryLineDesc units="MILLIMETER">
+      <EntryLineDesc id="fine">
+        <LineDesc lineWidth="0.15" lineEnd="FLAT"/>
+      </EntryLineDesc>
+    </DictionaryLineDesc>
+  </Content>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let entry = ipc.content().dictionary_line_desc.entries[0].clone();
+        let context = ExtractContext {
+            ipc: &ipc,
+            padstacks: HashMap::new(),
+            line_descs: HashMap::from([(entry.id, entry.line_desc)]),
+            standard_primitives: HashMap::new(),
+            user_primitives: HashMap::new(),
+        };
+        let mut doc = GeometryDocument::new("test".to_string());
+        let primitive = UserPrimitive::UserSpecial(ipc2581::types::UserSpecial {
+            shapes: vec![
+                ipc2581::types::UserShape {
+                    shape: UserShapeType::Line(ipc2581::types::primitives::Line {
+                        start: ipc2581::types::Point { x: 0.0, y: 0.0 },
+                        end: ipc2581::types::Point { x: 1.0, y: 0.0 },
+                    }),
+                    line_desc: None,
+                    line_desc_ref: Some(entry.id),
+                    fill_desc: None,
+                },
+                ipc2581::types::UserShape {
+                    shape: UserShapeType::Polyline(ipc2581::types::Polyline {
+                        begin: ipc2581::types::Point { x: 1.0, y: 0.0 },
+                        steps: vec![PolyStep::Curve(ipc2581::types::PolyStepCurve {
+                            point: ipc2581::types::Point { x: 0.0, y: 1.0 },
+                            center: ipc2581::types::Point { x: 0.0, y: 0.0 },
+                            clockwise: false,
+                        })],
+                    }),
+                    line_desc: None,
+                    line_desc_ref: Some(entry.id),
+                    fill_desc: None,
+                },
+            ],
+        });
+
+        let paint = lower_user_primitive(&context, &mut doc, &primitive, Affine2::identity());
+
+        assert_eq!(paint, PrimitivePaint::Fill);
+        assert_eq!(doc.paths.len(), 2);
+        assert!(doc.paths.iter().all(|path| path.flags.stroked));
+        assert!(doc.paths.iter().all(|path| path.stroke_width == 0.15));
+        assert!(doc.path_cmds.iter().any(|cmd| cmd.op == PathOp::ArcTo));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -744,16 +744,8 @@ fn extract_line(
     line: &ipc2581::types::ecad::Line,
     doc: &mut GeometryDocument,
 ) -> GeometryFeature {
-    let line_desc = line
-        .line_desc_ref
-        .and_then(|line_desc_ref| context.line_descs.get(&line_desc_ref).copied());
-    let line_width = line_desc
-        .map(|desc| desc.line_width)
-        .unwrap_or(line.line_width);
-    let line_cap = line_desc
-        .map(|desc| map_line_cap(desc.line_end))
-        .or_else(|| line.line_end.map(map_line_cap))
-        .unwrap_or(LineCap::Round);
+    let (line_width, line_cap) =
+        resolve_feature_line_style(context, line.line_desc_ref, line.line_width, line.line_end);
 
     push_stroked_polyline(
         doc,
@@ -779,16 +771,12 @@ fn extract_feature_polyline(
     polyline: &ipc2581::types::ecad::FeaturePolyline,
     doc: &mut GeometryDocument,
 ) -> GeometryFeature {
-    let line_desc = polyline
-        .line_desc_ref
-        .and_then(|line_desc_ref| context.line_descs.get(&line_desc_ref).copied());
-    let line_width = line_desc
-        .map(|desc| desc.line_width)
-        .unwrap_or(polyline.line_width);
-    let line_cap = line_desc
-        .map(|desc| map_line_cap(desc.line_end))
-        .or_else(|| polyline.line_end.map(map_line_cap))
-        .unwrap_or(LineCap::Round);
+    let (line_width, line_cap) = resolve_feature_line_style(
+        context,
+        polyline.line_desc_ref,
+        polyline.line_width,
+        polyline.line_end,
+    );
 
     push_stroked_steps(
         doc,
@@ -812,16 +800,8 @@ fn extract_arc(
     arc: &ipc2581::types::ecad::FeatureArc,
     doc: &mut GeometryDocument,
 ) -> GeometryFeature {
-    let line_desc = arc
-        .line_desc_ref
-        .and_then(|line_desc_ref| context.line_descs.get(&line_desc_ref).copied());
-    let line_width = line_desc
-        .map(|desc| desc.line_width)
-        .unwrap_or(arc.line_width);
-    let line_cap = line_desc
-        .map(|desc| map_line_cap(desc.line_end))
-        .or_else(|| arc.line_end.map(map_line_cap))
-        .unwrap_or(LineCap::Round);
+    let (line_width, line_cap) =
+        resolve_feature_line_style(context, arc.line_desc_ref, arc.line_width, arc.line_end);
 
     push_stroked_arc(
         doc,
@@ -837,6 +817,24 @@ fn extract_arc(
         Point::new(arc.center.x, arc.center.y),
         arc.clockwise,
     )
+}
+
+fn resolve_feature_line_style(
+    context: &ExtractContext<'_>,
+    line_desc_ref: Option<Symbol>,
+    inline_width: f64,
+    inline_end: Option<LineEnd>,
+) -> (f64, LineCap) {
+    let line_desc =
+        line_desc_ref.and_then(|line_desc_ref| context.line_descs.get(&line_desc_ref).copied());
+    let width = line_desc
+        .map(|desc| desc.line_width)
+        .unwrap_or(inline_width);
+    let line_cap = line_desc
+        .map(|desc| map_line_cap(desc.line_end))
+        .or_else(|| inline_end.map(map_line_cap))
+        .unwrap_or(LineCap::Round);
+    (width, line_cap)
 }
 
 fn extract_polygon(
@@ -1279,6 +1277,7 @@ fn lower_user_primitive(
             let mut paint = PrimitivePaint::Fill;
             for shape in &user_special.shapes {
                 let path_start = doc.paths.len() as u32;
+                let mut nested_paint = None;
                 match &shape.shape {
                     UserShapeType::Circle(circle) => {
                         push_ellipse_path(doc, transform, circle.diameter, circle.diameter);
@@ -1322,7 +1321,8 @@ fn lower_user_primitive(
                     UserShapeType::UserPrimitiveRef(primitive_ref) => {
                         if let Some(primitive) = context.user_primitives.get(primitive_ref).copied()
                         {
-                            let _ = lower_user_primitive(context, doc, primitive, transform);
+                            nested_paint =
+                                Some(lower_user_primitive(context, doc, primitive, transform));
                         } else {
                             make_paths_unpainted(doc, path_start);
                         }
@@ -1348,8 +1348,12 @@ fn lower_user_primitive(
                     }
                     Some(FillProperty::Fill)
                     | Some(FillProperty::Hatch)
-                    | Some(FillProperty::Mesh)
-                    | None => {}
+                    | Some(FillProperty::Mesh) => {}
+                    None => {
+                        if let Some(nested_paint) = nested_paint {
+                            paint = nested_paint;
+                        }
+                    }
                 }
             }
             paint

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -563,6 +563,7 @@ fn extract_pad(
     feature.primitive_ref = Some(primitive_ref);
     feature.flags.expanded_padstack = true;
     feature.flags.lowered_to_paths = true;
+    feature.flags.clears_previous_in_set = paint == PrimitivePaint::Void;
 
     Ok(Some(feature))
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use ipc2581::types::{
     FillProperty, LayerFunction, LineEnd, PadUse, PlatingStatus, Polarity, PolyStep, SlotShape,
-    StandardPrimitive,
+    StandardPrimitive, UserPrimitive, UserShapeType,
     ecad::{Layer, SetFeature, Step, StepRepeat},
 };
 use ipc2581::{Ipc2581, Symbol};
@@ -15,6 +15,13 @@ struct ExtractContext<'a> {
     padstacks: HashMap<Symbol, &'a ipc2581::types::PadStackDef>,
     line_descs: HashMap<Symbol, ipc2581::types::LineDesc>,
     standard_primitives: HashMap<Symbol, &'a StandardPrimitive>,
+    user_primitives: HashMap<Symbol, &'a UserPrimitive>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PadPrimitiveRef {
+    Standard(Symbol),
+    User(Symbol),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -146,6 +153,12 @@ fn extract_step_layer(
             .iter()
             .map(|entry| (entry.id, &entry.primitive))
             .collect(),
+        user_primitives: content
+            .dictionary_user
+            .entries
+            .iter()
+            .map(|entry| (entry.id, &entry.primitive))
+            .collect(),
     };
 
     let mut doc = GeometryDocument::new(ipc.resolve(step.name).to_string());
@@ -176,9 +189,9 @@ fn extract_step_layer(
                     SetFeature::Polygon(polygon) => Some(extract_polygon(
                         set.net, polarity, source, polygon, &mut doc,
                     )),
-                    SetFeature::Line(line) => {
-                        Some(extract_line(set.net, polarity, source, line, &mut doc))
-                    }
+                    SetFeature::Line(line) => Some(extract_line(
+                        &context, set.net, polarity, source, line, &mut doc,
+                    )),
                     SetFeature::Hole(_) | SetFeature::Slot(_) => None,
                 };
 
@@ -479,9 +492,7 @@ fn extract_pad(
     let center = Point::new(x + offset.x, y + offset.y);
     let transform = Affine2::placement(center, xform.rotation, xform.mirror, xform.scale);
 
-    let primitive_ref = pad
-        .standard_primitive_ref
-        .or_else(|| find_pad_primitive_ref(padstack, layer_ref));
+    let primitive_ref = pad_primitive_ref(pad, padstack, layer_ref);
     let Some(primitive_ref) = primitive_ref else {
         doc.warn(format!(
             "Skipping padstack '{}' because it has no regular primitive for layer '{}'",
@@ -490,17 +501,32 @@ fn extract_pad(
         ));
         return Ok(None);
     };
-    let Some(primitive) = context.standard_primitives.get(&primitive_ref).copied() else {
-        doc.warn(format!(
-            "Skipping padstack '{}' because primitive '{}' is missing",
-            context.ipc.resolve(padstack.name),
-            context.ipc.resolve(primitive_ref)
-        ));
-        return Ok(None);
-    };
 
     let path_start = doc.paths.len() as u32;
-    let paint = lower_standard_primitive(context, doc, primitive, transform, bucket)?;
+    let paint = match primitive_ref {
+        PadPrimitiveRef::Standard(primitive_ref) => {
+            let Some(primitive) = context.standard_primitives.get(&primitive_ref).copied() else {
+                doc.warn(format!(
+                    "Skipping padstack '{}' because primitive '{}' is missing",
+                    context.ipc.resolve(padstack.name),
+                    context.ipc.resolve(primitive_ref)
+                ));
+                return Ok(None);
+            };
+            lower_standard_primitive(context, doc, primitive, transform, bucket)?
+        }
+        PadPrimitiveRef::User(primitive_ref) => {
+            let Some(primitive) = context.user_primitives.get(&primitive_ref).copied() else {
+                doc.warn(format!(
+                    "Skipping padstack '{}' because user primitive '{}' is missing",
+                    context.ipc.resolve(padstack.name),
+                    context.ipc.resolve(primitive_ref)
+                ));
+                return Ok(None);
+            };
+            lower_user_primitive(doc, primitive, transform)
+        }
+    };
     let path_count = doc.paths.len() as u32 - path_start;
     if path_count == 0 {
         return Ok(None);
@@ -526,7 +552,11 @@ fn extract_pad(
     feature.rotation_degrees = xform.rotation;
     feature.scale = xform.scale;
     feature.padstack_ref = Some(padstack_ref);
-    feature.primitive_ref = Some(primitive_ref);
+    feature.primitive_ref = match primitive_ref {
+        PadPrimitiveRef::Standard(primitive_ref) | PadPrimitiveRef::User(primitive_ref) => {
+            Some(primitive_ref)
+        }
+    };
     feature.flags.expanded_padstack = true;
     feature.flags.lowered_to_paths = true;
     feature.flags.clears_previous_in_set = paint == PrimitivePaint::Void;
@@ -534,10 +564,21 @@ fn extract_pad(
     Ok(Some(feature))
 }
 
+fn pad_primitive_ref(
+    pad: &ipc2581::types::Pad,
+    padstack: &ipc2581::types::PadStackDef,
+    layer_ref: Symbol,
+) -> Option<PadPrimitiveRef> {
+    pad.standard_primitive_ref
+        .map(PadPrimitiveRef::Standard)
+        .or_else(|| pad.user_primitive_ref.map(PadPrimitiveRef::User))
+        .or_else(|| find_pad_primitive_ref(padstack, layer_ref))
+}
+
 fn find_pad_primitive_ref(
     padstack: &ipc2581::types::PadStackDef,
     layer_ref: Symbol,
-) -> Option<Symbol> {
+) -> Option<PadPrimitiveRef> {
     padstack
         .pad_defs
         .iter()
@@ -547,7 +588,12 @@ fn find_pad_primitive_ref(
                 pad_def.layer_ref == layer_ref && pad_def.pad_use == PadUse::Thermal
             })
         })
-        .and_then(|pad_def| pad_def.standard_primitive_ref)
+        .and_then(|pad_def| {
+            pad_def
+                .standard_primitive_ref
+                .map(PadPrimitiveRef::Standard)
+                .or_else(|| pad_def.user_primitive_ref.map(PadPrimitiveRef::User))
+        })
 }
 
 fn extract_trace(
@@ -588,12 +634,24 @@ fn extract_trace(
 }
 
 fn extract_line(
+    context: &ExtractContext<'_>,
     net: Option<Symbol>,
     polarity: GeometryPolarity,
     source: SourceRef,
     line: &ipc2581::types::ecad::Line,
     doc: &mut GeometryDocument,
 ) -> GeometryFeature {
+    let line_desc = line
+        .line_desc_ref
+        .and_then(|line_desc_ref| context.line_descs.get(&line_desc_ref).copied());
+    let line_width = line_desc
+        .map(|desc| desc.line_width)
+        .unwrap_or(line.line_width);
+    let line_cap = line_desc
+        .map(|desc| map_line_cap(desc.line_end))
+        .or_else(|| line.line_end.map(map_line_cap))
+        .unwrap_or(LineCap::Round);
+
     push_stroked_polyline(
         doc,
         net,
@@ -603,8 +661,8 @@ fn extract_line(
             Point::new(line.start_x, line.start_y),
             Point::new(line.end_x, line.end_y),
         ],
-        line.line_width,
-        line.line_end.map(map_line_cap).unwrap_or(LineCap::Round),
+        line_width,
+        line_cap,
     )
 }
 
@@ -967,6 +1025,59 @@ fn lower_standard_primitive(
     }
 
     Ok(paint)
+}
+
+fn lower_user_primitive(
+    doc: &mut GeometryDocument,
+    primitive: &UserPrimitive,
+    transform: Affine2,
+) -> PrimitivePaint {
+    match primitive {
+        UserPrimitive::UserSpecial(user_special) => {
+            let mut paint = PrimitivePaint::Fill;
+            for shape in &user_special.shapes {
+                let path_start = doc.paths.len() as u32;
+                match &shape.shape {
+                    UserShapeType::Circle(circle) => {
+                        push_ellipse_path(doc, transform, circle.diameter, circle.diameter);
+                    }
+                    UserShapeType::RectCenter(rect) => {
+                        push_rect_path(doc, transform, rect.size.width, rect.size.height);
+                    }
+                    UserShapeType::Oval(oval) => {
+                        push_oval_path(doc, transform, oval.size.width, oval.size.height);
+                    }
+                    UserShapeType::Polygon(polygon) => {
+                        push_polygon_path(doc, polygon, transform, FillRule::NonZero);
+                    }
+                }
+
+                match shape.fill_desc.map(|desc| desc.fill_property) {
+                    Some(FillProperty::Hollow) => {
+                        if let Some(line_desc) = shape.line_desc {
+                            make_paths_stroked(
+                                doc,
+                                path_start,
+                                line_desc.line_width,
+                                map_line_cap(line_desc.line_end),
+                            );
+                        } else {
+                            make_paths_unpainted(doc, path_start);
+                        }
+                        paint = PrimitivePaint::Hollow;
+                    }
+                    Some(FillProperty::Void) => {
+                        paint = PrimitivePaint::Void;
+                    }
+                    Some(FillProperty::Fill)
+                    | Some(FillProperty::Hatch)
+                    | Some(FillProperty::Mesh)
+                    | None => {}
+                }
+            }
+            paint
+        }
+    }
 }
 
 fn push_polygon_path(
@@ -1666,6 +1777,36 @@ mod tests {
         assert_eq!(doc.paths[0].bbox.min, Point::new(-0.1, -0.1));
         assert_eq!(doc.paths[0].bbox.max, Point::new(1.1, 1.1));
         assert!(doc.path_cmds.iter().any(|cmd| cmd.op == PathOp::ArcTo));
+    }
+
+    #[test]
+    fn lowers_hollow_user_circle_as_stroked_path() {
+        let mut doc = GeometryDocument::new("test".to_string());
+        let primitive = UserPrimitive::UserSpecial(ipc2581::types::UserSpecial {
+            shapes: vec![ipc2581::types::UserShape {
+                shape: UserShapeType::Circle(ipc2581::types::Circle { diameter: 1.4 }),
+                line_desc: Some(ipc2581::types::LineDesc {
+                    line_width: 0.1,
+                    line_end: LineEnd::Round,
+                    line_property: None,
+                }),
+                fill_desc: Some(ipc2581::types::FillDesc {
+                    fill_property: FillProperty::Hollow,
+                    angle1: None,
+                    angle2: None,
+                }),
+            }],
+        });
+
+        let paint = lower_user_primitive(&mut doc, &primitive, Affine2::identity());
+
+        assert_eq!(paint, PrimitivePaint::Hollow);
+        assert_eq!(doc.paths.len(), 1);
+        assert!(doc.paths[0].flags.stroked);
+        assert!(!doc.paths[0].flags.filled);
+        assert_eq!(doc.paths[0].stroke_width, 0.1);
+        assert_eq!(doc.paths[0].bbox.min, Point::new(-0.7, -0.7));
+        assert_eq!(doc.paths[0].bbox.max, Point::new(0.7, 0.7));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -24,6 +24,15 @@ enum PadPrimitiveRef {
     User(Symbol),
 }
 
+#[derive(Debug, Clone, Copy)]
+struct StrokedFeatureStyle {
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    width: f64,
+    line_cap: LineCap,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PrimitivePaint {
     Fill,
@@ -191,6 +200,9 @@ fn extract_step_layer(
                     )),
                     SetFeature::Line(line) => Some(extract_line(
                         &context, set.net, polarity, source, line, &mut doc,
+                    )),
+                    SetFeature::Arc(arc) => Some(extract_arc(
+                        &context, set.net, polarity, source, arc, &mut doc,
                     )),
                     SetFeature::Polyline(polyline) => Some(extract_feature_polyline(
                         &context, set.net, polarity, source, polyline, &mut doc,
@@ -745,15 +757,17 @@ fn extract_line(
 
     push_stroked_polyline(
         doc,
-        net,
-        polarity,
-        source,
+        StrokedFeatureStyle {
+            net,
+            polarity,
+            source,
+            width: line_width,
+            line_cap,
+        },
         vec![
             Point::new(line.start_x, line.start_y),
             Point::new(line.end_x, line.end_y),
         ],
-        line_width,
-        line_cap,
     )
 }
 
@@ -778,13 +792,50 @@ fn extract_feature_polyline(
 
     push_stroked_steps(
         doc,
-        net,
-        polarity,
-        source,
+        StrokedFeatureStyle {
+            net,
+            polarity,
+            source,
+            width: line_width,
+            line_cap,
+        },
         Point::new(polyline.begin.x, polyline.begin.y),
         &polyline.steps,
-        line_width,
-        line_cap,
+    )
+}
+
+fn extract_arc(
+    context: &ExtractContext<'_>,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    arc: &ipc2581::types::ecad::FeatureArc,
+    doc: &mut GeometryDocument,
+) -> GeometryFeature {
+    let line_desc = arc
+        .line_desc_ref
+        .and_then(|line_desc_ref| context.line_descs.get(&line_desc_ref).copied());
+    let line_width = line_desc
+        .map(|desc| desc.line_width)
+        .unwrap_or(arc.line_width);
+    let line_cap = line_desc
+        .map(|desc| map_line_cap(desc.line_end))
+        .or_else(|| arc.line_end.map(map_line_cap))
+        .unwrap_or(LineCap::Round);
+
+    push_stroked_arc(
+        doc,
+        StrokedFeatureStyle {
+            net,
+            polarity,
+            source,
+            width: line_width,
+            line_cap,
+        },
+        Point::new(arc.start.x, arc.start.y),
+        Point::new(arc.end.x, arc.end.y),
+        Point::new(arc.center.x, arc.center.y),
+        arc.clockwise,
     )
 }
 
@@ -811,12 +862,8 @@ fn extract_polygon(
 
 fn push_stroked_polyline(
     doc: &mut GeometryDocument,
-    net: Option<Symbol>,
-    polarity: GeometryPolarity,
-    source: SourceRef,
+    style: StrokedFeatureStyle,
     points: Vec<Point>,
-    width: f64,
-    line_cap: LineCap,
 ) -> GeometryFeature {
     let mut bbox = BBox::empty();
     let mut cmds = Vec::new();
@@ -828,19 +875,57 @@ fn push_stroked_polyline(
             PathCmd::line_to(point)
         });
     }
-    bbox = bbox.expand(width / 2.0);
+    bbox = bbox.expand(style.width / 2.0);
 
     let path_start = doc.paths.len() as u32;
-    doc.push_path(GeometryPath::stroked(width, line_cap, bbox), cmds);
+    doc.push_path(
+        GeometryPath::stroked(style.width, style.line_cap, bbox),
+        cmds,
+    );
 
-    let mut feature = GeometryFeature::new(FeatureKind::Trace, FeatureBucket::Trace, polarity);
-    feature.net = net;
-    feature.source = source;
+    let mut feature =
+        GeometryFeature::new(FeatureKind::Trace, FeatureBucket::Trace, style.polarity);
+    feature.net = style.net;
+    feature.source = style.source;
     feature.bbox = bbox;
     feature.path_start = path_start;
     feature.path_count = 1;
-    feature.stroke_width = width;
-    feature.line_cap = line_cap;
+    feature.stroke_width = style.width;
+    feature.line_cap = style.line_cap;
+    feature.flags.lowered_to_paths = true;
+    feature
+}
+
+fn push_stroked_arc(
+    doc: &mut GeometryDocument,
+    style: StrokedFeatureStyle,
+    start: Point,
+    end: Point,
+    center: Point,
+    clockwise: bool,
+) -> GeometryFeature {
+    let mut bbox = BBox::empty();
+    bbox.include_circular_arc(start, end, center, clockwise);
+    bbox = bbox.expand(style.width / 2.0);
+
+    let path_start = doc.paths.len() as u32;
+    doc.push_path(
+        GeometryPath::stroked(style.width, style.line_cap, bbox),
+        vec![
+            PathCmd::move_to(start),
+            PathCmd::arc_to(end, center, clockwise),
+        ],
+    );
+
+    let mut feature =
+        GeometryFeature::new(FeatureKind::Trace, FeatureBucket::Trace, style.polarity);
+    feature.net = style.net;
+    feature.source = style.source;
+    feature.bbox = bbox;
+    feature.path_start = path_start;
+    feature.path_count = 1;
+    feature.stroke_width = style.width;
+    feature.line_cap = style.line_cap;
     feature.flags.lowered_to_paths = true;
     feature
 }
@@ -860,30 +945,38 @@ fn push_stroked_trace(
             .iter()
             .map(|point| Point::new(point.x, point.y))
             .collect();
-        return push_stroked_polyline(doc, net, polarity, source, points, width, line_cap);
+        return push_stroked_polyline(
+            doc,
+            StrokedFeatureStyle {
+                net,
+                polarity,
+                source,
+                width,
+                line_cap,
+            },
+            points,
+        );
     }
 
     push_stroked_steps(
         doc,
-        net,
-        polarity,
-        source,
+        StrokedFeatureStyle {
+            net,
+            polarity,
+            source,
+            width,
+            line_cap,
+        },
         Point::new(trace.points[0].x, trace.points[0].y),
         &trace.steps,
-        width,
-        line_cap,
     )
 }
 
 fn push_stroked_steps(
     doc: &mut GeometryDocument,
-    net: Option<Symbol>,
-    polarity: GeometryPolarity,
-    source: SourceRef,
+    style: StrokedFeatureStyle,
     begin: Point,
     steps: &[PolyStep],
-    width: f64,
-    line_cap: LineCap,
 ) -> GeometryFeature {
     let mut current = begin;
     let mut bbox = BBox::from_point(current);
@@ -904,19 +997,23 @@ fn push_stroked_steps(
             }
         }
     }
-    bbox = bbox.expand(width / 2.0);
+    bbox = bbox.expand(style.width / 2.0);
 
     let path_start = doc.paths.len() as u32;
-    doc.push_path(GeometryPath::stroked(width, line_cap, bbox), cmds);
+    doc.push_path(
+        GeometryPath::stroked(style.width, style.line_cap, bbox),
+        cmds,
+    );
 
-    let mut feature = GeometryFeature::new(FeatureKind::Trace, FeatureBucket::Trace, polarity);
-    feature.net = net;
-    feature.source = source;
+    let mut feature =
+        GeometryFeature::new(FeatureKind::Trace, FeatureBucket::Trace, style.polarity);
+    feature.net = style.net;
+    feature.source = style.source;
     feature.bbox = bbox;
     feature.path_start = path_start;
     feature.path_count = 1;
-    feature.stroke_width = width;
-    feature.line_cap = line_cap;
+    feature.stroke_width = style.width;
+    feature.line_cap = style.line_cap;
     feature.flags.lowered_to_paths = true;
     feature
 }
@@ -1192,6 +1289,21 @@ fn lower_user_primitive(
                     UserShapeType::Oval(oval) => {
                         push_oval_path(doc, transform, oval.size.width, oval.size.height);
                     }
+                    UserShapeType::RectRound(rect) => {
+                        push_rounded_rect_path(
+                            doc,
+                            transform,
+                            rect.size.width,
+                            rect.size.height,
+                            rect.radius,
+                            [
+                                rect.upper_right,
+                                rect.lower_right,
+                                rect.lower_left,
+                                rect.upper_left,
+                            ],
+                        );
+                    }
                     UserShapeType::Polygon(polygon) => {
                         push_polygon_path(doc, polygon, transform, FillRule::NonZero);
                     }
@@ -1199,9 +1311,21 @@ fn lower_user_primitive(
                         let line_desc = user_shape_line_desc(context, shape);
                         push_user_line_path(doc, line, transform, line_desc);
                     }
+                    UserShapeType::Arc(arc) => {
+                        let line_desc = user_shape_line_desc(context, shape);
+                        push_user_arc_path(doc, arc, transform, line_desc);
+                    }
                     UserShapeType::Polyline(polyline) => {
                         let line_desc = user_shape_line_desc(context, shape);
                         push_user_polyline_path(doc, polyline, transform, line_desc);
+                    }
+                    UserShapeType::UserPrimitiveRef(primitive_ref) => {
+                        if let Some(primitive) = context.user_primitives.get(primitive_ref).copied()
+                        {
+                            let _ = lower_user_primitive(context, doc, primitive, transform);
+                        } else {
+                            make_paths_unpainted(doc, path_start);
+                        }
                     }
                 }
 
@@ -1262,6 +1386,36 @@ fn push_user_line_path(
     doc.push_path(
         GeometryPath::stroked(width, line_cap, bbox),
         vec![PathCmd::move_to(start), PathCmd::line_to(end)],
+    );
+}
+
+fn push_user_arc_path(
+    doc: &mut GeometryDocument,
+    arc: &ipc2581::types::Arc,
+    transform: Affine2,
+    line_desc: Option<ipc2581::types::LineDesc>,
+) {
+    let start = transform.transform_point(Point::new(arc.start.x, arc.start.y));
+    let end = transform.transform_point(Point::new(arc.end.x, arc.end.y));
+    let center = transform.transform_point(Point::new(arc.center.x, arc.center.y));
+    let clockwise = if transform.determinant() < 0.0 {
+        !arc.clockwise
+    } else {
+        arc.clockwise
+    };
+    let width = line_desc.map(|desc| desc.line_width).unwrap_or(0.25);
+    let line_cap = line_desc
+        .map(|desc| map_line_cap(desc.line_end))
+        .unwrap_or(LineCap::Round);
+    let mut bbox = BBox::empty();
+    bbox.include_circular_arc(start, end, center, clockwise);
+    bbox = bbox.expand(width / 2.0);
+    doc.push_path(
+        GeometryPath::stroked(width, line_cap, bbox),
+        vec![
+            PathCmd::move_to(start),
+            PathCmd::arc_to(end, center, clockwise),
+        ],
     );
 }
 

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -192,6 +192,9 @@ fn extract_step_layer(
                     SetFeature::Line(line) => Some(extract_line(
                         &context, set.net, polarity, source, line, &mut doc,
                     )),
+                    SetFeature::Polyline(polyline) => Some(extract_feature_polyline(
+                        &context, set.net, polarity, source, polyline, &mut doc,
+                    )),
                     SetFeature::Hole(_) | SetFeature::Slot(_) => None,
                 };
 
@@ -666,6 +669,37 @@ fn extract_line(
     )
 }
 
+fn extract_feature_polyline(
+    context: &ExtractContext<'_>,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    polyline: &ipc2581::types::ecad::FeaturePolyline,
+    doc: &mut GeometryDocument,
+) -> GeometryFeature {
+    let line_desc = polyline
+        .line_desc_ref
+        .and_then(|line_desc_ref| context.line_descs.get(&line_desc_ref).copied());
+    let line_width = line_desc
+        .map(|desc| desc.line_width)
+        .unwrap_or(polyline.line_width);
+    let line_cap = line_desc
+        .map(|desc| map_line_cap(desc.line_end))
+        .or_else(|| polyline.line_end.map(map_line_cap))
+        .unwrap_or(LineCap::Round);
+
+    push_stroked_steps(
+        doc,
+        net,
+        polarity,
+        source,
+        Point::new(polyline.begin.x, polyline.begin.y),
+        &polyline.steps,
+        line_width,
+        line_cap,
+    )
+}
+
 fn extract_polygon(
     net: Option<Symbol>,
     polarity: GeometryPolarity,
@@ -741,10 +775,32 @@ fn push_stroked_trace(
         return push_stroked_polyline(doc, net, polarity, source, points, width, line_cap);
     }
 
-    let mut current = Point::new(trace.points[0].x, trace.points[0].y);
+    push_stroked_steps(
+        doc,
+        net,
+        polarity,
+        source,
+        Point::new(trace.points[0].x, trace.points[0].y),
+        &trace.steps,
+        width,
+        line_cap,
+    )
+}
+
+fn push_stroked_steps(
+    doc: &mut GeometryDocument,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    begin: Point,
+    steps: &[PolyStep],
+    width: f64,
+    line_cap: LineCap,
+) -> GeometryFeature {
+    let mut current = begin;
     let mut bbox = BBox::from_point(current);
     let mut cmds = vec![PathCmd::move_to(current)];
-    for step in &trace.steps {
+    for step in steps {
         match step {
             PolyStep::Segment(segment) => {
                 current = Point::new(segment.point.x, segment.point.y);
@@ -1771,6 +1827,45 @@ mod tests {
             &trace,
             0.2,
             LineCap::Round,
+        );
+
+        assert_eq!(feature.path_count, 1);
+        assert_eq!(doc.paths[0].bbox.min, Point::new(-0.1, -0.1));
+        assert_eq!(doc.paths[0].bbox.max, Point::new(1.1, 1.1));
+        assert!(doc.path_cmds.iter().any(|cmd| cmd.op == PathOp::ArcTo));
+    }
+
+    #[test]
+    fn lowers_feature_poly_step_curves_as_arcs() {
+        let mut doc = GeometryDocument::new("test".to_string());
+        let polyline = ipc2581::types::ecad::FeaturePolyline {
+            begin: ipc2581::types::Point { x: 1.0, y: 0.0 },
+            steps: vec![PolyStep::Curve(ipc2581::types::PolyStepCurve {
+                point: ipc2581::types::Point { x: 0.0, y: 1.0 },
+                center: ipc2581::types::Point { x: 0.0, y: 0.0 },
+                clockwise: false,
+            })],
+            line_desc_ref: None,
+            line_width: 0.2,
+            line_end: Some(LineEnd::Round),
+        };
+
+        let feature = extract_feature_polyline(
+            &ExtractContext {
+                ipc: &Ipc2581::parse(
+                    r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581"><Content roleRef="Owner"><FunctionMode mode="FABRICATION"/></Content></IPC-2581>"#,
+                )
+                .unwrap(),
+                padstacks: HashMap::new(),
+                line_descs: HashMap::new(),
+                standard_primitives: HashMap::new(),
+                user_primitives: HashMap::new(),
+            },
+            None,
+            GeometryPolarity::Positive,
+            SourceRef::default(),
+            &polyline,
+            &mut doc,
         );
 
         assert_eq!(feature.path_count, 1);

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -315,6 +315,7 @@ pub enum FillRule {
 pub struct FeatureFlags {
     pub expanded_padstack: bool,
     pub lowered_to_paths: bool,
+    pub clears_previous_in_set: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -216,37 +216,47 @@ pub fn coalesce_related_trace_features(doc: &mut GeometryDocument) {
 pub fn resolve_set_voids(doc: &mut GeometryDocument) {
     for layer_index in 0..doc.layers.len() {
         let layer = doc.layers[layer_index].clone();
-        let mut previous_by_set: HashMap<u32, Vec<usize>> = HashMap::new();
+        for mut feature_indices in layer_features_by_set(doc, &layer).into_values() {
+            feature_indices.sort_by_key(|&index| doc.features[index].source.feature_index);
+            let mut previous = Vec::new();
 
-        for feature_index in layer_features(&layer) {
-            let feature = doc.features[feature_index].clone();
-            if feature.bucket == FeatureBucket::Cutout {
-                continue;
-            }
-
-            if feature.flags.clears_previous_in_set {
-                let cutters = feature_filled_contours(doc, &feature);
-                if !cutters.is_empty() {
-                    for subject_index in previous_by_set
-                        .get(&feature.source.set_index)
-                        .cloned()
-                        .unwrap_or_default()
-                    {
-                        subtract_contours_from_feature(doc, subject_index, &cutters);
-                    }
+            for feature_index in feature_indices {
+                let feature = doc.features[feature_index].clone();
+                if feature.bucket == FeatureBucket::Cutout {
+                    continue;
                 }
-                clear_feature_paths(doc, feature_index);
-                continue;
-            }
 
-            if feature.polarity == GeometryPolarity::Positive {
-                previous_by_set
-                    .entry(feature.source.set_index)
-                    .or_default()
-                    .push(feature_index);
+                if feature.flags.clears_previous_in_set {
+                    let cutters = feature_filled_contours(doc, &feature);
+                    if !cutters.is_empty() {
+                        for subject_index in previous.iter().copied() {
+                            subtract_contours_from_feature(doc, subject_index, &cutters);
+                        }
+                    }
+                    clear_feature_paths(doc, feature_index);
+                    continue;
+                }
+
+                if feature.polarity == GeometryPolarity::Positive {
+                    previous.push(feature_index);
+                }
             }
         }
     }
+}
+
+fn layer_features_by_set(
+    doc: &GeometryDocument,
+    layer: &GeometryLayer,
+) -> HashMap<u32, Vec<usize>> {
+    let mut features_by_set = HashMap::new();
+    for feature_index in layer_features(layer) {
+        features_by_set
+            .entry(doc.features[feature_index].source.set_index)
+            .or_insert_with(Vec::new)
+            .push(feature_index);
+    }
+    features_by_set
 }
 
 pub fn resolve_negative_polarity(doc: &mut GeometryDocument) {
@@ -1075,6 +1085,63 @@ mod tests {
         assert_eq!(doc.features[2].path_count, 0);
         assert_eq!(doc.features[3].bbox.min, Point::new(1.0, 1.0));
         assert_eq!(doc.features[3].bbox.max, Point::new(3.0, 3.0));
+    }
+
+    #[test]
+    fn resolves_voids_by_source_feature_order_within_set() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 1.0, 3.0, 3.0),
+        );
+        doc.features.push(GeometryFeature {
+            source: SourceRef {
+                set_index: 1,
+                feature_index: 1,
+            },
+            path_count: 1,
+            flags: FeatureFlags {
+                clears_previous_in_set: true,
+                ..FeatureFlags::default()
+            },
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Negative,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(0.0, 0.0, 4.0, 4.0),
+        );
+        doc.features.push(GeometryFeature {
+            source: SourceRef {
+                set_index: 1,
+                feature_index: 0,
+            },
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 2,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        assert_eq!(doc.features[0].path_count, 0);
+        assert!(doc.paths[doc.features[1].path_start as usize].contour_count > 1);
+        assert_eq!(doc.features[1].bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(doc.features[1].bbox.max, Point::new(4.0, 4.0));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -24,6 +24,7 @@ pub fn process_document(doc: &mut GeometryDocument) {
     outline_stroked_paths(doc);
     union_feature_filled_paths(doc);
     coalesce_related_trace_features(doc);
+    resolve_set_voids(doc);
     resolve_negative_polarity(doc);
     subtract_layer_cutouts(doc);
     normalize_bounds(doc);
@@ -212,6 +213,42 @@ pub fn coalesce_related_trace_features(doc: &mut GeometryDocument) {
     }
 }
 
+pub fn resolve_set_voids(doc: &mut GeometryDocument) {
+    for layer_index in 0..doc.layers.len() {
+        let layer = doc.layers[layer_index].clone();
+        let mut previous_by_set: HashMap<u32, Vec<usize>> = HashMap::new();
+
+        for feature_index in layer_features(&layer) {
+            let feature = doc.features[feature_index].clone();
+            if feature.bucket == FeatureBucket::Cutout {
+                continue;
+            }
+
+            if feature.flags.clears_previous_in_set {
+                let cutters = feature_filled_contours(doc, &feature);
+                if !cutters.is_empty() {
+                    for subject_index in previous_by_set
+                        .get(&feature.source.set_index)
+                        .cloned()
+                        .unwrap_or_default()
+                    {
+                        subtract_contours_from_feature(doc, subject_index, &cutters);
+                    }
+                }
+                clear_feature_paths(doc, feature_index);
+                continue;
+            }
+
+            if feature.polarity == GeometryPolarity::Positive {
+                previous_by_set
+                    .entry(feature.source.set_index)
+                    .or_default()
+                    .push(feature_index);
+            }
+        }
+    }
+}
+
 pub fn resolve_negative_polarity(doc: &mut GeometryDocument) {
     for layer_index in 0..doc.layers.len() {
         let layer = doc.layers[layer_index].clone();
@@ -219,6 +256,7 @@ pub fn resolve_negative_polarity(doc: &mut GeometryDocument) {
             .filter(|&feature_index| {
                 let feature = &doc.features[feature_index];
                 feature.bucket != FeatureBucket::Cutout
+                    && !feature.flags.clears_previous_in_set
                     && feature.polarity == GeometryPolarity::Negative
             })
             .collect::<Vec<_>>();
@@ -270,14 +308,15 @@ pub fn subtract_layer_cutouts(doc: &mut GeometryDocument) {
 fn subtract_contours_from_feature(
     doc: &mut GeometryDocument,
     feature_index: usize,
-    cutters: &Vec<PolygonContour>,
+    cutters: &[PolygonContour],
 ) {
     let subject = feature_filled_contours(doc, &doc.features[feature_index]);
     if subject.is_empty() {
         return;
     }
 
-    let result = subject.overlay(cutters, OverlayRule::Difference, OverlayFillRule::NonZero);
+    let cutters = cutters.to_vec();
+    let result = subject.overlay(&cutters, OverlayRule::Difference, OverlayFillRule::NonZero);
     let contours = polygon_shapes_to_contours(result);
     if contours.is_empty() {
         clear_feature_paths(doc, feature_index);
@@ -943,6 +982,99 @@ mod tests {
         assert_eq!(path.bbox.max, Point::new(4.0, 4.0));
         assert_eq!(doc.features[1].path_count, 0);
         assert!(doc.features[1].bbox.is_empty());
+    }
+
+    #[test]
+    fn resolves_voids_against_previous_features_in_same_set_only() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(0.0, 0.0, 4.0, 4.0),
+        );
+        doc.features.push(GeometryFeature {
+            source: SourceRef {
+                set_index: 1,
+                feature_index: 0,
+            },
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(10.0, 0.0, 14.0, 4.0),
+        );
+        doc.features.push(GeometryFeature {
+            source: SourceRef {
+                set_index: 2,
+                feature_index: 0,
+            },
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 1.0, 3.0, 3.0),
+        );
+        doc.features.push(GeometryFeature {
+            source: SourceRef {
+                set_index: 1,
+                feature_index: 1,
+            },
+            path_start: 2,
+            path_count: 1,
+            flags: FeatureFlags {
+                clears_previous_in_set: true,
+                ..FeatureFlags::default()
+            },
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Negative,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 1.0, 3.0, 3.0),
+        );
+        doc.features.push(GeometryFeature {
+            source: SourceRef {
+                set_index: 1,
+                feature_index: 2,
+            },
+            path_start: 3,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Polygon,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 4,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+
+        assert!(doc.paths[doc.features[0].path_start as usize].contour_count > 1);
+        assert_eq!(doc.features[1].bbox.min, Point::new(10.0, 0.0));
+        assert_eq!(doc.features[1].bbox.max, Point::new(14.0, 4.0));
+        assert_eq!(doc.features[2].path_count, 0);
+        assert_eq!(doc.features[3].bbox.min, Point::new(1.0, 1.0));
+        assert_eq!(doc.features[3].bbox.max, Point::new(3.0, 3.0));
     }
 
     #[test]


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core IPC-2581 ECAD parsing and the downstream geometry lowering/boolean ops pipeline (feature ordering, curve handling, and void subtraction), which can affect rendered output across many boards.
> 
> **Overview**
> Makes IPC-2581 ECAD geometry parsing/rendering more spec-faithful by **preserving Set child order** and **representing curves explicitly** instead of flattening them.
> 
> The parser now emits an ordered `FeatureSet.features: Vec<SetFeature>` covering holes/slots/pads/traces plus `Features` content (polygons, lines, polylines, arcs, and primitive refs), applies `Features/Location` offsets to polygons/lines/polylines/arcs, and adds support for richer `UserSpecial` shapes (e.g. nested `UserSpecial`, `RectRound`, `Line`, `Arc`, `Polyline`, `UserPrimitiveRef`) including `LineDescRef` style resolution.
> 
> The geometry tools switch extraction to iterate `SetFeature` in source order, lower trace/feature polyline `PolyStep::Curve` into arc path commands, add lowering for user primitives (including hollow/void handling and referenced primitives), and introduce `resolve_set_voids` so void features clear only *previous* positive features within the same Set (tracked via `clears_previous_in_set`). Adds targeted tests covering ordering, curve preservation, `UserSpecial` parsing, arc lowering, and set-scoped void behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 833787ff4fb47053c133ef40446c73f2758c9b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->