### PR TITLE
Downgrade sourcing deprecation to advice

### DIFF
--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -339,8 +339,8 @@ const LEGACY_COMPONENT_PROPERTY_KEYS: &[(&str, &str)] = &[
 const LEGACY_COMPONENT_SOURCING_PROPERTY_KEYS: &[&str] =
     &["mpn", "Mpn", "manufacturer", "Manufacturer"];
 
-/// Emit warnings for legacy `Component()` inputs. Each warning points users at
-/// the endorsed replacement; legacy values continue to be honored elsewhere.
+/// Emit diagnostics for legacy `Component()` inputs. Each diagnostic points
+/// users at the endorsed replacement; legacy values continue to be honored elsewhere.
 fn warn_legacy_component_inputs<'v>(
     eval: &Evaluator<'v, '_, '_>,
     component_name: &str,
@@ -348,12 +348,15 @@ fn warn_legacy_component_inputs<'v>(
     manufacturer_val: Option<Value<'v>>,
     properties_map: &SmallMap<String, Value<'v>>,
 ) {
-    let mut messages: Vec<String> = Vec::new();
+    let mut diagnostics: Vec<(String, EvalSeverity)> = Vec::new();
 
     for (legacy_key, typed_kwarg) in LEGACY_COMPONENT_PROPERTY_KEYS {
         if properties_map.contains_key(*legacy_key) {
-            messages.push(format!(
-                "Component '{component_name}': `properties[\"{legacy_key}\"]` is deprecated; pass `{typed_kwarg}=...` to Component() instead",
+            diagnostics.push((
+                format!(
+                    "Component '{component_name}': `properties[\"{legacy_key}\"]` is deprecated; pass `{typed_kwarg}=...` to Component() instead",
+                ),
+                EvalSeverity::Warning,
             ));
         }
     }
@@ -361,8 +364,11 @@ fn warn_legacy_component_inputs<'v>(
     let part_suggestion = "pass `part=Part(mpn=..., manufacturer=...)` to Component() instead";
     for key in LEGACY_COMPONENT_SOURCING_PROPERTY_KEYS {
         if properties_map.contains_key(*key) {
-            messages.push(format!(
-                "Component '{component_name}': `properties[\"{key}\"]` is deprecated; {part_suggestion}",
+            diagnostics.push((
+                format!(
+                    "Component '{component_name}': `properties[\"{key}\"]` is deprecated; {part_suggestion}",
+                ),
+                EvalSeverity::Advice,
             ));
         }
     }
@@ -371,24 +377,27 @@ fn warn_legacy_component_inputs<'v>(
         ("manufacturer", manufacturer_val.is_some()),
     ] {
         if present {
-            messages.push(format!(
-                "Component '{component_name}': `{kwarg}=...` is deprecated; {part_suggestion}",
+            diagnostics.push((
+                format!(
+                    "Component '{component_name}': `{kwarg}=...` is deprecated; {part_suggestion}",
+                ),
+                EvalSeverity::Advice,
             ));
         }
     }
 
-    if messages.is_empty() {
+    if diagnostics.is_empty() {
         return;
     }
 
     let (path, span) = diagnostic_location(eval);
-    for message in messages {
+    for (message, severity) in diagnostics {
         eval.add_diagnostic(
             crate::Diagnostic::categorized(
                 &path,
                 &message,
                 "deprecated.component_property",
-                EvalSeverity::Warning,
+                severity,
             )
             .with_span(span)
             .with_call_stack(Some(eval.call_stack())),

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -5,6 +5,7 @@ use pcb_zen_core::DiagnosticsPass;
 use pcb_zen_core::SortPass;
 use pcb_zen_core::lang::component::FrozenComponentValue;
 use pcb_zen_core::lang::error::CategorizedDiagnostic;
+use starlark::errors::EvalSeverity;
 
 fn eval_single_root_component(source: &str) -> FrozenComponentValue {
     let result = common::eval_zen(vec![("test.zen".to_string(), source.to_string())]);
@@ -1512,10 +1513,20 @@ fn component_modifier_match_component_ignores_electrical_checks() {
     assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
 }
 
-fn legacy_property_warnings(diagnostics: &pcb_zen_core::Diagnostics) -> Vec<String> {
+fn legacy_property_diagnostics(
+    diagnostics: &pcb_zen_core::Diagnostics,
+    severity: EvalSeverity,
+) -> Vec<String> {
     diagnostics
-        .warnings()
-        .into_iter()
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            matches!(
+                (&diag.severity, &severity),
+                (EvalSeverity::Warning, EvalSeverity::Warning)
+                    | (EvalSeverity::Advice, EvalSeverity::Advice)
+            )
+        })
         .filter_map(|diag| {
             let kind = diag
                 .innermost()
@@ -1568,7 +1579,8 @@ Component(
         .to_string(),
     )]);
 
-    let bodies = legacy_property_warnings(&diagnostics);
+    let warning_bodies = legacy_property_diagnostics(&diagnostics, EvalSeverity::Warning);
+    let advice_bodies = legacy_property_diagnostics(&diagnostics, EvalSeverity::Advice);
 
     for (legacy_key, typed_kwarg) in [
         ("do_not_populate", "dnp"),
@@ -1589,9 +1601,9 @@ Component(
             "Component 'R1': `properties[\"{legacy_key}\"]` is deprecated; pass `{typed_kwarg}=...` to Component() instead"
         );
         assert!(
-            bodies.iter().any(|b| b == &expected),
+            warning_bodies.iter().any(|b| b == &expected),
             "expected legacy-property warning for `{legacy_key}`, got: {:?}",
-            bodies
+            warning_bodies
         );
     }
 
@@ -1600,9 +1612,9 @@ Component(
             "Component 'R1': `properties[\"{sourcing_key}\"]` is deprecated; pass `part=Part(mpn=..., manufacturer=...)` to Component() instead"
         );
         assert!(
-            bodies.iter().any(|b| b == &expected),
-            "expected sourcing-key warning for `{sourcing_key}`, got: {:?}",
-            bodies
+            advice_bodies.iter().any(|b| b == &expected),
+            "expected sourcing-key advice for `{sourcing_key}`, got: {:?}",
+            advice_bodies
         );
     }
 }
@@ -1633,16 +1645,22 @@ Component(
         .to_string(),
     )]);
 
-    let bodies = legacy_property_warnings(&diagnostics);
+    let warning_bodies = legacy_property_diagnostics(&diagnostics, EvalSeverity::Warning);
+    let advice_bodies = legacy_property_diagnostics(&diagnostics, EvalSeverity::Advice);
     assert!(
-        bodies.is_empty(),
+        warning_bodies.is_empty(),
         "expected no legacy-property warnings, got: {:?}",
-        bodies
+        warning_bodies
+    );
+    assert!(
+        advice_bodies.is_empty(),
+        "expected no legacy-property advice, got: {:?}",
+        advice_bodies
     );
 }
 
 #[test]
-fn warns_for_mpn_and_manufacturer_kwargs() {
+fn advises_for_mpn_and_manufacturer_kwargs() {
     let diagnostics = eval_component_diagnostics(vec![(
         "test.zen".to_string(),
         r#"
@@ -1661,16 +1679,23 @@ Component(
         .to_string(),
     )]);
 
-    let bodies = legacy_property_warnings(&diagnostics);
+    let warning_bodies = legacy_property_diagnostics(&diagnostics, EvalSeverity::Warning);
+    let advice_bodies = legacy_property_diagnostics(&diagnostics, EvalSeverity::Advice);
+
+    assert!(
+        warning_bodies.is_empty(),
+        "expected sourcing kwargs to avoid warnings, got: {:?}",
+        warning_bodies
+    );
 
     for kwarg in ["mpn", "manufacturer"] {
         let expected = format!(
             "Component 'R1': `{kwarg}=...` is deprecated; pass `part=Part(mpn=..., manufacturer=...)` to Component() instead"
         );
         assert!(
-            bodies.iter().any(|b| b == &expected),
-            "expected sourcing-kwarg warning for `{kwarg}`, got: {:?}",
-            bodies
+            advice_bodies.iter().any(|b| b == &expected),
+            "expected sourcing-kwarg advice for `{kwarg}`, got: {:?}",
+            advice_bodies
         );
     }
 }
@@ -1694,11 +1719,17 @@ Component(
         .to_string(),
     )]);
 
-    let bodies = legacy_property_warnings(&diagnostics);
+    let warning_bodies = legacy_property_diagnostics(&diagnostics, EvalSeverity::Warning);
+    let advice_bodies = legacy_property_diagnostics(&diagnostics, EvalSeverity::Advice);
     assert!(
-        bodies.is_empty(),
+        warning_bodies.is_empty(),
         "expected no warnings when using part=Part(...), got: {:?}",
-        bodies
+        warning_bodies
+    );
+    assert!(
+        advice_bodies.is_empty(),
+        "expected no advice when using part=Part(...), got: {:?}",
+        advice_bodies
     );
 }
 


### PR DESCRIPTION
It was too much.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts diagnostic severity for deprecated `mpn`/`manufacturer` sourcing inputs and updates tests accordingly, with no functional changes to component parsing or sourcing resolution.
> 
> **Overview**
> Deprecation reporting for legacy `Component()` inputs is refined to emit **mixed severities**: legacy typed-property replacements (e.g. `properties["dnp"]`, `properties["type"]`, etc.) remain `Warning`, while legacy sourcing inputs (`mpn`/`manufacturer` kwargs or `properties[...]`) are downgraded to `Advice`.
> 
> Tests are updated to assert the new behavior by filtering diagnostics by `EvalSeverity` and expecting sourcing deprecations as advice (and no warnings) when `mpn`/`manufacturer` kwargs are used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9893c746755d81812d900554cd0a2e55d5d53d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->