### PR TITLE
Remove workspace vendor sync from pcb build for v2 workspaces

### DIFF
--- a/crates/pcb-zen/src/package_resolver/mod.rs
+++ b/crates/pcb-zen/src/package_resolver/mod.rs
@@ -14,6 +14,6 @@ pub use pcb_zen_core::resolution::{
 };
 pub use resolve::{
     attach_mvs_v2_resolution_for_packages, build_frozen_resolution_maps,
-    resolve_workspace_dependencies, sync_workspace_vendor, target_package_urls_for_path,
+    resolve_workspace_dependencies, target_package_urls_for_path,
 };
 pub use versions::SpecVersionResolver;

--- a/crates/pcb-zen/src/package_resolver/resolve.rs
+++ b/crates/pcb-zen/src/package_resolver/resolve.rs
@@ -76,7 +76,14 @@ pub fn resolve_workspace_dependencies(
     offline: bool,
     locked: bool,
 ) -> Result<ResolutionResult> {
-    let package_urls = target_package_urls_or_empty(&workspace_info, path);
+    let package_urls = target_package_urls_for_path(&workspace_info, path)
+        .inspect_err(|err| {
+            log::debug!(
+                "Skipping MVS v2 target discovery for {}: {err:#}",
+                path.display()
+            );
+        })
+        .unwrap_or_default();
     if use_frozen_resolution(&workspace_info, &package_urls) {
         return resolve_frozen(workspace_info, package_urls, offline);
     }
@@ -84,17 +91,6 @@ pub fn resolve_workspace_dependencies(
     let mut res = crate::resolve_dependencies(&mut workspace_info, offline, locked)?;
     attach_mvs_v2_resolution_for_packages(&mut res, package_urls, offline);
     Ok(res)
-}
-
-fn target_package_urls_or_empty(workspace_info: &WorkspaceInfo, path: &Path) -> Vec<String> {
-    target_package_urls_for_path(workspace_info, path)
-        .inspect_err(|err| {
-            log::debug!(
-                "Skipping MVS v2 target discovery for {}: {err:#}",
-                path.display()
-            );
-        })
-        .unwrap_or_default()
 }
 
 fn resolve_frozen(
@@ -124,56 +120,6 @@ fn resolve_frozen(
         resolution_set,
         symbol_parts,
     ))
-}
-
-fn workspace_vendor_enabled(workspace_info: &WorkspaceInfo) -> bool {
-    workspace_info
-        .config
-        .as_ref()
-        .and_then(|config| config.workspace.as_ref())
-        .is_some_and(|workspace| !workspace.vendor.is_empty())
-}
-
-fn workspace_selected_remote(
-    workspace_info: &WorkspaceInfo,
-    resolver: &mut PackageResolver,
-) -> Result<BTreeSet<(ResolvedDepId, Version)>> {
-    let mut selected = BTreeSet::new();
-
-    for package_url in workspace_info.packages.keys() {
-        let package_selected = if package_has_indirect(workspace_info, package_url) {
-            selected_remote_from_hydrated_manifest(workspace_info, package_url)?
-        } else {
-            resolver.resolve_package(package_url)?.resolved_remote
-        };
-        selected.extend(package_selected);
-    }
-
-    Ok(selected)
-}
-
-pub fn sync_workspace_vendor(
-    workspace_info: &WorkspaceInfo,
-    path: &Path,
-    offline: bool,
-) -> Result<()> {
-    if offline {
-        return Ok(());
-    }
-
-    let package_urls = target_package_urls_or_empty(workspace_info, path);
-    if !use_frozen_resolution(workspace_info, &package_urls)
-        || !workspace_vendor_enabled(workspace_info)
-    {
-        return Ok(());
-    }
-
-    let mut resolver = PackageResolver::new(workspace_info.clone(), offline)?;
-    let selected = workspace_selected_remote(workspace_info, &mut resolver)?;
-    let package_roots = resolver
-        .materialize_selected(selected.iter().map(|(dep_id, version)| (dep_id, version)))?;
-    crate::resolve::vendor_package_roots(workspace_info, &package_roots, &[], None, true)?;
-    Ok(())
 }
 
 pub fn attach_mvs_v2_resolution_for_packages(

--- a/crates/pcbc/src/resolve.rs
+++ b/crates/pcbc/src/resolve.rs
@@ -5,9 +5,7 @@ use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::resolution::ResolutionResult;
 use tracing::instrument;
 
-use pcb_zen::{
-    get_workspace_info, package_resolver::sync_workspace_vendor, resolve_workspace_dependencies,
-};
+use pcb_zen::{get_workspace_info, resolve_workspace_dependencies};
 
 /// Resolve dependencies for a workspace/board.
 /// This is a shared helper used by build, bom, layout, open, etc.
@@ -42,7 +40,6 @@ pub fn resolve(input_path: Option<&Path>, offline: bool, locked: bool) -> Result
         );
     }
 
-    sync_workspace_vendor(&workspace_info, path, offline)?;
     let mut res = resolve_workspace_dependencies(workspace_info, path, offline, locked)?;
 
     if res.package_resolutions.is_empty() {
@@ -60,7 +57,6 @@ pub fn resolve(input_path: Option<&Path>, offline: bool, locked: bool) -> Result
             vendor_result.pruned_count
         );
         let workspace_info = get_workspace_info(&DefaultFileProvider::new(), path)?;
-        sync_workspace_vendor(&workspace_info, path, offline)?;
         res = resolve_workspace_dependencies(workspace_info, path, offline, locked)?;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when and how `vendor/` is populated during resolve/build for frozen/MVS v2 workspaces; behavior should match `vendor_deps` but timing differs from the removed early sync.
> 
> **Overview**
> Removes the **pre-resolution** workspace vendor sync path (`sync_workspace_vendor` and its helpers) from `pcb-zen`, and stops calling it from the shared `pcbc` resolve helper used by build and related commands.
> 
> Target package URL discovery for MVS v2 is unchanged in behavior: the former `target_package_urls_or_empty` wrapper is inlined into `resolve_workspace_dependencies` with the same debug-on-error and empty fallback.
> 
> **Vendor directory updates** on build now rely solely on the existing post-resolution `vendor_deps` flow (add missing, optional prune/re-resolve), instead of also materializing and vendoring selected remotes up front when frozen resolution and workspace vendor config applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ce43ca2b955abd191a6df4e6a87916048e0ca03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->