### PR TITLE
Update `starlark-rust`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Workspaces with `pcb-version = "0.4"` or newer now always use MVS v2 dependency resolution.
 - `pcb migrate` now hydrates V2 dependency manifests and removes obsolete `pcb.sum` lockfiles.
 - Workspace package discovery is now implicit; use `[workspace].exclude` to prune paths.
+- Updated the embedded Starlark runtime integration to the current starlark-rust APIs.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 [[package]]
 name = "allocative"
 version = "0.3.6"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "allocative_derive",
  "bumpalo",
@@ -71,7 +71,7 @@ dependencies = [
 [[package]]
 name = "allocative_derive"
 version = "0.3.6"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -194,7 +194,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "parking_lot 0.12.5",
+ "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
@@ -1223,7 +1223,7 @@ checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 
 [[package]]
 name = "cobs"
@@ -1572,7 +1572,7 @@ dependencies = [
  "derive_more 2.1.1",
  "document-features",
  "mio",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
@@ -1719,7 +1719,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.12",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "either",
  "indenter",
@@ -1996,9 +1996,9 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
- "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
+ "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
 ]
 
 [[package]]
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2396,16 +2396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3330,15 +3320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,7 +3797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf3631712f5b790675292ff827af269f5d9f920c920b77dc41d0485e3719612"
 dependencies = [
  "atomic 0.5.3",
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4535,7 +4516,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "pagable"
 version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "allocative",
  "anyhow",
@@ -4543,7 +4524,7 @@ dependencies = [
  "blake3",
  "bytemuck",
  "dashmap",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
  "either",
  "erased-serde 0.4.10",
  "fancy-regex 0.16.2",
@@ -4552,28 +4533,24 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pagable_derive",
- "parking_lot 0.12.5",
+ "parking_lot",
  "postcard",
  "regex",
- "rusqlite",
  "sequence_trie",
  "serde",
  "serde_json",
- "sled",
  "smallvec",
- "sorted_vector_map",
  "static_assertions",
  "static_interner",
  "strong_hash",
  "take_mut",
- "tokio",
  "triomphe",
 ]
 
 [[package]]
 name = "pagable_derive"
 version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4606,37 +4583,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -5580,17 +5532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
-dependencies = [
- "env_logger",
- "log",
- "rand 0.10.1",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5696,7 +5637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.5",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -5981,15 +5922,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6705,7 +6637,7 @@ dependencies = [
  "indexmap",
  "intrusive-collections",
  "inventory",
- "parking_lot 0.12.5",
+ "parking_lot",
  "portable-atomic",
  "rustc-hash",
  "salsa-macro-rules",
@@ -6764,7 +6696,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -6983,7 +6915,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "parking_lot 0.12.5",
+ "parking_lot",
  "scc",
  "serial_test_derive",
 ]
@@ -7170,22 +7102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
-]
-
-[[package]]
 name = "slotmap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7214,15 +7130,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "sorted_vector_map"
-version = "0.2.1"
-source = "git+https://github.com/facebookexperimental/rust-shed#b244bffe9c3be94d3776ccdb35c215104c04ca9c"
-dependencies = [
- "itertools 0.14.0",
- "quickcheck",
 ]
 
 [[package]]
@@ -7264,7 +7171,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "starlark"
 version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "allocative",
  "anyhow",
@@ -7276,7 +7183,7 @@ dependencies = [
  "derivative",
  "derive_more 1.0.0",
  "display_container",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
  "either",
  "erased-serde 0.3.31",
  "hashbrown 0.16.1",
@@ -7296,7 +7203,6 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
- "sled",
  "starlark_derive",
  "starlark_map",
  "starlark_syntax",
@@ -7310,9 +7216,9 @@ dependencies = [
 [[package]]
 name = "starlark_derive"
 version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7321,10 +7227,10 @@ dependencies = [
 [[package]]
 name = "starlark_map"
 version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "allocative",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
  "equivalent",
  "fxhash",
  "hashbrown 0.16.1",
@@ -7336,14 +7242,14 @@ dependencies = [
 [[package]]
 name = "starlark_syntax"
 version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "allocative",
  "annotate-snippets",
  "anyhow",
  "derivative",
  "derive_more 1.0.0",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -7395,7 +7301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot 0.12.5",
+ "parking_lot",
  "phf_shared",
  "precomputed-hash",
 ]
@@ -7412,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "strong_hash"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "ref-cast",
  "strong_hash_derive",
@@ -7421,7 +7327,7 @@ dependencies = [
 [[package]]
 name = "strong_hash_derive"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -7906,24 +7812,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "tokio-macros",
- "tracing",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,18 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,20 +58,20 @@ dependencies = [
 
 [[package]]
 name = "allocative"
-version = "0.3.4"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+version = "0.3.6"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "allocative_derive",
  "bumpalo",
  "ctor",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "num-bigint",
 ]
 
 [[package]]
 name = "allocative_derive"
-version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+version = "0.3.6"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -206,7 +194,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "parking_lot",
+ "parking_lot 0.12.5",
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
@@ -304,12 +292,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -819,7 +833,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -827,6 +850,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -869,16 +898,17 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "digest 0.10.7",
+ "rayon-core",
 ]
 
 [[package]]
@@ -1193,7 +1223,16 @@ checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "collection_literals"
@@ -1320,9 +1359,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1411,6 +1450,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1472,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crokey"
@@ -1512,7 +1572,7 @@ dependencies = [
  "derive_more 2.1.1",
  "document-features",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.5",
  "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
@@ -1586,12 +1646,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 dependencies = [
- "quote",
- "syn 1.0.109",
+ "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -1659,7 +1719,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -1796,6 +1856,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1867,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "either",
  "indenter",
@@ -1935,9 +1996,9 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
- "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=e8962e20)",
+ "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
 ]
 
 [[package]]
@@ -1954,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1972,6 +2033,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -2062,6 +2135,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,8 +2203,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -2301,6 +2396,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2600,12 +2705,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
 ]
 
 [[package]]
@@ -2613,10 +2727,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2662,6 +2772,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3206,6 +3330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,15 +3455,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3512,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "diff",
  "ena",
  "is-terminal",
@@ -3641,6 +3765,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1e908a416d6e9f725743b84a36feea40c4c131e805fbc26d61f9f451f36080"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,6 +3807,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "lock_free_hashtable"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf3631712f5b790675292ff827af269f5d9f920c920b77dc41d0485e3719612"
+dependencies = [
+ "atomic 0.5.3",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -4117,6 +4263,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4386,6 +4533,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "pagable"
+version = "0.3.3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "async-trait",
+ "blake3",
+ "bytemuck",
+ "dashmap",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
+ "either",
+ "erased-serde 0.4.10",
+ "fancy-regex 0.16.2",
+ "indexmap",
+ "inventory",
+ "num-bigint",
+ "once_cell",
+ "pagable_derive",
+ "parking_lot 0.12.5",
+ "postcard",
+ "regex",
+ "rusqlite",
+ "sequence_trie",
+ "serde",
+ "serde_json",
+ "sled",
+ "smallvec",
+ "sorted_vector_map",
+ "static_assertions",
+ "static_interner",
+ "strong_hash",
+ "take_mut",
+ "tokio",
+ "triomphe",
+]
+
+[[package]]
+name = "pagable_derive"
+version = "0.3.3"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,12 +4606,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -4702,6 +4922,7 @@ dependencies = [
  "csv",
  "log",
  "natord",
+ "pagable",
  "pathdiff",
  "rust_decimal",
  "rust_decimal_macros",
@@ -4855,6 +5076,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "log",
+ "pagable",
  "pcb-canonical",
  "pcb-eda",
  "pcb-sch",
@@ -4904,7 +5126,6 @@ name = "pcbc"
 version = "0.3.85"
 dependencies = [
  "anyhow",
- "canon-json",
  "chrono",
  "clap",
  "colored",
@@ -5160,6 +5381,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "crc",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5345,6 +5580,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.10.1",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5450,7 +5696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.12.5",
  "scheduled-thread-pool",
 ]
 
@@ -5739,6 +5985,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -5976,9 +6231,9 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
@@ -6450,7 +6705,7 @@ dependencies = [
  "indexmap",
  "intrusive-collections",
  "inventory",
- "parking_lot",
+ "parking_lot 0.12.5",
  "portable-atomic",
  "rustc-hash",
  "salsa-macro-rules",
@@ -6509,7 +6764,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -6617,6 +6872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sequence_trie"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee22067b7ccd072eeb64454b9c6e1b33b61cd0d49e895fd48676a184580e0c3"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6722,7 +6983,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.5",
  "scc",
  "serial_test_derive",
 ]
@@ -6909,6 +7170,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6940,6 +7217,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted_vector_map"
+version = "0.2.1"
+source = "git+https://github.com/facebookexperimental/rust-shed#b244bffe9c3be94d3776ccdb35c215104c04ca9c"
+dependencies = [
+ "itertools 0.14.0",
+ "quickcheck",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "sqlite-vec"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6950,9 +7245,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
 dependencies = [
  "cc",
  "js-sys",
@@ -6968,28 +7263,32 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starlark"
-version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+version = "0.14.0"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "allocative",
  "anyhow",
+ "blake3",
  "bumpalo",
  "cmp_any",
+ "dashmap",
  "debugserver-types",
  "derivative",
  "derive_more 1.0.0",
  "display_container",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=e8962e20)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
  "either",
- "erased-serde",
- "hashbrown 0.14.5",
+ "erased-serde 0.3.31",
+ "hashbrown 0.16.1",
+ "indexmap",
  "inventory",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "maplit",
  "memoffset 0.6.5",
  "num-bigint",
  "num-traits",
  "once_cell",
+ "pagable",
  "paste",
  "ref-cast",
  "regex",
@@ -6997,21 +7296,23 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "sled",
  "starlark_derive",
  "starlark_map",
  "starlark_syntax",
  "static_assertions",
+ "strong_hash",
  "strsim 0.10.0",
  "textwrap 0.11.0",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "starlark_derive"
-version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+version = "0.14.0"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=e8962e20)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7019,29 +7320,30 @@ dependencies = [
 
 [[package]]
 name = "starlark_map"
-version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+version = "0.14.0"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "allocative",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=e8962e20)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
  "equivalent",
  "fxhash",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "pagable",
  "serde",
  "strong_hash",
 ]
 
 [[package]]
 name = "starlark_syntax"
-version = "0.13.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+version = "0.14.0"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "allocative",
  "annotate-snippets",
  "anyhow",
  "derivative",
  "derive_more 1.0.0",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=e8962e20)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d)",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -7050,8 +7352,9 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "once_cell",
+ "pagable",
  "starlark_map",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7059,6 +7362,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_interner"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab44341fbf4deae6e8d5ab450f24e1b34e0b2439d39ac0e9b5215a4e5493263"
+dependencies = [
+ "equivalent",
+ "lock_free_hashtable",
+]
 
 [[package]]
 name = "strict"
@@ -7082,7 +7395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.5",
  "phf_shared",
  "precomputed-hash",
 ]
@@ -7099,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "strong_hash"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "ref-cast",
  "strong_hash_derive",
@@ -7108,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "strong_hash_derive"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=e8962e20#e8962e20b7eeee77410d03bd5470c95703418937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d#5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -7251,6 +7564,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7364,7 +7683,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitflags 2.11.1",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset 0.4.2",
@@ -7587,10 +7906,24 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7785,6 +8118,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7818,6 +8161,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -8069,7 +8418,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "atomic",
+ "atomic 0.6.1",
  "getrandom 0.4.2",
  "js-sys",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ authors = ["Diode Computers, Inc. <founders@diode.computer>"]
 
 [workspace.dependencies]
 glam = "0.32"
-starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "e8962e20" }
-starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "e8962e20" }
-starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "e8962e20" }
-allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "e8962e20" }
+starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
+starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
+starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
+allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
+pagable = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
 
 ruff_python_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.11" }
 ruff_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.11" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ authors = ["Diode Computers, Inc. <founders@diode.computer>"]
 
 [workspace.dependencies]
 glam = "0.32"
-starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
-starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
-starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
-allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
-pagable = { git = "https://github.com/diodeinc/starlark-rust", rev = "5dda9bc94ae49b4560edb7b6e62dcfcfa4c7152d", default-features = false }
+starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
+starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
+starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
+allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
+pagable = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
 
 ruff_python_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.11" }
 ruff_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.11" }

--- a/crates/pcb-sch/Cargo.toml
+++ b/crates/pcb-sch/Cargo.toml
@@ -22,6 +22,7 @@ csv = { workspace = true }
 starlark = { workspace = true }
 starlark_map = { workspace = true }
 allocative = { workspace = true }
+pagable = { workspace = true }
 anyhow = { workspace = true }
 comfy-table = { workspace = true, optional = true }
 colored = { workspace = true, optional = true }

--- a/crates/pcb-sch/src/physical.rs
+++ b/crates/pcb-sch/src/physical.rs
@@ -27,7 +27,7 @@ use starlark::{
         function::FUNCTION_TYPE,
         starlark_value,
         string::StarlarkStr,
-        typing::{TypeInstanceId, TypeMatcher, TypeMatcherFactory},
+        typing::{TypeInstanceId, TypeMatcher, TypeMatcherDyn, TypeMatcherFactory},
     },
 };
 use starlark_map::{StarlarkHasher, sorted_map::SortedMap};
