### PR TITLE
Reduce cache index churn during sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced cache-index SQLite connection churn during `pcb sync` to avoid intermittent crashes.
+
 ## [0.3.88] - 2026-06-02
 
 ### Added

--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -59,6 +59,7 @@ impl CacheIndex {
         });
         let pool = Pool::builder()
             .max_size(8)
+            .min_idle(Some(1))
             .error_handler(Box::new(r2d2::NopErrorHandler))
             .build(manager)
             .with_context(|| format!("Failed to create connection pool at {}", path.display()))?;

--- a/crates/pcb-zen/src/package_resolver/materialize.rs
+++ b/crates/pcb-zen/src/package_resolver/materialize.rs
@@ -1,42 +1,46 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
 use crate::cache_index::CacheIndex;
 use anyhow::{Context, Result};
 use pcb_zen_core::kicad_library::{KicadRepoMatch, match_kicad_managed_repo};
-use pcb_zen_core::resolution::ModuleLine;
 use semver::Version;
 
 use super::ResolvedDepId;
 
-pub fn materialize_selected<'a>(
+pub(crate) fn materialize_selected<'a>(
     workspace: &crate::WorkspaceInfo,
     selected_remote: impl IntoIterator<Item = (&'a ResolvedDepId, &'a Version)>,
     offline: bool,
+    cache_index: &CacheIndex,
 ) -> Result<BTreeSet<(String, String)>> {
     let mut package_roots = BTreeSet::new();
-    let mut kicad_assets = HashMap::new();
+    let mut kicad_assets = BTreeSet::new();
     let kicad_entries = workspace.kicad_library_entries();
-    let cache_index = CacheIndex::open()?;
 
     for (dep_id, version) in selected_remote {
         package_roots.insert((dep_id.path.clone(), version.to_string()));
-        let line = ModuleLine::new(dep_id.path.clone(), version);
-        if match_kicad_managed_repo(&kicad_entries, &line.path, version)
+        if match_kicad_managed_repo(&kicad_entries, &dep_id.path, version)
             == KicadRepoMatch::SelectorMatched
         {
-            kicad_assets.insert(line, version.clone());
+            kicad_assets.insert((dep_id.path.clone(), version.clone()));
         } else {
             ensure_remote_package_materialized(
                 workspace,
                 &dep_id.path,
                 version,
                 offline,
-                &cache_index,
+                cache_index,
             )?;
         }
     }
 
-    crate::resolve::materialize_asset_deps(workspace, &kicad_assets, offline)?;
+    crate::resolve::materialize_asset_deps(
+        workspace,
+        kicad_assets
+            .iter()
+            .map(|(repo, version)| (repo.as_str(), version)),
+        offline,
+    )?;
     Ok(package_roots)
 }
 

--- a/crates/pcb-zen/src/package_resolver/mod.rs
+++ b/crates/pcb-zen/src/package_resolver/mod.rs
@@ -7,7 +7,7 @@ mod resolve;
 mod scan;
 mod versions;
 
