### PR TITLE
Add `pcb list -m` dependency discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - `pcb build` now accepts multiple explicit `.zen` file paths from the same workspace.
+- Added `pcb list -m -u` and `pcb list -m -versions` for read-only V2 dependency update discovery.
 
 ## [0.3.87] - 2026-05-29
 

--- a/crates/pcbc/src/list.rs
+++ b/crates/pcbc/src/list.rs
@@ -1,13 +1,12 @@
+use crate::pcb_mod;
+use crate::pcb_mod::request::available_versions_for_module;
+use crate::pcb_mod::target::discover_package_target;
 use anyhow::{Context, Result, bail};
 use clap::Args;
-use pcb_zen::WorkspaceInfo;
 use pcb_zen::package_resolver::{PackageResolver, compatibility_lane};
-use pcb_zen::tags;
 use pcb_zen::workspace::get_workspace_info;
 use pcb_zen_core::DefaultFileProvider;
-use pcb_zen_core::config::split_repo_and_subpath;
 use semver::Version;
-use std::path::{Path, PathBuf};
 
 #[derive(Args, Debug)]
 #[command(about = "List package dependency information")]
@@ -25,6 +24,12 @@ pub struct ListArgs {
 enum ListCommand {
     Updates,
     Versions(String),
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct AvailableUpdates {
+    compatible: Option<Version>,
+    breaking: Option<Version>,
 }
 
 pub fn execute(args: ListArgs) -> Result<()> {
@@ -51,17 +56,17 @@ fn usage() -> &'static str {
 fn list_updates() -> Result<()> {
     let cwd = std::env::current_dir()?;
     let workspace = get_workspace_info(&DefaultFileProvider::new(), &cwd)?;
-    validate_workspace(&workspace)?;
+    pcb_mod::validate_workspace(&workspace)?;
 
-    let Some(package_url) = discover_package_target(&workspace, &cwd) else {
+    let Some(target) = discover_package_target(&workspace, &cwd) else {
         bail!("`pcb list -m -u` must be run from a package directory.");
     };
 
     let mut resolver = PackageResolver::new(workspace.clone(), false)?;
-    let resolution = resolver.resolve_package(&package_url)?;
+    let resolution = resolver.resolve_package(&target.package_url)?;
 
     for dep_id in &resolution.direct_remote_ids {
-        if is_configured_kicad_repo(&workspace, &dep_id.path) {
+        if pcb_mod::is_configured_kicad_repo(&workspace, &dep_id.path) {
             continue;
         }
 
@@ -71,9 +76,9 @@ fn list_updates() -> Result<()> {
                 dep_id.path
             )
         })?;
-        let latest = latest_stable_compatible_version(&dep_id.path, current)
+        let updates = available_updates(&dep_id.path, current)
             .with_context(|| format!("Failed to check available versions for {}", dep_id.path))?;
-        print_update_line(&dep_id.path, current, latest.as_ref());
+        print_update_line(&dep_id.path, current, &updates);
     }
 
     Ok(())
@@ -100,81 +105,41 @@ fn list_versions(dep: &str) -> Result<()> {
     Ok(())
 }
 
-fn print_update_line(dep: &str, current: &Version, latest: Option<&Version>) {
-    match latest {
-        Some(latest) => println!("{dep} {current} [{latest}]"),
-        None => println!("{dep} {current}"),
+fn print_update_line(dep: &str, current: &Version, updates: &AvailableUpdates) {
+    let mut line = format!("{dep} {current}");
+    if let Some(compatible) = &updates.compatible {
+        line.push_str(&format!(" [{compatible}]"));
     }
+    if let Some(breaking) = &updates.breaking {
+        line.push_str(&format!(" [breaking: {breaking}]"));
+    }
+    println!("{line}");
 }
 
-fn latest_stable_compatible_version(
-    module_path: &str,
-    current: &Version,
-) -> Result<Option<Version>> {
+fn available_updates(module_path: &str, current: &Version) -> Result<AvailableUpdates> {
     let versions = available_versions_for_module(module_path)?;
-    Ok(select_latest_stable_compatible(&versions, current))
+    Ok(select_available_updates(&versions, current))
 }
 
-fn available_versions_for_module(module_path: &str) -> Result<Vec<Version>> {
-    let (repo_url, subpath) = split_repo_and_subpath(module_path);
-    let all_versions = tags::get_all_versions_for_repo(repo_url)?;
-    Ok(all_versions.get(subpath).cloned().unwrap_or_default())
-}
-
-fn select_latest_stable_compatible(versions: &[Version], current: &Version) -> Option<Version> {
+fn select_available_updates(versions: &[Version], current: &Version) -> AvailableUpdates {
     let lane = compatibility_lane(current);
-    versions
+    let mut updates = AvailableUpdates::default();
+
+    for version in versions
         .iter()
-        .filter(|version| {
-            version.pre.is_empty() && **version > *current && compatibility_lane(version) == lane
-        })
-        .max()
-        .cloned()
-}
-
-fn discover_package_target(workspace: &WorkspaceInfo, start_path: &Path) -> Option<String> {
-    let candidate_dir = candidate_dir(start_path);
-    workspace
-        .packages
-        .iter()
-        .filter_map(|(package_url, package)| {
-            let package_dir = canonicalize(&package.dir(&workspace.root));
-            (candidate_dir == package_dir || candidate_dir.starts_with(&package_dir))
-                .then(|| (package_dir.as_os_str().len(), package_url.clone()))
-        })
-        .max_by_key(|(score, _)| *score)
-        .map(|(_, package_url)| package_url)
-}
-
-fn candidate_dir(start_path: &Path) -> PathBuf {
-    let dir = if start_path.is_file() {
-        start_path.parent().unwrap_or(start_path)
-    } else {
-        start_path
-    };
-    canonicalize(dir)
-}
-
-fn canonicalize(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
-}
-
-fn is_configured_kicad_repo(workspace: &WorkspaceInfo, module_path: &str) -> bool {
-    workspace
-        .kicad_library_entries()
-        .iter()
-        .any(|entry| entry.repo_urls().any(|repo| repo == module_path))
-}
-
-fn validate_workspace(workspace: &WorkspaceInfo) -> Result<()> {
-    if workspace.errors.is_empty() {
-        return Ok(());
+        .filter(|version| version.pre.is_empty() && **version > *current)
+    {
+        let target = if compatibility_lane(version) == lane {
+            &mut updates.compatible
+        } else {
+            &mut updates.breaking
+        };
+        if target.as_ref().is_none_or(|current| version > current) {
+            *target = Some(version.clone());
+        }
     }
 
-    for err in &workspace.errors {
-        eprintln!("{}: {}", err.path.display(), err.error);
-    }
-    bail!("Found {} invalid pcb.toml file(s)", workspace.errors.len());
+    updates
 }
 
 #[cfg(test)]
@@ -208,7 +173,7 @@ mod tests {
     fn latest_compatible_ignores_prereleases() {
         let versions = vec![v("1.3.0-rc.1"), v("1.2.1"), v("1.2.0")];
         assert_eq!(
-            select_latest_stable_compatible(&versions, &v("1.2.0")),
+            select_available_updates(&versions, &v("1.2.0")).compatible,
             Some(v("1.2.1"))
         );
     }
@@ -217,7 +182,7 @@ mod tests {
     fn latest_compatible_stays_in_major_lane() {
         let versions = vec![v("2.0.0"), v("1.3.0"), v("1.2.1")];
         assert_eq!(
-            select_latest_stable_compatible(&versions, &v("1.2.0")),
+            select_available_updates(&versions, &v("1.2.0")).compatible,
             Some(v("1.3.0"))
         );
     }
@@ -226,8 +191,32 @@ mod tests {
     fn latest_compatible_treats_zero_minor_as_lane() {
         let versions = vec![v("0.4.0"), v("0.3.9"), v("0.3.2")];
         assert_eq!(
-            select_latest_stable_compatible(&versions, &v("0.3.2")),
+            select_available_updates(&versions, &v("0.3.2")).compatible,
             Some(v("0.3.9"))
+        );
+    }
+
+    #[test]
+    fn latest_breaking_uses_newer_different_lane() {
+        let versions = vec![v("0.3.6"), v("0.2.1"), v("0.1.3"), v("0.1.2")];
+        assert_eq!(
+            select_available_updates(&versions, &v("0.1.2")),
+            AvailableUpdates {
+                compatible: Some(v("0.1.3")),
+                breaking: Some(v("0.3.6")),
+            }
+        );
+    }
+
+    #[test]
+    fn latest_breaking_ignores_prereleases() {
+        let versions = vec![v("2.0.0-rc.1"), v("1.3.0"), v("1.2.0")];
+        assert_eq!(
+            select_available_updates(&versions, &v("1.2.0")),
+            AvailableUpdates {
+                compatible: Some(v("1.3.0")),
+                breaking: None,
+            }
         );
     }
 }

--- a/crates/pcbc/src/list.rs
+++ b/crates/pcbc/src/list.rs
@@ -1,0 +1,233 @@
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use pcb_zen::WorkspaceInfo;
+use pcb_zen::package_resolver::{PackageResolver, compatibility_lane};
+use pcb_zen::tags;
+use pcb_zen::workspace::get_workspace_info;
+use pcb_zen_core::DefaultFileProvider;
+use pcb_zen_core::config::split_repo_and_subpath;
+use semver::Version;
+use std::path::{Path, PathBuf};
+
+#[derive(Args, Debug)]
+#[command(about = "List package dependency information")]
+pub struct ListArgs {
+    /// Go-style list arguments. Supported: -m -u, -m -versions DEP
+    #[arg(
+        value_name = "ARGS",
+        allow_hyphen_values = true,
+        trailing_var_arg = true
+    )]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ListCommand {
+    Updates,
+    Versions(String),
+}
+
+pub fn execute(args: ListArgs) -> Result<()> {
+    match parse_args(&args.args)? {
+        ListCommand::Updates => list_updates(),
+        ListCommand::Versions(dep) => list_versions(&dep),
+    }
+}
+
+fn parse_args(args: &[String]) -> Result<ListCommand> {
+    match args {
+        [module, updates] if module == "-m" && updates == "-u" => Ok(ListCommand::Updates),
+        [module, versions, dep] if module == "-m" && versions == "-versions" => {
+            Ok(ListCommand::Versions(dep.clone()))
+        }
+        _ => bail!("unsupported `pcb list` arguments\n\n{}", usage()),
+    }
+}
+
+fn usage() -> &'static str {
+    "Usage:\n  pcb list -m -u\n  pcb list -m -versions <dependency>"
+}
+
+fn list_updates() -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let workspace = get_workspace_info(&DefaultFileProvider::new(), &cwd)?;
+    validate_workspace(&workspace)?;
+
+    let Some(package_url) = discover_package_target(&workspace, &cwd) else {
+        bail!("`pcb list -m -u` must be run from a package directory.");
+    };
+
+    let mut resolver = PackageResolver::new(workspace.clone(), false)?;
+    let resolution = resolver.resolve_package(&package_url)?;
+
+    for dep_id in &resolution.direct_remote_ids {
+        if is_configured_kicad_repo(&workspace, &dep_id.path) {
+            continue;
+        }
+
+        let current = resolution.resolved_remote.get(dep_id).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Resolved direct dependency {} is missing a selected version",
+                dep_id.path
+            )
+        })?;
+        let latest = latest_stable_compatible_version(&dep_id.path, current)
+            .with_context(|| format!("Failed to check available versions for {}", dep_id.path))?;
+        print_update_line(&dep_id.path, current, latest.as_ref());
+    }
+
+    Ok(())
+}
+
+fn list_versions(dep: &str) -> Result<()> {
+    if dep.contains('@') {
+        bail!("`pcb list -m -versions` expects a dependency URL without a version selector");
+    }
+
+    let mut versions = available_versions_for_module(dep)
+        .with_context(|| format!("Failed to fetch versions for {dep}"))?;
+    if versions.is_empty() {
+        bail!("No published versions found for {dep}");
+    }
+    versions.sort();
+
+    let rendered = versions
+        .iter()
+        .map(Version::to_string)
+        .collect::<Vec<_>>()
+        .join(" ");
+    println!("{dep} {rendered}");
+    Ok(())
+}
+
+fn print_update_line(dep: &str, current: &Version, latest: Option<&Version>) {
+    match latest {
+        Some(latest) => println!("{dep} {current} [{latest}]"),
+        None => println!("{dep} {current}"),
+    }
+}
+
+fn latest_stable_compatible_version(
+    module_path: &str,
+    current: &Version,
+) -> Result<Option<Version>> {
+    let versions = available_versions_for_module(module_path)?;
+    Ok(select_latest_stable_compatible(&versions, current))
+}
+
+fn available_versions_for_module(module_path: &str) -> Result<Vec<Version>> {
+    let (repo_url, subpath) = split_repo_and_subpath(module_path);
+    let all_versions = tags::get_all_versions_for_repo(repo_url)?;
+    Ok(all_versions.get(subpath).cloned().unwrap_or_default())
+}
+
+fn select_latest_stable_compatible(versions: &[Version], current: &Version) -> Option<Version> {
+    let lane = compatibility_lane(current);
+    versions
+        .iter()
+        .filter(|version| {
+            version.pre.is_empty() && **version > *current && compatibility_lane(version) == lane
+        })
+        .max()
+        .cloned()
+}
+
+fn discover_package_target(workspace: &WorkspaceInfo, start_path: &Path) -> Option<String> {
+    let candidate_dir = candidate_dir(start_path);
+    workspace
+        .packages
+        .iter()
+        .filter_map(|(package_url, package)| {
+            let package_dir = canonicalize(&package.dir(&workspace.root));
+            (candidate_dir == package_dir || candidate_dir.starts_with(&package_dir))
+                .then(|| (package_dir.as_os_str().len(), package_url.clone()))
+        })
+        .max_by_key(|(score, _)| *score)
+        .map(|(_, package_url)| package_url)
+}
+
+fn candidate_dir(start_path: &Path) -> PathBuf {
+    let dir = if start_path.is_file() {
+        start_path.parent().unwrap_or(start_path)
+    } else {
+        start_path
+    };
+    canonicalize(dir)
+}
+
+fn canonicalize(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn is_configured_kicad_repo(workspace: &WorkspaceInfo, module_path: &str) -> bool {
+    workspace
+        .kicad_library_entries()
+        .iter()
+        .any(|entry| entry.repo_urls().any(|repo| repo == module_path))
+}
+
+fn validate_workspace(workspace: &WorkspaceInfo) -> Result<()> {
+    if workspace.errors.is_empty() {
+        return Ok(());
+    }
+
+    for err in &workspace.errors {
+        eprintln!("{}: {}", err.path.display(), err.error);
+    }
+    bail!("Found {} invalid pcb.toml file(s)", workspace.errors.len());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(raw: &str) -> Version {
+        Version::parse(raw).unwrap()
+    }
+
+    #[test]
+    fn parse_update_args() {
+        let args = vec!["-m".to_string(), "-u".to_string()];
+        assert_eq!(parse_args(&args).unwrap(), ListCommand::Updates);
+    }
+
+    #[test]
+    fn parse_versions_args() {
+        let args = vec![
+            "-m".to_string(),
+            "-versions".to_string(),
+            "github.com/acme/foo".to_string(),
+        ];
+        assert_eq!(
+            parse_args(&args).unwrap(),
+            ListCommand::Versions("github.com/acme/foo".to_string())
+        );
+    }
+
+    #[test]
+    fn latest_compatible_ignores_prereleases() {
+        let versions = vec![v("1.3.0-rc.1"), v("1.2.1"), v("1.2.0")];
+        assert_eq!(
+            select_latest_stable_compatible(&versions, &v("1.2.0")),
+            Some(v("1.2.1"))
+        );
+    }
+
+    #[test]
+    fn latest_compatible_stays_in_major_lane() {
+        let versions = vec![v("2.0.0"), v("1.3.0"), v("1.2.1")];
+        assert_eq!(
+            select_latest_stable_compatible(&versions, &v("1.2.0")),
+            Some(v("1.3.0"))
+        );
+    }
+
+    #[test]
+    fn latest_compatible_treats_zero_minor_as_lane() {
+        let versions = vec![v("0.4.0"), v("0.3.9"), v("0.3.2")];
+        assert_eq!(
+            select_latest_stable_compatible(&versions, &v("0.3.2")),
+            Some(v("0.3.9"))
+        );
+    }
+}

--- a/crates/pcbc/src/main.rs
+++ b/crates/pcbc/src/main.rs
@@ -25,6 +25,7 @@ mod info;
 mod ipc2581;
 mod kq;
 mod layout;
+mod list;
 mod lsp;
 mod migrate;
 mod mod_cmd;
@@ -89,6 +90,9 @@ enum Commands {
 
     /// Reconcile source imports and hydrate package dependency manifests
     Sync(pcb_mod::SyncArgs),
+
+    /// List package dependency information
+    List(list::ListArgs),
 
     /// Create a new board, package, or component
     New(new::NewArgs),
@@ -212,6 +216,7 @@ fn run() -> anyhow::Result<()> {
         Commands::Mod(args) => mod_cmd::execute(args),
         Commands::Add(args) => pcb_mod::execute_mod_add(args),
         Commands::Sync(args) => pcb_mod::execute_sync(args),
+        Commands::List(args) => list::execute(args),
         Commands::New(args) => new::execute(args),
         Commands::Update(args) => update::execute(args),
         Commands::Bom(args) => bom::execute(args),

--- a/crates/pcbc/src/mod/mod.rs
+++ b/crates/pcbc/src/mod/mod.rs
@@ -1,5 +1,5 @@
-mod request;
-mod target;
+pub(crate) mod request;
+pub(crate) mod target;
 mod writeback;
 
 use anyhow::{Result, bail};
@@ -329,7 +329,7 @@ fn is_remote_dependency(
         && !is_configured_kicad_repo(workspace, module_path)
 }
 
-fn is_configured_kicad_repo(workspace: &WorkspaceInfo, module_path: &str) -> bool {
+pub(crate) fn is_configured_kicad_repo(workspace: &WorkspaceInfo, module_path: &str) -> bool {
     workspace
         .kicad_library_entries()
         .iter()
@@ -476,7 +476,7 @@ fn run_resolution(
     Ok(())
 }
 
-fn validate_workspace(workspace: &WorkspaceInfo) -> Result<()> {
+pub(crate) fn validate_workspace(workspace: &WorkspaceInfo) -> Result<()> {
     if workspace.errors.is_empty() {
         return Ok(());
     }

--- a/crates/pcbc/src/mod/request.rs
+++ b/crates/pcbc/src/mod/request.rs
@@ -117,7 +117,7 @@ fn resolve_requested_version(
     }
 }
 
-fn available_versions_for_module(module_path: &str) -> Result<Vec<Version>> {
+pub(crate) fn available_versions_for_module(module_path: &str) -> Result<Vec<Version>> {
     let (repo_url, subpath) = split_repo_and_subpath(module_path);
     let all_versions = tags::get_all_versions_for_repo(repo_url)
         .with_context(|| format!("Failed to fetch versions from {}", repo_url))?;

--- a/crates/pcbc/tests/snapshots/simple__help.snap
+++ b/crates/pcbc/tests/snapshots/simple__help.snap
@@ -18,6 +18,7 @@ Commands:
   mod         Manage package dependency manifests
   add         Add or update a direct dependency
   sync        Reconcile source imports and hydrate package dependency manifests
+  list        List package dependency information
   new         Create a new board, package, or component
   update      Update dependencies to latest compatible versions
   bom         Generate Bill of Materials (BOM)

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -511,8 +511,8 @@ pcb list -m -versions github.com/acme/foo   # Show published versions for a depe
 ```
 
 `pcb list -m -u` must be run from a package directory. It reports direct remote
-dependencies only and shows the latest stable version in the same compatibility
-lane when one is available. It does not update manifests.
+dependencies only, showing the latest stable version in the same compatibility
+lane and the latest newer breaking lane when available. It does not update manifests.
 
 ### pcb update
 

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -501,6 +501,19 @@ Subsequent builds verify against the lockfile when one is present. `--locked` do
 not create or update `pcb.sum`; if the lockfile is missing, resolution still proceeds
 without writing one.
 
+### pcb list
+
+Lists read-only package dependency information.
+
+```bash
+pcb list -m -u                              # Show compatible updates for direct dependencies
+pcb list -m -versions github.com/acme/foo   # Show published versions for a dependency
+```
+
+`pcb list -m -u` must be run from a package directory. It reports direct remote
+dependencies only and shows the latest stable version in the same compatibility
+lane when one is available. It does not update manifests.
+
 ### pcb update
 
 Updates dependencies to newer versions.


### PR DESCRIPTION
This is a non-interactive way for the model to know what versions of new dependencies are available to update to. Currently, `pcb update` is an interactive command and gets the model stuck. `pcb list` is very go-inspired but I think it works well.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only CLI with unit tests; reuses existing resolution/version-fetch paths and does not mutate manifests or lockfiles.
> 
> **Overview**
> Adds a new **`pcb list`** CLI for **read-only** V2 package dependency discovery, aimed at automation (e.g. agents) that should not run interactive **`pcb update`**.
> 
> **`pcb list -m -u`** (from a package directory) resolves the current package, walks **direct remote** dependencies (skipping configured KiCad repos), and prints each dep’s locked version plus optional **`[compatible]`** and **`[breaking: …]`** hints. Hints use the same **compatibility lane** rules as resolution, ignore prereleases, and pick the newest stable version per lane—without changing **`pcb.toml`**.
> 
> **`pcb list -m -versions <url>`** prints all published stable versions for a bare dependency URL (no `@` selector).
> 
> Wiring exposes **`validate_workspace`**, **`is_configured_kicad_repo`**, and **`available_versions_for_module`** from the mod layer for reuse. Changelog, **`packages.mdx`**, and CLI help snapshots document the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 459ce3116e7ceff922288528517846ec8ec5d243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->