### PR TITLE
Use `uppsala` for IPC-2581 parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added initial `pcb ipc2581 render` support for rendering a single IPC-2581 layer to SVG.
 - Added PNG output support to `pcb ipc2581 render`.
 - Added Kitty-compatible terminal graphics output for `pcb ipc2581 render` when no output path is provided.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,6 @@ dependencies = [
  "hex",
  "md-5",
  "quick-xml",
- "roxmltree 0.21.1",
  "thiserror 2.0.18",
  "uppsala",
  "zstd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,6 +3258,7 @@ dependencies = [
  "quick-xml",
  "roxmltree 0.21.1",
  "thiserror 2.0.18",
+ "uppsala",
  "zstd",
 ]
 
@@ -7876,6 +7877,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uppsala"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d87ccb81b1e9ddc119871ecbd40a5e93f173f0777838db1e8c0dec223ae3c49"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ tar = { version = "0.4", default-features = false }
 ruzstd = "0.8"
 terminal_size = "0.4.0"
 terminal_hyperlink = "0.1"
+uppsala = "0.4"
 termimad = "0.34"
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-onig"] }
 textwrap = "0.16"

--- a/crates/ipc2581/Cargo.toml
+++ b/crates/ipc2581/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["parsing", "hardware-support"]
 
 [dependencies]
 hex = { workspace = true }
-roxmltree = "0.21"
 quick-xml = { workspace = true }
 md-5 = { workspace = true }
 base64 = { workspace = true }

--- a/crates/ipc2581/Cargo.toml
+++ b/crates/ipc2581/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
-description = "Pure IPC-2581 XML parser - spec-compliant, zero dependencies on visualization"
+description = "IPC-2581 XML parser, typed data model, and XSD validation for PCB manufacturing data"
 license = "MIT OR Apache-2.0"
 keywords = ["pcb", "ipc-2581", "parser", "eda"]
 categories = ["parsing", "hardware-support"]
@@ -17,6 +17,7 @@ quick-xml = { workspace = true }
 md-5 = { workspace = true }
 base64 = { workspace = true }
 thiserror = { workspace = true }
+uppsala = { workspace = true }
 
 [dev-dependencies]
 zstd = { workspace = true }

