### PR TITLE
Publish Linux release artifacts as musl

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -55,6 +55,7 @@ jobs:
           base_dir="$RUNNER_TEMP/pcb-base"
           base_bin="$RUNNER_TEMP/pcb-base-bin"
           base_data="$RUNNER_TEMP/pcb-base-data"
+          base_shim="$base_bin/pcb"
           head_bin="$RUNNER_TEMP/pcb-head-bin"
           head_data="$RUNNER_TEMP/pcb-head-data"
           head_shim="$head_bin/pcb"
@@ -62,10 +63,11 @@ jobs:
 
           bench() {
             suffix="$1"
-            data_home="$2"
+            shim="$2"
+            data_home="$3"
             for workspace in $workspaces; do
               XDG_DATA_HOME="$data_home" python3 bin/pcb-build-perf \
-                --pcb "$head_shim" \
+                --pcb "$shim" \
                 --pcb-arg +local \
                 --workspace "workspaces/$workspace" \
                 --suppress bom \
@@ -77,8 +79,8 @@ jobs:
           XDG_DATA_HOME="$base_data" PCB_INSTALL_DIR="$base_bin" "$base_dir/install.sh" --local
 
           XDG_DATA_HOME="$head_data" PCB_INSTALL_DIR="$head_bin" ./install.sh --local
-          bench base "$base_data"
-          bench head "$head_data"
+          bench base "$base_shim" "$base_data"
+          bench head "$head_shim" "$head_data"
 
       - name: Create PR comment body
         id: perf_comment

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -77,7 +77,11 @@ jobs:
             runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
             runner: ubicloud-standard-16-arm
+          - target: aarch64-unknown-linux-musl
+            runner: ubicloud-standard-16-arm
           - target: x86_64-unknown-linux-gnu
+            runner: ubicloud-standard-16
+          - target: x86_64-unknown-linux-musl
             runner: ubicloud-standard-16
           - target: x86_64-pc-windows-msvc
             runner: diode-windows
@@ -100,6 +104,13 @@ jobs:
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 
+      - name: Install Linux musl build dependencies
+        if: contains(matrix.target, 'linux-musl')
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev
+
       - name: Install zstd
         shell: bash
         run: |
@@ -121,7 +132,17 @@ jobs:
           esac
 
       - name: Build
-        run: cargo build --profile dist -p pcb --bin pcb --target ${{ matrix.target }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == *linux-musl ]]; then
+            export CC=musl-gcc
+            export RUSTFLAGS="-C linker=musl-gcc"
+            export CFLAGS="-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
+          fi
+          cargo build --profile dist -p pcb --bin pcb --target "$TARGET"
 
       - name: Prepare artifacts
         shell: bash

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -94,7 +94,11 @@ jobs:
             runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
             runner: ubicloud-standard-16-arm
+          - target: aarch64-unknown-linux-musl
+            runner: ubicloud-standard-16-arm
           - target: x86_64-unknown-linux-gnu
+            runner: ubicloud-standard-16
+          - target: x86_64-unknown-linux-musl
             runner: ubicloud-standard-16
           - target: x86_64-pc-windows-msvc
             runner: diode-windows
@@ -117,8 +121,25 @@ jobs:
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 
+      - name: Install Linux musl build dependencies
+        if: contains(matrix.target, 'linux-musl')
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev
+
       - name: Build
-        run: cargo build --profile dist -p pcbc --bin pcbc --target ${{ matrix.target }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == *linux-musl ]]; then
+            export CC=musl-gcc
+            export RUSTFLAGS="-C linker=musl-gcc"
+            export CFLAGS="-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
+          fi
+          cargo build --profile dist -p pcbc --bin pcbc --target "$TARGET"
 
       - name: Prepare artifacts
         shell: bash

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -94,7 +94,11 @@ jobs:
             runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
             runner: ubicloud-standard-16-arm
+          - target: aarch64-unknown-linux-musl
+            runner: ubicloud-standard-16-arm
           - target: x86_64-unknown-linux-gnu
