### PR TITLE
Speed up `pcb sync` package indexing

### DIFF
--- a/crates/pcb-zen/src/package_resolver/mvs.rs
+++ b/crates/pcb-zen/src/package_resolver/mvs.rs
@@ -10,7 +10,7 @@ use semver::Version;
 use super::ResolvedDepId;
 use super::manifest::ManifestLoader;
 use super::materialize::materialize_selected;
-use super::scan::{ScannedDirectDeps, scan_package_direct_deps};
+use super::scan::{ScannedDirectDeps, WorkspacePackageIndex, scan_package_direct_deps};
 use super::versions::SpecVersionResolver;
 
 #[derive(Debug, Clone)]
@@ -142,16 +142,19 @@ pub struct PackageResolver {
     cache_index: CacheIndex,
     manifest_loader: ManifestLoader,
     spec_resolver: SpecVersionResolver,
+    package_index: WorkspacePackageIndex,
     package_states: BTreeMap<String, PackageResolutionState>,
 }
 
 impl PackageResolver {
     pub fn new(workspace: crate::WorkspaceInfo, offline: bool) -> Result<Self> {
+        let package_index = WorkspacePackageIndex::new(&workspace);
         Ok(Self {
             cache_index: CacheIndex::open()?,
             manifest_loader: ManifestLoader::new(workspace.clone(), offline),
             workspace,
             spec_resolver: SpecVersionResolver::new(offline),
+            package_index,
             package_states: BTreeMap::new(),
         })
     }
@@ -236,6 +239,7 @@ impl PackageResolver {
         let (package_dir, current_config) = self.package_manifest_source(package_url)?;
         let mut scanned = scan_package_direct_deps(
             &self.workspace,
+            &self.package_index,
             package_url,
             &package_dir,
             &current_config,

--- a/crates/pcb-zen/src/package_resolver/scan.rs
+++ b/crates/pcb-zen/src/package_resolver/scan.rs
@@ -21,6 +21,7 @@ pub(crate) struct ScannedDirectDeps {
 
 pub(crate) fn scan_package_direct_deps(
     workspace_info: &crate::WorkspaceInfo,
+    package_index: &WorkspacePackageIndex,
     package_url: &str,
     package_dir: &Path,
     current_config: &PcbToml,
@@ -31,7 +32,6 @@ pub(crate) fn scan_package_direct_deps(
     let kicad_aliases = kicad_dependency_aliases(&kicad_entries);
     let configured_kicad_versions = workspace_info.stdlib_asset_dep_versions();
     let file_provider = DefaultFileProvider::new();
-    let package_index = WorkspacePackageIndex::new(workspace_info);
     let mut scanned = ScannedDirectDeps::default();
 
     if let Some(version) = configured_kicad_versions.get(KICAD_SYMBOLS_REPO) {
@@ -103,12 +103,12 @@ pub(crate) fn scan_package_direct_deps(
 
 const KICAD_SYMBOLS_REPO: &str = "gitlab.com/kicad/libraries/kicad-symbols";
 
-struct WorkspacePackageIndex {
+pub(crate) struct WorkspacePackageIndex {
     package_dirs: BTreeMap<PathBuf, String>,
 }
 
 impl WorkspacePackageIndex {
-    fn new(workspace_info: &crate::WorkspaceInfo) -> Self {
+    pub(crate) fn new(workspace_info: &crate::WorkspaceInfo) -> Self {
         let package_dirs = workspace_info
             .packages
             .iter()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Refactor-only performance change; scan behavior should be identical with lower per-package overhead.
> 
> **Overview**
> **Reuses workspace package directory indexing** for the whole `PackageResolver` lifetime instead of rebuilding it on every dependency scan.
> 
> `WorkspacePackageIndex` is created once in `PackageResolver::new` and passed into `scan_package_direct_deps`, which previously called `WorkspacePackageIndex::new` on each scan. That index maps canonical package roots to URLs and drives `.zen` file walks and relative-import workspace detection—so multi-package `pcb sync` / MVS resolution should do less repeated filesystem canonicalization and map setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5934fc591c4de5a52a5805b985f14f9f1d33ac2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->