### PR TITLE
gerberx2/write: normalize "-0" to "0" in coordinate serialization

### DIFF
--- a/crates/gerberx2/src/write.rs
+++ b/crates/gerberx2/src/write.rs
@@ -604,7 +604,8 @@ impl<'a> Writer<'a> {
             self.layer.coordinate_format.y_decimal_digits
         };
         let scale = 10_f64.powi(decimals as i32);
-        format!("{:.0}", value * scale)
+        let formatted = format!("{:.0}", value * scale);
+        if formatted == "-0" { "0".to_string() } else { formatted }
     }
 
     fn write_decimal(&mut self, value: f64) {
@@ -739,5 +740,36 @@ mod tests {
 
         let err = write_layer(&layer).unwrap_err().to_string();
         assert!(err.contains("field separators"), "{err}");
+    }
+
+    #[test]
+    fn coordinate_near_zero_negative_does_not_emit_minus_zero() {
+        // A coordinate whose absolute value is less than 0.5e-6 mm rounds to zero
+        // after scaling by 10^6 (the default decimal count).  Without the "-0"
+        // guard the writer would emit "X-0" or "Y-0", which is invalid Gerber.
+        use pcb_ir::dialects::gerber::Polarity;
+        let layer = GerberLayer {
+            apertures: vec![WriterAperture {
+                code: 10,
+                template: WriterApertureTemplate::Circle {
+                    diameter: 0.1,
+                    hole_diameter: None,
+                },
+                attributes: Vec::new(),
+            }],
+            objects: vec![WriterObject {
+                kind: ObjectKind::Flash {
+                    at: Point { x: -0.0000001, y: 0.0 },
+                    aperture: 10,
+                },
+                polarity: Polarity::Dark,
+                attributes: Vec::new(),
+            }],
+            ..GerberLayer::default()
+        };
+
+        let output = write_layer(&layer).unwrap();
+        assert!(!output.contains("-0"), "output must not contain \"-0\", got:\n{output}");
+        assert!(output.contains("X0"), "near-zero negative X must be serialized as 0, got:\n{output}");
     }
 }


### PR DESCRIPTION
## What

`coordinate()` in `crates/gerberx2/src/write.rs` could emit `"-0"` for
any coordinate whose absolute value is less than `0.5 / 10^decimal_digits`
(e.g. < 5 × 10⁻⁷ mm with the default 6-decimal format). Rust's
`format!("{:.0}", -0.0001)` rounds and formats the result as `"-0"`,
which is technically invalid in a Gerber integer coordinate stream.

## Why it matters

Gerber files containing `X-0` or `Y-0` are malformed. Strict CAM tools
and board-house validators can reject them outright. The value `-0` also
carries no meaningful coordinate information and should always serialize
as `0`.

## How

Added the same `"-0"` → `"0"` guard that already exists in `trim_decimal()`
(line 674) to the `coordinate()` function:

```rust
let formatted = format!("{:.0}", value * scale);
if formatted == "-0" { "0".to_string() } else { formatted }
```

Also added an inline unit test that flashes an aperture at
`(-0.0000001, 0.0)` — a coordinate that reliably triggers the bug —
and asserts the output contains `"X0"` and no `"-0"`.

## Testing

- New test: `coordinate_near_zero_negative_does_not_emit_minus_zero`
- All existing `gerberx2` tests continue to pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small export-formatting fix in the Gerber writer with a targeted unit test; no security or data-path impact.
> 
> **Overview**
> **Gerber X2 coordinate serialization** now maps rounded `"-0"` to `"0"` in `coordinate()`, matching the existing guard in `trim_decimal()`. Tiny negative values that scale to zero no longer produce invalid `X-0` / `Y-0` tokens in exported files.
> 
> A regression test flashes at a near-zero negative X and asserts the written layer contains `X0` and no `"-0"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0327e9d114b51aa7c0c2bf9c58241def72ea0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->