### PR TITLE
Fix noisy auto-dep URL warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed remote package imports from non-GitHub/non-GitLab hosts such as `code.diode.computer`.
+- Fixed auto-dependency discovery warnings caused by non-import strings that only looked like remote URLs.
 - Fixed stdlib LPDDR4 channel impedance defaults to use 40 Ω single-ended and 80 Ω differential routing targets.
 
 ## [0.3.81] - 2026-05-11

--- a/crates/pcb-zen/src/auto_deps.rs
+++ b/crates/pcb-zen/src/auto_deps.rs
@@ -1,19 +1,16 @@
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
-use starlark::syntax::{AstModule, Dialect};
-use starlark_syntax::syntax::ast::StmtP;
-use starlark_syntax::syntax::top_level_stmts::top_level_stmts;
 use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
-use crate::ast_utils::{skip_vendor, visit_string_literals};
+use crate::ast_utils::skip_vendor;
 use crate::cache_index::CacheIndex;
+use crate::import_scanner::{CollectedImports, extract_imports};
 use crate::resolve::fetch_package;
 use crate::workspace::{WorkspaceInfo, WorkspaceInfoExt};
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::kicad_library::kicad_dependency_aliases;
-use pcb_zen_core::load_spec::LoadSpec;
 use pcb_zen_core::workspace::package_url_covers;
 use pcb_zen_core::{DefaultFileProvider, INITIAL_PACKAGE_VERSION};
 
@@ -24,13 +21,6 @@ pub struct AutoDepsSummary {
     pub packages_updated: usize,
     pub unknown_aliases: Vec<(PathBuf, Vec<String>)>,
     pub unknown_urls: Vec<(PathBuf, Vec<String>)>,
-}
-
-#[derive(Debug, Default)]
-struct CollectedImports {
-    aliases: HashSet<String>,
-    urls: HashSet<String>,
-    relative_paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -346,47 +336,6 @@ fn find_nearest_pcb_toml(from: &Path, workspace_root: &Path) -> Option<PathBuf> 
     None
 }
 
