### PR TITLE
MCAD-driven placement: apply IDF fixed positions to layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changes
 
+- Added MCAD-driven placement: `pcb layout` now consumes IDF (`.emn`) exports — discovered via `mechanical/<board>.emn` or declared under `[board.mechanical.idf]` in `pcb.toml` — and places MCAD-owned components at their exact mechanical pose, locked, using a `mechanical/footprint-datums.toml` catalog to map mechanical datums to footprint origins.
 - `pcb migrate` now upgrades workspace `pcb-version` after successful latest-toolchain migrations.
 - Added `[workspace.bom] strict = true` to require exact MPN matching when fetching BOM availability.
 - Updated stdlib generics to use KiCad 10.0.3 symbols and footprints, while keeping `Crystal()` compatible with KiCad 9 four-pin symbols.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,6 +4863,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcb-mechanical"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "dirs",
+ "log",
+ "pcb-sch",
+ "pcb-zen-core",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml",
+]
+
+[[package]]
 name = "pcb-sch"
 version = "0.4.0"
 dependencies = [
@@ -5110,6 +5126,7 @@ dependencies = [
  "pcb-ir",
  "pcb-kicad",
  "pcb-layout",
+ "pcb-mechanical",
  "pcb-sch",
  "pcb-sexpr",
  "pcb-sim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ pcb-command-runner = { path = "crates/pcb-command-runner" }
 pcb-eda = { path = "crates/pcb-eda" }
 pcb-component-gen = { path = "crates/pcb-component-gen" }
 pcb-layout = { path = "crates/pcb-layout" }
+pcb-mechanical = { path = "crates/pcb-mechanical" }
 pcb-sch = { path = "crates/pcb-sch" }
 pcb-canonical = { path = "crates/pcb-canonical" }
 pcb-zen = { path = "crates/pcb-zen" }

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -747,7 +747,6 @@ def apply_changeset(
         pcbnew: pcbnew module
         footprint_lib_map: Mapping of library nicknames to paths
         board_path: Path to the .kicad_pcb file (for resolving relative paths)
-
     Returns:
         OpLog with all operations performed
     """
@@ -825,12 +824,13 @@ def apply_changeset(
     # Phase 2: Additions (footprints and groups)
     # ==========================================================================
 
-    # 2a. FP-ADD - create footprints at origin (0,0)
-    # All new footprints start at origin; HierPlace will position them
-    # (including applying fragment positions if the fragment loads successfully)
+    # 2a. FP-ADD - create footprints at their resolved complement (fixed
+    # placements land directly at their pose; the rest start at origin).
     for entity_id in sorted(changeset.added_footprints, key=lambda e: str(e.path)):
         fp_view = view.footprints[entity_id]
-        fp_complement = default_footprint_complement()
+        fp_complement = changeset.complement.footprints.get(
+            entity_id, default_footprint_complement()
+        )
 
         try:
             fp = _create_footprint(
@@ -896,6 +896,11 @@ def apply_changeset(
         _update_footprint_view(
             fp, fp_view, pcbnew, package_roots=package_roots, layout_dir=layout_dir
         )
+        if fp_view.fixed_placement:
+            comp = changeset.complement.footprints.get(entity_id)
+            if comp is not None:
+                apply_footprint_placement(fp, comp, pcbnew)
+                oplog.place_fp(str(entity_id.path), comp.position.x, comp.position.y)
 
     # ==========================================================================
     # Phase 4: Group membership rebuild (uses fresh groups_by_name from above)
@@ -1246,6 +1251,7 @@ def _apply_position_inheritance(
     fps_by_entity_id: Dict[EntityId, Any],
     pcbnew: Any,
     oplog: OpLog,
+    exclude: Optional[Set[EntityId]] = None,
 ) -> Tuple[int, Set[EntityId]]:
     """Apply position inheritance for FPID changes.
 
@@ -1262,7 +1268,11 @@ def _apply_position_inheritance(
         eid.path: (eid, comp) for eid, comp in changeset.removed_footprints.items()
     }
 
+    excluded = exclude or set()
+
     for added_id in changeset.added_footprints:
+        if added_id in excluded:
+            continue
         removed_info = removed_by_path.get(added_id.path)
         if not removed_info:
             continue
@@ -1409,11 +1419,15 @@ def _run_hierarchical_placement(
     Rule C: Non-fragment groups use pure bottom-up HierPlace
     Rule D: Root integration with existing content
     """
+    fixed_footprints: Set[EntityId] = {
+        eid for eid, view in board_view.footprints.items() if view.fixed_placement
+    }
+
     placed, inherited = _apply_position_inheritance(
-        changeset, fps_by_entity_id, pcbnew, oplog
+        changeset, fps_by_entity_id, pcbnew, oplog, exclude=fixed_footprints
     )
 
-    newly_added = changeset.added_footprints - inherited
+    newly_added = changeset.added_footprints - inherited - fixed_footprints
     # IMPORTANT: group-only repairs (GR_ADD with no FP_ADD) must not trigger placement.
     # If a group wrapper was deleted in KiCad but its child footprints still exist,
     # running HierPlace could move existing footprints (via a `PLACE_GR`), which is
@@ -1436,7 +1450,7 @@ def _run_hierarchical_placement(
         plan, inherited, fps_by_entity_id, pcbnew, oplog
     )
     placed += frag_placed
-    exclude = inherited | fragment_fps
+    exclude = inherited | fragment_fps | fixed_footprints
 
     # Rule C & D: Build tree excluding fragment descendants
     tree = _build_group_tree(changeset, plan, exclude_footprints=exclude)
@@ -1447,8 +1461,11 @@ def _run_hierarchical_placement(
     sizes = _collect_item_sizes(
         changeset, fps_by_entity_id, groups_by_name, pcbnew, plan, exclude
     )
+    # Treat fixed footprints as existing content so HierPlace packs around them.
     existing_bbox = _compute_existing_bbox(
-        kicad_board, set(changeset.added_footprints), pcbnew
+        kicad_board,
+        set(changeset.added_footprints) - fixed_footprints,
+        pcbnew,
     )
     layout = _compute_hierarchical_layout(
         tree, sizes, set(changeset.added_groups), set(plan.loaded.keys()), existing_bbox

--- a/crates/pcb-layout/src/scripts/lens/lens.py
+++ b/crates/pcb-layout/src/scripts/lens/lens.py
@@ -56,6 +56,26 @@ from .kicad_adapter import (
 logger = logging.getLogger("pcb.lens")
 
 
+def _fixed_placement_from_raw(
+    raw: Optional[Dict[str, Any]],
+) -> Optional[FootprintComplement]:
+    """A compiler-supplied pose (`BoardPose`) pins the footprint fixed and locked."""
+    if not raw:
+        return None
+    side = raw.get("side", "top")
+    layer = {"top": "F.Cu", "bottom": "B.Cu"}.get(side)
+    if layer is None:
+        raise ValueError(f"unknown placement side {side!r}")
+    if "x_nm" not in raw or "y_nm" not in raw:
+        raise ValueError(f"fixed placement is missing x_nm/y_nm: {raw!r}")
+    return FootprintComplement(
+        position=Position(x=int(raw["x_nm"]), y=int(raw["y_nm"])),
+        orientation=float(raw.get("rotation_deg", 0.0)),
+        layer=layer,
+        locked=True,
+    )
+
+
 @dataclass
 class FragmentData:
     """Data extracted from a layout fragment for lens logic.
@@ -132,6 +152,7 @@ def get(netlist: Any) -> BoardView:
             exclude_from_bom=exclude_from_bom,
             exclude_from_pos=exclude_from_pos,
             fields=fields,
+            fixed_placement=_fixed_placement_from_raw(getattr(part, "placement", None)),
         )
 
     fp_id_by_ref: Dict[str, EntityId] = {
@@ -638,7 +659,10 @@ def adapt_complement(
     for entity_id, fp_view in new_view.footprints.items():
         existing = old_complement.footprints.get(entity_id)
 
-        if existing:
+        if fp_view.fixed_placement:
+            # Compiler-owned fixed placement wins over destination placement.
+            new_footprints[entity_id] = fp_view.fixed_placement
+        elif existing:
             # Exact match (same path + same fpid) - preserve complement
             new_footprints[entity_id] = existing
         else:

--- a/crates/pcb-layout/src/scripts/lens/tests/test_lens.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_lens.py
@@ -55,6 +55,46 @@ class TestAdaptComplement:
         changeset = build_sync_changeset(new_view, new_complement, old_complement)
         assert entity_id not in changeset.added_footprints
 
+    def test_fixed_placement_overrides_existing_complement(self):
+        """Fixed compiler placements should replace destination placement."""
+        entity_id = EntityId.from_string("Connectors.J1")
+
+        new_view = BoardView(
+            footprints={
+                entity_id: FootprintView(
+                    entity_id=entity_id,
+                    reference="J1",
+                    value="USB-C",
+                    fpid="Connector_USB:USB_C_Receptacle",
+                    fixed_placement=FootprintComplement(
+                        position=Position(x=11_000_000, y=22_000_000),
+                        orientation=180.0,
+                        layer="B.Cu",
+                        locked=True,
+                    ),
+                )
+            }
+        )
+
+        old_complement = BoardComplement(
+            footprints={
+                entity_id: FootprintComplement(
+                    position=Position(x=5000, y=6000),
+                    orientation=90.0,
+                    layer="F.Cu",
+                    locked=False,
+                )
+            }
+        )
+
+        new_complement = adapt_complement(new_view, old_complement)
+
+        complement = new_complement.footprints[entity_id]
+        assert complement.position == Position(x=11_000_000, y=22_000_000)
+        assert complement.orientation == 180.0
+        assert complement.layer == "B.Cu"
+        assert complement.locked
+
     def test_new_footprint_gets_default_complement(self):
         """New footprints should get default complement."""
         entity_id = EntityId.from_string("Power.C1")

--- a/crates/pcb-layout/src/scripts/lens/types.py
+++ b/crates/pcb-layout/src/scripts/lens/types.py
@@ -112,6 +112,8 @@ class FootprintView:
     exclude_from_bom: bool = False
     exclude_from_pos: bool = False
     fields: Dict[str, str] = field(default_factory=dict)
+    # Compiler-owned fixed placement (e.g. from MCAD); wins over destination.
+    fixed_placement: Optional["FootprintComplement"] = None
 
     @property
     def path(self) -> EntityPath:

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -144,11 +144,12 @@ class JsonNetlistParser:
     class Part:
         """Represents a component part from the netlist."""
 
-        def __init__(self, ref, value, footprint, sheetpath):
+        def __init__(self, ref, value, footprint, sheetpath, placement=None):
             self.ref = ref
             self.value = value
             self.footprint = footprint
             self.sheetpath = sheetpath
+            self.placement = placement
             self.properties = []
 
     class Module:
@@ -286,7 +287,9 @@ class JsonNetlistParser:
             sheetpath = JsonNetlistParser.SheetPath(hier_name, ts_uuid)
 
             # Create part
-            part = JsonNetlistParser.Part(ref, value, footprint, sheetpath)
+            part = JsonNetlistParser.Part(
+                ref, value, footprint, sheetpath, placement=instance.get("placement")
+            )
 
             # Add properties from attributes
             for attr_name, attr_value in instance["attributes"].items():

--- a/crates/pcb-mechanical/Cargo.toml
+++ b/crates/pcb-mechanical/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pcb-mechanical"
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+authors = { workspace = true }
+description = "Mechanical CAD ingestion and placement resolution for PCB designs"
+
+[dependencies]
+anyhow = { workspace = true }
+blake3 = { workspace = true }
+dirs = { workspace = true }
+log = { workspace = true }
+pcb-sch = { workspace = true }
+pcb-zen-core = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/pcb-mechanical/src/datum.rs
+++ b/crates/pcb-mechanical/src/datum.rs
@@ -1,0 +1,82 @@
+use crate::locate::dedup_paths;
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Deserialize)]
+struct FootprintDatumsFile {
+    #[serde(default)]
+    pub datum: Vec<FootprintDatum>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct FootprintDatum {
+    pub idf_package: String,
+    pub footprint: String,
+    #[serde(default)]
+    pub footprint_hash: Option<String>,
+    pub mechanical_origin_in_footprint: LocalDatumPose,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub(crate) struct LocalDatumPose {
+    pub x_mm: f64,
+    pub y_mm: f64,
+    #[serde(default)]
+    pub rotation_deg: f64,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct FootprintDatums {
+    entries: Vec<FootprintDatum>,
+}
+
+impl FootprintDatums {
+    #[cfg(test)]
+    pub(crate) fn from_entries_for_test(entries: Vec<FootprintDatum>) -> Self {
+        Self { entries }
+    }
+
+    pub(crate) fn load_for_board(zen_path: &Path, workspace_root: &Path) -> anyhow::Result<Self> {
+        Self::load(&catalog_paths_for_board(zen_path, workspace_root))
+    }
+
+    fn load(paths: &[PathBuf]) -> anyhow::Result<Self> {
+        let mut entries = Vec::new();
+        for path in paths {
+            if !path.exists() {
+                continue;
+            }
+            let raw = fs::read_to_string(path).map_err(|e| {
+                anyhow::anyhow!("failed to read datum catalog {}: {e}", path.display())
+            })?;
+            let parsed: FootprintDatumsFile = toml::from_str(&raw).map_err(|e| {
+                anyhow::anyhow!("failed to parse datum catalog {}: {e}", path.display())
+            })?;
+            entries.extend(parsed.datum);
+        }
+        Ok(Self { entries })
+    }
+
+    pub(crate) fn lookup(&self, idf_package: &str, footprint: &str) -> Option<&FootprintDatum> {
+        self.entries.iter().find(|entry| {
+            entry.idf_package.eq_ignore_ascii_case(idf_package) && entry.footprint == footprint
+        })
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+fn catalog_paths_for_board(zen_path: &Path, workspace_root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(parent) = zen_path.parent() {
+        paths.push(parent.join("mechanical/footprint-datums.toml"));
+    }
+    paths.push(workspace_root.join("mechanical/footprint-datums.toml"));
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".pcb/mechanical/footprint-datums.toml"));
+    }
+    dedup_paths(paths)
+}

--- a/crates/pcb-mechanical/src/idf.rs
+++ b/crates/pcb-mechanical/src/idf.rs
@@ -1,0 +1,293 @@
+use pcb_sch::BoardSide;
+use std::fs;
+use std::path::Path;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MechanicalPose {
+    pub x_mm: f64,
+    pub y_mm: f64,
+    pub rotation_deg: f64,
+    pub side: BoardSide,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IdfPlacementClaim {
+    pub refdes: String,
+    pub package: String,
+    pub part_number: Option<String>,
+    pub pose: MechanicalPose,
+    /// IDF placement status `MCAD`: mechanical owns this component's position.
+    pub mcad_owned: bool,
+}
+
+pub(crate) fn load_placement_claims(path: &Path) -> anyhow::Result<Vec<IdfPlacementClaim>> {
+    let source = fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("failed to read IDF board file {}: {e}", path.display()))?;
+    parse_placement_claims(&source)
+        .map_err(|e| anyhow::anyhow!("failed to parse IDF board file {}: {e}", path.display()))
+}
+
+#[derive(Debug, Error)]
+pub enum IdfError {
+    #[error("IDF file does not contain a .PLACEMENT section")]
+    MissingPlacementSection,
+    #[error("line {line}: malformed .PLACEMENT package record; expected 3 fields, got {count}")]
+    MalformedPackageRecord { line: usize, count: usize },
+    #[error(
+        "line {line}: malformed .PLACEMENT coordinate record; expected at least 6 fields, got {count}"
+    )]
+    MalformedCoordinateRecord { line: usize, count: usize },
+    #[error(
+        "line {line}: package record was not followed by a coordinate record before .END_PLACEMENT"
+    )]
+    MissingCoordinateRecord { line: usize },
+    #[error("line {line}: invalid {field} value {value:?}")]
+    InvalidNumber {
+        line: usize,
+        field: &'static str,
+        value: String,
+    },
+    #[error("line {line}: unknown board side {value:?}; expected TOP or BOTTOM")]
+    UnknownSide { line: usize, value: String },
+    #[error("line {line}: unterminated quoted token")]
+    UnterminatedQuote { line: usize },
+}
+
+pub fn parse_placement_claims(input: &str) -> Result<Vec<IdfPlacementClaim>, IdfError> {
+    let mut in_placement = false;
+    let mut saw_section = false;
+    let mut pending_package: Option<(usize, String, Option<String>, String)> = None;
+    let mut claims = Vec::new();
+
+    for (idx, raw_line) in input.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let upper = line.to_ascii_uppercase();
+        if upper == ".PLACEMENT" {
+            in_placement = true;
+            saw_section = true;
+            continue;
+        }
+        if upper == ".END_PLACEMENT" {
+            if let Some((line, _, _, _)) = pending_package.take() {
+                return Err(IdfError::MissingCoordinateRecord { line });
+            }
+            in_placement = false;
+            continue;
+        }
+        if !in_placement {
+            continue;
+        }
+
+        let tokens = tokenize(line, line_no)?;
+        if tokens.is_empty() || tokens[0].starts_with('#') {
+            continue;
+        }
+
+        if let Some((_, package, part_number, refdes)) = pending_package.take() {
+            if tokens.len() < 6 {
+                return Err(IdfError::MalformedCoordinateRecord {
+                    line: line_no,
+                    count: tokens.len(),
+                });
+            }
+            claims.push(parse_coordinate_record(
+                package,
+                part_number,
+                refdes,
+                &tokens,
+                line_no,
+            )?);
+            continue;
+        }
+
+        if tokens.len() >= 9 {
+            claims.push(parse_compact_record(&tokens, line_no)?);
+            continue;
+        }
+
+        if tokens.len() != 3 {
+            return Err(IdfError::MalformedPackageRecord {
+                line: line_no,
+                count: tokens.len(),
+            });
+        }
+
+        pending_package = Some((
+            line_no,
+            tokens[0].clone(),
+            none_if_empty_or_placeholder(&tokens[1]),
+            tokens[2].clone(),
+        ));
+    }
+
+    if !saw_section {
+        return Err(IdfError::MissingPlacementSection);
+    }
+    if let Some((line, _, _, _)) = pending_package {
+        return Err(IdfError::MissingCoordinateRecord { line });
+    }
+    Ok(claims)
+}
+
+fn parse_compact_record(tokens: &[String], line: usize) -> Result<IdfPlacementClaim, IdfError> {
+    parse_coordinate_record(
+        tokens[0].clone(),
+        none_if_empty_or_placeholder(&tokens[1]),
+        tokens[2].clone(),
+        &tokens[3..],
+        line,
+    )
+}
+
+fn parse_coordinate_record(
+    package: String,
+    part_number: Option<String>,
+    refdes: String,
+    tokens: &[String],
+    line: usize,
+) -> Result<IdfPlacementClaim, IdfError> {
+    if tokens.len() < 6 {
+        return Err(IdfError::MalformedCoordinateRecord {
+            line,
+            count: tokens.len(),
+        });
+    }
+
+    // tokens[2] is the mounting offset (z); validated but unused on a 2D board.
+    parse_f64(&tokens[2], line, "mounting offset")?;
+    Ok(IdfPlacementClaim {
+        refdes,
+        package,
+        part_number,
+        pose: MechanicalPose {
+            x_mm: parse_f64(&tokens[0], line, "x")?,
+            y_mm: parse_f64(&tokens[1], line, "y")?,
+            rotation_deg: parse_f64(&tokens[3], line, "rotation")?,
+            side: parse_side(&tokens[4], line)?,
+        },
+        mcad_owned: tokens[5].eq_ignore_ascii_case("MCAD"),
+    })
+}
+
+fn none_if_empty_or_placeholder(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed == "-" || trimmed == "~" {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+fn parse_f64(value: &str, line: usize, field: &'static str) -> Result<f64, IdfError> {
+    // Reject NaN/inf: `"NaN".parse::<f64>()` succeeds but would corrupt pose math.
+    match value.parse::<f64>() {
+        Ok(parsed) if parsed.is_finite() => Ok(parsed),
+        _ => Err(IdfError::InvalidNumber {
+            line,
+            field,
+            value: value.to_owned(),
+        }),
+    }
+}
+
+fn parse_side(value: &str, line: usize) -> Result<BoardSide, IdfError> {
+    match value.to_ascii_uppercase().as_str() {
+        "TOP" | "T" => Ok(BoardSide::Top),
+        "BOTTOM" | "BOT" | "B" => Ok(BoardSide::Bottom),
+        _ => Err(IdfError::UnknownSide {
+            line,
+            value: value.to_owned(),
+        }),
+    }
+}
+
+fn tokenize(line: &str, line_no: usize) -> Result<Vec<String>, IdfError> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = line.chars().peekable();
+    let mut in_quote = false;
+    let mut token_started = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' => {
+                in_quote = !in_quote;
+                token_started = true;
+            }
+            '#' if !in_quote => break,
+            c if c.is_whitespace() && !in_quote => {
+                if token_started {
+                    tokens.push(std::mem::take(&mut current));
+                    token_started = false;
+                }
+                while chars.peek().is_some_and(|c| c.is_whitespace()) {
+                    chars.next();
+                }
+            }
+            c => {
+                current.push(c);
+                token_started = true;
+            }
+        }
+    }
+
+    if in_quote {
+        return Err(IdfError::UnterminatedQuote { line: line_no });
+    }
+    if token_started {
+        tokens.push(current);
+    }
+    Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_spec_placement_record_pairs() {
+        let input = r#"
+.PLACEMENT
+"USB_C" "Molex" J1
+10.5 20.25 0 90 TOP MCAD
+.END_PLACEMENT
+"#;
+        let claims = parse_placement_claims(input).unwrap();
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].refdes, "J1");
+        assert_eq!(claims[0].package, "USB_C");
+        assert_eq!(claims[0].part_number.as_deref(), Some("Molex"));
+        assert_eq!(claims[0].pose.side, BoardSide::Top);
+        assert!(claims[0].mcad_owned);
+    }
+
+    #[test]
+    fn preserves_empty_quoted_part_number() {
+        let input = r#"
+.PLACEMENT
+"USB_C" "" J1
+10.5 20.25 0 90 TOP MCAD
+.END_PLACEMENT
+"#;
+        let claims = parse_placement_claims(input).unwrap();
+        assert_eq!(claims[0].part_number, None);
+    }
+
+    #[test]
+    fn tolerates_compact_placement_records() {
+        let input = r#"
+.PLACEMENT
+"USB_C" "Molex" J1 10.5 20.25 0 90 TOP MCAD
+.END_PLACEMENT
+"#;
+        let claims = parse_placement_claims(input).unwrap();
+        assert_eq!(claims.len(), 1);
+        assert!(claims[0].mcad_owned);
+    }
+}

