### PR TITLE
Fix nix flake; add `pcb` and `pcbc` target bins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build
 
 *.log
 *.layout.json
+result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Reduced cache-index SQLite connection churn during `pcb sync` to avoid intermittent crashes.
+- Fixed the Nix flake build and exposed both `pcb` and `pcbc`.
 
 ## [0.3.88] - 2026-06-02
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,15 +21,21 @@
       packageFor =
         system:
         let
-          pkgs = import nixpkgs { inherit system; };
+          pkgs = import nixpkgs {
+            inherit system;
+            config.problems.handlers =
+              lib.optionalAttrs (lib.hasSuffix "-darwin" system)
+                {
+                  kicad-base.broken = "warn";
+                };
+          };
           craneLib = crane.mkLib pkgs;
 
           src = lib.fileset.toSource {
             root = ./.;
             fileset = lib.fileset.unions [
               (craneLib.fileset.commonCargoSources ./.)
-              ./crates/pcb/src/fortune.txt
-              ./crates/pcb/src/templates
+              ./crates/pcbc/src/templates
               ./crates/pcb-component-gen/templates
               ./crates/ipc2581/IPC-2581C.xsd
               ./crates/pcb-ipc2581-tools/src/commands/html_template.html.jinja
@@ -46,7 +52,7 @@
             inherit src;
             strictDeps = true;
             doCheck = false;
-            cargoExtraArgs = "-p pcb";
+            cargoExtraArgs = "-p pcb -p pcbc";
 
             nativeBuildInputs = with pkgs; [
               makeWrapper
@@ -54,6 +60,7 @@
             ];
 
             buildInputs = with pkgs; [
+              openssl
               python312
               python312Packages.kicad
             ];
@@ -67,9 +74,11 @@
             inherit cargoArtifacts;
 
             postFixup = ''
-              wrapProgram $out/bin/pcb \
-                --set KICAD_PYTHON_SITE_PACKAGES "${pkgs.python312Packages.kicad}/${pkgs.python312.sitePackages}" \
-                --set KICAD_PYTHON_INTERPRETER "${pkgs.python312}/bin/python"
+              for binary in pcb pcbc; do
+                wrapProgram "$out/bin/$binary" \
+                  --set KICAD_PYTHON_SITE_PACKAGES "${pkgs.python312Packages.kicad}/${pkgs.python312.sitePackages}" \
+                  --set KICAD_PYTHON_INTERPRETER "${pkgs.python312}/bin/python"
+              done
             '';
 
             meta = with lib; {
@@ -87,10 +96,15 @@
         system:
         let
           pcb = packageFor system;
+          pcbc = pcb // {
+            meta = pcb.meta // {
+              mainProgram = "pcbc";
+            };
+          };
         in
         {
           default = pcb;
-          inherit pcb;
+          inherit pcb pcbc;
         }
       );
 
@@ -98,6 +112,7 @@
         system:
         let
           pcb = self.packages.${system}.pcb;
+          pcbc = self.packages.${system}.pcbc;
         in
         {
           default = {
@@ -107,6 +122,10 @@
           pcb = {
             type = "app";
             program = "${pcb}/bin/pcb";
+          };
+          pcbc = {
+            type = "app";
+            program = "${pcbc}/bin/pcbc";
           };
         }
       );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Packaging and ignore-file changes only; no runtime application logic.
> 
> **Overview**
> **Nix flake** now builds both **`pcb`** and **`pcbc`**, exposes them as separate **`packages`** / **`apps`**, and documents the fix in **CHANGELOG**.
> 
> The flake source set points at **`crates/pcbc/src/templates`** (replacing **`pcb`** templates), **`cargoExtraArgs`** includes **`-p pcbc`**, **`openssl`** is added to **`buildInputs`**, and **`postFixup`** wraps both binaries with KiCad Python env vars. On **darwin**, **`kicad-base.broken`** is downgraded to a **warn** so evaluation can proceed.
> 
> **`.gitignore`** adds **`result`** (typical Nix build output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5e5cffdc2cdb190a7d8537f5a5a45498ddb20f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->