+            runner: ubicloud-standard-16
+          - target: x86_64-unknown-linux-musl
             runner: ubicloud-standard-16
           - target: x86_64-pc-windows-msvc
             runner: diode-windows
@@ -117,6 +121,13 @@ jobs:
           toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 
+      - name: Install Linux musl build dependencies
+        if: contains(matrix.target, 'linux-musl')
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev
+
       - name: Install zstd
         shell: bash
         run: |
@@ -138,7 +149,17 @@ jobs:
           esac
 
       - name: Build
-        run: cargo build --profile dist -p pcbc --bin pcbc --target ${{ matrix.target }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == *linux-musl ]]; then
+            export CC=musl-gcc
+            export RUSTFLAGS="-C linker=musl-gcc"
+            export CFLAGS="-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
+          fi
+          cargo build --profile dist -p pcbc --bin pcbc --target "$TARGET"
 
       - name: Prepare artifacts
         shell: bash

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -625,9 +625,23 @@ fn install_nightly(release: &NightlyRelease) -> Result<(NightlyReceipt, PathBuf)
         target_triple()
     );
 
-    let name = binary_artifact_name("pcbc");
-    let url = format!("{}/{}", release.base_url.trim_end_matches('/'), name);
-    let bytes = download_artifact_bytes(&http_client(ARCHIVE_TIMEOUT)?, &url)?;
+    let client = http_client(ARCHIVE_TIMEOUT)?;
+    let mut download = None;
+    for target in download_target_triples().iter().copied() {
+        let name = binary_artifact_name_for("pcbc", target);
+        let url = format!("{}/{}", release.base_url.trim_end_matches('/'), name);
+        if let Some(bytes) = download_optional_artifact(&client, &url)? {
+            download = Some((name, url, bytes));
+            break;
+        }
+    }
+    let Some((name, url, bytes)) = download else {
+        anyhow::bail!(
+            "no pcbc nightly binary found for {} on {}",
+            release.date,
+            target_triple()
+        );
+    };
     let actual_sha256 = verify_checksum(&url, &bytes)?;
 
     fs::create_dir_all(downloads_dir())?;
