### PR TITLE
Fix release smoke issues

### DIFF
--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -96,6 +96,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-bin: false
+          rustflags: ""
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -94,6 +94,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-bin: false
+          rustflags: ""
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -96,6 +96,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-bin: false
+          rustflags: ""
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -954,10 +954,14 @@ fn self_update() -> Result<()> {
         let releases = fetch_release_versions(true)?;
         let latest_toolchain = releases
             .iter()
+            .filter(|version| version.pre.is_empty())
             .max()
             .ok_or_else(|| anyhow::anyhow!("no pcbc releases found"))?;
         requests.insert((latest_toolchain.major, latest_toolchain.minor));
-        for version in installed_toolchains()?.keys() {
+        for version in installed_toolchains()?
+            .keys()
+            .filter(|version| version.pre.is_empty())
+        {
             requests.insert((version.major, version.minor));
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches release workflows and `pcb` self-update selection logic; while small, it can change which toolchains get installed/updated and could impact release builds if the rust toolchain action interprets flags differently.
> 
> **Overview**
> Fixes release build flakiness by explicitly setting `rustflags: ""` in the GitHub Actions Rust toolchain setup for `pcb`/`pcbc` release and nightly workflows.
> 
> Updates `pcb`’s `self_update` toolchain refresh logic to **ignore prerelease versions** when determining the latest stable lane and when considering installed toolchains, preventing beta/prerelease installs from influencing stable updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce545e86f3f8fa0f5b15d34b7812365682bca34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->