### PR TITLE
Batch geometry boolean operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Batched IPC/Gerber polygon boolean operations for much faster real-board geometry processing.
+
 ### Fixed
 
 - `pcb open` now ignores diagnostics when evaluation still produces usable output.

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -447,6 +447,24 @@ fn process_applies_clear_polarity_cutouts() {
 }
 
 #[test]
+fn process_keeps_clear_polarity_semantics_after_overlapping_dark_runs() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\n%ADD10R,4.0X4.0*%\n%ADD11R,2.0X2.0*%\nD10*\nX0Y0D03*\nX0Y0D03*\n%LPC*%\nD11*\nX0Y0D03*\nM02*\n",
+    )
+    .unwrap();
+
+    let mut geometry = gerberx2::geometry::extract_document(&gerber);
+    pcb_ir::dialects::gerber::process::process_document(&mut geometry);
+    let summary = pcb_ir::dialects::gerber::compare::summarize(&geometry);
+
+    assert!(
+        close(summary.area_mm2, 12.0),
+        "area was {}",
+        summary.area_mm2
+    );
+}
+
+#[test]
 fn process_preserves_ordered_aperture_path_polarity() {
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%AMORDERED*\n21,1,4,4,0,0,0*\n21,0,2,2,0,0,0*\n21,1,1,1,0,0,0*\n%\n%ADD10ORDERED*%\nD10*\nX0Y0D03*\nM02*\n",

--- a/crates/pcb-ir/src/common.rs
+++ b/crates/pcb-ir/src/common.rs
@@ -157,6 +157,15 @@ impl BBox {
         self
     }
 
+    pub fn intersects(self, other: BBox) -> bool {
+        !self.is_empty()
+            && !other.is_empty()
+            && self.min.x <= other.max.x
+            && self.max.x >= other.min.x
+            && self.min.y <= other.max.y
+            && self.max.y >= other.min.y
+    }
+
     pub fn expand(self, amount: f64) -> Self {
         if self.is_empty() {
             return self;

--- a/crates/pcb-ir/src/dialects/gerber/process.rs
+++ b/crates/pcb-ir/src/dialects/gerber/process.rs
@@ -65,21 +65,23 @@ pub fn outline_stroked_paths<A: Clone>(doc: &mut GeometryDocument<A>) {
 }
 
 pub fn resolve_polarity_and_cutouts<A>(doc: &mut GeometryDocument<A>) {
-    let mut image = Vec::new();
+    let mut composer = common_path::PaintComposer::default();
+
     for feature in &doc.features {
         let feature_image = feature_image_contours(doc, feature);
         if feature_image.is_empty() {
             continue;
         }
-        if feature.polarity == Polarity::Clear || feature.bucket == FeatureBucket::Cutout {
-            image = common_path::difference_contours(image, feature_image);
+
+        let op = if feature.polarity == Polarity::Clear || feature.bucket == FeatureBucket::Cutout {
+            common_path::PaintOp::Clear
         } else {
-            image = common_path::union_contours(
-                image.into_iter().chain(feature_image).collect(),
-                FillRule::NonZero,
-            );
-        }
+            common_path::PaintOp::Dark
+        };
+        composer.push(op, feature_image);
     }
+    let image = composer.finish();
+
     if image.is_empty() {
         clear_all_features(doc);
         return;
@@ -102,7 +104,8 @@ fn feature_image_contours<A>(
     doc: &GeometryDocument<A>,
     feature: &GeometryFeature<A>,
 ) -> Vec<common_path::PolygonContour> {
-    let mut image = Vec::new();
+    let mut composer = common_path::PaintComposer::default();
+
     for path in
         &doc.paths[feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
     {
@@ -113,19 +116,16 @@ fn feature_image_contours<A>(
         if path_contours.is_empty() {
             continue;
         }
-        if path.polarity == Polarity::Clear {
-            image = common_path::difference_contours(
-                image,
-                common_path::union_contours(path_contours, FillRule::NonZero),
-            );
+
+        let op = if path.polarity == Polarity::Clear {
+            common_path::PaintOp::Clear
         } else {
-            image = common_path::union_contours(
-                image.into_iter().chain(path_contours).collect(),
-                FillRule::NonZero,
-            );
-        }
+            common_path::PaintOp::Dark
+        };
+        composer.push(op, path_contours);
     }
-    image
+
+    composer.finish()
 }
 
 fn clear_all_features<A>(doc: &mut GeometryDocument<A>) {

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -427,7 +427,7 @@ pub fn resolve_negative_polarity<S: Clone, L: Clone>(doc: &mut GeometryDocument<
 pub fn subtract_layer_cutouts<S: Clone, L: Clone>(doc: &mut GeometryDocument<S, L>) {
     for layer_index in 0..doc.layers.len() {
         let layer = doc.layers[layer_index].clone();
-        let cutouts = layer_cutout_contours(doc, &layer);
+        let cutouts = layer_cutout_images(doc, &layer);
         if cutouts.is_empty() {
             continue;
         }
@@ -438,7 +438,21 @@ pub fn subtract_layer_cutouts<S: Clone, L: Clone>(doc: &mut GeometryDocument<S, 
                 continue;
             }
 
-            subtract_contours_from_feature(doc, feature_index as usize, &cutouts);
+            let feature_bbox = paths_bbox(doc, feature.path_start, feature.path_count);
+            if feature_bbox.is_empty() {
+                continue;
+            }
+
+            let cutters = cutouts
+                .iter()
+                .filter(|cutout| feature_bbox.intersects(cutout.bbox))
+                .flat_map(|cutout| cutout.contours.iter().cloned())
+                .collect::<Vec<_>>();
+            if cutters.is_empty() {
+                continue;
+            }
+
+            subtract_contours_from_feature(doc, feature_index as usize, &cutters);
         }
     }
 }
@@ -530,14 +544,21 @@ fn path_payloads<S, L>(
         .collect()
 }
 
-fn layer_cutout_contours<S, L>(
+fn layer_cutout_images<S, L>(
     doc: &GeometryDocument<S, L>,
     layer: &GeometryLayer<S, L>,
-) -> Vec<PolygonContour> {
+) -> Vec<common_path::ContourImage> {
     doc.features[layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
         .iter()
         .filter(|feature| feature.bucket == FeatureBucket::Cutout)
-        .flat_map(|feature| feature_filled_contours(doc, feature))
+        .filter_map(|feature| {
+            let contours = feature_filled_contours(doc, feature);
+            if contours.is_empty() {
+                None
+            } else {
+                Some(common_path::ContourImage::new(contours))
+            }
+        })
         .collect()
 }
 

--- a/crates/pcb-ir/src/dialects/path.rs
+++ b/crates/pcb-ir/src/dialects/path.rs
@@ -7,6 +7,85 @@ use kurbo::{BezPath, Cap, Join, PathEl, Stroke, StrokeOpts};
 
 pub type PolygonContour = Vec<[f64; 2]>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaintOp {
+    Dark,
+    Clear,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ContourImage {
+    pub bbox: BBox,
+    pub contours: Vec<PolygonContour>,
+}
+
+impl ContourImage {
+    pub fn new(contours: Vec<PolygonContour>) -> Self {
+        Self {
+            bbox: polygon_contours_bbox(&contours),
+            contours,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.contours.is_empty()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct PaintComposer {
+    image: Vec<PolygonContour>,
+    run: Vec<PolygonContour>,
+    run_op: Option<PaintOp>,
+}
+
+impl PaintComposer {
+    pub fn push(&mut self, op: PaintOp, mut contours: Vec<PolygonContour>) {
+        if contours.is_empty() {
+            return;
+        }
+        if self.run_op != Some(op) {
+            self.flush_run();
+            self.run_op = Some(op);
+        }
+        self.run.append(&mut contours);
+    }
+
+    pub fn finish(mut self) -> Vec<PolygonContour> {
+        self.flush_run();
+        self.image
+    }
+
+    pub fn finish_image(self) -> ContourImage {
+        ContourImage::new(self.finish())
+    }
+
+    fn flush_run(&mut self) {
+        let Some(op) = self.run_op.take() else {
+            return;
+        };
+        if self.run.is_empty() {
+            return;
+        }
+
+        match op {
+            PaintOp::Dark => {
+                let mut contours = std::mem::take(&mut self.image);
+                contours.append(&mut self.run);
+                self.image = union_contours(contours, FillRule::NonZero);
+            }
+            PaintOp::Clear => {
+                if self.image.is_empty() {
+                    self.run.clear();
+                } else {
+                    let cutters = union_contours(std::mem::take(&mut self.run), FillRule::NonZero);
+                    self.image = difference_contours(std::mem::take(&mut self.image), cutters);
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PathPayload {
     pub bbox: BBox,
@@ -195,6 +274,16 @@ pub fn polygon_contours_to_payloads(contours: Vec<PolygonContour>) -> Vec<PathPa
         .into_iter()
         .filter_map(polygon_contour_to_payload)
         .collect()
+}
+
+pub fn polygon_contours_bbox(contours: &[PolygonContour]) -> BBox {
+    contours
+        .iter()
+        .flat_map(|contour| contour.iter())
+        .fold(BBox::empty(), |mut bbox, &[x, y]| {
+            bbox.include_point(Point::new(x, y));
+            bbox
+        })
 }
 
 pub fn overlay_fill_rule(fill_rule: FillRule) -> OverlayFillRule {


### PR DESCRIPTION
Mainly just wanted to run the tests faster.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Gerber/IPC fill and cutout semantics; batching should preserve paint order but deserves scrutiny on complex boards, and bbox-filtered cutouts rely on conservative bounding boxes.
> 
> **Overview**
> **Batches polygon boolean work** for Gerber and IPC geometry processing by introducing a `PaintComposer` that merges consecutive dark (union) and clear (difference) runs before calling the overlay engine, instead of doing a boolean on every feature or path step.
> 
> Gerber polarity resolution and per-feature filled images now feed dark/clear ops through that composer. IPC layer cutout subtraction builds bounded `ContourImage` cutouts and only applies cutters whose bbox overlaps each feature’s bbox, via new `BBox::intersects`.
> 
> A Gerber regression test checks clear polarity after overlapping dark flashes (expected area 12 mm²). The changelog notes faster real-board geometry processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc459a39e76f3296a28861be220373c33291119f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->