### PR TITLE
Add `pcb build --diagnostics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Board release uploads now derive the Diode workspace name from the first path segment of `[workspace].repository`, with `[workspace].name` available as an override.
 - `pcb layout` now deletes stale copied synced footprints.
 - Deprecated stdlib generic modules `generics/TerminalBlock.zen` and `generics/Standoff.zen`, and removed generic BOM matching for standoffs.
+- Removed the hidden `pcb build --board-config` JSON output option.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added Gerber geometry comparison helpers for IPC-2581-to-Gerber smoke tests.
 - Added `pcb ipc2581 render --flat` to render a layer as a single Gerber-style mask.
 - Added `pcb ipc2581 gerber` to export IPC-2581 fabrication layers as Gerber X2 files through a canonical artwork pipeline.
+- Added `pcb build --diagnostics <path>` to write structured JSON diagnostics for all evaluated root files.
 
 ### Changed
 

--- a/crates/pcb/src/build.rs
+++ b/crates/pcb/src/build.rs
@@ -1,12 +1,15 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Args;
 use log::debug;
 use pcb_sch::Schematic;
 use pcb_ui::prelude::*;
 use pcb_zen_core::resolution::ResolutionResult;
-use pcb_zen_core::{DefaultFileProvider, EvalContext, EvalContextConfig, FileProvider};
+use pcb_zen_core::{
+    DefaultFileProvider, Diagnostics, EvalContext, EvalContextConfig, FileProvider,
+};
 use serde_json::Value as JsonValue;
 use starlark::collections::SmallMap;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{info_span, instrument};
@@ -18,6 +21,11 @@ struct BuildEvalState {
     session: pcb_zen_core::lang::eval::EvalSession,
     file_provider: Arc<DefaultFileProvider>,
     resolution: Arc<ResolutionResult>,
+}
+
+struct BuildResult {
+    schematic: Option<Schematic>,
+    diagnostics: Diagnostics,
 }
 
 impl BuildEvalState {
@@ -61,7 +69,7 @@ impl BuildEvalState {
         deny_warnings: bool,
         has_errors: &mut bool,
         has_warnings: &mut bool,
-    ) -> Option<Schematic> {
+    ) -> BuildResult {
         let file_name = zen_path.file_name().unwrap().to_string_lossy();
 
         debug!("Compiling Zener file: {}", zen_path.display());
@@ -127,10 +135,16 @@ impl BuildEvalState {
                 pcb_ui::icons::error(),
                 file_name.with_style(Style::Red).bold()
             );
-            return None;
+            return BuildResult {
+                schematic: None,
+                diagnostics,
+            };
         }
 
-        schematic
+        BuildResult {
+            schematic,
+            diagnostics,
+        }
     }
 }
 
@@ -184,6 +198,10 @@ pub struct BuildArgs {
     /// Print JSON netlist to stdout (undocumented)
     #[arg(long = "netlist", hide = true)]
     pub netlist: bool,
+
+    /// Write build diagnostics as JSON to PATH, or '-' for stdout
+    #[arg(long = "diagnostics", value_name = "PATH", value_hint = clap::ValueHint::AnyPath)]
+    pub diagnostics: Option<PathBuf>,
 
     /// Disable network access (offline mode) - only use vendored dependencies
     #[arg(long = "offline")]
@@ -239,18 +257,58 @@ pub fn build(
 ) -> Option<Schematic> {
     let eval_state = BuildEvalState::new(resolution);
 
-    eval_state.build(
-        zen_path,
-        inputs,
-        passes,
-        deny_warnings,
-        has_errors,
-        has_warnings,
-    )
+    eval_state
+        .build(
+            zen_path,
+            inputs,
+            passes,
+            deny_warnings,
+            has_errors,
+            has_warnings,
+        )
+        .schematic
+}
+
+fn workspace_relative_path(path: &Path, workspace_root: &Path) -> String {
+    path.strip_prefix(workspace_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn diagnostics_report_for_file(
+    source_file: String,
+    diagnostics: &Diagnostics,
+) -> Vec<pcb_zen_core::DiagnosticReport> {
+    pcb_zen_core::DiagnosticsReport::from_diagnostics(diagnostics, &source_file)
+        .files
+        .remove(&source_file)
+        .unwrap_or_default()
+}
+
+fn write_diagnostics_report(
+    output_path: &Path,
+    report: &BTreeMap<String, Vec<pcb_zen_core::DiagnosticReport>>,
+) -> Result<()> {
+    let json = serde_json::to_string_pretty(report).context("Failed to serialize diagnostics")?;
+
+    if output_path == Path::new("-") {
+        println!("{json}");
+        return Ok(());
+    }
+
+    std::fs::write(output_path, json)
+        .with_context(|| format!("Failed to write diagnostics to {}", output_path.display()))
 }
 
 pub fn execute(args: BuildArgs) -> Result<()> {
     let mut has_errors = false;
+
+    if args.netlist && args.diagnostics.as_deref() == Some(Path::new("-")) {
+        anyhow::bail!(
+            "--diagnostics - cannot be used with --netlist because both write JSON to stdout"
+        );
+    }
 
     if !args.config.is_empty() {
         let Some(path) = args.path.as_deref() else {
@@ -268,6 +326,7 @@ pub fn execute(args: BuildArgs) -> Result<()> {
 
     // Resolve dependencies before finding .zen files
     let resolution = crate::resolve::resolve(args.path.as_deref(), args.offline, args.locked)?;
+    let workspace_root = resolution.workspace_info.root.clone();
 
     // Process .zen files using shared walker - always recursive for directories
     let zen_files =
@@ -278,16 +337,27 @@ pub fn execute(args: BuildArgs) -> Result<()> {
     // Process each .zen file
     let deny_warnings = args.deny.contains(&"warnings".to_string());
     let mut has_warnings = false;
+    let mut diagnostics_report = BTreeMap::new();
     for zen_path in &zen_files {
         let file_name = zen_path.file_name().unwrap().to_string_lossy();
-        let Some(schematic) = eval_state.build(
+        let build_result = eval_state.build(
             zen_path,
             config_inputs.clone(),
             create_diagnostics_passes(&args.suppress, &args.warn),
             deny_warnings,
             &mut has_errors,
             &mut has_warnings,
-        ) else {
+        );
+
+        if args.diagnostics.is_some() {
+            let source_file = workspace_relative_path(zen_path, &workspace_root);
+            diagnostics_report.insert(
+                source_file.clone(),
+                diagnostics_report_for_file(source_file, &build_result.diagnostics),
+            );
+        }
+
+        let Some(schematic) = build_result.schematic else {
             continue;
         };
 
@@ -302,6 +372,10 @@ pub fn execute(args: BuildArgs) -> Result<()> {
         } else {
             print_build_success(&file_name, &schematic);
         }
+    }
+
+    if let Some(output_path) = &args.diagnostics {
+        write_diagnostics_report(output_path, &diagnostics_report)?;
     }
 
     if has_errors {

--- a/crates/pcb/src/build.rs
+++ b/crates/pcb/src/build.rs
@@ -185,10 +185,6 @@ pub struct BuildArgs {
     #[arg(long = "netlist", hide = true)]
     pub netlist: bool,
 
-    /// Print board config JSON to stdout (undocumented)
-    #[arg(long = "board-config", hide = true)]
-    pub board_config: bool,
-
     /// Disable network access (offline mode) - only use vendored dependencies
     #[arg(long = "offline")]
     pub offline: bool,
@@ -301,18 +297,6 @@ pub fn execute(args: BuildArgs) -> Result<()> {
                 Err(e) => {
                     eprintln!("Error serializing netlist to JSON: {e}");
                     has_errors = true;
-                }
-            }
-        } else if args.board_config {
-            match pcb_layout::utils::extract_board_config(&schematic) {
-                Some(config) => {
-                    if let Ok(json) = serde_json::to_string_pretty(&config) {
-                        println!("{json}");
-                    }
-                }
-                None => {
-                    eprintln!("No board config found in {}", file_name);
-                    std::process::exit(1);
                 }
             }
         } else {

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -759,6 +759,65 @@ fn test_suppress_by_exact_kind() {
 }
 
 #[test]
+fn test_build_writes_diagnostics_json() {
+    let mut sandbox = Sandbox::new();
+    sandbox.write("test.zen", CATEGORIZED_DIAGNOSTICS_ZEN);
+
+    sandbox
+        .run(
+            "pcb",
+            ["build", "test.zen", "--diagnostics", "diagnostics.json"],
+        )
+        .run()
+        .expect("build should succeed");
+
+    let report_path = sandbox.root_path().join("diagnostics.json");
+    let report: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(report_path).expect("diagnostics report should be written"),
+    )
+    .expect("diagnostics report should be valid JSON");
+
+    let diagnostics = report
+        .get("test.zen")
+        .and_then(|value| value.as_array())
+        .expect("report should include diagnostics for the evaluated root file");
+    assert_eq!(diagnostics.len(), 4);
+    assert_eq!(diagnostics[0]["severity"], "warning");
+    assert_eq!(diagnostics[0]["body"], "Voltage mismatch detected");
+    assert_eq!(diagnostics[0]["suppressed"], false);
+}
+
+#[test]
+fn test_build_writes_diagnostics_json_on_failure() {
+    let mut sandbox = Sandbox::new();
+    sandbox.write("test.zen", r#"error("Build failed")"#);
+
+    let output = sandbox
+        .run(
+            "pcb",
+            ["build", "test.zen", "--diagnostics", "diagnostics.json"],
+        )
+        .unchecked()
+        .run()
+        .expect("build command should run");
+    assert!(!output.status.success());
+
+    let report_path = sandbox.root_path().join("diagnostics.json");
+    let report: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(report_path).expect("diagnostics report should be written"),
+    )
+    .expect("diagnostics report should be valid JSON");
+
+    let diagnostics = report
+        .get("test.zen")
+        .and_then(|value| value.as_array())
+        .expect("report should include diagnostics for the evaluated root file");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0]["severity"], "error");
+    assert_eq!(diagnostics[0]["body"], "Build failed");
+}
+
+#[test]
 fn test_suppress_by_hierarchical_kind() {
     // -S electrical should suppress all electrical.* warnings
     let output = Sandbox::new()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Modifies `pcb build` CLI behavior and output paths (including stdout conflicts) and changes the build pipeline to always retain diagnostics, which could affect CI/scripts relying on prior behavior.
> 
> **Overview**
> `pcb build` now supports `--diagnostics <path>` (or `-` for stdout) to write a structured JSON diagnostics report for every evaluated root `.zen` file, using workspace-relative file keys and emitting reports even when the build fails.
> 
> The build flow is refactored to return both `schematic` and `diagnostics` (`BuildResult`) so diagnostics can be collected regardless of success, and the hidden `--board-config` JSON output option is removed. Tests are added to verify diagnostics JSON is written on success and failure, and stdout JSON collisions with `--netlist` are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b7d4e0a793900cda3d3e70308a34ab0d43a0cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->