@@ -592,7 +592,9 @@ impl std::ops::Sub for PhysicalValue {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, ProvidesStaticType, Allocative, Hash)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, ProvidesStaticType, Allocative, Hash, pagable::Pagable,
+)]
 pub struct PhysicalUnitDims {
     pub current: i8,
     pub time: i8,
@@ -1533,8 +1535,8 @@ fn physical_value_methods(methods: &mut MethodsBuilder) {
 #[starlark_value(type = "PhysicalValue")]
 impl<'v> StarlarkValue<'v> for PhysicalValue {
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new();
-        RES.methods(physical_value_methods)
+        static RES: MethodsStatic = MethodsStatic::new("PhysicalValue", physical_value_methods);
+        Some(RES.methods())
     }
 
     fn write_hash(&self, hasher: &mut StarlarkHasher) -> starlark::Result<()> {
@@ -1542,7 +1544,7 @@ impl<'v> StarlarkValue<'v> for PhysicalValue {
         Ok(())
     }
 
-    fn div(&self, other: Value<'v>, heap: &'v Heap) -> Option<Result<Value<'v>, starlark::Error>> {
+    fn div(&self, other: Value<'v>, heap: Heap<'v>) -> Option<Result<Value<'v>, starlark::Error>> {
         let other = PhysicalValue::try_from(other).ok()?;
         let result = (*self / other).map(|v| heap.alloc(v)).map_err(|err| {
             PhysicalValueError::DivisionError {
@@ -1555,7 +1557,7 @@ impl<'v> StarlarkValue<'v> for PhysicalValue {
         Some(result)
     }
 
-    fn rdiv(&self, other: Value<'v>, heap: &'v Heap) -> Option<Result<Value<'v>, starlark::Error>> {
+    fn rdiv(&self, other: Value<'v>, heap: Heap<'v>) -> Option<Result<Value<'v>, starlark::Error>> {
         let other = PhysicalValue::try_from(other).ok()?;
         let result = (other / *self).map(|v| heap.alloc(v)).map_err(|err| {
             PhysicalValueError::DivisionError {
@@ -1568,19 +1570,19 @@ impl<'v> StarlarkValue<'v> for PhysicalValue {
         Some(result)
     }
 
-    fn mul(&self, other: Value<'v>, heap: &'v Heap) -> Option<Result<Value<'v>, starlark::Error>> {
+    fn mul(&self, other: Value<'v>, heap: Heap<'v>) -> Option<Result<Value<'v>, starlark::Error>> {
         let other = PhysicalValue::try_from(other).ok()?;
         let result = heap.alloc(*self * other);
         Some(Ok(result))
     }
 
-    fn rmul(&self, other: Value<'v>, heap: &'v Heap) -> Option<Result<Value<'v>, starlark::Error>> {
+    fn rmul(&self, other: Value<'v>, heap: Heap<'v>) -> Option<Result<Value<'v>, starlark::Error>> {
         let other = PhysicalValue::try_from(other).ok()?;
         let result = heap.alloc(other * *self);
         Some(Ok(result))
     }
 
-    fn add(&self, other: Value<'v>, heap: &'v Heap) -> Option<Result<Value<'v>, starlark::Error>> {
+    fn add(&self, other: Value<'v>, heap: Heap<'v>) -> Option<Result<Value<'v>, starlark::Error>> {
         let other = PhysicalValue::try_from(other).ok()?;
         let result = (*self + other).map(|v| heap.alloc(v)).map_err(|err| {
             PhysicalValueError::AdditionError {
@@ -1593,11 +1595,11 @@ impl<'v> StarlarkValue<'v> for PhysicalValue {
         Some(result)
     }
 
-    fn radd(&self, other: Value<'v>, heap: &'v Heap) -> Option<Result<Value<'v>, starlark::Error>> {
+    fn radd(&self, other: Value<'v>, heap: Heap<'v>) -> Option<Result<Value<'v>, starlark::Error>> {
         self.add(other, heap)
     }
 
-    fn sub(&self, other: Value<'v>, heap: &'v Heap) -> starlark::Result<Value<'v>> {
+    fn sub(&self, other: Value<'v>, heap: Heap<'v>) -> starlark::Result<Value<'v>> {
         let other = PhysicalValue::try_from(other).map_err(|_| {
             PhysicalValueError::SubtractionNonPhysical {
                 unit: self.unit.quantity(),
@@ -1651,7 +1653,7 @@ impl<'v> StarlarkValue<'v> for PhysicalValue {
         Ok(other_min >= self.min && other_max <= self.max)
     }
 
-    fn minus(&self, heap: &'v Heap) -> starlark::Result<Value<'v>> {
+    fn minus(&self, heap: Heap<'v>) -> starlark::Result<Value<'v>> {
         // Negate and swap min/max
         Ok(heap.alloc(PhysicalValue::from_bounds_nominal(
             -self.nominal,
@@ -2054,16 +2056,18 @@ impl<'v> StarlarkValue<'v> for PhysicalValueType {
     }
 
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new();
-        RES.methods(value_type_methods)
+        static RES: MethodsStatic = MethodsStatic::new("PhysicalValueType", value_type_methods);
+        Some(RES.methods())
     }
 }
 
-#[derive(Hash, Debug, PartialEq, Clone, Allocative)]
+#[derive(Hash, Debug, PartialEq, Clone, Allocative, pagable::Pagable)]
+#[pagable::pagable_typetag(TypeMatcherDyn)]
 struct ValueTypeMatcher {
     unit: PhysicalUnitDims,
 }
 
+#[starlark::type_matcher]
 impl TypeMatcher for ValueTypeMatcher {
     fn matches(&self, value: Value) -> bool {
         match value.downcast_ref::<PhysicalValue>() {
@@ -2723,106 +2727,112 @@ mod tests {
 
     #[test]
     fn test_try_from_physical_value() {
-        let heap = Heap::new();
-        let original = physical_value(10.0, 0.05, PhysicalUnit::Ohms);
-        let starlark_val = heap.alloc(original);
+        Heap::temp(|heap| {
+            let original = physical_value(10.0, 0.05, PhysicalUnit::Ohms);
+            let starlark_val = heap.alloc(original);
 
-        let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
-        assert_eq!(result.nominal, original.nominal);
-        assert_eq!(result.tolerance(), original.tolerance());
-        assert_eq!(result.unit, original.unit);
+            let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
+            assert_eq!(result.nominal, original.nominal);
+            assert_eq!(result.tolerance(), original.tolerance());
+            assert_eq!(result.unit, original.unit);
+        });
     }
 
     #[test]
     fn test_physical_value_is_hashable_in_starlark() {
-        let heap = Heap::new();
-        let v1 = heap.alloc(physical_value(10.0, 0.05, PhysicalUnit::Ohms));
-        let v2 = heap.alloc(physical_value(10.0, 0.05, PhysicalUnit::Ohms));
-        let v3 = heap.alloc(physical_value(11.0, 0.05, PhysicalUnit::Ohms));
+        Heap::temp(|heap| {
+            let v1 = heap.alloc(physical_value(10.0, 0.05, PhysicalUnit::Ohms));
+            let v2 = heap.alloc(physical_value(10.0, 0.05, PhysicalUnit::Ohms));
+            let v3 = heap.alloc(physical_value(11.0, 0.05, PhysicalUnit::Ohms));
 
-        let v1_hashed = v1.to_value().get_hashed().unwrap();
-        let v2_hashed = v2.to_value().get_hashed().unwrap();
-        let v3_hashed = v3.to_value().get_hashed().unwrap();
+            let v1_hashed = v1.to_value().get_hashed().unwrap();
+            let v2_hashed = v2.to_value().get_hashed().unwrap();
+            let v3_hashed = v3.to_value().get_hashed().unwrap();
 
-        assert_eq!(v1_hashed.hash(), v2_hashed.hash());
-        assert_ne!(v1_hashed.hash(), v3_hashed.hash());
-        assert!(v1.to_value().equals(v2.to_value()).unwrap());
-        assert!(!v1.to_value().equals(v3.to_value()).unwrap());
+            assert_eq!(v1_hashed.hash(), v2_hashed.hash());
+            assert_ne!(v1_hashed.hash(), v3_hashed.hash());
+            assert!(v1.to_value().equals(v2.to_value()).unwrap());
+            assert!(!v1.to_value().equals(v3.to_value()).unwrap());
+        });
     }
 
     #[test]
     fn test_physical_value_hash_is_stable_across_freeze() {
-        let heap = Heap::new();
-        let physical = physical_value(10.0, 0.05, PhysicalUnit::Ohms);
-        let value = heap.alloc(physical);
-        let unfrozen_hash = value.to_value().get_hashed().unwrap().hash();
+        Heap::temp(|heap| {
+            let physical = physical_value(10.0, 0.05, PhysicalUnit::Ohms);
+            let value = heap.alloc(physical);
+            let unfrozen_hash = value.to_value().get_hashed().unwrap().hash();
 
-        let frozen_heap = FrozenHeap::new();
-        let frozen = frozen_heap.alloc(physical);
-        let frozen_hash = frozen.get_hashed().unwrap().hash();
+            let frozen_heap = FrozenHeap::new();
+            let frozen = frozen_heap.alloc(physical);
+            let frozen_hash = frozen.get_hashed().unwrap().hash();
 
-        assert_eq!(unfrozen_hash, frozen_hash);
+            assert_eq!(unfrozen_hash, frozen_hash);
+        });
     }
 
     #[test]
     fn test_try_from_string() {
         // Test Starlark string conversion using helper
-        let heap = Heap::new();
-        for (input, unit, value) in [
-            ("10kOhm", PhysicalUnit::Ohms, 10000.0),
-            ("100nF", PhysicalUnit::Farads, 0.0000001),
-            ("3.3V", PhysicalUnit::Volts, 3.3),
-            ("100mA", PhysicalUnit::Amperes, 0.1),
-        ] {
-            let starlark_val = heap.alloc(input);
-            let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
-            assert_eq!(result.unit, unit.into());
-            assert!(
-                (result.nominal - Decimal::from_f64(value).unwrap()).abs() < Decimal::new(1, 6)
-            );
-        }
+        Heap::temp(|heap| {
+            for (input, unit, value) in [
+                ("10kOhm", PhysicalUnit::Ohms, 10000.0),
+                ("100nF", PhysicalUnit::Farads, 0.0000001),
+                ("3.3V", PhysicalUnit::Volts, 3.3),
+                ("100mA", PhysicalUnit::Amperes, 0.1),
+            ] {
+                let starlark_val = heap.alloc(input);
+                let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
+                assert_eq!(result.unit, unit.into());
+                assert!(
+                    (result.nominal - Decimal::from_f64(value).unwrap()).abs() < Decimal::new(1, 6)
+                );
+            }
+        });
     }
 
     #[test]
     fn test_try_from_string_with_tolerance() {
-        let heap = Heap::new();
-        let starlark_val = heap.alloc("10kOhm 5%");
-        let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
+        Heap::temp(|heap| {
+            let starlark_val = heap.alloc("10kOhm 5%");
+            let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
 
-        assert_eq!(result.unit, PhysicalUnit::Ohms.into());
-        assert_eq!(result.nominal, Decimal::from(10000));
-        assert_eq!(result.tolerance(), Decimal::from_f64(0.05).unwrap());
+            assert_eq!(result.unit, PhysicalUnit::Ohms.into());
+            assert_eq!(result.nominal, Decimal::from(10000));
+            assert_eq!(result.tolerance(), Decimal::from_f64(0.05).unwrap());
+        });
     }
 
     #[test]
     fn test_try_from_scalar() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // Test integer
+            let starlark_val = heap.alloc(42);
+            let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
+            assert_eq!(result.unit, PhysicalUnitDims::DIMENSIONLESS);
+            assert_eq!(result.nominal, Decimal::from(42));
+            assert_eq!(result.tolerance(), Decimal::ZERO);
 
-        // Test integer
-        let starlark_val = heap.alloc(42);
-        let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
-        assert_eq!(result.unit, PhysicalUnitDims::DIMENSIONLESS);
-        assert_eq!(result.nominal, Decimal::from(42));
-        assert_eq!(result.tolerance(), Decimal::ZERO);
-
-        // Test float
-        let starlark_val = heap.alloc(3.15);
-        let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
-        assert_eq!(result.unit, PhysicalUnitDims::DIMENSIONLESS);
-        assert_eq!(result.nominal, Decimal::from_f64(3.15).unwrap());
-        assert_eq!(result.tolerance(), Decimal::ZERO);
+            // Test float
+            let starlark_val = heap.alloc(3.15);
+            let result = PhysicalValue::try_from(starlark_val.to_value()).unwrap();
+            assert_eq!(result.unit, PhysicalUnitDims::DIMENSIONLESS);
+            assert_eq!(result.nominal, Decimal::from_f64(3.15).unwrap());
+            assert_eq!(result.tolerance(), Decimal::ZERO);
+        });
     }
 
     #[test]
     fn test_try_from_string_error() {
-        let heap = Heap::new();
-        let invalid_strings = ["invalid", "10kZzz", "abc%", ""];
+        Heap::temp(|heap| {
+            let invalid_strings = ["invalid", "10kZzz", "abc%", ""];
 
-        for invalid in invalid_strings {
-            let starlark_val = heap.alloc(invalid);
-            let result = PhysicalValue::try_from(starlark_val.to_value());
-            assert!(result.is_err(), "Expected error for '{}'", invalid);
-        }
+            for invalid in invalid_strings {
+                let starlark_val = heap.alloc(invalid);
+                let result = PhysicalValue::try_from(starlark_val.to_value());
+                assert!(result.is_err(), "Expected error for '{}'", invalid);
+            }
+        });
     }
 
     #[test]
@@ -2974,183 +2984,184 @@ mod tests {
 
     #[test]
     fn test_equality_and_comparison() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // Test equality with same units and values
+            let v1 = physical_value(5.0, 0.01, PhysicalUnit::Volts); // 5V ±1%
+            let v1_copy = physical_value(5.0, 0.01, PhysicalUnit::Volts); // 5V ±1% (same)
+            let v2 = physical_value(5.0, 0.02, PhysicalUnit::Volts); // 5V ±2% (different tolerance)
+            let v3 = physical_value(3.3, 0.0, PhysicalUnit::Volts); // 3.3V (different nominal)
 
-        // Test equality with same units and values
-        let v1 = physical_value(5.0, 0.01, PhysicalUnit::Volts); // 5V ±1%
-        let v1_copy = physical_value(5.0, 0.01, PhysicalUnit::Volts); // 5V ±1% (same)
-        let v2 = physical_value(5.0, 0.02, PhysicalUnit::Volts); // 5V ±2% (different tolerance)
-        let v3 = physical_value(3.3, 0.0, PhysicalUnit::Volts); // 3.3V (different nominal)
+            // Values with same unit, nominal, and bounds are equal
+            let v1_val = heap.alloc(v1);
+            assert!(v1.equals(v1_val).unwrap());
+            assert!(v1.equals(heap.alloc(v1_copy)).unwrap());
 
-        // Values with same unit, nominal, and bounds are equal
-        let v1_val = heap.alloc(v1);
-        assert!(v1.equals(v1_val).unwrap());
-        assert!(v1.equals(heap.alloc(v1_copy)).unwrap());
+            // Values with different tolerances are NOT equal (different bounds)
+            assert!(!v1.equals(heap.alloc(v2)).unwrap());
 
-        // Values with different tolerances are NOT equal (different bounds)
-        assert!(!v1.equals(heap.alloc(v2)).unwrap());
+            // Values with same unit but different nominal are not equal
+            assert!(!v1.equals(heap.alloc(v3)).unwrap());
 
-        // Values with same unit but different nominal are not equal
-        assert!(!v1.equals(heap.alloc(v3)).unwrap());
+            // Values with different units are not equal
+            let i1 = physical_value(5.0, 0.0, PhysicalUnit::Amperes);
+            assert!(!v1.equals(heap.alloc(i1)).unwrap());
 
-        // Values with different units are not equal
-        let i1 = physical_value(5.0, 0.0, PhysicalUnit::Amperes);
-        assert!(!v1.equals(heap.alloc(i1)).unwrap());
+            // Test comparison with same units
+            let v_small = physical_value(3.0, 0.0, PhysicalUnit::Volts);
+            let v_large = physical_value(10.0, 0.0, PhysicalUnit::Volts);
 
-        // Test comparison with same units
-        let v_small = physical_value(3.0, 0.0, PhysicalUnit::Volts);
-        let v_large = physical_value(10.0, 0.0, PhysicalUnit::Volts);
+            assert_eq!(
+                v_small.compare(heap.alloc(v_large)).unwrap(),
+                Ordering::Less
+            );
+            assert_eq!(
+                v_large.compare(heap.alloc(v_small)).unwrap(),
+                Ordering::Greater
+            );
+            // v1 and v1_copy have same nominal so compare equal
+            assert_eq!(v1.compare(heap.alloc(v1_copy)).unwrap(), Ordering::Equal);
 
-        assert_eq!(
-            v_small.compare(heap.alloc(v_large)).unwrap(),
-            Ordering::Less
-        );
-        assert_eq!(
-            v_large.compare(heap.alloc(v_small)).unwrap(),
-            Ordering::Greater
-        );
-        // v1 and v1_copy have same nominal so compare equal
-        assert_eq!(v1.compare(heap.alloc(v1_copy)).unwrap(), Ordering::Equal);
+            // Test comparison with different units fails
+            let r1 = physical_value(10.0, 0.0, PhysicalUnit::Ohms);
+            assert!(v1.compare(heap.alloc(r1)).is_err());
 
-        // Test comparison with different units fails
-        let r1 = physical_value(10.0, 0.0, PhysicalUnit::Ohms);
-        assert!(v1.compare(heap.alloc(r1)).is_err());
+            // Test comparison with point value string
+            let v_point = physical_value(5.0, 0.0, PhysicalUnit::Volts);
+            let v_str = heap.alloc("5V");
+            assert!(!v_point.equals(v_str).unwrap());
+            assert_eq!(v1.compare(v_str).unwrap(), Ordering::Equal);
 
-        // Test comparison with point value string
-        let v_point = physical_value(5.0, 0.0, PhysicalUnit::Volts);
-        let v_str = heap.alloc("5V");
-        assert!(!v_point.equals(v_str).unwrap());
-        assert_eq!(v1.compare(v_str).unwrap(), Ordering::Equal);
+            // Test comparison with numeric values (should be treated as dimensionless)
+            let num_val = heap.alloc(5.0);
+            assert!(!v1.equals(num_val).unwrap()); // Different units
 
-        // Test comparison with numeric values (should be treated as dimensionless)
-        let num_val = heap.alloc(5.0);
-        assert!(!v1.equals(num_val).unwrap()); // Different units
-
-        // Test with dimensionless values
-        let dim1 = PhysicalValue::dimensionless(10);
-        let dim2 = PhysicalValue::dimensionless(20);
-        assert_eq!(dim1.compare(heap.alloc(dim2)).unwrap(), Ordering::Less);
-        assert_eq!(dim2.compare(heap.alloc(dim1)).unwrap(), Ordering::Greater);
+            // Test with dimensionless values
+            let dim1 = PhysicalValue::dimensionless(10);
+            let dim2 = PhysicalValue::dimensionless(20);
+            assert_eq!(dim1.compare(heap.alloc(dim2)).unwrap(), Ordering::Less);
+            assert_eq!(dim2.compare(heap.alloc(dim1)).unwrap(), Ordering::Greater);
+        });
     }
 
     #[test]
     fn test_comparison_with_various_input_types() {
-        let heap = Heap::new();
-        let voltage = physical_value(12.0, 0.0, PhysicalUnit::Volts);
+        Heap::temp(|heap| {
+            let voltage = physical_value(12.0, 0.0, PhysicalUnit::Volts);
 
-        // Equality remains type-specific even though compare accepts coercions
-        let voltage_str = heap.alloc("12V");
-        assert!(!voltage.equals(voltage_str).unwrap());
+            // Equality remains type-specific even though compare accepts coercions
+            let voltage_str = heap.alloc("12V");
+            assert!(!voltage.equals(voltage_str).unwrap());
 
-        // Test comparison with string representation
-        let larger_voltage_str = heap.alloc("15V");
-        assert_eq!(voltage.compare(larger_voltage_str).unwrap(), Ordering::Less);
+            // Test comparison with string representation
+            let larger_voltage_str = heap.alloc("15V");
+            assert_eq!(voltage.compare(larger_voltage_str).unwrap(), Ordering::Less);
 
-        // Test equality with existing PhysicalValue
-        let same_voltage = heap.alloc(voltage);
-        assert!(voltage.equals(same_voltage).unwrap());
+            // Test equality with existing PhysicalValue
+            let same_voltage = heap.alloc(voltage);
+            assert!(voltage.equals(same_voltage).unwrap());
 
-        // Test with different string formats - now NOT equal (different bounds)
-        let voltage_with_tolerance = heap.alloc("12V 5%");
-        assert!(!voltage.equals(voltage_with_tolerance).unwrap()); // Point != toleranced
+            // Test with different string formats - now NOT equal (different bounds)
+            let voltage_with_tolerance = heap.alloc("12V 5%");
+            assert!(!voltage.equals(voltage_with_tolerance).unwrap()); // Point != toleranced
 
-        // Test comparison failure with non-convertible values
-        let non_physical = heap.alloc("not a physical value");
-        assert!(!voltage.equals(non_physical).unwrap());
-        assert!(voltage.compare(non_physical).is_err());
+            // Test comparison failure with non-convertible values
+            let non_physical = heap.alloc("not a physical value");
+            assert!(!voltage.equals(non_physical).unwrap());
+            assert!(voltage.compare(non_physical).is_err());
+        });
     }
 
     #[test]
     fn test_comparison_error_cases() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // Test unit mismatch in comparison
+            let voltage = physical_value(12.0, 0.0, PhysicalUnit::Volts);
+            let current = physical_value(2.0, 0.0, PhysicalUnit::Amperes);
 
-        // Test unit mismatch in comparison
-        let voltage = physical_value(12.0, 0.0, PhysicalUnit::Volts);
-        let current = physical_value(2.0, 0.0, PhysicalUnit::Amperes);
+            let result = voltage.compare(heap.alloc(current));
+            assert!(result.is_err());
 
-        let result = voltage.compare(heap.alloc(current));
-        assert!(result.is_err());
-
-        // Verify the error contains unit mismatch information
-        let error_str = format!("{}", result.unwrap_err());
-        assert!(error_str.contains("Unit mismatch"));
-        assert!(error_str.contains("Voltage"));
-        assert!(error_str.contains("Current"));
+            // Verify the error contains unit mismatch information
+            let error_str = format!("{}", result.unwrap_err());
+            assert!(error_str.contains("Unit mismatch"));
+            assert!(error_str.contains("Voltage"));
+            assert!(error_str.contains("Current"));
+        });
     }
 
     #[test]
     fn test_dimensionless_comparisons() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // Test with dimensionless values
+            let dimensionless_5 = PhysicalValue::dimensionless(5);
+            let dimensionless_10 = PhysicalValue::dimensionless(10);
+            let voltage_5 = physical_value(5.0, 0.0, PhysicalUnit::Volts);
+            let resistance_5 = physical_value(5.0, 0.0, PhysicalUnit::Ohms);
 
-        // Test with dimensionless values
-        let dimensionless_5 = PhysicalValue::dimensionless(5);
-        let dimensionless_10 = PhysicalValue::dimensionless(10);
-        let voltage_5 = physical_value(5.0, 0.0, PhysicalUnit::Volts);
-        let resistance_5 = physical_value(5.0, 0.0, PhysicalUnit::Ohms);
+            // Dimensionless to dimensionless comparisons
+            assert_eq!(
+                dimensionless_5
+                    .compare(heap.alloc(dimensionless_10))
+                    .unwrap(),
+                Ordering::Less
+            );
+            assert_eq!(
+                dimensionless_10
+                    .compare(heap.alloc(dimensionless_5))
+                    .unwrap(),
+                Ordering::Greater
+            );
+            assert_eq!(
+                dimensionless_5
+                    .compare(heap.alloc(dimensionless_5))
+                    .unwrap(),
+                Ordering::Equal
+            );
 
-        // Dimensionless to dimensionless comparisons
-        assert_eq!(
-            dimensionless_5
-                .compare(heap.alloc(dimensionless_10))
-                .unwrap(),
-            Ordering::Less
-        );
-        assert_eq!(
-            dimensionless_10
-                .compare(heap.alloc(dimensionless_5))
-                .unwrap(),
-            Ordering::Greater
-        );
-        assert_eq!(
-            dimensionless_5
-                .compare(heap.alloc(dimensionless_5))
-                .unwrap(),
-            Ordering::Equal
-        );
+            // Dimensionless to physical unit comparisons (should work)
+            assert_eq!(
+                dimensionless_5.compare(heap.alloc(voltage_5)).unwrap(),
+                Ordering::Equal
+            );
+            assert_eq!(
+                voltage_5.compare(heap.alloc(dimensionless_5)).unwrap(),
+                Ordering::Equal
+            );
+            assert_eq!(
+                dimensionless_10.compare(heap.alloc(voltage_5)).unwrap(),
+                Ordering::Greater
+            );
+            assert_eq!(
+                voltage_5.compare(heap.alloc(dimensionless_10)).unwrap(),
+                Ordering::Less
+            );
 
-        // Dimensionless to physical unit comparisons (should work)
-        assert_eq!(
-            dimensionless_5.compare(heap.alloc(voltage_5)).unwrap(),
-            Ordering::Equal
-        );
-        assert_eq!(
-            voltage_5.compare(heap.alloc(dimensionless_5)).unwrap(),
-            Ordering::Equal
-        );
-        assert_eq!(
-            dimensionless_10.compare(heap.alloc(voltage_5)).unwrap(),
-            Ordering::Greater
-        );
-        assert_eq!(
-            voltage_5.compare(heap.alloc(dimensionless_10)).unwrap(),
-            Ordering::Less
-        );
-
-        // Different units with dimensionless should work
-        assert_eq!(
-            dimensionless_5.compare(heap.alloc(resistance_5)).unwrap(),
-            Ordering::Equal
-        );
-        assert_eq!(
-            resistance_5.compare(heap.alloc(dimensionless_5)).unwrap(),
-            Ordering::Equal
-        );
+            // Different units with dimensionless should work
+            assert_eq!(
+                dimensionless_5.compare(heap.alloc(resistance_5)).unwrap(),
+                Ordering::Equal
+            );
+            assert_eq!(
+                resistance_5.compare(heap.alloc(dimensionless_5)).unwrap(),
+                Ordering::Equal
+            );
+        });
     }
 
     #[test]
     fn test_dimensionless_with_string_conversions() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            let voltage = physical_value(2023.0, 0.0, PhysicalUnit::Ohms);
 
-        let voltage = physical_value(2023.0, 0.0, PhysicalUnit::Ohms);
+            // Test comparison with numeric string (should be treated as dimensionless)
+            let numeric_str = heap.alloc("2000");
+            assert_eq!(voltage.compare(numeric_str).unwrap(), Ordering::Greater);
+            assert!(!voltage.equals(numeric_str).unwrap()); // Different values
 
-        // Test comparison with numeric string (should be treated as dimensionless)
-        let numeric_str = heap.alloc("2000");
-        assert_eq!(voltage.compare(numeric_str).unwrap(), Ordering::Greater);
-        assert!(!voltage.equals(numeric_str).unwrap()); // Different values
-
-        let same_numeric_str = heap.alloc("2023");
-        assert_eq!(voltage.compare(same_numeric_str).unwrap(), Ordering::Equal);
-        assert!(!voltage.equals(same_numeric_str).unwrap()); // Different types
+            let same_numeric_str = heap.alloc("2023");
+            assert_eq!(voltage.compare(same_numeric_str).unwrap(), Ordering::Equal);
+            assert!(!voltage.equals(same_numeric_str).unwrap()); // Different types
+        });
     }
 
     #[test]
@@ -3386,273 +3397,284 @@ mod tests {
         // Test that diff works when the other value is parsed from a string
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let pv1 = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
-        let pv2_str = heap.alloc("5V");
+        Heap::temp(|heap| {
+            let pv1 = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
+            let pv2_str = heap.alloc("5V");
 
-        // Convert string to PhysicalValue
-        let pv2 = PhysicalValue::try_from(pv2_str).unwrap();
-        let pv1_val = PhysicalValue::try_from(pv1).unwrap();
+            // Convert string to PhysicalValue
+            let pv2 = PhysicalValue::try_from(pv2_str).unwrap();
+            let pv1_val = PhysicalValue::try_from(pv1).unwrap();
 
-        // Test diff
-        let result = pv1_val.diff(&pv2).unwrap();
-        assert_eq!(result.nominal, Decimal::from_f64(1.7).unwrap());
-        assert_eq!(result.unit, PhysicalUnit::Volts.into());
+            // Test diff
+            let result = pv1_val.diff(&pv2).unwrap();
+            assert_eq!(result.nominal, Decimal::from_f64(1.7).unwrap());
+            assert_eq!(result.unit, PhysicalUnit::Volts.into());
+        });
     }
 
     #[test]
     fn test_within_same_nominal_different_tolerance() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // 3.3V ±5% fits within 3.3V ±10%
-        let tight = heap.alloc(physical_value(3.3, 0.05, PhysicalUnit::Volts)); // 3.135V - 3.465V
-        let loose = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // 2.97V - 3.63V
-        assert!(
-            loose
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(tight)
-                .unwrap()
-        );
+        Heap::temp(|heap| {
+            // 3.3V ±5% fits within 3.3V ±10%
+            let tight = heap.alloc(physical_value(3.3, 0.05, PhysicalUnit::Volts)); // 3.135V - 3.465V
+            let loose = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // 2.97V - 3.63V
+            assert!(
+                loose
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(tight)
+                    .unwrap()
+            );
 
-        // 3.3V ±10% does NOT fit within 3.3V ±5%
-        assert!(
-            !tight
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(loose)
-                .unwrap()
-        );
+            // 3.3V ±10% does NOT fit within 3.3V ±5%
+            assert!(
+                !tight
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(loose)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]
     fn test_within_different_nominal_values() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // 3.3V ±1% (3.267V - 3.333V) fits within 5V ±50% (2.5V - 7.5V)
-        let small = heap.alloc(physical_value(3.3, 0.01, PhysicalUnit::Volts));
-        let large = heap.alloc(physical_value(5.0, 0.50, PhysicalUnit::Volts));
-        assert!(
-            large
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(small)
-                .unwrap()
-        );
+        Heap::temp(|heap| {
+            // 3.3V ±1% (3.267V - 3.333V) fits within 5V ±50% (2.5V - 7.5V)
+            let small = heap.alloc(physical_value(3.3, 0.01, PhysicalUnit::Volts));
+            let large = heap.alloc(physical_value(5.0, 0.50, PhysicalUnit::Volts));
+            assert!(
+                large
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(small)
+                    .unwrap()
+            );
 
-        // 5V ±50% does NOT fit within 3.3V ±1%
-        assert!(
-            !small
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(large)
-                .unwrap()
-        );
+            // 5V ±50% does NOT fit within 3.3V ±1%
+            assert!(
+                !small
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(large)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]
     fn test_within_exact_match() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Exact values with no tolerance should be within each other
-        let v1 = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
-        let v2 = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
-        assert!(
-            v1.downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(v2)
-                .unwrap()
-        );
-        assert!(
-            v2.downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(v1)
-                .unwrap()
-        );
+        Heap::temp(|heap| {
+            // Exact values with no tolerance should be within each other
+            let v1 = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
+            let v2 = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
+            assert!(
+                v1.downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(v2)
+                    .unwrap()
+            );
+            assert!(
+                v2.downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(v1)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]
     fn test_within_zero_tolerance_in_range() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Zero tolerance value at the center of a range
-        let exact = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
-        let range = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // 2.97V - 3.63V
-        assert!(
-            range
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(exact)
-                .unwrap()
-        );
+        Heap::temp(|heap| {
+            // Zero tolerance value at the center of a range
+            let exact = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
+            let range = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // 2.97V - 3.63V
+            assert!(
+                range
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(exact)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]
     fn test_within_zero_tolerance_outside_range() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Zero tolerance value outside a range
-        let exact = heap.alloc(physical_value(5.0, 0.0, PhysicalUnit::Volts));
-        let range = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // 2.97V - 3.63V
-        assert!(
-            !range
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(exact)
-                .unwrap()
-        );
+        Heap::temp(|heap| {
+            // Zero tolerance value outside a range
+            let exact = heap.alloc(physical_value(5.0, 0.0, PhysicalUnit::Volts));
+            let range = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // 2.97V - 3.63V
+            assert!(
+                !range
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(exact)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]
     fn test_within_edge_cases() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Test boundary conditions
-        // Range: 3.3V ±10% = 2.97V - 3.63V
-        let range = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts));
+        Heap::temp(|heap| {
+            // Test boundary conditions
+            // Range: 3.3V ±10% = 2.97V - 3.63V
+            let range = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts));
 
-        // Value exactly at lower bound should be within
-        let at_min = heap.alloc(physical_value(2.97, 0.0, PhysicalUnit::Volts));
-        assert!(
-            range
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(at_min)
-                .unwrap()
-        );
+            // Value exactly at lower bound should be within
+            let at_min = heap.alloc(physical_value(2.97, 0.0, PhysicalUnit::Volts));
+            assert!(
+                range
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(at_min)
+                    .unwrap()
+            );
 
-        // Value exactly at upper bound should be within
-        let at_max = heap.alloc(physical_value(3.63, 0.0, PhysicalUnit::Volts));
-        assert!(
-            range
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(at_max)
-                .unwrap()
-        );
+            // Value exactly at upper bound should be within
+            let at_max = heap.alloc(physical_value(3.63, 0.0, PhysicalUnit::Volts));
+            assert!(
+                range
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(at_max)
+                    .unwrap()
+            );
 
-        // Value just outside lower bound should not be within
-        let below_min = heap.alloc(physical_value(2.96, 0.0, PhysicalUnit::Volts));
-        assert!(
-            !range
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(below_min)
-                .unwrap()
-        );
+            // Value just outside lower bound should not be within
+            let below_min = heap.alloc(physical_value(2.96, 0.0, PhysicalUnit::Volts));
+            assert!(
+                !range
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(below_min)
+                    .unwrap()
+            );
 
-        // Value just outside upper bound should not be within
-        let above_max = heap.alloc(physical_value(3.64, 0.0, PhysicalUnit::Volts));
-        assert!(
-            !range
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(above_max)
-                .unwrap()
-        );
+            // Value just outside upper bound should not be within
+            let above_max = heap.alloc(physical_value(3.64, 0.0, PhysicalUnit::Volts));
+            assert!(
+                !range
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(above_max)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]
     fn test_within_overlapping_but_not_contained() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Ranges that overlap but one doesn't contain the other
-        // Range 1: 3.3V ±10% = 2.97V - 3.63V
-        // Range 2: 3.5V ±5% = 3.325V - 3.675V
-        let range1 = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts));
-        let range2 = heap.alloc(physical_value(3.5, 0.05, PhysicalUnit::Volts));
+        Heap::temp(|heap| {
+            // Ranges that overlap but one doesn't contain the other
+            // Range 1: 3.3V ±10% = 2.97V - 3.63V
+            // Range 2: 3.5V ±5% = 3.325V - 3.675V
+            let range1 = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts));
+            let range2 = heap.alloc(physical_value(3.5, 0.05, PhysicalUnit::Volts));
 
-        // They overlap but neither contains the other
-        assert!(
-            !range2
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(range1)
-                .unwrap()
-        );
-        assert!(
-            !range1
-                .downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(range2)
-                .unwrap()
-        );
+            // They overlap but neither contains the other
+            assert!(
+                !range2
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(range1)
+                    .unwrap()
+            );
+            assert!(
+                !range1
+                    .downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(range2)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]
     fn test_within_unit_mismatch() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Different units should return an error
-        let volts = heap.alloc(physical_value(3.3, 0.1, PhysicalUnit::Volts));
-        let amps = heap.alloc(physical_value(3.3, 0.1, PhysicalUnit::Amperes));
+        Heap::temp(|heap| {
+            // Different units should return an error
+            let volts = heap.alloc(physical_value(3.3, 0.1, PhysicalUnit::Volts));
+            let amps = heap.alloc(physical_value(3.3, 0.1, PhysicalUnit::Amperes));
 
-        let result = volts.downcast_ref::<PhysicalValue>().unwrap().is_in(amps);
-        assert!(result.is_err());
+            let result = volts.downcast_ref::<PhysicalValue>().unwrap().is_in(amps);
+            assert!(result.is_err());
+        });
     }
 
     #[test]
     fn test_within_different_units() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Test with various unit types
-        let r1 = heap.alloc(physical_value(1000.0, 0.01, PhysicalUnit::Ohms)); // 1kΩ ±1%
-        let r2 = heap.alloc(physical_value(1000.0, 0.05, PhysicalUnit::Ohms)); // 1kΩ ±5%
-        assert!(
-            r2.downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(r1)
-                .unwrap()
-        );
+        Heap::temp(|heap| {
+            // Test with various unit types
+            let r1 = heap.alloc(physical_value(1000.0, 0.01, PhysicalUnit::Ohms)); // 1kΩ ±1%
+            let r2 = heap.alloc(physical_value(1000.0, 0.05, PhysicalUnit::Ohms)); // 1kΩ ±5%
+            assert!(
+                r2.downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(r1)
+                    .unwrap()
+            );
 
-        let c1 = heap.alloc(physical_value(1e-7, 0.05, PhysicalUnit::Farads)); // 100nF ±5%
-        let c2 = heap.alloc(physical_value(1e-7, 0.20, PhysicalUnit::Farads)); // 100nF ±20%
-        assert!(
-            c2.downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(c1)
-                .unwrap()
-        );
+            let c1 = heap.alloc(physical_value(1e-7, 0.05, PhysicalUnit::Farads)); // 100nF ±5%
+            let c2 = heap.alloc(physical_value(1e-7, 0.20, PhysicalUnit::Farads)); // 100nF ±20%
+            assert!(
+                c2.downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(c1)
+                    .unwrap()
+            );
 
-        let f1 = heap.alloc(physical_value(1e6, 0.001, PhysicalUnit::Hertz)); // 1MHz ±0.1%
-        let f2 = heap.alloc(physical_value(1e6, 0.01, PhysicalUnit::Hertz)); // 1MHz ±1%
-        assert!(
-            f2.downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(f1)
-                .unwrap()
-        );
+            let f1 = heap.alloc(physical_value(1e6, 0.001, PhysicalUnit::Hertz)); // 1MHz ±0.1%
+            let f2 = heap.alloc(physical_value(1e6, 0.01, PhysicalUnit::Hertz)); // 1MHz ±1%
+            assert!(
+                f2.downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(f1)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]
     fn test_within_negative_values() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Test with negative values
-        let v1 = heap.alloc(physical_value(-3.3, 0.05, PhysicalUnit::Volts)); // -3.3V ±5%
-        let v2 = heap.alloc(physical_value(-3.3, 0.10, PhysicalUnit::Volts)); // -3.3V ±10%
-        assert!(
-            v2.downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(v1)
-                .unwrap()
-        );
-        assert!(
-            !v1.downcast_ref::<PhysicalValue>()
-                .unwrap()
-                .is_in(v2)
-                .unwrap()
-        );
+        Heap::temp(|heap| {
+            // Test with negative values
+            let v1 = heap.alloc(physical_value(-3.3, 0.05, PhysicalUnit::Volts)); // -3.3V ±5%
+            let v2 = heap.alloc(physical_value(-3.3, 0.10, PhysicalUnit::Volts)); // -3.3V ±10%
+            assert!(
+                v2.downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(v1)
+                    .unwrap()
+            );
+            assert!(
+                !v1.downcast_ref::<PhysicalValue>()
+                    .unwrap()
+                    .is_in(v2)
+                    .unwrap()
+            );
+        });
     }
 
     // Helper for creating PhysicalValue from explicit bounds
@@ -3813,231 +3835,241 @@ mod tests {
     fn test_physical_value_unary_minus() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let v = heap.alloc(physical_value(3.3, 0.05, PhysicalUnit::Volts));
+        Heap::temp(|heap| {
+            let v = heap.alloc(physical_value(3.3, 0.05, PhysicalUnit::Volts));
 
-        // Test unary minus
-        let neg = v
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .minus(&heap)
-            .unwrap();
-        let neg_val = neg.downcast_ref::<PhysicalValue>().unwrap();
+            // Test unary minus
+            let neg = v
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .minus(heap)
+                .unwrap();
+            let neg_val = neg.downcast_ref::<PhysicalValue>().unwrap();
 
-        assert_eq!(neg_val.nominal, Decimal::from_f64(-3.3).unwrap());
-        assert_eq!(neg_val.tolerance(), Decimal::from_f64(0.05).unwrap()); // Tolerance preserved
-        assert_eq!(neg_val.unit, PhysicalUnit::Volts.into());
+            assert_eq!(neg_val.nominal, Decimal::from_f64(-3.3).unwrap());
+            assert_eq!(neg_val.tolerance(), Decimal::from_f64(0.05).unwrap()); // Tolerance preserved
+            assert_eq!(neg_val.unit, PhysicalUnit::Volts.into());
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_unary_minus() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let range = heap.alloc_simple(physical_value_bounds(1.0, 3.0, PhysicalUnit::Volts));
+        Heap::temp(|heap| {
+            let range = heap.alloc_simple(physical_value_bounds(1.0, 3.0, PhysicalUnit::Volts));
 
-        // Test unary minus (should flip and negate)
-        let neg = range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .minus(&heap)
-            .unwrap();
-        let neg_range = neg.downcast_ref::<PhysicalValue>().unwrap();
+            // Test unary minus (should flip and negate)
+            let neg = range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .minus(heap)
+                .unwrap();
+            let neg_range = neg.downcast_ref::<PhysicalValue>().unwrap();
 
-        assert_eq!(neg_range.min, Decimal::from_f64(-3.0).unwrap());
-        assert_eq!(neg_range.max, Decimal::from_f64(-1.0).unwrap());
-        assert_eq!(neg_range.unit, PhysicalUnit::Volts.into());
+            assert_eq!(neg_range.min, Decimal::from_f64(-3.0).unwrap());
+            assert_eq!(neg_range.max, Decimal::from_f64(-1.0).unwrap());
+            assert_eq!(neg_range.unit, PhysicalUnit::Volts.into());
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_unary_minus_with_nominal() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        // Create a value with explicit nominal
-        let range = PhysicalValue::from_bounds_nominal(
-            Decimal::from_f64(2.0).unwrap(),
-            Decimal::from_f64(1.0).unwrap(),
-            Decimal::from_f64(3.0).unwrap(),
-            PhysicalUnit::Volts.into(),
-        );
-        let range_val = heap.alloc_simple(range);
+        Heap::temp(|heap| {
+            // Create a value with explicit nominal
+            let range = PhysicalValue::from_bounds_nominal(
+                Decimal::from_f64(2.0).unwrap(),
+                Decimal::from_f64(1.0).unwrap(),
+                Decimal::from_f64(3.0).unwrap(),
+                PhysicalUnit::Volts.into(),
+            );
+            let range_val = heap.alloc_simple(range);
 
-        let neg = range_val
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .minus(&heap)
-            .unwrap();
-        let neg_range = neg.downcast_ref::<PhysicalValue>().unwrap();
+            let neg = range_val
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .minus(heap)
+                .unwrap();
+            let neg_range = neg.downcast_ref::<PhysicalValue>().unwrap();
 
-        assert_eq!(neg_range.nominal, Decimal::from_f64(-2.0).unwrap());
+            assert_eq!(neg_range.nominal, Decimal::from_f64(-2.0).unwrap());
+        });
     }
 
     #[test]
     fn test_is_in_value_in_range() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let range = heap.alloc_simple(physical_value_bounds(3.0, 3.6, PhysicalUnit::Volts));
-        let value = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
+        Heap::temp(|heap| {
+            let range = heap.alloc_simple(physical_value_bounds(3.0, 3.6, PhysicalUnit::Volts));
+            let value = heap.alloc(physical_value(3.3, 0.0, PhysicalUnit::Volts));
 
-        // Value should be in range
-        let result = range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(value)
-            .unwrap();
-        assert!(result);
+            // Value should be in range
+            let result = range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(value)
+                .unwrap();
+            assert!(result);
 
-        // Value outside range
-        let value_out = heap.alloc(physical_value(5.0, 0.0, PhysicalUnit::Volts));
-        let result = range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(value_out)
-            .unwrap();
-        assert!(!result);
+            // Value outside range
+            let value_out = heap.alloc(physical_value(5.0, 0.0, PhysicalUnit::Volts));
+            let result = range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(value_out)
+                .unwrap();
+            assert!(!result);
+        });
     }
 
     #[test]
     fn test_is_in_value_with_tolerance_in_range() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let range = heap.alloc_simple(physical_value_bounds(3.0, 3.6, PhysicalUnit::Volts));
-        let value = heap.alloc(physical_value(3.3, 0.05, PhysicalUnit::Volts)); // 3.135-3.465V
+        Heap::temp(|heap| {
+            let range = heap.alloc_simple(physical_value_bounds(3.0, 3.6, PhysicalUnit::Volts));
+            let value = heap.alloc(physical_value(3.3, 0.05, PhysicalUnit::Volts)); // 3.135-3.465V
 
-        // Value with tolerance fits in range
-        let result = range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(value)
-            .unwrap();
-        assert!(result);
+            // Value with tolerance fits in range
+            let result = range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(value)
+                .unwrap();
+            assert!(result);
 
-        // Value with tolerance that exceeds range
-        let value_big = heap.alloc(physical_value(3.3, 0.15, PhysicalUnit::Volts)); // 2.805-3.795V
-        let result = range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(value_big)
-            .unwrap();
-        assert!(!result);
+            // Value with tolerance that exceeds range
+            let value_big = heap.alloc(physical_value(3.3, 0.15, PhysicalUnit::Volts)); // 2.805-3.795V
+            let result = range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(value_big)
+                .unwrap();
+            assert!(!result);
+        });
     }
 
     #[test]
     fn test_is_in_range_in_range() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let wide = heap.alloc_simple(physical_value_bounds(2.7, 3.6, PhysicalUnit::Volts));
-        let tight = heap.alloc_simple(physical_value_bounds(3.0, 3.3, PhysicalUnit::Volts));
+        Heap::temp(|heap| {
+            let wide = heap.alloc_simple(physical_value_bounds(2.7, 3.6, PhysicalUnit::Volts));
+            let tight = heap.alloc_simple(physical_value_bounds(3.0, 3.3, PhysicalUnit::Volts));
 
-        // Tight range fits in wide range
-        let result = wide
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(tight)
-            .unwrap();
-        assert!(result);
+            // Tight range fits in wide range
+            let result = wide
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(tight)
+                .unwrap();
+            assert!(result);
 
-        // Wide range doesn't fit in tight range
-        let result = tight
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(wide)
-            .unwrap();
-        assert!(!result);
+            // Wide range doesn't fit in tight range
+            let result = tight
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(wide)
+                .unwrap();
+            assert!(!result);
+        });
     }
 
     #[test]
     fn test_is_in_value_in_value() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let wide = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // ±10%
-        let tight = heap.alloc(physical_value(3.3, 0.05, PhysicalUnit::Volts)); // ±5%
+        Heap::temp(|heap| {
+            let wide = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // ±10%
+            let tight = heap.alloc(physical_value(3.3, 0.05, PhysicalUnit::Volts)); // ±5%
 
-        // Tight tolerance fits in wide tolerance
-        let result = wide
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(tight)
-            .unwrap();
-        assert!(result);
+            // Tight tolerance fits in wide tolerance
+            let result = wide
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(tight)
+                .unwrap();
+            assert!(result);
 
-        // Wide tolerance doesn't fit in tight tolerance
-        let result = tight
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(wide)
-            .unwrap();
-        assert!(!result);
+            // Wide tolerance doesn't fit in tight tolerance
+            let result = tight
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(wide)
+                .unwrap();
+            assert!(!result);
+        });
     }
 
     #[test]
     fn test_is_in_range_in_value() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let value = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // 2.97-3.63V
-        let range = heap.alloc_simple(physical_value_bounds(3.0, 3.5, PhysicalUnit::Volts));
+        Heap::temp(|heap| {
+            let value = heap.alloc(physical_value(3.3, 0.10, PhysicalUnit::Volts)); // 2.97-3.63V
+            let range = heap.alloc_simple(physical_value_bounds(3.0, 3.5, PhysicalUnit::Volts));
 
-        // Range fits in value's tolerance
-        let result = value
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(range)
-            .unwrap();
-        assert!(result);
+            // Range fits in value's tolerance
+            let result = value
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(range)
+                .unwrap();
+            assert!(result);
 
-        // Range exceeds value's tolerance
-        let range_big = heap.alloc_simple(physical_value_bounds(2.0, 4.0, PhysicalUnit::Volts));
-        let result = value
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(range_big)
-            .unwrap();
-        assert!(!result);
+            // Range exceeds value's tolerance
+            let range_big = heap.alloc_simple(physical_value_bounds(2.0, 4.0, PhysicalUnit::Volts));
+            let result = value
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(range_big)
+                .unwrap();
+            assert!(!result);
+        });
     }
 
     #[test]
     fn test_is_in_string_arguments() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let range = heap.alloc_simple(physical_value_bounds(3.0, 3.6, PhysicalUnit::Volts));
-        let value_str = heap.alloc("3.3V");
+        Heap::temp(|heap| {
+            let range = heap.alloc_simple(physical_value_bounds(3.0, 3.6, PhysicalUnit::Volts));
+            let value_str = heap.alloc("3.3V");
 
-        // String value in range
-        let result = range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(value_str)
-            .unwrap();
-        assert!(result);
+            // String value in range
+            let result = range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(value_str)
+                .unwrap();
+            assert!(result);
 
-        // String range in range
-        let range_str = heap.alloc("3.0V to 3.3V");
-        let result = range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .is_in(range_str)
-            .unwrap();
-        assert!(result);
+            // String range in range
+            let range_str = heap.alloc("3.0V to 3.3V");
+            let result = range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .is_in(range_str)
+                .unwrap();
+            assert!(result);
+        });
     }
 
     #[test]
     fn test_is_in_unit_mismatch() {
         use starlark::values::Heap;
 
-        let heap = Heap::new();
-        let volts = heap.alloc_simple(physical_value_bounds(3.0, 3.6, PhysicalUnit::Volts));
-        let amps = heap.alloc(physical_value(1.0, 0.0, PhysicalUnit::Amperes));
+        Heap::temp(|heap| {
+            let volts = heap.alloc_simple(physical_value_bounds(3.0, 3.6, PhysicalUnit::Volts));
+            let amps = heap.alloc(physical_value(1.0, 0.0, PhysicalUnit::Amperes));
 
-        // Unit mismatch should error
-        let result = volts.downcast_ref::<PhysicalValue>().unwrap().is_in(amps);
-        assert!(result.is_err());
+            // Unit mismatch should error
+            let result = volts.downcast_ref::<PhysicalValue>().unwrap().is_in(amps);
+            assert!(result.is_err());
+        });
     }
 
     #[test]
@@ -4045,46 +4077,47 @@ mod tests {
         use starlark::environment::Module;
         use starlark::eval::Evaluator;
 
-        let module = Module::new();
-        let heap = module.heap();
-        let mut eval = Evaluator::new(&module);
+        Module::with_temp_heap(|module| {
+            let heap = module.heap();
+            let mut eval = Evaluator::new(&module);
 
-        // Test case from the regression: 4.7uF ±10% (house part) should fit within 4.7uF requirement
-        let house_part = heap.alloc(physical_value(4.7e-6, 0.1, PhysicalUnit::Farads)); // 4.7uF ±10%
-        let requirement = heap.alloc_str("4.7uF"); // 4.7uF (no tolerance = 0%)
+            // Test case from the regression: 4.7uF ±10% (house part) should fit within 4.7uF requirement
+            let house_part = heap.alloc(physical_value(4.7e-6, 0.1, PhysicalUnit::Farads)); // 4.7uF ±10%
+            let requirement = heap.alloc_str("4.7uF"); // 4.7uF (no tolerance = 0%)
 
-        // within() should check if house_part fits within requirement
-        let result = eval.eval_function(
-            house_part.get_attr("within", heap).unwrap().unwrap(),
-            &[requirement.to_value()],
-            &[],
-        );
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().unpack_bool(), Some(false)); // 10% tolerance doesn't fit in 0% tolerance
+            // within() should check if house_part fits within requirement
+            let result = eval.eval_function(
+                house_part.get_attr("within", heap).unwrap().unwrap(),
+                &[requirement.to_value()],
+                &[],
+            );
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().unpack_bool(), Some(false)); // 10% tolerance doesn't fit in 0% tolerance
 
-        // Test case: tight tolerance fits within loose tolerance
-        let tight = heap.alloc(physical_value(5.5, 0.01, PhysicalUnit::Volts)); // 5.5V ±1%
-        let loose = heap.alloc_str("6V 10%"); // 6V ±10% = [5.4V, 6.6V]
+            // Test case: tight tolerance fits within loose tolerance
+            let tight = heap.alloc(physical_value(5.5, 0.01, PhysicalUnit::Volts)); // 5.5V ±1%
+            let loose = heap.alloc_str("6V 10%"); // 6V ±10% = [5.4V, 6.6V]
 
-        let result = eval.eval_function(
-            tight.get_attr("within", heap).unwrap().unwrap(),
-            &[loose.to_value()],
-            &[],
-        );
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().unpack_bool(), Some(true)); // [5.445, 5.555] fits in [5.4, 6.6]
+            let result = eval.eval_function(
+                tight.get_attr("within", heap).unwrap().unwrap(),
+                &[loose.to_value()],
+                &[],
+            );
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().unpack_bool(), Some(true)); // [5.445, 5.555] fits in [5.4, 6.6]
 
-        // Test case: loose tolerance doesn't fit within tight tolerance
-        let loose_val = heap.alloc(physical_value(6.0, 0.1, PhysicalUnit::Volts)); // 6V ±10%
-        let tight_val = heap.alloc_str("5.5V 1%"); // 5.5V ±1%
+            // Test case: loose tolerance doesn't fit within tight tolerance
+            let loose_val = heap.alloc(physical_value(6.0, 0.1, PhysicalUnit::Volts)); // 6V ±10%
+            let tight_val = heap.alloc_str("5.5V 1%"); // 5.5V ±1%
 
-        let result = eval.eval_function(
-            loose_val.get_attr("within", heap).unwrap().unwrap(),
-            &[tight_val.to_value()],
-            &[],
-        );
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().unpack_bool(), Some(false)); // [5.4, 6.6] doesn't fit in [5.445, 5.555]
+            let result = eval.eval_function(
+                loose_val.get_attr("within", heap).unwrap().unwrap(),
+                &[tight_val.to_value()],
+                &[],
+            );
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().unpack_bool(), Some(false)); // [5.4, 6.6] doesn't fit in [5.445, 5.555]
+        });
     }
 
     #[test]
@@ -4092,44 +4125,45 @@ mod tests {
         use starlark::environment::Module;
         use starlark::eval::Evaluator;
 
-        let module = Module::new();
-        let heap = module.heap();
-        let mut eval = Evaluator::new(&module);
+        Module::with_temp_heap(|module| {
+            let heap = module.heap();
+            let mut eval = Evaluator::new(&module);
 
-        // Create values: tight = 5.5V ±1%, loose = 6V ±10%
-        let tight = heap.alloc(physical_value(5.5, 0.01, PhysicalUnit::Volts));
-        let loose = heap.alloc(physical_value(6.0, 0.1, PhysicalUnit::Volts));
+            // Create values: tight = 5.5V ±1%, loose = 6V ±10%
+            let tight = heap.alloc(physical_value(5.5, 0.01, PhysicalUnit::Volts));
+            let loose = heap.alloc(physical_value(6.0, 0.1, PhysicalUnit::Volts));
 
-        // tight.within(loose) should be true (tight fits in loose)
-        let within_result = eval
-            .eval_function(
-                tight.get_attr("within", heap).unwrap().unwrap(),
-                &[loose.to_value()],
-                &[],
-            )
-            .unwrap();
-        assert_eq!(within_result.unpack_bool(), Some(true));
+            // tight.within(loose) should be true (tight fits in loose)
+            let within_result = eval
+                .eval_function(
+                    tight.get_attr("within", heap).unwrap().unwrap(),
+                    &[loose.to_value()],
+                    &[],
+                )
+                .unwrap();
+            assert_eq!(within_result.unpack_bool(), Some(true));
 
-        // "tight in loose" (Starlark syntax) should also be true
-        // This calls loose.is_in(tight), checking if tight is in loose
-        let is_in_result = loose.downcast_ref::<PhysicalValue>().unwrap().is_in(tight);
-        assert!(is_in_result.is_ok());
-        assert!(is_in_result.unwrap());
+            // "tight in loose" (Starlark syntax) should also be true
+            // This calls loose.is_in(tight), checking if tight is in loose
+            let is_in_result = loose.downcast_ref::<PhysicalValue>().unwrap().is_in(tight);
+            assert!(is_in_result.is_ok());
+            assert!(is_in_result.unwrap());
 
-        // loose.within(tight) should be false (loose doesn't fit in tight)
-        let within_result2 = eval
-            .eval_function(
-                loose.get_attr("within", heap).unwrap().unwrap(),
-                &[tight.to_value()],
-                &[],
-            )
-            .unwrap();
-        assert_eq!(within_result2.unpack_bool(), Some(false));
+            // loose.within(tight) should be false (loose doesn't fit in tight)
+            let within_result2 = eval
+                .eval_function(
+                    loose.get_attr("within", heap).unwrap().unwrap(),
+                    &[tight.to_value()],
+                    &[],
+                )
+                .unwrap();
+            assert_eq!(within_result2.unpack_bool(), Some(false));
 
-        // tight.is_in(loose) checks if loose is in tight, should be false
-        let is_in_result2 = tight.downcast_ref::<PhysicalValue>().unwrap().is_in(loose);
-        assert!(is_in_result2.is_ok());
-        assert!(!is_in_result2.unwrap());
+            // tight.is_in(loose) checks if loose is in tight, should be false
+            let is_in_result2 = tight.downcast_ref::<PhysicalValue>().unwrap().is_in(loose);
+            assert!(is_in_result2.is_ok());
+            assert!(!is_in_result2.unwrap());
+        });
     }
 
     #[test]
@@ -4149,237 +4183,237 @@ mod tests {
     fn test_physical_value_bounds_compare_disjoint() {
         use starlark::values::Value;
 
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range1 = 1V to 2V, range2 = 3V to 4V (disjoint, range1 < range2)
+            let range1: PhysicalValue = "1V to 2V".parse().unwrap();
+            let range2: PhysicalValue = "3V to 4V".parse().unwrap();
 
-        // range1 = 1V to 2V, range2 = 3V to 4V (disjoint, range1 < range2)
-        let range1: PhysicalValue = "1V to 2V".parse().unwrap();
-        let range2: PhysicalValue = "3V to 4V".parse().unwrap();
+            let v1: Value = heap.alloc_simple(range1);
+            let v2: Value = heap.alloc_simple(range2);
 
-        let v1: Value = heap.alloc_simple(range1);
-        let v2: Value = heap.alloc_simple(range2);
+            // Conservative semantics: range1 < range2 because range1.max < range2.min
+            let cmp = v1.compare(v2).unwrap();
+            assert_eq!(cmp, std::cmp::Ordering::Less);
 
-        // Conservative semantics: range1 < range2 because range1.max < range2.min
-        let cmp = v1.compare(v2).unwrap();
-        assert_eq!(cmp, std::cmp::Ordering::Less);
-
-        // And the reverse
-        let cmp_rev = v2.compare(v1).unwrap();
-        assert_eq!(cmp_rev, std::cmp::Ordering::Greater);
+            // And the reverse
+            let cmp_rev = v2.compare(v1).unwrap();
+            assert_eq!(cmp_rev, std::cmp::Ordering::Greater);
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_compare_overlapping() {
         use starlark::values::Value;
 
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range1 = 1V to 3V, range2 = 2V to 4V (overlapping)
+            let range1: PhysicalValue = "1V to 3V".parse().unwrap();
+            let range2: PhysicalValue = "2V to 4V".parse().unwrap();
 
-        // range1 = 1V to 3V, range2 = 2V to 4V (overlapping)
-        let range1: PhysicalValue = "1V to 3V".parse().unwrap();
-        let range2: PhysicalValue = "2V to 4V".parse().unwrap();
+            let v1: Value = heap.alloc_simple(range1);
+            let v2: Value = heap.alloc_simple(range2);
 
-        let v1: Value = heap.alloc_simple(range1);
-        let v2: Value = heap.alloc_simple(range2);
-
-        // Overlapping ranges use max comparison as tiebreaker
-        // range1.max (3V) < range2.max (4V)
-        let cmp = v1.compare(v2).unwrap();
-        assert_eq!(cmp, std::cmp::Ordering::Less);
+            // Overlapping ranges use max comparison as tiebreaker
+            // range1.max (3V) < range2.max (4V)
+            let cmp = v1.compare(v2).unwrap();
+            assert_eq!(cmp, std::cmp::Ordering::Less);
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_compare_with_value() {
         use starlark::values::Value;
 
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range = 1V to 2V, value = 5V (no tolerance)
+            let range: PhysicalValue = "1V to 2V".parse().unwrap();
+            let value = physical_value(5.0, 0.0, PhysicalUnit::Volts);
 
-        // range = 1V to 2V, value = 5V (no tolerance)
-        let range: PhysicalValue = "1V to 2V".parse().unwrap();
-        let value = physical_value(5.0, 0.0, PhysicalUnit::Volts);
+            let v_range: Value = heap.alloc_simple(range);
+            let v_value: Value = heap.alloc(value);
 
-        let v_range: Value = heap.alloc_simple(range);
-        let v_value: Value = heap.alloc(value);
-
-        // range.max (2V) < value.min (5V), so range < value
-        let cmp = v_range.compare(v_value).unwrap();
-        assert_eq!(cmp, std::cmp::Ordering::Less);
+            // range.max (2V) < value.min (5V), so range < value
+            let cmp = v_range.compare(v_value).unwrap();
+            assert_eq!(cmp, std::cmp::Ordering::Less);
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_compare_unit_mismatch() {
         use starlark::values::Value;
 
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range1 = 1V to 2V, range2 = 1A to 2A (different units)
+            let range1: PhysicalValue = "1V to 2V".parse().unwrap();
+            let range2: PhysicalValue = "1A to 2A".parse().unwrap();
 
-        // range1 = 1V to 2V, range2 = 1A to 2A (different units)
-        let range1: PhysicalValue = "1V to 2V".parse().unwrap();
-        let range2: PhysicalValue = "1A to 2A".parse().unwrap();
+            let v1: Value = heap.alloc_simple(range1);
+            let v2: Value = heap.alloc_simple(range2);
 
-        let v1: Value = heap.alloc_simple(range1);
-        let v2: Value = heap.alloc_simple(range2);
-
-        // Should error on unit mismatch
-        let result = v1.compare(v2);
-        assert!(result.is_err());
+            // Should error on unit mismatch
+            let result = v1.compare(v2);
+            assert!(result.is_err());
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_equals() {
         use starlark::values::Value;
 
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            let range1: PhysicalValue = "1V to 2V".parse().unwrap();
+            let range2: PhysicalValue = "1V to 2V".parse().unwrap();
+            let range3: PhysicalValue = "1V to 3V".parse().unwrap();
+            let range4: PhysicalValue = "1V to 2V (1.5V nom.)".parse().unwrap();
+            let range5: PhysicalValue = "1V to 2V (1.2V nom.)".parse().unwrap();
 
-        let range1: PhysicalValue = "1V to 2V".parse().unwrap();
-        let range2: PhysicalValue = "1V to 2V".parse().unwrap();
-        let range3: PhysicalValue = "1V to 3V".parse().unwrap();
-        let range4: PhysicalValue = "1V to 2V (1.5V nom.)".parse().unwrap();
-        let range5: PhysicalValue = "1V to 2V (1.2V nom.)".parse().unwrap();
+            let v1: Value = heap.alloc_simple(range1);
+            let v2: Value = heap.alloc_simple(range2);
+            let v3: Value = heap.alloc_simple(range3);
+            let v4: Value = heap.alloc_simple(range4);
+            let v5: Value = heap.alloc_simple(range5);
 
-        let v1: Value = heap.alloc_simple(range1);
-        let v2: Value = heap.alloc_simple(range2);
-        let v3: Value = heap.alloc_simple(range3);
-        let v4: Value = heap.alloc_simple(range4);
-        let v5: Value = heap.alloc_simple(range5);
-
-        // Same range
-        assert!(v1.equals(v2).unwrap());
-        // Different max
-        assert!(!v1.equals(v3).unwrap());
-        // Same min/max with same nominal (1.5V is midpoint)
-        assert!(v1.equals(v4).unwrap());
-        // Same min/max but different nominal
-        assert!(!v1.equals(v5).unwrap());
+            // Same range
+            assert!(v1.equals(v2).unwrap());
+            // Different max
+            assert!(!v1.equals(v3).unwrap());
+            // Same min/max with same nominal (1.5V is midpoint)
+            assert!(v1.equals(v4).unwrap());
+            // Same min/max but different nominal
+            assert!(!v1.equals(v5).unwrap());
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_compare_with_string() {
         use starlark::values::Value;
 
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range = 1V to 2V
+            let range: PhysicalValue = "1V to 2V".parse().unwrap();
+            let v_range: Value = heap.alloc_simple(range);
 
-        // range = 1V to 2V
-        let range: PhysicalValue = "1V to 2V".parse().unwrap();
-        let v_range: Value = heap.alloc_simple(range);
+            // Compare with string "5V"
+            let v_str: Value = heap.alloc_str("5V").to_value();
 
-        // Compare with string "5V"
-        let v_str: Value = heap.alloc_str("5V").to_value();
-
-        // range.max (2V) < 5V, so range < "5V"
-        let cmp = v_range.compare(v_str).unwrap();
-        assert_eq!(cmp, std::cmp::Ordering::Less);
+            // range.max (2V) < 5V, so range < "5V"
+            let cmp = v_range.compare(v_str).unwrap();
+            assert_eq!(cmp, std::cmp::Ordering::Less);
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_add_value() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range = 1V to 2V (1.5V nominal), offset = 3V
+            let range: PhysicalValue = "1V to 2V".parse().unwrap();
+            let offset = physical_value(3.0, 0.0, PhysicalUnit::Volts);
 
-        // range = 1V to 2V (1.5V nominal), offset = 3V
-        let range: PhysicalValue = "1V to 2V".parse().unwrap();
-        let offset = physical_value(3.0, 0.0, PhysicalUnit::Volts);
+            let v_range = heap.alloc_simple(range);
+            let v_offset = heap.alloc(offset);
 
-        let v_range = heap.alloc_simple(range);
-        let v_offset = heap.alloc(offset);
+            // 1.5V (nominal) + 3V = 4.5V (point value - bounds dropped)
+            let result = v_range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .add(v_offset, heap)
+                .unwrap()
+                .unwrap();
+            let result_val = result.downcast_ref::<PhysicalValue>().unwrap();
 
-        // 1.5V (nominal) + 3V = 4.5V (point value - bounds dropped)
-        let result = v_range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .add(v_offset, &heap)
-            .unwrap()
-            .unwrap();
-        let result_val = result.downcast_ref::<PhysicalValue>().unwrap();
-
-        // Add returns point value based on nominal
-        assert_eq!(result_val.nominal, Decimal::from_str("4.5").unwrap());
-        assert!(result_val.is_point()); // Bounds are dropped
-        assert_eq!(result_val.unit, PhysicalUnit::Volts.into());
+            // Add returns point value based on nominal
+            assert_eq!(result_val.nominal, Decimal::from_str("4.5").unwrap());
+            assert!(result_val.is_point()); // Bounds are dropped
+            assert_eq!(result_val.unit, PhysicalUnit::Volts.into());
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_add_value_with_nominal() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range = 1V to 3V (2V nom.), offset = 5V
+            let range: PhysicalValue = "1V to 3V (2V nom.)".parse().unwrap();
+            let offset = physical_value(5.0, 0.0, PhysicalUnit::Volts);
 
-        // range = 1V to 3V (2V nom.), offset = 5V
-        let range: PhysicalValue = "1V to 3V (2V nom.)".parse().unwrap();
-        let offset = physical_value(5.0, 0.0, PhysicalUnit::Volts);
+            let v_range = heap.alloc_simple(range);
+            let v_offset = heap.alloc(offset);
 
-        let v_range = heap.alloc_simple(range);
-        let v_offset = heap.alloc(offset);
+            // 2V (nominal) + 5V = 7V (point value - bounds dropped)
+            let result = v_range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .add(v_offset, heap)
+                .unwrap()
+                .unwrap();
+            let result_val = result.downcast_ref::<PhysicalValue>().unwrap();
 
-        // 2V (nominal) + 5V = 7V (point value - bounds dropped)
-        let result = v_range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .add(v_offset, &heap)
-            .unwrap()
-            .unwrap();
-        let result_val = result.downcast_ref::<PhysicalValue>().unwrap();
-
-        // Add returns point value based on nominal
-        assert_eq!(result_val.nominal, Decimal::from(7));
-        assert!(result_val.is_point()); // Bounds are dropped
+            // Add returns point value based on nominal
+            assert_eq!(result_val.nominal, Decimal::from(7));
+            assert!(result_val.is_point()); // Bounds are dropped
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_sub_value() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range = 5V to 10V (7.5V nominal), offset = 2V
+            let range: PhysicalValue = "5V to 10V".parse().unwrap();
+            let offset = physical_value(2.0, 0.0, PhysicalUnit::Volts);
 
-        // range = 5V to 10V (7.5V nominal), offset = 2V
-        let range: PhysicalValue = "5V to 10V".parse().unwrap();
-        let offset = physical_value(2.0, 0.0, PhysicalUnit::Volts);
+            let v_range = heap.alloc_simple(range);
+            let v_offset = heap.alloc(offset);
 
-        let v_range = heap.alloc_simple(range);
-        let v_offset = heap.alloc(offset);
+            // 7.5V (nominal) - 2V = 5.5V (point value - bounds dropped)
+            let result = v_range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .sub(v_offset, heap)
+                .unwrap();
+            let result_val = result.downcast_ref::<PhysicalValue>().unwrap();
 
-        // 7.5V (nominal) - 2V = 5.5V (point value - bounds dropped)
-        let result = v_range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .sub(v_offset, &heap)
-            .unwrap();
-        let result_val = result.downcast_ref::<PhysicalValue>().unwrap();
-
-        // Sub returns point value based on nominal
-        assert_eq!(result_val.nominal, Decimal::from_str("5.5").unwrap());
-        assert!(result_val.is_point()); // Bounds are dropped
+            // Sub returns point value based on nominal
+            assert_eq!(result_val.nominal, Decimal::from_str("5.5").unwrap());
+            assert!(result_val.is_point()); // Bounds are dropped
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_add_unit_mismatch() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range = 1V to 2V, offset = 1A (wrong unit)
+            let range: PhysicalValue = "1V to 2V".parse().unwrap();
+            let offset = physical_value(1.0, 0.0, PhysicalUnit::Amperes);
 
-        // range = 1V to 2V, offset = 1A (wrong unit)
-        let range: PhysicalValue = "1V to 2V".parse().unwrap();
-        let offset = physical_value(1.0, 0.0, PhysicalUnit::Amperes);
+            let v_range = heap.alloc_simple(range);
+            let v_offset = heap.alloc(offset);
 
-        let v_range = heap.alloc_simple(range);
-        let v_offset = heap.alloc(offset);
-
-        // Should error on unit mismatch
-        let result = v_range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .add(v_offset, &heap)
-            .unwrap();
-        assert!(result.is_err());
+            // Should error on unit mismatch
+            let result = v_range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .add(v_offset, heap)
+                .unwrap();
+            assert!(result.is_err());
+        });
     }
 
     #[test]
     fn test_physical_value_bounds_add_dimensionless() {
-        let heap = Heap::new();
+        Heap::temp(|heap| {
+            // range = 1V to 2V, offset = 3 (dimensionless)
+            let range: PhysicalValue = "1V to 2V".parse().unwrap();
+            let offset = PhysicalValue::dimensionless(3);
 
-        // range = 1V to 2V, offset = 3 (dimensionless)
-        let range: PhysicalValue = "1V to 2V".parse().unwrap();
-        let offset = PhysicalValue::dimensionless(3);
+            let v_range = heap.alloc_simple(range);
+            let v_offset = heap.alloc(offset);
 
-        let v_range = heap.alloc_simple(range);
-        let v_offset = heap.alloc(offset);
-
-        // Adding dimensionless to voltage should fail (unit mismatch)
-        let result = v_range
-            .downcast_ref::<PhysicalValue>()
-            .unwrap()
-            .add(v_offset, &heap)
-            .unwrap();
-        assert!(result.is_err());
+            // Adding dimensionless to voltage should fail (unit mismatch)
+            let result = v_range
+                .downcast_ref::<PhysicalValue>()
+                .unwrap()
+                .add(v_offset, heap)
+                .unwrap();
+            assert!(result.is_err());
+        });
     }
 }

--- a/crates/pcb-sch/src/physical.rs
+++ b/crates/pcb-sch/src/physical.rs
@@ -1879,53 +1879,6 @@ impl<'v> StarlarkValue<'v> for PhysicalValueType {
                     }
                 };
 
-                let parse_bound = |value: Value, label: &str| -> starlark::Result<Decimal> {
-                    if let Some(pv) = value.downcast_ref::<PhysicalValue>() {
-                        if !pv.is_point() {
-                            return Err(PhysicalValueError::InvalidArguments {
-                                args: vec![label.to_string()],
-                            }
-                            .into());
-                        }
-                        return Ok(pv.nominal);
-                    }
-
-                    if let Some(s) = value.unpack_str() {
-                        let s = s.trim();
-                        if s.is_empty() {
-                            return Err(PhysicalValueError::InvalidNumberType.into());
-                        }
-                        if let Ok((number, unit_str)) = split_number_and_unit(s)
-                            && unit_str.is_empty()
-                        {
-                            return Ok(number);
-                        }
-                        let pv = PhysicalValue::from_str(s).map_err(|err| {
-                            PhysicalValueError::ParseError {
-                                unit: self.unit.quantity(),
-                                input: s.to_string(),
-                                source: err,
-                            }
-                        })?;
-                        if pv.unit != self.unit {
-                            return Err(PhysicalValueError::UnitMismatch {
-                                expected: self.unit.quantity(),
-                                actual: pv.unit.quantity(),
-                            }
-                            .into());
-                        }
-                        if !pv.is_point() {
-                            return Err(PhysicalValueError::InvalidArguments {
-                                args: vec![label.to_string()],
-                            }
-                            .into());
-                        }
-                        return Ok(pv.nominal);
-                    }
-
-                    starlark_value_to_decimal(&value).map_err(Into::into)
-                };
-
                 let parse_value = |value: Value| -> starlark::Result<PhysicalValue> {
                     if let Some(existing) = value.downcast_ref::<PhysicalValue>() {
                         // Casting semantics: constructors can re-tag other physical values.
@@ -1956,18 +1909,22 @@ impl<'v> StarlarkValue<'v> for PhysicalValueType {
                                 source: err,
                             }
                         })?;
-                        if pv.unit != self.unit {
-                            return Err(PhysicalValueError::UnitMismatch {
-                                expected: self.unit.quantity(),
-                                actual: pv.unit.quantity(),
-                            }
-                            .into());
-                        }
-                        return Ok(pv);
+                        return Ok(pv.check_unit(self.unit)?);
                     }
 
                     let v = starlark_value_to_decimal(&value)?;
                     Ok(PhysicalValue::point(v, self.unit))
+                };
+
+                let parse_bound = |value: Value, label: &str| -> starlark::Result<Decimal> {
+                    let pv = parse_value(value)?;
+                    if !pv.is_point() {
+                        return Err(PhysicalValueError::InvalidArguments {
+                            args: vec![label.to_string()],
+                        }
+                        .into());
+                    }
+                    Ok(pv.nominal)
                 };
 
                 let resolve_nominal = |nominal_kw: Option<Value>,

--- a/crates/pcb-zen-core/Cargo.toml
+++ b/crates/pcb-zen-core/Cargo.toml
@@ -21,6 +21,7 @@ table = ["pcb-sch/table"]
 
 [dependencies]
 allocative = { workspace = true }
+pagable = { workspace = true }
 
 starlark = { workspace = true }
 starlark_map = { workspace = true }

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -582,9 +582,8 @@ impl ModuleConverter {
                 .get(key)
                 .map(|val| {
                     // Try to interpret the value as a boolean
-                    if let Some(s) = val.downcast_frozen_str() {
-                        let s_str = s.to_string();
-                        s_str.to_lowercase() == "true" || s_str == "1"
+                    if let Some(s) = val.to_value().unpack_str() {
+                        s.eq_ignore_ascii_case("true") || s == "1"
                     } else {
                         val.unpack_bool().unwrap_or_default()
                     }
@@ -1266,7 +1265,7 @@ fn add_bool_attribute_if_true(instance: &mut Instance, attr_name: &str, value: b
 
 fn to_attribute_value(v: starlark::values::FrozenValue) -> anyhow::Result<AttributeValue> {
     // Handle scalars first
-    if let Some(s) = v.downcast_frozen_str() {
+    if let Some(s) = v.to_value().unpack_str() {
         return Ok(AttributeValue::String(s.to_string()));
     } else if let Some(n) = v.unpack_i32() {
         return Ok(AttributeValue::Number(n as f64));

--- a/crates/pcb-zen-core/src/graph/path.rs
+++ b/crates/pcb-zen-core/src/graph/path.rs
@@ -9,7 +9,7 @@ impl CircuitGraph {
     pub fn resolve_label_to_port<'v>(
         &self,
         label: Value<'v>,
-        _heap: &'v Heap,
+        _heap: Heap<'v>,
     ) -> starlark::Result<PortId> {
         // Check if it's a string (net name) - assume it's referring to external net
         if let Some(net_name) = label.unpack_str() {
@@ -59,7 +59,7 @@ impl CircuitGraph {
         port_path: &[PortId],
         factors: &[FactorId],
         components: &HashMap<ModulePath, FrozenValue>,
-        heap: &'v Heap,
+        heap: Heap<'v>,
     ) -> starlark::Result<Value<'v>> {
         use crate::graph::starlark::PathValueGen;
 

--- a/crates/pcb-zen-core/src/graph/starlark.rs
+++ b/crates/pcb-zen-core/src/graph/starlark.rs
@@ -132,8 +132,9 @@ impl<V: ValueLifetimeless> std::fmt::Display for ModuleGraphValueGen<V> {
 impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for ModuleGraphValueGen<V>
 where
     Self: ProvidesStaticType<'v>,
+    <Self as ProvidesStaticType<'v>>::StaticType: Send,
 {
-    fn get_attr(&self, attr: &str, heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attr: &str, heap: Heap<'v>) -> Option<Value<'v>> {
         match attr {
             "paths" => {
                 let callable = PathsCallableGen {
@@ -225,8 +226,9 @@ impl<V: ValueLifetimeless> std::fmt::Display for PathValueGen<V> {
 impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for PathValueGen<V>
 where
     Self: ProvidesStaticType<'v>,
+    <Self as ProvidesStaticType<'v>>::StaticType: Send,
 {
-    fn get_attr(&self, attr: &str, heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attr: &str, heap: Heap<'v>) -> Option<Value<'v>> {
         match attr {
             "ports" => {
                 Some(heap.alloc(self.ports.iter().map(|v| v.to_value()).collect::<Vec<_>>()))
@@ -253,8 +255,9 @@ where
 impl<'v, V: ValueLike<'v>> PathValueGen<V>
 where
     Self: ProvidesStaticType<'v>,
+    <Self as ProvidesStaticType<'v>>::StaticType: Send,
 {
-    fn create_validation_callable(&self, heap: &'v Heap, operation: PathValidationOp) -> Value<'v> {
+    fn create_validation_callable(&self, heap: Heap<'v>, operation: PathValidationOp) -> Value<'v> {
         let callable = PathValidationCallableGen {
             path_value: heap.alloc_complex(self.clone()).to_value(),
             operation,
@@ -262,7 +265,7 @@ where
         heap.alloc_complex(callable)
     }
 
-    fn create_matches_callable(&self, heap: &'v Heap) -> Value<'v> {
+    fn create_matches_callable(&self, heap: Heap<'v>) -> Value<'v> {
         let callable = PathMatchesCallableGen {
             path_value: heap.alloc_complex(self.clone()).to_value(),
         };

--- a/crates/pcb-zen-core/src/lang/builtin.rs
+++ b/crates/pcb-zen-core/src/lang/builtin.rs
@@ -55,8 +55,8 @@ starlark_simple_value!(Builtin);
 #[starlark_value(type = "builtin")]
 impl<'v> StarlarkValue<'v> for Builtin {
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new();
-        RES.methods(builtin_methods)
+        static RES: MethodsStatic = MethodsStatic::new("Builtin", builtin_methods);
+        Some(RES.methods())
     }
 }
 

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -12,7 +12,8 @@ use starlark::{
     eval::{Arguments, Evaluator, ParametersSpec, ParametersSpecParam},
     starlark_module, starlark_simple_value,
     values::{
-        Coerce, Freeze, FrozenValue, Heap, NoSerialize, StarlarkValue, Trace, Value, ValueLike,
+        Coerce, Freeze, FrozenValue, Heap, NoSerialize, StarlarkValue, Trace, Value,
+        ValueLifetimeless, ValueLike,
         dict::{AllocDict, DictRef},
         list::ListRef,
         starlark_value,
@@ -79,37 +80,23 @@ impl From<ComponentError> for starlark::Error {
     }
 }
 
-// Mutable data stored in ComponentValue (wrapped in RefCell)
-#[derive(Clone, Debug, Trace, ProvidesStaticType, Allocative)]
-pub struct ComponentData<'v> {
+#[derive(Clone, Debug, Coerce, Trace, ProvidesStaticType, Allocative, Freeze)]
+#[repr(C)]
+pub struct ComponentDataGen<V: ValueLifetimeless> {
     pub(crate) part: Option<PartValue>,
     pub(crate) bom_mpn: Option<String>,
-    pub(crate) spice_model: Option<Value<'v>>,
+    pub(crate) spice_model: Option<V>,
     pub(crate) dnp: bool,
     pub(crate) skip_bom: bool,
     pub(crate) skip_pos: bool,
     pub(crate) datasheet: Option<String>,
     pub(crate) component_datasheet: Option<String>,
     pub(crate) symbol_datasheet: Option<String>,
-    pub(crate) properties: SmallMap<String, Value<'v>>,
+    pub(crate) properties: SmallMap<String, V>,
 }
 
-// Frozen data stored in FrozenComponentValue (no RefCell needed)
-#[derive(Clone, Debug, ProvidesStaticType, Allocative)]
-pub struct FrozenComponentData {
-    pub(crate) part: Option<PartValue>,
-    pub(crate) bom_mpn: Option<String>,
-    pub(crate) spice_model: Option<FrozenValue>,
-    pub(crate) dnp: bool,
-    pub(crate) skip_bom: bool,
-    pub(crate) skip_pos: bool,
-    pub(crate) datasheet: Option<String>,
-    pub(crate) component_datasheet: Option<String>,
-    pub(crate) symbol_datasheet: Option<String>,
-    pub(crate) properties: SmallMap<String, FrozenValue>,
-}
-
-unsafe impl<'v> Coerce<ComponentData<'v>> for FrozenComponentData {}
+pub type ComponentData<'v> = ComponentDataGen<Value<'v>>;
+pub type FrozenComponentData = ComponentDataGen<FrozenValue>;
 
 // Generic component wrapper - T is either RefCell<ComponentData<'v>> or FrozenComponentData
 #[derive(Clone, Trace, ProvidesStaticType, NoSerialize, Allocative)]
@@ -150,27 +137,7 @@ impl<'v> Freeze for ComponentValue<'v> {
             footprint: self.footprint,
             prefix: self.prefix,
             connections: self.connections.freeze(freezer)?,
-            data: FrozenComponentData {
-                part: data.part,
-                bom_mpn: data.bom_mpn,
-                spice_model: match data.spice_model {
-                    Some(s) => Some(s.freeze(freezer)?),
-                    None => None,
-                },
-                dnp: data.dnp,
-                skip_bom: data.skip_bom,
-                skip_pos: data.skip_pos,
-                datasheet: data.datasheet,
-                component_datasheet: data.component_datasheet,
-                symbol_datasheet: data.symbol_datasheet,
-                properties: {
-                    let mut frozen_props = SmallMap::new();
-                    for (k, v) in data.properties.into_iter() {
-                        frozen_props.insert(k, v.freeze(freezer)?);
-                    }
-                    frozen_props
-                },
-            },
+            data: data.freeze(freezer)?,
             source_path: self.source_path,
             declaration_span: self.declaration_span,
             symbol: self.symbol.freeze(freezer)?,

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -706,7 +706,7 @@ fn resolve_symbol_spice_model<'v>(
     final_symbol: &SymbolValue,
     connections: &SmallMap<String, Value<'v>>,
     eval_ctx: &crate::EvalContext,
-    heap: &'v Heap,
+    heap: Heap<'v>,
 ) -> starlark::Result<Option<Value<'v>>> {
     let properties = final_symbol.properties();
     let sim_device = properties
@@ -881,7 +881,7 @@ fn pin_type_accepts_net_kind(pin_type: &str, net_kind: &str) -> bool {
 }
 
 fn alloc_not_connected<'v>(
-    heap: &'v Heap,
+    heap: Heap<'v>,
     declaration_path: String,
     declaration_span: Option<starlark::codemap::ResolvedSpan>,
 ) -> Value<'v> {
@@ -961,7 +961,7 @@ fn manifest_part_matches_symbol(part: &ManifestPart, symbol: &SymbolValue) -> bo
 fn append_alternatives_property<'v>(
     properties_map: &mut SmallMap<String, Value<'v>>,
     alternatives: Vec<PartValue>,
-    heap: &'v Heap,
+    heap: Heap<'v>,
 ) -> starlark::Result<()> {
     if alternatives.is_empty() {
         return Ok(());
@@ -1206,7 +1206,7 @@ fn validate_spice_model_value<'v>(value: Value<'v>) -> starlark::Result<()> {
 // StarlarkValue implementation for mutable ComponentValue
 #[starlark_value(type = "Component")]
 impl<'v> StarlarkValue<'v> for ComponentValue<'v> {
-    fn get_attr(&self, attr: &str, heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attr: &str, heap: Heap<'v>) -> Option<Value<'v>> {
         let data = self.data.borrow();
         match attr {
             "name" => Some(heap.alloc_str(&self.name).to_value()),
@@ -1413,7 +1413,7 @@ impl<'v> StarlarkValue<'v> for ComponentValue<'v> {
         }
     }
 
-    fn has_attr(&self, attr: &str, _heap: &'v Heap) -> bool {
+    fn has_attr(&self, attr: &str, _heap: Heap<'v>) -> bool {
         if matches!(
             attr,
             "name"
@@ -1467,7 +1467,7 @@ impl<'v> StarlarkValue<'v> for ComponentValue<'v> {
 impl<'v> StarlarkValue<'v> for FrozenComponentValue {
     type Canonical = FrozenComponentValue;
 
-    fn get_attr(&self, attr: &str, heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attr: &str, heap: Heap<'v>) -> Option<Value<'v>> {
         match attr {
             "name" => Some(heap.alloc_str(&self.name).to_value()),
             "prefix" => Some(heap.alloc_str(&self.prefix).to_value()),
@@ -1571,7 +1571,7 @@ impl<'v> StarlarkValue<'v> for FrozenComponentValue {
         }
     }
 
-    fn has_attr(&self, attr: &str, _heap: &'v Heap) -> bool {
+    fn has_attr(&self, attr: &str, _heap: Heap<'v>) -> bool {
         if matches!(
             attr,
             "name"
@@ -2329,7 +2329,7 @@ mod tests {
     }
 
     fn make_string_properties<'v>(
-        heap: &'v Heap,
+        heap: Heap<'v>,
         entries: &[(&str, &str)],
     ) -> SmallMap<String, Value<'v>> {
         let mut props = SmallMap::new();
@@ -2374,9 +2374,6 @@ mod tests {
 
     #[test]
     fn resolve_component_sourcing_prefers_part_when_present() {
-        let heap = Heap::new();
-        let properties =
-            make_string_properties(&heap, &[("mpn", "PROP-MPN"), ("manufacturer", "PROP-MFR")]);
         let symbol = test_symbol(Some("SYM-MPN"), Some("SYM-MFR"));
         let part = PartValue::new(
             "PART-MPN".to_string(),
@@ -2385,14 +2382,18 @@ mod tests {
             None,
         );
 
-        let resolved = resolve_component_sourcing(
-            Some(&part),
-            Some("KW-MPN".to_string()),
-            Some("KW-MFR".to_string()),
-            &properties,
-            &symbol,
-            None,
-        );
+        let resolved = Heap::temp(|heap| {
+            let properties =
+                make_string_properties(heap, &[("mpn", "PROP-MPN"), ("manufacturer", "PROP-MFR")]);
+            resolve_component_sourcing(
+                Some(&part),
+                Some("KW-MPN".to_string()),
+                Some("KW-MFR".to_string()),
+                &properties,
+                &symbol,
+                None,
+            )
+        });
 
         let (part, alternatives, _) = resolved;
         let part = part.expect("expected Some(PartValue)");
@@ -2404,8 +2405,6 @@ mod tests {
 
     #[test]
     fn resolve_component_sourcing_appends_manifest_parts_when_part_present() {
-        let heap = Heap::new();
-        let properties = make_string_properties(&heap, &[]);
         let symbol = test_symbol(None, None);
         let part = PartValue::new(
             "PART-MPN".to_string(),
@@ -2432,14 +2431,17 @@ mod tests {
             },
         ];
 
-        let resolved = resolve_component_sourcing(
-            Some(&part),
-            None,
-            None,
-            &properties,
-            &symbol,
-            Some(&manifest_parts),
-        );
+        let resolved = Heap::temp(|heap| {
+            let properties = make_string_properties(heap, &[]);
+            resolve_component_sourcing(
+                Some(&part),
+                None,
+                None,
+                &properties,
+                &symbol,
+                Some(&manifest_parts),
+            )
+        });
 
         let (part, alternatives, _) = resolved;
         let part = part.expect("expected Some(PartValue)");
@@ -2467,19 +2469,20 @@ mod tests {
 
     #[test]
     fn resolve_component_sourcing_prefers_explicit_without_part() {
-        let heap = Heap::new();
-        let properties =
-            make_string_properties(&heap, &[("mpn", "PROP-MPN"), ("manufacturer", "PROP-MFR")]);
         let symbol = test_symbol(Some("SYM-MPN"), Some("SYM-MFR"));
 
-        let resolved = resolve_component_sourcing(
-            None,
-            Some("KW-MPN".to_string()),
-            Some("KW-MFR".to_string()),
-            &properties,
-            &symbol,
-            None,
-        );
+        let resolved = Heap::temp(|heap| {
+            let properties =
+                make_string_properties(heap, &[("mpn", "PROP-MPN"), ("manufacturer", "PROP-MFR")]);
+            resolve_component_sourcing(
+                None,
+                Some("KW-MPN".to_string()),
+                Some("KW-MFR".to_string()),
+                &properties,
+                &symbol,
+                None,
+            )
+        });
 
         let (part, alternatives, _) = resolved;
         let part = part.expect("expected Some(PartValue)");
@@ -2490,22 +2493,25 @@ mod tests {
 
     #[test]
     fn resolve_component_sourcing_prefers_properties_then_symbol_without_part() {
-        let heap = Heap::new();
-        let properties =
-            make_string_properties(&heap, &[("mpn", "PROP-MPN"), ("manufacturer", "PROP-MFR")]);
         let symbol = test_symbol(Some("SYM-MPN"), Some("SYM-MFR"));
 
-        let resolved_from_props =
-            resolve_component_sourcing(None, None, None, &properties, &symbol, None);
+        let (resolved_from_props, resolved_from_symbol) = Heap::temp(|heap| {
+            let properties =
+                make_string_properties(heap, &[("mpn", "PROP-MPN"), ("manufacturer", "PROP-MFR")]);
+            let resolved_from_props =
+                resolve_component_sourcing(None, None, None, &properties, &symbol, None);
+
+            let empty_props = make_string_properties(heap, &[]);
+            let resolved_from_symbol =
+                resolve_component_sourcing(None, None, None, &empty_props, &symbol, None);
+            (resolved_from_props, resolved_from_symbol)
+        });
         let (part, alternatives, _) = resolved_from_props;
         let part = part.expect("expected Some(PartValue)");
         assert_eq!(part.mpn(), "PROP-MPN");
         assert_eq!(part.manufacturer(), "PROP-MFR");
         assert!(alternatives.is_empty());
 
-        let empty_props = make_string_properties(&heap, &[]);
-        let resolved_from_symbol =
-            resolve_component_sourcing(None, None, None, &empty_props, &symbol, None);
         let (part, alternatives, _) = resolved_from_symbol;
         let part = part.expect("expected Some(PartValue)");
         assert_eq!(part.mpn(), "SYM-MPN");
@@ -2515,8 +2521,6 @@ mod tests {
 
     #[test]
     fn resolve_component_sourcing_falls_back_to_manifest_parts() {
-        let heap = Heap::new();
-        let empty_props = make_string_properties(&heap, &[]);
         let symbol = test_symbol(None, None);
         let manifest_parts = vec![
             ManifestPart {
@@ -2537,14 +2541,17 @@ mod tests {
             },
         ];
 
-        let resolved = resolve_component_sourcing(
-            None,
-            None,
-            None,
-            &empty_props,
-            &symbol,
-            Some(&manifest_parts),
-        );
+        let resolved = Heap::temp(|heap| {
+            let empty_props = make_string_properties(heap, &[]);
+            resolve_component_sourcing(
+                None,
+                None,
+                None,
+                &empty_props,
+                &symbol,
+                Some(&manifest_parts),
+            )
+        });
 
         let (part, alternatives, _) = resolved;
         let part = part.expect("expected Some(PartValue)");

--- a/crates/pcb-zen-core/src/lang/context.rs
+++ b/crates/pcb-zen-core/src/lang/context.rs
@@ -86,6 +86,11 @@ pub struct ContextValue<'v> {
     pending_children: RefCell<Vec<PendingChild<'v>>>,
 }
 
+// SAFETY: `ContextValue` is allocated on the Starlark heap and is only used
+// while the owning evaluation context is active. Heap branding keeps contained
+// Starlark values tied to that heap; the raw pointer is not shared independently.
+unsafe impl<'v> Send for ContextValue<'v> {}
+
 #[derive(Debug, Trace, ProvidesStaticType, Allocative, Serialize)]
 #[repr(C)]
 pub struct FrozenContextValue {

--- a/crates/pcb-zen-core/src/lang/context.rs
+++ b/crates/pcb-zen-core/src/lang/context.rs
@@ -77,19 +77,10 @@ pub struct ContextValue<'v> {
     missing_inputs: RefCell<Vec<String>>,
     #[allocative(skip)]
     diagnostics: RefCell<Vec<crate::Diagnostic>>,
-    /// The eval::Context that the current evaluator is running in.
-    #[allocative(skip)]
-    #[serde(skip)]
-    context: *const EvalContext,
     #[allocative(skip)]
     #[serde(skip)]
     pending_children: RefCell<Vec<PendingChild<'v>>>,
 }
-
-// SAFETY: `ContextValue` is allocated on the Starlark heap and is only used
-// while the owning evaluation context is active. Heap branding keeps contained
-// Starlark values tied to that heap; the raw pointer is not shared independently.
-unsafe impl<'v> Send for ContextValue<'v> {}
 
 #[derive(Debug, Trace, ProvidesStaticType, Allocative, Serialize)]
 #[repr(C)]
@@ -148,7 +139,7 @@ impl FrozenContextValue {
 }
 
 impl<'v> ContextValue<'v> {
-    /// Create a new `ContextValue` with a parent eval::Context for sharing caches
+    /// Create a new `ContextValue` from the current evaluation context.
     pub fn from_context(context: &EvalContext) -> Self {
         let source_path = context
             .source_path()
@@ -173,15 +164,8 @@ impl<'v> ContextValue<'v> {
             strict_io_config: context.strict_io_config(),
             missing_inputs: RefCell::new(Vec::new()),
             diagnostics: RefCell::new(Vec::new()),
-            context: context as *const _,
             pending_children: RefCell::new(Vec::new()),
         }
-    }
-
-    /// Get the parent eval::Context
-    pub(crate) fn parent_context(&self) -> &EvalContext {
-        // SAFETY: We ensure the parent Context outlives this ContextValue
-        unsafe { &*self.context }
     }
 
     /// Return whether missing required io()/config() placeholders should be treated as

--- a/crates/pcb-zen-core/src/lang/enum.rs
+++ b/crates/pcb-zen-core/src/lang/enum.rs
@@ -10,7 +10,7 @@ use starlark::{
         Freeze, FreezeResult, Heap, StarlarkValue, Value, ValueLike,
         function::FUNCTION_TYPE,
         starlark_value,
-        typing::{TypeInstanceId, TypeMatcher, TypeMatcherFactory},
+        typing::{TypeInstanceId, TypeMatcher, TypeMatcherDyn, TypeMatcherFactory},
     },
 };
 use starlark_map::StarlarkHasher;
@@ -28,11 +28,13 @@ enum EnumError {
     InvalidIndex(i32, usize),
 }
 
-#[derive(Debug, Clone, Allocative)]
+#[derive(Debug, Clone, Allocative, pagable::Pagable)]
+#[pagable::pagable_typetag(TypeMatcherDyn)]
 struct EnumTypeMatcher {
     enum_type: EnumType,
 }
 
+#[starlark::type_matcher]
 impl TypeMatcher for EnumTypeMatcher {
     fn matches(&self, value: Value) -> bool {
         value
@@ -42,7 +44,16 @@ impl TypeMatcher for EnumTypeMatcher {
 }
 
 #[derive(
-    Clone, Hash, Debug, PartialEq, Eq, ProvidesStaticType, Allocative, Serialize, Deserialize,
+    Clone,
+    Hash,
+    Debug,
+    PartialEq,
+    Eq,
+    ProvidesStaticType,
+    Allocative,
+    Serialize,
+    Deserialize,
+    pagable::Pagable,
 )]
 pub struct EnumType {
     variants: Vec<String>,
@@ -150,14 +161,14 @@ impl<'v> StarlarkValue<'v> for EnumType {
         Ok(self.variants.len() as i32)
     }
 
-    fn at(&self, index: Value, heap: &'v Heap) -> starlark::Result<Value<'v>> {
+    fn at(&self, index: Value, heap: Heap<'v>) -> starlark::Result<Value<'v>> {
         let i = index.unpack_i32().ok_or_else(|| {
             starlark::Error::new_other(anyhow::anyhow!("Index must be an integer"))
         })?;
         Ok(heap.alloc(self.get_by_index(i)?))
     }
 
-    unsafe fn iterate(&self, me: Value<'v>, _heap: &'v Heap) -> starlark::Result<Value<'v>> {
+    unsafe fn iterate(&self, me: Value<'v>, _heap: Heap<'v>) -> starlark::Result<Value<'v>> {
         Ok(me)
     }
 
@@ -166,7 +177,7 @@ impl<'v> StarlarkValue<'v> for EnumType {
         (rem, Some(rem))
     }
 
-    unsafe fn iter_next(&self, index: usize, heap: &'v Heap) -> Option<Value<'v>> {
+    unsafe fn iter_next(&self, index: usize, heap: Heap<'v>) -> Option<Value<'v>> {
         (index < self.variants.len()).then(|| {
             heap.alloc(EnumValue {
                 r#type: self.clone(),
@@ -178,8 +189,8 @@ impl<'v> StarlarkValue<'v> for EnumType {
     unsafe fn iter_stop(&self) {}
 
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new();
-        RES.methods(enum_type_methods)
+        static RES: MethodsStatic = MethodsStatic::new("EnumType", enum_type_methods);
+        Some(RES.methods())
     }
 
     fn eval_type(&self) -> Option<Ty> {
@@ -218,12 +229,12 @@ impl<'v> StarlarkValue<'v> for EnumType {
 #[starlark_module]
 fn enum_type_methods(builder: &mut MethodsBuilder) {
     #[starlark(attribute)]
-    fn r#type<'v>(this: Value<'v>, heap: &'v Heap) -> starlark::Result<Value<'v>> {
+    fn r#type(this: Value) -> starlark::Result<&'static str> {
         // Return the string "enum" as the type name
-        Ok(heap.alloc("enum"))
+        Ok("enum")
     }
 
-    fn values<'v>(this: Value<'v>, heap: &'v Heap) -> starlark::Result<Value<'v>> {
+    fn values<'v>(this: Value<'v>, heap: Heap<'v>) -> starlark::Result<Value<'v>> {
         let enum_type = this
             .downcast_ref::<EnumType>()
             .ok_or_else(|| starlark::Error::new_other(anyhow::anyhow!("Expected EnumType")))?;
@@ -242,7 +253,16 @@ fn enum_type_methods(builder: &mut MethodsBuilder) {
 }
 
 #[derive(
-    Clone, Hash, Debug, PartialEq, Eq, ProvidesStaticType, Allocative, Serialize, Deserialize,
+    Clone,
+    Hash,
+    Debug,
+    PartialEq,
+    Eq,
+    ProvidesStaticType,
+    Allocative,
+    Serialize,
+    Deserialize,
+    pagable::Pagable,
 )]
 pub struct EnumValue {
     r#type: EnumType,
@@ -301,7 +321,7 @@ impl<'v> StarlarkValue<'v> for EnumValue {
         Ok(self.value().len() as i32)
     }
 
-    fn at(&self, index: Value<'v>, heap: &'v Heap) -> starlark::Result<Value<'v>> {
+    fn at(&self, index: Value<'v>, heap: Heap<'v>) -> starlark::Result<Value<'v>> {
         let s = self.value();
         let i = index.unpack_i32().ok_or_else(|| {
             starlark::Error::new_other(anyhow::anyhow!("Index must be an integer"))
@@ -324,21 +344,21 @@ impl<'v> StarlarkValue<'v> for EnumValue {
         Ok(heap.alloc(ch.to_string()))
     }
 
-    fn add(&self, other: Value<'v>, heap: &'v Heap) -> Option<starlark::Result<Value<'v>>> {
+    fn add(&self, other: Value<'v>, heap: Heap<'v>) -> Option<starlark::Result<Value<'v>>> {
         other
             .unpack_str()
             .map(|s| Ok(heap.alloc(format!("{}{}", self.value(), s))))
     }
 
-    fn radd(&self, other: Value<'v>, heap: &'v Heap) -> Option<starlark::Result<Value<'v>>> {
+    fn radd(&self, other: Value<'v>, heap: Heap<'v>) -> Option<starlark::Result<Value<'v>>> {
         other
             .unpack_str()
             .map(|s| Ok(heap.alloc(format!("{}{}", s, self.value()))))
     }
 
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new();
-        RES.methods(enum_value_methods)
+        static RES: MethodsStatic = MethodsStatic::new("EnumValue", enum_value_methods);
+        Some(RES.methods())
     }
 }
 
@@ -350,7 +370,7 @@ fn enum_value_methods(builder: &mut MethodsBuilder) {
     }
 
     #[starlark(attribute)]
-    fn value<'v>(this: &EnumValue, heap: &'v Heap) -> starlark::Result<Value<'v>> {
-        Ok(heap.alloc(this.value()))
+    fn value(this: &EnumValue) -> starlark::Result<String> {
+        Ok(this.value().to_owned())
     }
 }

--- a/crates/pcb-zen-core/src/lang/enum.rs
+++ b/crates/pcb-zen-core/src/lang/enum.rs
@@ -7,7 +7,7 @@ use starlark::{
     starlark_module, starlark_simple_value,
     typing::{ParamIsRequired, ParamSpec, Ty, TyCallable, TyStarlarkValue, TyUser, TyUserParams},
     values::{
-        Freeze, FreezeResult, Heap, StarlarkValue, Value, ValueLike,
+        Freeze, Heap, StarlarkValue, Value, ValueLike,
         function::FUNCTION_TYPE,
         starlark_value,
         typing::{TypeInstanceId, TypeMatcher, TypeMatcherDyn, TypeMatcherFactory},
@@ -51,19 +51,13 @@ impl TypeMatcher for EnumTypeMatcher {
     Eq,
     ProvidesStaticType,
     Allocative,
+    Freeze,
     Serialize,
     Deserialize,
     pagable::Pagable,
 )]
 pub struct EnumType {
     variants: Vec<String>,
-}
-
-impl Freeze for EnumType {
-    type Frozen = Self;
-    fn freeze(self, _freezer: &starlark::values::Freezer) -> FreezeResult<Self::Frozen> {
-        Ok(self)
-    }
 }
 
 starlark_simple_value!(EnumType);
@@ -260,6 +254,7 @@ fn enum_type_methods(builder: &mut MethodsBuilder) {
     Eq,
     ProvidesStaticType,
     Allocative,
+    Freeze,
     Serialize,
     Deserialize,
     pagable::Pagable,
@@ -267,13 +262,6 @@ fn enum_type_methods(builder: &mut MethodsBuilder) {
 pub struct EnumValue {
     r#type: EnumType,
     index: i32,
-}
-
-impl Freeze for EnumValue {
-    type Frozen = Self;
-    fn freeze(self, _freezer: &starlark::values::Freezer) -> FreezeResult<Self::Frozen> {
-        Ok(self)
-    }
 }
 
 starlark_simple_value!(EnumValue);

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -53,6 +53,8 @@ use crate::{Diagnostic, Diagnostics, WithDiagnostics};
 use crate::{FileProvider, ResolveContext};
 use crate::{convert::ModuleConverter, lang::context::FrozenPendingChild};
 
+pub use super::evaluator_ext::EvalContextRef;
+
 use super::{
     context::{ContextValue, FrozenContextValue},
     interface::interface_globals,
@@ -1537,11 +1539,13 @@ impl EvalContext {
                 PhysicalValueWarningHandler(emit_physical_value_deprecation);
 
             let eval_result = {
+                let mut eval_context_ref = EvalContextRef::new(&self);
                 let mut eval = Evaluator::new(&module);
                 eval.enable_static_typechecking(true);
                 eval.set_loader(&self);
                 eval.set_print_handler(&print_handler);
                 eval.extra = Some(&physical_value_warning_handler);
+                eval.extra_mut = Some(&mut eval_context_ref);
 
                 let globals = Self::build_globals();
 

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -4,21 +4,21 @@ use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, RwLock},
 };
 
 use anyhow::anyhow;
 use pcb_sch::physical::{PhysicalValue, PhysicalValueWarningHandler};
 use starlark::{
     PrintHandler,
-    environment::{GlobalsBuilder, LibraryExtension},
+    environment::{GlobalsBuilder, LibraryExtension, Module},
     errors::{EvalMessage, EvalSeverity},
     eval::{Evaluator, FileLoader},
     syntax::{AstModule, Dialect},
     typing::TypeMap,
-    values::{FrozenValue, Heap, Value, ValueLike},
+    values::{FrozenHeapName, FrozenValue, Heap, Value, ValueLike},
 };
-use starlark::{codemap::ResolvedSpan, collections::SmallMap, values::FrozenHeap};
+use starlark::{codemap::ResolvedSpan, collections::SmallMap};
 use starlark::{environment::FrozenModule, typing::Interface};
 use starlark_syntax::syntax::{
     ast::{LoadArgP, StmtP},
@@ -254,8 +254,7 @@ pub struct EvalOutput {
     pub print_output: Vec<String>,
     /// Eval config (file provider, path specs, etc.)
     pub config: EvalContextConfig,
-    /// Session keeps the frozen heap alive for the lifetime of this output.
-    /// Also provides access to the module tree.
+    /// Session owns the frozen module tree for this output.
     session: EvalSession,
 }
 
@@ -422,10 +421,8 @@ pub struct EvalSession {
     /// Per-file interface map for load path → Interface.
     #[allow(dead_code)]
     interface_map: Arc<RwLock<HashMap<PathBuf, HashMap<String, Interface>>>>,
-    /// Tree of all child modules indexed by fully qualified path.
-    module_tree: Arc<RwLock<BTreeMap<ModulePath, FrozenModuleValue>>>,
-    /// Shared frozen heap for the entire evaluation tree.
-    frozen_heap: Arc<Mutex<FrozenHeap>>,
+    /// Tree of all frozen child modules indexed by fully qualified path.
+    module_tree: Arc<RwLock<BTreeMap<ModulePath, FrozenModule>>>,
 }
 
 /// Configuration for creating an EvalContext. Send + Sync safe for passing across threads.
@@ -916,7 +913,6 @@ impl Default for EvalSession {
             type_cache: Arc::new(RwLock::new(HashMap::new())),
             interface_map: Arc::new(RwLock::new(HashMap::new())),
             module_tree: Arc::new(RwLock::new(BTreeMap::new())),
-            frozen_heap: Arc::new(Mutex::new(FrozenHeap::new())),
         }
     }
 }
@@ -929,25 +925,33 @@ impl EvalSession {
     /// since schematic conversion reads the shared module tree from the session.
     pub fn prepare_for_root_eval(&self) {
         self.clear_module_tree();
-        self.reset_frozen_heap();
     }
 
     // --- Module tree ---
 
-    fn insert_module(&self, path: ModulePath, module: FrozenModuleValue) {
+    fn insert_module(&self, path: ModulePath, module: FrozenModule) {
         self.module_tree.write().unwrap().insert(path, module);
     }
 
     fn clone_module_tree(&self) -> BTreeMap<ModulePath, FrozenModuleValue> {
-        self.module_tree.read().unwrap().clone()
+        self.module_tree
+            .read()
+            .unwrap()
+            .iter()
+            .map(|(path, module)| {
+                let module_value = module
+                    .extra_value()
+                    .and_then(|extra| extra.downcast_ref::<FrozenContextValue>())
+                    .expect("module_tree entry missing FrozenContextValue")
+                    .module
+                    .clone();
+                (path.clone(), module_value)
+            })
+            .collect()
     }
 
     fn clear_module_tree(&self) {
         self.module_tree.write().unwrap().clear();
-    }
-
-    fn reset_frozen_heap(&self) {
-        *self.frozen_heap.lock().unwrap() = FrozenHeap::new();
     }
 
     // --- Load cache ---
@@ -1086,28 +1090,23 @@ impl EvalSession {
         }
     }
 
-    /// Add a reference to the shared frozen heap.
-    fn add_frozen_heap_reference(&self, heap: &starlark::values::FrozenHeapRef) {
-        self.frozen_heap.lock().unwrap().add_reference(heap);
-    }
-
     /// Create an EvalContext from an EvalContextConfig.
     /// This is the primary way to create contexts for evaluation.
     pub fn create_context(&self, config: EvalContextConfig) -> EvalContext {
         EvalContext {
-            module: starlark::environment::Module::new(),
             session: self.clone(),
             config,
             load_diagnostics: RefCell::new(Vec::new()),
+            pending_inputs: SmallMap::new(),
+            pending_properties: SmallMap::new(),
+            pending_parent_component_modifiers: Vec::new(),
+            json_inputs: SmallMap::new(),
         }
     }
 }
 
 pub struct EvalContext {
-    /// The starlark::environment::Module we are evaluating.
-    pub module: starlark::environment::Module,
-
-    /// The shared session state (module_tree, frozen_heap, etc.)
+    /// The shared session state (module tree, load cache, symbol maps, etc.)
     session: EvalSession,
 
     /// Configuration for this evaluation context (Send + Sync safe).
@@ -1115,10 +1114,16 @@ pub struct EvalContext {
 
     /// Diagnostics collected during load() calls in this context.
     load_diagnostics: RefCell<Vec<Diagnostic>>,
+
+    /// Values to seed into the active module once its branded heap exists.
+    pending_inputs: SmallMap<String, FrozenValue>,
+    pending_properties: SmallMap<String, FrozenValue>,
+    pending_parent_component_modifiers: Vec<FrozenValue>,
+    json_inputs: SmallMap<String, serde_json::Value>,
 }
 
 /// Helper to recursively convert JSON to heap values
-fn json_value_to_heap_value<'v>(json: &serde_json::Value, heap: &'v Heap) -> Value<'v> {
+fn json_value_to_heap_value<'v>(json: &serde_json::Value, heap: Heap<'v>) -> Value<'v> {
     use starlark::values::dict::AllocDict;
     match json {
         serde_json::Value::Null => Value::new_none(),
@@ -1217,11 +1222,14 @@ impl EvalContext {
         self
     }
 
-    fn freeze(&mut self) -> FrozenModule {
-        let module = std::mem::take(&mut self.module);
-        let frozen = module.freeze().expect("failed to freeze module");
-        self.session.add_frozen_heap_reference(frozen.frozen_heap());
-        frozen
+    fn frozen_heap_name(&self) -> FrozenHeapName {
+        let source = self
+            .config
+            .source_path
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        FrozenHeapName::User(Box::new(format!("{}:{source}", self.config.module_path)))
     }
 
     /// Enable or disable eager workspace parsing.
@@ -1366,34 +1374,38 @@ impl EvalContext {
         self
     }
 
-    fn ensure_context_value(&mut self) {
-        if self.module.extra_value().is_none() {
-            let eval = Evaluator::new(&self.module);
-            let ctx_value = eval.heap().alloc_complex(ContextValue::from_context(self));
-            self.module.set_extra_value(ctx_value);
-        }
-    }
-
-    fn context_value(&self) -> &ContextValue<'_> {
-        self.module
-            .extra_value()
-            .unwrap()
+    fn initialize_context_value<'v>(&self, module: &Module<'v>) {
+        let heap = module.heap();
+        let ctx_value = heap.alloc_complex(ContextValue::from_context(self));
+        module.set_extra_value(ctx_value);
+        let ctx_value = ctx_value
             .downcast_ref::<ContextValue>()
-            .unwrap()
+            .expect("extra value should be a ContextValue");
+
+        {
+            let mut module_value = ctx_value.module_mut();
+            for (name, value) in self.pending_inputs.iter() {
+                module_value.add_input(name.clone(), value.to_value());
+            }
+            for (name, json) in self.json_inputs.iter() {
+                module_value.add_input(name.clone(), json_value_to_heap_value(json, heap));
+            }
+            let parent_modifiers = self
+                .pending_parent_component_modifiers
+                .iter()
+                .map(|value| value.to_value())
+                .collect();
+            module_value.set_parent_component_modifiers(parent_modifiers);
+        }
+
+        for (name, value) in self.pending_properties.iter() {
+            ctx_value.add_property(name.clone(), value.to_value());
+        }
     }
 
     /// Set inputs from already frozen parent values.
     pub fn set_inputs_from_frozen_values(&mut self, parent_inputs: SmallMap<String, FrozenValue>) {
-        if parent_inputs.is_empty() {
-            return;
-        }
-
-        self.ensure_context_value();
-        let ctx_value = self.context_value();
-        let mut module = ctx_value.module_mut();
-        for (name, value) in parent_inputs.into_iter() {
-            module.add_input(name, value.to_value());
-        }
+        self.pending_inputs.extend(parent_inputs);
     }
 
     /// Set properties from already frozen parent values.
@@ -1401,15 +1413,7 @@ impl EvalContext {
         &mut self,
         parent_properties: SmallMap<String, FrozenValue>,
     ) {
-        if parent_properties.is_empty() {
-            return;
-        }
-
-        self.ensure_context_value();
-        let ctx_value = self.context_value();
-        for (name, value) in parent_properties.into_iter() {
-            ctx_value.add_property(name, value.to_value());
-        }
+        self.pending_properties.extend(parent_properties);
     }
 
     /// Set parent component modifiers from already frozen parent values.
@@ -1417,18 +1421,7 @@ impl EvalContext {
         &mut self,
         parent_modifiers: Vec<FrozenValue>,
     ) {
-        if parent_modifiers.is_empty() {
-            return;
-        }
-
-        self.ensure_context_value();
-        let ctx_value = self.context_value();
-        let mut module = ctx_value.module_mut();
-        let unfrozen_modifiers: Vec<_> = parent_modifiers
-            .into_iter()
-            .map(|fv| fv.to_value())
-            .collect();
-        module.set_parent_component_modifiers(unfrozen_modifiers);
+        self.pending_parent_component_modifiers = parent_modifiers;
     }
 
     /// Apply component modifiers to all children after module evaluation but before freezing.
@@ -1463,18 +1456,7 @@ impl EvalContext {
 
     /// Convert JSON inputs directly to heap values and set them (for external APIs)
     pub fn set_json_inputs(&mut self, json_inputs: SmallMap<String, serde_json::Value>) {
-        if json_inputs.is_empty() {
-            return;
-        }
-
-        self.ensure_context_value();
-        let eval = Evaluator::new(&self.module);
-        let ctx_value = self.context_value();
-        let mut module = ctx_value.module_mut();
-        for (name, json) in json_inputs.iter() {
-            let value = json_value_to_heap_value(json, eval.heap());
-            module.add_input(name.clone(), value);
-        }
+        self.json_inputs.extend(json_inputs);
     }
 
     /// Evaluate the configured module. All required fields must be provided
@@ -1540,225 +1522,225 @@ impl EvalContext {
             self.add_load_diagnostic(diagnostic);
         }
 
-        // Make prelude symbols available before user code runs.
-        self.inject_prelude();
+        Module::with_temp_heap(|module| {
+            // Make prelude symbols available before user code runs.
+            self.inject_prelude(&module);
 
-        // Create a print handler to collect output
-        let print_handler = CollectingPrintHandler::new();
-        let physical_value_warning_handler =
-            PhysicalValueWarningHandler(emit_physical_value_deprecation);
+            // Attach a `ContextValue` so user code can access evaluation context,
+            // then seed any inputs/properties that were collected before the
+            // branded Starlark heap existed.
+            self.initialize_context_value(&module);
 
-        let eval_result = {
-            let mut eval = Evaluator::new(&self.module);
-            eval.enable_static_typechecking(true);
-            eval.set_loader(&self);
-            eval.set_print_handler(&print_handler);
-            eval.extra = Some(&physical_value_warning_handler);
+            // Create a print handler to collect output
+            let print_handler = CollectingPrintHandler::new();
+            let physical_value_warning_handler =
+                PhysicalValueWarningHandler(emit_physical_value_deprecation);
 
-            // Attach a `ContextValue` so user code can access evaluation context.
-            // Only create one if it doesn't already exist (copy_and_set_inputs/properties may have created it)
-            if self.module.extra_value().is_none() {
-                self.module
-                    .set_extra_value(eval.heap().alloc_complex(ContextValue::from_context(&self)));
-            }
+            let eval_result = {
+                let mut eval = Evaluator::new(&module);
+                eval.enable_static_typechecking(true);
+                eval.set_loader(&self);
+                eval.set_print_handler(&print_handler);
+                eval.extra = Some(&physical_value_warning_handler);
 
-            let globals = Self::build_globals();
+                let globals = Self::build_globals();
 
-            // We are only interested in whether evaluation succeeded, not in the
-            // value of the final expression, so map the result to `()`.
-            let _span = info_span!("starlark_eval").entered();
-            eval.eval_module(ast.clone(), &globals)
-                .and_then(|_| Self::apply_component_modifiers(&mut eval))
-        };
+                // We are only interested in whether evaluation succeeded, not in the
+                // value of the final expression, so map the result to `()`.
+                let _span = info_span!("starlark_eval").entered();
+                eval.eval_module(ast.clone(), &globals)
+                    .and_then(|_| Self::apply_component_modifiers(&mut eval))
+            };
 
-        // Collect print output after evaluation
-        let print_output = print_handler.take_output();
+            // Collect print output after evaluation
+            let print_output = print_handler.take_output();
 
-        // Collect load diagnostics - this becomes our accumulator for all diagnostics
-        let mut diagnostics = self.take_load_diagnostics();
+            // Collect load diagnostics - this becomes our accumulator for all diagnostics
+            let mut diagnostics = self.take_load_diagnostics();
 
-        match eval_result {
-            Ok(_) => {
-                // Extract needed references before freezing (which moves self.module)
-                let session_ref = self.session.clone();
-                let config_ref = self.config.clone();
+            match eval_result {
+                Ok(_) => {
+                    let frozen_module = {
+                        let _span = info_span!("freeze_module").entered();
+                        module
+                            .freeze_named(self.frozen_heap_name())
+                            .expect("failed to freeze module")
+                    };
+                    let extra = frozen_module
+                        .extra_value()
+                        .expect("extra value should be set before freezing")
+                        .downcast_ref::<FrozenContextValue>()
+                        .expect("extra value should be a FrozenContextValue");
+                    let signature = extra
+                        .module
+                        .signature()
+                        .iter()
+                        .map(|param| {
+                            // Convert frozen value to regular value for introspection
+                            let type_value = param.type_value.to_value();
+                            let type_info = TypeInfo::from_value(type_value);
 
-                let frozen_module = {
-                    let _span = info_span!("freeze_module").entered();
-                    self.freeze()
-                };
-                let extra = frozen_module
-                    .extra_value()
-                    .expect("extra value should be set before freezing")
-                    .downcast_ref::<FrozenContextValue>()
-                    .expect("extra value should be a FrozenContextValue");
-                let signature = extra
-                    .module
-                    .signature()
-                    .iter()
-                    .map(|param| {
-                        // Convert frozen value to regular value for introspection
-                        let type_value = param.type_value.to_value();
-                        let type_info = TypeInfo::from_value(type_value);
+                            // Convert default value to JSON using Starlark's native serialization
+                            let default_value = param
+                                .default_value
+                                .as_ref()
+                                .and_then(|v| serialize_parameter_value(v.to_value()));
 
-                        // Convert default value to JSON using Starlark's native serialization
-                        let default_value = param
-                            .default_value
-                            .as_ref()
-                            .and_then(|v| serialize_parameter_value(v.to_value()));
+                            // Get human-readable display of default value
+                            let default_display = param.default_display();
+                            let allowed_values = param.allowed_values.as_ref().map(|values| {
+                                values
+                                    .iter()
+                                    .filter_map(|value| serialize_parameter_value(value.to_value()))
+                                    .collect()
+                            });
+                            let allowed_display = param.allowed_display();
 
-                        // Get human-readable display of default value
-                        let default_display = param.default_display();
-                        let allowed_values = param.allowed_values.as_ref().map(|values| {
-                            values
-                                .iter()
-                                .filter_map(|value| serialize_parameter_value(value.to_value()))
-                                .collect()
-                        });
-                        let allowed_display = param.allowed_display();
+                            ParameterInfo {
+                                name: param.name.clone(),
+                                type_info,
+                                required: !param.optional,
+                                default_value,
+                                default_display,
+                                allowed_values,
+                                allowed_display,
+                                help: param.help.clone(),
+                                direction: param.direction,
+                            }
+                        })
+                        .collect();
+                    // Process pending children after parent is frozen
+                    let module_path = extra.module.path().clone();
+                    let is_root = module_path.segments.is_empty();
 
-                        ParameterInfo {
-                            name: param.name.clone(),
-                            type_info,
-                            required: !param.optional,
-                            default_value,
-                            default_display,
-                            allowed_values,
-                            allowed_display,
-                            help: param.help.clone(),
-                            direction: param.direction,
+                    if self.config.build_circuit || is_root {
+                        self.session
+                            .insert_module(module_path, frozen_module.clone());
+                        let process_children_span = info_span!("process_children", module = %extra.module.path().name(), count = extra.pending_children.len());
+                        let _guard = process_children_span.enter();
+
+                        let session = self.session.clone();
+                        let base_config = self.config.clone();
+
+                        #[cfg(feature = "native")]
+                        {
+                            // Collect into Vec to preserve deterministic ordering
+                            let child_diag_vecs: Vec<Vec<Diagnostic>> = extra
+                                .pending_children
+                                .par_iter()
+                                .map(|pending| {
+                                    let child_config =
+                                        base_config.child_for_pending(&pending.final_name);
+                                    session
+                                        .create_context(child_config)
+                                        .process_pending_child(pending.clone())
+                                })
+                                .collect();
+                            for child_diags in child_diag_vecs {
+                                diagnostics.extend(child_diags);
+                            }
                         }
-                    })
-                    .collect();
-                // Process pending children after parent is frozen
-                let module_path = extra.module.path().clone();
-                let is_root = module_path.segments.is_empty();
 
-                if self.config.build_circuit || is_root {
-                    session_ref.insert_module(module_path, extra.module.clone());
-                    let process_children_span = info_span!("process_children", module = %extra.module.path().name(), count = extra.pending_children.len());
-                    let _guard = process_children_span.enter();
-
-                    let session = self.session.clone();
-                    let base_config = self.config.clone();
-
-                    #[cfg(feature = "native")]
-                    {
-                        // Collect into Vec to preserve deterministic ordering
-                        let child_diag_vecs: Vec<Vec<Diagnostic>> = extra
-                            .pending_children
-                            .par_iter()
-                            .map(|pending| {
+                        #[cfg(not(feature = "native"))]
+                        {
+                            for pending in extra.pending_children.iter() {
                                 let child_config =
                                     base_config.child_for_pending(&pending.final_name);
-                                session
-                                    .create_context(child_config)
-                                    .process_pending_child(pending.clone())
-                            })
-                            .collect();
-                        for child_diags in child_diag_vecs {
-                            diagnostics.extend(child_diags);
+                                diagnostics.extend(
+                                    session
+                                        .create_context(child_config)
+                                        .process_pending_child(pending.clone()),
+                                );
+                            }
                         }
                     }
 
-                    #[cfg(not(feature = "native"))]
-                    {
-                        for pending in extra.pending_children.iter() {
-                            let child_config = base_config.child_for_pending(&pending.final_name);
-                            diagnostics.extend(
-                                session
-                                    .create_context(child_config)
-                                    .process_pending_child(pending.clone()),
+                    // Module's own diagnostics (from ContextValue)
+                    diagnostics.extend(extra.diagnostics().iter().cloned());
+
+                    if !diagnostics.iter().any(Diagnostic::is_error) {
+                        diagnostics.extend(ast_style_lints(&ast));
+                    }
+
+                    // Emit warnings for nets renamed due to collisions or unnamed nets
+                    // Skip warnings for NotConnected nets (they're expected to have no name or duplicate names)
+                    for (_id, net_info) in extra.module.introduced_nets() {
+                        // Skip all warnings for NotConnected nets
+                        if net_info.net_type == "NotConnected" {
+                            continue;
+                        }
+
+                        let location = net_info
+                            .call_stack
+                            .frames
+                            .iter()
+                            .rev()
+                            .find_map(|f| f.location.as_ref());
+                        let span = location.map(|loc| loc.resolve_span());
+                        let path = location
+                            .map(|loc| loc.file.filename().to_string())
+                            .unwrap_or_else(|| extra.module.source_path().to_string());
+
+                        if let Some(original) = &net_info.original_name {
+                            if original == "NC" {
+                                continue;
+                            }
+                            let body = format!(
+                                "Net '{}' was renamed to '{}' due to name collision",
+                                original, net_info.final_name
+                            );
+                            diagnostics.push(
+                                crate::Diagnostic::categorized(
+                                    &path,
+                                    &body,
+                                    "net.name_collision",
+                                    EvalSeverity::Warning,
+                                )
+                                .with_span(span)
+                                .with_call_stack(Some(net_info.call_stack.clone())),
+                            );
+                        } else if net_info.auto_named {
+                            let body = format!(
+                                "Net had no explicit name; assigned '{}'",
+                                net_info.final_name
+                            );
+                            diagnostics.push(
+                                crate::Diagnostic::categorized(
+                                    &path,
+                                    &body,
+                                    "net.unnamed",
+                                    EvalSeverity::Warning,
+                                )
+                                .with_span(span)
+                                .with_call_stack(Some(net_info.call_stack.clone())),
                             );
                         }
                     }
-                }
 
-                // Module's own diagnostics (from ContextValue)
-                diagnostics.extend(extra.diagnostics().iter().cloned());
+                    let output = EvalOutput {
+                        ast,
+                        star_module: frozen_module,
+                        sch_module: extra.module.clone(),
+                        signature,
+                        print_output,
+                        config: self.config.clone(),
+                        session: self.session.clone(),
+                    };
 
-                if !diagnostics.iter().any(Diagnostic::is_error) {
-                    diagnostics.extend(ast_style_lints(&ast));
-                }
-
-                // Emit warnings for nets renamed due to collisions or unnamed nets
-                // Skip warnings for NotConnected nets (they're expected to have no name or duplicate names)
-                for (_id, net_info) in extra.module.introduced_nets() {
-                    // Skip all warnings for NotConnected nets
-                    if net_info.net_type == "NotConnected" {
-                        continue;
-                    }
-
-                    let location = net_info
-                        .call_stack
-                        .frames
-                        .iter()
-                        .rev()
-                        .find_map(|f| f.location.as_ref());
-                    let span = location.map(|loc| loc.resolve_span());
-                    let path = location
-                        .map(|loc| loc.file.filename().to_string())
-                        .unwrap_or_else(|| extra.module.source_path().to_string());
-
-                    if let Some(original) = &net_info.original_name {
-                        if original == "NC" {
-                            continue;
-                        }
-                        let body = format!(
-                            "Net '{}' was renamed to '{}' due to name collision",
-                            original, net_info.final_name
-                        );
-                        diagnostics.push(
-                            crate::Diagnostic::categorized(
-                                &path,
-                                &body,
-                                "net.name_collision",
-                                EvalSeverity::Warning,
-                            )
-                            .with_span(span)
-                            .with_call_stack(Some(net_info.call_stack.clone())),
-                        );
-                    } else if net_info.auto_named {
-                        let body = format!(
-                            "Net had no explicit name; assigned '{}'",
-                            net_info.final_name
-                        );
-                        diagnostics.push(
-                            crate::Diagnostic::categorized(
-                                &path,
-                                &body,
-                                "net.unnamed",
-                                EvalSeverity::Warning,
-                            )
-                            .with_span(span)
-                            .with_call_stack(Some(net_info.call_stack.clone())),
-                        );
+                    WithDiagnostics {
+                        output: Some(output),
+                        diagnostics: Diagnostics::from(diagnostics),
                     }
                 }
-
-                let output = EvalOutput {
-                    ast,
-                    star_module: frozen_module,
-                    sch_module: extra.module.clone(),
-                    signature,
-                    print_output,
-                    config: config_ref.clone(),
-                    session: session_ref.clone(),
-                };
-
-                WithDiagnostics {
-                    output: Some(output),
-                    diagnostics: Diagnostics::from(diagnostics),
+                Err(err) => {
+                    diagnostics.push(err.into());
+                    WithDiagnostics {
+                        output: None,
+                        diagnostics: Diagnostics::from(diagnostics),
+                    }
                 }
             }
-            Err(err) => {
-                diagnostics.push(err.into());
-                WithDiagnostics {
-                    output: None,
-                    diagnostics: Diagnostics::from(diagnostics),
-                }
-            }
-        }
+        })
     }
 
     /// Get the file contents from the in-memory cache
@@ -2058,7 +2040,7 @@ impl EvalContext {
 
     /// Inject prelude symbols into the module scope before evaluation.
     /// Controlled by `config.inject_prelude`.
-    fn inject_prelude(&self) {
+    fn inject_prelude<'v>(&self, module: &Module<'v>) {
         if !self.config.inject_prelude {
             return;
         }
@@ -2087,15 +2069,9 @@ impl EvalContext {
                 }
             };
 
-            // Keep the loaded module's heap alive through our module.
-            self.module
-                .frozen_heap()
-                .add_reference(frozen_module.frozen_heap());
-
             for &name in symbols {
                 if let Ok(owned) = frozen_module.get(name) {
-                    self.module
-                        .set(name, owned.owned_value(self.module.frozen_heap()));
+                    module.set(name, module.heap().access_owned_frozen_value(&owned));
                 }
             }
         }
@@ -2249,7 +2225,7 @@ impl EvalContext {
     fn process_pending_child(mut self, pending: FrozenPendingChild) -> Vec<Diagnostic> {
         self.config.strict_io_config = true;
         self.config.build_circuit = true;
-        self.config.source_path = Some(PathBuf::from(&pending.loader.source_path));
+        self = self.set_source_path(PathBuf::from(&pending.loader.source_path));
 
         if let Some(props) = pending.properties {
             self.set_properties_from_frozen_values(props);
@@ -2302,17 +2278,10 @@ impl EvalContext {
 
         // Validate unused arguments
         let used_inputs: HashSet<String> = output
-            .star_module
-            .extra_value()
-            .and_then(|extra| extra.downcast_ref::<FrozenContextValue>())
-            .map(|fctx| {
-                fctx.module
-                    .signature()
-                    .iter()
-                    .map(|param| param.name.clone())
-                    .collect()
-            })
-            .unwrap_or_default();
+            .signature
+            .iter()
+            .map(|param| param.name.clone())
+            .collect();
 
         let provided_set: HashSet<String> = pending.provided_names.into_iter().collect();
         let unused: Vec<String> = provided_set.difference(&used_inputs).cloned().collect();

--- a/crates/pcb-zen-core/src/lang/evaluator_ext.rs
+++ b/crates/pcb-zen-core/src/lang/evaluator_ext.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use starlark::{
+    any::{AnyLifetime, ProvidesStaticType},
     eval::Evaluator,
     values::{FrozenValue, Value, ValueLike},
 };
@@ -16,6 +17,22 @@ use crate::{
         module::{ModulePath, ModuleValue},
     },
 };
+
+pub struct EvalContextRef<'a> {
+    context: &'a EvalContext,
+}
+
+impl<'a> EvalContextRef<'a> {
+    pub fn new(context: &'a EvalContext) -> Self {
+        Self { context }
+    }
+}
+
+// SAFETY: `EvalContextRef` only carries a lifetime on its borrowed context.
+// Replacing that lifetime with `'static` gives the corresponding static shape.
+unsafe impl<'a> ProvidesStaticType<'a> for EvalContextRef<'a> {
+    type StaticType = EvalContextRef<'static>;
+}
 
 /// Convenience trait that adds helper methods to Starlark `Evaluator`s so they can
 /// interact with the current [`ContextValue`].
@@ -98,7 +115,12 @@ impl<'v> EvaluatorExt<'v> for Evaluator<'v, '_, '_> {
     }
 
     fn eval_context(&self) -> Option<&EvalContext> {
-        self.context_value().map(|ctx| ctx.parent_context())
+        self.extra_mut.as_ref().and_then(|extra| {
+            let extra: &dyn AnyLifetime<'_> = &**extra;
+            extra
+                .downcast_ref::<EvalContextRef>()
+                .map(|extra| extra.context)
+        })
     }
 
     fn module_tree(&self) -> Option<BTreeMap<ModulePath, FrozenModuleValue>> {

--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -102,7 +102,7 @@ fn clone_net_template<'v>(
     field_name_opt: Option<&str>,
     should_register: bool,
     cloned_nets: &mut HashMap<NetId, Value<'v>>,
-    heap: &'v Heap,
+    heap: Heap<'v>,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Value<'v>> {
     let (source_id, template_name_opt) = if let Some(net_val) =
@@ -200,7 +200,7 @@ fn clone_interface_template<'v>(
     instance: Value<'v>,
     prefix: &InstancePrefix,
     should_register: bool,
-    heap: &'v Heap,
+    heap: Heap<'v>,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Value<'v>> {
     fn clone_inner<'v>(
@@ -208,7 +208,7 @@ fn clone_interface_template<'v>(
         prefix: &InstancePrefix,
         should_register: bool,
         cloned_nets: &mut HashMap<NetId, Value<'v>>,
-        heap: &'v Heap,
+        heap: Heap<'v>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> starlark::Result<Value<'v>> {
         // Helper to clone a field value based on its type
@@ -218,7 +218,7 @@ fn clone_interface_template<'v>(
             prefix: &InstancePrefix,
             should_register: bool,
             cloned_nets: &mut HashMap<NetId, Value<'v>>,
-            heap: &'v Heap,
+            heap: Heap<'v>,
             eval: &mut Evaluator<'v, '_, '_>,
         ) -> starlark::Result<Value<'v>> {
             match val.get_type() {
@@ -322,7 +322,7 @@ fn create_field_value<'v>(
     provided_value: Option<Value<'v>>,
     prefix: &InstancePrefix,
     should_register: bool,
-    heap: &'v Heap,
+    heap: Heap<'v>,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Value<'v>> {
     if let Some(value) = validate_field(field_name, field_spec, provided_value, eval)? {
@@ -369,7 +369,7 @@ fn create_interface_instance<'v, V>(
     provided_values: SmallMap<String, Value<'v>>,
     prefix: &InstancePrefix,
     should_register: bool,
-    heap: &'v Heap,
+    heap: Heap<'v>,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Value<'v>>
 where
@@ -652,7 +652,7 @@ where
 {
     type Canonical = FrozenInterfaceValue;
 
-    fn get_attr(&self, attr: &str, _heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attr: &str, _heap: Heap<'v>) -> Option<Value<'v>> {
         self.fields.get(attr).map(|v| v.to_value())
     }
 
@@ -840,7 +840,7 @@ pub(crate) fn instantiate_interface<'v>(
     spec: Value<'v>,
     prefix: &InstancePrefix,
     should_register: bool,
-    heap: &'v Heap,
+    heap: Heap<'v>,
     eval: &mut Evaluator<'v, '_, '_>,
 ) -> starlark::Result<Value<'v>> {
     // Handle interface factories first

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -489,8 +489,9 @@ starlark_complex_value!(pub ModuleValue);
 impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for ModuleValueGen<V>
 where
     Self: ProvidesStaticType<'v>,
+    <Self as ProvidesStaticType<'v>>::StaticType: Send,
 {
-    fn get_attr(&self, attr: &str, heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attr: &str, heap: Heap<'v>) -> Option<Value<'v>> {
         let module_value = heap.alloc_complex(self.clone()).to_value();
 
         match attr {
@@ -516,7 +517,7 @@ where
         }
     }
 
-    fn has_attr(&self, attr: &str, _heap: &'v Heap) -> bool {
+    fn has_attr(&self, attr: &str, _heap: Heap<'v>) -> bool {
         matches!(attr, "nets" | "components" | "graph")
     }
 
@@ -963,7 +964,7 @@ pub struct ModuleLoader {
     pub param_types: SmallMap<String, String>,
 
     #[freeze(identity)]
-    pub frozen_module: Option<FrozenModule>,
+    pub frozen_module: FrozenModule,
 }
 starlark_simple_value!(ModuleLoader);
 
@@ -1184,23 +1185,19 @@ where
     // Expose exports from the target module as attributes on the loader so users can refer to
     // them via the familiar dot-notation (e.g. `Sub.Component`).  We lazily evaluate the target
     // file with an *empty* input map – mirroring the lightweight introspection pass in
-    // `Module()` – and then deep-copy the requested symbol into the current heap so that it
-    // lives alongside the callerʼs values.
-    fn get_attr(&self, attr: &str, _heap: &'v Heap) -> Option<Value<'v>> {
+    // `Module()` – and then access the owned frozen value through the current heap so the
+    // heap records the upstream frozen-module dependency.
+    fn get_attr(&self, attr: &str, heap: Heap<'v>) -> Option<Value<'v>> {
         // Fast-path: ignore private/internal names.
         if attr.starts_with("__") {
             return None;
         }
 
-        if let Some(frozen_module) = &self.frozen_module {
-            return frozen_module.get_option(attr).ok().flatten().map(|owned| {
-                // SAFETY: we know the frozen module is alive because we added a reference to it
-                let fv = unsafe { owned.unchecked_frozen_value() };
-                fv.to_value()
-            });
-        }
-
-        None
+        self.frozen_module
+            .get_option(attr)
+            .ok()
+            .flatten()
+            .map(|owned| heap.access_owned_frozen_value(&owned))
     }
 }
 
@@ -1319,7 +1316,7 @@ fn validate_type<'v>(
     name: &str,
     value: Value<'v>,
     typ: Value<'v>,
-    heap: &'v Heap,
+    heap: Heap<'v>,
 ) -> anyhow::Result<()> {
     if typ.downcast_ref::<EnumType>().is_some() && value.downcast_ref::<EnumValue>().is_some() {
         return Ok(());
@@ -1858,14 +1855,8 @@ where
             source_path: output.sch_module.source_path.clone(),
             params,
             param_types,
-            frozen_module: Some(output.star_module),
+            frozen_module: output.star_module,
         };
-
-        // Retain the child heap so the cached values remain valid for the lifetime of the
-        // parent module.
-        if let Some(frozen_mod) = &loader.frozen_module {
-            eval.frozen_heap().add_reference(frozen_mod.frozen_heap());
-        }
 
         Ok(eval.heap().alloc(loader))
     }

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -255,7 +255,7 @@ impl From<MissingInputError> for starlark::Error {
 }
 
 /// Metadata for a module parameter (from io() or config() calls)
-#[derive(Clone, Debug, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
+#[derive(Clone, Debug, Coerce, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
 #[repr(C)]
 pub struct ParameterMetadataGen<V: ValueLifetimeless> {
     /// Parameter name
@@ -284,12 +284,6 @@ pub struct ParameterMetadataGen<V: ValueLifetimeless> {
     #[freeze(identity)]
     #[allocative(skip)]
     pub declaration_call_stack: starlark::eval::CallStack,
-}
-
-// Manual because no instance for Option<V>
-unsafe impl<From: Coerce<To> + ValueLifetimeless, To: ValueLifetimeless>
-    Coerce<ParameterMetadataGen<To>> for ParameterMetadataGen<From>
-{
 }
 
 starlark_complex_value!(pub ParameterMetadata);

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -189,6 +189,9 @@ where
 
     fn dir_attr(&self) -> Vec<String> {
         let mut attrs: Vec<String> = self.properties.keys().cloned().collect();
+        if !attrs.iter().any(|existing| existing == "NET") {
+            attrs.push("NET".to_string());
+        }
         for attr in self.builtin_optional_attrs() {
             if !attrs.iter().any(|existing| existing == attr) {
                 attrs.push(attr.to_string());

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -17,7 +17,7 @@ use starlark::{
         Trace, Value, ValueLike,
         record::field::FieldGen,
         starlark_value,
-        typing::{TypeCompiled, TypeInstanceId, TypeMatcher, TypeMatcherFactory},
+        typing::{TypeCompiled, TypeInstanceId, TypeMatcher, TypeMatcherDyn, TypeMatcherFactory},
     },
 };
 use starlark_map::sorted_map::SortedMap;
@@ -163,22 +163,28 @@ where
     Self: ProvidesStaticType<'v>,
 {
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new();
-        RES.methods(builtin_net_methods)
+        static RES: MethodsStatic = MethodsStatic::new("Net", builtin_net_methods);
+        Some(RES.methods())
     }
 
-    fn get_attr(&self, attribute: &str, heap: &'v Heap) -> Option<Value<'v>> {
-        self.properties
-            .get(attribute)
-            .map(|v| v.to_value())
-            .or_else(|| {
-                self.is_builtin_optional_attr(attribute)
-                    .then(|| heap.alloc(starlark::values::none::NoneType))
-            })
+    fn get_attr(&self, attribute: &str, heap: Heap<'v>) -> Option<Value<'v>> {
+        match attribute {
+            "NET" => Some(self.with_net_type("Net", heap)),
+            _ => self
+                .properties
+                .get(attribute)
+                .map(|v| v.to_value())
+                .or_else(|| {
+                    self.is_builtin_optional_attr(attribute)
+                        .then(|| heap.alloc(starlark::values::none::NoneType))
+                }),
+        }
     }
 
-    fn has_attr(&self, attribute: &str, _heap: &'v Heap) -> bool {
-        self.properties.contains_key(attribute) || self.is_builtin_optional_attr(attribute)
+    fn has_attr(&self, attribute: &str, _heap: Heap<'v>) -> bool {
+        attribute == "NET"
+            || self.properties.contains_key(attribute)
+            || self.is_builtin_optional_attr(attribute)
     }
 
     fn dir_attr(&self) -> Vec<String> {
@@ -244,7 +250,7 @@ impl<V> NetValueGen<V> {
 }
 
 impl<'v, V: ValueLike<'v>> NetValueGen<V> {
-    fn alloc_clone(&self, heap: &'v Heap, net_id: NetId, type_name: String) -> Value<'v> {
+    fn alloc_clone(&self, heap: Heap<'v>, net_id: NetId, type_name: String) -> Value<'v> {
         let properties: SmallMap<String, Value<'v>> = self
             .properties
             .iter()
@@ -378,13 +384,13 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
 
     /// Create a new net with the same fields but a fresh net ID.
     /// This avoids deep copying - properties are shared via Value references.
-    pub fn with_new_id(&self, heap: &'v Heap) -> Value<'v> {
+    pub fn with_new_id(&self, heap: Heap<'v>) -> Value<'v> {
         self.alloc_clone(heap, generate_net_id(), self.type_name.clone())
     }
 
     /// Create a new net with the same ID/name/properties but a different type name.
     /// Used for casting between net types (e.g., Power -> Net).
-    pub fn with_net_type(&self, new_type_name: &str, heap: &'v Heap) -> Value<'v> {
+    pub fn with_net_type(&self, new_type_name: &str, heap: Heap<'v>) -> Value<'v> {
         self.alloc_clone(heap, self.net_id, new_type_name.to_string())
     }
 
@@ -393,7 +399,7 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
         &self,
         declaration_path: impl Into<String>,
         declaration_span: Option<starlark::codemap::ResolvedSpan>,
-        heap: &'v Heap,
+        heap: Heap<'v>,
     ) -> Value<'v> {
         let properties: SmallMap<String, Value<'v>> = self
             .properties
@@ -439,12 +445,6 @@ fn builtin_net_methods(methods: &mut MethodsBuilder) {
     #[starlark(attribute)]
     fn r#type<'v>(this: &NetValue<'v>) -> starlark::Result<String> {
         Ok(this.net_type_name().to_string())
-    }
-
-    /// Convert this net to base Net type, preserving all properties
-    #[starlark(attribute)]
-    fn NET<'v>(this: &NetValue<'v>, heap: &'v Heap) -> starlark::Result<Value<'v>> {
-        Ok(this.with_net_type("Net", heap))
     }
 }
 
@@ -756,7 +756,7 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
 
 fn compile_field_type<'v>(
     field_spec: Value<'v>,
-    heap: &'v Heap,
+    heap: Heap<'v>,
 ) -> anyhow::Result<TypeCompiled<Value<'v>>> {
     if let Some(field_gen) = field_spec.downcast_ref::<FieldGen<Value<'v>>>() {
         Ok(TypeCompiled::from_ty(field_gen.typ().as_ty(), heap))
@@ -1058,8 +1058,8 @@ where
     }
 
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new();
-        RES.methods(net_type_methods)
+        static RES: MethodsStatic = MethodsStatic::new("NetType", net_type_methods);
+        Some(RES.methods())
     }
 }
 
@@ -1079,11 +1079,13 @@ fn net_type_methods(methods: &mut MethodsBuilder) {
 /// Runtime type matcher for typed nets
 ///
 /// Validates that a NetValue instance has the expected type_name
-#[derive(Hash, Debug, PartialEq, Clone, Allocative)]
+#[derive(Hash, Debug, PartialEq, Clone, Allocative, pagable::Pagable)]
+#[pagable::pagable_typetag(TypeMatcherDyn)]
 struct NetTypeMatcher {
     type_name: String,
 }
 
+#[starlark::type_matcher]
 impl TypeMatcher for NetTypeMatcher {
     fn matches(&self, value: Value) -> bool {
         match NetValue::from_value(value) {

--- a/crates/pcb-zen-core/src/lang/param_decl.rs
+++ b/crates/pcb-zen-core/src/lang/param_decl.rs
@@ -136,7 +136,7 @@ struct DeferredParam<'v> {
 }
 
 impl<'v> starlark::values::AllocValue<'v> for DeferredParam<'v> {
-    fn alloc_value(self, heap: &'v Heap) -> Value<'v> {
+    fn alloc_value(self, heap: Heap<'v>) -> Value<'v> {
         heap.alloc_complex(self)
     }
 }
@@ -219,7 +219,7 @@ fn none_if_none(value: Value<'_>) -> Option<Value<'_>> {
 fn parse_decl_args<'v>(
     kind: ParamKind,
     args: &Arguments<'v, '_>,
-    heap: &'v Heap,
+    heap: Heap<'v>,
 ) -> starlark::Result<(Option<String>, DeclArgs<'v>)> {
     let function = kind.kind_name();
     let positional_values: Vec<Value<'v>> = args.positions(heap)?.collect();
@@ -738,7 +738,7 @@ fn net_skips_implicit_checks<'v>(value: Value<'v>) -> bool {
 
 fn materialize_net_template<'v>(
     template: Value<'v>,
-    heap: &'v Heap,
+    heap: Heap<'v>,
 ) -> starlark::Result<Value<'v>> {
     if let Some(net) = template.downcast_ref::<NetValue<'v>>() {
         Ok(net.with_declaration_site(

--- a/crates/pcb-zen-core/src/lang/part.rs
+++ b/crates/pcb-zen-core/src/lang/part.rs
@@ -105,7 +105,7 @@ impl<'v> StarlarkValue<'v> for PartValue
 where
     Self: ProvidesStaticType<'v>,
 {
-    fn get_attr(&self, attr: &str, heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attr: &str, heap: Heap<'v>) -> Option<Value<'v>> {
         match attr {
             "mpn" => Some(heap.alloc_str(self.mpn()).to_value()),
             "manufacturer" => Some(heap.alloc_str(self.manufacturer()).to_value()),
@@ -126,7 +126,7 @@ where
         }
     }
 
-    fn has_attr(&self, attr: &str, _heap: &'v Heap) -> bool {
+    fn has_attr(&self, attr: &str, _heap: Heap<'v>) -> bool {
         matches!(
             attr,
             "mpn" | "manufacturer" | "qualifications" | "datasheet"

--- a/crates/pcb-zen-core/src/lang/symbol.rs
+++ b/crates/pcb-zen-core/src/lang/symbol.rs
@@ -115,7 +115,7 @@ impl<'v> StarlarkValue<'v> for SymbolValue
 where
     Self: ProvidesStaticType<'v>,
 {
-    fn get_attr(&self, attr: &str, heap: &'v Heap) -> Option<Value<'v>> {
+    fn get_attr(&self, attr: &str, heap: Heap<'v>) -> Option<Value<'v>> {
         match attr {
             "properties" => {
                 let props_vec: Vec<(Value<'v>, Value<'v>)> = self
@@ -134,7 +134,7 @@ where
         }
     }
 
-    fn has_attr(&self, attr: &str, _heap: &'v Heap) -> bool {
+    fn has_attr(&self, attr: &str, _heap: Heap<'v>) -> bool {
         matches!(attr, "properties")
     }
 

--- a/crates/pcb-zen-core/src/lang/symbol.rs
+++ b/crates/pcb-zen-core/src/lang/symbol.rs
@@ -491,13 +491,9 @@ where
         let (library_spec_val, name_val, definition_val, library_val) =
             param_spec.parser(args, eval, |param_parser, _eval_ctx| {
                 let library_spec_val: Option<Value> = param_parser.next_opt()?;
-                let name_val: Option<String> = param_parser
-                    .next_opt()?
-                    .and_then(|v: Value<'v>| v.unpack_str().map(|s| s.to_owned()));
+                let name_val: Option<String> = param_parser.next_opt()?;
                 let definition_val: Option<Value> = param_parser.next_opt()?;
-                let library_val: Option<String> = param_parser
-                    .next_opt()?
-                    .and_then(|v: Value<'v>| v.unpack_str().map(|s| s.to_owned()));
+                let library_val: Option<String> = param_parser.next_opt()?;
 
                 Ok((library_spec_val, name_val, definition_val, library_val))
             })?;

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -321,6 +321,27 @@ snapshot_eval!(interface_net_template_naming, {
     "#,
 });
 
+#[test]
+fn net_dir_lists_net_attribute() {
+    let result = common::eval_zen(vec![(
+        "test.zen".to_string(),
+        r#"
+        Power = interface(
+            NET = Net("VCC"),
+        )
+
+        power = Power("POWER")
+        net = Net("SIG")
+
+        check("NET" in dir(power.NET), "dir(power.NET) should include NET")
+        check("NET" in dir(net), "dir(net) should include NET")
+    "#
+        .to_string(),
+    )]);
+
+    assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
+}
+
 snapshot_eval!(net_type_cast_preserves_name_across_modules, {
     "interfaces.zen" => r#"
         # Typed net definitions for testing net type promotion

--- a/crates/pcb-zen/src/dap.rs
+++ b/crates/pcb-zen/src/dap.rs
@@ -77,16 +77,17 @@ impl Backend {
         let go = move || -> anyhow::Result<String> {
             client.log(&format!("EVALUATION PREPARE: {}", path.display()));
             let ast = AstModule::parse_file(&path, &dialect).into_anyhow_result()?;
-            let module = Module::new();
-            let mut eval = Evaluator::new(&module);
-            wrapper.add_dap_hooks(&mut eval);
+            Module::with_temp_heap(|module| {
+                let mut eval = Evaluator::new(&module);
+                wrapper.add_dap_hooks(&mut eval);
 
-            // No way to pass back success/failure to the caller
-            client.log(&format!("EVALUATION START: {}", path.display()));
-            let v = eval.eval_module(ast, &globals).into_anyhow_result()?;
-            let s = v.to_string();
-            client.log(&format!("EVALUATION FINISHED: {}", path.display()));
-            Ok(s)
+                // No way to pass back success/failure to the caller
+                client.log(&format!("EVALUATION START: {}", path.display()));
+                let v = eval.eval_module(ast, &globals).into_anyhow_result()?;
+                let s = v.to_string();
+                client.log(&format!("EVALUATION FINISHED: {}", path.display()));
+                Ok(s)
+            })
         };
 
         thread::spawn(move || {

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -71,7 +71,6 @@ syntect = { workspace = true }
 gltfpack-sys = { workspace = true }
 thiserror = { workspace = true }
 minijinja = { workspace = true }
-canon-json = "0.2"
 tracing = { workspace = true }
 tracing-chrome = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/pcbc/src/build.rs
+++ b/crates/pcbc/src/build.rs
@@ -154,14 +154,17 @@ fn execute_electrical_check(
 ) -> pcb_zen_core::Diagnostic {
     use starlark::environment::Module;
     use starlark::eval::Evaluator;
-    use starlark::values::Heap;
 
-    let heap = Heap::new();
-    let module = Module::new();
-    let mut eval = Evaluator::new(&module);
-    let module_value = heap.alloc_simple(defining_module.clone());
+    Module::with_temp_heap(|module| {
+        let mut eval = Evaluator::new(&module);
+        let module_value = module.heap().alloc_simple(defining_module.clone());
 
-    pcb_zen_core::lang::electrical_check::execute_electrical_check(&mut eval, check, module_value)
+        pcb_zen_core::lang::electrical_check::execute_electrical_check(
+            &mut eval,
+            check,
+            module_value,
+        )
+    })
 }
 
 pub fn create_diagnostics_passes(

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -24,15 +24,6 @@ use zip::{ZipWriter, write::FileOptions};
 
 use pcb_zen::git;
 
-/// Serialize a value to RFC 8785 canonical JSON (sorted keys, consistent formatting).
-fn to_canonical_json<T: serde::Serialize>(value: &T) -> Result<Vec<u8>> {
-    let mut buf = Vec::new();
-    let mut ser =
-        serde_json::Serializer::with_formatter(&mut buf, canon_json::CanonicalFormatter::new());
-    serde::Serialize::serialize(value, &mut ser)?;
-    Ok(buf)
-}
-
 #[derive(ValueEnum, Debug, Clone, PartialEq)]
 #[value(rename_all = "lowercase")]
 pub enum ArtifactType {
@@ -789,8 +780,8 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<()> {
                 .context("Failed to write fp-lib-table for staged layout")?;
         }
 
-        // Write netlist JSON to staging directory (RFC 8785 canonical for deterministic output)
-        let netlist_json = to_canonical_json(sch).context("Failed to serialize netlist")?;
+        // Write RFC 8785 canonical netlist JSON to staging directory.
+        let netlist_json = sch.to_json().context("Failed to serialize netlist")?;
         fs::write(info.staging_dir.join("netlist.json"), &netlist_json)
             .context("Failed to write netlist.json")?;
     }

--- a/crates/pcbc/src/test.rs
+++ b/crates/pcbc/src/test.rs
@@ -7,7 +7,9 @@ use pcb_zen_core::ModulePath;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use starlark::collections::SmallMap;
+use starlark::errors::EvalSeverity;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::build::create_diagnostics_passes;
 use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
@@ -144,7 +146,7 @@ fn execute_testbench_checks(
     use pcb_zen_core::lang::test_bench::execute_deferred_check;
     use starlark::environment::Module;
     use starlark::eval::Evaluator;
-    use starlark::values::{Heap, ValueLike, dict::AllocDict};
+    use starlark::values::{ValueLike, dict::AllocDict};
 
     let mut all_diagnostics = Vec::new();
     let mut total_checks = 0;
@@ -157,20 +159,46 @@ fn execute_testbench_checks(
     )
     .set_source_path(std::path::PathBuf::from(testbench.source_path()));
 
-    // Create a ContextValue and attach it to the module
-    let heap = Heap::new();
-    let module = Module::new();
-    let ctx_value = pcb_zen_core::lang::context::ContextValue::from_context(&eval_ctx);
-    module.set_extra_value(heap.alloc_complex(ctx_value));
-    let mut eval = Evaluator::new(&module);
+    Module::with_temp_heap(|module| {
+        // Create a ContextValue and attach it to the module
+        let heap = module.heap();
+        let ctx_value = pcb_zen_core::lang::context::ContextValue::from_context(&eval_ctx);
+        module.set_extra_value(heap.alloc_complex(ctx_value));
+        let mut eval = Evaluator::new(&module);
 
-    let module_tree = eval_output.module_tree();
-    for deferred_case in testbench.deferred_cases().iter() {
-        // Look up evaluated module from tree by full path
-        let module_path = ModulePath::from(deferred_case.case_final_name.clone());
-        let case_module = module_tree.get(&module_path).cloned();
+        let module_tree = eval_output.module_tree();
+        for deferred_case in testbench.deferred_cases().iter() {
+            // Look up evaluated module from tree by full path
+            let module_path = ModulePath::from(deferred_case.case_final_name.clone());
+            let Some(module_value) = module_tree.get(&module_path).cloned() else {
+                all_diagnostics.push(pcb_zen_core::Diagnostic {
+                    path: testbench.source_path().to_string(),
+                    span: testbench.call_span().cloned(),
+                    severity: EvalSeverity::Error,
+                    body: format!(
+                        "TestBench '{}' case '{}' module '{}' was not evaluated",
+                        testbench.name(),
+                        deferred_case.case_name,
+                        deferred_case.case_final_name
+                    ),
+                    call_stack: None,
+                    child: None,
+                    source_error: Some(Arc::new(
+                        pcb_zen_core::lang::error::BenchTestResult {
+                            test_bench_name: testbench.name().to_string(),
+                            case_name: Some(deferred_case.case_name.clone()),
+                            check_name: "<module evaluation>".to_string(),
+                            file_path: testbench.source_path().to_string(),
+                            passed: false,
+                        }
+                        .into(),
+                    )),
+                    related: Vec::new(),
+                    suppressed: false,
+                });
+                continue;
+            };
 
-        if let Some(module_value) = case_module {
             // Reconstruct inputs dict from deferred case params
             let inputs_dict = heap
                 .alloc(AllocDict(
@@ -205,28 +233,28 @@ fn execute_testbench_checks(
                 all_diagnostics.append(&mut diagnostics);
             }
         }
-    }
 
-    // Print summary for successful test benches
-    if total_checks > 0 && passed_checks == total_checks {
-        let case_word = if testbench.case_count() == 1 {
-            "case"
-        } else {
-            "cases"
-        };
-        let check_word = if total_checks == 1 { "check" } else { "checks" };
-        eprintln!(
-            "{} {}: {} {} passed across {} {}",
-            pcb_ui::icons::success().with_style(pcb_ui::Style::Green),
-            testbench.name(),
-            total_checks,
-            check_word,
-            testbench.case_count(),
-            case_word
-        );
-    }
+        // Print summary for successful test benches
+        if total_checks > 0 && passed_checks == total_checks {
+            let case_word = if testbench.case_count() == 1 {
+                "case"
+            } else {
+                "cases"
+            };
+            let check_word = if total_checks == 1 { "check" } else { "checks" };
+            eprintln!(
+                "{} {}: {} {} passed across {} {}",
+                pcb_ui::icons::success().with_style(pcb_ui::Style::Green),
+                testbench.name(),
+                total_checks,
+                check_word,
+                testbench.case_count(),
+                case_word
+            );
+        }
 
-    all_diagnostics
+        all_diagnostics
+    })
 }
 
 pub fn execute(args: TestArgs) -> Result<()> {

--- a/crates/pcbc/src/test.rs
+++ b/crates/pcbc/src/test.rs
@@ -142,7 +142,7 @@ fn execute_testbench_checks(
     testbench: &pcb_zen_core::lang::test_bench::FrozenTestBenchValue,
     eval_output: &pcb_zen_core::lang::eval::EvalOutput,
 ) -> Vec<pcb_zen_core::Diagnostic> {
-    use pcb_zen_core::lang::eval::EvalContext;
+    use pcb_zen_core::lang::eval::{EvalContext, EvalContextRef};
     use pcb_zen_core::lang::test_bench::execute_deferred_check;
     use starlark::environment::Module;
     use starlark::eval::Evaluator;
@@ -164,7 +164,9 @@ fn execute_testbench_checks(
         let heap = module.heap();
         let ctx_value = pcb_zen_core::lang::context::ContextValue::from_context(&eval_ctx);
         module.set_extra_value(heap.alloc_complex(ctx_value));
+        let mut eval_context_ref = EvalContextRef::new(&eval_ctx);
         let mut eval = Evaluator::new(&module);
+        eval.extra_mut = Some(&mut eval_context_ref);
 
         let module_tree = eval_output.module_tree();
         for deferred_case in testbench.deferred_cases().iter() {


### PR DESCRIPTION
The new pagable stuff in `starlark-rust` was quite buggy, so I didn't switch to it yet.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the embedded Starlark runtime and all custom Zen/schematic value types; mostly mechanical API updates but regressions in evaluation, typing, or freeze/serialization would affect every design build.
> 
> **Overview**
> Bumps the workspace **starlark-rust** pin from `0.13` to **`0.14`** (new git rev), turns on **`default-features = false`** for Starlark crates, and wires in the **`pagable`** workspace dependency used by the updated runtime.
> 
> Custom Starlark types in **`pcb-sch`** and **`pcb-zen-core`** are adapted to current APIs: **`Heap<'v>`** instead of heap references, **`MethodsStatic::new(name, …)`** + **`Some(RES.methods())`**, **`TypeMatcherDyn`** / **`#[starlark::type_matcher]`**, and **`pagable::Pagable`** (plus **`Freeze`** where applicable) on values and matchers. **`ComponentData`** is collapsed into a generic **`ComponentDataGen`** with derived freeze; **`ContextValue`** drops the unsafe parent-context pointer.
> 
> Smaller behavior/cleanup touches: frozen property strings read via **`unpack_str()`** after **`to_value()`**, DNP parsing uses case-insensitive **`true`**, and physical-value constructor parsing is simplified (**`check_unit`**, shared **`parse_bound`**). Tests move to **`Heap::temp`** / **`Module::with_temp_heap`**. **`CHANGELOG`** notes the Starlark integration update; **`Cargo.lock`** reflects the dependency graph shift (including transitive crates from **`pagable`** / Starlark 0.14).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0934f0374853c5929fa19498d5d766fa8cbc0886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->