### PR TITLE
feat: `pcb layout` json mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
+- Added `pcb layout -f json` and `pcb layout --no-sync` for machine-readable layout output and existing-layout discovery.
 - Added initial `gerberx2` crate and `pcb gerber render` SVG/PNG/terminal previews.
 - Added Gerber X2 writer scaffolding over an artwork/object IR with file, aperture, and object attributes.
 - Added native aperture macro and block aperture emission to the Gerber X2 writer.

--- a/crates/pcb/src/layout.rs
+++ b/crates/pcb/src/layout.rs
@@ -1,8 +1,10 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use clap::Args;
-use pcb_layout::process_layout;
+use pcb_layout::{process_layout, utils as layout_utils};
+use pcb_sch::Schematic;
 use pcb_ui::prelude::*;
-use std::path::PathBuf;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
 
 use crate::build::{build, create_diagnostics_passes};
 use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
@@ -44,11 +46,37 @@ pub struct LayoutArgs {
     /// Does not write pcb.toml or pcb.sum. Recommended for CI.
     #[arg(long)]
     pub locked: bool,
+
+    /// Resolve existing layout files without updating them
+    #[arg(long = "no-sync", conflicts_with_all = ["temp", "check"])]
+    pub no_sync: bool,
+
+    /// Output format
+    #[arg(short = 'f', long, value_enum, default_value_t = LayoutOutputFormat::Human)]
+    pub format: LayoutOutputFormat,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum LayoutOutputFormat {
+    /// Human-readable output
+    #[default]
+    Human,
+    /// JSON output
+    Json,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LayoutCommandResult {
+    source_file: PathBuf,
+    layout_dir: Option<PathBuf>,
+    pcb_file: Option<PathBuf>,
 }
 
 pub fn execute(mut args: LayoutArgs) -> Result<()> {
     crate::file_walker::require_zen_file(&args.file)?;
     let config_inputs = parse_config_overrides(&args.config)?;
+    let hide_progress = args.format == LayoutOutputFormat::Json;
 
     // --check implies --no-open
     if args.check {
@@ -77,13 +105,26 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
         anyhow::bail!("Build failed");
     };
 
+    if args.no_sync {
+        let result = resolve_existing_layout(zen_path, &schematic)?;
+        print_layout_result(&result, args.format, zen_path, &file_name)?;
+
+        if !args.no_open
+            && let Some(pcb_file) = &result.pcb_file
+        {
+            pcb_kicad::open_pcbnew(pcb_file)?;
+        }
+
+        return Ok(());
+    }
+
     // Process layout and collect diagnostics
     let spinner_msg = if args.check {
         format!("{file_name}: Checking layout")
     } else {
         format!("{file_name}: Generating layout")
     };
-    let spinner = Spinner::builder(spinner_msg).start();
+    let spinner = Spinner::builder(spinner_msg).hidden(hide_progress).start();
     let mut diagnostics = pcb_zen_core::Diagnostics::default();
     let result = process_layout(
         &schematic,
@@ -100,25 +141,38 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
             anyhow::bail!("Layout sync failed with errors");
         }
 
+        print_layout_result(
+            &LayoutCommandResult {
+                source_file: zen_path.to_path_buf(),
+                layout_dir: None,
+                pcb_file: None,
+            },
+            args.format,
+            zen_path,
+            &file_name,
+        )?;
+
         return Ok(());
     };
     let pcb_file = layout_result.pcb_file.clone();
     let display_pcb_file = layout_result.display_pcb_file().to_path_buf();
 
-    let relative_path = zen_path
-        .parent()
-        .and_then(|parent| display_pcb_file.strip_prefix(parent).ok())
-        .unwrap_or(&display_pcb_file);
-    println!(
-        "{} {} ({})",
-        pcb_ui::icons::success(),
-        file_name.clone().with_style(Style::Green).bold(),
-        relative_path.display()
-    );
+    print_layout_result(
+        &LayoutCommandResult {
+            source_file: zen_path.to_path_buf(),
+            layout_dir: Some(layout_result.layout_dir.clone()),
+            pcb_file: Some(display_pcb_file.clone()),
+        },
+        args.format,
+        zen_path,
+        &file_name,
+    )?;
 
     // Run DRC in check mode.
     if args.check {
-        let spinner = Spinner::builder(format!("{file_name}: Running DRC checks")).start();
+        let spinner = Spinner::builder(format!("{file_name}: Running DRC checks"))
+            .hidden(hide_progress)
+            .start();
         let drc_output = tempfile::NamedTempFile::new()?;
         let working_dir = pcb_file.parent();
         let report = pcb_kicad::run_drc(&pcb_file, false, working_dir, drc_output.path())?;
@@ -137,5 +191,57 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
         pcb_kicad::open_pcbnew(&pcb_file)?;
     }
 
+    Ok(())
+}
+
+fn resolve_existing_layout(zen_path: &Path, schematic: &Schematic) -> Result<LayoutCommandResult> {
+    let Some(layout_dir) = layout_utils::resolve_layout_dir(schematic)? else {
+        return Ok(LayoutCommandResult {
+            source_file: zen_path.to_path_buf(),
+            layout_dir: None,
+            pcb_file: None,
+        });
+    };
+
+    let kicad_files = layout_utils::require_kicad_files(&layout_dir)?;
+    let pcb_file = kicad_files.kicad_pcb();
+    if !pcb_file.exists() {
+        bail!(
+            "Layout file not found: {}. Run 'pcb layout {}' to generate it.",
+            pcb_file.display(),
+            zen_path.display()
+        );
+    }
+
+    Ok(LayoutCommandResult {
+        source_file: zen_path.to_path_buf(),
+        layout_dir: Some(layout_dir),
+        pcb_file: Some(pcb_file),
+    })
+}
+
+fn print_layout_result(
+    result: &LayoutCommandResult,
+    format: LayoutOutputFormat,
+    zen_path: &Path,
+    file_name: &str,
+) -> Result<()> {
+    match format {
+        LayoutOutputFormat::Json => println!("{}", serde_json::to_string_pretty(result)?),
+        LayoutOutputFormat::Human => {
+            if let Some(pcb_file) = &result.pcb_file {
+                let relative_path = zen_path
+                    .parent()
+                    .and_then(|parent| pcb_file.strip_prefix(parent).ok())
+                    .unwrap_or(pcb_file);
+                println!(
+                    "{} {} ({})",
+                    pcb_ui::icons::success(),
+                    file_name.with_style(Style::Green).bold(),
+                    relative_path.display()
+                );
+            }
+        }
+    }
     Ok(())
 }

--- a/crates/pcb/tests/layout.rs
+++ b/crates/pcb/tests/layout.rs
@@ -1,0 +1,92 @@
+#![cfg(not(target_os = "windows"))]
+
+use pcb_test_utils::sandbox::Sandbox;
+use serde_json::Value;
+
+const PCB_TOML: &str = r#"
+[workspace]
+pcb-version = "0.3"
+"#;
+
+const BOARD_ZEN: &str = r#"
+SimpleComponent = Module("modules/component.zen")
+
+Layout(name="TestBoard", path="build/TestBoard", bom_profile=None)
+
+vcc_3v3 = Net("VCC_3V3")
+gnd = Net("GND")
+
+SimpleComponent(name = "foo", P1 = vcc_3v3, P2 = gnd)
+"#;
+
+const COMPONENT_ZEN: &str = r#"
+P1 = io(Net)
+P2 = io(Net)
+
+Component(
+    name = "R",
+    prefix = "R",
+    footprint = File("test.kicad_mod"),
+    pin_defs = {"P1": "1", "P2": "2"},
+    pins = {"P1": P1, "P2": P2},
+    properties = {"value": "10kOhm", "type": "resistor"},
+)
+"#;
+
+const TEST_KICAD_MOD: &str = r#"(footprint "test"
+  (layer "F.Cu")
+  (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu"))
+  (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu"))
+)
+"#;
+
+const NO_LAYOUT_ZEN: &str = r#"
+p1 = Net("P1")
+"#;
+
+#[test]
+fn layout_json_output_is_parseable() {
+    let mut sandbox = Sandbox::new();
+    sandbox
+        .write("pcb.toml", PCB_TOML)
+        .write("board.zen", BOARD_ZEN)
+        .write("modules/component.zen", COMPONENT_ZEN)
+        .write("modules/test.kicad_mod", TEST_KICAD_MOD)
+        .write("no-layout.zen", NO_LAYOUT_ZEN);
+
+    let output = sandbox
+        .run("pcb", ["layout", "--no-open", "-f", "json", "board.zen"])
+        .stderr_capture()
+        .stdout_capture()
+        .run()
+        .expect("layout command failed");
+    let json: Value = serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["sourceFile"], "board.zen");
+    assert!(
+        json["pcbFile"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("layout.kicad_pcb"))
+    );
+
+    let no_sync_output = sandbox
+        .run(
+            "pcb",
+            [
+                "layout",
+                "--no-sync",
+                "--no-open",
+                "-f",
+                "json",
+                "no-layout.zen",
+            ],
+        )
+        .stderr_capture()
+        .stdout_capture()
+        .run()
+        .expect("layout --no-sync command failed");
+    let json: Value =
+        serde_json::from_slice(&no_sync_output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["sourceFile"], "no-layout.zen");
+    assert!(json["layoutDir"].is_null());
+    assert!(json["pcbFile"].is_null());
+}


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes `pcb layout` CLI behavior/output (new flags, conditional spinner/printing, and an early return path) which could affect tooling and user workflows, but it is scoped to the layout command and adds tests.
> 
> **Overview**
> `pcb layout` now supports **machine-readable output** via `-f json`, emitting a structured result (`sourceFile`, `layoutDir`, `pcbFile`) and suppressing progress spinners when in JSON mode.
> 
> Adds `--no-sync` to **discover existing KiCad layout files without running sync**, optionally opening the resolved board if present, and errors with a clear message when a layout path exists but the `.kicad_pcb` file is missing.
> 
> Includes a new integration test ensuring JSON output is parseable for both normal layout generation and `--no-sync` when no layout is defined, and updates the changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19fc0f4b7529042feb76e30ba9427478bbb9a928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->