### PR TITLE
gerberx2/write: normalize "-0" coordinate to "0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Gerber writer emitting invalid `"-0"` integer coordinates for small negative values that round to zero.
+
 ## [0.3.84] - 2026-05-21
 
 ### Added

--- a/crates/gerberx2/src/write.rs
+++ b/crates/gerberx2/src/write.rs
@@ -604,7 +604,8 @@ impl<'a> Writer<'a> {
             self.layer.coordinate_format.y_decimal_digits
         };
         let scale = 10_f64.powi(decimals as i32);
-        format!("{:.0}", value * scale)
+        let encoded = format!("{:.0}", value * scale);
+        if encoded == "-0" { "0".to_string() } else { encoded }
     }
 
     fn write_decimal(&mut self, value: f64) {

--- a/crates/gerberx2/src/write.rs
+++ b/crates/gerberx2/src/write.rs
@@ -605,7 +605,11 @@ impl<'a> Writer<'a> {
         };
         let scale = 10_f64.powi(decimals as i32);
         let encoded = format!("{:.0}", value * scale);
-        if encoded == "-0" { "0".to_string() } else { encoded }
+        if encoded == "-0" {
+            "0".to_string()
+        } else {
+            encoded
+        }
     }
 
     fn write_decimal(&mut self, value: f64) {

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -579,3 +579,32 @@ fn writes_polygon_hole_with_explicit_zero_rotation() {
 fn close(a: f64, b: f64) -> bool {
     (a - b).abs() <= 1e-9
 }
+
+#[test]
+fn coordinate_negative_zero_is_normalized_to_zero() {
+    let layer = GerberLayer {
+        apertures: vec![WriterAperture {
+            code: 10,
+            template: WriterApertureTemplate::Circle {
+                diameter: 0.1,
+                hole_diameter: None,
+            },
+            attributes: vec![],
+        }],
+        objects: vec![WriterObject::dark(ObjectKind::Flash {
+            at: Point { x: 0.0, y: -1e-8 },
+            aperture: 10,
+        })],
+        ..GerberLayer::default()
+    };
+
+    let output = gerberx2::write_layer(&layer).unwrap();
+    assert!(
+        !output.contains("Y-0"),
+        "writer emitted \"-0\" coordinate which is not a valid Gerber integer:\n{output}"
+    );
+    assert!(
+        output.contains("Y0"),
+        "writer did not emit a Y0 coordinate:\n{output}"
+    );
+}


### PR DESCRIPTION
## What

`coordinate()` in `write.rs` uses `format!("{:.0}", value * scale)` to
encode floating-point coordinates as Gerber integers. For small negative
values whose magnitude rounds to zero (range `(-0.5/scale, 0)`), Rust's
formatter produces the string `"-0"` rather than `"0"`.

## Why it matters

`"-0"` is not a valid integer in the Gerber X2 spec (§4.5). Third-party
EDA tools that parse Gerber files strictly — including some KiCad legacy
readers and Altium — reject it as a malformed coordinate field, corrupting
any layer that contains a coordinate in that range.

The sister function `trim_decimal()` in the same file already guards
against this case explicitly. `coordinate()` was missing the same guard.

## Fix

After formatting, check if the result is `"-0"` and return `"0"` instead:

```rust
let encoded = format!("{:.0}", value * scale);
if encoded == "-0" { "0".to_string() } else { encoded }
```

## Test

Added `coordinate_negative_zero_is_normalized_to_zero` in
`crates/gerberx2/tests/basic.rs`. It writes a `Flash` at
`y = -1e-8` mm (which hits the trap zone with the default 6-decimal-digit
format) and asserts the output contains `Y0` and not `Y-0`. This test
fails on the unfixed code and passes after the fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized formatting change in the Gerber writer plus a regression test; impact is limited to edge-case coordinate encoding.
> 
> **Overview**
> Prevents the Gerber X2 writer from emitting invalid `"-0"` integer coordinates by normalizing that formatted output to `"0"` in `coordinate()`.
> 
> Adds a regression test asserting the writer output contains `Y0` (not `Y-0`) for tiny negative coordinates, and documents the fix in the `CHANGELOG` under *Unreleased*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7312140c5d489df83e7fbe7447cceeaa443e9fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->