### PR TITLE
Export .dxf of board outline from IPC2581 xml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,13 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
-- Added initial `pcb ipc2581 render` support for rendering a single IPC-2581 layer to SVG.
-- Added PNG output support to `pcb ipc2581 render`.
-- Added Kitty-compatible terminal graphics output for `pcb ipc2581 render` when no output path is provided.
-
-### Fixed
-
-- Preserved IPC-2581 `PolyStepCurve` arc geometry when rendering layer SVGs.
-- Applied IPC-2581 slot/cavity cutouts only to affected layers and subtracted them from rendered layer geometry.
+- Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
+- Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
 
 ### Changed
 
 - `pcb new board <name> <repo-url>` now creates a board repository directly, replacing the separate `pcb new workspace` flow.
 - `pcb import` now writes directly into a board repository root instead of creating `boards/<name>/` under a workspace.
-- Increased default `pcb ipc2581 render` PNG resolution.
 
 ## [0.3.81] - 2026-05-11
 

--- a/crates/pcb-ipc2581-tools/src/commands/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub mod bom;
 pub mod bom_edit;
 pub mod html_export;
 pub mod info;
+pub mod outline;
 pub mod render;
 pub mod view;

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -1,6 +1,9 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use ipc2581::Symbol;
+use ipc2581::types::Profile;
 use ipc2581::types::ecad::Step;
 
 use crate::geometry;
@@ -17,13 +20,7 @@ pub struct OutlineOptions {
 pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = Ipc2581::parse(&content)?;
-    let step = primary_step(&ipc)?;
-    let profile = step.profile.as_ref().with_context(|| {
-        format!(
-            "IPC-2581 step '{}' has no board Profile outline",
-            ipc.resolve(step.name)
-        )
-    })?;
+    let profile = board_profile(&ipc)?;
 
     let dxf = geometry::dxf::render_outline_dxf(profile);
     std::fs::write(&options.output, dxf)
@@ -35,20 +32,76 @@ pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
     Ok(())
 }
 
-fn primary_step(ipc: &Ipc2581) -> Result<&Step> {
+fn board_profile(ipc: &Ipc2581) -> Result<&Profile> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
-    if let Some(step_ref) = ipc.content().step_refs.first()
-        && let Some(step) = ecad
-            .cad_data
-            .steps
-            .iter()
-            .find(|step| step.name == *step_ref)
-    {
-        return Ok(step);
+    let primary = geometry::primary_step(ipc, &ecad.cad_data.steps)?;
+    find_profile_step(primary, &ecad.cad_data.steps, &mut HashSet::new())
+        .and_then(|step| step.profile.as_ref())
+        .with_context(|| {
+            format!(
+                "IPC-2581 step '{}' and its repeated child steps have no board Profile outline",
+                ipc.resolve(primary.name)
+            )
+        })
+}
+
+fn find_profile_step<'a>(
+    step: &'a Step,
+    steps: &'a [Step],
+    visited: &mut HashSet<Symbol>,
+) -> Option<&'a Step> {
+    if !visited.insert(step.name) {
+        return None;
+    }
+    if step.profile.is_some() {
+        return Some(step);
     }
 