--- a/crates/ipc2581/IPC-2581C.xsd
+++ b/crates/ipc2581/IPC-2581C.xsd
@@ -1,0 +1,3111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Schema File for IPC-2581 revision C -->
+<xsd:schema xmlns="http://webstds.ipc.org/2581" xmlns:tn="http://webstds.ipc.org/2581" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://webstds.ipc.org/2581">
+	<xsd:simpleType name="angleType">
+		<xsd:restriction base="xsd:decimal">
+			<xsd:minInclusive value="0.00"/>
+			<xsd:maxExclusive value="360.00"/>
+			<xsd:totalDigits value="3"/>
+			<xsd:fractionDigits value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="backdrillListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="START_LAYER"/>
+			<xsd:enumeration value="MUST_NOT_CUT_LAYER"/>
+			<xsd:enumeration value="MAX_STUB_LENGTH"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="bendSideType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="TOP"/>
+			<xsd:enumeration value="BOTTOM"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="bomCategoryType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ELECTRICAL"/>
+			<xsd:enumeration value="PROGRAMMABLE"/>
+			<xsd:enumeration value="MECHANICAL"/>
+			<xsd:enumeration value="MATERIAL"/>
+			<xsd:enumeration value="DOCUMENT"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="boardTechnologyType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="RIGID"/>
+			<xsd:enumeration value="RIGID_FLEX"/>
+			<xsd:enumeration value="FLEX"/>
+			<xsd:enumeration value="HDI"/>
+			<xsd:enumeration value="EMBEDDED_COMPONENT"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="butterflyShapeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ROUND"/>
+			<xsd:enumeration value="SQUARE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="cadPinType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="THRU"/>
+			<xsd:enumeration value="BLIND"/>
+			<xsd:enumeration value="SURFACE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="cadPropertyType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="DOUBLE"/>
+			<xsd:enumeration value="INTEGER"/>
+			<xsd:enumeration value="BOOLEAN"/>
+			<xsd:enumeration value="STRING"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="certificationCategoryType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ASSEMBLYDRAWING"/>
+			<xsd:enumeration value="ASSEMBLYFIXTUREGENERATION"/>
+			<xsd:enumeration value="ASSEMBLYPANEL"/>
+			<xsd:enumeration value="ASSEMBLYPREPTOOLS"/>
+			<xsd:enumeration value="ASSEMBLYTESTFIXTUREGENERATION"/>
+			<xsd:enumeration value="ASSEMBLYTESTGENERATION"/>
+			<xsd:enumeration value="BOARDFABRICATION"/>
+			<xsd:enumeration value="BOARDFIXTUREGENERATION"/>
+			<xsd:enumeration value="BOARDPANEL"/>
+			<xsd:enumeration value="BOARDTESTGENERATION"/>
+			<xsd:enumeration value="COMPONENTPLACEMENT"/>
+			<xsd:enumeration value="DETAILEDDRAWING"/>
+			<xsd:enumeration value="FABRICATIONDRAWING"/>
+			<xsd:enumeration value="GENERALASSEMBLY"/>
+			<xsd:enumeration value="GLUEDOT"/>
+			<xsd:enumeration value="MECHANICALHARDWARE"/>
+			<xsd:enumeration value="MULTIBOARDPARTSLIST"/>
+			<xsd:enumeration value="PHOTOTOOLS"/>
+			<xsd:enumeration value="SCHEMATICDRAWINGS"/>
+			<xsd:enumeration value="SINGLEBOARDPARTSLIST"/>
+			<xsd:enumeration value="SOLDERSTENCILPASTE"/>
+			<xsd:enumeration value="SPECSOURCECONTROLDRAWING"/>
+			<xsd:enumeration value="EMBEDDEDCOMPONENT"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="certificationStatusType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ALPHA"/>
+			<xsd:enumeration value="BETA"/>
+			<xsd:enumeration value="CERTIFIED"/>
+			<xsd:enumeration value="SELFTEST"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="complianceListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ROHS"/>
+			<xsd:enumeration value="CONFLICT_MINERALS"/>
+			<xsd:enumeration value="WEEE"/>
+			<xsd:enumeration value="REACH"/>
+			<xsd:enumeration value="HALOGEN_FREE"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="conductorListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="CONDUCTIVITY"/>
+			<xsd:enumeration value="SURFACE_ROUGHNESS_UPFACING"/>
+			<xsd:enumeration value="SURFACE_ROUGHNESS_DOWNFACING"/>
+			<xsd:enumeration value="SURFACE_ROUGHNESS_TREATED"/>
+			<xsd:enumeration value="ETCH_FACTOR"/>
+			<xsd:enumeration value="FINISHED_HEIGHT"/>
+			<xsd:enumeration value="WEIGHT"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="conductorMaterialType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="COPPER"/>
+			<xsd:enumeration value="SILVER_INK"/>
+			<xsd:enumeration value="CARBON_INK"/>
+			<xsd:enumeration value="CONDUCTIVE_INK"/>
+			<xsd:enumeration value="GRAPHENE"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="constraintTypeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="MIN"/>
+			<xsd:enumeration value="MAX"/>
+			<xsd:enumeration value="NONE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="colorListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="BLACK"/>
+			<xsd:enumeration value="WHITE"/>
+			<xsd:enumeration value="RED"/>
+			<xsd:enumeration value="GREEN"/>
+			<xsd:enumeration value="YELLOW"/>
+			<xsd:enumeration value="BLUE"/>
+			<xsd:enumeration value="BROWN"/>
+			<xsd:enumeration value="ORANGE"/>
+			<xsd:enumeration value="PINK"/>
+			<xsd:enumeration value="PURPLE"/>
+			<xsd:enumeration value="GRAY"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="contextType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="BOARD"/>
+			<xsd:enumeration value="BOARDPANEL"/>
+			<xsd:enumeration value="ASSEMBLY"/>
+			<xsd:enumeration value="ASSEMBLYPALLET"/>
+			<xsd:enumeration value="DOCUMENTATION"/>
+			<xsd:enumeration value="TOOLING"/>
+			<xsd:enumeration value="COUPON"/>
+			<xsd:enumeration value="MISCELLANEOUS"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="dfxCategoryType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="COMPONENT"/>
+			<xsd:enumeration value="BOARDFAB"/>
+			<xsd:enumeration value="ASSEMBLY"/>
+			<xsd:enumeration value="STACKUP"/>
+			<xsd:enumeration value="TESTING"/>
+			<xsd:enumeration value="DATAQUALITY"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="dfxResponseChoices">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="YES"/>
+			<xsd:enumeration value="NO"/>
+			<xsd:enumeration value="APPROVED"/>
+			<xsd:enumeration value="CONDITIONALLY_APPROVED"/>
+			<xsd:enumeration value="REJECTED"/>
+			<xsd:enumeration value="WAIVED"/>
+			<xsd:enumeration value="IGNORE"/>
+			<xsd:enumeration value="OPEN"/>
+			<xsd:enumeration value="CLOSED"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="dielectricListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="DIELECTRIC_CONSTANT"/>
+			<xsd:enumeration value="LOSS_TANGENT"/>
+			<xsd:enumeration value="GLASS_STYLE"/>
+			<xsd:enumeration value="RESIN_CONTENT"/>
+			<xsd:enumeration value="Tg_DSC"/>
+			<xsd:enumeration value="Tg_DMA"/>
+			<xsd:enumeration value="Tg_TMA"/>
+			<xsd:enumeration value="Td"/>
+			<xsd:enumeration value="SLASH_NUM_IPC4101"/>
+			<xsd:enumeration value="SLASH_NUM_IPC4103"/>
+			<xsd:enumeration value="PRODUCT_NAME"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="donutShapeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ROUND"/>
+			<xsd:enumeration value="SQUARE"/>
+			<xsd:enumeration value="HEXAGON"/>
+			<xsd:enumeration value="OCTAGON"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="embeddedTypeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="IMAGE"/>
+			<xsd:enumeration value="FIRMWARE"/>
+			<xsd:enumeration value="EXECUTABLE"/>
+			<xsd:enumeration value="DOCUMENT"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="toolListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="CARBIDE"/>
+			<xsd:enumeration value="ROUTER"/>
+			<xsd:enumeration value="LASER"/>
+			<xsd:enumeration value="PLASMA"/>
+			<xsd:enumeration value="PUNCH"/>
+			<xsd:enumeration value="FLATNOSE"/>
+			<xsd:enumeration value="EXTENSION"/>
+			<xsd:enumeration value="V_CUTTER"/>
+			<xsd:enumeration value="SCREWDRIVER"/>
+			<xsd:enumeration value="WRENCH"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="toolPropertyListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="DRILL_SIZE"/>
+			<xsd:enumeration value="FINISHED_SIZE"/>
+			<xsd:enumeration value="BIT_ANGLE"/>
+			<xsd:enumeration value="TORQUE"/>
+			<xsd:enumeration value="HEX_NUT_SIZE"/>
+			<xsd:enumeration value="PHILIPS_HEAD"/>
+			<xsd:enumeration value="FLAT_HEAD"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="enterpriseCodeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="DUNNS"/>
+			<xsd:enumeration value="CAGE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="exposureType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="EXPOSED"/>
+			<xsd:enumeration value="COVERED_PRIMARY"/>
+			<xsd:enumeration value="COVERED_SECONDARY"/>
+			<xsd:enumeration value="COVERED"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="featureObjectType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="PAD"/>
+			<xsd:enumeration value="SHAPE"/>
+			<xsd:enumeration value="POLYGON"/>
+			<xsd:enumeration value="DRILL/HOLE"/>
+			<xsd:enumeration value="CUTOUT"/>
+			<xsd:enumeration value="OUTLINE"/>
+			<xsd:enumeration value="TEXT"/>
+			<xsd:enumeration value="SLOT"/>
+			<xsd:enumeration value="CAVITY"/>
+			<xsd:enumeration value="ZONE"/>
+			<xsd:enumeration value="BEND"/>
+			<xsd:enumeration value="PORT"/>
+			<xsd:enumeration value="MILLING"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="flexListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ADHESIVE_SQUEEZE_OUT"/>
+			<xsd:enumeration value="DIELECTRIC_SQUEEZE_OUT"/>
+			<xsd:enumeration value="STRESS_RELIEF_FILLET_WIDTH"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="foilTypeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="CU-E1"/>
+			<xsd:enumeration value="CU-E2"/>
+			<xsd:enumeration value="CU-E3"/>
+			<xsd:enumeration value="CU-W5"/>
+			<xsd:enumeration value="CU-W6"/>
+			<xsd:enumeration value="CU-W7"/>
+			<xsd:enumeration value="CU-W8"/>
+			<xsd:enumeration value="NI/E1"/>
+			<xsd:enumeration value="CU-E10"/>
+			<xsd:enumeration value="CU-E11"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="surfaceFinishType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="S"/>
+			<xsd:enumeration value="b1"/>
+			<xsd:enumeration value="T"/>
+			<xsd:enumeration value="X"/>
+			<xsd:enumeration value="TLU"/>
+			<xsd:enumeration value="G"/>
+			<xsd:enumeration value="GS"/>
+			<xsd:enumeration value="GWB-1-G"/>
+			<xsd:enumeration value="GWB-1-N"/>
+			<xsd:enumeration value="GWB-2-G"/>
+			<xsd:enumeration value="GWB-2-N"/>
+			<xsd:enumeration value="N"/>
+			<xsd:enumeration value="NB"/>
+			<xsd:enumeration value="OSP"/>
+			<xsd:enumeration value="HT_OSP"/>
+			<xsd:enumeration value="ENIG-N"/>
+			<xsd:enumeration value="ENIG-G"/>
+			<xsd:enumeration value="ENEPIG-N"/>
+			<xsd:enumeration value="ENEPIG-G"/>
+			<xsd:enumeration value="ENEPIG-P"/>
+			<xsd:enumeration value="DIG"/>
+			<xsd:enumeration value="IAg"/>
+			<xsd:enumeration value="ISn"/>
+			<xsd:enumeration value="C"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="floorLifeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="UNLIMITED"/>
+			<xsd:enumeration value="1_YEAR"/>
+			<xsd:enumeration value="4_WEEKS"/>
+			<xsd:enumeration value="168_HOURS"/>
+			<xsd:enumeration value="72_HOURS"/>
+			<xsd:enumeration value="48_HOURS"/>
+			<xsd:enumeration value="24_HOURS"/>
+			<xsd:enumeration value="BAKE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="geometryUsageType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="THIEVING"/>
+			<xsd:enumeration value="THERMAL_RELIEF"/>
+			<xsd:enumeration value="TEXT"/>
+			<xsd:enumeration value="TEARDROP"/>
+			<xsd:enumeration value="GRAPHIC"/>
+			<xsd:enumeration value="NONE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="generalListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ELECTRICAL"/>
+			<xsd:enumeration value="THERMAL"/>
+			<xsd:enumeration value="MATERIAL"/>
+			<xsd:enumeration value="INSTRUCTION"/>
+			<xsd:enumeration value="STANDARD"/>
+			<xsd:enumeration value="CONFIGURATION"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="historyNumberType">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="[0-9]+(.[0-9]+)*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="holeShapeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="CIRCLE"/>
+			<xsd:enumeration value="SQUARE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="impedanceListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="IMPEDANCE"/>
+			<xsd:enumeration value="LINEWIDTH"/>
+			<xsd:enumeration value="SPACING"/>
+			<xsd:enumeration value="REF_PLANE_LAYER_ID"/>
+			<xsd:enumeration value="COPLANAR_GROUND_SPACING"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="isoCodeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="AD"/>
+			<xsd:enumeration value="AE"/>
+			<xsd:enumeration value="AF"/>
+			<xsd:enumeration value="AG"/>
+			<xsd:enumeration value="AI"/>
+			<xsd:enumeration value="AL"/>
+			<xsd:enumeration value="AM"/>
+			<xsd:enumeration value="AN"/>
+			<xsd:enumeration value="AO"/>
+			<xsd:enumeration value="AQ"/>
+			<xsd:enumeration value="AR"/>
+			<xsd:enumeration value="AS"/>
+			<xsd:enumeration value="AT"/>
+			<xsd:enumeration value="AU"/>
+			<xsd:enumeration value="AW"/>
+			<xsd:enumeration value="AZ"/>
+			<xsd:enumeration value="BA"/>
+			<xsd:enumeration value="BB"/>
+			<xsd:enumeration value="BD"/>
+			<xsd:enumeration value="BE"/>
+			<xsd:enumeration value="BF"/>
+			<xsd:enumeration value="BG"/>
+			<xsd:enumeration value="BH"/>
+			<xsd:enumeration value="BI"/>
+			<xsd:enumeration value="BJ"/>
+			<xsd:enumeration value="BM"/>
+			<xsd:enumeration value="BN"/>
+			<xsd:enumeration value="BO"/>
+			<xsd:enumeration value="BR"/>
+			<xsd:enumeration value="BS"/>
+			<xsd:enumeration value="BT"/>
+			<xsd:enumeration value="BV"/>
+			<xsd:enumeration value="BW"/>
+			<xsd:enumeration value="BY"/>
+			<xsd:enumeration value="BZ"/>
+			<xsd:enumeration value="CA"/>
+			<xsd:enumeration value="CC"/>
+			<xsd:enumeration value="CF"/>
+			<xsd:enumeration value="CG"/>
+			<xsd:enumeration value="CH"/>
+			<xsd:enumeration value="CI"/>
+			<xsd:enumeration value="CK"/>
+			<xsd:enumeration value="CL"/>
+			<xsd:enumeration value="CM"/>
+			<xsd:enumeration value="CN"/>
+			<xsd:enumeration value="CO"/>
+			<xsd:enumeration value="CR"/>
+			<xsd:enumeration value="CU"/>
+			<xsd:enumeration value="CV"/>
+			<xsd:enumeration value="CX"/>
+			<xsd:enumeration value="CY"/>
+			<xsd:enumeration value="CZ"/>
+			<xsd:enumeration value="DE"/>
+			<xsd:enumeration value="DJ"/>
+			<xsd:enumeration value="DK"/>
+			<xsd:enumeration value="DM"/>
+			<xsd:enumeration value="DO"/>
+			<xsd:enumeration value="DZ"/>
+			<xsd:enumeration value="EC"/>
+			<xsd:enumeration value="EE"/>
+			<xsd:enumeration value="EG"/>
+			<xsd:enumeration value="EH"/>
+			<xsd:enumeration value="ER"/>
+			<xsd:enumeration value="ES"/>
+			<xsd:enumeration value="ET"/>
+			<xsd:enumeration value="FI"/>
+			<xsd:enumeration value="FJ"/>
+			<xsd:enumeration value="FK"/>
+			<xsd:enumeration value="FM"/>
+			<xsd:enumeration value="FO"/>
+			<xsd:enumeration value="FR"/>
+			<xsd:enumeration value="FX"/>
+			<xsd:enumeration value="GA"/>
+			<xsd:enumeration value="GB"/>
+			<xsd:enumeration value="GD"/>
+			<xsd:enumeration value="GE"/>
+			<xsd:enumeration value="GF"/>
+			<xsd:enumeration value="GH"/>
+			<xsd:enumeration value="GI"/>
+			<xsd:enumeration value="GL"/>
+			<xsd:enumeration value="GM"/>
+			<xsd:enumeration value="GN"/>
+			<xsd:enumeration value="GP"/>
+			<xsd:enumeration value="GQ"/>
+			<xsd:enumeration value="GR"/>
+			<xsd:enumeration value="GS"/>
+			<xsd:enumeration value="GT"/>
+			<xsd:enumeration value="GU"/>
+			<xsd:enumeration value="GW"/>
+			<xsd:enumeration value="GY"/>
+			<xsd:enumeration value="HK"/>
+			<xsd:enumeration value="HM"/>
+			<xsd:enumeration value="HN"/>
+			<xsd:enumeration value="HR"/>
+			<xsd:enumeration value="HT"/>
+			<xsd:enumeration value="HU"/>
+			<xsd:enumeration value="ID"/>
+			<xsd:enumeration value="IE"/>
+			<xsd:enumeration value="IL"/>
+			<xsd:enumeration value="IN"/>
+			<xsd:enumeration value="IO"/>
+			<xsd:enumeration value="IQ"/>
+			<xsd:enumeration value="IR"/>
+			<xsd:enumeration value="IS"/>
+			<xsd:enumeration value="IT"/>
+			<xsd:enumeration value="JM"/>
+			<xsd:enumeration value="JO"/>
+			<xsd:enumeration value="JP"/>
+			<xsd:enumeration value="KE"/>
+			<xsd:enumeration value="KG"/>
+			<xsd:enumeration value="KH"/>
+			<xsd:enumeration value="KI"/>
+			<xsd:enumeration value="KM"/>
+			<xsd:enumeration value="KN"/>
+			<xsd:enumeration value="KP"/>
+			<xsd:enumeration value="KR"/>
+			<xsd:enumeration value="KW"/>
+			<xsd:enumeration value="KY"/>
+			<xsd:enumeration value="KZ"/>
+			<xsd:enumeration value="LA"/>
+			<xsd:enumeration value="LB"/>
+			<xsd:enumeration value="LC"/>
+			<xsd:enumeration value="LI"/>
+			<xsd:enumeration value="LK"/>
+			<xsd:enumeration value="LR"/>
+			<xsd:enumeration value="LS"/>
+			<xsd:enumeration value="LT"/>
+			<xsd:enumeration value="LU"/>
+			<xsd:enumeration value="LV"/>
+			<xsd:enumeration value="LY"/>
+			<xsd:enumeration value="MA"/>
+			<xsd:enumeration value="MC"/>
+			<xsd:enumeration value="MD"/>
+			<xsd:enumeration value="MG"/>
+			<xsd:enumeration value="MH"/>
+			<xsd:enumeration value="MK"/>
+			<xsd:enumeration value="ML"/>
+			<xsd:enumeration value="MM"/>
+			<xsd:enumeration value="MN"/>
+			<xsd:enumeration value="MO"/>
+			<xsd:enumeration value="MP"/>
+			<xsd:enumeration value="MQ"/>
+			<xsd:enumeration value="MR"/>
+			<xsd:enumeration value="MS"/>
+			<xsd:enumeration value="MT"/>
+			<xsd:enumeration value="MU"/>
+			<xsd:enumeration value="MV"/>
+			<xsd:enumeration value="MW"/>
+			<xsd:enumeration value="MX"/>
+			<xsd:enumeration value="MY"/>
+			<xsd:enumeration value="MZ"/>
+			<xsd:enumeration value="NA"/>
+			<xsd:enumeration value="NC"/>
+			<xsd:enumeration value="NE"/>
+			<xsd:enumeration value="NF"/>
+			<xsd:enumeration value="NG"/>
+			<xsd:enumeration value="NI"/>
+			<xsd:enumeration value="NL"/>
+			<xsd:enumeration value="NO"/>
+			<xsd:enumeration value="NP"/>
+			<xsd:enumeration value="NR"/>
+			<xsd:enumeration value="NU"/>
+			<xsd:enumeration value="NZ"/>
+			<xsd:enumeration value="OM"/>
+			<xsd:enumeration value="PA"/>
+			<xsd:enumeration value="PE"/>
+			<xsd:enumeration value="PF"/>
+			<xsd:enumeration value="PG"/>
+			<xsd:enumeration value="PH"/>
+			<xsd:enumeration value="PK"/>
+			<xsd:enumeration value="PL"/>
+			<xsd:enumeration value="PM"/>
+			<xsd:enumeration value="PN"/>
+			<xsd:enumeration value="PR"/>
+			<xsd:enumeration value="PT"/>
+			<xsd:enumeration value="PW"/>
+			<xsd:enumeration value="PY"/>
+			<xsd:enumeration value="QA"/>
+			<xsd:enumeration value="RE"/>
+			<xsd:enumeration value="RO"/>
+			<xsd:enumeration value="RU"/>
+			<xsd:enumeration value="RW"/>
+			<xsd:enumeration value="SA"/>
+			<xsd:enumeration value="SB"/>
+			<xsd:enumeration value="SC"/>
+			<xsd:enumeration value="SD"/>
+			<xsd:enumeration value="SE"/>
+			<xsd:enumeration value="SG"/>
+			<xsd:enumeration value="SH"/>
+			<xsd:enumeration value="SI"/>
+			<xsd:enumeration value="SJ"/>
+			<xsd:enumeration value="SK"/>
+			<xsd:enumeration value="SL"/>
+			<xsd:enumeration value="SM"/>
+			<xsd:enumeration value="SN"/>
+			<xsd:enumeration value="SO"/>
+			<xsd:enumeration value="SR"/>
+			<xsd:enumeration value="ST"/>
+			<xsd:enumeration value="SV"/>
+			<xsd:enumeration value="SY"/>
+			<xsd:enumeration value="SZ"/>
+			<xsd:enumeration value="TC"/>
+			<xsd:enumeration value="TD"/>
+			<xsd:enumeration value="TF"/>
+			<xsd:enumeration value="TG"/>
+			<xsd:enumeration value="TH"/>
+			<xsd:enumeration value="TJ"/>
+			<xsd:enumeration value="TK"/>
+			<xsd:enumeration value="TM"/>
+			<xsd:enumeration value="TN"/>
+			<xsd:enumeration value="TO"/>
+			<xsd:enumeration value="TP"/>
+			<xsd:enumeration value="TR"/>
+			<xsd:enumeration value="TT"/>
+			<xsd:enumeration value="TV"/>
+			<xsd:enumeration value="TW"/>
+			<xsd:enumeration value="TZ"/>
+			<xsd:enumeration value="UA"/>
+			<xsd:enumeration value="UG"/>
+			<xsd:enumeration value="UM"/>
+			<xsd:enumeration value="US"/>
+			<xsd:enumeration value="UY"/>
+			<xsd:enumeration value="UZ"/>
+			<xsd:enumeration value="VA"/>
+			<xsd:enumeration value="VC"/>
+			<xsd:enumeration value="VE"/>
+			<xsd:enumeration value="VG"/>
+			<xsd:enumeration value="VI"/>
+			<xsd:enumeration value="VN"/>
+			<xsd:enumeration value="VU"/>
+			<xsd:enumeration value="WF"/>
+			<xsd:enumeration value="WS"/>
+			<xsd:enumeration value="YE"/>
+			<xsd:enumeration value="YT"/>
+			<xsd:enumeration value="YU"/>
+			<xsd:enumeration value="ZA"/>
+			<xsd:enumeration value="ZM"/>
+			<xsd:enumeration value="ZR"/>
+			<xsd:enumeration value="ZW"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="layerFunctionType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ASSEMBLY"/>
+			<xsd:enumeration value="BOARDFAB"/>
+			<xsd:enumeration value="BOARD_OUTLINE"/>
+			<xsd:enumeration value="CAPACITIVE"/>
+			<xsd:enumeration value="COATINGCOND"/>
+			<xsd:enumeration value="COATINGNONCOND"/>
+			<xsd:enumeration value="COMPONENT"/>
+			<xsd:enumeration value="COMPONENT_BOTTOM"/>
+			<xsd:enumeration value="COMPONENT_TOP"/>
+			<xsd:enumeration value="COMPONENT_EMBEDDED"/>
+			<xsd:enumeration value="COMPONENT_FORMED"/>
+			<xsd:enumeration value="CONDFILM"/>
+			<xsd:enumeration value="CONDFOIL"/>
+			<xsd:enumeration value="CONDUCTIVE_ADHESIVE"/>
+			<xsd:enumeration value="CONDUCTOR"/>
+			<xsd:enumeration value="COURTYARD"/>
+			<xsd:enumeration value="DIELBASE"/>
+			<xsd:enumeration value="DIELCORE"/>
+			<xsd:enumeration value="DIELPREG"/>
+			<xsd:enumeration value="DIELADHV"/>
+			<xsd:enumeration value="DIELBONDPLY"/>
+			<xsd:enumeration value="DIELCOVERLAY"/>
+			<xsd:enumeration value="DOCUMENT"/>
+			<xsd:enumeration value="DRILL"/>
+			<xsd:enumeration value="FIXTURE"/>
+			<xsd:enumeration value="GLUE"/>
+			<xsd:enumeration value="GRAPHIC"/>
+			<xsd:enumeration value="HOLEFILL"/>
+			<xsd:enumeration value="SOLDERBUMP"/>
+			<xsd:enumeration value="PASTEMASK"/>
+			<xsd:enumeration value="LANDPATTERN"/>
+			<xsd:enumeration value="LEGEND"/>
+			<xsd:enumeration value="MIXED"/>
+			<xsd:enumeration value="OTHER"/>
+			<xsd:enumeration value="PIN"/>
+			<xsd:enumeration value="PLANE"/>
+			<xsd:enumeration value="PROBE"/>
+			<xsd:enumeration value="RESISTIVE"/>
+			<xsd:enumeration value="SIGNAL"/>
+			<xsd:enumeration value="SILKSCREEN"/>
+			<xsd:enumeration value="SOLDERMASK"/>
+			<xsd:enumeration value="SOLDERPASTE"/>
+			<xsd:enumeration value="STACKUP_COMPOSITE"/>
+			<xsd:enumeration value="REWORK"/>
+			<xsd:enumeration value="ROUT"/>
+			<xsd:enumeration value="V_CUT"/>
+			<xsd:enumeration value="EDGE_CHAMFER"/>
+			<xsd:enumeration value="EDGE_PLATING"/>
+			<xsd:enumeration value="THIEVING_KEEP_INOUT"/>
+			<xsd:enumeration value="STIFFENER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="lengthUnitType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="MM"/>
+			<xsd:enumeration value="INCH"/>
+			<xsd:enumeration value="MICRON"/>
+			<xsd:enumeration value="MILS"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="lineEndType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="NONE"/>
+			<xsd:enumeration value="ROUND"/>
+			<xsd:enumeration value="SQUARE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="fillPropertyType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="HOLLOW"/>
+			<xsd:enumeration value="HATCH"/>
+			<xsd:enumeration value="MESH"/>
+			<xsd:enumeration value="FILL"/>
+			<xsd:enumeration value="VOID"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="linePropertyType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SOLID"/>
+			<xsd:enumeration value="DOTTED"/>
+			<xsd:enumeration value="DASHED"/>
+			<xsd:enumeration value="CENTER"/>
+			<xsd:enumeration value="PHANTOM"/>
+			<xsd:enumeration value="ERASE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="lossListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ATTENUATION"/>
+			<xsd:enumeration value="IMPEDANCE"/>
+			<xsd:enumeration value="INSERTION"/>
+			<xsd:enumeration value="POWER"/>
+			<xsd:enumeration value="SIGNAL"/>
+			<xsd:enumeration value="VOLTAGE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="markingUsageType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="REFDES"/>
+			<xsd:enumeration value="PARTNAME"/>
+			<xsd:enumeration value="TARGET"/>
+			<xsd:enumeration value="POLARITY_MARKING"/>
+			<xsd:enumeration value="ATTRIBUTE_GRAPHICS"/>
+			<xsd:enumeration value="PIN_ONE"/>
+			<xsd:enumeration value="NONE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="measurementModeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="DISTANCE"/>
+			<xsd:enumeration value="AREA"/>
+			<xsd:enumeration value="RESISTANCE"/>
+			<xsd:enumeration value="CAPACITANCE"/>
+			<xsd:enumeration value="IMPEDANCE"/>
+			<xsd:enumeration value="INDUCTANCE"/>
+			<xsd:enumeration value="VOLTAGE_DC"/>
+			<xsd:enumeration value="VOLTAGE_AC"/>
+			<xsd:enumeration value="FREQUENCY"/>
+			<xsd:enumeration value="CURRENT"/>
+			<xsd:enumeration value="POWER"/>
+			<xsd:enumeration value="PERCENTAGE"/>
+			<xsd:enumeration value="SIZE"/>
+			<xsd:enumeration value="NONE"/>
+			<xsd:enumeration value="TEXT"/>
+			<xsd:enumeration value="TOLERANCE"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="modeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="USERDEF"/>
+			<xsd:enumeration value="BOM"/>
+			<xsd:enumeration value="STACKUP"/>
+			<xsd:enumeration value="FABRICATION"/>
+			<xsd:enumeration value="ASSEMBLY"/>
+			<xsd:enumeration value="TEST"/>
+			<xsd:enumeration value="STENCIL"/>
+			<xsd:enumeration value="DFX"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="mountType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SMT"/>
+			<xsd:enumeration value="THMT"/>
+			<xsd:enumeration value="EMBEDDED"/>
+			<xsd:enumeration value="PRESSFIT"/>
+			<xsd:enumeration value="WIRE_BONDED"/>
+			<xsd:enumeration value="GLUED"/>
+			<xsd:enumeration value="CLAMPED"/>
+			<xsd:enumeration value="SOCKETED"/>
+			<xsd:enumeration value="FORMED"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="pinPolarityType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="PLUS"/>
+			<xsd:enumeration value="MINUS"/>
+			<xsd:enumeration value="ANODE"/>
+			<xsd:enumeration value="CATHODE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="netClassType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="CLK"/>
+			<xsd:enumeration value="FIXED"/>
+			<xsd:enumeration value="GROUND"/>
+			<xsd:enumeration value="SIGNAL"/>
+			<xsd:enumeration value="POWER"/>
+			<xsd:enumeration value="UNUSED"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="netFunctionType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="INPUT"/>
+			<xsd:enumeration value="OUTPUT"/>
+			<xsd:enumeration value="BIDIRECTIONAL"/>
+			<xsd:enumeration value="POWER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="netPointType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="END"/>
+			<xsd:enumeration value="MIDDLE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="nonNegativeDoubleType">
+		<xsd:restriction base="xsd:double">
+			<xsd:minInclusive value="0.0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="packageTypeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="AXIAL_LEADED"/>
+			<xsd:enumeration value="BARE_DIE"/>
+			<xsd:enumeration value="CERAMIC_BGA"/>
+			<xsd:enumeration value="CERAMIC_DIP"/>
+			<xsd:enumeration value="CERAMIC_FLATPACK"/>
+			<xsd:enumeration value="CERAMIC_QUAD_FLATPACK"/>
+			<xsd:enumeration value="CERAMIC_SIP"/>
+			<xsd:enumeration value="CHIP"/>
+			<xsd:enumeration value="CHIP_SCALE"/>
+			<xsd:enumeration value="CHOKE_SWITCH_SM"/>
+			<xsd:enumeration value="COIL"/>
+			<xsd:enumeration value="CONNECTOR_SM"/>
+			<xsd:enumeration value="CONNECTOR_TH"/>
+			<xsd:enumeration value="EMBEDDED"/>
+			<xsd:enumeration value="FLIPCHIP"/>
+			<xsd:enumeration value="HERMETIC_HYBRED"/>
+			<xsd:enumeration value="LEADLESS_CERAMIC_CHIP_CARRIER"/>
+			<xsd:enumeration value="MCM"/>
+			<xsd:enumeration value="MELF"/>
+			<xsd:enumeration value="FINEPITCH_BGA"/>
+			<xsd:enumeration value="MOLDED"/>
+			<xsd:enumeration value="NETWORK"/>
+			<xsd:enumeration value="PGA"/>
+			<xsd:enumeration value="PLASTIC_BGA"/>
+			<xsd:enumeration value="PLASTIC_CHIP_CARRIER"/>
+			<xsd:enumeration value="PLASTIC_DIP"/>
+			<xsd:enumeration value="PLASTIC_SIP"/>
+			<xsd:enumeration value="POWER_TRANSISTOR"/>
+			<xsd:enumeration value="RADIAL_LEADED"/>
+			<xsd:enumeration value="RECTANGULAR_QUAD_FLATPACK"/>
+			<xsd:enumeration value="RELAY_SM"/>
+			<xsd:enumeration value="RELAY_TH"/>
+			<xsd:enumeration value="SOD123"/>
+			<xsd:enumeration value="SOIC"/>
+			<xsd:enumeration value="SOJ"/>
+			<xsd:enumeration value="SOPIC"/>
+			<xsd:enumeration value="SOT143"/>
+			<xsd:enumeration value="SOT23"/>
+			<xsd:enumeration value="SOT52"/>
+			<xsd:enumeration value="SOT89"/>
+			<xsd:enumeration value="SQUARE_QUAD_FLATPACK"/>
+			<xsd:enumeration value="SSOIC"/>
+			<xsd:enumeration value="SWITCH_TH"/>
+			<xsd:enumeration value="TANTALUM"/>
+			<xsd:enumeration value="TO_TYPE"/>
+			<xsd:enumeration value="TRANSFORMER"/>
+			<xsd:enumeration value="TRIMPOT_SM"/>
+			<xsd:enumeration value="TRIMPOT_TH"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="padUsageType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="TERMINATION"/>
+			<xsd:enumeration value="VIA"/>
+			<xsd:enumeration value="PLANE"/>
+			<xsd:enumeration value="MASK"/>
+			<xsd:enumeration value="TOOLING_HOLE"/>
+			<xsd:enumeration value="THIEVING"/>
+			<xsd:enumeration value="THERMAL_RELIEF"/>
+			<xsd:enumeration value="FIDUCIAL"/>
+			<xsd:enumeration value="NONE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="padUseType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="REGULAR"/>
+			<xsd:enumeration value="ANTIPAD"/>
+			<xsd:enumeration value="THERMAL"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="pinElectricalType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ELECTRICAL"/>
+			<xsd:enumeration value="MECHANICAL"/>
+			<xsd:enumeration value="UNDEFINED"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="pinMountType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SURFACE_MOUNT_PIN"/>
+			<xsd:enumeration value="SURFACE_MOUNT_PAD"/>
+			<xsd:enumeration value="THROUGH_HOLE_PIN"/>
+			<xsd:enumeration value="THROUGH_HOLE_HOLE"/>
+			<xsd:enumeration value="PRESSFIT"/>
+			<xsd:enumeration value="NONBOARD"/>
+			<xsd:enumeration value="HOLE"/>
+			<xsd:enumeration value="WIRE_BOND"/>
+			<xsd:enumeration value="UNDEFINED"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="pinOneOrientationType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="LOWER_LEFT"/>
+			<xsd:enumeration value="LEFT"/>
+			<xsd:enumeration value="LEFT_CENTER"/>
+			<xsd:enumeration value="UPPER_LEFT"/>
+			<xsd:enumeration value="UPPER_CENTER"/>
+			<xsd:enumeration value="UPPER_RIGHT"/>
+			<xsd:enumeration value="RIGHT"/>
+			<xsd:enumeration value="RIGHT_CENTER"/>
+			<xsd:enumeration value="LOWER_RIGHT"/>
+			<xsd:enumeration value="LOWER_CENTER"/>
+			<xsd:enumeration value="CENTER"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="polarityType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="POSITIVE"/>
+			<xsd:enumeration value="NEGATIVE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="portPhysicalType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="COMPONENT"/>
+			<xsd:enumeration value="CONNECTOR"/>
+			<xsd:enumeration value="WIRE_BOND"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="productCriteriaType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ALLOWED"/>
+			<xsd:enumeration value="SUGGESTED"/>
+			<xsd:enumeration value="PREFERRED"/>
+			<xsd:enumeration value="REQUIRED"/>
+			<xsd:enumeration value="CHOSEN"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="propertyUnitType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="MM"/>
+			<xsd:enumeration value="INCH"/>
+			<xsd:enumeration value="MICRON"/>
+			<xsd:enumeration value="MILS"/>
+			<xsd:enumeration value="OHMS"/>
+			<xsd:enumeration value="MHO/CM"/>
+			<xsd:enumeration value="SIEMENS/M"/>
+			<xsd:enumeration value="CELCIUS"/>
+			<xsd:enumeration value="FARANHEIT"/>
+			<xsd:enumeration value="PERCENT"/>
+			<xsd:enumeration value="Hz"/>
+			<xsd:enumeration value="DEGREES"/>
+			<xsd:enumeration value="RMAX"/>
+			<xsd:enumeration value="RZ"/>
+			<xsd:enumeration value="RMS"/>
+			<xsd:enumeration value="SECTION"/>
+			<xsd:enumeration value="CLASS"/>
+			<xsd:enumeration value="ITEM"/>
+			<xsd:enumeration value="GAUGE"/>
+			<xsd:enumeration value="IN-LB"/>
+			<xsd:enumeration value="IN-OZ"/>
+			<xsd:enumeration value="FT-LB"/>
+			<xsd:enumeration value="N-m"/>
+			<xsd:enumeration value="N-cm"/>
+			<xsd:enumeration value="MIN"/>
+			<xsd:enumeration value="MAX"/>
+			<xsd:enumeration value="OZ"/>
+			<xsd:enumeration value="OZ/SQ-FT"/>
+			<xsd:enumeration value="GRAMS"/>
+			<xsd:enumeration value="HENRYS"/>
+			<xsd:enumeration value="AMPS"/>
+			<xsd:enumeration value="WATTS"/>
+			<xsd:enumeration value="VOLTS"/>
+			<xsd:enumeration value="FARAD"/>
+			<xsd:enumeration value="dB"/>
+			<xsd:enumeration value="dB/INCH"/>
+			<xsd:enumeration value="dB/MM"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="qualifiedNameType">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="([^:]+)(:[^:]+)?"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="roleFunctionType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SENDER"/>
+			<xsd:enumeration value="OWNER"/>
+			<xsd:enumeration value="RECEIVER"/>
+			<xsd:enumeration value="DESIGNER"/>
+			<xsd:enumeration value="ENGINEER"/>
+			<xsd:enumeration value="BUYER"/>
+			<xsd:enumeration value="CUSTOMERSERVICE"/>
+			<xsd:enumeration value="DELIVERTO"/>
+			<xsd:enumeration value="BILLTO"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="scaleType">
+		<xsd:restriction base="xsd:double">
+			<xsd:minExclusive value="0.0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="secondaryDrillListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="MAJOR_DIAMETER"/>
+			<xsd:enumeration value="DEPTH"/>
+			<xsd:enumeration value="SIDE"/>
+			<xsd:enumeration value="ANGLE"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="sectionKeyType">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="[ABCDEFGIKLMOPRSUXY]*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="sideType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="TOP"/>
+			<xsd:enumeration value="BOTTOM"/>
+			<xsd:enumeration value="BOTH"/>
+			<xsd:enumeration value="INTERNAL"/>
+			<xsd:enumeration value="ALL"/>
+			<xsd:enumeration value="NONE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="spokeCountType">
+		<xsd:restriction base="xsd:integer">
+			<xsd:maxInclusive value="4"/>
+			<xsd:minInclusive value="0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="stackupStatusType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SPECIFIED"/>
+			<xsd:enumeration value="PROPOSED"/>
+			<xsd:enumeration value="APPROVED"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="stepType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="BOARD"/>
+			<xsd:enumeration value="PALLET"/>
+			<xsd:enumeration value="IC"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="platingStatusType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="PLATED"/>
+			<xsd:enumeration value="NONPLATED"/>
+			<xsd:enumeration value="VIA"/>
+			<xsd:enumeration value="VIA_CAPPED"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="structureListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="STRIPLINE_SYMMETRIC"/>
+			<xsd:enumeration value="STRIPLINE_ASYMMETRIC"/>
+			<xsd:enumeration value="STRIPLINE_PLANE_LESS"/>
+			<xsd:enumeration value="MICROSTRIP_EMBEDDED"/>
+			<xsd:enumeration value="MICROSTRIP_NO_MASK "/>
+			<xsd:enumeration value="MICROSTRIP_MASK_COVERED"/>
+			<xsd:enumeration value="MICROSTRIP_DUAL_MASKED_COVERED"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="coplanarListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="COPLANAR_WAVEGUIDE_STRIPLINE"/>
+			<xsd:enumeration value="COPLANAR_WAVEGUIDE_EMBEDDED"/>
+			<xsd:enumeration value="COPLANAR_WAVEGUIDE_NO_MASK"/>
+			<xsd:enumeration value="COPLANAR_WAVEGUIDE_MASK_COVERED"/>
+			<xsd:enumeration value="COPLANAR_WAVEGUIDE_DUAL_MASKED_COVERED"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="broadsideListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="STRIPLINE_SYMMETRIC"/>
+			<xsd:enumeration value="STRIPLINE_ASYMMETRIC"/>
+			<xsd:enumeration value="STRIPLINE_PLANE_LESS"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="technologyListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="RIGID"/>
+			<xsd:enumeration value="RIGID_FLEX"/>
+			<xsd:enumeration value="FLEX"/>
+			<xsd:enumeration value="HDI"/>
+			<xsd:enumeration value="EMBEDDED_COMPONENT"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="temperatureListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="THERMAL_DELAMINATION"/>
+			<xsd:enumeration value="EXPANSION_Z_AXIS"/>
+			<xsd:enumeration value="EXPANSION_X_Y_AXIS"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="thermalShapeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ROUND"/>
+			<xsd:enumeration value="SQUARE"/>
+			<xsd:enumeration value="HEXAGON"/>
+			<xsd:enumeration value="OCTAGON"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="thievingListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="KEEP_IN"/>
+			<xsd:enumeration value="KEEP_OUT"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="transmissionListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SINGLE_ENDED"/>
+			<xsd:enumeration value="EDGE_COUPLED"/>
+			<xsd:enumeration value="BROADSIDE_COUPLED"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="unitModeType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="DISTANCE"/>
+			<xsd:enumeration value="AREA"/>
+			<xsd:enumeration value="RESISTANCE"/>
+			<xsd:enumeration value="CAPACITANCE"/>
+			<xsd:enumeration value="IMPEDANCE"/>
+			<xsd:enumeration value="PERCENTAGE"/>
+			<xsd:enumeration value="SIZE"/>
+			<xsd:enumeration value="NONE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="unitsType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="MILLIMETER"/>
+			<xsd:enumeration value="MICRON"/>
+			<xsd:enumeration value="INCH"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="unsignedByte">
+		<xsd:restriction base="xsd:nonNegativeInteger">
+			<xsd:maxInclusive value="255"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="vCutListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ANGLE"/>
+			<xsd:enumeration value="THICKNESS_REMAINING"/>
+			<xsd:enumeration value="OFFSET"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="edgeChamferListType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ANGLE"/>
+			<xsd:enumeration value="WIDTH"/>
+			<xsd:enumeration value="SIDE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="whereMeasuredType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="LAMINATE"/>
+			<xsd:enumeration value="METAL"/>
+			<xsd:enumeration value="MASK"/>
+			<xsd:enumeration value="OTHER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="Approval" type="ApprovalType"/>
+	<xsd:complexType name="ApprovalType">
+		<xsd:attribute name="datetime" type="xsd:dateTime" use="required"/>
+		<xsd:attribute name="personRef" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Arc" type="ArcType" substitutionGroup="Simple"/>
+	<xsd:complexType name="ArcType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup"/>
+		</xsd:sequence>
+		<xsd:attribute name="startX" type="xsd:double" use="required"/>
+		<xsd:attribute name="startY" type="xsd:double" use="required"/>
+		<xsd:attribute name="endX" type="xsd:double" use="required"/>
+		<xsd:attribute name="endY" type="xsd:double" use="required"/>
+		<xsd:attribute name="centerX" type="xsd:double" use="required"/>
+		<xsd:attribute name="centerY" type="xsd:double" use="required"/>
+		<xsd:attribute name="clockwise" type="xsd:boolean" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="AssemblyDrawing" type="AssemblyDrawingType"/>
+	<xsd:complexType name="AssemblyDrawingType">
+		<xsd:sequence>
+			<xsd:element ref="Outline"/>
+			<xsd:element ref="Marking" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Avl" type="AvlType"/>
+	<xsd:element name="AvlHeader" type="AvlHeaderType"/>
+	<xsd:complexType name="AvlHeaderType">
+		<xsd:attribute name="title" type="xsd:string" use="required"/>
+		<xsd:attribute name="source" type="xsd:string" use="required"/>
+		<xsd:attribute name="author" type="xsd:string" use="required"/>
+		<xsd:attribute name="datetime" type="xsd:dateTime" use="required"/>
+		<xsd:attribute name="version" type="xsd:positiveInteger" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string"/>
+		<xsd:attribute name="modRef" type="modeType"/>
+	</xsd:complexType>
+	<xsd:element name="AvlItem" type="AvlItemType"/>
+	<xsd:complexType name="AvlItemType">
+		<xsd:sequence>
+			<xsd:element ref="AvlVmpn" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="OEMDesignNumber" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="AvlMpn" type="AvlMpnType"/>
+	<xsd:complexType name="AvlMpnType">
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="rank" type="xsd:nonNegativeInteger"/>
+		<xsd:attribute name="cost" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="moistureSensitivity" type="floorLifeType"/>
+		<xsd:attribute name="availability" type="xsd:boolean"/>
+		<xsd:attribute name="other" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="AvlRef" type="AvlRefType"/>
+	<xsd:complexType name="AvlRefType">
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="AvlType">
+		<xsd:sequence>
+			<xsd:element ref="AvlHeader"/>
+			<xsd:element ref="AvlItem" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="AvlVendor" type="AvlVendorType"/>
+	<xsd:complexType name="AvlVendorType">
+		<xsd:attribute name="enterpriseRef" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="AvlVmpn" type="AvlVmpnType"/>
+	<xsd:complexType name="AvlVmpnType">
+		<xsd:sequence>
+			<xsd:element ref="AvlMpn"/>
+			<xsd:element ref="AvlVendor"/>
+		</xsd:sequence>
+		<xsd:attribute name="evplVendor" type="xsd:string" use="optional"/>
+		<xsd:attribute name="evplMpn" type="xsd:string" use="optional"/>
+		<xsd:attribute name="qualified" type="xsd:boolean" use="optional"/>
+		<xsd:attribute name="chosen" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="BendArea" type="BendAreaType"/>
+	<xsd:complexType name="BendAreaType">
+		<xsd:sequence>
+			<xsd:element ref="CircularBend"/>
+			<xsd:element ref="Outline"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="sequenceNumber" type="xsd:integer" use="optional"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="BendLine" type="LineType"/>
+	<xsd:element name="BadBoardMark" type="FiducialType" substitutionGroup="Fiducial"/>
+	<xsd:element name="Bom" type="BomType"/>
+	<xsd:element name="BomHeader" type="BomHeaderType"/>
+	<xsd:complexType name="BomHeaderType">
+		<xsd:sequence>
+			<xsd:element ref="StepRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="assembly" type="xsd:string" use="required"/>
+		<xsd:attribute name="revision" type="xsd:string" use="required"/>
+		<xsd:attribute name="affecting" type="xsd:boolean"/>
+	</xsd:complexType>
+	<xsd:element name="BomItem" type="BomItemType"/>
+	<xsd:complexType name="BomItemType">
+		<xsd:sequence>
+			<xsd:element ref="BomDes" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Characteristics"/>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="OEMDesignNumberRef" type="xsd:string" use="required"/>
+		<xsd:attribute name="quantity" type="xsd:string" use="required"/>
+		<xsd:attribute name="pinCount" type="xsd:nonNegativeInteger" use="optional"/>
+		<xsd:attribute name="category" type="bomCategoryType" use="required"/>
+		<xsd:attribute name="internalPartNumber" type="xsd:string"/>
+		<xsd:attribute name="description" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="BomDes" abstract="true"/>
+	<xsd:element name="RefDes" type="RefDesType" substitutionGroup="BomDes"/>
+	<xsd:complexType name="RefDesType">
+		<xsd:sequence>
+			<xsd:element ref="Tuning" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Firmware" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="packageRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="populate" type="xsd:boolean"/>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="modelRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="MatDes" type="MatDesType" substitutionGroup="BomDes"/>
+	<xsd:complexType name="MatDesType">
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="DocDes" type="DocDesType" substitutionGroup="BomDes"/>
+	<xsd:complexType name="DocDesType">
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="ToolDes" type="ToolDesType" substitutionGroup="BomDes"/>
+	<xsd:complexType name="ToolDesType">
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="FindDes" type="FindDesType" substitutionGroup="BomDes"/>
+	<xsd:complexType name="FindDesType">
+		<xsd:attribute name="number" type="xsd:positiveInteger" use="required"/>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="modelRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="BomRef" type="BomRefType"/>
+	<xsd:complexType name="BomRefType">
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="BomType">
+		<xsd:sequence>
+			<xsd:element ref="BomHeader"/>
+			<xsd:element ref="BomItem" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="BoundingBox" type="BoundingBoxType"/>
+	<xsd:complexType name="BoundingBoxType">
+		<xsd:attribute name="lowerLeftX" type="xsd:double" use="required"/>
+		<xsd:attribute name="lowerLeftY" type="xsd:double" use="required"/>
+		<xsd:attribute name="upperRightX" type="xsd:double" use="required"/>
+		<xsd:attribute name="upperRightY" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Butterfly" type="ButterflyType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="ButterflyType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="shape" type="butterflyShapeType" use="required"/>
+		<xsd:attribute name="diameter" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="side" type="nonNegativeDoubleType"/>
+	</xsd:complexType>
+	<xsd:element name="CachedFirmware" type="CachedFirmwareType" substitutionGroup="FirmwareGroup"/>
+	<xsd:complexType name="CachedFirmwareType">
+		<xsd:attribute name="hexEncodedBinary" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="CadData" type="CadDataType"/>
+	<xsd:complexType name="CadDataType">
+		<xsd:sequence>
+			<xsd:element ref="Layer" maxOccurs="unbounded"/>
+			<xsd:element ref="Stackup" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Step" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="CadHeader" type="CadHeaderType"/>
+	<xsd:complexType name="CadHeaderType">
+		<xsd:sequence>
+			<xsd:element ref="Spec" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="ChangeRec" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="units" type="unitsType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Certification" type="CertificationType"/>
+	<xsd:complexType name="CertificationType">
+		<xsd:attribute name="certificationStatus" type="certificationStatusType" use="required"/>
+		<xsd:attribute name="certificationCategory" type="certificationCategoryType"/>
+	</xsd:complexType>
+	<xsd:element name="ChangeRec" type="ChangeRecType"/>
+	<xsd:complexType name="ChangeRecType">
+		<xsd:sequence>
+			<xsd:element ref="Approval" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="datetime" type="xsd:dateTime" use="required"/>
+		<xsd:attribute name="personRef" type="xsd:string" use="required"/>
+		<xsd:attribute name="application" type="xsd:string" use="required"/>
+		<xsd:attribute name="change" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Characteristics" type="CharacteristicsType"/>
+	<xsd:complexType name="CharacteristicsType">
+		<xsd:sequence>
+			<xsd:element ref="Measured" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Ranged" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Enumerated" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Textual" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="category" type="bomCategoryType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Circle" type="CircleType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="CircleType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="diameter" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="CircularBend" type="CircularBendType"/>
+	<xsd:complexType name="CircularBendType">
+		<xsd:sequence>
+			<xsd:element ref="BendLine"/>
+		</xsd:sequence>
+		<xsd:attribute name="innerSide" type="bendSideType" use="required"/>
+		<xsd:attribute name="innerRadius" type="xsd:double" use="required"/>
+		<xsd:attribute name="innerAngle" type="angleType"/>
+	</xsd:complexType>
+	<xsd:element name="Color" type="ColorType" substitutionGroup="ColorGroup"/>
+	<xsd:element name="ColorGroup" abstract="true"/>
+	<xsd:element name="ColorRef" type="ColorRefType" substitutionGroup="ColorGroup"/>
+	<xsd:complexType name="ColorRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="ColorType">
+		<xsd:attribute name="r" type="unsignedByte" use="required"/>
+		<xsd:attribute name="g" type="unsignedByte" use="required"/>
+		<xsd:attribute name="b" type="unsignedByte" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="ColorTerm" type="ColorTermType" substitutionGroup="ColorGroup"/>
+	<xsd:complexType name="ColorTermType">
+		<xsd:attribute name="name" type="colorListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Component" type="ComponentType"/>
+	<xsd:complexType name="ComponentType">
+		<xsd:sequence>
+			<xsd:element ref="NonstandardAttribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location"/>
+			<xsd:element ref="SlotCavityRef" minOccurs="0"/>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="refDes" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="matDes" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="packageRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="part" type="xsd:string" use="required"/>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="layerRefTopside" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="mountType" type="mountType" use="required"/>
+		<xsd:attribute name="modelRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="weight" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="standoff" type="nonNegativeDoubleType"/>
+	</xsd:complexType>
+	<xsd:element name="Content" type="ContentType"/>
+	<xsd:complexType name="ContentType">
+		<xsd:sequence>
+			<xsd:element ref="FunctionMode"/>
+			<xsd:element ref="StepRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="LayerRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="BomRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="AvlRef" minOccurs="0"/>
+			<xsd:element ref="DictionaryColor" minOccurs="0"/>
+			<xsd:element ref="DictionaryLineDesc" minOccurs="0"/>
+			<xsd:element ref="DictionaryFillDesc" minOccurs="0"/>
+			<xsd:element ref="DictionaryFont" minOccurs="0"/>
+			<xsd:element ref="DictionaryStandard" minOccurs="0"/>
+			<xsd:element ref="DictionaryUser" minOccurs="0"/>
+			<xsd:element ref="DictionaryFirmware" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="roleRef" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Contour" type="ContourType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="ContourType">
+		<xsd:sequence>
+			<xsd:element ref="Polygon"/>
+			<xsd:element ref="Cutout" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Criteria" type="CriteriaType"/>
+	<xsd:complexType name="CriteriaType">
+		<xsd:sequence>
+			<xsd:element ref="Property"/>
+			<xsd:element ref="DfxMeasurement" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="measurementMode" type="measurementModeType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Cutout" type="PolygonType"/>
+	<xsd:element name="Dfx" type="DfxType"/>
+	<xsd:complexType name="DfxType">
+		<xsd:sequence>
+			<xsd:element ref="Criteria" minOccurs="0"/>
+			<xsd:element ref="DfxQuery" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="category" type="dfxCategoryType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="DfxDetails" type="DfxDetailsType"/>
+	<xsd:complexType name="DfxDetailsType">
+		<xsd:sequence>
+			<xsd:element ref="FeatureDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Marker" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="EmbeddedRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="ExternalRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="DfxMeasurement" type="DfxMeasurementType"/>
+	<xsd:complexType name="DfxMeasurementType">
+		<xsd:sequence>
+			<xsd:element ref="Property"/>
+			<xsd:element ref="MeasurementPoint" maxOccurs="unbounded"/>
+			<xsd:element ref="DfxDetails" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="severity" type="xsd:string" use="optional"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="DfxQuery" type="DfxQueryType"/>
+	<xsd:complexType name="DfxQueryType">
+		<xsd:sequence>
+			<xsd:element ref="DfxDetails" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="DfxResponse" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="query" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="DfxResponse" type="DfxResponseType"/>
+	<xsd:complexType name="DfxResponseType">
+		<xsd:sequence>
+			<xsd:element ref="DfxDetails" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="dfxMeasurementRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="response" type="dfxResponseChoices" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Diamond" type="DiamondType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="DiamondType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="width" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="DictionaryColor" type="DictionaryColorType"/>
+	<xsd:complexType name="DictionaryColorType">
+		<xsd:sequence>
+			<xsd:element ref="EntryColor" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="DictionaryFirmware" type="DictionaryFirmwareType"/>
+	<xsd:complexType name="DictionaryFirmwareType">
+		<xsd:sequence>
+			<xsd:element ref="EntryFirmware" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="DictionaryFont" type="DictionaryFontType"/>
+	<xsd:complexType name="DictionaryFontType">
+		<xsd:sequence>
+			<xsd:element ref="EntryFont" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="units" type="unitsType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="DictionaryLineDesc" type="DictionaryLineDescType"/>
+	<xsd:complexType name="DictionaryLineDescType">
+		<xsd:sequence>
+			<xsd:element ref="EntryLineDesc" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="units" type="unitsType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="DictionaryFillDesc" type="DictionaryFillDescType"/>
+	<xsd:complexType name="DictionaryFillDescType">
+		<xsd:sequence>
+			<xsd:element ref="EntryFillDesc" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="units" type="unitsType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="DictionaryStandard" type="DictionaryStandardType"/>
+	<xsd:complexType name="DictionaryStandardType">
+		<xsd:sequence>
+			<xsd:element ref="EntryStandard" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="units" type="unitsType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="DictionaryUser" type="DictionaryUserType"/>
+	<xsd:complexType name="DictionaryUserType">
+		<xsd:sequence>
+			<xsd:element ref="EntryUser" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="units" type="unitsType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Donut" type="DonutType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="DonutType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="shape" type="donutShapeType" use="required"/>
+		<xsd:attribute name="outerDiameter" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="innerDiameter" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Ecad" type="EcadType"/>
+	<xsd:complexType name="EcadType">
+		<xsd:sequence>
+			<xsd:element ref="CadHeader"/>
+			<xsd:element ref="CadData" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="EdgeCoupled" type="EdgeCoupledType" substitutionGroup="TransmissionType"/>
+	<xsd:complexType name="EdgeCoupledType">
+		<xsd:sequence>
+			<xsd:element ref="LineWidth"/>
+			<xsd:element ref="LineGap"/>
+			<xsd:element ref="RefPlane" minOccurs="0" maxOccurs="2"/>
+		</xsd:sequence>
+		<xsd:attribute name="structure" type="structureListType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Ellipse" type="EllipseType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="EllipseType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="width" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="EmbeddedData" type="xsd:base64Binary"/>
+	<xsd:element name="EmbeddedRef" type="EmbeddedRefType"/>
+	<xsd:complexType name="EmbeddedRefType">
+		<xsd:sequence>
+			<xsd:element ref="EmbeddedData"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="embeddedType" type="embeddedTypeType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Enterprise" type="EnterpriseType"/>
+	<xsd:complexType name="EnterpriseType">
+		<xsd:attribute name="id" type="xsd:string" use="required"/>
+		<xsd:attribute name="name" type="xsd:string"/>
+		<xsd:attribute name="code" type="xsd:string" use="required"/>
+		<xsd:attribute name="codeType" type="enterpriseCodeType"/>
+		<xsd:attribute name="address1" type="xsd:string"/>
+		<xsd:attribute name="address2" type="xsd:string"/>
+		<xsd:attribute name="city" type="xsd:string"/>
+		<xsd:attribute name="stateProvince" type="xsd:string"/>
+		<xsd:attribute name="country" type="isoCodeType"/>
+		<xsd:attribute name="postalCode" type="xsd:string"/>
+		<xsd:attribute name="phone" type="xsd:string"/>
+		<xsd:attribute name="fax" type="xsd:string"/>
+		<xsd:attribute name="email" type="xsd:string"/>
+		<xsd:attribute name="url" type="xsd:anyURI"/>
+	</xsd:complexType>
+	<xsd:element name="EntryColor" type="EntryColorType"/>
+	<xsd:complexType name="EntryColorType">
+		<xsd:sequence>
+			<xsd:element ref="Color"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="EntryFirmware" type="EntryFirmwareType"/>
+	<xsd:complexType name="EntryFirmwareType">
+		<xsd:sequence>
+			<xsd:element ref="CachedFirmware"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="EntryFont" type="EntryFontType"/>
+	<xsd:complexType name="EntryFontType">
+		<xsd:sequence>
+			<xsd:element ref="FontDef"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="EntryLineDesc" type="EntryLineDescType"/>
+	<xsd:complexType name="EntryLineDescType">
+		<xsd:sequence>
+			<xsd:element ref="LineDesc"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="EntryFillDesc" type="EntryFillDescType"/>
+	<xsd:complexType name="EntryFillDescType">
+		<xsd:sequence>
+			<xsd:element ref="FillDesc"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="EntryStandard" type="EntryStandardType"/>
+	<xsd:complexType name="EntryStandardType">
+		<xsd:sequence>
+			<xsd:element ref="StandardPrimitive"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="EntryUser" type="EntryUserType"/>
+	<xsd:complexType name="EntryUserType">
+		<xsd:sequence>
+			<xsd:element ref="UserPrimitive"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Enumerated" type="EnumeratedType"/>
+	<xsd:complexType name="EnumeratedType">
+		<xsd:attribute name="definitionSource" type="xsd:string"/>
+		<xsd:attribute name="enumeratedCharacteristicName" type="xsd:string"/>
+		<xsd:attribute name="enumeratedCharacteristicValue" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="ExternalRef" type="xsd:anyURI"/>
+	<xsd:element name="Extrusion" type="ExtrusionType"/>
+	<xsd:complexType name="ExtrusionType">
+		<xsd:sequence>
+			<xsd:element ref="Feature" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="Location" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="Xform" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="startHeight" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Feature" abstract="true"/>
+	<xsd:element name="FeatureDescription" type="FeatureDescriptionType"/>
+	<xsd:complexType name="FeatureDescriptionType">
+		<xsd:sequence>
+			<xsd:element ref="Feature" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="Xform" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="Location" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="pinRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="componentRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="packageRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="specRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="firmwareRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="padstackDefRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="netRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="stackupRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="bomRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="featureObject" type="featureObjectType" use="optional"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+		<!--xsd:attribute name = "featureRef" use = "required" type = "qualifiedNameType"/-->
+	</xsd:complexType>
+	<xsd:element name="Features" type="FeaturesType"/>
+	<xsd:complexType name="FeaturesType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Feature"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Fiducial" abstract="true"/>
+	<xsd:complexType name="FiducialType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location"/>
+			<xsd:element ref="StandardShape"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="File" type="FileType"/>
+	<xsd:element name="FileRevision" type="FileRevisionType"/>
+	<xsd:complexType name="FileRevisionType">
+		<xsd:sequence>
+			<xsd:element ref="SoftwarePackage"/>
+		</xsd:sequence>
+		<xsd:attribute name="fileRevisionId" type="xsd:string" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="required"/>
+		<xsd:attribute name="label" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:complexType name="FileType">
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+		<xsd:attribute name="crc" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Firmware" type="FirmwareType"/>
+	<xsd:element name="FirmwareGroup" abstract="true"/>
+	<xsd:element name="FirmwareRef" type="FirmwareRefType" substitutionGroup="FirmwareGroup"/>
+	<xsd:complexType name="FirmwareRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="FirmwareType">
+		<xsd:sequence>
+			<xsd:element ref="File"/>
+			<xsd:element ref="FirmwareGroup"/>
+		</xsd:sequence>
+		<xsd:attribute name="progName" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="progVersion" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="FontDef" abstract="true"/>
+	<xsd:element name="FontDefEmbedded" type="FontDefEmbeddedType" substitutionGroup="FontDef"/>
+	<xsd:complexType name="FontDefEmbeddedType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup"/>
+			<xsd:element ref="Glyph" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="FontDefExternal" type="FontDefExternalType" substitutionGroup="FontDef"/>
+	<xsd:complexType name="FontDefExternalType">
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+		<xsd:attribute name="urn" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="FontRef" type="FontRefType"/>
+	<xsd:complexType name="FontRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="FunctionMode" type="FunctionModeType"/>
+	<xsd:complexType name="FunctionModeType">
+		<xsd:attribute name="mode" type="modeType" use="required"/>
+		<xsd:attribute name="sectionKey" type="sectionKeyType" use="optional"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="GlobalFiducial" type="FiducialType" substitutionGroup="Fiducial"/>
+	<xsd:element name="Glyph" type="GlyphType"/>
+	<xsd:complexType name="GlyphType">
+		<xsd:sequence>
+			<xsd:element ref="Simple" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="charCode" type="xsd:hexBinary" use="required"/>
+		<xsd:attribute name="lowerLeftX" type="xsd:double" use="required"/>
+		<xsd:attribute name="lowerLeftY" type="xsd:double" use="required"/>
+		<xsd:attribute name="upperRightX" type="xsd:double" use="required"/>
+		<xsd:attribute name="upperRightY" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="GoodPanelMark" type="FiducialType" substitutionGroup="Fiducial"/>
+	<xsd:element name="Hexagon" type="HexagonType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="HexagonType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="length" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="HistoryRecord" type="HistoryRecordType"/>
+	<xsd:complexType name="HistoryRecordType">
+		<xsd:sequence>
+			<xsd:element ref="FileRevision"/>
+			<xsd:element ref="ChangeRec" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="number" type="historyNumberType" use="required"/>
+		<xsd:attribute name="origination" type="xsd:dateTime" use="required"/>
+		<xsd:attribute name="software" type="xsd:string" use="required"/>
+		<xsd:attribute name="lastChange" type="xsd:dateTime" use="required"/>
+		<xsd:attribute name="lifecyclePhase" type="xsd:string" use="optional"/>
+		<xsd:attribute name="externalConfigurationEntryPoint" type="xsd:anyURI"/>
+	</xsd:complexType>
+	<xsd:element name="Hole" type="HoleType"/>
+	<xsd:complexType name="HoleType">
+		<xsd:sequence>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Xform" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="type" type="holeShapeType" use="optional" default="CIRCLE"/>
+		<xsd:attribute name="diameter" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="platingStatus" type="platingStatusType" use="required"/>
+		<xsd:attribute name="plusTol" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="minusTol" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="IPC-2581" type="IPC-2581Type">
+		<xsd:key name="enterpriseKey">
+			<xsd:selector xpath="tn:LogisticHeader/tn:Enterprise"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="enterpriseKeyRef" refer="enterpriseKey">
+			<xsd:selector xpath=".//tn:AvlVendor"/>
+			<xsd:field xpath="@enterpriseRef"/>
+		</xsd:keyref>
+		<xsd:key name="stepKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Step"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="stepKeyRef" refer="stepKey">
+			<xsd:selector xpath=".//tn:StepRepeat|.//tn:BomHeader|.//tn:ConnectorMate|.//tn:ComponentPad|.//tn:PortConnect"/>
+			<xsd:field xpath="@stepRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="stepKeyRef2" refer="stepKey">
+			<xsd:selector xpath=".//tn:StepRef"/>
+			<xsd:field xpath="@name"/>
+		</xsd:keyref>
+		<xsd:key name="PackageKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Step/tn:Package"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="PackageKeyRef" refer="PackageKey">
+			<xsd:selector xpath=".//tn:Component|.//tn:FeatureDescription"/>
+			<xsd:field xpath="@packageRef"/>
+		</xsd:keyref>
+		<xsd:key name="BomKey">
+			<xsd:selector xpath="tn:Bom"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="BomKeyRef" refer="BomKey">
+			<xsd:selector xpath=".//tn:BomRef"/>
+			<xsd:field xpath="@name"/>
+		</xsd:keyref>
+		<!-- Unrealistic requirement for unique names -->
+		<xsd:key name="personKey">
+			<xsd:selector xpath="tn:LogisticHeader/tn:Person"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="personKeyRef" refer="personKey">
+			<xsd:selector xpath=".//tn:ChangeRec|.//tn:Approval"/>
+			<xsd:field xpath="@personRef"/>
+		</xsd:keyref>
+		<xsd:key name="AvlKey">
+			<xsd:selector xpath="tn:Avl"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="AvlKeyRef" refer="AvlKey">
+			<xsd:selector xpath=".//tn:AvlRef"/>
+			<xsd:field xpath="@name"/>
+		</xsd:keyref>
+		<xsd:key name="ColorKey">
+			<xsd:selector xpath="tn:Content/tn:DictionaryColor/tn:EntryColor"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="ColorKeyRef" refer="ColorKey">
+			<xsd:selector xpath=".//tn:ColorRef"/>
+			<xsd:field xpath="@id"/>
+		</xsd:keyref>
+		<xsd:key name="layerKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Layer"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="layerKeyRef" refer="layerKey">
+			<!-- See also layerKeyRef2 -->
+			<xsd:selector xpath=".//tn:Component|.//tn:FeatureDescription|.//tn:LayerFeature|.//tn:PhyNetPoint|.//tn:RefDes|.//tn:MatDes|.//tn:DocDes|.//tn:ToolDes|.//tn:WireBond"/>
+			<xsd:field xpath="@layerRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="layerKeyRef2" refer="layerKey">
+			<!-- See also layerKeyRef -->
+			<xsd:selector xpath=".//tn:LayerRef"/>
+			<xsd:field xpath="@name"/>
+		</xsd:keyref>
+		<xsd:key name="StandardPrimitiveKey">
+			<xsd:selector xpath="tn:Content/tn:DictionaryStandard/tn:EntryStandard"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="StandardPrimitiveKeyRef" refer="StandardPrimitiveKey">
+			<xsd:selector xpath=".//tn:StandardPrimitiveRef"/>
+			<xsd:field xpath="@id"/>
+		</xsd:keyref>
+		<xsd:key name="UserPrimitiveKey">
+			<xsd:selector xpath="tn:Content/tn:DictionaryUser/tn:EntryUser"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="UserPrimitiveKeyRef" refer="UserPrimitiveKey">
+			<xsd:selector xpath=".//tn:UserPrimitiveRef"/>
+			<xsd:field xpath="@id"/>
+		</xsd:keyref>
+		<xsd:key name="FirmwareKey">
+			<xsd:selector xpath="tn:Content/tn:DictionaryFirmware/tn:EntryFirmware"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="FirmwareKeyRef" refer="FirmwareKey">
+			<xsd:selector xpath=".//tn:FirmwareRef"/>
+			<xsd:field xpath="@id"/>
+		</xsd:keyref>
+		<xsd:keyref name="FirmwareKeyRef2" refer="FirmwareKey">
+			<xsd:selector xpath=".//tn:FeatureDescription"/>
+			<xsd:field xpath="@firmwareRef"/>
+		</xsd:keyref>
+		<xsd:key name="FontKey">
+			<xsd:selector xpath="tn:Content/tn:DictionaryFont/tn:EntryFont"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="FontKeyRef" refer="FontKey">
+			<xsd:selector xpath=".//tn:FontRef"/>
+			<xsd:field xpath="@id"/>
+		</xsd:keyref>
+		<xsd:key name="LineDescKey">
+			<xsd:selector xpath="tn:Content/tn:DictionaryLineDesc/tn:EntryLineDesc"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="LineDescKeyRef" refer="LineDescKey">
+			<xsd:selector xpath=".//tn:LineDescRef"/>
+			<xsd:field xpath="@id"/>
+		</xsd:keyref>
+		<xsd:key name="RefDesKey">
+			<xsd:selector xpath="tn:Bom/tn:BomItem/tn:RefDes"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="RefDesKeyRef" refer="RefDesKey">
+			<xsd:selector xpath=".//tn:LogicalNetPin|.//tn:PinRef|.//tn:FeatureDescription"/>
+			<xsd:field xpath="@componentRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="RefDesKeyRef2" refer="RefDesKey">
+			<xsd:selector xpath=".//tn:Component"/>
+			<xsd:field xpath="@refDes"/>
+		</xsd:keyref>
+		<xsd:keyref name="RefDesKeyRef3" refer="RefDesKey">
+			<xsd:selector xpath=".//tn:ConnectorMate|.//tn:ConnectorPad|.//tn:PortConnect|.//tn:WireBond"/>
+			<xsd:field xpath="@compRef"/>
+		</xsd:keyref>
+		<xsd:key name="roleKey">
+			<xsd:selector xpath="tn:LogisticHeader/tn:Role"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="roleKeyRef" refer="roleKey">
+			<xsd:selector xpath=".//tn:Person"/>
+			<xsd:field xpath="@roleRef"/>
+		</xsd:keyref>
+		<xsd:key name="bomItemKey">
+			<xsd:selector xpath="tn:Bom/tn:BomItem"/>
+			<xsd:field xpath="@OEMDesignNumberRef"/>
+		</xsd:key>
+		<xsd:key name="layerOrStackupGroupNameKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Stackup/tn:StackupGroup|tn:Ecad/tn:CadData/tn:Layer"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="layerOrGroupKeyRef" refer="layerOrStackupGroupNameKey">
+			<xsd:selector xpath=".//tn:RefPlane|.//tn:ZoneLayer|.//tn:Property|.//tn:StackupLayer"/>
+			<xsd:field xpath="@layerOrGroupRef"/>
+		</xsd:keyref>
+		<xsd:key name="stackupKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Stackup"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="stackupKeyRef" refer="stackupKey">
+			<xsd:selector xpath=".//tn:Step|.//tn:StackupZone"/>
+			<xsd:field xpath="@stackupRef"/>
+		</xsd:keyref>
+		<xsd:key name="specKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadHeader/tn:Spec"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="specKeyRef" refer="specKey">
+			<xsd:selector xpath=".//tn:SpecRef"/>
+			<xsd:field xpath="@id"/>
+		</xsd:keyref>
+		<xsd:keyref name="specKeyRef2" refer="specKey">
+			<xsd:selector xpath=".//tn:FeatureDescription"/>
+			<xsd:field xpath="@specRef"/>
+		</xsd:keyref>
+		<xsd:key name="MatDesKey">
+			<xsd:selector xpath="tn:Bom/tn:BomItem/tn:MatDes"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="MatDesKeyRef" refer="MatDesKey">
+			<xsd:selector xpath=".//tn:Stackup|.//tn:StackupGroup|.//tn:StackupLayer|.//tn:Fill"/>
+			<xsd:field xpath="@matDes"/>
+		</xsd:keyref>
+		<xsd:key name="PortKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Step/tn:Port"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="PortKeyRef" refer="PortKey">
+			<xsd:selector xpath=".//tn:PortRef"/>
+			<xsd:field xpath="@portName"/>
+		</xsd:keyref>
+		<xsd:key name="SlotCavityKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Step/tn:LayerFeature/tn:Set/tn:SlotCavity"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="SlotCavityKeyRef" refer="SlotCavityKey">
+			<xsd:selector xpath=".//tn:SlotCavityRef"/>
+			<xsd:field xpath="@id"/>
+		</xsd:keyref>
+		<xsd:key name="NetKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Step/tn:PhyNetGroup/tn:PhyNet|tn:Ecad/tn:CadData/tn:Step/tn:LogicalNet"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="NetKeyRef" refer="NetKey">
+			<xsd:selector xpath=".//NetRef"/>
+			<xsd:field xpath="@name"/>
+		</xsd:keyref>
+		<xsd:keyref name="NetKeyRef2" refer="NetKey">
+			<xsd:selector xpath=".//FeatureDescription"/>
+			<xsd:field xpath="@netRef"/>
+		</xsd:keyref>
+		<xsd:key name="PadStackDefKey">
+			<xsd:selector xpath="tn:Ecad/tn:CadData/tn:Step/tn:PadStackDef"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:keyref name="PadStackDefKeyRef" refer="PadStackDefKey">
+			<xsd:selector xpath=".//tn:Pad|.//tn:FeatureDescription"/>
+			<xsd:field xpath="@padstackDefRef"/>
+		</xsd:keyref>
+	</xsd:element>
+	<xsd:complexType name="IPC-2581Type">
+		<xsd:sequence>
+			<xsd:element ref="Content"/>
+			<xsd:element ref="LogisticHeader"/>
+			<xsd:element ref="HistoryRecord"/>
+			<xsd:element ref="Bom" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Ecad"/>
+			<xsd:element ref="Avl" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="revision" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Inset" type="InsetType"/>
+	<xsd:complexType name="InsetType">
+		<xsd:sequence>
+			<xsd:element ref="StackupZoneRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="insetSize" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="LandPattern" type="LandPatternType"/>
+	<xsd:complexType name="LandPatternType">
+		<xsd:sequence>
+			<xsd:element ref="Pad" maxOccurs="unbounded"/>
+			<xsd:element ref="Target" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Layer" type="LayerType"/>
+	<xsd:element name="LayerFeature" type="LayerFeatureType"/>
+	<xsd:complexType name="LayerFeatureType">
+		<xsd:sequence>
+			<xsd:element ref="Set" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Model" type="ModelType"/>
+	<xsd:complexType name="ModelType">
+		<xsd:sequence>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="Extrusion" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="PadstackHoleDef" type="PadstackHoleDefType"/>
+	<xsd:complexType name="PadstackHoleDefType">
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="diameter" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="platingStatus" type="platingStatusType" use="required"/>
+		<xsd:attribute name="plusTol" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="minusTol" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="PadstackPadDef" type="PadstackPadDefType"/>
+	<xsd:complexType name="PadstackPadDefType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location"/>
+			<xsd:element ref="Feature"/>
+		</xsd:sequence>
+		<xsd:attribute name="layerRef" use="required"/>
+		<xsd:attribute name="padUse" use="required"/>
+		<xsd:attribute name="comment" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="LayerRef" type="LayerRefType"/>
+	<xsd:complexType name="LayerRefType">
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="LayerType">
+		<xsd:sequence>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Span" minOccurs="0"/>
+			<xsd:element ref="Profile" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="layerFunction" type="layerFunctionType" use="required"/>
+		<xsd:attribute name="side" type="sideType" use="required"/>
+		<xsd:attribute name="polarity" type="polarityType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Line" type="LineType" substitutionGroup="Simple"/>
+	<xsd:element name="LineDesc" type="LineDescType" substitutionGroup="LineDescGroup"/>
+	<xsd:element name="LineDescGroup" abstract="true"/>
+	<xsd:element name="LineDescRef" type="LineDescRefType" substitutionGroup="LineDescGroup"/>
+	<xsd:complexType name="LineDescRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="LineDescType">
+		<xsd:attribute name="lineEnd" type="lineEndType" use="required"/>
+		<xsd:attribute name="lineWidth" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="lineProperty" type="linePropertyType"/>
+	</xsd:complexType>
+	<xsd:complexType name="LineType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup"/>
+		</xsd:sequence>
+		<xsd:attribute name="startX" type="xsd:double" use="required"/>
+		<xsd:attribute name="startY" type="xsd:double" use="required"/>
+		<xsd:attribute name="endX" type="xsd:double" use="required"/>
+		<xsd:attribute name="endY" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="FillDesc" type="FillDescType" substitutionGroup="FillDescGroup"/>
+	<xsd:element name="FillDescGroup" abstract="true"/>
+	<xsd:element name="FillDescRef" type="FillDescRefType" substitutionGroup="FillDescGroup"/>
+	<xsd:complexType name="FillDescRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:complexType name="FillDescType">
+		<xsd:sequence>
+			<xsd:element ref="ColorGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="fillProperty" type="fillPropertyType" use="required"/>
+		<xsd:attribute name="lineWidth" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="pitch1" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="pitch2" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="angle1" type="angleType"/>
+		<xsd:attribute name="angle2" type="angleType"/>
+	</xsd:complexType>
+	<xsd:element name="LocalFiducial" type="FiducialType" substitutionGroup="Fiducial"/>
+	<xsd:element name="Location" type="LocationType"/>
+	<xsd:element name="PickupPoint" type="LocationType"/>
+	<xsd:complexType name="LocationType">
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="LogicalNet" type="LogicalNetType"/>
+	<xsd:complexType name="LogicalNetType">
+		<xsd:sequence>
+			<xsd:element ref="NonstandardAttribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="PinRef" maxOccurs="unbounded"/>
+			<xsd:element ref="PortRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="netClass" type="netClassType"/>
+		<xsd:attribute name="netPair" type="qualifiedNameType"/>
+	</xsd:complexType>
+	<xsd:element name="LogisticHeader" type="LogisticHeaderType"/>
+	<xsd:complexType name="LogisticHeaderType">
+		<xsd:sequence>
+			<xsd:element ref="Role" maxOccurs="unbounded"/>
+			<xsd:element ref="Enterprise" maxOccurs="unbounded"/>
+			<xsd:element ref="Person" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Marking" type="MarkingType"/>
+	<xsd:complexType name="MarkingType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location" minOccurs="0"/>
+			<xsd:element ref="Feature"/>
+		</xsd:sequence>
+		<xsd:attribute name="markingUsage" type="markingUsageType"/>
+	</xsd:complexType>
+	<xsd:element name="Marker" type="MarkerType"/>
+	<xsd:complexType name="MarkerType">
+		<xsd:sequence>
+			<xsd:element ref="LayerRef"/>
+			<xsd:element ref="StandardPrimitive"/>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="MaterialCut" type="MaterialCutType" substitutionGroup="Z_AxisDim"/>
+	<xsd:complexType name="MaterialCutType">
+		<xsd:attribute name="depth" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="plusTol" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="minusTol" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="startCutLayer" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="MaterialLeft" type="MaterialLeftType" substitutionGroup="Z_AxisDim"/>
+	<xsd:complexType name="MaterialLeftType">
+		<xsd:attribute name="thickness" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="plusTol" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="minusTol" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="startCutLayer" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Measured" type="MeasuredType"/>
+	<xsd:complexType name="MeasuredType">
+		<xsd:attribute name="definitionSource" type="xsd:string"/>
+		<xsd:attribute name="measuredCharacteristicName" type="xsd:string"/>
+		<xsd:attribute name="measuredCharacteristicValue" type="xsd:double"/>
+		<xsd:attribute name="engineeringUnitOfMeasure" type="xsd:string"/>
+		<xsd:attribute name="engineeringNegativeTolerance" type="xsd:double"/>
+		<xsd:attribute name="engineeringPositiveTolerance" type="xsd:double"/>
+	</xsd:complexType>
+	<xsd:element name="MeasurementPoint" type="MeasurementPointType"/>
+	<xsd:complexType name="MeasurementPointType">
+		<xsd:sequence>
+			<xsd:element ref="LayerRef"/>
+			<xsd:element ref="Location" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="OtherSideView" type="OtherSideViewType"/>
+	<xsd:complexType name="OtherSideViewType">
+		<xsd:sequence>
+			<xsd:element ref="Outline" minOccurs="0"/>
+			<xsd:element ref="SilkScreen" minOccurs="0"/>
+			<xsd:element ref="AssemblyDrawing" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Modification" type="ModificationType"/>
+	<xsd:complexType name="ModificationType">
+		<xsd:attribute name="repairInfo" type="xsd:string"/>
+		<xsd:attribute name="weldsPermitted" type="xsd:boolean"/>
+	</xsd:complexType>
+	<xsd:element name="Moire" type="MoireType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="MoireType">
+		<xsd:attribute name="diameter" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="ringWidth" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="ringGap" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="ringNumber" type="xsd:nonNegativeInteger" use="required"/>
+		<xsd:attribute name="lineWidth" type="nonNegativeDoubleType" default="0"/>
+		<xsd:attribute name="lineLength" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="lineAngle" type="angleType"/>
+	</xsd:complexType>
+	<xsd:element name="NonstandardAttribute" type="NonstandardAttributeType"/>
+	<xsd:complexType name="NonstandardAttributeType">
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+		<xsd:attribute name="type" type="cadPropertyType" use="required"/>
+		<xsd:attribute name="value" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Octagon" type="OctagonType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="OctagonType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="length" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="NetShort" type="NetShortType"/>
+	<xsd:complexType name="NetShortType">
+		<xsd:sequence>
+			<xsd:element ref="NetRef" minOccurs="2" maxOccurs="unbounded"/>
+			<xsd:element ref="Location" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="LayerRef" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="NetRef" type="NetRefType"/>
+	<xsd:complexType name="NetRefType">
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Outline" type="OutlineType" substitutionGroup="Simple"/>
+	<xsd:complexType name="OutlineType">
+		<xsd:sequence>
+			<xsd:element ref="Polygon"/>
+			<xsd:element ref="LineDescGroup"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Oval" type="OvalType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="OvalType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="width" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Package" type="PackageType"/>
+	<xsd:complexType name="PackageType">
+		<xsd:sequence>
+			<xsd:element ref="Outline"/>
+			<xsd:element ref="PickupPoint" minOccurs="0"/>
+			<xsd:element ref="LandPattern" minOccurs="0"/>
+			<xsd:element ref="SilkScreen" minOccurs="0"/>
+			<xsd:element ref="AssemblyDrawing" minOccurs="0"/>
+			<xsd:element ref="Pin" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Topside" minOccurs="0"/>
+			<xsd:element ref="OtherSideView" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="type" type="packageTypeType" use="required"/>
+		<xsd:attribute name="pinOne" type="xsd:string"/>
+		<xsd:attribute name="pinOneOrientation" type="pinOneOrientationType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="negativeBodyExtension" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="comment" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="Topside" type="PackageTopSideType"/>
+	<xsd:complexType name="PackageTopSideType">
+		<xsd:sequence>
+			<xsd:element ref="Outline" minOccurs="0"/>
+			<xsd:element ref="LandPattern" minOccurs="0"/>
+			<xsd:element ref="SilkScreen" minOccurs="0"/>
+			<xsd:element ref="AssemblyDrawing" minOccurs="0"/>
+			<xsd:element ref="Pin" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Pad" type="PadType"/>
+	<xsd:element name="PadStackDef" type="PadStackDefType"/>
+	<xsd:complexType name="PadStackDefType">
+		<xsd:sequence>
+			<xsd:element ref="PadstackHoleDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="PadstackPadDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType"/>
+	</xsd:complexType>
+	<xsd:complexType name="PadType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location"/>
+			<xsd:element ref="Feature"/>
+			<xsd:element ref="PinRef" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="padstackDefRef" type="qualifiedNameType"/>
+	</xsd:complexType>
+	<xsd:element name="Person" type="PersonType"/>
+	<xsd:complexType name="PersonType">
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+		<xsd:attribute name="enterpriseRef" type="xsd:string" use="required"/>
+		<xsd:attribute name="title" type="xsd:string"/>
+		<xsd:attribute name="email" type="xsd:string"/>
+		<xsd:attribute name="phone" type="xsd:string"/>
+		<xsd:attribute name="fax" type="xsd:string"/>
+		<xsd:attribute name="mailstop" type="xsd:string"/>
+		<xsd:attribute name="publicKey" type="xsd:base64Binary"/>
+		<xsd:attribute name="roleRef" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="PhyNet" type="PhyNetType"/>
+	<xsd:element name="PhyNetGroup" type="PhyNetGroupType"/>
+	<xsd:complexType name="PhyNetGroupType">
+		<xsd:sequence>
+			<xsd:element ref="PhyNet" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="optimized" type="xsd:boolean"/>
+	</xsd:complexType>
+	<xsd:element name="PhyNetPoint" type="PhyNetPointType"/>
+	<xsd:complexType name="PhyNetPointType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Feature"/>
+			<xsd:element ref="PortRef" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="secondaryLayerRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="netNode" type="netPointType" use="required"/>
+		<xsd:attribute name="exposure" type="exposureType" use="required"/>
+		<xsd:attribute name="layerIndex" type="xsd:string"/>
+		<xsd:attribute name="comment" type="xsd:string"/>
+		<xsd:attribute name="via" type="xsd:boolean"/>
+		<xsd:attribute name="fiducial" type="xsd:boolean"/>
+		<xsd:attribute name="test" type="xsd:boolean"/>
+		<xsd:attribute name="staggerX" type="xsd:double"/>
+		<xsd:attribute name="staggerY" type="xsd:double"/>
+		<xsd:attribute name="staggerRadius" type="xsd:double"/>
+	</xsd:complexType>
+	<xsd:complexType name="PhyNetType">
+		<xsd:sequence>
+			<xsd:element ref="PhyNetPoint" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Pin" type="PinType"/>
+	<xsd:complexType name="PinType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location" minOccurs="0"/>
+			<xsd:element ref="StandardShape"/>
+		</xsd:sequence>
+		<xsd:attribute name="number" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="name" type="qualifiedNameType"/>
+		<xsd:attribute name="type" type="cadPinType" use="required"/>
+		<xsd:attribute name="electricalType" type="pinElectricalType"/>
+		<xsd:attribute name="mountType" type="pinMountType"/>
+		<xsd:attribute name="pinPolarity" type="pinPolarityType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="PinRef" type="PinRefType"/>
+	<xsd:complexType name="PinRefType">
+		<xsd:attribute name="componentRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="pin" type="xsd:string" use="required"/>
+		<xsd:attribute name="title" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="PlatingThickness" type="LengthPropertyType"/>
+	<xsd:element name="PlatingGap" type="LengthPropertyType"/>
+	<xsd:element name="PolyBegin" type="PolyBeginType"/>
+	<xsd:complexType name="PolyBeginType">
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Polygon" type="PolygonType"/>
+	<xsd:complexType name="PolygonType">
+		<xsd:sequence>
+			<xsd:element ref="PolyBegin"/>
+			<xsd:element ref="PolyStep" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Polyline" type="PolylineType" substitutionGroup="Simple"/>
+	<xsd:complexType name="PolylineType">
+		<xsd:sequence>
+			<xsd:element ref="PolyBegin"/>
+			<xsd:element ref="PolyStep" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="LineDescGroup"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="PolyStep" abstract="true"/>
+	<xsd:element name="PolyStepCurve" type="PolyStepCurveType" substitutionGroup="PolyStep"/>
+	<xsd:complexType name="PolyStepCurveType">
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+		<xsd:attribute name="centerX" type="xsd:double" use="required"/>
+		<xsd:attribute name="centerY" type="xsd:double" use="required"/>
+		<xsd:attribute name="clockwise" type="xsd:boolean" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="PolyStepSegment" type="PolyStepSegmentType" substitutionGroup="PolyStep"/>
+	<xsd:complexType name="PolyStepSegmentType">
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Port" type="PortDef"/>
+	<xsd:complexType name="PortDef">
+		<xsd:sequence>
+			<xsd:element ref="PortType" minOccurs="1"/>
+			<xsd:element ref="Location" minOccurs="0"/>
+			<xsd:element ref="PortConnect" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="netType" type="netFunctionType"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="PortType" abstract="true"/>
+	<xsd:element name="PortConnect" type="PortConnectType"/>
+	<xsd:complexType name="PortConnectType">
+		<xsd:sequence>
+			<xsd:element ref="Location" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="portName" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="stepRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="compRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="pinRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="PortRef" type="PortRefType"/>
+	<xsd:complexType name="PortRefType">
+		<xsd:attribute name="portName" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Product" type="ProductType"/>
+	<xsd:complexType name="ProductType">
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+		<xsd:attribute name="criteria" type="productCriteriaType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="WireBond" type="WireBondType" substitutionGroup="PortType"/>
+	<xsd:complexType name="WireBondType">
+		<xsd:sequence>
+			<xsd:element ref="WireHeight" minOccurs="0"/>
+			<xsd:element ref="Location" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="layerRef" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="compRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="pinRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="ConnectorMate" type="ConnCompType" substitutionGroup="PortType"/>
+	<xsd:element name="ComponentPad" type="ConnCompType" substitutionGroup="PortType"/>
+	<xsd:complexType name="ConnCompType">
+		<xsd:sequence>
+			<xsd:element ref="Location" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="compRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="pinRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="WireHeight" type="LengthPropertyType"/>
+	<xsd:element name="Ranged" type="RangedType"/>
+	<xsd:complexType name="RangedType">
+		<xsd:attribute name="definitionSource" type="xsd:string"/>
+		<xsd:attribute name="rangedCharacteristicName" type="xsd:string"/>
+		<xsd:attribute name="rangedCharacteristicLowerValue" type="xsd:double"/>
+		<xsd:attribute name="rangedCharacteristicUpperValue" type="xsd:double"/>
+		<xsd:attribute name="engineeringUnitOfMeasure" type="xsd:string"/>
+		<xsd:attribute name="engineeringNegativeTolerance" type="xsd:double"/>
+		<xsd:attribute name="engineeringPositiveTolerance" type="xsd:double"/>
+	</xsd:complexType>
+	<xsd:element name="RectCenter" type="RectCenterType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="RectCenterType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="width" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="RectCham" type="RectChamType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="RectChamType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="width" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="chamfer" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="upperRight" type="xsd:boolean"/>
+		<xsd:attribute name="upperLeft" type="xsd:boolean"/>
+		<xsd:attribute name="lowerLeft" type="xsd:boolean"/>
+		<xsd:attribute name="lowerRight" type="xsd:boolean"/>
+	</xsd:complexType>
+	<xsd:element name="RectCorner" type="RectCornerType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="RectCornerType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="lowerLeftX" type="xsd:double" use="required"/>
+		<xsd:attribute name="lowerLeftY" type="xsd:double" use="required"/>
+		<xsd:attribute name="upperRightX" type="xsd:double" use="required"/>
+		<xsd:attribute name="upperRightY" type="xsd:double" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="RectRound" type="RectRoundType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="RectRoundType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="width" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="radius" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="upperRight" type="xsd:boolean"/>
+		<xsd:attribute name="upperLeft" type="xsd:boolean"/>
+		<xsd:attribute name="lowerLeft" type="xsd:boolean"/>
+		<xsd:attribute name="lowerRight" type="xsd:boolean"/>
+	</xsd:complexType>
+	<xsd:element name="Role" type="RoleType"/>
+	<xsd:complexType name="RoleType">
+		<xsd:attribute name="id" type="xsd:string" use="required"/>
+		<xsd:attribute name="roleFunction" type="roleFunctionType" use="required"/>
+		<xsd:attribute name="description" type="xsd:string"/>
+		<xsd:attribute name="publicKey" type="xsd:base64Binary"/>
+		<xsd:attribute name="authority" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="Set" type="SetType"/>
+	<xsd:complexType name="SetType">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="NonstandardAttribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Pad"/>
+			<xsd:element ref="Fiducial"/>
+			<xsd:element ref="Hole"/>
+			<xsd:element ref="SlotCavity"/>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Features"/>
+			<xsd:element ref="ColorGroup"/>
+			<xsd:element ref="LineDescGroup"/>
+			<xsd:element ref="NetShort"/>
+		</xsd:choice>
+		<xsd:attribute name="net" type="qualifiedNameType"/>
+		<xsd:attribute name="netPair" type="qualifiedNameType"/>
+		<xsd:attribute name="polarity" type="polarityType"/>
+		<xsd:attribute name="padUsage" type="padUsageType"/>
+		<xsd:attribute name="testPoint" type="xsd:boolean"/>
+		<xsd:attribute name="geometry" type="xsd:string"/>
+		<xsd:attribute name="plate" type="xsd:boolean"/>
+		<xsd:attribute name="componentRef" type="xsd:string"/>
+		<xsd:attribute name="geometryUsage" type="geometryUsageType"/>
+	</xsd:complexType>
+	<xsd:element name="SilkScreen" type="SilkScreenType"/>
+	<xsd:complexType name="SilkScreenType">
+		<xsd:sequence>
+			<xsd:element ref="Outline" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Marking" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Simple" abstract="true" substitutionGroup="UserPrimitive"/>
+	<xsd:element name="SlotCavity" type="SlotCavityType"/>
+	<xsd:complexType name="SlotCavityType">
+		<xsd:sequence>
+			<xsd:element ref="Location"/>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Feature"/>
+			<xsd:element ref="Z_AxisDim" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="Fill" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="platingStatus" type="platingStatusType" use="required"/>
+		<xsd:attribute name="plusTol" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="minusTol" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Fill" type="FillType"/>
+	<xsd:complexType name="FillType">
+		<xsd:sequence>
+			<xsd:element ref="SpecRef"/>
+		</xsd:sequence>
+		<xsd:attribute name="depthRemaining" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="matDes" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="SoftwarePackage" type="SoftwarePackageType"/>
+	<xsd:complexType name="SoftwarePackageType">
+		<xsd:sequence>
+			<xsd:element ref="Certification" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+		<xsd:attribute name="vendor" type="xsd:string" use="required"/>
+		<xsd:attribute name="revision" type="xsd:string" use="required"/>
+		<xsd:attribute name="model" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="Span" type="SpanType"/>
+	<xsd:complexType name="SpanType">
+		<xsd:attribute name="fromLayer" type="qualifiedNameType"/>
+		<xsd:attribute name="toLayer" type="qualifiedNameType"/>
+	</xsd:complexType>
+	<xsd:element name="SpecificationType" abstract="true"/>
+	<xsd:element name="Backdrill" type="BackdrillType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="BackdrillType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="backdrillListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Dielectric" type="DielectricType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="DielectricType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="dielectricListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Conductor" type="ConductorType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="ConductorType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="material" type="conductorMaterialType" use="optional"/>
+		<xsd:attribute name="foilType" type="foilTypeType" use="optional"/>
+		<xsd:attribute name="type" type="conductorListType" use="optional"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Compliance" type="ComplianceType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="ComplianceType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="complianceListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Technology" type="TechnologyType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="TechnologyType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="technologyListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="General" type="GeneralType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="GeneralType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="ColorGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="generalListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Temperature" type="TemperatureType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="TemperatureType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="temperatureListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="V_Cut" type="V_CutType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="V_CutType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="vCutListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Tool" type="ToolType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="ToolType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="toolListType" use="required"/>
+		<xsd:attribute name="toolProperty" type="toolPropertyListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Impedance" type="ImpedanceType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="ImpedanceType">
+		<xsd:sequence>
+			<xsd:element ref="TransmissionType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="value" type="xsd:double" use="required"/>
+		<xsd:attribute name="tolPlus" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="tolMinus" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="tolPercent" type="xsd:boolean" use="optional" default="false"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Thieving" type="ThievingType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="ThievingType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="thievingListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="EdgeChamfer" type="EdgeChamferType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="EdgeChamferType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="edgeChamferListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="EdgePlating" type="EdgePlatingType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="EdgePlatingType">
+		<xsd:sequence>
+			<xsd:element ref="PlatingThickness" minOccurs="0" maxOccurs="2"/>
+			<xsd:element ref="PlatingGap" minOccurs="0" maxOccurs="2"/>
+			<xsd:element ref="SurfaceFinish" minOccurs="0" maxOccurs="2"/>
+		</xsd:sequence>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="SecondaryDrill" type="SecondaryDrillType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="SecondaryDrillType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="secondaryDrillListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="SurfaceFinish" type="SurfaceFinishType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="SurfaceFinishType">
+		<xsd:sequence>
+			<xsd:element ref="Product" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="surfaceFinishType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Flex" type="FlexType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="FlexType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="flexListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Loss" type="LossType" substitutionGroup="SpecificationType"/>
+	<xsd:complexType name="LossType">
+		<xsd:sequence>
+			<xsd:element ref="Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="lossListType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="LineGap" abstract="true"/>
+	<xsd:element name="TransmissionType" abstract="true"/>
+	<xsd:element name="Spacing" type="LengthPropertyType" substitutionGroup="LineGap"/>
+	<xsd:element name="Pitch" type="LengthPropertyType" substitutionGroup="LineGap"/>
+	<xsd:element name="LineWidth" type="LengthPropertyType"/>
+	<xsd:element name="CoplanarGroundSpacing" type="LengthPropertyType"/>
+	<xsd:element name="Offset" type="LengthPropertyType"/>
+	<xsd:complexType name="LengthPropertyType">
+		<xsd:attribute name="value" type="xsd:double"/>
+		<xsd:attribute name="unit" type="lengthUnitType"/>
+		<xsd:attribute name="tolPlus" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="tolMinus" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="tolPercent" type="xsd:boolean" use="optional" default="false"/>
+		<xsd:attribute name="constraintType" type="constraintTypeType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="RefPlane" type="RefPlaneType"/>
+	<xsd:element name="PairLayerRef" type="RefPlaneType"/>
+	<xsd:complexType name="RefPlaneType">
+		<xsd:attribute name="layerOrGroupRef" type="qualifiedNameType"/>
+	</xsd:complexType>
+	<xsd:element name="BroadsideCoupled" type="BroadsideCoupledType" substitutionGroup="TransmissionType"/>
+	<xsd:complexType name="BroadsideCoupledType">
+		<xsd:sequence>
+			<xsd:element ref="LineWidth"/>
+			<xsd:element ref="Offset" minOccurs="0"/>
+			<xsd:element ref="PairLayerRef"/>
+			<xsd:element ref="RefPlane" minOccurs="0" maxOccurs="2"/>
+		</xsd:sequence>
+		<xsd:attribute name="structure" type="broadsideListType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="SingleEnded" type="SingleEndedType" substitutionGroup="TransmissionType"/>
+	<xsd:complexType name="SingleEndedType">
+		<xsd:sequence>
+			<xsd:element ref="LineWidth"/>
+			<xsd:element ref="RefPlane" minOccurs="0" maxOccurs="2"/>
+		</xsd:sequence>
+		<xsd:attribute name="structure" type="structureListType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="CoplanarWaveguide" type="CoplanarWaveguideType" substitutionGroup="TransmissionType"/>
+	<xsd:complexType name="CoplanarWaveguideType">
+		<xsd:sequence>
+			<xsd:element ref="LineWidth"/>
+			<xsd:element ref="LineGap"/>
+			<xsd:element ref="CoplanarGroundSpacing"/>
+			<xsd:element ref="RefPlane" minOccurs="0" maxOccurs="2"/>
+		</xsd:sequence>
+		<xsd:attribute name="structure" type="coplanarListType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Property" type="PropertyType"/>
+	<xsd:complexType name="PropertyType">
+		<xsd:attribute name="name" type="xsd:string" use="optional"/>
+		<xsd:attribute name="value" type="xsd:double" use="optional"/>
+		<xsd:attribute name="text" type="xsd:string" use="optional"/>
+		<xsd:attribute name="unit" type="propertyUnitType" use="optional"/>
+		<xsd:attribute name="tolPlus" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="tolMinus" type="nonNegativeDoubleType" use="optional"/>
+		<xsd:attribute name="tolPercent" type="xsd:boolean" use="optional" default="false"/>
+		<xsd:attribute name="refUnit" type="propertyUnitType" use="optional"/>
+		<xsd:attribute name="refValue" type="xsd:double" use="optional"/>
+		<xsd:attribute name="refText" type="xsd:string" use="optional"/>
+		<xsd:attribute name="layerOrGroupRef" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Spec" type="SpecType"/>
+	<xsd:complexType name="SpecType">
+		<xsd:sequence>
+			<xsd:element ref="SpecificationType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location" minOccurs="0"/>
+			<xsd:element ref="Outline" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Stackup" type="StackupType"/>
+	<xsd:complexType name="StackupType">
+		<xsd:sequence>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="StackupGroup" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="overallThickness" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolPlus" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolMinus" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolPercent" type="xsd:boolean" use="optional" default="false"/>
+		<xsd:attribute name="whereMeasured" type="whereMeasuredType" use="required"/>
+		<xsd:attribute name="matDes" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="stackupStatus" type="stackupStatusType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="StackupGroup" type="StackupGroupType"/>
+	<xsd:complexType name="StackupGroupType">
+		<xsd:sequence>
+			<xsd:element ref="StackupLayer" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="CADDataLayerRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="thickness" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolPlus" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolMinus" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolPercent" type="xsd:boolean" use="optional" default="false"/>
+		<xsd:attribute name="matDes" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="StackupLayer" type="StackupLayerType"/>
+	<xsd:complexType name="StackupLayerType">
+		<xsd:sequence>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="layerOrGroupRef" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="thickness" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolPlus" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolMinus" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="tolPercent" type="xsd:boolean" use="optional" default="false"/>
+		<xsd:attribute name="sequence" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="matDes" type="qualifiedNameType" use="optional"/>
+		<xsd:attribute name="comment" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="CADDataLayerRef" type="CADDataLayerRefType"/>
+	<xsd:complexType name="CADDataLayerRefType">
+		<xsd:attribute name="layerId" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="SlotCavityRef" type="SlotCavityRefType"/>
+	<xsd:complexType name="SlotCavityRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="SpecRef" type="SpecRefType"/>
+	<xsd:complexType name="SpecRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="StackupZone" type="StackupZoneType"/>
+	<xsd:complexType name="StackupZoneType">
+		<xsd:sequence>
+			<xsd:element ref="Profile"/>
+			<xsd:element ref="ZoneLayer" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="SpecRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="stackupRef" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="StackupZoneRef" type="StackupZoneRefType"/>
+	<xsd:complexType name="StackupZoneRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="StandardPrimitive" abstract="true" substitutionGroup="StandardShape"/>
+	<xsd:element name="StandardPrimitiveRef" type="StandardPrimitiveRefType" substitutionGroup="StandardShape"/>
+	<xsd:complexType name="StandardPrimitiveRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="StandardShape" abstract="true" substitutionGroup="Feature"/>
+	<xsd:element name="Step" type="StepType"/>
+	<xsd:element name="StepRef" type="StepRefType"/>
+	<xsd:complexType name="StepRefType">
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="StepRepeat" type="StepRepeatType"/>
+	<xsd:complexType name="StepRepeatType">
+		<xsd:attribute name="stepRef" type="xsd:string" use="required"/>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+		<xsd:attribute name="nx" type="xsd:nonNegativeInteger" use="required"/>
+		<xsd:attribute name="ny" type="xsd:nonNegativeInteger" use="required"/>
+		<xsd:attribute name="dx" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="dy" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="angle" type="angleType" use="required"/>
+		<xsd:attribute name="mirror" type="xsd:boolean" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Datum" type="LocationType"/>
+	<xsd:element name="Profile" type="ContourType"/>
+	<xsd:complexType name="StepType">
+		<xsd:sequence>
+			<xsd:element ref="NonstandardAttribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="PadStackDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Datum"/>
+			<xsd:element ref="Profile" minOccurs="0"/>
+			<xsd:element ref="StepRepeat" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Package" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Component" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="LogicalNet" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="PhyNetGroup" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="LayerFeature" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="BendArea" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="StackupZone" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Port" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Model" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="Dfx" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+		<xsd:attribute name="type" type="stepType" use="optional"/>
+		<xsd:attribute name="stackupRef" type="qualifiedNameType" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="Target" type="TargetType"/>
+	<xsd:complexType name="TargetType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="Location"/>
+			<xsd:element ref="StandardShape"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Text" type="TextType" substitutionGroup="UserPrimitive"/>
+	<xsd:complexType name="TextType">
+		<xsd:sequence>
+			<xsd:element ref="Xform" minOccurs="0"/>
+			<xsd:element ref="BoundingBox"/>
+			<xsd:element ref="FontRef" minOccurs="0"/>
+			<xsd:element ref="ColorGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="textString" type="xsd:string" use="required"/>
+		<xsd:attribute name="fontSize" type="xsd:positiveInteger" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Textual" type="TextualType"/>
+	<xsd:complexType name="TextualType">
+		<xsd:attribute name="definitionSource" type="xsd:string"/>
+		<xsd:attribute name="textualCharacteristicName" type="xsd:string"/>
+		<xsd:attribute name="textualCharacteristicValue" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="Thermal" type="ThermalType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="ThermalType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="shape" type="thermalShapeType" use="required"/>
+		<xsd:attribute name="outerDiameter" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="innerDiameter" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="spokeCount" type="spokeCountType" default="4"/>
+		<xsd:attribute name="spokeWidth" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="spokeStartAngle" type="angleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Triangle" type="TriangleType" substitutionGroup="StandardPrimitive"/>
+	<xsd:complexType name="TriangleType">
+		<xsd:sequence>
+			<xsd:element ref="LineDescGroup" minOccurs="0"/>
+			<xsd:element ref="FillDescGroup" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="base" type="nonNegativeDoubleType" use="required"/>
+		<xsd:attribute name="height" type="nonNegativeDoubleType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="Tuning" type="TuningType"/>
+	<xsd:complexType name="TuningType">
+		<xsd:attribute name="value" type="qualifiedNameType" use="required"/>
+		<xsd:attribute name="comments" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:element name="UserPrimitive" abstract="true" substitutionGroup="UserShape"/>
+	<xsd:element name="UserPrimitiveRef" type="UserPrimitiveRefType" substitutionGroup="UserShape"/>
+	<xsd:complexType name="UserPrimitiveRefType">
+		<xsd:attribute name="id" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="UserShape" abstract="true" substitutionGroup="Feature"/>
+	<xsd:element name="UserSpecial" type="UserSpecialType" substitutionGroup="UserPrimitive"/>
+	<xsd:complexType name="UserSpecialType">
+		<xsd:sequence>
+			<xsd:element ref="Feature" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Xform" type="XformType"/>
+	<xsd:complexType name="XformType">
+		<xsd:attribute name="xOffset" type="xsd:double"/>
+		<xsd:attribute name="yOffset" type="xsd:double"/>
+		<xsd:attribute name="rotation" type="nonNegativeDoubleType"/>
+		<xsd:attribute name="mirror" type="xsd:boolean" default="false"/>
+		<xsd:attribute name="faceUp" type="xsd:boolean" default="false"/>
+		<xsd:attribute name="scale" type="scaleType"/>
+	</xsd:complexType>
+	<xsd:element name="Z_AxisDim" abstract="true"/>
+	<xsd:element name="ZoneLayer" type="ZoneLayerType"/>
+	<xsd:complexType name="ZoneLayerType">
+		<xsd:sequence>
+			<xsd:element ref="Inset" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="layerOrGroupRef" type="qualifiedNameType" use="required"/>
+	</xsd:complexType>
+</xsd:schema>

