### PR TITLE
Add SOD-882 TVS power rating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Net kind merging now promotes empty or `NotConnected` placeholders to observed concrete kinds.
+- Stdlib TVS matching now includes the `SP3022-01ETG-NM` SOD-882 peak pulse power rating.
 
 ## [0.4.0] - 2026-06-17
 

--- a/lib/std/bom/match_generics.zen
+++ b/lib/std/bom/match_generics.zen
@@ -1006,7 +1006,7 @@ HOUSE_TVS_BY_PKG = {
         tvs(
             "5.3V",
             "13V",
-            None,
+            "20W",
             "SP3022-01ETG-NM",
             "Littelfuse Inc.",
             "https://www.littelfuse.com/assetdocs/littelfuse-tvs-diode-array-sp3022-01etg-nm-datasheet?assetguid=60969493-fae9-418a-91ac-bc92d273bb80",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single stdlib house-part metadata change; no runtime logic changes beyond improved TVS matching.
> 
> **Overview**
> Stdlib **generic TVS house matching** for bidirectional **SOD-882** parts now records **20W** peak pulse power on **Littelfuse `SP3022-01ETG-NM`**, aligned with the base **`SP3022-01ETG`** entry.
> 
> That lets designs that specify **`peak_pulse_power`** match the NM variant instead of being filtered out when power is required. The unreleased changelog notes the fix under **Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b67baff8e55944b318a83851ca140171382a897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->