### PR TITLE
Preserve borrowed net names in io templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Net aliases used inside `io()` interface templates no longer unregister the original net name.
 - Child net-symbol position overrides (`# pcb:sch <child>.<NET>.<idx>`) are no longer dropped when the net is renamed across the module boundary.
 - Package content hashes ignore generated `pcb.sum` files.
 - Read/evaluation paths now require hydrated manifests and never mutate dependency state.

--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -80,15 +80,32 @@ impl InstancePrefix {
     }
 }
 
-/// Return the factory of an Interface instance (handles both frozen and unfrozen)
-/// Recursively unregister all nets within an interface instance
-fn unregister_interface_nets<'v>(interface: &InterfaceValue<'v>, ctx: &ContextValue) {
-    for (_field_name, field_value) in interface.fields.iter() {
-        if let Some(net_val) = field_value.downcast_ref::<NetValue<'v>>() {
-            ctx.unregister_net(net_val.id());
-        } else if let Some(nested_interface) = field_value.downcast_ref::<InterfaceValue<'v>>() {
-            // Recursively unregister nets in nested interfaces
-            unregister_interface_nets(nested_interface, ctx);
+/// Recursively unregister nets that are owned by an interface/template expression.
+pub(crate) fn unregister_template_owned_nets<'v>(value: Value<'v>, ctx: &ContextValue) {
+    if let Some(net) = value.downcast_ref::<NetValue<'v>>() {
+        if net.is_template_owned() {
+            ctx.unregister_net(net.id());
+        }
+        return;
+    }
+
+    if let Some(net) = value.downcast_ref::<FrozenNetValue>() {
+        if net.is_template_owned() {
+            ctx.unregister_net(net.id());
+        }
+        return;
+    }
+
+    if let Some(interface) = value.downcast_ref::<InterfaceValue<'v>>() {
+        for (_field_name, field_value) in interface.fields().iter() {
+            unregister_template_owned_nets(field_value.to_value(), ctx);
+        }
+        return;
+    }
+
+    if let Some(interface) = value.downcast_ref::<FrozenInterfaceValue>() {
+        for (_field_name, field_value) in interface.fields().iter() {
+            unregister_template_owned_nets(field_value.to_value(), ctx);
         }
     }
 }
