### PR TITLE
Use our s3 + cf for pcb updates

### DIFF
--- a/.github/workflows/s3-release-upload.yml
+++ b/.github/workflows/s3-release-upload.yml
@@ -52,3 +52,28 @@ jobs:
               "s3://diode-pcb-releases/pcb/${{ github.ref_name }}/pcb-installer.ps1" \
               --cache-control "public, max-age=300"
           fi
+
+      - name: Publish latest release metadata
+        run: |
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            echo "Skipping latest.json for prerelease $GITHUB_REF_NAME"
+            exit 0
+          fi
+
+          jq -n \
+            --arg version "${GITHUB_REF_NAME#v}" \
+            --arg tag "$GITHUB_REF_NAME" \
+            --arg published_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg base_url "https://pcb.api.diode.computer/pcb/$GITHUB_REF_NAME" \
+            '{
+              version: $version,
+              tag: $tag,
+              published_at: $published_at,
+              shell_installer: ($base_url + "/pcb-installer.sh"),
+              powershell_installer: ($base_url + "/pcb-installer.ps1"),
+              dist_manifest: ($base_url + "/dist-manifest.json")
+            }' > latest.json
+
+          aws s3 cp latest.json "s3://diode-pcb-releases/pcb/latest.json" \
+            --cache-control "public, max-age=60" \
+            --content-type "application/json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Standalone `pcb` releases now use the Diode CDN for faster, less exciting downloads and update checks.
+
 ## [0.3.82] - 2026-05-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,67 +777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axoasset"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be1b9c2739b635e04c7bbcde9e89dd5e874b9e86e28f1b41c44eb830635d83e"
