### PR TITLE
Add `--flat` render option to ipc2581, ipc2581 -> gerber x2 conversion, gerber rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
-- Added initial `gerberx2` crate support for parsing Gerber X2 command streams and metadata, decoding coordinates, building graphical objects, lowering aperture geometry, extracting/processing render geometry, and rendering SVG/PNG/terminal previews.
+- Added initial `gerberx2` crate and `pcb gerber render` support for parsing Gerber X2 command streams and metadata, decoding coordinates, building graphical objects, lowering aperture geometry, extracting/processing render geometry, and rendering SVG/PNG/terminal previews.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- `pcb gerber render` now draws Profile layers as black board outlines instead of grey filled geometry.
+- `pcb ipc2581 render --flat` now uses Gerber-style colors for copper, paste, mask, legend, profile, and unknown layers.
 - `pcb new board <name> <repo-url>` now creates a board repository directly, replacing the separate `pcb new workspace` flow.
 - `pcb import` now writes directly into a board repository root instead of creating `boards/<name>/` under a workspace.
 - Board release uploads now derive the Diode workspace name from the first path segment of `[workspace].repository`, with `[workspace].name` available as an override.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
 - Added initial `gerberx2` crate and `pcb gerber render` SVG/PNG/terminal previews.
+- Added Gerber X2 writer scaffolding over an artwork/object IR with file, aperture, and object attributes.
+- Added native aperture macro and block aperture emission to the Gerber X2 writer.
+- Added Gerber geometry comparison helpers for IPC-2581-to-Gerber smoke tests.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added Gerber X2 writer scaffolding over an artwork/object IR with file, aperture, and object attributes.
 - Added native aperture macro and block aperture emission to the Gerber X2 writer.
 - Added Gerber geometry comparison helpers for IPC-2581-to-Gerber smoke tests.
+- Added `pcb ipc2581 render --flat` to render a layer as a single Gerber-style mask.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
-- Added initial `gerberx2` crate scaffolding for parsing Gerber X2 command streams and metadata.
+- Added initial `gerberx2` crate support for parsing Gerber X2 command streams and metadata, decoding coordinates, building graphical objects, and lowering standard aperture geometry.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
+- Added initial `gerberx2` crate scaffolding for parsing Gerber X2 command streams and metadata.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
-- Added initial `gerberx2` crate support for parsing Gerber X2 command streams and metadata, decoding coordinates, building graphical objects, and lowering standard aperture geometry.
+- Added initial `gerberx2` crate support for parsing Gerber X2 command streams and metadata, decoding coordinates, building graphical objects, lowering aperture geometry, and extracting/processing render geometry.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
-- Added initial `gerberx2` crate and `pcb gerber render` support for parsing Gerber X2 command streams and metadata, decoding coordinates, building graphical objects, lowering aperture geometry, extracting/processing render geometry, and rendering SVG/PNG/terminal previews.
+- Added initial `gerberx2` crate and `pcb gerber render` SVG/PNG/terminal previews.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
-- Added initial `gerberx2` crate support for parsing Gerber X2 command streams and metadata, decoding coordinates, building graphical objects, lowering aperture geometry, and extracting/processing render geometry.
+- Added initial `gerberx2` crate support for parsing Gerber X2 command streams and metadata, decoding coordinates, building graphical objects, lowering aperture geometry, extracting/processing render geometry, and rendering SVG/PNG/terminal previews.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added native aperture macro and block aperture emission to the Gerber X2 writer.
 - Added Gerber geometry comparison helpers for IPC-2581-to-Gerber smoke tests.
 - Added `pcb ipc2581 render --flat` to render a layer as a single Gerber-style mask.
