### PR TITLE
Stop creating pcb.sum for new boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - `pcb build` now accepts multiple explicit `.zen` file paths from the same workspace.
 - Added `pcb list -m -u` and `pcb list -m -versions` for read-only V2 dependency update discovery.
 
+### Fixed
+
+- `pcb new board` and fresh `pcb import` output no longer create obsolete `pcb.sum` files.
+
 ## [0.3.87] - 2026-05-29
 
 ### Changed

--- a/crates/pcbc/src/new.rs
+++ b/crates/pcbc/src/new.rs
@@ -329,7 +329,6 @@ pub(crate) fn init_board_repo(dir: &Path, board: &str, repository: &str) -> Resu
         .render(&ctx)
         .context("Failed to render pcb.toml template")?;
     std::fs::write(dir.join("pcb.toml"), pcb_toml_content).context("Failed to write pcb.toml")?;
-    std::fs::write(dir.join("pcb.sum"), "").context("Failed to write pcb.sum")?;
 
     let zen_content = env
         .get_template("board_zen")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line removal of lockfile creation during board init; no dependency resolution or auth changes.
> 
> **Overview**
> Stops scaffolding an empty **`pcb.sum`** when initializing a new board repository in **`init_board_repo`** (`crates/pcbc/src/new.rs`), so **`pcb new board`** no longer leaves a legacy lockfile on disk. Fresh **`pcb import`** output gets the same behavior because it reuses that helper.
> 
> Documents the fix under **[Unreleased] → Fixed** in **`CHANGELOG.md`**, aligned with MVS v2 / **`pcb migrate`** removing obsolete **`pcb.sum`** files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842bc84f928a0c1aaf6387319a740e0941279201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->