### PR TITLE
Bump version to 0.4, add `pcb migrate` version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changes
 
-- `pcb migrate` now runs the latest stable `pcbc` toolchain and updates the workspace `pcb-version` after migrations succeed.
+- `pcb migrate` now upgrades workspace `pcb-version` after successful latest-toolchain migrations.
 - Added `[workspace.bom] strict = true` to require exact MPN matching when fetching BOM availability.
 - Updated stdlib generics to use KiCad 10.0.3 symbols and footprints, while keeping `Crystal()` compatible with KiCad 9 four-pin symbols.
 - `pcb publish` now bundles only referenced KiCad split-symbol files instead of whole split-library directories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changes
 
+- `pcb migrate` now runs the latest stable `pcbc` toolchain and updates the workspace `pcb-version` after migrations succeed.
 - Added `[workspace.bom] strict = true` to require exact MPN matching when fetching BOM availability.
 - Updated stdlib generics to use KiCad 10.0.3 symbols and footprints, while keeping `Crystal()` compatible with KiCad 9 four-pin symbols.
 - `pcb publish` now bundles only referenced KiCad split-symbol files instead of whole split-library directories.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-canonical"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-command-runner"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-component-gen"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "deunicode",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-diode-api"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-eda"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-fmt"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ruff_formatter",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-ipc2581-tools"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4813,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-kicad"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-layout"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-sch"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "allocative",
  "anyhow",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-sexpr"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hex",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-sim"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4916,7 +4916,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-starlark-lsp"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "derivative",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-test-utils"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-ui"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-zen"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-zen-core"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "allocative",
  "anyhow",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-zen-wasm"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "pcbc"
-version = "0.3.92"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5133,6 +5133,7 @@ dependencies = [
  "termimad",
  "thiserror 2.0.18",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
@@ -7874,6 +7875,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.92"
+version = "0.4.0"
 edition = "2024"
 repository = "https://github.com/diodeinc/pcb"
 homepage = "https://github.com/diodeinc/pcb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ serde_json = "1.0"
 tempfile = "3.10.1"
 thiserror = "2"
 toml = "1"
+toml_edit = "0.25"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "1.4", features = ["v4", "v5", "js"] }
 walkdir = "2.3"

--- a/crates/pcb-layout/tests/resources/complex/pcb.toml
+++ b/crates/pcb-layout/tests/resources/complex/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/component_side_sync/pcb.toml
+++ b/crates/pcb-layout/tests/resources/component_side_sync/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/dnp/pcb.toml
+++ b/crates/pcb-layout/tests/resources/dnp/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/fpid_change/pcb.toml
+++ b/crates/pcb-layout/tests/resources/fpid_change/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/graphics/pcb.toml
+++ b/crates/pcb-layout/tests/resources/graphics/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/module_layout/pcb.toml
+++ b/crates/pcb-layout/tests/resources/module_layout/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/moved/pcb.toml
+++ b/crates/pcb-layout/tests/resources/moved/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/multi_pads/pcb.toml
+++ b/crates/pcb-layout/tests/resources/multi_pads/pcb.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [dependencies]
 "gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"

--- a/crates/pcb-layout/tests/resources/netclass_assignment/pcb.toml
+++ b/crates/pcb-layout/tests/resources/netclass_assignment/pcb.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [dependencies]
 "gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"

--- a/crates/pcb-layout/tests/resources/not_connected/pcb.toml
+++ b/crates/pcb-layout/tests/resources/not_connected/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/not_connected_single_pin_multi_pad/pcb.toml
+++ b/crates/pcb-layout/tests/resources/not_connected_single_pin_multi_pad/pcb.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [dependencies]
 "gitlab.com/kicad/libraries/kicad-footprints" = "9.0.3"

