### PR TITLE
Fix net kind merging for cast views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Net kind merging now promotes empty or `NotConnected` placeholders to observed concrete kinds.
+
 ## [0.4.0] - 2026-06-17
 
 ### Fixed

--- a/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
+++ b/crates/pcb-layout/tests/snapshots/layout_generation__not_connected.log.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcb-layout/tests/layout_generation.rs
-assertion_line: 108
 expression: content
 ---
 INFO: Creating new board file at <TEMP_DIR>
@@ -26,7 +25,7 @@ INFO: Added footprint: R2.R
 INFO: HierPlace: placed 2 items
 INFO: OPLOG FP_ADD path=R1.R ref=R1 fpid=stdlib_kicad-footprints_Resistor_SMD:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
 INFO: OPLOG FP_ADD path=R2.R ref=R2 fpid=stdlib_kicad-footprints_Resistor_SMD:R_0603_1608Metric value=10k x=0 y=0 layer=F.Cu pads=2
-INFO: OPLOG NET_ADD name=R1.NC_R_2
+INFO: OPLOG NET_ADD name=R1.P2
 INFO: OPLOG NET_ADD name=VCC
 INFO: OPLOG NET_ADD name=GND
 INFO: OPLOG PLACE_FP path=R1.R x=146995000 y=104245000 w=3010000 h=1510000

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -664,6 +664,10 @@ impl ModuleConverter {
     fn update_net(&mut self, net: &FrozenNetValue, instance_ref: &InstanceRef) {
         let net_info = self.net_info_mut(net.id());
         net_info.ports.push(instance_ref.clone());
+        // Derived values are typed views; unintroduced canonical nets still seed kind here.
+        if !net.derived_from_base_net() {
+            merge_canonical_net_type_name(&mut net_info.type_name, net.net_type_name());
+        }
 
         // For unnamed NotConnected nets, use a stable port-derived name when possible.
         if net_info.type_name == "NotConnected"

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -2,7 +2,7 @@ use crate::lang::r#enum::EnumValue;
 use crate::lang::interface::FrozenInterfaceValue;
 use crate::lang::io_direction::IoDirection;
 use crate::lang::module::{ModulePath, find_moved_span};
-use crate::lang::net::merge_net_type_name;
+use crate::lang::net::{merge_canonical_net_type_name, net_type_requires_name};
 use crate::lang::part::PartValue;
 use crate::lang::symbol::SymbolValue;
 use crate::lang::type_info::TypeInfo;
@@ -269,7 +269,7 @@ impl ModuleConverter {
                 continue;
             }
 
-            if net_info.type_name != "NotConnected" && net_info.name.is_none() {
+            if net_type_requires_name(&net_info.type_name) && net_info.name.is_none() {
                 let mut diagnostics = Diagnostics::default();
                 diagnostics.push(Diagnostic::new(
                     "Net is unnamed",
@@ -641,7 +641,7 @@ impl ModuleConverter {
             }
 
             let info = self.net_info_mut(*net_id);
-            merge_net_type_name(&mut info.type_name, &introduced_net.net_type);
+            merge_canonical_net_type_name(&mut info.type_name, &introduced_net.net_type);
         }
 
         // Add direct child components
@@ -664,7 +664,6 @@ impl ModuleConverter {
     fn update_net(&mut self, net: &FrozenNetValue, instance_ref: &InstanceRef) {
         let net_info = self.net_info_mut(net.id());
         net_info.ports.push(instance_ref.clone());
-        merge_net_type_name(&mut net_info.type_name, net.net_type_name());
 
         // For unnamed NotConnected nets, use a stable port-derived name when possible.
         if net_info.type_name == "NotConnected"

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -34,8 +34,12 @@ struct NetInfo {
     ports: Vec<InstanceRef>,
     /// Aggregated properties for this net.
     properties: HashMap<String, AttributeValue>,
-    /// Canonical Starlark net type name (e.g. "Net", "Power", "Ground", "NotConnected").
-    type_name: String,
+    /// Canonical Starlark net kind, if observed.
+    kind: Option<String>,
+}
+
+fn net_kind_requires_name(kind: Option<&str>) -> bool {
+    kind.is_none_or(net_type_requires_name)
 }
 
 /// Convert a [`FrozenModuleValue`] to a [`Schematic`].
@@ -265,11 +269,11 @@ impl ModuleConverter {
 
         // Create Net objects directly using the accumulated NetInfo.
         for (net_id, net_info) in &self.net_to_info {
-            if net_info.type_name == "NotConnected" && net_info.ports.is_empty() {
+            if net_info.kind.as_deref() == Some("NotConnected") && net_info.ports.is_empty() {
                 continue;
             }
 
-            if net_type_requires_name(&net_info.type_name) && net_info.name.is_none() {
+            if net_kind_requires_name(net_info.kind.as_deref()) && net_info.name.is_none() {
                 let mut diagnostics = Diagnostics::default();
                 diagnostics.push(Diagnostic::new(
                     "Net is unnamed",
@@ -281,12 +285,7 @@ impl ModuleConverter {
                     diagnostics,
                 };
             }
-            // Use the recorded type_name as the kind string if present, otherwise default.
-            let net_kind = if net_info.type_name.is_empty() {
-                "Net".to_string()
-            } else {
-                net_info.type_name.clone()
-            };
+            let net_kind = net_info.kind.clone().unwrap_or_else(|| "Net".to_string());
             let net_name = net_info.name.clone().unwrap_or_else(|| {
                 debug_assert_eq!(net_kind, "NotConnected");
                 String::new()
@@ -326,7 +325,7 @@ impl ModuleConverter {
                     .get(&net_id)
                     .expect("NetInfo must exist for model net");
                 let name = net_info.name.clone().unwrap_or_else(|| {
-                    debug_assert_eq!(net_info.type_name, "NotConnected");
+                    debug_assert_eq!(net_info.kind.as_deref(), Some("NotConnected"));
                     String::new()
                 });
                 net_names.push(AttributeValue::String(name));
@@ -641,7 +640,9 @@ impl ModuleConverter {
             }
 
             let info = self.net_info_mut(*net_id);
-            merge_canonical_net_type_name(&mut info.type_name, &introduced_net.net_type);
+            if let Some(kind) = introduced_net.kind.as_deref() {
+                merge_canonical_net_type_name(&mut info.kind, kind);
+            }
         }
 
         // Add direct child components
@@ -664,13 +665,10 @@ impl ModuleConverter {
     fn update_net(&mut self, net: &FrozenNetValue, instance_ref: &InstanceRef) {
         let net_info = self.net_info_mut(net.id());
         net_info.ports.push(instance_ref.clone());
-        // Derived values are typed views; unintroduced canonical nets still seed kind here.
-        if !net.derived_from_base_net() {
-            merge_canonical_net_type_name(&mut net_info.type_name, net.net_type_name());
-        }
+        merge_canonical_net_type_name(&mut net_info.kind, net.net_type_name());
 
         // For unnamed NotConnected nets, use a stable port-derived name when possible.
-        if net_info.type_name == "NotConnected"
+        if net_info.kind.as_deref() == Some("NotConnected")
             && net.original_name_opt().is_none()
             && net_info.ports.len() == 1
         {

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -2,6 +2,7 @@ use crate::lang::r#enum::EnumValue;
 use crate::lang::interface::FrozenInterfaceValue;
 use crate::lang::io_direction::IoDirection;
 use crate::lang::module::{ModulePath, find_moved_span};
+use crate::lang::net::merge_net_type_name;
 use crate::lang::part::PartValue;
 use crate::lang::symbol::SymbolValue;
 use crate::lang::type_info::TypeInfo;
@@ -33,8 +34,8 @@ struct NetInfo {
     ports: Vec<InstanceRef>,
     /// Aggregated properties for this net.
     properties: HashMap<String, AttributeValue>,
-    /// Starlark net type name (e.g. "Net", "Power", "Ground", "NotConnected").
-    original_type_name: String,
+    /// Canonical Starlark net type name (e.g. "Net", "Power", "Ground", "NotConnected").
+    type_name: String,
 }
 
 /// Convert a [`FrozenModuleValue`] to a [`Schematic`].
@@ -264,11 +265,11 @@ impl ModuleConverter {
 
         // Create Net objects directly using the accumulated NetInfo.
         for (net_id, net_info) in &self.net_to_info {
-            if net_info.original_type_name == "NotConnected" && net_info.ports.is_empty() {
+            if net_info.type_name == "NotConnected" && net_info.ports.is_empty() {
                 continue;
             }
 
-            if net_info.original_type_name != "NotConnected" && net_info.name.is_none() {
+            if net_info.type_name != "NotConnected" && net_info.name.is_none() {
                 let mut diagnostics = Diagnostics::default();
                 diagnostics.push(Diagnostic::new(
                     "Net is unnamed",
@@ -281,10 +282,10 @@ impl ModuleConverter {
                 };
             }
             // Use the recorded type_name as the kind string if present, otherwise default.
-            let net_kind = if net_info.original_type_name.is_empty() {
+            let net_kind = if net_info.type_name.is_empty() {
                 "Net".to_string()
             } else {
-                net_info.original_type_name.clone()
+                net_info.type_name.clone()
             };
             let net_name = net_info.name.clone().unwrap_or_else(|| {
                 debug_assert_eq!(net_kind, "NotConnected");
@@ -325,7 +326,7 @@ impl ModuleConverter {
                     .get(&net_id)
                     .expect("NetInfo must exist for model net");
                 let name = net_info.name.clone().unwrap_or_else(|| {
-                    debug_assert_eq!(net_info.original_type_name, "NotConnected");
+                    debug_assert_eq!(net_info.type_name, "NotConnected");
                     String::new()
                 });
                 net_names.push(AttributeValue::String(name));
@@ -639,13 +640,8 @@ impl ModuleConverter {
                 }
             }
 
-            // Set original_type_name from introduced_nets if not already set.
-            // Since parent modules are processed before children (BTreeMap ordering),
-            // the creating module's original type is captured first.
             let info = self.net_info_mut(*net_id);
-            if info.original_type_name.is_empty() {
-                info.original_type_name = introduced_net.net_type.clone();
-            }
+            merge_net_type_name(&mut info.type_name, &introduced_net.net_type);
         }
 
         // Add direct child components
@@ -668,12 +664,10 @@ impl ModuleConverter {
     fn update_net(&mut self, net: &FrozenNetValue, instance_ref: &InstanceRef) {
         let net_info = self.net_info_mut(net.id());
         net_info.ports.push(instance_ref.clone());
-        if net_info.original_type_name.is_empty() {
-            net_info.original_type_name = net.net_type_name().to_string();
-        }
+        merge_net_type_name(&mut net_info.type_name, net.net_type_name());
 
         // For unnamed NotConnected nets, use a stable port-derived name when possible.
-        if net_info.original_type_name == "NotConnected"
+        if net_info.type_name == "NotConnected"
             && net.original_name_opt().is_none()
             && net_info.ports.len() == 1
         {

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -906,7 +906,6 @@ fn alloc_not_connected<'v>(
         template_name: None,
         original_name: None,
         assignment_inferable: false,
-        derived_from_base_net: false,
         was_bound: std::sync::OnceLock::new(),
         inferred_name: std::sync::OnceLock::new(),
         declaration_path,

--- a/crates/pcb-zen-core/src/lang/context.rs
+++ b/crates/pcb-zen-core/src/lang/context.rs
@@ -312,13 +312,13 @@ impl<'v> ContextValue<'v> {
         id: NetId,
         local_name: &str,
         assignment_inferable: bool,
-        net_type: &str,
+        kind: &str,
     ) -> anyhow::Result<String> {
         self.module.borrow_mut().register_net(
             id,
             local_name.to_string(),
             assignment_inferable,
-            net_type.to_string(),
+            kind.to_string(),
         )
     }
 

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -1548,7 +1548,7 @@ impl EvalContext {
                         .expect("extra value should be a FrozenContextValue");
 
                     for (_id, net_info) in extra.module.introduced_nets() {
-                        if net_info.net_type != "NotConnected"
+                        if net_info.kind.as_deref() != Some("NotConnected")
                             && net_info.name.is_pending_inference()
                         {
                             diagnostics.push(anyhow!("Net is unnamed").into());

--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -159,7 +159,7 @@ fn clone_net_template<'v>(
                     cloned_net.id(),
                     &net_name,
                     prefix.assignment_inferable,
-                    &cloned_net.type_name,
+                    cloned_net.net_type_name(),
                 )
             })
             .transpose()?
@@ -174,7 +174,6 @@ fn clone_net_template<'v>(
         template_name: cloned_net.template_name_opt().map(str::to_owned),
         original_name: cloned_net.original_name_opt().map(|s| s.to_owned()),
         assignment_inferable: prefix.assignment_inferable,
-        derived_from_base_net: cloned_net.derived_from_base_net(),
         was_bound: cloned_net.cloned_bound_marker(),
         inferred_name: OnceLock::new(),
         declaration_path: cloned_net

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -58,7 +58,8 @@ macro_rules! downcast_frozen_module {
 }
 
 use super::net::{
-    FrozenNetType, FrozenNetValue, NetId, NetType, NetValue, generate_net_id, merge_net_type_name,
+    FrozenNetType, FrozenNetValue, NetId, NetType, NetValue, generate_net_id,
+    merge_canonical_net_type_name, net_type_requires_name,
 };
 use crate::lang::context::FrozenContextValue;
 use starlark::errors::EvalMessage;
@@ -767,28 +768,32 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             .filter_map(move |child| child.downcast_ref::<FrozenTestBenchValue>())
     }
 
-    fn validate_net_registration_name(
-        &self,
+    fn record_net_name(
+        &mut self,
         id: NetId,
         base_name: &str,
         assignment_inferable: bool,
         net_type: &str,
     ) -> anyhow::Result<()> {
-        if net_type == "NotConnected" {
+        if !net_type_requires_name(net_type) {
             return Ok(());
         }
 
-        if !assignment_inferable && base_name.trim().is_empty() {
+        if assignment_inferable {
+            return Ok(());
+        }
+
+        if base_name.trim().is_empty() {
             anyhow::bail!("Net is unnamed");
         }
 
-        if !assignment_inferable
-            && let Some(existing_id) = self.net_name_to_id.get(base_name)
+        if let Some(existing_id) = self.net_name_to_id.get(base_name)
             && *existing_id != id
         {
             anyhow::bail!("Duplicate net name: {base_name}");
         }
 
+        self.net_name_to_id.insert(base_name.to_string(), id);
         Ok(())
     }
 
@@ -799,18 +804,6 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             IntroducedNetName::Unnamed
         } else {
             IntroducedNetName::Named(base_name.to_string())
-        }
-    }
-
-    fn remember_registered_net_name(
-        &mut self,
-        id: NetId,
-        base_name: &str,
-        assignment_inferable: bool,
-        net_type: &str,
-    ) {
-        if net_type != "NotConnected" && !assignment_inferable && !base_name.trim().is_empty() {
-            self.net_name_to_id.insert(base_name.to_string(), id);
         }
     }
 
@@ -826,25 +819,14 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
 
         if let Some(existing) = self.introduced_nets.get(&id).cloned() {
             let mut merged_type = existing.net_type.clone();
-            merge_net_type_name(&mut merged_type, &net_type);
+            merge_canonical_net_type_name(&mut merged_type, &net_type);
             if merged_type == existing.net_type {
                 return Ok(existing.name.as_str().to_string());
             }
 
             let has_name_evidence = assignment_inferable || !base_name.trim().is_empty();
             let (name, returned_name) = if has_name_evidence {
-                self.validate_net_registration_name(
-                    id,
-                    &base_name,
-                    assignment_inferable,
-                    &merged_type,
-                )?;
-                self.remember_registered_net_name(
-                    id,
-                    &base_name,
-                    assignment_inferable,
-                    &merged_type,
-                );
+                self.record_net_name(id, &base_name, assignment_inferable, &merged_type)?;
                 (
                     Self::registration_name(&base_name, assignment_inferable),
                     base_name,
@@ -852,6 +834,7 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             } else if existing.name.as_str().is_empty() {
                 return Ok(existing.name.as_str().to_string());
             } else {
+                self.record_net_name(id, existing.name.as_str(), false, &merged_type)?;
                 (existing.name.clone(), existing.name.as_str().to_string())
             };
 
@@ -865,9 +848,8 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             return Ok(returned_name);
         }
 
-        self.validate_net_registration_name(id, &base_name, assignment_inferable, &net_type)?;
+        self.record_net_name(id, &base_name, assignment_inferable, &net_type)?;
         let name = Self::registration_name(&base_name, assignment_inferable);
-        self.remember_registered_net_name(id, &base_name, assignment_inferable, &net_type);
         self.introduced_nets
             .insert(id, IntroducedNet { name, net_type });
         Ok(base_name)
@@ -884,8 +866,7 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             return Ok(existing.name.as_str().to_string());
         }
 
-        self.validate_net_registration_name(id, &inferred_name, false, &existing.net_type)?;
-        self.remember_registered_net_name(id, &inferred_name, false, &existing.net_type);
+        self.record_net_name(id, &inferred_name, false, &existing.net_type)?;
         self.introduced_nets.insert(
             id,
             IntroducedNet {
@@ -1352,7 +1333,7 @@ fn validate_type<'v>(
         return Ok(());
     }
 
-    // NetType validation with asymmetric conversion rules
+    // Net compatibility is handled by typed-view conversion.
     if let Some(expected_type_name) = typ
         .downcast_ref::<NetType>()
         .map(|nt| &nt.type_name)
@@ -1371,14 +1352,10 @@ fn validate_type<'v>(
             });
 
         if let Some(actual_type_name) = actual_type_name {
-            // Only allow exact type match - conversion will be handled by try_net_conversion
             if expected_type_name == actual_type_name {
                 return Ok(());
             }
 
-            // Type mismatch - fail validation
-            // Note: If expected is "Net" and actual is different (e.g., "Power"),
-            // this will fail here and try_net_conversion will handle the conversion
             anyhow::bail!(
                 "Input '{name}' has wrong net type: expected {expected_type_name}, got {actual_type_name}"
             );

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -57,7 +57,9 @@ macro_rules! downcast_frozen_module {
     };
 }
 
-use super::net::{FrozenNetType, FrozenNetValue, NetId, NetType, NetValue, generate_net_id};
+use super::net::{
+    FrozenNetType, FrozenNetValue, NetId, NetType, NetValue, generate_net_id, merge_net_type_name,
+};
 use crate::lang::context::FrozenContextValue;
 use starlark::errors::EvalMessage;
 
@@ -765,6 +767,53 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             .filter_map(move |child| child.downcast_ref::<FrozenTestBenchValue>())
     }
 
+    fn validate_net_registration_name(
+        &self,
+        id: NetId,
+        base_name: &str,
+        assignment_inferable: bool,
+        net_type: &str,
+    ) -> anyhow::Result<()> {
+        if net_type == "NotConnected" {
+            return Ok(());
+        }
+
+        if !assignment_inferable && base_name.trim().is_empty() {
+            anyhow::bail!("Net is unnamed");
+        }
+
+        if !assignment_inferable
+            && let Some(existing_id) = self.net_name_to_id.get(base_name)
+            && *existing_id != id
+        {
+            anyhow::bail!("Duplicate net name: {base_name}");
+        }
+
+        Ok(())
+    }
+
+    fn registration_name(base_name: &str, assignment_inferable: bool) -> IntroducedNetName {
+        if assignment_inferable {
+            IntroducedNetName::PendingInference(base_name.to_string())
+        } else if base_name.trim().is_empty() {
+            IntroducedNetName::Unnamed
+        } else {
+            IntroducedNetName::Named(base_name.to_string())
+        }
+    }
+
+    fn remember_registered_net_name(
+        &mut self,
+        id: NetId,
+        base_name: &str,
+        assignment_inferable: bool,
+        net_type: &str,
+    ) {
+        if net_type != "NotConnected" && !assignment_inferable && !base_name.trim().is_empty() {
+            self.net_name_to_id.insert(base_name.to_string(), id);
+        }
+    }
+
     /// Record that this module introduced a net with `id` and `local_name`.
     pub fn register_net(
         &mut self,
@@ -773,37 +822,52 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
         assignment_inferable: bool,
         net_type: String,
     ) -> anyhow::Result<String> {
-        // If this id was already registered, keep the first assignment (idempotent)
-        if let Some(info) = self.introduced_nets.get(&id) {
-            return Ok(info.name.as_str().to_string());
-        }
-
         let base_name = local_name;
-        let regular_net = net_type != "NotConnected";
 
-        if regular_net && !assignment_inferable && base_name.trim().is_empty() {
-            anyhow::bail!("Net is unnamed");
+        if let Some(existing) = self.introduced_nets.get(&id).cloned() {
+            let mut merged_type = existing.net_type.clone();
+            merge_net_type_name(&mut merged_type, &net_type);
+            if merged_type == existing.net_type {
+                return Ok(existing.name.as_str().to_string());
+            }
+
+            let has_name_evidence = assignment_inferable || !base_name.trim().is_empty();
+            let (name, returned_name) = if has_name_evidence {
+                self.validate_net_registration_name(
+                    id,
+                    &base_name,
+                    assignment_inferable,
+                    &merged_type,
+                )?;
+                self.remember_registered_net_name(
+                    id,
+                    &base_name,
+                    assignment_inferable,
+                    &merged_type,
+                );
+                (
+                    Self::registration_name(&base_name, assignment_inferable),
+                    base_name,
+                )
+            } else if existing.name.as_str().is_empty() {
+                return Ok(existing.name.as_str().to_string());
+            } else {
+                (existing.name.clone(), existing.name.as_str().to_string())
+            };
+
+            self.introduced_nets.insert(
+                id,
+                IntroducedNet {
+                    name,
+                    net_type: merged_type,
+                },
+            );
+            return Ok(returned_name);
         }
 
-        let name = if assignment_inferable {
-            IntroducedNetName::PendingInference(base_name.clone())
-        } else if base_name.trim().is_empty() {
-            IntroducedNetName::Unnamed
-        } else {
-            IntroducedNetName::Named(base_name.clone())
-        };
-
-        if !assignment_inferable
-            && regular_net
-            && let Some(existing_id) = self.net_name_to_id.get(&base_name)
-            && *existing_id != id
-        {
-            anyhow::bail!("Duplicate net name: {base_name}");
-        }
-
-        if regular_net && !assignment_inferable && !base_name.trim().is_empty() {
-            self.net_name_to_id.insert(base_name.clone(), id);
-        }
+        self.validate_net_registration_name(id, &base_name, assignment_inferable, &net_type)?;
+        let name = Self::registration_name(&base_name, assignment_inferable);
+        self.remember_registered_net_name(id, &base_name, assignment_inferable, &net_type);
         self.introduced_nets
             .insert(id, IntroducedNet { name, net_type });
         Ok(base_name)
@@ -820,22 +884,8 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             return Ok(existing.name.as_str().to_string());
         }
 
-        let regular_net = existing.net_type != "NotConnected";
-
-        if regular_net && inferred_name.trim().is_empty() {
-            anyhow::bail!("Net is unnamed");
-        }
-
-        if regular_net
-            && let Some(existing_id) = self.net_name_to_id.get(&inferred_name)
-            && *existing_id != id
-        {
-            anyhow::bail!("Duplicate net name: {inferred_name}");
-        }
-
-        if regular_net && !inferred_name.trim().is_empty() {
-            self.net_name_to_id.insert(inferred_name.clone(), id);
-        }
+        self.validate_net_registration_name(id, &inferred_name, false, &existing.net_type)?;
+        self.remember_registered_net_name(id, &inferred_name, false, &existing.net_type);
         self.introduced_nets.insert(
             id,
             IntroducedNet {

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -68,8 +68,8 @@ use starlark::errors::EvalMessage;
 #[derive(Clone, Debug, Trace, Allocative, Freeze)]
 pub struct IntroducedNet {
     pub name: IntroducedNetName,
-    /// The net type name (e.g., "Net", "Power", "Ground", "NotConnected")
-    pub net_type: String,
+    /// Canonical kind evidence, if this module introduced any.
+    pub kind: Option<String>,
 }
 
 #[derive(Clone, Debug, Trace, Allocative, Freeze)]
@@ -813,20 +813,26 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
         id: NetId,
         local_name: String,
         assignment_inferable: bool,
-        net_type: String,
+        observed_kind: String,
     ) -> anyhow::Result<String> {
         let base_name = local_name;
 
         if let Some(existing) = self.introduced_nets.get(&id).cloned() {
-            let mut merged_type = existing.net_type.clone();
-            merge_canonical_net_type_name(&mut merged_type, &net_type);
-            if merged_type == existing.net_type {
+            let mut merged_kind = existing.kind.clone();
+            merge_canonical_net_type_name(&mut merged_kind, &observed_kind);
+
+            let has_name_evidence = assignment_inferable || !base_name.trim().is_empty();
+            if merged_kind == existing.kind && !has_name_evidence {
                 return Ok(existing.name.as_str().to_string());
             }
 
-            let has_name_evidence = assignment_inferable || !base_name.trim().is_empty();
             let (name, returned_name) = if has_name_evidence {
-                self.record_net_name(id, &base_name, assignment_inferable, &merged_type)?;
+                self.record_net_name(
+                    id,
+                    &base_name,
+                    assignment_inferable,
+                    merged_kind.as_deref().unwrap_or("Net"),
+                )?;
                 (
                     Self::registration_name(&base_name, assignment_inferable),
                     base_name,
@@ -834,7 +840,12 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             } else if existing.name.as_str().is_empty() {
                 return Ok(existing.name.as_str().to_string());
             } else {
-                self.record_net_name(id, existing.name.as_str(), false, &merged_type)?;
+                self.record_net_name(
+                    id,
+                    existing.name.as_str(),
+                    false,
+                    merged_kind.as_deref().unwrap_or("Net"),
+                )?;
                 (existing.name.clone(), existing.name.as_str().to_string())
             };
 
@@ -842,16 +853,23 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
                 id,
                 IntroducedNet {
                     name,
-                    net_type: merged_type,
+                    kind: merged_kind,
                 },
             );
             return Ok(returned_name);
         }
 
-        self.record_net_name(id, &base_name, assignment_inferable, &net_type)?;
+        let mut kind = None;
+        merge_canonical_net_type_name(&mut kind, &observed_kind);
+        self.record_net_name(
+            id,
+            &base_name,
+            assignment_inferable,
+            kind.as_deref().unwrap_or("Net"),
+        )?;
         let name = Self::registration_name(&base_name, assignment_inferable);
         self.introduced_nets
-            .insert(id, IntroducedNet { name, net_type });
+            .insert(id, IntroducedNet { name, kind });
         Ok(base_name)
     }
 
@@ -866,12 +884,17 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             return Ok(existing.name.as_str().to_string());
         }
 
-        self.record_net_name(id, &inferred_name, false, &existing.net_type)?;
+        self.record_net_name(
+            id,
+            &inferred_name,
+            false,
+            existing.kind.as_deref().unwrap_or("Net"),
+        )?;
         self.introduced_nets.insert(
             id,
             IntroducedNet {
                 name: IntroducedNetName::Named(inferred_name.clone()),
-                net_type: existing.net_type,
+                kind: existing.kind,
             },
         );
 

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -34,6 +34,47 @@ use super::validation::validate_identifier_name;
 
 pub type NetId = u64;
 
+fn is_concrete_net_type_name(kind: &str) -> bool {
+    !kind.is_empty() && kind != "NotConnected"
+}
+
+pub(crate) fn merge_net_type_name(current: &mut String, observed: &str) {
+    if current.is_empty()
+        || (current.as_str() == "NotConnected" && is_concrete_net_type_name(observed))
+    {
+        current.clear();
+        current.push_str(observed);
+    }
+}
+
+#[cfg(test)]
+mod net_type_merge_tests {
+    use super::merge_net_type_name;
+
+    #[test]
+    fn merge_net_type_name_promotes_only_empty_or_not_connected() {
+        let mut kind = String::new();
+        merge_net_type_name(&mut kind, "NotConnected");
+        assert_eq!(kind, "NotConnected");
+        merge_net_type_name(&mut kind, "Net");
+        assert_eq!(kind, "Net");
+        merge_net_type_name(&mut kind, "Power");
+        assert_eq!(kind, "Net");
+        merge_net_type_name(&mut kind, "Net");
+        assert_eq!(kind, "Net");
+        merge_net_type_name(&mut kind, "NotConnected");
+        assert_eq!(kind, "Net");
+
+        let mut kind = String::new();
+        merge_net_type_name(&mut kind, "Power");
+        assert_eq!(kind, "Power");
+        merge_net_type_name(&mut kind, "NotConnected");
+        assert_eq!(kind, "Power");
+        merge_net_type_name(&mut kind, "Net");
+        assert_eq!(kind, "Power");
+    }
+}
+
 /// Global atomic counter for net IDs. Must be global (not thread-local) to ensure
 /// unique IDs across all threads when using parallel evaluation (rayon).
 static NEXT_NET_ID: AtomicU64 = AtomicU64::new(1);

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -34,11 +34,12 @@ use super::validation::validate_identifier_name;
 
 pub type NetId = u64;
 
-// Net-kind semantics:
-// - compatibility may create typed views for IO/type checking, but views never set canonical kind
-// - canonical observations merge only from declarations/type constructors: empty accepts any kind,
-//   NotConnected may upgrade to a concrete kind, concrete kinds stay concrete
-// - only NotConnected may remain unnamed; all other canonical kinds need a name
+// Net kind semantics:
+// - Net values have a current runtime kind used for type checks and casts.
+// - Each registration/port observation merges that kind into the net id's canonical kind.
+// - Canonical kind merge is monotonic: empty accepts any kind, NotConnected upgrades to
+//   concrete, and concrete kinds stay concrete.
+// - Only NotConnected may remain unnamed; all other canonical kinds need a name.
 fn is_concrete_net_type_name(kind: &str) -> bool {
     !kind.is_empty() && kind != "NotConnected"
 }
@@ -66,12 +67,11 @@ pub(crate) fn net_type_requires_name(kind: &str) -> bool {
     kind != "NotConnected"
 }
 
-pub(crate) fn merge_canonical_net_type_name(current: &mut String, observed: &str) {
-    if current.is_empty()
-        || (current.as_str() == "NotConnected" && is_concrete_net_type_name(observed))
+pub(crate) fn merge_canonical_net_type_name(current: &mut Option<String>, observed: &str) {
+    if current.is_none()
+        || (current.as_deref() == Some("NotConnected") && is_concrete_net_type_name(observed))
     {
-        current.clear();
-        current.push_str(observed);
+        *current = Some(observed.to_string());
     }
 }
 
@@ -81,26 +81,26 @@ mod net_type_merge_tests {
 
     #[test]
     fn merge_canonical_net_type_name_promotes_only_empty_or_not_connected() {
-        let mut kind = String::new();
+        let mut kind = None;
         for (observed, expected) in [
-            ("NotConnected", "NotConnected"),
-            ("Net", "Net"),
-            ("Power", "Net"),
-            ("Net", "Net"),
-            ("NotConnected", "Net"),
+            ("NotConnected", Some("NotConnected")),
+            ("Net", Some("Net")),
+            ("Power", Some("Net")),
+            ("Net", Some("Net")),
+            ("NotConnected", Some("Net")),
         ] {
             merge_canonical_net_type_name(&mut kind, observed);
-            assert_eq!(kind, expected);
+            assert_eq!(kind.as_deref(), expected);
         }
 
-        let mut kind = String::new();
+        let mut kind = None;
         for (observed, expected) in [
-            ("Power", "Power"),
-            ("NotConnected", "Power"),
-            ("Net", "Power"),
+            ("Power", Some("Power")),
+            ("NotConnected", Some("Power")),
+            ("Net", Some("Power")),
         ] {
             merge_canonical_net_type_name(&mut kind, observed);
-            assert_eq!(kind, expected);
+            assert_eq!(kind.as_deref(), expected);
         }
     }
 
@@ -187,9 +187,6 @@ pub struct NetValueGen<V> {
     /// Whether this net may adopt an assigned variable name after construction.
     #[serde(skip, default)]
     pub(crate) assignment_inferable: bool,
-    /// Whether this net was constructed from another net value.
-    #[serde(skip, default)]
-    pub(crate) derived_from_base_net: bool,
     /// Whether this net value has been bound to a variable.
     #[serde(skip, default)]
     #[freeze(identity)]
@@ -333,13 +330,7 @@ impl<V> NetValueGen<V> {
 }
 
 impl<'v, V: ValueLike<'v>> NetValueGen<V> {
-    fn alloc_clone(
-        &self,
-        heap: Heap<'v>,
-        net_id: NetId,
-        type_name: String,
-        derived_from_base_net: bool,
-    ) -> Value<'v> {
+    fn alloc_clone(&self, heap: Heap<'v>, net_id: NetId, type_name: String) -> Value<'v> {
         let properties: SmallMap<String, Value<'v>> = self
             .properties
             .iter()
@@ -352,7 +343,6 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
             template_name: self.template_name.clone(),
             original_name: self.original_name_opt().map(str::to_owned),
             assignment_inferable: self.assignment_inferable,
-            derived_from_base_net,
             was_bound: Self::clone_once_lock(&self.was_bound),
             inferred_name: Self::clone_once_lock(&self.inferred_name),
             declaration_path: self.declaration_path.clone(),
@@ -398,7 +388,6 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
             template_name: None,
             original_name: None,
             assignment_inferable: false,
-            derived_from_base_net: false,
             was_bound: OnceLock::new(),
             inferred_name: OnceLock::new(),
             declaration_path: String::new(),
@@ -456,20 +445,16 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
         self.template_name.as_deref()
     }
 
-    pub(crate) fn derived_from_base_net(&self) -> bool {
-        self.derived_from_base_net
-    }
-
     pub(crate) fn was_bound(&self) -> bool {
         self.was_bound.get().is_some()
     }
 
     pub(crate) fn is_external_reference(&self) -> bool {
-        self.derived_from_base_net() || self.was_bound()
+        self.was_bound()
     }
 
     pub(crate) fn is_template_owned(&self) -> bool {
-        !self.is_external_reference()
+        !self.was_bound()
     }
 
     pub(crate) fn skips_implicit_checks(&self) -> bool {
@@ -479,17 +464,12 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
     /// Create a new net with the same fields but a fresh net ID.
     /// This avoids deep copying - properties are shared via Value references.
     pub fn with_new_id(&self, heap: Heap<'v>) -> Value<'v> {
-        self.alloc_clone(
-            heap,
-            generate_net_id(),
-            self.type_name.clone(),
-            self.derived_from_base_net,
-        )
+        self.alloc_clone(heap, generate_net_id(), self.type_name.clone())
     }
 
     /// Create a typed compatibility view with the same identity and properties.
     pub fn with_net_type(&self, new_type_name: &str, heap: Heap<'v>) -> Value<'v> {
-        self.alloc_clone(heap, self.net_id, new_type_name.to_string(), true)
+        self.alloc_clone(heap, self.net_id, new_type_name.to_string())
     }
 
     /// Create a new net with identical runtime identity but updated declaration metadata.
@@ -511,7 +491,6 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
             template_name: self.template_name.clone(),
             original_name: self.original_name_opt().map(str::to_owned),
             assignment_inferable: self.assignment_inferable,
-            derived_from_base_net: self.derived_from_base_net,
             was_bound: Self::clone_once_lock(&self.was_bound),
             inferred_name: Self::clone_once_lock(&self.inferred_name),
             declaration_path: declaration_path.into(),
@@ -743,6 +722,9 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
         }
 
         let net_name = runtime_name.unwrap_or_default();
+        let was_bound = base_net
+            .map(|net| net.cloned_bound_marker())
+            .unwrap_or_default();
         let final_name = if options.should_register {
             eval.module()
                 .extra_value()
@@ -763,8 +745,7 @@ impl<'v, V: ValueLike<'v>> NetTypeGen<V> {
             template_name,
             original_name,
             assignment_inferable,
-            derived_from_base_net: base_net.is_some(),
-            was_bound: OnceLock::new(),
+            was_bound,
             inferred_name: OnceLock::new(),
             declaration_path,
             declaration_span,

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -34,11 +34,39 @@ use super::validation::validate_identifier_name;
 
 pub type NetId = u64;
 
+// Net-kind semantics:
+// - compatibility may create typed views for IO/type checking, but views never set canonical kind
+// - canonical observations merge only from declarations/type constructors: empty accepts any kind,
+//   NotConnected may upgrade to a concrete kind, concrete kinds stay concrete
+// - only NotConnected may remain unnamed; all other canonical kinds need a name
 fn is_concrete_net_type_name(kind: &str) -> bool {
     !kind.is_empty() && kind != "NotConnected"
 }
 
-pub(crate) fn merge_net_type_name(current: &mut String, observed: &str) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NetTypeCompatibility<'a> {
+    Exact,
+    View(&'a str),
+    Incompatible,
+}
+
+pub(crate) fn net_type_compatibility<'a>(
+    actual: &'a str,
+    expected: &'a str,
+) -> NetTypeCompatibility<'a> {
+    match (actual, expected) {
+        (a, e) if a == e => NetTypeCompatibility::Exact,
+        ("NotConnected", expected) => NetTypeCompatibility::View(expected),
+        (_, "Net") => NetTypeCompatibility::View("Net"),
+        _ => NetTypeCompatibility::Incompatible,
+    }
+}
+
+pub(crate) fn net_type_requires_name(kind: &str) -> bool {
+    kind != "NotConnected"
+}
+
+pub(crate) fn merge_canonical_net_type_name(current: &mut String, observed: &str) {
     if current.is_empty()
         || (current.as_str() == "NotConnected" && is_concrete_net_type_name(observed))
     {
@@ -49,29 +77,47 @@ pub(crate) fn merge_net_type_name(current: &mut String, observed: &str) {
 
 #[cfg(test)]
 mod net_type_merge_tests {
-    use super::merge_net_type_name;
+    use super::{NetTypeCompatibility, merge_canonical_net_type_name, net_type_compatibility};
 
     #[test]
-    fn merge_net_type_name_promotes_only_empty_or_not_connected() {
+    fn merge_canonical_net_type_name_promotes_only_empty_or_not_connected() {
         let mut kind = String::new();
-        merge_net_type_name(&mut kind, "NotConnected");
-        assert_eq!(kind, "NotConnected");
-        merge_net_type_name(&mut kind, "Net");
-        assert_eq!(kind, "Net");
-        merge_net_type_name(&mut kind, "Power");
-        assert_eq!(kind, "Net");
-        merge_net_type_name(&mut kind, "Net");
-        assert_eq!(kind, "Net");
-        merge_net_type_name(&mut kind, "NotConnected");
-        assert_eq!(kind, "Net");
+        for (observed, expected) in [
+            ("NotConnected", "NotConnected"),
+            ("Net", "Net"),
+            ("Power", "Net"),
+            ("Net", "Net"),
+            ("NotConnected", "Net"),
+        ] {
+            merge_canonical_net_type_name(&mut kind, observed);
+            assert_eq!(kind, expected);
+        }
 
         let mut kind = String::new();
-        merge_net_type_name(&mut kind, "Power");
-        assert_eq!(kind, "Power");
-        merge_net_type_name(&mut kind, "NotConnected");
-        assert_eq!(kind, "Power");
-        merge_net_type_name(&mut kind, "Net");
-        assert_eq!(kind, "Power");
+        for (observed, expected) in [
+            ("Power", "Power"),
+            ("NotConnected", "Power"),
+            ("Net", "Power"),
+        ] {
+            merge_canonical_net_type_name(&mut kind, observed);
+            assert_eq!(kind, expected);
+        }
+    }
+
+    #[test]
+    fn net_type_compatibility_is_not_canonical_promotion() {
+        for (actual, expected, compatibility) in [
+            ("NotConnected", "Power", NetTypeCompatibility::View("Power")),
+            ("NotConnected", "Net", NetTypeCompatibility::View("Net")),
+            ("Power", "Net", NetTypeCompatibility::View("Net")),
+            ("Ground", "Net", NetTypeCompatibility::View("Net")),
+            ("Power", "Power", NetTypeCompatibility::Exact),
+            ("Net", "Power", NetTypeCompatibility::Incompatible),
+            ("Power", "NotConnected", NetTypeCompatibility::Incompatible),
+            ("Ground", "Power", NetTypeCompatibility::Incompatible),
+        ] {
+            assert_eq!(net_type_compatibility(actual, expected), compatibility);
+        }
     }
 }
 
@@ -441,8 +487,7 @@ impl<'v, V: ValueLike<'v>> NetValueGen<V> {
         )
     }
 
-    /// Create a new net with the same ID/name/properties but a different type name.
-    /// Used for casting between net types (e.g., Power -> Net).
+    /// Create a typed compatibility view with the same identity and properties.
     pub fn with_net_type(&self, new_type_name: &str, heap: Heap<'v>) -> Value<'v> {
         self.alloc_clone(heap, self.net_id, new_type_name.to_string(), true)
     }

--- a/crates/pcb-zen-core/src/lang/param_decl.rs
+++ b/crates/pcb-zen-core/src/lang/param_decl.rs
@@ -28,7 +28,9 @@ use super::module::{
     normalize_config_default, record_parameter_metadata, run_checks, validate_allowed_config_value,
     validate_or_convert,
 };
-use super::net::{FrozenNetValue, NetType, NetValue};
+use super::net::{
+    FrozenNetType, FrozenNetValue, NetInstantiateOptions, NetType, NetTypeGen, NetValue,
+};
 
 #[derive(Debug, Clone, Trace, Allocative)]
 struct DeclArgs<'v> {
@@ -490,6 +492,7 @@ fn resolve_io<'v>(
 
     let (value, metadata_default) = if let Some(provided) = eval.request_input(name)? {
         let converted = validate_or_convert(name, provided, normalized.typ, eval)?;
+        let converted = register_provided_io_net(name, converted, normalized.typ, eval)?;
         for failure in run_implicit_checks(name, &normalized.implicit_checks, converted) {
             eval.add_diagnostic(implicit_check_diag(failure, declaration_site));
         }
@@ -753,6 +756,56 @@ fn normalize_io_args<'v>(
             .map(IoTemplateValue::derive_implicit_checks)
             .unwrap_or_default(),
     })
+}
+
+fn register_provided_io_net<'v>(
+    name: &str,
+    value: Value<'v>,
+    typ: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> starlark::Result<Value<'v>> {
+    if let Some(net_type) = typ.downcast_ref::<NetType>() {
+        return register_provided_io_net_type(name, value, net_type, eval);
+    }
+
+    if let Some(net_type) = typ.downcast_ref::<FrozenNetType>() {
+        return register_provided_io_net_type(name, value, net_type, eval);
+    }
+
+    Ok(value)
+}
+
+fn register_provided_io_net_type<'v, V: ValueLike<'v>>(
+    name: &str,
+    value: Value<'v>,
+    net_type: &NetTypeGen<V>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> starlark::Result<Value<'v>> {
+    let value = if value.downcast_ref::<NetValue<'v>>().is_some() {
+        value
+    } else if let Some(net) = value.downcast_ref::<FrozenNetValue>() {
+        net.with_net_type(&net_type.type_name, eval.heap())
+    } else {
+        return Ok(value);
+    };
+
+    let net = value
+        .downcast_ref::<NetValue<'v>>()
+        .expect("materialized net should be allocated on the current heap");
+    if !net.name().is_empty() {
+        return Ok(value);
+    }
+
+    net_type.instantiate(
+        Some(net),
+        (net_type.type_name != "NotConnected").then(|| name.to_owned()),
+        SmallMap::new(),
+        NetInstantiateOptions {
+            should_register: true,
+            assignment_inferable: false,
+        },
+        eval,
+    )
 }
 
 fn instantiate_net_template<'v>(

--- a/crates/pcb-zen-core/src/lang/type_conversion.rs
+++ b/crates/pcb-zen-core/src/lang/type_conversion.rs
@@ -33,7 +33,7 @@ fn try_function_conversion<'v>(
     }
 }
 
-/// Return a typed compatibility view of a net without changing its canonical kind.
+/// Return a typed compatibility view of a net, preserving identity for canonical kind merge.
 pub(crate) fn try_net_conversion<'v>(
     value: Value<'v>,
     expected_typ: Value<'v>,

--- a/crates/pcb-zen-core/src/lang/type_conversion.rs
+++ b/crates/pcb-zen-core/src/lang/type_conversion.rs
@@ -4,7 +4,9 @@ use starlark::eval::Evaluator;
 use starlark::values::{Value, ValueLike, float::StarlarkFloat, typing::TypeCompiled};
 
 use crate::lang::r#enum::{EnumType, EnumValue};
-use crate::lang::net::{FrozenNetType, FrozenNetValue, NetType, NetValue};
+use crate::lang::net::{
+    FrozenNetType, FrozenNetValue, NetType, NetTypeCompatibility, NetValue, net_type_compatibility,
+};
 
 fn has_type_name<'v>(typ: Value<'v>, names: &[&str]) -> bool {
     names.contains(&typ.get_type()) || names.contains(&typ.to_string().as_str())
@@ -31,23 +33,7 @@ fn try_function_conversion<'v>(
     }
 }
 
-/// Determines if a net type can be promoted/demoted to another.
-///
-/// Net type promotion hierarchy:
-///   - NotConnected -> any type (universal donor)
-///   - Power, Ground, etc. -> Net (demotion to base type)
-///   - Net -> nothing (cannot be promoted)
-///   - Nothing -> NotConnected (NotConnected only accepts NotConnected)
-fn can_convert_net_type<'a>(actual: &'a str, expected: &'a str) -> Option<&'a str> {
-    match (actual, expected) {
-        (a, e) if a == e => None,
-        ("NotConnected", expected) => Some(expected),
-        (_, "Net") => Some("Net"),
-        _ => None,
-    }
-}
-
-/// Attempt to convert a value to another compatible net type.
+/// Return a typed compatibility view of a net without changing its canonical kind.
 pub(crate) fn try_net_conversion<'v>(
     value: Value<'v>,
     expected_typ: Value<'v>,
@@ -66,12 +52,14 @@ pub(crate) fn try_net_conversion<'v>(
         return Ok(None);
     };
 
-    if let Some(nv) = value.downcast_ref::<NetValue>() {
-        if let Some(target) = can_convert_net_type(nv.net_type_name(), expected) {
-            return Ok(Some(nv.with_net_type(target, eval.heap())));
-        }
+    if let Some(nv) = value.downcast_ref::<NetValue>()
+        && let NetTypeCompatibility::View(target) =
+            net_type_compatibility(nv.net_type_name(), expected)
+    {
+        return Ok(Some(nv.with_net_type(target, eval.heap())));
     } else if let Some(fnv) = value.downcast_ref::<FrozenNetValue>()
-        && let Some(target) = can_convert_net_type(fnv.net_type_name(), expected)
+        && let NetTypeCompatibility::View(target) =
+            net_type_compatibility(fnv.net_type_name(), expected)
     {
         return Ok(Some(fnv.with_net_type(target, eval.heap())));
     }

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -755,6 +755,14 @@ fn net_constructor_positional_cast_preserves_behavior() {
             other_net = Net("SIG")
             power = Power(other_net)
 
+            Component(
+                name = "U1",
+                footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod"),
+                pin_defs = {"P1": "1"},
+                pins = {"P1": power},
+                skip_bom = True,
+            )
+
             check(power.name == "SIG", "positional cast should preserve the base net name")
         "#
         .to_string(),
@@ -765,4 +773,14 @@ fn net_constructor_positional_cast_preserves_behavior() {
         "did not expect errors, got: {:?}",
         result.diagnostics
     );
+
+    let eval_output = result.output.expect("expected eval output");
+    let sch_result = eval_output.to_schematic_with_diagnostics();
+    assert!(
+        !sch_result.diagnostics.has_errors(),
+        "schematic conversion failed: {:?}",
+        sch_result.diagnostics
+    );
+    let schematic = sch_result.output.expect("expected schematic output");
+    assert_eq!(schematic.nets["SIG"].kind, "Net");
 }

--- a/crates/pcb-zen-core/tests/not_connected.rs
+++ b/crates/pcb-zen-core/tests/not_connected.rs
@@ -113,6 +113,71 @@ Component(
 
 #[test]
 #[cfg(not(target_os = "windows"))]
+fn net_wrapped_not_connected_io_is_regular_net() {
+    for _ in 0..64 {
+        let mut files = std::collections::HashMap::new();
+        files.insert(
+            "test.zen".to_string(),
+            r#"
+NotConnected = builtin.net_type("NotConnected")
+Net = builtin.net_type("Net")
+io = builtin.io
+
+PGFB = io(Net(NotConnected()), optional=True)
+VIN = Net("VIN")
+
+Component(
+    name = "IC1",
+    prefix = "IC",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod"),
+    pin_defs = {"PGFB": "1"},
+    pins = {"PGFB": PGFB},
+)
+
+Component(
+    name = "R_PGFB",
+    prefix = "R",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod"),
+    pin_defs = {"P1": "1", "P2": "2"},
+    pins = {"P1": PGFB, "P2": VIN},
+)
+"#
+            .to_string(),
+        );
+
+        let mut result = eval_to_schematic(files, "test.zen");
+        SortPass.apply(&mut result.diagnostics);
+        let warnings = result.diagnostics.warnings();
+        assert!(
+            warnings
+                .iter()
+                .all(|w| !w.body.contains("NotConnected net connects to")),
+            "did not expect multi-port NotConnected warning, got: {:?}",
+            warnings
+        );
+
+        let schematic = result.output.unwrap_or_else(|| {
+            panic!(
+                "expected schematic output, got diagnostics: {:?}",
+                result.diagnostics
+            )
+        });
+        let pgfb = schematic.nets.get("PGFB").unwrap_or_else(|| {
+            panic!(
+                "expected PGFB net, got: {:?}",
+                schematic
+                    .nets
+                    .iter()
+                    .map(|(name, net)| (name.clone(), net.kind.clone()))
+                    .collect::<Vec<_>>()
+            )
+        });
+        assert_eq!(pgfb.kind, "Net");
+    }
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
 fn not_connected_auto_names_are_stable_by_port() {
     // Two programs that only differ in where unrelated nets are created.
     // The NotConnected net connected to R1.P2 should get a stable, port-derived name.

--- a/crates/pcb-zen-core/tests/not_connected.rs
+++ b/crates/pcb-zen-core/tests/not_connected.rs
@@ -113,6 +113,63 @@ Component(
 
 #[test]
 #[cfg(not(target_os = "windows"))]
+fn omitted_no_connect_pin_converts_to_not_connected_net() {
+    let mut files = std::collections::HashMap::new();
+    files.insert(
+        "nc_pin.kicad_sym".to_string(),
+        r#"(kicad_symbol_lib
+  (version 20211014)
+  (generator "test")
+  (symbol "NcPin"
+    (property "Reference" "U")
+    (symbol "NcPin_0_1"
+      (pin no_connect line
+        (at 0 0 0)
+        (length 2.54)
+        (name "NC")
+        (number "1")
+      )
+    )
+  )
+)"#
+        .to_string(),
+    );
+    files.insert(
+        "test.zen".to_string(),
+        r#"
+symbol = Symbol(library = "nc_pin.kicad_sym")
+
+Component(
+    name = "U1",
+    prefix = "U",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod"),
+    symbol = symbol,
+    skip_bom = True,
+    pins = {},
+)
+"#
+        .to_string(),
+    );
+
+    let result = eval_to_schematic(files, "test.zen");
+    assert!(
+        result.is_success(),
+        "expected schematic output, got diagnostics: {:?}",
+        result.diagnostics
+    );
+    let schematic = result.output.expect("expected schematic output");
+    assert!(!schematic.nets.contains_key(""));
+    assert!(schematic.nets.values().any(|net| {
+        net.kind == "NotConnected"
+            && net.ports.iter().any(|port| {
+                port.instance_path
+                    .ends_with(&["U1".to_string(), "NC".to_string()])
+            })
+    }));
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
 fn net_wrapped_not_connected_io_is_regular_net() {
     for _ in 0..64 {
         let mut files = std::collections::HashMap::new();

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_custom_type.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_custom_type.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen-core/tests/net.rs
-assertion_line: 500
+assertion_line: 521
 expression: output
 ---
 NotConnected promotes to Gpio: success
@@ -21,7 +21,7 @@ NotConnected promotes to Gpio: success
                     connections: {
                         "1": FrozenValue(
                             Net {
-                                name: "",
+                                name: "gpio",
                                 id: "<ID>",
                             },
                         ),

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_ground.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_ground.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen-core/tests/net.rs
-assertion_line: 443
+assertion_line: 464
 expression: output
 ---
 NotConnected promotes to Ground: success
@@ -21,7 +21,7 @@ NotConnected promotes to Ground: success
                     connections: {
                         "1": FrozenValue(
                             Net {
-                                name: "",
+                                name: "gnd",
                                 id: "<ID>",
                             },
                         ),

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_net.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_net.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen-core/tests/net.rs
-assertion_line: 473
+assertion_line: 494
 expression: output
 ---
 NotConnected promotes to Net: success
@@ -21,7 +21,7 @@ NotConnected promotes to Net: success
                     connections: {
                         "1": FrozenValue(
                             Net {
-                                name: "",
+                                name: "sig",
                                 id: "<ID>",
                             },
                         ),

--- a/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_power.snap
+++ b/crates/pcb-zen-core/tests/snapshots/net__not_connected_promotes_to_power.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pcb-zen-core/tests/net.rs
-assertion_line: 413
+assertion_line: 434
 expression: output
 ---
 NotConnected promotes to Power: success
@@ -21,7 +21,7 @@ NotConnected promotes to Power: success
                     connections: {
                         "1": FrozenValue(
                             Net {
-                                name: "",
+                                name: "vcc",
                                 id: "<ID>",
                             },
                         ),

--- a/crates/pcbc/tests/snapshots/netlist__netlist_not_connected_promotion.snap
+++ b/crates/pcbc/tests/snapshots/netlist__netlist_not_connected_promotion.snap
@@ -1,16 +1,29 @@
 ---
 source: crates/pcbc/tests/netlist.rs
-assertion_line: 397
+assertion_line: 431
 expression: output
 ---
 {
-  "U1.NC_R1_1": {
+  "U1.vcc": {
     "id": "<ID>",
-    "kind": "NotConnected",
-    "name": "U1.NC_R1_1",
+    "kind": "Power",
+    "name": "U1.vcc",
     "ports": [
       "<TEMP_DIR>/boards/NCBoard.zen:<root>.U1.R1.1"
     ],
-    "properties": {}
+    "properties": {
+      "__symbol_value": {
+        "String": "(symbol \"VCC\"\n\t(power global)\n\t(pin_numbers\n\t\t(hide yes)\n\t)\n\t(pin_names\n\t\t(offset 0)\n\t\t(hide yes)\n\t)\n\t(exclude_from_sim no)\n\t(in_bom yes)\n\t(on_board yes)\n\t(in_pos_files yes)\n\t(duplicate_pin_numbers_are_jumpers no)\n\t(property \"Reference\" \"#PWR\"\n\t\t(at 0 -3.81 0)\n\t\t(show_name no)\n\t\t(do_not_autoplace no)\n\t\t(hide yes)\n\t\t(effects\n\t\t\t(font\n\t\t\t\t(size 1.27 1.27)\n\t\t\t)\n\t\t)\n\t)\n\t(property \"Value\" \"VCC\"\n\t\t(at 0 3.556 0)\n\t\t(show_name no)\n\t\t(do_not_autoplace no)\n\t\t(effects\n\t\t\t(font\n\t\t\t\t(size 1.27 1.27)\n\t\t\t)\n\t\t)\n\t)\n\t(property \"Footprint\" \"\"\n\t\t(at 0 0 0)\n\t\t(show_name no)\n\t\t(do_not_autoplace no)\n\t\t(hide yes)\n\t\t(effects\n\t\t\t(font\n\t\t\t\t(size 1.27 1.27)\n\t\t\t)\n\t\t)\n\t)\n\t(property \"Datasheet\" \"\"\n\t\t(at 0 0 0)\n\t\t(show_name no)\n\t\t(do_not_autoplace no)\n\t\t(hide yes)\n\t\t(effects\n\t\t\t(font\n\t\t\t\t(size 1.27 1.27)\n\t\t\t)\n\t\t)\n\t)\n\t(property \"Description\" \"Power symbol creates a global label with name \\\"VCC\\\"\"\n\t\t(at 0 0 0)\n\t\t(show_name no)\n\t\t(do_not_autoplace no)\n\t\t(hide yes)\n\t\t(effects\n\t\t\t(font\n\t\t\t\t(size 1.27 1.27)\n\t\t\t)\n\t\t)\n\t)\n\t(property \"ki_keywords\" \"global power\"\n\t\t(at 0 0 0)\n\t\t(show_name no)\n\t\t(do_not_autoplace no)\n\t\t(hide yes)\n\t\t(effects\n\t\t\t(font\n\t\t\t\t(size 1.27 1.27)\n\t\t\t)\n\t\t)\n\t)\n\t(symbol \"VCC_0_1\"\n\t\t(polyline\n\t\t\t(pts\n\t\t\t\t(xy -0.762 1.27) (xy 0 2.54)\n\t\t\t)\n\t\t\t(stroke\n\t\t\t\t(width 0)\n\t\t\t\t(type default)\n\t\t\t)\n\t\t\t(fill\n\t\t\t\t(type none)\n\t\t\t)\n\t\t)\n\t\t(polyline\n\t\t\t(pts\n\t\t\t\t(xy 0 2.54) (xy 0.762 1.27)\n\t\t\t)\n\t\t\t(stroke\n\t\t\t\t(width 0)\n\t\t\t\t(type default)\n\t\t\t)\n\t\t\t(fill\n\t\t\t\t(type none)\n\t\t\t)\n\t\t)\n\t\t(polyline\n\t\t\t(pts\n\t\t\t\t(xy 0 0) (xy 0 2.54)\n\t\t\t)\n\t\t\t(stroke\n\t\t\t\t(width 0)\n\t\t\t\t(type default)\n\t\t\t)\n\t\t\t(fill\n\t\t\t\t(type none)\n\t\t\t)\n\t\t)\n\t)\n\t(symbol \"VCC_1_1\"\n\t\t(pin power_in line\n\t\t\t(at 0 0 90)\n\t\t\t(length 0)\n\t\t\t(name \"\"\n\t\t\t\t(effects\n\t\t\t\t\t(font\n\t\t\t\t\t\t(size 1.27 1.27)\n\t\t\t\t\t)\n\t\t\t\t)\n\t\t\t)\n\t\t\t(number \"1\"\n\t\t\t\t(effects\n\t\t\t\t\t(font\n\t\t\t\t\t\t(size 1.27 1.27)\n\t\t\t\t\t)\n\t\t\t\t)\n\t\t\t)\n\t\t)\n\t)\n\t(embedded_fonts no)\n)\n"
+      },
+      "symbol": {
+        "String": "Symbol { name: \"VCC\", pins: { \"1\": \"1\" } }"
+      },
+      "symbol_name": {
+        "String": "VCC"
+      },
+      "symbol_path": {
+        "String": "package://stdlib/kicad-symbols/power.kicad_symdir/VCC.kicad_sym"
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core Starlark net typing, registration, and schematic conversion paths that drive netlists and layout sync; behavior changes are intentional but broad across designs using NotConnected promotion and net casts.
> 
> **Overview**
> Fixes **net kind** handling so schematic/netlist output reflects the **concrete** kind seen on connections, not stale `NotConnected` placeholders left behind by typed **cast views** (e.g. `Power(NotConnected())`, `io(Net(NotConnected()))`).
> 
> The PR introduces **canonical kind** tracking (`merge_canonical_net_type_name`) separate from runtime **compatibility views** (`net_type_compatibility` / `try_net_conversion`). Observations from registration and port connections merge into `NetInfo` / `IntroducedNet.kind`; empty or `NotConnected` promotes to concrete kinds, while an established concrete kind is not downgraded. `derived_from_base_net` is removed—`with_net_type` keeps the same net id and bound state.
> 
> **Module `register_net`** is refactored to merge kind on repeat registration and to register **provided `io()` nets** that arrive unnamed (`register_provided_io_net`). Schematic conversion and eval unnamed-net checks use the merged kind.
> 
> **User-visible output** changes: promoted nets get real names and kinds in netlists (e.g. `Power` / `vcc` instead of `NotConnected` auto-names), layout logs use port-style names like `R1.P2`, and casts such as `Power(other_net)` can emit schematic kind **`Net`** when connectivity implies it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7557197384ded7bac62a193be31d2262be69c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->