### PR TITLE
Checkout release tag before creating GitHub releases

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -49,17 +49,14 @@ jobs:
           mkdir -p "$RUNNER_TEMP/pcbc-base"
           cp "target/release/pcbc" "$RUNNER_TEMP/pcbc-base/pcbc"
 
-      - name: Checkout demo workspace
-        uses: actions/checkout@v5
-        with:
-          repository: dioderobot/demo
-          path: workspaces/demo
-
-      - name: Checkout arduino workspace
-        uses: actions/checkout@v5
-        with:
-          repository: dioderobot/arduino
-          path: workspaces/arduino
+      - name: Checkout benchmark workspace
+        run: |
+          key="$RUNNER_TEMP/code-diode-key"
+          ssh-keygen -q -t ed25519 -N '' -f "$key"
+          export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o IdentitiesOnly=yes -o IdentityFile=$key -o IdentityAgent=none -o StrictHostKeyChecking=accept-new"
+          git clone --depth 1 git@code.diode.computer:demo/b/DM0001 workspaces/DM0001
+          git clone --depth 1 git@code.diode.computer:arduino/b/Nano workspaces/Nano
+          git clone --depth 1 git@code.diode.computer:arduino/b/unoQ workspaces/unoQ
 
       - name: Install hyperfine
         run: |
@@ -69,26 +66,18 @@ jobs:
       - name: Run performance benchmarks
         run: |
           mkdir -p perf
-          python3 bin/pcb-build-perf \
-            --pcb "$RUNNER_TEMP/pcbc-base/pcbc" \
-            --workspace workspaces/demo \
-            --suppress bom \
-            --output perf/demo-base.json
-          python3 bin/pcb-build-perf \
-            --pcb "$RUNNER_TEMP/pcbc-base/pcbc" \
-            --workspace workspaces/arduino \
-            --suppress bom \
-            --output perf/arduino-base.json
-          python3 bin/pcb-build-perf \
-            --pcb "$RUNNER_TEMP/pcbc-head/pcbc" \
-            --workspace workspaces/demo \
-            --suppress bom \
-            --output perf/demo-head.json
-          python3 bin/pcb-build-perf \
-            --pcb "$RUNNER_TEMP/pcbc-head/pcbc" \
-            --workspace workspaces/arduino \
-            --suppress bom \
-            --output perf/arduino-head.json
+          for workspace in DM0001 Nano unoQ; do
+            python3 bin/pcb-build-perf \
+              --pcb "$RUNNER_TEMP/pcbc-base/pcbc" \
+              --workspace "workspaces/$workspace" \
+              --suppress bom \
+              --output "perf/$workspace-base.json"
+            python3 bin/pcb-build-perf \
+              --pcb "$RUNNER_TEMP/pcbc-head/pcbc" \
+              --workspace "workspaces/$workspace" \
+              --suppress bom \
+              --output "perf/$workspace-head.json"
+          done
 
       - name: Create PR comment body
         id: perf_comment
@@ -157,7 +146,7 @@ jobs:
           rows = []
           has_significant = False
 
-          for name in ["demo", "arduino"]:
+          for name in ["DM0001", "Nano", "unoQ"]:
             base = load(Path("perf") / f"{name}-base.json")
             head = load(Path("perf") / f"{name}-head.json")
             base_boards = {b["zen_path"]: b for b in base.get("boards", [])}

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -27,27 +27,27 @@ jobs:
         with:
           cache-bin: false
 
-      - name: Build pcb (head)
-        run: cargo build -p pcb --release
+      - name: Build pcbc (head)
+        run: cargo build -p pcbc --release
 
       - name: Stash head binary
         run: |
-          mkdir -p "$RUNNER_TEMP/pcb-head"
-          cp "target/release/pcb" "$RUNNER_TEMP/pcb-head/pcb"
+          mkdir -p "$RUNNER_TEMP/pcbc-head"
+          cp "target/release/pcbc" "$RUNNER_TEMP/pcbc-head/pcbc"
 
       - name: Create base worktree
         run: |
           git worktree add "$RUNNER_TEMP/pcb-base" "${{ github.event.pull_request.base.sha }}"
 
-      - name: Build pcb (base)
-        run: cargo build -p pcb --release --manifest-path "$RUNNER_TEMP/pcb-base/Cargo.toml"
+      - name: Build pcbc (base)
+        run: cargo build -p pcbc --release --manifest-path "$RUNNER_TEMP/pcb-base/Cargo.toml"
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/target
 
       - name: Stash base binary
         run: |
-          mkdir -p "$RUNNER_TEMP/pcb-base-bin"
-          cp "target/release/pcb" "$RUNNER_TEMP/pcb-base-bin/pcb"
+          mkdir -p "$RUNNER_TEMP/pcbc-base"
+          cp "target/release/pcbc" "$RUNNER_TEMP/pcbc-base/pcbc"
 
       - name: Checkout demo workspace
         uses: actions/checkout@v5
@@ -70,20 +70,24 @@ jobs:
         run: |
           mkdir -p perf
           python3 bin/pcb-build-perf \
