### PR TITLE
Expand build performance benchmark boards

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Find existing comment
         id: find_comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
@@ -246,7 +246,7 @@ jobs:
 
       - name: Create or update comment
         if: steps.perf_comment.outputs.has_changes == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
@@ -255,7 +255,7 @@ jobs:
 
       - name: Delete stale comment
         if: steps.perf_comment.outputs.has_changes == 'false' && steps.find_comment.outputs.comment-id != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.deleteComment({

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -54,7 +54,13 @@ jobs:
           key="$RUNNER_TEMP/code-diode-key"
           ssh-keygen -q -t ed25519 -N '' -f "$key"
           export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o IdentitiesOnly=yes -o IdentityFile=$key -o IdentityAgent=none -o StrictHostKeyChecking=accept-new"
+          git clone --depth 1 git@code.diode.computer:demo/b/Demeter workspaces/Demeter
           git clone --depth 1 git@code.diode.computer:demo/b/DM0001 workspaces/DM0001
+          git clone --depth 1 git@code.diode.computer:demo/b/DM0002 workspaces/DM0002
+          git clone --depth 1 git@code.diode.computer:demo/b/DM0003 workspaces/DM0003
+          git clone --depth 1 git@code.diode.computer:demo/b/Feign workspaces/Feign
+          git clone --depth 1 git@code.diode.computer:demo/b/Renfield workspaces/Renfield
+          git clone --depth 1 git@code.diode.computer:demo/b/Seward workspaces/Seward
           git clone --depth 1 git@code.diode.computer:arduino/b/Nano workspaces/Nano
           git clone --depth 1 git@code.diode.computer:arduino/b/unoQ workspaces/unoQ
 
@@ -66,7 +72,7 @@ jobs:
       - name: Run performance benchmarks
         run: |
           mkdir -p perf
-          for workspace in DM0001 Nano unoQ; do
+          for workspace in Demeter DM0001 DM0002 DM0003 Feign Renfield Seward Nano unoQ; do
             python3 bin/pcb-build-perf \
               --pcb "$RUNNER_TEMP/pcbc-base/pcbc" \
               --workspace "workspaces/$workspace" \
@@ -145,8 +151,19 @@ jobs:
 
           rows = []
           has_significant = False
+          workspace_labels = {
+            "Demeter": "demo/b/Demeter",
+            "DM0001": "demo/b/DM0001",
+            "DM0002": "demo/b/DM0002",
+            "DM0003": "demo/b/DM0003",
+            "Feign": "demo/b/Feign",
+            "Renfield": "demo/b/Renfield",
+            "Seward": "demo/b/Seward",
+            "Nano": "arduino/b/Nano",
+            "unoQ": "arduino/b/unoQ",
+          }
 
-          for name in ["DM0001", "Nano", "unoQ"]:
+          for name in ["Demeter", "DM0001", "DM0002", "DM0003", "Feign", "Renfield", "Seward", "Nano", "unoQ"]:
             base = load(Path("perf") / f"{name}-base.json")
             head = load(Path("perf") / f"{name}-head.json")
             base_boards = {b["zen_path"]: b for b in base.get("boards", [])}
@@ -161,7 +178,11 @@ jobs:
                 board_name = head_board["name"]
               elif base_board and base_board.get("name"):
                 board_name = base_board["name"]
-              label = f"{name}/{board_name}"
+              workspace_label = workspace_labels[name]
+              if board_name.lower() == name.lower():
+                label = workspace_label
+              else:
+                label = f"{workspace_label}/{board_name}"
 
               if not base_board or not head_board:
                 rows.append((label, "—", "—", "missing"))

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Cache KiCad (macOS)
         if: matrix.config.name == 'macOS'
         id: cache-kicad-mac
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /Applications/KiCad
           key: ${{ runner.os }}-kicad-${{ env.KICAD_VERSION }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,9 +17,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jetli/wasm-pack-action@v0.4.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: taiki-e/install-action@wasm-pack
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
           submodules: recursive
@@ -87,7 +87,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive
@@ -145,7 +145,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pcb-${{ matrix.target }}
           path: artifacts/*
@@ -156,12 +156,12 @@ jobs:
       - build
     runs-on: ubicloud-standard-16
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: pcb-*
           path: artifacts
@@ -169,7 +169,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/pcb-version-bump.yml
+++ b/.github/workflows/pcb-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
   bump:
     runs-on: ubicloud-standard-16
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -25,14 +25,14 @@ jobs:
       tag: ${{ steps.nightly.outputs.tag }}
       base_url: ${{ steps.nightly.outputs.base_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
           submodules: recursive
 
       - name: Configure AWS credentials
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
           aws-region: us-east-1
@@ -85,7 +85,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.sha }}
           submodules: recursive
@@ -122,7 +122,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pcbc-nightly-${{ matrix.target }}
           path: artifacts/*
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubicloud-standard-16
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: pcbc-nightly-*
           path: artifacts
@@ -143,7 +143,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
           submodules: recursive
@@ -87,7 +87,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive
@@ -145,7 +145,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pcbc-${{ matrix.target }}
           path: artifacts/*
@@ -156,12 +156,12 @@ jobs:
       - build
     runs-on: ubicloud-standard-16
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: pcbc-*
           path: artifacts
@@ -169,7 +169,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/pcbc-version-bump.yml
+++ b/.github/workflows/pcbc-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
   bump:
     runs-on: ubicloud-standard-16
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
           git config user.email "info@diode.run"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo clippy --workspace -- -D warnings
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Type check Python with ty
         run: uv sync && uvx ty check
@@ -78,7 +78,7 @@ jobs:
       - name: Cache KiCad (macOS)
         if: contains(matrix.config.name, 'macOS')
         id: cache-kicad-mac
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /Applications/KiCad
           key: ${{ runner.os }}-kicad-${{ env.KICAD_VERSION }}
@@ -153,7 +153,7 @@ jobs:
         working-directory: crates/pcb-layout/src/scripts
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync
         working-directory: .
       - run: uv run ruff check .


### PR DESCRIPTION
moar boards
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to GitHub Actions workflow configuration and benchmark reporting logic, with no impact on shipped binaries. Main risk is CI instability (extra clones/benchmarks or action version bumps) causing longer or flaky runs.
> 
> **Overview**
> **Build performance CI now benchmarks more repositories.** The `build-perf` workflow clones additional demo workspaces and runs `pcb-build-perf` across a larger set, while improving PR comment labeling to show `org/repo[/board]` names.
> 
> **CI maintenance updates.** Multiple workflows bump GitHub Actions versions (e.g., `checkout`, `cache`, `upload/download-artifact`, `configure-aws-credentials`, `setup-uv`), and npm publish switches to `taiki-e/install-action@wasm-pack` with `setup-node@v6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9c78b9a74117e8f44f822c6ea39d01213823227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->