--- a/crates/pcb-mechanical/src/lib.rs
+++ b/crates/pcb-mechanical/src/lib.rs
@@ -1,0 +1,7 @@
+mod datum;
+mod idf;
+mod locate;
+mod mcad;
+mod placement;
+
+pub use mcad::apply_mcad_positions;

--- a/crates/pcb-mechanical/src/locate.rs
+++ b/crates/pcb-mechanical/src/locate.rs
@@ -1,0 +1,159 @@
+//! Locates the IDF board file (`.emn`) that provides mechanical placements for a board.
+
+use pcb_sch::{ATTR_LAYOUT_NAME, AttributeValue, Schematic};
+use pcb_zen_core::config::{Board, IdfConfig};
+use pcb_zen_core::resolution::ResolutionResult;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Returns the path to the board's IDF `.emn` file, if one is configured.
+///
+/// Resolution order: a `[board.mechanical.idf]` declaration in a matching
+/// pcb.toml wins; otherwise the well-known path `mechanical/<board>.emn` next
+/// to the board's .zen file or at the workspace root. Ambiguity is an error.
+pub fn idf_for_board(
+    schematic: &Schematic,
+    zen_path: &Path,
+    resolution: &ResolutionResult,
+) -> anyhow::Result<Option<PathBuf>> {
+    let board_name = board_name(schematic, zen_path);
+    if let Some(declared) = declared_in_pcb_toml(zen_path, &board_name, resolution)? {
+        return Ok(Some(declared));
+    }
+    at_well_known_path(zen_path, &board_name, resolution)
+}
+
+fn declared_in_pcb_toml(
+    zen_path: &Path,
+    board_name: &str,
+    resolution: &ResolutionResult,
+) -> anyhow::Result<Option<PathBuf>> {
+    let workspace = &resolution.workspace_info;
+
+    let workspace_board = workspace
+        .config
+        .iter()
+        .filter_map(|config| config.board.as_ref())
+        .map(|board| (workspace.root.clone(), board));
+    let package_boards = workspace.packages.values().filter_map(|package| {
+        let board = package.config.board.as_ref()?;
+        Some((package.dir(&workspace.root), board))
+    });
+
+    let declarations: Vec<(PathBuf, &IdfConfig)> = workspace_board
+        .chain(package_boards)
+        .filter(|(root, board)| board_matches(board, root, zen_path, board_name))
+        .filter_map(|(root, board)| {
+            let idf = board.mechanical.as_ref()?.idf.as_ref()?;
+            Some((root, idf))
+        })
+        .collect();
+
+    let Some((root, config)) = at_most_one(declarations, |_| {
+        format!(
+            "multiple [board.mechanical.idf] configs match {}; keep only one explicit IDF input",
+            zen_path.display()
+        )
+    })?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(resolve_declared(&root, config)?))
+}
+
+fn resolve_declared(root: &Path, config: &IdfConfig) -> anyhow::Result<PathBuf> {
+    let emn = root.join(&config.emn);
+    if !emn.exists() {
+        anyhow::bail!("declared IDF board file does not exist: {}", emn.display());
+    }
+    Ok(emn)
+}
+
+fn at_well_known_path(
+    zen_path: &Path,
+    board_name: &str,
+    resolution: &ResolutionResult,
+) -> anyhow::Result<Option<PathBuf>> {
+    let mut candidates = Vec::new();
+    if let Some(parent) = zen_path.parent() {
+        candidates.push(parent.join("mechanical").join(format!("{board_name}.emn")));
+    }
+    candidates.push(
+        resolution
+            .workspace_info
+            .root
+            .join("mechanical")
+            .join(format!("{board_name}.emn")),
+    );
+
+    let existing: Vec<PathBuf> = dedup_paths(candidates)
+        .into_iter()
+        .filter(|path| path.exists())
+        .collect();
+
+    at_most_one(existing, |found| {
+        format!(
+            "multiple convention IDF files match board '{}': {}. Declare [board.mechanical.idf] explicitly.",
+            board_name,
+            found
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    })
+}
+
+/// Zero candidates is None, one is the answer, two or more is an error — never a guess.
+fn at_most_one<T>(
+    mut candidates: Vec<T>,
+    ambiguity: impl FnOnce(&[T]) -> String,
+) -> anyhow::Result<Option<T>> {
+    match candidates.len() {
+        0 => Ok(None),
+        1 => Ok(Some(candidates.remove(0))),
+        _ => anyhow::bail!("{}", ambiguity(&candidates)),
+    }
+}
+
+fn board_matches(board: &Board, root: &Path, zen_path: &Path, board_name: &str) -> bool {
+    if let Some(path) = &board.path {
+        same_path(&root.join(path), zen_path)
+    } else {
+        board.name == board_name
+    }
+}
+
+fn same_path(a: &Path, b: &Path) -> bool {
+    let a = fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
+    let b = fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
+    a == b
+}
+
+fn board_name(schematic: &Schematic, zen_path: &Path) -> String {
+    schematic
+        .root_ref
+        .as_ref()
+        .and_then(|root_ref| schematic.instances.get(root_ref))
+        .and_then(|root| root.attributes.get(ATTR_LAYOUT_NAME))
+        .and_then(AttributeValue::string)
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            zen_path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("board")
+                .to_owned()
+        })
+}
+
+pub(crate) fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for path in paths {
+        if !out.iter().any(|existing: &PathBuf| existing == &path) {
+            out.push(path);
+        }
+    }
+    out
+}