-            --pcb "$RUNNER_TEMP/pcb-base-bin/pcb" \
+            --pcb "$RUNNER_TEMP/pcbc-base/pcbc" \
             --workspace workspaces/demo \
+            --suppress bom \
             --output perf/demo-base.json
           python3 bin/pcb-build-perf \
-            --pcb "$RUNNER_TEMP/pcb-base-bin/pcb" \
+            --pcb "$RUNNER_TEMP/pcbc-base/pcbc" \
             --workspace workspaces/arduino \
+            --suppress bom \
             --output perf/arduino-base.json
           python3 bin/pcb-build-perf \
-            --pcb "$RUNNER_TEMP/pcb-head/pcb" \
+            --pcb "$RUNNER_TEMP/pcbc-head/pcbc" \
             --workspace workspaces/demo \
+            --suppress bom \
             --output perf/demo-head.json
           python3 bin/pcb-build-perf \
-            --pcb "$RUNNER_TEMP/pcb-head/pcb" \
+            --pcb "$RUNNER_TEMP/pcbc-head/pcbc" \
             --workspace workspaces/arduino \
+            --suppress bom \
             --output perf/arduino-head.json
 
       - name: Create PR comment body

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -164,7 +164,7 @@ jobs:
               label = f"{name}/{board_name}"
 
               if not base_board or not head_board:
-                rows.append((label, "—", "—", "—", "missing"))
+                rows.append((label, "—", "—", "missing"))
                 continue
 
               delta, pct, significant = analyze_change(base_board, head_board)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Test workspace with pcb.toml
         env:
-          RUST_LOG: info,pcb::release=debug,pcb::bom=debug
+          RUST_LOG: info,pcbc::release=debug,pcbc::bom=debug
         run: |
           pcbc bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
           pcbc layout test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen --no-open

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,31 +63,33 @@ jobs:
 
       - name: Build and install pcb CLI
         run: |
-          cargo build --release -p pcb
+          cargo build --release -p pcb -p pcbc
           cp target/release/pcb ~/.cargo/bin/pcb
+          cp target/release/pcbc ~/.cargo/bin/pcbc
           pcb --help
+          pcbc --help
 
       - name: Build examples
-        run: pcb build examples
+        run: pcbc build examples
 
       - name: Test workspace with pcb.toml
         env:
           RUST_LOG: info,pcb::release=debug,pcb::bom=debug
         run: |
-          pcb bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
-          pcb layout test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen --no-open
-          pcb publish test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen -S layout.drc.invalid_outline
+          pcbc bom test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen
+          pcbc layout test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen --no-open
+          pcbc publish test-workspaces/with-pcb-toml/boards/WorkspaceTestBoard.zen -S layout.drc.invalid_outline
 
       - name: Test pcb new
         run: |
           cd /tmp
-          pcb new board TB0001 github.com/test/TB0001
+          pcbc new board TB0001 github.com/test/TB0001
           cd TB0001
-          pcb new package modules/mod_a
-          pcb build .
+          pcbc new package modules/mod_a
+          pcbc build .
 
       - name: Test stdlib builds
-        run: pcb build stdlib/
+        run: pcbc build stdlib/ -S bom
 
       - name: Checkout kicad-test-fixtures
         uses: actions/checkout@v5
@@ -101,11 +103,11 @@ jobs:
           find kicad-test-fixtures -name '*.kicad_pro' | while IFS= read -r pro; do
             echo "=== Importing $pro ==="
             out="./test-import/$(basename "${pro%.kicad_pro}")"
