### PR TITLE
Install stdlib with managed pcbc toolchains

### DIFF
--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -190,6 +190,11 @@ jobs:
       - name: Upload artifacts to S3
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
         run: |
+          # Upload the stdlib first: the shim discovers a release as soon as any
+          # object exists under its prefix and requires stdlib.tar.zst to install.
+          aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/${{ needs.prepare.outputs.tag }}/" \
+            --exclude "*" --include "stdlib.tar.zst*" \
+            --cache-control "public, max-age=31536000, immutable"
           aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/${{ needs.prepare.outputs.tag }}/" \
             --cache-control "public, max-age=31536000, immutable"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4640,6 +4640,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tar",
  "tempfile",
  "toml",
  "ureq",

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -27,6 +27,7 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+tar = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
 ureq = { workspace = true }

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -548,7 +548,7 @@ fn read_workspace_pcb_version(path: &Path) -> Result<Option<String>> {
 fn ensure_installed(version: &Version) -> Result<PathBuf> {
     ensure_supported_target()?;
 
-    let binary = installed_dir(version).join(pcbc_binary_name());
+    let binary = installed_binary_path(version);
     if binary.is_file() {
         return Ok(binary);
     }
@@ -613,10 +613,11 @@ fn install_nightly(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)
         &bytes,
     )?;
 
-    let toolchain_root = toolchains_dir().join("nightly");
-    let staging_root = toolchains_dir().join("nightly.tmp");
-    remove_path(&staging_root)?;
-    let staging_dir = staging_root.join(target_triple());
+    let install_dir = nightly_dir();
+    let staging_dir = install_dir.with_extension("tmp");
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir)?;
+    }
     fs::create_dir_all(&staging_dir)?;
     let binary = staging_dir.join(pcbc_binary_name());
     fs::write(&binary, bytes)?;
@@ -635,15 +636,17 @@ fn install_nightly(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)
         staging_dir.join("receipt.json"),
         serde_json::to_vec_pretty(&receipt)?,
     )?;
-    stage_stdlib_archive(
-        &release.base_url,
-        &staging_root,
-        &format!("stdlib-nightly-{}.tar.zst", release.sha),
-    )?;
+    stage_stdlib_archive(&release.base_url, &staging_dir)?;
 
-    replace_toolchain_root(&staging_root, &toolchain_root)?;
+    if install_dir.exists() {
+        fs::remove_dir_all(&install_dir)?;
+    }
+    if let Some(parent) = install_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::rename(&staging_dir, &install_dir)?;
 
-    Ok((receipt, nightly_dir().join(pcbc_binary_name())))
+    Ok((receipt, install_dir.join(pcbc_binary_name())))
 }
 
 fn installed_nightly_toolchain() -> Result<Option<(NightlyReceipt, PathBuf)>> {
@@ -685,10 +688,11 @@ fn install_toolchain(version: &Version) -> Result<PathBuf> {
             find_extracted_binary(&extract_dir)?
         }
     };
-    let toolchain_root = toolchains_dir().join(version.to_string());
-    let staging_root = toolchains_dir().join(format!("{version}.tmp"));
-    remove_path(&staging_root)?;
-    let staging_dir = staging_root.join(target_triple());
+    let install_dir = installed_dir(version);
+    let staging_dir = install_dir.with_extension("tmp");
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir)?;
+    }
     fs::create_dir_all(&staging_dir)?;
     let dst_binary = staging_dir.join(pcbc_binary_name());
     fs::copy(&src_binary, &dst_binary)?;
@@ -705,89 +709,35 @@ fn install_toolchain(version: &Version) -> Result<PathBuf> {
         staging_dir.join("receipt.json"),
         serde_json::to_vec_pretty(&receipt)?,
     )?;
-    stage_stdlib_archive(
-        &format!("{RELEASE_BASE_URL}/v{version}"),
-        &staging_root,
-        &format!("stdlib-v{version}.tar.zst"),
-    )?;
+    stage_stdlib_archive(&format!("{RELEASE_BASE_URL}/v{version}"), &staging_dir)?;
 
-    replace_toolchain_root(&staging_root, &toolchain_root)?;
+    if install_dir.exists() {
+        fs::remove_dir_all(&install_dir)?;
+    }
+    if let Some(parent) = install_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::rename(&staging_dir, &install_dir)?;
 