-/// Extract imports from .zen file content
-fn extract_imports(content: &str) -> Option<CollectedImports> {
-    let mut dialect = Dialect::Extended;
-    dialect.enable_f_strings = true;
-
-    let ast = AstModule::parse("<memory>", content.to_owned(), &dialect).ok()?;
-    let mut result = CollectedImports::default();
-
-    ast.statement().visit_expr(|expr| {
-        visit_string_literals(expr, &mut |s, _| {
-            extract_from_str(s, &mut result);
-        });
-    });
-
-    for stmt in top_level_stmts(ast.statement()) {
-        if let StmtP::Load(load) = &stmt.node {
-            extract_from_str(&load.module.node, &mut result);
-        }
-    }
-
-    Some(result)
-}
-
-/// Extract alias, URL, or relative path from a string
-fn extract_from_str(s: &str, result: &mut CollectedImports) {
-    if let Some(spec) = LoadSpec::parse(s) {
-        match spec {
-            LoadSpec::Stdlib { .. } | LoadSpec::PackageUri { .. } => {}
-            LoadSpec::Package { package, .. } => {
-                result.aliases.insert(package);
-            }
-            LoadSpec::Url { .. } => {
-                result.urls.insert(s.to_string());
-            }
-            LoadSpec::Path { path, .. } => {
-                result.relative_paths.push(path);
-            }
-        }
-    }
-}
-
 /// Add dependencies to a pcb.toml file and correct workspace member versions
 fn mutate_manifest_dependencies(
     pcb_toml_path: &Path,
@@ -476,63 +425,6 @@ fn is_upgrade_version(current: &str, target: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_extract_from_str() {
-        let mut result = CollectedImports::default();
-
-        // Aliases are treated generically.
-        extract_from_str(
-            "@kicad-footprints/Resistor_SMD.pretty/R_0603.kicad_mod",
-            &mut result,
-        );
-        assert!(result.aliases.contains("kicad-footprints"));
-        assert!(result.urls.is_empty());
-
-        // stdlib is not considered by auto-deps.
-        result = CollectedImports::default();
-        extract_from_str("@stdlib/units.zen", &mut result);
-        assert!(result.aliases.is_empty());
-        assert!(result.urls.is_empty());
-
-        result = CollectedImports::default();
-        extract_from_str("github.com/diodeinc/stdlib/units.zen", &mut result);
-        assert!(result.aliases.is_empty());
-        assert!(result.urls.is_empty());
-
-        // Dynamic alias path still tracks alias.
-        result = CollectedImports::default();
-        extract_from_str("@kicad-footprints/{}.pretty/{}.kicad_mod", &mut result);
-        assert!(result.aliases.contains("kicad-footprints"));
-        assert!(result.urls.is_empty());
-
-        // Direct URLs still participate in normal package auto-deps.
-        result = CollectedImports::default();
-        extract_from_str(
-            "github.com/example/components/Resistor/Resistor.zen",
-            &mut result,
-        );
-        assert!(result.aliases.is_empty());
-        assert!(
-            result
-                .urls
-                .contains("github.com/example/components/Resistor/Resistor.zen")
-        );
-
-        // Relative paths are collected for cross-package resolution.
-        result = CollectedImports::default();
-        extract_from_str("../../other-pkg/foo.zen", &mut result);
-        assert_eq!(result.relative_paths.len(), 1);
-        assert_eq!(
-            result.relative_paths[0],
-            PathBuf::from("../../other-pkg/foo.zen")
-        );
-
-        // All LoadSpec::Path values are collected (filtered at resolution time).
-        result = CollectedImports::default();
-        extract_from_str("VCC", &mut result);
-        assert_eq!(result.relative_paths.len(), 1);
-    }
 
     #[test]
     fn test_is_upgrade_version() {

--- a/crates/pcb-zen/src/import_scanner.rs
+++ b/crates/pcb-zen/src/import_scanner.rs
@@ -1,0 +1,179 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use pcb_zen_core::load_spec::LoadSpec;
+use starlark::syntax::{AstModule, Dialect};
+use starlark_syntax::syntax::ast::StmtP;
+use starlark_syntax::syntax::top_level_stmts::top_level_stmts;
+
+use crate::ast_utils::visit_string_literals;
+
+#[derive(Debug, Default)]
+pub struct CollectedImports {
+    pub aliases: BTreeSet<String>,
+    pub urls: BTreeSet<String>,
+    pub relative_paths: Vec<PathBuf>,
+}
+
+pub fn extract_imports(content: &str) -> Option<CollectedImports> {
+    let mut dialect = Dialect::Extended;
+    dialect.enable_f_strings = true;
+
+    let ast = AstModule::parse("<memory>", content.to_owned(), &dialect).ok()?;
+    let mut result = CollectedImports::default();
+
+    ast.statement().visit_expr(|expr| {
+        visit_string_literals(expr, &mut |s, _| {
+            extract_from_literal(s, &mut result);
+        });
+    });
+
+    for stmt in top_level_stmts(ast.statement()) {
+        if let StmtP::Load(load) = &stmt.node {
+            extract_from_load(&load.module.node, &mut result);
+        }
+    }
+
+    Some(result)
+}
+
+fn extract_from_load(s: &str, result: &mut CollectedImports) {
+    if let Some(spec) = LoadSpec::parse(s) {
+        collect_spec(s, spec, result);
+    }
+}
+
+/// Extract dependency-looking aliases, URLs, or relative paths from arbitrary string literals.
+///
+/// Unlike `load()` arguments, ordinary strings may be pin names, docstrings, or labels, so keep
+/// this intentionally narrower than the full `LoadSpec` grammar.
+fn extract_from_literal(s: &str, result: &mut CollectedImports) {
+    if !s.starts_with('@') && !is_explicit_path(s) && !is_dependency_url(s) {
+        return;
+    }
+
+    if let Some(spec) = LoadSpec::parse(s) {
+        collect_spec(s, spec, result);
+    }
+}
+
+fn collect_spec(s: &str, spec: LoadSpec, result: &mut CollectedImports) {
+    match spec {
+        LoadSpec::Stdlib { .. } | LoadSpec::PackageUri { .. } => {}
+        LoadSpec::Package { package, .. } => {
+            result.aliases.insert(package);
+        }
+        LoadSpec::Url { .. } => {
+            result.urls.insert(s.to_string());
+        }
+        LoadSpec::Path { path, .. } => {
+            result.relative_paths.push(path);
+        }
+    }
+}
+
+fn is_explicit_path(s: &str) -> bool {
+    s.starts_with("./") || s.starts_with("../") || s.starts_with('/')
+}
+
+fn is_dependency_url(s: &str) -> bool {
+    let Some(last_segment) = s.rsplit('/').next() else {
+        return false;
+    };
+    last_segment.contains('.')
+        && [
+            ".zen",
+            ".kicad_sym",
+            ".kicad_mod",
+            ".pretty",
+            ".step",
+            ".wrl",
+        ]
+        .iter()
+        .any(|suffix| last_segment.ends_with(suffix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_from_literal() {
+        let mut result = CollectedImports::default();
+
+        extract_from_literal(
+            "@kicad-footprints/Resistor_SMD.pretty/R_0603.kicad_mod",
+            &mut result,
+        );
+        assert!(result.aliases.contains("kicad-footprints"));
+        assert!(result.urls.is_empty());
+
+        result = CollectedImports::default();
+        extract_from_literal("@stdlib/units.zen", &mut result);
+        assert!(result.aliases.is_empty());
+        assert!(result.urls.is_empty());
+
+        result = CollectedImports::default();
+        extract_from_literal("github.com/diodeinc/stdlib/units.zen", &mut result);
+        assert!(result.aliases.is_empty());
+        assert!(result.urls.is_empty());
+
+        result = CollectedImports::default();
+        extract_from_literal("@kicad-footprints/{}.pretty/{}.kicad_mod", &mut result);
+        assert!(result.aliases.contains("kicad-footprints"));
+        assert!(result.urls.is_empty());
+
+        result = CollectedImports::default();
+        extract_from_literal(
+            "github.com/example/components/Resistor/Resistor.zen",
+            &mut result,
+        );
+        assert!(result.aliases.is_empty());
+        assert!(
+            result
+                .urls
+                .contains("github.com/example/components/Resistor/Resistor.zen")
+        );
+
+        result = CollectedImports::default();
+        extract_from_literal("../../other-pkg/foo.zen", &mut result);
+        assert_eq!(result.relative_paths.len(), 1);
+        assert_eq!(
+            result.relative_paths[0],
+            PathBuf::from("../../other-pkg/foo.zen")
+        );
+
+        result = CollectedImports::default();
+        extract_from_literal("VCC", &mut result);
+        extract_from_literal(
+            "\nBX-DS1.27-3PTP\n\n3-position SMD DIP switch, 1.27mm pitch.\n",
+            &mut result,
+        );
+        extract_from_literal("GPIO_VREF(1.8v/3.3v_Input)", &mut result);
+        assert!(result.aliases.is_empty());
+        assert!(result.urls.is_empty());
+        assert!(result.relative_paths.is_empty());
+    }
+
+    #[test]
+    fn test_extract_from_load_uses_full_load_spec_grammar() {
+        let mut result = CollectedImports::default();
+
+        extract_from_load(
+            "github.com/example/components/Resistor/Resistor.zen",
+            &mut result,
+        );
+        assert!(
+            result
+                .urls
+                .contains("github.com/example/components/Resistor/Resistor.zen")
+        );
+
+        result = CollectedImports::default();
+        extract_from_load("relative_module.zen", &mut result);
+        assert_eq!(
+            result.relative_paths,
+            vec![PathBuf::from("relative_module.zen")]
+        );
+    }
+}

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -4,6 +4,7 @@ mod auto_deps;
 pub mod cache_index;
 pub mod diagnostics;
 pub mod git;
+pub mod import_scanner;
 pub mod lsp;
 pub mod resolve;
 pub mod suppression;

--- a/crates/pcb/src/mod/scan.rs
+++ b/crates/pcb/src/mod/scan.rs
@@ -3,30 +3,20 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
-use pcb_zen::ast_utils::{skip_vendor, visit_string_literals};
+use pcb_zen::ast_utils::skip_vendor;
 use pcb_zen::cache_index::CacheIndex;
+use pcb_zen::import_scanner::extract_imports;
 use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::FileProvider;
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::kicad_library::kicad_dependency_aliases;
-use pcb_zen_core::load_spec::LoadSpec;
 use pcb_zen_core::workspace::package_url_covers;
-use starlark::syntax::{AstModule, Dialect};
-use starlark_syntax::syntax::ast::StmtP;
-use starlark_syntax::syntax::top_level_stmts::top_level_stmts;
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct ScannedDirectDeps {
     pub(crate) remote: BTreeMap<String, DependencySpec>,
     pub(crate) workspace: BTreeSet<String>,
     pub(crate) implicit_remote: BTreeMap<String, DependencySpec>,
-}
-
-#[derive(Debug, Default)]
-struct CollectedImports {
-    aliases: BTreeSet<String>,
-    urls: BTreeSet<String>,
-    relative_paths: Vec<PathBuf>,
 }
 
 pub(crate) fn scan_package_direct_deps(
@@ -231,41 +221,4 @@ fn resolve_kicad_url(
             package_url_covers(repo, url)
                 .then(|| (repo.clone(), DependencySpec::Version(version.to_string())))
         })
-}
-
-fn extract_imports(content: &str) -> Option<CollectedImports> {
-    let mut dialect = Dialect::Extended;
-    dialect.enable_f_strings = true;
-
-    let ast = AstModule::parse("<memory>", content.to_owned(), &dialect).ok()?;
-    let mut result = CollectedImports::default();
-
-    ast.statement().visit_expr(|expr| {
-        visit_string_literals(expr, &mut |s, _| extract_from_str(s, &mut result));
-    });
-
-    for stmt in top_level_stmts(ast.statement()) {
-        if let StmtP::Load(load) = &stmt.node {
-            extract_from_str(&load.module.node, &mut result);
-        }
-    }
-
-    Some(result)
-}
-
-fn extract_from_str(s: &str, result: &mut CollectedImports) {
-    if let Some(spec) = LoadSpec::parse(s) {
-        match spec {
-            LoadSpec::Stdlib { .. } | LoadSpec::PackageUri { .. } => {}
-            LoadSpec::Package { package, .. } => {
-                result.aliases.insert(package);
-            }
-            LoadSpec::Url { .. } => {
-                result.urls.insert(s.to_string());
-            }
-            LoadSpec::Path { path, .. } => {
-                result.relative_paths.push(path);
-            }
-        }
-    }
 }


### PR DESCRIPTION
Be a bit more strict on what we attempt to parse.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes import scanning logic used to infer dependencies; overly strict heuristics could miss legitimate deps or reduce auto-add coverage.
> 
> **Overview**
> **Auto-deps/import scanning is now stricter about what string literals are treated as dependencies.** A new shared `import_scanner` module parses `load()` arguments with the full `LoadSpec` grammar, but only considers ordinary string literals when they look like an alias (`@...`), an explicit path, or a URL ending in dependency-related file extensions.
> 
> This scanner is reused by both `pcb-zen` auto-deps (`auto_deps.rs`) and the `pcb scan` dependency walker (`scan.rs`), replacing duplicated AST-walking code and eliminating warnings triggered by non-import strings that merely resemble remote URLs. The changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bdace183ee92ebe630869829ec093032a385090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->