--- a/crates/ipc2581/README.md
+++ b/crates/ipc2581/README.md
@@ -9,6 +9,9 @@ use ipc2581::Ipc2581;
 
 let doc = Ipc2581::parse_file("design.xml")?;
 
+// Optionally validate XML against the vendored IPC-2581C XSD.
+ipc2581::validate_file("design.xml")?;
+
 // Access parsed data
 println!("Revision: {}", doc.revision());
 

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -13,6 +13,9 @@ use parse::Parser;
 use roxmltree::Document;
 use std::path::Path;
 use thiserror::Error;
+use uppsala::XsdValidator;
+
+const IPC_2581C_XSD: &str = include_str!("../IPC-2581C.xsd");
 
 #[derive(Debug, Error)]
 pub enum Ipc2581Error {
@@ -42,9 +45,40 @@ pub enum Ipc2581Error {
 
     #[error("Unsupported revision: {0}")]
     UnsupportedRevision(String),
+
+    #[error("IPC-2581 schema validation failed: {0}")]
+    SchemaValidation(String),
 }
 
 pub type Result<T> = std::result::Result<T, Ipc2581Error>;
+
+/// Validate IPC-2581 XML against the vendored IPC-2581C XML Schema.
+pub fn validate(xml: &str) -> Result<()> {
+    let schema_doc = uppsala::parse(IPC_2581C_XSD)
+        .map_err(|err| Ipc2581Error::SchemaValidation(err.to_string()))?;
+    let validator = XsdValidator::from_schema(&schema_doc)
+        .map_err(|err| Ipc2581Error::SchemaValidation(err.to_string()))?;
+    let doc = uppsala::parse(xml).map_err(|err| Ipc2581Error::SchemaValidation(err.to_string()))?;
+
+    let errors = validator.validate(&doc);
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(Ipc2581Error::SchemaValidation(
+            errors
+                .into_iter()
+                .map(|err| err.to_string())
+                .collect::<Vec<_>>()
+                .join("; "),
+        ))
+    }
+}
+
+/// Validate an IPC-2581 XML file against the vendored IPC-2581C XML Schema.
+pub fn validate_file(path: impl AsRef<Path>) -> Result<()> {
+    let xml = std::fs::read_to_string(path)?;
+    validate(&xml)
+}
 
 /// Main IPC-2581 document structure
 #[derive(Debug)]
