### PR TITLE
Publish stdlib source archives in pcbc releases

### DIFF
--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -61,6 +61,25 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "base_url=$base_url" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare stdlib source archive
+        if: steps.nightly.outputs.should_build == 'true'
+        run: |
+          set -euo pipefail
+          if ! command -v zstd >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y zstd
+          fi
+          mkdir -p artifacts
+          git archive --format=tar HEAD:lib/std | zstd -q -3 -c > artifacts/stdlib.tar.zst
+          sha256sum artifacts/stdlib.tar.zst > artifacts/stdlib.tar.zst.sha256
+
+      - name: Upload stdlib source archive
+        if: steps.nightly.outputs.should_build == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pcbc-nightly-stdlib
+          path: artifacts/stdlib.tar.zst*
+
   build:
     needs: prepare
     if: needs.prepare.outputs.should_build == 'true'

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -64,6 +64,23 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare stdlib source archive
+        run: |
+          set -euo pipefail
+          if ! command -v zstd >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y zstd
+          fi
+          mkdir -p artifacts
+          git archive --format=tar HEAD:lib/std | zstd -q -3 -c > artifacts/stdlib.tar.zst
+          sha256sum artifacts/stdlib.tar.zst > artifacts/stdlib.tar.zst.sha256
+
+      - name: Upload stdlib source archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: pcbc-stdlib
+          path: artifacts/stdlib.tar.zst*
+
   build:
     needs: prepare
     name: build pcbc (${{ matrix.target }})
@@ -156,10 +173,6 @@ jobs:
       - build
     runs-on: ubicloud-standard-16
     steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
-
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
@@ -184,6 +197,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           prerelease_flag=""
           if [ "${{ needs.prepare.outputs.prerelease }}" = "true" ]; then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions release packaging; no runtime, auth, or application code is modified.
> 
> **Overview**
> **pcbc** nightly and release pipelines now ship a **stdlib source bundle** alongside compiler binaries.
> 
> In both `pcbc-nightly.yml` and `pcbc-release.yml`, the **prepare** job archives `lib/std` with `git archive`, compresses it to `stdlib.tar.zst`, writes a SHA256 sidecar, and uploads it as a workflow artifact (`pcbc-nightly-stdlib` / `pcbc-stdlib`). The existing **publish** steps already download all `pcbc-*` artifacts and sync to S3 / attach to GitHub releases, so the stdlib archive is included without further publish logic.
> 
> The release workflow’s **publish** job drops the redundant `actions/checkout` step (artifacts come from download only) and sets `GH_REPO` for `gh release create`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7dc9f6b3175f18d03433faf651573263362b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->