--- a/crates/pcb-mechanical/src/mcad.rs
+++ b/crates/pcb-mechanical/src/mcad.rs
@@ -1,0 +1,35 @@
+use crate::{datum::FootprintDatums, idf, locate, placement};
+use pcb_sch::Schematic;
+use pcb_zen_core::resolution::ResolutionResult;
+use std::path::Path;
+
+/// Apply MCAD-owned placements from the board's IDF input (if any) onto the
+/// schematic's component instances as fixed poses.
+pub fn apply_mcad_positions(
+    schematic: &mut Schematic,
+    board_zen_path: &Path,
+    resolution: &ResolutionResult,
+) -> anyhow::Result<()> {
+    let Some(emn) = locate::idf_for_board(schematic, board_zen_path, resolution)? else {
+        return Ok(());
+    };
+
+    let datums = FootprintDatums::load_for_board(board_zen_path, &resolution.workspace_info.root)?;
+    let claims = idf::load_placement_claims(&emn)?;
+    let positions = placement::resolve_mcad_positions(schematic, &claims, &datums)?;
+
+    let count = positions.len();
+    for (instance_ref, pose) in positions {
+        let instance = schematic
+            .instances
+            .get_mut(&instance_ref)
+            .expect("resolved MCAD position came from schematic");
+        instance.placement = Some(pose);
+    }
+
+    log::info!(
+        "applied {count} MCAD position(s) from IDF {}",
+        emn.display()
+    );
+    Ok(())
+}

