### PR TITLE
Fix dropped child net-symbol overrides for io-renamed nets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Child net-symbol position overrides (`# pcb:sch <child>.<NET>.<idx>`) are no longer dropped when the net is renamed across the module boundary.
+
 ### Changes
 
 - `pcb migrate` now upgrades workspace `pcb-version` after successful latest-toolchain migrations.

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -1014,34 +1014,29 @@ impl ModuleConverter {
         }
 
         for split_idx in 1..segments.len() {
-            let descendant_ref =
-                segments[..split_idx]
-                    .iter()
-                    .try_fold(instance_ref, |current_ref, part| {
-                        let child_ref = self
-                            .schematic
-                            .instances
-                            .get(current_ref)?
-                            .children
-                            .get(*part)?;
-                        let child_instance = self.schematic.instances.get(child_ref)?;
-                        (child_instance.kind == InstanceKind::Module).then_some(child_ref)
-                    })?;
+            // The prefix must resolve to a descendant module instance.
+            segments[..split_idx]
+                .iter()
+                .try_fold(instance_ref, |current_ref, part| {
+                    let child_ref = self
+                        .schematic
+                        .instances
+                        .get(current_ref)?
+                        .children
+                        .get(*part)?;
+                    let child_instance = self.schematic.instances.get(child_ref)?;
+                    (child_instance.kind == InstanceKind::Module).then_some(child_ref)
+                })?;
 
-            let Some(descendant_module) =
-                self.module_instances
-                    .iter()
-                    .find_map(|(candidate_ref, module)| {
-                        (candidate_ref == descendant_ref).then_some(module)
-                    })
-            else {
-                continue;
-            };
-
-            let descendant_local_key = format!("{}.{}", segments[split_idx..].join("."), suffix);
-            if descendant_module
-                .positions()
-                .contains_key(descendant_local_key.as_str())
+            // The remainder must name an actual net. Override keys are
+            // `<module path>.<global net name>.<index>` because converted net-symbol
+            // keys use global net names (e.g. a descendant's local `IN_GD.0` comment
+            // converts to `sym:VBUS_RAW#0` when the parent connects `IN_GD=VBUS_RAW`).
+            let rest = segments[split_idx..].join(".");
+            if self
+                .net_to_info
+                .values()
+                .any(|info| info.name.as_deref() == Some(rest.as_str()))
             {
                 return Some(format!("sym:{}#{}", net_part, suffix));
             }

--- a/crates/pcbc/tests/netlist.rs
+++ b/crates/pcbc/tests/netlist.rs
@@ -384,6 +384,63 @@ nc = NotConnected()
 PowerConsumer(name = "U1", vcc = nc)
 "#;
 
+const IO_RENAMED_CHILD_ZEN: &str = r#"
+IN_GD = io("IN_GD", Net)
+GND = io("GND", Net)
+
+Component(
+    name = "R1",
+    footprint = "TEST:0402",
+    pin_defs = {"1": "1", "2": "2"},
+    skip_bom = True,
+    pins = {"1": IN_GD, "2": GND},
+)
+
+# pcb:sch IN_GD.0 x=-351.5200 y=-140.7000 rot=0
+# pcb:sch GND.1 x=-100.0000 y=-50.0000 rot=0
+"#;
+
+const IO_RENAMED_PARENT_ZEN: &str = r#"
+Child = Module("Child.zen")
+
+VBUS_RAW = Net("VBUS_RAW")
+GND = Net("GND")
+
+Child(name = "U1", IN_GD = VBUS_RAW, GND = GND)
+
+# pcb:sch U1.VBUS_RAW.0 x=-1498.6000 y=-25.4000 rot=0
+# pcb:sch U1.GND.1 x=-1562.1000 y=12.7000 rot=0
+"#;
+
+/// Descendant net-symbol overrides (`<child>.<NET>.<idx>` comments in the parent)
+/// must survive conversion even when the parent renames the net across the module
+/// boundary (here `IN_GD=VBUS_RAW`); the override key uses the global net name.
+#[test]
+fn test_netlist_descendant_net_symbol_override_with_renamed_io() {
+    let mut sandbox = Sandbox::new();
+    sandbox
+        .write("boards/Child.zen", IO_RENAMED_CHILD_ZEN)
+        .write("boards/Parent.zen", IO_RENAMED_PARENT_ZEN);
+    let output = sandbox.snapshot_run("pcbc", &["build", "boards/Parent.zen", "--netlist"]);
+
+    let json_start = output.find('{').expect("netlist JSON in output");
+    let json_end = output.rfind('}').expect("netlist JSON in output");
+    let netlist: serde_json::Value =
+        serde_json::from_str(&output[json_start..=json_end]).expect("netlist parses as JSON");
+
+    let root_positions = netlist["instances"]
+        .as_object()
+        .unwrap()
+        .iter()
+        .find_map(|(path, inst)| path.ends_with(":<root>").then(|| &inst["symbol_positions"]))
+        .expect("root instance present");
+
+    // Renamed io: parent override uses the global net name, not the child's local name.
+    assert_eq!(root_positions["sym:U1.VBUS_RAW#0"]["x"], -1498.6);
+    // Same-named net keeps working.
+    assert_eq!(root_positions["sym:U1.GND#1"]["x"], -1562.1);
+}
+
 #[test]
 fn test_netlist_not_connected_promotion() {
     let mut sandbox = Sandbox::new();


### PR DESCRIPTION
Parent-level position overrides like `# pcb:sch U1.VBUS_RAW.0 ...` were silently dropped during netlist conversion whenever the parent's net name differed from the child's local port name (e.g. `IN_GD=VBUS_RAW`), because the descendant-override resolver validated the key against the child's raw comment text (local names) instead of the global net names that converted symbol keys (and the LSP write side) actually use.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to descendant override resolution during schematic conversion; regression covered by a new netlist integration test.
> 
> **Overview**
> Fixes **silent loss** of parent `# pcb:sch <child>.<NET>.<idx>` net-symbol positions when the parent wires a child `io()` to a **different global net name** (e.g. child `IN_GD` → parent `VBUS_RAW`).
> 
> Netlist conversion in `find_descendant_override_net_symbol_key` no longer requires the override suffix to match a position key on the **child module** (local names). It now checks that the path prefix is a descendant module and that the remainder names a **global** net in `net_to_info`, matching converted keys like `sym:U1.VBUS_RAW#0`.
> 
> Adds an integration test and a **Fixed** changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf02346e19c2a6d97995557d52e3ab48c24e144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->