### PR TITLE
`bom.strict` flag for `pcb publish`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb migrate` now upgrades workspace `pcb-version` after successful latest-toolchain migrations.
 - Added `[workspace.bom] strict = true` to require exact MPN matching when fetching BOM availability.
+- `pcb publish` release metadata now records strict workspace BOM matching when enabled.
 - Updated stdlib generics to use KiCad 10.0.3 symbols and footprints, while keeping `Crystal()` compatible with KiCad 9 four-pin symbols.
 - `pcb publish` now bundles only referenced KiCad split-symbol files instead of whole split-library directories.
 - Removed legacy manifest and import support: `[module]`, `[packages]`, `[assets]`, and `[workspace].resolver` are rejected; legacy stdlib load paths are no longer accepted; `pcb migrate` no longer runs V1 codemods.

--- a/crates/pcbc/src/bundle.rs
+++ b/crates/pcbc/src/bundle.rs
@@ -428,6 +428,10 @@ fn create_metadata_json(input: &MetadataInput<'_>) -> serde_json::Value {
         release_obj["description"] = serde_json::json!(description);
     }
 
+    if input.bom_strict {
+        release_obj["bom"] = serde_json::json!({ "strict": true });
+    }
+
     let workspace_root = input.workspace_root;
     let (branch, remotes) = {
         let _span = info_span!("collect_git_metadata").entered();
@@ -463,10 +467,6 @@ fn create_metadata_json(input: &MetadataInput<'_>) -> serde_json::Value {
                 .unwrap_or_else(|| "unknown".to_string())
         };
         system_obj["kicad_version"] = serde_json::Value::String(kicad_version);
-    }
-
-    if input.bom_strict {
-        system_obj["bom"] = serde_json::json!({ "strict": true });
     }
 
     serde_json::json!({

--- a/crates/pcbc/src/bundle.rs
+++ b/crates/pcbc/src/bundle.rs
@@ -22,6 +22,7 @@ pub(crate) struct MetadataInput<'a> {
     pub layout_path: Option<&'a Path>,
     pub description: Option<&'a str>,
     pub include_kicad_version: bool,
+    pub bom_strict: bool,
 }
 
 pub(crate) struct SourceBundlePlan<'a> {
@@ -462,6 +463,10 @@ fn create_metadata_json(input: &MetadataInput<'_>) -> serde_json::Value {
                 .unwrap_or_else(|| "unknown".to_string())
         };
         system_obj["kicad_version"] = serde_json::Value::String(kicad_version);
+    }
+
+    if input.bom_strict {
+        system_obj["bom"] = serde_json::json!({ "strict": true });
     }
 
     serde_json::json!({

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -831,6 +831,7 @@ fn write_metadata(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         layout_path: info.layout.as_ref().map(|layout| layout.layout_dir_rel()),
         description: board_description.as_deref(),
         include_kicad_version: true,
+        bom_strict: info.workspace_info().workspace_config().bom.strict,
     })
 }
 

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -287,6 +287,49 @@ fn test_publish_board_full() {
 }
 
 #[test]
+fn test_publish_metadata_includes_bom_strict() {
+    let mut sb = Sandbox::new();
+    sb.cwd("src")
+        .write(
+            "pcb.toml",
+            r#"
+[workspace]
+pcb-version = "0.3"
+
+[workspace.bom]
+strict = true
+"#,
+        )
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write("boards/modules/component.zen", SIMPLE_COMPONENT)
+        .write("boards/modules/test.kicad_mod", TEST_KICAD_MOD)
+        .write(
+            "boards/modules/datasheet.txt",
+            "Simple component datasheet.",
+        )
+        .write("boards/TestBoard.zen", SIMPLE_BOARD_ZEN)
+        .ignore_globs(["layout/*", "**/vendor/**", "**/build/**"])
+        .init_git()
+        .commit("Initial commit")
+        .sync();
+
+    sb.run("pcbc", source_only_args("boards/TestBoard.zen"))
+        .run()
+        .expect("Failed to run pcb publish command");
+
+    let staging_dir = find_staging_dir(&sb, "TestBoard");
+    let metadata_file = File::open(
+        sb.root_path()
+            .join("src")
+            .join(&staging_dir)
+            .join("metadata.json"),
+    )
+    .unwrap();
+    let metadata_json: Value = serde_json::from_reader(metadata_file).unwrap();
+    assert_eq!(metadata_json["system"]["bom"]["strict"], true);
+}
+
+#[test]
 fn test_publish_board_with_file() {
     let mut sb = Sandbox::new();
     const DATASHEET_CONTENTS: &str = "Simple component datasheet.";

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -326,7 +326,7 @@ strict = true
     )
     .unwrap();
     let metadata_json: Value = serde_json::from_reader(metadata_file).unwrap();
-    assert_eq!(metadata_json["system"]["bom"]["strict"], true);
+    assert_eq!(metadata_json["release"]["bom"]["strict"], true);
 }
 
 #[test]


### PR DESCRIPTION
`pcb publish` propagates `bom.strict` into release metadata. the backend later uses that flag to enable/disable strict mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metadata only when strict is enabled; no change to publish staging or BOM generation logic.
> 
> **Overview**
> **`pcb publish`** now copies the workspace **`[workspace.bom] strict`** setting into staged **`metadata.json`** as **`release.bom.strict: true`** when strict mode is enabled, so release consumers (e.g. backend BOM availability) can honor exact MPN matching without re-reading `pcb.toml`.
> 
> Wiring: **`MetadataInput`** gains **`bom_strict`**, **`create_metadata_json`** only emits the **`bom`** object when strict is on, and board release **`write_metadata`** passes **`workspace_config().bom.strict`**. Changelog updated; integration test **`test_publish_metadata_includes_bom_strict`** asserts the JSON field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6755e587d2cd9f0a4a417d419d9d061bf464f46d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->