@@ -60,6 +94,16 @@ pub struct Ipc2581 {
 }
 
 impl Ipc2581 {
+    /// Validate IPC-2581 XML against the vendored IPC-2581C XML Schema.
+    pub fn validate(xml: &str) -> Result<()> {
+        validate(xml)
+    }
+
+    /// Validate an IPC-2581 XML file against the vendored IPC-2581C XML Schema.
+    pub fn validate_file(path: impl AsRef<Path>) -> Result<()> {
+        validate_file(path)
+    }
+
     /// Parse IPC-2581 from XML string
     pub fn parse(xml: &str) -> Result<Self> {
         // Validate checksum if present
@@ -196,6 +240,20 @@ mod tests {
         let doc = result.unwrap();
         assert_eq!(doc.revision(), "C");
         assert_eq!(doc.resolve(doc.content().role_ref), "Owner");
+    }
+
+    #[test]
+    fn validate_reports_schema_errors() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="NOT_A_MODE"/>
+  </Content>
+</IPC-2581>"#;
+
+        let err = validate(xml).unwrap_err().to_string();
+        assert!(err.contains("schema validation failed"));
+        assert!(err.contains("LogisticHeader"));
     }
 
     #[test]

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -10,7 +10,6 @@ pub use types::*;
 
 use checksum::validate_checksum;
 use parse::Parser;
-use roxmltree::Document;
 use std::path::Path;
 use thiserror::Error;
 use uppsala::XsdValidator;
@@ -20,7 +19,7 @@ const IPC_2581C_XSD: &str = include_str!("../IPC-2581C.xsd");
 #[derive(Debug, Error)]
 pub enum Ipc2581Error {
     #[error("XML parse error: {0}")]
-    XmlParse(#[from] roxmltree::Error),
+    XmlParse(String),
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -109,15 +108,18 @@ impl Ipc2581 {
         // Validate checksum if present
         validate_checksum(xml)?;
 
-        // Parse XML with roxmltree
-        let doc = Document::parse(xml)?;
+        // Parse XML with Uppsala's arena-backed DOM.
+        let doc = uppsala::parse(xml).map_err(|err| Ipc2581Error::XmlParse(err.to_string()))?;
 
         // Validate namespace
-        let root = doc.root_element();
-        if root.tag_name().namespace() != Some("http://webstds.ipc.org/2581") {
+        let root = doc
+            .document_element()
+            .ok_or(Ipc2581Error::MissingElement("IPC-2581"))?;
+        let root_name = doc.element(root).expect("root is an element").name.clone();
+        if root_name.namespace_uri.as_deref() != Some("http://webstds.ipc.org/2581") {
             return Err(Ipc2581Error::InvalidStructure(format!(
                 "Expected IPC-2581 namespace, got {:?}",
-                root.tag_name().namespace()
+                root_name.namespace_uri
             )));
         }
 

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -11,10 +11,17 @@ pub use types::*;
 use checksum::validate_checksum;
 use parse::Parser;
 use std::path::Path;
+use std::sync::LazyLock;
 use thiserror::Error;
 use uppsala::XsdValidator;
 
 const IPC_2581C_XSD: &str = include_str!("../IPC-2581C.xsd");
+
+static IPC_2581C_VALIDATOR: LazyLock<std::result::Result<XsdValidator, String>> =
+    LazyLock::new(|| {
+        let schema_doc = uppsala::parse(IPC_2581C_XSD).map_err(|err| err.to_string())?;
+        XsdValidator::from_schema(&schema_doc).map_err(|err| err.to_string())
+    });
 
 #[derive(Debug, Error)]
 pub enum Ipc2581Error {
@@ -53,10 +60,9 @@ pub type Result<T> = std::result::Result<T, Ipc2581Error>;
 
 /// Validate IPC-2581 XML against the vendored IPC-2581C XML Schema.
 pub fn validate(xml: &str) -> Result<()> {
-    let schema_doc = uppsala::parse(IPC_2581C_XSD)
-        .map_err(|err| Ipc2581Error::SchemaValidation(err.to_string()))?;
-    let validator = XsdValidator::from_schema(&schema_doc)
-        .map_err(|err| Ipc2581Error::SchemaValidation(err.to_string()))?;
+    let validator = IPC_2581C_VALIDATOR
+        .as_ref()
+        .map_err(|err| Ipc2581Error::SchemaValidation(err.clone()))?;
     let doc = uppsala::parse(xml).map_err(|err| Ipc2581Error::SchemaValidation(err.to_string()))?;
 
     let errors = validator.validate(&doc);

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -871,7 +871,7 @@ impl<'a> Parser<'a> {
 
     fn parse_history_record(&mut self, node: &Node) -> Result<HistoryRecord> {
         // Parse number as f64 first, then convert to u32 (some files use "1.0")
-        let number = match self.attr(&node, "number") {
+        let number = match self.attr(node, "number") {
             Some(s) => {
                 if let Ok(f) = s.parse::<f64>() {
                     f as u32
@@ -964,13 +964,13 @@ impl<'a> Parser<'a> {
         attr: &'static str,
         element: &'static str,
     ) -> Result<Symbol> {
-        self.attr(&node, attr)
+        self.attr(node, attr)
             .ok_or(Ipc2581Error::MissingAttribute { element, attr })
             .map(|s| self.interner.intern(s))
     }
 
     fn optional_attr(&mut self, node: &Node, attr: &str) -> Option<Symbol> {
-        self.attr(&node, attr).map(|s| self.interner.intern(s))
+        self.attr(node, attr).map(|s| self.interner.intern(s))
     }
 
     fn parse_f64_attr(
@@ -1035,7 +1035,7 @@ impl<'a> Parser<'a> {
 
     /// Parse optional f64 attribute (no unit conversion)
     fn parse_optional_f64_attr(&self, node: &Node, attr: &'static str) -> Result<Option<f64>> {
-        self.attr(&node, attr)
+        self.attr(node, attr)
             .map(|v| {
                 v.parse::<f64>().map_err(|_| {
                     Ipc2581Error::InvalidAttribute(format!("Invalid f64 value for {}", attr))
@@ -1046,7 +1046,7 @@ impl<'a> Parser<'a> {
 
     /// Parse optional u32 attribute
     fn parse_optional_u32_attr(&self, node: &Node, attr: &'static str) -> Result<Option<u32>> {
-        self.attr(&node, attr)
+        self.attr(node, attr)
             .map(|v| {
                 v.parse::<u32>().map_err(|_| {
                     Ipc2581Error::InvalidAttribute(format!("Invalid u32 value for {}", attr))
@@ -1062,13 +1062,13 @@ impl<'a> Parser<'a> {
         attr: &'static str,
         units: Units,
     ) -> Result<Option<f64>> {
-        self.attr(&node, attr)
+        self.attr(node, attr)
             .map(|v| self.parse_f64_str_with_units(v, units))
             .transpose()
     }
 
     fn parse_bool_attr(&self, node: &Node, attr: &'static str) -> Result<bool> {
-        match self.attr(&node, attr) {
+        match self.attr(node, attr) {
             Some("true") => Ok(true),
             Some("false") => Ok(false),
             Some(_) => Err(Ipc2581Error::InvalidAttribute(format!(
@@ -1249,9 +1249,9 @@ impl<'a> Parser<'a> {
         // KiCad bug format: <SurfaceFinish><Finish type="S"/></SurfaceFinish>
 
         // First, try the correct IPC-2581C format: type attribute directly on SurfaceFinish
-        if let Some(finish_type_str) = self.attr(&node, "type") {
+        if let Some(finish_type_str) = self.attr(node, "type") {
             let finish_type = self.parse_finish_type(finish_type_str)?;
-            let comment = self.attr(&node, "comment").map(|s| self.interner.intern(s));
+            let comment = self.attr(node, "comment").map(|s| self.interner.intern(s));
 
             let mut products = Vec::new();
             for product_node in self.element_children(node) {
@@ -1458,7 +1458,7 @@ impl<'a> Parser<'a> {
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
-        let layer_number = self.attr(&node, "sequence").and_then(|s| s.parse().ok());
+        let layer_number = self.attr(node, "sequence").and_then(|s| s.parse().ok());
 
         // Look up material and dielectric properties from Spec via SpecRef
         let mut material = None;
@@ -1575,8 +1575,8 @@ impl<'a> Parser<'a> {
     fn parse_package(&mut self, node: &Node) -> Result<Package> {
         let name = self.required_attr(node, "name", "Package")?;
         let package_type = self.required_attr(node, "type", "Package")?;
-        let pin_one = self.attr(&node, "pinOne").map(|s| self.interner.intern(s));
-        let height = self.attr(&node, "height").and_then(|s| s.parse().ok());
+        let pin_one = self.attr(node, "pinOne").map(|s| self.interner.intern(s));
+        let height = self.attr(node, "height").and_then(|s| s.parse().ok());
 
         Ok(Package {
             name,
@@ -1591,13 +1591,13 @@ impl<'a> Parser<'a> {
         let package_ref = self.required_attr(node, "packageRef", "Component")?;
         let layer_ref = self.required_attr(node, "layerRef", "Component")?;
 
-        let mount_type = self.attr(&node, "mountType").map(|s| match s {
+        let mount_type = self.attr(node, "mountType").map(|s| match s {
             "SMT" => MountType::Smt,
             "THT" => MountType::Tht,
             _ => MountType::Other,
         });
 
-        let part = self.attr(&node, "part").map(|s| self.interner.intern(s));
+        let part = self.attr(node, "part").map(|s| self.interner.intern(s));
 
         Ok(Component {
             ref_des,
@@ -1696,13 +1696,11 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_feature_set(&mut self, node: &Node) -> Result<FeatureSet> {
-        let net = self.attr(&node, "net").map(|s| self.interner.intern(s));
-        let geometry = self
-            .attr(&node, "geometry")
-            .map(|s| self.interner.intern(s));
+        let net = self.attr(node, "net").map(|s| self.interner.intern(s));
+        let geometry = self.attr(node, "geometry").map(|s| self.interner.intern(s));
 
         // Parse polarity attribute
-        let polarity = self.attr(&node, "polarity").and_then(|s| match s {
+        let polarity = self.attr(node, "polarity").and_then(|s| match s {
             "POSITIVE" => Some(Polarity::Positive),
             "NEGATIVE" => Some(Polarity::Negative),
             _ => None,
@@ -1753,8 +1751,8 @@ impl<'a> Parser<'a> {
 
     fn parse_nonstandard_attribute(&mut self, node: &Node) -> Result<ecad::NonstandardAttribute> {
         let name = self.required_attr(node, "name", "NonstandardAttribute")?;
-        let value = self.attr(&node, "value").map(|s| self.interner.intern(s));
-        let attr_type = self.attr(&node, "type").map(|s| self.interner.intern(s));
+        let value = self.attr(node, "value").map(|s| self.interner.intern(s));
+        let attr_type = self.attr(node, "type").map(|s| self.interner.intern(s));
 
         Ok(ecad::NonstandardAttribute {
             name,
@@ -1964,7 +1962,7 @@ impl<'a> Parser<'a> {
         // Hole is in ECAD section, use ECAD units
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
 
-        let name = self.attr(&node, "name").map(|s| self.interner.intern(s));
+        let name = self.attr(node, "name").map(|s| self.interner.intern(s));
         let diameter = self.parse_f64_attr_with_units(node, "diameter", "Hole", units)?;
         let plating_status_str = self.required_attr(node, "platingStatus", "Hole")?;
         let plating_status =
@@ -1985,7 +1983,7 @@ impl<'a> Parser<'a> {
         // SlotCavity is in ECAD section, use ECAD units
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
 
-        let name = self.attr(&node, "name").map(|s| self.interner.intern(s));
+        let name = self.attr(node, "name").map(|s| self.interner.intern(s));
         let plating_status_str = self.required_attr(node, "platingStatus", "SlotCavity")?;
         let plating_status =
             self.parse_plating_status(self.interner.resolve(plating_status_str))?;
@@ -2387,10 +2385,10 @@ impl<'a> Parser<'a> {
     fn parse_bom_item(&mut self, node: &Node) -> Result<BomItem> {
         let oem_design_number_ref = self.required_attr(node, "OEMDesignNumberRef", "BomItem")?;
 
-        let quantity = self.attr(&node, "quantity").and_then(|s| s.parse().ok());
-        let pin_count = self.attr(&node, "pinCount").and_then(|s| s.parse().ok());
+        let quantity = self.attr(node, "quantity").and_then(|s| s.parse().ok());
+        let pin_count = self.attr(node, "pinCount").and_then(|s| s.parse().ok());
 
-        let category = self.attr(&node, "category").map(|s| match s {
+        let category = self.attr(node, "category").map(|s| match s {
             "ELECTRICAL" => BomCategory::Electrical,
             "MECHANICAL" => BomCategory::Mechanical,
             "DOCUMENT" => BomCategory::Document,
@@ -2442,7 +2440,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_characteristics(&mut self, node: &Node) -> Result<Characteristics> {
-        let category = self.attr(&node, "category").map(|s| match s {
+        let category = self.attr(node, "category").map(|s| match s {
             "ELECTRICAL" => BomCategory::Electrical,
             "MECHANICAL" => BomCategory::Mechanical,
             "DOCUMENT" => BomCategory::Document,
@@ -2554,9 +2552,9 @@ impl<'a> Parser<'a> {
         let evpl_vendor = self.optional_attr(node, "evplVendor");
         let evpl_mpn = self.optional_attr(node, "evplMpn");
 
-        let qualified = self.attr(&node, "qualified").map(|s| s == "true");
+        let qualified = self.attr(node, "qualified").map(|s| s == "true");
 
-        let chosen = self.attr(&node, "chosen").map(|s| s == "true");
+        let chosen = self.attr(node, "chosen").map(|s| s == "true");
 
         let mut mpns = Vec::new();
         let mut vendors = Vec::new();
@@ -2582,15 +2580,15 @@ impl<'a> Parser<'a> {
     fn parse_avl_mpn(&mut self, node: &Node) -> Result<AvlMpn> {
         let name = self.required_attr(node, "name", "AvlMpn")?;
 
-        let rank = self.attr(&node, "rank").and_then(|s| s.parse().ok());
+        let rank = self.attr(node, "rank").and_then(|s| s.parse().ok());
 
-        let cost = self.attr(&node, "cost").and_then(|s| s.parse().ok());
+        let cost = self.attr(node, "cost").and_then(|s| s.parse().ok());
 
         let moisture_sensitivity = self
             .attr(node, "moistureSensitivity")
             .and_then(MoistureSensitivity::parse);
 
-        let availability = self.attr(&node, "availability").map(|s| s == "true");
+        let availability = self.attr(node, "availability").map(|s| s == "true");
 
         let other = self.optional_attr(node, "other");
 

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1,39 +1,69 @@
 use crate::types::*;
 use crate::{Interner, Ipc2581Error, Result, Symbol};
-use roxmltree::{Document, Node};
+use uppsala::{Document, NodeId as Node};
 
 /// Parser context holding the string interner and unit context
-pub struct Parser {
+pub struct Parser<'a> {
     pub interner: Interner,
     /// Current ECAD units for converting dimensions (set when parsing CadHeader)
     ecad_units: Option<Units>,
     /// Specs from CadHeader (set when parsing CadHeader, used by StackupLayer parsing)
     specs: std::collections::HashMap<Symbol, ecad::Spec>,
+    doc: Option<&'a Document<'a>>,
 }
 
-impl Parser {
+impl<'a> Parser<'a> {
     pub fn new() -> Self {
         Self {
             interner: Interner::new(),
             ecad_units: None,
             specs: std::collections::HashMap::new(),
+            doc: None,
         }
     }
 
-    pub fn parse_document(&mut self, doc: &Document) -> Result<ParsedIpc2581> {
-        let root = doc.root_element();
+    fn doc(&self) -> &'a Document<'a> {
+        self.doc.expect("parser document is set while parsing")
+    }
+
+    fn name<'n>(&self, node: &'n Node) -> &'a str {
+        self.doc()
+            .element(*node)
+            .expect("expected XML element")
+            .name
+            .local_name
+            .as_ref()
+    }
+
+    fn attr<'n>(&self, node: &'n Node, attr: &str) -> Option<&'a str> {
+        self.doc().get_attribute(*node, attr)
+    }
+
+    fn element_children(&self, node: &Node) -> std::vec::IntoIter<Node> {
+        self.doc()
+            .children_iter(*node)
+            .filter(|child| self.doc().element(*child).is_some())
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    pub fn parse_document(&mut self, doc: &'a Document<'a>) -> Result<ParsedIpc2581> {
+        self.doc = Some(doc);
+        let root = doc
+            .document_element()
+            .ok_or(Ipc2581Error::MissingElement("IPC-2581"))?;
 
         // Verify root element
-        if root.tag_name().name() != "IPC-2581" {
+        if self.name(&root) != "IPC-2581" {
             return Err(Ipc2581Error::InvalidStructure(format!(
                 "Expected root element 'IPC-2581', found '{}'",
-                root.tag_name().name()
+                self.name(&root)
             )));
         }
 
         // Parse revision
-        let revision = root
-            .attribute("revision")
+        let revision = self
+            .attr(&root, "revision")
             .ok_or(Ipc2581Error::MissingAttribute {
                 element: "IPC-2581",
                 attr: "revision",
@@ -48,8 +78,8 @@ impl Parser {
         let mut bom = None;
         let mut avl = None;
 
-        for child in root.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(&root) {
+            match self.name(&child) {
                 "Content" => content_node = Some(child),
                 "LogisticHeader" => logistic_header = Some(self.parse_logistic_header(&child)?),
                 "HistoryRecord" => history_record = Some(self.parse_history_record(&child)?),
@@ -89,8 +119,8 @@ impl Parser {
         let mut dictionary_standard = None;
         let mut dictionary_user = None;
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "FunctionMode" => function_mode_node = Some(child),
                 "StepRef" => step_refs.push(self.required_attr(&child, "name", "StepRef")?),
                 "LayerRef" => layer_refs.push(self.required_attr(&child, "name", "LayerRef")?),
@@ -134,8 +164,8 @@ impl Parser {
         let mode_str = self.required_attr(node, "mode", "FunctionMode")?;
         let mode = self.parse_mode(self.interner.resolve(mode_str))?;
 
-        let level = node
-            .attribute("level")
+        let level = self
+            .attr(node, "level")
             .map(|s| self.parse_level(s))
             .transpose()?;
 
@@ -177,9 +207,12 @@ impl Parser {
     }
 
     fn parse_dictionary_color(&mut self, node: &Node) -> Result<DictionaryColor> {
-        let entries = node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "EntryColor")
+        let entry_nodes = self
+            .element_children(node)
+            .filter(|n| self.name(n) == "EntryColor")
+            .collect::<Vec<_>>();
+        let entries = entry_nodes
+            .into_iter()
             .map(|n| self.parse_entry_color(&n))
             .collect::<Result<Vec<_>>>()?;
 
@@ -189,9 +222,9 @@ impl Parser {
     fn parse_entry_color(&mut self, node: &Node) -> Result<EntryColor> {
         let id = self.required_attr(node, "id", "EntryColor")?;
 
-        let color_node = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "Color")
+        let color_node = self
+            .element_children(node)
+            .find(|n| self.name(n) == "Color")
             .ok_or(Ipc2581Error::MissingElement("Color"))?;
 
         let r = self.parse_u8_attr(&color_node, "r", "Color")?;
@@ -205,17 +238,20 @@ impl Parser {
     }
 
     fn parse_dictionary_line_desc(&mut self, node: &Node) -> Result<DictionaryLineDesc> {
-        let units = node
-            .attribute("units")
+        let units = self
+            .attr(node, "units")
             .map(|s| self.parse_units(s))
             .transpose()?;
 
         // Use MILLIMETER as default if not specified
         let dict_units = units.unwrap_or(Units::Millimeter);
 
-        let entries = node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "EntryLineDesc")
+        let entry_nodes = self
+            .element_children(node)
+            .filter(|n| self.name(n) == "EntryLineDesc")
+            .collect::<Vec<_>>();
+        let entries = entry_nodes
+            .into_iter()
             .map(|n| self.parse_entry_line_desc(&n, dict_units))
             .collect::<Result<Vec<_>>>()?;
 
@@ -225,9 +261,9 @@ impl Parser {
     fn parse_entry_line_desc(&mut self, node: &Node, units: Units) -> Result<EntryLineDesc> {
         let id = self.required_attr(node, "id", "EntryLineDesc")?;
 
-        let line_desc_node = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "LineDesc")
+        let line_desc_node = self
+            .element_children(node)
+            .find(|n| self.name(n) == "LineDesc")
             .ok_or(Ipc2581Error::MissingElement("LineDesc"))?;
 
         let line_desc = self.parse_line_desc(&line_desc_node, units)?;
@@ -240,8 +276,8 @@ impl Parser {
         let line_end_str = self.required_attr(node, "lineEnd", "LineDesc")?;
         let line_end = self.parse_line_end(self.interner.resolve(line_end_str))?;
 
-        let line_property = node
-            .attribute("lineProperty")
+        let line_property = self
+            .attr(node, "lineProperty")
             .map(|s| self.parse_line_property(s))
             .transpose()?;
 
@@ -285,14 +321,14 @@ impl Parser {
         let fill_property_str = self.required_attr(node, "fillProperty", "FillDesc")?;
         let fill_property = self.parse_fill_property(self.interner.resolve(fill_property_str))?;
 
-        let angle1 = node
-            .attribute("angle1")
+        let angle1 = self
+            .attr(node, "angle1")
             .map(|s| s.parse::<f64>())
             .transpose()
             .map_err(|_| Ipc2581Error::InvalidAttribute("angle1".to_string()))?;
 
-        let angle2 = node
-            .attribute("angle2")
+        let angle2 = self
+            .attr(node, "angle2")
             .map(|s| s.parse::<f64>())
             .transpose()
             .map_err(|_| Ipc2581Error::InvalidAttribute("angle2".to_string()))?;
@@ -331,14 +367,14 @@ impl Parser {
         let mut fill_property = None;
         let mut line_desc_ref = None;
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "FillDesc" => {
                     let fill_desc = self.parse_fill_desc(&child)?;
                     fill_property = Some(fill_desc.fill_property);
                 }
                 "LineDescRef" => {
-                    if let Some(id) = child.attribute("id") {
+                    if let Some(id) = self.attr(&child, "id") {
                         line_desc_ref = Some(self.interner.intern(id));
                     }
                 }
@@ -360,17 +396,20 @@ impl Parser {
     }
 
     fn parse_dictionary_standard(&mut self, node: &Node) -> Result<DictionaryStandard> {
-        let units = node
-            .attribute("units")
+        let units = self
+            .attr(node, "units")
             .map(|s| self.parse_units(s))
             .transpose()?;
 
         // Use MILLIMETER as default if not specified
         let dict_units = units.unwrap_or(Units::Millimeter);
 
-        let entries = node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "EntryStandard")
+        let entry_nodes = self
+            .element_children(node)
+            .filter(|n| self.name(n) == "EntryStandard")
+            .collect::<Vec<_>>();
+        let entries = entry_nodes
+            .into_iter()
             .map(|n| self.parse_entry_standard(&n, dict_units))
             .collect::<Result<Vec<_>>>()?;
 
@@ -381,9 +420,9 @@ impl Parser {
         let id = self.required_attr(node, "id", "EntryStandard")?;
 
         // Find the primitive child element
-        let primitive_node = node
-            .children()
-            .find(|n| n.is_element())
+        let primitive_node = self
+            .element_children(node)
+            .find(|n| self.doc().element(*n).is_some())
             .ok_or(Ipc2581Error::MissingElement("StandardPrimitive"))?;
 
         let primitive = self.parse_standard_primitive(&primitive_node, units)?;
@@ -392,7 +431,7 @@ impl Parser {
     }
 
     fn parse_standard_primitive(&mut self, node: &Node, units: Units) -> Result<StandardPrimitive> {
-        match node.tag_name().name() {
+        match self.name(node) {
             "Circle" => Ok(StandardPrimitive::Circle(self.styled(
                 node,
                 Circle {
@@ -624,16 +663,19 @@ impl Parser {
             )?)),
             "Contour" => {
                 // Parse Polygon and Cutouts
-                let polygon_node = node
-                    .children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "Polygon")
+                let polygon_node = self
+                    .element_children(node)
+                    .find(|n| self.name(n) == "Polygon")
                     .ok_or(Ipc2581Error::MissingElement("Polygon"))?;
 
                 let polygon = self.parse_polygon(&polygon_node, units)?;
 
-                let cutouts = node
-                    .children()
-                    .filter(|n| n.is_element() && n.tag_name().name() == "Cutout")
+                let cutout_nodes = self
+                    .element_children(node)
+                    .filter(|n| self.name(n) == "Cutout")
+                    .collect::<Vec<_>>();
+                let cutouts = cutout_nodes
+                    .into_iter()
                     .map(|n| self.parse_polygon(&n, units))
                     .collect::<Result<Vec<_>>>()?;
 
@@ -650,8 +692,8 @@ impl Parser {
         let mut begin: Option<Point> = None;
         let mut steps = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "PolyBegin" => {
                     begin = Some(Point {
                         x: self.parse_f64_attr_with_units(&child, "x", "PolyBegin", units)?,
@@ -696,17 +738,20 @@ impl Parser {
     }
 
     fn parse_dictionary_user(&mut self, node: &Node) -> Result<DictionaryUser> {
-        let units = node
-            .attribute("units")
+        let units = self
+            .attr(node, "units")
             .map(|s| self.parse_units(s))
             .transpose()?;
 
         // Use MILLIMETER as default if not specified
         let dict_units = units.unwrap_or(Units::Millimeter);
 
-        let entries = node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "EntryUser")
+        let entry_nodes = self
+            .element_children(node)
+            .filter(|n| self.name(n) == "EntryUser")
+            .collect::<Vec<_>>();
+        let entries = entry_nodes
+            .into_iter()
             .map(|n| self.parse_entry_user(&n, dict_units))
             .collect::<Result<Vec<_>>>()?;
 
@@ -717,9 +762,9 @@ impl Parser {
         let id = self.required_attr(node, "id", "EntryUser")?;
 
         // Find the primitive child element (currently only supporting UserSpecial)
-        let primitive_node = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "UserSpecial")
+        let primitive_node = self
+            .element_children(node)
+            .find(|n| self.name(n) == "UserSpecial")
             .ok_or(Ipc2581Error::MissingElement("UserPrimitive"))?;
 
         let primitive = self.parse_user_special(&primitive_node, units)?;
@@ -730,12 +775,8 @@ impl Parser {
     fn parse_user_special(&mut self, node: &Node, units: Units) -> Result<UserPrimitive> {
         let mut shapes = Vec::new();
 
-        for child in node.children() {
-            if !child.is_element() {
-                continue;
-            }
-
-            let tag_name = child.tag_name().name();
+        for child in self.element_children(node) {
+            let tag_name = self.name(&child);
 
             // Parse shape based on tag name
             let shape_type = match tag_name {
@@ -771,15 +812,15 @@ impl Parser {
 
             if let Some(shape_type) = shape_type {
                 // Parse optional LineDesc and FillDesc children
-                let line_desc = child
-                    .children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "LineDesc")
+                let line_desc = self
+                    .element_children(&child)
+                    .find(|n| self.name(n) == "LineDesc")
                     .map(|n| self.parse_line_desc(&n, units))
                     .transpose()?;
 
-                let fill_desc = child
-                    .children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "FillDesc")
+                let fill_desc = self
+                    .element_children(&child)
+                    .find(|n| self.name(n) == "FillDesc")
                     .map(|n| self.parse_fill_desc(&n))
                     .transpose()?;
 
@@ -799,8 +840,8 @@ impl Parser {
         let mut enterprises = Vec::new();
         let mut persons = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "Role" => {
                     let id = self.required_attr(&child, "id", "Role")?;
                     let role_function = self.required_attr(&child, "roleFunction", "Role")?;
@@ -830,7 +871,7 @@ impl Parser {
 
     fn parse_history_record(&mut self, node: &Node) -> Result<HistoryRecord> {
         // Parse number as f64 first, then convert to u32 (some files use "1.0")
-        let number = match node.attribute("number") {
+        let number = match self.attr(&node, "number") {
             Some(s) => {
                 if let Ok(f) = s.parse::<f64>() {
                     f as u32
@@ -855,8 +896,8 @@ impl Parser {
 
         // Parse FileRevision child element
         let mut file_revision = None;
-        for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "FileRevision" {
+        for child in self.element_children(node) {
+            if self.name(&child) == "FileRevision" {
                 file_revision = Some(self.parse_file_revision(&child)?);
                 break;
             }
@@ -877,8 +918,8 @@ impl Parser {
 
         // Parse SoftwarePackage child element
         let mut software_package = None;
-        for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "SoftwarePackage" {
+        for child in self.element_children(node) {
+            if self.name(&child) == "SoftwarePackage" {
                 software_package = Some(self.parse_software_package(&child)?);
                 break;
             }
@@ -923,13 +964,13 @@ impl Parser {
         attr: &'static str,
         element: &'static str,
     ) -> Result<Symbol> {
-        node.attribute(attr)
+        self.attr(&node, attr)
             .ok_or(Ipc2581Error::MissingAttribute { element, attr })
             .map(|s| self.interner.intern(s))
     }
 
     fn optional_attr(&mut self, node: &Node, attr: &str) -> Option<Symbol> {
-        node.attribute(attr).map(|s| self.interner.intern(s))
+        self.attr(&node, attr).map(|s| self.interner.intern(s))
     }
 
     fn parse_f64_attr(
@@ -938,8 +979,8 @@ impl Parser {
         attr: &'static str,
         element: &'static str,
     ) -> Result<f64> {
-        let attr_val = node
-            .attribute(attr)
+        let attr_val = self
+            .attr(node, attr)
             .ok_or(Ipc2581Error::MissingAttribute { element, attr })?;
         attr_val
             .parse()
@@ -962,8 +1003,8 @@ impl Parser {
     }
 
     fn parse_u8_attr(&self, node: &Node, attr: &'static str, element: &'static str) -> Result<u8> {
-        let attr_val = node
-            .attribute(attr)
+        let attr_val = self
+            .attr(node, attr)
             .ok_or(Ipc2581Error::MissingAttribute { element, attr })?;
         attr_val.parse().map_err(|_| {
             Ipc2581Error::InvalidAttribute(format!("Invalid u8 value for {} in {}", attr, element))
@@ -976,8 +1017,8 @@ impl Parser {
         attr: &'static str,
         element: &'static str,
     ) -> Result<u32> {
-        let attr_val = node
-            .attribute(attr)
+        let attr_val = self
+            .attr(node, attr)
             .ok_or(Ipc2581Error::MissingAttribute { element, attr })?;
         attr_val.parse().map_err(|_| {
             Ipc2581Error::InvalidAttribute(format!("Invalid u32 value for {} in {}", attr, element))
@@ -994,7 +1035,7 @@ impl Parser {
 
     /// Parse optional f64 attribute (no unit conversion)
     fn parse_optional_f64_attr(&self, node: &Node, attr: &'static str) -> Result<Option<f64>> {
-        node.attribute(attr)
+        self.attr(&node, attr)
             .map(|v| {
                 v.parse::<f64>().map_err(|_| {
                     Ipc2581Error::InvalidAttribute(format!("Invalid f64 value for {}", attr))
@@ -1005,7 +1046,7 @@ impl Parser {
 
     /// Parse optional u32 attribute
     fn parse_optional_u32_attr(&self, node: &Node, attr: &'static str) -> Result<Option<u32>> {
-        node.attribute(attr)
+        self.attr(&node, attr)
             .map(|v| {
                 v.parse::<u32>().map_err(|_| {
                     Ipc2581Error::InvalidAttribute(format!("Invalid u32 value for {}", attr))
@@ -1021,13 +1062,13 @@ impl Parser {
         attr: &'static str,
         units: Units,
     ) -> Result<Option<f64>> {
-        node.attribute(attr)
+        self.attr(&node, attr)
             .map(|v| self.parse_f64_str_with_units(v, units))
             .transpose()
     }
 
     fn parse_bool_attr(&self, node: &Node, attr: &'static str) -> Result<bool> {
-        match node.attribute(attr) {
+        match self.attr(&node, attr) {
             Some("true") => Ok(true),
             Some("false") => Ok(false),
             Some(_) => Err(Ipc2581Error::InvalidAttribute(format!(
@@ -1043,9 +1084,9 @@ impl Parser {
 
     fn parse_ecad(&mut self, node: &Node) -> Result<Ecad> {
         // Parse CadHeader first to establish units for the ECAD section
-        let cad_header_node = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "CadHeader")
+        let cad_header_node = self
+            .element_children(node)
+            .find(|n| self.name(n) == "CadHeader")
             .ok_or(Ipc2581Error::MissingElement("CadHeader"))?;
         let mut cad_header = self.parse_cad_header(&cad_header_node)?;
 
@@ -1056,9 +1097,9 @@ impl Parser {
         // We'll move them back after parsing CadData
         self.specs = std::mem::take(&mut cad_header.specs);
 
-        let cad_data_node = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "CadData")
+        let cad_data_node = self
+            .element_children(node)
+            .find(|n| self.name(n) == "CadData")
             .ok_or(Ipc2581Error::MissingElement("CadData"))?;
         let cad_data = self.parse_cad_data(&cad_data_node)?;
 
@@ -1072,8 +1113,8 @@ impl Parser {
     }
 
     fn parse_cad_header(&mut self, node: &Node) -> Result<CadHeader> {
-        let units = node
-            .attribute("units")
+        let units = self
+            .attr(node, "units")
             .ok_or(Ipc2581Error::MissingAttribute {
                 element: "CadHeader",
                 attr: "units",
@@ -1082,8 +1123,8 @@ impl Parser {
 
         // Parse Spec elements
         let mut specs = std::collections::HashMap::new();
-        for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "Spec" {
+        for child in self.element_children(node) {
+            if self.name(&child) == "Spec" {
                 let spec = self.parse_spec(&child)?;
                 specs.insert(spec.name, spec);
             }
@@ -1105,14 +1146,14 @@ impl Parser {
         let mut color_rgb = None;
 
         // Parse child elements for material and dielectric properties
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
-                "General" if child.attribute("type") == Some("MATERIAL") => {
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "General" if self.attr(&child, "type") == Some("MATERIAL") => {
                     // Look for Property, ColorTerm, and Color elements
-                    for prop in child.children().filter(|n| n.is_element()) {
-                        match prop.tag_name().name() {
+                    for prop in self.element_children(&child) {
+                        match self.name(&prop) {
                             "Property" => {
-                                if let Some(text) = prop.attribute("text")
+                                if let Some(text) = self.attr(&prop, "text")
                                     && !text.is_empty()
                                 {
                                     let text_sym = self.interner.intern(text);
@@ -1126,16 +1167,16 @@ impl Parser {
                             }
                             "ColorTerm" => {
                                 // Parse ColorTerm name attribute (e.g., "GREEN", "WHITE", "BLACK")
-                                if let Some(color_name) = prop.attribute("name") {
+                                if let Some(color_name) = self.attr(&prop, "name") {
                                     color_term = Some(self.interner.intern(color_name));
                                 }
                             }
                             "Color" => {
                                 // Parse Color r, g, b attributes (0-255)
                                 if let (Some(r_str), Some(g_str), Some(b_str)) = (
-                                    prop.attribute("r"),
-                                    prop.attribute("g"),
-                                    prop.attribute("b"),
+                                    self.attr(&prop, "r"),
+                                    self.attr(&prop, "g"),
+                                    self.attr(&prop, "b"),
                                 ) && let (Ok(r), Ok(g), Ok(b)) = (
                                     r_str.parse::<u8>(),
                                     g_str.parse::<u8>(),
@@ -1149,11 +1190,11 @@ impl Parser {
                     }
                 }
                 "Dielectric" => {
-                    let dielectric_type = child.attribute("type");
+                    let dielectric_type = self.attr(&child, "type");
                     // Look for Property with value attribute
-                    for prop in child.children().filter(|n| n.is_element()) {
-                        if prop.tag_name().name() == "Property"
-                            && let Some(value_str) = prop.attribute("value")
+                    for prop in self.element_children(&child) {
+                        if self.name(&prop) == "Property"
+                            && let Some(value_str) = self.attr(&prop, "value")
                             && let Ok(value) = value_str.parse::<f64>()
                         {
                             match dielectric_type {
@@ -1164,14 +1205,14 @@ impl Parser {
                         }
                     }
                 }
-                "Conductor" if child.attribute("type") == Some("WEIGHT") => {
-                    for prop in child.children().filter(|n| n.is_element()) {
-                        if prop.tag_name().name() == "Property"
-                            && let Some(value_str) = prop.attribute("value")
+                "Conductor" if self.attr(&child, "type") == Some("WEIGHT") => {
+                    for prop in self.element_children(&child) {
+                        if self.name(&prop) == "Property"
+                            && let Some(value_str) = self.attr(&prop, "value")
                             && let Ok(value) = value_str.parse::<f64>()
                         {
                             // Check unit - should be OZ
-                            let unit = prop.attribute("unit").unwrap_or("OZ");
+                            let unit = self.attr(&prop, "unit").unwrap_or("OZ");
                             if unit.to_uppercase() == "OZ" {
                                 copper_weight_oz = Some(value);
                             }
@@ -1208,17 +1249,17 @@ impl Parser {
         // KiCad bug format: <SurfaceFinish><Finish type="S"/></SurfaceFinish>
 
         // First, try the correct IPC-2581C format: type attribute directly on SurfaceFinish
-        if let Some(finish_type_str) = node.attribute("type") {
+        if let Some(finish_type_str) = self.attr(&node, "type") {
             let finish_type = self.parse_finish_type(finish_type_str)?;
-            let comment = node.attribute("comment").map(|s| self.interner.intern(s));
+            let comment = self.attr(&node, "comment").map(|s| self.interner.intern(s));
 
             let mut products = Vec::new();
-            for product_node in node.children().filter(|n| n.is_element()) {
-                if product_node.tag_name().name() == "Product"
-                    && let Some(product_name) = product_node.attribute("name")
+            for product_node in self.element_children(node) {
+                if self.name(&product_node) == "Product"
+                    && let Some(product_name) = self.attr(&product_node, "name")
                 {
-                    let criteria = product_node
-                        .attribute("criteria")
+                    let criteria = self
+                        .attr(&product_node, "criteria")
                         .and_then(|s| self.parse_product_criteria(s).ok());
 
                     products.push(ecad::FinishProduct {
@@ -1239,19 +1280,21 @@ impl Parser {
         // See: https://gitlab.com/kicad/code/kicad/-/issues/XXXXX
         // Fallback: support incorrect KiCad format with nested Finish element
         // This is non-compliant but allows parsing legacy KiCad exports
-        for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "Finish" {
-                let finish_type_str = child.attribute("type").unwrap_or("OTHER");
+        for child in self.element_children(node) {
+            if self.name(&child) == "Finish" {
+                let finish_type_str = self.attr(&child, "type").unwrap_or("OTHER");
                 let finish_type = self.parse_finish_type(finish_type_str)?;
-                let comment = child.attribute("comment").map(|s| self.interner.intern(s));
+                let comment = self
+                    .attr(&child, "comment")
+                    .map(|s| self.interner.intern(s));
 
                 let mut products = Vec::new();
-                for product_node in child.children().filter(|n| n.is_element()) {
-                    if product_node.tag_name().name() == "Product"
-                        && let Some(product_name) = product_node.attribute("name")
+                for product_node in self.element_children(&child) {
+                    if self.name(&product_node) == "Product"
+                        && let Some(product_name) = self.attr(&product_node, "name")
                     {
-                        let criteria = product_node
-                            .attribute("criteria")
+                        let criteria = self
+                            .attr(&product_node, "criteria")
                             .and_then(|s| self.parse_product_criteria(s).ok());
 
                         products.push(ecad::FinishProduct {
@@ -1323,8 +1366,8 @@ impl Parser {
         let mut layers = Vec::new();
         let mut stackups = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "Step" => steps.push(self.parse_step(&child)?),
                 "Layer" => layers.push(self.parse_layer(&child)?),
                 "Stackup" => stackups.push(self.parse_stackup(&child)?),
@@ -1346,33 +1389,33 @@ impl Parser {
         let name = self.required_attr(node, "name", "Stackup")?;
 
         // Convert overall thickness if present
-        let overall_thickness = node
-            .attribute("overallThickness")
+        let overall_thickness = self
+            .attr(node, "overallThickness")
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
         // Parse whereMeasured attribute
-        let where_measured = node
-            .attribute("whereMeasured")
+        let where_measured = self
+            .attr(node, "whereMeasured")
             .and_then(|s| self.parse_where_measured(s).ok());
 
         // Parse tolerances
-        let tol_plus = node
-            .attribute("tolPlus")
+        let tol_plus = self
+            .attr(node, "tolPlus")
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
-        let tol_minus = node
-            .attribute("tolMinus")
+        let tol_minus = self
+            .attr(node, "tolMinus")
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
         let mut layers = Vec::new();
-        for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "StackupGroup" {
+        for child in self.element_children(node) {
+            if self.name(&child) == "StackupGroup" {
                 // StackupGroup contains StackupLayer elements
-                for layer_node in child.children().filter(|n| n.is_element()) {
-                    if layer_node.tag_name().name() == "StackupLayer" {
+                for layer_node in self.element_children(&child) {
+                    if self.name(&layer_node) == "StackupLayer" {
                         layers.push(self.parse_stackup_layer(&layer_node)?);
                     }
                 }
@@ -1396,8 +1439,8 @@ impl Parser {
         let layer_ref = self.required_attr(node, "layerOrGroupRef", "StackupLayer")?;
 
         // Convert thickness if present
-        let thickness = node
-            .attribute("thickness")
+        let thickness = self
+            .attr(node, "thickness")
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
@@ -1405,17 +1448,17 @@ impl Parser {
         // NOTE: IPC-2581 spec allows tolPercent attribute to indicate if these are percentages
         // For a pure parser, we should keep the raw values and let downstream code handle interpretation
         // Currently we convert to mm for convenience (TODO: make this a separate normalization step)
-        let tol_plus = node
-            .attribute("tolPlus")
+        let tol_plus = self
+            .attr(node, "tolPlus")
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
-        let tol_minus = node
-            .attribute("tolMinus")
+        let tol_minus = self
+            .attr(node, "tolMinus")
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
-        let layer_number = node.attribute("sequence").and_then(|s| s.parse().ok());
+        let layer_number = self.attr(&node, "sequence").and_then(|s| s.parse().ok());
 
         // Look up material and dielectric properties from Spec via SpecRef
         let mut material = None;
@@ -1424,9 +1467,9 @@ impl Parser {
         let mut loss_tangent = None;
 
         // Parse SpecRef child element
-        for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "SpecRef"
-                && let Some(spec_id) = child.attribute("id")
+        for child in self.element_children(node) {
+            if self.name(&child) == "SpecRef"
+                && let Some(spec_id) = self.attr(&child, "id")
             {
                 // Exact match - pure IPC-2581 spec
                 let spec_symbol = self.interner.intern(spec_id);
@@ -1467,8 +1510,8 @@ impl Parser {
         let mut phy_net_groups = Vec::new();
         let mut layer_features = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "Datum" => datum = Some(self.parse_datum(&child)?),
                 "Profile" => profile = Some(self.parse_profile(&child)?),
                 "PadStackDef" => padstack_defs.push(self.parse_padstack_def(&child)?),
@@ -1503,9 +1546,9 @@ impl Parser {
     }
 
     fn parse_profile(&mut self, node: &Node) -> Result<Profile> {
-        let polygon_node = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "Polygon")
+        let polygon_node = self
+            .element_children(node)
+            .find(|n| self.name(n) == "Polygon")
             .ok_or(Ipc2581Error::MissingElement("Polygon in Profile"))?;
 
         // Profile is in ECAD section, use ECAD units
@@ -1514,12 +1557,12 @@ impl Parser {
 
         // Parse cutouts (voids within the board outline)
         let mut cutouts = Vec::new();
-        for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "Cutout" {
+        for child in self.element_children(node) {
+            if self.name(&child) == "Cutout" {
                 // Cutout contains a Polygon child
-                if let Some(cutout_polygon_node) = child
-                    .children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "Polygon")
+                if let Some(cutout_polygon_node) = self
+                    .element_children(&child)
+                    .find(|n| self.name(n) == "Polygon")
                 {
                     cutouts.push(self.parse_polygon(&cutout_polygon_node, units)?);
                 }
@@ -1532,8 +1575,8 @@ impl Parser {
     fn parse_package(&mut self, node: &Node) -> Result<Package> {
         let name = self.required_attr(node, "name", "Package")?;
         let package_type = self.required_attr(node, "type", "Package")?;
-        let pin_one = node.attribute("pinOne").map(|s| self.interner.intern(s));
-        let height = node.attribute("height").and_then(|s| s.parse().ok());
+        let pin_one = self.attr(&node, "pinOne").map(|s| self.interner.intern(s));
+        let height = self.attr(&node, "height").and_then(|s| s.parse().ok());
 
         Ok(Package {
             name,
@@ -1548,13 +1591,13 @@ impl Parser {
         let package_ref = self.required_attr(node, "packageRef", "Component")?;
         let layer_ref = self.required_attr(node, "layerRef", "Component")?;
 
-        let mount_type = node.attribute("mountType").map(|s| match s {
+        let mount_type = self.attr(&node, "mountType").map(|s| match s {
             "SMT" => MountType::Smt,
             "THT" => MountType::Tht,
             _ => MountType::Other,
         });
 
-        let part = node.attribute("part").map(|s| self.interner.intern(s));
+        let part = self.attr(&node, "part").map(|s| self.interner.intern(s));
 
         Ok(Component {
             ref_des,
@@ -1568,9 +1611,12 @@ impl Parser {
     fn parse_logical_net(&mut self, node: &Node) -> Result<LogicalNet> {
         let name = self.required_attr(node, "name", "LogicalNet")?;
 
-        let pin_refs = node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "PinRef")
+        let pin_ref_nodes = self
+            .element_children(node)
+            .filter(|n| self.name(n) == "PinRef")
+            .collect::<Vec<_>>();
+        let pin_refs = pin_ref_nodes
+            .into_iter()
             .map(|n| self.parse_pin_ref(&n))
             .collect::<Result<Vec<_>>>()?;
 
@@ -1594,25 +1640,27 @@ impl Parser {
         let layer_function =
             self.parse_layer_function(self.interner.resolve(layer_function_str))?;
 
-        let side = node
-            .attribute("side")
+        let side = self
+            .attr(node, "side")
             .map(|s| self.parse_side(s))
             .transpose()?;
-        let polarity = node
-            .attribute("polarity")
+        let polarity = self
+            .attr(node, "polarity")
             .map(|s| self.parse_polarity(s))
             .transpose()?;
 
         let mut span = None;
         let mut profile = None;
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "Span" => {
                     span = Some(ecad::LayerSpan {
-                        from_layer: child
-                            .attribute("fromLayer")
+                        from_layer: self
+                            .attr(&child, "fromLayer")
                             .map(|s| self.interner.intern(s)),
-                        to_layer: child.attribute("toLayer").map(|s| self.interner.intern(s)),
+                        to_layer: self
+                            .attr(&child, "toLayer")
+                            .map(|s| self.interner.intern(s)),
                     });
                 }
                 "Profile" => {
@@ -1635,9 +1683,12 @@ impl Parser {
     fn parse_layer_feature(&mut self, node: &Node) -> Result<LayerFeature> {
         let layer_ref = self.required_attr(node, "layerRef", "LayerFeature")?;
 
-        let sets = node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "Set")
+        let set_nodes = self
+            .element_children(node)
+            .filter(|n| self.name(n) == "Set")
+            .collect::<Vec<_>>();
+        let sets = set_nodes
+            .into_iter()
             .map(|n| self.parse_feature_set(&n))
             .collect::<Result<Vec<_>>>()?;
 
@@ -1645,11 +1696,13 @@ impl Parser {
     }
 
     fn parse_feature_set(&mut self, node: &Node) -> Result<FeatureSet> {
-        let net = node.attribute("net").map(|s| self.interner.intern(s));
-        let geometry = node.attribute("geometry").map(|s| self.interner.intern(s));
+        let net = self.attr(&node, "net").map(|s| self.interner.intern(s));
+        let geometry = self
+            .attr(&node, "geometry")
+            .map(|s| self.interner.intern(s));
 
         // Parse polarity attribute
-        let polarity = node.attribute("polarity").and_then(|s| match s {
+        let polarity = self.attr(&node, "polarity").and_then(|s| match s {
             "POSITIVE" => Some(Polarity::Positive),
             "NEGATIVE" => Some(Polarity::Negative),
             _ => None,
@@ -1663,8 +1716,8 @@ impl Parser {
         let mut lines = Vec::new();
         let mut nonstandard_attributes = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "Hole" => holes.push(self.parse_hole(&child)?),
                 "SlotCavity" => slots.push(self.parse_slot_cavity(&child)?),
                 "Pad" => pads.push(self.parse_pad(&child)?),
@@ -1700,8 +1753,8 @@ impl Parser {
 
     fn parse_nonstandard_attribute(&mut self, node: &Node) -> Result<ecad::NonstandardAttribute> {
         let name = self.required_attr(node, "name", "NonstandardAttribute")?;
-        let value = node.attribute("value").map(|s| self.interner.intern(s));
-        let attr_type = node.attribute("type").map(|s| self.interner.intern(s));
+        let value = self.attr(&node, "value").map(|s| self.interner.intern(s));
+        let attr_type = self.attr(&node, "type").map(|s| self.interner.intern(s));
 
         Ok(ecad::NonstandardAttribute {
             name,
@@ -1718,15 +1771,15 @@ impl Parser {
         // Check for Location offset (applies to all geometry in Features)
         let mut offset_x = 0.0;
         let mut offset_y = 0.0;
-        for child in features_node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "Location" {
-                offset_x = child
-                    .attribute("x")
+        for child in self.element_children(features_node) {
+            if self.name(&child) == "Location" {
+                offset_x = self
+                    .attr(&child, "x")
                     .and_then(|s| s.parse::<f64>().ok())
                     .map(|v| crate::units::to_mm(v, units))
                     .unwrap_or(0.0);
-                offset_y = child
-                    .attribute("y")
+                offset_y = self
+                    .attr(&child, "y")
                     .and_then(|s| s.parse::<f64>().ok())
                     .map(|v| crate::units::to_mm(v, units))
                     .unwrap_or(0.0);
@@ -1734,8 +1787,8 @@ impl Parser {
             }
         }
 
-        for child in features_node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(features_node) {
+            match self.name(&child) {
                 "Polygon" => {
                     if let Ok(poly) = self.parse_polygon(&child, units) {
                         polygons.push(poly);
@@ -1747,11 +1800,11 @@ impl Parser {
                 }
                 "UserSpecial" => {
                     // UserSpecial contains Contour > Polygon OR Line
-                    for inner in child.children().filter(|n| n.is_element()) {
-                        match inner.tag_name().name() {
+                    for inner in self.element_children(&child) {
+                        match self.name(&inner) {
                             "Contour" => {
-                                for poly_node in inner.children().filter(|n| n.is_element()) {
-                                    if poly_node.tag_name().name() == "Polygon"
+                                for poly_node in self.element_children(&inner) {
+                                    if self.name(&poly_node) == "Polygon"
                                         && let Ok(poly) = self.parse_polygon(&poly_node, units)
                                     {
                                         polygons.push(poly);
@@ -1784,15 +1837,15 @@ impl Parser {
         let mut line_end = None;
 
         // Look for LineDesc child
-        for child in node.children().filter(|n| n.is_element()) {
-            if child.tag_name().name() == "LineDesc" {
-                line_width = child
-                    .attribute("lineWidth")
+        for child in self.element_children(node) {
+            if self.name(&child) == "LineDesc" {
+                line_width = self
+                    .attr(&child, "lineWidth")
                     .and_then(|s| s.parse::<f64>().ok())
                     .map(|v| crate::units::to_mm(v, units))
                     .unwrap_or(0.25);
 
-                line_end = child.attribute("lineEnd").and_then(|s| match s {
+                line_end = self.attr(&child, "lineEnd").and_then(|s| match s {
                     "ROUND" => Some(LineEnd::Round),
                     "SQUARE" => Some(LineEnd::Square),
                     "FLAT" => Some(LineEnd::Flat),
@@ -1826,8 +1879,8 @@ impl Parser {
         let mut line_end = None;
 
         // Parse points and LineDesc, tessellating curves
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "PolyBegin" => {
                     current_x = self
                         .parse_f64_attr_with_units(&child, "x", "PolyBegin", units)
@@ -1888,12 +1941,12 @@ impl Parser {
                     current_y = end_y;
                 }
                 "LineDesc" => {
-                    line_width = child
-                        .attribute("lineWidth")
+                    line_width = self
+                        .attr(&child, "lineWidth")
                         .and_then(|s| s.parse::<f64>().ok())
                         .map(|v| crate::units::to_mm(v, units))
                         .unwrap_or(0.25);
-                    line_end = child.attribute("lineEnd").and_then(|s| match s {
+                    line_end = self.attr(&child, "lineEnd").and_then(|s| match s {
                         "ROUND" => Some(LineEnd::Round),
                         "SQUARE" => Some(LineEnd::Square),
                         "FLAT" => Some(LineEnd::Flat),
@@ -1911,7 +1964,7 @@ impl Parser {
         // Hole is in ECAD section, use ECAD units
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
 
-        let name = node.attribute("name").map(|s| self.interner.intern(s));
+        let name = self.attr(&node, "name").map(|s| self.interner.intern(s));
         let diameter = self.parse_f64_attr_with_units(node, "diameter", "Hole", units)?;
         let plating_status_str = self.required_attr(node, "platingStatus", "Hole")?;
         let plating_status =
@@ -1932,15 +1985,15 @@ impl Parser {
         // SlotCavity is in ECAD section, use ECAD units
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
 
-        let name = node.attribute("name").map(|s| self.interner.intern(s));
+        let name = self.attr(&node, "name").map(|s| self.interner.intern(s));
         let plating_status_str = self.required_attr(node, "platingStatus", "SlotCavity")?;
         let plating_status =
             self.parse_plating_status(self.interner.resolve(plating_status_str))?;
 
         // Parse Location child element
-        let (x, y) = if let Some(location_node) = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "Location")
+        let (x, y) = if let Some(location_node) = self
+            .element_children(node)
+            .find(|n| self.name(n) == "Location")
         {
             let x = self.parse_f64_attr_with_units(&location_node, "x", "Location", units)?;
             let y = self.parse_f64_attr_with_units(&location_node, "y", "Location", units)?;
@@ -1953,14 +2006,14 @@ impl Parser {
         // Per IPC-2581 spec 8.2.3.10.6: "The shape is defined by the substitution
         // group Feature, which can be either a user defined shape or a standard
         // primitive shape."
-        let shape = if let Some(outline_node) = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "Outline")
+        let shape = if let Some(outline_node) = self
+            .element_children(node)
+            .find(|n| self.name(n) == "Outline")
         {
             // Outline path with polygon
-            if let Some(polygon_node) = outline_node
-                .children()
-                .find(|n| n.is_element() && n.tag_name().name() == "Polygon")
+            if let Some(polygon_node) = self
+                .element_children(&outline_node)
+                .find(|n| self.name(n) == "Polygon")
             {
                 SlotShape::Outline(self.parse_polygon(&polygon_node, units)?)
             } else {
@@ -1971,22 +2024,21 @@ impl Parser {
         } else {
             // Try to parse as StandardPrimitive (Circle, Oval, RectCenter, etc.)
             // Find first child that is a StandardPrimitive
-            let primitive_node = node
-                .children()
+            let primitive_node = self
+                .element_children(node)
                 .find(|n| {
-                    n.is_element()
-                        && matches!(
-                            n.tag_name().name(),
-                            "Circle"
-                                | "Oval"
-                                | "RectCenter"
-                                | "RectRound"
-                                | "Ellipse"
-                                | "Diamond"
-                                | "Hexagon"
-                                | "Octagon"
-                                | "Triangle"
-                        )
+                    matches!(
+                        self.name(n),
+                        "Circle"
+                            | "Oval"
+                            | "RectCenter"
+                            | "RectRound"
+                            | "Ellipse"
+                            | "Diamond"
+                            | "Hexagon"
+                            | "Octagon"
+                            | "Triangle"
+                    )
                 })
                 .ok_or(Ipc2581Error::MissingElement(
                     "Shape (Outline or StandardPrimitive) in SlotCavity",
@@ -1995,7 +2047,7 @@ impl Parser {
             SlotShape::Primitive(self.parse_standard_primitive(&primitive_node, units)?)
         };
 
-        let z_axis_dim = has_z_axis_dim(node);
+        let z_axis_dim = has_z_axis_dim(self.doc(), node);
 
         Ok(Slot {
             name,
@@ -2011,29 +2063,29 @@ impl Parser {
         // Pad is in ECAD section, use ECAD units
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
 
-        let padstack_def_ref = node
-            .attribute("padstackDefRef")
+        let padstack_def_ref = self
+            .attr(node, "padstackDefRef")
             .map(|s| self.interner.intern(s));
 
         // Check for x, y as attributes first (legacy format)
-        let mut x = node
-            .attribute("x")
+        let mut x = self
+            .attr(node, "x")
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
-        let mut y = node
-            .attribute("y")
+        let mut y = self
+            .attr(node, "y")
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
         // Look for Location child element (standard format)
-        for child in node.children() {
-            if child.tag_name().name() == "Location" {
-                x = child
-                    .attribute("x")
+        for child in self.element_children(node) {
+            if self.name(&child) == "Location" {
+                x = self
+                    .attr(&child, "x")
                     .and_then(|s| s.parse::<f64>().ok())
                     .map(|v| crate::units::to_mm(v, units));
-                y = child
-                    .attribute("y")
+                y = self
+                    .attr(&child, "y")
                     .and_then(|s| s.parse::<f64>().ok())
                     .map(|v| crate::units::to_mm(v, units));
                 break;
@@ -2042,25 +2094,25 @@ impl Parser {
 
         // Parse Xform child element if present
         let mut xform = None;
-        for child in node.children() {
-            if child.tag_name().name() == "Xform" {
+        for child in self.element_children(node) {
+            if self.name(&child) == "Xform" {
                 xform = Some(self.parse_xform(&child));
                 break;
             }
         }
 
         // Parse inline StandardPrimitiveRef if present
-        let standard_primitive_ref = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "StandardPrimitiveRef")
-            .and_then(|n| n.attribute("id"))
+        let standard_primitive_ref = self
+            .element_children(node)
+            .find(|n| self.name(n) == "StandardPrimitiveRef")
+            .and_then(|n| self.attr(&n, "id"))
             .map(|id| self.interner.intern(id));
 
         // Parse inline UserPrimitiveRef if present
-        let user_primitive_ref = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "UserPrimitiveRef")
-            .and_then(|n| n.attribute("id"))
+        let user_primitive_ref = self
+            .element_children(node)
+            .find(|n| self.name(n) == "UserPrimitiveRef")
+            .and_then(|n| self.attr(&n, "id"))
             .map(|id| self.interner.intern(id));
 
         Ok(Pad {
@@ -2078,20 +2130,20 @@ impl Parser {
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
 
         // LineDescRef can be attribute OR child element <LineDescRef id="..."/>
-        let mut line_desc_ref = node
-            .attribute("lineDescRef")
+        let mut line_desc_ref = self
+            .attr(node, "lineDescRef")
             .map(|s| self.interner.intern(s));
 
         let mut points = Vec::new();
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "PolyBegin" | "PolyStepSegment" => {
                     let x = self.parse_f64_attr_with_units(&child, "x", "TracePoint", units)?;
                     let y = self.parse_f64_attr_with_units(&child, "y", "TracePoint", units)?;
                     points.push(TracePoint { x, y });
                 }
                 "LineDescRef" => {
-                    if let Some(id) = child.attribute("id") {
+                    if let Some(id) = self.attr(&child, "id") {
                         line_desc_ref = Some(self.interner.intern(id));
                     }
                 }
@@ -2224,8 +2276,8 @@ impl Parser {
         let mut hole_def = None;
         let mut pad_defs = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "PadstackHoleDef" => hole_def = Some(self.parse_padstack_hole_def(&child)?),
                 "PadstackPadDef" => pad_defs.push(self.parse_padstack_pad_def(&child)?),
                 _ => {}
@@ -2272,17 +2324,17 @@ impl Parser {
         let pad_use = self.parse_pad_use(self.interner.resolve(pad_use_str))?;
 
         // Parse StandardPrimitiveRef if present
-        let standard_primitive_ref = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "StandardPrimitiveRef")
-            .and_then(|n| n.attribute("id"))
+        let standard_primitive_ref = self
+            .element_children(node)
+            .find(|n| self.name(n) == "StandardPrimitiveRef")
+            .and_then(|n| self.attr(&n, "id"))
             .map(|id| self.interner.intern(id));
 
         // Parse UserPrimitiveRef if present
-        let user_primitive_ref = node
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "UserPrimitiveRef")
-            .and_then(|n| n.attribute("id"))
+        let user_primitive_ref = self
+            .element_children(node)
+            .find(|n| self.name(n) == "UserPrimitiveRef")
+            .and_then(|n| self.attr(&n, "id"))
             .map(|id| self.interner.intern(id));
 
         Ok(PadstackPadDef {
@@ -2320,9 +2372,12 @@ impl Parser {
     fn parse_bom(&mut self, node: &Node) -> Result<Bom> {
         let name = self.required_attr(node, "name", "Bom")?;
 
-        let items = node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "BomItem")
+        let item_nodes = self
+            .element_children(node)
+            .filter(|n| self.name(n) == "BomItem")
+            .collect::<Vec<_>>();
+        let items = item_nodes
+            .into_iter()
             .map(|n| self.parse_bom_item(&n))
             .collect::<Result<Vec<_>>>()?;
 
@@ -2332,25 +2387,25 @@ impl Parser {
     fn parse_bom_item(&mut self, node: &Node) -> Result<BomItem> {
         let oem_design_number_ref = self.required_attr(node, "OEMDesignNumberRef", "BomItem")?;
 
-        let quantity = node.attribute("quantity").and_then(|s| s.parse().ok());
-        let pin_count = node.attribute("pinCount").and_then(|s| s.parse().ok());
+        let quantity = self.attr(&node, "quantity").and_then(|s| s.parse().ok());
+        let pin_count = self.attr(&node, "pinCount").and_then(|s| s.parse().ok());
 
-        let category = node.attribute("category").map(|s| match s {
+        let category = self.attr(&node, "category").map(|s| match s {
             "ELECTRICAL" => BomCategory::Electrical,
             "MECHANICAL" => BomCategory::Mechanical,
             "DOCUMENT" => BomCategory::Document,
             _ => BomCategory::Electrical, // Default
         });
 
-        let description = node
-            .attribute("description")
+        let description = self
+            .attr(node, "description")
             .map(|s| self.interner.intern(s));
 
         let mut ref_des_list = Vec::new();
         let mut characteristics = None;
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "RefDes" => ref_des_list.push(self.parse_bom_ref_des(&child)?),
                 "Characteristics" => characteristics = Some(self.parse_characteristics(&child)?),
                 _ => {}
@@ -2373,8 +2428,8 @@ impl Parser {
         let package_ref = self.required_attr(node, "packageRef", "RefDes")?;
         let layer_ref = self.required_attr(node, "layerRef", "RefDes")?;
 
-        let populate = node
-            .attribute("populate")
+        let populate = self
+            .attr(node, "populate")
             .map(|s| s == "true")
             .unwrap_or(true);
 
@@ -2387,16 +2442,19 @@ impl Parser {
     }
 
     fn parse_characteristics(&mut self, node: &Node) -> Result<Characteristics> {
-        let category = node.attribute("category").map(|s| match s {
+        let category = self.attr(&node, "category").map(|s| match s {
             "ELECTRICAL" => BomCategory::Electrical,
             "MECHANICAL" => BomCategory::Mechanical,
             "DOCUMENT" => BomCategory::Document,
             _ => BomCategory::Electrical,
         });
 
-        let textuals = node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "Textual")
+        let textual_nodes = self
+            .element_children(node)
+            .filter(|n| self.name(n) == "Textual")
+            .collect::<Vec<_>>();
+        let textuals = textual_nodes
+            .into_iter()
             .map(|n| self.parse_textual_characteristic(&n))
             .collect::<Result<Vec<_>>>()?;
 
@@ -2404,14 +2462,14 @@ impl Parser {
     }
 
     fn parse_textual_characteristic(&mut self, node: &Node) -> Result<TextualCharacteristic> {
-        let definition_source = node
-            .attribute("definitionSource")
+        let definition_source = self
+            .attr(node, "definitionSource")
             .map(|s| self.interner.intern(s));
-        let name = node
-            .attribute("textualCharacteristicName")
+        let name = self
+            .attr(node, "textualCharacteristicName")
             .map(|s| self.interner.intern(s));
-        let value = node
-            .attribute("textualCharacteristicValue")
+        let value = self
+            .attr(node, "textualCharacteristicValue")
             .map(|s| self.interner.intern(s));
 
         Ok(TextualCharacteristic {
@@ -2427,8 +2485,8 @@ impl Parser {
         let mut header = None;
         let mut items = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "AvlHeader" => header = Some(self.parse_avl_header(&child)?),
                 "AvlItem" => items.push(self.parse_avl_item(&child)?),
                 _ => {}
@@ -2448,8 +2506,8 @@ impl Parser {
         let author = self.required_attr(node, "author", "AvlHeader")?;
         let datetime = self.required_attr(node, "datetime", "AvlHeader")?;
 
-        let version = node
-            .attribute("version")
+        let version = self
+            .attr(node, "version")
             .and_then(|s| s.parse().ok())
             .unwrap_or(1);
 
@@ -2473,11 +2531,11 @@ impl Parser {
         let mut vmpn_list = Vec::new();
         let mut spec_refs = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "AvlVmpn" => vmpn_list.push(self.parse_avl_vmpn(&child)?),
                 "SpecRef" => {
-                    if let Some(id) = child.attribute("id") {
+                    if let Some(id) = self.attr(&child, "id") {
                         spec_refs.push(self.interner.intern(id));
                     }
                 }
@@ -2496,15 +2554,15 @@ impl Parser {
         let evpl_vendor = self.optional_attr(node, "evplVendor");
         let evpl_mpn = self.optional_attr(node, "evplMpn");
 
-        let qualified = node.attribute("qualified").map(|s| s == "true");
+        let qualified = self.attr(&node, "qualified").map(|s| s == "true");
 
-        let chosen = node.attribute("chosen").map(|s| s == "true");
+        let chosen = self.attr(&node, "chosen").map(|s| s == "true");
 
         let mut mpns = Vec::new();
         let mut vendors = Vec::new();
 
-        for child in node.children().filter(|n| n.is_element()) {
-            match child.tag_name().name() {
+        for child in self.element_children(node) {
+            match self.name(&child) {
                 "AvlMpn" => mpns.push(self.parse_avl_mpn(&child)?),
                 "AvlVendor" => vendors.push(self.parse_avl_vendor(&child)?),
                 _ => {}
@@ -2524,15 +2582,15 @@ impl Parser {
     fn parse_avl_mpn(&mut self, node: &Node) -> Result<AvlMpn> {
         let name = self.required_attr(node, "name", "AvlMpn")?;
 
-        let rank = node.attribute("rank").and_then(|s| s.parse().ok());
+        let rank = self.attr(&node, "rank").and_then(|s| s.parse().ok());
 
-        let cost = node.attribute("cost").and_then(|s| s.parse().ok());
+        let cost = self.attr(&node, "cost").and_then(|s| s.parse().ok());
 
-        let moisture_sensitivity = node
-            .attribute("moistureSensitivity")
+        let moisture_sensitivity = self
+            .attr(node, "moistureSensitivity")
             .and_then(MoistureSensitivity::parse);
 
-        let availability = node.attribute("availability").map(|s| s == "true");
+        let availability = self.attr(&node, "availability").map(|s| s == "true");
 
         let other = self.optional_attr(node, "other");
 
@@ -2553,24 +2611,24 @@ impl Parser {
     }
 
     fn parse_xform(&self, node: &Node) -> Xform {
-        let x_offset = node
-            .attribute("xOffset")
+        let x_offset = self
+            .attr(node, "xOffset")
             .and_then(|s| s.parse().ok())
             .unwrap_or(0.0);
-        let y_offset = node
-            .attribute("yOffset")
+        let y_offset = self
+            .attr(node, "yOffset")
             .and_then(|s| s.parse().ok())
             .unwrap_or(0.0);
-        let rotation = node
-            .attribute("rotation")
+        let rotation = self
+            .attr(node, "rotation")
             .and_then(|s| s.parse().ok())
             .unwrap_or(0.0);
-        let mirror = node
-            .attribute("mirror")
+        let mirror = self
+            .attr(node, "mirror")
             .map(|s| s == "true")
             .unwrap_or(false);
-        let scale = node
-            .attribute("scale")
+        let scale = self
+            .attr(node, "scale")
             .and_then(|s| s.parse().ok())
             .unwrap_or(1.0);
 
@@ -2584,17 +2642,20 @@ impl Parser {
     }
 }
 
-fn has_z_axis_dim(node: &Node) -> bool {
-    node.children()
-        .filter(|child| child.is_element())
+fn has_z_axis_dim(doc: &Document, node: &Node) -> bool {
+    doc.children_iter(*node)
+        .filter(|child| doc.element(*child).is_some())
         .any(|child| {
-            matches!(child.tag_name().name(), "MaterialCut" | "MaterialLeft")
-                || (matches!(child.tag_name().name(), "Z_AxisDim" | "ZAxisDim")
-                    && child
-                        .children()
-                        .filter(|grandchild| grandchild.is_element())
+            let name = doc.element(child).unwrap().name.local_name.as_ref();
+            matches!(name, "MaterialCut" | "MaterialLeft")
+                || (matches!(name, "Z_AxisDim" | "ZAxisDim")
+                    && doc
+                        .children_iter(child)
+                        .filter(|grandchild| doc.element(*grandchild).is_some())
                         .any(|grandchild| {
-                            matches!(grandchild.tag_name().name(), "MaterialCut" | "MaterialLeft")
+                            let grandchild_name =
+                                doc.element(grandchild).unwrap().name.local_name.as_ref();
+                            matches!(grandchild_name, "MaterialCut" | "MaterialLeft")
                         }))
         })
 }
@@ -2605,22 +2666,24 @@ mod tests {
 
     #[test]
     fn detects_slot_cavity_z_axis_substitution_children() {
-        let doc = Document::parse(
+        let doc = uppsala::parse(
             r#"<SlotCavity><Location x="0" y="0"/><MaterialCut depth="0.1"/></SlotCavity>"#,
         )
         .unwrap();
+        let root = doc.document_element().unwrap();
 
-        assert!(has_z_axis_dim(&doc.root_element()));
+        assert!(has_z_axis_dim(&doc, &root));
     }
 
     #[test]
     fn detects_wrapped_slot_cavity_z_axis_dimensions() {
-        let doc = Document::parse(
+        let doc = uppsala::parse(
             r#"<SlotCavity><Location x="0" y="0"/><ZAxisDim><MaterialLeft thickness="0.1"/></ZAxisDim></SlotCavity>"#,
         )
         .unwrap();
+        let root = doc.document_element().unwrap();
 
-        assert!(has_z_axis_dim(&doc.root_element()));
+        assert!(has_z_axis_dim(&doc, &root));
     }
 }
 

--- a/crates/ipc2581/src/types/content.rs
+++ b/crates/ipc2581/src/types/content.rs
@@ -36,5 +36,20 @@ pub enum Mode {
     Dfx,
 }
 
+impl Mode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UserDef => "USERDEF",
+            Self::Bom => "BOM",
+            Self::Stackup => "STACKUP",
+            Self::Fabrication => "FABRICATION",
+            Self::Assembly => "ASSEMBLY",
+            Self::Test => "TEST",
+            Self::Stencil => "STENCIL",
+            Self::Dfx => "DFX",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Level(pub u8);

--- a/crates/pcb-ipc2581-tools/src/commands/html_export.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/html_export.rs
@@ -57,9 +57,9 @@ pub fn generate_html(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<
     let content = ipc.content();
     let ipc_revision = ipc.revision();
     let mode_str = if let Some(level) = content.function_mode.level {
-        format!("{:?}/{:?}", content.function_mode.mode, level)
+        format!("{}/{:?}", content.function_mode.mode.as_str(), level)
     } else {
-        format!("{:?}", content.function_mode.mode)
+        content.function_mode.mode.as_str().to_string()
     };
     let file_metadata = accessor.file_metadata();
 

--- a/crates/pcb-ipc2581-tools/src/commands/info.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/info.rs
@@ -494,9 +494,9 @@ fn output_text(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<()> {
     let ipc = accessor.ipc();
     let content = ipc.content();
     let mode_str = if let Some(level) = content.function_mode.level {
-        format!("{:?}/{:?}", content.function_mode.mode, level)
+        format!("{}/{:?}", content.function_mode.mode.as_str(), level)
     } else {
-        format!("{:?}", content.function_mode.mode)
+        content.function_mode.mode.as_str().to_string()
     };
 
     println!(
@@ -541,7 +541,7 @@ fn output_json(accessor: &IpcAccessor) -> Result<()> {
 
     let mut info = json!({
         "revision": ipc.revision(),
-        "mode": format!("{:?}", content.function_mode.mode),
+        "mode": content.function_mode.mode.as_str(),
         "level": content.function_mode.level.map(|l| format!("{:?}", l)),
     });
 

--- a/crates/pcb-ipc2581-tools/src/commands/view.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/view.rs
@@ -7,14 +7,17 @@ use quick_xml::{
 };
 use std::io::Cursor;
 
+use ipc2581::Mode;
+
 use crate::ViewMode;
 use crate::utils::file as file_utils;
 
 /// Defines which sections to exclude for each mode
 /// Based on IPC-2581C Function Mode Table (Table 4)
-fn excluded_sections(mode: ViewMode) -> &'static [&'static str] {
+fn excluded_sections(mode: Mode) -> &'static [&'static str] {
     match mode {
-        ViewMode::Bom => &[
+        Mode::UserDef => &[],
+        Mode::Bom => &[
             // ECAD data
             "PadstackDef",
             "Package",
@@ -27,15 +30,15 @@ fn excluded_sections(mode: ViewMode) -> &'static [&'static str] {
             // Layers - BOM doesn't need any layer data
             "Layer",
         ],
-        ViewMode::Assembly => &[
+        Mode::Assembly => &[
             // Assembly needs most data except stackup details
             "Stackup",
         ],
-        ViewMode::Fabrication => &[
+        Mode::Fabrication => &[
             // Fabrication doesn't need component placement
             "Component",
         ],
-        ViewMode::Stackup => &[
+        Mode::Stackup => &[
             // Stackup only needs layer definitions and stackup info
             "PadstackDef",
             "Package",
@@ -43,13 +46,13 @@ fn excluded_sections(mode: ViewMode) -> &'static [&'static str] {
             "PhyNetGroup",
             "LayerFeature",
         ],
-        ViewMode::Test => &[
+        Mode::Test => &[
             // Test needs placement and nets but not fabrication details
             "PadstackDef",
             "Stackup",
             "LayerFeature",
         ],
-        ViewMode::Stencil => &[
+        Mode::Stencil => &[
             // Stencil only needs paste layers
             "PadstackDef",
             "Package",
@@ -60,7 +63,7 @@ fn excluded_sections(mode: ViewMode) -> &'static [&'static str] {
             "LogicalNet",
             "PhyNetGroup",
         ],
-        ViewMode::Dfx => &[
+        Mode::Dfx => &[
             // DFX only needs measurement data
             "PadstackDef",
             "Package",
@@ -92,7 +95,7 @@ pub fn execute(input: &Path, mode: ViewMode, output: &Path) -> Result<()> {
 }
 
 fn filter_by_mode(xml: &str, mode: ViewMode) -> Result<String> {
-    let excluded = excluded_sections(mode);
+    let excluded = excluded_sections(mode.as_ipc_mode());
     let mut reader = Reader::from_str(xml);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
@@ -157,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_bom_excludes_components() {
-        let excluded = excluded_sections(ViewMode::Bom);
+        let excluded = excluded_sections(Mode::Bom);
         assert!(excluded.contains(&"Component"));
         assert!(excluded.contains(&"Package"));
         assert!(excluded.contains(&"Layer"));
@@ -165,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_assembly_minimal_exclusions() {
-        let excluded = excluded_sections(ViewMode::Assembly);
+        let excluded = excluded_sections(Mode::Assembly);
         assert!(excluded.contains(&"Stackup"));
         assert!(!excluded.contains(&"Component"));
     }

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use ipc2581::Mode;
 
 pub mod accessors;
 pub mod commands;
@@ -40,15 +41,19 @@ pub enum ViewMode {
 }
 
 impl ViewMode {
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_ipc_mode(self) -> Mode {
         match self {
-            Self::Bom => "BOM",
-            Self::Assembly => "ASSEMBLY",
-            Self::Fabrication => "FABRICATION",
-            Self::Stackup => "STACKUP",
-            Self::Test => "TEST",
-            Self::Stencil => "STENCIL",
-            Self::Dfx => "DFX",
+            Self::Bom => Mode::Bom,
+            Self::Assembly => Mode::Assembly,
+            Self::Fabrication => Mode::Fabrication,
+            Self::Stackup => Mode::Stackup,
+            Self::Test => Mode::Test,
+            Self::Stencil => Mode::Stencil,
+            Self::Dfx => Mode::Dfx,
         }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        self.as_ipc_mode().as_str()
     }
 }


### PR DESCRIPTION
Faster than `roxmltree` and supports XSD validation. And it supports an arena DOM memory strategy <3.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new XML/XSD parsing and validation dependency (`uppsala`) and changes error handling and document parsing semantics, which could affect IPC-2581 ingestion and downstream tooling. Main risk is runtime/compatibility differences from the previous XML parser plus the added large vendored schema.
> 
> **Overview**
> **Adds IPC-2581C schema validation to `ipc2581`.** The crate now vendors `IPC-2581C.xsd` and exposes `validate`/`validate_file` (also as `Ipc2581::validate*`) that validate documents and return aggregated schema errors.
> 
> **Switches XML parsing plumbing to `uppsala` and updates dependencies/docs.** Removes the `roxmltree` dependency, updates parsing entrypoints and `Ipc2581Error` variants accordingly, updates the crate description/README, and records the new validation capability in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d3e262da26d3f4a8a49bc939b3adfff5cbb95ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->