### PR TITLE
Add local installer workflow for pcbc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added a 48 V Vishay SMBJ DO-214AA unidirectional TVS house part.
+- Added `install.sh --local` to build and install local `pcb` and `pcbc` binaries side-by-side for development.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ cd pcb
 
 # Build locally
 cargo build -p pcb -p pcbc
+
+# Install local release builds for development
+./install.sh --local
 ```
 
 ### Requirements

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,26 @@ set -euo pipefail
 
 base_url="https://pcb.api.diode.computer/pcb"
 install_dir="${PCB_INSTALL_DIR:-$HOME/.local/bin}"
+mode="release"
+
+usage() {
+  cat <<EOF
+Usage: install.sh [--local]
+
+Options:
+  --local    Build pcb and pcbc from this checkout and install them side-by-side.
+  -h, --help Show this help.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --local) mode="local" ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
 
 case "$(uname -s)-$(uname -m)" in
   Darwin-arm64) target="aarch64-apple-darwin" ;;
@@ -11,8 +31,6 @@ case "$(uname -s)-$(uname -m)" in
   Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
   *) echo "unsupported platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
 esac
-
-command -v curl >/dev/null || { echo "missing required command: curl" >&2; exit 1; }
 
 add_install_dir_to_path() {
   case ":$PATH:" in *":$install_dir:"*) return 0 ;; esac
@@ -44,6 +62,40 @@ EOF
 
   echo "Added $install_dir to PATH. Restart your shell or run: $source_line"
 }
+
+install_local() {
+  command -v cargo >/dev/null || { echo "missing required command: cargo" >&2; exit 1; }
+
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ -f "$script_dir/Cargo.toml" ] && [ -d "$script_dir/crates/pcb" ] && [ -d "$script_dir/crates/pcbc" ]; then
+    source_dir="$script_dir"
+  elif [ -f "Cargo.toml" ] && [ -d "crates/pcb" ] && [ -d "crates/pcbc" ]; then
+    source_dir="$(pwd)"
+  else
+    echo "could not find pcb checkout; run ./install.sh --local from the repository root" >&2
+    exit 1
+  fi
+
+  cargo build --release -p pcb -p pcbc --manifest-path "$source_dir/Cargo.toml"
+
+  target_dir="${CARGO_TARGET_DIR:-$source_dir/target}"
+
+  mkdir -p "$install_dir"
+  install -m 755 "$target_dir/release/pcb" "$install_dir/pcb"
+  install -m 755 "$target_dir/release/pcbc" "$install_dir/pcbc"
+
+  add_install_dir_to_path
+
+  echo "Installed local pcb to $install_dir/pcb"
+  echo "Installed local pcbc to $install_dir/pcbc"
+}
+
+if [ "$mode" = "local" ]; then
+  install_local
+  exit 0
+fi
+
+command -v curl >/dev/null || { echo "missing required command: curl" >&2; exit 1; }
 
 json="$(curl -fsSL "$base_url/pcb-latest.json")"
 tag="$(printf '%s' "$json" | sed -n 's/.*"tag"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"

--- a/install.sh
+++ b/install.sh
@@ -24,14 +24,6 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-case "$(uname -s)-$(uname -m)" in
-  Darwin-arm64) target="aarch64-apple-darwin" ;;
-  Darwin-x86_64) target="x86_64-apple-darwin" ;;
-  Linux-aarch64|Linux-arm64) target="aarch64-unknown-linux-gnu" ;;
-  Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
-  *) echo "unsupported platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
-esac
-
 add_install_dir_to_path() {
   case ":$PATH:" in *":$install_dir:"*) return 0 ;; esac
 
@@ -76,9 +68,8 @@ install_local() {
     exit 1
   fi
 
-  cargo build --release -p pcb -p pcbc --manifest-path "$source_dir/Cargo.toml"
-
-  target_dir="${CARGO_TARGET_DIR:-$source_dir/target}"
+  target_dir="$source_dir/target"
+  cargo build --release -p pcb -p pcbc --manifest-path "$source_dir/Cargo.toml" --target-dir "$target_dir"
 
   mkdir -p "$install_dir"
   install -m 755 "$target_dir/release/pcb" "$install_dir/pcb"
@@ -94,6 +85,14 @@ if [ "$mode" = "local" ]; then
   install_local
   exit 0
 fi
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64) target="aarch64-apple-darwin" ;;
+  Darwin-x86_64) target="x86_64-apple-darwin" ;;
+  Linux-aarch64|Linux-arm64) target="aarch64-unknown-linux-gnu" ;;
+  Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
+  *) echo "unsupported platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
 
 command -v curl >/dev/null || { echo "missing required command: curl" >&2; exit 1; }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Installer and documentation only; no runtime product logic changes.
> 
> **Overview**
> Adds a **`install.sh --local`** development path that **`cargo build --release`** for **`pcb`** and **`pcbc`**, then installs both into **`$PCB_INSTALL_DIR`** (default **`~/.local/bin`**) with the same PATH setup as the release installer. The default CDN-based install is unchanged; **`--help`** documents the new option.
> 
> **README** and **CHANGELOG** now point contributors at **`./install.sh --local`** after a from-source build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe891b076a56bacf46c0759b295b8ad93384da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->