-    ecad.cad_data
-        .steps
-        .first()
-        .context("IPC-2581 ECAD section has no Step")
+    step.step_repeats.iter().find_map(|repeat| {
+        steps
+            .iter()
+            .find(|candidate| candidate.name == repeat.step_ref)
+            .and_then(|child| find_profile_step(child, steps, visited))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_repeated_child_profile_when_primary_step_is_panel() {
+        let ipc = Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="panel"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Step name="board" type="BOARD">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="5"/>
+            <PolyStepSegment x="0" y="5"/>
+          </Polygon>
+        </Profile>
+      </Step>
+      <Step name="panel" type="PALLET">
+        <StepRepeat stepRef="board" x="0" y="0" nx="1" ny="1"/>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+
+        let profile = board_profile(&ipc).unwrap();
+
+        assert_eq!(profile.polygon.steps.len(), 3);
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -1,0 +1,54 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use ipc2581::types::ecad::Step;
+
+use crate::geometry;
+use crate::ipc2581::Ipc2581;
+use crate::utils::file as file_utils;
+
+/// Options for exporting the IPC-2581 board outline.
+#[derive(Debug, Clone)]
+pub struct OutlineOptions {
+    pub output: PathBuf,
+}
+
+/// Export the board outline from Step/Profile as a DXF file.
+pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
+    let content = file_utils::load_ipc_file(input_file)?;
+    let ipc = Ipc2581::parse(&content)?;
+    let step = primary_step(&ipc)?;
+    let profile = step.profile.as_ref().with_context(|| {
+        format!(
+            "IPC-2581 step '{}' has no board Profile outline",
+            ipc.resolve(step.name)
+        )
+    })?;
+
+    let dxf = geometry::dxf::render_outline_dxf(profile);
+    std::fs::write(&options.output, dxf)
+        .with_context(|| format!("Failed to write DXF to {}", options.output.display()))?;
+    println!(
+        "✓ IPC-2581 board outline exported to {}",
+        options.output.display()
+    );
+    Ok(())
+}
+
+fn primary_step(ipc: &Ipc2581) -> Result<&Step> {
+    let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
+    if let Some(step_ref) = ipc.content().step_refs.first()
+        && let Some(step) = ecad
+            .cad_data
+            .steps
+            .iter()
+            .find(|step| step.name == *step_ref)
+    {
+        return Ok(step);
+    }
+
+    ecad.cad_data
+        .steps
+        .first()
+        .context("IPC-2581 ECAD section has no Step")
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
@@ -1,0 +1,247 @@
+use std::fmt::Write;
+
+use ipc2581::types::{PolyStep, Polygon, Profile};
+
+const OUTLINE_LAYER: &str = "BOARD_OUTLINE";
+const EPSILON: f64 = 1e-9;
+
+#[derive(Debug, Clone, Copy)]
+struct DxfVertex {
+    x: f64,
+    y: f64,
+    bulge: f64,
+}
+
+/// Render an IPC-2581 board profile as an ASCII DXF outline in millimeters.
+pub fn render_outline_dxf(profile: &Profile) -> String {
+    let mut dxf = String::new();
+    write_header(&mut dxf);
+    write_tables(&mut dxf);
+    write_entities_start(&mut dxf);
+    write_polygon(&mut dxf, &profile.polygon);
+    for cutout in &profile.cutouts {
+        write_polygon(&mut dxf, cutout);
+    }
+    write_footer(&mut dxf);
+    dxf
+}
+
+fn write_header(dxf: &mut String) {
+    dxf.push_str("0\nSECTION\n2\nHEADER\n");
+    dxf.push_str("9\n$ACADVER\n1\nAC1021\n");
+    dxf.push_str("9\n$INSUNITS\n70\n4\n");
+    dxf.push_str("0\nENDSEC\n");
+}
+
+fn write_tables(dxf: &mut String) {
+    dxf.push_str("0\nSECTION\n2\nTABLES\n");
+    dxf.push_str("0\nTABLE\n2\nLAYER\n70\n1\n");
+    dxf.push_str("0\nLAYER\n2\nBOARD_OUTLINE\n70\n0\n62\n7\n6\nCONTINUOUS\n");
+    dxf.push_str("0\nENDTAB\n0\nENDSEC\n");
+}
+
+fn write_entities_start(dxf: &mut String) {
+    dxf.push_str("0\nSECTION\n2\nENTITIES\n");
+}
+
+fn write_footer(dxf: &mut String) {
+    dxf.push_str("0\nENDSEC\n0\nEOF\n");
+}
+
+fn write_polygon(dxf: &mut String, polygon: &Polygon) {
+    let vertices = polygon_vertices(polygon);
+    if vertices.len() < 2 {
+        return;
+    }
+
+    dxf.push_str("0\nLWPOLYLINE\n100\nAcDbEntity\n");
+    writeln!(dxf, "8\n{OUTLINE_LAYER}").unwrap();
+    dxf.push_str("62\n7\n100\nAcDbPolyline\n");
+    writeln!(dxf, "90\n{}", vertices.len()).unwrap();
+    dxf.push_str("70\n1\n");
+    for vertex in vertices {
+        writeln!(dxf, "10\n{}\n20\n{}", fmt_num(vertex.x), fmt_num(vertex.y)).unwrap();
+        if vertex.bulge.abs() > EPSILON {
+            writeln!(dxf, "42\n{}", fmt_num(vertex.bulge)).unwrap();
+        }
+    }
+}
+
+fn polygon_vertices(polygon: &Polygon) -> Vec<DxfVertex> {
+    let first = point(polygon.begin);
+    let mut current = first;
+    let mut vertices = vec![DxfVertex {
+        x: first.0,
+        y: first.1,
+        bulge: 0.0,
+    }];
+
+    for (index, step) in polygon.steps.iter().enumerate() {
+        let is_last = index + 1 == polygon.steps.len();
+        match step {
+            PolyStep::Segment(segment) => {
+                current = point(segment.point);
+                vertices.last_mut().unwrap().bulge = 0.0;
+                push_endpoint(&mut vertices, current, first, is_last);
+            }
+            PolyStep::Curve(curve) => {
+                let end = point(curve.point);
+                let center = point(curve.center);
+                if same_point(current, end) && distance(current, center) > EPSILON {
+                    let opposite = opposite_arc_point(current, center, curve.clockwise);
+                    vertices.last_mut().unwrap().bulge = half_circle_bulge(curve.clockwise);
+                    vertices.push(DxfVertex {
+                        x: opposite.0,
+                        y: opposite.1,
+                        bulge: half_circle_bulge(curve.clockwise),
+                    });
+                    push_endpoint(&mut vertices, end, first, is_last);
+                } else {
+                    vertices.last_mut().unwrap().bulge =
+                        arc_bulge(current, end, center, curve.clockwise);
+                    push_endpoint(&mut vertices, end, first, is_last);
+                }
+                current = end;
+            }
+        }
+    }
+
+    vertices
+}
+
+fn push_endpoint(
+    vertices: &mut Vec<DxfVertex>,
+    point: (f64, f64),
+    first: (f64, f64),
+    is_last: bool,
+) {
+    if is_last && same_point(point, first) {
+        return;
+    }
+    vertices.push(DxfVertex {
+        x: point.0,
+        y: point.1,
+        bulge: 0.0,
+    });
+}
+
+fn point(point: ipc2581::types::Point) -> (f64, f64) {
+    (point.x, point.y)
+}
+
+fn arc_bulge(start: (f64, f64), end: (f64, f64), center: (f64, f64), clockwise: bool) -> f64 {
+    let start_angle = (start.1 - center.1).atan2(start.0 - center.0);
+    let end_angle = (end.1 - center.1).atan2(end.0 - center.0);
+    let ccw_sweep = (end_angle - start_angle).rem_euclid(std::f64::consts::TAU);
+    let signed_sweep = if clockwise {
+        -(std::f64::consts::TAU - ccw_sweep)
+    } else {
+        ccw_sweep
+    };
+    (signed_sweep / 4.0).tan()
+}
+
+fn opposite_arc_point(start: (f64, f64), center: (f64, f64), clockwise: bool) -> (f64, f64) {
+    let radius = distance(start, center);
+    let start_angle = (start.1 - center.1).atan2(start.0 - center.0);
+    let angle = start_angle
+        + if clockwise {
+            -std::f64::consts::PI
+        } else {
+            std::f64::consts::PI
+        };
+    (
+        center.0 + radius * angle.cos(),
+        center.1 + radius * angle.sin(),
+    )
+}
+
+fn half_circle_bulge(clockwise: bool) -> f64 {
+    if clockwise { -1.0 } else { 1.0 }
+}
+
+fn distance(a: (f64, f64), b: (f64, f64)) -> f64 {
+    ((a.0 - b.0).powi(2) + (a.1 - b.1).powi(2)).sqrt()
+}
+
+fn same_point(a: (f64, f64), b: (f64, f64)) -> bool {
+    (a.0 - b.0).abs() <= EPSILON && (a.1 - b.1).abs() <= EPSILON
+}
+
+fn fmt_num(value: f64) -> String {
+    if value.abs() < EPSILON {
+        return "0".to_string();
+    }
+    let mut s = format!("{value:.6}");
+    while s.contains('.') && s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ipc2581::types::{Point, PolyStepCurve, PolyStepSegment};
+
+    #[test]
+    fn renders_profile_as_mm_dxf_with_closed_outline_layer() {
+        let dxf = render_outline_dxf(&Profile {
+            polygon: rect_polygon(),
+            cutouts: Vec::new(),
+        });
+
+        assert!(dxf.contains("9\n$INSUNITS\n70\n4\n"));
+        assert!(dxf.contains("2\nBOARD_OUTLINE\n"));
+        assert!(dxf.contains("0\nLWPOLYLINE\n"));
+        assert!(dxf.contains("90\n4\n"));
+        assert!(dxf.contains("70\n1\n"));
+    }
+
+    #[test]
+    fn preserves_profile_arcs_as_lwpolyline_bulges() {
+        let dxf = render_outline_dxf(&Profile {
+            polygon: Polygon {
+                begin: Point { x: 1.0, y: 0.0 },
+                steps: vec![
+                    PolyStep::Curve(PolyStepCurve {
+                        point: Point { x: -1.0, y: 0.0 },
+                        center: Point { x: 0.0, y: 0.0 },
+                        clockwise: false,
+                    }),
+                    PolyStep::Curve(PolyStepCurve {
+                        point: Point { x: 1.0, y: 0.0 },
+                        center: Point { x: 0.0, y: 0.0 },
+                        clockwise: false,
+                    }),
+                ],
+            },
+            cutouts: Vec::new(),
+        });
+
+        assert!(dxf.contains("42\n1\n"));
+    }
+
+    fn rect_polygon() -> Polygon {
+        Polygon {
+            begin: Point { x: 0.0, y: 0.0 },
+            steps: vec![
+                PolyStep::Segment(PolyStepSegment {
+                    point: Point { x: 10.0, y: 0.0 },
+                }),
+                PolyStep::Segment(PolyStepSegment {
+                    point: Point { x: 10.0, y: 5.0 },
+                }),
+                PolyStep::Segment(PolyStepSegment {
+                    point: Point { x: 0.0, y: 5.0 },
+                }),
+                PolyStep::Segment(PolyStepSegment {
+                    point: Point { x: 0.0, y: 0.0 },
+                }),
+            ],
+        }
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -9,6 +9,7 @@ use ipc2581::types::{
 use ipc2581::{Ipc2581, Symbol};
 
 use super::ir::*;
+use super::primary_step;
 
 struct ExtractContext<'a> {
     ipc: &'a Ipc2581,
@@ -62,16 +63,6 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
     }
 
     extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)
-}
-
-fn primary_step<'a>(ipc: &Ipc2581, steps: &'a [Step]) -> Result<&'a Step> {
-    if let Some(step_ref) = ipc.content().step_refs.first()
-        && let Some(step) = steps.iter().find(|step| step.name == *step_ref)
-    {
-        return Ok(step);
-    }
-
-    steps.first().context("IPC-2581 ECAD section has no Step")
 }
 
 fn extract_panel_layer(

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -96,6 +96,11 @@ fn extract_panel_layer(
         0,
         Affine2::identity(),
     )?);
+    layer_bbox = layer_bbox.union(append_transformed_outlines(
+        &mut doc,
+        &panel_doc,
+        Affine2::identity(),
+    ));
 
     for repeat in &panel.step_repeats {
         let source_step = steps
@@ -119,6 +124,11 @@ fn extract_panel_layer(
                     0,
                     transform,
                 )?);
+                layer_bbox = layer_bbox.union(append_transformed_outlines(
+                    &mut doc,
+                    &source_doc,
+                    transform,
+                ));
             }
         }
     }
