### PR TITLE
Include diagnostic kind in JSON reports

### DIFF
--- a/crates/pcb-zen-core/src/diagnostics.rs
+++ b/crates/pcb-zen-core/src/diagnostics.rs
@@ -30,6 +30,24 @@ pub fn diagnostic_kind_short(diagnostic: &Diagnostic) -> Option<String> {
         .map(|c| c.kind.rsplit('.').next().unwrap_or(&c.kind).to_string())
 }
 
+/// Extract the full diagnostic kind, if it has one.
+pub fn diagnostic_kind(diagnostic: &Diagnostic) -> Option<String> {
+    use crate::lang::error::{CategorizedDiagnostic, SuppressedDiagnostics};
+
+    let innermost = diagnostic.innermost();
+    innermost
+        .source_error
+        .as_ref()
+        .and_then(|e| e.downcast_ref::<CategorizedDiagnostic>())
+        .map(|c| c.kind.clone())
+        .or_else(|| {
+            diagnostic
+                .downcast_error_ref::<SuppressedDiagnostics>()
+                .and_then(|suppressed| suppressed.suppressed.first())
+                .and_then(diagnostic_kind)
+        })
+}
+
 /// Prepare a diagnostic for compact, spanless-friendly rendering.
 pub fn compact_diagnostic(diagnostic: &Diagnostic) -> CompactDiagnostic {
     let mut lines = diagnostic.body.lines();
@@ -490,6 +508,8 @@ pub struct DiagnosticFrame {
 pub struct DiagnosticReport {
     /// Combined location of the innermost diagnostic
     pub location: String,
+    /// Full diagnostic kind, when available
+    pub kind: Option<String>,
     /// Severity of the innermost diagnostic
     pub severity: starlark::errors::EvalSeverity,
     /// Body/message of the innermost diagnostic
@@ -529,6 +549,7 @@ impl DiagnosticReport {
 
         DiagnosticReport {
             location: format_location(&innermost.path, innermost.span),
+            kind: diagnostic_kind(diagnostic),
             severity: innermost.severity,
             body: innermost.body.clone(),
             suppressed: diagnostic.suppressed, // Use outermost suppression status

--- a/crates/pcb/tests/build.rs
+++ b/crates/pcb/tests/build.rs
@@ -783,8 +783,10 @@ fn test_build_writes_diagnostics_json() {
         .expect("report should include diagnostics for the evaluated root file");
     assert_eq!(diagnostics.len(), 4);
     assert_eq!(diagnostics[0]["severity"], "warning");
+    assert_eq!(diagnostics[0]["kind"], "electrical.voltage_mismatch");
     assert_eq!(diagnostics[0]["body"], "Voltage mismatch detected");
     assert_eq!(diagnostics[0]["suppressed"], false);
+    assert_eq!(diagnostics[3]["kind"], serde_json::Value::Null);
 }
 
 #[test]

--- a/crates/pcb/tests/snapshots/release__publish_full.snap
+++ b/crates/pcb/tests/snapshots/release__publish_full.snap
@@ -73,6 +73,7 @@ expression: sb.snapshot_dir(&staging_dir)
   "boards/TestBoard.zen": [
     {
       "location": "<TEMP_DIR>/src/.pcb/releases/TestBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:12:7-17",
+      "kind": "module.io.unused",
       "severity": "warning",
       "body": "io() 'GND' in module 'LED1' is not connected to any ports",
       "suppressed": false,

--- a/crates/pcb/tests/snapshots/release__publish_source_only.snap
+++ b/crates/pcb/tests/snapshots/release__publish_source_only.snap
@@ -7,6 +7,7 @@ expression: sb.snapshot_dir(&staging_dir)
   "boards/TestBoard.zen": [
     {
       "location": "<TEMP_DIR>/src/.pcb/releases/TestBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:12:7-17",
+      "kind": "module.io.unused",
       "severity": "warning",
       "body": "io() 'GND' in module 'LED1' is not connected to any ports",
       "suppressed": false,

--- a/crates/pcb/tests/snapshots/release__publish_with_description.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_description.snap
@@ -7,6 +7,7 @@ expression: sb.snapshot_dir(&staging_dir)
   "boards/DescBoard.zen": [
     {
       "location": "<TEMP_DIR>/src/.pcb/releases/DescBoard-<GIT_HASH>/src/boards/modules/LedModule.zen:12:7-17",
+      "kind": "module.io.unused",
       "severity": "warning",
       "body": "io() 'GND' in module 'LED1' is not connected to any ports",
       "suppressed": false,

--- a/crates/pcb/tests/snapshots/release__publish_with_version.snap
+++ b/crates/pcb/tests/snapshots/release__publish_with_version.snap
@@ -7,6 +7,7 @@ expression: sb.snapshot_dir(staging_dir)
   "boards/TB0001.zen": [
     {
       "location": "<TEMP_DIR>/src/.pcb/releases/TB0001-v1.3.0/src/boards/modules/LedModule.zen:12:7-17",
+      "kind": "module.io.unused",
       "severity": "warning",
       "body": "io() 'GND' in module 'LED1' is not connected to any ports",
       "suppressed": false,


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `diagnostics.json` schema by adding a new `kind` field, which may affect downstream consumers that assume the previous structure. Logic also adds recursive kind extraction for suppressed/aggregated diagnostics, which could surface unexpected values in edge cases.
> 
> **Overview**
> **Adds diagnostic kind to structured reports.** `DiagnosticReport` now includes an optional `kind` field, populated via a new `diagnostic_kind()` helper that extracts the full categorized kind from the innermost diagnostic (and falls back to the first suppressed diagnostic when the outer diagnostic is an aggregation).
> 
> Tests and release snapshots are updated to assert the new `kind` field is present for categorized warnings and `null` when no kind exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 353d82d3fbf0f67c120a7234dc743be41c742ae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->