### PR TITLE
`config()` does not support record types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `config()` now rejects Starlark `record()` types as module input types.
+
 ### Fixed
 
 - Removed stale KiCad board items that reference layers deleted by layout stackup sync.

--- a/crates/pcb-docgen/src/signature.rs
+++ b/crates/pcb-docgen/src/signature.rs
@@ -119,7 +119,6 @@ fn format_type_info(type_info: &TypeInfo) -> String {
             )
         }
         TypeInfo::Enum { variants, .. } => variants.join(" | "),
-        TypeInfo::Record { name, .. } => name.clone(),
         TypeInfo::Interface { name, .. } => name.clone(),
         TypeInfo::Unknown { type_name } => type_name.clone(),
     }

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -19,7 +19,6 @@ use pcb_sch::{AttributeValue, Instance, InstanceKind, InstanceRef, ModuleRef, Ne
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
 use starlark::values::list::ListRef;
-use starlark::values::record::FrozenRecord;
 use starlark::values::{FrozenValue, Value, ValueLike, dict::DictRef};
 use starlark::{codemap::ResolvedSpan, errors::EvalSeverity};
 use std::collections::{BTreeMap, HashMap};
@@ -1279,16 +1278,6 @@ fn to_attribute_value(v: starlark::values::FrozenValue) -> anyhow::Result<Attrib
         return Ok(AttributeValue::String(enum_val.value().to_string()));
     } else if let Some(part) = v.downcast_ref::<PartValue>() {
         return Ok(AttributeValue::Json(part.to_json_value()));
-    }
-
-    if v.downcast_ref::<FrozenRecord>().is_some() {
-        match v.to_value().to_json_value() {
-            Ok(json) => return Ok(AttributeValue::Json(json)),
-            Err(_) => {
-                // If JSON conversion fails, fall back to string
-                return Ok(AttributeValue::String(v.to_string()));
-            }
-        }
     }
 
     // Handle lists (no nested list support)

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -15,7 +15,6 @@ use allocative::Allocative;
 use pcb_sch::physical::PhysicalValueType;
 use serde::Serialize;
 use starlark::environment::FrozenModule;