--- a/crates/pcb-mechanical/src/placement.rs
+++ b/crates/pcb-mechanical/src/placement.rs
@@ -1,0 +1,237 @@
+use crate::datum::{FootprintDatums, LocalDatumPose};
+use crate::idf::IdfPlacementClaim;
+use pcb_sch::{
+    ATTR_FOOTPRINT, AttributeValue, BoardPose, BoardSide, InstanceKind, InstanceRef, Schematic,
+};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn resolve_mcad_positions(
+    schematic: &Schematic,
+    claims: &[IdfPlacementClaim],
+    datums: &FootprintDatums,
+) -> anyhow::Result<Vec<(InstanceRef, BoardPose)>> {
+    let mut by_refdes = HashMap::<String, InstanceRef>::new();
+    for (instance_ref, instance) in &schematic.instances {
+        if instance.kind != InstanceKind::Component {
+            continue;
+        }
+        if let Some(refdes) = &instance.reference_designator {
+            by_refdes.insert(refdes.clone(), instance_ref.clone());
+        }
+    }
+
+    let mut errors = Vec::new();
+    let mut seen_refdes = HashSet::new();
+    let mut resolved = Vec::new();
+
+    // Ownership contract: IDF `MCAD` status means mechanical owns this component's position.
+    for claim in claims.iter().filter(|claim| claim.mcad_owned) {
+        if !seen_refdes.insert(claim.refdes.clone()) {
+            errors.push(format!(
+                "duplicate IDF placement for reference designator {}",
+                claim.refdes
+            ));
+            continue;
+        }
+
+        let Some(instance_ref) = by_refdes.get(&claim.refdes).cloned() else {
+            errors.push(format!(
+                "IDF placement for {} has no matching Zener component instance",
+                claim.refdes
+            ));
+            continue;
+        };
+
+        let footprint = schematic
+            .instances
+            .get(&instance_ref)
+            .and_then(|instance| instance.attributes.get(ATTR_FOOTPRINT))
+            .and_then(AttributeValue::string)
+            .map(str::to_owned);
+        let Some(footprint) = footprint else {
+            errors.push(format!(
+                "Zener component {} matched IDF placement but has no footprint",
+                claim.refdes
+            ));
+            continue;
+        };
+
+        let Some(datum) = datums.lookup(&claim.package, &footprint) else {
+            let extra = if datums.is_empty() {
+                " (no footprint datums were found)"
+            } else {
+                ""
+            };
+            errors.push(format!(
+                "no footprint datum for IDF package '{}' and footprint '{}'{}",
+                claim.package, footprint, extra
+            ));
+            continue;
+        };
+
+        if let Some(expected_hash) = &datum.footprint_hash {
+            match footprint_hash(schematic, &footprint) {
+                Ok(Some(actual_hash)) if &actual_hash == expected_hash => {}
+                Ok(Some(actual_hash)) => {
+                    errors.push(format!(
+                        "footprint hash mismatch for '{}': datum has {}, current file is {}",
+                        footprint, expected_hash, actual_hash
+                    ));
+                    continue;
+                }
+                Ok(None) => {
+                    errors.push(format!(
+                        "datum for '{}' requires footprint hash {}, but the footprint path could not be resolved",
+                        footprint, expected_hash
+                    ));
+                    continue;
+                }
+                Err(err) => {
+                    errors.push(format!(
+                        "failed to hash footprint '{}' for datum validation: {err}",
+                        footprint
+                    ));
+                    continue;
+                }
+            }
+        }
+
+        let pose = resolve_footprint_pose(claim, datum.mechanical_origin_in_footprint);
+        resolved.push((instance_ref, pose));
+    }
+
+    if !errors.is_empty() {
+        anyhow::bail!(
+            "mechanical placement resolution failed:\n{}",
+            errors.join("\n")
+        );
+    }
+
+    Ok(resolved)
+}
+
+fn resolve_footprint_pose(claim: &IdfPlacementClaim, local: LocalDatumPose) -> BoardPose {
+    // On the bottom side KiCad mirrors the footprint's local X axis (and negates
+    // local angles), so flip the sign of the datum's X offset and rotation.
+    let mirror = match claim.pose.side {
+        BoardSide::Top => 1.0,
+        BoardSide::Bottom => -1.0,
+    };
+    let footprint_rotation =
+        normalize_degrees(claim.pose.rotation_deg - mirror * local.rotation_deg);
+    let theta = footprint_rotation.to_radians();
+    let local_x = mirror * local.x_mm;
+    let dx = local_x * theta.cos() - local.y_mm * theta.sin();
+    let dy = local_x * theta.sin() + local.y_mm * theta.cos();
+
+    BoardPose {
+        x_nm: mm_to_nm(claim.pose.x_mm - dx),
+        y_nm: mm_to_nm(claim.pose.y_mm - dy),
+        rotation_deg: footprint_rotation,
+        side: claim.pose.side,
+    }
+}
+
+fn mm_to_nm(mm: f64) -> i64 {
+    (mm * 1_000_000.0).round() as i64
+}
+
+fn normalize_degrees(deg: f64) -> f64 {
+    deg.rem_euclid(360.0)
+}
+
+fn footprint_hash(schematic: &Schematic, footprint: &str) -> anyhow::Result<Option<String>> {
+    let path = if footprint.starts_with(pcb_sch::PACKAGE_URI_PREFIX) {
+        schematic.resolve_package_uri(footprint).ok()
+    } else {
+        Some(PathBuf::from(footprint))
+    };
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    if !Path::new(&path).exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path)?;
+    Ok(Some(format!("blake3:{}", blake3::hash(&bytes).to_hex())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datum::{FootprintDatum, FootprintDatums, LocalDatumPose};
+    use crate::idf::MechanicalPose;
+    use pcb_sch::{Instance, ModuleRef};
+
+    #[test]
+    fn resolves_claim_to_component_placement() {
+        let mut schematic = Schematic::new();
+        let module = ModuleRef::new("/board.zen", "<root>");
+        let instance_ref = InstanceRef::new(module.clone(), vec!["J".to_owned()]);
+        let mut instance = Instance::component(module);
+        instance.reference_designator = Some("J1".to_owned());
+        instance.add_attribute("footprint", "package://pkg/fp.kicad_mod".to_owned());
+        schematic.instances.insert(instance_ref.clone(), instance);
+
+        let datums = FootprintDatums::from_entries_for_test(vec![FootprintDatum {
+            idf_package: "USB".to_owned(),
+            footprint: "package://pkg/fp.kicad_mod".to_owned(),
+            footprint_hash: None,
+            mechanical_origin_in_footprint: LocalDatumPose {
+                x_mm: 1.0,
+                y_mm: 0.0,
+                rotation_deg: 0.0,
+            },
+        }]);
+
+        let claim = IdfPlacementClaim {
+            refdes: "J1".to_owned(),
+            package: "USB".to_owned(),
+            part_number: None,
+            pose: MechanicalPose {
+                x_mm: 10.0,
+                y_mm: 20.0,
+                rotation_deg: 0.0,
+                side: BoardSide::Top,
+            },
+            mcad_owned: true,
+        };
+
+        let positions = resolve_mcad_positions(&schematic, &[claim], &datums).unwrap();
+        let (resolved_ref, pose) = positions.into_iter().next().unwrap();
+        assert_eq!(resolved_ref, instance_ref);
+        assert_eq!(pose.x_nm, 9_000_000);
+        assert_eq!(pose.y_nm, 20_000_000);
+        assert_eq!(pose.side, BoardSide::Top);
+    }
+
+    #[test]
+    fn bottom_side_mirrors_datum_x_offset() {
+        let claim = IdfPlacementClaim {
+            refdes: "J1".to_owned(),
+            package: "USB".to_owned(),
+            part_number: None,
+            pose: MechanicalPose {
+                x_mm: 10.0,
+                y_mm: 20.0,
+                rotation_deg: 0.0,
+                side: BoardSide::Bottom,
+            },
+            mcad_owned: true,
+        };
+        let local = LocalDatumPose {
+            x_mm: 1.0,
+            y_mm: 0.0,
+            rotation_deg: 0.0,
+        };
+
+        let pose = resolve_footprint_pose(&claim, local);
+        // The same datum on the top resolves to x = 9mm; the bottom-side mirror
+        // flips the X offset, landing the footprint origin at x = 11mm.
+        assert_eq!(pose.x_nm, 11_000_000);
+        assert_eq!(pose.y_nm, 20_000_000);
+        assert_eq!(pose.side, BoardSide::Bottom);
+    }
+}

--- a/crates/pcb-sch/src/bom/core.rs
+++ b/crates/pcb-sch/src/bom/core.rs
@@ -791,6 +791,7 @@ mod tests {
             attributes,
             children: Default::default(),
             reference_designator: Some("U1".to_string()),
+            placement: None,
             symbol_positions: HashMap::new(),
         }
     }

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -42,6 +42,14 @@ pub const ATTR_LAYOUT_PATH: &str = "layout_path";
 /// `AttributeValue::String`.
 pub const ATTR_LAYOUT_HINTS: &str = "layout_hints";
 
