### PR TITLE
Add ESR-aware crystal house matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added ESR-aware stdlib crystal matching, 24 MHz house parts, and lower-ESR ECS 2520 options.
+
 ### Fixed
 
 - `pcb publish` now rehydrates V2 package dependency manifests when publishing dependents of newly tagged workspace packages.

--- a/lib/std/bom/helpers.zen
+++ b/lib/std/bom/helpers.zen
@@ -296,9 +296,9 @@ def abracon_datasheet(path):
     return "https://abracon.com/" + path
 
 
-def abracon_crystal(frequency, load_capacitance, mpn, datasheet_path):
+def abracon_crystal(frequency, load_capacitance, mpn, datasheet_path, esr=None):
     """Helper to create an Abracon crystal entry with a verified PDF datasheet path."""
-    return crystal(frequency, load_capacitance, mpn, "Abracon LLC", abracon_datasheet(datasheet_path))
+    return crystal(frequency, load_capacitance, mpn, "Abracon LLC", abracon_datasheet(datasheet_path), esr=esr)
 
 
 def onsemi_datasheet(filename):
@@ -371,9 +371,9 @@ def ecs_datasheet(filename):
     return "https://ecsxtal.com/store/pdf/" + filename
 
 
-def ecs_crystal(frequency, load_capacitance, mpn, datasheet_filename):
+def ecs_crystal(frequency, load_capacitance, mpn, datasheet_filename, esr=None):
     """Helper to create an ECS crystal entry with a verified PDF datasheet filename."""
-    return crystal(frequency, load_capacitance, mpn, "ECS Inc.", ecs_datasheet(datasheet_filename))
+    return crystal(frequency, load_capacitance, mpn, "ECS Inc.", ecs_datasheet(datasheet_filename), esr=esr)
 
 
 def discrete_resistor_series(manufacturer, series, max_v, power, tolerance, values_with_mpns, datasheet=None):
@@ -630,7 +630,9 @@ def zener(zener_voltage: str, power: str, mpn: str, manufacturer: str, datasheet
     }
 
 
