### PR TITLE
Show shim version in `pcb toolchain show`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,7 +4458,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pcb"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcb"
-version = "0.2.0"
+version = "0.2.1"
 edition = { workspace = true }
 repository = { workspace = true }
 description = "PCB toolchain shim and version manager"

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -871,6 +871,7 @@ fn toolchain_list() -> Result<()> {
 
 fn toolchain_show() -> Result<()> {
     let selection = select_toolchain(None, false)?;
+    println!("shim: {}", env!("CARGO_PKG_VERSION"));
     println!("active: {}", selection.label);
     println!("reason: {}", selection.reason);
     println!("binary: {}", selection.binary.display());

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -864,8 +864,8 @@ fn toolchain_list() -> Result<()> {
 }
 
 fn toolchain_show() -> Result<()> {
-    let selection = select_toolchain(None, false)?;
     println!("shim: {}", env!("CARGO_PKG_VERSION"));
+    let selection = select_toolchain(None, false)?;
     println!("active: {}", selection.label);
     println!("reason: {}", selection.reason);
     println!("binary: {}", selection.binary.display());

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -979,8 +979,6 @@ fn self_update() -> Result<()> {
     match stable_result {
         Ok(changelogs) => {
             for (from, to, binary) in changelogs {
-                println!();
-                println!("pcbc {from} → {to}");
                 let selector = format!("{from}..{to}");
                 match Command::new(binary).args(["changelog", &selector]).status() {
                     Ok(status) if status.success() => {}
@@ -1001,8 +999,6 @@ fn self_update() -> Result<()> {
 
     if let Some(version) = updated_shim {
         println!("Updated pcb {current_version} → {version}");
-    } else {
-        println!("pcb is already up to date; pcbc toolchains checked.");
     }
     Ok(())
 }

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -19,7 +19,6 @@ const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 const ARCHIVE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const MAX_DOWNLOAD_BYTES: u64 = 512 * 1024 * 1024;
 const RELEASE_LIST_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
-const STANDALONE_INSTALL_REQUIRED: &str = "Self-update is only available for pcb installed via the standalone installer.\nIf you installed pcb via a package manager, please update using that tool.";
 
 enum ShimCommand {
     SelfUpdate,
@@ -63,11 +62,6 @@ struct InstallReceipt {
 struct LatestRelease {
     version: Version,
     tag: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct StandaloneInstallReceipt {
-    install_prefix: PathBuf,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -930,8 +924,6 @@ fn toolchain_uninstall(raw: &str) -> Result<()> {
 }
 
 fn self_update() -> Result<()> {
-    ensure_standalone_install()?;
-
     let current_version = Version::parse(env!("CARGO_PKG_VERSION"))?;
     let mut updated_shim = None;
     match fetch_latest_release() {
@@ -1041,24 +1033,6 @@ fn install_shim_update(latest: &LatestRelease) -> Result<()> {
     Ok(())
 }
 
-fn ensure_standalone_install() -> Result<()> {
-    let receipt = fs::read_to_string(standalone_receipt_path())
-        .ok()
-        .and_then(|content| serde_json::from_str::<StandaloneInstallReceipt>(&content).ok())
-        .ok_or_else(|| anyhow::anyhow!(STANDALONE_INSTALL_REQUIRED))?;
-    let install_prefix = receipt
-        .install_prefix
-        .canonicalize()
-        .map_err(|_| anyhow::anyhow!(STANDALONE_INSTALL_REQUIRED))?;
-    let current_exe = std::env::current_exe()?.canonicalize()?;
-    anyhow::ensure!(
-        current_exe.starts_with(&install_prefix),
-        STANDALONE_INSTALL_REQUIRED
-    );
-
-    Ok(())
-}
-
 fn exec_toolchain(binary: &Path, args: &[OsString]) -> Result<()> {
     #[cfg(unix)]
     {
@@ -1158,18 +1132,6 @@ fn locks_dir() -> PathBuf {
 
 fn release_list_cache_path() -> PathBuf {
     data_dir().join("release-list-cache.json")
-}
-
-fn standalone_receipt_path() -> PathBuf {
-    let config_dir = if cfg!(windows) {
-        PathBuf::from(std::env::var_os("LOCALAPPDATA").unwrap_or_default())
-    } else {
-        std::env::var_os("XDG_CONFIG_HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".config"))
-    };
-
-    config_dir.join("pcb").join("pcb-receipt.json")
 }
 
 fn binary_artifact_name(binary: &str) -> String {

--- a/install.ps1
+++ b/install.ps1
@@ -67,11 +67,6 @@ try {
     New-Item -ItemType Directory -Force $installDir | Out-Null
     Move-Item -Force $binary (Join-Path $installDir "pcb.exe")
 
-    $configDir = Join-Path $env:LOCALAPPDATA "pcb"
-    New-Item -ItemType Directory -Force $configDir | Out-Null
-    $receipt = @{ install_prefix = $installDir } | ConvertTo-Json -Compress
-    [IO.File]::WriteAllText((Join-Path $configDir "pcb-receipt.json"), $receipt, (New-Object Text.UTF8Encoding $false))
-
     Add-InstallDirToPath $installDir
 
     Write-Host "Installed pcb to $(Join-Path $installDir "pcb.exe")"

--- a/install.sh
+++ b/install.sh
@@ -76,11 +76,6 @@ mkdir -p "$install_dir"
 chmod +x "$tmp/pcb"
 mv "$tmp/pcb" "$install_dir/pcb"
 
-config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/pcb"
-mkdir -p "$config_dir"
-json_install_dir="$(printf '%s' "$install_dir" | sed 's/\\/\\\\/g; s/"/\\"/g')"
-printf '{"install_prefix":"%s"}\n' "$json_install_dir" > "$config_dir/pcb-receipt.json"
-
 add_install_dir_to_path
 
 echo "Installed pcb to $install_dir/pcb"


### PR DESCRIPTION
Allow `pcb self update` even if local install. Not worth the complexity to prevent this imo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables `pcb self update` for non-standalone installs, which can overwrite package-managed binaries and change update behavior across environments. Otherwise changes are small, mostly output/installer metadata removal.
> 
> **Overview**
> **`pcb toolchain show` now prints the shim version** (`shim: <version>`) before showing the active toolchain.
> 
> **Removes the standalone-install restriction for `pcb self update`** by deleting receipt validation and stopping the install scripts from writing `pcb-receipt.json`, allowing self-update even for locally/package-managed installs. Also bumps `pcb` to `0.2.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e44f1ddad0f0536685ccb1fdc357a580f52c5c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->