### PR TITLE
Fix v2 workspace vendoring before build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb open` now ignores diagnostics when evaluation still produces usable output.
 - `pcb build` now syncs workspace-vendored dependencies before evaluating hydrated MVS v2 projects.
+- V2 workspaces now derive KiCad footprint library names from resolved stdlib dependencies.
 
 ## [0.3.86] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb open` now ignores diagnostics when evaluation still produces usable output.
 - `pcb build` now syncs workspace-vendored dependencies before evaluating hydrated MVS v2 projects.
+- `pcb publish` V2 source bundles now validate offline without requiring KiCad assets in `.pcb/cache`.
 - V2 workspaces now derive KiCad footprint library names from resolved stdlib dependencies.
 
 ## [0.3.86] - 2026-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `pcb open` now ignores diagnostics when evaluation still produces usable output.
+- `pcb build` now syncs workspace-vendored dependencies before evaluating hydrated MVS v2 projects.
 
 ## [0.3.86] - 2026-05-28
 

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -265,12 +265,11 @@ pub fn select_version_for_detail(
 
 /// Build the package coordinate → absolute root directory mapping.
 ///
-/// Workspace packages come from `workspace_info.packages`. External deps
-/// are discovered from `package_resolutions` values (already resolved by the
-/// resolver through patches → vendor → cache).
-pub fn build_package_roots(
+/// Workspace packages come from `workspace_info.packages`. External deps are
+/// discovered from resolved package-local dependency maps.
+pub fn build_package_roots<'a>(
     workspace_info: &WorkspaceInfo,
-    package_resolutions: &HashMap<PathBuf, BTreeMap<String, PathBuf>>,
+    dependency_maps: impl IntoIterator<Item = &'a BTreeMap<String, PathBuf>>,
 ) -> BTreeMap<String, PathBuf> {
     let mut roots = BTreeMap::new();
     roots.insert(
@@ -294,7 +293,7 @@ pub fn build_package_roots(
         );
     }
 
-    for deps in package_resolutions.values() {
+    for deps in dependency_maps {
         for (module_path, dep_root) in deps {
             let version = dep_root.file_name().and_then(|f| f.to_str());
             let parent_matches = dep_root
@@ -318,15 +317,22 @@ fn resolution_package_roots(
     package_resolutions: &HashMap<PathBuf, BTreeMap<String, PathBuf>>,
     mvs_v2_resolution: Option<&FrozenResolutionSet>,
 ) -> BTreeMap<String, PathBuf> {
-    let mut roots = build_package_roots(workspace_info, package_resolutions);
-    if let Some(resolution) = mvs_v2_resolution {
-        roots.extend(
-            resolution
-                .values()
-                .flat_map(FrozenResolutionMap::package_roots),
-        );
-    }
-    roots
+    build_package_roots(
+        workspace_info,
+        package_resolutions
+            .values()
+            .chain(frozen_dependency_maps(mvs_v2_resolution)),
+    )
+}
+
+fn frozen_dependency_maps(
+    resolution: Option<&FrozenResolutionSet>,
+) -> impl Iterator<Item = &BTreeMap<String, PathBuf>> {
+    resolution
+        .into_iter()
+        .flat_map(|resolution_set| resolution_set.values())
+        .flat_map(|resolution| resolution.packages.values())
+        .map(|package| &package.deps)
 }
 
 /// Resolve a single dependency to its path.
@@ -587,38 +593,6 @@ pub struct FrozenResolutionMap {
 }
 
 impl FrozenResolutionMap {
-    pub fn package_roots(&self) -> BTreeMap<String, PathBuf> {
-        self.packages
-            .iter()
-            .map(|(root, package)| (package.identity.package_coord(), root.clone()))
-            .collect()
-    }
-
-    pub fn kicad_model_dirs(&self, workspace_info: &WorkspaceInfo) -> BTreeMap<String, PathBuf> {
-        let workspace_cfg = workspace_info.workspace_config();
-        let mut model_dirs = BTreeMap::new();
-
-        for (root, package) in &self.packages {
-            let FrozenPackageIdentity::Remote { dep_id, version } = &package.identity else {
-                continue;
-            };
-            let Some(entry) = effective_kicad_library_for_repo(
-                &workspace_cfg.kicad_library,
-                &dep_id.path,
-                version,
-            ) else {
-                continue;
-            };
-            for (var, model_repo) in &entry.models {
-                if model_repo == &dep_id.path {
-                    model_dirs.insert(var.clone(), root.clone());
-                }
-            }
-        }
-
-        model_dirs
-    }
-
     pub fn package_for_file(&self, file: &Path) -> Option<(&PathBuf, &FrozenPackage)> {
         self.packages
             .iter()
@@ -800,14 +774,6 @@ impl FrozenPackageIdentity {
             Self::Remote { dep_id, version } => {
                 format!("{}@{} = {}", dep_id.path, dep_id.lane, version)
             }
-            Self::Stdlib => STDLIB_MODULE_PATH.to_string(),
-        }
-    }
-
-    pub fn package_coord(&self) -> String {
-        match self {
-            Self::Workspace(url) => url.clone(),
-            Self::Remote { dep_id, version } => format!("{}@{}", dep_id.path, version),
             Self::Stdlib => STDLIB_MODULE_PATH.to_string(),
         }
     }
@@ -1126,7 +1092,12 @@ impl ResolutionResult {
     pub fn kicad_model_dirs(&self) -> BTreeMap<String, PathBuf> {
         let mut model_dirs = BTreeMap::new();
         let workspace_cfg = self.workspace_info.workspace_config();
-        for deps in self.package_resolutions.values() {
+
+        for deps in self
+            .package_resolutions
+            .values()
+            .chain(frozen_dependency_maps(self.mvs_v2_resolution.as_ref()))
+        {
             for (repo, path) in deps {
                 let Some(version_str) = path.file_name().and_then(|name| name.to_str()) else {
                     continue;
@@ -1144,11 +1115,6 @@ impl ResolutionResult {
                         model_dirs.insert(var.clone(), path.clone());
                     }
                 }
-            }
-        }
-        if let Some(resolution_set) = &self.mvs_v2_resolution {
-            for resolution in resolution_set.values() {
-                model_dirs.extend(resolution.kicad_model_dirs(&self.workspace_info));
             }
         }
         model_dirs
@@ -1262,7 +1228,7 @@ mod tests {
     }
 
     #[test]
-    fn package_roots_reflect_attached_mvs_v2_resolution() {
+    fn package_roots_reflect_mvs_v2_dependency_roots() {
         let mut result = ResolutionResult::native(
             WorkspaceInfo {
                 root: PathBuf::from("/workspace"),
@@ -1287,16 +1253,10 @@ mod tests {
             FrozenResolutionMap {
                 selected_remote: BTreeMap::new(),
                 packages: BTreeMap::from([(
-                    dep_root.clone(),
+                    PathBuf::from("/workspace"),
                     FrozenPackage {
-                        identity: FrozenPackageIdentity::Remote {
-                            dep_id: FrozenDepId {
-                                path: "github.com/acme/dep".into(),
-                                lane: "v1".into(),
-                            },
-                            version: Version::parse("1.2.3").unwrap(),
-                        },
-                        deps: BTreeMap::new(),
+                        identity: FrozenPackageIdentity::Workspace("github.com/acme/root".into()),
+                        deps: BTreeMap::from([("github.com/acme/dep".into(), dep_root.clone())]),
                         parts: Vec::new(),
                     },
                 )]),

--- a/crates/pcb-zen/src/package_resolver/materialize.rs
+++ b/crates/pcb-zen/src/package_resolver/materialize.rs
@@ -1,20 +1,22 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap};
 
-use anyhow::Result;
+use crate::cache_index::CacheIndex;
+use anyhow::{Context, Result};
 use pcb_zen_core::kicad_library::{KicadRepoMatch, match_kicad_managed_repo};
 use pcb_zen_core::resolution::ModuleLine;
 use semver::Version;
 
 use super::ResolvedDepId;
 
-pub fn materialize_selected(
+pub fn materialize_selected<'a>(
     workspace: &crate::WorkspaceInfo,
-    selected_remote: &BTreeMap<ResolvedDepId, Version>,
+    selected_remote: impl IntoIterator<Item = (&'a ResolvedDepId, &'a Version)>,
     offline: bool,
 ) -> Result<BTreeSet<(String, String)>> {
     let mut package_roots = BTreeSet::new();
     let mut kicad_assets = HashMap::new();
     let kicad_entries = workspace.kicad_library_entries();
+    let cache_index = CacheIndex::open()?;
 
     for (dep_id, version) in selected_remote {
         package_roots.insert((dep_id.path.clone(), version.to_string()));
@@ -23,11 +25,49 @@ pub fn materialize_selected(
             == KicadRepoMatch::SelectorMatched
         {
             kicad_assets.insert(line, version.clone());
+        } else {
+            ensure_remote_package_materialized(
+                workspace,
+                &dep_id.path,
+                version,
+                offline,
+                &cache_index,
+            )?;
         }
     }
 
     crate::resolve::materialize_asset_deps(workspace, &kicad_assets, offline)?;
     Ok(package_roots)
+}
+
+fn ensure_remote_package_materialized(
+    workspace: &crate::WorkspaceInfo,
+    module_path: &str,
+    version: &Version,
+    offline: bool,
+    cache_index: &CacheIndex,
+) -> Result<()> {
+    let version_str = version.to_string();
+    let manifest_rel = std::path::Path::new(module_path)
+        .join(&version_str)
+        .join("pcb.toml");
+    if workspace.root.join("vendor").join(&manifest_rel).exists()
+        || workspace.cache_dir.join(&manifest_rel).exists()
+    {
+        return Ok(());
+    }
+
+    if offline {
+        anyhow::bail!(
+            "{}@{} is not cached. Run `pcb build` once online to fetch it.",
+            module_path,
+            version_str
+        );
+    }
+
+    crate::resolve::ensure_package_manifest_in_cache(module_path, version, cache_index)
+        .with_context(|| format!("Failed to materialize {}@{}", module_path, version))?;
+    Ok(())
 }
 
 pub fn vendor_selected(

--- a/crates/pcb-zen/src/package_resolver/mod.rs
+++ b/crates/pcb-zen/src/package_resolver/mod.rs
@@ -14,6 +14,6 @@ pub use pcb_zen_core::resolution::{
 };
 pub use resolve::{
     attach_mvs_v2_resolution_for_packages, build_frozen_resolution_maps,
-    resolve_workspace_dependencies, target_package_urls_for_path,
+    resolve_workspace_dependencies, sync_workspace_vendor, target_package_urls_for_path,
 };
 pub use versions::SpecVersionResolver;

--- a/crates/pcb-zen/src/package_resolver/resolve.rs
+++ b/crates/pcb-zen/src/package_resolver/resolve.rs
@@ -76,14 +76,7 @@ pub fn resolve_workspace_dependencies(
     offline: bool,
     locked: bool,
 ) -> Result<ResolutionResult> {
-    let package_urls = target_package_urls_for_path(&workspace_info, path)
-        .inspect_err(|err| {
-            log::debug!(
-                "Skipping MVS v2 target discovery for {}: {err:#}",
-                path.display()
-            );
-        })
-        .unwrap_or_default();
+    let package_urls = target_package_urls_or_empty(&workspace_info, path);
     if use_frozen_resolution(&workspace_info, &package_urls) {
         return resolve_frozen(workspace_info, package_urls, offline);
     }
@@ -91,6 +84,17 @@ pub fn resolve_workspace_dependencies(
     let mut res = crate::resolve_dependencies(&mut workspace_info, offline, locked)?;
     attach_mvs_v2_resolution_for_packages(&mut res, package_urls, offline);
     Ok(res)
+}
+
+fn target_package_urls_or_empty(workspace_info: &WorkspaceInfo, path: &Path) -> Vec<String> {
+    target_package_urls_for_path(workspace_info, path)
+        .inspect_err(|err| {
+            log::debug!(
+                "Skipping MVS v2 target discovery for {}: {err:#}",
+                path.display()
+            );
+        })
+        .unwrap_or_default()
 }
 
 fn resolve_frozen(
@@ -120,6 +124,55 @@ fn resolve_frozen(
         resolution_set,
         symbol_parts,
     ))
+}
+
+fn workspace_vendor_enabled(workspace_info: &WorkspaceInfo) -> bool {
+    workspace_info
+        .config
+        .as_ref()
+        .and_then(|config| config.workspace.as_ref())
+        .is_some_and(|workspace| !workspace.vendor.is_empty())
+}
+
+fn workspace_selected_remote(
+    workspace_info: &WorkspaceInfo,
+    offline: bool,
+) -> Result<BTreeSet<(ResolvedDepId, Version)>> {
+    let mut selected = BTreeSet::new();
+    let mut resolver = PackageResolver::new(workspace_info.clone(), offline)?;
+
+    for package_url in workspace_info.packages.keys() {
+        let package_selected = if package_has_indirect(workspace_info, package_url) {
+            selected_remote_from_hydrated_manifest(workspace_info, package_url)?
+        } else {
+            resolver.resolve_package(package_url)?.resolved_remote
+        };
+        selected.extend(package_selected);
+    }
+
+    Ok(selected)
+}
+
+pub fn sync_workspace_vendor(
+    workspace_info: &WorkspaceInfo,
+    path: &Path,
+    offline: bool,
+) -> Result<()> {
+    let package_urls = target_package_urls_or_empty(workspace_info, path);
+    if !use_frozen_resolution(workspace_info, &package_urls)
+        || !workspace_vendor_enabled(workspace_info)
+    {
+        return Ok(());
+    }
+
+    let selected = workspace_selected_remote(workspace_info, offline)?;
+    let package_roots = materialize_selected(
+        workspace_info,
+        selected.iter().map(|(dep_id, version)| (dep_id, version)),
+        offline,
+    )?;
+    crate::resolve::vendor_package_roots(workspace_info, &package_roots, &[], None, true)?;
+    Ok(())
 }
 
 pub fn attach_mvs_v2_resolution_for_packages(
@@ -257,7 +310,7 @@ impl FrozenResolutionBuilder {
             return Ok(());
         }
 
-        materialize_selected(&self.workspace, &pending, self.offline)?;
+        materialize_selected(&self.workspace, pending.iter(), self.offline)?;
         self.materialized_remote.extend(pending);
         Ok(())
     }

--- a/crates/pcb-zen/src/package_resolver/resolve.rs
+++ b/crates/pcb-zen/src/package_resolver/resolve.rs
@@ -158,6 +158,10 @@ pub fn sync_workspace_vendor(
     path: &Path,
     offline: bool,
 ) -> Result<()> {
+    if offline {
+        return Ok(());
+    }
+
     let package_urls = target_package_urls_or_empty(workspace_info, path);
     if !use_frozen_resolution(workspace_info, &package_urls)
         || !workspace_vendor_enabled(workspace_info)

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -1755,7 +1755,7 @@ pub fn build_symbol_parts(
     package_resolutions: &HashMap<PathBuf, BTreeMap<String, PathBuf>>,
 ) -> Result<HashMap<String, Vec<ManifestPart>>> {
     let mut result: HashMap<String, Vec<ManifestPart>> = HashMap::new();
-    let package_roots = build_package_roots(workspace_info, package_resolutions);
+    let package_roots = build_package_roots(workspace_info, package_resolutions.values());
     let kicad_entries = workspace_info.kicad_library_entries();
     let mut seen_roots = HashSet::new();
 
@@ -1818,7 +1818,10 @@ pub fn build_frozen_symbol_parts(
     resolution: &FrozenResolutionMap,
 ) -> Result<HashMap<String, Vec<ManifestPart>>> {
     let mut result: HashMap<String, Vec<ManifestPart>> = HashMap::new();
-    let package_roots = resolution.package_roots();
+    let package_roots = build_package_roots(
+        workspace_info,
+        resolution.packages.values().map(|package| &package.deps),
+    );
     let kicad_entries = workspace_info.kicad_library_entries();
     let mut seen_roots = HashSet::new();
 

--- a/crates/pcbc/src/mod/mod.rs
+++ b/crates/pcbc/src/mod/mod.rs
@@ -466,7 +466,7 @@ fn run_resolution(
         }
         package_roots.extend(materialize_selected(
             workspace,
-            &resolution.resolved_remote,
+            resolution.resolved_remote.iter(),
             offline,
         )?);
     }

--- a/crates/pcbc/src/resolve.rs
+++ b/crates/pcbc/src/resolve.rs
@@ -5,7 +5,9 @@ use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::resolution::ResolutionResult;
 use tracing::instrument;
 
-use pcb_zen::{get_workspace_info, resolve_workspace_dependencies};
+use pcb_zen::{
+    get_workspace_info, package_resolver::sync_workspace_vendor, resolve_workspace_dependencies,
+};
 
 /// Resolve dependencies for a workspace/board.
 /// This is a shared helper used by build, bom, layout, open, etc.
@@ -40,6 +42,7 @@ pub fn resolve(input_path: Option<&Path>, offline: bool, locked: bool) -> Result
         );
     }
 
+    sync_workspace_vendor(&workspace_info, path, offline)?;
     let mut res = resolve_workspace_dependencies(workspace_info, path, offline, locked)?;
 
     if res.package_resolutions.is_empty() {
@@ -57,6 +60,7 @@ pub fn resolve(input_path: Option<&Path>, offline: bool, locked: bool) -> Result
             vendor_result.pruned_count
         );
         let workspace_info = get_workspace_info(&DefaultFileProvider::new(), path)?;
+        sync_workspace_vendor(&workspace_info, path, offline)?;
         res = resolve_workspace_dependencies(workspace_info, path, offline, locked)?;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core dependency resolution, vendoring, and KiCad path mapping used by build and publish; behavior changes are targeted but affect all hydrated v2 workspaces with vendor enabled.
> 
> **Overview**
> **`pcb build` and shared resolve** now call **`sync_workspace_vendor`** before frozen MVS v2 evaluation when the workspace has vendoring enabled, so remote deps are materialized and copied into **`vendor/`** ahead of hydrated resolution instead of failing mid-build.
> 
> **Package roots and KiCad paths** are unified: **`build_package_roots`** takes any package-local dependency maps (native resolution plus frozen v2 **`package.deps`**), and **`kicad_model_dirs`** uses the same sources—so v2 workspaces get correct footprint/model library roots without requiring KiCad-only assets in **`.pcb/cache`** for offline publish validation.
> 
> **Materialization** now ensures non–KiCad-managed remote packages have **`pcb.toml`** in vendor/cache (fetching online when needed); **`materialize_selected`** accepts iterator refs and drops duplicate frozen-only helpers (**`package_roots`**, **`package_coord`**, frozen **`kicad_model_dirs`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41774de75a1d28bcc03e0082116d40ce0f71ad98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->