-    Ok(installed_dir(version).join(pcbc_binary_name()))
+    Ok(install_dir.join(pcbc_binary_name()))
 }
 
-fn stage_stdlib_archive(base_url: &str, staging_root: &Path, cache_name: &str) -> Result<()> {
+fn stage_stdlib_archive(base_url: &str, staging_dir: &Path) -> Result<()> {
     let url = format!("{}/{}", base_url.trim_end_matches('/'), STDLIB_ARCHIVE_NAME);
-    let Some(bytes) = download_optional(&http_client(ARCHIVE_TIMEOUT)?, &url)? else {
-        return Ok(());
-    };
+    let bytes = download_optional(&http_client(ARCHIVE_TIMEOUT)?, &url)?
+        .ok_or_else(|| anyhow::anyhow!("not found: {url}"))?;
     verify_checksum(&url, &bytes)?;
 
-    fs::create_dir_all(downloads_dir())?;
-    fs::write(downloads_dir().join(cache_name), &bytes)?;
-
     let unpacked = decompress_zstd(&url, bytes)?;
-    let stdlib_dir = staging_root.join("lib").join("std");
+    let stdlib_dir = staging_dir.join("lib").join("std");
     fs::create_dir_all(&stdlib_dir)?;
-
     tar::Archive::new(Cursor::new(unpacked))
         .unpack(&stdlib_dir)
         .with_context(|| format!("failed to extract stdlib archive {url}"))?;
-    validate_stdlib_archive(&stdlib_dir, &url)?;
-    Ok(())
-}
-
-fn validate_stdlib_archive(stdlib_dir: &Path, url: &str) -> Result<()> {
     anyhow::ensure!(
         stdlib_dir.join("interfaces.zen").is_file(),
         "stdlib archive {url} did not contain interfaces.zen at the archive root"
     );
-    anyhow::ensure!(
-        stdlib_dir.join("generics").is_dir(),
-        "stdlib archive {url} did not contain generics/ at the archive root"
-    );
-    Ok(())
-}
-
-fn replace_toolchain_root(staging_root: &Path, toolchain_root: &Path) -> Result<()> {
-    let backup_root = toolchain_root.with_file_name(format!(
-        "{}.old",
-        toolchain_root
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("toolchain")
-    ));
-
-    remove_path(&backup_root)?;
-    if let Some(parent) = toolchain_root.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    if toolchain_root.exists() {
-        fs::rename(toolchain_root, &backup_root)?;
-    }
-
-    if let Err(err) = fs::rename(staging_root, toolchain_root) {
-        if backup_root.exists() {
-            let _ = fs::rename(&backup_root, toolchain_root);
-        }
-        return Err(err).with_context(|| {
-            format!(
-                "failed to install toolchain at {}",
-                toolchain_root.display()
-            )
-        });
-    }
-
-    remove_path(&backup_root)?;
-    Ok(())
-}
-
-fn remove_path(path: &Path) -> Result<()> {
-    if path.is_dir() {
-        fs::remove_dir_all(path)?;
-    } else if path.exists() {
-        fs::remove_file(path)?;
-    }
     Ok(())
 }
 
@@ -1206,6 +1156,10 @@ fn pcbc_version(binary: &Path) -> Option<Version> {
     let stdout = String::from_utf8(output.stdout).ok()?;
     let version = stdout.split_whitespace().last()?;
     Version::parse(version).ok()
+}
+
+fn installed_binary_path(version: &Version) -> PathBuf {
+    installed_dir(version).join(pcbc_binary_name())
 }
 
 fn installed_dir(version: &Version) -> PathBuf {

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -15,6 +15,7 @@ const RELEASE_BASE_URL: &str = "https://pcb.api.diode.computer/pcb";
 const SHIM_LATEST_RELEASE_URL: &str = "https://pcb.api.diode.computer/pcb/pcb-latest.json";
 const NIGHTLY_LATEST_RELEASE_URL: &str = "https://pcb.api.diode.computer/pcb/nightly/latest.json";
 const USER_AGENT: &str = "pcb";
+const STDLIB_ARCHIVE_NAME: &str = "stdlib.tar.zst";
 const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 const ARCHIVE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const MAX_DOWNLOAD_BYTES: u64 = 512 * 1024 * 1024;
@@ -381,13 +382,55 @@ fn resolve_nightly(reason: String) -> Result<ResolvedToolchain> {
 fn best_local_toolchain(request: &ToolchainRequest) -> Result<Option<(Version, PathBuf)>> {
     let mut candidates = installed_toolchains()?;
 
+    let local_binary = toolchains_dir()
+        .join("local")
+        .join(target_triple())
+        .join(pcbc_binary_name());
+    if local_binary.is_file()
+        && let Some(version) = pcbc_version(&local_binary)
+    {
+        candidates.insert(version, local_binary);
+    }
+
     if let Some((version, binary)) = sibling_pcbc() {
         candidates.insert(version, binary);
     }
 
-    Ok(candidates
+    let selected = candidates
         .into_iter()
-        .rfind(|(version, _)| request_matches(request, version)))
+        .rfind(|(version, _)| request_matches(request, version));
+
+    if let Some((version, binary)) = &selected {
+        let toolchain_root = toolchains_dir().join(version.to_string());
+        if *binary
+            == toolchain_root
+                .join(target_triple())
+                .join(pcbc_binary_name())
+            && !toolchain_root.join("lib").join("std").is_dir()
+        {
+            let lock_path =
+                locks_dir().join(format!("install-{}-{}.lock", version, target_triple()));
+            if let Some(parent) = lock_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let mut lock = fslock::LockFile::open(&lock_path)?;
+            lock.lock()?;
+            let result = if toolchain_root.join("lib").join("std").is_dir() {
+                Ok(())
+            } else {
+                install_stdlib_archive(
+                    &format!("{RELEASE_BASE_URL}/v{version}"),
+                    &toolchain_root,
+                    &format!("stdlib-v{version}.tar.zst"),
+                    stdlib_archive_required(version),
+                )
+            };
+            lock.unlock()?;
+            result?;
+        }
+    }
+
+    Ok(selected)
 }
 
 fn installed_toolchains() -> Result<BTreeMap<Version, PathBuf>> {
@@ -537,8 +580,11 @@ fn read_workspace_pcb_version(path: &Path) -> Result<Option<String>> {
 fn ensure_installed(version: &Version) -> Result<PathBuf> {
     ensure_supported_target()?;
 
-    let binary = installed_binary_path(version);
-    if binary.is_file() {
+    let toolchain_root = toolchains_dir().join(version.to_string());
+    let binary = toolchain_root
+        .join(target_triple())
+        .join(pcbc_binary_name());
+    if binary.is_file() && toolchain_root.join("lib").join("std").is_dir() {
         return Ok(binary);
     }
 
@@ -549,6 +595,14 @@ fn ensure_installed(version: &Version) -> Result<PathBuf> {
     let mut lock = fslock::LockFile::open(&lock_path)?;
     lock.lock()?;
     let result = if binary.is_file() {
+        if !toolchain_root.join("lib").join("std").is_dir() {
+            install_stdlib_archive(
+                &format!("{RELEASE_BASE_URL}/v{version}"),
+                &toolchain_root,
+                &format!("stdlib-v{version}.tar.zst"),
+                stdlib_archive_required(version),
+            )?;
+        }
         Ok(binary)
     } else {
         install_toolchain(version)
@@ -560,8 +614,10 @@ fn ensure_installed(version: &Version) -> Result<PathBuf> {
 fn ensure_nightly_installed(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)> {
     ensure_supported_target()?;
 
+    let toolchain_root = toolchains_dir().join("nightly");
     if let Some((receipt, binary)) = installed_nightly_toolchain()?
         && receipt.sha == release.sha
+        && toolchain_root.join("lib").join("std").is_dir()
     {
         return Ok((receipt, binary));
     }
@@ -575,6 +631,14 @@ fn ensure_nightly_installed(release: &NightlyRelease) -> Result<(NightlyReceipt,
     let result = if let Some((receipt, binary)) = installed_nightly_toolchain()?
         && receipt.sha == release.sha
     {
+        if !toolchain_root.join("lib").join("std").is_dir() {
+            install_stdlib_archive(
+                &release.base_url,
+                &toolchain_root,
+                &format!("stdlib-nightly-{}.tar.zst", release.sha),
+                true,
+            )?;
+        }
         Ok((receipt, binary))
     } else {
         install_nightly(release)
@@ -633,6 +697,12 @@ fn install_nightly(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)
         fs::create_dir_all(parent)?;
     }
     fs::rename(&staging_dir, &install_dir)?;
+    install_stdlib_archive(
+        &release.base_url,
+        &toolchains_dir().join("nightly"),
+        &format!("stdlib-nightly-{}.tar.zst", release.sha),
+        true,
+    )?;
 
     Ok((receipt, install_dir.join(pcbc_binary_name())))
 }
@@ -705,8 +775,60 @@ fn install_toolchain(version: &Version) -> Result<PathBuf> {
         fs::create_dir_all(parent)?;
     }
     fs::rename(&staging_dir, &install_dir)?;
+    install_stdlib_archive(
+        &format!("{RELEASE_BASE_URL}/v{version}"),
+        &toolchains_dir().join(version.to_string()),
+        &format!("stdlib-v{version}.tar.zst"),
+        stdlib_archive_required(version),
+    )?;
 
     Ok(install_dir.join(pcbc_binary_name()))
+}
+
+fn stdlib_archive_required(version: &Version) -> bool {
+    version.major > 0 || version.minor >= 4
+}
+
+fn install_stdlib_archive(
+    base_url: &str,
+    toolchain_root: &Path,
+    cache_name: &str,
+    required: bool,
+) -> Result<()> {
+    let stdlib_dir = toolchain_root.join("lib").join("std");
+    let url = format!("{}/{}", base_url.trim_end_matches('/'), STDLIB_ARCHIVE_NAME);
+    let Some(bytes) = download_optional(&http_client(ARCHIVE_TIMEOUT)?, &url)? else {
+        anyhow::ensure!(!required, "not found: {url}");
+        return Ok(());
+    };
+    verify_checksum(&url, &bytes)?;
+
+    fs::create_dir_all(downloads_dir())?;
+    fs::write(downloads_dir().join(cache_name), &bytes)?;
+
+    let unpacked = decompress_zstd(&url, bytes)?;
+    let staging_dir = stdlib_dir.with_extension("tmp");
+    if staging_dir.is_dir() {
+        fs::remove_dir_all(&staging_dir)?;
+    } else if staging_dir.exists() {
+        fs::remove_file(&staging_dir)?;
+    }
+    fs::create_dir_all(&staging_dir)?;
+
+    tar::Archive::new(Cursor::new(unpacked))
+        .unpack(&staging_dir)
+        .with_context(|| format!("failed to extract stdlib archive {url}"))?;
+
+    if stdlib_dir.is_dir() {
+        fs::remove_dir_all(&stdlib_dir)?;
+    } else if stdlib_dir.exists() {
+        fs::remove_file(&stdlib_dir)?;
+    }
+    if let Some(parent) = stdlib_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::rename(&staging_dir, &stdlib_dir)?;
+    Ok(())
 }
 
 fn download_toolchain(version: &Version) -> Result<Download> {
@@ -888,7 +1010,13 @@ fn copy_executable_permissions(_src: &Path, _dst: &Path) -> Result<()> {
 fn toolchain_list() -> Result<()> {
     let installed = installed_toolchains()?;
     let nightly = installed_nightly_toolchain()?;
-    if installed.is_empty() && nightly.is_none() {
+    let local_binary = toolchains_dir()
+        .join("local")
+        .join(target_triple())
+        .join(pcbc_binary_name());
+    let local = local_binary.is_file();
+
+    if installed.is_empty() && nightly.is_none() && !local {
         println!("No pcbc toolchains installed.");
         return Ok(());
     }
@@ -903,6 +1031,9 @@ fn toolchain_list() -> Result<()> {
             short_sha(&receipt.sha),
             binary.display()
         );
+    }
+    if local {
+        println!("local\t{}", local_binary.display());
     }
     Ok(())
 }
@@ -1103,11 +1234,11 @@ fn sibling_pcbc() -> Option<(Version, PathBuf)> {
     if sibling == current || !sibling.is_file() {
         return None;
     }
-    let version = sibling_pcbc_version(&sibling)?;
+    let version = pcbc_version(&sibling)?;
     Some((version, sibling))
 }
 
-fn sibling_pcbc_version(binary: &Path) -> Option<Version> {
+fn pcbc_version(binary: &Path) -> Option<Version> {
     let output = Command::new(binary).arg("--version").output().ok()?;
     if !output.status.success() {
         return None;
@@ -1115,10 +1246,6 @@ fn sibling_pcbc_version(binary: &Path) -> Option<Version> {
     let stdout = String::from_utf8(output.stdout).ok()?;
     let version = stdout.split_whitespace().last()?;
     Version::parse(version).ok()
-}
-
-fn installed_binary_path(version: &Version) -> PathBuf {
-    installed_dir(version).join(pcbc_binary_name())
 }
 
 fn installed_dir(version: &Version) -> PathBuf {

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -396,41 +396,9 @@ fn best_local_toolchain(request: &ToolchainRequest) -> Result<Option<(Version, P
         candidates.insert(version, binary);
     }
 
-    let selected = candidates
+    Ok(candidates
         .into_iter()
-        .rfind(|(version, _)| request_matches(request, version));
-
-    if let Some((version, binary)) = &selected {
-        let toolchain_root = toolchains_dir().join(version.to_string());
-        if *binary
-            == toolchain_root
-                .join(target_triple())
-                .join(pcbc_binary_name())
-            && !toolchain_root.join("lib").join("std").is_dir()
-        {
-            let lock_path =
-                locks_dir().join(format!("install-{}-{}.lock", version, target_triple()));
-            if let Some(parent) = lock_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            let mut lock = fslock::LockFile::open(&lock_path)?;
-            lock.lock()?;
-            let result = if toolchain_root.join("lib").join("std").is_dir() {
-                Ok(())
-            } else {
-                install_stdlib_archive(
-                    &format!("{RELEASE_BASE_URL}/v{version}"),
-                    &toolchain_root,
-                    &format!("stdlib-v{version}.tar.zst"),
-                    stdlib_archive_required(version),
-                )
-            };
-            lock.unlock()?;
-            result?;
-        }
-    }
-
-    Ok(selected)
+        .rfind(|(version, _)| request_matches(request, version)))
 }
 
 fn installed_toolchains() -> Result<BTreeMap<Version, PathBuf>> {
@@ -580,11 +548,8 @@ fn read_workspace_pcb_version(path: &Path) -> Result<Option<String>> {
 fn ensure_installed(version: &Version) -> Result<PathBuf> {
     ensure_supported_target()?;
 
-    let toolchain_root = toolchains_dir().join(version.to_string());
-    let binary = toolchain_root
-        .join(target_triple())
-        .join(pcbc_binary_name());
-    if binary.is_file() && toolchain_root.join("lib").join("std").is_dir() {
+    let binary = installed_dir(version).join(pcbc_binary_name());
+    if binary.is_file() {
         return Ok(binary);
     }
 
@@ -595,14 +560,6 @@ fn ensure_installed(version: &Version) -> Result<PathBuf> {
     let mut lock = fslock::LockFile::open(&lock_path)?;
     lock.lock()?;
     let result = if binary.is_file() {
-        if !toolchain_root.join("lib").join("std").is_dir() {
-            install_stdlib_archive(
-                &format!("{RELEASE_BASE_URL}/v{version}"),
-                &toolchain_root,
-                &format!("stdlib-v{version}.tar.zst"),
-                stdlib_archive_required(version),
-            )?;
-        }
         Ok(binary)
     } else {
         install_toolchain(version)
@@ -614,10 +571,8 @@ fn ensure_installed(version: &Version) -> Result<PathBuf> {
 fn ensure_nightly_installed(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)> {
     ensure_supported_target()?;
 
-    let toolchain_root = toolchains_dir().join("nightly");
     if let Some((receipt, binary)) = installed_nightly_toolchain()?
         && receipt.sha == release.sha
-        && toolchain_root.join("lib").join("std").is_dir()
     {
         return Ok((receipt, binary));
     }
@@ -631,14 +586,6 @@ fn ensure_nightly_installed(release: &NightlyRelease) -> Result<(NightlyReceipt,
     let result = if let Some((receipt, binary)) = installed_nightly_toolchain()?
         && receipt.sha == release.sha
     {
-        if !toolchain_root.join("lib").join("std").is_dir() {
-            install_stdlib_archive(
-                &release.base_url,
-                &toolchain_root,
-                &format!("stdlib-nightly-{}.tar.zst", release.sha),
-                true,
-            )?;
-        }
         Ok((receipt, binary))
     } else {
         install_nightly(release)
@@ -666,11 +613,10 @@ fn install_nightly(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)
         &bytes,
     )?;
 
-    let install_dir = nightly_dir();
-    let staging_dir = install_dir.with_extension("tmp");
-    if staging_dir.exists() {
-        fs::remove_dir_all(&staging_dir)?;
-    }
+    let toolchain_root = toolchains_dir().join("nightly");
+    let staging_root = toolchains_dir().join("nightly.tmp");
+    remove_path(&staging_root)?;
+    let staging_dir = staging_root.join(target_triple());
     fs::create_dir_all(&staging_dir)?;
     let binary = staging_dir.join(pcbc_binary_name());
     fs::write(&binary, bytes)?;
@@ -689,22 +635,15 @@ fn install_nightly(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)
         staging_dir.join("receipt.json"),
         serde_json::to_vec_pretty(&receipt)?,
     )?;
-
-    if install_dir.exists() {
-        fs::remove_dir_all(&install_dir)?;
-    }
-    if let Some(parent) = install_dir.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    fs::rename(&staging_dir, &install_dir)?;
-    install_stdlib_archive(
+    stage_stdlib_archive(
         &release.base_url,
-        &toolchains_dir().join("nightly"),
+        &staging_root,
         &format!("stdlib-nightly-{}.tar.zst", release.sha),
-        true,
     )?;
 
-    Ok((receipt, install_dir.join(pcbc_binary_name())))
+    replace_toolchain_root(&staging_root, &toolchain_root)?;
+
+    Ok((receipt, nightly_dir().join(pcbc_binary_name())))
 }
 
 fn installed_nightly_toolchain() -> Result<Option<(NightlyReceipt, PathBuf)>> {
@@ -746,11 +685,10 @@ fn install_toolchain(version: &Version) -> Result<PathBuf> {
             find_extracted_binary(&extract_dir)?
         }
     };
-    let install_dir = installed_dir(version);
-    let staging_dir = install_dir.with_extension("tmp");
-    if staging_dir.exists() {
-        fs::remove_dir_all(&staging_dir)?;
-    }
+    let toolchain_root = toolchains_dir().join(version.to_string());
+    let staging_root = toolchains_dir().join(format!("{version}.tmp"));
+    remove_path(&staging_root)?;
+    let staging_dir = staging_root.join(target_triple());
     fs::create_dir_all(&staging_dir)?;
     let dst_binary = staging_dir.join(pcbc_binary_name());
     fs::copy(&src_binary, &dst_binary)?;
@@ -767,38 +705,20 @@ fn install_toolchain(version: &Version) -> Result<PathBuf> {
         staging_dir.join("receipt.json"),
         serde_json::to_vec_pretty(&receipt)?,
     )?;
-
-    if install_dir.exists() {
-        fs::remove_dir_all(&install_dir)?;
-    }
-    if let Some(parent) = install_dir.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    fs::rename(&staging_dir, &install_dir)?;
-    install_stdlib_archive(
+    stage_stdlib_archive(
         &format!("{RELEASE_BASE_URL}/v{version}"),
-        &toolchains_dir().join(version.to_string()),
+        &staging_root,
         &format!("stdlib-v{version}.tar.zst"),
-        stdlib_archive_required(version),
     )?;
 
-    Ok(install_dir.join(pcbc_binary_name()))
+    replace_toolchain_root(&staging_root, &toolchain_root)?;
+
+    Ok(installed_dir(version).join(pcbc_binary_name()))
 }
 
-fn stdlib_archive_required(version: &Version) -> bool {
-    version.major > 0 || version.minor >= 4
-}
-
-fn install_stdlib_archive(
-    base_url: &str,
-    toolchain_root: &Path,
-    cache_name: &str,
-    required: bool,
-) -> Result<()> {
-    let stdlib_dir = toolchain_root.join("lib").join("std");
+fn stage_stdlib_archive(base_url: &str, staging_root: &Path, cache_name: &str) -> Result<()> {
     let url = format!("{}/{}", base_url.trim_end_matches('/'), STDLIB_ARCHIVE_NAME);
     let Some(bytes) = download_optional(&http_client(ARCHIVE_TIMEOUT)?, &url)? else {
-        anyhow::ensure!(!required, "not found: {url}");
         return Ok(());
     };
     verify_checksum(&url, &bytes)?;
@@ -807,27 +727,67 @@ fn install_stdlib_archive(
     fs::write(downloads_dir().join(cache_name), &bytes)?;
 
     let unpacked = decompress_zstd(&url, bytes)?;
-    let staging_dir = stdlib_dir.with_extension("tmp");
-    if staging_dir.is_dir() {
-        fs::remove_dir_all(&staging_dir)?;
-    } else if staging_dir.exists() {
-        fs::remove_file(&staging_dir)?;
-    }
-    fs::create_dir_all(&staging_dir)?;
+    let stdlib_dir = staging_root.join("lib").join("std");
+    fs::create_dir_all(&stdlib_dir)?;
 
     tar::Archive::new(Cursor::new(unpacked))
-        .unpack(&staging_dir)
+        .unpack(&stdlib_dir)
         .with_context(|| format!("failed to extract stdlib archive {url}"))?;
+    validate_stdlib_archive(&stdlib_dir, &url)?;
+    Ok(())
+}
 
-    if stdlib_dir.is_dir() {
-        fs::remove_dir_all(&stdlib_dir)?;
-    } else if stdlib_dir.exists() {
-        fs::remove_file(&stdlib_dir)?;
-    }
-    if let Some(parent) = stdlib_dir.parent() {
+fn validate_stdlib_archive(stdlib_dir: &Path, url: &str) -> Result<()> {
+    anyhow::ensure!(
+        stdlib_dir.join("interfaces.zen").is_file(),
+        "stdlib archive {url} did not contain interfaces.zen at the archive root"
+    );
+    anyhow::ensure!(
+        stdlib_dir.join("generics").is_dir(),
+        "stdlib archive {url} did not contain generics/ at the archive root"
+    );
+    Ok(())
+}
+
+fn replace_toolchain_root(staging_root: &Path, toolchain_root: &Path) -> Result<()> {
+    let backup_root = toolchain_root.with_file_name(format!(
+        "{}.old",
+        toolchain_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("toolchain")
+    ));
+
+    remove_path(&backup_root)?;
+    if let Some(parent) = toolchain_root.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::rename(&staging_dir, &stdlib_dir)?;
+    if toolchain_root.exists() {
+        fs::rename(toolchain_root, &backup_root)?;
+    }
+
+    if let Err(err) = fs::rename(staging_root, toolchain_root) {
+        if backup_root.exists() {
+            let _ = fs::rename(&backup_root, toolchain_root);
+        }
+        return Err(err).with_context(|| {
+            format!(
+                "failed to install toolchain at {}",
+                toolchain_root.display()
+            )
+        });
+    }
+
+    remove_path(&backup_root)?;
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> Result<()> {
+    if path.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else if path.exists() {
+        fs::remove_file(path)?;
+    }
     Ok(())
 }
 

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ usage() {
 Usage: install.sh [--local]
 
 Options:
-  --local    Build pcb and pcbc from this checkout and install them side-by-side.
+  --local    Build pcb and pcbc from this checkout and install a local toolchain.
   -h, --help Show this help.
 EOF
 }
@@ -71,28 +71,41 @@ install_local() {
   target_dir="$source_dir/target"
   cargo build --release -p pcb -p pcbc --manifest-path "$source_dir/Cargo.toml" --target-dir "$target_dir"
 
+  local_toolchain_dir="$data_dir/toolchains/local"
+  local_target_dir="$local_toolchain_dir/$target"
+  stdlib_dir="$local_toolchain_dir/lib/std"
+
+  [ -d "$source_dir/lib/std" ] || { echo "missing stdlib: $source_dir/lib/std" >&2; exit 1; }
+
   mkdir -p "$install_dir"
   install -m 755 "$target_dir/release/pcb" "$install_dir/pcb"
-  install -m 755 "$target_dir/release/pcbc" "$install_dir/pcbc"
+  rm -f "$install_dir/pcbc"
+
+  mkdir -p "$local_target_dir" "$(dirname "$stdlib_dir")"
+  install -m 755 "$target_dir/release/pcbc" "$local_target_dir/pcbc"
+  rm -rf "$stdlib_dir"
+  cp -R "$source_dir/lib/std" "$stdlib_dir"
 
   add_install_dir_to_path
 
   echo "Installed local pcb to $install_dir/pcb"
-  echo "Installed local pcbc to $install_dir/pcbc"
+  echo "Installed local pcbc to $local_target_dir/pcbc"
+  echo "Installed local stdlib to $stdlib_dir"
 }
+
+platform="$(uname -s)-$(uname -m)"
+case "$platform" in
+  Darwin-arm64) target="aarch64-apple-darwin"; data_dir="$HOME/Library/Application Support/pcb" ;;
+  Darwin-x86_64) target="x86_64-apple-darwin"; data_dir="$HOME/Library/Application Support/pcb" ;;
+  Linux-aarch64|Linux-arm64) target="aarch64-unknown-linux-gnu"; data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/pcb" ;;
+  Linux-x86_64) target="x86_64-unknown-linux-gnu"; data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/pcb" ;;
+  *) echo "unsupported platform: $platform" >&2; exit 1 ;;
+esac
 
 if [ "$mode" = "local" ]; then
   install_local
   exit 0
 fi
-
-case "$(uname -s)-$(uname -m)" in
-  Darwin-arm64) target="aarch64-apple-darwin" ;;
-  Darwin-x86_64) target="x86_64-apple-darwin" ;;
-  Linux-aarch64|Linux-arm64) target="aarch64-unknown-linux-gnu" ;;
-  Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
-  *) echo "unsupported platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
-esac
 
 command -v curl >/dev/null || { echo "missing required command: curl" >&2; exit 1; }
 

--- a/install.sh
+++ b/install.sh
@@ -71,9 +71,8 @@ install_local() {
   target_dir="$source_dir/target"
   cargo build --release -p pcb -p pcbc --manifest-path "$source_dir/Cargo.toml" --target-dir "$target_dir"
 
-  local_toolchain_dir="$data_dir/toolchains/local"
-  local_target_dir="$local_toolchain_dir/$target"
-  stdlib_dir="$local_toolchain_dir/lib/std"
+  local_target_dir="$data_dir/toolchains/local/$target"
+  stdlib_dir="$local_target_dir/lib/std"
 
   [ -d "$source_dir/lib/std" ] || { echo "missing stdlib: $source_dir/lib/std" >&2; exit 1; }
 
@@ -81,7 +80,7 @@ install_local() {
   install -m 755 "$target_dir/release/pcb" "$install_dir/pcb"
   rm -f "$install_dir/pcbc"
 
-  mkdir -p "$local_target_dir" "$(dirname "$stdlib_dir")"
+  mkdir -p "$local_target_dir/lib"
   install -m 755 "$target_dir/release/pcbc" "$local_target_dir/pcbc"
   rm -rf "$stdlib_dir"
   cp -R "$source_dir/lib/std" "$stdlib_dir"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes remote install requirements (stdlib mandatory) and local toolchain layout; release S3 ordering affects discoverability during publish.
> 
> **Overview**
> Managed **pcbc** installs (stable and nightly) now pull **`stdlib.tar.zst`** from the release URL, verify it, and unpack into **`lib/std`** under the toolchain directory before the install is finalized. Install fails if the archive or **`interfaces.zen`** is missing.
> 
> The **pcbc** release workflow uploads **`stdlib.tar.zst*`** to S3 **before** other artifacts so partial prefixes are not visible without the stdlib the shim needs.
> 
> **`install.sh --local`** stops putting **pcbc** next to **pcb** in **`~/.local/bin`**; it registers a **local** toolchain under the platform data dir (**`toolchains/local/<triple>/`**) with **pcbc** and a copied **`lib/std`**. The shim treats that path as a local candidate (**`best_local_toolchain`**, **`pcb toolchain list`**).
> 
> **`pcbc_version`** replaces the sibling-only helper for reading **pcbc** version from a binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a70adb4bde623545076aa2a1527d52bc267b2b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->