### PR TITLE
fix(publish): include board manifests in package mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `pcb publish` package mode now includes board manifests.
+
 ## [0.3.91] - 2026-06-08
 
 ### Changed

--- a/crates/pcbc/src/publish.rs
+++ b/crates/pcbc/src/publish.rs
@@ -244,10 +244,6 @@ fn expand_dirty_set(
     // Build reverse dependency map: url -> packages that depend on it
     let mut reverse_deps: HashMap<String, Vec<String>> = HashMap::new();
     for (url, pkg) in &workspace.packages {
-        // Skip boards
-        if pkg.config.board.is_some() {
-            continue;
-        }
         for dep_url in pkg.dependencies() {
             reverse_deps
                 .entry(dep_url.to_string())
@@ -742,11 +738,11 @@ fn publish_packages(start_path: &Path, args: &PublishArgs) -> Result<()> {
         );
     }
 
-    // Get dirty non-board packages
+    // Get dirty packages
     let directly_dirty: HashSet<String> = workspace
         .packages
         .iter()
-        .filter(|(_, p)| p.dirty && p.config.board.is_none())
+        .filter(|(_, p)| p.dirty)
         .map(|(url, _)| url.clone())
         .collect();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI package publish selection and dependency-wave expansion when boards are dirty or sit in the dependency graph; scope is limited to `publish_packages` logic in `publish.rs`.
> 
> **Overview**
> **`pcb publish` package mode** no longer skips workspace members whose `pcb.toml` has a `[board]` section.
> 
> Dirty **board manifests** are now included in the initial dirty set, and board packages participate in the reverse-dependency expansion so dependents that need a bumped `pcb.toml` are published in the same waves as for library packages. Board releases via a `.zen` path are unchanged.
> 
> The unreleased changelog notes that package-mode publish now includes board manifests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8336f66efbaa6c556e0b6ea7f2930caf4217f35f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->