### PR TITLE
Add Wurth 1210 power inductor house parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added Würth Elektronik WE-PMFI 1210 power inductors to stdlib house BOM matching.
+
 ## [0.3.84] - 2026-05-21
 
 ### Added

--- a/stdlib/bom/match_generics.zen
+++ b/stdlib/bom/match_generics.zen
@@ -470,6 +470,49 @@ HOUSE_POWER_INDUCTORS_BY_PKG = {
             "https://www.we-online.com/components/products/datasheet/74479777310.pdf",
         ),
     ],
+    "1210": [
+        # Würth Elektronik WE-PMFI, 1210 (3225 Metric), shielded molded power inductors.
+        power_inductor(
+            "100nH 30%",
+            "11.4A",
+            "9mOhm",
+            "74479332257110",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479332257110.pdf",
+        ),
+        power_inductor(
+            "470nH 20%",
+            "7.9A",
+            "19mOhm",
+            "74479332257147",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479332257147.pdf",
+        ),
+        power_inductor(
+            "1uH 20%",
+            "5.8A",
+            "30mOhm",
+            "74479332257210",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479332257210.pdf",
+        ),
+        power_inductor(
+            "2.2uH 20%",
+            "4.1A",
+            "67mOhm",
+            "74479332257222",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479332257222.pdf",
+        ),
+        power_inductor(
+            "4.7uH 20%",
+            "2.7A",
+            "130mOhm",
+            "74479332257247",
+            "Würth Elektronik",
+            "https://www.we-online.com/components/products/datasheet/74479332257247.pdf",
+        ),
+    ],
 }
 
 # House crystal catalog by package


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely adds new house-part entries for BOM matching plus a changelog note, with no logic changes.
> 
> **Overview**
> Adds **stdlib house BOM matching** coverage for Würth Elektronik WE-PMFI *1210 (3225)* shielded molded power inductors by introducing a new `HOUSE_POWER_INDUCTORS_BY_PKG["1210"]` ladder with several inductance/current/DCR options.
> 
> Updates `CHANGELOG.md` under *Unreleased* to document the new 1210 inductor matching support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba472e0648262ad689d5496fb415d6d04ac31cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->