### PR TITLE
Improve remote layout sync recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Regular nets now require explicit or assignment-inferred unique names; unnamed or duplicate regular nets fail evaluation.
 - `NotConnected` nets are now source-unnamed; explicit names are ignored with a warning and downstream tools assign connection-derived names as needed.
 - Added KiCad 10 jumper-pin support.
+- Remote sandbox sync now uses octet-stream writes, refreshes auth during sessions, and keeps recoverable local KiCad session files when sync exits unexpectedly.
 
 ## [0.3.92] - 2026-06-09
 

--- a/crates/pcb-diode-api/src/sandbox.rs
+++ b/crates/pcb-diode-api/src/sandbox.rs
@@ -8,22 +8,22 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64;
 use chrono::{DateTime, Utc};
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
+use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::WorkspaceContext;
 
 pub const SANDBOX_LOCK_FILE_PATH: &str = "/home/sandbox/.diode/sandbox-lock.json";
+const LOCK_HEARTBEAT_MAX_FAILURES: usize = 3;
 
 #[derive(Clone)]
 pub struct SandboxClient {
     api_base_url: String,
-    auth_token: Arc<String>,
+    ctx: WorkspaceContext,
     http: Client,
 }
 
@@ -127,7 +127,7 @@ impl SandboxLockOptions {
             message: Some("This sandbox is open for local editing.".to_string()),
             kind: "local-edit".to_string(),
             ttl: Duration::from_secs(90),
-            heartbeat_interval: Duration::from_secs(15),
+            heartbeat_interval: Duration::from_secs(5),
             force_reclaim_stale: true,
         }
     }