@@ -767,26 +781,28 @@ fn stage_stdlib_archive(base_url: &str, staging_dir: &Path) -> Result<()> {
 fn download_toolchain(version: &Version) -> Result<Download> {
     let client = http_client(ARCHIVE_TIMEOUT)?;
 
-    let name = binary_artifact_name("pcbc");
-    let url = format!("{RELEASE_BASE_URL}/v{version}/{name}");
-    if let Some(bytes) = download_optional_artifact(&client, &url)? {
-        return Ok(Download {
-            name,
-            url,
-            bytes,
-            kind: DownloadKind::Binary,
-        });
-    }
+    for target in download_target_triples().iter().copied() {
+        let name = binary_artifact_name_for("pcbc", target);
+        let url = format!("{RELEASE_BASE_URL}/v{version}/{name}");
+        if let Some(bytes) = download_optional_artifact(&client, &url)? {
+            return Ok(Download {
+                name,
+                url,
+                bytes,
+                kind: DownloadKind::Binary,
+            });
+        }
 
-    let name = toolchain_archive_name("pcbc");
-    let url = format!("{RELEASE_BASE_URL}/v{version}/{name}");
-    if let Some(bytes) = download_optional(&client, &url)? {
-        return Ok(Download {
-            name,
-            url,
-            bytes,
-            kind: DownloadKind::Archive,
-        });
+        let name = toolchain_archive_name_for("pcbc", target);
+        let url = format!("{RELEASE_BASE_URL}/v{version}/{name}");
+        if let Some(bytes) = download_optional(&client, &url)? {
+            return Ok(Download {
+                name,
+                url,
+                bytes,
+                kind: DownloadKind::Archive,
+            });
+        }
     }
 
     anyhow::bail!(
@@ -810,10 +826,6 @@ fn download_optional_artifact(client: &ureq::Agent, url: &str) -> Result<Option<
         return Ok(Some(decompress_zstd(&compressed_url, compressed)?));
     }
     download_optional(client, url)
-}
-
-fn download_artifact_bytes(client: &ureq::Agent, url: &str) -> Result<Vec<u8>> {
-    download_optional_artifact(client, url)?.ok_or_else(|| anyhow::anyhow!("not found: {url}"))
 }
 
 fn read_download_bytes(body: &mut ureq::Body) -> Result<Vec<u8>> {
@@ -1155,9 +1167,22 @@ fn install_shim_update(latest: &LatestRelease) -> Result<()> {
 
     let client = http_client(ARCHIVE_TIMEOUT)?;
     let temp = tempfile::tempdir()?;
-    let binary_name = binary_artifact_name("pcb");
-    let binary_url = format!("{RELEASE_BASE_URL}/{}/{}", latest.tag, binary_name);
-    let bytes = download_artifact_bytes(&client, &binary_url)?;
+    let mut download = None;
+    for target in download_target_triples().iter().copied() {
+        let binary_name = binary_artifact_name_for("pcb", target);
+        let binary_url = format!("{RELEASE_BASE_URL}/{}/{}", latest.tag, binary_name);
+        if let Some(bytes) = download_optional_artifact(&client, &binary_url)? {
+            download = Some((binary_url, bytes));
+            break;
+        }
+    }
+    let Some((binary_url, bytes)) = download else {
+        anyhow::bail!(
+            "no pcb shim binary found for {} on {}",
+            latest.tag,
+            target_triple()
+        );
+    };
     verify_checksum(&binary_url, &bytes)?;
     let binary = temp.path().join(legacy_pcb_binary_name());
     fs::write(&binary, bytes)?;
@@ -1287,14 +1312,14 @@ fn nightly_release_cache_path() -> PathBuf {
     data_dir().join("nightly-release-cache.json")
 }
 
-fn binary_artifact_name(binary: &str) -> String {
+fn binary_artifact_name_for(binary: &str, target: &str) -> String {
     let ext = if cfg!(windows) { ".exe" } else { "" };
-    format!("{}-{}{}", binary, target_triple(), ext)
+    format!("{binary}-{target}{ext}")
 }
 
-fn toolchain_archive_name(binary: &str) -> String {
+fn toolchain_archive_name_for(binary: &str, target: &str) -> String {
     let ext = if cfg!(windows) { "zip" } else { "tar.xz" };
-    format!("{}-{}.{}", binary, target_triple(), ext)
+    format!("{binary}-{target}.{ext}")
 }
 
 fn pcbc_binary_name() -> &'static str {
@@ -1313,6 +1338,18 @@ fn target_triple() -> &'static str {
         ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
         ("windows", "x86_64") => "x86_64-pc-windows-msvc",
         _ => "unsupported",
+    }
+}
+
+fn download_target_triples() -> &'static [&'static str] {
+    // Linux downloads prefer static musl artifacts, then GNU compatibility artifacts.
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "aarch64") => &["aarch64-unknown-linux-musl", "aarch64-unknown-linux-gnu"],
+        ("linux", "x86_64") => &["x86_64-unknown-linux-musl", "x86_64-unknown-linux-gnu"],
+        ("macos", "aarch64") => &["aarch64-apple-darwin"],
+        ("macos", "x86_64") => &["x86_64-apple-darwin"],
+        ("windows", "x86_64") => &["x86_64-pc-windows-msvc"],
+        _ => &["unsupported"],
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -93,11 +93,12 @@ install_local() {
 }
 
 platform="$(uname -s)-$(uname -m)"
+download_targets=""
 case "$platform" in
-  Darwin-arm64) target="aarch64-apple-darwin"; data_dir="$HOME/Library/Application Support/pcb" ;;
-  Darwin-x86_64) target="x86_64-apple-darwin"; data_dir="$HOME/Library/Application Support/pcb" ;;
-  Linux-aarch64|Linux-arm64) target="aarch64-unknown-linux-gnu"; data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/pcb" ;;
-  Linux-x86_64) target="x86_64-unknown-linux-gnu"; data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/pcb" ;;
+  Darwin-arm64) target="aarch64-apple-darwin"; download_targets="$target"; data_dir="$HOME/Library/Application Support/pcb" ;;
+  Darwin-x86_64) target="x86_64-apple-darwin"; download_targets="$target"; data_dir="$HOME/Library/Application Support/pcb" ;;
+  Linux-aarch64|Linux-arm64) target="aarch64-unknown-linux-gnu"; download_targets="aarch64-unknown-linux-musl $target"; data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/pcb" ;;
+  Linux-x86_64) target="x86_64-unknown-linux-gnu"; download_targets="x86_64-unknown-linux-musl $target"; data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/pcb" ;;
   *) echo "unsupported platform: $platform" >&2; exit 1 ;;
 esac
 
