### PR TITLE
fix: smarter workplace name detection with pcb.toml fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb new board <name> <repo-url>` now creates a board repository directly, replacing the separate `pcb new workspace` flow.
 - `pcb import` now writes directly into a board repository root instead of creating `boards/<name>/` under a workspace.
+- Board release uploads now derive the Diode workspace name from the first path segment of `[workspace].repository`, with `[workspace].name` available as an override.
 
 ### Fixed
 

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -356,7 +356,7 @@ impl PcbToml {
 /// Workspace configuration
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
-    /// Optional workspace name (legacy; ignored)
+    /// Optional Diode workspace name override.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 

--- a/crates/pcb/src/import/flow.rs
+++ b/crates/pcb/src/import/flow.rs
@@ -118,95 +118,6 @@ fn remove_generated_output(board_dir: &std::path::Path, board_name: &str) -> Res
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::PathBuf;
-
-    #[test]
-    fn force_import_preserves_existing_board_repo_metadata() -> Result<()> {
-        let temp = tempfile::tempdir()?;
-        let board_repo = temp.path().join("board");
-        std::fs::create_dir(&board_repo)?;
-
-        let pcb_toml = board_repo.join("pcb.toml");
-        let pcb_sum = board_repo.join("pcb.sum");
-        let readme = board_repo.join("README.md");
-        let gitignore = board_repo.join(".gitignore");
-        let board_zen = board_repo.join("ImportedBoard.zen");
-        let modules = board_repo.join("modules");
-
-        let pcb_toml_contents = r#"[workspace]
-members = ["modules/*"]
-repository = "github.com/example/custom-board"
-endpoint = "https://example.invalid"
-
-[board]
-name = "ImportedBoard"
-path = "ImportedBoard.zen"
-description = "Custom board description."
-
-[dependencies]
-foo = { path = "modules/foo" }
-"#;
-        let pcb_sum_contents = "custom lockfile contents\n";
-        let readme_contents = "# Custom README\n";
-        let gitignore_contents = "custom-ignore\n";
-
-        std::fs::write(&pcb_toml, pcb_toml_contents)?;
-        std::fs::write(&pcb_sum, pcb_sum_contents)?;
-        std::fs::write(&readme, readme_contents)?;
-        std::fs::write(&gitignore, gitignore_contents)?;
-        std::fs::write(&board_zen, "old generated board\n")?;
-        std::fs::create_dir(&modules)?;
-        std::fs::write(modules.join("old.zen"), "old generated module\n")?;
-
-        let paths = ImportPaths {
-            workspace_root: board_repo.clone(),
-            kicad_project_root: temp.path().to_path_buf(),
-            kicad_pro_abs: temp.path().join("ImportedBoard.kicad_pro"),
-        };
-        let selection = ImportSelection {
-            board_name: "ImportedBoard".to_string(),
-            board_name_source: BoardNameSource::KicadProArgument,
-            files: KicadDiscoveredFiles::default(),
-            selected: SelectedKicadFiles {
-                kicad_pro: PathBuf::from("ImportedBoard.kicad_pro"),
-                kicad_sch: PathBuf::from("ImportedBoard.kicad_sch"),
-                kicad_pcb: PathBuf::from("ImportedBoard.kicad_pcb"),
-            },
-            portable: PortableKicadProject {
-                project_dir: temp.path().to_path_buf(),
-                project_name: "ImportedBoard".to_string(),
-                kicad_pro_rel: PathBuf::from("ImportedBoard.kicad_pro"),
-                root_schematic_rel: PathBuf::from("ImportedBoard.kicad_sch"),
-                primary_kicad_pcb_rel: PathBuf::from("ImportedBoard.kicad_pcb"),
-                schematic_files_rel: Vec::new(),
-                files_to_bundle_rel: Vec::new(),
-                extra_files_to_bundle: Vec::new(),
-                manifest_json: "{}".to_string(),
-            },
-        };
-        let args = ImportArgs {
-            kicad_pro: paths.kicad_pro_abs.clone(),
-            output_dir: board_repo.clone(),
-            force: true,
-        };
-
-        prepare_output(&paths, &selection, &args)?;
-
-        assert_eq!(std::fs::read_to_string(&pcb_toml)?, pcb_toml_contents);
-        assert_eq!(std::fs::read_to_string(&pcb_sum)?, pcb_sum_contents);
-        assert_eq!(std::fs::read_to_string(&readme)?, readme_contents);
-        assert_eq!(std::fs::read_to_string(&gitignore)?, gitignore_contents);
-        assert!(!board_zen.exists());
-        assert!(!modules.exists());
-        assert!(board_repo.join("ImportedBoard.kicad.archive.zip").is_file());
-
-        Ok(())
-    }
-}
-
 struct Validated {
     ctx: ImportContext,
     selection: ImportSelection,
@@ -355,5 +266,94 @@ impl Materialized {
             ir,
             board,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn force_import_preserves_existing_board_repo_metadata() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let board_repo = temp.path().join("board");
+        std::fs::create_dir(&board_repo)?;
+
+        let pcb_toml = board_repo.join("pcb.toml");
+        let pcb_sum = board_repo.join("pcb.sum");
+        let readme = board_repo.join("README.md");
+        let gitignore = board_repo.join(".gitignore");
+        let board_zen = board_repo.join("ImportedBoard.zen");
+        let modules = board_repo.join("modules");
+
+        let pcb_toml_contents = r#"[workspace]
+members = ["modules/*"]
+repository = "github.com/example/custom-board"
+endpoint = "https://example.invalid"
+
+[board]
+name = "ImportedBoard"
+path = "ImportedBoard.zen"
+description = "Custom board description."
+
+[dependencies]
+foo = { path = "modules/foo" }
+"#;
+        let pcb_sum_contents = "custom lockfile contents\n";
+        let readme_contents = "# Custom README\n";
+        let gitignore_contents = "custom-ignore\n";
+
+        std::fs::write(&pcb_toml, pcb_toml_contents)?;
+        std::fs::write(&pcb_sum, pcb_sum_contents)?;
+        std::fs::write(&readme, readme_contents)?;
+        std::fs::write(&gitignore, gitignore_contents)?;
+        std::fs::write(&board_zen, "old generated board\n")?;
+        std::fs::create_dir(&modules)?;
+        std::fs::write(modules.join("old.zen"), "old generated module\n")?;
+
+        let paths = ImportPaths {
+            workspace_root: board_repo.clone(),
+            kicad_project_root: temp.path().to_path_buf(),
+            kicad_pro_abs: temp.path().join("ImportedBoard.kicad_pro"),
+        };
+        let selection = ImportSelection {
+            board_name: "ImportedBoard".to_string(),
+            board_name_source: BoardNameSource::KicadProArgument,
+            files: KicadDiscoveredFiles::default(),
+            selected: SelectedKicadFiles {
+                kicad_pro: PathBuf::from("ImportedBoard.kicad_pro"),
+                kicad_sch: PathBuf::from("ImportedBoard.kicad_sch"),
+                kicad_pcb: PathBuf::from("ImportedBoard.kicad_pcb"),
+            },
+            portable: PortableKicadProject {
+                project_dir: temp.path().to_path_buf(),
+                project_name: "ImportedBoard".to_string(),
+                kicad_pro_rel: PathBuf::from("ImportedBoard.kicad_pro"),
+                root_schematic_rel: PathBuf::from("ImportedBoard.kicad_sch"),
+                primary_kicad_pcb_rel: PathBuf::from("ImportedBoard.kicad_pcb"),
+                schematic_files_rel: Vec::new(),
+                files_to_bundle_rel: Vec::new(),
+                extra_files_to_bundle: Vec::new(),
+                manifest_json: "{}".to_string(),
+            },
+        };
+        let args = ImportArgs {
+            kicad_pro: paths.kicad_pro_abs.clone(),
+            output_dir: board_repo.clone(),
+            force: true,
+        };
+
+        prepare_output(&paths, &selection, &args)?;
+
+        assert_eq!(std::fs::read_to_string(&pcb_toml)?, pcb_toml_contents);
+        assert_eq!(std::fs::read_to_string(&pcb_sum)?, pcb_sum_contents);
+        assert_eq!(std::fs::read_to_string(&readme)?, readme_contents);
+        assert_eq!(std::fs::read_to_string(&gitignore)?, gitignore_contents);
+        assert!(!board_zen.exists());
+        assert!(!modules.exists());
+        assert!(board_repo.join("ImportedBoard.kicad.archive.zip").is_file());
+
+        Ok(())
     }
 }

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -598,28 +598,39 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
 }
 
 fn release_workspace_name(workspace: &WorkspaceInfo) -> Result<String> {
+    if let Some(name) = workspace.config.as_ref().and_then(|config| {
+        config
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.name.as_deref())
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+    }) {
+        return Ok(name.to_string());
+    }
+
     if let Some(name) = workspace
         .repository()
-        .and_then(workspace_name_from_code_diode_repository)
+        .and_then(workspace_name_from_repository)
     {
         return Ok(name);
     }
 
-    workspace
-        .root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(str::to_string)
-        .context("Invalid workspace root")
+    bail!(
+        "Unable to determine Diode workspace name. Set [workspace].name or [workspace].repository in pcb.toml."
+    )
 }
 
-fn workspace_name_from_code_diode_repository(repository: &str) -> Option<String> {
+fn workspace_name_from_repository(repository: &str) -> Option<String> {
+    let repository = git::parse_remote_url(repository).unwrap_or_else(|_| repository.trim().into());
     repository
-        .trim()
-        .strip_prefix("code.diode.computer/")
-        .and_then(|path| path.split('/').next())
-        .filter(|workspace| !workspace.is_empty())
-        .map(str::to_string)
+        .split('/')
+        .nth(1)
+        .map(str::trim)
+        .and_then(|segment| {
+            let segment = segment.strip_suffix(".git").unwrap_or(segment);
+            (!segment.is_empty()).then(|| segment.to_string())
+        })
 }
 
 fn ensure_board_publish_has_no_workspace_overrides(workspace: &WorkspaceInfo) -> Result<()> {
@@ -1477,12 +1488,17 @@ P1 = io(Net)
         urls.iter().map(|url| (*url).to_string()).collect()
     }
 
-    fn workspace_with_repository(root: &str, repository: Option<&str>) -> WorkspaceInfo {
+    fn workspace_with_config(
+        root: &str,
+        name: Option<&str>,
+        repository: Option<&str>,
+    ) -> WorkspaceInfo {
         WorkspaceInfo {
             root: PathBuf::from(root),
             cache_dir: PathBuf::new(),
             config: Some(PcbToml {
                 workspace: Some(WorkspaceConfig {
+                    name: name.map(str::to_string),
                     repository: repository.map(str::to_string),
                     ..WorkspaceConfig::default()
                 }),
@@ -1495,19 +1511,60 @@ P1 = io(Net)
     }
 
     #[test]
-    fn release_workspace_name_uses_code_diode_repository_owner_segment() {
+    fn release_workspace_name_uses_workspace_name_override() {
+        let workspace = workspace_with_config(
+            "/tmp/IP0010",
+            Some("custom"),
+            Some("code.diode.computer/diode/b/IP0010"),
+        );
+
+        assert_eq!(release_workspace_name(&workspace).unwrap(), "custom");
+    }
+
+    #[test]
+    fn release_workspace_name_uses_first_repository_path_segment() {
         let workspace =
-            workspace_with_repository("/tmp/IP0010", Some("code.diode.computer/diode/b/IP0010"));
+            workspace_with_config("/tmp/IP0010", None, Some("anything.com/XYZ/boards/IP0010"));
+
+        assert_eq!(release_workspace_name(&workspace).unwrap(), "XYZ");
+    }
+
+    #[test]
+    fn release_workspace_name_handles_repository_url_forms() {
+        assert_eq!(
+            workspace_name_from_repository("https://anything.com/XYZ/boards/IP0010.git"),
+            Some("XYZ".to_string())
+        );
+        assert_eq!(
+            workspace_name_from_repository("git@anything.com:XYZ/boards/IP0010.git"),
+            Some("XYZ".to_string())
+        );
+        assert_eq!(
+            workspace_name_from_repository("anything.com/XYZ.git"),
+            Some("XYZ".to_string())
+        );
+    }
+
+    #[test]
+    fn release_workspace_name_preserves_code_diode_owner_segment() {
+        let workspace = workspace_with_config(
+            "/tmp/IP0010",
+            None,
+            Some("code.diode.computer/diode/b/IP0010"),
+        );
 
         assert_eq!(release_workspace_name(&workspace).unwrap(), "diode");
     }
 
     #[test]
-    fn release_workspace_name_falls_back_to_workspace_directory() {
-        let workspace =
-            workspace_with_repository("/tmp/IP0010", Some("github.com/diodeinc/IP0010"));
+    fn release_workspace_name_requires_name_or_repository() {
+        let workspace = workspace_with_config("/tmp/IP0010", None, None);
 
-        assert_eq!(release_workspace_name(&workspace).unwrap(), "IP0010");
+        let err = release_workspace_name(&workspace).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unable to determine Diode workspace name")
+        );
     }
 
     /// Helper to create a dependency map from a list of (package, [dependencies])

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -374,6 +374,17 @@ vendor = ["github.com/myorg/**"]
 - `pcb vendor` without `--all` uses `[workspace].vendor`.
 - `pcb vendor --all` vendors everything.
 
+## Workspace Name (`[workspace].name`)
+
+Workspace manifests can override the Diode workspace name used by board release uploads:
+
+```toml
+[workspace]
+name = "my-workspace"
+```
+
+If `name` is omitted, `pcb publish` derives the workspace name from the first path segment of `[workspace].repository`. For example, `anything.com/XYZ/boards/MyBoard` uses `XYZ`.
+
 ## Endpoint (`[workspace].endpoint`)
 
 Workspace manifests can override the Diode host suffix used by CLI commands that talk to Diode services:

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -139,6 +139,7 @@ path = "MainBoard.zen"
 description = "Replace with concise board description."
 ```
 
+- `name`: Optional Diode workspace name override for board release uploads. When omitted, publish uses the first path segment of `repository`, such as `myorg` from `github.com/myorg/MainBoard`.
 - `repository`: Git remote URL (used to derive package URLs for publishing)
 - `pcb-version`: Minimum compatible `pcb` toolchain release series (e.g., `"0.3"`). Required for workspaces.
 - `endpoint`: Optional Diode host suffix used for workspace-scoped app/API URLs. `"diode.computer"` resolves to `app.diode.computer` and `api.diode.computer`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes board release upload naming logic in `pcb publish`, which can affect where releases are uploaded and may break existing workflows if workspace metadata is missing or misconfigured.
> 
> **Overview**
> Board release uploads in `pcb publish` now resolve the Diode workspace name by first honoring an explicit `[workspace].name` override, otherwise deriving it from the first path segment of `[workspace].repository` (with support for common URL forms like HTTPS/SSH and optional `.git`).
> 
> If neither `name` nor `repository` is available, publishing now errors instead of falling back to the local directory name. Documentation and changelog entries were updated accordingly, and unit tests were expanded to cover the new resolution rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e136eeb980530a7304d8e38078715ec02696b78b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->