@@ -775,31 +792,12 @@ pub(crate) fn interface_globals(builder: &mut GlobalsBuilder) {
                         .downcast_ref::<FrozenInterfaceFactory>()
                         .is_some()
                 {
-                    // If a Net instance literal was provided as a template field,
-                    // unregister it from the current module so it does not count as
-                    // an introduced net of this module. It will be (re)registered
-                    // when an interface instance is created.
-                    if type_str == "Net" {
-                        if let Some(net_val) = field_value.downcast_ref::<NetValue<'v>>()
-                            && let Some(ctx) = eval
-                                .module()
-                                .extra_value()
-                                .and_then(|e| e.downcast_ref::<ContextValue>())
-                        {
-                            ctx.unregister_net(net_val.id());
-                        }
-                    } else if type_str == "InterfaceValue" {
-                        // If an Interface instance was provided as a template field,
-                        // recursively unregister all nets inside it
-                        if let Some(interface_val) =
-                            field_value.downcast_ref::<InterfaceValue<'v>>()
-                            && let Some(ctx) = eval
-                                .module()
-                                .extra_value()
-                                .and_then(|e| e.downcast_ref::<ContextValue>())
-                        {
-                            unregister_interface_nets(interface_val, ctx);
-                        }
+                    if let Some(ctx) = eval
+                        .module()
+                        .extra_value()
+                        .and_then(|e| e.downcast_ref::<ContextValue>())
+                    {
+                        unregister_template_owned_nets(field_value, ctx);
                     }
                     fields.insert(name.clone(), field_value);
                 } else {

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -246,7 +246,13 @@ impl<V> NetValueGen<V> {
 }
 
 impl<'v, V: ValueLike<'v>> NetValueGen<V> {
-    fn alloc_clone(&self, heap: Heap<'v>, net_id: NetId, type_name: String) -> Value<'v> {
+    fn alloc_clone(
+        &self,
+        heap: Heap<'v>,
+        net_id: NetId,
+        type_name: String,
+        derived_from_base_net: bool,
+    ) -> Value<'v> {
         let properties: SmallMap<String, Value<'v>> = self
             .properties
             .iter()
@@ -259,7 +265,7 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
             template_name: self.template_name.clone(),
             original_name: self.original_name_opt().map(str::to_owned),
             assignment_inferable: self.assignment_inferable,
-            derived_from_base_net: self.derived_from_base_net,
+            derived_from_base_net,
             was_bound: Self::clone_once_lock(&self.was_bound),
             inferred_name: Self::clone_once_lock(&self.inferred_name),
             declaration_path: self.declaration_path.clone(),
@@ -371,20 +377,33 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
         self.was_bound.get().is_some()
     }
 
-    pub(crate) fn skips_implicit_checks(&self) -> bool {
+    pub(crate) fn is_external_reference(&self) -> bool {
         self.derived_from_base_net() || self.was_bound()
+    }
+
+    pub(crate) fn is_template_owned(&self) -> bool {
+        !self.is_external_reference()
+    }
+
+    pub(crate) fn skips_implicit_checks(&self) -> bool {
+        self.is_external_reference()
     }
 
     /// Create a new net with the same fields but a fresh net ID.
     /// This avoids deep copying - properties are shared via Value references.
     pub fn with_new_id(&self, heap: Heap<'v>) -> Value<'v> {
-        self.alloc_clone(heap, generate_net_id(), self.type_name.clone())
+        self.alloc_clone(
+            heap,
+            generate_net_id(),
+            self.type_name.clone(),
+            self.derived_from_base_net,
+        )
     }
 
     /// Create a new net with the same ID/name/properties but a different type name.
     /// Used for casting between net types (e.g., Power -> Net).
     pub fn with_net_type(&self, new_type_name: &str, heap: Heap<'v>) -> Value<'v> {
-        self.alloc_clone(heap, self.net_id, new_type_name.to_string())
+        self.alloc_clone(heap, self.net_id, new_type_name.to_string(), true)
     }
 
     /// Create a new net with identical runtime identity but updated declaration metadata.

--- a/crates/pcb-zen-core/src/lang/param_decl.rs
+++ b/crates/pcb-zen-core/src/lang/param_decl.rs
@@ -20,6 +20,7 @@ use crate::lang::{
 use super::context::ContextValue;
 use super::interface::{
     FrozenInterfaceValue, InstancePrefix, InterfaceValue, instantiate_interface,
+    unregister_template_owned_nets,
 };
 use super::module::{
     DeclarationSite, MissingInputError, ParameterMetadataInput, current_declaration_site,
@@ -580,8 +581,7 @@ impl<'v> IoTemplateValue<'v> {
 
     fn unregister(self, ctx: &ContextValue) {
         match self {
-            Self::Net(value) => unregister_net_template(value, ctx),
-            Self::Interface(value) => unregister_interface_template(value, ctx),
+            Self::Net(value) | Self::Interface(value) => unregister_template_owned_nets(value, ctx),
         }
     }
 
@@ -618,31 +618,6 @@ impl<'v> IoTemplateValue<'v> {
                 eval.heap(),
                 eval,
             ),
-        }
-    }
-}
-
-fn unregister_net_template<'v>(value: Value<'v>, ctx: &ContextValue) {
-    if let Some(net) = value.downcast_ref::<NetValue<'v>>() {
-        ctx.unregister_net(net.id());
-    } else if let Some(net) = value.downcast_ref::<FrozenNetValue>() {
-        ctx.unregister_net(net.id());
-    }
-}
-
-fn unregister_interface_template<'v>(value: Value<'v>, ctx: &ContextValue) {
-    if let Some(interface) = value.downcast_ref::<InterfaceValue<'v>>() {
-        for (_field_name, field_value) in interface.fields().iter() {
-            if let Some(template) = IoTemplateValue::from_value(field_value.to_value()) {
-                template.unregister(ctx);
-            }
-        }
-    }
-    if let Some(interface) = value.downcast_ref::<FrozenInterfaceValue>() {
-        for (_field_name, field_value) in interface.fields().iter() {
-            if let Some(template) = IoTemplateValue::from_value(field_value.to_value()) {
-                template.unregister(ctx);
-            }
         }
     }
 }

--- a/crates/pcb-zen-core/tests/name_inference.rs
+++ b/crates/pcb-zen-core/tests/name_inference.rs
@@ -24,6 +24,46 @@ fn redundancy_advice_count(diagnostics: &pcb_zen_core::Diagnostics, body_substri
 
 #[test]
 #[cfg(not(target_os = "windows"))]
+fn io_interface_template_preserves_borrowed_net_name() {
+    let result = eval_ok(
+        r#"
+load("@stdlib/interfaces.zen", "Ground", "I2c")
+
+GND = io(Ground())
+I2C_TARGET = io(I2c(SDA=GND, SCL=GND), optional=True)
+
+Component(
+    name = "U1",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod"),
+    pin_defs = {"P1": "1", "P2": "2"},
+    pins = {"P1": I2C_TARGET.SDA, "P2": GND},
+    skip_bom = True,
+)
+"#,
+    );
+
+    let eval_output = result.output.expect("expected eval output");
+    let sch_result = eval_output.to_schematic_with_diagnostics();
+    assert!(
+        !sch_result.diagnostics.has_errors(),
+        "schematic conversion failed: {:?}",
+        sch_result.diagnostics
+    );
+
+    let schematic = sch_result.output.expect("expected schematic");
+    let mut ground_like_nets = schematic
+        .nets
+        .keys()
+        .filter(|name| name.as_str() == "GND" || name.ends_with(".GND"))
+        .cloned()
+        .collect::<Vec<_>>();
+    ground_like_nets.sort();
+
+    assert_eq!(ground_like_nets, vec!["GND".to_string()]);
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
 fn infers_direct_net_names_from_assignment() {
     let result = eval_ok(
         r#"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core net registration during `io()` and interface template evaluation; behavior is narrowed with a focused test but affects naming and module net bookkeeping.
> 
> **Overview**
> Fixes a bug where **reusing an existing module net inside an `io()` interface template** (e.g. `GND = io(Ground())` then `io(I2c(SDA=GND, SCL=GND))`) could **unregister** that net from the module because template parsing treated every embedded `Net`/`Interface` field as disposable scaffolding.
> 
> **Net ownership** is now explicit: a net is **template-owned** only when it is not an external reference (`derived_from_base_net` or bound via assignment). Unregistration goes through shared **`unregister_template_owned_nets`**, used from **`interface(...)`**, **`io(template)`**, and related paths, instead of unregistering all nested nets indiscriminately.
> 
> **`with_net_type`** marks casts as derived so they are not mistaken for template-owned literals. A regression test checks schematic output keeps a single **`GND`** when I2C lines alias the same ground io.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94523c7b209f1eaa54b126459cfa7671ddc4688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->