### PR TITLE
Restrict release workflows to top-level tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,10 @@ name: Publish to npm
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      # Only publish the top-level PCB npm package from top-level PCB release tags.
+      # Crate-specific tags like crate/ipc2581/v0.3.0 are used for crates.io
+      # publishing and must not trigger npm publishing.
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -41,7 +41,7 @@ permissions:
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'v**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,17 +10,13 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = [
-    "aarch64-apple-darwin",
-    "x86_64-apple-darwin",
-    "x86_64-unknown-linux-gnu",
-    "aarch64-unknown-linux-gnu",
-    "x86_64-pc-windows-msvc",
-]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = true
+# A prefix git tags must include for dist to care about them
+tag-namespace = "v"
 # Which actions to run on pull requests
 pr-run-mode = "skip"
 # Additional build setup steps for generated release workflow


### PR DESCRIPTION
I tagged the ipc2581 crate publish and that broke some stuff.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation by changing which git tags trigger npm publishing and GitHub releases; a mis-specified tag glob could skip or accidentally trigger releases.
> 
> **Overview**
> Restricts release automation to **top-level `v<semver>` tags** so crate-specific tags (e.g. `crate/.../vX.Y.Z`) don’t trigger npm publishing or the `cargo-dist` GitHub release workflow.
> 
> Updates `dist-workspace.toml` to set `tag-namespace = "v"` (so `dist` only considers `v*` tags) and reformats the `targets` list without changing the actual target set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00d8989571e799965ab8627d8d979fadc901c0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->