### PR TITLE
add debounced switch

### DIFF
--- a/examples/DebouncedButton/DebouncedButton.zen
+++ b/examples/DebouncedButton/DebouncedButton.zen
@@ -16,21 +16,21 @@ package = config(str, default="0603", optional=True)
 
 VCC = io(Power, direction="input")
 GND = io(Ground)
-BUTTON_OUT = io(Gpio, direction="output")
+BUTTON = io(Gpio, direction="input")
 
 Resistor(
     name="R_PULLUP",
     value=pullup_value,
     package=package,
     P1=VCC,
-    P2=BUTTON_OUT,
+    P2=BUTTON,
 )
 
 Capacitor(
     name="C_DEBOUNCE",
     value=debounce_cap_value,
     package=package,
-    P1=BUTTON_OUT,
+    P1=BUTTON,
     P2=GND,
 )
 
@@ -43,7 +43,7 @@ Component(
         manufacturer="TE Connectivity",
     ),
     pins={
-        "1": BUTTON_OUT,
+        "1": BUTTON,
         "2": GND,
     },
 )

--- a/examples/DebouncedButton/DebouncedButton.zen
+++ b/examples/DebouncedButton/DebouncedButton.zen
@@ -1,0 +1,49 @@
+"""
+Type: Debounced Button Input
+
+Description:
+A reusable GPIO button input circuit with pull-up resistor and RC debounce capacitor.
+"""
+
+load("@stdlib/interfaces.zen", "Gpio")
+
+Resistor = Module("@stdlib/generics/Resistor.zen")
+Capacitor = Module("@stdlib/generics/Capacitor.zen")
+
+pullup_value = config(str, default="10kohms", optional=True)
+debounce_cap_value = config(str, default="100nF", optional=True)
+package = config(str, default="0603", optional=True)
+
+VCC = io(Power, direction="input")
+GND = io(Ground)
+BUTTON_OUT = io(Gpio, direction="output")
+
+Resistor(
+    name="R_PULLUP",
+    value=pullup_value,
+    package=package,
+    P1=VCC,
+    P2=BUTTON_OUT,
+)
+
+Capacitor(
+    name="C_DEBOUNCE",
+    value=debounce_cap_value,
+    package=package,
+    P1=BUTTON_OUT,
+    P2=GND,
+)
+
+Component(
+    name="SW_BUTTON",
+    symbol=Symbol(library="@kicad-symbols/Switch.kicad_sym", name="SW_Push"),
+    footprint="Button_Switch_THT:SW_PUSH_6mm",
+    part=Part(
+        mpn="FSM6JH",
+        manufacturer="TE Connectivity",
+    ),
+    pins={
+        "1": BUTTON_OUT,
+        "2": GND,
+    },
+)

--- a/examples/DebouncedButton/DebouncedButton.zen
+++ b/examples/DebouncedButton/DebouncedButton.zen
@@ -16,7 +16,8 @@ package = config(str, default="0603", optional=True)
 
 VCC = io(Power, direction="input")
 GND = io(Ground)
-BUTTON = io(Gpio, direction="input")
+BUTTON = io(Gpio, direction="output")
+
 
 Resistor(
     name="R_PULLUP",

--- a/examples/DebouncedButton/pcb.toml
+++ b/examples/DebouncedButton/pcb.toml
@@ -1,0 +1,6 @@
+[dependencies]
+"gitlab.com/kicad/libraries/kicad-symbols" = "10.0.3"
+
+[dependencies.indirect]
+"gitlab.com/kicad/libraries/kicad-footprints@10" = "10.0.3"
+"gitlab.com/kicad/libraries/kicad-packages3D@10" = "10.0.3"


### PR DESCRIPTION
**Component**

debounced GPIO button input

**Contains**
- pull-up resistor
- rc debounce capacitor
- momentary pushbutton
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-style example addition only; no changes to core libraries or runtime behavior.
> 
> **Overview**
> Adds a new **`examples/DebouncedButton`** reusable circuit: pull-up on `VCC`, RC debounce cap on the `BUTTON` GPIO node, and a momentary `SW_Push` tied to ground.
> 
> Configurable defaults cover pull-up (`10kohms`), debounce cap (`100nF`), and SMD package (`0603`); the switch uses a THT footprint and TE **FSM6JH** part. **`pcb.toml`** pins KiCad symbol/footprint/3D library deps at **10.0.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1e92eb2fa9893ba9dbb3a1111eadea2fe9ecf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->