### PR TITLE
Cleanup ipc2581 / pcb-ir related changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,15 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added IPC-2581C XSD validation APIs to the `ipc2581` crate.
 - Added `pcb ipc2581 render` for processed IPC-2581 layer output to SVG, PNG, and terminal graphics, including board outline overlays.
 - Added `pcb ipc2581 outline` to export the IPC-2581 board profile as a KiCad-importable DXF.
-- Added `pcb layout -f json` and `pcb layout --no-sync` for machine-readable layout output and existing-layout discovery.
-- Added initial `gerberx2` crate and `pcb gerber render` SVG/PNG/terminal previews.
-- Added Gerber X2 writer scaffolding over an artwork/object IR with file, aperture, and object attributes.
-- Added native aperture macro and block aperture emission to the Gerber X2 writer.
-- Added Gerber geometry comparison helpers for IPC-2581-to-Gerber smoke tests.
-- Added `pcb ipc2581 render --flat` to render a layer as a single Gerber-style mask.
 - Added `pcb ipc2581 gerber` to export IPC-2581 fabrication layers as Gerber X2 files through a canonical artwork pipeline.
+- Added initial `gerberx2` crate and `pcb gerber render` SVG/PNG/terminal previews.
 - Added `pcb build --diagnostics <path>` to write structured JSON diagnostics for all evaluated root files.
+- Added `pcb layout -f json` and `pcb layout --no-sync` for machine-readable layout output and existing-layout discovery.
 
 ### Changed
 
-- `pcb gerber render` now draws Profile layers as black board outlines instead of grey filled geometry.
-- `pcb ipc2581 render --flat` now uses Gerber-style colors for copper, paste, mask, legend, profile, and unknown layers.
 - `pcb new board <name> <repo-url>` now creates a board repository directly, replacing the separate `pcb new workspace` flow.
 - `pcb import` now writes directly into a board repository root instead of creating `boards/<name>/` under a workspace.
 - Board release uploads now derive the Diode workspace name from the first path segment of `[workspace].repository`, with `[workspace].name` available as an override.


### PR DESCRIPTION
They were way too verbose

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits that just reword and trim `CHANGELOG.md` entries with no functional code changes.
> 
> **Overview**
> **Cleans up the Unreleased changelog section** by removing overly detailed/duplicated IPC-2581/Gerber-related bullets and keeping a shorter, higher-level list of the new CLI commands and crates that were added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4f4aaa70730ca10dfcda204e9a54be98672c7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->