-            pcb import "$pro" "$out"
+            pcbc import "$pro" "$out"
           done
           for board_zen in ./test-import/*/*.zen; do
             echo "=== Build $board_zen ==="
-            pcb build "$board_zen"
+            pcbc build "$board_zen" -S bom
             echo "=== Layout $board_zen ==="
-            pcb layout "$board_zen" --no-open
+            pcbc layout "$board_zen" --no-open -S bom
           done

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -135,6 +135,10 @@ jobs:
       - build
     runs-on: ubicloud-standard-30-ubuntu-2204
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -135,6 +135,10 @@ jobs:
       - build
     runs-on: ubicloud-standard-30-ubuntu-2204
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/bin/pcb-build-perf
+++ b/bin/pcb-build-perf
@@ -114,6 +114,12 @@ def main() -> int:
         help="Pass --offline to pcb build.",
     )
     parser.add_argument(
+        "--suppress",
+        action="append",
+        default=[],
+        help="Pass -S/--suppress to pcb build (repeatable).",
+    )
+    parser.add_argument(
         "--warmup",
         type=int,
         default=3,
@@ -137,6 +143,8 @@ def main() -> int:
         build_flags.append("--locked")
     if args.offline:
         build_flags.append("--offline")
+    for kind in args.suppress:
+        build_flags.extend(["-S", kind])
 
     if args.warmup < 0:
         raise SystemExit("--warmup must be >= 0")

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -950,21 +950,20 @@ fn self_update() -> Result<()> {
     }
 
     let mut requests = BTreeSet::new();
-    let stable_result: Result<()> = (|| {
+    let stable_result: Result<Vec<(Version, Version, PathBuf)>> = (|| {
         let releases = fetch_release_versions(true)?;
+        let installed = installed_toolchains()?;
         let latest_toolchain = releases
             .iter()
             .filter(|version| version.pre.is_empty())
             .max()
             .ok_or_else(|| anyhow::anyhow!("no pcbc releases found"))?;
         requests.insert((latest_toolchain.major, latest_toolchain.minor));
-        for version in installed_toolchains()?
-            .keys()
-            .filter(|version| version.pre.is_empty())
-        {
+        for version in installed.keys().filter(|version| version.pre.is_empty()) {
             requests.insert((version.major, version.minor));
         }
 
+        let mut changelogs = Vec::new();
         for (major, minor) in requests {
             let request = ToolchainRequest::Lane { major, minor };
             let version = releases
@@ -974,15 +973,47 @@ fn self_update() -> Result<()> {
                 .ok_or_else(|| {
                     anyhow::anyhow!("no pcbc release found for `{}`", format_request(&request))
                 })?;
-            let _ = ensure_installed(version)?;
+            let previous = installed
+                .keys()
+                .filter(|installed| request_matches(&request, installed))
+                .max()
+                .cloned();
+            let binary = ensure_installed(version)?;
+            if let Some(previous) = previous
+                && previous < *version
+            {
+                changelogs.push((previous, version.clone(), binary));
+            }
         }
-        Ok(())
+        Ok(changelogs)
     })();
-    if let Err(err) = stable_result {
-        eprintln!(
+    match stable_result {
+        Ok(changelogs) => {
+            for (from, to, binary) in changelogs {
+                println!();
+                println!(
+                    "pcbc {} → {}",
+                    from.to_string().dimmed(),
+                    to.to_string().green()
+                );
+                let selector = format!("{from}..{to}");
+                match Command::new(binary).args(["changelog", &selector]).status() {
+                    Ok(status) if status.success() => {}
+                    Ok(status) => eprintln!(
+                        "{} failed to print pcbc changelog ({status})",
+                        "Warning:".yellow()
+                    ),
+                    Err(err) => eprintln!(
+                        "{} failed to print pcbc changelog ({err})",
+                        "Warning:".yellow()
+                    ),
+                }
+            }
+        }
+        Err(err) => eprintln!(
             "{} failed to update managed pcbc toolchains ({err})",
             "Warning:".yellow()
-        );
+        ),
     }
 
     if installed_nightly_toolchain()?.is_some()

--- a/test-workspaces/with-pcb-toml/boards/pcb.toml
+++ b/test-workspaces/with-pcb-toml/boards/pcb.toml
@@ -2,5 +2,5 @@
 name = "WorkspaceTestBoard"
 
 [dependencies]
-"github.com/diodeinc/kicad" = "0.2.1"
+"github.com/diodeinc/kicad" = "0.2.2"
 "gitlab.com/kicad/libraries/kicad-symbols" = "9.0.3"

--- a/test-workspaces/with-pcb-toml/pcb.sum
+++ b/test-workspaces/with-pcb-toml/pcb.sum
@@ -1,2 +1,2 @@
-github.com/diodeinc/kicad 0.2.1 h1:y9QxHY5SsxX1RUwQlOiKTq1RI0VsQl9h4TYNrOPJcDo=
-github.com/diodeinc/kicad 0.2.1/pcb.toml h1:OILEhMGY1WVUmwWhJbonaAiMmuvpmgMKzk7xry19VQo=
+github.com/diodeinc/kicad 0.2.2 h1:CulGAM4wTaW7BUS3gJvh/94Ep/s+G7AvauDGI6JNQpk=
+github.com/diodeinc/kicad 0.2.2/pcb.toml h1:OILEhMGY1WVUmwWhJbonaAiMmuvpmgMKzk7xry19VQo=


### PR DESCRIPTION
Also fix tests to use pcbc instead of pcb


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes GitHub Actions release publishing behavior and the binaries/workspaces used in E2E/perf pipelines, which can break releases or CI if tags/SSH access/workspace assumptions are wrong.
> 
> **Overview**
> **Release workflows now checkout the release tag in the `publish` job** (for both `pcb` and `pcbc`) before creating GitHub releases, ensuring metadata/files come from the tagged ref.
> 
> **CI is migrated from `pcb` to `pcbc`**: E2E runs `pcbc` for builds/import/layout and suppresses BOM where needed, and the performance workflow now benchmarks `pcbc` against base/head using three SSH-cloned internal workspaces and a looped runner.
> 
> The `bin/pcb-build-perf` helper gains repeatable `--suppress` support (forwarded as `-S` flags), and the test workspace bumps `github.com/diodeinc/kicad` from `0.2.1` to `0.2.2` (with updated `pcb.sum`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af543d57bc750a0c7af1748f02a1caf813e71545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->