### PR TITLE
Use setup-rust-toolchain in CI

### DIFF
--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -8,5 +8,3 @@
 - name: Setup Rust toolchain
   if: runner.os != 'Windows'
   uses: actions-rust-lang/setup-rust-toolchain@v1
-  with:
-    toolchain: stable

--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -4,7 +4,10 @@
   with:
     rustflags: ""
     toolchain: stable-x86_64-pc-windows-msvc
+    cache-bin: false
 
 - name: Setup Rust toolchain
   if: runner.os != 'Windows'
   uses: actions-rust-lang/setup-rust-toolchain@v1
+  with:
+    cache-bin: false

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -22,6 +22,8 @@ jobs:
       
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-bin: false
       
       - name: Build PCB CLI
         run: cargo build --release --bin pcb

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -21,10 +21,7 @@ jobs:
           submodules: recursive
       
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-      
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       
       - name: Build PCB CLI
         run: cargo build --release --bin pcb

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-bin: false
 
       - name: Build pcb (head)
         run: cargo build -p pcb --release

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -23,10 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build pcb (head)
         run: cargo build -p pcb --release

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-bin: false
 
       - name: Build and install pcb CLI
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,12 +57,7 @@ jobs:
           brew install --cask kicad
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build and install pcb CLI
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
+          cache-bin: false
 
       - name: Check All
         run: cargo check --workspace --all
@@ -119,12 +120,14 @@ jobs:
           rustflags: ""
           toolchain: stable-x86_64-pc-windows-msvc
           components: rustfmt, clippy
+          cache-bin: false
 
       - name: Install Rust
         if: runner.os != 'Windows'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
+          cache-bin: false
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           components: rustfmt, clippy
 
       - name: Check All
@@ -125,7 +124,6 @@ jobs:
         if: runner.os != 'Windows'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           components: rustfmt, clippy
 
       - name: Install nextest

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -135,8 +135,6 @@ jobs:
       - name: "Setup Rust toolchain"
         uses: "actions-rust-lang/setup-rust-toolchain@v1"
         if: "runner.os != 'Windows'"
-        with:
-          "toolchain": "stable"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -132,9 +132,12 @@ jobs:
         with:
           "rustflags": ""
           "toolchain": "stable-x86_64-pc-windows-msvc"
+          "cache-bin": false
       - name: "Setup Rust toolchain"
         uses: "actions-rust-lang/setup-rust-toolchain@v1"
         if: "runner.os != 'Windows'"
+        with:
+          "cache-bin": false
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -42,7 +42,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Update changelog
         run: ./bin/changelog.py release ${{ inputs.version }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-bin: false
 
       - name: Update changelog
         run: ./bin/changelog.py release ${{ inputs.version }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -22,15 +22,9 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: wasm32-unknown-unknown
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          # Only save cache from main branch to prevent cache proliferation
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          target: wasm32-unknown-unknown
 
       - name: Build WASM
         run: cargo build --package pcb-zen-wasm --target wasm32-unknown-unknown --release

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: wasm32-unknown-unknown
+          cache-bin: false
 
       - name: Build WASM
         run: cargo build --package pcb-zen-wasm --target wasm32-unknown-unknown --release


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI-only change but touches every build/test/release workflow; misconfigured toolchain or caching behavior could break pipelines or change build performance.
> 
> **Overview**
> Replaces `dtolnay/rust-toolchain` (and removes `Swatinem/rust-cache` steps) across build, test, e2e, perf, wasm, version-bump, and release workflows, standardizing Rust installation on `actions-rust-lang/setup-rust-toolchain@v1`.
> 
> Explicitly disables toolchain binary caching via `cache-bin: false` everywhere (and updates wasm config to use `target: wasm32-unknown-unknown`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842a5ef761b63c54e82b84a2d589a897b340028a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->