-dependencies = [
- "camino",
- "image",
- "lazy_static",
- "miette",
- "mime",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "axoprocess"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4b4798a6c02e91378537c63cd6e91726900b595450daa5d487bc3c11e95e1b"
-dependencies = [
- "miette",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "axotag"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc923121fbc4cc72e9008436b5650b98e56f94b5799df59a1b4f572b5c6a7e6b"
-dependencies = [
- "miette",
- "semver",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "axoupdater"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab66f118bab79524a27139b7341cdf1c4f839c6274ef89a6d8fb4365cb218cf"
-dependencies = [
- "axoasset",
- "axoprocess",
- "axotag",
- "camino",
- "homedir",
- "miette",
- "self-replace",
- "serde",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,9 +1036,6 @@ name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "canon-json"
@@ -1180,7 +1116,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2485,7 +2421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2722,18 +2658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "homedir"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527"
-dependencies = [
- "cfg-if",
- "nix 0.30.1",
- "widestring",
- "windows 0.61.3",
 ]
 
 [[package]]
@@ -3879,28 +3803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miette"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
-dependencies = [
- "cfg-if",
- "miette-derive",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "miette-derive"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "mimalloc"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,18 +3928,6 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset 0.9.1",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
 ]
 
 [[package]]
@@ -4378,7 +4268,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4410,7 +4300,6 @@ name = "pcb"
 version = "0.3.82"
 dependencies = [
  "anyhow",
- "axoupdater",
  "canon-json",
  "chrono",
  "clap",
@@ -4455,6 +4344,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
+ "self-replace",
  "semver",
  "serde",
  "serde_json",
@@ -5545,7 +5435,7 @@ dependencies = [
  "ratatui",
  "rustix 0.38.44",
  "thiserror 1.0.69",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -7507,23 +7397,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -8289,12 +8166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8336,28 +8207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core 0.61.2",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8372,39 +8221,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading",
 ]
 
 [[package]]
@@ -8453,25 +8278,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-registry"
@@ -8479,7 +8288,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
 ]
@@ -8495,20 +8304,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -8523,20 +8323,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -8581,7 +8372,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -8621,7 +8412,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -8630,15 +8421,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ aws-config = "1.8.16"
 aws-credential-types = "1.2.14"
 aws-sigv4 = "1.4.3"
 aws-smithy-runtime-api = "1.12.0"
-axoupdater = { version = "0.10", features = ["blocking"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "wrap_help"] }
 colored = "3"
@@ -116,6 +115,7 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 rand = "0.8"
 serde-wasm-bindgen = "0.6"
 serde_yaml = "0.9"
+self-replace = "1.5"
 serial_test = "3.0"
 smallvec = "1.15"
 strip-ansi-escapes = "0.2"

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -69,6 +69,7 @@ tempfile = { workspace = true }
 ignore = { workspace = true }
 globset = { workspace = true }
 semver = { workspace = true }
+self-replace = { workspace = true }
 rayon = { workspace = true }
 jiff = { workspace = true }
 crossterm = { workspace = true }
@@ -77,7 +78,6 @@ reqwest = { workspace = true }
 termimad = { workspace = true }
 syntect = { workspace = true }
 gltfpack-sys = { workspace = true }
-axoupdater = { workspace = true }
 thiserror = { workspace = true }
 minijinja = { workspace = true }
 canon-json = "0.2"

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -308,10 +308,12 @@ fn is_update_command(command: &Commands) -> bool {
 }
 
 fn check_and_update() {
-    let mut updater = axoupdater::AxoUpdater::new_for("pcb");
-    if let Ok(updater) = updater.load_receipt()
-        && let Ok(true) = updater.is_update_needed_sync()
-    {
+    if !self_update::update_check_due() {
+        return;
+    }
+    self_update::mark_update_checked();
+
+    if let Ok(true) = self_update::is_update_available() {
         eprintln!("{}", "A new version of pcb is available!".blue().bold());
         eprintln!("Run {} to update.", "pcb self update".yellow().bold());
     }

--- a/crates/pcb/src/self_update.rs
+++ b/crates/pcb/src/self_update.rs
@@ -2,6 +2,14 @@ use clap::{Args, Subcommand};
 use colored::Colorize;
 use rand::seq::SliceRandom;
 use semver::Version;
+use serde::Deserialize;
+use std::{env, fs, io, path::PathBuf, process::Command, time::Duration};
+
+const LATEST_RELEASE_URL: &str = "https://pcb.api.diode.computer/pcb/latest.json";
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
+const ARCHIVE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const STANDALONE_INSTALL_REQUIRED: &str = "Self-update is only available for pcb installed via the standalone installer.\nIf you installed pcb via a package manager, please update using that tool.";
 
 const FORTUNES: &str = include_str!("fortune.txt");
 
@@ -20,66 +28,178 @@ enum SelfUpdateCommands {
 pub fn execute(args: SelfUpdateArgs) -> anyhow::Result<()> {
     match args.command {
         SelfUpdateCommands::Update => {
-            let mut updater = axoupdater::AxoUpdater::new_for("pcb");
-            if updater.load_receipt().is_err() {
-                anyhow::bail!(
-                    "Self-update is only available for pcb installed via the standalone installer.\n\
-                     If you installed pcb via a package manager, please update using that tool."
-                );
+            ensure_standalone_install()?;
+            let current_version = Version::parse(env!("CARGO_PKG_VERSION"))?;
+            let latest = fetch_latest_release()?;
+            if latest.version <= current_version {
+                println!("Already up to date.");
+                return Ok(());
             }
 
-            match updater.run_sync()? {
-                Some(result) => {
-                    // Update was performed - print changelog for the version range.
-                    println!();
-                    let selector =
-                        changelog_selector(result.old_version.as_ref(), &result.new_version);
-                    let _ = crate::changelog::execute(crate::changelog::ChangelogArgs { selector });
+            install_update(&latest)?;
 
-                    // Print a random fortune
-                    let fortunes: Vec<&str> = FORTUNES.lines().filter(|l| !l.is_empty()).collect();
-                    if let Some(fortune) = fortunes.choose(&mut rand::thread_rng()) {
-                        println!();
-                        println!("{}", format!("> {}", fortune).truecolor(90, 90, 90));
-                    }
+            // Update was performed - print changelog for the version range.
+            println!();
+            let selector = format!("{}..{}", current_version, latest.version);
+            let _ = crate::changelog::execute(crate::changelog::ChangelogArgs { selector });
 
-                    if let Some(old) = result.old_version {
-                        println!();
-                        println!(
-                            "Updated {} → {}",
-                            old.to_string().dimmed(),
-                            result.new_version.to_string().green()
-                        );
-                    }
-                }
-                None => {
-                    println!("Already up to date.");
-                }
+            // Print a random fortune
+            let fortunes: Vec<&str> = FORTUNES.lines().filter(|l| !l.is_empty()).collect();
+            if let Some(fortune) = fortunes.choose(&mut rand::thread_rng()) {
+                println!();
+                println!("{}", format!("> {}", fortune).truecolor(90, 90, 90));
             }
+
+            println!();
+            println!(
+                "Updated {} → {}",
+                current_version.to_string().dimmed(),
+                latest.version.to_string().green()
+            );
 
             Ok(())
         }
     }
 }
 
-fn changelog_selector(old: Option<&Version>, new: &Version) -> String {
-    old.map_or_else(|| "latest".to_string(), |old| format!("{old}..{new}"))
+pub fn is_update_available() -> anyhow::Result<bool> {
+    ensure_standalone_install()?;
+    let current_version = Version::parse(env!("CARGO_PKG_VERSION"))?;
+    Ok(fetch_latest_release()?.version > current_version)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub fn update_check_due() -> bool {
+    let Some(path) = update_check_stamp_path() else {
+        return true;
+    };
+    let Ok(modified) = fs::metadata(path).and_then(|metadata| metadata.modified()) else {
+        return true;
+    };
+    modified
+        .elapsed()
+        .map_or(true, |elapsed| elapsed >= UPDATE_CHECK_INTERVAL)
+}
 
-    #[test]
-    fn changelog_selector_uses_old_to_new_range() {
-        assert_eq!(
-            changelog_selector(Some(&Version::new(0, 3, 78)), &Version::new(0, 3, 80)),
-            "0.3.78..0.3.80"
-        );
+pub fn mark_update_checked() {
+    let Some(path) = update_check_stamp_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(path, b"");
+}
+
+#[derive(Debug, Deserialize)]
+struct LatestRelease {
+    version: Version,
+    tag: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallReceipt {
+    install_prefix: PathBuf,
+}
+
+fn ensure_standalone_install() -> anyhow::Result<()> {
+    let receipt = fs::read_to_string(receipt_path())
+        .ok()
+        .and_then(|content| serde_json::from_str::<InstallReceipt>(&content).ok())
+        .ok_or_else(|| anyhow::anyhow!(STANDALONE_INSTALL_REQUIRED))?;
+    let install_prefix = receipt
+        .install_prefix
+        .canonicalize()
+        .map_err(|_| anyhow::anyhow!(STANDALONE_INSTALL_REQUIRED))?;
+    let current_exe = env::current_exe()?.canonicalize()?;
+    anyhow::ensure!(
+        current_exe.starts_with(&install_prefix),
+        STANDALONE_INSTALL_REQUIRED
+    );
+
+    Ok(())
+}
+
+fn receipt_path() -> PathBuf {
+    let config_dir = if cfg!(windows) {
+        PathBuf::from(env::var_os("LOCALAPPDATA").unwrap_or_default())
+    } else {
+        env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".config"))
+    };
+
+    config_dir.join("pcb").join("pcb-receipt.json")
+}
+
+fn fetch_latest_release() -> anyhow::Result<LatestRelease> {
+    Ok(reqwest::blocking::Client::builder()
+        .timeout(METADATA_TIMEOUT)
+        .build()?
+        .get(LATEST_RELEASE_URL)
+        .header(reqwest::header::USER_AGENT, "pcb")
+        .send()?
+        .error_for_status()?
+        .json()?)
+}
+
+fn update_check_stamp_path() -> Option<PathBuf> {
+    dirs::cache_dir().map(|dir| dir.join("pcb").join("update-check"))
+}
+
+fn install_update(latest: &LatestRelease) -> anyhow::Result<()> {
+    let archive_name = archive_name();
+    let archive_url = format!(
+        "https://pcb.api.diode.computer/pcb/{}/{}",
+        latest.tag, archive_name
+    );
+    let archive = reqwest::blocking::Client::builder()
+        .timeout(ARCHIVE_TIMEOUT)
+        .build()?
+        .get(archive_url)
+        .header(reqwest::header::USER_AGENT, "pcb")
+        .send()?
+        .error_for_status()?
+        .bytes()?;
+
+    let temp = tempfile::tempdir()?;
+    let archive_path = temp.path().join(archive_name);
+    fs::write(&archive_path, archive)?;
+
+    if archive_name.ends_with(".zip") {
+        let mut zip = zip::ZipArchive::new(fs::File::open(&archive_path)?)?;
+        let mut src = zip.by_name(binary_name())?;
+        let mut dst = fs::File::create(temp.path().join(binary_name()))?;
+        io::copy(&mut src, &mut dst)?;
+    } else {
+        let status = Command::new("tar")
+            .args([
+                "xf",
+                archive_path.to_str().unwrap(),
+                "--strip-components",
+                "1",
+                "-C",
+            ])
+            .arg(temp.path())
+            .status()?;
+        anyhow::ensure!(status.success(), "failed to extract pcb archive");
     }
 
-    #[test]
-    fn changelog_selector_falls_back_to_latest_without_old_version() {
-        assert_eq!(changelog_selector(None, &Version::new(0, 3, 80)), "latest");
+    self_replace::self_replace(temp.path().join(binary_name()))?;
+
+    Ok(())
+}
+
+fn archive_name() -> &'static str {
+    match (env::consts::OS, env::consts::ARCH) {
+        ("macos", "aarch64") => "pcb-aarch64-apple-darwin.tar.xz",
+        ("macos", "x86_64") => "pcb-x86_64-apple-darwin.tar.xz",
+        ("linux", "aarch64") => "pcb-aarch64-unknown-linux-gnu.tar.xz",
+        ("linux", "x86_64") => "pcb-x86_64-unknown-linux-gnu.tar.xz",
+        ("windows", "x86_64") => "pcb-x86_64-pc-windows-msvc.zip",
+        _ => panic!("unsupported self-update platform"),
     }
+}
+
+fn binary_name() -> &'static str {
+    if cfg!(windows) { "pcb.exe" } else { "pcb" }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `pcb` self-update mechanism and its release publication flow to fetch and install binaries from CDN-hosted artifacts, which can impact upgrade reliability across platforms. Adds new network/download/extraction paths and a timed update-check stamp that could fail in edge environments if assumptions (tar availability, receipt format, CDN metadata) don’t hold.
> 
> **Overview**
> Standalone `pcb` releases now publish a `latest.json` pointer (skipping prereleases) during the S3 upload workflow, enabling CDN-backed “latest” discovery.
> 
> The CLI self-update path is refactored to stop using `axoupdater` and instead fetch `latest.json`, download the platform archive from `https://pcb.api.diode.computer`, extract the binary (tar/zip), and swap the running executable via `self-replace`, with a 1-hour cached update-check stamp and stricter “standalone install only” receipt validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472c037d5fe17db886907fe303be455b46d22ecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->