### PR TITLE
cleanup: remove api feature

### DIFF
--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -23,9 +23,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 quick-xml = { workspace = true }
 zstd = { workspace = true }
-pcb-diode-api = { workspace = true, optional = true }
-pcb-ui = { workspace = true, optional = true }
-
-[features]
-default = []
-api = ["dep:pcb-diode-api", "dep:pcb-ui"]
+pcb-diode-api = { workspace = true }
+pcb-ui = { workspace = true }

--- a/crates/pcb-ipc2581-tools/src/commands/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/bom.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 use std::path::Path;
 
-#[cfg(feature = "api")]
 use anyhow::Context;
 use anyhow::Result;
 use pcb_sch::bom::{Bom, BomEntry, Capacitor, GenericComponent, Resistor};
@@ -61,17 +60,14 @@ fn to_sch_alternative(alt: &Alternative) -> Alternative {
     }
 }
 
-pub fn execute(file: &Path, format: OutputFormat, _offline: bool) -> Result<()> {
+pub fn execute(file: &Path, format: OutputFormat, offline: bool) -> Result<()> {
     let content = file_utils::load_ipc_file(file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
     let accessor = IpcAccessor::new(&ipc);
 
-    // Extract BOM from IPC-2581
-    #[cfg_attr(not(feature = "api"), allow(unused_mut))]
     let mut bom = extract_bom_from_ipc(&accessor)?;
 
-    #[cfg(feature = "api")]
-    if !_offline {
+    if !offline {
         use pcb_ui::prelude::*;
         let file_name = file.file_name().unwrap_or_default().to_string_lossy();
         let spinner = Spinner::builder(format!("{file_name}: Fetching availability")).start();

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -9,8 +9,7 @@ authors = { workspace = true }
 default-run = "pcb"
 
 [features]
-default = ["api", "mimalloc"]
-api = ["dep:pcb-diode-api"]
+default = ["mimalloc"]
 mimalloc = ["dep:mimalloc"]
 
 [package.metadata.wix]
@@ -33,9 +32,9 @@ pcb-canonical = { workspace = true }
 pcb-sch = { workspace = true, features = ["table"] }
 pcb-layout = { workspace = true }
 pcb-sim = { workspace = true }
-pcb-diode-api = { workspace = true, optional = true }
+pcb-diode-api = { workspace = true }
 pcb-docgen = { workspace = true }
-pcb-ipc2581-tools = { workspace = true, features = ["api"] }
+pcb-ipc2581-tools = { workspace = true }
 pcb-eda = { workspace = true }
 pcb-sexpr = { workspace = true }
 pcb-component-gen = { workspace = true }

--- a/crates/pcb/src/api.rs
+++ b/crates/pcb/src/api.rs
@@ -1,6 +1,0 @@
-pub use pcb_diode_api::{AuthArgs, ScanArgs, SearchArgs, execute_scan, execute_search};
-
-pub fn execute_auth(args: AuthArgs) -> anyhow::Result<()> {
-    let ctx = pcb_diode_api::WorkspaceContext::from_cwd()?;
-    pcb_diode_api::execute_auth(args, &ctx)
-}

--- a/crates/pcb/src/bom.rs
+++ b/crates/pcb/src/bom.rs
@@ -126,7 +126,6 @@ pub fn execute(args: BomArgs) -> Result<()> {
     // Filter out components marked as skip_bom
     bom = bom.filter_excluded();
 
-    #[cfg(feature = "api")]
     if !args.offline {
         let ctx = pcb_diode_api::WorkspaceContext::from_path(&args.file);
         match ctx.token() {

--- a/crates/pcb/src/ipc2581.rs
+++ b/crates/pcb/src/ipc2581.rs
@@ -31,7 +31,6 @@ enum Commands {
         #[arg(short, long, default_value = "text")]
         format: OutputFormat,
         /// Run in offline mode without fetching part availability
-        #[cfg(feature = "api")]
         #[arg(long)]
         offline: bool,
     },
@@ -128,18 +127,8 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
         Commands::Bom {
             file,
             format,
-            #[cfg(feature = "api")]
             offline,
-        } => commands::bom::execute(&file, format, {
-            #[cfg(feature = "api")]
-            {
-                offline
-            }
-            #[cfg(not(feature = "api"))]
-            {
-                true
-            }
-        }),
+        } => commands::bom::execute(&file, format, offline),
         Commands::Edit { command } => match command {
             EditCommands::Bom {
                 file,

--- a/crates/pcb/src/lsp.rs
+++ b/crates/pcb/src/lsp.rs
@@ -3,23 +3,12 @@ use clap::Args;
 #[derive(Args)]
 pub struct LspArgs {}
 
-#[cfg(feature = "api")]
 const RESOLVE_DATASHEET_METHOD: &str = "pcb/resolveDatasheet";
 
 pub fn execute(_args: LspArgs) -> anyhow::Result<()> {
-    #[cfg(feature = "api")]
-    {
-        pcb_zen::lsp_with_custom_request_handler(false, handle_custom_request)
-    }
-
-    #[cfg(not(feature = "api"))]
-    {
-        pcb_zen::lsp_with_eager(false)?;
-        Ok(())
-    }
+    pcb_zen::lsp_with_custom_request_handler(false, handle_custom_request)
 }
 
-#[cfg(feature = "api")]
 fn handle_custom_request(
     method: &str,
     params: &serde_json::Value,
@@ -34,7 +23,7 @@ fn handle_custom_request(
     Ok(Some(serde_json::to_value(response)?))
 }
 
-#[cfg(all(test, feature = "api"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -8,8 +8,6 @@ use env_logger::Env;
 use std::ffi::OsString;
 use std::process::Command;
 
-#[cfg(feature = "api")]
-mod api;
 mod bom;
 mod build;
 mod bundle;
@@ -35,11 +33,9 @@ mod open;
 mod package;
 #[path = "mod/mod.rs"]
 mod pcb_mod;
-#[cfg(feature = "api")]
 mod preview;
 mod publish;
 mod release;
-#[cfg(feature = "api")]
 mod route;
 mod self_update;
 mod sim;
@@ -72,8 +68,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Manage authentication
-    #[cfg(feature = "api")]
-    Auth(api::AuthArgs),
+    Auth(pcb_diode_api::AuthArgs),
 
     /// Build PCB projects
     #[command(alias = "b")]
@@ -142,7 +137,6 @@ enum Commands {
     Publish(publish::PublishArgs),
 
     /// Build and upload a preview release for a board
-    #[cfg(feature = "api")]
     Preview(preview::PreviewArgs),
 
     /// Vendor external dependencies
@@ -155,15 +149,12 @@ enum Commands {
     EmbedStep(embed_step::EmbedStepArgs),
 
     /// Scan datasheets from local PDFs or URLs
-    #[cfg(feature = "api")]
-    Scan(api::ScanArgs),
+    Scan(pcb_diode_api::ScanArgs),
 
     /// Search for electronic components
-    #[cfg(feature = "api")]
-    Search(api::SearchArgs),
+    Search(pcb_diode_api::SearchArgs),
 
     /// Auto-route PCB using DeepPCB cloud service
-    #[cfg(feature = "api")]
     #[command(hide = true)]
     Route(route::RouteArgs),
 
@@ -221,8 +212,10 @@ fn run() -> anyhow::Result<()> {
     }
 
     match cli.command {
-        #[cfg(feature = "api")]
-        Commands::Auth(args) => api::execute_auth(args),
+        Commands::Auth(args) => {
+            let ctx = pcb_diode_api::WorkspaceContext::from_cwd()?;
+            pcb_diode_api::execute_auth(args, &ctx)
+        }
         Commands::Build(args) => build::execute(args),
         Commands::Test(args) => test::execute(args),
         Commands::Migrate(args) => migrate::execute(args),
@@ -242,19 +235,15 @@ fn run() -> anyhow::Result<()> {
         Commands::Lsp(args) => lsp::execute(args),
         Commands::Open(args) => open::execute(args),
         Commands::Publish(args) => publish::execute(args),
-        #[cfg(feature = "api")]
         Commands::Preview(args) => preview::execute(args),
         Commands::Vendor(args) => vendor::execute(args),
         Commands::Fork => {
             println!("`pcb fork` is a reserved subcommand for future use.");
             Ok(())
         }
-        #[cfg(feature = "api")]
-        Commands::Scan(args) => api::execute_scan(args),
-        #[cfg(feature = "api")]
-        Commands::Search(args) => api::execute_search(args),
+        Commands::Scan(args) => pcb_diode_api::execute_scan(args),
+        Commands::Search(args) => pcb_diode_api::execute_search(args),
         Commands::EmbedStep(args) => embed_step::execute(args),
-        #[cfg(feature = "api")]
         Commands::Route(args) => route::execute(args),
         Commands::Simulate(args) => sim::execute(args),
         Commands::Ipc2581(args) => ipc2581::execute(args),

--- a/crates/pcb/src/new.rs
+++ b/crates/pcb/src/new.rs
@@ -212,7 +212,6 @@ fn require_workspace() -> Result<(std::path::PathBuf, PcbToml)> {
     get_workspace().ok_or_else(|| anyhow::anyhow!("Not inside a pcb workspace"))
 }
 
-#[cfg(feature = "api")]
 fn execute_new_component(args: NewComponentArgs) -> Result<()> {
     if let Some(dir) = args.dir.as_deref() {
         return pcb_diode_api::execute_component_from_local_dir(dir);
@@ -230,17 +229,9 @@ fn execute_new_component(args: NewComponentArgs) -> Result<()> {
     pcb_diode_api::execute_web_components_tui(&workspace_root)
 }
 
-#[cfg(not(feature = "api"))]
-fn execute_new_component(_args: NewComponentArgs) -> Result<()> {
-    bail!("Component creation requires the 'api' feature")
-}
-
 fn execute_interactive() -> Result<()> {
     if get_workspace().is_some() {
-        #[cfg(feature = "api")]
         let options = vec!["package", "component"];
-        #[cfg(not(feature = "api"))]
-        let options = vec!["package"];
 
         let selection = Select::new("What would you like to create?", options)
             .prompt()
@@ -248,7 +239,6 @@ fn execute_interactive() -> Result<()> {
 
         match selection {
             "package" => prompt_new_package(),
-            #[cfg(feature = "api")]
             "component" => execute_new_component(NewComponentArgs::default()),
             _ => unreachable!(),
         }

--- a/crates/pcb/src/publish.rs
+++ b/crates/pcb/src/publish.rs
@@ -554,7 +554,6 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
     )?;
 
     // Upload to API (must succeed before creating tag)
-    #[cfg(feature = "api")]
     if remote.is_some() {
         let ws_name = release_workspace_name(&workspace)?;
         let ctx = pcb_diode_api::WorkspaceContext::from_workspace_root(&workspace.root);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes build-time feature gating and makes `pcb-diode-api`/network-backed functionality compile in all builds, which can affect packaging, dependencies, and runtime behavior when offline/auth is missing.
> 
> **Overview**
> Removes the `api` feature flag across `pcb` and `pcb-ipc2581-tools`, making `pcb-diode-api`/`pcb-ui` **always-on dependencies** and simplifying conditional compilation.
> 
> CLI/LSP commands that were previously `#[cfg(feature = "api")]` are now always available: `pcb auth/scan/search`, `pcb lsp` custom `pcb/resolveDatasheet` handling, IPC-2581 BOM availability fetching via the `--offline` flag, interactive `pcb new component`, and release upload during `publish` when pushing to a remote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8878bdf8f814aee0f5e4a22a499a61f828d2e187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->