### PR TITLE
Use smaller Ubicloud runners

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build_perf:
     name: pcb build performance
-    runs-on: ubicloud-standard-16-ubuntu-2404
+    runs-on: ubicloud-standard-16
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
           - name: macOS
             runs-on: macos-15-xlarge
           - name: Ubuntu
-            runs-on: ubicloud-standard-30-ubuntu-2204
+            runs-on: ubicloud-standard-16
             container:
               image: ghcr.io/diodeinc/kicad:10.0.0
               options: --user root

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-16
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
@@ -76,9 +76,9 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
-            runner: ubicloud-standard-30-arm-ubuntu-2204
+            runner: ubicloud-standard-16-arm
           - target: x86_64-unknown-linux-gnu
-            runner: ubicloud-standard-30-ubuntu-2204
+            runner: ubicloud-standard-16
           - target: x86_64-pc-windows-msvc
             runner: diode-windows
     runs-on: ${{ matrix.runner }}
@@ -133,7 +133,7 @@ jobs:
     needs:
       - prepare
       - build
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-16
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-16
     outputs:
       should_build: ${{ steps.nightly.outputs.should_build }}
       sha: ${{ steps.nightly.outputs.sha }}
@@ -74,9 +74,9 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
-            runner: ubicloud-standard-30-arm-ubuntu-2204
+            runner: ubicloud-standard-16-arm
           - target: x86_64-unknown-linux-gnu
-            runner: ubicloud-standard-30-ubuntu-2204
+            runner: ubicloud-standard-16
           - target: x86_64-pc-windows-msvc
             runner: diode-windows
     runs-on: ${{ matrix.runner }}
@@ -132,7 +132,7 @@ jobs:
       - prepare
       - build
     if: needs.prepare.outputs.should_build == 'true'
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-16
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-16
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
@@ -76,9 +76,9 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
-            runner: ubicloud-standard-30-arm-ubuntu-2204
+            runner: ubicloud-standard-16-arm
           - target: x86_64-unknown-linux-gnu
-            runner: ubicloud-standard-30-ubuntu-2204
+            runner: ubicloud-standard-16
           - target: x86_64-pc-windows-msvc
             runner: diode-windows
     runs-on: ${{ matrix.runner }}
@@ -133,7 +133,7 @@ jobs:
     needs:
       - prepare
       - build
-    runs-on: ubicloud-standard-30-ubuntu-2204
+    runs-on: ubicloud-standard-16
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   lint:
     name: Lint and Check
-    runs-on: ubicloud-standard-16-ubuntu-2404
+    runs-on: ubicloud-standard-16
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
@@ -62,7 +62,7 @@ jobs:
           - name: macOS
             runs-on: macos-15-xlarge
           - name: Ubuntu
-            runs-on: ubicloud-standard-30-ubuntu-2204
+            runs-on: ubicloud-standard-16
             container:
               image: ghcr.io/diodeinc/kicad:10.0.0  # Keep in sync with KICAD_VERSION
               options: --user root


### PR DESCRIPTION
The larger Ubicloud runners can take longer to provision during peak hours, and these jobs do not need 30 cores. Use standard-16 runners for Linux CI. And standardize on Ubuntu 24.04.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI-only change that swaps Linux runner types; main risk is unexpected performance/resource constraints or subtle environment differences from removing pinned Ubuntu runner labels.
> 
> **Overview**
> Updates GitHub Actions workflows to run Linux CI, E2E, build-performance, and release/nightly jobs on smaller Ubicloud runners (`ubicloud-standard-16` and `ubicloud-standard-16-arm`) instead of the previous `standard-30`/Ubuntu-version-pinned runners.
> 
> This is a runner-sizing/provisioning change only; job steps and release logic are otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ef6ffab13070de2bd3c463afb8dac76e495eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->