### PR TITLE
Install stdlib in Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,18 +17,21 @@
       ];
       forAllSystems = lib.genAttrs systems;
       workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      pkgsFor =
+        system:
+        import nixpkgs {
+          inherit system;
+          config.problems.handlers =
+            lib.optionalAttrs (lib.hasSuffix "-darwin" system)
+              {
+                kicad-base.broken = "warn";
+              };
+        };
 
       packageFor =
         system:
         let
-          pkgs = import nixpkgs {
-            inherit system;
-            config.problems.handlers =
-              lib.optionalAttrs (lib.hasSuffix "-darwin" system)
-                {
-                  kicad-base.broken = "warn";
-                };
-          };
+          pkgs = pkgsFor system;
           craneLib = crane.mkLib pkgs;
 
           src = lib.fileset.toSource {
@@ -73,6 +76,12 @@
           // {
             inherit cargoArtifacts;
 
+            postInstall = ''
+              mkdir -p "$out/lib"
+              cp -R ${src}/lib/std "$out/lib/std"
+              chmod -R u+w "$out/lib/std"
+            '';
+
             postFixup = ''
               for binary in pcb pcbc; do
                 wrapProgram "$out/bin/$binary" \
@@ -105,6 +114,20 @@
         {
           default = pcb;
           inherit pcb pcbc;
+        }
+      );
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          pcbc = self.packages.${system}.pcbc;
+        in
+        {
+          pcbc-stdlib-installed = pkgs.runCommand "pcbc-stdlib-installed" { } ''
+            test -f "${pcbc}/lib/std/pcb.toml"
+            touch "$out"
+          '';
         }
       );
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only changes to install-time layout and a smoke check; no runtime application logic is modified.
> 
> **Overview**
> The Nix flake now **ships the standard library** with the built `pcb`/`pcbc` packages by copying `lib/std` into `$out/lib/std` during `postInstall` (with writable permissions on that tree).
> 
> `pkgsFor` is extracted so the same nixpkgs import (including the Darwin KiCad handler) is reused for packages and checks. A new flake check **`pcbc-stdlib-installed`** asserts that `${pcbc}/lib/std/pcb.toml` exists on each supported system.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d24ca9f79d185f65e9b1a3ea64f9d6e552d928c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->