### PR TITLE
Add KiCad 10 jumper pin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Removed deprecated language shims, including `config(convert=...)`, bare `add_property(...)`, `NET=` net casts, module DNP properties, automatic component property key capitalization, legacy `Component(properties={...})` sourcing/DNP keys, and legacy net moved aliases.
 - Regular nets now require explicit or assignment-inferred unique names; unnamed or duplicate regular nets fail evaluation.
 - `NotConnected` nets are now source-unnamed; explicit names are ignored with a warning and downstream tools assign connection-derived names as needed.
+- Added KiCad 10 jumper-pin support.
 
 ## [0.3.92] - 2026-06-09
 

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -133,7 +133,7 @@ fn signal_is_only_no_connect(metadata: &SignalPinMetadata) -> bool {
 
 pub fn generated_signal_io_names(symbol: &Symbol) -> BTreeMap<String, String> {
     let mut signals: BTreeMap<String, SignalPinMetadata> = BTreeMap::new();
-    for pin in &symbol.pins {
+    for pin in symbol.canonical_pins() {
         let signal_name = pin.signal_name().to_string();
         let metadata = signals
             .entry(signal_name)
@@ -397,6 +397,53 @@ mod tests {
         assert!(zen.contains("\"NC\": NC"));
         // No pin_defs needed
         assert!(!zen.contains("pin_defs"));
+    }
+
+    #[test]
+    fn duplicate_pin_numbers_collapse_to_first_public_signal() {
+        let symbol = pcb_eda::Symbol {
+            name: "X".to_string(),
+            internal_connectivity: pcb_eda::InternalConnectivity {
+                duplicate_numbers_are_jumpers: true,
+                groups: Vec::new(),
+            },
+            pins: vec![
+                pcb_eda::Pin {
+                    name: "A".to_string(),
+                    number: "1".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "B".to_string(),
+                    number: "1".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "C".to_string(),
+                    number: "2".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let zen = generate_component_zen(GenerateComponentZenArgs {
+            component_name: "MPN1",
+            symbol: &symbol,
+            symbol_filename: "MPN1.kicad_sym",
+            generated_by: "pcb import",
+            include_skip_bom: false,
+            include_skip_pos: false,
+            skip_bom_default: false,
+            skip_pos_default: false,
+        })
+        .unwrap();
+
+        assert!(zen.contains("A = io(Net)"));
+        assert!(zen.contains("\"A\": A"));
+        assert!(!zen.contains("B = io(Net)"));
+        assert!(!zen.contains("\"B\": B"));
+        assert!(zen.contains("C = io(Net)"));
     }
 
     #[test]

--- a/crates/pcb-eda/src/kicad/symbol.rs
+++ b/crates/pcb-eda/src/kicad/symbol.rs
@@ -1,10 +1,12 @@
 use crate::kicad::metadata::SymbolMetadata;
-use crate::{Part, Pin, PinAlternate, PinAt, Symbol, is_placeholder_kicad_pin_name};
+use crate::{
+    InternalConnectivity, Part, Pin, PinAlternate, PinAt, Symbol, is_placeholder_kicad_pin_name,
+};
 use anyhow::Result;
 use pcb_sexpr::{Sexpr, SexprKind, parse};
 use serde::Serialize;
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
@@ -16,6 +18,7 @@ pub struct KicadSymbol {
     pub(super) extends: Option<String>,
     pub(super) footprint: String,
     pub(super) in_bom: bool,
+    pub(super) internal_connectivity: InternalConnectivity,
     pub(super) pins: Vec<KicadPin>,
     pub(super) mpn: Option<String>,
     pub(super) manufacturer: Option<String>,
@@ -104,6 +107,7 @@ impl From<KicadSymbol> for Symbol {
             footprint: symbol.footprint,
             reference: symbol.reference,
             in_bom: symbol.in_bom,
+            internal_connectivity: symbol.internal_connectivity,
             mpn: symbol.mpn,
             datasheet: symbol.datasheet_url,
             manufacturer: symbol.manufacturer,
@@ -202,6 +206,13 @@ pub(super) fn parse_symbol(symbol_data: &[Sexpr]) -> Result<KicadSymbol> {
                     }
                 }
                 "in_bom" => parse_in_bom(&mut symbol, prop_list),
+                "duplicate_pin_numbers_are_jumpers" => {
+                    symbol.internal_connectivity.duplicate_numbers_are_jumpers =
+                        prop_list.get(1).and_then(parse_bool_atom).unwrap_or(false);
+                }
+                "jumper_pin_groups" => {
+                    symbol.internal_connectivity.groups = parse_jumper_pin_groups(prop_list);
+                }
                 "property" => parse_property(&mut symbol, prop_list),
                 "pin" => {
                     if let Some(pin) = parse_pin(prop_list) {
@@ -350,10 +361,35 @@ fn parse_pin_from_section(pin_data: &[Sexpr]) -> Option<KicadPin> {
 }
 
 fn parse_in_bom(symbol: &mut KicadSymbol, prop_list: &[Sexpr]) {
-    symbol.in_bom = prop_list
-        .get(1)
-        .map(|v| matches!(&v.kind, SexprKind::Symbol(s) if s == "yes"))
-        .unwrap_or(false);
+    symbol.in_bom = prop_list.get(1).and_then(parse_bool_atom).unwrap_or(false);
+}
+
+fn parse_bool_atom(node: &Sexpr) -> Option<bool> {
+    match node.as_atom() {
+        Some("yes") | Some("1") => Some(true),
+        Some("no") | Some("0") => Some(false),
+        _ => match node.as_int() {
+            Some(1) => Some(true),
+            Some(0) => Some(false),
+            _ => None,
+        },
+    }
+}
+
+fn parse_jumper_pin_groups(prop_list: &[Sexpr]) -> Vec<BTreeSet<String>> {
+    prop_list
+        .iter()
+        .skip(1)
+        .filter_map(|group| {
+            Some(
+                group
+                    .as_list()?
+                    .iter()
+                    .filter_map(|pin| pin.as_str().or_else(|| pin.as_sym()).map(ToOwned::to_owned))
+                    .collect(),
+            )
+        })
+        .collect()
 }
 
 fn parse_property(symbol: &mut KicadSymbol, prop_list: &[Sexpr]) {

--- a/crates/pcb-eda/src/kicad/symbol_library.rs
+++ b/crates/pcb-eda/src/kicad/symbol_library.rs
@@ -635,6 +635,10 @@ fn merge_symbols(parent: &KicadSymbol, child: &KicadSymbol) -> KicadSymbol {
     merged.name = child.name.clone();
     merged.extends = child.extends.clone();
 
+    if !child.internal_connectivity.is_empty() {
+        merged.internal_connectivity = child.internal_connectivity.clone();
+    }
+
     // Override properties that are explicitly set in child
     if !child.footprint.is_empty() {
         merged.footprint = child.footprint.clone();
@@ -1149,6 +1153,29 @@ mod tests {
         let lib = KicadSymbolLibrary::from_string(content).unwrap();
         let extended = lib.get_symbol_lazy("Extended").unwrap().unwrap();
         assert_eq!(extended.reference, "J");
+    }
+
+    #[test]
+    fn test_extends_overrides_jumper_metadata() {
+        let content = r#"(kicad_symbol_lib
+            (symbol "Base"
+                (duplicate_pin_numbers_are_jumpers yes)
+                (jumper_pin_groups ("1" "2"))
+            )
+            (symbol "Extended"
+                (extends "Base")
+                (duplicate_pin_numbers_are_jumpers no)
+                (jumper_pin_groups ("5" "6"))
+            )
+        )"#;
+
+        let lib = KicadSymbolLibrary::from_string(content).unwrap();
+        let extended = lib.get_symbol_lazy("Extended").unwrap().unwrap();
+        let expected: std::collections::BTreeSet<String> =
+            ["5", "6"].into_iter().map(String::from).collect();
+
+        assert!(!extended.internal_connectivity.duplicate_numbers_are_jumpers);
+        assert_eq!(extended.internal_connectivity.groups, vec![expected]);
     }
 
     #[test]

--- a/crates/pcb-eda/src/kicad/symbol_library.rs
+++ b/crates/pcb-eda/src/kicad/symbol_library.rs
@@ -635,9 +635,9 @@ fn merge_symbols(parent: &KicadSymbol, child: &KicadSymbol) -> KicadSymbol {
     merged.name = child.name.clone();
     merged.extends = child.extends.clone();
 
-    if !child.internal_connectivity.is_empty() {
-        merged.internal_connectivity = child.internal_connectivity.clone();
-    }
+    // Jumper metadata always comes from the parent: KiCad's LIB_SYMBOL::Flatten()
+    // never transfers a derived symbol's own jumper fields, so any declared on a
+    // derived symbol are ignored.
 
     // Override properties that are explicitly set in child
     if !child.footprint.is_empty() {
@@ -1156,7 +1156,9 @@ mod tests {
     }
 
     #[test]
-    fn test_extends_overrides_jumper_metadata() {
+    fn test_extends_inherits_parent_jumper_metadata() {
+        // Matches KiCad's LIB_SYMBOL::Flatten(): jumper metadata on a derived
+        // symbol is ignored; the parent's always wins.
         let content = r#"(kicad_symbol_lib
             (symbol "Base"
                 (duplicate_pin_numbers_are_jumpers yes)
@@ -1172,9 +1174,9 @@ mod tests {
         let lib = KicadSymbolLibrary::from_string(content).unwrap();
         let extended = lib.get_symbol_lazy("Extended").unwrap().unwrap();
         let expected: std::collections::BTreeSet<String> =
-            ["5", "6"].into_iter().map(String::from).collect();
+            ["1", "2"].into_iter().map(String::from).collect();
 
-        assert!(!extended.internal_connectivity.duplicate_numbers_are_jumpers);
+        assert!(extended.internal_connectivity.duplicate_numbers_are_jumpers);
         assert_eq!(extended.internal_connectivity.groups, vec![expected]);
     }
 

--- a/crates/pcb-eda/src/lib.rs
+++ b/crates/pcb-eda/src/lib.rs
@@ -6,7 +6,7 @@ use kicad::symbol_library::KicadSymbolLibrary;
 use pcb_sexpr::Sexpr;
 use serde::Serialize;
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::io;
 use std::path::Path;
 use std::str::FromStr;
@@ -17,6 +17,8 @@ pub struct Symbol {
     pub footprint: String,
     pub reference: String,
     pub in_bom: bool,
+    #[serde(default, skip_serializing_if = "InternalConnectivity::is_empty")]
+    pub internal_connectivity: InternalConnectivity,
     pub pins: Vec<Pin>,
     pub datasheet: Option<String>,
     pub manufacturer: Option<String>,
@@ -26,6 +28,23 @@ pub struct Symbol {
     pub properties: HashMap<String, String>,
     #[serde(skip)]
     pub raw_sexp: Option<Sexpr>,
+}
+
+/// KiCad jumper metadata parsed from a symbol, preserved as written in the file.
+/// Normalization (merging overlapping groups, dropping singletons) happens when
+/// converting to `pcb_sch::InternalConnectivity`.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize)]
+pub struct InternalConnectivity {
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub duplicate_numbers_are_jumpers: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<BTreeSet<String>>,
+}
+
+impl InternalConnectivity {
+    pub fn is_empty(&self) -> bool {
+        !self.duplicate_numbers_are_jumpers && self.groups.is_empty()
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Clone, Serialize)]
@@ -116,6 +135,17 @@ impl Symbol {
 
     pub fn raw_sexp(&self) -> Option<&Sexpr> {
         self.raw_sexp.as_ref()
+    }
+
+    /// Pins deduplicated by pin number, first occurrence wins.
+    ///
+    /// Repeated pin numbers (multi-unit shared pins, KiCad 10 duplicate-number
+    /// jumpers) are one logical terminal; the first occurrence names it.
+    pub fn canonical_pins(&self) -> impl Iterator<Item = &Pin> {
+        let mut seen = BTreeSet::new();
+        self.pins
+            .iter()
+            .filter(move |pin| seen.insert(pin.number.as_str()))
     }
 }
 

--- a/crates/pcb-eda/tests/test_eda.rs
+++ b/crates/pcb-eda/tests/test_eda.rs
@@ -3,7 +3,7 @@ mod test_utils;
 use test_utils::setup_symbol;
 
 use pcb_eda::{Part, Symbol, SymbolLibrary};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 fn test_symbol_property(symbol_name: &str, property: impl Fn(&Symbol) -> String, expected: &str) {
     let symbol = setup_symbol(symbol_name);
@@ -256,6 +256,38 @@ fn test_kicad10_duplicate_pin_numbers_marked_as_jumpers_are_preserved() {
     assert_eq!(symbol.pins[1].number, "1");
     assert_eq!(symbol.pins[0].name, "A");
     assert_eq!(symbol.pins[1].name, "B");
+    assert!(symbol.internal_connectivity.duplicate_numbers_are_jumpers);
+    assert!(symbol.internal_connectivity.groups.is_empty());
+}
+
+#[test]
+fn test_kicad10_jumper_pin_groups_are_preserved() {
+    let content = r#"(kicad_symbol_lib
+  (version 20251024)
+  (generator "kicad_symbol_editor")
+  (generator_version "10.0")
+  (symbol "Jumper_Groups"
+    (jumper_pin_groups ("3" "1") ("3" "4") ("2" "2"))
+    (property "Reference" "JP" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (symbol "Jumper_Groups_1_1"
+      (pin passive line (at 0 0 0) (length 2.54) (name "A") (number "1"))
+      (pin passive line (at 0 0 0) (length 2.54) (name "B") (number "3"))
+      (pin passive line (at 0 0 0) (length 2.54) (name "C") (number "4"))
+    )
+  )
+)"#;
+
+    let lib = SymbolLibrary::from_string(content, "kicad_sym").unwrap();
+    let symbol = lib.get_symbol("Jumper_Groups").unwrap();
+
+    // Groups are preserved as written; normalization (merging overlaps, dropping
+    // singletons) happens downstream in pcb_sch::InternalConnectivity.
+    let group =
+        |numbers: &[&str]| -> BTreeSet<String> { numbers.iter().map(|n| n.to_string()).collect() };
+    assert_eq!(
+        symbol.internal_connectivity.groups,
+        vec![group(&["1", "3"]), group(&["3", "4"]), group(&["2"])]
+    );
 }
 
 #[test]

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -1194,9 +1194,11 @@ fn footprint_internal_connectivity_insert_at(footprint: &[pcb_sexpr::Sexpr]) -> 
             .as_list()
             .and_then(|child| child.first())
             .and_then(pcb_sexpr::Sexpr::as_sym);
+        // KiCad's board writer emits the jumper nodes right after these, in this
+        // order: attr, stackup, private_layers, net_tie_pad_groups.
         if matches!(
             tag,
-            Some("property" | "attr" | "net_tie_pad_groups" | "private_layers")
+            Some("property" | "attr" | "stackup" | "private_layers" | "net_tie_pad_groups")
         ) {
             insert_at = item.span.end;
         }

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -582,6 +582,7 @@ pub fn process_layout(
         &paths.pcb,
         board_config.as_ref(),
         layout_name.as_deref(),
+        &component_internal_connectivity_by_path(schematic),
         kicad_model_dirs,
         &footprint_lib_dirs,
     )?;
@@ -864,6 +865,13 @@ mod diff_tests {
                     .to_string(),
             ),
         );
+        component.internal_connectivity = pcb_sch::InternalConnectivity::new(
+            true,
+            [std::collections::BTreeSet::from([
+                "1".to_string(),
+                "3".to_string(),
+            ])],
+        );
 
         schematic.add_instance(component_ref.clone(), component);
 
@@ -878,6 +886,12 @@ mod diff_tests {
             instance["footprint_fpid"],
             "kicad_libraries_kicad-footprints_Resistor_SMD@10.0.3:R_0603_1608Metric"
         );
+        assert_eq!(
+            instance["internal_connectivity"]["duplicate_numbers_are_jumpers"],
+            true
+        );
+        assert_eq!(instance["internal_connectivity"]["groups"][0][0], "1");
+        assert_eq!(instance["internal_connectivity"]["groups"][0][1], "3");
 
         Ok(())
     }
@@ -956,6 +970,7 @@ fn patch_pcb_file(
     pcb_path: &Path,
     board_config: Option<&BoardConfig>,
     layout_name: Option<&str>,
+    internal_connectivity_by_path: &BTreeMap<String, pcb_sch::InternalConnectivity>,
     kicad_model_dirs: &BTreeMap<String, PathBuf>,
     footprint_lib_dirs: &HashMap<String, PathBuf>,
 ) -> Result<(), LayoutError> {
@@ -967,7 +982,12 @@ fn patch_pcb_file(
         LayoutError::StackupPatchingError(format!("Failed to parse PCB file: {}", e))
     })?;
 
-    let patches = build_pcb_patchset(&board, board_config, layout_name)?;
+    let patches = build_pcb_patchset(
+        &board,
+        board_config,
+        layout_name,
+        internal_connectivity_by_path,
+    )?;
     let patched = render_patches(&pcb_content, &patches).map_err(|e| {
         LayoutError::StackupPatchingError(format!(
             "Failed to patch PCB file {}: {}",
@@ -1034,9 +1054,14 @@ fn build_pcb_patchset(
     board: &pcb_sexpr::Sexpr,
     board_config: Option<&BoardConfig>,
     layout_name: Option<&str>,
+    internal_connectivity_by_path: &BTreeMap<String, pcb_sch::InternalConnectivity>,
 ) -> Result<pcb_sexpr::PatchSet, LayoutError> {
     let mut patches = build_title_block_patchset(board)?;
     patches.extend(build_board_properties_patchset(board, layout_name)?);
+    patches.extend(build_footprint_internal_connectivity_patchset(
+        board,
+        internal_connectivity_by_path,
+    )?);
 
     if let Some(stackup) = board_config.and_then(|config| config.stackup.as_ref()) {
         let board_thickness_iu = stackup_thickness_iu(stackup);
@@ -1052,6 +1077,143 @@ fn build_pcb_patchset(
     }
 
     Ok(patches)
+}
+
+fn component_internal_connectivity_by_path(
+    schematic: &Schematic,
+) -> BTreeMap<String, pcb_sch::InternalConnectivity> {
+    schematic
+        .instances
+        .iter()
+        .filter(|(_, instance)| instance.kind == InstanceKind::Component)
+        .map(|(instance_ref, instance)| {
+            (
+                instance_ref.instance_path.join("."),
+                instance.internal_connectivity.clone(),
+            )
+        })
+        .collect()
+}
+
+fn build_footprint_internal_connectivity_patchset(
+    board: &pcb_sexpr::Sexpr,
+    internal_connectivity_by_path: &BTreeMap<String, pcb_sch::InternalConnectivity>,
+) -> Result<pcb_sexpr::PatchSet, LayoutError> {
+    let root_items = board.as_list().ok_or_else(|| {
+        LayoutError::StackupPatchingError("PCB root is not an S-expression list".to_string())
+    })?;
+    if root_items.first().and_then(pcb_sexpr::Sexpr::as_sym) != Some("kicad_pcb") {
+        return Err(LayoutError::StackupPatchingError(
+            "PCB root must start with (kicad_pcb ...)".to_string(),
+        ));
+    }
+
+    let mut patches = pcb_sexpr::PatchSet::new();
+    for item in root_items.iter().skip(1) {
+        let Some(footprint) = item.as_list() else {
+            continue;
+        };
+        if footprint.first().and_then(pcb_sexpr::Sexpr::as_sym) != Some("footprint") {
+            continue;
+        }
+
+        // Managed footprints carry the schematic component path in their "Path"
+        // property (written by the lens, which runs before this postprocess).
+        let Some(connectivity) = pcb_sexpr::kicad::schematic_properties(footprint)
+            .get("Path")
+            .and_then(|path| internal_connectivity_by_path.get(path))
+        else {
+            continue;
+        };
+
+        // KiCad 10 writes the boolean on every footprint, so rewrite it in place
+        // when present but only insert it when true.
+        let duplicate_text = format!(
+            "(duplicate_pad_numbers_are_jumpers {})",
+            if connectivity.duplicate_numbers_are_jumpers {
+                "yes"
+            } else {
+                "no"
+            }
+        );
+        match direct_child_node(footprint, "duplicate_pad_numbers_are_jumpers") {
+            Some(node) => patches.replace_raw(node.span, duplicate_text),
+            None if connectivity.duplicate_numbers_are_jumpers => {
+                insert_footprint_child(&mut patches, footprint, &duplicate_text);
+            }
+            None => {}
+        }
+
+        // Groups are written only when non-empty, matching KiCad's board writer.
+        let groups_text = (!connectivity.groups.is_empty())
+            .then(|| format_jumper_pad_groups(&connectivity.groups));
+        match (
+            direct_child_node(footprint, "jumper_pad_groups"),
+            groups_text,
+        ) {
+            (Some(node), Some(text)) => patches.replace_raw(node.span, text),
+            (Some(node), None) => patches.replace_raw(node.span, String::new()),
+            (None, Some(text)) => insert_footprint_child(&mut patches, footprint, &text),
+            (None, None) => {}
+        }
+    }
+
+    Ok(patches)
+}
+
+fn insert_footprint_child(
+    patches: &mut pcb_sexpr::PatchSet,
+    footprint: &[pcb_sexpr::Sexpr],
+    text: &str,
+) {
+    let at = footprint_internal_connectivity_insert_at(footprint);
+    patches.replace_raw(pcb_sexpr::Span::new(at, at), format!("\n\t\t{text}"));
+}
+
+fn direct_child_node<'a>(
+    parent: &'a [pcb_sexpr::Sexpr],
+    name: &str,
+) -> Option<&'a pcb_sexpr::Sexpr> {
+    parent.iter().skip(1).find(|item| {
+        item.as_list()
+            .and_then(|items| items.first())
+            .and_then(pcb_sexpr::Sexpr::as_sym)
+            == Some(name)
+    })
+}
+
+fn footprint_internal_connectivity_insert_at(footprint: &[pcb_sexpr::Sexpr]) -> usize {
+    let mut insert_at = footprint
+        .get(1)
+        .map(|node| node.span.end)
+        .or_else(|| footprint.first().map(|node| node.span.end))
+        .unwrap_or_default();
+
+    for item in footprint.iter().skip(2) {
+        let tag = item
+            .as_list()
+            .and_then(|child| child.first())
+            .and_then(pcb_sexpr::Sexpr::as_sym);
+        if matches!(
+            tag,
+            Some("property" | "attr" | "net_tie_pad_groups" | "private_layers")
+        ) {
+            insert_at = item.span.end;
+        }
+    }
+
+    insert_at
+}
+
+fn format_jumper_pad_groups(groups: &[std::collections::BTreeSet<String>]) -> String {
+    let mut group_items = vec![pcb_sexpr::Sexpr::symbol("jumper_pad_groups")];
+    for group in groups {
+        group_items.push(pcb_sexpr::Sexpr::list(
+            group.iter().map(pcb_sexpr::Sexpr::string).collect(),
+        ));
+    }
+
+    pcb_sexpr::Sexpr::list(group_items).to_string()
 }
 
 fn build_board_properties_patchset(
@@ -1333,9 +1495,11 @@ fn stackup_thickness_iu(stackup: &Stackup) -> Option<PcbIu> {
 mod tests {
     use super::{
         PCB_GIT_HASH_PLACEHOLDER, PCB_VERSION_PLACEHOLDER, PcbIu, build_board_properties_patchset,
-        build_stackup_patchset, build_title_block_patchset, stackup_thickness_iu,
+        build_footprint_internal_connectivity_patchset, build_stackup_patchset,
+        build_title_block_patchset, stackup_thickness_iu,
     };
     use pcb_zen_core::lang::stackup::{CopperRole, DielectricForm, Layer, Stackup};
+    use std::collections::{BTreeMap, BTreeSet};
 
     #[test]
     fn stackup_thickness_iu_rounds_like_kicad() {
@@ -1397,6 +1561,90 @@ mod tests {
         assert!(out.contains(&format!(
             r#"(property "PCB_GIT_HASH" "{PCB_GIT_HASH_PLACEHOLDER}")"#
         )));
+    }
+
+    #[test]
+    fn build_footprint_internal_connectivity_patchset_applies_jumper_metadata() {
+        let input = r#"(kicad_pcb
+	(footprint "Lib:JP"
+		(layer "F.Cu")
+		(property "Path" "J1")
+		(path "/old")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(jumper_pad_groups
+			("8" "9")
+		)
+		(pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu"))
+	)
+)"#;
+
+        let board = pcb_sexpr::parse(input).unwrap();
+        let connectivity = BTreeMap::from([(
+            "J1".to_string(),
+            pcb_sch::InternalConnectivity::new(
+                true,
+                [BTreeSet::from(["1".to_string(), "3".to_string()])],
+            ),
+        )]);
+        let patches =
+            build_footprint_internal_connectivity_patchset(&board, &connectivity).unwrap();
+        let mut out = Vec::new();
+        patches.write_to(input, &mut out).unwrap();
+        let out = String::from_utf8(out).unwrap();
+
+        assert!(out.contains("(duplicate_pad_numbers_are_jumpers yes)"));
+        assert!(out.contains("(jumper_pad_groups"));
+        assert!(out.contains(r#"("1" "3")"#));
+        assert!(!out.contains(r#"("8" "9")"#));
+    }
+
+    #[test]
+    fn build_footprint_internal_connectivity_patchset_clears_stale_jumper_groups() {
+        let input = r#"(kicad_pcb
+	(footprint "Lib:JP"
+		(layer "F.Cu")
+		(property "Path" "J1")
+		(path "/old")
+		(duplicate_pad_numbers_are_jumpers yes)
+		(jumper_pad_groups
+			("1" "3")
+		)
+		(pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu"))
+	)
+)"#;
+
+        let board = pcb_sexpr::parse(input).unwrap();
+        let connectivity =
+            BTreeMap::from([("J1".to_string(), pcb_sch::InternalConnectivity::default())]);
+        let patches =
+            build_footprint_internal_connectivity_patchset(&board, &connectivity).unwrap();
+        let mut out = Vec::new();
+        patches.write_to(input, &mut out).unwrap();
+        let out = String::from_utf8(out).unwrap();
+
+        assert!(out.contains("(duplicate_pad_numbers_are_jumpers no)"));
+        assert!(!out.contains("(jumper_pad_groups"));
+    }
+
+    #[test]
+    fn build_footprint_internal_connectivity_patchset_leaves_default_empty_metadata_absent() {
+        let input = r#"(kicad_pcb
+	(footprint "Lib:JP"
+		(layer "F.Cu")
+		(property "Path" "J1")
+		(path "/old")
+		(pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu"))
+	)
+)"#;
+
+        let board = pcb_sexpr::parse(input).unwrap();
+        let connectivity =
+            BTreeMap::from([("J1".to_string(), pcb_sch::InternalConnectivity::default())]);
+        let patches =
+            build_footprint_internal_connectivity_patchset(&board, &connectivity).unwrap();
+
+        assert!(patches.is_empty());
     }
 
     #[test]

--- a/crates/pcb-sch/src/bom/core.rs
+++ b/crates/pcb-sch/src/bom/core.rs
@@ -791,6 +791,7 @@ mod tests {
             attributes,
             children: Default::default(),
             reference_designator: Some("U1".to_string()),
+            internal_connectivity: Default::default(),
             symbol_positions: HashMap::new(),
         }
     }

--- a/crates/pcb-sch/src/kicad_netlist.rs
+++ b/crates/pcb-sch/src/kicad_netlist.rs
@@ -213,6 +213,26 @@ pub fn to_kicad_netlist(sch: &Schematic) -> String {
         .unwrap();
         writeln!(out, "      (tstamps \"{ts_uuid}\")").unwrap();
 
+        if comp
+            .instance
+            .internal_connectivity
+            .duplicate_numbers_are_jumpers
+        {
+            writeln!(out, "      (duplicate_pin_numbers_are_jumpers 1)").unwrap();
+        }
+
+        if !comp.instance.internal_connectivity.groups.is_empty() {
+            writeln!(out, "      (jumper_pin_groups").unwrap();
+            for group in &comp.instance.internal_connectivity.groups {
+                write!(out, "        (group").unwrap();
+                for pin in group {
+                    write!(out, " (pin \"{}\")", escape_kicad_string(pin)).unwrap();
+                }
+                writeln!(out, ")").unwrap();
+            }
+            writeln!(out, "      )").unwrap();
+        }
+
         // Explicitly add the standard KiCad "Reference" property pointing to the component's
         // reference designator.  This ensures the field is always present and consistent
         // irrespective of user-specified attributes.
@@ -344,6 +364,8 @@ pub fn to_kicad_netlist(sch: &Schematic) -> String {
                 ord
             }
         });
+        let mut seen_nodes = HashSet::new();
+        sorted_nodes.retain(|node| seen_nodes.insert((node.refdes.clone(), node.pad.clone())));
 
         writeln!(
             out,
@@ -1016,5 +1038,49 @@ mod tests {
 
         let netlist = to_kicad_netlist(&schematic);
         assert!(netlist.contains("(node (ref \"D1\") (pin \"2\") (pintype \"stereo\"))"));
+    }
+
+    #[test]
+    fn emits_component_internal_connectivity() {
+        let module_ref = crate::ModuleRef::from_path(Path::new("/tmp/test.zen"), "<root>");
+        let comp_ref = InstanceRef::new(module_ref.clone(), vec!["JP1".into()]);
+        let mut component = crate::Instance::component(module_ref.clone());
+        component.reference_designator = Some("JP1".to_owned());
+        component.attributes.insert(
+            "footprint".into(),
+            AttributeValue::String("Jumper:SolderJumper".to_owned()),
+        );
+        component.internal_connectivity = crate::InternalConnectivity::new(
+            true,
+            [std::collections::BTreeSet::from([
+                "1".to_owned(),
+                "3".to_owned(),
+            ])],
+        );
+
+        let port_ref = InstanceRef::new(module_ref.clone(), vec!["JP1".into(), "A".into()]);
+        let mut port = crate::Instance::port(module_ref.clone());
+        port.attributes.insert(
+            "pads".into(),
+            AttributeValue::Array(vec![AttributeValue::String("1".to_owned())]),
+        );
+        component.add_child("A", port_ref.clone());
+
+        let mut schematic = Schematic::new();
+        schematic.add_instance(comp_ref, component);
+        schematic.add_instance(port_ref.clone(), port);
+        schematic.add_net(crate::Net {
+            kind: "Net".to_owned(),
+            id: 1,
+            name: "SHARED".to_owned(),
+            ports: vec![port_ref],
+            properties: HashMap::new(),
+        });
+
+        let netlist = to_kicad_netlist(&schematic);
+
+        assert!(netlist.contains("(duplicate_pin_numbers_are_jumpers 1)"));
+        assert!(netlist.contains("(jumper_pin_groups"));
+        assert!(netlist.contains("(group (pin \"1\") (pin \"3\"))"));
     }
 }

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -20,7 +20,7 @@ pub mod natural_string;
 pub mod physical;
 pub mod position;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
@@ -44,6 +44,10 @@ pub const ATTR_LAYOUT_HINTS: &str = "layout_hints";
 
 /// URI prefix for stable, machine-independent package references.
 pub const PACKAGE_URI_PREFIX: &str = "package://";
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
 
 /// Resolve a `package://` URI to an absolute filesystem path.
 ///
@@ -464,6 +468,48 @@ impl AttributeValue {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InternalConnectivity {
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub duplicate_numbers_are_jumpers: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<BTreeSet<String>>,
+}
+
+impl InternalConnectivity {
+    /// Build normalized internal connectivity: singleton groups are dropped,
+    /// overlapping groups are merged, and the group list is sorted.
+    pub fn new(
+        duplicate_numbers_are_jumpers: bool,
+        groups: impl IntoIterator<Item = BTreeSet<String>>,
+    ) -> Self {
+        let mut normalized: Vec<BTreeSet<String>> = Vec::new();
+        for mut group in groups {
+            if group.len() < 2 {
+                continue;
+            }
+            // Groups already in `normalized` are pairwise disjoint, so merging
+            // everything that overlaps the incoming group preserves that invariant.
+            let (overlapping, disjoint): (Vec<_>, Vec<_>) = normalized
+                .into_iter()
+                .partition(|existing| !existing.is_disjoint(&group));
+            group.extend(overlapping.into_iter().flatten());
+            normalized = disjoint;
+            normalized.push(group);
+        }
+        normalized.sort();
+
+        Self {
+            duplicate_numbers_are_jumpers,
+            groups: normalized,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        !self.duplicate_numbers_are_jumpers && self.groups.is_empty()
+    }
+}
+
 impl From<String> for AttributeValue {
     fn from(s: String) -> Self {
         AttributeValue::String(s)
@@ -486,6 +532,8 @@ pub struct Instance {
     pub attributes: HashMap<Symbol, AttributeValue>,
     pub children: HashMap<Symbol, InstanceRef>,
     pub reference_designator: Option<String>,
+    #[serde(default, skip_serializing_if = "InternalConnectivity::is_empty")]
+    pub internal_connectivity: InternalConnectivity,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub symbol_positions: HashMap<String, Position>,
 }
@@ -498,6 +546,7 @@ impl Instance {
             attributes: HashMap::new(),
             children: HashMap::new(),
             reference_designator: None,
+            internal_connectivity: InternalConnectivity::default(),
             symbol_positions: HashMap::new(),
         }
     }
@@ -1446,5 +1495,29 @@ mod tests {
         assert_ne!(a, "R22");
         assert_ne!(b, "R22");
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn internal_connectivity_normalizes_groups() {
+        let connectivity = InternalConnectivity::new(
+            false,
+            [
+                ["3", "1"].into_iter().map(String::from).collect(),
+                ["3", "4"].into_iter().map(String::from).collect(),
+                ["2", "2"].into_iter().map(String::from).collect(),
+            ],
+        );
+
+        let expected: BTreeSet<String> = ["1", "3", "4"].into_iter().map(String::from).collect();
+        assert_eq!(connectivity.groups, vec![expected]);
+    }
+
+    #[test]
+    fn internal_connectivity_empty_ignores_singleton_groups() {
+        let connectivity =
+            InternalConnectivity::new(false, [["2", "2"].into_iter().map(String::from).collect()]);
+
+        assert!(connectivity.is_empty());
+        assert!(connectivity.groups.is_empty());
     }
 }

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -801,6 +801,8 @@ impl ModuleConverter {
         if !symbol_value.is_none()
             && let Some(symbol) = symbol_value.downcast_ref::<SymbolValue>()
         {
+            comp_inst.internal_connectivity = symbol.internal_connectivity().clone();
+
             // Add symbol_name for backwards compatibility
             if let Some(name) = symbol.name() {
                 comp_inst.add_attribute(

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -812,6 +812,66 @@ fn net_kind_and_name<'v>(value: Value<'v>) -> Option<(&'v str, &'v str)> {
         })
 }
 
+fn net_id_from_value<'v>(value: Value<'v>) -> Option<u64> {
+    value
+        .downcast_ref::<NetValue>()
+        .map(|net| net.net_id())
+        .or_else(|| {
+            value
+                .downcast_ref::<FrozenNetValue>()
+                .map(|net| net.net_id())
+        })
+}
+
+/// Expand explicit jumper groups (symbol pins the part internally bridges) into
+/// effective connections: connected peers auto-fill missing ones, and assigning
+/// distinct nets within one group is an error.
+fn apply_explicit_jumper_connections<'v>(
+    component_name: &str,
+    symbol: &SymbolValue,
+    connections: &mut SmallMap<String, Value<'v>>,
+) -> Result<(), starlark::Error> {
+    for group in symbol.explicit_jumper_signal_groups() {
+        let connected: Vec<(&str, Value<'v>, u64)> = group
+            .iter()
+            .filter_map(|signal_name| {
+                let net = *connections.get(*signal_name)?;
+                Some((*signal_name, net, net_id_from_value(net)?))
+            })
+            .collect();
+
+        let Some(&(_, net, first_id)) = connected.first() else {
+            continue;
+        };
+
+        if connected.iter().any(|&(_, _, id)| id != first_id) {
+            let describe = |net: Value<'v>| match net_kind_and_name(net) {
+                Some((kind, name)) if !name.is_empty() => format!("{kind} '{name}'"),
+                _ => "unnamed net".to_string(),
+            };
+            let assignments: Vec<String> = connected
+                .iter()
+                .map(|&(signal_name, net, _)| format!("{signal_name} -> {}", describe(net)))
+                .collect();
+
+            return Err(starlark::Error::new_other(anyhow!(format!(
+                "Jumpered pins {} on component {} are internally connected but were assigned to different nets: {}. Use one net for the group or explicitly tie the labels together before import.",
+                group.join(", "),
+                component_name,
+                assignments.join(", ")
+            ))));
+        }
+
+        for signal_name in group {
+            if !connections.contains_key(signal_name) {
+                connections.insert(signal_name.to_owned(), net);
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn net_diagnostic_location<'v>(
     eval: &Evaluator<'v, '_, '_>,
     value: Value<'v>,
@@ -1906,6 +1966,7 @@ where
                             raw_sexp: symbol_value.raw_sexp.clone(),
                             properties: symbol_value.properties.clone(),
                             in_bom: symbol_value.in_bom,
+                            internal_connectivity: symbol_value.internal_connectivity.clone(),
                         }
                     } else {
                         // symbol is not a Symbol type, just use pin_defs
@@ -1918,6 +1979,7 @@ where
                             raw_sexp: None,
                             properties: SmallMap::new(),
                             in_bom: true,
+                            internal_connectivity: pcb_sch::InternalConnectivity::default(),
                         }
                     }
                 } else {
@@ -1931,6 +1993,7 @@ where
                         raw_sexp: None,
                         properties: SmallMap::new(),
                         in_bom: true,
+                        internal_connectivity: pcb_sch::InternalConnectivity::default(),
                     }
                 }
             } else if let Some(symbol) = &symbol_val {
@@ -1994,6 +2057,8 @@ where
                 warn_pin_net_compatibility(eval_ctx, &name, &final_symbol, &signal_name, v_val);
                 connections.insert(signal_name, v_val);
             }
+
+            apply_explicit_jumper_connections(&name, &final_symbol, &mut connections)?;
 
             // Auto-fill unambiguously no_connect pins and error on all other missing pins.
             let mut missing_pins: Vec<&str> = final_symbol
@@ -2270,6 +2335,7 @@ mod tests {
             raw_sexp: None,
             properties,
             in_bom: true,
+            internal_connectivity: pcb_sch::InternalConnectivity::default(),
         }
     }
 

--- a/crates/pcb-zen-core/src/lang/symbol.rs
+++ b/crates/pcb-zen-core/src/lang/symbol.rs
@@ -74,6 +74,10 @@ pub struct SymbolValue {
     pub raw_sexp: Option<String>, // Raw s-expression of the symbol (if loaded from file, otherwise None)
     pub properties: SmallMap<String, String>, // Properties from the symbol definition
     pub in_bom: bool,             // KiCad in_bom flag (inverse of skip_bom)
+    #[freeze(identity)]
+    #[trace(unsafe_ignore)]
+    #[allocative(skip)]
+    pub internal_connectivity: pcb_sch::InternalConnectivity,
 }
 
 impl std::fmt::Debug for SymbolValue {
@@ -249,6 +253,7 @@ impl<'v> SymbolValue {
                 raw_sexp: None,
                 properties: SmallMap::new(),
                 in_bom: true,
+                internal_connectivity: pcb_sch::InternalConnectivity::default(),
             })
         }
         // Case 2: Load from library
@@ -389,6 +394,32 @@ impl<'v> SymbolValue {
         &self.properties
     }
 
+    pub fn internal_connectivity(&self) -> &pcb_sch::InternalConnectivity {
+        &self.internal_connectivity
+    }
+
+    pub fn explicit_jumper_signal_groups(&self) -> Vec<Vec<&str>> {
+        self.internal_connectivity
+            .groups
+            .iter()
+            .filter_map(|group| {
+                let mut signals = Vec::new();
+                let mut seen = HashSet::new();
+
+                for number in group {
+                    let Some(signal) = self.pad_to_signal.get(number) else {
+                        continue;
+                    };
+                    if seen.insert(signal.as_str()) {
+                        signals.push(signal.as_str());
+                    }
+                }
+
+                (signals.len() >= 2).then_some(signals)
+            })
+            .collect()
+    }
+
     fn from_eda_symbol(
         symbol: &pcb_eda::Symbol,
         source_uri: Option<String>,
@@ -400,7 +431,11 @@ impl<'v> SymbolValue {
             .pins
             .iter()
             .map(|pin| {
-                pad_to_signal.insert(pin.number.clone(), pin.signal_name().to_owned());
+                // First occurrence wins: repeated pin numbers are one logical
+                // terminal, and the first occurrence names its public signal.
+                if !pad_to_signal.contains_key(&pin.number) {
+                    pad_to_signal.insert(pin.number.clone(), pin.signal_name().to_owned());
+                }
                 SymbolPin {
                     name: pin.name.clone(),
                     number: pin.number.clone(),
@@ -428,6 +463,10 @@ impl<'v> SymbolValue {
             raw_sexp,
             properties,
             in_bom: symbol.in_bom,
+            internal_connectivity: pcb_sch::InternalConnectivity::new(
+                symbol.internal_connectivity.duplicate_numbers_are_jumpers,
+                symbol.internal_connectivity.groups.iter().cloned(),
+            ),
         }
     }
 }
@@ -872,6 +911,66 @@ mod tests {
         assert_eq!(
             pin.alternates[1].graphical_style.as_deref(),
             Some("inverted")
+        );
+    }
+
+    #[test]
+    fn duplicate_pin_numbers_collapse_to_first_signal() {
+        let symbol = pcb_eda::Symbol::from_string(
+            r#"(kicad_symbol_lib
+  (version 20251024)
+  (generator "test")
+  (symbol "DuplicatePins"
+    (duplicate_pin_numbers_are_jumpers yes)
+    (symbol "DuplicatePins_1_1"
+      (pin passive line (at 0 0 0) (length 2.54) (name "A") (number "1"))
+      (pin passive line (at 0 0 0) (length 2.54) (name "B") (number "1"))
+    )
+  )
+)"#,
+            "kicad_sym",
+        )
+        .expect("symbol should parse");
+
+        let symbol_value = SymbolValue::from_eda_symbol(&symbol, None, None, SmallMap::new());
+
+        assert_eq!(
+            symbol_value.pad_to_signal().get("1").map(String::as_str),
+            Some("A")
+        );
+        assert_eq!(symbol_value.pins().len(), 2);
+        assert_eq!(symbol_value.pins()[0].name, "A");
+        assert_eq!(symbol_value.pins()[1].name, "B");
+        assert!(
+            symbol_value
+                .internal_connectivity()
+                .duplicate_numbers_are_jumpers
+        );
+    }
+
+    #[test]
+    fn explicit_jumper_groups_map_to_public_signals() {
+        let symbol = pcb_eda::Symbol::from_string(
+            r#"(kicad_symbol_lib
+  (version 20251024)
+  (generator "test")
+  (symbol "ExplicitJumpers"
+    (jumper_pin_groups ("1" "3") ("3" "99"))
+    (symbol "ExplicitJumpers_1_1"
+      (pin passive line (at 0 0 0) (length 2.54) (name "A") (number "1"))
+      (pin passive line (at 0 0 0) (length 2.54) (name "B") (number "3"))
+    )
+  )
+)"#,
+            "kicad_sym",
+        )
+        .expect("symbol should parse");
+
+        let symbol_value = SymbolValue::from_eda_symbol(&symbol, None, None, SmallMap::new());
+
+        assert_eq!(
+            symbol_value.explicit_jumper_signal_groups(),
+            vec![vec!["A", "B"]]
         );
     }
 }

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -5,10 +5,21 @@ use pcb_zen_core::DiagnosticsPass;
 use pcb_zen_core::SortPass;
 use pcb_zen_core::lang::component::FrozenComponentValue;
 use pcb_zen_core::lang::error::CategorizedDiagnostic;
+use pcb_zen_core::lang::net::FrozenNetValue;
 use starlark::errors::EvalSeverity;
+use starlark::values::{FrozenValue, ValueLike};
 
 fn eval_single_root_component(source: &str) -> FrozenComponentValue {
-    let result = common::eval_zen(vec![("test.zen".to_string(), source.to_string())]);
+    eval_single_root_component_with_files(vec![("test.zen", source)])
+}
+
+fn eval_single_root_component_with_files(files: Vec<(&str, &str)>) -> FrozenComponentValue {
+    let result = common::eval_zen(
+        files
+            .into_iter()
+            .map(|(path, content)| (path.to_string(), content.to_string()))
+            .collect(),
+    );
     assert!(result.is_success(), "eval failed: {:?}", result.diagnostics);
 
     let output = result.output.expect("expected eval output");
@@ -31,6 +42,27 @@ fn eval_single_root_component(source: &str) -> FrozenComponentValue {
         .next()
         .expect("expected one component")
 }
+
+fn frozen_net_id(value: FrozenValue) -> u64 {
+    value
+        .downcast_ref::<FrozenNetValue>()
+        .expect("expected frozen net")
+        .net_id()
+}
+
+const EXPLICIT_JUMPER_SYMBOL: &str = r#"(kicad_symbol_lib
+  (version 20251024)
+  (generator "test")
+  (symbol "ExplicitJumper"
+    (property "Reference" "JP")
+    (property "Footprint" "Jumper:SolderJumper")
+    (jumper_pin_groups ("1" "3"))
+    (symbol "ExplicitJumper_1_1"
+      (pin passive line (at 0 0 0) (length 2.54) (name "A") (number "1"))
+      (pin passive line (at 0 0 0) (length 2.54) (name "B") (number "3"))
+    )
+  )
+)"#;
 
 #[test]
 fn component_prefers_part_datasheet_over_component_datasheet() {
@@ -260,6 +292,65 @@ snapshot_eval!(component_with_symbol, {
         )
     "#
 });
+
+#[test]
+fn component_explicit_jumper_group_auto_fills_missing_peer() {
+    let component = eval_single_root_component_with_files(vec![
+        ("explicit_jumper.kicad_sym", EXPLICIT_JUMPER_SYMBOL),
+        (
+            "test.zen",
+            r#"
+shared = Net("SHARED")
+
+Component(
+    name = "JP1",
+    footprint = "Jumper:SolderJumper",
+    symbol = Symbol(library = "explicit_jumper.kicad_sym", name = "ExplicitJumper"),
+    pins = {"A": shared},
+)
+"#,
+        ),
+    ]);
+
+    assert!(component.connections().contains_key("A"));
+    assert!(component.connections().contains_key("B"));
+    assert_eq!(
+        frozen_net_id(*component.connections().get("A").unwrap()),
+        frozen_net_id(*component.connections().get("B").unwrap())
+    );
+}
+
+#[test]
+fn component_explicit_jumper_group_conflicting_nets_error() {
+    let result = common::eval_zen(vec![
+        (
+            "explicit_jumper.kicad_sym".to_string(),
+            EXPLICIT_JUMPER_SYMBOL.to_string(),
+        ),
+        (
+            "test.zen".to_string(),
+            r#"
+Component(
+    name = "JP1",
+    footprint = "Jumper:SolderJumper",
+    symbol = Symbol(library = "explicit_jumper.kicad_sym", name = "ExplicitJumper"),
+    pins = {"A": Net("LEFT"), "B": Net("RIGHT")},
+)
+"#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(!result.is_success(), "expected eval failure");
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.to_string().contains("Jumpered pins A, B")),
+        "expected jumper conflict diagnostic, got {:?}",
+        result.diagnostics
+    );
+}
 
 snapshot_eval!(component_infers_spice_model_from_symbol, {
     "my_model.lib" => r#"

--- a/crates/pcbc/src/import/generate.rs
+++ b/crates/pcbc/src/import/generate.rs
@@ -2059,7 +2059,7 @@ fn render_component_zen(
 ) -> Result<RenderedComponentZen> {
     let generated_io_names = component_gen::generated_signal_io_names(symbol);
     let mut io_pins: BTreeMap<String, BTreeSet<KiCadPinNumber>> = BTreeMap::new();
-    for pin in &symbol.pins {
+    for pin in symbol.canonical_pins() {
         let signal_name = pin.signal_name().to_string();
         let Some(io_name) = generated_io_names.get(&signal_name) else {
             continue;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes schematic connectivity rules, netlist output, and layout PCB patching for jumpers; behavior is covered by tests but affects import/sync paths for jumper parts.
> 
> **Overview**
> Adds **KiCad 10 jumper-pin support** end to end: symbols can carry `duplicate_pin_numbers_are_jumpers` and `jumper_pin_groups`, which are parsed in **pcb-eda**, normalized on **schematic instances** (`InternalConnectivity`), and forwarded through evaluation, KiCad netlist export, layout JSON, and **PCB footprint patching** (`duplicate_pad_numbers_are_jumpers` / `jumper_pad_groups`).
> 
> **Symbol and pin handling** now treats repeated pin numbers as one logical terminal via `canonical_pins()` (first occurrence names the public signal). Generated/imported component `.zen` and `pad_to_signal` mapping follow that rule so duplicate-number jumpers do not spawn extra `io()` pins.
> 
> **Component wiring** applies explicit jumper groups: connecting one pin in a group auto-fills missing peers to the same net, and assigning different nets within a group is a hard error. Derived symbols that `extends` a parent **inherit parent jumper metadata** (child overrides are ignored), matching KiCad flatten behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bacac3308079a5cedc3f5368f39e49f951bf21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->