@@ -286,6 +296,8 @@ fn extract_step_layer(
         }
     }
 
+    layer_bbox = layer_bbox.union(push_board_outline(&mut doc, step, Affine2::identity()));
+
     let feature_count = doc.features.len() as u32 - feature_start;
     doc.layers.push(GeometryLayer {
         name: layer_name.to_string(),
@@ -393,6 +405,31 @@ fn append_transformed_layer(
     }
 
     Ok(layer_bbox)
+}
+
+fn append_transformed_outlines(
+    target: &mut GeometryDocument,
+    source: &GeometryDocument,
+    transform: Affine2,
+) -> BBox {
+    let mut outline_bbox = BBox::empty();
+    for outline in &source.board_outlines {
+        let path_start = target.paths.len() as u32;
+        for path in &source.paths
+            [outline.path_start as usize..(outline.path_start + outline.path_count) as usize]
+        {
+            append_transformed_path(target, source, path, transform);
+        }
+        let path_count = target.paths.len() as u32 - path_start;
+        let bbox = paths_bbox(target, path_start, path_count);
+        target.board_outlines.push(BoardOutline {
+            path_start,
+            path_count,
+            bbox,
+        });
+        outline_bbox = outline_bbox.union(bbox);
+    }
+    outline_bbox
 }
 
 fn append_transformed_path(
@@ -856,6 +893,46 @@ fn extract_polygon(
     feature.path_count = path_count;
     feature.flags.lowered_to_paths = true;
     feature
+}
+
+const BOARD_OUTLINE_STROKE_WIDTH: f64 = 0.1;
+
+fn push_board_outline(doc: &mut GeometryDocument, step: &Step, transform: Affine2) -> BBox {
+    let Some(profile) = &step.profile else {
+        return BBox::empty();
+    };
+
+    let path_start = doc.paths.len() as u32;
+    push_outline_polygon(doc, &profile.polygon, transform);
+    for cutout in &profile.cutouts {
+        push_outline_polygon(doc, cutout, transform);
+    }
+    let path_count = doc.paths.len() as u32 - path_start;
+    let bbox = paths_bbox(doc, path_start, path_count);
+    if path_count > 0 {
+        doc.board_outlines.push(BoardOutline {
+            path_start,
+            path_count,
+            bbox,
+        });
+    }
+    bbox
+}
+
+fn push_outline_polygon(
+    doc: &mut GeometryDocument,
+    polygon: &ipc2581::types::Polygon,
+    transform: Affine2,
+) {
+    let (bbox, cmds) = polygon_contour(polygon, transform);
+    doc.push_path(
+        GeometryPath::stroked(
+            BOARD_OUTLINE_STROKE_WIDTH,
+            LineCap::Round,
+            bbox.expand(BOARD_OUTLINE_STROKE_WIDTH / 2.0),
+        ),
+        cmds,
+    );
 }
 
 fn push_stroked_polyline(
@@ -2400,6 +2477,20 @@ mod tests {
     }
 
     #[test]
+    fn extracts_step_profile_and_cutouts_as_board_outlines() {
+        let ipc = ipc2581::Ipc2581::parse(profile_fixture())
+            .expect("synthetic profile fixture should parse");
+        let doc = extract_layer(&ipc, "TOP").expect("profile outline should extract");
+
+        assert_eq!(doc.board_outlines.len(), 1);
+        assert_eq!(doc.board_outlines[0].path_count, 2);
+        assert_eq!(doc.layers[0].bbox.min, Point::new(-0.05, -0.05));
+        assert_eq!(doc.layers[0].bbox.max, Point::new(20.05, 10.05));
+        assert!(doc.paths.iter().all(|path| path.flags.stroked));
+        assert!(doc.path_cmds.iter().any(|cmd| cmd.op == PathOp::ArcTo));
+    }
+
+    #[test]
     fn chamfered_rect_respects_corner_flags() {
         let mut doc = GeometryDocument::new("test".to_string());
 
@@ -2576,6 +2667,40 @@ mod tests {
       </Step>
       <Step name="panel" type="PALLET">
         <StepRepeat stepRef="board" x="0" y="0" nx="2" ny="1" dx="20" dy="0"/>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#
+    }
+
+    fn profile_fixture() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="20" y="0"/>
+            <PolyStepSegment x="20" y="10"/>
+            <PolyStepSegment x="0" y="10"/>
+          </Polygon>
+          <Cutout>
+            <Polygon>
+              <PolyBegin x="6" y="5"/>
+              <PolyStepCurve x="4" y="5" centerX="5" centerY="5" clockwise="false"/>
+              <PolyStepCurve x="6" y="5" centerX="5" centerY="5" clockwise="false"/>
+            </Polygon>
+          </Cutout>
+        </Profile>
       </Step>
     </CadData>
   </Ecad>

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -4,6 +4,7 @@ use ipc2581::Symbol;
 pub struct GeometryDocument {
     pub board_name: String,
     pub layers: Vec<GeometryLayer>,
+    pub board_outlines: Vec<BoardOutline>,
     pub features: Vec<GeometryFeature>,
     pub paths: Vec<GeometryPath>,
     pub contours: Vec<GeometryContour>,
@@ -16,6 +17,7 @@ impl GeometryDocument {
         Self {
             board_name,
             layers: Vec::new(),
+            board_outlines: Vec::new(),
             features: Vec::new(),
             paths: Vec::new(),
             contours: Vec::new(),
@@ -84,6 +86,13 @@ impl GeometryDocument {
             message: message.into(),
         });
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct BoardOutline {
+    pub path_start: u32,
+    pub path_count: u32,
+    pub bbox: BBox,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -6,4 +6,18 @@ pub mod raster;
 pub mod svg;
 pub mod terminal;
 
+use anyhow::{Context, Result};
+use ipc2581::Ipc2581;
+use ipc2581::types::ecad::Step;
+
 pub use extract::extract_layer;
+
+pub(crate) fn primary_step<'a>(ipc: &Ipc2581, steps: &'a [Step]) -> Result<&'a Step> {
+    if let Some(step_ref) = ipc.content().step_refs.first()
+        && let Some(step) = steps.iter().find(|step| step.name == *step_ref)
+    {
+        return Ok(step);
+    }
+
+    steps.first().context("IPC-2581 ECAD section has no Step")
+}

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -1,3 +1,4 @@
+pub mod dxf;
 mod extract;
 pub mod ir;
 pub mod process;

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -39,6 +39,12 @@ pub fn normalize_bounds(doc: &mut GeometryDocument) {
         doc.paths[path_index].bbox = path_bbox(doc, path_index);
     }
 
+    for outline_index in 0..doc.board_outlines.len() {
+        let outline = &doc.board_outlines[outline_index];
+        doc.board_outlines[outline_index].bbox =
+            paths_bbox(doc, outline.path_start, outline.path_count);
+    }
+
     for feature_index in 0..doc.features.len() {
         doc.features[feature_index].bbox = feature_bbox(doc, feature_index);
     }
@@ -752,7 +758,11 @@ fn path_bbox(doc: &GeometryDocument, path_index: usize) -> BBox {
 
 fn feature_bbox(doc: &GeometryDocument, feature_index: usize) -> BBox {
     let feature = &doc.features[feature_index];
-    doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+    paths_bbox(doc, feature.path_start, feature.path_count)
+}
+
+fn paths_bbox(doc: &GeometryDocument, path_start: u32, path_count: u32) -> BBox {
+    doc.paths[path_start as usize..(path_start + path_count) as usize]
         .iter()
         .fold(BBox::empty(), |bbox, path| bbox.union(path.bbox))
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/raster.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/raster.rs
@@ -42,7 +42,7 @@ fn pixel_size_for_layer(
     layer_index: usize,
     max_dimension_px: u32,
 ) -> (u32, u32) {
-    let bbox = doc.layers[layer_index].bbox;
+    let bbox = super::svg::render_layer_bbox(doc, layer_index);
     if bbox.is_empty() || bbox.width() <= 0.0 || bbox.height() <= 0.0 {
         return (max_dimension_px, max_dimension_px);
     }
@@ -56,7 +56,7 @@ fn pixel_size_for_layer(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::geometry::ir::{BBox, GeometryLayer, Point};
+    use crate::geometry::ir::{BBox, BoardOutline, GeometryLayer, Point};
 
     #[test]
     fn preserves_layer_aspect_ratio_for_png_size() {
@@ -74,5 +74,29 @@ mod tests {
         });
 
         assert_eq!(pixel_size_for_layer(&doc, 0, 1600), (1600, 800));
+    }
+
+    #[test]
+    fn sizes_png_from_board_outline_bounds_when_layer_has_no_features() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(40.0, 20.0),
+        };
+        doc.board_outlines.push(BoardOutline {
+            path_start: 0,
+            path_count: 0,
+            bbox,
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 0,
+            bbox: BBox::empty(),
+        });
+
+        assert_eq!(pixel_size_for_layer(&doc, 0, 2100), (2100, 1100));
     }
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -4,6 +4,25 @@ use super::ir::*;
 
 const VIEWBOX_PADDING_MM: f64 = 1.0;
 
+pub fn render_layer_bbox(doc: &GeometryDocument, layer_index: usize) -> BBox {
+    let layer = &doc.layers[layer_index];
+    let bbox = doc
+        .board_outlines
+        .iter()
+        .fold(layer.bbox, |bbox, outline| bbox.union(outline.bbox));
+
+    if bbox.is_empty() {
+        BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(100.0, 100.0),
+        }
+    } else if doc.board_outlines.is_empty() {
+        bbox
+    } else {
+        bbox.expand(VIEWBOX_PADDING_MM)
+    }
+}
+
 pub fn render_layer_svg(doc: &GeometryDocument, layer_index: usize) -> String {
     render_layer_svg_with_size(doc, layer_index, None)
 }
@@ -23,18 +42,7 @@ fn render_layer_svg_with_size(
     pixel_size: Option<(u32, u32)>,
 ) -> String {
     let layer = &doc.layers[layer_index];
-    let layer_bbox = doc
-        .board_outlines
-        .iter()
-        .fold(layer.bbox, |bbox, outline| bbox.union(outline.bbox));
-    let geometry_bbox = if layer_bbox.is_empty() {
-        BBox {
-            min: Point::new(0.0, 0.0),
-            max: Point::new(100.0, 100.0),
-        }
-    } else {
-        layer_bbox.expand(VIEWBOX_PADDING_MM)
-    };
+    let geometry_bbox = render_layer_bbox(doc, layer_index);
     let viewbox_y = -geometry_bbox.max.y;
 
     let mut svg = String::new();
@@ -499,6 +507,27 @@ mod tests {
 
         assert_eq!(svg.matches("<path d='").count(), 2);
         assert!(svg.find("fill='#2f9e44'").unwrap() < svg.find("fill='#64748b'").unwrap());
+    }
+
+    #[test]
+    fn renders_layer_without_outline_without_viewbox_padding() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(10.0, 5.0),
+        };
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 0,
+            bbox,
+        });
+
+        let svg = render_layer_svg(&doc, 0);
+
+        assert!(svg.contains("viewBox='0 -5 10 5'"));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -2,6 +2,8 @@ use std::fmt::Write;
 
 use super::ir::*;
 
+const VIEWBOX_PADDING_MM: f64 = 1.0;
+
 pub fn render_layer_svg(doc: &GeometryDocument, layer_index: usize) -> String {
     render_layer_svg_with_size(doc, layer_index, None)
 }
@@ -21,13 +23,17 @@ fn render_layer_svg_with_size(
     pixel_size: Option<(u32, u32)>,
 ) -> String {
     let layer = &doc.layers[layer_index];
-    let geometry_bbox = if layer.bbox.is_empty() {
+    let layer_bbox = doc
+        .board_outlines
+        .iter()
+        .fold(layer.bbox, |bbox, outline| bbox.union(outline.bbox));
+    let geometry_bbox = if layer_bbox.is_empty() {
         BBox {
             min: Point::new(0.0, 0.0),
             max: Point::new(100.0, 100.0),
         }
     } else {
-        layer.bbox
+        layer_bbox.expand(VIEWBOX_PADDING_MM)
     };
     let viewbox_y = -geometry_bbox.max.y;
 
@@ -73,9 +79,28 @@ fn render_layer_svg_with_size(
         write_feature_paths(&mut svg, doc, feature, true);
     }
 
+    write_board_outlines(&mut svg, doc);
+
     writeln!(svg, "  </g>").unwrap();
     writeln!(svg, "</svg>").unwrap();
     svg
+}
+
+fn write_board_outlines(svg: &mut String, doc: &GeometryDocument) {
+    for outline in &doc.board_outlines {
+        for path in &doc.paths
+            [outline.path_start as usize..(outline.path_start + outline.path_count) as usize]
+        {
+            writeln!(
+                svg,
+                "    <path d='{}' fill='none' stroke='#000000' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='round' data-board-outline='true'/>",
+                path_data(doc, path),
+                fmt_num(path.stroke_width),
+                line_cap(path.line_cap)
+            )
+            .unwrap();
+        }
+    }
 }
 
 fn write_feature_paths(
@@ -474,5 +499,42 @@ mod tests {
 
         assert_eq!(svg.matches("<path d='").count(), 2);
         assert!(svg.find("fill='#2f9e44'").unwrap() < svg.find("fill='#64748b'").unwrap());
+    }
+
+    #[test]
+    fn renders_board_outline_as_black_overlay_and_includes_it_in_viewbox() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(10.0, 5.0),
+        };
+        doc.push_path(
+            GeometryPath::stroked(0.1, LineCap::Round, bbox),
+            [
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(10.0, 0.0)),
+                PathCmd::line_to(Point::new(10.0, 5.0)),
+                PathCmd::close(),
+            ],
+        );
+        doc.board_outlines.push(BoardOutline {
+            path_start: 0,
+            path_count: 1,
+            bbox,
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 0,
+            bbox: BBox::empty(),
+        });
+
+        let svg = render_layer_svg(&doc, 0);
+
+        assert!(svg.contains("viewBox='-1 -6 12 7'"));
+        assert!(svg.contains("stroke='#000000'"));
+        assert!(svg.contains("data-board-outline='true'"));
     }
 }

--- a/crates/pcb/src/ipc2581.rs
+++ b/crates/pcb/src/ipc2581.rs
@@ -60,6 +60,15 @@ enum Commands {
         #[arg(short, long, default_value = "mm")]
         units: UnitFormat,
     },
+    /// Export the board outline as a KiCad-importable DXF
+    Outline {
+        /// IPC-2581 XML file to export from
+        #[arg(value_hint = clap::ValueHint::FilePath)]
+        file: PathBuf,
+        /// Output DXF file path
+        #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
+        output: PathBuf,
+    },
     /// Render processed geometry for a single IPC-2581 layer
     Render {
         /// IPC-2581 XML file to render from
@@ -135,6 +144,9 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             output,
             units,
         } => commands::html_export::execute(&file, output.as_deref(), units),
+        Commands::Outline { file, output } => {
+            commands::outline::execute(&file, &commands::outline::OutlineOptions { output })
+        }
         Commands::Render {
             file,
             layer,

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
               ./crates/pcb/src/fortune.txt
               ./crates/pcb/src/templates
               ./crates/pcb-component-gen/templates
+              ./crates/ipc2581/IPC-2581C.xsd
               ./crates/pcb-ipc2581-tools/src/commands/html_template.html.jinja
               ./crates/pcb-ipc2581-tools/src/commands/style.css
               ./crates/pcb-layout/src/scripts


### PR DESCRIPTION
```
pcb ipc2581 outline <path to ipc2581.xml> --output outline.dxf
```


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a new CLI export path and modifies IPC-2581 geometry extraction/bounding-box logic used by SVG/PNG rendering, which could affect existing render outputs and sizing.
> 
> **Overview**
> Adds a new `pcb ipc2581 outline` command that extracts the board `Profile` (following `StepRepeat` references when needed) and writes a KiCad-importable ASCII DXF, including cutouts and arc preservation via LWPOLYLINE bulges.
> 
> Updates IPC-2581 layer rendering to also extract board outlines into the geometry IR, overlay them as black strokes in SVG/terminal/PNG output, and size viewboxes/rasters using outline bounds (with padding) when present. Also centralizes `primary_step` lookup in `geometry` and updates Nix build inputs to include the IPC-2581C XSD.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c38d6927a1cc7dadb4f97323ac17260907b17a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->