### PR TITLE
Allow pcb open with diagnostic output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `pcb open` now ignores diagnostics when evaluation still produces usable output.
+
 ## [0.3.86] - 2026-05-28
 
 ### Added

--- a/crates/pcbc/src/open.rs
+++ b/crates/pcbc/src/open.rs
@@ -31,7 +31,7 @@ pub fn execute(args: OpenArgs) -> Result<()> {
 
     crate::file_walker::require_zen_file(&args.file)?;
 
-    // Resolve dependencies before building
+    // Resolve dependencies before evaluating
     let resolution_result = crate::resolve::resolve(Some(&args.file), args.offline, args.locked)?;
 
     let zen_path = &args.file;
@@ -40,11 +40,13 @@ pub fn execute(args: OpenArgs) -> Result<()> {
     // Evaluate the zen file
     let eval_result = pcb_zen::eval(zen_path, resolution_result, Default::default());
 
-    let output = eval_result
-        .output_result()
-        .map_err(|_| anyhow::anyhow!("Build failed for {}", file_name))?;
+    let Some(output) = eval_result.output else {
+        anyhow::bail!("Build failed for {}", file_name);
+    };
 
-    let schematic = output.to_schematic()?;
+    let Some(schematic) = output.to_schematic_with_diagnostics().output else {
+        anyhow::bail!("Build failed for {}", file_name);
+    };
     let layout_dir = utils::resolve_layout_dir(&schematic)?
         .ok_or_else(|| anyhow::anyhow!("No layout path defined in {}", file_name))?;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrows failure conditions for `pcb open` only; does not change locked build or CI evaluation semantics elsewhere.
> 
> **Overview**
> **`pcb open`** no longer treats Starlark evaluation or schematic conversion diagnostics as a hard failure when a schematic is still produced.
> 
> The open path now requires only that evaluation and `to_schematic_with_diagnostics()` return usable **output**, instead of using `output_result()` / `to_schematic()`, which previously failed on error-level diagnostics even when a layout could be resolved. Warnings and similar issues can still be present in the build, but KiCad will open when the layout file exists.
> 
> The unreleased changelog records this as a fix for opening boards with diagnostic output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97cb0452cd5eeae57c50986a5f0437a505a99e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->