-def crystal(frequency: str, load_capacitance: str | None, mpn: str, manufacturer: str, datasheet=None) -> dict:
+def crystal(
+    frequency: str, load_capacitance: str | None, mpn: str, manufacturer: str, datasheet=None, esr: str | None = None
+) -> dict:
     """Helper to create crystal catalog entry.
 
     Args:
@@ -638,6 +640,7 @@ def crystal(frequency: str, load_capacitance: str | None, mpn: str, manufacturer
         load_capacitance: Load capacitance (e.g., "7pF", "12.5pF") or None
         mpn: Manufacturer part number
         manufacturer: Manufacturer name
+        esr: Maximum equivalent series resistance, or an explicit resistance range
 
     Returns:
         Crystal dictionary
@@ -645,6 +648,7 @@ def crystal(frequency: str, load_capacitance: str | None, mpn: str, manufacturer
     return {
         "frequency": Frequency(frequency),
         "load_capacitance": Capacitance(load_capacitance) if load_capacitance else None,
+        "esr": Resistance(esr) if esr else None,
         "mpn": mpn,
         "manufacturer": manufacturer,
         "datasheet": datasheet,

--- a/lib/std/bom/match_generics.zen
+++ b/lib/std/bom/match_generics.zen
@@ -518,35 +518,51 @@ HOUSE_POWER_INDUCTORS_BY_PKG = {
 # House crystal catalog by package
 HOUSE_CRYSTALS_BY_PKG = {
     "3215_2Pin": [
-        crystal("32.768kHz", "12.5pF", "ABS07-32.768KHZ-T", "Abracon LLC", abracon_datasheet("Resonators/ABS07.pdf")),
-        ecs_crystal("32.768kHz", "12.5pF", "ECS-.327-12.5-34QCS-TR", "ECX-34Q.pdf"),
-        crystal("32.768kHz", "12.5pF", "XKXGI-SUA-32.768K", "YXC Crystal Oscillators"),
-        crystal("32.768kHz", "12pF", "Q13FC13500004", "Seiko Epson"),
+        crystal(
+            "32.768kHz",
+            "12.5pF",
+            "ABS07-32.768KHZ-T",
+            "Abracon LLC",
+            abracon_datasheet("Resonators/ABS07.pdf"),
+            esr="70kOhm",
+        ),
+        ecs_crystal("32.768kHz", "12.5pF", "ECS-.327-12.5-34QCS-TR", "ECX-34Q.pdf", esr="70kOhm"),
+        crystal("32.768kHz", "12.5pF", "XKXGI-SUA-32.768K", "YXC Crystal Oscillators", esr="70kOhm"),
+        crystal("32.768kHz", "12pF", "Q13FC13500004", "Seiko Epson", esr="70kOhm"),
     ],
     "3225_4Pin": [
-        ecs_crystal("8MHz", "12pF", "ECS-80-12-33Q-GN-TR", "ECX-33Q.pdf"),
-        abracon_crystal("8MHz", "12pF", "ABM8AIG-8.000MHZ-12-R150-V-T3", "AIGcrystals/ABM8AIG.pdf"),
-        crystal("8MHz", "12pF", "X32258MOB4SI", "YXC Crystal Oscillators"),
-        ecs_crystal("12MHz", "12pF", "ECS-120-12-33Q-JES-TR", "ECX-33Q.pdf"),
-        abracon_crystal("12MHz", "12pF", "ABM8AIG-12.000MHZ-12-2Z-T3", "AIGcrystals/ABM8AIG.pdf"),
-        crystal("12MHz", "12pF", "X322512MOB4SI", "YXC Crystal Oscillators"),
-        ecs_crystal("16MHz", "12pF", "ECS-160-12-33Q-JEN-TR", "ECX-33Q.pdf"),
-        abracon_crystal("16MHz", "12pF", "ABM8AIG-16.000MHZ-12-2Z-T3", "AIGcrystals/ABM8AIG.pdf"),
-        crystal("16MHz", "12pF", "X322516MOB4SI", "YXC Crystal Oscillators"),
-        ecs_crystal("25MHz", "12pF", "ECS-250-12-33Q-JES-TR", "ECX-33Q.pdf"),
-        abracon_crystal("25MHz", "12pF", "ABM8AIG-25.000MHZ-12-2Z-T3", "AIGcrystals/ABM8AIG.pdf"),
-        crystal("25MHz", "12pF", "X322525MOB4SI", "YXC Crystal Oscillators"),
+        ecs_crystal("8MHz", "12pF", "ECS-80-12-33Q-GN-TR", "ECX-33Q.pdf", esr="500Ohm"),
+        abracon_crystal("8MHz", "12pF", "ABM8AIG-8.000MHZ-12-R150-V-T3", "AIGcrystals/ABM8AIG.pdf", esr="150Ohm"),
+        crystal("8MHz", "12pF", "X32258MOB4SI", "YXC Crystal Oscillators", esr="150Ohm"),
+        ecs_crystal("12MHz", "12pF", "ECS-120-12-33Q-JES-TR", "ECX-33Q.pdf", esr="100Ohm"),
+        abracon_crystal("12MHz", "12pF", "ABM8AIG-12.000MHZ-12-2Z-T3", "AIGcrystals/ABM8AIG.pdf", esr="100Ohm"),
+        crystal("12MHz", "12pF", "X322512MOB4SI", "YXC Crystal Oscillators", esr="80Ohm"),
+        ecs_crystal("16MHz", "12pF", "ECS-160-12-33Q-JEN-TR", "ECX-33Q.pdf", esr="80Ohm"),
+        abracon_crystal("16MHz", "12pF", "ABM8AIG-16.000MHZ-12-2Z-T3", "AIGcrystals/ABM8AIG.pdf", esr="70Ohm"),
+        crystal("16MHz", "12pF", "X322516MOB4SI", "YXC Crystal Oscillators", esr="80Ohm"),
+        ecs_crystal("24MHz", "12pF", "ECS-240-12-33Q-JES-TR", "ECX-33Q.pdf", esr="40Ohm"),
+        abracon_crystal("24MHz", "12pF", "ABM8AIG-24.000MHZ-12-2Z-T3", "AIGcrystals/ABM8AIG.pdf", esr="50Ohm"),
+        crystal("24MHz", "12pF", "X322524MOB4SI", "YXC Crystal Oscillators", esr="50Ohm"),
+        ecs_crystal("25MHz", "12pF", "ECS-250-12-33Q-JES-TR", "ECX-33Q.pdf", esr="40Ohm"),
+        abracon_crystal("25MHz", "12pF", "ABM8AIG-25.000MHZ-12-2Z-T3", "AIGcrystals/ABM8AIG.pdf", esr="50Ohm"),
+        crystal("25MHz", "12pF", "X322525MOB4SI", "YXC Crystal Oscillators", esr="50Ohm"),
     ],
     "2520_4Pin": [
-        ecs_crystal("12MHz", "10pF", "ECS-120-10-36Q-AES-TR", "ECX-2236Q.pdf"),
-        abracon_crystal("12MHz", "10pF", "ABM10AIG-12.000MHZ-4Z-T3", "AIGcrystals/ABM10AIG.pdf"),
-        crystal("12MHz", "10pF", "TXM12M0004252DBCEO00T", "Yajingxin"),
-        ecs_crystal("16MHz", "10pF", "ECS-160-10-36Q-ES-TR", "ECX-2236Q.pdf"),
-        abracon_crystal("16MHz", "10pF", "ABM10AIG-16.000MHZ-4Z-T3", "AIGcrystals/ABM10AIG.pdf"),
-        crystal("16MHz", "10pF", "TXM16M0004252DBCEO00T", "Yajingxin"),
-        ecs_crystal("25MHz", "10pF", "ECS-250-10-36Q-ES-TR", "ECX-2236Q.pdf"),
-        abracon_crystal("25MHz", "10pF", "ABM10AIG-25.000MHZ-4Z-T3", "AIGcrystals/ABM10AIG.pdf"),
-        crystal("25MHz", "10pF", "TXM25M0004252DBCEO00T", "Yajingxin"),
+        ecs_crystal("12MHz", "10pF", "ECS-120-10-36Q-AES-TR", "ECX-2236Q.pdf", esr="150Ohm"),
+        abracon_crystal("12MHz", "10pF", "ABM10AIG-12.000MHZ-4Z-T3", "AIGcrystals/ABM10AIG.pdf", esr="150Ohm"),
+        ecs_crystal("12MHz", "10pF", "ECS-120-10-36B-CWY-TR3", "ECX-2236B.pdf", esr="130Ohm"),
+        crystal("12MHz", "10pF", "TXM12M0004252DBCEO00T", "Yajingxin", esr="120Ohm"),
+        ecs_crystal("16MHz", "10pF", "ECS-160-10-36Q-ES-TR", "ECX-2236Q.pdf", esr="80Ohm"),
+        abracon_crystal("16MHz", "10pF", "ABM10AIG-16.000MHZ-4Z-T3", "AIGcrystals/ABM10AIG.pdf", esr="80Ohm"),
+        ecs_crystal("16MHz", "10pF", "ECS-160-10-36B-CKM-TR", "ECX-2236B.pdf", esr="70Ohm"),
+        crystal("16MHz", "10pF", "TXM16M0004252DBCEO00T", "Yajingxin", esr="60Ohm"),
+        ecs_crystal("24MHz", "10pF", "ECS-240-10-36Q-ES-TR", "ECX-2236Q.pdf", esr="60Ohm"),
+        abracon_crystal("24MHz", "10pF", "ABM10AIG-24.000MHZ-4Z-T3", "AIGcrystals/ABM10AIG.pdf", esr="60Ohm"),
+        ecs_crystal("24MHz", "10pF", "ECS-240-10-36B-CTN-TR", "ECX-2236B.pdf", esr="50Ohm"),
+        ecs_crystal("25MHz", "10pF", "ECS-250-10-36Q-ES-TR", "ECX-2236Q.pdf", esr="60Ohm"),
+        abracon_crystal("25MHz", "10pF", "ABM10AIG-25.000MHZ-4Z-T3", "AIGcrystals/ABM10AIG.pdf", esr="60Ohm"),
+        ecs_crystal("25MHz", "10pF", "ECS-250-10-36B-CTN-TR", "ECX-2236B.pdf", esr="50Ohm"),
+        crystal("25MHz", "10pF", "TXM25M0004252DBCEO00T", "Yajingxin", esr="45Ohm"),
     ],
 }
 
@@ -1507,12 +1523,17 @@ def assign_house_crystal(c, house_crystals_by_pkg):
     pkg = prop(c, ["package", "Package"])
     freq_req = prop(c, ["frequency", "Frequency"])
     cl_req = prop(c, ["load_capacitance", "Load_capacitance"])
+    esr_req = prop(c, ["esr", "ESR", "Esr"])
 
     if not freq_req:
         return
 
     req_frequency = Frequency(freq_req)
     req_load_cap = Capacitance(cl_req) if cl_req else None
+    req_esr = Resistance(esr_req) if esr_req else None
+    if req_esr and req_esr.min == req_esr.max:
+        # Treat a point ESR request as a maximum allowed ESR.
+        req_esr = Resistance(min="0Ohm", max=req_esr)
 
     parts = house_crystals_by_pkg.get(pkg, [])
     matches = []
@@ -1530,6 +1551,13 @@ def assign_house_crystal(c, house_crystals_by_pkg):
             if req_load_cap.tolerance == 0.0:
                 req_load_cap = req_load_cap.with_tolerance(0.20)
             if not p["load_capacitance"].within(req_load_cap):
+                continue
+
+        if req_esr:
+            part_esr = p.get("esr")
+            if not part_esr:
+                continue
+            if not part_esr.within(req_esr):
                 continue
 
         matches.append(p)

--- a/lib/std/generics/Crystal.zen
+++ b/lib/std/generics/Crystal.zen
@@ -1,6 +1,6 @@
 load("../io.zen", "io")
 load("../interfaces.zen", "Net")
-load("../units.zen", "Capacitance", "Frequency")
+load("../units.zen", "Capacitance", "Frequency", "Resistance")
 load("../utils.zen", "format_value")
 
 Mount = enum("SMD")
@@ -24,6 +24,7 @@ mpn = config(str, optional=True, help="Manufacturer Part Number")
 manufacturer = config(str, optional=True, help="Manufacturer")
 mount = config(Mount, default=Mount("SMD"), optional=True, help="Mounting type")
 load_capacitance = config(Capacitance, optional=True, help="Load capacitance for oscillator circuit")
+esr = config(Resistance, optional=True, help="Equivalent series resistance")
 properties = {
     "value": format_value(frequency, load_capacitance),
     "package": package,
@@ -32,6 +33,8 @@ properties = {
 
 if load_capacitance:
     properties["load_capacitance"] = load_capacitance
+if esr:
+    properties["esr"] = esr
 
 # For 2-pin crystals
 XIN = io(Net)

--- a/lib/std/generics/test/test_Crystal.zen
+++ b/lib/std/generics/test/test_Crystal.zen
@@ -41,35 +41,69 @@ for package in [package for package in Crystal.Package.values() if "4Pin" in str
 
 
 CRYSTAL_MATCH_CASES = [
-    ("3215_2Pin", "32.768kHz", "12.5pF"),
-    ("3225_4Pin", "8MHz", "12pF"),
-    ("3225_4Pin", "12MHz", "12pF"),
-    ("3225_4Pin", "16MHz", "12pF"),
-    ("3225_4Pin", "25MHz", "12pF"),
-    ("2520_4Pin", "12MHz", "10pF"),
-    ("2520_4Pin", "16MHz", "10pF"),
-    ("2520_4Pin", "25MHz", "10pF"),
+    ("3215_2Pin", "32.768kHz", "12.5pF", None),
+    ("3225_4Pin", "8MHz", "12pF", None),
+    ("3225_4Pin", "12MHz", "12pF", None),
+    ("3225_4Pin", "16MHz", "12pF", None),
+    ("3225_4Pin", "24MHz", "12pF", None),
+    ("3225_4Pin", "25MHz", "12pF", None),
+    ("2520_4Pin", "12MHz", "10pF", None),
+    ("2520_4Pin", "16MHz", "10pF", None),
+    ("2520_4Pin", "24MHz", "10pF", None),
+    ("2520_4Pin", "25MHz", "10pF", None),
+    ("3225_4Pin", "16MHz", "12pF", "70Ohm"),
+    ("2520_4Pin", "16MHz", "10pF", "70Ohm"),
+    ("2520_4Pin", "16MHz", "10pF", "0Ohm to 70Ohm"),
+    ("2520_4Pin", "16MHz", "10pF", "0Ohm to 60Ohm"),
+    ("2520_4Pin", "24MHz", "10pF", "50Ohm"),
+    ("2520_4Pin", "25MHz", "10pF", "50Ohm"),
+    ("3215_2Pin", "32.768kHz", "12.5pF", "80kOhm"),
 ]
 
-for i, (package, frequency, load_capacitance) in enumerate(CRYSTAL_MATCH_CASES):
+for i, (package, frequency, load_capacitance, esr) in enumerate(CRYSTAL_MATCH_CASES):
+    kwargs = {
+        "name": "Y_MATCH_" + str(i),
+        "package": package,
+        "frequency": frequency,
+        "load_capacitance": load_capacitance,
+        "XIN": Net("Y_MATCH_" + str(i) + "_XIN"),
+        "XOUT": Net("Y_MATCH_" + str(i) + "_XOUT"),
+    }
+    if esr:
+        kwargs["esr"] = esr
     if "4Pin" in package:
-        Crystal(
-            name="Y_MATCH_" + str(i),
-            package=package,
-            frequency=frequency,
-            load_capacitance=load_capacitance,
-            XIN=Net("Y_MATCH_" + str(i) + "_XIN"),
-            XOUT=Net("Y_MATCH_" + str(i) + "_XOUT"),
-            GND=Net("Y_MATCH_" + str(i) + "_GND"),
-        )
-    else:
-        Crystal(
-            name="Y_MATCH_" + str(i),
-            package=package,
-            frequency=frequency,
-            load_capacitance=load_capacitance,
-            XIN=Net("Y_MATCH_" + str(i) + "_XIN"),
-            XOUT=Net("Y_MATCH_" + str(i) + "_XOUT"),
-        )
+        kwargs["GND"] = Net("Y_MATCH_" + str(i) + "_GND")
+    Crystal(**kwargs)
 
-builtin.add_component_modifier(assign_house_parts)
+
+def _check_mpn(c, expected_mpn):
+    if c.mpn != expected_mpn:
+        error("Expected " + c.value + " to match " + expected_mpn + ", got " + str(c.mpn))
+
+
+def _check_house_parts(c):
+    assign_house_parts(c)
+
+    if not hasattr(c, "type") or c.type != "crystal":
+        return
+
+    if c.properties["package"].value != "2520_4Pin":
+        return
+    if str(c.properties["frequency"]) != "16MHz":
+        return
+    if str(c.properties["load_capacitance"]) != "10pF":
+        return
+
+    esr = c.properties.get("esr")
+    if not esr:
+        return
+
+    if esr.min == 70.0 and esr.max == 70.0:
+        _check_mpn(c, "ECS-160-10-36B-CKM-TR")
+    elif esr.min == 0.0 and esr.max == 70.0:
+        _check_mpn(c, "ECS-160-10-36B-CKM-TR")
+    elif esr.min == 0.0 and esr.max == 60.0:
+        _check_mpn(c, "TXM16M0004252DBCEO00T")
+
+
+builtin.add_component_modifier(_check_house_parts)


### PR DESCRIPTION
Also add 24 MHz crystal house parts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to stdlib generic crystal properties, BOM catalog data, and matching logic; behavior without `esr` stays the same, with test coverage for new matching paths.
> 
> **Overview**
> Adds **optional ESR** on the stdlib `Crystal` generic and threads it through BOM helpers and house crystal matching so designs can constrain equivalent series resistance when auto-picking parts.
> 
> **House matching** now reads `esr` from component properties; a single-value ESR is treated as a **maximum** allowed ESR, and catalog entries without ESR metadata are skipped when ESR is required. Existing house crystals are annotated with per-MPN ESR limits.
> 
> **Catalog expansion:** **24 MHz** options for `3225_4Pin` and `2520_4Pin`, plus additional **ECS 2520 “B”** variants with lower ESR than the prior Q-series entries. Tests cover 24 MHz matching and ESR-driven MPN selection (e.g. tighter ESR picking lower-ESR alternates).
> 
> Changelog documents the unreleased stdlib BOM/crystal behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb18aeed6897d30eb940be3f87b3fa316ae52ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->