-pub use materialize::{materialize_selected, vendor_selected};
+pub use materialize::vendor_selected;
 pub use mvs::{DepGraph, DepGraphNode, PackageResolution, PackageResolver};
 pub use pcb_zen_core::resolution::{
     FrozenDepId as ResolvedDepId, compatibility_lane, parse_lane_qualified_key,

--- a/crates/pcb-zen/src/package_resolver/mvs.rs
+++ b/crates/pcb-zen/src/package_resolver/mvs.rs
@@ -9,6 +9,7 @@ use semver::Version;
 
 use super::ResolvedDepId;
 use super::manifest::ManifestLoader;
+use super::materialize::materialize_selected;
 use super::scan::{ScannedDirectDeps, scan_package_direct_deps};
 use super::versions::SpecVersionResolver;
 
@@ -198,6 +199,18 @@ impl PackageResolver {
             return self.resolve_package(package_url);
         }
         self.build_package_resolution(package_url, direct_overrides)
+    }
+
+    pub fn materialize_selected<'a>(
+        &self,
+        selected_remote: impl IntoIterator<Item = (&'a ResolvedDepId, &'a Version)>,
+    ) -> Result<BTreeSet<(String, String)>> {
+        materialize_selected(
+            &self.workspace,
+            selected_remote,
+            self.spec_resolver.is_offline(),
+            &self.cache_index,
+        )
     }
 
     pub fn build_package_graph(&mut self, package_url: &str) -> Result<DepGraph> {

--- a/crates/pcb-zen/src/package_resolver/resolve.rs
+++ b/crates/pcb-zen/src/package_resolver/resolve.rs
@@ -136,10 +136,9 @@ fn workspace_vendor_enabled(workspace_info: &WorkspaceInfo) -> bool {
 
 fn workspace_selected_remote(
     workspace_info: &WorkspaceInfo,
-    offline: bool,
+    resolver: &mut PackageResolver,
 ) -> Result<BTreeSet<(ResolvedDepId, Version)>> {
     let mut selected = BTreeSet::new();
-    let mut resolver = PackageResolver::new(workspace_info.clone(), offline)?;
 
     for package_url in workspace_info.packages.keys() {
         let package_selected = if package_has_indirect(workspace_info, package_url) {
@@ -169,12 +168,10 @@ pub fn sync_workspace_vendor(
         return Ok(());
     }
 
-    let selected = workspace_selected_remote(workspace_info, offline)?;
-    let package_roots = materialize_selected(
-        workspace_info,
-        selected.iter().map(|(dep_id, version)| (dep_id, version)),
-        offline,
-    )?;
+    let mut resolver = PackageResolver::new(workspace_info.clone(), offline)?;
+    let selected = workspace_selected_remote(workspace_info, &mut resolver)?;
+    let package_roots = resolver
+        .materialize_selected(selected.iter().map(|(dep_id, version)| (dep_id, version)))?;
     crate::resolve::vendor_package_roots(workspace_info, &package_roots, &[], None, true)?;
     Ok(())
 }
@@ -314,7 +311,12 @@ impl FrozenResolutionBuilder {
             return Ok(());
         }
 
-        materialize_selected(&self.workspace, pending.iter(), self.offline)?;
+        materialize_selected(
+            &self.workspace,
+            pending.iter(),
+            self.offline,
+            &self.cache_index,
+        )?;
         self.materialized_remote.extend(pending);
         Ok(())
     }

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -803,7 +803,13 @@ pub fn resolve_dependencies(
 
     // Phase 2.5: Materialize asset dependencies (KiCad symbol/footprint/model repos).
     log::debug!("Phase 2.5: Materialize asset dependencies");
-    materialize_asset_deps(workspace_info, &selected_kicad_assets, offline)?;
+    materialize_asset_deps(
+        workspace_info,
+        selected_kicad_assets
+            .iter()
+            .map(|(line, version)| (line.path.as_str(), version)),
+        offline,
+    )?;
     log::debug!("Materialized asset dependencies");
 
     // Phase 3: (Removed - sparse checkout and hashing now done in Phase 1)
@@ -1365,11 +1371,16 @@ fn parse_version_string(s: &str) -> Result<Version> {
 }
 
 /// Materialize asset dependencies selected by dependency resolution.
-pub fn materialize_asset_deps(
+pub fn materialize_asset_deps<'a>(
     workspace_info: &WorkspaceInfo,
-    selected_kicad_assets: &HashMap<ModuleLine, Version>,
+    selected_kicad_assets: impl IntoIterator<Item = (&'a str, &'a Version)>,
     offline: bool,
 ) -> Result<()> {
+    let selected_kicad_assets: BTreeSet<(String, Version)> = selected_kicad_assets
+        .into_iter()
+        .map(|(repo, version)| (repo.to_string(), version.clone()))
+        .collect();
+
     if selected_kicad_assets.is_empty() {
         return Ok(());
     }
@@ -1377,14 +1388,14 @@ pub fn materialize_asset_deps(
     let workspace_cache = workspace_info.root.join(".pcb/cache");
     let missing: Vec<(String, Version)> = selected_kicad_assets
         .iter()
-        .filter(|(line, version)| {
+        .filter(|(repo, version)| {
             !workspace_cache
-                .join(&line.path)
+                .join(repo)
                 .join(version.to_string())
                 .join(".pcb-cached")
                 .exists()
         })
-        .map(|(line, version)| (line.path.clone(), version.clone()))
+        .map(|(repo, version)| (repo.clone(), version.clone()))
         .collect();
 
     if offline && !missing.is_empty() {
@@ -1446,17 +1457,17 @@ pub fn materialize_asset_deps(
         spinner.finish();
     }
 
-    materialize_kicad_symbol_manifests(&kicad_entries, selected_kicad_assets, offline)?;
+    materialize_kicad_symbol_manifests(&kicad_entries, &selected_kicad_assets, offline)?;
     Ok(())
 }
 
 fn materialize_kicad_symbol_manifests(
     kicad_entries: &[pcb_zen_core::config::KicadLibraryConfig],
-    selected_kicad_assets: &HashMap<ModuleLine, Version>,
+    selected_kicad_assets: &BTreeSet<(String, Version)>,
     offline: bool,
 ) -> Result<()> {
-    for (line, version) in selected_kicad_assets {
-        ensure_kicad_parts_index(&cache_base(), kicad_entries, &line.path, version, offline)?;
+    for (repo, version) in selected_kicad_assets {
+        ensure_kicad_parts_index(&cache_base(), kicad_entries, repo, version, offline)?;
     }
 
     Ok(())
@@ -2690,17 +2701,34 @@ mod tests {
         let mut workspace = workspace_with_root_config(config);
         workspace.root = temp.path().to_path_buf();
         let version = Version::new(9, 0, 0);
-        let selected_kicad_assets = HashMap::from([(
-            ModuleLine::new(
-                "gitlab.com/kicad/libraries/kicad-symbols".to_string(),
-                &version,
-            ),
-            version,
-        )]);
-        let err = materialize_asset_deps(&workspace, &selected_kicad_assets, true)
+        let selected_kicad_assets = [("gitlab.com/kicad/libraries/kicad-symbols", &version)];
+        let err = materialize_asset_deps(&workspace, selected_kicad_assets, true)
             .expect_err("expected offline mode to require cached asset deps");
 
         assert!(err.to_string().contains("not cached"));
+    }
+
+    #[test]
+    fn test_kicad_repos_offline_keeps_same_family_versions() {
+        let temp = TempDir::new().unwrap();
+        let mut workspace = workspace_with_root_config(PcbToml::default());
+        workspace.root = temp.path().to_path_buf();
+
+        let repo = "gitlab.com/kicad/libraries/kicad-symbols";
+        let cached = Version::new(9, 0, 0);
+        let missing = Version::new(9, 0, 1);
+        let cached_dir = workspace
+            .root
+            .join(".pcb/cache")
+            .join(repo)
+            .join(cached.to_string());
+        std::fs::create_dir_all(&cached_dir).unwrap();
+        std::fs::write(cached_dir.join(".pcb-cached"), "").unwrap();
+
+        let err = materialize_asset_deps(&workspace, [(repo, &cached), (repo, &missing)], true)
+            .expect_err("expected uncached same-family asset version to be required");
+
+        assert!(err.to_string().contains("@9.0.1"));
     }
 
     #[test]

--- a/crates/pcbc/src/mod/mod.rs
+++ b/crates/pcbc/src/mod/mod.rs
@@ -7,7 +7,7 @@ use clap::Args;
 use pcb_zen::WorkspaceInfo;
 use pcb_zen::cache_index::{CacheIndex, ensure_workspace_cache_symlink};
 use pcb_zen::package_resolver::{
-    DepGraph, DepGraphNode, PackageResolver, build_frozen_resolution_maps, materialize_selected,
+    DepGraph, DepGraphNode, PackageResolver, build_frozen_resolution_maps,
     target_package_urls_for_path, vendor_selected,
 };
 use pcb_zen::resolve::ensure_package_manifest_in_cache;
@@ -449,7 +449,7 @@ fn run_resolution(
 ) -> Result<()> {
     ensure_workspace_cache_symlink(&workspace.root)?;
     let mut resolver = PackageResolver::new(workspace.clone(), offline)?;
-    let mut package_roots = BTreeSet::new();
+    let mut selected_remote = BTreeSet::new();
 
     for target in targets {
         let overrides = direct_overrides
@@ -464,13 +464,14 @@ fn run_resolution(
                 workspace_relative_path(&workspace.root, &target.pcb_toml_path).display()
             );
         }
-        package_roots.extend(materialize_selected(
-            workspace,
-            resolution.resolved_remote.iter(),
-            offline,
-        )?);
+        selected_remote.extend(resolution.resolved_remote);
     }
 
+    let package_roots = resolver.materialize_selected(
+        selected_remote
+            .iter()
+            .map(|(dep_id, version)| (dep_id, version)),
+    )?;
     vendor_selected(workspace, &package_roots, prune_vendor)?;
 
     Ok(())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Refactors dependency materialization to share an existing cache index and tunes pool idle connections; behavior change is limited to stricter offline KiCad multi-version checks.
> 
> **Overview**
> Reuses a single **`CacheIndex`** (and its SQLite pool) through **`PackageResolver::materialize_selected`** instead of opening a new index inside **`materialize_selected`**, so **`pcb sync`** / **`pcbc mod`** resolution and vendor sync share one pool. The cache-index pool now keeps **`min_idle(1)`** to reduce connection churn.
> 
> **`materialize_selected`** is crate-private; callers use the resolver method. KiCad asset handling uses **`BTreeSet<(repo, version)>`** and **`materialize_asset_deps`** takes repo/version pairs directly. Offline mode now fails per missing KiCad asset version when multiple versions of the same repo are selected (new test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f202f982415f97bfdc2af1de213ade95b0826286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->