--- a/crates/pcb-layout/tests/resources/simple/pcb.toml
+++ b/crates/pcb-layout/tests/resources/simple/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/tracks/pcb.toml
+++ b/crates/pcb-layout/tests/resources/tracks/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-layout/tests/resources/zones/pcb.toml
+++ b/crates/pcb-layout/tests/resources/zones/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -4,7 +4,7 @@ use pcb_eda::kicad::symbol_library::KicadSymbolLibrary;
 use pcb_ui::{Colorize, Spinner, Style, StyledText};
 use pcb_zen_core::config::{
     DependencyDetail, DependencySpec, LockEntry, Lockfile, ManifestPart, PatchSpec, PcbToml,
-    pcb_version_from_cargo, pcb_version_is_older, split_repo_and_subpath,
+    split_repo_and_subpath,
 };
 use pcb_zen_core::kicad_library::{
     KICAD_PARTS_INDEX_FILE, KicadRepoMatch, kicad_http_mirror_template_for_repo,
@@ -235,33 +235,6 @@ fn run_auto_deps(workspace_info: &mut WorkspaceInfo) -> Result<()> {
     Ok(())
 }
 
-fn sync_root_workspace_pcb_version(workspace_info: &mut WorkspaceInfo) -> Result<()> {
-    let Some(config) = workspace_info.config.as_mut() else {
-        return Ok(());
-    };
-    let Some(workspace) = config.workspace.as_mut() else {
-        return Ok(());
-    };
-    let Some(existing) = workspace.pcb_version.as_deref() else {
-        return Ok(());
-    };
-
-    let current = pcb_version_from_cargo();
-    if pcb_version_is_older(existing, &current) != Some(true) {
-        return Ok(());
-    }
-
-    workspace.pcb_version = Some(current);
-    let pcb_toml_path = workspace_info.root.join("pcb.toml");
-    fs::write(&pcb_toml_path, toml::to_string_pretty(&config)?)?;
-    eprintln!(
-        "{} synced workspace pcb-version in {}",
-        "updated:".with_style(Style::Green),
-        pcb_toml_path.display().to_string().bold()
-    );
-    Ok(())
-}
-
 fn is_branch_only_dep(detail: &DependencyDetail) -> bool {
     detail.branch.is_some()
         && detail.rev.is_none()
@@ -475,7 +448,6 @@ pub fn resolve_dependencies(
     // Skip for standalone mode (no pcb.toml to modify)
     // Skip for locked/offline modes (trust the lockfile)
     if !is_standalone && !locked && !offline {
-        sync_root_workspace_pcb_version(workspace_info)?;
         run_auto_deps(workspace_info)?;
     }
 

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -112,7 +112,11 @@ fn run() -> Result<()> {
     }
 
     let override_request = take_cli_override(&mut args)?;
-    let selection = select_toolchain(override_request, is_help_request(&args))?;
+    let selection = select_toolchain(
+        override_request,
+        is_migrate_command(&args),
+        is_help_request(&args),
+    )?;
     exec_toolchain(&selection.binary, &args)
 }
 
@@ -127,6 +131,13 @@ fn is_shim_command(args: &[OsString]) -> bool {
     matches!(
         args.first().and_then(|arg| arg.to_str()),
         Some("self" | "toolchain")
+    )
+}
+
+fn is_migrate_command(args: &[OsString]) -> bool {
+    matches!(
+        args.first().and_then(|arg| arg.to_str()),
+        Some("migrate" | "m")
     )
 }
 
@@ -222,10 +233,16 @@ fn parse_request(raw: &str) -> Result<ToolchainRequest> {
 
 fn select_toolchain(
     override_request: Option<ToolchainRequest>,
+    migrate_command: bool,
     prefer_local: bool,
 ) -> Result<ResolvedToolchain> {
     let (request, reason) = if let Some(request) = override_request {
         (request, "command-line override".to_string())
+    } else if migrate_command {
+        (
+            ToolchainRequest::Latest,
+            "migrate uses the latest stable pcbc".to_string(),
+        )
     } else if let Some((path, lane)) = find_workspace_pcb_version()? {
         (
             parse_request(&lane)?,
@@ -860,7 +877,7 @@ fn toolchain_list() -> Result<()> {
 
 fn toolchain_show() -> Result<()> {
     println!("shim: {}", env!("CARGO_PKG_VERSION"));
-    let selection = select_toolchain(None, false)?;
+    let selection = select_toolchain(None, false, false)?;
     println!("active: {}", selection.label);
     println!("reason: {}", selection.reason);
     println!("binary: {}", selection.binary.display());
@@ -1178,6 +1195,17 @@ fn isoish_timestamp() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn args(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn migrate_command_uses_latest_stable_toolchain() {
+        assert!(is_migrate_command(&args(&["migrate"])));
+        assert!(is_migrate_command(&args(&["m", "--dry-run"])));
+        assert!(!is_migrate_command(&args(&["build"])));
+    }
 
     #[test]
     fn release_listing_parser_extracts_only_version_prefixes() {

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -135,10 +135,21 @@ fn is_shim_command(args: &[OsString]) -> bool {
 }
 
 fn is_migrate_command(args: &[OsString]) -> bool {
-    matches!(
-        args.first().and_then(|arg| arg.to_str()),
-        Some("migrate" | "m")
-    )
+    matches!(first_command_arg(args), Some("migrate" | "m"))
+}
+
+fn first_command_arg(args: &[OsString]) -> Option<&str> {
+    let mut index = 0;
+    while index < args.len() {
+        let arg = args[index].to_str()?;
+        match arg {
+            "-d" | "--debug" => index += 1,
+            "--profile" => index += 2,
+            _ if arg.starts_with("--profile=") => index += 1,
+            _ => return Some(arg),
+        }
+    }
+    None
 }
 
 fn parse_shim_command(args: &[OsString]) -> Result<ShimCommand> {
@@ -1204,6 +1215,17 @@ mod tests {
     fn migrate_command_uses_latest_stable_toolchain() {
         assert!(is_migrate_command(&args(&["migrate"])));
         assert!(is_migrate_command(&args(&["m", "--dry-run"])));
+        assert!(is_migrate_command(&args(&["-d", "migrate"])));
+        assert!(is_migrate_command(&args(&["--debug", "migrate"])));
+        assert!(is_migrate_command(&args(&[
+            "--profile",
+            "profile.json",
+            "migrate"
+        ])));
+        assert!(is_migrate_command(&args(&[
+            "--profile=profile.json",
+            "migrate"
+        ])));
         assert!(!is_migrate_command(&args(&["build"])));
     }
 

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -247,32 +247,53 @@ fn select_toolchain(
     migrate_command: bool,
     prefer_local: bool,
 ) -> Result<ResolvedToolchain> {
-    let (request, reason) = if let Some(request) = override_request {
-        (request, "command-line override".to_string())
-    } else if migrate_command {
+    let (request, reason, allow_latest_fallback) = if let Some(request) = override_request {
+        let allow_latest_fallback =
+            should_allow_latest_fallback(&request, migrate_command, prefer_local);
         (
-            ToolchainRequest::Latest,
+            request,
+            "command-line override".to_string(),
+            allow_latest_fallback,
+        )
+    } else if migrate_command {
+        let request = ToolchainRequest::Latest;
+        let allow_latest_fallback =
+            should_allow_latest_fallback(&request, migrate_command, prefer_local);
+        (
+            request,
             "migrate uses the latest stable pcbc".to_string(),
+            allow_latest_fallback,
         )
     } else if let Some((path, lane)) = find_workspace_pcb_version()? {
         (
             parse_request(&lane)?,
             format!("{} requires {lane}", path.display()),
+            true,
         )
     } else {
         (
             ToolchainRequest::Latest,
             "no pcb.toml found; using latest".to_string(),
+            true,
         )
     };
 
-    resolve_request(&request, reason, prefer_local)
+    resolve_request(&request, reason, prefer_local, allow_latest_fallback)
+}
+
+fn should_allow_latest_fallback(
+    request: &ToolchainRequest,
+    migrate_command: bool,
+    prefer_local: bool,
+) -> bool {
+    !matches!(request, ToolchainRequest::Latest) || !migrate_command || prefer_local
 }
 
 fn resolve_request(
     request: &ToolchainRequest,
     reason: String,
     prefer_local: bool,
+    allow_latest_fallback: bool,
 ) -> Result<ResolvedToolchain> {
     if matches!(request, ToolchainRequest::Nightly) {
         return resolve_nightly(reason);
@@ -299,7 +320,7 @@ fn resolve_request(
                 });
             }
             Err(remote_error) => {
-                if let Some(local) = best_local_toolchain(request)? {
+                if allow_latest_fallback && let Some(local) = best_local_toolchain(request)? {
                     eprintln!(
                         "Warning: failed to check latest release ({remote_error}); using installed pcbc {}",
                         local.0
@@ -1227,6 +1248,30 @@ mod tests {
             "migrate"
         ])));
         assert!(!is_migrate_command(&args(&["build"])));
+    }
+
+    #[test]
+    fn migrate_latest_does_not_fallback_to_installed_toolchain() {
+        assert!(!should_allow_latest_fallback(
+            &ToolchainRequest::Latest,
+            true,
+            false
+        ));
+        assert!(should_allow_latest_fallback(
+            &ToolchainRequest::Latest,
+            true,
+            true
+        ));
+        assert!(should_allow_latest_fallback(
+            &ToolchainRequest::Latest,
+            false,
+            false
+        ));
+        assert!(should_allow_latest_fallback(
+            &ToolchainRequest::Lane { major: 0, minor: 4 },
+            true,
+            false
+        ));
     }
 
     #[test]

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -52,6 +52,7 @@ comfy-table = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 walkdir = { workspace = true }
 tar = { workspace = true }
 zip = { workspace = true }

--- a/crates/pcbc/src/migrate/mod.rs
+++ b/crates/pcbc/src/migrate/mod.rs
@@ -102,11 +102,7 @@ fn migrate_workspace(root: &Path) -> Result<()> {
     let from_lane = existing.and_then(parse_pcb_version);
     run_versioned_migrations(root, from_lane, target_lane)?;
 
-    let updated = set_workspace_pcb_version(&original, &target, existing.is_none())
-        .with_context(|| format!("Failed to update {}", pcb_toml_path.display()))?;
-    PcbToml::parse_with_path(&updated, &pcb_toml_path)?;
-    fs::write(&pcb_toml_path, updated)
-        .with_context(|| format!("Failed to write {}", pcb_toml_path.display()))?;
+    write_workspace_pcb_version(&pcb_toml_path, &target)?;
 
     if let Some(previous) = existing {
         println!(
@@ -122,6 +118,24 @@ fn migrate_workspace(root: &Path) -> Result<()> {
             target
         );
     }
+    Ok(())
+}
+
+fn write_workspace_pcb_version(pcb_toml_path: &Path, target: &str) -> Result<()> {
+    let content = fs::read_to_string(pcb_toml_path)
+        .with_context(|| format!("Failed to read {}", pcb_toml_path.display()))?;
+    let config = PcbToml::parse_with_path(&content, pcb_toml_path)?;
+    let workspace = config.workspace.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Migration target is not a workspace manifest: {}",
+            pcb_toml_path.display()
+        )
+    })?;
+    let updated = set_workspace_pcb_version(&content, target, workspace.pcb_version.is_none())
+        .with_context(|| format!("Failed to update {}", pcb_toml_path.display()))?;
+    PcbToml::parse_with_path(&updated, pcb_toml_path)?;
+    fs::write(pcb_toml_path, updated)
+        .with_context(|| format!("Failed to write {}", pcb_toml_path.display()))?;
     Ok(())
 }
 
@@ -218,5 +232,23 @@ pcb-version = "not this"
             output,
             "[workspace]\nname = \"demo\"\npcb-version = \"0.4\"\n"
         );
+    }
+
+    #[test]
+    fn writes_workspace_pcb_version_from_current_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pcb.toml");
+        fs::write(&path, "[workspace]\npcb-version = \"0.3\"\n").unwrap();
+
+        fs::write(
+            &path,
+            "[workspace]\npcb-version = \"0.3\"\nname = \"from-migration\"\n",
+        )
+        .unwrap();
+        write_workspace_pcb_version(&path, "0.4").unwrap();
+
+        let output = fs::read_to_string(path).unwrap();
+        assert!(output.contains("name = \"from-migration\""));
+        assert!(output.contains("pcb-version = \"0.4\""));
     }
 }

--- a/crates/pcbc/src/migrate/mod.rs
+++ b/crates/pcbc/src/migrate/mod.rs
@@ -1,6 +1,23 @@
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use clap::Args;
-use std::path::PathBuf;
+use pcb_zen_core::DefaultFileProvider;
+use pcb_zen_core::config::{
+    PcbToml, find_workspace_root, parse_pcb_version, pcb_version_from_cargo, pcb_version_is_older,
+};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml_edit::{DocumentMut, Item, value};
+
+type PcbLane = (u32, u32);
+
+struct Migration {
+    target: PcbLane,
+    apply: fn(&Path) -> Result<()>,
+}
+
+// Add migrations by target lane; the manifest version is bumped only after all apply.
+const MIGRATIONS: &[Migration] = &[];
 
 /// Arguments for the `migrate` command
 #[derive(Args, Debug, Default, Clone)]
@@ -12,7 +29,194 @@ pub struct MigrateArgs {
 }
 
 /// Execute the `migrate` command
-pub fn execute(_args: MigrateArgs) -> Result<()> {
-    eprintln!("No migrations are currently available for this release.");
+pub fn execute(args: MigrateArgs) -> Result<()> {
+    let roots = migration_roots(args.paths)?;
+    for root in roots {
+        migrate_workspace(&root)?;
+    }
     Ok(())
+}
+
+fn migration_roots(paths: Vec<PathBuf>) -> Result<BTreeSet<PathBuf>> {
+    let file_provider = DefaultFileProvider::new();
+    let starts = if paths.is_empty() {
+        vec![std::env::current_dir()?]
+    } else {
+        paths
+    };
+
+    let mut roots = BTreeSet::new();
+    for path in starts {
+        let root = find_workspace_root(&file_provider, &path)
+            .with_context(|| format!("Failed to find workspace for {}", path.display()))?;
+        let pcb_toml_path = root.join("pcb.toml");
+        if !pcb_toml_path.is_file() {
+            bail!(
+                "No pcb.toml found for migration target {}\n  Start from a workspace or pass a path inside one.",
+                path.display()
+            );
+        }
+        roots.insert(root);
+    }
+    Ok(roots)
+}
+
+fn migrate_workspace(root: &Path) -> Result<()> {
+    let pcb_toml_path = root.join("pcb.toml");
+    let original = fs::read_to_string(&pcb_toml_path)
+        .with_context(|| format!("Failed to read {}", pcb_toml_path.display()))?;
+    let config = PcbToml::parse_with_path(&original, &pcb_toml_path)?;
+    let workspace = config.workspace.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Migration target is not a workspace manifest: {}",
+            pcb_toml_path.display()
+        )
+    })?;
+
+    let target = pcb_version_from_cargo();
+    let target_lane = parse_pcb_version(&target).expect("running pcb version must be major.minor");
+    let existing = workspace.pcb_version.as_deref();
+
+    if let Some(required) = existing
+        && pcb_version_is_older(&target, required) == Some(true)
+    {
+        bail!(
+            "Workspace requires pcb-version = \"{}\" but the current pcbc is {}\n  \
+             Run `pcb migrate` without a +toolchain override, or install a newer toolchain.\n  \
+             Manifest: {}",
+            required,
+            target,
+            pcb_toml_path.display()
+        );
+    }
+
+    if existing == Some(target.as_str()) {
+        println!(
+            "pcb: {} already uses pcb-version = \"{}\"",
+            pcb_toml_path.display(),
+            target
+        );
+        return Ok(());
+    }
+
+    let from_lane = existing.and_then(parse_pcb_version);
+    run_versioned_migrations(root, from_lane, target_lane)?;
+
+    let updated = set_workspace_pcb_version(&original, &target, existing.is_none())
+        .with_context(|| format!("Failed to update {}", pcb_toml_path.display()))?;
+    PcbToml::parse_with_path(&updated, &pcb_toml_path)?;
+    fs::write(&pcb_toml_path, updated)
+        .with_context(|| format!("Failed to write {}", pcb_toml_path.display()))?;
+
+    if let Some(previous) = existing {
+        println!(
+            "pcb: migrated {} from pcb-version = \"{}\" to \"{}\"",
+            pcb_toml_path.display(),
+            previous,
+            target
+        );
+    } else {
+        println!(
+            "pcb: set {} pcb-version = \"{}\"",
+            pcb_toml_path.display(),
+            target
+        );
+    }
+    Ok(())
+}
+
+fn run_versioned_migrations(root: &Path, from: Option<PcbLane>, to: PcbLane) -> Result<()> {
+    for migration in MIGRATIONS {
+        if from.is_none_or(|from| from < migration.target) && migration.target <= to {
+            (migration.apply)(root).with_context(|| {
+                format!(
+                    "Failed to apply migration for pcb-version {}",
+                    format_lane(migration.target)
+                )
+            })?;
+            println!(
+                "pcb: applied migration for pcb-version {}",
+                format_lane(migration.target)
+            );
+        }
+    }
+    Ok(())
+}
+
+fn format_lane((major, minor): PcbLane) -> String {
+    format!("{major}.{minor}")
+}
+
+fn set_workspace_pcb_version(
+    content: &str,
+    version: &str,
+    insert_if_missing: bool,
+) -> Result<String> {
+    let mut document = content
+        .parse::<DocumentMut>()
+        .context("Failed to parse manifest for editing")?;
+    let workspace = document
+        .get_mut("workspace")
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| anyhow::anyhow!("Could not locate a [workspace] table"))?;
+
+    match workspace.get_mut("pcb-version") {
+        Some(item) => replace_string_value(item, version)?,
+        None if insert_if_missing => {
+            workspace.insert("pcb-version", value(version));
+        }
+        None => bail!("Could not locate the existing [workspace].pcb-version assignment"),
+    }
+
+    Ok(document.to_string())
+}
+
+fn replace_string_value(item: &mut Item, version: &str) -> Result<()> {
+    let original = item
+        .as_value()
+        .filter(|value| value.as_str().is_some())
+        .ok_or_else(|| anyhow::anyhow!("existing [workspace].pcb-version is not a string"))?;
+    let decor = original.decor().clone();
+
+    let mut replacement = value(version);
+    if let Some(value) = replacement.as_value_mut() {
+        *value.decor_mut() = decor;
+    }
+    *item = replacement;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_workspace_pcb_version_without_reformatting_manifest() {
+        let input = r#"# keep
+[workspace] # root
+name = "demo"
+pcb-version = "0.3" # old lane
+
+[dependencies]
+pcb-version = "not this"
+"#;
+
+        let output = set_workspace_pcb_version(input, "0.4", false).unwrap();
+
+        assert!(output.contains("# keep\n[workspace] # root\nname = \"demo\"\n"));
+        assert!(output.contains("pcb-version = \"0.4\" # old lane"));
+        assert!(output.contains("[dependencies]\npcb-version = \"not this\""));
+    }
+
+    #[test]
+    fn inserts_missing_workspace_pcb_version() {
+        let input = "[workspace]\nname = \"demo\"\n";
+
+        let output = set_workspace_pcb_version(input, "0.4", true).unwrap();
+
+        assert_eq!(
+            output,
+            "[workspace]\nname = \"demo\"\npcb-version = \"0.4\"\n"
+        );
+    }
 }

--- a/crates/pcbc/tests/migrate.rs
+++ b/crates/pcbc/tests/migrate.rs
@@ -1,0 +1,57 @@
+use pcb_test_utils::sandbox::Sandbox;
+use pcb_zen_core::config::pcb_version_from_cargo;
+use std::fs;
+
+#[test]
+fn migrate_bumps_workspace_pcb_version_to_current_lane() {
+    let target = pcb_version_from_cargo();
+    let previous = if target == "0.3" { "0.2" } else { "0.3" };
+    let mut sandbox = Sandbox::new();
+    sandbox.write(
+        "pcb.toml",
+        format!(
+            r#"# workspace comment
+[workspace]
+name = "demo"
+pcb-version = "{previous}" # old lane
+
+[dependencies]
+"#
+        ),
+    );
+
+    run_migrate(&mut sandbox);
+
+    let content = fs::read_to_string(sandbox.root_path().join("pcb.toml")).unwrap();
+    assert!(content.contains("# workspace comment"));
+    assert!(content.contains(&format!("pcb-version = \"{target}\" # old lane")));
+}
+
+#[test]
+fn migrate_leaves_current_workspace_manifest_unchanged() {
+    let target = pcb_version_from_cargo();
+    let original = format!("[workspace]\npcb-version = \"{target}\"\nname = \"demo\"\n");
+    let mut sandbox = Sandbox::new();
+    sandbox.write("pcb.toml", &original);
+
+    run_migrate(&mut sandbox);
+
+    let content = fs::read_to_string(sandbox.root_path().join("pcb.toml")).unwrap();
+    assert_eq!(content, original);
+}
+
+fn run_migrate(sandbox: &mut Sandbox) {
+    let output = sandbox
+        .run("pcbc", ["migrate"])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "pcbc migrate failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -466,8 +466,10 @@ code. For production builds, prefer tagged releases.
 
 ### pcb migrate
 
-Runs project migrations supplied by the active toolchain. When no migrations are
-available, the command prints that nothing needs to run.
+Runs project migrations using the latest stable `pcbc` toolchain, regardless of
+the workspace's current `pcb-version` lane. After all migrations succeed, the
+command updates `[workspace].pcb-version` in `pcb.toml` to the target toolchain
+lane.
 
 ```bash
 pcb migrate

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -117,7 +117,7 @@ description = "Replace with concise board description."
 
 - `name`: Optional Diode workspace name override for board release uploads. When omitted, publish uses the first path segment of `repository`, such as `myorg` from `github.com/myorg/MainBoard`.
 - `repository`: Git remote URL (used to derive package URLs for publishing)
-- `pcb-version`: Required `pcbc` toolchain lane, such as `"0.3"`, `"0.4"`, or `"nightly"`. For semver lanes, `pcb` selects the newest installed patch in that lane and installs one if needed. It never auto-upgrades across lanes; change this field intentionally after applying the release notes.
+- `pcb-version`: Required `pcbc` toolchain lane, such as `"0.3"`, `"0.4"`, or `"nightly"`. For semver lanes, `pcb` selects the newest installed patch in that lane and installs one if needed. Ordinary commands never auto-upgrade across lanes; use `pcb migrate` to run the latest stable toolchain migrations and update this field after they succeed.
 - `endpoint`: Optional Diode host suffix used for workspace-scoped app/API URLs. `"diode.computer"` resolves to `app.diode.computer` and `api.diode.computer`.
 - `[board]`: Defines the repository's buildable board with `name`, entry `path`, and a short `description`
 

--- a/examples/pcb.toml
+++ b/examples/pcb.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "pcb"
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [dependencies.indirect]
 "gitlab.com/kicad/libraries/kicad-footprints@10" = "10.0.3"

--- a/lib/pcb.toml
+++ b/lib/pcb.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "lib"
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [dependencies.indirect]
 "gitlab.com/kicad/libraries/kicad-footprints@10" = "10.0.3"

--- a/test-workspaces/bench/pcb.toml
+++ b/test-workspaces/bench/pcb.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [dependencies]
 "github.com/diodeinc/registry/reference/BMI270x" = "0.6.2"

--- a/test-workspaces/with-pcb-toml/pcb.toml
+++ b/test-workspaces/with-pcb-toml/pcb.toml
@@ -1,3 +1,3 @@
 [workspace]
 name = "zener"
-pcb-version = "0.3"
+pcb-version = "0.4"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how users cross toolchain lanes (migrate vs implicit sync) and edits root `pcb.toml`; migrate toolchain selection is stricter when release checks fail.
> 
> **Overview**
> Introduces a real **`pcb migrate`** flow on the **0.4** toolchain: the shim routes **`migrate`** to the **latest stable `pcbc`** and, on that failure, **does not** fall back to an older installed toolchain (unlike normal commands).
> 
> **`pcbc migrate`** resolves workspace roots, runs registered lane migrations (the `MIGRATIONS` table is empty for now), then sets **`[workspace].pcb-version`** in `pcb.toml` via **`toml_edit`** so comments and layout stay intact. It errors if the workspace requires a newer lane than the running binary.
> 
> **Dependency resolve** no longer auto-syncs `pcb-version` during auto-deps; lane upgrades are **explicit** through migrate. Docs and changelogs describe migrate as the supported cross-lane upgrade path. Workspace manifests and crate versions move to **0.4.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5606f811fee14f68948fce31af624f000469b45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->