### PR TITLE
Limit board name length

### DIFF
--- a/crates/pcb/src/new.rs
+++ b/crates/pcb/src/new.rs
@@ -119,6 +119,32 @@ fn validate_name(name: &str, kind: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validate a board name for use as a directory/git repo name.
+fn validate_board_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("Board name cannot be empty");
+    }
+
+    if name.len() > 40 {
+        bail!("Board name cannot exceed 40 characters");
+    }
+
+    if name.starts_with('.') || name.starts_with('-') {
+        bail!("Board name cannot start with '.' or '-'");
+    }
+
+    for c in name.chars() {
+        if !c.is_ascii_alphanumeric() && c != '-' && c != '_' && c != '.' {
+            bail!(
+                "Board name contains invalid character '{}'. Only alphanumeric, hyphens, underscores, and dots are allowed",
+                c
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Clean a git repository URL to the canonical format (e.g., "github.com/user/repo")
 fn clean_repo_url(url: &str) -> Result<String> {
     let url = url.trim();
@@ -273,7 +299,7 @@ fn execute_new_board(board: &str, repo: &str) -> Result<()> {
         bail!("Cannot create a board inside an existing workspace");
     }
 
-    validate_name(board, "Board")?;
+    validate_board_name(board)?;
 
     let repository = clean_repo_url(repo)?;
 
@@ -429,20 +455,29 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_name() {
+    fn test_validate_board_name() {
         // Valid names
-        assert!(validate_name("my-project", "Board").is_ok());
-        assert!(validate_name("my_project", "Board").is_ok());
-        assert!(validate_name("myProject123", "Board").is_ok());
-        assert!(validate_name("project.v2", "Board").is_ok());
+        assert!(validate_board_name("my-project").is_ok());
+        assert!(validate_board_name("my_project").is_ok());
+        assert!(validate_board_name("myProject123").is_ok());
+        assert!(validate_board_name("project.v2").is_ok());
+        assert!(validate_board_name(&"a".repeat(40)).is_ok());
 
         // Invalid names
-        assert!(validate_name("", "Board").is_err());
-        assert!(validate_name(".hidden", "Board").is_err());
-        assert!(validate_name("-invalid", "Board").is_err());
-        assert!(validate_name("has spaces", "Board").is_err());
-        assert!(validate_name("has/slash", "Board").is_err());
-        assert!(validate_name(&"a".repeat(101), "Board").is_err());
+        assert!(validate_board_name("").is_err());
+        assert!(validate_board_name(".hidden").is_err());
+        assert!(validate_board_name("-invalid").is_err());
+        assert!(validate_board_name("has spaces").is_err());
+        assert!(validate_board_name("has/slash").is_err());
+        assert!(validate_board_name(&"a".repeat(41)).is_err());
+    }
+
+    #[test]
+    fn test_validate_name() {
+        // Package names still allow dots and up to 100 characters.
+        assert!(validate_name("project.v2", "Package").is_ok());
+        assert!(validate_name(&"a".repeat(100), "Package").is_ok());
+        assert!(validate_name(&"a".repeat(101), "Package").is_err());
     }
 
     #[test]


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes input validation for `pcb new board`, which may reject previously accepted board names and affect existing user workflows. Scope is small and localized to CLI validation and tests.
> 
> **Overview**
> `pcb new board` now uses a dedicated `validate_board_name` validator that enforces a **stricter board-name policy**, notably a **40-character maximum** (instead of sharing the 100-character `validate_name` rule).
> 
> Tests are updated to cover the new board limits and to explicitly assert that `validate_name` remains unchanged for package naming (still allows up to 100 characters).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56af17b22a85ed5a7484964229acb3098fc2466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->