@@ -112,17 +113,27 @@ json="$(curl -fsSL "$base_url/pcb-latest.json")"
 tag="$(printf '%s' "$json" | sed -n 's/.*"tag"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
 [ -n "$tag" ] || { echo "could not read latest pcb release" >&2; exit 1; }
 
-artifact="pcb-$target"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-curl -fsSL "$base_url/$tag/$artifact.sha256" -o "$tmp/pcb.sha256"
-if command -v zstd >/dev/null \
-  && curl -fsSL "$base_url/$tag/$artifact.zst" -o "$tmp/pcb.zst" 2>/dev/null; then
-  zstd -q -d -f "$tmp/pcb.zst" -o "$tmp/pcb"
-else
-  curl -fsSL "$base_url/$tag/$artifact" -o "$tmp/pcb"
-fi
+artifact=""
+downloaded=""
+for artifact_target in $download_targets; do
+  rm -f "$tmp/pcb" "$tmp/pcb.zst" "$tmp/pcb.sha256"
+  artifact="pcb-$artifact_target"
+  if ! curl -fsSL "$base_url/$tag/$artifact.sha256" -o "$tmp/pcb.sha256" 2>/dev/null; then
+    continue
+  fi
+  if command -v zstd >/dev/null \
+    && curl -fsSL "$base_url/$tag/$artifact.zst" -o "$tmp/pcb.zst" 2>/dev/null; then
+    zstd -q -d -f "$tmp/pcb.zst" -o "$tmp/pcb"
+  elif ! curl -fsSL "$base_url/$tag/$artifact" -o "$tmp/pcb" 2>/dev/null; then
+    continue
+  fi
+  downloaded="true"
+  break
+done
+[ -n "$downloaded" ] || { echo "could not find pcb release artifact for $target" >&2; exit 1; }
 
 expected="$(sed 's/[[:space:]].*//' "$tmp/pcb.sha256")"
 if command -v shasum >/dev/null; then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how Linux users fetch and install released binaries (musl-first with GNU fallback); CI must successfully produce new musl artifacts or installs fall back until musl builds ship.
> 
> **Overview**
> Adds **static Linux musl** release builds for `pcb` and `pcbc` (alongside existing GNU targets) in the pcb/pcbc release and nightly workflows, including musl toolchain deps and `musl-gcc` linker flags for those matrix jobs.
> 
> **Linux clients** now try **musl artifacts first**, then fall back to GNU: the `pcb` shim (`download_target_triples`, toolchain/nightly/shim self-update downloads), and `install.sh` release installs loop over `download_targets` the same way. Artifact helpers are generalized to `binary_artifact_name_for` / `toolchain_archive_name_for` with an explicit target triple.
> 
> The **build-perf** workflow is fixed so base vs head benchmarks invoke the correct installed `pcb` shim (`base_shim` / `head_shim`) instead of always using head.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4dcfaac92185bdcf8a564dc0665cf08fc62c360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->