-use starlark::values::record::{FrozenRecordType, RecordType};
 use starlark::values::typing::{TypeCompiled, TypeType};
 use starlark::values::{Heap, UnpackValue, ValueLifetimeless};
 use starlark::{
@@ -41,8 +40,6 @@ use crate::lang::validation::validate_identifier_name;
 use regex::Regex;
 use starlark::codemap::{CodeMap, Pos, ResolvedSpan, Span};
 use starlark::values::dict::{AllocDict, DictRef};
-
-use starlark::values::record::{FrozenRecord, Record};
 use std::fs;
 
 /// Helper macro for frozen module downcasting to reduce repetition
@@ -1227,14 +1224,6 @@ pub(crate) fn default_for_type<'v>(
     // Our EnumType is a simple value (no separate Frozen version)
     // It's already handled above, so this block is no longer needed
 
-    if typ.downcast_ref::<RecordType>().is_some()
-        || typ.downcast_ref::<FrozenRecordType>().is_some()
-    {
-        return Err(anyhow::anyhow!(
-            "Record dependencies require a default value"
-        ));
-    }
-
     // Check if it's a TypeType (like str, int, float constructors)
     if TypeType::unpack_value_opt(typ).is_some() {
         // Use the string representation to determine the type
@@ -1281,7 +1270,7 @@ pub(crate) fn default_for_type<'v>(
             .map_err(|e| anyhow::anyhow!(e.to_string()))?,
         other => {
             return Err(anyhow::anyhow!(
-                "config/io() only accepts Net, Interface, Enum, Record, str, int, or float types, got {other}"
+                "config/io() only accepts Net, Interface, Enum, str, int, or float types, got {other}"
             ));
         }
     };
@@ -1332,14 +1321,6 @@ fn validate_type<'v>(
     typ: Value<'v>,
     heap: &'v Heap,
 ) -> anyhow::Result<()> {
-    if (typ.downcast_ref::<RecordType>().is_some()
-        || typ.downcast_ref::<FrozenRecordType>().is_some())
-        && (value.downcast_ref::<Record>().is_some()
-            || value.downcast_ref::<FrozenRecord>().is_some())
-    {
-        return Ok(());
-    }
-
     if typ.downcast_ref::<EnumType>().is_some() && value.downcast_ref::<EnumValue>().is_some() {
         return Ok(());
     }

--- a/crates/pcb-zen-core/src/lang/param_decl.rs
+++ b/crates/pcb-zen-core/src/lang/param_decl.rs
@@ -9,6 +9,7 @@ use starlark::{
     collections::SmallMap,
     errors::EvalSeverity,
     eval::{Arguments, Evaluator},
+    values::record::{FrozenRecordType, RecordType},
     values::{Freeze, Heap, NoSerialize, StarlarkValue, Trace, Value, ValueLike, starlark_value},
 };
 
@@ -399,6 +400,15 @@ fn resolve_config<'v>(
     declaration_site: &DeclarationSite,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Value<'v>> {
+    if args.typ.downcast_ref::<RecordType>().is_some()
+        || args.typ.downcast_ref::<FrozenRecordType>().is_some()
+    {
+        return Err(anyhow::anyhow!(
+            "config() does not support record types; use primitive, enum, or physical-value config parameters"
+        )
+        .into());
+    }
+
     let convert_value = |eval: &mut Evaluator<'v, '_, '_>, value| {
         validate_or_convert(name, value, args.typ, args.convert, eval)
             .map_err(starlark::Error::from)

--- a/crates/pcb-zen-core/src/lang/type_info.rs
+++ b/crates/pcb-zen-core/src/lang/type_info.rs
@@ -4,10 +4,8 @@ use crate::lang::interface::{FrozenInterfaceFactory, InterfaceFactory};
 use crate::lang::io_direction::IoDirection;
 use crate::lang::net::{FrozenNetType, NetType, NetValue};
 use serde::{Deserialize, Serialize};
-use starlark::values::record::{FrozenRecordType, RecordType};
 use starlark::values::typing::TypeType;
 use starlark::values::{UnpackValue, Value, ValueLike};
-use std::collections::HashMap;
 
 /// Structured representation of Starlark types for introspection
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -32,11 +30,6 @@ pub enum TypeInfo {
     Net,
     /// Enum type with possible variants
     Enum { name: String, variants: Vec<String> },
-    /// Record type with named fields
-    Record {
-        name: String,
-        fields: HashMap<String, TypeInfo>,
-    },
     /// Interface type - a special record that contains nets and sub-interfaces
     Interface {
         name: String,
@@ -68,18 +61,6 @@ impl TypeInfo {
             return TypeInfo::Enum {
                 name: type_name.to_string(),
                 variants: enum_type.variants().to_vec(),
-            };
-        }
-
-        // Check for record types
-        if value.downcast_ref::<RecordType>().is_some()
-            || value.downcast_ref::<FrozenRecordType>().is_some()
-        {
-            let fields = HashMap::new();
-            // TODO: Extract field information when starlark provides an API for it
-            return TypeInfo::Record {
-                name: type_name.to_string(),
-                fields,
             };
         }
 

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -1531,26 +1531,15 @@ snapshot_eval!(interface_mixed_templates_and_types, {
     "#
 });
 
-snapshot_eval!(config_without_convert_fails_type_check, {
+snapshot_eval!(config_record_type_rejected, {
     "Module.zen" => r#"
         UnitType = record(
             value = field(float),
             unit = field(str),
         )
 
-        # This should fail because "5V" is not a record and no converter is provided
-        # Provide a default since records require defaults
         voltage = config(UnitType, default = UnitType(value = 0.0, unit = "V"))
     "#,
-    "top.zen" => r#"
-        Mod = Module("Module.zen")
-
-        # This should fail - string cannot be used for record type without converter
-        Mod(
-            name = "test",
-            voltage = "5V",
-        )
-    "#
 });
 
 snapshot_eval!(io_config_with_help_text, {
@@ -2074,15 +2063,10 @@ snapshot_eval!(config_allowed_invalid_default, {
 
 snapshot_eval!(config_allowed_unsupported_type, {
     "test.zen" => r#"
-        Range = record(
-            min = field(float),
-            max = field(float),
-        )
-
         value = config(
             "value",
-            Range,
-            allowed = [Range(min = 0.0, max = 1.0)],
+            list,
+            allowed = [[]],
         )
     "#
 });

--- a/crates/pcb-zen-core/tests/snapshots/input__config_allowed_unsupported_type.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_allowed_unsupported_type.snap
@@ -3,4 +3,4 @@ source: crates/pcb-zen-core/tests/input.rs
 assertion_line: 813
 expression: output
 ---
-Error: test.zen:10:9-14:2 config `value` uses unsupported type for `allowed`: expected str, int, float, bool, enum, or physical value type
+Error: test.zen:5:9-9:2 config `value` uses unsupported type for `allowed`: expected str, int, float, bool, enum, or physical value type

--- a/crates/pcb-zen-core/tests/snapshots/input__config_record_type_rejected.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_record_type_rejected.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pcb-zen-core/tests/input.rs
+assertion_line: 1534
+expression: output
+---
+Error: Module.zen:10:1-8 config() does not support record types; use primitive, enum, or physical-value config parameters

--- a/crates/pcb-zen-core/tests/snapshots/input__config_without_convert_fails_type_check.snap
+++ b/crates/pcb-zen-core/tests/snapshots/input__config_without_convert_fails_type_check.snap
@@ -1,7 +1,0 @@
----
-source: crates/pcb-zen-core/tests/input.rs
-assertion_line: 867
-expression: output
----
-Error: top.zen:8:1-11:2 Error instantiating `Module`
-Error: /Module.zen:12:1-8 Input 'voltage' (type) has wrong type for this placeholder: expected record(value=field(float), unit=field(str)), got "5V"

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -518,7 +518,7 @@ Declare a typed configuration input for a module. This defines parameters that c
 **Signature:** `config(name, typ, checks=None, default=None, allowed=None, optional=None, help=None)` or `config(typ, checks=None, default=None, allowed=None, optional=None, help=None)`
 
 - `name`: Optional explicit input name (conventionally lowercase). If omitted, `config()` must be assigned to a top-level variable and that variable name is used.
-- `typ`: Expected type — primitives (`str`, `int`, `float`, `bool`), `enum`, `record`, or physical quantity constructors.
+- `typ`: Expected type — primitives (`str`, `int`, `float`, `bool`), `enum`, or physical quantity constructors. `record()` types are not supported as module `config()` inputs.
 - `checks`: Optional check function or list of checks.
 - `default`: Default value. When provided, `optional` defaults to `True`.
 - `allowed`: Optional finite set of allowed values. Accepts a `list`, `tuple`, or `dict` (using only the keys). Supported for `str`, `int`, `float`, `bool`, `enum`, and physical quantity types.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is a behavior change in the module input/type system: existing `.zen` modules that use `config(record(...))` will now error, and related signature/type introspection paths were adjusted accordingly.
> 
> **Overview**
> `config()` now **explicitly rejects Starlark `record()` types** as module configuration inputs, failing early with a clear error message.
> 
> To align with this, record-type handling was removed from type/signature introspection (`TypeInfo` and docgen formatting) and from record-to-JSON attribute conversion paths, and tests/docs were updated with new snapshots and spec wording reflecting the unsupported type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d3b74c86d6a61bb7d1e536b6f42c8ea16920d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->