+- Added `pcb ipc2581 gerber` to export IPC-2581 fabrication layers as Gerber X2 files through a canonical artwork pipeline.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,6 +2447,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "gerberx2"
+version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "get-size-derive2"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4617,6 +4617,7 @@ dependencies = [
  "clap",
  "colored",
  "comfy-table",
+ "gerberx2",
  "i_overlay",
  "ipc2581",
  "jiff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,8 +2450,11 @@ dependencies = [
 name = "gerberx2"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "i_overlay",
  "kurbo",
+ "resvg",
+ "terminal_size",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4424,6 +4424,7 @@ dependencies = [
  "ctrlc",
  "dirs",
  "env_logger",
+ "gerberx2",
  "glam",
  "globset",
  "gltfpack-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,6 +2450,8 @@ dependencies = [
 name = "gerberx2"
 version = "0.1.0"
 dependencies = [
+ "i_overlay",
+ "kurbo",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ mimalloc = "0.1"
 similar = "3"
 
 ipc2581 = { path = "crates/ipc2581" }
+gerberx2 = { path = "crates/gerberx2" }
 pcb-command-runner = { path = "crates/pcb-command-runner" }
 pcb-eda = { path = "crates/pcb-eda" }
 pcb-component-gen = { path = "crates/pcb-component-gen" }

--- a/crates/gerberx2/Cargo.toml
+++ b/crates/gerberx2/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gerberx2"
+version = "0.1.0"
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Fast Gerber X2 parser, typed data model, and writer scaffolding for PCB fabrication layers"
+license = "MIT OR Apache-2.0"
+keywords = ["pcb", "gerber", "x2", "parser", "eda"]
+categories = ["parsing", "hardware-support"]
+
+[dependencies]
+thiserror = { workspace = true }

--- a/crates/gerberx2/Cargo.toml
+++ b/crates/gerberx2/Cargo.toml
@@ -11,4 +11,6 @@ keywords = ["pcb", "gerber", "x2", "parser", "eda"]
 categories = ["parsing", "hardware-support"]
 
 [dependencies]
+i_overlay = { workspace = true }
+kurbo = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/gerberx2/Cargo.toml
+++ b/crates/gerberx2/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["pcb", "gerber", "x2", "parser", "eda"]
 categories = ["parsing", "hardware-support"]
 
 [dependencies]
+base64 = { workspace = true }
 i_overlay = { workspace = true }
 kurbo = { workspace = true }
+resvg = { workspace = true }
+terminal_size = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/gerberx2/README.md
+++ b/crates/gerberx2/README.md
@@ -67,12 +67,10 @@ This keeps the original command stream for round-trip/generation work while prov
 
 Next implementation steps:
 
-1. Parse and evaluate fixed-format coordinates into real units using `FS` + `MO`.
-2. Maintain graphics state while parsing commands.
-3. Build ordered `GraphicalObject`s for `D01/D02/D03` outside regions.
-4. Build region contours for `G36/G37`.
-5. Lower standard apertures to geometry paths.
-6. Add aperture macro expression parsing/evaluation.
-7. Add block aperture and step-repeat object expansion.
-8. Add Gerber writer that emits attributes comprehensively.
-9. Add SVG renderer using the same geometry/rendering concepts as IPC-2581 tools.
+1. Add aperture macro expression parsing/evaluation.
+2. Add block aperture and step-repeat object expansion.
+3. Validate region contours for closure/connectivity/self-intersection constraints.
+4. Add Gerber writer that emits attributes comprehensively.
+5. Add SVG renderer using the same geometry/rendering concepts as IPC-2581 tools.
+
+Initial support already decodes fixed-format coordinates through `FS` + `MO`, maintains graphics state for operations, builds ordered graphical objects for flashes/draws/arcs/regions, and lowers standard apertures (`C`, `R`, `O`, `P`) to geometry paths.

--- a/crates/gerberx2/README.md
+++ b/crates/gerberx2/README.md
@@ -1,0 +1,78 @@
+# gerberx2
+
+Fast Gerber X2 parser, typed data model, and writer scaffolding for PCB fabrication layers.
+
+This crate is intentionally shaped like `ipc2581`: a pure parser/data-model crate with no CLI concerns. Higher-level tools should live in a separate crate or in `pcb` commands.
+
+## Spec references read
+
+Primary local reference:
+
+- PDF: `/Users/akhilles/.pcb/cache/datasheets/materialized/c8655187-b74b-558f-985f-dc59209475c9/gerber-layer-format-specification-revision-2022-02_en.pdf`
+- Markdown: `/Users/akhilles/.pcb/cache/datasheets/materialized/c8655187-b74b-558f-985f-dc59209475c9/gerber-layer-format-specification-revision-2022-02_en.md`
+
+Important concepts from the spec:
+
+- A Gerber file is one complete 2D binary vector image, represented as an ordered command stream.
+- X2 means the file uses attributes: `TF`, `TA`, `TO`, `TD`.
+- Attributes do not affect geometry, but preserve design intent such as layer function, aperture function, net, pin, component, generation software, project id, and checksum.
+- The graphics state controls operation interpretation: units, coordinate format, current point, current aperture, plot mode, polarity, mirroring, rotation, and scaling.
+- Graphical objects are ordered. Dark objects add material/image; clear objects erase previously generated material/image.
+- Core objects are draws, arcs, flashes, and regions.
+- Standard apertures are circle, rectangle, obround, and regular polygon; aperture macros and block apertures extend this.
+- `G36/G37` creates regions from one or more closed contours. Regions can carry aperture attributes.
+- `SR` step-and-repeat and `AB` block apertures create reusable/repeated object streams.
+- `M02*` is mandatory and must be the final command.
+- `.FileFunction` is the primary X2 layer identifier (`Copper,L1,Top`, `Paste,Top`, `Soldermask,Bot`, `Plated,1,4,PTH`, `Profile,NP`, etc.).
+- `.AperFunction` identifies object intent (`SMDPad`, `HeatsinkPad`, `ViaPad`, `Conductor`, `Material`, `ViaDrill`, `ComponentDrill`, etc.).
+
+## Initial crate shape
+
+- `GerberX2` owns an `Interner`, parsed commands, attributes, aperture definitions, macro definitions, and final graphics state.
+- `types` contains fat structs/enums for commands, attributes, apertures, graphics state, and future graphical objects.
+- `parse` is a fast direct scanner over the input string. It avoids regex and parses Gerber word/extended commands in one pass.
+
+## Proposed fat data model direction
+
+Keep data broad and explicit rather than overly normalized:
+
+```rust
+pub struct GerberX2 {
+    interner: Interner,
+    commands: Vec<Command>,
+    file_attributes: Vec<Attribute>,
+    aperture_definitions: Vec<ApertureDefinition>,
+    aperture_macros: Vec<ApertureMacro>,
+    objects: Vec<GraphicalObject>,
+    final_state: GraphicsState,
+    diagnostics: Vec<Diagnostic>,
+}
+```
+
+For fast rendering/export, lower command streams into object streams:
+
+```rust
+pub struct GraphicalObject {
+    kind: ObjectKind,
+    polarity: Polarity,
+    mirroring: Mirroring,
+    rotation_degrees: f64,
+    scaling: f64,
+    aperture_attributes: Vec<Attribute>,
+    object_attributes: Vec<Attribute>,
+}
+```
+
+This keeps the original command stream for round-trip/generation work while providing a direct, renderer-friendly object list for SVG and IPC-2581 conversion.
+
+Next implementation steps:
+
+1. Parse and evaluate fixed-format coordinates into real units using `FS` + `MO`.
+2. Maintain graphics state while parsing commands.
+3. Build ordered `GraphicalObject`s for `D01/D02/D03` outside regions.
+4. Build region contours for `G36/G37`.
+5. Lower standard apertures to geometry paths.
+6. Add aperture macro expression parsing/evaluation.
+7. Add block aperture and step-repeat object expansion.
+8. Add Gerber writer that emits attributes comprehensively.
+9. Add SVG renderer using the same geometry/rendering concepts as IPC-2581 tools.

--- a/crates/gerberx2/README.md
+++ b/crates/gerberx2/README.md
@@ -65,12 +65,30 @@ pub struct GraphicalObject {
 
 This keeps the original command stream for round-trip/generation work while providing a direct, renderer-friendly object list for SVG and IPC-2581 conversion.
 
-Next implementation steps:
+Remaining implementation steps:
 
-1. Add aperture macro expression parsing/evaluation.
-2. Add block aperture and step-repeat object expansion.
-3. Validate region contours for closure/connectivity/self-intersection constraints.
-4. Add Gerber writer that emits attributes comprehensively.
-5. Add SVG renderer using the same geometry/rendering concepts as IPC-2581 tools.
+1. Validate region contours for self-intersection constraints.
+2. Broaden writer coverage as IPC-2581 lowering exposes additional Gerber constructs.
+3. Add end-to-end IPC-2581-to-Gerber smoke tests once IPC lowering is wired to the writer.
 
 Initial support already decodes fixed-format coordinates through `FS` + `MO`, maintains graphics state for operations, builds ordered graphical objects for flashes/draws/arcs/regions, and lowers standard apertures (`C`, `R`, `O`, `P`) to geometry paths.
+
+## Writer direction for IPC-2581 export
+
+The writer intentionally accepts a string-backed artwork/object IR (`GerberLayer`) rather than flattened render geometry. IPC-2581 export should lower manufacturing layers into this level so semantic Gerber X2 can be emitted:
+
+- standard pads as aperture flashes,
+- tracks as aperture draws and native circular arcs,
+- filled copper/mask/paste/legend as regions,
+- file/aperture/object attributes as `TF`/`TA`/`TO`,
+- flattened regions only when a source feature cannot be represented faithfully as a Gerber primitive.
+
+The current writer emits standard apertures, aperture macros, block apertures, flashes, draws, arcs, regions, polarity changes, and X2 file/aperture/object attributes. Macro and block apertures are emitted as native Gerber constructs rather than silently flattened or approximated.
+
+The intended smoke test for IPC-2581 export is geometry-level comparison between two generated fabrication sets:
+
+1. `layout.kicad_pcb` → KiCad Gerber X2 export.
+2. `layout.kicad_pcb` → KiCad IPC-2581 export → `gerberx2` writer export.
+3. Parse both Gerber sets, process both to final `GeometryDocument`s, and compare each matching layer with `geometry::compare::compare_documents`.
+
+This comparison deliberately allows different command streams/aperture tables, but fails on layer function, final image bounds, or filled area drift beyond tolerance.

--- a/crates/gerberx2/README.md
+++ b/crates/gerberx2/README.md
@@ -4,14 +4,9 @@ Fast Gerber X2 parser, typed data model, and writer scaffolding for PCB fabricat
 
 This crate is intentionally shaped like `ipc2581`: a pure parser/data-model crate with no CLI concerns. Higher-level tools should live in a separate crate or in `pcb` commands.
 
-## Spec references read
+## Gerber concepts
 
-Primary local reference:
-
-- PDF: `/Users/akhilles/.pcb/cache/datasheets/materialized/c8655187-b74b-558f-985f-dc59209475c9/gerber-layer-format-specification-revision-2022-02_en.pdf`
-- Markdown: `/Users/akhilles/.pcb/cache/datasheets/materialized/c8655187-b74b-558f-985f-dc59209475c9/gerber-layer-format-specification-revision-2022-02_en.md`
-
-Important concepts from the spec:
+Important concepts from the Gerber layer format specification:
 
 - A Gerber file is one complete 2D binary vector image, represented as an ordered command stream.
 - X2 means the file uses attributes: `TF`, `TA`, `TO`, `TD`.

--- a/crates/gerberx2/src/geometry/compare.rs
+++ b/crates/gerberx2/src/geometry/compare.rs
@@ -1,0 +1,290 @@
+use super::ir::*;
+
+/// Tolerances for comparing two processed Gerber geometry documents.
+///
+/// The comparison is intended for smoke tests where two different export paths
+/// should describe the same layer image but are not expected to produce bytewise
+/// identical Gerber.
+#[derive(Debug, Clone, Copy)]
+pub struct GeometryCompareTolerance {
+    pub bbox_mm: f64,
+    pub area_mm2: f64,
+}
+
+impl Default for GeometryCompareTolerance {
+    fn default() -> Self {
+        Self {
+            bbox_mm: 0.01,
+            area_mm2: 0.01,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometryCompareReport {
+    pub reference: GeometrySummary,
+    pub candidate: GeometrySummary,
+    pub mismatches: Vec<String>,
+}
+
+impl GeometryCompareReport {
+    pub fn is_match(&self) -> bool {
+        self.mismatches.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometrySummary {
+    pub file_function: Vec<String>,
+    pub bbox: BBox,
+    pub area_mm2: f64,
+    pub feature_count: usize,
+    pub path_count: usize,
+}
+
+/// Compare two processed layer geometries using manufacturing-relevant summary
+/// metrics.
+///
+/// Call `process::process_document` on both inputs first. This helper assumes
+/// strokes and clear polarity have already been resolved into the final layer
+/// image, then compares the final image bounds and filled area. It intentionally
+/// does not compare object counts or command streams, because idiomatic exports
+/// may use different apertures/regions while preserving geometry.
+pub fn compare_documents(
+    reference: &GeometryDocument,
+    candidate: &GeometryDocument,
+    tolerance: GeometryCompareTolerance,
+) -> GeometryCompareReport {
+    let reference_summary = summarize(reference);
+    let candidate_summary = summarize(candidate);
+    let mut mismatches = Vec::new();
+
+    if reference_summary.file_function != candidate_summary.file_function {
+        mismatches.push(format!(
+            "file function differs: reference={:?}, candidate={:?}",
+            reference_summary.file_function, candidate_summary.file_function
+        ));
+    }
+
+    compare_bbox(
+        "bbox",
+        reference_summary.bbox,
+        candidate_summary.bbox,
+        tolerance.bbox_mm,
+        &mut mismatches,
+    );
+
+    let area_delta = (reference_summary.area_mm2 - candidate_summary.area_mm2).abs();
+    if area_delta > tolerance.area_mm2 {
+        mismatches.push(format!(
+            "filled area differs by {area_delta:.6} mm²: reference={:.6}, candidate={:.6}, tolerance={:.6}",
+            reference_summary.area_mm2, candidate_summary.area_mm2, tolerance.area_mm2
+        ));
+    }
+
+    GeometryCompareReport {
+        reference: reference_summary,
+        candidate: candidate_summary,
+        mismatches,
+    }
+}
+
+pub fn summarize(doc: &GeometryDocument) -> GeometrySummary {
+    GeometrySummary {
+        file_function: doc.file_function.clone(),
+        bbox: doc.bbox,
+        area_mm2: filled_area(doc),
+        feature_count: doc.features.len(),
+        path_count: doc.paths.len(),
+    }
+}
+
+fn compare_bbox(
+    label: &str,
+    reference: BBox,
+    candidate: BBox,
+    tolerance: f64,
+    mismatches: &mut Vec<String>,
+) {
+    if reference.is_empty() || candidate.is_empty() {
+        if reference.is_empty() != candidate.is_empty() {
+            mismatches.push(format!(
+                "{label} emptiness differs: reference_empty={}, candidate_empty={}",
+                reference.is_empty(),
+                candidate.is_empty()
+            ));
+        }
+        return;
+    }
+
+    for (name, reference, candidate) in [
+        ("min.x", reference.min.x, candidate.min.x),
+        ("min.y", reference.min.y, candidate.min.y),
+        ("max.x", reference.max.x, candidate.max.x),
+        ("max.y", reference.max.y, candidate.max.y),
+    ] {
+        let delta = (reference - candidate).abs();
+        if delta > tolerance {
+            mismatches.push(format!(
+                "{label}.{name} differs by {delta:.6} mm: reference={reference:.6}, candidate={candidate:.6}, tolerance={tolerance:.6}"
+            ));
+        }
+    }
+}
+
+fn filled_area(doc: &GeometryDocument) -> f64 {
+    let mut area = 0.0;
+    for feature in &doc.features {
+        for path in &doc.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+        {
+            if !path.flags.filled {
+                continue;
+            }
+            for contour in &doc.contours
+                [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+            {
+                area += contour_signed_area(doc, contour);
+            }
+        }
+    }
+    area.abs()
+}
+
+fn contour_signed_area(doc: &GeometryDocument, contour: &GeometryContour) -> f64 {
+    let mut points = Vec::new();
+    let mut current = Point::default();
+    for cmd in
+        &doc.path_cmds[contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+    {
+        match cmd.op {
+            PathOp::MoveTo => {
+                current = cmd.p0;
+                points.push(cmd.p0);
+            }
+            PathOp::LineTo => {
+                current = cmd.p0;
+                points.push(cmd.p0);
+            }
+            PathOp::ArcTo => {
+                let steps = arc_steps(current, cmd.p0, cmd.p1, cmd.clockwise);
+                for index in 1..=steps {
+                    points.push(point_on_arc(
+                        current,
+                        cmd.p0,
+                        cmd.p1,
+                        cmd.clockwise,
+                        index,
+                        steps,
+                    ));
+                }
+                current = cmd.p0;
+            }
+            PathOp::Close => {}
+        }
+    }
+    signed_area(&points)
+}
+
+fn signed_area(points: &[Point]) -> f64 {
+    if points.len() < 3 {
+        return 0.0;
+    }
+    let mut area = 0.0;
+    for (a, b) in points
+        .iter()
+        .zip(points.iter().cycle().skip(1))
+        .take(points.len())
+    {
+        area += a.x * b.y - b.x * a.y;
+    }
+    area * 0.5
+}
+
+fn arc_steps(start: Point, end: Point, center: Point, clockwise: bool) -> usize {
+    let sweep = arc_sweep_radians(start, end, center, clockwise);
+    (sweep / 0.05).ceil().max(8.0) as usize
+}
+
+fn point_on_arc(
+    start: Point,
+    end: Point,
+    center: Point,
+    clockwise: bool,
+    index: usize,
+    steps: usize,
+) -> Point {
+    let radius = start.distance_to(center);
+    if radius == 0.0 {
+        return end;
+    }
+    let start_angle = start.angle_from(center);
+    let sweep = arc_sweep_radians(start, end, center, clockwise);
+    let signed_sweep = if clockwise { -sweep } else { sweep };
+    let angle = start_angle + signed_sweep * index as f64 / steps as f64;
+    Point::new(
+        center.x + radius * angle.cos(),
+        center.y + radius * angle.sin(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compares_processed_geometry_summaries_with_tolerance() {
+        let mut reference = triangle_doc("Top");
+        let mut candidate = triangle_doc("Top");
+        candidate.bbox.max.x += 0.005;
+
+        let report = compare_documents(
+            &reference,
+            &candidate,
+            GeometryCompareTolerance {
+                bbox_mm: 0.01,
+                area_mm2: 0.001,
+            },
+        );
+        assert!(report.is_match(), "{:#?}", report.mismatches);
+
+        reference.file_function = vec!["Copper".to_string(), "L1".to_string(), "Top".to_string()];
+        candidate.file_function = vec!["Copper".to_string(), "L2".to_string(), "Inr".to_string()];
+        let report = compare_documents(&reference, &candidate, GeometryCompareTolerance::default());
+        assert!(!report.is_match());
+        assert!(report.mismatches[0].contains("file function differs"));
+    }
+
+    fn triangle_doc(side: &str) -> GeometryDocument {
+        let mut doc = GeometryDocument::new(vec![
+            "Copper".to_string(),
+            "L1".to_string(),
+            side.to_string(),
+        ]);
+        let path = doc.push_path(
+            GeometryPath::filled(FillRule::NonZero),
+            vec![ContourPayload {
+                bbox: BBox {
+                    min: Point::new(0.0, 0.0),
+                    max: Point::new(1.0, 1.0),
+                },
+                cmds: vec![
+                    PathCmd::move_to(Point::new(0.0, 0.0)),
+                    PathCmd::line_to(Point::new(1.0, 0.0)),
+                    PathCmd::line_to(Point::new(0.0, 1.0)),
+                    PathCmd::close(),
+                ],
+            }],
+        );
+        let mut feature = GeometryFeature::new(
+            FeatureKind::Composite,
+            FeatureBucket::Fill,
+            crate::Polarity::Dark,
+        );
+        feature.path_start = path;
+        feature.path_count = 1;
+        doc.features.push(feature);
+        super::super::process::normalize_bounds(&mut doc);
+        doc
+    }
+}

--- a/crates/gerberx2/src/geometry/compare.rs
+++ b/crates/gerberx2/src/geometry/compare.rs
@@ -1,4 +1,10 @@
 use super::ir::*;
+use i_overlay::core::fill_rule::FillRule as OverlayFillRule;
+use i_overlay::core::overlay_rule::OverlayRule;
+use i_overlay::float::simplify::SimplifyShape;
+use i_overlay::float::single::SingleFloatOverlay;
+
+type PolygonContour = Vec<[f64; 2]>;
 
 /// Tolerances for comparing two processed Gerber geometry documents.
 ///
@@ -82,6 +88,14 @@ pub fn compare_documents(
         ));
     }
 
+    let symmetric_difference_area = symmetric_difference_area(reference, candidate);
+    if symmetric_difference_area > tolerance.area_mm2 {
+        mismatches.push(format!(
+            "symmetric difference area is {symmetric_difference_area:.6} mm², tolerance={:.6}",
+            tolerance.area_mm2
+        ));
+    }
+
     GeometryCompareReport {
         reference: reference_summary,
         candidate: candidate_summary,
@@ -133,7 +147,18 @@ fn compare_bbox(
 }
 
 fn filled_area(doc: &GeometryDocument) -> f64 {
-    let mut area = 0.0;
+    polygon_area(&document_image_contours(doc))
+}
+
+fn symmetric_difference_area(reference: &GeometryDocument, candidate: &GeometryDocument) -> f64 {
+    let reference = document_image_contours(reference);
+    let candidate = document_image_contours(candidate);
+    polygon_area(&difference_contours(reference.clone(), candidate.clone()))
+        + polygon_area(&difference_contours(candidate, reference))
+}
+
+fn document_image_contours(doc: &GeometryDocument) -> Vec<PolygonContour> {
+    let mut contours = Vec::new();
     for feature in &doc.features {
         for path in &doc.paths
             [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
@@ -144,14 +169,14 @@ fn filled_area(doc: &GeometryDocument) -> f64 {
             for contour in &doc.contours
                 [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
             {
-                area += contour_signed_area(doc, contour);
+                contours.push(contour_polygon(doc, contour));
             }
         }
     }
-    area.abs()
+    union_contours(contours)
 }
 
-fn contour_signed_area(doc: &GeometryDocument, contour: &GeometryContour) -> f64 {
+fn contour_polygon(doc: &GeometryDocument, contour: &GeometryContour) -> PolygonContour {
     let mut points = Vec::new();
     let mut current = Point::default();
     for cmd in
@@ -183,7 +208,46 @@ fn contour_signed_area(doc: &GeometryDocument, contour: &GeometryContour) -> f64
             PathOp::Close => {}
         }
     }
-    signed_area(&points)
+    points.into_iter().map(|point| [point.x, point.y]).collect()
+}
+
+fn polygon_area(contours: &[PolygonContour]) -> f64 {
+    contours
+        .iter()
+        .map(|contour| {
+            let points = contour
+                .iter()
+                .map(|[x, y]| Point::new(*x, *y))
+                .collect::<Vec<_>>();
+            signed_area(&points)
+        })
+        .sum::<f64>()
+        .abs()
+}
+
+fn union_contours(contours: Vec<PolygonContour>) -> Vec<PolygonContour> {
+    contours
+        .into_iter()
+        .filter(|contour| contour.len() >= 3)
+        .collect::<Vec<_>>()
+        .simplify_shape(OverlayFillRule::NonZero)
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+fn difference_contours(
+    subject: Vec<PolygonContour>,
+    cutters: Vec<PolygonContour>,
+) -> Vec<PolygonContour> {
+    if subject.is_empty() || cutters.is_empty() {
+        return subject;
+    }
+    subject
+        .overlay(&cutters, OverlayRule::Difference, OverlayFillRule::NonZero)
+        .into_iter()
+        .flatten()
+        .collect()
 }
 
 fn signed_area(points: &[Point]) -> f64 {
@@ -253,6 +317,36 @@ mod tests {
         let report = compare_documents(&reference, &candidate, GeometryCompareTolerance::default());
         assert!(!report.is_match());
         assert!(report.mismatches[0].contains("file function differs"));
+    }
+
+    #[test]
+    fn detects_symmetric_difference_with_same_area_geometry() {
+        let reference = triangle_doc("Top");
+        let mut candidate = triangle_doc("Top");
+        for cmd in &mut candidate.path_cmds {
+            cmd.p0.x += 0.25;
+            cmd.p1.x += 0.25;
+        }
+        super::super::process::normalize_bounds(&mut candidate);
+
+        let report = compare_documents(
+            &reference,
+            &candidate,
+            GeometryCompareTolerance {
+                bbox_mm: 1.0,
+                area_mm2: 0.001,
+            },
+        );
+
+        assert!(!report.is_match());
+        assert!(
+            report
+                .mismatches
+                .iter()
+                .any(|message| message.contains("symmetric difference")),
+            "{:#?}",
+            report.mismatches
+        );
     }
 
     fn triangle_doc(side: &str) -> GeometryDocument {

--- a/crates/gerberx2/src/geometry/extract.rs
+++ b/crates/gerberx2/src/geometry/extract.rs
@@ -1,0 +1,289 @@
+use std::collections::HashMap;
+
+use super::ir::*;
+use crate::GerberX2;
+use crate::types as gerber;
+
+pub fn extract_document(gerber: &GerberX2) -> GeometryDocument {
+    let mut doc = GeometryDocument::new(file_function(gerber));
+    let apertures = gerber
+        .aperture_definitions()
+        .iter()
+        .map(|aperture| (aperture.code, aperture))
+        .collect::<HashMap<_, _>>();
+
+    for (object_index, object) in gerber.objects().iter().enumerate() {
+        match &object.kind {
+            gerber::ObjectKind::Flash { at, aperture } => {
+                let Some(definition) = apertures.get(aperture) else {
+                    doc.warn(format!("flash references undefined aperture D{aperture}"));
+                    continue;
+                };
+                let Some(geometry) = &definition.geometry else {
+                    doc.warn(format!(
+                        "flash aperture D{aperture} has no lowered geometry"
+                    ));
+                    continue;
+                };
+                let transform = Affine2::placement(
+                    point(*at),
+                    object.rotation_degrees,
+                    object.mirroring,
+                    object.scaling,
+                );
+                let mut feature = feature_from_object(
+                    object,
+                    object_index,
+                    FeatureKind::Flash,
+                    classify_bucket(object, FeatureKind::Flash),
+                );
+                feature.aperture = Some(*aperture);
+                doc.push_feature(feature, aperture_paths(geometry, transform));
+            }
+            gerber::ObjectKind::Draw {
+                start,
+                end,
+                aperture,
+            } => {
+                let mut feature = feature_from_object(
+                    object,
+                    object_index,
+                    FeatureKind::Draw,
+                    classify_bucket(object, FeatureKind::Draw),
+                );
+                feature.aperture = Some(*aperture);
+                let width = circular_aperture_diameter(&apertures, *aperture).unwrap_or_else(|| {
+                    doc.warn(format!(
+                        "D{aperture} draw uses a non-circular aperture; approximating with zero-width path"
+                    ));
+                    0.0
+                });
+                doc.push_feature(feature, vec![line_path(point(*start), point(*end), width)]);
+            }
+            gerber::ObjectKind::Arc {
+                start,
+                end,
+                center_offset,
+                clockwise,
+                aperture,
+            } => {
+                let mut feature = feature_from_object(
+                    object,
+                    object_index,
+                    FeatureKind::Arc,
+                    classify_bucket(object, FeatureKind::Arc),
+                );
+                feature.aperture = Some(*aperture);
+                let width = circular_aperture_diameter(&apertures, *aperture).unwrap_or_else(|| {
+                    doc.warn(format!(
+                        "D{aperture} arc uses a non-circular aperture; approximating with zero-width path"
+                    ));
+                    0.0
+                });
+                let start = point(*start);
+                let center = Point::new(start.x + center_offset.x, start.y + center_offset.y);
+                doc.push_feature(
+                    feature,
+                    vec![arc_path(start, point(*end), center, *clockwise, width)],
+                );
+            }
+            gerber::ObjectKind::Region { contours } => {
+                let feature = feature_from_object(
+                    object,
+                    object_index,
+                    FeatureKind::Region,
+                    classify_bucket(object, FeatureKind::Region),
+                );
+                doc.push_feature(feature, vec![region_path(contours)]);
+            }
+        }
+    }
+
+    super::process::normalize_bounds(&mut doc);
+    doc
+}
+
+fn file_function(gerber: &GerberX2) -> Vec<String> {
+    gerber
+        .file_attributes()
+        .iter()
+        .find(|attr| gerber.resolve(attr.name) == ".FileFunction")
+        .map(|attr| {
+            attr.fields
+                .iter()
+                .map(|field| gerber.resolve(*field).to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn feature_from_object(
+    object: &gerber::GraphicalObject,
+    object_index: usize,
+    kind: FeatureKind,
+    bucket: FeatureBucket,
+) -> GeometryFeature {
+    let mut feature = GeometryFeature::new(kind, bucket, object.polarity);
+    feature.object_index = object_index as u32;
+    feature.aperture_attributes = object.aperture_attributes.clone();
+    feature.object_attributes = object.object_attributes.clone();
+    feature.mirroring = object.mirroring;
+    feature.rotation_degrees = object.rotation_degrees;
+    feature.scaling = object.scaling;
+    feature
+}
+
+fn classify_bucket(object: &gerber::GraphicalObject, kind: FeatureKind) -> FeatureBucket {
+    if object.polarity == gerber::Polarity::Clear {
+        return FeatureBucket::Cutout;
+    }
+    match kind {
+        FeatureKind::Region => FeatureBucket::Fill,
+        FeatureKind::Draw | FeatureKind::Arc => FeatureBucket::Trace,
+        FeatureKind::Flash => FeatureBucket::Pad,
+        FeatureKind::Composite => FeatureBucket::Unknown,
+    }
+}
+
+fn circular_aperture_diameter(
+    apertures: &HashMap<i32, &gerber::ApertureDefinition>,
+    code: i32,
+) -> Option<f64> {
+    match apertures.get(&code)?.template {
+        gerber::ApertureTemplate::Circle { diameter, .. } => Some(diameter),
+        _ => None,
+    }
+}
+
+fn aperture_paths(geometry: &gerber::ApertureGeometry, transform: Affine2) -> Vec<PathPayload> {
+    geometry
+        .paths
+        .iter()
+        .map(|path| {
+            let contours = path
+                .contours
+                .iter()
+                .map(|contour| transform_contour(&contour.commands, transform))
+                .collect();
+            PathPayload {
+                path: GeometryPath::filled_with_polarity(FillRule::NonZero, path.polarity),
+                contours,
+            }
+        })
+        .collect()
+}
+
+fn transform_contour(commands: &[gerber::PathCommand], transform: Affine2) -> ContourPayload {
+    let mut bbox = BBox::empty();
+    let mut cmds = Vec::new();
+    for command in commands {
+        let cmd = match *command {
+            gerber::PathCommand::MoveTo(p) => PathCmd::move_to(transform.transform_point(point(p))),
+            gerber::PathCommand::LineTo(p) => PathCmd::line_to(transform.transform_point(point(p))),
+            gerber::PathCommand::ArcTo {
+                end,
+                center,
+                clockwise,
+            } => PathCmd::arc_to(
+                transform.transform_point(point(end)),
+                transform.transform_point(point(center)),
+                clockwise,
+            ),
+            gerber::PathCommand::Close => PathCmd::close(),
+        };
+        include_cmd_bbox(&mut bbox, cmds.last().copied(), cmd);
+        cmds.push(cmd);
+    }
+    ContourPayload { bbox, cmds }
+}
+
+fn line_path(start: Point, end: Point, width: f64) -> PathPayload {
+    let bbox = BBox::from_point(start)
+        .union(BBox::from_point(end))
+        .expand(width / 2.0);
+    PathPayload {
+        path: GeometryPath::stroked(width, LineCap::Round),
+        contours: vec![ContourPayload {
+            bbox,
+            cmds: vec![PathCmd::move_to(start), PathCmd::line_to(end)],
+        }],
+    }
+}
+
+fn arc_path(start: Point, end: Point, center: Point, clockwise: bool, width: f64) -> PathPayload {
+    let mut bbox = BBox::from_point(start)
+        .union(BBox::from_point(end))
+        .union(BBox::from_point(center));
+    bbox = bbox.expand(start.distance_to(center) + width / 2.0);
+    PathPayload {
+        path: GeometryPath::stroked(width, LineCap::Round),
+        contours: vec![ContourPayload {
+            bbox,
+            cmds: vec![
+                PathCmd::move_to(start),
+                PathCmd::arc_to(end, center, clockwise),
+            ],
+        }],
+    }
+}
+
+fn region_path(contours: &[gerber::Contour]) -> PathPayload {
+    let contours = contours.iter().map(region_contour).collect();
+    PathPayload {
+        path: GeometryPath::filled(FillRule::NonZero),
+        contours,
+    }
+}
+
+fn region_contour(contour: &gerber::Contour) -> ContourPayload {
+    let mut bbox = BBox::empty();
+    let mut cmds = Vec::new();
+    if let Some(first) = contour.segments.first() {
+        let start = match *first {
+            gerber::ContourSegment::Line { start, .. }
+            | gerber::ContourSegment::Arc { start, .. } => point(start),
+        };
+        cmds.push(PathCmd::move_to(start));
+        bbox.include_point(start);
+    }
+    for segment in &contour.segments {
+        let cmd = match *segment {
+            gerber::ContourSegment::Line { end, .. } => PathCmd::line_to(point(end)),
+            gerber::ContourSegment::Arc {
+                start,
+                end,
+                center_offset,
+                clockwise,
+            } => {
+                let start = point(start);
+                PathCmd::arc_to(
+                    point(end),
+                    Point::new(start.x + center_offset.x, start.y + center_offset.y),
+                    clockwise,
+                )
+            }
+        };
+        include_cmd_bbox(&mut bbox, cmds.last().copied(), cmd);
+        cmds.push(cmd);
+    }
+    cmds.push(PathCmd::close());
+    ContourPayload { bbox, cmds }
+}
+
+fn include_cmd_bbox(bbox: &mut BBox, previous: Option<PathCmd>, cmd: PathCmd) {
+    match cmd.op {
+        PathOp::MoveTo | PathOp::LineTo => bbox.include_point(cmd.p0),
+        PathOp::ArcTo => {
+            if let Some(previous) = previous {
+                bbox.include_point(previous.p0);
+            }
+            bbox.include_point(cmd.p0);
+            bbox.include_point(cmd.p1);
+        }
+        PathOp::Close => {}
+    }
+}
+
+fn point(p: gerber::Point) -> Point {
+    Point::new(p.x, p.y)
+}

--- a/crates/gerberx2/src/geometry/extract.rs
+++ b/crates/gerberx2/src/geometry/extract.rs
@@ -4,6 +4,8 @@ use super::ir::*;
 use crate::GerberX2;
 use crate::types as gerber;
 
+const SWEEP_SAMPLE_MM: f64 = 0.025;
+
 pub fn extract_document(gerber: &GerberX2) -> GeometryDocument {
     let mut doc = GeometryDocument::new(file_function(gerber));
     let apertures = gerber
@@ -52,13 +54,16 @@ pub fn extract_document(gerber: &GerberX2) -> GeometryDocument {
                     classify_bucket(object, FeatureKind::Draw),
                 );
                 feature.aperture = Some(*aperture);
-                let width = circular_aperture_diameter(&apertures, *aperture).unwrap_or_else(|| {
-                    doc.warn(format!(
-                        "D{aperture} draw uses a non-circular aperture; approximating with zero-width path"
-                    ));
-                    0.0
-                });
-                doc.push_feature(feature, vec![line_path(point(*start), point(*end), width)]);
+                if let Some(width) = circular_aperture_diameter(&apertures, *aperture) {
+                    doc.push_feature(feature, vec![line_path(point(*start), point(*end), width)]);
+                } else if let Some(geometry) = aperture_geometry(&apertures, *aperture) {
+                    doc.push_feature(
+                        feature,
+                        sampled_line_sweep(point(*start), point(*end), object, geometry),
+                    );
+                } else {
+                    doc.warn(format!("D{aperture} draw aperture has no lowered geometry"));
+                }
             }
             gerber::ObjectKind::Arc {
                 start,
@@ -74,18 +79,21 @@ pub fn extract_document(gerber: &GerberX2) -> GeometryDocument {
                     classify_bucket(object, FeatureKind::Arc),
                 );
                 feature.aperture = Some(*aperture);
-                let width = circular_aperture_diameter(&apertures, *aperture).unwrap_or_else(|| {
-                    doc.warn(format!(
-                        "D{aperture} arc uses a non-circular aperture; approximating with zero-width path"
-                    ));
-                    0.0
-                });
                 let start = point(*start);
                 let center = Point::new(start.x + center_offset.x, start.y + center_offset.y);
-                doc.push_feature(
-                    feature,
-                    vec![arc_path(start, point(*end), center, *clockwise, width)],
-                );
+                if let Some(width) = circular_aperture_diameter(&apertures, *aperture) {
+                    doc.push_feature(
+                        feature,
+                        vec![arc_path(start, point(*end), center, *clockwise, width)],
+                    );
+                } else if let Some(geometry) = aperture_geometry(&apertures, *aperture) {
+                    doc.push_feature(
+                        feature,
+                        sampled_arc_sweep(start, point(*end), center, *clockwise, object, geometry),
+                    );
+                } else {
+                    doc.warn(format!("D{aperture} arc aperture has no lowered geometry"));
+                }
             }
             gerber::ObjectKind::Region { contours } => {
                 let feature = feature_from_object(
@@ -101,6 +109,13 @@ pub fn extract_document(gerber: &GerberX2) -> GeometryDocument {
 
     super::process::normalize_bounds(&mut doc);
     doc
+}
+
+fn aperture_geometry<'a>(
+    apertures: &'a HashMap<i32, &gerber::ApertureDefinition>,
+    code: i32,
+) -> Option<&'a gerber::ApertureGeometry> {
+    apertures.get(&code)?.geometry.as_ref()
 }
 
 fn file_function(gerber: &GerberX2) -> Vec<String> {
@@ -211,10 +226,9 @@ fn line_path(start: Point, end: Point, width: f64) -> PathPayload {
 }
 
 fn arc_path(start: Point, end: Point, center: Point, clockwise: bool, width: f64) -> PathPayload {
-    let mut bbox = BBox::from_point(start)
-        .union(BBox::from_point(end))
-        .union(BBox::from_point(center));
-    bbox = bbox.expand(start.distance_to(center) + width / 2.0);
+    let mut bbox = BBox::empty();
+    bbox.include_circular_arc(start, end, center, clockwise);
+    bbox = bbox.expand(width / 2.0);
     PathPayload {
         path: GeometryPath::stroked(width, LineCap::Round),
         contours: vec![ContourPayload {
@@ -225,6 +239,65 @@ fn arc_path(start: Point, end: Point, center: Point, clockwise: bool, width: f64
             ],
         }],
     }
+}
+
+fn sampled_line_sweep(
+    start: Point,
+    end: Point,
+    object: &gerber::GraphicalObject,
+    geometry: &gerber::ApertureGeometry,
+) -> Vec<PathPayload> {
+    let length = start.distance_to(end);
+    let steps = sample_steps(length);
+    (0..=steps)
+        .flat_map(|index| {
+            let t = index as f64 / steps.max(1) as f64;
+            let at = Point::new(
+                start.x + (end.x - start.x) * t,
+                start.y + (end.y - start.y) * t,
+            );
+            aperture_paths(geometry, object_transform(object, at))
+        })
+        .collect()
+}
+
+fn sampled_arc_sweep(
+    start: Point,
+    end: Point,
+    center: Point,
+    clockwise: bool,
+    object: &gerber::GraphicalObject,
+    geometry: &gerber::ApertureGeometry,
+) -> Vec<PathPayload> {
+    let radius = start.distance_to(center);
+    let sweep = arc_sweep_radians(start, end, center, clockwise);
+    let steps = sample_steps(radius * sweep);
+    let signed_sweep = if clockwise { -sweep } else { sweep };
+    let start_angle = start.angle_from(center);
+    (0..=steps)
+        .flat_map(|index| {
+            let t = index as f64 / steps.max(1) as f64;
+            let angle = start_angle + signed_sweep * t;
+            let at = Point::new(
+                center.x + radius * angle.cos(),
+                center.y + radius * angle.sin(),
+            );
+            aperture_paths(geometry, object_transform(object, at))
+        })
+        .collect()
+}
+
+fn object_transform(object: &gerber::GraphicalObject, at: Point) -> Affine2 {
+    Affine2::placement(
+        at,
+        object.rotation_degrees,
+        object.mirroring,
+        object.scaling,
+    )
+}
+
+fn sample_steps(length: f64) -> usize {
+    (length / SWEEP_SAMPLE_MM).ceil().max(1.0) as usize
 }
 
 fn region_path(contours: &[gerber::Contour]) -> PathPayload {
@@ -275,10 +348,11 @@ fn include_cmd_bbox(bbox: &mut BBox, previous: Option<PathCmd>, cmd: PathCmd) {
         PathOp::MoveTo | PathOp::LineTo => bbox.include_point(cmd.p0),
         PathOp::ArcTo => {
             if let Some(previous) = previous {
-                bbox.include_point(previous.p0);
+                bbox.include_circular_arc(previous.p0, cmd.p0, cmd.p1, cmd.clockwise);
+            } else {
+                bbox.include_point(cmd.p0);
+                bbox.include_point(cmd.p1);
             }
-            bbox.include_point(cmd.p0);
-            bbox.include_point(cmd.p1);
         }
         PathOp::Close => {}
     }

--- a/crates/gerberx2/src/geometry/extract.rs
+++ b/crates/gerberx2/src/geometry/extract.rs
@@ -55,7 +55,14 @@ pub fn extract_document(gerber: &GerberX2) -> GeometryDocument {
                 );
                 feature.aperture = Some(*aperture);
                 if let Some(width) = circular_aperture_diameter(&apertures, *aperture) {
-                    doc.push_feature(feature, vec![line_path(point(*start), point(*end), width)]);
+                    doc.push_feature(
+                        feature,
+                        vec![line_path(
+                            point(*start),
+                            point(*end),
+                            width * object.scaling.abs(),
+                        )],
+                    );
                 } else if let Some(geometry) = aperture_geometry(&apertures, *aperture) {
                     doc.push_feature(
                         feature,
@@ -84,7 +91,13 @@ pub fn extract_document(gerber: &GerberX2) -> GeometryDocument {
                 if let Some(width) = circular_aperture_diameter(&apertures, *aperture) {
                     doc.push_feature(
                         feature,
-                        vec![arc_path(start, point(*end), center, *clockwise, width)],
+                        vec![arc_path(
+                            start,
+                            point(*end),
+                            center,
+                            *clockwise,
+                            width * object.scaling.abs(),
+                        )],
                     );
                 } else if let Some(geometry) = aperture_geometry(&apertures, *aperture) {
                     doc.push_feature(
@@ -191,6 +204,7 @@ fn aperture_paths(geometry: &gerber::ApertureGeometry, transform: Affine2) -> Ve
 fn transform_contour(commands: &[gerber::PathCommand], transform: Affine2) -> ContourPayload {
     let mut bbox = BBox::empty();
     let mut cmds = Vec::new();
+    let flips_orientation = transform.determinant() < 0.0;
     for command in commands {
         let cmd = match *command {
             gerber::PathCommand::MoveTo(p) => PathCmd::move_to(transform.transform_point(point(p))),
@@ -202,7 +216,7 @@ fn transform_contour(commands: &[gerber::PathCommand], transform: Affine2) -> Co
             } => PathCmd::arc_to(
                 transform.transform_point(point(end)),
                 transform.transform_point(point(center)),
-                clockwise,
+                clockwise ^ flips_orientation,
             ),
             gerber::PathCommand::Close => PathCmd::close(),
         };

--- a/crates/gerberx2/src/geometry/ir.rs
+++ b/crates/gerberx2/src/geometry/ir.rs
@@ -1,0 +1,393 @@
+use crate::types::{Attribute, Mirroring, Polarity};
+
+#[derive(Debug, Clone)]
+pub struct GeometryDocument {
+    pub file_function: Vec<String>,
+    pub features: Vec<GeometryFeature>,
+    pub paths: Vec<GeometryPath>,
+    pub contours: Vec<GeometryContour>,
+    pub path_cmds: Vec<PathCmd>,
+    pub bbox: BBox,
+    pub diagnostics: Vec<GeometryDiagnostic>,
+}
+
+impl GeometryDocument {
+    pub fn new(file_function: Vec<String>) -> Self {
+        Self {
+            file_function,
+            features: Vec::new(),
+            paths: Vec::new(),
+            contours: Vec::new(),
+            path_cmds: Vec::new(),
+            bbox: BBox::empty(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    pub fn push_feature(&mut self, mut feature: GeometryFeature, paths: Vec<PathPayload>) {
+        let path_start = self.paths.len() as u32;
+        for payload in paths {
+            self.push_path(payload.path, payload.contours);
+        }
+        feature.path_start = path_start;
+        feature.path_count = self.paths.len() as u32 - path_start;
+        self.features.push(feature);
+    }
+
+    pub fn push_path(&mut self, mut path: GeometryPath, contours: Vec<ContourPayload>) -> u32 {
+        let contour_start = self.contours.len() as u32;
+        let mut bbox = BBox::empty();
+        for contour in contours {
+            bbox = bbox.union(contour.bbox);
+            self.push_contour(contour);
+        }
+        path.contour_start = contour_start;
+        path.contour_count = self.contours.len() as u32 - contour_start;
+        path.bbox = bbox;
+        let id = self.paths.len() as u32;
+        self.paths.push(path);
+        id
+    }
+
+    fn push_contour(&mut self, contour: ContourPayload) {
+        let cmd_start = self.path_cmds.len() as u32;
+        self.path_cmds.extend(contour.cmds);
+        self.contours.push(GeometryContour {
+            cmd_start,
+            cmd_count: self.path_cmds.len() as u32 - cmd_start,
+            bbox: contour.bbox,
+        });
+    }
+
+    pub fn warn(&mut self, message: impl Into<String>) {
+        self.diagnostics.push(GeometryDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            message: message.into(),
+        });
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryFeature {
+    pub kind: FeatureKind,
+    pub bucket: FeatureBucket,
+    pub polarity: Polarity,
+    pub path_start: u32,
+    pub path_count: u32,
+    pub bbox: BBox,
+    pub aperture: Option<i32>,
+    pub object_index: u32,
+    pub aperture_attributes: Vec<Attribute>,
+    pub object_attributes: Vec<Attribute>,
+    pub mirroring: Mirroring,
+    pub rotation_degrees: f64,
+    pub scaling: f64,
+}
+
+impl GeometryFeature {
+    pub fn new(kind: FeatureKind, bucket: FeatureBucket, polarity: Polarity) -> Self {
+        Self {
+            kind,
+            bucket,
+            polarity,
+            path_start: 0,
+            path_count: 0,
+            bbox: BBox::empty(),
+            aperture: None,
+            object_index: 0,
+            aperture_attributes: Vec::new(),
+            object_attributes: Vec::new(),
+            mirroring: Mirroring::None,
+            rotation_degrees: 0.0,
+            scaling: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PathPayload {
+    pub path: GeometryPath,
+    pub contours: Vec<ContourPayload>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ContourPayload {
+    pub bbox: BBox,
+    pub cmds: Vec<PathCmd>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryPath {
+    pub contour_start: u32,
+    pub contour_count: u32,
+    pub bbox: BBox,
+    pub polarity: Polarity,
+    pub fill_rule: FillRule,
+    pub stroke_width: f64,
+    pub line_cap: LineCap,
+    pub flags: PathFlags,
+}
+
+impl GeometryPath {
+    pub fn filled(fill_rule: FillRule) -> Self {
+        Self::filled_with_polarity(fill_rule, Polarity::Dark)
+    }
+
+    pub fn filled_with_polarity(fill_rule: FillRule, polarity: Polarity) -> Self {
+        Self {
+            contour_start: 0,
+            contour_count: 0,
+            bbox: BBox::empty(),
+            polarity,
+            fill_rule,
+            stroke_width: 0.0,
+            line_cap: LineCap::Round,
+            flags: PathFlags {
+                filled: true,
+                stroked: false,
+            },
+        }
+    }
+
+    pub fn stroked(width: f64, line_cap: LineCap) -> Self {
+        Self {
+            contour_start: 0,
+            contour_count: 0,
+            bbox: BBox::empty(),
+            polarity: Polarity::Dark,
+            fill_rule: FillRule::NonZero,
+            stroke_width: width,
+            line_cap,
+            flags: PathFlags {
+                filled: false,
+                stroked: true,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryContour {
+    pub cmd_start: u32,
+    pub cmd_count: u32,
+    pub bbox: BBox,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct PathCmd {
+    pub op: PathOp,
+    pub p0: Point,
+    pub p1: Point,
+    pub clockwise: bool,
+}
+
+impl PathCmd {
+    pub fn move_to(p: Point) -> Self {
+        Self {
+            op: PathOp::MoveTo,
+            p0: p,
+            ..Self::default()
+        }
+    }
+    pub fn line_to(p: Point) -> Self {
+        Self {
+            op: PathOp::LineTo,
+            p0: p,
+            ..Self::default()
+        }
+    }
+    pub fn arc_to(end: Point, center: Point, clockwise: bool) -> Self {
+        Self {
+            op: PathOp::ArcTo,
+            p0: end,
+            p1: center,
+            clockwise,
+        }
+    }
+    pub fn close() -> Self {
+        Self {
+            op: PathOp::Close,
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PathOp {
+    #[default]
+    MoveTo,
+    LineTo,
+    ArcTo,
+    Close,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureKind {
+    Flash,
+    Draw,
+    Arc,
+    Region,
+    Composite,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureBucket {
+    Pad,
+    Trace,
+    Fill,
+    Cutout,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FillRule {
+    NonZero,
+    EvenOdd,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineCap {
+    Round,
+    Square,
+    Butt,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PathFlags {
+    pub filled: bool,
+    pub stroked: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticSeverity {
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Point {
+    pub fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+    pub fn distance_to(self, other: Point) -> f64 {
+        ((self.x - other.x).powi(2) + (self.y - other.y).powi(2)).sqrt()
+    }
+    pub fn angle_from(self, center: Point) -> f64 {
+        (self.y - center.y).atan2(self.x - center.x)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BBox {
+    pub min: Point,
+    pub max: Point,
+}
+
+impl BBox {
+    pub fn empty() -> Self {
+        Self {
+            min: Point::new(f64::INFINITY, f64::INFINITY),
+            max: Point::new(f64::NEG_INFINITY, f64::NEG_INFINITY),
+        }
+    }
+    pub fn from_point(p: Point) -> Self {
+        Self { min: p, max: p }
+    }
+    pub fn include_point(&mut self, p: Point) {
+        self.min.x = self.min.x.min(p.x);
+        self.min.y = self.min.y.min(p.y);
+        self.max.x = self.max.x.max(p.x);
+        self.max.y = self.max.y.max(p.y);
+    }
+    pub fn union(mut self, other: BBox) -> Self {
+        if other.is_empty() {
+            return self;
+        }
+        self.include_point(other.min);
+        self.include_point(other.max);
+        self
+    }
+    pub fn expand(self, amount: f64) -> Self {
+        if self.is_empty() {
+            self
+        } else {
+            Self {
+                min: Point::new(self.min.x - amount, self.min.y - amount),
+                max: Point::new(self.max.x + amount, self.max.y + amount),
+            }
+        }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.min.x.is_infinite() || self.min.y.is_infinite()
+    }
+}
+
+impl Default for BBox {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Affine2 {
+    pub m00: f64,
+    pub m01: f64,
+    pub m02: f64,
+    pub m10: f64,
+    pub m11: f64,
+    pub m12: f64,
+}
+
+impl Affine2 {
+    pub fn identity() -> Self {
+        Self {
+            m00: 1.0,
+            m01: 0.0,
+            m02: 0.0,
+            m10: 0.0,
+            m11: 1.0,
+            m12: 0.0,
+        }
+    }
+    pub fn placement(
+        center: Point,
+        rotation_degrees: f64,
+        mirroring: Mirroring,
+        scale: f64,
+    ) -> Self {
+        let sx = match mirroring {
+            Mirroring::X | Mirroring::XY => -scale,
+            _ => scale,
+        };
+        let sy = match mirroring {
+            Mirroring::Y | Mirroring::XY => -scale,
+            _ => scale,
+        };
+        let r = rotation_degrees.to_radians();
+        let (sin, cos) = r.sin_cos();
+        Self {
+            m00: cos * sx,
+            m01: -sin * sy,
+            m02: center.x,
+            m10: sin * sx,
+            m11: cos * sy,
+            m12: center.y,
+        }
+    }
+    pub fn transform_point(&self, p: Point) -> Point {
+        Point::new(
+            self.m00 * p.x + self.m01 * p.y + self.m02,
+            self.m10 * p.x + self.m11 * p.y + self.m12,
+        )
+    }
+}

--- a/crates/gerberx2/src/geometry/ir.rs
+++ b/crates/gerberx2/src/geometry/ir.rs
@@ -309,6 +309,36 @@ impl BBox {
         self.max.x = self.max.x.max(p.x);
         self.max.y = self.max.y.max(p.y);
     }
+
+    pub fn include_circular_arc(
+        &mut self,
+        start: Point,
+        end: Point,
+        center: Point,
+        clockwise: bool,
+    ) {
+        self.include_point(start);
+        self.include_point(end);
+        let radius = start.distance_to(center).max(end.distance_to(center));
+        if radius <= 0.0 {
+            return;
+        }
+        let start_angle = start.angle_from(center);
+        let end_angle = end.angle_from(center);
+        for angle in [
+            0.0,
+            std::f64::consts::FRAC_PI_2,
+            std::f64::consts::PI,
+            std::f64::consts::PI * 1.5,
+        ] {
+            if angle_is_on_arc(start_angle, end_angle, angle, clockwise) {
+                self.include_point(Point::new(
+                    center.x + radius * angle.cos(),
+                    center.y + radius * angle.sin(),
+                ));
+            }
+        }
+    }
     pub fn union(mut self, other: BBox) -> Self {
         if other.is_empty() {
             return self;
@@ -327,6 +357,12 @@ impl BBox {
             }
         }
     }
+    pub fn width(&self) -> f64 {
+        self.max.x - self.min.x
+    }
+    pub fn height(&self) -> f64 {
+        self.max.y - self.min.y
+    }
     pub fn is_empty(&self) -> bool {
         self.min.x.is_infinite() || self.min.y.is_infinite()
     }
@@ -336,6 +372,34 @@ impl Default for BBox {
     fn default() -> Self {
         Self::empty()
     }
+}
+
+pub fn arc_sweep_radians(start: Point, end: Point, center: Point, clockwise: bool) -> f64 {
+    if start.distance_to(end) <= 1e-9 && start.distance_to(center) > 1e-9 {
+        return std::f64::consts::TAU;
+    }
+    let start_angle = start.angle_from(center);
+    let end_angle = end.angle_from(center);
+    if clockwise {
+        normalize_angle(start_angle - end_angle)
+    } else {
+        normalize_angle(end_angle - start_angle)
+    }
+}
+
+fn angle_is_on_arc(start: f64, end: f64, angle: f64, clockwise: bool) -> bool {
+    if normalize_angle(end - start) <= 1e-12 {
+        return true;
+    }
+    if clockwise {
+        normalize_angle(start - angle) <= normalize_angle(start - end) + 1e-12
+    } else {
+        normalize_angle(angle - start) <= normalize_angle(end - start) + 1e-12
+    }
+}
+
+fn normalize_angle(angle: f64) -> f64 {
+    angle.rem_euclid(std::f64::consts::TAU)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/gerberx2/src/geometry/ir.rs
+++ b/crates/gerberx2/src/geometry/ir.rs
@@ -454,4 +454,8 @@ impl Affine2 {
             self.m10 * p.x + self.m11 * p.y + self.m12,
         )
     }
+
+    pub fn determinant(&self) -> f64 {
+        self.m00 * self.m11 - self.m01 * self.m10
+    }
 }

--- a/crates/gerberx2/src/geometry/mod.rs
+++ b/crates/gerberx2/src/geometry/mod.rs
@@ -1,5 +1,8 @@
 pub mod extract;
 pub mod ir;
 pub mod process;
+pub mod raster;
+pub mod svg;
+pub mod terminal;
 
 pub use extract::extract_document;

--- a/crates/gerberx2/src/geometry/mod.rs
+++ b/crates/gerberx2/src/geometry/mod.rs
@@ -1,3 +1,4 @@
+pub mod compare;
 pub mod extract;
 pub mod ir;
 pub mod process;

--- a/crates/gerberx2/src/geometry/mod.rs
+++ b/crates/gerberx2/src/geometry/mod.rs
@@ -1,0 +1,5 @@
+pub mod extract;
+pub mod ir;
+pub mod process;
+
+pub use extract::extract_document;

--- a/crates/gerberx2/src/geometry/process.rs
+++ b/crates/gerberx2/src/geometry/process.rs
@@ -1,0 +1,404 @@
+use super::ir::*;
+use crate::types::Polarity;
+use i_overlay::core::fill_rule::FillRule as OverlayFillRule;
+use i_overlay::core::overlay_rule::OverlayRule;
+use i_overlay::float::simplify::SimplifyShape;
+use i_overlay::float::single::SingleFloatOverlay;
+use kurbo::{BezPath, Cap, Join, PathEl, Stroke, StrokeOpts};
+
+type PolygonContour = Vec<[f64; 2]>;
+
+pub fn process_document(doc: &mut GeometryDocument) {
+    normalize_bounds(doc);
+    outline_stroked_paths(doc);
+    resolve_polarity_and_cutouts(doc);
+    normalize_bounds(doc);
+}
+
+pub fn normalize_bounds(doc: &mut GeometryDocument) {
+    for contour_index in 0..doc.contours.len() {
+        doc.contours[contour_index].bbox = contour_bbox(doc, contour_index);
+    }
+    for path_index in 0..doc.paths.len() {
+        doc.paths[path_index].bbox = path_bbox(doc, path_index);
+    }
+    for feature_index in 0..doc.features.len() {
+        doc.features[feature_index].bbox = feature_bbox(doc, feature_index);
+    }
+    doc.bbox = doc
+        .features
+        .iter()
+        .filter(|feature| feature.path_count > 0)
+        .fold(BBox::empty(), |bbox, feature| bbox.union(feature.bbox));
+}
+
+pub fn outline_stroked_paths(doc: &mut GeometryDocument) {
+    let feature_count = doc.features.len();
+    for feature_index in 0..feature_count {
+        let feature = doc.features[feature_index].clone();
+        let paths = doc.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+            .to_vec();
+        if !paths.iter().any(|path| path.flags.stroked) {
+            continue;
+        }
+
+        let path_start = doc.paths.len() as u32;
+        for path in paths {
+            if path.flags.stroked {
+                if let Some(payload) = stroked_path_outline(doc, &path) {
+                    doc.push_path(payload.path, payload.contours);
+                }
+            } else {
+                let contours = path_contours(doc, &path);
+                doc.push_path(path, contours);
+            }
+        }
+        let feature = &mut doc.features[feature_index];
+        feature.path_start = path_start;
+        feature.path_count = doc.paths.len() as u32 - path_start;
+    }
+}
+
+pub fn resolve_polarity_and_cutouts(doc: &mut GeometryDocument) {
+    let mut image = Vec::new();
+    for feature in &doc.features {
+        let feature_image = feature_image_contours(doc, feature);
+        if feature_image.is_empty() {
+            continue;
+        }
+        if feature.polarity == Polarity::Clear || feature.bucket == FeatureBucket::Cutout {
+            image = difference_contours(image, feature_image);
+        } else {
+            image = union_contours(image.into_iter().chain(feature_image).collect());
+        }
+    }
+    if image.is_empty() {
+        clear_all_features(doc);
+        return;
+    }
+
+    let path_id = doc.push_path(
+        GeometryPath::filled(FillRule::NonZero),
+        polygon_contours_to_contours(image),
+    );
+    let mut composite =
+        GeometryFeature::new(FeatureKind::Composite, FeatureBucket::Fill, Polarity::Dark);
+    composite.path_start = path_id;
+    composite.path_count = 1;
+    composite.object_index = doc.features.len() as u32;
+    clear_all_features(doc);
+    doc.features.push(composite);
+}
+
+fn stroked_path_outline(doc: &GeometryDocument, path: &GeometryPath) -> Option<PathPayload> {
+    if path.stroke_width <= 0.0 {
+        return None;
+    }
+    let source = path_to_kurbo(doc, path);
+    if source.elements().is_empty() {
+        return None;
+    }
+    let stroke = Stroke::new(path.stroke_width)
+        .with_join(Join::Round)
+        .with_caps(kurbo_cap(path.line_cap));
+    let outline = kurbo::stroke(source, &stroke, &StrokeOpts::default(), 0.01);
+    let contours = kurbo_path_to_line_contours(&outline);
+    (!contours.is_empty()).then_some(PathPayload {
+        path: GeometryPath::filled(FillRule::NonZero),
+        contours,
+    })
+}
+
+fn path_to_kurbo(doc: &GeometryDocument, path: &GeometryPath) -> BezPath {
+    let mut out = BezPath::new();
+    let mut current = Point::default();
+    for contour in &doc.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+    {
+        for cmd in &doc.path_cmds
+            [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+        {
+            match cmd.op {
+                PathOp::MoveTo => {
+                    current = cmd.p0;
+                    out.move_to(kurbo_point(cmd.p0));
+                }
+                PathOp::LineTo => {
+                    current = cmd.p0;
+                    out.line_to(kurbo_point(cmd.p0));
+                }
+                PathOp::ArcTo => {
+                    append_arc_to_kurbo(&mut out, current, cmd.p0, cmd.p1, cmd.clockwise);
+                    current = cmd.p0;
+                }
+                PathOp::Close => out.close_path(),
+            }
+        }
+    }
+    out
+}
+
+fn append_arc_to_kurbo(
+    out: &mut BezPath,
+    start: Point,
+    end: Point,
+    center: Point,
+    clockwise: bool,
+) {
+    let radius = start.distance_to(center);
+    if radius == 0.0 {
+        out.line_to(kurbo_point(end));
+        return;
+    }
+    let sweep = arc_sweep_radians(start, end, center, clockwise);
+    let signed_sweep = if clockwise { -sweep } else { sweep };
+    let segment_count = (signed_sweep.abs() / std::f64::consts::FRAC_PI_2)
+        .ceil()
+        .max(1.0) as usize;
+    let delta = signed_sweep / segment_count as f64;
+    let mut angle = start.angle_from(center);
+    for _ in 0..segment_count {
+        let next_angle = angle + delta;
+        let k = 4.0 / 3.0 * (delta / 4.0).tan();
+        let p0 = Point::new(
+            center.x + radius * angle.cos(),
+            center.y + radius * angle.sin(),
+        );
+        let p3 = Point::new(
+            center.x + radius * next_angle.cos(),
+            center.y + radius * next_angle.sin(),
+        );
+        let c1 = Point::new(
+            p0.x - radius * angle.sin() * k,
+            p0.y + radius * angle.cos() * k,
+        );
+        let c2 = Point::new(
+            p3.x + radius * next_angle.sin() * k,
+            p3.y - radius * next_angle.cos() * k,
+        );
+        out.curve_to(kurbo_point(c1), kurbo_point(c2), kurbo_point(p3));
+        angle = next_angle;
+    }
+}
+
+fn kurbo_path_to_line_contours(path: &BezPath) -> Vec<ContourPayload> {
+    let mut contours = Vec::new();
+    let mut current = Vec::new();
+    kurbo::flatten(path.clone(), 0.005, |element| match element {
+        PathEl::MoveTo(point) => {
+            push_line_contour(&mut contours, &mut current);
+            current.push(Point::new(point.x, point.y));
+        }
+        PathEl::LineTo(point) => current.push(Point::new(point.x, point.y)),
+        PathEl::ClosePath => push_line_contour(&mut contours, &mut current),
+        PathEl::QuadTo(..) | PathEl::CurveTo(..) => unreachable!("kurbo::flatten emits lines"),
+    });
+    push_line_contour(&mut contours, &mut current);
+    contours
+}
+
+fn push_line_contour(contours: &mut Vec<ContourPayload>, points: &mut Vec<Point>) {
+    if points.len() < 2 {
+        points.clear();
+        return;
+    }
+    let mut bbox = BBox::empty();
+    let mut cmds = Vec::with_capacity(points.len() + 1);
+    for (index, point) in points.drain(..).enumerate() {
+        bbox.include_point(point);
+        if index == 0 {
+            cmds.push(PathCmd::move_to(point));
+        } else {
+            cmds.push(PathCmd::line_to(point));
+        }
+    }
+    cmds.push(PathCmd::close());
+    contours.push(ContourPayload { bbox, cmds });
+}
+
+fn feature_image_contours(
+    doc: &GeometryDocument,
+    feature: &GeometryFeature,
+) -> Vec<PolygonContour> {
+    let mut positive = Vec::new();
+    let mut cutters = Vec::new();
+    for path in
+        &doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+    {
+        if !path.flags.filled {
+            continue;
+        }
+        if path.polarity == Polarity::Clear {
+            cutters.extend(path_polygon_contours(doc, path));
+        } else {
+            positive.extend(path_polygon_contours(doc, path));
+        }
+    }
+    let positive = union_contours(positive);
+    if cutters.is_empty() {
+        positive
+    } else {
+        difference_contours(positive, union_contours(cutters))
+    }
+}
+
+fn path_polygon_contours(doc: &GeometryDocument, path: &GeometryPath) -> Vec<PolygonContour> {
+    let mut contours = Vec::new();
+    let bez_path = path_to_kurbo(doc, path);
+    let mut current = Vec::new();
+    kurbo::flatten(bez_path, 0.005, |element| match element {
+        PathEl::MoveTo(point) => {
+            push_polygon_contour(&mut contours, &mut current);
+            current.push([point.x, point.y]);
+        }
+        PathEl::LineTo(point) => current.push([point.x, point.y]),
+        PathEl::ClosePath => push_polygon_contour(&mut contours, &mut current),
+        PathEl::QuadTo(..) | PathEl::CurveTo(..) => unreachable!("kurbo::flatten emits lines"),
+    });
+    push_polygon_contour(&mut contours, &mut current);
+    contours
+}
+
+fn push_polygon_contour(out: &mut Vec<PolygonContour>, contour: &mut PolygonContour) {
+    if contour.first() == contour.last() {
+        contour.pop();
+    }
+    if contour.len() >= 3 {
+        out.push(std::mem::take(contour));
+    } else {
+        contour.clear();
+    }
+}
+
+fn union_contours(contours: Vec<PolygonContour>) -> Vec<PolygonContour> {
+    polygon_shapes_to_polygon_contours(contours.simplify_shape(OverlayFillRule::NonZero))
+}
+
+fn difference_contours(
+    subject: Vec<PolygonContour>,
+    cutters: Vec<PolygonContour>,
+) -> Vec<PolygonContour> {
+    if subject.is_empty() || cutters.is_empty() {
+        return subject;
+    }
+    polygon_shapes_to_polygon_contours(subject.overlay(
+        &cutters,
+        OverlayRule::Difference,
+        OverlayFillRule::NonZero,
+    ))
+}
+
+fn polygon_shapes_to_polygon_contours(shapes: Vec<Vec<PolygonContour>>) -> Vec<PolygonContour> {
+    shapes.into_iter().flatten().collect()
+}
+
+fn polygon_contours_to_contours(contours: Vec<PolygonContour>) -> Vec<ContourPayload> {
+    contours
+        .into_iter()
+        .filter(|contour| contour.len() >= 3)
+        .map(|contour| {
+            let mut bbox = BBox::empty();
+            let mut cmds = Vec::with_capacity(contour.len() + 1);
+            for (index, [x, y]) in contour.into_iter().enumerate() {
+                let point = Point::new(x, y);
+                bbox.include_point(point);
+                if index == 0 {
+                    cmds.push(PathCmd::move_to(point));
+                } else {
+                    cmds.push(PathCmd::line_to(point));
+                }
+            }
+            cmds.push(PathCmd::close());
+            ContourPayload { bbox, cmds }
+        })
+        .collect()
+}
+
+fn clear_all_features(doc: &mut GeometryDocument) {
+    let path_start = doc.paths.len() as u32;
+    for feature in &mut doc.features {
+        feature.path_count = 0;
+        feature.path_start = path_start;
+    }
+}
+
+fn path_contours(doc: &GeometryDocument, path: &GeometryPath) -> Vec<ContourPayload> {
+    doc.contours[path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+        .iter()
+        .map(|contour| ContourPayload {
+            bbox: contour.bbox,
+            cmds: doc.path_cmds
+                [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+                .to_vec(),
+        })
+        .collect()
+}
+
+fn contour_bbox(doc: &GeometryDocument, contour_index: usize) -> BBox {
+    let contour = &doc.contours[contour_index];
+    let mut bbox = BBox::empty();
+    for cmd in
+        &doc.path_cmds[contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+    {
+        match cmd.op {
+            PathOp::MoveTo | PathOp::LineTo | PathOp::ArcTo => {
+                bbox.include_point(cmd.p0);
+                if cmd.op == PathOp::ArcTo {
+                    bbox.include_point(cmd.p1);
+                }
+            }
+            PathOp::Close => {}
+        }
+    }
+    bbox
+}
+
+fn path_bbox(doc: &GeometryDocument, path_index: usize) -> BBox {
+    let path = &doc.paths[path_index];
+    let bbox = doc.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+        .iter()
+        .fold(BBox::empty(), |bbox, contour| bbox.union(contour.bbox));
+    if path.flags.stroked {
+        bbox.expand(path.stroke_width / 2.0)
+    } else {
+        bbox
+    }
+}
+
+fn feature_bbox(doc: &GeometryDocument, feature_index: usize) -> BBox {
+    let feature = &doc.features[feature_index];
+    doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+        .iter()
+        .fold(BBox::empty(), |bbox, path| bbox.union(path.bbox))
+}
+
+fn arc_sweep_radians(start: Point, end: Point, center: Point, clockwise: bool) -> f64 {
+    if start.distance_to(end) <= 1e-9 && start.distance_to(center) > 1e-9 {
+        return std::f64::consts::TAU;
+    }
+    let start_angle = start.angle_from(center);
+    let end_angle = end.angle_from(center);
+    if clockwise {
+        normalize_angle(start_angle - end_angle)
+    } else {
+        normalize_angle(end_angle - start_angle)
+    }
+}
+
+fn normalize_angle(angle: f64) -> f64 {
+    angle.rem_euclid(std::f64::consts::TAU)
+}
+
+fn kurbo_cap(line_cap: LineCap) -> Cap {
+    match line_cap {
+        LineCap::Round => Cap::Round,
+        LineCap::Square => Cap::Square,
+        LineCap::Butt => Cap::Butt,
+    }
+}
+
+fn kurbo_point(point: Point) -> kurbo::Point {
+    kurbo::Point::new(point.x, point.y)
+}

--- a/crates/gerberx2/src/geometry/process.rs
+++ b/crates/gerberx2/src/geometry/process.rs
@@ -338,15 +338,18 @@ fn path_contours(doc: &GeometryDocument, path: &GeometryPath) -> Vec<ContourPayl
 fn contour_bbox(doc: &GeometryDocument, contour_index: usize) -> BBox {
     let contour = &doc.contours[contour_index];
     let mut bbox = BBox::empty();
+    let mut current = Point::default();
     for cmd in
         &doc.path_cmds[contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
     {
         match cmd.op {
-            PathOp::MoveTo | PathOp::LineTo | PathOp::ArcTo => {
+            PathOp::MoveTo | PathOp::LineTo => {
                 bbox.include_point(cmd.p0);
-                if cmd.op == PathOp::ArcTo {
-                    bbox.include_point(cmd.p1);
-                }
+                current = cmd.p0;
+            }
+            PathOp::ArcTo => {
+                bbox.include_circular_arc(current, cmd.p0, cmd.p1, cmd.clockwise);
+                current = cmd.p0;
             }
             PathOp::Close => {}
         }
@@ -372,23 +375,6 @@ fn feature_bbox(doc: &GeometryDocument, feature_index: usize) -> BBox {
     doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
         .iter()
         .fold(BBox::empty(), |bbox, path| bbox.union(path.bbox))
-}
-
-fn arc_sweep_radians(start: Point, end: Point, center: Point, clockwise: bool) -> f64 {
-    if start.distance_to(end) <= 1e-9 && start.distance_to(center) > 1e-9 {
-        return std::f64::consts::TAU;
-    }
-    let start_angle = start.angle_from(center);
-    let end_angle = end.angle_from(center);
-    if clockwise {
-        normalize_angle(start_angle - end_angle)
-    } else {
-        normalize_angle(end_angle - start_angle)
-    }
-}
-
-fn normalize_angle(angle: f64) -> f64 {
-    angle.rem_euclid(std::f64::consts::TAU)
 }
 
 fn kurbo_cap(line_cap: LineCap) -> Cap {

--- a/crates/gerberx2/src/geometry/process.rs
+++ b/crates/gerberx2/src/geometry/process.rs
@@ -221,26 +221,24 @@ fn feature_image_contours(
     doc: &GeometryDocument,
     feature: &GeometryFeature,
 ) -> Vec<PolygonContour> {
-    let mut positive = Vec::new();
-    let mut cutters = Vec::new();
+    let mut image = Vec::new();
     for path in
         &doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
     {
         if !path.flags.filled {
             continue;
         }
+        let path_contours = path_polygon_contours(doc, path);
+        if path_contours.is_empty() {
+            continue;
+        }
         if path.polarity == Polarity::Clear {
-            cutters.extend(path_polygon_contours(doc, path));
+            image = difference_contours(image, union_contours(path_contours));
         } else {
-            positive.extend(path_polygon_contours(doc, path));
+            image = union_contours(image.into_iter().chain(path_contours).collect());
         }
     }
-    let positive = union_contours(positive);
-    if cutters.is_empty() {
-        positive
-    } else {
-        difference_contours(positive, union_contours(cutters))
-    }
+    image
 }
 
 fn path_polygon_contours(doc: &GeometryDocument, path: &GeometryPath) -> Vec<PolygonContour> {

--- a/crates/gerberx2/src/geometry/raster.rs
+++ b/crates/gerberx2/src/geometry/raster.rs
@@ -1,0 +1,50 @@
+use resvg::{tiny_skia, usvg};
+
+use super::ir::GeometryDocument;
+
+const DEFAULT_MAX_DIMENSION_PX: u32 = 3200;
+
+pub fn render_png(doc: &GeometryDocument) -> crate::Result<Vec<u8>> {
+    render_png_with_max_dimension(doc, DEFAULT_MAX_DIMENSION_PX)
+}
+
+pub fn render_png_with_max_dimension(
+    doc: &GeometryDocument,
+    max_dimension_px: u32,
+) -> crate::Result<Vec<u8>> {
+    let (width_px, height_px) = pixel_size(doc, max_dimension_px);
+    let svg = super::svg::render_svg_sized(doc, width_px, height_px);
+    svg_to_png(&svg)
+}
+
+fn svg_to_png(svg: &str) -> crate::Result<Vec<u8>> {
+    let options = usvg::Options::default();
+    let tree = usvg::Tree::from_data(svg.as_bytes(), &options)
+        .map_err(|err| crate::GerberError::Render(format!("failed to parse SVG: {err}")))?;
+    let size = tree.size();
+    let width = size.width().ceil().max(1.0) as u32;
+    let height = size.height().ceil().max(1.0) as u32;
+    let mut pixmap = tiny_skia::Pixmap::new(width, height).ok_or_else(|| {
+        crate::GerberError::Render(format!("failed to allocate {width}x{height} PNG raster"))
+    })?;
+    resvg::render(
+        &tree,
+        tiny_skia::Transform::identity(),
+        &mut pixmap.as_mut(),
+    );
+    pixmap
+        .encode_png()
+        .map_err(|err| crate::GerberError::Render(format!("failed to encode PNG: {err}")))
+}
+
+fn pixel_size(doc: &GeometryDocument, max_dimension_px: u32) -> (u32, u32) {
+    let bbox = super::svg::render_bbox(doc);
+    if bbox.is_empty() || bbox.width() <= 0.0 || bbox.height() <= 0.0 {
+        return (max_dimension_px, max_dimension_px);
+    }
+    let scale = max_dimension_px as f64 / bbox.width().max(bbox.height());
+    (
+        (bbox.width() * scale).ceil().max(1.0) as u32,
+        (bbox.height() * scale).ceil().max(1.0) as u32,
+    )
+}

--- a/crates/gerberx2/src/geometry/svg.rs
+++ b/crates/gerberx2/src/geometry/svg.rs
@@ -121,6 +121,21 @@ fn write_path(
         FillRule::NonZero => "nonzero",
         FillRule::EvenOdd => "evenodd",
     };
+    if mode == RenderMode::Final && is_profile_layer(doc) {
+        let stroke_width = if path.stroke_width > 0.0 {
+            path.stroke_width
+        } else {
+            0.1
+        };
+        writeln!(
+            svg,
+            "    <path d='{d}' fill='none' stroke='#000000' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='round' data-board-outline='true'/>",
+            fmt_num(stroke_width),
+            line_cap(path.line_cap)
+        )
+        .unwrap();
+        return;
+    }
     if path.flags.stroked {
         writeln!(
             svg,
@@ -134,6 +149,13 @@ fn write_path(
             style.color, fmt_num(style.opacity), feature.kind, feature.bucket
         ).unwrap();
     }
+}
+
+fn is_profile_layer(doc: &GeometryDocument) -> bool {
+    matches!(
+        doc.file_function.first().map(String::as_str),
+        Some("Profile")
+    )
 }
 
 fn path_data(doc: &GeometryDocument, path: &GeometryPath) -> String {

--- a/crates/gerberx2/src/geometry/svg.rs
+++ b/crates/gerberx2/src/geometry/svg.rs
@@ -1,0 +1,293 @@
+use std::fmt::Write;
+
+use super::ir::*;
+
+const VIEWBOX_PADDING_MM: f64 = 1.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderMode {
+    Final,
+    Debug,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SvgOptions {
+    pub mode: RenderMode,
+    pub width_px: Option<u32>,
+    pub height_px: Option<u32>,
+}
+
+impl Default for SvgOptions {
+    fn default() -> Self {
+        Self {
+            mode: RenderMode::Final,
+            width_px: None,
+            height_px: None,
+        }
+    }
+}
+
+pub fn render_svg(doc: &GeometryDocument) -> String {
+    render_svg_with_options(doc, SvgOptions::default())
+}
+
+pub fn render_svg_sized(doc: &GeometryDocument, width_px: u32, height_px: u32) -> String {
+    render_svg_with_options(
+        doc,
+        SvgOptions {
+            width_px: Some(width_px),
+            height_px: Some(height_px),
+            ..SvgOptions::default()
+        },
+    )
+}
+
+pub fn render_svg_with_options(doc: &GeometryDocument, options: SvgOptions) -> String {
+    let bbox = render_bbox(doc);
+    let viewbox_y = -bbox.max.y;
+    let mut svg = String::new();
+    let size = match (options.width_px, options.height_px) {
+        (Some(w), Some(h)) => format!(" width='{w}' height='{h}'"),
+        _ => String::new(),
+    };
+    writeln!(
+        svg,
+        "<svg xmlns='http://www.w3.org/2000/svg'{size} viewBox='{} {} {} {}'>",
+        fmt_num(bbox.min.x),
+        fmt_num(viewbox_y),
+        fmt_num(bbox.width()),
+        fmt_num(bbox.height())
+    )
+    .unwrap();
+    writeln!(svg, "  <title>{}</title>", escape_xml(&layer_title(doc))).unwrap();
+    writeln!(svg, "  <g transform='scale(1 -1)'>").unwrap();
+
+    for bucket in bucket_order(options.mode) {
+        for feature in doc
+            .features
+            .iter()
+            .filter(|feature| feature.bucket == *bucket && feature.path_count > 0)
+        {
+            for path in &doc.paths
+                [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+            {
+                write_path(&mut svg, doc, feature, path, options.mode);
+            }
+        }
+    }
+
+    writeln!(svg, "  </g>").unwrap();
+    writeln!(svg, "</svg>").unwrap();
+    svg
+}
+
+pub fn render_bbox(doc: &GeometryDocument) -> BBox {
+    if doc.bbox.is_empty() {
+        BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(100.0, 100.0),
+        }
+    } else {
+        doc.bbox.expand(VIEWBOX_PADDING_MM)
+    }
+}
+
+fn bucket_order(mode: RenderMode) -> &'static [FeatureBucket] {
+    match mode {
+        RenderMode::Final => &[FeatureBucket::Fill, FeatureBucket::Unknown],
+        RenderMode::Debug => &[
+            FeatureBucket::Fill,
+            FeatureBucket::Trace,
+            FeatureBucket::Pad,
+            FeatureBucket::Cutout,
+            FeatureBucket::Unknown,
+        ],
+    }
+}
+
+fn write_path(
+    svg: &mut String,
+    doc: &GeometryDocument,
+    feature: &GeometryFeature,
+    path: &GeometryPath,
+    mode: RenderMode,
+) {
+    let d = path_data(doc, path);
+    if d.is_empty() {
+        return;
+    }
+    let style = style_for(doc, feature, mode);
+    let fill_rule = match path.fill_rule {
+        FillRule::NonZero => "nonzero",
+        FillRule::EvenOdd => "evenodd",
+    };
+    if path.flags.stroked {
+        writeln!(
+            svg,
+            "    <path d='{d}' fill='none' stroke='{}' stroke-opacity='{}' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='round' data-kind='{:?}' data-bucket='{:?}'/>",
+            style.color, fmt_num(style.opacity), fmt_num(path.stroke_width), line_cap(path.line_cap), feature.kind, feature.bucket
+        ).unwrap();
+    } else if path.flags.filled {
+        writeln!(
+            svg,
+            "    <path d='{d}' fill='{}' fill-opacity='{}' fill-rule='{fill_rule}' data-kind='{:?}' data-bucket='{:?}'/>",
+            style.color, fmt_num(style.opacity), feature.kind, feature.bucket
+        ).unwrap();
+    }
+}
+
+fn path_data(doc: &GeometryDocument, path: &GeometryPath) -> String {
+    let mut data = String::new();
+    for contour in &doc.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+    {
+        let mut current = Point::default();
+        for cmd in &doc.path_cmds
+            [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+        {
+            match cmd.op {
+                PathOp::MoveTo => {
+                    current = cmd.p0;
+                    write!(data, "M{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap();
+                }
+                PathOp::LineTo => {
+                    current = cmd.p0;
+                    write!(data, " L{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap();
+                }
+                PathOp::ArcTo => {
+                    let radius = current.distance_to(cmd.p1);
+                    let sweep_flag = if cmd.clockwise { 0 } else { 1 };
+                    let large_arc = if arc_sweep_radians(current, cmd.p0, cmd.p1, cmd.clockwise)
+                        > std::f64::consts::PI
+                    {
+                        1
+                    } else {
+                        0
+                    };
+                    if current.distance_to(cmd.p0) <= 1e-9 && radius > 0.0 {
+                        let mid =
+                            Point::new(2.0 * cmd.p1.x - current.x, 2.0 * cmd.p1.y - current.y);
+                        write!(
+                            data,
+                            " A{} {} 0 1 {sweep_flag} {} {} A{} {} 0 1 {sweep_flag} {} {}",
+                            fmt_num(radius),
+                            fmt_num(radius),
+                            fmt_num(mid.x),
+                            fmt_num(mid.y),
+                            fmt_num(radius),
+                            fmt_num(radius),
+                            fmt_num(cmd.p0.x),
+                            fmt_num(cmd.p0.y)
+                        )
+                        .unwrap();
+                    } else {
+                        write!(
+                            data,
+                            " A{} {} 0 {large_arc} {sweep_flag} {} {}",
+                            fmt_num(radius),
+                            fmt_num(radius),
+                            fmt_num(cmd.p0.x),
+                            fmt_num(cmd.p0.y)
+                        )
+                        .unwrap();
+                    }
+                    current = cmd.p0;
+                }
+                PathOp::Close => data.push_str(" Z"),
+            }
+        }
+    }
+    data
+}
+
+struct Style {
+    color: &'static str,
+    opacity: f64,
+}
+
+fn style_for(doc: &GeometryDocument, feature: &GeometryFeature, mode: RenderMode) -> Style {
+    if mode == RenderMode::Debug {
+        return match feature.bucket {
+            FeatureBucket::Pad => Style {
+                color: "#f4b942",
+                opacity: 0.78,
+            },
+            FeatureBucket::Trace => Style {
+                color: "#d87822",
+                opacity: 0.78,
+            },
+            FeatureBucket::Fill => Style {
+                color: "#b7661f",
+                opacity: 0.78,
+            },
+            FeatureBucket::Cutout => Style {
+                color: "#808080",
+                opacity: 1.0,
+            },
+            FeatureBucket::Unknown => Style {
+                color: "#5c7cfa",
+                opacity: 0.78,
+            },
+        };
+    }
+    match doc.file_function.first().map(String::as_str) {
+        Some("Paste") => Style {
+            color: "#aeb4bb",
+            opacity: 0.9,
+        },
+        Some("Soldermask") => Style {
+            color: "#159447",
+            opacity: 0.55,
+        },
+        Some("Legend") => Style {
+            color: "#f8f9fa",
+            opacity: 0.95,
+        },
+        Some("Profile") => Style {
+            color: "#606060",
+            opacity: 1.0,
+        },
+        Some("Copper") => Style {
+            color: "#d87822",
+            opacity: 0.9,
+        },
+        _ => Style {
+            color: "#5c7cfa",
+            opacity: 0.85,
+        },
+    }
+}
+
+fn layer_title(doc: &GeometryDocument) -> String {
+    if doc.file_function.is_empty() {
+        "Gerber X2 layer".to_string()
+    } else {
+        doc.file_function.join(", ")
+    }
+}
+
+fn line_cap(line_cap: LineCap) -> &'static str {
+    match line_cap {
+        LineCap::Round => "round",
+        LineCap::Square => "square",
+        LineCap::Butt => "butt",
+    }
+}
+
+fn fmt_num(value: f64) -> String {
+    let value = if value.abs() < 1e-9 { 0.0 } else { value };
+    let mut s = format!("{value:.6}");
+    while s.contains('.') && s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    s
+}
+
+fn escape_xml(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}

--- a/crates/gerberx2/src/geometry/terminal.rs
+++ b/crates/gerberx2/src/geometry/terminal.rs
@@ -1,0 +1,54 @@
+use std::io::{self, IsTerminal, Write};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use terminal_size::{Width, terminal_size};
+
+use super::ir::GeometryDocument;
+
+const KITTY_CHUNK_SIZE: usize = 4096;
+const MAX_TERMINAL_DIMENSION_PX: u32 = 1200;
+
+pub fn can_render_to_terminal() -> bool {
+    io::stdout().is_terminal()
+}
+
+pub fn render_to_terminal(doc: &GeometryDocument) -> crate::Result<()> {
+    if !io::stdout().is_terminal() {
+        return Err(crate::GerberError::Render(
+            "stdout is not an interactive terminal; pass an SVG or PNG output path".to_string(),
+        ));
+    }
+    let png = super::raster::render_png_with_max_dimension(doc, terminal_max_dimension_px())?;
+    let mut stdout = io::stdout().lock();
+    write_kitty_png(&mut stdout, &png)?;
+    stdout.write_all(b"\n")?;
+    Ok(())
+}
+
+fn terminal_max_dimension_px() -> u32 {
+    let Some((Width(columns), _)) = terminal_size() else {
+        return MAX_TERMINAL_DIMENSION_PX;
+    };
+    u32::from(columns)
+        .saturating_mul(12)
+        .clamp(1, MAX_TERMINAL_DIMENSION_PX)
+}
+
+fn write_kitty_png<W: Write>(writer: &mut W, png: &[u8]) -> io::Result<()> {
+    let encoded = STANDARD.encode(png);
+    let mut chunks = encoded.as_bytes().chunks(KITTY_CHUNK_SIZE).peekable();
+    let mut first = true;
+    while let Some(chunk) = chunks.next() {
+        let more = u8::from(chunks.peek().is_some());
+        if first {
+            write!(writer, "\x1b_Ga=T,f=100,m={more};")?;
+            first = false;
+        } else {
+            write!(writer, "\x1b_Gm={more};")?;
+        }
+        writer.write_all(chunk)?;
+        writer.write_all(b"\x1b\\")?;
+    }
+    Ok(())
+}

--- a/crates/gerberx2/src/intern.rs
+++ b/crates/gerberx2/src/intern.rs
@@ -1,0 +1,90 @@
+// Simple string interner for Gerber X2 parsing.
+// Deduplicates repeated identifiers and attribute fields.
+// Derived from: https://matklad.github.io/2020/03/22/fast-simple-rust-interner.html
+
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Symbol(u32);
+
+#[derive(Debug)]
+pub struct Interner {
+    map: HashMap<&'static str, Symbol>,
+    vec: Vec<&'static str>,
+    buf: String,
+    full: Vec<String>,
+}
+
+impl Default for Interner {
+    fn default() -> Self {
+        Self::with_capacity(1024)
+    }
+}
+
+impl Interner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            map: HashMap::with_capacity(cap),
+            vec: Vec::with_capacity(cap),
+            buf: String::with_capacity(cap),
+            full: Vec::new(),
+        }
+    }
+
+    pub fn intern(&mut self, s: &str) -> Symbol {
+        if let Some(&sym) = self.map.get(s) {
+            return sym;
+        }
+
+        // SAFETY: The returned reference points into `self.buf` or `self.full`,
+        // which are never dropped or reallocated (only moved to `self.full`).
+        // The 'static lifetime is sound because the Interner owns the storage
+        // and the strings live as long as the Interner itself.
+        let s = unsafe { self.alloc(s) };
+        let sym = Symbol(u32::try_from(self.vec.len()).expect("too many symbols"));
+        self.map.insert(s, sym);
+        self.vec.push(s);
+        sym
+    }
+
+    pub fn get(&self, s: &str) -> Option<Symbol> {
+        self.map.get(s).copied()
+    }
+
+    pub fn resolve(&self, sym: Symbol) -> &str {
+        self.vec[sym.0 as usize]
+    }
+
+    unsafe fn alloc(&mut self, s: &str) -> &'static str {
+        let need = s.len();
+        if self.buf.capacity() - self.buf.len() < need {
+            let old_cap = self.buf.capacity();
+            let new_cap = (old_cap + need).next_power_of_two();
+            let old = std::mem::replace(&mut self.buf, String::with_capacity(new_cap));
+            self.full.push(old);
+        }
+
+        let start = self.buf.len();
+        self.buf.push_str(s);
+
+        unsafe { &*(&self.buf[start..] as *const str) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_interning() {
+        let mut interner = Interner::new();
+        let x1 = interner.intern(".FileFunction");
+        let x2 = interner.intern(".FileFunction");
+        assert_eq!(x1, x2);
+        assert_eq!(interner.resolve(x1), ".FileFunction");
+    }
+}

--- a/crates/gerberx2/src/lib.rs
+++ b/crates/gerberx2/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod geometry;
 mod intern;
 mod parse;
 pub mod types;

--- a/crates/gerberx2/src/lib.rs
+++ b/crates/gerberx2/src/lib.rs
@@ -1,0 +1,104 @@
+mod intern;
+mod parse;
+pub mod types;
+
+pub use intern::{Interner, Symbol};
+pub use types::*;
+
+use parse::Parser;
+use std::path::Path;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GerberError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Syntax error at byte {offset}: {message}")]
+    Syntax { offset: usize, message: String },
+
+    #[error("Invalid Gerber structure: {0}")]
+    InvalidStructure(String),
+
+    #[error("Invalid numeric value: {0}")]
+    InvalidNumber(String),
+}
+
+pub type Result<T> = std::result::Result<T, GerberError>;
+
+#[derive(Debug)]
+pub struct GerberX2 {
+    interner: Interner,
+    commands: Vec<Command>,
+    file_attributes: Vec<Attribute>,
+    aperture_attributes: Vec<Attribute>,
+    object_attributes: Vec<Attribute>,
+    aperture_definitions: Vec<ApertureDefinition>,
+    aperture_macros: Vec<ApertureMacro>,
+    final_state: GraphicsState,
+}
+
+impl GerberX2 {
+    pub fn parse(source: &str) -> Result<Self> {
+        let mut parser = Parser::new(source);
+        parser.parse()
+    }
+
+    pub fn parse_file(path: impl AsRef<Path>) -> Result<Self> {
+        let source = std::fs::read_to_string(path)?;
+        Self::parse(&source)
+    }
+
+    pub fn commands(&self) -> &[Command] {
+        &self.commands
+    }
+
+    pub fn file_attributes(&self) -> &[Attribute] {
+        &self.file_attributes
+    }
+
+    pub fn aperture_attributes(&self) -> &[Attribute] {
+        &self.aperture_attributes
+    }
+
+    pub fn object_attributes(&self) -> &[Attribute] {
+        &self.object_attributes
+    }
+
+    pub fn aperture_definitions(&self) -> &[ApertureDefinition] {
+        &self.aperture_definitions
+    }
+
+    pub fn aperture_macros(&self) -> &[ApertureMacro] {
+        &self.aperture_macros
+    }
+
+    pub fn final_state(&self) -> &GraphicsState {
+        &self.final_state
+    }
+
+    pub fn resolve(&self, sym: Symbol) -> &str {
+        self.interner.resolve(sym)
+    }
+
+    pub fn interner(&self) -> &Interner {
+        &self.interner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_flash_file() {
+        let gerber = GerberX2::parse(
+            "%FSLAX26Y26*%\n%MOMM*%\n%TF.FileFunction,Paste,Top*%\n%TA.AperFunction,Material*%\n%ADD10C,1.5*%\nD10*\nX0Y0D03*\nM02*\n",
+        )
+        .unwrap();
+
+        assert_eq!(gerber.aperture_definitions().len(), 1);
+        assert_eq!(gerber.file_attributes().len(), 1);
+        assert!(matches!(gerber.commands().last(), Some(Command::EndOfFile)));
+    }
+}

--- a/crates/gerberx2/src/lib.rs
+++ b/crates/gerberx2/src/lib.rs
@@ -23,6 +23,9 @@ pub enum GerberError {
 
     #[error("Invalid numeric value: {0}")]
     InvalidNumber(String),
+
+    #[error("Render error: {0}")]
+    Render(String),
 }
 
 pub type Result<T> = std::result::Result<T, GerberError>;

--- a/crates/gerberx2/src/lib.rs
+++ b/crates/gerberx2/src/lib.rs
@@ -35,6 +35,7 @@ pub struct GerberX2 {
     object_attributes: Vec<Attribute>,
     aperture_definitions: Vec<ApertureDefinition>,
     aperture_macros: Vec<ApertureMacro>,
+    objects: Vec<GraphicalObject>,
     final_state: GraphicsState,
 }
 
@@ -73,6 +74,10 @@ impl GerberX2 {
         &self.aperture_macros
     }
 
+    pub fn objects(&self) -> &[GraphicalObject] {
+        &self.objects
+    }
+
     pub fn final_state(&self) -> &GraphicsState {
         &self.final_state
     }
@@ -99,6 +104,7 @@ mod tests {
 
         assert_eq!(gerber.aperture_definitions().len(), 1);
         assert_eq!(gerber.file_attributes().len(), 1);
+        assert_eq!(gerber.objects().len(), 1);
         assert!(matches!(gerber.commands().last(), Some(Command::EndOfFile)));
     }
 }

--- a/crates/gerberx2/src/lib.rs
+++ b/crates/gerberx2/src/lib.rs
@@ -2,9 +2,14 @@ pub mod geometry;
 mod intern;
 mod parse;
 pub mod types;
+pub mod write;
 
 pub use intern::{Interner, Symbol};
 pub use types::*;
+pub use write::{
+    AttributeValue, GerberLayer, WriterAperture, WriterApertureMacro, WriterApertureTemplate,
+    WriterMacroExpression, WriterMacroPrimitive, WriterObject, write_layer,
+};
 
 use parse::Parser;
 use std::path::Path;

--- a/crates/gerberx2/src/parse.rs
+++ b/crates/gerberx2/src/parse.rs
@@ -11,9 +11,18 @@ pub struct Parser<'a> {
     aperture_attributes: HashMap<Symbol, Attribute>,
     object_attributes: HashMap<Symbol, Attribute>,
     aperture_definitions: Vec<ApertureDefinition>,
+    aperture_lookup: HashMap<i32, ApertureDefinition>,
     aperture_macros: Vec<ApertureMacro>,
+    objects: Vec<GraphicalObject>,
+    region: Option<RegionBuilder>,
     state: GraphicsState,
     saw_m02: bool,
+}
+
+#[derive(Debug, Default)]
+struct RegionBuilder {
+    contours: Vec<Contour>,
+    current: Option<Contour>,
 }
 
 impl<'a> Parser<'a> {
@@ -27,7 +36,10 @@ impl<'a> Parser<'a> {
             aperture_attributes: HashMap::new(),
             object_attributes: HashMap::new(),
             aperture_definitions: Vec::new(),
+            aperture_lookup: HashMap::new(),
             aperture_macros: Vec::new(),
+            objects: Vec::new(),
+            region: None,
             state: GraphicsState::default(),
             saw_m02: false,
         }
@@ -64,6 +76,7 @@ impl<'a> Parser<'a> {
             object_attributes,
             aperture_definitions: std::mem::take(&mut self.aperture_definitions),
             aperture_macros: std::mem::take(&mut self.aperture_macros),
+            objects: std::mem::take(&mut self.objects),
             final_state: self.state.clone(),
         })
     }
@@ -140,6 +153,7 @@ impl<'a> Parser<'a> {
             let aperture = self.parse_aperture_definition(rest)?;
             self.commands
                 .push(Command::ApertureDefinition(aperture.clone()));
+            self.aperture_lookup.insert(aperture.code, aperture.clone());
             self.aperture_definitions.push(aperture);
             return Ok(());
         }
@@ -280,10 +294,27 @@ impl<'a> Parser<'a> {
                 return Ok(());
             }
             "G36" => {
+                if self.region.is_some() {
+                    return Err(self.syntax("nested region statements are not allowed"));
+                }
+                self.region = Some(RegionBuilder::default());
                 self.commands.push(Command::BeginRegion);
                 return Ok(());
             }
             "G37" => {
+                let mut region = self
+                    .region
+                    .take()
+                    .ok_or_else(|| self.syntax("G37 without matching G36"))?;
+                if let Some(contour) = region.current.take() {
+                    region.contours.push(contour);
+                }
+                if region.contours.is_empty() {
+                    return Err(self.syntax("empty region statement"));
+                }
+                self.objects.push(self.graphical_object(ObjectKind::Region {
+                    contours: region.contours,
+                }));
                 self.commands.push(Command::EndRegion);
                 return Ok(());
             }
@@ -302,8 +333,180 @@ impl<'a> Parser<'a> {
         }
 
         let (fields, code) = parse_operation(word)?;
+        self.interpret_operation(fields, code)?;
         self.commands.push(Command::Operation { fields, code });
         Ok(())
+    }
+
+    fn interpret_operation(&mut self, fields: CoordinateFields, code: OperationCode) -> Result<()> {
+        let point = self.operation_point(fields)?;
+        match code {
+            OperationCode::Move => {
+                if let Some(region) = &mut self.region {
+                    if let Some(contour) = region.current.take() {
+                        region.contours.push(contour);
+                    }
+                    region.current = Some(Contour {
+                        segments: Vec::new(),
+                    });
+                }
+                self.state.current_point = Some(point);
+            }
+            OperationCode::Flash => {
+                if self.region.is_some() {
+                    return Err(self.syntax("D03 flash is not allowed inside a region"));
+                }
+                let aperture = self.current_aperture()?;
+                self.objects.push(self.graphical_object(ObjectKind::Flash {
+                    at: point,
+                    aperture,
+                }));
+                self.state.current_point = Some(point);
+            }
+            OperationCode::Plot => {
+                let start = self
+                    .state
+                    .current_point
+                    .ok_or_else(|| self.syntax("D01 plot requires a current point"))?;
+                let plot_mode = self
+                    .state
+                    .plot_mode
+                    .ok_or_else(|| self.syntax("D01 plot requires G01/G02/G03 plot mode"))?;
+                let segment = match plot_mode {
+                    PlotMode::Linear => ContourSegment::Line { start, end: point },
+                    PlotMode::ClockwiseArc | PlotMode::CounterclockwiseArc => {
+                        let center_offset = self.coordinate_offset(fields)?;
+                        ContourSegment::Arc {
+                            start,
+                            end: point,
+                            center_offset,
+                            clockwise: plot_mode == PlotMode::ClockwiseArc,
+                        }
+                    }
+                };
+                if let Some(region) = &mut self.region {
+                    let Some(contour) = region.current.as_mut() else {
+                        return Err(GerberError::Syntax {
+                            offset: self.pos,
+                            message: "region D01 must follow D02 contour start".to_string(),
+                        });
+                    };
+                    contour.segments.push(segment);
+                } else {
+                    let aperture = self.current_aperture()?;
+                    let kind = match segment {
+                        ContourSegment::Line { start, end } => ObjectKind::Draw {
+                            start,
+                            end,
+                            aperture,
+                        },
+                        ContourSegment::Arc {
+                            start,
+                            end,
+                            center_offset,
+                            clockwise,
+                        } => ObjectKind::Arc {
+                            start,
+                            end,
+                            center_offset,
+                            clockwise,
+                            aperture,
+                        },
+                    };
+                    self.objects.push(self.graphical_object(kind));
+                }
+                self.state.current_point = Some(point);
+            }
+        }
+        Ok(())
+    }
+
+    fn operation_point(&self, fields: CoordinateFields) -> Result<Point> {
+        let current = self.state.current_point;
+        let x = match fields.x {
+            Some(x) => self.decode_x(x)?,
+            None => current
+                .map(|point| point.x)
+                .ok_or_else(|| self.syntax("modal X coordinate requires a current point"))?,
+        };
+        let y = match fields.y {
+            Some(y) => self.decode_y(y)?,
+            None => current
+                .map(|point| point.y)
+                .ok_or_else(|| self.syntax("modal Y coordinate requires a current point"))?,
+        };
+        Ok(Point { x, y })
+    }
+
+    fn coordinate_offset(&self, fields: CoordinateFields) -> Result<Point> {
+        let i = fields
+            .i
+            .ok_or_else(|| self.syntax("arc D01 requires I offset"))?;
+        let j = fields
+            .j
+            .ok_or_else(|| self.syntax("arc D01 requires J offset"))?;
+        Ok(Point {
+            x: self.decode_x(i)?,
+            y: self.decode_y(j)?,
+        })
+    }
+
+    fn decode_x(&self, value: i64) -> Result<f64> {
+        let format = self.coordinate_format()?;
+        Ok(scale_coordinate(
+            value,
+            format.x_decimal_digits,
+            self.unit()?,
+        ))
+    }
+
+    fn decode_y(&self, value: i64) -> Result<f64> {
+        let format = self.coordinate_format()?;
+        Ok(scale_coordinate(
+            value,
+            format.y_decimal_digits,
+            self.unit()?,
+        ))
+    }
+
+    fn unit(&self) -> Result<Unit> {
+        self.state
+            .unit
+            .ok_or_else(|| self.syntax("operation requires MO unit command first"))
+    }
+
+    fn coordinate_format(&self) -> Result<CoordinateFormat> {
+        self.state
+            .coordinate_format
+            .ok_or_else(|| self.syntax("operation requires FS coordinate format first"))
+    }
+
+    fn current_aperture(&self) -> Result<i32> {
+        self.state
+            .current_aperture
+            .ok_or_else(|| self.syntax("operation requires current aperture"))
+    }
+
+    fn graphical_object(&self, kind: ObjectKind) -> GraphicalObject {
+        let aperture_attributes = match &kind {
+            ObjectKind::Draw { aperture, .. }
+            | ObjectKind::Arc { aperture, .. }
+            | ObjectKind::Flash { aperture, .. } => self
+                .aperture_lookup
+                .get(aperture)
+                .map(|aperture| aperture.attributes.clone())
+                .unwrap_or_default(),
+            ObjectKind::Region { .. } => self.aperture_attributes.values().cloned().collect(),
+        };
+        GraphicalObject {
+            kind,
+            polarity: self.state.polarity,
+            mirroring: self.state.mirroring,
+            rotation_degrees: self.state.rotation_degrees,
+            scaling: self.state.scaling,
+            aperture_attributes,
+            object_attributes: self.object_attributes.values().cloned().collect(),
+        }
     }
 
     fn parse_attribute(&mut self, rest: &str) -> Result<Attribute> {
@@ -326,9 +529,11 @@ impl<'a> Parser<'a> {
         let code = parse_aperture_code(&rest[..d_len])?;
         let template_call = &rest[d_len..];
         let template = self.parse_template_call(template_call)?;
+        let geometry = lower_standard_aperture(&template);
         Ok(ApertureDefinition {
             code,
             template,
+            geometry,
             attributes: self.aperture_attributes.values().cloned().collect(),
         })
     }
@@ -412,6 +617,200 @@ fn parse_format(rest: &str) -> Option<CoordinateFormat> {
         y_integer_digits,
         y_decimal_digits,
     })
+}
+
+fn scale_coordinate(value: i64, decimal_digits: u8, unit: Unit) -> f64 {
+    let value = value as f64 / 10_f64.powi(decimal_digits as i32);
+    match unit {
+        Unit::Millimeter => value,
+        Unit::Inch => value * 25.4,
+    }
+}
+
+fn lower_standard_aperture(template: &ApertureTemplate) -> Option<ApertureGeometry> {
+    let paths = match *template {
+        ApertureTemplate::Circle {
+            diameter,
+            hole_diameter,
+        } => circle_paths(diameter, hole_diameter),
+        ApertureTemplate::Rectangle {
+            width,
+            height,
+            hole_diameter,
+        } => rect_paths(width, height, hole_diameter),
+        ApertureTemplate::Obround {
+            width,
+            height,
+            hole_diameter,
+        } => obround_paths(width, height, hole_diameter),
+        ApertureTemplate::Polygon {
+            outer_diameter,
+            vertices,
+            rotation_degrees,
+            hole_diameter,
+        } => polygon_paths(
+            outer_diameter,
+            vertices,
+            rotation_degrees.unwrap_or(0.0),
+            hole_diameter,
+        ),
+        ApertureTemplate::Macro { .. } => return None,
+    };
+    Some(ApertureGeometry { paths })
+}
+
+fn circle_paths(diameter: f64, hole_diameter: Option<f64>) -> Vec<GeometryPath> {
+    let mut paths = Vec::new();
+    if diameter > 0.0 {
+        paths.push(circle_path(diameter / 2.0, Polarity::Dark));
+    }
+    if let Some(hole_diameter) = hole_diameter
+        && hole_diameter > 0.0
+    {
+        paths.push(circle_path(hole_diameter / 2.0, Polarity::Clear));
+    }
+    paths
+}
+
+fn rect_paths(width: f64, height: f64, hole_diameter: Option<f64>) -> Vec<GeometryPath> {
+    let mut paths = vec![rect_path(width, height, Polarity::Dark)];
+    if let Some(hole_diameter) = hole_diameter
+        && hole_diameter > 0.0
+    {
+        paths.push(circle_path(hole_diameter / 2.0, Polarity::Clear));
+    }
+    paths
+}
+
+fn obround_paths(width: f64, height: f64, hole_diameter: Option<f64>) -> Vec<GeometryPath> {
+    let mut paths = Vec::new();
+    let rx = width / 2.0;
+    let ry = height / 2.0;
+    let commands = if width >= height {
+        let r = ry;
+        let cx = rx - r;
+        vec![
+            PathCommand::MoveTo(Point { x: -cx, y: -r }),
+            PathCommand::LineTo(Point { x: cx, y: -r }),
+            PathCommand::ArcTo {
+                end: Point { x: cx, y: r },
+                center: Point { x: cx, y: 0.0 },
+                clockwise: false,
+            },
+            PathCommand::LineTo(Point { x: -cx, y: r }),
+            PathCommand::ArcTo {
+                end: Point { x: -cx, y: -r },
+                center: Point { x: -cx, y: 0.0 },
+                clockwise: false,
+            },
+            PathCommand::Close,
+        ]
+    } else {
+        let r = rx;
+        let cy = ry - r;
+        vec![
+            PathCommand::MoveTo(Point { x: r, y: -cy }),
+            PathCommand::LineTo(Point { x: r, y: cy }),
+            PathCommand::ArcTo {
+                end: Point { x: -r, y: cy },
+                center: Point { x: 0.0, y: cy },
+                clockwise: false,
+            },
+            PathCommand::LineTo(Point { x: -r, y: -cy }),
+            PathCommand::ArcTo {
+                end: Point { x: r, y: -cy },
+                center: Point { x: 0.0, y: -cy },
+                clockwise: false,
+            },
+            PathCommand::Close,
+        ]
+    };
+    paths.push(GeometryPath {
+        contours: vec![GeometryContour { commands }],
+        polarity: Polarity::Dark,
+    });
+    if let Some(hole_diameter) = hole_diameter
+        && hole_diameter > 0.0
+    {
+        paths.push(circle_path(hole_diameter / 2.0, Polarity::Clear));
+    }
+    paths
+}
+
+fn polygon_paths(
+    outer_diameter: f64,
+    vertices: i32,
+    rotation_degrees: f64,
+    hole_diameter: Option<f64>,
+) -> Vec<GeometryPath> {
+    let mut paths = Vec::new();
+    if vertices >= 3 {
+        let radius = outer_diameter / 2.0;
+        let rotation = rotation_degrees.to_radians();
+        let mut commands = Vec::new();
+        for i in 0..vertices {
+            let angle = rotation + i as f64 * std::f64::consts::TAU / vertices as f64;
+            let point = Point {
+                x: radius * angle.cos(),
+                y: radius * angle.sin(),
+            };
+            if i == 0 {
+                commands.push(PathCommand::MoveTo(point));
+            } else {
+                commands.push(PathCommand::LineTo(point));
+            }
+        }
+        commands.push(PathCommand::Close);
+        paths.push(GeometryPath {
+            contours: vec![GeometryContour { commands }],
+            polarity: Polarity::Dark,
+        });
+    }
+    if let Some(hole_diameter) = hole_diameter
+        && hole_diameter > 0.0
+    {
+        paths.push(circle_path(hole_diameter / 2.0, Polarity::Clear));
+    }
+    paths
+}
+
+fn circle_path(radius: f64, polarity: Polarity) -> GeometryPath {
+    GeometryPath {
+        contours: vec![GeometryContour {
+            commands: vec![
+                PathCommand::MoveTo(Point { x: radius, y: 0.0 }),
+                PathCommand::ArcTo {
+                    end: Point { x: -radius, y: 0.0 },
+                    center: Point { x: 0.0, y: 0.0 },
+                    clockwise: false,
+                },
+                PathCommand::ArcTo {
+                    end: Point { x: radius, y: 0.0 },
+                    center: Point { x: 0.0, y: 0.0 },
+                    clockwise: false,
+                },
+                PathCommand::Close,
+            ],
+        }],
+        polarity,
+    }
+}
+
+fn rect_path(width: f64, height: f64, polarity: Polarity) -> GeometryPath {
+    let hw = width / 2.0;
+    let hh = height / 2.0;
+    GeometryPath {
+        contours: vec![GeometryContour {
+            commands: vec![
+                PathCommand::MoveTo(Point { x: -hw, y: -hh }),
+                PathCommand::LineTo(Point { x: hw, y: -hh }),
+                PathCommand::LineTo(Point { x: hw, y: hh }),
+                PathCommand::LineTo(Point { x: -hw, y: hh }),
+                PathCommand::Close,
+            ],
+        }],
+        polarity,
+    }
 }
 
 fn parse_aperture_code(value: &str) -> Result<i32> {

--- a/crates/gerberx2/src/parse.rs
+++ b/crates/gerberx2/src/parse.rs
@@ -623,8 +623,9 @@ impl<'a> Parser<'a> {
         }
         let code = parse_aperture_code(&rest[..d_len])?;
         let template_call = &rest[d_len..];
-        let template = self.parse_template_call(template_call)?;
-        let geometry = self.lower_aperture(&template)?;
+        let unit = self.unit()?;
+        let template = self.parse_template_call(template_call, unit)?;
+        let geometry = self.lower_aperture(&template, unit)?;
         Ok(ApertureDefinition {
             code,
             template,
@@ -633,7 +634,11 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn lower_aperture(&self, template: &ApertureTemplate) -> Result<Option<ApertureGeometry>> {
+    fn lower_aperture(
+        &self,
+        template: &ApertureTemplate,
+        unit: Unit,
+    ) -> Result<Option<ApertureGeometry>> {
         if let ApertureTemplate::Macro { name, parameters } = template {
             let Some(macro_def) = self.macro_lookup.get(name) else {
                 return Err(GerberError::InvalidStructure(format!(
@@ -641,12 +646,12 @@ impl<'a> Parser<'a> {
                     self.interner.resolve(*name)
                 )));
             };
-            return lower_macro_aperture(macro_def, parameters);
+            return lower_macro_aperture(macro_def, parameters, unit);
         }
         Ok(lower_standard_aperture(template))
     }
 
-    fn parse_template_call(&mut self, template_call: &str) -> Result<ApertureTemplate> {
+    fn parse_template_call(&mut self, template_call: &str, unit: Unit) -> Result<ApertureTemplate> {
         let (name, params) = template_call
             .split_once(',')
             .map(|(name, params)| (name, params.split('X').collect::<Vec<_>>()))
@@ -658,24 +663,39 @@ impl<'a> Parser<'a> {
 
         match name {
             "C" => Ok(ApertureTemplate::Circle {
-                diameter: required_param(&values, 0, "circle diameter")?,
-                hole_diameter: values.get(1).copied(),
+                diameter: scale_length(required_param(&values, 0, "circle diameter")?, unit),
+                hole_diameter: values
+                    .get(1)
+                    .copied()
+                    .map(|value| scale_length(value, unit)),
             }),
             "R" => Ok(ApertureTemplate::Rectangle {
-                width: required_param(&values, 0, "rectangle width")?,
-                height: required_param(&values, 1, "rectangle height")?,
-                hole_diameter: values.get(2).copied(),
+                width: scale_length(required_param(&values, 0, "rectangle width")?, unit),
+                height: scale_length(required_param(&values, 1, "rectangle height")?, unit),
+                hole_diameter: values
+                    .get(2)
+                    .copied()
+                    .map(|value| scale_length(value, unit)),
             }),
             "O" => Ok(ApertureTemplate::Obround {
-                width: required_param(&values, 0, "obround width")?,
-                height: required_param(&values, 1, "obround height")?,
-                hole_diameter: values.get(2).copied(),
+                width: scale_length(required_param(&values, 0, "obround width")?, unit),
+                height: scale_length(required_param(&values, 1, "obround height")?, unit),
+                hole_diameter: values
+                    .get(2)
+                    .copied()
+                    .map(|value| scale_length(value, unit)),
             }),
             "P" => Ok(ApertureTemplate::Polygon {
-                outer_diameter: required_param(&values, 0, "polygon outer diameter")?,
+                outer_diameter: scale_length(
+                    required_param(&values, 0, "polygon outer diameter")?,
+                    unit,
+                ),
                 vertices: required_param(&values, 1, "polygon vertices")? as i32,
                 rotation_degrees: values.get(2).copied(),
-                hole_diameter: values.get(3).copied(),
+                hole_diameter: values
+                    .get(3)
+                    .copied()
+                    .map(|value| scale_length(value, unit)),
             }),
             _ => Ok(ApertureTemplate::Macro {
                 name: self.interner.intern(name),
@@ -759,6 +779,10 @@ fn parse_format(rest: &str) -> Option<CoordinateFormat> {
 
 fn scale_coordinate(value: i64, decimal_digits: u8, unit: Unit) -> f64 {
     let value = value as f64 / 10_f64.powi(decimal_digits as i32);
+    scale_length(value, unit)
+}
+
+fn scale_length(value: f64, unit: Unit) -> f64 {
     match unit {
         Unit::Millimeter => value,
         Unit::Inch => value * 25.4,
@@ -800,6 +824,7 @@ fn lower_standard_aperture(template: &ApertureTemplate) -> Option<ApertureGeomet
 fn lower_macro_aperture(
     macro_def: &ApertureMacro,
     parameters: &[f64],
+    unit: Unit,
 ) -> Result<Option<ApertureGeometry>> {
     let mut vars: HashMap<usize, f64> = parameters
         .iter()
@@ -821,21 +846,21 @@ fn lower_macro_aperture(
                     .iter()
                     .map(|expr| eval_macro_expr(expr, &vars))
                     .collect::<Result<Vec<_>>>()?;
-                paths.extend(lower_macro_shape(*code, &values)?);
+                paths.extend(lower_macro_shape(*code, &values, unit)?);
             }
         }
     }
     Ok(Some(ApertureGeometry { paths }))
 }
 
-fn lower_macro_shape(code: i32, values: &[f64]) -> Result<Vec<GeometryPath>> {
+fn lower_macro_shape(code: i32, values: &[f64], unit: Unit) -> Result<Vec<GeometryPath>> {
     match code {
         1 => {
             let exposure = macro_bool(values, 0)?;
-            let diameter = macro_value(values, 1, "macro circle diameter")?;
+            let diameter = macro_length(values, 1, "macro circle diameter", unit)?;
             let center = Point {
-                x: macro_value(values, 2, "macro circle center x")?,
-                y: macro_value(values, 3, "macro circle center y")?,
+                x: macro_length(values, 2, "macro circle center x", unit)?,
+                y: macro_length(values, 3, "macro circle center y", unit)?,
             };
             let rotation = values.get(4).copied().unwrap_or(0.0);
             Ok(vec![transform_path(
@@ -846,14 +871,14 @@ fn lower_macro_shape(code: i32, values: &[f64]) -> Result<Vec<GeometryPath>> {
         }
         20 => {
             let exposure = macro_bool(values, 0)?;
-            let width = macro_value(values, 1, "macro vector line width")?;
+            let width = macro_length(values, 1, "macro vector line width", unit)?;
             let start = Point {
-                x: macro_value(values, 2, "macro vector line start x")?,
-                y: macro_value(values, 3, "macro vector line start y")?,
+                x: macro_length(values, 2, "macro vector line start x", unit)?,
+                y: macro_length(values, 3, "macro vector line start y", unit)?,
             };
             let end = Point {
-                x: macro_value(values, 4, "macro vector line end x")?,
-                y: macro_value(values, 5, "macro vector line end y")?,
+                x: macro_length(values, 4, "macro vector line end x", unit)?,
+                y: macro_length(values, 5, "macro vector line end y", unit)?,
             };
             let rotation = macro_value(values, 6, "macro vector line rotation")?;
             Ok(vec![vector_line_path(
@@ -862,11 +887,11 @@ fn lower_macro_shape(code: i32, values: &[f64]) -> Result<Vec<GeometryPath>> {
         }
         21 => {
             let exposure = macro_bool(values, 0)?;
-            let width = macro_value(values, 1, "macro center line width")?;
-            let height = macro_value(values, 2, "macro center line height")?;
+            let width = macro_length(values, 1, "macro center line width", unit)?;
+            let height = macro_length(values, 2, "macro center line height", unit)?;
             let center = Point {
-                x: macro_value(values, 3, "macro center line x")?,
-                y: macro_value(values, 4, "macro center line y")?,
+                x: macro_length(values, 3, "macro center line x", unit)?,
+                y: macro_length(values, 4, "macro center line y", unit)?,
             };
             let rotation = macro_value(values, 5, "macro center line rotation")?;
             Ok(vec![transform_path(
@@ -907,8 +932,8 @@ fn lower_macro_shape(code: i32, values: &[f64]) -> Result<Vec<GeometryPath>> {
             for index in 0..=vertices {
                 let point = rotate_point(
                     Point {
-                        x: values[2 + index * 2],
-                        y: values[3 + index * 2],
+                        x: scale_length(values[2 + index * 2], unit),
+                        y: scale_length(values[3 + index * 2], unit),
                     },
                     rotation,
                 );
@@ -928,10 +953,10 @@ fn lower_macro_shape(code: i32, values: &[f64]) -> Result<Vec<GeometryPath>> {
             let exposure = macro_bool(values, 0)?;
             let vertices = macro_value(values, 1, "macro polygon vertices")? as i32;
             let center = Point {
-                x: macro_value(values, 2, "macro polygon center x")?,
-                y: macro_value(values, 3, "macro polygon center y")?,
+                x: macro_length(values, 2, "macro polygon center x", unit)?,
+                y: macro_length(values, 3, "macro polygon center y", unit)?,
             };
-            let diameter = macro_value(values, 4, "macro polygon diameter")?;
+            let diameter = macro_length(values, 4, "macro polygon diameter", unit)?;
             let rotation = macro_value(values, 5, "macro polygon rotation")?;
             Ok(polygon_paths(diameter, vertices, rotation, None)
                 .into_iter()
@@ -940,12 +965,12 @@ fn lower_macro_shape(code: i32, values: &[f64]) -> Result<Vec<GeometryPath>> {
         }
         7 => {
             let center = Point {
-                x: macro_value(values, 0, "macro thermal center x")?,
-                y: macro_value(values, 1, "macro thermal center y")?,
+                x: macro_length(values, 0, "macro thermal center x", unit)?,
+                y: macro_length(values, 1, "macro thermal center y", unit)?,
             };
-            let outer = macro_value(values, 2, "macro thermal outer diameter")?;
-            let inner = macro_value(values, 3, "macro thermal inner diameter")?;
-            let gap = macro_value(values, 4, "macro thermal gap")?;
+            let outer = macro_length(values, 2, "macro thermal outer diameter", unit)?;
+            let inner = macro_length(values, 3, "macro thermal inner diameter", unit)?;
+            let gap = macro_length(values, 4, "macro thermal gap", unit)?;
             let rotation = macro_value(values, 5, "macro thermal rotation")?;
             let mut paths = circle_paths(outer, Some(inner));
             paths.push(rect_path(outer, gap, Polarity::Clear));
@@ -1158,6 +1183,10 @@ fn macro_value(values: &[f64], index: usize, name: &str) -> Result<f64> {
         .get(index)
         .copied()
         .ok_or_else(|| GerberError::InvalidStructure(format!("missing {name}")))
+}
+
+fn macro_length(values: &[f64], index: usize, name: &str, unit: Unit) -> Result<f64> {
+    Ok(scale_length(macro_value(values, index, name)?, unit))
 }
 
 fn macro_bool(values: &[f64], index: usize) -> Result<Polarity> {

--- a/crates/gerberx2/src/parse.rs
+++ b/crates/gerberx2/src/parse.rs
@@ -12,9 +12,13 @@ pub struct Parser<'a> {
     object_attributes: HashMap<Symbol, Attribute>,
     aperture_definitions: Vec<ApertureDefinition>,
     aperture_lookup: HashMap<i32, ApertureDefinition>,
+    macro_lookup: HashMap<Symbol, ApertureMacro>,
+    block_lookup: HashMap<i32, Vec<GraphicalObject>>,
     aperture_macros: Vec<ApertureMacro>,
     objects: Vec<GraphicalObject>,
     region: Option<RegionBuilder>,
+    block: Option<BlockBuilder>,
+    step_repeat: Option<StepRepeatBuilder>,
     state: GraphicsState,
     saw_m02: bool,
 }
@@ -23,6 +27,18 @@ pub struct Parser<'a> {
 struct RegionBuilder {
     contours: Vec<Contour>,
     current: Option<Contour>,
+}
+
+#[derive(Debug)]
+struct BlockBuilder {
+    aperture_code: i32,
+    object_start: usize,
+}
+
+#[derive(Debug)]
+struct StepRepeatBuilder {
+    repeat: StepRepeat,
+    object_start: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -37,9 +53,13 @@ impl<'a> Parser<'a> {
             object_attributes: HashMap::new(),
             aperture_definitions: Vec::new(),
             aperture_lookup: HashMap::new(),
+            macro_lookup: HashMap::new(),
+            block_lookup: HashMap::new(),
             aperture_macros: Vec::new(),
             objects: Vec::new(),
             region: None,
+            block: None,
+            step_repeat: None,
             state: GraphicsState::default(),
             saw_m02: false,
         }
@@ -63,6 +83,21 @@ impl<'a> Parser<'a> {
         if !self.saw_m02 {
             return Err(GerberError::InvalidStructure(
                 "missing required M02 end-of-file command".to_string(),
+            ));
+        }
+        if self.region.is_some() {
+            return Err(GerberError::InvalidStructure(
+                "G36 region was not closed before M02".to_string(),
+            ));
+        }
+        if self.block.is_some() {
+            return Err(GerberError::InvalidStructure(
+                "AB block aperture was not closed before M02".to_string(),
+            ));
+        }
+        if self.step_repeat.is_some() {
+            return Err(GerberError::InvalidStructure(
+                "SR step-repeat was not closed before M02".to_string(),
             ));
         }
 
@@ -121,6 +156,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_extended_command(&mut self, command: &'a str) -> Result<()> {
+        if command.starts_with("AM") {
+            return self.parse_extended_word(command.trim_end_matches('*'));
+        }
         for word in command.split_terminator('*') {
             if word.is_empty() {
                 continue;
@@ -162,6 +200,7 @@ impl<'a> Parser<'a> {
             let macro_def = self.parse_aperture_macro(rest)?;
             self.commands
                 .push(Command::ApertureMacro(macro_def.clone()));
+            self.macro_lookup.insert(macro_def.name, macro_def.clone());
             self.aperture_macros.push(macro_def);
             return Ok(());
         }
@@ -206,9 +245,31 @@ impl<'a> Parser<'a> {
 
         if let Some(rest) = word.strip_prefix("AB") {
             if rest.is_empty() {
+                let block = self
+                    .block
+                    .take()
+                    .ok_or_else(|| self.syntax("AB close without matching AB open"))?;
+                let objects = self.objects.split_off(block.object_start);
+                self.block_lookup
+                    .insert(block.aperture_code, objects.clone());
+                let aperture = ApertureDefinition {
+                    code: block.aperture_code,
+                    template: ApertureTemplate::Block { objects },
+                    geometry: None,
+                    attributes: self.aperture_attributes.values().cloned().collect(),
+                };
+                self.aperture_lookup.insert(aperture.code, aperture.clone());
+                self.aperture_definitions.push(aperture);
                 self.commands.push(Command::EndBlockAperture);
             } else {
                 let code = parse_aperture_code(rest)?;
+                if self.block.is_some() {
+                    return Err(self.syntax("nested AB block apertures are not supported"));
+                }
+                self.block = Some(BlockBuilder {
+                    aperture_code: code,
+                    object_start: self.objects.len(),
+                });
                 self.commands.push(Command::BeginBlockAperture(code));
             }
             return Ok(());
@@ -216,9 +277,34 @@ impl<'a> Parser<'a> {
 
         if let Some(rest) = word.strip_prefix("SR") {
             if rest.is_empty() {
+                let step = self
+                    .step_repeat
+                    .take()
+                    .ok_or_else(|| self.syntax("SR close without matching SR open"))?;
+                let seed = self.objects.split_off(step.object_start);
+                let mut expanded = Vec::new();
+                for ix in 0..step.repeat.x_repeats {
+                    for iy in 0..step.repeat.y_repeats {
+                        let dx = ix as f64 * step.repeat.x_step;
+                        let dy = iy as f64 * step.repeat.y_step;
+                        expanded.extend(
+                            seed.iter()
+                                .cloned()
+                                .map(|object| translate_object(object, dx, dy)),
+                        );
+                    }
+                }
+                self.objects.extend(expanded);
                 self.commands.push(Command::EndStepRepeat);
             } else {
                 let sr = parse_step_repeat(rest)?;
+                if self.step_repeat.is_some() {
+                    return Err(self.syntax("nested SR statements are not supported"));
+                }
+                self.step_repeat = Some(StepRepeatBuilder {
+                    repeat: sr,
+                    object_start: self.objects.len(),
+                });
                 self.commands.push(Command::BeginStepRepeat(sr));
             }
             return Ok(());
@@ -312,6 +398,7 @@ impl<'a> Parser<'a> {
                 if region.contours.is_empty() {
                     return Err(self.syntax("empty region statement"));
                 }
+                validate_region_contours(&region.contours)?;
                 self.objects.push(self.graphical_object(ObjectKind::Region {
                     contours: region.contours,
                 }));
@@ -357,10 +444,18 @@ impl<'a> Parser<'a> {
                     return Err(self.syntax("D03 flash is not allowed inside a region"));
                 }
                 let aperture = self.current_aperture()?;
-                self.objects.push(self.graphical_object(ObjectKind::Flash {
-                    at: point,
-                    aperture,
-                }));
+                if let Some(block_objects) = self.block_lookup.get(&aperture) {
+                    let objects = block_objects
+                        .iter()
+                        .cloned()
+                        .map(|object| translate_object(object, point.x, point.y));
+                    self.objects.extend(objects);
+                } else {
+                    self.objects.push(self.graphical_object(ObjectKind::Flash {
+                        at: point,
+                        aperture,
+                    }));
+                }
                 self.state.current_point = Some(point);
             }
             OperationCode::Plot => {
@@ -529,13 +624,26 @@ impl<'a> Parser<'a> {
         let code = parse_aperture_code(&rest[..d_len])?;
         let template_call = &rest[d_len..];
         let template = self.parse_template_call(template_call)?;
-        let geometry = lower_standard_aperture(&template);
+        let geometry = self.lower_aperture(&template)?;
         Ok(ApertureDefinition {
             code,
             template,
             geometry,
             attributes: self.aperture_attributes.values().cloned().collect(),
         })
+    }
+
+    fn lower_aperture(&self, template: &ApertureTemplate) -> Result<Option<ApertureGeometry>> {
+        if let ApertureTemplate::Macro { name, parameters } = template {
+            let Some(macro_def) = self.macro_lookup.get(name) else {
+                return Err(GerberError::InvalidStructure(format!(
+                    "aperture macro '{}' was not defined before use",
+                    self.interner.resolve(*name)
+                )));
+            };
+            return lower_macro_aperture(macro_def, parameters);
+        }
+        Ok(lower_standard_aperture(template))
     }
 
     fn parse_template_call(&mut self, template_call: &str) -> Result<ApertureTemplate> {
@@ -580,13 +688,43 @@ impl<'a> Parser<'a> {
         let Some((name, body)) = rest.split_once('*') else {
             return Err(self.syntax("AM missing body"));
         };
+        let mut primitives = Vec::new();
+        for word in body
+            .split_terminator('*')
+            .map(str::trim)
+            .filter(|word| !word.is_empty())
+        {
+            if let Some(text) = word.strip_prefix('0') {
+                primitives.push(MacroPrimitive::Comment(
+                    self.interner.intern(text.trim_start()),
+                ));
+            } else if let Some((variable, expression)) = word.split_once('=') {
+                let variable = variable
+                    .strip_prefix('$')
+                    .ok_or_else(|| self.syntax("macro variable definition missing $ prefix"))?
+                    .parse::<usize>()
+                    .map_err(|_| GerberError::InvalidNumber(variable.to_string()))?;
+                let mut parser = MacroExpressionParser::new(expression);
+                primitives.push(MacroPrimitive::VariableDefinition {
+                    variable,
+                    expression: parser.parse()?,
+                });
+            } else {
+                let mut fields = word.split(',');
+                let code = fields
+                    .next()
+                    .ok_or_else(|| self.syntax("macro primitive missing code"))?
+                    .parse::<i32>()
+                    .map_err(|_| GerberError::InvalidNumber(word.to_string()))?;
+                let parameters = fields
+                    .map(|field| MacroExpressionParser::new(field).parse())
+                    .collect::<Result<Vec<_>>>()?;
+                primitives.push(MacroPrimitive::Shape { code, parameters });
+            }
+        }
         Ok(ApertureMacro {
             name: self.interner.intern(name),
-            body: body
-                .split_terminator('*')
-                .filter(|word| !word.is_empty())
-                .map(|word| self.interner.intern(word))
-                .collect(),
+            primitives,
         })
     }
 
@@ -654,9 +792,211 @@ fn lower_standard_aperture(template: &ApertureTemplate) -> Option<ApertureGeomet
             rotation_degrees.unwrap_or(0.0),
             hole_diameter,
         ),
-        ApertureTemplate::Macro { .. } => return None,
+        ApertureTemplate::Macro { .. } | ApertureTemplate::Block { .. } => return None,
     };
     Some(ApertureGeometry { paths })
+}
+
+fn lower_macro_aperture(
+    macro_def: &ApertureMacro,
+    parameters: &[f64],
+) -> Result<Option<ApertureGeometry>> {
+    let mut vars: HashMap<usize, f64> = parameters
+        .iter()
+        .enumerate()
+        .map(|(index, value)| (index + 1, *value))
+        .collect();
+    let mut paths = Vec::new();
+    for primitive in &macro_def.primitives {
+        match primitive {
+            MacroPrimitive::Comment(_) => {}
+            MacroPrimitive::VariableDefinition {
+                variable,
+                expression,
+            } => {
+                vars.insert(*variable, eval_macro_expr(expression, &vars)?);
+            }
+            MacroPrimitive::Shape { code, parameters } => {
+                let values = parameters
+                    .iter()
+                    .map(|expr| eval_macro_expr(expr, &vars))
+                    .collect::<Result<Vec<_>>>()?;
+                paths.extend(lower_macro_shape(*code, &values)?);
+            }
+        }
+    }
+    Ok(Some(ApertureGeometry { paths }))
+}
+
+fn lower_macro_shape(code: i32, values: &[f64]) -> Result<Vec<GeometryPath>> {
+    match code {
+        1 => {
+            let exposure = macro_bool(values, 0)?;
+            let diameter = macro_value(values, 1, "macro circle diameter")?;
+            let center = Point {
+                x: macro_value(values, 2, "macro circle center x")?,
+                y: macro_value(values, 3, "macro circle center y")?,
+            };
+            let rotation = values.get(4).copied().unwrap_or(0.0);
+            Ok(vec![transform_path(
+                circle_path(diameter / 2.0, exposure),
+                center,
+                rotation,
+            )])
+        }
+        20 => {
+            let exposure = macro_bool(values, 0)?;
+            let width = macro_value(values, 1, "macro vector line width")?;
+            let start = Point {
+                x: macro_value(values, 2, "macro vector line start x")?,
+                y: macro_value(values, 3, "macro vector line start y")?,
+            };
+            let end = Point {
+                x: macro_value(values, 4, "macro vector line end x")?,
+                y: macro_value(values, 5, "macro vector line end y")?,
+            };
+            let rotation = macro_value(values, 6, "macro vector line rotation")?;
+            Ok(vec![vector_line_path(
+                start, end, width, exposure, rotation,
+            )])
+        }
+        21 => {
+            let exposure = macro_bool(values, 0)?;
+            let width = macro_value(values, 1, "macro center line width")?;
+            let height = macro_value(values, 2, "macro center line height")?;
+            let center = Point {
+                x: macro_value(values, 3, "macro center line x")?,
+                y: macro_value(values, 4, "macro center line y")?,
+            };
+            let rotation = macro_value(values, 5, "macro center line rotation")?;
+            Ok(vec![transform_path(
+                rect_path(width, height, exposure),
+                center,
+                rotation,
+            )])
+        }
+        4 => {
+            let exposure = macro_bool(values, 0)?;
+            let vertices = macro_value(values, 1, "macro outline vertices")? as usize;
+            let expected = 2 + (vertices + 1) * 2 + 1;
+            if values.len() != expected {
+                return Err(GerberError::InvalidStructure(
+                    "macro outline has the wrong number of parameters".to_string(),
+                ));
+            }
+            if vertices < 3 {
+                return Err(GerberError::InvalidStructure(
+                    "macro outline requires at least 3 vertices".to_string(),
+                ));
+            }
+            let rotation = values[expected - 1];
+            let first = Point {
+                x: values[2],
+                y: values[3],
+            };
+            let last = Point {
+                x: values[2 + vertices * 2],
+                y: values[3 + vertices * 2],
+            };
+            if !points_close(first, last) {
+                return Err(GerberError::InvalidStructure(
+                    "macro outline last vertex must equal first vertex".to_string(),
+                ));
+            }
+            let mut commands = Vec::new();
+            for index in 0..=vertices {
+                let point = rotate_point(
+                    Point {
+                        x: values[2 + index * 2],
+                        y: values[3 + index * 2],
+                    },
+                    rotation,
+                );
+                if index == 0 {
+                    commands.push(PathCommand::MoveTo(point));
+                } else {
+                    commands.push(PathCommand::LineTo(point));
+                }
+            }
+            commands.push(PathCommand::Close);
+            Ok(vec![GeometryPath {
+                contours: vec![GeometryContour { commands }],
+                polarity: exposure,
+            }])
+        }
+        5 => {
+            let exposure = macro_bool(values, 0)?;
+            let vertices = macro_value(values, 1, "macro polygon vertices")? as i32;
+            let center = Point {
+                x: macro_value(values, 2, "macro polygon center x")?,
+                y: macro_value(values, 3, "macro polygon center y")?,
+            };
+            let diameter = macro_value(values, 4, "macro polygon diameter")?;
+            let rotation = macro_value(values, 5, "macro polygon rotation")?;
+            Ok(polygon_paths(diameter, vertices, rotation, None)
+                .into_iter()
+                .map(|path| transform_path(repolarity(path, exposure), center, 0.0))
+                .collect())
+        }
+        7 => {
+            let center = Point {
+                x: macro_value(values, 0, "macro thermal center x")?,
+                y: macro_value(values, 1, "macro thermal center y")?,
+            };
+            let outer = macro_value(values, 2, "macro thermal outer diameter")?;
+            let inner = macro_value(values, 3, "macro thermal inner diameter")?;
+            let gap = macro_value(values, 4, "macro thermal gap")?;
+            let rotation = macro_value(values, 5, "macro thermal rotation")?;
+            let mut paths = circle_paths(outer, Some(inner));
+            paths.push(rect_path(outer, gap, Polarity::Clear));
+            paths.push(rect_path(gap, outer, Polarity::Clear));
+            Ok(paths
+                .into_iter()
+                .map(|path| transform_path(path, center, rotation))
+                .collect())
+        }
+        _ => Err(GerberError::InvalidStructure(format!(
+            "unsupported aperture macro primitive {code}"
+        ))),
+    }
+}
+
+fn validate_region_contours(contours: &[Contour]) -> Result<()> {
+    for contour in contours {
+        if contour.segments.is_empty() {
+            return Err(GerberError::InvalidStructure(
+                "region contour has no segments".to_string(),
+            ));
+        }
+        let mut first = None;
+        let mut previous = None;
+        for segment in &contour.segments {
+            let (start, end) = match *segment {
+                ContourSegment::Line { start, end } | ContourSegment::Arc { start, end, .. } => {
+                    (start, end)
+                }
+            };
+            if let Some(previous) = previous
+                && !points_close(previous, start)
+            {
+                return Err(GerberError::InvalidStructure(
+                    "region contour segments must be connected".to_string(),
+                ));
+            }
+            first.get_or_insert(start);
+            previous = Some(end);
+        }
+        if !points_close(first.unwrap(), previous.unwrap()) {
+            return Err(GerberError::InvalidStructure(
+                "region contour must be closed".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn points_close(a: Point, b: Point) -> bool {
+    (a.x - b.x).abs() <= 1e-9 && (a.y - b.y).abs() <= 1e-9
 }
 
 fn circle_paths(diameter: f64, hole_diameter: Option<f64>) -> Vec<GeometryPath> {
@@ -810,6 +1150,275 @@ fn rect_path(width: f64, height: f64, polarity: Polarity) -> GeometryPath {
             ],
         }],
         polarity,
+    }
+}
+
+fn macro_value(values: &[f64], index: usize, name: &str) -> Result<f64> {
+    values
+        .get(index)
+        .copied()
+        .ok_or_else(|| GerberError::InvalidStructure(format!("missing {name}")))
+}
+
+fn macro_bool(values: &[f64], index: usize) -> Result<Polarity> {
+    Ok(if macro_value(values, index, "macro exposure")? == 0.0 {
+        Polarity::Clear
+    } else {
+        Polarity::Dark
+    })
+}
+
+fn eval_macro_expr(expr: &MacroExpression, vars: &HashMap<usize, f64>) -> Result<f64> {
+    Ok(match expr {
+        MacroExpression::Number(value) => *value,
+        MacroExpression::Variable(index) => *vars.get(index).ok_or_else(|| {
+            GerberError::InvalidStructure(format!("macro variable ${index} used before definition"))
+        })?,
+        MacroExpression::UnaryMinus(inner) => -eval_macro_expr(inner, vars)?,
+        MacroExpression::Add(left, right) => {
+            eval_macro_expr(left, vars)? + eval_macro_expr(right, vars)?
+        }
+        MacroExpression::Subtract(left, right) => {
+            eval_macro_expr(left, vars)? - eval_macro_expr(right, vars)?
+        }
+        MacroExpression::Multiply(left, right) => {
+            eval_macro_expr(left, vars)? * eval_macro_expr(right, vars)?
+        }
+        MacroExpression::Divide(left, right) => {
+            eval_macro_expr(left, vars)? / eval_macro_expr(right, vars)?
+        }
+    })
+}
+
+fn repolarity(mut path: GeometryPath, polarity: Polarity) -> GeometryPath {
+    path.polarity = polarity;
+    path
+}
+
+fn vector_line_path(
+    start: Point,
+    end: Point,
+    width: f64,
+    polarity: Polarity,
+    rotation: f64,
+) -> GeometryPath {
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len == 0.0 {
+        return transform_path(rect_path(0.0, width, polarity), start, rotation);
+    }
+    let nx = -dy / len * width / 2.0;
+    let ny = dx / len * width / 2.0;
+    let mut path = GeometryPath {
+        contours: vec![GeometryContour {
+            commands: vec![
+                PathCommand::MoveTo(Point {
+                    x: start.x + nx,
+                    y: start.y + ny,
+                }),
+                PathCommand::LineTo(Point {
+                    x: end.x + nx,
+                    y: end.y + ny,
+                }),
+                PathCommand::LineTo(Point {
+                    x: end.x - nx,
+                    y: end.y - ny,
+                }),
+                PathCommand::LineTo(Point {
+                    x: start.x - nx,
+                    y: start.y - ny,
+                }),
+                PathCommand::Close,
+            ],
+        }],
+        polarity,
+    };
+    if rotation != 0.0 {
+        path = transform_path(path, Point { x: 0.0, y: 0.0 }, rotation);
+    }
+    path
+}
+
+fn transform_path(mut path: GeometryPath, offset: Point, rotation: f64) -> GeometryPath {
+    for contour in &mut path.contours {
+        for command in &mut contour.commands {
+            match command {
+                PathCommand::MoveTo(point) | PathCommand::LineTo(point) => {
+                    *point = translate_point(rotate_point(*point, rotation), offset.x, offset.y);
+                }
+                PathCommand::ArcTo { end, center, .. } => {
+                    *end = translate_point(rotate_point(*end, rotation), offset.x, offset.y);
+                    *center = translate_point(rotate_point(*center, rotation), offset.x, offset.y);
+                }
+                PathCommand::Close => {}
+            }
+        }
+    }
+    path
+}
+
+fn translate_object(mut object: GraphicalObject, dx: f64, dy: f64) -> GraphicalObject {
+    match &mut object.kind {
+        ObjectKind::Draw { start, end, .. } => {
+            *start = translate_point(*start, dx, dy);
+            *end = translate_point(*end, dx, dy);
+        }
+        ObjectKind::Arc { start, end, .. } => {
+            *start = translate_point(*start, dx, dy);
+            *end = translate_point(*end, dx, dy);
+        }
+        ObjectKind::Flash { at, .. } => *at = translate_point(*at, dx, dy),
+        ObjectKind::Region { contours } => {
+            for contour in contours {
+                for segment in &mut contour.segments {
+                    match segment {
+                        ContourSegment::Line { start, end } => {
+                            *start = translate_point(*start, dx, dy);
+                            *end = translate_point(*end, dx, dy);
+                        }
+                        ContourSegment::Arc { start, end, .. } => {
+                            *start = translate_point(*start, dx, dy);
+                            *end = translate_point(*end, dx, dy);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    object
+}
+
+fn translate_point(point: Point, dx: f64, dy: f64) -> Point {
+    Point {
+        x: point.x + dx,
+        y: point.y + dy,
+    }
+}
+
+fn rotate_point(point: Point, degrees: f64) -> Point {
+    if degrees == 0.0 {
+        return point;
+    }
+    let radians = degrees.to_radians();
+    let (sin, cos) = radians.sin_cos();
+    Point {
+        x: point.x * cos - point.y * sin,
+        y: point.x * sin + point.y * cos,
+    }
+}
+
+struct MacroExpressionParser<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl<'a> MacroExpressionParser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    fn parse(&mut self) -> Result<MacroExpression> {
+        let expr = self.parse_add_sub()?;
+        self.skip_ws();
+        if self.pos != self.input.len() {
+            return Err(GerberError::InvalidStructure(format!(
+                "invalid macro expression '{}'",
+                self.input
+            )));
+        }
+        Ok(expr)
+    }
+
+    fn parse_add_sub(&mut self) -> Result<MacroExpression> {
+        let mut expr = self.parse_mul_div()?;
+        loop {
+            self.skip_ws();
+            if self.eat('+') {
+                expr = MacroExpression::Add(Box::new(expr), Box::new(self.parse_mul_div()?));
+            } else if self.eat('-') {
+                expr = MacroExpression::Subtract(Box::new(expr), Box::new(self.parse_mul_div()?));
+            } else {
+                break;
+            }
+        }
+        Ok(expr)
+    }
+
+    fn parse_mul_div(&mut self) -> Result<MacroExpression> {
+        let mut expr = self.parse_factor()?;
+        loop {
+            self.skip_ws();
+            if self.eat('x') || self.eat('X') {
+                expr = MacroExpression::Multiply(Box::new(expr), Box::new(self.parse_factor()?));
+            } else if self.eat('/') {
+                expr = MacroExpression::Divide(Box::new(expr), Box::new(self.parse_factor()?));
+            } else {
+                break;
+            }
+        }
+        Ok(expr)
+    }
+
+    fn parse_factor(&mut self) -> Result<MacroExpression> {
+        self.skip_ws();
+        if self.eat('-') {
+            return Ok(MacroExpression::UnaryMinus(Box::new(self.parse_factor()?)));
+        }
+        if self.eat('+') {
+            return self.parse_factor();
+        }
+        if self.eat('(') {
+            let expr = self.parse_add_sub()?;
+            self.skip_ws();
+            if !self.eat(')') {
+                return Err(GerberError::InvalidStructure(format!(
+                    "unclosed macro expression '{}'",
+                    self.input
+                )));
+            }
+            return Ok(expr);
+        }
+        if self.eat('$') {
+            let start = self.pos;
+            while self.peek().is_some_and(|c| c.is_ascii_digit()) {
+                self.pos += 1;
+            }
+            return Ok(MacroExpression::Variable(
+                self.input[start..self.pos]
+                    .parse()
+                    .map_err(|_| GerberError::InvalidNumber(self.input.to_string()))?,
+            ));
+        }
+        let start = self.pos;
+        while self.peek().is_some_and(|c| c.is_ascii_digit() || c == '.') {
+            self.pos += 1;
+        }
+        if start == self.pos {
+            return Err(GerberError::InvalidNumber(self.input.to_string()));
+        }
+        Ok(MacroExpression::Number(
+            self.input[start..self.pos]
+                .parse()
+                .map_err(|_| GerberError::InvalidNumber(self.input[start..self.pos].to_string()))?,
+        ))
+    }
+
+    fn skip_ws(&mut self) {
+        while self.peek().is_some_and(char::is_whitespace) {
+            self.pos += 1;
+        }
+    }
+    fn peek(&self) -> Option<char> {
+        self.input[self.pos..].chars().next()
+    }
+    fn eat(&mut self, ch: char) -> bool {
+        if self.peek() == Some(ch) {
+            self.pos += ch.len_utf8();
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/crates/gerberx2/src/parse.rs
+++ b/crates/gerberx2/src/parse.rs
@@ -1,0 +1,583 @@
+use crate::types::*;
+use crate::{GerberError, GerberX2, Interner, Result, Symbol};
+use std::collections::HashMap;
+
+pub struct Parser<'a> {
+    source: &'a str,
+    pos: usize,
+    interner: Interner,
+    commands: Vec<Command>,
+    file_attributes: Vec<Attribute>,
+    aperture_attributes: HashMap<Symbol, Attribute>,
+    object_attributes: HashMap<Symbol, Attribute>,
+    aperture_definitions: Vec<ApertureDefinition>,
+    aperture_macros: Vec<ApertureMacro>,
+    state: GraphicsState,
+    saw_m02: bool,
+}
+
+impl<'a> Parser<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            pos: 0,
+            interner: Interner::new(),
+            commands: Vec::new(),
+            file_attributes: Vec::new(),
+            aperture_attributes: HashMap::new(),
+            object_attributes: HashMap::new(),
+            aperture_definitions: Vec::new(),
+            aperture_macros: Vec::new(),
+            state: GraphicsState::default(),
+            saw_m02: false,
+        }
+    }
+
+    pub fn parse(&mut self) -> Result<GerberX2> {
+        while self.skip_line_breaks() {
+            if self.saw_m02 {
+                return Err(self.syntax("data after M02 end-of-file command"));
+            }
+
+            if self.current_byte() == Some(b'%') {
+                let command = self.read_extended_command()?;
+                self.parse_extended_command(command)?;
+            } else {
+                let command = self.read_word_command()?;
+                self.parse_word_command(command)?;
+            }
+        }
+
+        if !self.saw_m02 {
+            return Err(GerberError::InvalidStructure(
+                "missing required M02 end-of-file command".to_string(),
+            ));
+        }
+
+        let aperture_attributes = self.aperture_attributes.values().cloned().collect();
+        let object_attributes = self.object_attributes.values().cloned().collect();
+        Ok(GerberX2 {
+            interner: std::mem::take(&mut self.interner),
+            commands: std::mem::take(&mut self.commands),
+            file_attributes: std::mem::take(&mut self.file_attributes),
+            aperture_attributes,
+            object_attributes,
+            aperture_definitions: std::mem::take(&mut self.aperture_definitions),
+            aperture_macros: std::mem::take(&mut self.aperture_macros),
+            final_state: self.state.clone(),
+        })
+    }
+
+    fn skip_line_breaks(&mut self) -> bool {
+        while matches!(self.current_byte(), Some(b'\n' | b'\r' | b'\t' | b' ')) {
+            self.pos += 1;
+        }
+        self.pos < self.source.len()
+    }
+
+    fn current_byte(&self) -> Option<u8> {
+        self.source.as_bytes().get(self.pos).copied()
+    }
+
+    fn read_extended_command(&mut self) -> Result<&'a str> {
+        let start = self.pos;
+        self.pos += 1;
+        while self.pos < self.source.len() && self.current_byte() != Some(b'%') {
+            self.pos += 1;
+        }
+        if self.current_byte() != Some(b'%') {
+            return Err(self.syntax("unterminated extended command"));
+        }
+        self.pos += 1;
+        Ok(&self.source[start + 1..self.pos - 1])
+    }
+
+    fn read_word_command(&mut self) -> Result<&'a str> {
+        let start = self.pos;
+        while self.pos < self.source.len() && self.current_byte() != Some(b'*') {
+            if self.current_byte() == Some(b'%') {
+                return Err(self.syntax("unexpected '%' in word command"));
+            }
+            self.pos += 1;
+        }
+        if self.current_byte() != Some(b'*') {
+            return Err(self.syntax("unterminated word command"));
+        }
+        self.pos += 1;
+        Ok(&self.source[start..self.pos])
+    }
+
+    fn parse_extended_command(&mut self, command: &'a str) -> Result<()> {
+        for word in command.split_terminator('*') {
+            if word.is_empty() {
+                continue;
+            }
+            self.parse_extended_word(word)?;
+        }
+        Ok(())
+    }
+
+    fn parse_extended_word(&mut self, word: &'a str) -> Result<()> {
+        if let Some(rest) = word.strip_prefix("MO") {
+            let unit = match rest {
+                "MM" => Unit::Millimeter,
+                "IN" => Unit::Inch,
+                _ => return Err(self.syntax(format!("invalid MO unit '{rest}'"))),
+            };
+            self.state.unit = Some(unit);
+            self.commands.push(Command::Unit(unit));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("FS") {
+            let format = parse_format(rest).ok_or_else(|| self.syntax("invalid FS command"))?;
+            self.state.coordinate_format = Some(format);
+            self.commands.push(Command::Format(format));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("AD") {
+            let aperture = self.parse_aperture_definition(rest)?;
+            self.commands
+                .push(Command::ApertureDefinition(aperture.clone()));
+            self.aperture_definitions.push(aperture);
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("AM") {
+            let macro_def = self.parse_aperture_macro(rest)?;
+            self.commands
+                .push(Command::ApertureMacro(macro_def.clone()));
+            self.aperture_macros.push(macro_def);
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("LP") {
+            let polarity = match rest {
+                "D" => Polarity::Dark,
+                "C" => Polarity::Clear,
+                _ => return Err(self.syntax(format!("invalid LP polarity '{rest}'"))),
+            };
+            self.state.polarity = polarity;
+            self.commands.push(Command::LoadPolarity(polarity));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("LM") {
+            let mirroring = match rest {
+                "N" => Mirroring::None,
+                "X" => Mirroring::X,
+                "Y" => Mirroring::Y,
+                "XY" => Mirroring::XY,
+                _ => return Err(self.syntax(format!("invalid LM mirroring '{rest}'"))),
+            };
+            self.state.mirroring = mirroring;
+            self.commands.push(Command::LoadMirroring(mirroring));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("LR") {
+            let rotation = parse_f64(rest)?;
+            self.state.rotation_degrees = rotation;
+            self.commands.push(Command::LoadRotation(rotation));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("LS") {
+            let scaling = parse_f64(rest)?;
+            self.state.scaling = scaling;
+            self.commands.push(Command::LoadScaling(scaling));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("AB") {
+            if rest.is_empty() {
+                self.commands.push(Command::EndBlockAperture);
+            } else {
+                let code = parse_aperture_code(rest)?;
+                self.commands.push(Command::BeginBlockAperture(code));
+            }
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("SR") {
+            if rest.is_empty() {
+                self.commands.push(Command::EndStepRepeat);
+            } else {
+                let sr = parse_step_repeat(rest)?;
+                self.commands.push(Command::BeginStepRepeat(sr));
+            }
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("TF") {
+            let attr = self.parse_attribute(rest)?;
+            self.file_attributes.push(attr.clone());
+            self.commands.push(Command::FileAttribute(attr));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("TA") {
+            let attr = self.parse_attribute(rest)?;
+            self.aperture_attributes.insert(attr.name, attr.clone());
+            self.commands.push(Command::ApertureAttribute(attr));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("TO") {
+            let attr = self.parse_attribute(rest)?;
+            self.object_attributes.insert(attr.name, attr.clone());
+            self.commands.push(Command::ObjectAttribute(attr));
+            return Ok(());
+        }
+
+        if let Some(rest) = word.strip_prefix("TD") {
+            let name = if rest.is_empty() {
+                self.aperture_attributes.clear();
+                self.object_attributes.clear();
+                None
+            } else {
+                let name = self.interner.intern(rest);
+                self.aperture_attributes.remove(&name);
+                self.object_attributes.remove(&name);
+                Some(name)
+            };
+            self.commands.push(Command::DeleteAttribute(name));
+            return Ok(());
+        }
+
+        Err(self.syntax(format!("unsupported extended command '{word}'")))
+    }
+
+    fn parse_word_command(&mut self, command: &'a str) -> Result<()> {
+        let word = command.strip_suffix('*').unwrap_or(command);
+        if let Some(comment) = word.strip_prefix("G04") {
+            let comment = self.interner.intern(comment);
+            self.commands.push(Command::Comment(comment));
+            return Ok(());
+        }
+
+        match word {
+            "G01" => {
+                self.state.plot_mode = Some(PlotMode::Linear);
+                self.commands.push(Command::PlotMode(PlotMode::Linear));
+                return Ok(());
+            }
+            "G02" => {
+                self.state.plot_mode = Some(PlotMode::ClockwiseArc);
+                self.commands
+                    .push(Command::PlotMode(PlotMode::ClockwiseArc));
+                return Ok(());
+            }
+            "G03" => {
+                self.state.plot_mode = Some(PlotMode::CounterclockwiseArc);
+                self.commands
+                    .push(Command::PlotMode(PlotMode::CounterclockwiseArc));
+                return Ok(());
+            }
+            "G75" => {
+                self.commands.push(Command::QuadrantModeMulti);
+                return Ok(());
+            }
+            "G36" => {
+                self.commands.push(Command::BeginRegion);
+                return Ok(());
+            }
+            "G37" => {
+                self.commands.push(Command::EndRegion);
+                return Ok(());
+            }
+            "M02" => {
+                self.saw_m02 = true;
+                self.commands.push(Command::EndOfFile);
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        if let Some(code) = parse_set_aperture(word) {
+            self.state.current_aperture = Some(code);
+            self.commands.push(Command::SetCurrentAperture(code));
+            return Ok(());
+        }
+
+        let (fields, code) = parse_operation(word)?;
+        self.commands.push(Command::Operation { fields, code });
+        Ok(())
+    }
+
+    fn parse_attribute(&mut self, rest: &str) -> Result<Attribute> {
+        let mut fields = rest.split(',');
+        let Some(name) = fields.next().filter(|name| !name.is_empty()) else {
+            return Err(self.syntax("attribute missing name"));
+        };
+        Ok(Attribute {
+            name: self.interner.intern(name),
+            fields: fields.map(|field| self.interner.intern(field)).collect(),
+        })
+    }
+
+    fn parse_aperture_definition(&mut self, rest: &str) -> Result<ApertureDefinition> {
+        let rest = rest.strip_prefix('D').unwrap_or(rest);
+        let d_len = rest.bytes().take_while(|b| b.is_ascii_digit()).count();
+        if d_len == 0 {
+            return Err(self.syntax("AD missing aperture code"));
+        }
+        let code = parse_aperture_code(&rest[..d_len])?;
+        let template_call = &rest[d_len..];
+        let template = self.parse_template_call(template_call)?;
+        Ok(ApertureDefinition {
+            code,
+            template,
+            attributes: self.aperture_attributes.values().cloned().collect(),
+        })
+    }
+
+    fn parse_template_call(&mut self, template_call: &str) -> Result<ApertureTemplate> {
+        let (name, params) = template_call
+            .split_once(',')
+            .map(|(name, params)| (name, params.split('X').collect::<Vec<_>>()))
+            .unwrap_or((template_call, Vec::new()));
+        let values = params
+            .into_iter()
+            .map(parse_f64)
+            .collect::<Result<Vec<_>>>()?;
+
+        match name {
+            "C" => Ok(ApertureTemplate::Circle {
+                diameter: required_param(&values, 0, "circle diameter")?,
+                hole_diameter: values.get(1).copied(),
+            }),
+            "R" => Ok(ApertureTemplate::Rectangle {
+                width: required_param(&values, 0, "rectangle width")?,
+                height: required_param(&values, 1, "rectangle height")?,
+                hole_diameter: values.get(2).copied(),
+            }),
+            "O" => Ok(ApertureTemplate::Obround {
+                width: required_param(&values, 0, "obround width")?,
+                height: required_param(&values, 1, "obround height")?,
+                hole_diameter: values.get(2).copied(),
+            }),
+            "P" => Ok(ApertureTemplate::Polygon {
+                outer_diameter: required_param(&values, 0, "polygon outer diameter")?,
+                vertices: required_param(&values, 1, "polygon vertices")? as i32,
+                rotation_degrees: values.get(2).copied(),
+                hole_diameter: values.get(3).copied(),
+            }),
+            _ => Ok(ApertureTemplate::Macro {
+                name: self.interner.intern(name),
+                parameters: values,
+            }),
+        }
+    }
+
+    fn parse_aperture_macro(&mut self, rest: &str) -> Result<ApertureMacro> {
+        let Some((name, body)) = rest.split_once('*') else {
+            return Err(self.syntax("AM missing body"));
+        };
+        Ok(ApertureMacro {
+            name: self.interner.intern(name),
+            body: body
+                .split_terminator('*')
+                .filter(|word| !word.is_empty())
+                .map(|word| self.interner.intern(word))
+                .collect(),
+        })
+    }
+
+    fn syntax(&self, message: impl Into<String>) -> GerberError {
+        GerberError::Syntax {
+            offset: self.pos,
+            message: message.into(),
+        }
+    }
+}
+
+fn parse_format(rest: &str) -> Option<CoordinateFormat> {
+    let rest = rest.strip_prefix("LA")?;
+    let rest = rest.strip_prefix('X')?;
+    let mut chars = rest.chars();
+    let x_integer_digits = chars.next()?.to_digit(10)? as u8;
+    let x_decimal_digits = chars.next()?.to_digit(10)? as u8;
+    let rest = chars.as_str().strip_prefix('Y')?;
+    let mut chars = rest.chars();
+    let y_integer_digits = chars.next()?.to_digit(10)? as u8;
+    let y_decimal_digits = chars.next()?.to_digit(10)? as u8;
+    if !chars.as_str().is_empty() {
+        return None;
+    }
+    Some(CoordinateFormat {
+        x_integer_digits,
+        x_decimal_digits,
+        y_integer_digits,
+        y_decimal_digits,
+    })
+}
+
+fn parse_aperture_code(value: &str) -> Result<i32> {
+    let code = value
+        .strip_prefix('D')
+        .unwrap_or(value)
+        .parse::<i32>()
+        .map_err(|_| GerberError::InvalidNumber(value.to_string()))?;
+    if code < 10 {
+        return Err(GerberError::InvalidStructure(format!(
+            "aperture code must be >= 10, got {code}"
+        )));
+    }
+    Ok(code)
+}
+
+fn parse_set_aperture(word: &str) -> Option<i32> {
+    let code = word.strip_prefix('D')?.parse::<i32>().ok()?;
+    (code >= 10).then_some(code)
+}
+
+fn parse_operation(word: &str) -> Result<(CoordinateFields, OperationCode)> {
+    let (body, code) = if let Some(body) = word.strip_suffix("D01") {
+        (body, OperationCode::Plot)
+    } else if let Some(body) = word.strip_suffix("D02") {
+        (body, OperationCode::Move)
+    } else if let Some(body) = word.strip_suffix("D03") {
+        (body, OperationCode::Flash)
+    } else {
+        return Err(GerberError::InvalidStructure(format!(
+            "unsupported word command '{word}'"
+        )));
+    };
+
+    Ok((parse_coordinate_fields(body)?, code))
+}
+
+fn parse_coordinate_fields(mut body: &str) -> Result<CoordinateFields> {
+    let mut fields = CoordinateFields::default();
+    while !body.is_empty() {
+        let axis = body.as_bytes()[0] as char;
+        if !matches!(axis, 'X' | 'Y' | 'I' | 'J') {
+            return Err(GerberError::InvalidStructure(format!(
+                "invalid coordinate field '{body}'"
+            )));
+        }
+        body = &body[1..];
+        let len = body
+            .bytes()
+            .take_while(|b| b.is_ascii_digit() || *b == b'+' || *b == b'-')
+            .count();
+        if len == 0 {
+            return Err(GerberError::InvalidStructure(format!(
+                "missing value for coordinate field {axis}"
+            )));
+        }
+        let value_text = &body[..len];
+        let value = value_text
+            .parse::<i64>()
+            .map_err(|_| GerberError::InvalidNumber(value_text.to_string()))?;
+        match axis {
+            'X' => fields.x = Some(value),
+            'Y' => fields.y = Some(value),
+            'I' => fields.i = Some(value),
+            'J' => fields.j = Some(value),
+            _ => unreachable!(),
+        }
+        body = &body[len..];
+    }
+    Ok(fields)
+}
+
+fn parse_step_repeat(rest: &str) -> Result<StepRepeat> {
+    let Some(rest) = rest.strip_prefix('X') else {
+        return Err(GerberError::InvalidStructure(
+            "SR missing X repeats".to_string(),
+        ));
+    };
+    let (x_repeats, rest) = parse_i32_prefix(rest)?;
+    let Some(rest) = rest.strip_prefix('Y') else {
+        return Err(GerberError::InvalidStructure(
+            "SR missing Y repeats".to_string(),
+        ));
+    };
+    let (y_repeats, rest) = parse_i32_prefix(rest)?;
+    let Some(rest) = rest.strip_prefix('I') else {
+        return Err(GerberError::InvalidStructure(
+            "SR missing I step".to_string(),
+        ));
+    };
+    let (x_step, rest) = parse_f64_prefix(rest)?;
+    let Some(rest) = rest.strip_prefix('J') else {
+        return Err(GerberError::InvalidStructure(
+            "SR missing J step".to_string(),
+        ));
+    };
+    let (y_step, rest) = parse_f64_prefix(rest)?;
+    if !rest.is_empty() {
+        return Err(GerberError::InvalidStructure(format!(
+            "unexpected SR suffix '{rest}'"
+        )));
+    }
+    Ok(StepRepeat {
+        x_repeats,
+        y_repeats,
+        x_step,
+        y_step,
+    })
+}
+
+fn parse_i32_prefix(value: &str) -> Result<(i32, &str)> {
+    let len = value.bytes().take_while(|b| b.is_ascii_digit()).count();
+    if len == 0 {
+        return Err(GerberError::InvalidNumber(value.to_string()));
+    }
+    Ok((
+        value[..len]
+            .parse()
+            .map_err(|_| GerberError::InvalidNumber(value[..len].to_string()))?,
+        &value[len..],
+    ))
+}
+
+fn parse_f64_prefix(value: &str) -> Result<(f64, &str)> {
+    let len = value
+        .bytes()
+        .take_while(|b| b.is_ascii_digit() || matches!(*b, b'+' | b'-' | b'.'))
+        .count();
+    if len == 0 {
+        return Err(GerberError::InvalidNumber(value.to_string()));
+    }
+    Ok((parse_f64(&value[..len])?, &value[len..]))
+}
+
+fn parse_f64(value: &str) -> Result<f64> {
+    value
+        .parse::<f64>()
+        .map_err(|_| GerberError::InvalidNumber(value.to_string()))
+}
+
+fn required_param(values: &[f64], index: usize, name: &str) -> Result<f64> {
+    values
+        .get(index)
+        .copied()
+        .ok_or_else(|| GerberError::InvalidStructure(format!("missing {name}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_coordinate_fields() {
+        let fields = parse_coordinate_fields("X+100Y-200I0J30").unwrap();
+        assert_eq!(fields.x, Some(100));
+        assert_eq!(fields.y, Some(-200));
+        assert_eq!(fields.i, Some(0));
+        assert_eq!(fields.j, Some(30));
+    }
+
+    #[test]
+    fn parses_step_repeat() {
+        let sr = parse_step_repeat("X2Y3I4.5J0").unwrap();
+        assert_eq!(sr.x_repeats, 2);
+        assert_eq!(sr.y_repeats, 3);
+        assert_eq!(sr.x_step, 4.5);
+        assert_eq!(sr.y_step, 0.0);
+    }
+}

--- a/crates/gerberx2/src/parse.rs
+++ b/crates/gerberx2/src/parse.rs
@@ -1218,16 +1218,16 @@ fn vector_line_path(
                     y: start.y + ny,
                 }),
                 PathCommand::LineTo(Point {
-                    x: end.x + nx,
-                    y: end.y + ny,
+                    x: start.x - nx,
+                    y: start.y - ny,
                 }),
                 PathCommand::LineTo(Point {
                     x: end.x - nx,
                     y: end.y - ny,
                 }),
                 PathCommand::LineTo(Point {
-                    x: start.x - nx,
-                    y: start.y - ny,
+                    x: end.x + nx,
+                    y: end.y + ny,
                 }),
                 PathCommand::Close,
             ],

--- a/crates/gerberx2/src/parse.rs
+++ b/crates/gerberx2/src/parse.rs
@@ -448,7 +448,7 @@ impl<'a> Parser<'a> {
                     let objects = block_objects
                         .iter()
                         .cloned()
-                        .map(|object| translate_object(object, point.x, point.y));
+                        .map(|object| transform_block_object(object, point, &self.state));
                     self.objects.extend(objects);
                 } else {
                     self.objects.push(self.graphical_object(ObjectKind::Flash {
@@ -1258,35 +1258,165 @@ fn transform_path(mut path: GeometryPath, offset: Point, rotation: f64) -> Geome
     path
 }
 
-fn translate_object(mut object: GraphicalObject, dx: f64, dy: f64) -> GraphicalObject {
+fn translate_object(object: GraphicalObject, dx: f64, dy: f64) -> GraphicalObject {
+    transform_object(object, LinearTransform::identity(), Point { x: dx, y: dy })
+}
+
+fn transform_block_object(
+    object: GraphicalObject,
+    origin: Point,
+    state: &GraphicsState,
+) -> GraphicalObject {
+    transform_object(object, LinearTransform::from_state(state), origin)
+}
+
+fn transform_object(
+    mut object: GraphicalObject,
+    outer: LinearTransform,
+    origin: Point,
+) -> GraphicalObject {
+    let flips_orientation = outer.determinant() < 0.0;
     match &mut object.kind {
         ObjectKind::Draw { start, end, .. } => {
-            *start = translate_point(*start, dx, dy);
-            *end = translate_point(*end, dx, dy);
+            *start = outer.transform_point(*start, origin);
+            *end = outer.transform_point(*end, origin);
         }
-        ObjectKind::Arc { start, end, .. } => {
-            *start = translate_point(*start, dx, dy);
-            *end = translate_point(*end, dx, dy);
+        ObjectKind::Arc {
+            start,
+            end,
+            center_offset,
+            clockwise,
+            ..
+        } => {
+            *start = outer.transform_point(*start, origin);
+            *end = outer.transform_point(*end, origin);
+            *center_offset = outer.transform_vector(*center_offset);
+            *clockwise ^= flips_orientation;
         }
-        ObjectKind::Flash { at, .. } => *at = translate_point(*at, dx, dy),
+        ObjectKind::Flash { at, .. } => *at = outer.transform_point(*at, origin),
         ObjectKind::Region { contours } => {
             for contour in contours {
                 for segment in &mut contour.segments {
                     match segment {
                         ContourSegment::Line { start, end } => {
-                            *start = translate_point(*start, dx, dy);
-                            *end = translate_point(*end, dx, dy);
+                            *start = outer.transform_point(*start, origin);
+                            *end = outer.transform_point(*end, origin);
                         }
-                        ContourSegment::Arc { start, end, .. } => {
-                            *start = translate_point(*start, dx, dy);
-                            *end = translate_point(*end, dx, dy);
+                        ContourSegment::Arc {
+                            start,
+                            end,
+                            center_offset,
+                            clockwise,
+                        } => {
+                            *start = outer.transform_point(*start, origin);
+                            *end = outer.transform_point(*end, origin);
+                            *center_offset = outer.transform_vector(*center_offset);
+                            *clockwise ^= flips_orientation;
                         }
                     }
                 }
             }
         }
     }
+    let modifiers = outer.compose(LinearTransform::from_parts(
+        object.mirroring,
+        object.rotation_degrees,
+        object.scaling,
+    ));
+    let (mirroring, rotation_degrees, scaling) = modifiers.decompose();
+    object.mirroring = mirroring;
+    object.rotation_degrees = rotation_degrees;
+    object.scaling = scaling;
     object
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LinearTransform {
+    m00: f64,
+    m01: f64,
+    m10: f64,
+    m11: f64,
+}
+
+impl LinearTransform {
+    fn identity() -> Self {
+        Self {
+            m00: 1.0,
+            m01: 0.0,
+            m10: 0.0,
+            m11: 1.0,
+        }
+    }
+
+    fn from_state(state: &GraphicsState) -> Self {
+        Self::from_parts(state.mirroring, state.rotation_degrees, state.scaling)
+    }
+
+    fn from_parts(mirroring: Mirroring, rotation_degrees: f64, scale: f64) -> Self {
+        let sx = match mirroring {
+            Mirroring::X | Mirroring::XY => -scale,
+            _ => scale,
+        };
+        let sy = match mirroring {
+            Mirroring::Y | Mirroring::XY => -scale,
+            _ => scale,
+        };
+        let (sin, cos) = rotation_degrees.to_radians().sin_cos();
+        Self {
+            m00: cos * sx,
+            m01: -sin * sy,
+            m10: sin * sx,
+            m11: cos * sy,
+        }
+    }
+
+    fn transform_point(self, point: Point, origin: Point) -> Point {
+        let vector = self.transform_vector(point);
+        Point {
+            x: origin.x + vector.x,
+            y: origin.y + vector.y,
+        }
+    }
+
+    fn transform_vector(self, point: Point) -> Point {
+        Point {
+            x: self.m00 * point.x + self.m01 * point.y,
+            y: self.m10 * point.x + self.m11 * point.y,
+        }
+    }
+
+    fn compose(self, rhs: Self) -> Self {
+        Self {
+            m00: self.m00 * rhs.m00 + self.m01 * rhs.m10,
+            m01: self.m00 * rhs.m01 + self.m01 * rhs.m11,
+            m10: self.m10 * rhs.m00 + self.m11 * rhs.m10,
+            m11: self.m10 * rhs.m01 + self.m11 * rhs.m11,
+        }
+    }
+
+    fn determinant(self) -> f64 {
+        self.m00 * self.m11 - self.m01 * self.m10
+    }
+
+    fn decompose(self) -> (Mirroring, f64, f64) {
+        let scale = self.m00.hypot(self.m10);
+        if scale == 0.0 {
+            return (Mirroring::None, 0.0, 0.0);
+        }
+        let mirroring = if self.determinant() < 0.0 {
+            Mirroring::X
+        } else {
+            Mirroring::None
+        };
+        let sx = if mirroring == Mirroring::X {
+            -scale
+        } else {
+            scale
+        };
+        let cos = self.m00 / sx;
+        let sin = self.m10 / sx;
+        (mirroring, sin.atan2(cos).to_degrees(), scale)
+    }
 }
 
 fn translate_point(point: Point, dx: f64, dy: f64) -> Point {

--- a/crates/gerberx2/src/types/mod.rs
+++ b/crates/gerberx2/src/types/mod.rs
@@ -1,0 +1,227 @@
+use crate::Symbol;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Unit {
+    Millimeter,
+    Inch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoordinateFormat {
+    pub x_integer_digits: u8,
+    pub x_decimal_digits: u8,
+    pub y_integer_digits: u8,
+    pub y_decimal_digits: u8,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Attribute {
+    pub name: Symbol,
+    pub fields: Vec<Symbol>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApertureDefinition {
+    pub code: i32,
+    pub template: ApertureTemplate,
+    /// Aperture attributes active at definition time.
+    pub attributes: Vec<Attribute>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ApertureTemplate {
+    Circle {
+        diameter: f64,
+        hole_diameter: Option<f64>,
+    },
+    Rectangle {
+        width: f64,
+        height: f64,
+        hole_diameter: Option<f64>,
+    },
+    Obround {
+        width: f64,
+        height: f64,
+        hole_diameter: Option<f64>,
+    },
+    Polygon {
+        outer_diameter: f64,
+        vertices: i32,
+        rotation_degrees: Option<f64>,
+        hole_diameter: Option<f64>,
+    },
+    Macro {
+        name: Symbol,
+        parameters: Vec<f64>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApertureMacro {
+    pub name: Symbol,
+    /// Raw macro body commands. Macro expression lowering will be layered on this.
+    pub body: Vec<Symbol>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlotMode {
+    Linear,
+    ClockwiseArc,
+    CounterclockwiseArc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Polarity {
+    Dark,
+    Clear,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mirroring {
+    None,
+    X,
+    Y,
+    XY,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationCode {
+    Plot,
+    Move,
+    Flash,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CoordinateFields {
+    pub x: Option<i64>,
+    pub y: Option<i64>,
+    pub i: Option<i64>,
+    pub j: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Command {
+    Comment(Symbol),
+    Unit(Unit),
+    Format(CoordinateFormat),
+    ApertureDefinition(ApertureDefinition),
+    ApertureMacro(ApertureMacro),
+    SetCurrentAperture(i32),
+    PlotMode(PlotMode),
+    QuadrantModeMulti,
+    Operation {
+        fields: CoordinateFields,
+        code: OperationCode,
+    },
+    LoadPolarity(Polarity),
+    LoadMirroring(Mirroring),
+    LoadRotation(f64),
+    LoadScaling(f64),
+    BeginRegion,
+    EndRegion,
+    BeginBlockAperture(i32),
+    EndBlockAperture,
+    BeginStepRepeat(StepRepeat),
+    EndStepRepeat,
+    FileAttribute(Attribute),
+    ApertureAttribute(Attribute),
+    ObjectAttribute(Attribute),
+    DeleteAttribute(Option<Symbol>),
+    EndOfFile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StepRepeat {
+    pub x_repeats: i32,
+    pub y_repeats: i32,
+    pub x_step: f64,
+    pub y_step: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphicsState {
+    pub unit: Option<Unit>,
+    pub coordinate_format: Option<CoordinateFormat>,
+    pub current_point: Option<Point>,
+    pub current_aperture: Option<i32>,
+    pub plot_mode: Option<PlotMode>,
+    pub polarity: Polarity,
+    pub mirroring: Mirroring,
+    pub rotation_degrees: f64,
+    pub scaling: f64,
+}
+
+impl Default for GraphicsState {
+    fn default() -> Self {
+        Self {
+            unit: None,
+            coordinate_format: None,
+            current_point: None,
+            current_aperture: None,
+            plot_mode: None,
+            polarity: Polarity::Dark,
+            mirroring: Mirroring::None,
+            rotation_degrees: 0.0,
+            scaling: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ObjectKind {
+    Draw {
+        start: Point,
+        end: Point,
+        aperture: i32,
+    },
+    Arc {
+        start: Point,
+        end: Point,
+        center_offset: Point,
+        clockwise: bool,
+        aperture: i32,
+    },
+    Flash {
+        at: Point,
+        aperture: i32,
+    },
+    Region {
+        contours: Vec<Contour>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphicalObject {
+    pub kind: ObjectKind,
+    pub polarity: Polarity,
+    pub mirroring: Mirroring,
+    pub rotation_degrees: f64,
+    pub scaling: f64,
+    pub aperture_attributes: Vec<Attribute>,
+    pub object_attributes: Vec<Attribute>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Contour {
+    pub segments: Vec<ContourSegment>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ContourSegment {
+    Line {
+        start: Point,
+        end: Point,
+    },
+    Arc {
+        start: Point,
+        end: Point,
+        center_offset: Point,
+        clockwise: bool,
+    },
+}

--- a/crates/gerberx2/src/types/mod.rs
+++ b/crates/gerberx2/src/types/mod.rs
@@ -55,13 +55,39 @@ pub enum ApertureTemplate {
         name: Symbol,
         parameters: Vec<f64>,
     },
+    Block {
+        objects: Vec<GraphicalObject>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ApertureMacro {
     pub name: Symbol,
-    /// Raw macro body commands. Macro expression lowering will be layered on this.
-    pub body: Vec<Symbol>,
+    pub primitives: Vec<MacroPrimitive>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MacroPrimitive {
+    Comment(Symbol),
+    VariableDefinition {
+        variable: usize,
+        expression: MacroExpression,
+    },
+    Shape {
+        code: i32,
+        parameters: Vec<MacroExpression>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MacroExpression {
+    Number(f64),
+    Variable(usize),
+    UnaryMinus(Box<MacroExpression>),
+    Add(Box<MacroExpression>, Box<MacroExpression>),
+    Subtract(Box<MacroExpression>, Box<MacroExpression>),
+    Multiply(Box<MacroExpression>, Box<MacroExpression>),
+    Divide(Box<MacroExpression>, Box<MacroExpression>),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/gerberx2/src/types/mod.rs
+++ b/crates/gerberx2/src/types/mod.rs
@@ -24,6 +24,7 @@ pub struct Attribute {
 pub struct ApertureDefinition {
     pub code: i32,
     pub template: ApertureTemplate,
+    pub geometry: Option<ApertureGeometry>,
     /// Aperture attributes active at definition time.
     pub attributes: Vec<Attribute>,
 }
@@ -61,6 +62,34 @@ pub struct ApertureMacro {
     pub name: Symbol,
     /// Raw macro body commands. Macro expression lowering will be layered on this.
     pub body: Vec<Symbol>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApertureGeometry {
+    pub paths: Vec<GeometryPath>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometryPath {
+    pub contours: Vec<GeometryContour>,
+    pub polarity: Polarity,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometryContour {
+    pub commands: Vec<PathCommand>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PathCommand {
+    MoveTo(Point),
+    LineTo(Point),
+    ArcTo {
+        end: Point,
+        center: Point,
+        clockwise: bool,
+    },
+    Close,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -205,6 +234,11 @@ pub struct GraphicalObject {
     pub scaling: f64,
     pub aperture_attributes: Vec<Attribute>,
     pub object_attributes: Vec<Attribute>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectStream {
+    pub objects: Vec<GraphicalObject>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/gerberx2/src/write.rs
+++ b/crates/gerberx2/src/write.rs
@@ -387,9 +387,9 @@ impl<'a> Writer<'a> {
                 self.write_decimal(*outer_diameter);
                 self.output.push('X');
                 self.output.push_str(&vertices.to_string());
-                if let Some(rotation_degrees) = rotation_degrees {
+                if rotation_degrees.is_some() || hole_diameter.is_some() {
                     self.output.push('X');
-                    self.write_decimal(*rotation_degrees);
+                    self.write_decimal(rotation_degrees.unwrap_or(0.0));
                 }
                 if let Some(hole_diameter) = hole_diameter {
                     self.output.push('X');

--- a/crates/gerberx2/src/write.rs
+++ b/crates/gerberx2/src/write.rs
@@ -1,0 +1,698 @@
+use crate::types::*;
+use crate::{GerberError, Result};
+
+/// String-backed X2 attribute used by the Gerber writer.
+///
+/// Attribute names should include the leading X2 dot, for example
+/// `.FileFunction`, `.AperFunction`, `.N`, `.C`, or `.P`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttributeValue {
+    pub name: String,
+    pub fields: Vec<String>,
+}
+
+impl AttributeValue {
+    pub fn new(
+        name: impl Into<String>,
+        fields: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            fields: fields.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// One aperture definition plus X2 aperture attributes active while defining it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WriterAperture {
+    pub code: i32,
+    pub template: WriterApertureTemplate,
+    pub attributes: Vec<AttributeValue>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WriterApertureTemplate {
+    Circle {
+        diameter: f64,
+        hole_diameter: Option<f64>,
+    },
+    Rectangle {
+        width: f64,
+        height: f64,
+        hole_diameter: Option<f64>,
+    },
+    Obround {
+        width: f64,
+        height: f64,
+        hole_diameter: Option<f64>,
+    },
+    Polygon {
+        outer_diameter: f64,
+        vertices: i32,
+        rotation_degrees: Option<f64>,
+        hole_diameter: Option<f64>,
+    },
+    Macro {
+        name: String,
+        parameters: Vec<f64>,
+    },
+    Block {
+        objects: Vec<WriterObject>,
+    },
+}
+
+impl TryFrom<ApertureTemplate> for WriterApertureTemplate {
+    type Error = GerberError;
+
+    fn try_from(template: ApertureTemplate) -> Result<Self> {
+        match template {
+            ApertureTemplate::Circle {
+                diameter,
+                hole_diameter,
+            } => Ok(Self::Circle {
+                diameter,
+                hole_diameter,
+            }),
+            ApertureTemplate::Rectangle {
+                width,
+                height,
+                hole_diameter,
+            } => Ok(Self::Rectangle {
+                width,
+                height,
+                hole_diameter,
+            }),
+            ApertureTemplate::Obround {
+                width,
+                height,
+                hole_diameter,
+            } => Ok(Self::Obround {
+                width,
+                height,
+                hole_diameter,
+            }),
+            ApertureTemplate::Polygon {
+                outer_diameter,
+                vertices,
+                rotation_degrees,
+                hole_diameter,
+            } => Ok(Self::Polygon {
+                outer_diameter,
+                vertices,
+                rotation_degrees,
+                hole_diameter,
+            }),
+            ApertureTemplate::Macro { .. } | ApertureTemplate::Block { .. } => Err(
+                GerberError::InvalidStructure(
+                    "parsed macro/block aperture templates contain interned data; construct WriterApertureTemplate directly"
+                        .to_string(),
+                ),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WriterApertureMacro {
+    pub name: String,
+    pub primitives: Vec<WriterMacroPrimitive>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WriterMacroPrimitive {
+    Comment(String),
+    VariableDefinition {
+        variable: usize,
+        expression: WriterMacroExpression,
+    },
+    Shape {
+        code: i32,
+        parameters: Vec<WriterMacroExpression>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WriterMacroExpression {
+    Number(f64),
+    Variable(usize),
+    UnaryMinus(Box<WriterMacroExpression>),
+    Add(Box<WriterMacroExpression>, Box<WriterMacroExpression>),
+    Subtract(Box<WriterMacroExpression>, Box<WriterMacroExpression>),
+    Multiply(Box<WriterMacroExpression>, Box<WriterMacroExpression>),
+    Divide(Box<WriterMacroExpression>, Box<WriterMacroExpression>),
+}
+
+/// One ordered graphical object plus X2 object attributes active while emitting it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WriterObject {
+    pub kind: ObjectKind,
+    pub polarity: Polarity,
+    pub attributes: Vec<AttributeValue>,
+}
+
+impl WriterObject {
+    pub fn dark(kind: ObjectKind) -> Self {
+        Self {
+            kind,
+            polarity: Polarity::Dark,
+            attributes: Vec::new(),
+        }
+    }
+}
+
+/// Format-neutral artwork/object IR for writing one Gerber X2 layer file.
+///
+/// This is intentionally close to Gerber's object stream: apertures remain
+/// apertures, pads remain flashes, tracks remain draws/arcs, and filled copper
+/// remains regions. IPC-2581 export should lower into this level before writing
+/// Gerber, and use flattened geometry only for validation or unavoidable
+/// fallback regions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GerberLayer {
+    pub unit: Unit,
+    pub coordinate_format: CoordinateFormat,
+    pub file_attributes: Vec<AttributeValue>,
+    pub aperture_macros: Vec<WriterApertureMacro>,
+    pub apertures: Vec<WriterAperture>,
+    pub objects: Vec<WriterObject>,
+}
+
+impl Default for GerberLayer {
+    fn default() -> Self {
+        Self {
+            unit: Unit::Millimeter,
+            coordinate_format: CoordinateFormat {
+                x_integer_digits: 6,
+                x_decimal_digits: 6,
+                y_integer_digits: 6,
+                y_decimal_digits: 6,
+            },
+            file_attributes: Vec::new(),
+            aperture_macros: Vec::new(),
+            apertures: Vec::new(),
+            objects: Vec::new(),
+        }
+    }
+}
+
+/// Write one complete Gerber X2 layer.
+pub fn write_layer(layer: &GerberLayer) -> Result<String> {
+    let mut writer = Writer::new(layer);
+    writer.write_layer()?;
+    Ok(writer.output)
+}
+
+struct Writer<'a> {
+    layer: &'a GerberLayer,
+    output: String,
+    current_aperture: Option<i32>,
+    current_polarity: Polarity,
+    current_plot_mode: Option<PlotMode>,
+}
+
+impl<'a> Writer<'a> {
+    fn new(layer: &'a GerberLayer) -> Self {
+        Self {
+            layer,
+            output: String::new(),
+            current_aperture: None,
+            current_polarity: Polarity::Dark,
+            current_plot_mode: None,
+        }
+    }
+
+    fn write_layer(&mut self) -> Result<()> {
+        self.output.push_str("G04 generated by gerberx2*\n");
+        self.write_format();
+        self.write_unit();
+        self.output.push_str("G75*\n");
+
+        for attr in &self.layer.file_attributes {
+            self.write_attribute("TF", attr)?;
+        }
+
+        for macro_def in &self.layer.aperture_macros {
+            self.write_macro(macro_def)?;
+        }
+
+        for aperture in &self.layer.apertures {
+            for attr in &aperture.attributes {
+                self.write_attribute("TA", attr)?;
+            }
+            self.write_aperture(aperture)?;
+            if !aperture.attributes.is_empty() {
+                self.output.push_str("%TD*%\n");
+            }
+        }
+
+        for object in &self.layer.objects {
+            self.write_object(object)?;
+        }
+
+        self.output.push_str("M02*\n");
+        Ok(())
+    }
+
+    fn write_macro(&mut self, macro_def: &WriterApertureMacro) -> Result<()> {
+        validate_identifier(&macro_def.name, "aperture macro name")?;
+        self.output.push_str("%AM");
+        self.output.push_str(&macro_def.name);
+        self.output.push_str("*\n");
+        for primitive in &macro_def.primitives {
+            match primitive {
+                WriterMacroPrimitive::Comment(comment) => {
+                    validate_no_command_delimiters(comment, "aperture macro comment")?;
+                    self.output.push_str("0 ");
+                    self.output.push_str(comment);
+                    self.output.push_str("*\n");
+                }
+                WriterMacroPrimitive::VariableDefinition {
+                    variable,
+                    expression,
+                } => {
+                    self.output.push('$');
+                    self.output.push_str(&variable.to_string());
+                    self.output.push('=');
+                    self.output.push_str(&format_macro_expression(expression));
+                    self.output.push_str("*\n");
+                }
+                WriterMacroPrimitive::Shape { code, parameters } => {
+                    self.output.push_str(&code.to_string());
+                    for parameter in parameters {
+                        self.output.push(',');
+                        self.output.push_str(&format_macro_expression(parameter));
+                    }
+                    self.output.push_str("*\n");
+                }
+            }
+        }
+        self.output.push_str("%\n");
+        Ok(())
+    }
+
+    fn write_format(&mut self) {
+        let format = self.layer.coordinate_format;
+        self.output.push_str(&format!(
+            "%FSLAX{}{}Y{}{}*%\n",
+            format.x_integer_digits,
+            format.x_decimal_digits,
+            format.y_integer_digits,
+            format.y_decimal_digits
+        ));
+    }
+
+    fn write_unit(&mut self) {
+        let unit = match self.layer.unit {
+            Unit::Millimeter => "MM",
+            Unit::Inch => "IN",
+        };
+        self.output.push_str(&format!("%MO{unit}*%\n"));
+    }
+
+    fn write_attribute(&mut self, command: &str, attr: &AttributeValue) -> Result<()> {
+        validate_attribute(attr)?;
+        self.output.push('%');
+        self.output.push_str(command);
+        self.output.push_str(&attr.name);
+        for field in &attr.fields {
+            self.output.push(',');
+            self.output.push_str(field);
+        }
+        self.output.push_str("*%\n");
+        Ok(())
+    }
+
+    fn write_aperture(&mut self, aperture: &WriterAperture) -> Result<()> {
+        if aperture.code < 10 {
+            return Err(GerberError::InvalidStructure(format!(
+                "aperture D{} is invalid; aperture codes must be >= 10",
+                aperture.code
+            )));
+        }
+
+        if let WriterApertureTemplate::Block { objects } = &aperture.template {
+            self.write_block_aperture(aperture.code, objects)?;
+            return Ok(());
+        }
+
+        self.output.push_str(&format!("%ADD{}", aperture.code));
+        match &aperture.template {
+            WriterApertureTemplate::Circle {
+                diameter,
+                hole_diameter,
+            } => {
+                self.output.push_str("C,");
+                self.write_decimal(*diameter);
+                if let Some(hole_diameter) = hole_diameter {
+                    self.output.push('X');
+                    self.write_decimal(*hole_diameter);
+                }
+            }
+            WriterApertureTemplate::Rectangle {
+                width,
+                height,
+                hole_diameter,
+            } => {
+                self.output.push_str("R,");
+                self.write_decimal(*width);
+                self.output.push('X');
+                self.write_decimal(*height);
+                if let Some(hole_diameter) = hole_diameter {
+                    self.output.push('X');
+                    self.write_decimal(*hole_diameter);
+                }
+            }
+            WriterApertureTemplate::Obround {
+                width,
+                height,
+                hole_diameter,
+            } => {
+                self.output.push_str("O,");
+                self.write_decimal(*width);
+                self.output.push('X');
+                self.write_decimal(*height);
+                if let Some(hole_diameter) = hole_diameter {
+                    self.output.push('X');
+                    self.write_decimal(*hole_diameter);
+                }
+            }
+            WriterApertureTemplate::Polygon {
+                outer_diameter,
+                vertices,
+                rotation_degrees,
+                hole_diameter,
+            } => {
+                self.output.push_str("P,");
+                self.write_decimal(*outer_diameter);
+                self.output.push('X');
+                self.output.push_str(&vertices.to_string());
+                if let Some(rotation_degrees) = rotation_degrees {
+                    self.output.push('X');
+                    self.write_decimal(*rotation_degrees);
+                }
+                if let Some(hole_diameter) = hole_diameter {
+                    self.output.push('X');
+                    self.write_decimal(*hole_diameter);
+                }
+            }
+            WriterApertureTemplate::Macro { name, parameters } => {
+                validate_identifier(name, "aperture macro name")?;
+                self.output.push_str(name);
+                if !parameters.is_empty() {
+                    self.output.push(',');
+                    for (index, parameter) in parameters.iter().enumerate() {
+                        if index > 0 {
+                            self.output.push('X');
+                        }
+                        self.write_decimal(*parameter);
+                    }
+                }
+            }
+            WriterApertureTemplate::Block { .. } => {
+                unreachable!("block apertures are handled above")
+            }
+        }
+        self.output.push_str("*%\n");
+        Ok(())
+    }
+
+    fn write_block_aperture(&mut self, code: i32, objects: &[WriterObject]) -> Result<()> {
+        self.output.push_str(&format!("%ABD{code}*%\n"));
+        let saved_aperture = self.current_aperture;
+        let saved_polarity = self.current_polarity;
+        let saved_plot_mode = self.current_plot_mode;
+        self.current_aperture = None;
+        self.current_polarity = Polarity::Dark;
+        self.current_plot_mode = None;
+        for object in objects {
+            self.write_object(object)?;
+        }
+        self.output.push_str("%AB*%\n");
+        self.current_aperture = saved_aperture;
+        self.current_polarity = saved_polarity;
+        self.current_plot_mode = saved_plot_mode;
+        Ok(())
+    }
+
+    fn write_object(&mut self, object: &WriterObject) -> Result<()> {
+        self.set_polarity(object.polarity);
+        for attr in &object.attributes {
+            self.write_attribute("TO", attr)?;
+        }
+
+        match &object.kind {
+            ObjectKind::Draw {
+                start,
+                end,
+                aperture,
+            } => {
+                self.set_aperture(*aperture);
+                self.set_plot_mode(PlotMode::Linear);
+                self.write_move(*start);
+                self.write_plot(*end, None);
+            }
+            ObjectKind::Arc {
+                start,
+                end,
+                center_offset,
+                clockwise,
+                aperture,
+            } => {
+                self.set_aperture(*aperture);
+                self.set_plot_mode(if *clockwise {
+                    PlotMode::ClockwiseArc
+                } else {
+                    PlotMode::CounterclockwiseArc
+                });
+                self.write_move(*start);
+                self.write_plot(*end, Some(*center_offset));
+            }
+            ObjectKind::Flash { at, aperture } => {
+                self.set_aperture(*aperture);
+                self.write_point(*at);
+                self.output.push_str("D03*\n");
+            }
+            ObjectKind::Region { contours } => {
+                self.write_region(contours)?;
+            }
+        }
+
+        if !object.attributes.is_empty() {
+            self.output.push_str("%TD*%\n");
+        }
+        Ok(())
+    }
+
+    fn write_region(&mut self, contours: &[Contour]) -> Result<()> {
+        self.output.push_str("G36*\n");
+        for contour in contours {
+            let Some(first) = contour.segments.first() else {
+                continue;
+            };
+            self.set_plot_mode(PlotMode::Linear);
+            self.write_move(segment_start(first));
+            for segment in &contour.segments {
+                match *segment {
+                    ContourSegment::Line { end, .. } => {
+                        self.set_plot_mode(PlotMode::Linear);
+                        self.write_plot(end, None);
+                    }
+                    ContourSegment::Arc {
+                        end,
+                        center_offset,
+                        clockwise,
+                        ..
+                    } => {
+                        self.set_plot_mode(if clockwise {
+                            PlotMode::ClockwiseArc
+                        } else {
+                            PlotMode::CounterclockwiseArc
+                        });
+                        self.write_plot(end, Some(center_offset));
+                    }
+                }
+            }
+        }
+        self.output.push_str("G37*\n");
+        Ok(())
+    }
+
+    fn set_aperture(&mut self, aperture: i32) {
+        if self.current_aperture != Some(aperture) {
+            self.output.push_str(&format!("D{aperture}*\n"));
+            self.current_aperture = Some(aperture);
+        }
+    }
+
+    fn set_polarity(&mut self, polarity: Polarity) {
+        if self.current_polarity != polarity {
+            let code = match polarity {
+                Polarity::Dark => "D",
+                Polarity::Clear => "C",
+            };
+            self.output.push_str(&format!("%LP{code}*%\n"));
+            self.current_polarity = polarity;
+        }
+    }
+
+    fn set_plot_mode(&mut self, mode: PlotMode) {
+        if self.current_plot_mode != Some(mode) {
+            let code = match mode {
+                PlotMode::Linear => "G01",
+                PlotMode::ClockwiseArc => "G02",
+                PlotMode::CounterclockwiseArc => "G03",
+            };
+            self.output.push_str(code);
+            self.output.push_str("*\n");
+            self.current_plot_mode = Some(mode);
+        }
+    }
+
+    fn write_move(&mut self, point: Point) {
+        self.write_point(point);
+        self.output.push_str("D02*\n");
+    }
+
+    fn write_plot(&mut self, point: Point, center_offset: Option<Point>) {
+        self.write_point(point);
+        if let Some(center_offset) = center_offset {
+            self.output.push('I');
+            self.output
+                .push_str(&self.coordinate(center_offset.x, true));
+            self.output.push('J');
+            self.output
+                .push_str(&self.coordinate(center_offset.y, false));
+        }
+        self.output.push_str("D01*\n");
+    }
+
+    fn write_point(&mut self, point: Point) {
+        self.output.push('X');
+        self.output.push_str(&self.coordinate(point.x, true));
+        self.output.push('Y');
+        self.output.push_str(&self.coordinate(point.y, false));
+    }
+
+    fn coordinate(&self, value: f64, x_axis: bool) -> String {
+        let decimals = if x_axis {
+            self.layer.coordinate_format.x_decimal_digits
+        } else {
+            self.layer.coordinate_format.y_decimal_digits
+        };
+        let scale = 10_f64.powi(decimals as i32);
+        format!("{:.0}", value * scale)
+    }
+
+    fn write_decimal(&mut self, value: f64) {
+        self.output.push_str(&trim_decimal(value));
+    }
+}
+
+fn validate_attribute(attr: &AttributeValue) -> Result<()> {
+    if attr.name.is_empty() {
+        return Err(GerberError::InvalidStructure(
+            "attribute name must not be empty".to_string(),
+        ));
+    }
+    if !attr.name.starts_with('.') {
+        return Err(GerberError::InvalidStructure(format!(
+            "X2 attribute name '{}' must start with '.'",
+            attr.name
+        )));
+    }
+    validate_no_command_delimiters(&attr.name, "attribute name")?;
+    for field in &attr.fields {
+        validate_no_command_delimiters(field, "attribute field")?;
+    }
+    Ok(())
+}
+
+fn validate_identifier(value: &str, label: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(GerberError::InvalidStructure(format!(
+            "{label} must not be empty"
+        )));
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'.')
+    {
+        return Err(GerberError::InvalidStructure(format!(
+            "{label} '{value}' contains characters that are not safe in Gerber identifiers"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_no_command_delimiters(value: &str, label: &str) -> Result<()> {
+    if value.contains(['*', '%']) {
+        return Err(GerberError::InvalidStructure(format!(
+            "{label} must not contain Gerber command delimiters"
+        )));
+    }
+    Ok(())
+}
+
+fn segment_start(segment: &ContourSegment) -> Point {
+    match *segment {
+        ContourSegment::Line { start, .. } | ContourSegment::Arc { start, .. } => start,
+    }
+}
+
+fn trim_decimal(value: f64) -> String {
+    let mut text = format!("{value:.9}");
+    while text.contains('.') && text.ends_with('0') {
+        text.pop();
+    }
+    if text.ends_with('.') {
+        text.pop();
+    }
+    if text == "-0" { "0".to_string() } else { text }
+}
+
+fn format_macro_expression(expression: &WriterMacroExpression) -> String {
+    match expression {
+        WriterMacroExpression::Number(value) => trim_decimal(*value),
+        WriterMacroExpression::Variable(index) => format!("${index}"),
+        WriterMacroExpression::UnaryMinus(inner) => format!("-{}", format_macro_factor(inner)),
+        WriterMacroExpression::Add(left, right) => {
+            format!(
+                "{}+{}",
+                format_macro_expression(left),
+                format_macro_term(right)
+            )
+        }
+        WriterMacroExpression::Subtract(left, right) => {
+            format!(
+                "{}-{}",
+                format_macro_expression(left),
+                format_macro_term(right)
+            )
+        }
+        WriterMacroExpression::Multiply(left, right) => {
+            format!("{}x{}", format_macro_term(left), format_macro_factor(right))
+        }
+        WriterMacroExpression::Divide(left, right) => {
+            format!("{}/{}", format_macro_term(left), format_macro_factor(right))
+        }
+    }
+}
+
+fn format_macro_term(expression: &WriterMacroExpression) -> String {
+    match expression {
+        WriterMacroExpression::Add(..) | WriterMacroExpression::Subtract(..) => {
+            format!("({})", format_macro_expression(expression))
+        }
+        _ => format_macro_expression(expression),
+    }
+}
+
+fn format_macro_factor(expression: &WriterMacroExpression) -> String {
+    match expression {
+        WriterMacroExpression::Number(_) | WriterMacroExpression::Variable(_) => {
+            format_macro_expression(expression)
+        }
+        _ => format!("({})", format_macro_expression(expression)),
+    }
+}

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -155,3 +155,40 @@ fn rejects_unclosed_region_contours() {
 
     assert!(err.to_string().contains("region contour must be closed"));
 }
+
+#[test]
+fn extracts_and_processes_render_geometry() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%TF.FileFunction,Copper,L1,Top*%\n%ADD10C,0.2*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nX1000000Y1000000D03*\nM02*\n",
+    )
+    .unwrap();
+
+    let mut geometry = gerberx2::geometry::extract_document(&gerber);
+    assert_eq!(geometry.file_function, vec!["Copper", "L1", "Top"]);
+    assert_eq!(geometry.features.len(), 2);
+    assert!(geometry.paths.iter().any(|path| path.flags.stroked));
+
+    gerberx2::geometry::process::process_document(&mut geometry);
+    assert!(geometry.features.iter().any(|feature| {
+        feature.kind == gerberx2::geometry::ir::FeatureKind::Composite && feature.path_count == 1
+    }));
+    assert!(!geometry.bbox.is_empty());
+}
+
+#[test]
+fn process_applies_clear_polarity_cutouts() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10R,2.0X2.0*%\n%ADD11C,1.0*%\nD10*\nX0Y0D03*\n%LPC*%\nD11*\nX0Y0D03*\nM02*\n",
+    )
+    .unwrap();
+
+    let mut geometry = gerberx2::geometry::extract_document(&gerber);
+    gerberx2::geometry::process::process_document(&mut geometry);
+    let composite = geometry
+        .features
+        .iter()
+        .find(|feature| feature.kind == gerberx2::geometry::ir::FeatureKind::Composite)
+        .unwrap();
+    let path = &geometry.paths[composite.path_start as usize];
+    assert!(path.contour_count >= 2);
+}

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -415,3 +415,19 @@ fn renders_svg_and_png_from_processed_geometry() {
     let png = gerberx2::geometry::raster::render_png_with_max_dimension(&geometry, 64).unwrap();
     assert!(png.starts_with(b"\x89PNG"));
 }
+
+#[test]
+fn renders_profile_gerber_as_black_board_outline() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%TF.FileFunction,Profile,NP*%\n%ADD10C,0.1*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nX1000000Y1000000D01*\nX0Y1000000D01*\nX0Y0D01*\nM02*\n",
+    )
+    .unwrap();
+
+    let mut geometry = gerberx2::geometry::extract_document(&gerber);
+    gerberx2::geometry::process::process_document(&mut geometry);
+    let svg = gerberx2::geometry::svg::render_svg(&geometry);
+
+    assert!(svg.contains("fill='none' stroke='#000000'"));
+    assert!(svg.contains("data-board-outline='true'"));
+    assert!(!svg.contains("fill='#606060'"));
+}

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -323,6 +323,26 @@ fn expands_block_apertures_when_flashed() {
 }
 
 #[test]
+fn expands_block_apertures_with_flash_transform() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,0.1*%\n%ABD20*%\nD10*\nX1000000Y0D03*\n%AB*%\n%LR90*%\n%LS2*%\nD20*\nX2000000Y3000000D03*\nM02*\n",
+    )
+    .unwrap();
+
+    assert_eq!(gerber.objects().len(), 1);
+    let object = &gerber.objects()[0];
+    assert!(matches!(
+        object.kind,
+        ObjectKind::Flash {
+            at,
+            aperture: 10,
+        } if close(at.x, 2.0) && close(at.y, 5.0)
+    ));
+    assert!(close(object.rotation_degrees, 90.0));
+    assert!(close(object.scaling, 2.0));
+}
+
+#[test]
 fn expands_step_repeat_in_y_then_x_order() {
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,0.1*%\nD10*\n%SRX2Y2I1.0J2.0*%\nX0Y0D03*\n%SR*%\nM02*\n",
@@ -388,6 +408,56 @@ fn process_applies_clear_polarity_cutouts() {
 }
 
 #[test]
+fn process_preserves_ordered_aperture_path_polarity() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%AMORDERED*\n21,1,4,4,0,0,0*\n21,0,2,2,0,0,0*\n21,1,1,1,0,0,0*\n%\n%ADD10ORDERED*%\nD10*\nX0Y0D03*\nM02*\n",
+    )
+    .unwrap();
+
+    let mut geometry = gerberx2::geometry::extract_document(&gerber);
+    gerberx2::geometry::process::process_document(&mut geometry);
+    let summary = gerberx2::geometry::compare::summarize(&geometry);
+
+    assert!(
+        close(summary.area_mm2, 13.0),
+        "area was {}",
+        summary.area_mm2
+    );
+}
+
+#[test]
+fn extraction_applies_scaling_to_circular_draw_width() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,0.2*%\n%LS2*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nM02*\n",
+    )
+    .unwrap();
+
+    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let path = geometry
+        .paths
+        .iter()
+        .find(|path| path.flags.stroked)
+        .unwrap();
+    assert!(close(path.stroke_width, 0.4));
+}
+
+#[test]
+fn extraction_flips_mirrored_aperture_arc_direction() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10O,2.0X1.0*%\n%LMX*%\nD10*\nX0Y0D03*\nM02*\n",
+    )
+    .unwrap();
+
+    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let arc = geometry
+        .path_cmds
+        .iter()
+        .find(|cmd| cmd.op == gerberx2::geometry::ir::PathOp::ArcTo)
+        .unwrap();
+    assert!(arc.clockwise);
+}
+
+#[test]
 fn extracts_non_circular_aperture_sweeps_without_diagnostics() {
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10R,0.2X0.4*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nM02*\n",
@@ -430,4 +500,42 @@ fn renders_profile_gerber_as_black_board_outline() {
     assert!(svg.contains("fill='none' stroke='#000000'"));
     assert!(svg.contains("data-board-outline='true'"));
     assert!(!svg.contains("fill='#606060'"));
+}
+
+#[test]
+fn writes_polygon_hole_with_explicit_zero_rotation() {
+    let layer = GerberLayer {
+        apertures: vec![WriterAperture {
+            code: 10,
+            template: WriterApertureTemplate::Polygon {
+                outer_diameter: 2.0,
+                vertices: 6,
+                rotation_degrees: None,
+                hole_diameter: Some(0.5),
+            },
+            attributes: Vec::new(),
+        }],
+        objects: vec![WriterObject::dark(ObjectKind::Flash {
+            at: Point { x: 0.0, y: 0.0 },
+            aperture: 10,
+        })],
+        ..GerberLayer::default()
+    };
+
+    let output = gerberx2::write_layer(&layer).unwrap();
+    assert!(output.contains("%ADD10P,2X6X0X0.5*%"));
+
+    let parsed = GerberX2::parse(&output).unwrap();
+    assert!(matches!(
+        parsed.aperture_definitions()[0].template,
+        ApertureTemplate::Polygon {
+            rotation_degrees: Some(rotation),
+            hole_diameter: Some(hole),
+            ..
+        } if close(rotation, 0.0) && close(hole, 0.5)
+    ));
+}
+
+fn close(a: f64, b: f64) -> bool {
+    (a - b).abs() <= 1e-9
 }

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -192,3 +192,32 @@ fn process_applies_clear_polarity_cutouts() {
     let path = &geometry.paths[composite.path_start as usize];
     assert!(path.contour_count >= 2);
 }
+
+#[test]
+fn extracts_non_circular_aperture_sweeps_without_diagnostics() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10R,0.2X0.4*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nM02*\n",
+    )
+    .unwrap();
+
+    let geometry = gerberx2::geometry::extract_document(&gerber);
+    assert!(geometry.diagnostics.is_empty());
+    assert!(geometry.paths.len() > 1);
+}
+
+#[test]
+fn renders_svg_and_png_from_processed_geometry() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%TF.FileFunction,Paste,Top*%\n%ADD10R,1.0X1.0*%\nD10*\nX0Y0D03*\nM02*\n",
+    )
+    .unwrap();
+
+    let mut geometry = gerberx2::geometry::extract_document(&gerber);
+    gerberx2::geometry::process::process_document(&mut geometry);
+    let svg = gerberx2::geometry::svg::render_svg(&geometry);
+    assert!(svg.contains("<svg"));
+    assert!(svg.contains("<path"));
+    assert!(svg.contains("Paste, Top"));
+    let png = gerberx2::geometry::raster::render_png_with_max_dimension(&geometry, 64).unwrap();
+    assert!(png.starts_with(b"\x89PNG"));
+}

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -1,4 +1,4 @@
-use gerberx2::{ApertureTemplate, Command, GerberX2, Unit};
+use gerberx2::{ApertureTemplate, Command, GerberX2, ObjectKind, PathCommand, Unit};
 
 #[test]
 fn parses_basic_x2_layer() {
@@ -24,4 +24,66 @@ fn parses_basic_x2_layer() {
             .iter()
             .any(|command| matches!(command, Command::Operation { .. }))
     );
+    assert_eq!(gerber.objects().len(), 1);
+    assert!(matches!(
+        gerber.objects()[0].kind,
+        ObjectKind::Flash {
+            at,
+            aperture: 10,
+        } if at.x == 142.0 && at.y == -108.55
+    ));
+}
+
+#[test]
+fn builds_draw_arc_and_region_objects() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%TA.AperFunction,Conductor*%\n%ADD10C,0.2*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nG75*\nG02*\nX1000000Y1000000I0J500000D01*\nG36*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nX1000000Y1000000D01*\nX0Y0D01*\nG37*\nM02*\n",
+    )
+    .unwrap();
+
+    assert_eq!(gerber.objects().len(), 3);
+    assert!(matches!(
+        gerber.objects()[0].kind,
+        ObjectKind::Draw {
+            start,
+            end,
+            aperture: 10,
+        } if start.x == 0.0 && start.y == 0.0 && end.x == 1.0 && end.y == 0.0
+    ));
+    assert!(matches!(
+        gerber.objects()[1].kind,
+        ObjectKind::Arc {
+            end,
+            center_offset,
+            clockwise: true,
+            aperture: 10,
+            ..
+        } if end.x == 1.0 && end.y == 1.0 && center_offset.x == 0.0 && center_offset.y == 0.5
+    ));
+    assert!(matches!(
+        &gerber.objects()[2].kind,
+        ObjectKind::Region { contours } if contours.len() == 1 && contours[0].segments.len() == 3
+    ));
+}
+
+#[test]
+fn lowers_standard_apertures_to_geometry_paths() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,1.0X0.25*%\n%ADD11R,1.0X2.0*%\n%ADD12O,2.0X1.0*%\n%ADD13P,2.0X6X30*%\nD10*\nX0Y0D03*\nM02*\n",
+    )
+    .unwrap();
+
+    assert_eq!(gerber.aperture_definitions().len(), 4);
+    let circle = gerber.aperture_definitions()[0].geometry.as_ref().unwrap();
+    assert_eq!(circle.paths.len(), 2);
+    assert!(matches!(
+        circle.paths[0].contours[0].commands[1],
+        PathCommand::ArcTo { .. }
+    ));
+    let rect = gerber.aperture_definitions()[1].geometry.as_ref().unwrap();
+    assert_eq!(rect.paths[0].contours[0].commands.len(), 5);
+    let obround = gerber.aperture_definitions()[2].geometry.as_ref().unwrap();
+    assert_eq!(obround.paths[0].contours[0].commands.len(), 6);
+    let polygon = gerber.aperture_definitions()[3].geometry.as_ref().unwrap();
+    assert_eq!(polygon.paths[0].contours[0].commands.len(), 7);
 }

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -1,0 +1,27 @@
+use gerberx2::{ApertureTemplate, Command, GerberX2, Unit};
+
+#[test]
+fn parses_basic_x2_layer() {
+    let gerber = GerberX2::parse(
+        "G04 paste layer*\n%FSLAX36Y36*%\n%MOMM*%\n%TF.FileFunction,Paste,Top*%\n%TA.AperFunction,Material*%\n%ADD10R,0.93X0.93*%\nD10*\nX142000000Y-108550000D03*\nM02*\n",
+    )
+    .unwrap();
+
+    assert_eq!(gerber.final_state().unit, Some(Unit::Millimeter));
+    assert_eq!(gerber.file_attributes().len(), 1);
+    assert_eq!(gerber.aperture_definitions().len(), 1);
+    assert!(matches!(
+        gerber.aperture_definitions()[0].template,
+        ApertureTemplate::Rectangle {
+            width: 0.93,
+            height: 0.93,
+            hole_diameter: None
+        }
+    ));
+    assert!(
+        gerber
+            .commands()
+            .iter()
+            .any(|command| matches!(command, Command::Operation { .. }))
+    );
+}

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -283,6 +283,30 @@ fn lowers_standard_apertures_to_geometry_paths() {
 }
 
 #[test]
+fn normalizes_inch_coordinates_and_standard_apertures_to_mm() {
+    let gerber =
+        GerberX2::parse("%FSLAX26Y26*%\n%MOIN*%\n%ADD10C,0.1X0.02*%\nD10*\nX1000000Y0D03*\nM02*\n")
+            .unwrap();
+
+    assert!(matches!(
+        gerber.aperture_definitions()[0].template,
+        ApertureTemplate::Circle {
+            diameter,
+            hole_diameter: Some(hole),
+        } if close(diameter, 2.54) && close(hole, 0.508)
+    ));
+    assert!(matches!(
+        gerber.objects()[0].kind,
+        ObjectKind::Flash { at, .. } if close(at.x, 25.4) && close(at.y, 0.0)
+    ));
+
+    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let feature = &geometry.features[0];
+    assert!(close(feature.bbox.min.x, 25.4 - 1.27));
+    assert!(close(feature.bbox.max.x, 25.4 + 1.27));
+}
+
+#[test]
 fn lowers_aperture_macro_primitives_to_geometry_paths() {
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%AMMAC*\n0 comment*\n$3=$1+$2x2*\n1,1,$3,0,0,0*\n20,1,0.1,-0.5,0,0.5,0,0*\n21,0,0.2,0.3,0,0,0*\n4,1,3,0,0,1,0,0,1,0,0,0*\n5,1,6,0,0,1.2,30*\n7,0,0,1.0,0.5,0.1,45*\n%\n%ADD10MAC,0.2X0.4*%\nD10*\nX0Y0D03*\nM02*\n",
@@ -297,6 +321,20 @@ fn lowers_aperture_macro_primitives_to_geometry_paths() {
     assert!(matches!(
         geometry.paths[3].contours[0].commands.last(),
         Some(PathCommand::Close)
+    ));
+}
+
+#[test]
+fn normalizes_inch_macro_aperture_geometry_to_mm() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOIN*%\n%AMMAC*\n1,1,$1,0,0,0*\n%\n%ADD10MAC,0.1*%\nD10*\nX0Y0D03*\nM02*\n",
+    )
+    .unwrap();
+
+    let geometry = gerber.aperture_definitions()[0].geometry.as_ref().unwrap();
+    assert!(matches!(
+        geometry.paths[0].contours[0].commands[0],
+        PathCommand::MoveTo(point) if close(point.x, 1.27) && close(point.y, 0.0)
     ));
 }
 

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -1,4 +1,4 @@
-use gerberx2::{ApertureTemplate, Command, GerberX2, ObjectKind, PathCommand, Unit};
+use gerberx2::{ApertureTemplate, Command, GerberX2, ObjectKind, PathCommand, Polarity, Unit};
 
 #[test]
 fn parses_basic_x2_layer() {
@@ -86,4 +86,72 @@ fn lowers_standard_apertures_to_geometry_paths() {
     assert_eq!(obround.paths[0].contours[0].commands.len(), 6);
     let polygon = gerber.aperture_definitions()[3].geometry.as_ref().unwrap();
     assert_eq!(polygon.paths[0].contours[0].commands.len(), 7);
+}
+
+#[test]
+fn lowers_aperture_macro_primitives_to_geometry_paths() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%AMMAC*\n0 comment*\n$3=$1+$2x2*\n1,1,$3,0,0,0*\n20,1,0.1,-0.5,0,0.5,0,0*\n21,0,0.2,0.3,0,0,0*\n4,1,3,0,0,1,0,0,1,0,0,0*\n5,1,6,0,0,1.2,30*\n7,0,0,1.0,0.5,0.1,45*\n%\n%ADD10MAC,0.2X0.4*%\nD10*\nX0Y0D03*\nM02*\n",
+    )
+    .unwrap();
+
+    assert_eq!(gerber.aperture_macros().len(), 1);
+    let geometry = gerber.aperture_definitions()[0].geometry.as_ref().unwrap();
+    assert_eq!(geometry.paths.len(), 9);
+    assert_eq!(geometry.paths[0].polarity, Polarity::Dark);
+    assert_eq!(geometry.paths[2].polarity, Polarity::Clear);
+    assert!(matches!(
+        geometry.paths[3].contours[0].commands.last(),
+        Some(PathCommand::Close)
+    ));
+}
+
+#[test]
+fn expands_block_apertures_when_flashed() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,0.1*%\n%ABD20*%\nD10*\nX1000000Y0D03*\n%AB*%\nD20*\nX2000000Y3000000D03*\nM02*\n",
+    )
+    .unwrap();
+
+    assert_eq!(gerber.aperture_definitions().len(), 2);
+    assert!(matches!(
+        gerber.aperture_definitions()[1].template,
+        ApertureTemplate::Block { .. }
+    ));
+    assert_eq!(gerber.objects().len(), 1);
+    assert!(matches!(
+        gerber.objects()[0].kind,
+        ObjectKind::Flash {
+            at,
+            aperture: 10,
+        } if at.x == 3.0 && at.y == 3.0
+    ));
+}
+
+#[test]
+fn expands_step_repeat_in_y_then_x_order() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,0.1*%\nD10*\n%SRX2Y2I1.0J2.0*%\nX0Y0D03*\n%SR*%\nM02*\n",
+    )
+    .unwrap();
+
+    let points = gerber
+        .objects()
+        .iter()
+        .map(|object| match object.kind {
+            ObjectKind::Flash { at, .. } => (at.x, at.y),
+            _ => unreachable!(),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(points, vec![(0.0, 0.0), (0.0, 2.0), (1.0, 0.0), (1.0, 2.0)]);
+}
+
+#[test]
+fn rejects_unclosed_region_contours() {
+    let err = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\nG36*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nX1000000Y1000000D01*\nG37*\nM02*\n",
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("region contour must be closed"));
 }

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -1,4 +1,8 @@
-use gerberx2::{ApertureTemplate, Command, GerberX2, ObjectKind, PathCommand, Polarity, Unit};
+use gerberx2::{
+    ApertureTemplate, AttributeValue, Command, Contour, ContourSegment, GerberLayer, GerberX2,
+    ObjectKind, PathCommand, Point, Polarity, Unit, WriterAperture, WriterApertureMacro,
+    WriterApertureTemplate, WriterMacroExpression, WriterMacroPrimitive, WriterObject,
+};
 
 #[test]
 fn parses_basic_x2_layer() {
@@ -31,6 +35,196 @@ fn parses_basic_x2_layer() {
             at,
             aperture: 10,
         } if at.x == 142.0 && at.y == -108.55
+    ));
+}
+
+#[test]
+fn writes_idiomatic_x2_layer_from_object_ir() {
+    let mut layer = GerberLayer {
+        file_attributes: vec![
+            AttributeValue::new(".FileFunction", ["Copper", "L1", "Top"]),
+            AttributeValue::new(".Part", ["Single"]),
+        ],
+        apertures: vec![
+            WriterAperture {
+                code: 10,
+                template: WriterApertureTemplate::Circle {
+                    diameter: 0.2,
+                    hole_diameter: None,
+                },
+                attributes: vec![AttributeValue::new(".AperFunction", ["Conductor"])],
+            },
+            WriterAperture {
+                code: 11,
+                template: WriterApertureTemplate::Rectangle {
+                    width: 1.0,
+                    height: 1.5,
+                    hole_diameter: None,
+                },
+                attributes: vec![AttributeValue::new(".AperFunction", ["SMDPad", "CuDef"])],
+            },
+        ],
+        ..GerberLayer::default()
+    };
+    layer.objects = vec![
+        WriterObject {
+            kind: ObjectKind::Flash {
+                at: Point { x: 1.0, y: 2.0 },
+                aperture: 11,
+            },
+            polarity: Polarity::Dark,
+            attributes: vec![
+                AttributeValue::new(".N", ["GND"]),
+                AttributeValue::new(".C", ["U1"]),
+                AttributeValue::new(".P", ["1"]),
+            ],
+        },
+        WriterObject::dark(ObjectKind::Draw {
+            start: Point { x: 1.0, y: 2.0 },
+            end: Point { x: 3.0, y: 2.0 },
+            aperture: 10,
+        }),
+        WriterObject::dark(ObjectKind::Arc {
+            start: Point { x: 3.0, y: 2.0 },
+            end: Point { x: 4.0, y: 3.0 },
+            center_offset: Point { x: 0.5, y: 0.5 },
+            clockwise: false,
+            aperture: 10,
+        }),
+        WriterObject::dark(ObjectKind::Region {
+            contours: vec![Contour {
+                segments: vec![
+                    ContourSegment::Line {
+                        start: Point { x: 0.0, y: 0.0 },
+                        end: Point { x: 1.0, y: 0.0 },
+                    },
+                    ContourSegment::Line {
+                        start: Point { x: 1.0, y: 0.0 },
+                        end: Point { x: 1.0, y: 1.0 },
+                    },
+                    ContourSegment::Line {
+                        start: Point { x: 1.0, y: 1.0 },
+                        end: Point { x: 0.0, y: 0.0 },
+                    },
+                ],
+            }],
+        }),
+    ];
+
+    let output = gerberx2::write_layer(&layer).unwrap();
+    assert!(output.contains("%TF.FileFunction,Copper,L1,Top*%"));
+    assert!(output.contains("%TA.AperFunction,SMDPad,CuDef*%"));
+    assert!(output.contains("%TO.N,GND*%"));
+    assert!(output.contains("G36*"));
+
+    let parsed = GerberX2::parse(&output).unwrap();
+    assert_eq!(parsed.file_attributes().len(), 2);
+    assert_eq!(parsed.aperture_definitions().len(), 2);
+    assert_eq!(parsed.objects().len(), 4);
+    assert!(matches!(
+        parsed.objects()[0].kind,
+        ObjectKind::Flash { at, aperture: 11 } if at.x == 1.0 && at.y == 2.0
+    ));
+    assert!(matches!(
+        parsed.objects()[2].kind,
+        ObjectKind::Arc {
+            clockwise: false,
+            ..
+        }
+    ));
+    assert_eq!(parsed.objects()[0].object_attributes.len(), 3);
+}
+
+#[test]
+fn writes_macro_and_block_apertures_without_flattening() {
+    let layer = GerberLayer {
+        aperture_macros: vec![WriterApertureMacro {
+            name: "ROUNDRECT".to_string(),
+            primitives: vec![
+                WriterMacroPrimitive::Comment("rounded rectangle test macro".to_string()),
+                WriterMacroPrimitive::VariableDefinition {
+                    variable: 3,
+                    expression: WriterMacroExpression::Add(
+                        Box::new(WriterMacroExpression::Variable(1)),
+                        Box::new(WriterMacroExpression::Multiply(
+                            Box::new(WriterMacroExpression::Variable(2)),
+                            Box::new(WriterMacroExpression::Number(2.0)),
+                        )),
+                    ),
+                },
+                WriterMacroPrimitive::Shape {
+                    code: 1,
+                    parameters: vec![
+                        WriterMacroExpression::Number(1.0),
+                        WriterMacroExpression::Variable(3),
+                        WriterMacroExpression::Number(0.0),
+                        WriterMacroExpression::Number(0.0),
+                        WriterMacroExpression::Number(0.0),
+                    ],
+                },
+            ],
+        }],
+        apertures: vec![
+            WriterAperture {
+                code: 10,
+                template: WriterApertureTemplate::Circle {
+                    diameter: 0.1,
+                    hole_diameter: None,
+                },
+                attributes: Vec::new(),
+            },
+            WriterAperture {
+                code: 11,
+                template: WriterApertureTemplate::Macro {
+                    name: "ROUNDRECT".to_string(),
+                    parameters: vec![0.2, 0.4],
+                },
+                attributes: vec![AttributeValue::new(".AperFunction", ["SMDPad", "CuDef"])],
+            },
+            WriterAperture {
+                code: 20,
+                template: WriterApertureTemplate::Block {
+                    objects: vec![WriterObject::dark(ObjectKind::Flash {
+                        at: Point { x: 1.0, y: 0.0 },
+                        aperture: 10,
+                    })],
+                },
+                attributes: Vec::new(),
+            },
+        ],
+        objects: vec![
+            WriterObject::dark(ObjectKind::Flash {
+                at: Point { x: 0.0, y: 0.0 },
+                aperture: 11,
+            }),
+            WriterObject::dark(ObjectKind::Flash {
+                at: Point { x: 2.0, y: 3.0 },
+                aperture: 20,
+            }),
+        ],
+        ..GerberLayer::default()
+    };
+
+    let output = gerberx2::write_layer(&layer).unwrap();
+    assert!(output.contains("%AMROUNDRECT*"));
+    assert!(output.contains("%ADD11ROUNDRECT,0.2X0.4*%"));
+    assert!(output.contains("%ABD20*%"));
+
+    let parsed = GerberX2::parse(&output).unwrap();
+    assert_eq!(parsed.aperture_macros().len(), 1);
+    assert_eq!(parsed.aperture_definitions().len(), 3);
+    assert!(matches!(
+        parsed.aperture_definitions()[1].template,
+        ApertureTemplate::Macro { .. }
+    ));
+    assert!(matches!(
+        parsed.aperture_definitions()[2].template,
+        ApertureTemplate::Block { .. }
+    ));
+    assert_eq!(parsed.objects().len(), 2);
+    assert!(matches!(
+        parsed.objects()[1].kind,
+        ObjectKind::Flash { at, aperture: 10 } if at.x == 3.0 && at.y == 3.0
     ));
 }
 

--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -15,6 +15,7 @@ colored = { workspace = true }
 comfy-table = { workspace = true }
 i_overlay = { workspace = true }
 ipc2581 = { workspace = true }
+gerberx2 = { workspace = true }
 jiff = { workspace = true }
 kurbo = { workspace = true }
 log = { workspace = true }

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -13,6 +13,7 @@ pub struct RenderOptions {
     pub layer: String,
     pub output: Option<PathBuf>,
     pub format: RenderFormat,
+    pub flat: bool,
 }
 
 /// Render processed geometry for one IPC-2581 layer.
@@ -22,6 +23,9 @@ pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
     let ipc = ipc2581::Ipc2581::parse(&content)?;
     let mut geometry = geometry::extract_layer(&ipc, &options.layer)?;
     geometry::process::process_document(&mut geometry);
+    if options.flat {
+        geometry::process::flatten_layers_to_masks(&mut geometry);
+    }
 
     match target {
         RenderTarget::Svg => render_svg(&geometry, options)?,

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -128,6 +128,7 @@ fn extract_panel_layer(
     doc.layers.push(GeometryLayer {
         name: layer_name.to_string(),
         source_layer_ref: layer.name,
+        layer_function: layer.layer_function,
         feature_start,
         feature_count,
         bbox: layer_bbox,
@@ -293,6 +294,7 @@ fn extract_step_layer(
     doc.layers.push(GeometryLayer {
         name: layer_name.to_string(),
         source_layer_ref: layer.name,
+        layer_function: layer.layer_function,
         feature_start,
         feature_count,
         bbox: layer_bbox,

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -482,6 +482,10 @@ fn layer_span_applies_to_layer(
     target_layer: &Layer,
     layers: &[Layer],
 ) -> bool {
+    if source_layer.name == target_layer.name {
+        return true;
+    }
+
     let Some(span) = source_layer.span else {
         return true;
     };
@@ -2530,9 +2534,11 @@ mod tests {
         assert!(slot_applies_to_layer(&route, &l1, &layers, &slot));
         assert!(slot_applies_to_layer(&route, &l2, &layers, &slot));
         assert!(!slot_applies_to_layer(&route, &l3, &layers, &slot));
+        assert!(slot_applies_to_layer(&route, &route, &layers, &slot));
         assert!(layer_span_applies_to_layer(&route, &l1, &layers));
         assert!(layer_span_applies_to_layer(&route, &l2, &layers));
         assert!(!layer_span_applies_to_layer(&route, &l3, &layers));
+        assert!(layer_span_applies_to_layer(&route, &route, &layers));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -309,7 +309,7 @@ pub enum GeometryPolarity {
     Negative,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LineCap {
     Round,
     Square,

--- a/crates/pcb-ipc2581-tools/src/geometry/ir.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/ir.rs
@@ -1,4 +1,5 @@
 use ipc2581::Symbol;
+use ipc2581::types::LayerFunction;
 
 #[derive(Debug, Clone)]
 pub struct GeometryDocument {
@@ -99,6 +100,7 @@ pub struct BoardOutline {
 pub struct GeometryLayer {
     pub name: String,
     pub source_layer_ref: Symbol,
+    pub layer_function: LayerFunction,
     pub feature_start: u32,
     pub feature_count: u32,
     pub bbox: BBox,

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -992,6 +992,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 3,
             bbox: BBox::empty(),
@@ -1040,6 +1041,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox: BBox::empty(),
@@ -1135,6 +1137,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 4,
             bbox: BBox::empty(),
@@ -1194,6 +1197,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox: BBox::empty(),
@@ -1257,6 +1261,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox: BBox::empty(),
@@ -1307,6 +1312,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox: BBox::empty(),
@@ -1354,6 +1360,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox: BBox::empty(),
@@ -1400,6 +1407,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox: BBox::empty(),
@@ -1454,6 +1462,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox: BBox::empty(),
@@ -1500,6 +1509,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox: BBox::empty(),

--- a/crates/pcb-ipc2581-tools/src/geometry/process.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/process.rs
@@ -30,6 +30,59 @@ pub fn process_document(doc: &mut GeometryDocument) {
     normalize_bounds(doc);
 }
 
+pub fn flatten_layers_to_masks(doc: &mut GeometryDocument) {
+    for layer_index in 0..doc.layers.len() {
+        let layer = doc.layers[layer_index].clone();
+        if layer.feature_count == 0 {
+            continue;
+        }
+
+        let feature_indices = layer_features(&layer).collect::<Vec<_>>();
+        let contours = feature_indices
+            .iter()
+            .flat_map(|&feature_index| {
+                let feature = &doc.features[feature_index];
+                if feature.bucket == FeatureBucket::Cutout
+                    || feature.polarity != GeometryPolarity::Positive
+                {
+                    Vec::new()
+                } else {
+                    feature_filled_contours(doc, feature)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        for &feature_index in &feature_indices {
+            clear_feature_paths(doc, feature_index);
+        }
+
+        if contours.is_empty() {
+            continue;
+        }
+
+        let contours =
+            polygon_shapes_to_contours(contours.simplify_shape(OverlayFillRule::NonZero));
+        if contours.is_empty() {
+            continue;
+        }
+
+        let mask_index = feature_indices[0];
+        replace_feature_with_compound_path(
+            doc,
+            mask_index,
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            contours,
+        );
+        let mask = &mut doc.features[mask_index];
+        mask.kind = FeatureKind::FlattenedBucket;
+        mask.bucket = FeatureBucket::Fill;
+        mask.polarity = GeometryPolarity::Positive;
+        mask.net = None;
+    }
+
+    normalize_bounds(doc);
+}
+
 pub fn normalize_bounds(doc: &mut GeometryDocument) {
     for contour_index in 0..doc.contours.len() {
         doc.contours[contour_index].bbox = contour_bbox(doc, contour_index);
@@ -1413,6 +1466,58 @@ mod tests {
         let path = &doc.paths[feature.path_start as usize];
         assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
         assert_eq!(path.bbox.max, Point::new(3.5, 4.0));
+    }
+
+    #[test]
+    fn flattens_processed_layer_features_to_single_mask() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(0.0, 0.0, 2.0, 1.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Padstack,
+                FeatureBucket::Smd,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, BBox::empty()),
+            rect_cmds(1.0, 0.0, 3.0, 1.0),
+        );
+        doc.features.push(GeometryFeature {
+            path_start: 1,
+            path_count: 1,
+            ..GeometryFeature::new(
+                FeatureKind::Trace,
+                FeatureBucket::Trace,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 2,
+            bbox: BBox::empty(),
+        });
+
+        process_document(&mut doc);
+        flatten_layers_to_masks(&mut doc);
+
+        assert_eq!(doc.features[0].kind, FeatureKind::FlattenedBucket);
+        assert_eq!(doc.features[0].bucket, FeatureBucket::Fill);
+        assert_eq!(doc.features[0].path_count, 1);
+        assert_eq!(doc.features[1].path_count, 0);
+        let path = &doc.paths[doc.features[0].path_start as usize];
+        assert_eq!(path.contour_count, 1);
+        assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(path.bbox.max, Point::new(3.0, 1.0));
+        assert_eq!(doc.layers[0].bbox.min, Point::new(0.0, 0.0));
+        assert_eq!(doc.layers[0].bbox.max, Point::new(3.0, 1.0));
     }
 
     fn rect_cmds(x0: f64, y0: f64, x1: f64, y1: f64) -> [PathCmd; 5] {

--- a/crates/pcb-ipc2581-tools/src/geometry/raster.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/raster.rs
@@ -65,6 +65,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 0,
             bbox: BBox {
@@ -92,6 +93,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 0,
             bbox: BBox::empty(),

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 
 use super::ir::*;
+use ipc2581::types::LayerFunction;
 
 const VIEWBOX_PADDING_MM: f64 = 1.0;
 
@@ -275,26 +276,37 @@ fn style_for_feature(layer: &GeometryLayer, feature: &GeometryFeature) -> Style 
 }
 
 fn flat_layer_style(layer: &GeometryLayer) -> Style {
-    let name = layer.name.to_ascii_lowercase();
-    let (color, opacity) = if name.contains("paste") {
-        ("#aeb4bb", 0.9)
-    } else if name.contains("mask") {
-        ("#159447", 0.55)
-    } else if name.contains("legend") || name.contains("silk") {
-        ("#f8f9fa", 0.95)
-    } else if name.contains("profile") || name.contains("outline") || name.contains("rout") {
-        ("#606060", 1.0)
-    } else if name.contains("cu")
-        || name.contains("copper")
-        || name == "top"
-        || name == "bottom"
-        || name.starts_with('l')
-    {
-        ("#d87822", 0.9)
-    } else {
-        ("#5c7cfa", 0.85)
-    };
-    Style { color, opacity }
+    match layer.layer_function {
+        LayerFunction::Conductor
+        | LayerFunction::CondFilm
+        | LayerFunction::CondFoil
+        | LayerFunction::Plane
+        | LayerFunction::Signal
+        | LayerFunction::Mixed => Style {
+            color: "#d87822",
+            opacity: 0.9,
+        },
+        LayerFunction::Solderpaste | LayerFunction::Pastemask => Style {
+            color: "#aeb4bb",
+            opacity: 0.9,
+        },
+        LayerFunction::Soldermask => Style {
+            color: "#159447",
+            opacity: 0.55,
+        },
+        LayerFunction::Silkscreen | LayerFunction::Legend => Style {
+            color: "#f8f9fa",
+            opacity: 0.95,
+        },
+        LayerFunction::Rout | LayerFunction::BoardOutline => Style {
+            color: "#606060",
+            opacity: 1.0,
+        },
+        _ => Style {
+            color: "#5c7cfa",
+            opacity: 0.85,
+        },
+    }
 }
 
 fn color_for_bucket(bucket: FeatureBucket, polarity: GeometryPolarity) -> &'static str {
@@ -390,6 +402,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 1,
             bbox,
@@ -428,6 +441,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 1,
             bbox,
@@ -487,6 +501,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 1,
             bbox: outer,
@@ -547,6 +562,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 2,
             bbox,
@@ -593,6 +609,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 4,
             bbox,
@@ -613,13 +630,19 @@ mod tests {
 
     #[test]
     fn renders_flattened_masks_with_gerber_layer_colors() {
-        assert_flat_color("F.Cu", "#d87822", "0.9");
-        assert_flat_color("F.Paste", "#aeb4bb", "0.9");
-        assert_flat_color("F.Mask", "#159447", "0.55");
-        assert_flat_color("F.SilkS", "#f8f9fa", "0.95");
+        assert_flat_color("F.Cu", LayerFunction::Signal, "#d87822", "0.9");
+        assert_flat_color("F.Paste", LayerFunction::Solderpaste, "#aeb4bb", "0.9");
+        assert_flat_color("F.Mask", LayerFunction::Soldermask, "#159447", "0.55");
+        assert_flat_color("F.SilkS", LayerFunction::Silkscreen, "#f8f9fa", "0.95");
+        assert_flat_color("LAMINATE", LayerFunction::DielCore, "#5c7cfa", "0.85");
     }
 
-    fn assert_flat_color(layer_name: &str, color: &str, opacity: &str) {
+    fn assert_flat_color(
+        layer_name: &str,
+        layer_function: LayerFunction,
+        color: &str,
+        opacity: &str,
+    ) {
         let mut interner = ipc2581::Interner::new();
         let mut doc = GeometryDocument::new("test".to_string());
         let bbox = BBox {
@@ -647,6 +670,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: layer_name.to_string(),
             source_layer_ref: interner.intern(layer_name),
+            layer_function,
             feature_start: 0,
             feature_count: 1,
             bbox,
@@ -668,6 +692,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 0,
             bbox,
@@ -703,6 +728,7 @@ mod tests {
         doc.layers.push(GeometryLayer {
             name: "F.Cu".to_string(),
             source_layer_ref: interner.intern("F.Cu"),
+            layer_function: ipc2581::types::LayerFunction::Signal,
             feature_start: 0,
             feature_count: 0,
             bbox: BBox::empty(),

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -75,17 +75,21 @@ fn render_layer_svg_with_size(
     )
     .unwrap();
 
-    for feature in &doc.features
-        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
-    {
-        write_feature_paths(&mut svg, doc, feature, false);
-    }
-
-    for feature in &doc.features
-        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
-    {
-        write_feature_paths(&mut svg, doc, feature, true);
-    }
+    write_feature_paths_by_bucket(&mut svg, doc, layer, &[FeatureBucket::Fill]);
+    write_feature_paths_by_bucket(&mut svg, doc, layer, &[FeatureBucket::Trace]);
+    write_feature_paths_by_bucket(&mut svg, doc, layer, &[FeatureBucket::Smd]);
+    write_feature_paths_by_bucket(&mut svg, doc, layer, &[FeatureBucket::Thermal]);
+    write_feature_paths_by_bucket(
+        &mut svg,
+        doc,
+        layer,
+        &[
+            FeatureBucket::Pth,
+            FeatureBucket::Via,
+            FeatureBucket::Cutout,
+            FeatureBucket::Antipad,
+        ],
+    );
 
     write_board_outlines(&mut svg, doc);
 
@@ -111,20 +115,24 @@ fn write_board_outlines(svg: &mut String, doc: &GeometryDocument) {
     }
 }
 
-fn write_feature_paths(
+fn write_feature_paths_by_bucket(
     svg: &mut String,
     doc: &GeometryDocument,
-    feature: &GeometryFeature,
-    cutouts: bool,
+    layer: &GeometryLayer,
+    buckets: &[FeatureBucket],
 ) {
-    if (feature.bucket == FeatureBucket::Cutout) != cutouts {
-        return;
-    }
-
-    for path in
-        &doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+    for feature in &doc.features
+        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
     {
-        write_path(svg, doc, feature, path);
+        if !buckets.contains(&feature.bucket) {
+            continue;
+        }
+
+        for path in &doc.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+        {
+            write_path(svg, doc, feature, path);
+        }
     }
 }
 
@@ -271,11 +279,11 @@ fn opacity_for_bucket(bucket: FeatureBucket, polarity: GeometryPolarity) -> f64 
     }
 
     match bucket {
-        FeatureBucket::Fill => 0.82,
+        FeatureBucket::Fill => 0.78,
         FeatureBucket::Trace => 0.95,
         FeatureBucket::Smd | FeatureBucket::Pth => 0.95,
         FeatureBucket::Via => 0.9,
-        FeatureBucket::Cutout | FeatureBucket::Antipad => 0.85,
+        FeatureBucket::Cutout | FeatureBucket::Antipad => 1.0,
         FeatureBucket::Thermal => 0.92,
     }
 }
@@ -507,6 +515,59 @@ mod tests {
 
         assert_eq!(svg.matches("<path d='").count(), 2);
         assert!(svg.find("fill='#2f9e44'").unwrap() < svg.find("fill='#64748b'").unwrap());
+    }
+
+    #[test]
+    fn renders_features_in_visual_stack_order() {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(1.0, 1.0),
+        };
+
+        for (kind, bucket) in [
+            (FeatureKind::Hole, FeatureBucket::Cutout),
+            (FeatureKind::Padstack, FeatureBucket::Smd),
+            (FeatureKind::Trace, FeatureBucket::Trace),
+            (FeatureKind::Polygon, FeatureBucket::Fill),
+        ] {
+            let path_start = doc.paths.len() as u32;
+            doc.push_path(
+                GeometryPath::filled(FillRule::NonZero, bbox),
+                [
+                    PathCmd::move_to(Point::new(0.0, 0.0)),
+                    PathCmd::line_to(Point::new(1.0, 0.0)),
+                    PathCmd::line_to(Point::new(1.0, 1.0)),
+                    PathCmd::close(),
+                ],
+            );
+            doc.features.push(GeometryFeature {
+                path_start,
+                path_count: 1,
+                bbox,
+                ..GeometryFeature::new(kind, bucket, GeometryPolarity::Positive)
+            });
+        }
+        doc.layers.push(GeometryLayer {
+            name: "F.Cu".to_string(),
+            source_layer_ref: interner.intern("F.Cu"),
+            feature_start: 0,
+            feature_count: 4,
+            bbox,
+        });
+
+        let svg = render_layer_svg(&doc, 0);
+
+        let fill = svg.find("fill='#2f9e44'").unwrap();
+        let trace = svg.find("fill='#c2410c'").unwrap();
+        let smd = svg.find("fill='#d97706'").unwrap();
+        let cutout = svg.find("fill='#64748b'").unwrap();
+        assert!(fill < trace);
+        assert!(trace < smd);
+        assert!(smd < cutout);
+        assert!(svg.contains("fill='#2f9e44' fill-opacity='0.78'"));
+        assert!(svg.contains("fill='#64748b' fill-opacity='1'"));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/svg.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/svg.rs
@@ -131,7 +131,7 @@ fn write_feature_paths_by_bucket(
         for path in &doc.paths
             [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
         {
-            write_path(svg, doc, feature, path);
+            write_path(svg, doc, layer, feature, path);
         }
     }
 }
@@ -139,12 +139,12 @@ fn write_feature_paths_by_bucket(
 fn write_path(
     svg: &mut String,
     doc: &GeometryDocument,
+    layer: &GeometryLayer,
     feature: &GeometryFeature,
     path: &GeometryPath,
 ) {
     let d = path_data(doc, path);
-    let color = color_for_bucket(feature.bucket, feature.polarity);
-    let opacity = opacity_for_bucket(feature.bucket, feature.polarity);
+    let style = style_for_feature(layer, feature);
     let fill_rule = match path.fill_rule {
         FillRule::NonZero => "nonzero",
         FillRule::EvenOdd => "evenodd",
@@ -155,8 +155,8 @@ fn write_path(
             svg,
             "    <path d='{}' fill='none' stroke='{}' stroke-opacity='{}' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='round'/>",
             d,
-            color,
-            fmt_num(opacity),
+            style.color,
+            fmt_num(style.opacity),
             fmt_num(path.stroke_width),
             line_cap(path.line_cap)
         )
@@ -166,8 +166,8 @@ fn write_path(
             svg,
             "    <path d='{}' fill='{}' fill-opacity='{}' fill-rule='{}'/>",
             d,
-            color,
-            fmt_num(opacity),
+            style.color,
+            fmt_num(style.opacity),
             fill_rule
         )
         .unwrap();
@@ -254,6 +254,47 @@ fn path_data(doc: &GeometryDocument, path: &GeometryPath) -> String {
         }
     }
     data
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Style {
+    color: &'static str,
+    opacity: f64,
+}
+
+fn style_for_feature(layer: &GeometryLayer, feature: &GeometryFeature) -> Style {
+    if feature.kind == FeatureKind::FlattenedBucket
+        && feature.polarity == GeometryPolarity::Positive
+    {
+        return flat_layer_style(layer);
+    }
+    Style {
+        color: color_for_bucket(feature.bucket, feature.polarity),
+        opacity: opacity_for_bucket(feature.bucket, feature.polarity),
+    }
+}
+
+fn flat_layer_style(layer: &GeometryLayer) -> Style {
+    let name = layer.name.to_ascii_lowercase();
+    let (color, opacity) = if name.contains("paste") {
+        ("#aeb4bb", 0.9)
+    } else if name.contains("mask") {
+        ("#159447", 0.55)
+    } else if name.contains("legend") || name.contains("silk") {
+        ("#f8f9fa", 0.95)
+    } else if name.contains("profile") || name.contains("outline") || name.contains("rout") {
+        ("#606060", 1.0)
+    } else if name.contains("cu")
+        || name.contains("copper")
+        || name == "top"
+        || name == "bottom"
+        || name.starts_with('l')
+    {
+        ("#d87822", 0.9)
+    } else {
+        ("#5c7cfa", 0.85)
+    };
+    Style { color, opacity }
 }
 
 fn color_for_bucket(bucket: FeatureBucket, polarity: GeometryPolarity) -> &'static str {
@@ -568,6 +609,52 @@ mod tests {
         assert!(smd < cutout);
         assert!(svg.contains("fill='#2f9e44' fill-opacity='0.78'"));
         assert!(svg.contains("fill='#64748b' fill-opacity='1'"));
+    }
+
+    #[test]
+    fn renders_flattened_masks_with_gerber_layer_colors() {
+        assert_flat_color("F.Cu", "#d87822", "0.9");
+        assert_flat_color("F.Paste", "#aeb4bb", "0.9");
+        assert_flat_color("F.Mask", "#159447", "0.55");
+        assert_flat_color("F.SilkS", "#f8f9fa", "0.95");
+    }
+
+    fn assert_flat_color(layer_name: &str, color: &str, opacity: &str) {
+        let mut interner = ipc2581::Interner::new();
+        let mut doc = GeometryDocument::new("test".to_string());
+        let bbox = BBox {
+            min: Point::new(0.0, 0.0),
+            max: Point::new(1.0, 1.0),
+        };
+        doc.push_path(
+            GeometryPath::filled(FillRule::NonZero, bbox),
+            [
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(1.0, 0.0)),
+                PathCmd::line_to(Point::new(1.0, 1.0)),
+                PathCmd::close(),
+            ],
+        );
+        doc.features.push(GeometryFeature {
+            path_count: 1,
+            bbox,
+            ..GeometryFeature::new(
+                FeatureKind::FlattenedBucket,
+                FeatureBucket::Fill,
+                GeometryPolarity::Positive,
+            )
+        });
+        doc.layers.push(GeometryLayer {
+            name: layer_name.to_string(),
+            source_layer_ref: interner.intern(layer_name),
+            feature_start: 0,
+            feature_count: 1,
+            bbox,
+        });
+
+        let svg = render_layer_svg(&doc, 0);
+
+        assert!(svg.contains(&format!("fill='{color}' fill-opacity='{opacity}'")));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/gerber/artwork.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/artwork.rs
@@ -1,11 +1,8 @@
-use ipc2581::types::{LayerFunction, Side};
-
-use crate::geometry::ir::{LineCap, Point};
+use crate::geometry::ir::Point;
 
 #[derive(Debug, Clone)]
 pub struct ArtworkLayer {
-    pub function: LayerFunction,
-    pub side: Option<Side>,
+    pub file_function: Vec<String>,
     pub objects: Vec<ArtworkObject>,
 }
 
@@ -13,12 +10,19 @@ pub struct ArtworkLayer {
 pub enum ArtworkObject {
     Region {
         contours: Vec<ArtworkContour>,
+        attributes: ObjectAttributes,
     },
     Stroke {
         width: f64,
-        line_cap: LineCap,
         contours: Vec<ArtworkContour>,
+        aperture_function: String,
+        attributes: ObjectAttributes,
     },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ObjectAttributes {
+    pub net: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/pcb-ipc2581-tools/src/gerber/artwork.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/artwork.rs
@@ -1,0 +1,41 @@
+use ipc2581::types::{LayerFunction, Side};
+
+use crate::geometry::ir::{LineCap, Point};
+
+#[derive(Debug, Clone)]
+pub struct ArtworkLayer {
+    pub function: LayerFunction,
+    pub side: Option<Side>,
+    pub objects: Vec<ArtworkObject>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ArtworkObject {
+    Region {
+        contours: Vec<ArtworkContour>,
+    },
+    Stroke {
+        width: f64,
+        line_cap: LineCap,
+        contours: Vec<ArtworkContour>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtworkContour {
+    pub segments: Vec<ArtworkSegment>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ArtworkSegment {
+    Line {
+        start: Point,
+        end: Point,
+    },
+    Arc {
+        start: Point,
+        end: Point,
+        center: Point,
+        clockwise: bool,
+    },
+}

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1,0 +1,346 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use gerberx2::{GerberLayer, write_layer};
+use ipc2581::Ipc2581;
+use ipc2581::types::{LayerFunction, Side};
+
+use super::artwork::{ArtworkContour, ArtworkLayer, ArtworkObject, ArtworkSegment};
+use super::lower::lower_artwork_layer;
+use crate::geometry::ir::{GeometryDocument, GeometryPath, PathCmd, PathOp, Point};
+use crate::{geometry, ipc2581 as ipc};
+
+#[derive(Debug, Clone)]
+pub struct GerberExportOptions {
+    pub output_dir: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct GerberExportSet {
+    pub files: Vec<GerberExportFile>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GerberExportFile {
+    pub filename: String,
+    pub layer: GerberLayer,
+    pub contents: String,
+}
+
+pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<GerberExportSet> {
+    let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
+    let mut files = Vec::new();
+    let mut first_doc = None;
+
+    for source_layer in &ecad.cad_data.layers {
+        if !is_gerber_layer_function(source_layer.layer_function) {
+            continue;
+        }
+        let layer_name = ipc.resolve(source_layer.name);
+        let mut doc = geometry::extract_layer(ipc, layer_name)
+            .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
+        geometry::process::process_document(&mut doc);
+        if first_doc.is_none() {
+            first_doc = Some(doc.clone());
+        }
+        let artwork = artwork_from_processed_layer(&doc, 0, source_layer.side)?;
+        let layer = lower_artwork_layer(&artwork)?;
+        let contents = write_layer(&layer)?;
+        files.push(GerberExportFile {
+            filename: format!("{}.gbr", sanitize_filename(layer_name)),
+            layer,
+            contents,
+        });
+    }
+
+    if let Some(doc) = first_doc {
+        let profile = profile_artwork_from_outlines(&doc)?;
+        if !profile.objects.is_empty() {
+            let layer = lower_artwork_layer(&profile)?;
+            let contents = write_layer(&layer)?;
+            files.push(GerberExportFile {
+                filename: "profile.gbr".to_string(),
+                layer,
+                contents,
+            });
+        }
+    }
+
+    std::fs::create_dir_all(&options.output_dir).with_context(|| {
+        format!(
+            "failed to create Gerber output directory {}",
+            options.output_dir.display()
+        )
+    })?;
+    for file in &files {
+        std::fs::write(options.output_dir.join(&file.filename), &file.contents).with_context(
+            || {
+                format!(
+                    "failed to write Gerber file {}",
+                    options.output_dir.join(&file.filename).display()
+                )
+            },
+        )?;
+    }
+
+    Ok(GerberExportSet { files })
+}
+
+fn is_gerber_layer_function(function: LayerFunction) -> bool {
+    matches!(
+        function,
+        LayerFunction::Conductor
+            | LayerFunction::CondFilm
+            | LayerFunction::CondFoil
+            | LayerFunction::Plane
+            | LayerFunction::Signal
+            | LayerFunction::Mixed
+            | LayerFunction::Solderpaste
+            | LayerFunction::Pastemask
+            | LayerFunction::Soldermask
+            | LayerFunction::Silkscreen
+            | LayerFunction::Legend
+            | LayerFunction::Rout
+            | LayerFunction::BoardOutline
+    )
+}
+
+fn artwork_from_processed_layer(
+    doc: &GeometryDocument,
+    layer_index: usize,
+    side: Option<Side>,
+) -> Result<ArtworkLayer> {
+    let layer = &doc.layers[layer_index];
+    let mut objects = Vec::new();
+    for feature in &doc.features
+        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
+    {
+        for path in &doc.paths
+            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+        {
+            if path.flags.filled {
+                objects.push(ArtworkObject::Region {
+                    contours: artwork_contours(doc, path)?,
+                });
+            } else if path.flags.stroked {
+                objects.push(ArtworkObject::Stroke {
+                    width: path.stroke_width,
+                    line_cap: path.line_cap,
+                    contours: artwork_contours(doc, path)?,
+                });
+            } else {
+                bail!(
+                    "IPC geometry path is neither filled nor stroked on layer '{}'",
+                    layer.name
+                );
+            }
+        }
+    }
+    Ok(ArtworkLayer {
+        function: layer.layer_function,
+        side,
+        objects,
+    })
+}
+
+fn profile_artwork_from_outlines(doc: &GeometryDocument) -> Result<ArtworkLayer> {
+    let mut objects = Vec::new();
+    for outline in &doc.board_outlines {
+        for path in &doc.paths
+            [outline.path_start as usize..(outline.path_start + outline.path_count) as usize]
+        {
+            if path.flags.stroked {
+                objects.push(ArtworkObject::Stroke {
+                    width: path.stroke_width,
+                    line_cap: path.line_cap,
+                    contours: artwork_contours(doc, path)?,
+                });
+            } else if path.flags.filled {
+                objects.push(ArtworkObject::Region {
+                    contours: artwork_contours(doc, path)?,
+                });
+            } else {
+                bail!("IPC board outline path is neither filled nor stroked");
+            }
+        }
+    }
+    Ok(ArtworkLayer {
+        function: LayerFunction::BoardOutline,
+        side: None,
+        objects,
+    })
+}
+
+fn artwork_contours(doc: &GeometryDocument, path: &GeometryPath) -> Result<Vec<ArtworkContour>> {
+    let mut contours = Vec::new();
+    for contour in &doc.contours
+        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+    {
+        let cmds = &doc.path_cmds
+            [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize];
+        contours.push(ArtworkContour {
+            segments: artwork_segments(cmds)?,
+        });
+    }
+    Ok(contours)
+}
+
+fn artwork_segments(cmds: &[PathCmd]) -> Result<Vec<ArtworkSegment>> {
+    let mut first = None;
+    let mut current = None;
+    let mut segments = Vec::new();
+    for cmd in cmds {
+        match cmd.op {
+            PathOp::MoveTo => {
+                first = Some(cmd.p0);
+                current = Some(cmd.p0);
+            }
+            PathOp::LineTo => {
+                let start = current.context("path line command appears before move command")?;
+                segments.push(ArtworkSegment::Line { start, end: cmd.p0 });
+                current = Some(cmd.p0);
+            }
+            PathOp::ArcTo => {
+                let start = current.context("path arc command appears before move command")?;
+                segments.push(ArtworkSegment::Arc {
+                    start,
+                    end: cmd.p0,
+                    center: cmd.p1,
+                    clockwise: cmd.clockwise,
+                });
+                current = Some(cmd.p0);
+            }
+            PathOp::CubicTo => {
+                let start = current.context("path cubic command appears before move command")?;
+                let steps = 16;
+                for step in 1..=steps {
+                    let end =
+                        cubic_point(start, cmd.p0, cmd.p1, cmd.p2, step as f64 / steps as f64);
+                    let segment_start = current.unwrap_or(start);
+                    segments.push(ArtworkSegment::Line {
+                        start: segment_start,
+                        end,
+                    });
+                    current = Some(end);
+                }
+            }
+            PathOp::Close => {
+                if let (Some(start), Some(end)) = (first, current)
+                    && !points_close(start, end)
+                {
+                    segments.push(ArtworkSegment::Line {
+                        start: end,
+                        end: start,
+                    });
+                }
+                current = first;
+            }
+        }
+    }
+    Ok(segments)
+}
+
+fn points_close(a: Point, b: Point) -> bool {
+    a.distance_to(b) <= 1e-9
+}
+
+fn cubic_point(start: Point, c1: Point, c2: Point, end: Point, t: f64) -> Point {
+    let mt = 1.0 - t;
+    Point::new(
+        mt.powi(3) * start.x
+            + 3.0 * mt.powi(2) * t * c1.x
+            + 3.0 * mt * t.powi(2) * c2.x
+            + t.powi(3) * end.x,
+        mt.powi(3) * start.y
+            + 3.0 * mt.powi(2) * t * c1.y
+            + 3.0 * mt * t.powi(2) * c2.y
+            + t.powi(3) * end.y,
+    )
+}
+
+fn sanitize_filename(name: &str) -> String {
+    let mut out = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "layer".to_string()
+    } else {
+        out
+    }
+}
+
+pub fn execute_file(input_file: &Path, output_dir: &Path) -> Result<GerberExportSet> {
+    let content = crate::utils::file::load_ipc_file(input_file)?;
+    let ipc = ipc::Ipc2581::parse(&content)?;
+    export_gerber_x2(
+        &ipc,
+        &GerberExportOptions {
+            output_dir: output_dir.to_path_buf(),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exports_ipc_layer_to_parseable_gerber_x2() {
+        let ipc = ipc::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="pad"><Circle diameter="1"/></EntryStandard>
+    </DictionaryStandard>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="10"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+        </Profile>
+        <PadStackDef name="padstack">
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR">
+            <StandardPrimitiveRef id="pad"/>
+          </PadstackPadDef>
+        </PadStackDef>
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <Pad padstackDefRef="padstack"><Location x="2" y="3"/></Pad>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let output_dir =
+            std::env::temp_dir().join(format!("pcb-ipc-gerber-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&output_dir);
+
+        let set = export_gerber_x2(&ipc, &GerberExportOptions { output_dir }).unwrap();
+
+        assert!(set.files.iter().any(|file| file.filename == "TOP.gbr"));
+        assert!(set.files.iter().any(|file| file.filename == "profile.gbr"));
+        for file in &set.files {
+            gerberx2::GerberX2::parse(&file.contents).unwrap();
+        }
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -3,9 +3,11 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use gerberx2::{GerberLayer, write_layer};
 use ipc2581::Ipc2581;
-use ipc2581::types::{LayerFunction, Side};
+use ipc2581::types::{LayerFunction, Side, ecad::Layer};
 
-use super::artwork::{ArtworkContour, ArtworkLayer, ArtworkObject, ArtworkSegment};
+use super::artwork::{
+    ArtworkContour, ArtworkLayer, ArtworkObject, ArtworkSegment, ObjectAttributes,
+};
 use super::lower::lower_artwork_layer;
 use crate::geometry::ir::{GeometryDocument, GeometryPath, PathCmd, PathOp, Point};
 use crate::{geometry, ipc2581 as ipc};
@@ -31,11 +33,10 @@ pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let mut files = Vec::new();
     let mut first_doc = None;
+    let plans = export_layer_plans(&ecad.cad_data.layers);
 
-    for source_layer in &ecad.cad_data.layers {
-        if !is_gerber_layer_function(source_layer.layer_function) {
-            continue;
-        }
+    for plan in &plans {
+        let source_layer = plan.layer;
         let layer_name = ipc.resolve(source_layer.name);
         let mut doc = geometry::extract_layer(ipc, layer_name)
             .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
@@ -43,11 +44,11 @@ pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<
         if first_doc.is_none() {
             first_doc = Some(doc.clone());
         }
-        let artwork = artwork_from_processed_layer(&doc, 0, source_layer.side)?;
+        let artwork = artwork_from_processed_layer(ipc, &doc, 0, plan.file_function.clone())?;
         let layer = lower_artwork_layer(&artwork)?;
         let contents = write_layer(&layer)?;
         files.push(GerberExportFile {
-            filename: format!("{}.gbr", sanitize_filename(layer_name)),
+            filename: plan.filename.clone(),
             layer,
             contents,
         });
@@ -86,29 +87,143 @@ pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<
     Ok(GerberExportSet { files })
 }
 
-fn is_gerber_layer_function(function: LayerFunction) -> bool {
-    matches!(
-        function,
+struct ExportLayerPlan<'a> {
+    layer: &'a Layer,
+    filename: String,
+    file_function: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GerberLayerRole {
+    Copper,
+    Paste,
+    Soldermask,
+    Legend,
+    Profile,
+}
+
+fn export_layer_plans(layers: &[Layer]) -> Vec<ExportLayerPlan<'_>> {
+    let copper_count = layers
+        .iter()
+        .filter(|layer| gerber_layer_role(layer.layer_function) == Some(GerberLayerRole::Copper))
+        .count();
+    let mut copper_index = 0;
+    let mut plans = Vec::new();
+
+    for layer in layers {
+        let Some(role) = gerber_layer_role(layer.layer_function) else {
+            continue;
+        };
+        if role == GerberLayerRole::Copper {
+            copper_index += 1;
+        }
+        let (filename, file_function) = layer_output(role, layer.side, copper_index, copper_count);
+        plans.push(ExportLayerPlan {
+            layer,
+            filename,
+            file_function,
+        });
+    }
+
+    plans
+}
+
+fn gerber_layer_role(function: LayerFunction) -> Option<GerberLayerRole> {
+    match function {
         LayerFunction::Conductor
-            | LayerFunction::CondFilm
-            | LayerFunction::CondFoil
-            | LayerFunction::Plane
-            | LayerFunction::Signal
-            | LayerFunction::Mixed
-            | LayerFunction::Solderpaste
-            | LayerFunction::Pastemask
-            | LayerFunction::Soldermask
-            | LayerFunction::Silkscreen
-            | LayerFunction::Legend
-            | LayerFunction::Rout
-            | LayerFunction::BoardOutline
+        | LayerFunction::CondFilm
+        | LayerFunction::CondFoil
+        | LayerFunction::Plane
+        | LayerFunction::Signal
+        | LayerFunction::Mixed => Some(GerberLayerRole::Copper),
+        LayerFunction::Solderpaste | LayerFunction::Pastemask => Some(GerberLayerRole::Paste),
+        LayerFunction::Soldermask => Some(GerberLayerRole::Soldermask),
+        LayerFunction::Silkscreen | LayerFunction::Legend => Some(GerberLayerRole::Legend),
+        LayerFunction::Rout | LayerFunction::BoardOutline => Some(GerberLayerRole::Profile),
+        _ => None,
+    }
+}
+
+fn layer_output(
+    role: GerberLayerRole,
+    side: Option<Side>,
+    copper_index: usize,
+    copper_count: usize,
+) -> (String, Vec<String>) {
+    match role {
+        GerberLayerRole::Copper => copper_layer_output(side, copper_index, copper_count),
+        GerberLayerRole::Paste => match side {
+            Some(Side::Bottom) => (
+                "B_Paste.gbp".to_string(),
+                vec!["Paste".into(), "Bot".into()],
+            ),
+            _ => (
+                "F_Paste.gtp".to_string(),
+                vec!["Paste".into(), "Top".into()],
+            ),
+        },
+        GerberLayerRole::Soldermask => match side {
+            Some(Side::Bottom) => (
+                "B_Mask.gbs".to_string(),
+                vec!["Soldermask".into(), "Bot".into()],
+            ),
+            _ => (
+                "F_Mask.gts".to_string(),
+                vec!["Soldermask".into(), "Top".into()],
+            ),
+        },
+        GerberLayerRole::Legend => match side {
+            Some(Side::Bottom) => (
+                "B_SilkS.gbo".to_string(),
+                vec!["Legend".into(), "Bot".into()],
+            ),
+            _ => (
+                "F_SilkS.gto".to_string(),
+                vec!["Legend".into(), "Top".into()],
+            ),
+        },
+        GerberLayerRole::Profile => (
+            "Edge_Cuts.gm1".to_string(),
+            vec!["Profile".into(), "NP".into()],
+        ),
+    }
+}
+
+fn copper_layer_output(
+    side: Option<Side>,
+    copper_index: usize,
+    copper_count: usize,
+) -> (String, Vec<String>) {
+    let side_field = match side {
+        Some(Side::Top) => "Top",
+        Some(Side::Bottom) => "Bot",
+        _ => "Inr",
+    };
+    let filename = match side {
+        Some(Side::Top) => "F_Cu.gtl".to_string(),
+        Some(Side::Bottom) => "B_Cu.gbl".to_string(),
+        _ => format!("In{}_Cu.gbr", copper_index),
+    };
+    let index = match side {
+        Some(Side::Top) => 1,
+        Some(Side::Bottom) => copper_count,
+        _ => copper_index,
+    };
+    (
+        filename,
+        vec![
+            "Copper".to_string(),
+            format!("L{index}"),
+            side_field.to_string(),
+        ],
     )
 }
 
 fn artwork_from_processed_layer(
+    ipc: &Ipc2581,
     doc: &GeometryDocument,
     layer_index: usize,
-    side: Option<Side>,
+    file_function: Vec<String>,
 ) -> Result<ArtworkLayer> {
     let layer = &doc.layers[layer_index];
     let mut objects = Vec::new();
@@ -121,12 +236,14 @@ fn artwork_from_processed_layer(
             if path.flags.filled {
                 objects.push(ArtworkObject::Region {
                     contours: artwork_contours(doc, path)?,
+                    attributes: object_attributes(ipc, feature.net),
                 });
             } else if path.flags.stroked {
                 objects.push(ArtworkObject::Stroke {
                     width: path.stroke_width,
-                    line_cap: path.line_cap,
                     contours: artwork_contours(doc, path)?,
+                    aperture_function: aperture_function(feature.bucket).to_string(),
+                    attributes: object_attributes(ipc, feature.net),
                 });
             } else {
                 bail!(
@@ -137,8 +254,7 @@ fn artwork_from_processed_layer(
         }
     }
     Ok(ArtworkLayer {
-        function: layer.layer_function,
-        side,
+        file_function,
         objects,
     })
 }
@@ -152,12 +268,14 @@ fn profile_artwork_from_outlines(doc: &GeometryDocument) -> Result<ArtworkLayer>
             if path.flags.stroked {
                 objects.push(ArtworkObject::Stroke {
                     width: path.stroke_width,
-                    line_cap: path.line_cap,
                     contours: artwork_contours(doc, path)?,
+                    aperture_function: "Profile".to_string(),
+                    attributes: ObjectAttributes::default(),
                 });
             } else if path.flags.filled {
                 objects.push(ArtworkObject::Region {
                     contours: artwork_contours(doc, path)?,
+                    attributes: ObjectAttributes::default(),
                 });
             } else {
                 bail!("IPC board outline path is neither filled nor stroked");
@@ -165,10 +283,28 @@ fn profile_artwork_from_outlines(doc: &GeometryDocument) -> Result<ArtworkLayer>
         }
     }
     Ok(ArtworkLayer {
-        function: LayerFunction::BoardOutline,
-        side: None,
+        file_function: vec!["Profile".into(), "NP".into()],
         objects,
     })
+}
+
+fn object_attributes(ipc: &Ipc2581, net: Option<ipc2581::Symbol>) -> ObjectAttributes {
+    ObjectAttributes {
+        net: net.map(|symbol| ipc.resolve(symbol).to_string()),
+    }
+}
+
+fn aperture_function(bucket: crate::geometry::ir::FeatureBucket) -> &'static str {
+    match bucket {
+        crate::geometry::ir::FeatureBucket::Smd => "SMDPad",
+        crate::geometry::ir::FeatureBucket::Pth => "ComponentPad",
+        crate::geometry::ir::FeatureBucket::Via => "ViaPad",
+        crate::geometry::ir::FeatureBucket::Trace => "Conductor",
+        crate::geometry::ir::FeatureBucket::Fill => "Conductor",
+        crate::geometry::ir::FeatureBucket::Cutout => "Other",
+        crate::geometry::ir::FeatureBucket::Thermal => "ThermalRelief",
+        crate::geometry::ir::FeatureBucket::Antipad => "AntiPad",
+    }
 }
 
 fn artwork_contours(doc: &GeometryDocument, path: &GeometryPath) -> Result<Vec<ArtworkContour>> {
@@ -258,22 +394,6 @@ fn cubic_point(start: Point, c1: Point, c2: Point, end: Point, t: f64) -> Point 
     )
 }
 
-fn sanitize_filename(name: &str) -> String {
-    let mut out = String::new();
-    for ch in name.chars() {
-        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
-            out.push(ch);
-        } else {
-            out.push('_');
-        }
-    }
-    if out.is_empty() {
-        "layer".to_string()
-    } else {
-        out
-    }
-}
-
 pub fn execute_file(input_file: &Path, output_dir: &Path) -> Result<GerberExportSet> {
     let content = crate::utils::file::load_ipc_file(input_file)?;
     let ipc = ipc::Ipc2581::parse(&content)?;
@@ -321,7 +441,7 @@ mod tests {
           </PadstackPadDef>
         </PadStackDef>
         <LayerFeature layerRef="TOP">
-          <Set>
+          <Set net="N1">
             <Pad padstackDefRef="padstack"><Location x="2" y="3"/></Pad>
           </Set>
         </LayerFeature>
@@ -337,10 +457,17 @@ mod tests {
 
         let set = export_gerber_x2(&ipc, &GerberExportOptions { output_dir }).unwrap();
 
-        assert!(set.files.iter().any(|file| file.filename == "TOP.gbr"));
+        assert!(set.files.iter().any(|file| file.filename == "F_Cu.gtl"));
         assert!(set.files.iter().any(|file| file.filename == "profile.gbr"));
         for file in &set.files {
             gerberx2::GerberX2::parse(&file.contents).unwrap();
         }
+        let copper = set
+            .files
+            .iter()
+            .find(|file| file.filename == "F_Cu.gtl")
+            .unwrap();
+        assert!(copper.contents.contains("%TF.FileFunction,Copper,L1,Top*%"));
+        assert!(copper.contents.contains("%TO.N,N1*%"));
     }
 }

--- a/crates/pcb-ipc2581-tools/src/gerber/lower.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/lower.rs
@@ -5,10 +5,11 @@ use gerberx2::{
     AttributeValue, Contour, ContourSegment, GerberLayer, ObjectKind, Point as GerberPoint,
     WriterAperture, WriterApertureTemplate, WriterObject,
 };
-use ipc2581::types::{LayerFunction, Side};
 
-use super::artwork::{ArtworkContour, ArtworkLayer, ArtworkObject, ArtworkSegment};
-use crate::geometry::ir::{LineCap, Point};
+use super::artwork::{
+    ArtworkContour, ArtworkLayer, ArtworkObject, ArtworkSegment, ObjectAttributes,
+};
+use crate::geometry::ir::Point;
 
 pub fn lower_artwork_layer(layer: &ArtworkLayer) -> Result<GerberLayer> {
     let mut apertures = ApertureTable::default();
@@ -16,41 +17,51 @@ pub fn lower_artwork_layer(layer: &ArtworkLayer) -> Result<GerberLayer> {
 
     for object in &layer.objects {
         match object {
-            ArtworkObject::Region { contours } => {
-                objects.push(WriterObject::dark(ObjectKind::Region {
+            ArtworkObject::Region {
+                contours,
+                attributes,
+            } => objects.push(WriterObject {
+                kind: ObjectKind::Region {
                     contours: lower_region_contours(contours)?,
-                }));
-            }
+                },
+                polarity: gerberx2::Polarity::Dark,
+                attributes: lower_object_attributes(attributes),
+            }),
             ArtworkObject::Stroke {
                 width,
-                line_cap,
                 contours,
+                aperture_function,
+                attributes,
             } => {
-                let aperture = apertures.circle(*width, *line_cap)?;
+                let aperture = apertures.circle(*width, aperture_function)?;
                 for contour in contours {
                     for segment in &contour.segments {
-                        objects.push(WriterObject::dark(match *segment {
-                            ArtworkSegment::Line { start, end } => ObjectKind::Draw {
-                                start: lower_point(start),
-                                end: lower_point(end),
-                                aperture,
+                        objects.push(WriterObject {
+                            kind: match *segment {
+                                ArtworkSegment::Line { start, end } => ObjectKind::Draw {
+                                    start: lower_point(start),
+                                    end: lower_point(end),
+                                    aperture,
+                                },
+                                ArtworkSegment::Arc {
+                                    start,
+                                    end,
+                                    center,
+                                    clockwise,
+                                } => ObjectKind::Arc {
+                                    start: lower_point(start),
+                                    end: lower_point(end),
+                                    center_offset: lower_point(Point::new(
+                                        center.x - start.x,
+                                        center.y - start.y,
+                                    )),
+                                    clockwise,
+                                    aperture,
+                                },
                             },
-                            ArtworkSegment::Arc {
-                                start,
-                                end,
-                                center,
-                                clockwise,
-                            } => ObjectKind::Arc {
-                                start: lower_point(start),
-                                end: lower_point(end),
-                                center_offset: lower_point(Point::new(
-                                    center.x - start.x,
-                                    center.y - start.y,
-                                )),
-                                clockwise,
-                                aperture,
-                            },
-                        }));
+                            polarity: gerberx2::Polarity::Dark,
+                            attributes: lower_object_attributes(attributes),
+                        });
                     }
                 }
             }
@@ -60,7 +71,7 @@ pub fn lower_artwork_layer(layer: &ArtworkLayer) -> Result<GerberLayer> {
     Ok(GerberLayer {
         file_attributes: vec![AttributeValue::new(
             ".FileFunction",
-            file_function_fields(layer.function, layer.side),
+            layer.file_function.iter().cloned(),
         )],
         apertures: apertures.into_apertures(),
         objects,
@@ -75,20 +86,20 @@ struct ApertureTable {
     apertures: Vec<WriterAperture>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ApertureKey {
     diameter_nm: i64,
-    line_cap: LineCap,
+    function: String,
 }
 
 impl ApertureTable {
-    fn circle(&mut self, diameter: f64, line_cap: LineCap) -> Result<i32> {
+    fn circle(&mut self, diameter: f64, function: &str) -> Result<i32> {
         if diameter <= 0.0 {
             bail!("cannot export non-positive Gerber stroke aperture diameter {diameter}");
         }
         let key = ApertureKey {
             diameter_nm: quantize_mm(diameter),
-            line_cap,
+            function: function.to_string(),
         };
         if let Some(code) = self.by_key.get(&key) {
             return Ok(*code);
@@ -107,7 +118,7 @@ impl ApertureTable {
                 diameter,
                 hole_diameter: None,
             },
-            attributes: Vec::new(),
+            attributes: vec![AttributeValue::new(".AperFunction", [function.to_string()])],
         });
         Ok(code)
     }
@@ -155,54 +166,18 @@ fn lower_region_contours(contours: &[ArtworkContour]) -> Result<Vec<Contour>> {
         .context("failed to lower artwork contours to Gerber regions")
 }
 
+fn lower_object_attributes(attributes: &ObjectAttributes) -> Vec<AttributeValue> {
+    attributes
+        .net
+        .as_ref()
+        .map(|net| vec![AttributeValue::new(".N", [net.clone()])])
+        .unwrap_or_default()
+}
+
 fn lower_point(point: Point) -> GerberPoint {
     GerberPoint {
         x: point.x,
         y: point.y,
-    }
-}
-
-fn file_function_fields(function: LayerFunction, side: Option<Side>) -> Vec<String> {
-    match function {
-        LayerFunction::Conductor
-        | LayerFunction::CondFilm
-        | LayerFunction::CondFoil
-        | LayerFunction::Plane
-        | LayerFunction::Signal
-        | LayerFunction::Mixed => vec![
-            "Copper".to_string(),
-            side_layer_field(side).to_string(),
-            side_field(side).to_string(),
-        ],
-        LayerFunction::Solderpaste | LayerFunction::Pastemask => {
-            vec!["Paste".to_string(), side_field(side).to_string()]
-        }
-        LayerFunction::Soldermask => vec!["Soldermask".to_string(), side_field(side).to_string()],
-        LayerFunction::Silkscreen | LayerFunction::Legend => {
-            vec!["Legend".to_string(), side_field(side).to_string()]
-        }
-        LayerFunction::Rout | LayerFunction::BoardOutline => {
-            vec!["Profile".to_string(), "NP".to_string()]
-        }
-        LayerFunction::Drill => vec!["Drill".to_string(), "PTH".to_string()],
-        _ => vec![format!("{:?}", function)],
-    }
-}
-
-fn side_field(side: Option<Side>) -> &'static str {
-    match side {
-        Some(Side::Top) => "Top",
-        Some(Side::Bottom) => "Bot",
-        Some(Side::Internal) => "Inr",
-        _ => "Other",
-    }
-}
-
-fn side_layer_field(side: Option<Side>) -> &'static str {
-    match side {
-        Some(Side::Top) => "L1",
-        Some(Side::Bottom) => "L2",
-        _ => "L0",
     }
 }
 

--- a/crates/pcb-ipc2581-tools/src/gerber/lower.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/lower.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, bail};
+use gerberx2::{
+    AttributeValue, Contour, ContourSegment, GerberLayer, ObjectKind, Point as GerberPoint,
+    WriterAperture, WriterApertureTemplate, WriterObject,
+};
+use ipc2581::types::{LayerFunction, Side};
+
+use super::artwork::{ArtworkContour, ArtworkLayer, ArtworkObject, ArtworkSegment};
+use crate::geometry::ir::{LineCap, Point};
+
+pub fn lower_artwork_layer(layer: &ArtworkLayer) -> Result<GerberLayer> {
+    let mut apertures = ApertureTable::default();
+    let mut objects = Vec::new();
+
+    for object in &layer.objects {
+        match object {
+            ArtworkObject::Region { contours } => {
+                objects.push(WriterObject::dark(ObjectKind::Region {
+                    contours: lower_region_contours(contours)?,
+                }));
+            }
+            ArtworkObject::Stroke {
+                width,
+                line_cap,
+                contours,
+            } => {
+                let aperture = apertures.circle(*width, *line_cap)?;
+                for contour in contours {
+                    for segment in &contour.segments {
+                        objects.push(WriterObject::dark(match *segment {
+                            ArtworkSegment::Line { start, end } => ObjectKind::Draw {
+                                start: lower_point(start),
+                                end: lower_point(end),
+                                aperture,
+                            },
+                            ArtworkSegment::Arc {
+                                start,
+                                end,
+                                center,
+                                clockwise,
+                            } => ObjectKind::Arc {
+                                start: lower_point(start),
+                                end: lower_point(end),
+                                center_offset: lower_point(Point::new(
+                                    center.x - start.x,
+                                    center.y - start.y,
+                                )),
+                                clockwise,
+                                aperture,
+                            },
+                        }));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(GerberLayer {
+        file_attributes: vec![AttributeValue::new(
+            ".FileFunction",
+            file_function_fields(layer.function, layer.side),
+        )],
+        apertures: apertures.into_apertures(),
+        objects,
+        ..GerberLayer::default()
+    })
+}
+
+#[derive(Default)]
+struct ApertureTable {
+    next_code: i32,
+    by_key: HashMap<ApertureKey, i32>,
+    apertures: Vec<WriterAperture>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ApertureKey {
+    diameter_nm: i64,
+    line_cap: LineCap,
+}
+
+impl ApertureTable {
+    fn circle(&mut self, diameter: f64, line_cap: LineCap) -> Result<i32> {
+        if diameter <= 0.0 {
+            bail!("cannot export non-positive Gerber stroke aperture diameter {diameter}");
+        }
+        let key = ApertureKey {
+            diameter_nm: quantize_mm(diameter),
+            line_cap,
+        };
+        if let Some(code) = self.by_key.get(&key) {
+            return Ok(*code);
+        }
+        let code = if self.next_code == 0 {
+            self.next_code = 10;
+            10
+        } else {
+            self.next_code += 1;
+            self.next_code
+        };
+        self.by_key.insert(key, code);
+        self.apertures.push(WriterAperture {
+            code,
+            template: WriterApertureTemplate::Circle {
+                diameter,
+                hole_diameter: None,
+            },
+            attributes: Vec::new(),
+        });
+        Ok(code)
+    }
+
+    fn into_apertures(self) -> Vec<WriterAperture> {
+        self.apertures
+    }
+}
+
+fn lower_region_contours(contours: &[ArtworkContour]) -> Result<Vec<Contour>> {
+    contours
+        .iter()
+        .map(|contour| {
+            if contour.segments.is_empty() {
+                bail!("cannot export empty Gerber region contour");
+            }
+            Ok(Contour {
+                segments: contour
+                    .segments
+                    .iter()
+                    .map(|segment| match *segment {
+                        ArtworkSegment::Line { start, end } => ContourSegment::Line {
+                            start: lower_point(start),
+                            end: lower_point(end),
+                        },
+                        ArtworkSegment::Arc {
+                            start,
+                            end,
+                            center,
+                            clockwise,
+                        } => ContourSegment::Arc {
+                            start: lower_point(start),
+                            end: lower_point(end),
+                            center_offset: lower_point(Point::new(
+                                center.x - start.x,
+                                center.y - start.y,
+                            )),
+                            clockwise,
+                        },
+                    })
+                    .collect(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()
+        .context("failed to lower artwork contours to Gerber regions")
+}
+
+fn lower_point(point: Point) -> GerberPoint {
+    GerberPoint {
+        x: point.x,
+        y: point.y,
+    }
+}
+
+fn file_function_fields(function: LayerFunction, side: Option<Side>) -> Vec<String> {
+    match function {
+        LayerFunction::Conductor
+        | LayerFunction::CondFilm
+        | LayerFunction::CondFoil
+        | LayerFunction::Plane
+        | LayerFunction::Signal
+        | LayerFunction::Mixed => vec![
+            "Copper".to_string(),
+            side_layer_field(side).to_string(),
+            side_field(side).to_string(),
+        ],
+        LayerFunction::Solderpaste | LayerFunction::Pastemask => {
+            vec!["Paste".to_string(), side_field(side).to_string()]
+        }
+        LayerFunction::Soldermask => vec!["Soldermask".to_string(), side_field(side).to_string()],
+        LayerFunction::Silkscreen | LayerFunction::Legend => {
+            vec!["Legend".to_string(), side_field(side).to_string()]
+        }
+        LayerFunction::Rout | LayerFunction::BoardOutline => {
+            vec!["Profile".to_string(), "NP".to_string()]
+        }
+        LayerFunction::Drill => vec!["Drill".to_string(), "PTH".to_string()],
+        _ => vec![format!("{:?}", function)],
+    }
+}
+
+fn side_field(side: Option<Side>) -> &'static str {
+    match side {
+        Some(Side::Top) => "Top",
+        Some(Side::Bottom) => "Bot",
+        Some(Side::Internal) => "Inr",
+        _ => "Other",
+    }
+}
+
+fn side_layer_field(side: Option<Side>) -> &'static str {
+    match side {
+        Some(Side::Top) => "L1",
+        Some(Side::Bottom) => "L2",
+        _ => "L0",
+    }
+}
+
+fn quantize_mm(value: f64) -> i64 {
+    (value * 1_000_000.0).round() as i64
+}

--- a/crates/pcb-ipc2581-tools/src/gerber/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/mod.rs
@@ -1,0 +1,7 @@
+mod artwork;
+mod export;
+mod lower;
+
+pub use export::{
+    GerberExportFile, GerberExportOptions, GerberExportSet, execute_file, export_gerber_x2,
+};

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -4,6 +4,7 @@ use ipc2581::Mode;
 pub mod accessors;
 pub mod commands;
 pub mod geometry;
+pub mod gerber;
 pub mod utils;
 
 // Re-export ipc2581 for external use

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -49,6 +49,7 @@ open = { workspace = true }
 inquire = { workspace = true }
 pcb-ui = { workspace = true }
 pcb-fmt = { workspace = true }
+gerberx2 = { workspace = true }
 similar = { workspace = true }
 pathdiff = { workspace = true }
 petgraph = { workspace = true }

--- a/crates/pcb/src/gerber.rs
+++ b/crates/pcb/src/gerber.rs
@@ -1,0 +1,145 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::{Args, Subcommand, ValueEnum};
+
+#[derive(Args)]
+pub struct GerberArgs {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Render a single Gerber X2 layer to SVG, PNG, or terminal graphics
+    Render {
+        /// Gerber layer file to render
+        #[arg(value_hint = clap::ValueHint::FilePath)]
+        file: PathBuf,
+        /// Output file path. If omitted, auto renders to the terminal when possible.
+        #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
+        output: Option<PathBuf>,
+        /// Render format. Auto infers SVG/PNG from output extension or uses terminal graphics.
+        #[arg(short, long, default_value = "auto")]
+        format: RenderFormat,
+        /// Render pre-composition feature buckets for debugging geometry extraction.
+        #[arg(long)]
+        debug_geometry: bool,
+    },
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+enum RenderFormat {
+    Auto,
+    Svg,
+    Png,
+}
+
+enum RenderTarget {
+    Svg,
+    Png,
+    Terminal,
+}
+
+pub fn execute(args: GerberArgs) -> Result<()> {
+    match args.command {
+        Commands::Render {
+            file,
+            output,
+            format,
+            debug_geometry,
+        } => render(&file, output.as_deref(), format, debug_geometry),
+    }
+}
+
+fn render(
+    file: &Path,
+    output: Option<&Path>,
+    format: RenderFormat,
+    debug_geometry: bool,
+) -> Result<()> {
+    let target = resolve_target(output, format)?;
+    let gerber = gerberx2::GerberX2::parse_file(file)
+        .with_context(|| format!("Failed to parse Gerber file {}", file.display()))?;
+    let mut geometry = gerberx2::geometry::extract_document(&gerber);
+    if !debug_geometry {
+        gerberx2::geometry::process::process_document(&mut geometry);
+    }
+
+    for diagnostic in &geometry.diagnostics {
+        eprintln!("warning: {}", diagnostic.message);
+    }
+
+    match target {
+        RenderTarget::Svg => {
+            let options = gerberx2::geometry::svg::SvgOptions {
+                mode: if debug_geometry {
+                    gerberx2::geometry::svg::RenderMode::Debug
+                } else {
+                    gerberx2::geometry::svg::RenderMode::Final
+                },
+                width_px: None,
+                height_px: None,
+            };
+            let svg = gerberx2::geometry::svg::render_svg_with_options(&geometry, options);
+            if let Some(output) = output {
+                std::fs::write(output, svg)
+                    .with_context(|| format!("Failed to write SVG to {}", output.display()))?;
+                println!("✓ Gerber layer rendered to {}", output.display());
+            } else {
+                print!("{svg}");
+            }
+        }
+        RenderTarget::Png => {
+            let png = gerberx2::geometry::raster::render_png(&geometry)?;
+            if let Some(output) = output {
+                std::fs::write(output, png)
+                    .with_context(|| format!("Failed to write PNG to {}", output.display()))?;
+                println!("✓ Gerber layer rendered to {}", output.display());
+            } else {
+                std::io::stdout()
+                    .lock()
+                    .write_all(&png)
+                    .context("Failed to write PNG to stdout")?;
+            }
+        }
+        RenderTarget::Terminal => gerberx2::geometry::terminal::render_to_terminal(&geometry)?,
+    }
+
+    Ok(())
+}
+
+fn resolve_target(output: Option<&Path>, format: RenderFormat) -> Result<RenderTarget> {
+    match format {
+        RenderFormat::Auto => {
+            if let Some(output) = output {
+                infer_format_from_output(output)
+            } else if gerberx2::geometry::terminal::can_render_to_terminal() {
+                Ok(RenderTarget::Terminal)
+            } else {
+                bail!(
+                    "Could not render Gerber layer to stdout; run from an interactive terminal or pass --output <path>.svg or <path>.png"
+                )
+            }
+        }
+        RenderFormat::Svg => Ok(RenderTarget::Svg),
+        RenderFormat::Png => Ok(RenderTarget::Png),
+    }
+}
+
+fn infer_format_from_output(output: &Path) -> Result<RenderTarget> {
+    match output
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("svg") => Ok(RenderTarget::Svg),
+        Some("png") => Ok(RenderTarget::Png),
+        _ => bail!(
+            "Could not infer Gerber render format from {}; pass --format svg or --format png",
+            output.display()
+        ),
+    }
+}

--- a/crates/pcb/src/ipc2581.rs
+++ b/crates/pcb/src/ipc2581.rs
@@ -1,7 +1,9 @@
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
-use pcb_ipc2581_tools::{OutputFormat, RenderFormat, UnitFormat, ViewMode, commands, utils};
+use pcb_ipc2581_tools::{
+    OutputFormat, RenderFormat, UnitFormat, ViewMode, commands, gerber, utils,
+};
 
 #[derive(Args)]
 pub struct Ipc2581Args {
@@ -87,6 +89,15 @@ enum Commands {
         #[arg(long)]
         flat: bool,
     },
+    /// Export IPC-2581 fabrication layers as Gerber X2 files
+    Gerber {
+        /// IPC-2581 XML file to export from
+        #[arg(value_hint = clap::ValueHint::FilePath)]
+        file: PathBuf,
+        /// Output directory for generated Gerber files
+        #[arg(short, long, value_hint = clap::ValueHint::DirPath)]
+        output: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -165,5 +176,14 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 flat,
             },
         ),
+        Commands::Gerber { file, output } => {
+            let set = gerber::execute_file(&file, &output)?;
+            println!(
+                "✓ IPC-2581 exported {} Gerber X2 file(s) to {}",
+                set.files.len(),
+                output.display()
+            );
+            Ok(())
+        }
     }
 }

--- a/crates/pcb/src/ipc2581.rs
+++ b/crates/pcb/src/ipc2581.rs
@@ -83,6 +83,9 @@ enum Commands {
         /// Render format. Auto infers SVG/PNG from the output extension or uses terminal graphics.
         #[arg(short, long, default_value = "auto")]
         format: RenderFormat,
+        /// Flatten the layer into a single Gerber-style mask before rendering.
+        #[arg(long)]
+        flat: bool,
     },
 }
 
@@ -152,12 +155,14 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             layer,
             output,
             format,
+            flat,
         } => commands::render::execute(
             &file,
             &commands::render::RenderOptions {
                 layer,
                 output,
                 format,
+                flat,
             },
         ),
     }

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -21,6 +21,7 @@ mod drc;
 mod embed_step;
 mod file_walker;
 mod fmt;
+mod gerber;
 mod import;
 mod info;
 mod ipc2581;
@@ -173,6 +174,9 @@ enum Commands {
     /// IPC-2581 parser and inspection tool
     Ipc2581(ipc2581::Ipc2581Args),
 
+    /// Gerber X2 parser and rendering tool
+    Gerber(gerber::GerberArgs),
+
     /// Inspect KiCad symbol libraries as structured JSON
     #[command(hide = true)]
     Kq(kq::KqArgs),
@@ -254,6 +258,7 @@ fn run() -> anyhow::Result<()> {
         Commands::Route(args) => route::execute(args),
         Commands::Simulate(args) => sim::execute(args),
         Commands::Ipc2581(args) => ipc2581::execute(args),
+        Commands::Gerber(args) => gerber::execute(args),
         Commands::Kq(args) => kq::execute(args),
         Commands::Package(args) => package::execute(args),
         Commands::External(args) => {

--- a/crates/pcb/tests/snapshots/simple__help.snap
+++ b/crates/pcb/tests/snapshots/simple__help.snap
@@ -37,6 +37,7 @@ Commands:
   search      Search for electronic components
   simulate    Run SPICE simulations
   ipc2581     IPC-2581 parser and inspection tool
+  gerber      Gerber X2 parser and rendering tool
   help        Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new `gerberx2` parser/writer plus geometry processing/rendering pipelines and wires it into existing tooling; mistakes could affect fabrication output correctness and preview fidelity.
> 
> **Overview**
> Adds an initial `gerberx2` crate that can **parse Gerber X2 into a typed command/object model**, lower apertures/objects into a processed geometry document, and render previews via `SVG`, `PNG`, or terminal output; it also includes a writer that emits X2 files with file/aperture/object attributes, macro apertures, and block apertures without flattening.
> 
> Extends `pcb-ipc2581-tools` rendering with `--flat` to optionally flatten a layer into a single Gerber-style mask after processing, and adjusts IPC-2581 geometry extraction to carry `layer_function` plus fixes span logic so a layer always applies to itself (and updates tests accordingly). Workspace manifests are updated to include the new `gerberx2` dependency, and preview styling changes include rendering `Profile` layers as black board outlines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80a4d900697a08333eb65ce5c952e9745e1e4c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->