+/// Attribute key that stores the board's layout name (set by `Board(name = …)`).
+/// Used with `AttributeValue::String`.
+pub const ATTR_LAYOUT_NAME: &str = "layout_name";
+
+/// Attribute key that stores a component's resolved footprint reference
+/// (a `package://` URI or file path). Used with `AttributeValue::String`.
+pub const ATTR_FOOTPRINT: &str = "footprint";
+
 /// URI prefix for stable, machine-independent package references.
 pub const PACKAGE_URI_PREFIX: &str = "package://";
 
@@ -321,6 +329,24 @@ pub enum InstanceKind {
     Pin,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BoardSide {
+    Top,
+    Bottom,
+}
+
+/// A fixed, locked footprint pose. When an `Instance` carries one, the layout
+/// sync places the component here and leaves it alone — it is mechanically
+/// owned (e.g. by an MCAD/IDF export), not the auto-placer's to move.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BoardPose {
+    pub x_nm: i64,
+    pub y_nm: i64,
+    pub rotation_deg: f64,
+    pub side: BoardSide,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PhysicalUnit {
     Ohms,
@@ -486,6 +512,10 @@ pub struct Instance {
     pub attributes: HashMap<Symbol, AttributeValue>,
     pub children: HashMap<Symbol, InstanceRef>,
     pub reference_designator: Option<String>,
+    /// Fixed, mechanically-owned pose. `Some` means the layout sync must place
+    /// the component here, locked, instead of auto-placing it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<BoardPose>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub symbol_positions: HashMap<String, Position>,
 }
@@ -498,6 +528,7 @@ impl Instance {
             attributes: HashMap::new(),
             children: HashMap::new(),
             reference_designator: None,
+            placement: None,
             symbol_positions: HashMap::new(),
         }
     }

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -421,9 +421,26 @@ pub struct Board {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 
+    /// External mechanical inputs for this board.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mechanical: Option<MechanicalConfig>,
+
     /// Optional description of the board
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MechanicalConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idf: Option<IdfConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdfConfig {
+    /// IDF board file (`.emn`).
+    #[serde(alias = "board")]
+    pub emn: String,
 }
 
 /// Board configuration (used for compatibility with external crates expecting BoardConfig name)
@@ -801,6 +818,22 @@ description = "A test board"
         assert_eq!(board.name, "TestBoard");
         assert_eq!(board.path, Some("test_board.zen".to_string()));
         assert_eq!(board.description, "A test board");
+    }
+
+    #[test]
+    fn test_parse_board_mechanical_idf() {
+        let content = r#"
+[board]
+name = "TestBoard"
+path = "test_board.zen"
+
+[board.mechanical.idf]
+emn = "mechanical/TestBoard.emn"
+"#;
+
+        let config = PcbToml::parse(content).unwrap();
+        let idf = config.board.unwrap().mechanical.unwrap().idf.unwrap();
+        assert_eq!(idf.emn, "mechanical/TestBoard.emn");
     }
 
     #[test]

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -25,6 +25,7 @@ pcb-zen = { workspace = true }
 pcb-canonical = { workspace = true }
 pcb-sch = { workspace = true, features = ["table"] }
 pcb-layout = { workspace = true }
+pcb-mechanical = { workspace = true }
 pcb-sim = { workspace = true }
 pcb-diode-api = { workspace = true }
 pcb-docgen = { workspace = true }

--- a/crates/pcbc/src/layout.rs
+++ b/crates/pcbc/src/layout.rs
@@ -98,14 +98,14 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
     let zen_path = &args.file;
     let file_name = zen_path.file_name().unwrap().to_string_lossy().to_string();
 
-    let Some(schematic) = build(
+    let Some(mut schematic) = build(
         zen_path,
         config_inputs,
         create_diagnostics_passes(&args.suppress, &[]),
         false,
         &mut false.clone(),
         &mut false.clone(),
-        resolution_result,
+        resolution_result.clone(),
     ) else {
         anyhow::bail!("Build failed");
     };
@@ -122,6 +122,8 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
 
         return Ok(());
     }
+
+    pcb_mechanical::apply_mcad_positions(&mut schematic, zen_path, &resolution_result)?;
 
     // Process layout and collect diagnostics
     let spinner_msg = if args.check {

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,3 @@
 pcb.sum
 layout/blinky
+usbc_mcad/layout/

--- a/examples/usbc_mcad/README.md
+++ b/examples/usbc_mcad/README.md
@@ -1,0 +1,66 @@
+# MCAD-driven placement (IDF) demo
+
+A small USB-C board whose enclosure dictates where the connector and the
+mounting holes go. The mechanical CAD exports that contract as an IDF board
+file, and `pcb layout` honors it: MCAD-owned components land at the exact
+mechanical pose, locked; everything else stays ECAD-owned and is auto-placed
+around them.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `board.zen` | The board: USB-C receptacle, CC pull-downs, power LED, two M3 mounting holes. |
+| `usbc.zen` | USB-C receptacle (USB 2.0, 16-pin) wrapped as a module. |
+| `mechanical/usbc_mcad.emn` | IDF 3.0 export "from the enclosure CAD". Its `.PLACEMENT` section claims `J1`, `H1`, `H2` as `MCAD`-owned at fixed poses. |
+| `mechanical/footprint-datums.toml` | Maps each IDF package's mechanical datum into footprint-local coordinates. |
+
+## Run it
+
+```sh
+pcb layout examples/usbc_mcad/board.zen
+```
+
+The log reports `applied 3 MCAD position(s) from IDF …/usbc_mcad.emn`. In
+`layout/layout.kicad_pcb` (a 30 × 20 mm board, centered on the A4 sheet —
+IDF coordinates map 1:1 onto the KiCad sheet frame):
+
+- `J1` sits at (148.5, 111.35) mm, locked. The IDF claims the *mating face*
+  at (148.5, 115) — centered on the bottom board edge; the datum catalog says
+  that face is 3.65 mm along +Y from the footprint origin, so the resolver
+  back-computes the footprint origin and the face lands exactly on the edge.
+- `H1`/`H2` sit at (137, 98.5) and (160, 98.5) mm, locked (datum offset is
+  zero — hole axis is the footprint origin).
+- `R1`–`R3` and `D1` are ECAD-owned: HierPlace drops them on first
+  generation, after which their positions live in the `.kicad_pcb` (this
+  example has them hand-placed mid-board). `D1` has an `ECAD` claim in the
+  IDF file, which is ignored — only `MCAD` status transfers ownership.
+
+The board outline on `Edge.Cuts` was drawn once in the layout file (the IDF
+`.BOARD_OUTLINE` section is not imported — the system is placement-only) and
+persists through re-syncs, like any other destination-owned content.
+`pcb layout --check` passes DRC with no errors.
+
+## The MCAD revision loop
+
+When the enclosure changes, the mechanical engineer re-exports the `.emn`.
+Edit the `J1` coordinate record in `mechanical/usbc_mcad.emn` (e.g.
+`148.5 → 151.5`) and re-run `pcb layout`: `J1` moves to (151.5, 111.35);
+every other footprint keeps its position.
+
+## How discovery works
+
+This example uses the zero-config convention: `mechanical/<board>.emn` next
+to the board's `.zen` file (`<board>` is the `Board(name = …)`). You can also
+declare it explicitly in `pcb.toml`:
+
+```toml
+[board.mechanical.idf]
+emn = "mechanical/usbc_mcad.emn"
+```
+
+## Datum integrity (optional)
+
+A `[[datum]]` entry can pin `footprint_hash = "blake3:…"`. If the footprint
+file changes after the datum was calibrated, resolution fails instead of
+silently placing against a stale origin.

--- a/examples/usbc_mcad/board.zen
+++ b/examples/usbc_mcad/board.zen
@@ -1,0 +1,43 @@
+# MCAD-driven placement demo: mechanical/usbc_mcad.emn fixes the USB-C and
+# mounting-hole positions; everything else is ECAD-owned. See README.md.
+
+UsbC = Module("./usbc.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
+Led = Module("@stdlib/generics/Led.zen")
+MountingHole = Module("@stdlib/generics/MountingHole.zen")
+
+VBUS = Power("VBUS")
+GND = Ground("GND")
+DP = Net("DP")
+DM = Net("DM")
+CC1 = Net("CC1")
+CC2 = Net("CC2")
+LED_A = Net("LED_A")
+
+UsbC(
+    name = "J1",
+    VBUS = VBUS,
+    GND = GND,
+    DP = DP,
+    DM = DM,
+    CC1 = CC1,
+    CC2 = CC2,
+)
+
+# USB sink: 5.1k pull-downs on CC advertise a UFP to the source.
+Resistor(name = "R1", value = "5.1kohm", package = "0402", P1 = CC1, P2 = GND)
+Resistor(name = "R2", value = "5.1kohm", package = "0402", P1 = CC2, P2 = GND)
+
+# Power indicator.
+Resistor(name = "R3", value = "1kohm", package = "0402", P1 = VBUS, P2 = LED_A)
+Led(name = "D1", package = "0402", color = "green", A = LED_A, K = GND)
+
+# Enclosure-positioned mounting holes.
+MountingHole(name = "H1", diameter = "M3", P1 = GND)
+MountingHole(name = "H2", diameter = "M3", P1 = GND)
+
+Board(
+    name = "usbc_mcad",
+    layers = 2,
+    layout_path = "layout",
+)

--- a/examples/usbc_mcad/mechanical/footprint-datums.toml
+++ b/examples/usbc_mcad/mechanical/footprint-datums.toml
@@ -1,0 +1,14 @@
+# Maps each IDF package's mechanical datum into footprint-local mm so the
+# resolver can place the footprint origin where the datum lands as declared.
+
+# USB-C datum is the mating face: 3.65 mm along +Y from the footprint origin.
+[[datum]]
+idf_package = "USB_C_RECEPTACLE"
+footprint = "package://gitlab.com/kicad/libraries/kicad-footprints@10.0.3/Connector_USB.pretty/USB_C_Receptacle_HRO_TYPE-C-31-M-12.kicad_mod"
+mechanical_origin_in_footprint = { x_mm = 0.0, y_mm = 3.65 }
+
+# Mounting holes: datum is the hole axis, which is also the footprint origin.
+[[datum]]
+idf_package = "MTG_HOLE_M3"
+footprint = "package://gitlab.com/kicad/libraries/kicad-footprints@10.0.3/MountingHole.pretty/MountingHole_3.2mm_M3_DIN965_Pad_TopBottom.kicad_mod"
+mechanical_origin_in_footprint = { x_mm = 0.0, y_mm = 0.0 }

--- a/examples/usbc_mcad/mechanical/usbc_mcad.emn
+++ b/examples/usbc_mcad/mechanical/usbc_mcad.emn
@@ -1,0 +1,30 @@
+# IDF 3.0 export "from the enclosure CAD" — the .PLACEMENT section is the
+# MCAD/ECAD ownership contract. Coordinates in mm, mapped 1:1 to the KiCad sheet.
+.HEADER
+BOARD_FILE 3.0 "usbc_mcad enclosure export" 2026/06/10.10:00:00 1
+usbc_mcad.emn MM
+.END_HEADER
+
+# 30 x 20 mm rectangular outline.
+.BOARD_OUTLINE MCAD
+1.6
+0 133.5 95.0 0.0
+0 163.5 95.0 0.0
+0 163.5 115.0 0.0
+0 133.5 115.0 0.0
+0 133.5 95.0 0.0
+.END_BOARD_OUTLINE
+
+.PLACEMENT
+# USB-C mating face centered on the y = 115 board edge; MCAD owns it.
+"USB_C_RECEPTACLE" "TYPE-C-31-M-12" J1
+148.5 115.0 0.0 0 TOP MCAD
+# M3 mounting bosses in the enclosure base; MCAD owns them.
+"MTG_HOLE_M3" "" H1
+137.0 98.5 0.0 0 TOP MCAD
+"MTG_HOLE_M3" "" H2
+160.0 98.5 0.0 0 TOP MCAD
+# The LED stays ECAD-owned; its row is parsed and ignored.
+"LED_0402" "" D1
+0.0 0.0 0.0 0 TOP ECAD
+.END_PLACEMENT

--- a/examples/usbc_mcad/pcb.toml
+++ b/examples/usbc_mcad/pcb.toml
@@ -1,0 +1,6 @@
+[dependencies]
+"gitlab.com/kicad/libraries/kicad-symbols" = "10.0.3"
+"gitlab.com/kicad/libraries/kicad-footprints" = "10.0.3"
+
+[dependencies.indirect]
+"gitlab.com/kicad/libraries/kicad-packages3D@10" = "10.0.3"

--- a/examples/usbc_mcad/usbc.zen
+++ b/examples/usbc_mcad/usbc.zen
@@ -1,0 +1,30 @@
+# USB Type-C receptacle (USB 2.0, 16-pin) wrapped as a reusable module.
+
+VBUS = io(Power)
+GND = io(Ground)
+DP = io(Net)
+DM = io(Net)
+CC1 = io(Net)
+CC2 = io(Net)
+
+Component(
+    name = "USBC",
+    prefix = "J",
+    part = builtin.Part(mpn = "TYPE-C-31-M-12", manufacturer = "HRO"),
+    symbol = Symbol(
+        library = "@kicad-symbols/Connector.kicad_sym",
+        name = "USB_C_Receptacle_USB2.0_16P",
+    ),
+    footprint = File("@kicad-footprints/Connector_USB.pretty/USB_C_Receptacle_HRO_TYPE-C-31-M-12.kicad_mod"),
+    pins = {
+        "VBUS": VBUS.NET,
+        "GND": GND.NET,
+        "D+": DP,
+        "D-": DM,
+        "CC1": CC1,
+        "CC2": CC2,
+        "SBU1": NotConnected("SBU1_NC"),
+        "SBU2": NotConnected("SBU2_NC"),
+        "SHIELD": GND.NET,
+    },
+)


### PR DESCRIPTION
Adds a pcb-mechanical crate that consumes IDF (.emn) exports from mechanical CAD and pins MCAD-owned components at their exact mechanical pose. Claims are matched to components by reference designator, translated through a footprint-datum catalog
(mechanical/footprint-datums.toml) that maps each mechanical datum into footprint-local coordinates, and applied to the schematic as fixed, locked placements that the layout sync enforces on every run while HierPlace packs ECAD-owned parts around them.

The .emn is discovered by convention (mechanical/<board>.emn next to the board's .zen or at the workspace root) or declared explicitly via [board.mechanical.idf] in pcb.toml. Includes an end-to-end example (examples/usbc_mcad) with a USB-C receptacle and mounting holes fixed by the enclosure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches layout sync placement logic and introduces new resolution failures (missing datums, ambiguous IDF paths, hash mismatches); incorrect pose math could misplace MCAD-owned parts on every sync.
> 
> **Overview**
> Adds **MCAD-driven placement** so `pcb layout` can honor mechanical CAD exports before KiCad sync.
> 
> A new **`pcb-mechanical`** crate discovers IDF board files (`.emn`) via `mechanical/<board>.emn` or `[board.mechanical.idf]` in `pcb.toml`, parses `.PLACEMENT` for `MCAD`-owned refdes, and resolves footprint origins through **`mechanical/footprint-datums.toml`** (optional `footprint_hash` validation). Resolved poses are written onto schematic instances as **`BoardPose`** / `Instance.placement`.
> 
> **`pcbc layout`** calls `apply_mcad_positions` after the schematic build. The layout lens treats compiler **`fixed_placement`** as authoritative: it overrides saved KiCad placement, creates new footprints at that pose (locked), re-applies pose on updates, and excludes those parts from HierPlace auto-packing (fixed footprints count as existing content). JSON netlist parsing forwards per-instance `placement`.
> 
> Includes **`examples/usbc_mcad`** demonstrating USB-C and mounting holes fixed by IDF while ECAD parts stay auto-placed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17001ce35851e3628ea4a470a9695d196039827d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->