@@ -186,10 +186,11 @@ pub struct SandboxLockGuard {
 
 impl SandboxClient {
     pub fn new(ctx: WorkspaceContext) -> Result<Self> {
-        let auth_token = ctx.token()?;
+        ctx.token()?;
+        let api_base_url = ctx.api_base_url().trim_end_matches('/').to_string();
         Ok(Self {
-            api_base_url: ctx.api_base_url().trim_end_matches('/').to_string(),
-            auth_token: Arc::new(auth_token),
+            api_base_url,
+            ctx,
             http: Client::builder()
                 .connect_timeout(Duration::from_secs(10))
                 .build()
@@ -231,7 +232,7 @@ impl SandboxClient {
         let response = self
             .http
             .get(url)
-            .bearer_auth(self.auth_token.as_str())
+            .bearer_auth(self.auth_token()?)
             .send()
             .context("Failed to read sandbox file")?;
         let response = self.ensure_success(response)?;
@@ -239,23 +240,22 @@ impl SandboxClient {
     }
 
     pub fn write_file(&self, sandbox_id: &str, path: &str, bytes: &[u8]) -> Result<()> {
-        #[derive(Serialize)]
-        struct WriteRequest {
-            content: String,
-            encoding: &'static str,
-        }
-
-        let _: serde_json::Value = self.put_json(
-            &format!(
+        let response = self
+            .http
+            .put(self.url(&format!(
                 "/api/sandboxes/{}/fs/write{}",
                 encode_segment(sandbox_id),
                 encoded_absolute_path(path)?
-            ),
-            &WriteRequest {
-                content: BASE64.encode(bytes),
-                encoding: "base64",
-            },
-        )?;
+            )))
+            .bearer_auth(self.auth_token()?)
+            .header(CONTENT_TYPE, "application/octet-stream")
+            .body(bytes.to_vec())
+            .send()
+            .context("Sandbox PUT request failed")?;
+        let _: serde_json::Value = self
+            .ensure_success(response)?
+            .json()
+            .context("Invalid sandbox response")?;
         Ok(())
     }
 
@@ -332,7 +332,7 @@ impl SandboxClient {
         let response = self
             .http
             .get(self.url(path))
-            .bearer_auth(self.auth_token.as_str())
+            .bearer_auth(self.auth_token()?)
             .send()
             .context("Sandbox GET request failed")?;
         self.ensure_success(response)?
@@ -348,27 +348,10 @@ impl SandboxClient {
         let response = self
             .http
             .post(self.url(path))
-            .bearer_auth(self.auth_token.as_str())
+            .bearer_auth(self.auth_token()?)
             .json(body)
             .send()
             .context("Sandbox POST request failed")?;
-        self.ensure_success(response)?
-            .json()
-            .context("Invalid sandbox response")
-    }
-
-    fn put_json<T: for<'de> Deserialize<'de>, B: Serialize>(
-        &self,
-        path: &str,
-        body: &B,
-    ) -> Result<T> {
-        let response = self
-            .http
-            .put(self.url(path))
-            .bearer_auth(self.auth_token.as_str())
-            .json(body)
-            .send()
-            .context("Sandbox PUT request failed")?;
         self.ensure_success(response)?
             .json()
             .context("Invalid sandbox response")
@@ -392,6 +375,10 @@ impl SandboxClient {
 
     fn url(&self, path: &str) -> String {
         format!("{}{}", self.api_base_url, path)
+    }
+
+    fn auth_token(&self) -> Result<String> {
+        self.ctx.token()
     }
 }
 
@@ -441,7 +428,13 @@ impl Drop for SandboxLockGuard {
     }
 }
 
+enum LockHeartbeat {
+    Active,
+    Lost,
+}
+
 fn heartbeat_loop(state: Arc<SandboxLockState>, interval: Duration, stop_rx: Receiver<()>) {
+    let mut failures = 0;
     while !state.stop.load(Ordering::SeqCst) {
         match stop_rx.recv_timeout(interval) {
             Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
@@ -450,19 +443,34 @@ fn heartbeat_loop(state: Arc<SandboxLockState>, interval: Duration, stop_rx: Rec
         if state.stop.load(Ordering::SeqCst) {
             break;
         }
-        if heartbeat_once(&state).is_err() {
-            state.active.store(false, Ordering::SeqCst);
-            break;
+        match heartbeat_once(&state) {
+            Ok(LockHeartbeat::Active) => failures = 0,
+            Ok(LockHeartbeat::Lost) => {
+                state.active.store(false, Ordering::SeqCst);
+                break;
+            }
+            Err(err) => {
+                failures += 1;
+                if failures >= LOCK_HEARTBEAT_MAX_FAILURES {
+                    log::warn!(
+                        "Sandbox lock heartbeat failed {LOCK_HEARTBEAT_MAX_FAILURES} times; marking lock inactive: {err:#}"
+                    );
+                    state.active.store(false, Ordering::SeqCst);
+                    break;
+                }
+            }
         }
     }
 }
 
-fn heartbeat_once(state: &SandboxLockState) -> Result<()> {
-    let current = read_lock_file(&state.client, &state.sandbox_id)
+fn heartbeat_once(state: &SandboxLockState) -> Result<LockHeartbeat> {
+    let Some(current) = read_lock_file(&state.client, &state.sandbox_id)
         .context("Failed to refresh sandbox lock")?
-        .context("lock file is missing")?;
+    else {
+        return Ok(LockHeartbeat::Lost);
+    };
     if current.lease_id != state.lease_id {
-        bail!("lock lease no longer matches");
+        return Ok(LockHeartbeat::Lost);
     }
 
     let now = Utc::now();
@@ -473,7 +481,8 @@ fn heartbeat_once(state: &SandboxLockState) -> Result<()> {
         ..current
     };
     write_lock_file(&state.client, &state.sandbox_id, &lock)
-        .context("Failed to refresh sandbox lock")
+        .context("Failed to refresh sandbox lock")?;
+    Ok(LockHeartbeat::Active)
 }
 
 fn release_once(state: &SandboxLockState) -> Result<()> {
@@ -532,7 +541,7 @@ fn delete_lock_file(client: &SandboxClient, sandbox_id: &str) -> Result<()> {
             encode_segment(sandbox_id),
             encoded_absolute_path(SANDBOX_LOCK_FILE_PATH)?
         )))
-        .bearer_auth(client.auth_token.as_str())
+        .bearer_auth(client.auth_token()?)
         .send()
         .context("Failed to delete sandbox lock file")?;
     if response.status() == StatusCode::NOT_FOUND {
@@ -554,7 +563,7 @@ fn read_file_if_exists(
             encode_segment(sandbox_id),
             encoded_absolute_path(path)?
         )))
-        .bearer_auth(client.auth_token.as_str())
+        .bearer_auth(client.auth_token()?)
         .send()
         .context("Failed to read sandbox file")?;
     if response.status() == StatusCode::NOT_FOUND {

--- a/crates/pcb-kicad/src/lib.rs
+++ b/crates/pcb-kicad/src/lib.rs
@@ -94,7 +94,6 @@ fn require_tool_path(
     }
 }
 
-#[cfg(target_os = "macos")]
 fn pcbnew_app_bundle_path(pcbnew_path: &str) -> Result<String> {
     let path = Path::new(pcbnew_path);
 
@@ -363,12 +362,32 @@ pub fn ensure_board_compatible_with_installed_kicad(pcb_path: &Path) -> Result<(
 
 /// Open a KiCad board in the GUI that matches this toolchain's discovered install.
 pub fn open_pcbnew(pcb_path: impl AsRef<Path>) -> Result<()> {
-    let _child = spawn_pcbnew(pcb_path.as_ref(), false)?;
+    let pcb_path = pcb_path.as_ref();
+    let pcbnew_path = require_pcbnew_launch(pcb_path)?;
+
+    #[cfg(target_os = "macos")]
+    let cmd = {
+        let mut cmd = Command::new("open");
+        cmd.arg("-a")
+            .arg(pcbnew_app_bundle_path(&pcbnew_path)?)
+            .arg(pcb_path);
+        cmd
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let cmd = {
+        let mut cmd = Command::new(&pcbnew_path);
+        cmd.arg(pcb_path);
+        cmd
+    };
+
+    spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path)?;
     Ok(())
 }
 
 pub struct PcbnewSession {
     child: Child,
+    pcbnew_app: String,
 }
 
 impl PcbnewSession {
@@ -377,48 +396,49 @@ impl PcbnewSession {
             .try_wait()
             .context("Failed while checking KiCad PCB Editor status")
     }
+
+    pub fn terminate(&mut self) -> Result<()> {
+        if self.try_wait()?.is_some() {
+            return Ok(());
+        }
+        request_pcbnew_shutdown(self)?;
+        self.child
+            .wait()
+            .context("Failed while waiting for KiCad PCB Editor to terminate")?;
+        Ok(())
+    }
 }
 
 /// Open a KiCad board in a process that can be waited on.
 pub fn open_pcbnew_session(pcb_path: impl AsRef<Path>) -> Result<PcbnewSession> {
-    Ok(PcbnewSession {
-        child: spawn_pcbnew(pcb_path.as_ref(), true)?,
-    })
+    let pcb_path = pcb_path.as_ref();
+    let pcbnew_path = require_pcbnew_launch(pcb_path)?;
+    let pcbnew_app = pcbnew_app_bundle_path(&pcbnew_path)?;
+
+    let mut cmd = Command::new("open");
+    cmd.arg("-n")
+        .arg("-W")
+        .arg("-a")
+        .arg(&pcbnew_app)
+        .arg(pcb_path);
+    spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path)
+        .map(|child| PcbnewSession { child, pcbnew_app })
 }
 
-fn spawn_pcbnew(pcb_path: &Path, wait_for_exit: bool) -> Result<Child> {
-    #[cfg(not(target_os = "macos"))]
-    let _ = wait_for_exit;
-
+fn require_pcbnew_launch(pcb_path: &Path) -> Result<String> {
     if !pcb_path.exists() {
         anyhow::bail!("PCB file not found: {}", pcb_path.display());
     }
 
-    let pcbnew_path = require_tool_path(
+    require_tool_path(
         paths::pcbnew(),
         "KiCad PCB Editor",
         "KICAD_PCBNEW",
         "Please ensure KiCad is installed.",
-    )?;
+    )
+}
 
-    #[cfg(target_os = "macos")]
-    let mut cmd = {
-        let pcbnew_app = pcbnew_app_bundle_path(&pcbnew_path)?;
-        let mut cmd = Command::new("open");
-        if wait_for_exit {
-            cmd.arg("-n").arg("-W");
-        }
-        cmd.arg("-a").arg(pcbnew_app).arg(pcb_path);
-        cmd
-    };
-
-    #[cfg(not(target_os = "macos"))]
-    let mut cmd = {
-        let mut cmd = Command::new(&pcbnew_path);
-        cmd.arg(pcb_path);
-        cmd
-    };
-
+fn spawn_pcbnew_command(mut cmd: Command, pcbnew_path: &str, pcb_path: &Path) -> Result<Child> {
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -430,6 +450,29 @@ fn spawn_pcbnew(pcb_path: &Path, wait_for_exit: bool) -> Result<Child> {
                 pcb_path.display()
             )
         })
+}
+
+fn request_pcbnew_shutdown(session: &mut PcbnewSession) -> Result<()> {
+    quit_macos_app(&session.pcbnew_app)
+}
+
+fn quit_macos_app(app_path: &str) -> Result<()> {
+    let script = format!("tell application {} to quit", applescript_string(app_path));
+    let status = Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .status()
+        .with_context(|| format!("Failed to ask macOS to quit KiCad PCB Editor at {app_path}"))?;
+    if !status.success() {
+        return Err(anyhow!(
+            "macOS failed to quit KiCad PCB Editor at {app_path}"
+        ));
+    }
+    Ok(())
+}
+
+fn applescript_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 /// Builder for KiCad CLI commands

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -1,10 +1,12 @@
 use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use inquire::Confirm;
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use pcb_diode_api::{
     ExecSyncRequest, SandboxClient, SandboxFileUri, SandboxLockGuard, SandboxLockOptions,
 };
 use rayon::prelude::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -14,7 +16,7 @@ use std::sync::{
     mpsc::{self, Receiver, RecvTimeoutError},
 };
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
 use crate::layout::{LayoutArgs, LayoutOutputFormat};
@@ -23,6 +25,10 @@ use crate::open::OpenArgs;
 const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const WATCH_DEBOUNCE: Duration = Duration::from_millis(150);
 const REMOTE_LAYOUT_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const LOCAL_LAYOUT_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+const SYNC_RETRY_ATTEMPTS: usize = 3;
+const SYNC_RETRY_DELAY: Duration = Duration::from_millis(500);
+const SESSION_MANIFEST: &str = ".pcb-sync-session.json";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,7 +52,8 @@ pub fn execute_layout(uri: SandboxFileUri, args: LayoutArgs) -> Result<()> {
     let status = pcb_ui::Spinner::builder("Running pcb layout in sandbox...").start();
     let result = run_remote_layout(&client, &uri, &args)?;
     status.set_message("Downloading layout from sandbox...");
-    let local = sync_layout_down(&client, &uri, &result)?;
+    let restore_status = should_open.then_some(&status);
+    let local = sync_layout_down(&client, &uri, &result, restore_status)?;
     if should_open {
         return open_layout_and_sync(&client, &uri, &local, lock, status);
     }
@@ -68,7 +75,7 @@ pub fn execute_open(uri: SandboxFileUri, args: OpenArgs) -> Result<()> {
 
     let status = pcb_ui::Spinner::builder("Downloading layout from sandbox...").start();
     let local = if crate::sandbox_uri::is_remote_kicad_pcb_file(&uri) {
-        sync_remote_pcb_file_down(&client, &uri)?
+        sync_remote_pcb_file_down(&client, &uri, Some(&status))?
     } else {
         let layout_args = LayoutArgs {
             file: PathBuf::from(&uri.sandbox_path),
@@ -85,7 +92,7 @@ pub fn execute_open(uri: SandboxFileUri, args: OpenArgs) -> Result<()> {
         status.set_message("Running pcb layout in sandbox...");
         let result = run_remote_layout(&client, &uri, &layout_args)?;
         status.set_message("Downloading layout from sandbox...");
-        sync_layout_down(&client, &uri, &result)?
+        sync_layout_down(&client, &uri, &result, Some(&status))?
     };
 
     open_layout_and_sync(&client, &uri, &local, lock, status)
@@ -95,12 +102,69 @@ struct LocalLayout {
     remote_layout_dir: String,
     local_layout_dir: PathBuf,
     pcb_file: PathBuf,
+    sync_session: Option<SyncSession>,
+    restored_from_recovery: bool,
 }
 
 #[derive(Default)]
 struct SyncStats {
     uploaded: usize,
     removed: usize,
+}
+
+enum SyncOutcome {
+    Clean(SyncStats),
+    Recoverable {
+        reason: RecoverableStopReason,
+        error: anyhow::Error,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RecoverableStopReason {
+    LockReclaimed,
+    SyncFailed,
+}
+
+impl RecoverableStopReason {
+    fn message(self) -> &'static str {
+        match self {
+            Self::LockReclaimed => {
+                "Sandbox lock was reclaimed while KiCad was open; stopped syncing remote changes"
+            }
+            Self::SyncFailed => "Remote layout sync failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SyncSession {
+    manifest_path: PathBuf,
+    manifest: SyncSessionManifest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncSessionManifest {
+    version: u32,
+    uri: String,
+    remote_layout_dir: String,
+    local_layout_dir: PathBuf,
+    layout_file: PathBuf,
+    state: SyncSessionState,
+    stop_reason: Option<RecoverableStopReason>,
+    prompt_seen: bool,
+    started_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SyncSessionState {
+    Active,
+    Complete,
+    Recoverable,
 }
 
 fn sandbox_client(uri: &SandboxFileUri) -> Result<SandboxClient> {
@@ -123,27 +187,123 @@ fn open_layout_and_sync(
     lock: SandboxLockGuard,
     status: pcb_ui::Spinner,
 ) -> Result<()> {
+    let mut sync_session = local
+        .sync_session
+        .clone()
+        .context("Remote sync session was not initialized")?;
+    restore_recovered_layout_if_needed(client, uri, local, &status).with_context(|| {
+        format!(
+            "Failed to restore local recovery file {}",
+            local.pcb_file.display()
+        )
+    })?;
+    sync_session.mark_active()?;
     let running = install_shutdown_flag()?;
     status.set_message(format!("Opening {}...", local.pcb_file.display()));
-    let mut session = pcb_kicad::open_pcbnew_session(&local.pcb_file)?;
     let watcher = LocalLayoutWatcher::new(&local.local_layout_dir)?;
+    let mut session = match pcb_kicad::open_pcbnew_session(&local.pcb_file) {
+        Ok(session) => session,
+        Err(err) => {
+            sync_session.mark_complete()?;
+            return Err(err);
+        }
+    };
     status.set_message(format!(
         "Watching {} for KiCad changes...",
         local.local_layout_dir.display()
     ));
 
+    match run_local_sync_loop(
+        client,
+        uri,
+        local,
+        &lock,
+        &mut session,
+        &watcher,
+        &running,
+        &status,
+    ) {
+        SyncOutcome::Clean(stats) => {
+            sync_session.mark_complete()?;
+            lock.release()?;
+            status.success(format!(
+                "Final sync complete ({} uploaded, {} removed). Local recovery file: {}",
+                stats.uploaded,
+                stats.removed,
+                local.pcb_file.display()
+            ));
+            Ok(())
+        }
+        SyncOutcome::Recoverable { reason, error } => {
+            sync_session.mark_recoverable(reason)?;
+            status.error(format!(
+                "Remote sync stopped; local recovery file is {}",
+                local.pcb_file.display()
+            ));
+            let terminate_result = session.terminate();
+            let release_result = lock.release();
+            if let Err(terminate_err) = terminate_result {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Remote sync stopped. Local recovery file: {}. Also failed to quit KiCad: {terminate_err:#}",
+                        local.pcb_file.display()
+                    )
+                });
+            }
+            if let Err(release_err) = release_result {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Remote sync stopped. Local recovery file: {}. Also failed to release the sandbox lock: {release_err:#}",
+                        local.pcb_file.display()
+                    )
+                });
+            }
+            Err(error).with_context(|| {
+                format!(
+                    "Remote sync stopped. Local recovery file: {}",
+                    local.pcb_file.display()
+                )
+            })
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_local_sync_loop(
+    client: &SandboxClient,
+    uri: &SandboxFileUri,
+    local: &LocalLayout,
+    lock: &SandboxLockGuard,
+    session: &mut pcb_kicad::PcbnewSession,
+    watcher: &LocalLayoutWatcher,
+    running: &AtomicBool,
+    status: &pcb_ui::Spinner,
+) -> SyncOutcome {
     loop {
-        if session.try_wait()?.is_some() || !running.load(Ordering::SeqCst) {
+        match session.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {}
+            Err(err) => return recoverable_outcome(RecoverableStopReason::SyncFailed, err),
+        }
+        if !running.load(Ordering::SeqCst) {
             break;
         }
         if !lock.is_active() {
-            bail!(
-                "Sandbox lock was reclaimed while KiCad was open; stopped syncing remote changes"
+            return recoverable_outcome(
+                RecoverableStopReason::LockReclaimed,
+                anyhow::anyhow!(RecoverableStopReason::LockReclaimed.message()),
             );
         }
-        if watcher.changed_with_timeout(WATCH_POLL_INTERVAL)? {
+        let changed = match watcher.changed_with_timeout(WATCH_POLL_INTERVAL) {
+            Ok(changed) => changed,
+            Err(err) => return recoverable_outcome(RecoverableStopReason::SyncFailed, err),
+        };
+        if changed {
             status.set_message("Syncing local changes to sandbox...");
-            let stats = sync_layout_up(client, uri, local)?;
+            let stats = match sync_layout_up_with_retry(client, uri, local) {
+                Ok(stats) => stats,
+                Err(err) => return recoverable_outcome(RecoverableStopReason::SyncFailed, err),
+            };
             status.set_message(format!(
                 "Synced {} uploaded, {} removed. Watching for more changes...",
                 stats.uploaded, stats.removed
@@ -153,16 +313,20 @@ fn open_layout_and_sync(
 
     if lock.is_active() {
         status.set_message("Final sync to sandbox...");
-        let stats = sync_layout_up(client, uri, local)?;
-        status.success(format!(
-            "Final sync complete ({} uploaded, {} removed)",
-            stats.uploaded, stats.removed
-        ));
+        match sync_layout_up_with_retry(client, uri, local) {
+            Ok(stats) => SyncOutcome::Clean(stats),
+            Err(err) => recoverable_outcome(RecoverableStopReason::SyncFailed, err),
+        }
     } else {
-        status.finish();
+        recoverable_outcome(
+            RecoverableStopReason::LockReclaimed,
+            anyhow::anyhow!(RecoverableStopReason::LockReclaimed.message()),
+        )
     }
-    lock.release()?;
-    Ok(())
+}
+
+fn recoverable_outcome(reason: RecoverableStopReason, error: anyhow::Error) -> SyncOutcome {
+    SyncOutcome::Recoverable { reason, error }
 }
 
 struct LocalLayoutWatcher {
@@ -277,18 +441,23 @@ fn parse_remote_layout_result(stdout: &str) -> Result<RemoteLayoutResult> {
     Ok(result)
 }
 
-fn sync_remote_pcb_file_down(client: &SandboxClient, uri: &SandboxFileUri) -> Result<LocalLayout> {
+fn sync_remote_pcb_file_down(
+    client: &SandboxClient,
+    uri: &SandboxFileUri,
+    status: Option<&pcb_ui::Spinner>,
+) -> Result<LocalLayout> {
     let result = RemoteLayoutResult {
         layout_dir: Some(remote_parent_dir(&uri.sandbox_path)?),
         pcb_file: Some(uri.sandbox_path.clone()),
     };
-    sync_layout_down(client, uri, &result)
+    sync_layout_down(client, uri, &result, status)
 }
 
 fn sync_layout_down(
     client: &SandboxClient,
     uri: &SandboxFileUri,
     result: &RemoteLayoutResult,
+    restore_status: Option<&pcb_ui::Spinner>,
 ) -> Result<LocalLayout> {
     let remote_layout_dir = result
         .layout_dir
@@ -300,30 +469,76 @@ fn sync_layout_down(
         .as_ref()
         .context("Remote layout result is missing pcbFile")?
         .to_string();
-    let local_layout_dir = local_layout_cache_dir(uri, &remote_layout_dir)?;
-    if local_layout_dir.exists() {
-        fs::remove_dir_all(&local_layout_dir).with_context(|| {
-            format!(
-                "Failed to remove local layout cache {}",
-                local_layout_dir.display()
-            )
-        })?;
-    }
-    fs::create_dir_all(&local_layout_dir)?;
-    sync_remote_dir_down(
-        client,
-        &uri.sandbox_id,
-        &remote_layout_dir,
-        &local_layout_dir,
-    )?;
-
+    let cache_root = local_layout_cache_root(uri, &remote_layout_dir)?;
     let relative_pcb = remote_relative_path(&remote_layout_dir, &remote_pcb_file)?;
-    let pcb_file = local_layout_dir.join(relative_pcb);
+
+    let mut recovered_session = None;
+    if let Some(status) = restore_status
+        && let Some(session) = latest_recoverable_session(&cache_root)?
+        && let Some(restore) = prompt_restore_recovery(status, &session)
+    {
+        mark_recoverable_sessions_prompt_seen(&cache_root);
+        if restore {
+            recovered_session = Some(session);
+        }
+    }
+
+    let (local_layout_dir, pcb_file, sync_session, restored_from_recovery) =
+        if let Some(session) = recovered_session {
+            let local_layout_dir = session.manifest.local_layout_dir.clone();
+            let pcb_file = session.manifest.layout_file.clone();
+            (local_layout_dir, pcb_file, Some(session), true)
+        } else {
+            let local_layout_dir = new_local_layout_session_dir(&cache_root);
+            fs::create_dir_all(&local_layout_dir)?;
+            sync_remote_dir_down(
+                client,
+                &uri.sandbox_id,
+                &remote_layout_dir,
+                &local_layout_dir,
+            )?;
+            let pcb_file = local_layout_dir.join(&relative_pcb);
+            let sync_session = if restore_status.is_some() {
+                Some(SyncSession::create(
+                    uri,
+                    &remote_layout_dir,
+                    local_layout_dir.clone(),
+                    pcb_file.clone(),
+                )?)
+            } else {
+                None
+            };
+            (local_layout_dir, pcb_file, sync_session, false)
+        };
+
     Ok(LocalLayout {
         remote_layout_dir,
         local_layout_dir,
         pcb_file,
+        sync_session,
+        restored_from_recovery,
     })
+}
+
+fn restore_recovered_layout_if_needed(
+    client: &SandboxClient,
+    uri: &SandboxFileUri,
+    local: &LocalLayout,
+    status: &pcb_ui::Spinner,
+) -> Result<()> {
+    if !local.restored_from_recovery {
+        return Ok(());
+    }
+    status.set_message(format!(
+        "Restoring local recovery file {} to sandbox...",
+        local.pcb_file.display()
+    ));
+    let stats = sync_layout_up_with_retry(client, uri, local)?;
+    status.set_message(format!(
+        "Restored recovery file ({} uploaded, {} removed).",
+        stats.uploaded, stats.removed
+    ));
+    Ok(())
 }
 
 fn sync_remote_dir_down(
@@ -412,16 +627,284 @@ fn sync_layout_up(
     })
 }
 
-fn local_layout_cache_dir(uri: &SandboxFileUri, remote_layout_dir: &str) -> Result<PathBuf> {
+fn sync_layout_up_with_retry(
+    client: &SandboxClient,
+    uri: &SandboxFileUri,
+    local: &LocalLayout,
+) -> Result<SyncStats> {
+    for attempt in 1..=SYNC_RETRY_ATTEMPTS {
+        match sync_layout_up(client, uri, local) {
+            Ok(stats) => return Ok(stats),
+            Err(err) if attempt < SYNC_RETRY_ATTEMPTS => {
+                log::warn!(
+                    "Remote layout sync attempt {attempt}/{SYNC_RETRY_ATTEMPTS} failed: {err:#}"
+                );
+                thread::sleep(SYNC_RETRY_DELAY);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    unreachable!("sync retry loop always returns")
+}
+
+fn local_layout_cache_root(uri: &SandboxFileUri, remote_layout_dir: &str) -> Result<PathBuf> {
     let home = dirs::home_dir().context("Failed to find home directory")?;
     let key = format!("{}:{}:{}", uri.host, uri.sandbox_id, remote_layout_dir);
     let id = Uuid::new_v5(&Uuid::NAMESPACE_URL, key.as_bytes());
-    Ok(home
+    let cache_root = home
         .join(".pcb")
         .join("sandbox-layouts")
         .join(sanitize_path_component(&uri.host))
         .join(sanitize_path_component(&uri.sandbox_id))
-        .join(id.to_string()))
+        .join(id.to_string());
+    if let Err(err) = prune_old_layout_sessions(&cache_root, LOCAL_LAYOUT_RETENTION) {
+        log::warn!(
+            "Failed to prune old local sandbox layout sessions in {}: {err:#}",
+            cache_root.display()
+        );
+    }
+    Ok(cache_root)
+}
+
+fn new_local_layout_session_dir(cache_root: &Path) -> PathBuf {
+    let session_id = format!("{}-{}", Utc::now().format("%Y%m%dT%H%M%SZ"), Uuid::new_v4());
+    cache_root.join(session_id)
+}
+
+impl SyncSession {
+    fn create(
+        uri: &SandboxFileUri,
+        remote_layout_dir: &str,
+        local_layout_dir: PathBuf,
+        layout_file: PathBuf,
+    ) -> Result<Self> {
+        let now = Utc::now();
+        let mut session = Self {
+            manifest_path: local_layout_dir.join(SESSION_MANIFEST),
+            manifest: SyncSessionManifest {
+                version: 1,
+                uri: sandbox_uri_string(uri),
+                remote_layout_dir: remote_layout_dir.to_string(),
+                local_layout_dir,
+                layout_file,
+                state: SyncSessionState::Active,
+                stop_reason: None,
+                prompt_seen: false,
+                started_at: now,
+                updated_at: now,
+            },
+        };
+        session.save()?;
+        Ok(session)
+    }
+
+    fn load(local_layout_dir: PathBuf) -> Result<Self> {
+        let manifest_path = local_layout_dir.join(SESSION_MANIFEST);
+        let bytes = fs::read(&manifest_path)
+            .with_context(|| format!("Failed to read {}", manifest_path.display()))?;
+        let manifest = serde_json::from_slice(&bytes)
+            .with_context(|| format!("Failed to parse {}", manifest_path.display()))?;
+        Ok(Self {
+            manifest_path,
+            manifest,
+        })
+    }
+
+    fn mark_active(&mut self) -> Result<()> {
+        self.manifest.state = SyncSessionState::Active;
+        self.manifest.stop_reason = None;
+        self.manifest.updated_at = Utc::now();
+        self.save()
+    }
+
+    fn mark_complete(&mut self) -> Result<()> {
+        self.manifest.state = SyncSessionState::Complete;
+        self.manifest.stop_reason = None;
+        self.manifest.prompt_seen = true;
+        self.manifest.updated_at = Utc::now();
+        self.save()
+    }
+
+    fn mark_recoverable(&mut self, reason: RecoverableStopReason) -> Result<()> {
+        self.manifest.state = SyncSessionState::Recoverable;
+        self.manifest.stop_reason = Some(reason);
+        self.manifest.prompt_seen = false;
+        self.manifest.updated_at = Utc::now();
+        self.save()
+    }
+
+    fn mark_prompt_seen(&mut self) -> Result<()> {
+        self.manifest.prompt_seen = true;
+        self.manifest.updated_at = Utc::now();
+        self.save()
+    }
+
+    fn save(&mut self) -> Result<()> {
+        let bytes = serde_json::to_vec_pretty(&self.manifest)
+            .context("Failed to encode local sync session manifest")?;
+        fs::write(&self.manifest_path, bytes)
+            .with_context(|| format!("Failed to write {}", self.manifest_path.display()))
+    }
+}
+
+fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> {
+    if !cache_root.exists() {
+        return Ok(None);
+    }
+    let mut latest: Option<SyncSession> = None;
+    for entry in fs::read_dir(cache_root)
+        .with_context(|| format!("Failed to read {}", cache_root.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let Ok(session) = SyncSession::load(entry.path()) else {
+            continue;
+        };
+        if !is_recovery_candidate(&session.manifest) {
+            continue;
+        }
+        if latest
+            .as_ref()
+            .is_none_or(|current| session.manifest.updated_at > current.manifest.updated_at)
+        {
+            latest = Some(session);
+        }
+    }
+    Ok(latest)
+}
+
+fn prompt_restore_recovery(status: &pcb_ui::Spinner, session: &SyncSession) -> Option<bool> {
+    if !crate::tty::is_interactive() {
+        eprintln!(
+            "Found local recovery file for this remote layout at {}. Re-run interactively to restore it.",
+            session.manifest.layout_file.display()
+        );
+        return None;
+    }
+    let prompt = format!(
+        "Restore previous local KiCad recovery file from {}?",
+        session.manifest.layout_file.display()
+    );
+    let ask = || {
+        Confirm::new(&prompt)
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+    };
+    Some(status.suspend(ask))
+}
+
+fn mark_recoverable_sessions_prompt_seen(cache_root: &Path) {
+    let entries = match fs::read_dir(cache_root) {
+        Ok(entries) => entries,
+        Err(err) => {
+            if cache_root.exists() {
+                log::warn!(
+                    "Failed to mark recovery prompts seen in {}: {err:#}",
+                    cache_root.display()
+                );
+            }
+            return;
+        }
+    };
+
+    for entry in entries {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let Ok(mut session) = SyncSession::load(entry.path()) else {
+            continue;
+        };
+        if is_recovery_candidate(&session.manifest)
+            && let Err(err) = session.mark_prompt_seen()
+        {
+            log::warn!(
+                "Failed to mark local recovery prompt seen at {}: {err:#}",
+                session.manifest_path.display()
+            );
+        }
+    }
+}
+
+fn is_recovery_candidate(manifest: &SyncSessionManifest) -> bool {
+    matches!(
+        manifest.state,
+        SyncSessionState::Active | SyncSessionState::Recoverable
+    ) && !manifest.prompt_seen
+        && manifest.layout_file.is_file()
+}
+
+fn prune_old_layout_sessions(cache_root: &Path, retention: Duration) -> Result<()> {
+    if !cache_root.exists() {
+        return Ok(());
+    }
+    let cutoff = SystemTime::now()
+        .checked_sub(retention)
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    for entry in fs::read_dir(cache_root)
+        .with_context(|| format!("Failed to read {}", cache_root.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if session_contains_lock_file(&path)? {
+            continue;
+        }
+        if let Some(modified) = newest_direct_child_mtime(&path)?
+            && modified < cutoff
+        {
+            fs::remove_dir_all(&path)
+                .with_context(|| format!("Failed to remove old layout cache {}", path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn session_contains_lock_file(path: &Path) -> Result<bool> {
+    for entry in fs::read_dir(path).with_context(|| format!("Failed to read {}", path.display()))? {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if name.ends_with(".lck") || name.ends_with(".lock") {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn newest_direct_child_mtime(path: &Path) -> Result<Option<SystemTime>> {
+    let mut newest = path
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .ok();
+    for entry in fs::read_dir(path).with_context(|| format!("Failed to read {}", path.display()))? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let Ok(modified) = entry.metadata().and_then(|metadata| metadata.modified()) else {
+            continue;
+        };
+        newest = Some(match newest {
+            Some(current) => current.max(modified),
+            None => modified,
+        });
+    }
+    Ok(newest)
 }
 
 fn remote_parent_dir(path: &str) -> Result<String> {
@@ -437,6 +920,13 @@ fn remote_relative_path(remote_base: &str, remote_path: &str) -> Result<PathBuf>
     path.strip_prefix(base)
         .map(Path::to_path_buf)
         .with_context(|| format!("{remote_path} is not inside {remote_base}"))
+}
+
+fn sandbox_uri_string(uri: &SandboxFileUri) -> String {
+    format!(
+        "diode://{}/sandboxes/{}/fs{}",
+        uri.host, uri.sandbox_id, uri.sandbox_path
+    )
 }
 
 fn sanitize_path_component(value: &str) -> String {
@@ -465,6 +955,7 @@ fn should_skip_sync_path(path: &Path) -> bool {
 
 fn should_skip_sync_name(name: &str) -> bool {
     name == ".DS_Store"
+        || name == SESSION_MANIFEST
         || name.ends_with('~')
         // KiCad layout logs are disposable, and prod rejects raw GETs for *.log paths.
         || name.ends_with(".log")


### PR DESCRIPTION
Perform JWT refresh during layout sync session, be more lenient with heartbeat retries, automatically soft-quit KiCad on sync disconnect, and proactively suggest restoring previous session when reconnecting. This should make the layout syncing more stable in the short term


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote file upload format, lock heartbeat semantics, and KiCad shutdown behavior during sync failures; incorrect recovery or terminate logic could strand locks or overwrite remote layouts.
> 
> **Overview**
> Improves **remote sandbox layout sync** so interrupted KiCad sessions are less likely to lose work and long sessions stay authenticated.
> 
> **Sandbox API client** now uploads layout files as raw `application/octet-stream` instead of base64 JSON, resolves the bearer token through `WorkspaceContext` on each request (so tokens can refresh mid-session), tightens lock heartbeats (5s interval, up to three transient failures before the lock is treated as inactive), and treats a missing or mismatched lock lease as “lost” rather than failing immediately.
> 
> **`pcb open` / remote layout** adds per-session local caches with a `.pcb-sync-session.json` manifest, optional interactive restore of the latest recoverable local board after a bad exit, retries uploads three times, and on recoverable stops (lock reclaimed or sync errors) keeps the local recovery copy, marks the session recoverable, and attempts to quit KiCad via `PcbnewSession::terminate()` before releasing the lock. Successful exits still do a final upload; messaging points users at the on-disk recovery file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd950ae594e20f95b1c3b281735bd8163ae9b2a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->