### PR TITLE
Add "simple" release hosting backend to dist

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -35,15 +36,27 @@ jobs:
           path: target/release/pcb
           retention-days: 30
 
-      - name: Update latest prerelease
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Prepare latest main build
         run: |
-          # Delete existing prerelease and tag if they exist
-          gh release delete latest --yes || true
-          git push origin --delete refs/tags/latest || true
-          # Create new prerelease
-          gh release create latest target/release/pcb \
-            --title "Latest Main Build" \
-            --notes "Automated build from main branch (commit: ${{ github.sha }})" \
-            --prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          mkdir -p dist-main
+          cp target/release/pcb dist-main/pcb
+          shasum -a 256 dist-main/pcb | awk '{print $1}' > dist-main/pcb.sha256
+          cat > dist-main/latest.json <<EOF
+          {
+            "sha": "${{ github.sha }}",
+            "ref": "${{ github.ref_name }}",
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}"
+          }
+          EOF
+
+      - name: Upload latest main build to S3
+        run: |
+          aws s3 sync dist-main/ "s3://diode-pcb-releases/pcb/latest/" \
+            --cache-control "public, max-age=60"

--- a/.github/workflows/s3-release-upload.yml
+++ b/.github/workflows/s3-release-upload.yml
@@ -1,0 +1,54 @@
+name: Upload release artifacts to S3
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  upload:
+    name: upload-s3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: artifacts-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Remove dist manifest artifacts
+        run: rm -f artifacts/*-dist-manifest.json
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Upload immutable release artifacts
+        run: |
+          aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/${{ github.ref_name }}/" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "pcb-installer.sh" \
+            --exclude "pcb-installer.ps1"
+
+      - name: Upload installer scripts with short cache
+        run: |
+          if [ -f artifacts/pcb-installer.sh ]; then
+            aws s3 cp artifacts/pcb-installer.sh \
+              "s3://diode-pcb-releases/pcb/${{ github.ref_name }}/pcb-installer.sh" \
+              --cache-control "public, max-age=300"
+          fi
+
+          if [ -f artifacts/pcb-installer.ps1 ]; then
+            aws s3 cp artifacts/pcb-installer.ps1 \
+              "s3://diode-pcb-releases/pcb/${{ github.ref_name }}/pcb-installer.ps1" \
+              --cache-control "public, max-age=300"
+          fi

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -16,6 +16,7 @@
 name: Release
 permissions:
   "contents": "write"
+  "id-token": "write"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -289,14 +290,27 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  upload-s3:
+    needs:
+      - plan
+      - host
+    if: ${{ always() && needs.host.result == 'success' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/s3-release-upload.yml
+    with:
+      plan: ${{ needs.host.outputs.val }}
+
   announce:
     needs:
       - plan
       - host
+      - upload-s3
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ always() && needs.host.result == 'success' && needs.upload-s3.result == 'success' }}
     runs-on: "ubicloud-standard-30-ubuntu-2204"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,6 +7,10 @@ members = ["cargo:."]
 cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
+# Release hosting backends. Use the CDN first, with GitHub Releases as a fallback.
+hosting = ["simple", "github"]
+# CDN base URL for statically-hosted release artifacts.
+simple-download-url = "https://pcb.api.diode.computer/pcb/{tag}"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release/build publishing pipeline and introduces OIDC-based AWS role assumption plus S3 cache-control behaviors that could affect artifact availability.
> 
> **Overview**
> **Moves release hosting toward an S3-backed CDN.** `dist-workspace.toml` enables cargo-dist’s `simple` hosting with a configured `simple-download-url`, keeping GitHub Releases as fallback.
> 
> **Updates CI publishing flows to upload artifacts to S3.** `build-main.yml` replaces the `latest` GitHub prerelease step with preparing `pcb`, a SHA256 file, and `latest.json`, then syncing to `s3://diode-pcb-releases/pcb/latest/` using OIDC-assumed AWS credentials. Tagged releases (`v-release.yml`) add an `upload-s3` job (via new reusable `s3-release-upload.yml`) that uploads dist artifacts to `s3://diode-pcb-releases/pcb/${ref}/`, with long-lived immutable caching for binaries and short caching for installer scripts, and gates `announce` on S3 upload success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5816ca97defef85e7935a7b1029f7ca6303371d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->