### PR TITLE
Add zstd, better install message

### DIFF
--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -11,13 +11,13 @@ on:
         required: true
         type: string
       dry_run:
-        description: 'Build artifacts without publishing to S3 or GitHub Releases'
+        description: 'Build artifacts without publishing to S3'
         required: false
         type: boolean
         default: false
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
@@ -171,19 +171,3 @@ jobs:
           aws s3 cp pcb-latest.json "s3://diode-pcb-releases/pcb/pcb-latest.json" \
             --cache-control "public, max-age=60" \
             --content-type "application/json"
-
-      - name: Create GitHub release
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          prerelease_flag=""
-          if [ "${{ needs.prepare.outputs.prerelease }}" = "true" ]; then
-            prerelease_flag="--prerelease"
-          fi
-          gh release create "${{ needs.prepare.outputs.tag }}" \
-            --verify-tag \
-            $prerelease_flag \
-            --title "${{ needs.prepare.outputs.tag }}" \
-            --notes "Release ${{ needs.prepare.outputs.tag }}" \
-            artifacts/*

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -100,6 +100,26 @@ jobs:
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 
+      - name: Install zstd
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v zstd >/dev/null; then
+            exit 0
+          fi
+          case "${{ runner.os }}" in
+            Linux)
+              sudo apt-get update
+              sudo apt-get install -y zstd
+              ;;
+            macOS)
+              brew install zstd
+              ;;
+            Windows)
+              choco install zstandard -y
+              ;;
+          esac
+
       - name: Build
         run: cargo build --profile dist -p pcb --bin pcb --target ${{ matrix.target }}
 
@@ -117,6 +137,7 @@ jobs:
             artifact="$artifact.exe"
           fi
           cp "target/$TARGET/dist/$exe" "artifacts/$artifact"
+          zstd -q -f -3 "artifacts/$artifact" -o "artifacts/$artifact.zst"
           if command -v shasum >/dev/null; then
             shasum -a 256 "artifacts/$artifact" > "artifacts/$artifact.sha256"
           else

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -192,6 +192,6 @@ jobs:
           gh release create "${{ needs.prepare.outputs.tag }}" \
             --verify-tag \
             $prerelease_flag \
-            --title "${{ needs.prepare.outputs.tag }}" \
+            --title "${{ needs.prepare.outputs.version }} - $(date -u +%Y-%m-%d)" \
             --notes "Release ${{ needs.prepare.outputs.tag }}" \
             artifacts/*

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -100,6 +100,26 @@ jobs:
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 
+      - name: Install zstd
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v zstd >/dev/null; then
+            exit 0
+          fi
+          case "${{ runner.os }}" in
+            Linux)
+              sudo apt-get update
+              sudo apt-get install -y zstd
+              ;;
+            macOS)
+              brew install zstd
+              ;;
+            Windows)
+              choco install zstandard -y
+              ;;
+          esac
+
       - name: Build
         run: cargo build --profile dist -p pcbc --bin pcbc --target ${{ matrix.target }}
 
@@ -117,6 +137,7 @@ jobs:
             artifact="$artifact.exe"
           fi
           cp "target/$TARGET/dist/$exe" "artifacts/$artifact"
+          zstd -q -f -3 "artifacts/$artifact" -o "artifacts/$artifact.zst"
           if command -v shasum >/dev/null; then
             shasum -a 256 "artifacts/$artifact" > "artifacts/$artifact.sha256"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Added Würth Elektronik WE-PMFI 1210 power inductors to stdlib house BOM matching.
 
-### Changed
-
-- Removed the shim version from installer success messages.
-
 ## [0.3.84] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Added Würth Elektronik WE-PMFI 1210 power inductors to stdlib house BOM matching.
 
+### Changed
+
+- Removed the shim version from installer success messages.
+
 ## [0.3.84] - 2026-05-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,12 +4458,11 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pcb"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs",
  "fslock",
- "mimalloc",
  "self-replace",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1686,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,6 +2278,21 @@ dependencies = [
  "tinyvec",
  "ttf-parser",
 ]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3934,6 +3965,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "natord"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,10 +4294,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -4881,6 +4966,15 @@ dependencies = [
  "walkdir",
  "zip 8.5.1",
  "zstd",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -6203,9 +6297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -7883,13 +7975,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
+ "der",
  "log",
+ "native-tls",
  "percent-encoding",
- "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-root-certs",
 ]
 
 [[package]]
@@ -8204,15 +8297,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,12 +4376,9 @@ name = "pcb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
- "colored",
  "dirs",
  "fslock",
  "mimalloc",
- "reqwest",
  "self-replace",
  "semver",
  "serde",
@@ -4389,6 +4386,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "toml",
+ "ureq",
  "zip 8.5.1",
 ]
 
@@ -6205,7 +6203,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -7877,6 +7877,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d87ccb81b1e9ddc119871ecbd40a5e93f173f0777838db1e8c0dec223ae3c49"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7922,6 +7950,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -8170,6 +8204,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4473,6 +4473,7 @@ dependencies = [
  "toml",
  "ureq",
  "zip 8.5.1",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ pathdiff = "0.2"
 petgraph = "0.8"
 rayon = "1.10"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "http2", "json", "multipart", "rustls", "system-proxy"] }
-ureq = { version = "3", default-features = false, features = ["rustls"] }
+ureq = { version = "3", default-features = false, features = ["native-tls"] }
 rand = "0.8"
 serde-wasm-bindgen = "0.6"
 serde_yaml = "0.9"
@@ -163,3 +163,4 @@ inherits = "release"
 lto = "fat"           # Maximum link-time optimization
 codegen-units = 1     # Better optimization
 strip = "symbols"     # Strip symbols from published binaries
+panic = "abort"       # Published binaries should not carry unwinding machinery.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ pathdiff = "0.2"
 petgraph = "0.8"
 rayon = "1.10"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "http2", "json", "multipart", "rustls", "system-proxy"] }
+ureq = { version = "3", default-features = false, features = ["rustls"] }
 rand = "0.8"
 serde-wasm-bindgen = "0.6"
 serde_yaml = "0.9"
@@ -161,4 +162,4 @@ tracing-chrome = "0.7"
 inherits = "release"
 lto = "fat"           # Maximum link-time optimization
 codegen-units = 1     # Better optimization
-strip = "debuginfo"   # Strip debug symbols
+strip = "symbols"     # Strip symbols from published binaries

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -1,16 +1,12 @@
 [package]
 name = "pcb"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 repository = { workspace = true }
 description = "PCB toolchain shim and version manager"
 homepage = { workspace = true }
 authors = { workspace = true }
 default-run = "pcb"
-
-[features]
-default = []
-mimalloc = ["dep:mimalloc"]
 
 [package.metadata.wix]
 upgrade-guid = "8F8B3FF2-0D55-454F-B80D-1E216FCA6C42"
@@ -26,7 +22,6 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 dirs = { workspace = true }
 fslock = { workspace = true }
-mimalloc = { workspace = true, optional = true }
 self-replace = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -36,3 +36,4 @@ tempfile = { workspace = true }
 toml = { workspace = true }
 ureq = { workspace = true }
 zip = { workspace = true }
+zstd = { workspace = true }

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -9,7 +9,7 @@ authors = { workspace = true }
 default-run = "pcb"
 
 [features]
-default = ["mimalloc"]
+default = []
 mimalloc = ["dep:mimalloc"]
 
 [package.metadata.wix]
@@ -24,12 +24,9 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true }
-colored = { workspace = true }
 dirs = { workspace = true }
 fslock = { workspace = true }
 mimalloc = { workspace = true, optional = true }
-reqwest = { workspace = true }
 self-replace = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
@@ -37,4 +34,5 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
+ureq = { workspace = true }
 zip = { workspace = true }

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -1,7 +1,3 @@
-#[cfg(all(feature = "mimalloc", not(target_family = "wasm")))]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use anyhow::{Context, Result};
 use semver::Version;
 use serde::{Deserialize, Serialize};

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -730,6 +730,11 @@ fn read_download_bytes(body: &mut ureq::Body) -> Result<Vec<u8>> {
 
 fn http_client(timeout: Duration) -> Result<ureq::Agent> {
     Ok(ureq::Agent::config_builder()
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .provider(ureq::tls::TlsProvider::NativeTls)
+                .build(),
+        )
         .timeout_global(Some(timeout))
         .build()
         .into())

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fs;
+use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -553,7 +554,7 @@ fn install_nightly(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)
 
     let name = binary_artifact_name("pcbc");
     let url = format!("{}/{}", release.base_url.trim_end_matches('/'), name);
-    let bytes = download_text_bytes(&http_client(ARCHIVE_TIMEOUT)?, &url)?;
+    let bytes = download_artifact_bytes(&http_client(ARCHIVE_TIMEOUT)?, &url)?;
     let actual_sha256 = verify_checksum(&url, &bytes)?;
 
     fs::create_dir_all(downloads_dir())?;
@@ -675,7 +676,7 @@ fn download_toolchain(version: &Version) -> Result<Download> {
     for binary in ["pcbc", "pcb"] {
         let name = binary_artifact_name(binary);
         let url = format!("{RELEASE_BASE_URL}/v{version}/{name}");
-        if let Some(bytes) = download_optional(&client, &url)? {
+        if let Some(bytes) = download_optional_artifact(&client, &url)? {
             return Ok(Download {
                 name,
                 url,
@@ -713,19 +714,35 @@ fn download_optional(client: &ureq::Agent, url: &str) -> Result<Option<Vec<u8>>>
     }
 }
 
-fn download_text_bytes(client: &ureq::Agent, url: &str) -> Result<Vec<u8>> {
-    Ok(client
-        .get(url)
-        .header("User-Agent", USER_AGENT)
-        .call()?
-        .body_mut()
-        .with_config()
-        .limit(MAX_DOWNLOAD_BYTES)
-        .read_to_vec()?)
+fn download_optional_artifact(client: &ureq::Agent, url: &str) -> Result<Option<Vec<u8>>> {
+    let compressed_url = format!("{url}.zst");
+    if let Some(compressed) = download_optional(client, &compressed_url)? {
+        return Ok(Some(decompress_zstd(&compressed_url, compressed)?));
+    }
+    download_optional(client, url)
+}
+
+fn download_artifact_bytes(client: &ureq::Agent, url: &str) -> Result<Vec<u8>> {
+    download_optional_artifact(client, url)?.ok_or_else(|| anyhow::anyhow!("not found: {url}"))
 }
 
 fn read_download_bytes(body: &mut ureq::Body) -> Result<Vec<u8>> {
     Ok(body.with_config().limit(MAX_DOWNLOAD_BYTES).read_to_vec()?)
+}
+
+fn decompress_zstd(url: &str, bytes: Vec<u8>) -> Result<Vec<u8>> {
+    let decoder = zstd::stream::read::Decoder::new(Cursor::new(bytes))
+        .with_context(|| format!("failed to decompress {url}"))?;
+    let mut limited = decoder.take(MAX_DOWNLOAD_BYTES + 1);
+    let mut decompressed = Vec::new();
+    limited
+        .read_to_end(&mut decompressed)
+        .with_context(|| format!("failed to decompress {url}"))?;
+    anyhow::ensure!(
+        decompressed.len() <= MAX_DOWNLOAD_BYTES as usize,
+        "decompressed artifact exceeds maximum size: {url}"
+    );
+    Ok(decompressed)
 }
 
 fn http_client(timeout: Duration) -> Result<ureq::Agent> {
@@ -1018,7 +1035,7 @@ fn install_shim_update(latest: &LatestRelease) -> Result<()> {
     let temp = tempfile::tempdir()?;
     let binary_name = binary_artifact_name("pcb");
     let binary_url = format!("{RELEASE_BASE_URL}/{}/{}", latest.tag, binary_name);
-    let bytes = download_text_bytes(&client, &binary_url)?;
+    let bytes = download_artifact_bytes(&client, &binary_url)?;
     verify_checksum(&binary_url, &bytes)?;
     let binary = temp.path().join(legacy_pcb_binary_name());
     fs::write(&binary, bytes)?;

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -3,8 +3,6 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
-use colored::Colorize;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -22,59 +20,16 @@ const NIGHTLY_LATEST_RELEASE_URL: &str = "https://pcb.api.diode.computer/pcb/nig
 const USER_AGENT: &str = "pcb";
 const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 const ARCHIVE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const MAX_DOWNLOAD_BYTES: u64 = 512 * 1024 * 1024;
 const RELEASE_LIST_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const STANDALONE_INSTALL_REQUIRED: &str = "Self-update is only available for pcb installed via the standalone installer.\nIf you installed pcb via a package manager, please update using that tool.";
 
-#[derive(Parser)]
-#[command(name = "pcb")]
-#[command(about = "PCB toolchain shim and version manager", long_about = None)]
-#[command(version)]
-struct ShimCli {
-    #[command(subcommand)]
-    command: ShimCommands,
-}
-
-#[derive(Subcommand)]
-enum ShimCommands {
-    /// Update the pcb shim and managed pcbc toolchains
-    #[command(name = "self")]
-    SelfUpdate(SelfUpdateArgs),
-
-    /// Manage installed pcbc toolchains
-    Toolchain(ToolchainArgs),
-}
-
-#[derive(Parser)]
-struct SelfUpdateArgs {
-    #[command(subcommand)]
-    command: SelfUpdateCommands,
-}
-
-#[derive(Subcommand)]
-enum SelfUpdateCommands {
-    /// Update the pcb shim and managed pcbc toolchains
-    Update,
-}
-
-#[derive(Parser)]
-struct ToolchainArgs {
-    #[command(subcommand)]
-    command: ToolchainCommands,
-}
-
-#[derive(Subcommand)]
-enum ToolchainCommands {
-    /// List installed pcbc toolchains
-    List,
-
-    /// Show the active pcbc toolchain for the current directory
-    Show,
-
-    /// Install a pcbc toolchain request such as 0.3, 0.3.83, latest, or nightly
-    Install { request: String },
-
-    /// Uninstall an exact pcbc toolchain version such as 0.3.83, or nightly
-    Uninstall { version: String },
+enum ShimCommand {
+    SelfUpdate,
+    ToolchainList,
+    ToolchainShow,
+    ToolchainInstall(String),
+    ToolchainUninstall(String),
 }
 
 #[derive(Debug, Clone)]
@@ -150,7 +105,7 @@ struct Download {
 
 fn main() {
     if let Err(e) = run() {
-        eprintln!("{} {e}", "Error:".red());
+        eprintln!("Error: {e}");
         for cause in e.chain().skip(1) {
             eprintln!("  {cause}");
         }
@@ -162,8 +117,7 @@ fn run() -> Result<()> {
     let mut args: Vec<OsString> = std::env::args_os().skip(1).collect();
 
     if is_shim_command(&args) {
-        let cli = ShimCli::parse_from(std::iter::once(OsString::from("pcb")).chain(args));
-        return execute_shim(cli);
+        return execute_shim(parse_shim_command(&args)?);
     }
 
     let override_request = take_cli_override(&mut args)?;
@@ -185,17 +139,48 @@ fn is_shim_command(args: &[OsString]) -> bool {
     )
 }
 
-fn execute_shim(cli: ShimCli) -> Result<()> {
-    match cli.command {
-        ShimCommands::SelfUpdate(args) => match args.command {
-            SelfUpdateCommands::Update => self_update(),
-        },
-        ShimCommands::Toolchain(args) => match args.command {
-            ToolchainCommands::List => toolchain_list(),
-            ToolchainCommands::Show => toolchain_show(),
-            ToolchainCommands::Install { request } => toolchain_install(&request),
-            ToolchainCommands::Uninstall { version } => toolchain_uninstall(&version),
-        },
+fn parse_shim_command(args: &[OsString]) -> Result<ShimCommand> {
+    let strings: Vec<&str> = args
+        .iter()
+        .map(|arg| {
+            arg.to_str()
+                .ok_or_else(|| anyhow::anyhow!("shim commands must be valid UTF-8"))
+        })
+        .collect::<Result<_>>()?;
+
+    match strings.as_slice() {
+        ["self", "update"] => Ok(ShimCommand::SelfUpdate),
+        ["toolchain", "list"] => Ok(ShimCommand::ToolchainList),
+        ["toolchain", "show"] => Ok(ShimCommand::ToolchainShow),
+        ["toolchain", "install", request] => Ok(ShimCommand::ToolchainInstall((*request).into())),
+        ["toolchain", "uninstall", version] => {
+            Ok(ShimCommand::ToolchainUninstall((*version).into()))
+        }
+        ["self", "--help" | "-h" | "help"] => {
+            println!("Usage: pcb self update");
+            std::process::exit(0);
+        }
+        ["toolchain", "--help" | "-h" | "help"] => {
+            println!(
+                "Usage:\n  pcb toolchain list\n  pcb toolchain show\n  pcb toolchain install <request>\n  pcb toolchain uninstall <version>"
+            );
+            std::process::exit(0);
+        }
+        ["self", ..] => anyhow::bail!("usage: pcb self update"),
+        ["toolchain", ..] => {
+            anyhow::bail!("usage: pcb toolchain <list|show|install|uninstall> [request|version]")
+        }
+        _ => anyhow::bail!("unknown shim command"),
+    }
+}
+
+fn execute_shim(command: ShimCommand) -> Result<()> {
+    match command {
+        ShimCommand::SelfUpdate => self_update(),
+        ShimCommand::ToolchainList => toolchain_list(),
+        ShimCommand::ToolchainShow => toolchain_show(),
+        ShimCommand::ToolchainInstall(request) => toolchain_install(&request),
+        ShimCommand::ToolchainUninstall(version) => toolchain_uninstall(&version),
     }
 }
 
@@ -297,8 +282,7 @@ fn resolve_request(
             Err(remote_error) => {
                 if let Some(local) = best_local_toolchain(request)? {
                     eprintln!(
-                        "{} failed to check latest release ({remote_error}); using installed pcbc {}",
-                        "Warning:".yellow(),
+                        "Warning: failed to check latest release ({remote_error}); using installed pcbc {}",
                         local.0
                     );
                     return Ok(ResolvedToolchain {
@@ -339,8 +323,7 @@ fn resolve_nightly(reason: String) -> Result<ResolvedToolchain> {
         Err(remote_error) => {
             if let Some((receipt, binary)) = installed_nightly_toolchain()? {
                 eprintln!(
-                    "{} failed to check nightly release ({remote_error}); using installed pcbc nightly {} ({})",
-                    "Warning:".yellow(),
+                    "Warning: failed to check nightly release ({remote_error}); using installed pcbc nightly {} ({})",
                     receipt.date,
                     short_sha(&receipt.sha)
                 );
@@ -428,14 +411,7 @@ fn fetch_release_versions(force_refresh: bool) -> Result<Vec<Version>> {
         "{RELEASE_LIST_URL}?list-type=2&prefix=pcb/&delimiter=/&_pcb_cache_bust={}",
         unix_timestamp()
     );
-    let body = reqwest::blocking::Client::builder()
-        .timeout(METADATA_TIMEOUT)
-        .build()?
-        .get(url)
-        .header(reqwest::header::USER_AGENT, USER_AGENT)
-        .send()?
-        .error_for_status()?
-        .text()?;
+    let body = download_text(&http_client(METADATA_TIMEOUT)?, &url)?;
 
     let versions = parse_release_versions(&body);
     write_release_cache(&versions)?;
@@ -729,31 +705,34 @@ fn download_toolchain(version: &Version) -> Result<Download> {
     )
 }
 
-fn download_optional(client: &reqwest::blocking::Client, url: &str) -> Result<Option<Vec<u8>>> {
-    let response = client
-        .get(url)
-        .header(reqwest::header::USER_AGENT, USER_AGENT)
-        .send()?;
-    if response.status() == reqwest::StatusCode::NOT_FOUND {
-        return Ok(None);
+fn download_optional(client: &ureq::Agent, url: &str) -> Result<Option<Vec<u8>>> {
+    match client.get(url).header("User-Agent", USER_AGENT).call() {
+        Ok(mut response) => Ok(Some(read_download_bytes(response.body_mut())?)),
+        Err(ureq::Error::StatusCode(404)) => Ok(None),
+        Err(err) => Err(err.into()),
     }
-    Ok(Some(response.error_for_status()?.bytes()?.to_vec()))
 }
 
-fn download_text_bytes(client: &reqwest::blocking::Client, url: &str) -> Result<Vec<u8>> {
+fn download_text_bytes(client: &ureq::Agent, url: &str) -> Result<Vec<u8>> {
     Ok(client
         .get(url)
-        .header(reqwest::header::USER_AGENT, USER_AGENT)
-        .send()?
-        .error_for_status()?
-        .bytes()?
-        .to_vec())
+        .header("User-Agent", USER_AGENT)
+        .call()?
+        .body_mut()
+        .with_config()
+        .limit(MAX_DOWNLOAD_BYTES)
+        .read_to_vec()?)
 }
 
-fn http_client(timeout: Duration) -> Result<reqwest::blocking::Client> {
-    Ok(reqwest::blocking::Client::builder()
-        .timeout(timeout)
-        .build()?)
+fn read_download_bytes(body: &mut ureq::Body) -> Result<Vec<u8>> {
+    Ok(body.with_config().limit(MAX_DOWNLOAD_BYTES).read_to_vec()?)
+}
+
+fn http_client(timeout: Duration) -> Result<ureq::Agent> {
+    Ok(ureq::Agent::config_builder()
+        .timeout_global(Some(timeout))
+        .build()
+        .into())
 }
 
 fn verify_checksum(url: &str, bytes: &[u8]) -> Result<String> {
@@ -767,13 +746,13 @@ fn verify_checksum(url: &str, bytes: &[u8]) -> Result<String> {
     Ok(actual_sha256)
 }
 
-fn download_text(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
+fn download_text(client: &ureq::Agent, url: &str) -> Result<String> {
     Ok(client
         .get(url)
-        .header(reqwest::header::USER_AGENT, USER_AGENT)
-        .send()?
-        .error_for_status()?
-        .text()?)
+        .header("User-Agent", USER_AGENT)
+        .call()?
+        .body_mut()
+        .read_to_string()?)
 }
 
 fn parse_sha256(content: &str) -> Result<String> {
@@ -944,8 +923,7 @@ fn self_update() -> Result<()> {
         }
         Ok(_) => {}
         Err(err) => eprintln!(
-            "{} failed to check latest pcb shim release ({err}); continuing with pcbc updates",
-            "Warning:".yellow()
+            "Warning: failed to check latest pcb shim release ({err}); continuing with pcbc updates"
         ),
     }
 
@@ -991,47 +969,27 @@ fn self_update() -> Result<()> {
         Ok(changelogs) => {
             for (from, to, binary) in changelogs {
                 println!();
-                println!(
-                    "pcbc {} → {}",
-                    from.to_string().dimmed(),
-                    to.to_string().green()
-                );
+                println!("pcbc {from} → {to}");
                 let selector = format!("{from}..{to}");
                 match Command::new(binary).args(["changelog", &selector]).status() {
                     Ok(status) if status.success() => {}
-                    Ok(status) => eprintln!(
-                        "{} failed to print pcbc changelog ({status})",
-                        "Warning:".yellow()
-                    ),
-                    Err(err) => eprintln!(
-                        "{} failed to print pcbc changelog ({err})",
-                        "Warning:".yellow()
-                    ),
+                    Ok(status) => eprintln!("Warning: failed to print pcbc changelog ({status})"),
+                    Err(err) => eprintln!("Warning: failed to print pcbc changelog ({err})"),
                 }
             }
         }
-        Err(err) => eprintln!(
-            "{} failed to update managed pcbc toolchains ({err})",
-            "Warning:".yellow()
-        ),
+        Err(err) => eprintln!("Warning: failed to update managed pcbc toolchains ({err})"),
     }
 
     if installed_nightly_toolchain()?.is_some()
         && let Err(err) =
             fetch_nightly_release().and_then(|nightly| ensure_nightly_installed(&nightly))
     {
-        eprintln!(
-            "{} failed to update installed nightly toolchain ({err})",
-            "Warning:".yellow()
-        );
+        eprintln!("Warning: failed to update installed nightly toolchain ({err})");
     }
 
     if let Some(version) = updated_shim {
-        println!(
-            "Updated pcb {} → {}",
-            current_version.to_string().dimmed(),
-            version.to_string().green()
-        );
+        println!("Updated pcb {current_version} → {version}");
     } else {
         println!("pcb is already up to date; pcbc toolchains checked.");
     }
@@ -1039,25 +997,13 @@ fn self_update() -> Result<()> {
 }
 
 fn fetch_latest_release() -> Result<LatestRelease> {
-    Ok(reqwest::blocking::Client::builder()
-        .timeout(METADATA_TIMEOUT)
-        .build()?
-        .get(SHIM_LATEST_RELEASE_URL)
-        .header(reqwest::header::USER_AGENT, USER_AGENT)
-        .send()?
-        .error_for_status()?
-        .json()?)
+    let content = download_text(&http_client(METADATA_TIMEOUT)?, SHIM_LATEST_RELEASE_URL)?;
+    Ok(serde_json::from_str(&content)?)
 }
 
 fn fetch_nightly_release() -> Result<NightlyRelease> {
-    Ok(reqwest::blocking::Client::builder()
-        .timeout(METADATA_TIMEOUT)
-        .build()?
-        .get(NIGHTLY_LATEST_RELEASE_URL)
-        .header(reqwest::header::USER_AGENT, USER_AGENT)
-        .send()?
-        .error_for_status()?
-        .json()?)
+    let content = download_text(&http_client(METADATA_TIMEOUT)?, NIGHTLY_LATEST_RELEASE_URL)?;
+    Ok(serde_json::from_str(&content)?)
 }
 
 fn install_shim_update(latest: &LatestRelease) -> Result<()> {
@@ -1067,13 +1013,7 @@ fn install_shim_update(latest: &LatestRelease) -> Result<()> {
     let temp = tempfile::tempdir()?;
     let binary_name = binary_artifact_name("pcb");
     let binary_url = format!("{RELEASE_BASE_URL}/{}/{}", latest.tag, binary_name);
-    let bytes = client
-        .get(&binary_url)
-        .header(reqwest::header::USER_AGENT, USER_AGENT)
-        .send()?
-        .error_for_status()?
-        .bytes()?
-        .to_vec();
+    let bytes = download_text_bytes(&client, &binary_url)?;
     verify_checksum(&binary_url, &bytes)?;
     let binary = temp.path().join(legacy_pcb_binary_name());
     fs::write(&binary, bytes)?;

--- a/install.ps1
+++ b/install.ps1
@@ -39,9 +39,24 @@ $tmp = New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) 
 try {
     $binary = Join-Path $tmp "pcb.exe"
     $sum = Join-Path $tmp "pcb.exe.sha256"
-
-    Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact" -OutFile $binary
     Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact.sha256" -OutFile $sum
+    $zstd = Get-Command zstd -ErrorAction SilentlyContinue
+    $downloadedCompressed = $false
+    if ($zstd) {
+        $compressedPath = Join-Path $tmp "pcb.exe.zst"
+        try {
+            Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact.zst" -OutFile $compressedPath
+            $downloadedCompressed = $true
+        } catch {
+            $downloadedCompressed = $false
+        }
+    }
+
+    if ($downloadedCompressed) {
+        & $zstd.Source -q -d -f $compressedPath -o $binary
+    } else {
+        Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact" -OutFile $binary
+    }
 
     $expected = ((Get-Content $sum -Raw) -split "\s+")[0].ToLowerInvariant()
     $actual = (Get-FileHash -Algorithm SHA256 $binary).Hash.ToLowerInvariant()

--- a/install.ps1
+++ b/install.ps1
@@ -59,7 +59,7 @@ try {
 
     Add-InstallDirToPath $installDir
 
-    Write-Host "Installed pcb $($latest.version) to $(Join-Path $installDir "pcb.exe")"
+    Write-Host "Installed pcb to $(Join-Path $installDir "pcb.exe")"
 } finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
 }

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,6 @@ EOF
 
 json="$(curl -fsSL "$base_url/pcb-latest.json")"
 tag="$(printf '%s' "$json" | sed -n 's/.*"tag"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
-version="$(printf '%s' "$json" | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
 [ -n "$tag" ] || { echo "could not read latest pcb release" >&2; exit 1; }
 
 artifact="pcb-$target"
@@ -78,4 +77,4 @@ printf '{"install_prefix":"%s"}\n' "$json_install_dir" > "$config_dir/pcb-receip
 
 add_install_dir_to_path
 
-echo "Installed pcb ${version:-$tag} to $install_dir/pcb"
+echo "Installed pcb to $install_dir/pcb"

--- a/install.sh
+++ b/install.sh
@@ -53,8 +53,14 @@ artifact="pcb-$target"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-curl -fsSL "$base_url/$tag/$artifact" -o "$tmp/pcb"
 curl -fsSL "$base_url/$tag/$artifact.sha256" -o "$tmp/pcb.sha256"
+if command -v zstd >/dev/null \
+  && curl -fsSL "$base_url/$tag/$artifact.zst" -o "$tmp/pcb.zst" 2>/dev/null; then
+  zstd -q -d -f "$tmp/pcb.zst" -o "$tmp/pcb"
+else
+  curl -fsSL "$base_url/$tag/$artifact" -o "$tmp/pcb"
+fi
+
 expected="$(sed 's/[[:space:]].*//' "$tmp/pcb.sha256")"
 if command -v shasum >/dev/null; then
   actual="$(shasum -a 256 "$tmp/pcb" | sed 's/[[:space:]].*//')"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release artifact format and the shim’s download/update path (switching HTTP client and adding zstd decompression/size limits), which could break installs or self-updates if misconfigured.
> 
> **Overview**
> **Adds zstd-compressed release artifacts** for both `pcb` and `pcbc` builds (CI installs `zstd`, generates `*.zst` alongside binaries, and uploads them). The `pcb` shim is updated to **prefer downloading `*.zst` artifacts** and decompress them with a hard size cap, while falling back to uncompressed downloads.
> 
> The `pcb` shim also drops `clap`/`colored`/`mimalloc`, replaces `reqwest` with `ureq` (native TLS), and switches to a small manual parser for `pcb self update`/`pcb toolchain ...` commands. Install scripts (`install.sh`/`install.ps1`) now opportunistically download and decompress `*.zst` when `zstd` is available, and install messaging is simplified; release workflow for `pcb` no longer creates GitHub Releases and uses read-only contents permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe5255d298f9b7805981298ca86a91ab115e5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->