### PR TITLE
Use source checkouts for remote package cache

### DIFF
--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -19,20 +19,20 @@ use crate::tags;
 /// Bump this when changing table schemas. Encoded in the filename so a new
 /// version just creates a fresh file — no migration logic needed.
 const SCHEMA_VERSION: i32 = 4;
-static FETCHED_BARE_REPOS: LazyLock<Mutex<BTreeSet<String>>> =
+static FETCHED_SOURCE_REPOS: LazyLock<Mutex<BTreeSet<String>>> =
     LazyLock::new(|| Mutex::new(BTreeSet::new()));
 
-fn bare_repo_fetched_in_process(repo_url: &str) -> bool {
-    FETCHED_BARE_REPOS
+fn source_repo_fetched_in_process(repo_url: &str) -> bool {
+    FETCHED_SOURCE_REPOS
         .lock()
-        .expect("bare repo cache mutex poisoned")
+        .expect("source repo cache mutex poisoned")
         .contains(repo_url)
 }
 
-fn mark_bare_repo_fetched(repo_url: &str) {
-    FETCHED_BARE_REPOS
+fn mark_source_repo_fetched(repo_url: &str) {
+    FETCHED_SOURCE_REPOS
         .lock()
-        .expect("bare repo cache mutex poisoned")
+        .expect("source repo cache mutex poisoned")
         .insert(repo_url.to_string());
 }
 
@@ -175,8 +175,8 @@ impl CacheIndex {
     }
 
     fn discover_remote_packages(&self, repo_url: &str) -> Result<()> {
-        let bare_dir = ensure_bare_repo(repo_url)?;
-        let tags = git::list_all_tags(&bare_dir)?;
+        let source_dir = ensure_source_repo(repo_url)?;
+        let tags = git::list_all_tags(&source_dir)?;
 
         let mut packages: BTreeMap<String, Version> = BTreeMap::new();
         for tag in tags {
@@ -363,39 +363,39 @@ pub fn ensure_workspace_cache_symlink(workspace_root: &std::path::Path) -> Resul
     Ok(())
 }
 
-pub fn ensure_bare_repo(repo_url: &str) -> Result<PathBuf> {
-    let bare_dir = bare_repo_dir(repo_url)?;
+pub fn ensure_source_repo(repo_url: &str) -> Result<PathBuf> {
+    let source_dir = source_repo_dir(repo_url)?;
 
-    if bare_dir.join("HEAD").exists() && bare_repo_fetched_in_process(repo_url) {
-        return Ok(bare_dir);
+    if source_dir.join(".git").exists() && source_repo_fetched_in_process(repo_url) {
+        return Ok(source_dir);
     }
 
-    let _lock = git::lock_dir(&bare_dir)?;
-    let repo_exists = bare_dir.join("HEAD").exists();
-    if repo_exists && bare_repo_fetched_in_process(repo_url) {
-        return Ok(bare_dir);
+    let _lock = git::lock_dir(&source_dir)?;
+    let repo_exists = source_dir.join(".git").exists();
+    if repo_exists && source_repo_fetched_in_process(repo_url) {
+        return Ok(source_dir);
     }
 
     let spinner = Spinner::builder(format!("Fetching {repo_url}")).start();
     let result = if repo_exists {
-        git::fetch_in_bare_repo(&bare_dir)
+        git::fetch_in_source_repo(&source_dir)
     } else {
-        git::clone_bare_with_fallback(repo_url, &bare_dir)
+        git::clone_with_fallback(repo_url, &source_dir)
     };
     if let Err(err) = result {
         spinner.error(format!("Failed to fetch {repo_url}"));
         return Err(err);
     }
     spinner.finish();
-    mark_bare_repo_fetched(repo_url);
+    mark_source_repo_fetched(repo_url);
 
-    Ok(bare_dir)
+    Ok(source_dir)
 }
 
-pub fn bare_repo_dir(repo_url: &str) -> Result<PathBuf> {
+pub fn source_repo_dir(repo_url: &str) -> Result<PathBuf> {
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
-    Ok(home.join(".pcb/bare").join(repo_url))
+    Ok(home.join(".pcb/src").join(repo_url))
 }
 
 #[cfg(test)]

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -378,32 +378,16 @@ fn parse_git_timezone_offset(offset: &str) -> Option<i32> {
     Some(sign * (hour * 3_600 + minute * 60))
 }
 
-fn clone(remote_url: &str, dest_dir: &Path, bare: bool, prompt: bool) -> anyhow::Result<()> {
+fn clone(remote_url: &str, dest_dir: &Path, prompt: bool) -> anyhow::Result<()> {
     let mut cmd = git_global_with_prompt(prompt);
     cmd.arg("clone");
-    if bare {
-        cmd.arg("--bare");
-    }
     cmd.args(["--quiet", remote_url]).arg(dest_dir);
     run_silent(cmd)
 }
 
-pub fn clone_bare(remote_url: &str, dest_dir: &Path) -> anyhow::Result<()> {
-    clone(remote_url, dest_dir, true, true)
-}
-
-pub fn clone_bare_with_fallback(repo_url: &str, dest: &Path) -> anyhow::Result<()> {
-    std::fs::create_dir_all(dest.parent().unwrap_or(dest))?;
-    let https_url = format!("https://{}.git", repo_url);
-    if clone(&https_url, dest, true, false).is_ok() {
-        return Ok(());
-    }
-    clone_bare(&format_ssh_url(repo_url), dest)
-}
-
-pub fn fetch_in_bare_repo(bare_repo: &Path) -> anyhow::Result<()> {
+pub fn fetch_in_source_repo(source_repo: &Path) -> anyhow::Result<()> {
     run_in(
-        bare_repo,
+        source_repo,
         &[
             "fetch",
             "origin",
@@ -417,19 +401,17 @@ pub fn fetch_in_bare_repo(bare_repo: &Path) -> anyhow::Result<()> {
     )
 }
 
-pub fn ensure_rev_in_bare_repo(bare_repo: &Path, rev: &str) -> anyhow::Result<()> {
-    if rev_parse(bare_repo, rev).is_some() {
+pub fn ensure_rev_in_source_repo(source_repo: &Path, rev: &str) -> anyhow::Result<()> {
+    if rev_parse(source_repo, rev).is_some() {
         return Ok(());
     }
 
-    run_in(bare_repo, &["fetch", "origin", "--quiet", rev])
+    run_in(source_repo, &["fetch", "origin", "--quiet", rev])
 }
 
 pub fn archive_to_dir(repo_root: &Path, treeish: &str, dest_dir: &Path) -> anyhow::Result<()> {
-    let mut cmd = git_global();
-    cmd.arg("--git-dir")
-        .arg(repo_root)
-        .args(["archive", "--format=tar", treeish])
+    let mut cmd = git(repo_root);
+    cmd.args(["archive", "--format=tar", treeish])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
@@ -488,19 +470,14 @@ pub fn push_branch_force(repo_root: &Path, branch: &str, remote: &str) -> anyhow
     run_in(repo_root, &["push", "--force", remote, branch])
 }
 
-/// Clone a repository to a destination directory (regular clone, not bare)
-pub fn clone_repo(remote_url: &str, dest_dir: &Path) -> anyhow::Result<()> {
-    clone(remote_url, dest_dir, false, true)
-}
-
 /// Clone a repository with HTTPS, falling back to SSH
 pub fn clone_with_fallback(repo_url: &str, dest: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(dest.parent().unwrap_or(dest))?;
     let https_url = format!("https://{}.git", repo_url);
-    if clone(&https_url, dest, false, false).is_ok() {
+    if clone(&https_url, dest, false).is_ok() {
         return Ok(());
     }
-    clone_repo(&format_ssh_url(repo_url), dest)
+    clone(&format_ssh_url(repo_url), dest, true)
 }
 
 /// Create or reset a branch to point at a specific ref

--- a/crates/pcb-zen/src/package_resolver/versions.rs
+++ b/crates/pcb-zen/src/package_resolver/versions.rs
@@ -11,7 +11,7 @@ use semver::Version;
 #[derive(Default)]
 pub struct SpecVersionResolver {
     offline: bool,
-    bare_repos: BTreeMap<String, PathBuf>,
+    source_repos: BTreeMap<String, PathBuf>,
     base_versions: BTreeMap<String, BTreeMap<String, Version>>,
 }
 
@@ -89,18 +89,18 @@ impl SpecVersionResolver {
 
     fn generate_pseudo_version(&mut self, module_path: &str, commit: &str) -> Result<Version> {
         let (repo_url, subpath) = split_repo_and_subpath(module_path);
-        let bare_dir = self.ensure_bare_repo(repo_url)?;
-        let commit_full = git::rev_parse(&bare_dir, commit).ok_or_else(|| {
+        let source_dir = self.ensure_source_repo(repo_url)?;
+        let commit_full = git::rev_parse(&source_dir, commit).ok_or_else(|| {
             anyhow::anyhow!(
                 "Failed to resolve rev '{}' in {}",
                 &commit[..commit.len().min(12)],
                 repo_url
             )
         })?;
-        let timestamp = git::show_commit_timestamp(&bare_dir, &commit_full)
+        let timestamp = git::show_commit_timestamp(&source_dir, &commit_full)
             .ok_or_else(|| anyhow::anyhow!("Failed to read timestamp for {}", commit_full))?;
         let base_version = self
-            .latest_tagged_version(repo_url, subpath, &bare_dir)
+            .latest_tagged_version(repo_url, subpath, &source_dir)
             .unwrap_or_else(initial_package_version);
         let dt = jiff::Timestamp::from_second(timestamp)?;
         let pseudo = format!(
@@ -115,12 +115,12 @@ impl SpecVersionResolver {
             .map_err(|e| anyhow::anyhow!("Failed to parse pseudo-version {}: {}", pseudo, e))
     }
 
-    fn ensure_bare_repo(&mut self, repo_url: &str) -> Result<PathBuf> {
-        if let Some(path) = self.bare_repos.get(repo_url) {
+    fn ensure_source_repo(&mut self, repo_url: &str) -> Result<PathBuf> {
+        if let Some(path) = self.source_repos.get(repo_url) {
             return Ok(path.clone());
         }
-        let path = crate::cache_index::ensure_bare_repo(repo_url)?;
-        self.bare_repos.insert(repo_url.to_string(), path.clone());
+        let path = crate::cache_index::ensure_source_repo(repo_url)?;
+        self.source_repos.insert(repo_url.to_string(), path.clone());
         Ok(path)
     }
 
@@ -128,11 +128,11 @@ impl SpecVersionResolver {
         &mut self,
         repo_url: &str,
         subpath: &str,
-        bare_dir: &std::path::Path,
+        source_dir: &std::path::Path,
     ) -> Option<Version> {
         if !self.base_versions.contains_key(repo_url) {
             let mut versions = BTreeMap::new();
-            if let Ok(tags) = git::list_all_tags(bare_dir) {
+            if let Ok(tags) = git::list_all_tags(source_dir) {
                 for tag in tags {
                     if let Some((pkg_path, version)) = tags::parse_tag(&tag) {
                         versions

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -27,8 +27,8 @@ use tracing::{info_span, instrument};
 use std::time::Instant;
 
 use crate::cache_index::{
-    CacheIndex, bare_repo_dir, cache_base, ensure_bare_repo, ensure_stdlib_materialized,
-    ensure_workspace_cache_symlink,
+    CacheIndex, cache_base, ensure_source_repo, ensure_stdlib_materialized,
+    ensure_workspace_cache_symlink, source_repo_dir,
 };
 use crate::git;
 use crate::tags;
@@ -2039,7 +2039,7 @@ fn resolve_to_version(
 /// Context for pseudo-version generation, caching expensive operations.
 struct PseudoVersionContext {
     index: CacheIndex,
-    bare_repos: HashMap<String, PathBuf>,
+    source_repos: HashMap<String, PathBuf>,
     base_versions: HashMap<String, HashMap<String, Version>>,
 }
 
@@ -2047,17 +2047,17 @@ impl PseudoVersionContext {
     fn new() -> Result<Self> {
         Ok(Self {
             index: CacheIndex::open()?,
-            bare_repos: HashMap::new(),
+            source_repos: HashMap::new(),
             base_versions: HashMap::new(),
         })
     }
 
-    fn ensure_bare_repo(&mut self, repo_url: &str) -> Result<PathBuf> {
-        if let Some(path) = self.bare_repos.get(repo_url) {
+    fn ensure_source_repo(&mut self, repo_url: &str) -> Result<PathBuf> {
+        if let Some(path) = self.source_repos.get(repo_url) {
             return Ok(path.clone());
         }
-        let path = ensure_bare_repo(repo_url)?;
-        self.bare_repos.insert(repo_url.to_string(), path.clone());
+        let path = ensure_source_repo(repo_url)?;
+        self.source_repos.insert(repo_url.to_string(), path.clone());
         Ok(path)
     }
 
@@ -2082,11 +2082,11 @@ impl PseudoVersionContext {
 
     fn generate_pseudo_version(&mut self, module_path: &str, commit: &str) -> Result<Version> {
         let (repo_url, subpath) = split_repo_and_subpath(module_path);
-        let bare_dir = self.ensure_bare_repo(repo_url)?;
+        let source_dir = self.ensure_source_repo(repo_url)?;
 
         // `git fetch origin <sha>` only works with full 40-char object IDs.
         // Users (and tests) may provide short hashes, so resolve to a full commit first.
-        let commit_full = git::rev_parse(&bare_dir, commit).ok_or_else(|| {
+        let commit_full = git::rev_parse(&source_dir, commit).ok_or_else(|| {
             anyhow::anyhow!(
                 "Failed to resolve rev '{}' in {} (provide a full commit hash or a ref that exists)",
                 commit,
@@ -2098,7 +2098,7 @@ impl PseudoVersionContext {
         let timestamp = match self.index.get_commit_metadata(repo_url, commit) {
             Some((ts, _)) => ts,
             None => {
-                let ts = git::show_commit_timestamp(&bare_dir, commit).unwrap_or_else(|| {
+                let ts = git::show_commit_timestamp(&source_dir, commit).unwrap_or_else(|| {
                     std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap()
@@ -2110,7 +2110,7 @@ impl PseudoVersionContext {
         };
 
         let base_version = self
-            .get_base_version(&bare_dir, repo_url, subpath)
+            .get_base_version(&source_dir, repo_url, subpath)
             .unwrap_or_else(initial_package_version);
 
         // Build pseudo-version:
@@ -2131,13 +2131,13 @@ impl PseudoVersionContext {
 
     fn get_base_version(
         &mut self,
-        bare_dir: &Path,
+        source_dir: &Path,
         repo_url: &str,
         subpath: &str,
     ) -> Option<Version> {
         if !self.base_versions.contains_key(repo_url) {
             let mut versions: HashMap<String, Version> = HashMap::new();
-            if let Ok(tags) = git::list_all_tags(bare_dir) {
+            if let Ok(tags) = git::list_all_tags(source_dir) {
                 for tag in tags {
                     if let Some((pkg_path, version)) = tags::parse_tag(&tag) {
                         versions
@@ -2213,16 +2213,16 @@ fn verify_tag_hashes(
     manifest_hash: &str,
 ) -> Result<()> {
     let (repo_url, subpath) = split_repo_and_subpath(module_path);
-    let bare_dir = bare_repo_dir(repo_url)?;
+    let source_dir = source_repo_dir(repo_url)?;
     let tag_name = if subpath.is_empty() {
         format!("v{}", version)
     } else {
         format!("{}/v{}", subpath, version)
     };
 
-    // Read the annotated tag directly from the shared bare repo. Materialized
+    // Read the annotated tag directly from the shared source repo. Materialized
     // cache directories are plain extracted files now, not git repos.
-    let Some(tag_body) = git::cat_file(&bare_dir, &tag_name) else {
+    let Some(tag_body) = git::cat_file(&source_dir, &tag_name) else {
         return Ok(());
     };
 
@@ -2456,7 +2456,7 @@ where
 ///
 /// On a warm cache hit, this returns the existing immutable cache entry without
 /// touching Git. On a cold miss, it materializes the package once from the
-/// shared bare repo into `~/.pcb/cache/...`, then later builds reuse that cache.
+/// shared source repo into `~/.pcb/cache/...`, then later builds reuse that cache.
 /// Tagged versions archive from the version tag; pseudo-versions archive from
 /// the pinned commit.
 ///
@@ -2553,14 +2553,14 @@ fn fetch_via_git(
     subpath: &str,
     is_pseudo: bool,
 ) -> Result<()> {
-    // Materialize packages directly from the shared bare repo. With fully
-    // hydrated bare repos, this is both simpler and much faster than creating a
-    // temporary repo just to fetch, sparse-checkout, and flatten a subdirectory.
+    // Materialize packages directly from the shared source checkout instead of
+    // creating a temporary repo just to fetch, sparse-checkout, and flatten a
+    // subdirectory.
     std::fs::create_dir_all(dest)?;
-    let bare_dir = ensure_bare_repo(repo_url)?;
+    let source_dir = ensure_source_repo(repo_url)?;
 
     if is_pseudo {
-        git::ensure_rev_in_bare_repo(&bare_dir, ref_spec)?;
+        git::ensure_rev_in_source_repo(&source_dir, ref_spec)?;
     }
     let ref_name = ref_spec.to_string();
     let treeish = if subpath.is_empty() {
@@ -2568,7 +2568,7 @@ fn fetch_via_git(
     } else {
         format!("{ref_name}:{subpath}")
     };
-    git::archive_to_dir(&bare_dir, &treeish, dest)?;
+    git::archive_to_dir(&source_dir, &treeish, dest)?;
 
     Ok(())
 }

--- a/crates/pcb-zen/src/tags.rs
+++ b/crates/pcb-zen/src/tags.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 use path_slash::PathExt;
 use semver::Version;
 
-use crate::cache_index::ensure_bare_repo;
+use crate::cache_index::ensure_source_repo;
 use crate::git;
 
 /// Parse a version string, with or without 'v' prefix.
@@ -119,14 +119,14 @@ pub fn find_latest_tag(tags: &[String], prefix: &str) -> Option<String> {
 /// Get all available versions for packages in a repository.
 ///
 /// Returns a map from package_path (relative to repo) to all available versions,
-/// sorted descending (newest first). This fetches/updates the bare repo and parses
+/// sorted descending (newest first). This fetches/updates the source repo and parses
 /// all version tags.
 ///
 /// For root packages (tags like `v1.0.0`), the package path is an empty string.
 /// For nested packages (tags like `path/to/pkg/v1.0.0`), the package path is `path/to/pkg`.
 pub fn get_all_versions_for_repo(repo_url: &str) -> Result<BTreeMap<String, Vec<Version>>> {
-    let bare_dir = ensure_bare_repo(repo_url)?;
-    let tags = git::list_all_tags(&bare_dir)?;
+    let source_dir = ensure_source_repo(repo_url)?;
+    let tags = git::list_all_tags(&source_dir)?;
 
     let mut packages: BTreeMap<String, Vec<Version>> = BTreeMap::new();
     for tag in tags {


### PR DESCRIPTION
Bare repos were a bit better for this use-case when I originally started using them because they clone is a bit faster. But in sandboxes, we get very cheap cache copies of regular checkouts (and not of bare checkouts). So, using regular git clones to fetch dependencies ends up being way better in sandboxes and its marginally worse for regular local dev.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core remote fetch/cache path and on-disk layout (`~/.pcb/bare` → `~/.pcb/src`), so users re-fetch until new caches warm; resolution behavior should stay equivalent.
> 
> **Overview**
> Remote dependency repos are no longer stored as **bare** clones under `~/.pcb/bare`; they are **full working-tree checkouts** under `~/.pcb/src`, with readiness keyed on `.git` instead of bare `HEAD`.
> 
> The git layer drops bare-only clone/fetch helpers and routes initial clone through **`clone_with_fallback`** (HTTPS then SSH). **`git archive`** runs from a normal repo via `git -C` rather than `--git-dir` on a bare mirror. Cache index, resolution, pseudo-version generation, tag discovery, and package materialization all call **`ensure_source_repo`** / **`source_repo_dir`** instead of the bare equivalents.
> 
> **Note:** Existing bare caches are not migrated; first use after upgrade will populate the new `~/.pcb/src` layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8ee2b94d5532935b43ede7583d9440e8d8af99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->