### PR TITLE
Add IPC-2581 panel layout IR

### DIFF
--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -290,6 +290,71 @@ mod tests {
     }
 
     #[test]
+    fn preserves_vcut_specs_spec_refs_and_fiducials() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER">
+      <Spec name="VCut_1">
+        <V_Cut type="ANGLE">
+          <Property value="90" unit="DEGREES" plusTol="5" minusTol="5" tolPercent="true"/>
+        </V_Cut>
+        <V_Cut type="THICKNESS_REMAINING">
+          <Property value="0.5" unit="MM" plusTol="0.1" minusTol="0.1"/>
+        </V_Cut>
+      </Spec>
+    </CadHeader>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL">
+        <SpecRef id="VCut_1"/>
+      </Layer>
+      <Step name="Panel" type="PALLET">
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <SpecRef id="VCut_1"/>
+            <GlobalFiducial>
+              <Location x="1" y="2"/>
+              <Circle diameter="1"/>
+            </GlobalFiducial>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+        let doc = Ipc2581::parse(xml).expect("parse IPC-2581");
+        let ecad = doc.ecad().unwrap();
+        let spec = ecad
+            .cad_header
+            .specs
+            .get(&doc.interner().get("VCut_1").unwrap())
+            .unwrap();
+        assert_eq!(spec.items.len(), 2);
+        assert_eq!(spec.items[0].kind, ecad::SpecItemKind::VCut);
+        assert_eq!(doc.resolve(spec.items[0].item_type.unwrap()), "ANGLE");
+        assert_eq!(spec.items[0].properties[0].value, Some(90.0));
+        assert_eq!(spec.items[0].properties[0].tol_percent, Some(true));
+
+        let layer = &ecad.cad_data.layers[0];
+        assert_eq!(doc.resolve(layer.spec_refs[0]), "VCut_1");
+
+        let set = &ecad.cad_data.steps[0].layer_features[0].sets[0];
+        assert_eq!(doc.resolve(set.spec_refs[0]), "VCut_1");
+        assert_eq!(set.fiducials.len(), 1);
+        assert!(matches!(
+            set.features[0],
+            ecad::SetFeature::Fiducial(ecad::Fiducial {
+                kind: ecad::FiducialKind::Global,
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn preserves_set_feature_source_order() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1284,9 +1284,11 @@ impl<'a> Parser<'a> {
         let mut copper_weight_oz = None;
         let mut color_term = None;
         let mut color_rgb = None;
+        let mut items = Vec::new();
 
         // Parse child elements for material and dielectric properties
         for child in self.element_children(node) {
+            items.push(self.parse_spec_item(&child));
             match self.name(&child) {
                 "General" if self.attr(&child, "type") == Some("MATERIAL") => {
                     // Look for Property, ColorTerm, and Color elements
@@ -1368,6 +1370,7 @@ impl<'a> Parser<'a> {
 
         Ok(ecad::Spec {
             name,
+            items,
             material,
             dielectric_constant,
             loss_tangent,
@@ -1377,6 +1380,46 @@ impl<'a> Parser<'a> {
             color_term,
             color_rgb,
         })
+    }
+
+    fn parse_spec_item(&mut self, node: &Node) -> ecad::SpecItem {
+        let element_name = self.name(node).to_string();
+        let element = self.interner.intern(&element_name);
+        let item_type = self.attr(node, "type").map(|s| self.interner.intern(s));
+        let comment = self.attr(node, "comment").map(|s| self.interner.intern(s));
+        let property_nodes = self
+            .element_children(node)
+            .filter(|child| self.name(child) == "Property")
+            .collect::<Vec<_>>();
+        let properties = property_nodes
+            .into_iter()
+            .map(|child| self.parse_spec_property(&child))
+            .collect();
+
+        ecad::SpecItem {
+            element,
+            kind: spec_item_kind(&element_name),
+            item_type,
+            comment,
+            properties,
+        }
+    }
+
+    fn parse_spec_property(&mut self, node: &Node) -> ecad::SpecProperty {
+        ecad::SpecProperty {
+            value: self
+                .attr(node, "value")
+                .and_then(|value| value.parse::<f64>().ok()),
+            text: self.attr(node, "text").map(|s| self.interner.intern(s)),
+            unit: self.attr(node, "unit").map(|s| self.interner.intern(s)),
+            plus_tol: self
+                .attr(node, "plusTol")
+                .and_then(|value| value.parse::<f64>().ok()),
+            minus_tol: self
+                .attr(node, "minusTol")
+                .and_then(|value| value.parse::<f64>().ok()),
+            tol_percent: self.attr(node, "tolPercent").and_then(parse_optional_bool),
+        }
     }
 
     fn parse_surface_finish(&mut self, node: &Node) -> Result<ecad::SurfaceFinish> {
@@ -1828,9 +1871,16 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_pin_ref(&mut self, node: &Node) -> Result<PinRef> {
-        let component_ref = self.required_attr(node, "componentRef", "PinRef")?;
+        let component_ref = self
+            .attr(node, "componentRef")
+            .map(|s| self.interner.intern(s));
         let pin = self.required_attr(node, "pin", "PinRef")?;
-        Ok(PinRef { component_ref, pin })
+        let title = self.attr(node, "title").map(|s| self.interner.intern(s));
+        Ok(PinRef {
+            component_ref,
+            pin,
+            title,
+        })
     }
 
     fn parse_phy_net_group(&mut self, node: &Node) -> Result<PhyNetGroup> {
@@ -1855,8 +1905,14 @@ impl<'a> Parser<'a> {
 
         let mut span = None;
         let mut profile = None;
+        let mut spec_refs = Vec::new();
         for child in self.element_children(node) {
             match self.name(&child) {
+                "SpecRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        spec_refs.push(self.interner.intern(id));
+                    }
+                }
                 "Span" => {
                     span = Some(ecad::LayerSpan {
                         from_layer: self
@@ -1880,6 +1936,7 @@ impl<'a> Parser<'a> {
             side,
             polarity,
             span,
+            spec_refs,
             profile,
         })
     }
@@ -1913,15 +1970,22 @@ impl<'a> Parser<'a> {
         let mut holes = Vec::new();
         let mut slots = Vec::new();
         let mut pads = Vec::new();
+        let mut fiducials = Vec::new();
         let mut traces = Vec::new();
         let mut polygons = Vec::new();
         let mut lines = Vec::new();
         let mut polylines = Vec::new();
         let mut features = Vec::new();
+        let mut spec_refs = Vec::new();
         let mut nonstandard_attributes = Vec::new();
 
         for child in self.element_children(node) {
             match self.name(&child) {
+                "SpecRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        spec_refs.push(self.interner.intern(id));
+                    }
+                }
                 "Hole" => {
                     let hole = self.parse_hole(&child)?;
                     features.push(ecad::SetFeature::Hole(hole.clone()));
@@ -1937,6 +2001,11 @@ impl<'a> Parser<'a> {
                     features.push(ecad::SetFeature::Pad(pad.clone()));
                     pads.push(pad);
                 }
+                "BadBoardMark" | "GlobalFiducial" | "GoodPanelMark" | "LocalFiducial" => {
+                    let fiducial = self.parse_fiducial(&child)?;
+                    features.push(ecad::SetFeature::Fiducial(fiducial.clone()));
+                    fiducials.push(fiducial);
+                }
                 "Polyline" => {
                     let trace = self.parse_trace(&child)?;
                     features.push(ecad::SetFeature::Trace(trace.clone()));
@@ -1949,6 +2018,9 @@ impl<'a> Parser<'a> {
                             ecad::SetFeature::Line(line) => lines.push(line.clone()),
                             ecad::SetFeature::Polyline(polyline) => {
                                 polylines.push(polyline.clone())
+                            }
+                            ecad::SetFeature::Fiducial(fiducial) => {
+                                fiducials.push(fiducial.clone())
                             }
                             ecad::SetFeature::Arc(_)
                             | ecad::SetFeature::StandardPrimitiveRef(_)
@@ -1971,10 +2043,12 @@ impl<'a> Parser<'a> {
             net,
             geometry,
             polarity,
+            spec_refs,
             features,
             holes,
             slots,
             pads,
+            fiducials,
             traces,
             polygons,
             lines,
@@ -1992,6 +2066,60 @@ impl<'a> Parser<'a> {
             name,
             value,
             attr_type,
+        })
+    }
+
+    fn parse_fiducial(&mut self, node: &Node) -> Result<ecad::Fiducial> {
+        let units = self.ecad_units.unwrap_or(Units::Millimeter);
+        let kind = match self.name(node) {
+            "BadBoardMark" => ecad::FiducialKind::BadBoardMark,
+            "GlobalFiducial" => ecad::FiducialKind::Global,
+            "GoodPanelMark" => ecad::FiducialKind::GoodPanelMark,
+            "LocalFiducial" => ecad::FiducialKind::Local,
+            name => {
+                return Err(Ipc2581Error::InvalidStructure(format!(
+                    "Unknown fiducial element: {name}"
+                )));
+            }
+        };
+
+        let mut location = None;
+        let mut xform = None;
+        let mut shape = None;
+        let mut pin_ref = None;
+
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Xform" => xform = Some(self.parse_xform(&child)),
+                "Location" => {
+                    location = Some(Location {
+                        x: self.parse_f64_attr_with_units(&child, "x", "Location", units)?,
+                        y: self.parse_f64_attr_with_units(&child, "y", "Location", units)?,
+                    });
+                }
+                "PinRef" => pin_ref = Some(self.parse_pin_ref(&child)?),
+                "StandardPrimitiveRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        shape = Some(ecad::FiducialShape::StandardPrimitiveRef(
+                            self.interner.intern(id),
+                        ));
+                    }
+                }
+                name if is_standard_primitive_name(name) => {
+                    shape = Some(ecad::FiducialShape::Primitive(
+                        self.parse_standard_primitive(&child, units)?,
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(ecad::Fiducial {
+            kind,
+            location: location.ok_or(Ipc2581Error::MissingElement("Location"))?,
+            xform,
+            shape: shape.ok_or(Ipc2581Error::MissingElement("StandardShape"))?,
+            pin_ref,
         })
     }
 
@@ -3089,6 +3217,47 @@ fn has_z_axis_dim(doc: &Document, node: &Node) -> bool {
                             matches!(grandchild_name, "MaterialCut" | "MaterialLeft")
                         }))
         })
+}
+
+fn parse_optional_bool(value: &str) -> Option<bool> {
+    match value {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn spec_item_kind(element: &str) -> ecad::SpecItemKind {
+    match element {
+        "General" => ecad::SpecItemKind::General,
+        "Dielectric" => ecad::SpecItemKind::Dielectric,
+        "Conductor" => ecad::SpecItemKind::Conductor,
+        "SurfaceFinish" => ecad::SpecItemKind::SurfaceFinish,
+        "V_Cut" => ecad::SpecItemKind::VCut,
+        _ => ecad::SpecItemKind::Other,
+    }
+}
+
+fn is_standard_primitive_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Butterfly"
+            | "Circle"
+            | "Contour"
+            | "Diamond"
+            | "Donut"
+            | "Ellipse"
+            | "Hexagon"
+            | "Moire"
+            | "Octagon"
+            | "Oval"
+            | "RectCenter"
+            | "RectCham"
+            | "RectCorner"
+            | "RectRound"
+            | "Thermal"
+            | "Triangle"
+    )
 }
 
 #[cfg(test)]

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -20,6 +20,8 @@ pub struct CadHeader {
 #[derive(Debug, Clone)]
 pub struct Spec {
     pub name: Symbol,
+    /// Typed child elements exactly as carried by the IPC Spec payload.
+    pub items: Vec<SpecItem>,
     pub material: Option<Symbol>,
     pub dielectric_constant: Option<f64>,
     pub loss_tangent: Option<f64>,
@@ -33,6 +35,36 @@ pub struct Spec {
     pub color_term: Option<Symbol>,
     /// RGB color specified via Color element (r, g, b values 0-255)
     pub color_rgb: Option<(u8, u8, u8)>,
+}
+
+/// A child item inside a CadHeader Spec.
+#[derive(Debug, Clone)]
+pub struct SpecItem {
+    pub element: Symbol,
+    pub kind: SpecItemKind,
+    pub item_type: Option<Symbol>,
+    pub comment: Option<Symbol>,
+    pub properties: Vec<SpecProperty>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecItemKind {
+    General,
+    Dielectric,
+    Conductor,
+    SurfaceFinish,
+    VCut,
+    Other,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpecProperty {
+    pub value: Option<f64>,
+    pub text: Option<Symbol>,
+    pub unit: Option<Symbol>,
+    pub plus_tol: Option<f64>,
+    pub minus_tol: Option<f64>,
+    pub tol_percent: Option<bool>,
 }
 
 /// Ecad section containing CadHeader and CadData
@@ -206,8 +238,9 @@ pub struct LogicalNet {
 /// PinRef references a component pin
 #[derive(Debug, Clone)]
 pub struct PinRef {
-    pub component_ref: Symbol,
+    pub component_ref: Option<Symbol>,
     pub pin: Symbol,
+    pub title: Option<Symbol>,
 }
 
 /// PhyNetGroup contains physical net routing data
@@ -224,6 +257,7 @@ pub struct Layer {
     pub side: Option<Side>,
     pub polarity: Option<Polarity>,
     pub span: Option<LayerSpan>,
+    pub spec_refs: Vec<Symbol>,
     pub profile: Option<Profile>, // Layer-specific outline (for rigid-flex)
 }
 
@@ -246,10 +280,12 @@ pub struct FeatureSet {
     pub net: Option<Symbol>,      // Net name from Set element
     pub geometry: Option<Symbol>, // Reference to PadStackDef or other geometry definition
     pub polarity: Option<Polarity>,
+    pub spec_refs: Vec<Symbol>,
     pub features: Vec<SetFeature>,
     pub holes: Vec<Hole>,
     pub slots: Vec<Slot>,
     pub pads: Vec<Pad>,
+    pub fiducials: Vec<Fiducial>,
     pub traces: Vec<Trace>,
     pub polygons: Vec<super::Polygon>, // Copper pours from Features
     pub lines: Vec<Line>,              // Trace lines from Features > UserSpecial > Line
@@ -263,6 +299,7 @@ pub enum SetFeature {
     Hole(Hole),
     Slot(Slot),
     Pad(Pad),
+    Fiducial(Fiducial),
     Trace(Trace),
     Polygon(super::Polygon),
     Line(Line),
@@ -270,6 +307,30 @@ pub enum SetFeature {
     Polyline(FeaturePolyline),
     StandardPrimitiveRef(FeaturePrimitiveRef),
     UserPrimitiveRef(FeaturePrimitiveRef),
+}
+
+/// IPC fiducial and panel mark feature carried by a Set.
+#[derive(Debug, Clone)]
+pub struct Fiducial {
+    pub kind: FiducialKind,
+    pub location: super::Location,
+    pub xform: Option<super::Xform>,
+    pub shape: FiducialShape,
+    pub pin_ref: Option<PinRef>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FiducialKind {
+    BadBoardMark,
+    Global,
+    GoodPanelMark,
+    Local,
+}
+
+#[derive(Debug, Clone)]
+pub enum FiducialShape {
+    Primitive(super::StandardPrimitive),
+    StandardPrimitiveRef(Symbol),
 }
 
 /// NonstandardAttribute from Set elements

--- a/crates/pcb-ipc2581-tools/src/accessors/board.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/board.rs
@@ -21,7 +21,6 @@ impl BoardDimensions {
         }
     }
 
-    // Legacy accessors for backward compatibility
     pub fn width_mm(&self) -> f64 {
         self.width.mm()
     }
@@ -63,7 +62,6 @@ pub struct StackupInfo {
 }
 
 impl StackupInfo {
-    // Legacy accessor for backward compatibility
     pub fn overall_thickness_mm(&self) -> Option<f64> {
         self.thickness.map(|t| t.mm())
     }
@@ -72,7 +70,7 @@ impl StackupInfo {
 impl<'a> IpcAccessor<'a> {
     /// Extract board and panel geometry from canonical IPC layout IR.
     pub fn board_layout_info(&self) -> Option<BoardLayoutInfo> {
-        let doc = geometry::extract_profiles(self.ipc()).ok()?;
+        let doc = geometry::extract_layout(self.ipc()).ok()?;
         let board_dimensions =
             pcb_ir::dialects::ipc::board_bbox(&doc).and_then(dimensions_from_bbox);
         let panel = pcb_ir::dialects::ipc::root_panel_step(&doc).map(|(_, panel_step)| PanelInfo {

--- a/crates/pcb-ipc2581-tools/src/accessors/board.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/board.rs
@@ -75,11 +75,11 @@ impl<'a> IpcAccessor<'a> {
         let doc = geometry::extract_profiles(self.ipc()).ok()?;
         let board_dimensions =
             pcb_ir::dialects::ipc::board_bbox(&doc).and_then(dimensions_from_bbox);
-        let panel = doc.panels.first().map(|panel| PanelInfo {
-            step_name: self.ipc().resolve(panel.step_ref).to_string(),
-            board_count: doc.boards.len(),
-            board_instances: panel.board_instance_count as usize,
-            dimensions: dimensions_from_bbox(panel.bbox),
+        let panel = pcb_ir::dialects::ipc::root_panel_step(&doc).map(|(_, panel_step)| PanelInfo {
+            step_name: self.ipc().resolve(panel_step.source_step_ref).to_string(),
+            board_count: pcb_ir::dialects::ipc::board_step_count(&doc),
+            board_instances: pcb_ir::dialects::ipc::board_instance_count(&doc),
+            dimensions: pcb_ir::dialects::ipc::panel_bbox(&doc).and_then(dimensions_from_bbox),
         });
 
         if board_dimensions.is_none() && panel.is_none() {

--- a/crates/pcb-ipc2581-tools/src/commands/html_export.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/html_export.rs
@@ -6,6 +6,7 @@ use ipc2581::types::ecad::Layer;
 use minijinja::{Environment, context};
 use serde::Serialize;
 
+use crate::LayoutTarget;
 use crate::UnitFormat;
 use crate::accessors::{ColorInfo, IpcAccessor, StackupLayerType, SurfaceFinishInfo};
 use crate::geometry;
@@ -100,11 +101,21 @@ struct BoardSummary {
     design_name: Option<String>,
     width: Option<String>,
     height: Option<String>,
+    panel: Option<PanelSummary>,
     thickness: Option<String>,
     copper_layers: Option<usize>,
     components: Option<usize>,
     nets: Option<usize>,
     drill_holes: Option<String>,
+}
+
+#[derive(Serialize)]
+struct PanelSummary {
+    step_name: String,
+    width: Option<String>,
+    height: Option<String>,
+    board_count: usize,
+    board_instances: usize,
 }
 
 #[derive(Serialize)]
@@ -168,26 +179,34 @@ fn extract_board_summary(accessor: &IpcAccessor, unit_format: UnitFormat) -> Boa
     let design_name = accessor
         .primary_step()
         .map(|step| accessor.ipc().resolve(step.name).to_string());
+    let layout = accessor.board_layout_info();
 
-    let (width, height) = if let Some(dims) = accessor.board_dimensions() {
-        let (w, h) = match unit_format {
-            UnitFormat::Mm => (
-                format!("{:.2} mm", dims.width_mm()),
-                format!("{:.2} mm", dims.height_mm()),
-            ),
-            UnitFormat::Mil => (
-                format!("{:.1} mil", dims.width_mm() / 0.0254),
-                format!("{:.1} mil", dims.height_mm() / 0.0254),
-            ),
-            UnitFormat::Inch => (
-                format!("{:.3} in", dims.width_mm() / 25.4),
-                format!("{:.3} in", dims.height_mm() / 25.4),
-            ),
-        };
-        (Some(w), Some(h))
+    let (width, height) = if let Some(dims) = layout
+        .as_ref()
+        .and_then(|layout| layout.board_dimensions.as_ref())
+    {
+        formatted_dimensions(dims.width_mm(), dims.height_mm(), unit_format)
     } else {
         (None, None)
     };
+
+    let panel = layout
+        .as_ref()
+        .and_then(|layout| layout.panel.as_ref())
+        .map(|panel| {
+            let (width, height) = panel
+                .dimensions
+                .as_ref()
+                .map(|dims| formatted_dimensions(dims.width_mm(), dims.height_mm(), unit_format))
+                .unwrap_or((None, None));
+            PanelSummary {
+                step_name: panel.step_name.clone(),
+                width,
+                height,
+                board_count: panel.board_count,
+                board_instances: panel.board_instances,
+            }
+        });
 
     let thickness = if let Some(stackup) = accessor.stackup_details() {
         stackup.overall_thickness_mm.map(|t| match unit_format {
@@ -223,11 +242,33 @@ fn extract_board_summary(accessor: &IpcAccessor, unit_format: UnitFormat) -> Boa
         design_name,
         width,
         height,
+        panel,
         thickness,
         copper_layers,
         components,
         nets,
         drill_holes,
+    }
+}
+
+fn formatted_dimensions(
+    width_mm: f64,
+    height_mm: f64,
+    unit_format: UnitFormat,
+) -> (Option<String>, Option<String>) {
+    match unit_format {
+        UnitFormat::Mm => (
+            Some(format!("{width_mm:.2} mm")),
+            Some(format!("{height_mm:.2} mm")),
+        ),
+        UnitFormat::Mil => (
+            Some(format!("{:.1} mil", width_mm / 0.0254)),
+            Some(format!("{:.1} mil", height_mm / 0.0254)),
+        ),
+        UnitFormat::Inch => (
+            Some(format!("{:.3} in", width_mm / 25.4)),
+            Some(format!("{:.3} in", height_mm / 25.4)),
+        ),
     }
 }
 
@@ -318,11 +359,15 @@ fn rendered_source_layer(
         has_native_content: false,
     };
 
-    match geometry::extract_layer(ipc, &name) {
+    match geometry::extract_layer_for_layout_target(ipc, &name, LayoutTarget::Layout) {
         Ok(mut geometry) => {
             rendered.has_native_content = geometry::render::layer_has_native_content(&geometry);
             pcb_ir::dialects::ipc::process::process_document(&mut geometry);
-            rendered.svg = Some(geometry::render::render_layer_svg(&geometry, true));
+            rendered.svg = Some(geometry::render::render_layer_svg(
+                &geometry,
+                true,
+                LayoutTarget::Layout.profile_set(),
+            ));
             if !geometry.diagnostics.is_empty() {
                 rendered.warning = Some(format!("{} warning(s)", geometry.diagnostics.len()));
             }
@@ -467,6 +512,9 @@ mod tests {
 
         assert!(design_row.contains(r#"<span class="summary-value">panel</span>"#));
         assert!(!design_row.contains(r#"<span class="summary-value">board</span>"#));
+        assert!(html.contains("Panel Step:"));
+        assert!(html.contains("Panel Boards:"));
+        assert!(html.contains("1 instance from 1 board step"));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/html_template.html.jinja
+++ b/crates/pcb-ipc2581-tools/src/commands/html_template.html.jinja
@@ -24,6 +24,22 @@
             <span class="summary-value">{{ board_summary.width }} × {{ board_summary.height }}</span>
         </div>
         {% endif %}
+        {% if board_summary.panel %}
+        <div class="summary-item">
+            <span class="summary-label">Panel Step:</span>
+            <span class="summary-value">{{ board_summary.panel.step_name }}</span>
+        </div>
+        {% if board_summary.panel.width and board_summary.panel.height %}
+        <div class="summary-item">
+            <span class="summary-label">Panel Dimensions:</span>
+            <span class="summary-value">{{ board_summary.panel.width }} × {{ board_summary.panel.height }}</span>
+        </div>
+        {% endif %}
+        <div class="summary-item">
+            <span class="summary-label">Panel Boards:</span>
+            <span class="summary-value">{{ board_summary.panel.board_instances }} instance{% if board_summary.panel.board_instances != 1 %}s{% endif %} from {{ board_summary.panel.board_count }} board step{% if board_summary.panel.board_count != 1 %}s{% endif %}</span>
+        </div>
+        {% endif %}
         {% if board_summary.thickness %}
         <div class="summary-item">
             <span class="summary-label">Board Thickness:</span>

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -16,15 +16,15 @@ pub struct OutlineOptions {
 pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = Ipc2581::parse(&content)?;
-    let profiles = geometry::extract_profiles(&ipc)?;
-    if pcb_ir::dialects::ipc::render_profiles(&profiles)
+    let layout = geometry::extract_layout(&ipc)?;
+    if pcb_ir::dialects::ipc::render_profiles(&layout)
         .next()
         .is_none()
     {
         bail!("IPC-2581 primary step and repeated child steps have no board Profile outline");
     }
 
-    let dxf = geometry::dxf::render_profiles_dxf(&profiles);
+    let dxf = geometry::dxf::render_profiles_dxf(&layout);
     std::fs::write(&options.output, dxf)
         .with_context(|| format!("Failed to write DXF to {}", options.output.display()))?;
     println!(
@@ -69,12 +69,12 @@ mod tests {
         )
         .unwrap();
 
-        let profiles = geometry::extract_profiles(&ipc).unwrap();
+        let layout = geometry::extract_layout(&ipc).unwrap();
 
-        assert_eq!(pcb_ir::dialects::ipc::board_step_count(&profiles), 1);
-        assert_eq!(pcb_ir::dialects::ipc::panel_step_count(&profiles), 1);
-        assert_eq!(pcb_ir::dialects::ipc::board_instance_count(&profiles), 1);
-        assert_eq!(profiles.profiles.len(), 2);
-        assert_eq!(pcb_ir::dialects::ipc::render_profiles(&profiles).count(), 1);
+        assert_eq!(pcb_ir::dialects::ipc::board_step_count(&layout), 1);
+        assert_eq!(pcb_ir::dialects::ipc::panel_step_count(&layout), 1);
+        assert_eq!(pcb_ir::dialects::ipc::board_instance_count(&layout), 1);
+        assert_eq!(layout.profiles.len(), 2);
+        assert_eq!(pcb_ir::dialects::ipc::render_profiles(&layout).count(), 1);
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -71,9 +71,9 @@ mod tests {
 
         let profiles = geometry::extract_profiles(&ipc).unwrap();
 
-        assert_eq!(profiles.boards.len(), 1);
-        assert_eq!(profiles.panels.len(), 1);
-        assert_eq!(profiles.board_instances.len(), 1);
+        assert_eq!(pcb_ir::dialects::ipc::board_step_count(&profiles), 1);
+        assert_eq!(pcb_ir::dialects::ipc::panel_step_count(&profiles), 1);
+        assert_eq!(pcb_ir::dialects::ipc::board_instance_count(&profiles), 1);
         assert_eq!(profiles.profiles.len(), 2);
         assert_eq!(pcb_ir::dialects::ipc::render_profiles(&profiles).count(), 1);
     }

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use pcb_ir::dialects::ipc::{ProfileSet, profile_occurrences_for};
 
 use crate::geometry;
 use crate::ipc2581::Ipc2581;
@@ -17,14 +18,11 @@ pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = Ipc2581::parse(&content)?;
     let layout = geometry::extract_layout(&ipc)?;
-    if pcb_ir::dialects::ipc::render_profiles(&layout)
-        .next()
-        .is_none()
-    {
+    if profile_occurrences_for(&layout, ProfileSet::FabricationOutlines).is_empty() {
         bail!("IPC-2581 primary step and repeated child steps have no board Profile outline");
     }
 
-    let dxf = geometry::dxf::render_profiles_dxf(&layout);
+    let dxf = geometry::dxf::render_profile_set_dxf(&layout, ProfileSet::FabricationOutlines);
     std::fs::write(&options.output, dxf)
         .with_context(|| format!("Failed to write DXF to {}", options.output.display()))?;
     println!(
@@ -74,7 +72,10 @@ mod tests {
         assert_eq!(pcb_ir::dialects::ipc::board_step_count(&layout), 1);
         assert_eq!(pcb_ir::dialects::ipc::panel_step_count(&layout), 1);
         assert_eq!(pcb_ir::dialects::ipc::board_instance_count(&layout), 1);
-        assert_eq!(layout.profiles.len(), 2);
-        assert_eq!(pcb_ir::dialects::ipc::render_profiles(&layout).count(), 1);
+        assert_eq!(layout.profiles.len(), 1);
+        assert_eq!(
+            profile_occurrences_for(&layout, ProfileSet::FabricationOutlines).len(),
+            1
+        );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -1,32 +1,35 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use pcb_ir::dialects::ipc::{ProfileSet, profile_occurrences_for};
+use pcb_ir::dialects::ipc::profile_occurrences_for;
 
+use crate::LayoutTarget;
 use crate::geometry;
 use crate::ipc2581::Ipc2581;
 use crate::utils::file as file_utils;
 
-/// Options for exporting the IPC-2581 board outline.
+/// Options for exporting IPC-2581 profile outlines.
 #[derive(Debug, Clone)]
 pub struct OutlineOptions {
     pub output: PathBuf,
+    pub layout_target: LayoutTarget,
 }
 
-/// Export the board outline from Step/Profile as a DXF file.
+/// Export Step/Profile outlines as a DXF file.
 pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = Ipc2581::parse(&content)?;
     let layout = geometry::extract_layout(&ipc)?;
-    if profile_occurrences_for(&layout, ProfileSet::FabricationOutlines).is_empty() {
+    let profile_set = options.layout_target.profile_set();
+    if profile_occurrences_for(&layout, profile_set).is_empty() {
         bail!("IPC-2581 primary step and repeated child steps have no board Profile outline");
     }
 
-    let dxf = geometry::dxf::render_profile_set_dxf(&layout, ProfileSet::FabricationOutlines);
+    let dxf = geometry::dxf::render_profile_set_dxf(&layout, profile_set);
     std::fs::write(&options.output, dxf)
         .with_context(|| format!("Failed to write DXF to {}", options.output.display()))?;
     println!(
-        "✓ IPC-2581 board outline exported to {}",
+        "✓ IPC-2581 outline exported to {}",
         options.output.display()
     );
     Ok(())
@@ -74,7 +77,7 @@ mod tests {
         assert_eq!(pcb_ir::dialects::ipc::board_instance_count(&layout), 1);
         assert_eq!(layout.profiles.len(), 1);
         assert_eq!(
-            profile_occurrences_for(&layout, ProfileSet::FabricationOutlines).len(),
+            profile_occurrences_for(&layout, LayoutTarget::Panel.profile_set()).len(),
             1
         );
     }

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::geometry;
 use crate::utils::file as file_utils;
-use crate::{RenderFormat, ipc2581};
+use crate::{LayoutTarget, RenderFormat, ipc2581};
 
 /// Options for rendering processed geometry from a single IPC-2581 layer.
 #[derive(Debug, Clone)]
@@ -13,6 +13,7 @@ pub struct RenderOptions {
     pub layer: String,
     pub output: Option<PathBuf>,
     pub format: RenderFormat,
+    pub layout_target: LayoutTarget,
     pub flat: bool,
 }
 
@@ -21,7 +22,8 @@ pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
     let target = resolve_target(options)?;
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
-    let mut geometry = geometry::extract_layer(&ipc, &options.layer)?;
+    let mut geometry =
+        geometry::extract_layer_for_layout_target(&ipc, &options.layer, options.layout_target)?;
     pcb_ir::dialects::ipc::process::process_document(&mut geometry);
     if options.flat {
         pcb_ir::dialects::ipc::process::flatten_layers_to_masks(&mut geometry);
@@ -31,7 +33,8 @@ pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
         RenderTarget::Svg => render_svg(&geometry, options)?,
         RenderTarget::Png => render_png(&geometry, options)?,
         RenderTarget::Terminal => {
-            let mask = geometry::render::layer_mask(&geometry, true);
+            let mask =
+                geometry::render::layer_mask(&geometry, true, options.layout_target.profile_set());
             pcb_ir::dialects::mask::render_all_to_terminal(&mask).map_err(anyhow::Error::msg)?;
         }
     }
@@ -90,7 +93,8 @@ fn render_svg(
     >,
     options: &RenderOptions,
 ) -> Result<()> {
-    let svg = geometry::render::render_layer_svg(geometry, true);
+    let svg =
+        geometry::render::render_layer_svg(geometry, true, options.layout_target.profile_set());
 
     if let Some(output) = &options.output {
         std::fs::write(output, svg)
@@ -114,7 +118,7 @@ fn render_png(
     >,
     options: &RenderOptions,
 ) -> Result<()> {
-    let mask = geometry::render::layer_mask(geometry, true);
+    let mask = geometry::render::layer_mask(geometry, true, options.layout_target.profile_set());
     let png = pcb_ir::dialects::mask::render_png_all(&mask).map_err(anyhow::Error::msg)?;
 
     if let Some(output) = &options.output {

--- a/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
@@ -228,7 +228,7 @@ fn fmt_num(value: f64) -> String {
 mod tests {
     use super::*;
     use pcb_ir::common::{Affine2, BBox};
-    use pcb_ir::dialects::ipc::{BoardProfile, BoardProfileCutout, BoardProfileKind, GeometryPath};
+    use pcb_ir::dialects::ipc::{GeometryPath, StepProfile, StepProfileCutout};
 
     #[test]
     fn renders_profile_ir_as_mm_dxf_with_closed_outline_layer() {
@@ -255,8 +255,7 @@ mod tests {
                 PathCmd::close(),
             ],
         );
-        doc.profiles.push(BoardProfile {
-            kind: BoardProfileKind::BoardDefinition,
+        doc.profiles.push(StepProfile {
             source_step_ref: 0,
             transform: Affine2::identity(),
             outer_path: path,
@@ -292,12 +291,11 @@ mod tests {
                 PathCmd::close(),
             ],
         );
-        doc.profile_cutouts.push(BoardProfileCutout {
+        doc.profile_cutouts.push(StepProfileCutout {
             path: cutout_path,
             bbox: BBox::empty(),
         });
-        doc.profiles.push(BoardProfile {
-            kind: BoardProfileKind::BoardDefinition,
+        doc.profiles.push(StepProfile {
             source_step_ref: 0,
             transform: Affine2::identity(),
             outer_path,

--- a/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
@@ -1,7 +1,10 @@
 use std::fmt::Write;
 
 use pcb_ir::common::Point;
-use pcb_ir::dialects::ipc::{GeometryDocument, PathCmd, PathOp, render_profiles};
+use pcb_ir::dialects::ipc::{
+    GeometryDocument, PathCmd, PathOp, ProfileSet, profile_occurrences_for,
+    transformed_path_payloads,
+};
 
 const OUTLINE_LAYER: &str = "BOARD_OUTLINE";
 const EPSILON: f64 = 1e-9;
@@ -13,20 +16,25 @@ struct DxfVertex {
     bulge: f64,
 }
 
-/// Render physical IPC profile geometry as an ASCII DXF outline in millimeters.
-pub fn render_profiles_dxf<Symbol, LayerFunction>(
+pub fn render_profile_set_dxf<Symbol, LayerFunction>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
+    profile_set: ProfileSet,
 ) -> String {
     let mut dxf = String::new();
     write_header(&mut dxf);
     write_tables(&mut dxf);
     write_entities_start(&mut dxf);
-    for profile in render_profiles(doc) {
-        write_path(&mut dxf, doc, profile.outer_path);
-        for cutout in &doc.profile_cutouts
-            [profile.cutout_start as usize..(profile.cutout_start + profile.cutout_count) as usize]
+    for occurrence in profile_occurrences_for(doc, profile_set) {
+        write_path(
+            &mut dxf,
+            doc,
+            occurrence.profile.outer_path,
+            occurrence.transform,
+        );
+        for cutout in &doc.profile_cutouts[occurrence.profile.cutout_start as usize
+            ..(occurrence.profile.cutout_start + occurrence.profile.cutout_count) as usize]
         {
-            write_path(&mut dxf, doc, cutout.path);
+            write_path(&mut dxf, doc, cutout.path, occurrence.transform);
         }
     }
     write_footer(&mut dxf);
@@ -59,14 +67,10 @@ fn write_path<Symbol, LayerFunction>(
     dxf: &mut String,
     doc: &GeometryDocument<Symbol, LayerFunction>,
     path_index: u32,
+    transform: pcb_ir::common::Affine2,
 ) {
-    let path = &doc.paths[path_index as usize];
-    for contour in &doc.contours
-        [path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
-    {
-        let cmds = &doc.path_cmds
-            [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize];
-        write_polyline(dxf, &contour_vertices(cmds));
+    for payload in transformed_path_payloads(doc, path_index, transform) {
+        write_polyline(dxf, &contour_vertices(&payload.cmds));
     }
 }
 
@@ -234,7 +238,7 @@ mod tests {
     fn renders_profile_ir_as_mm_dxf_with_closed_outline_layer() {
         let doc = rect_profile_doc();
 
-        let dxf = render_profiles_dxf(&doc);
+        let dxf = render_profile_set_dxf(&doc, ProfileSet::FabricationOutlines);
 
         assert!(dxf.contains("9\n$INSUNITS\n70\n4\n"));
         assert!(dxf.contains("2\nBOARD_OUTLINE\n"));
@@ -262,7 +266,7 @@ mod tests {
             bbox: BBox::empty(),
         });
 
-        let dxf = render_profiles_dxf(&doc);
+        let dxf = render_profile_set_dxf(&doc, ProfileSet::FabricationOutlines);
 
         assert!(dxf.contains("42\n1\n"));
     }

--- a/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
@@ -227,7 +227,7 @@ fn fmt_num(value: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pcb_ir::common::{Affine2, BBox};
+    use pcb_ir::common::BBox;
     use pcb_ir::dialects::ipc::{GeometryPath, StepProfile, StepProfileCutout};
 
     #[test]
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn preserves_profile_arcs_as_lwpolyline_bulges() {
-        let mut doc = GeometryDocument::<u32, ()>::new("test".to_string());
+        let mut doc = GeometryDocument::<u32, ()>::new();
         let path = doc.push_path(
             GeometryPath::unpainted(BBox::empty()),
             [
@@ -256,8 +256,6 @@ mod tests {
             ],
         );
         doc.profiles.push(StepProfile {
-            source_step_ref: 0,
-            transform: Affine2::identity(),
             outer_path: path,
             cutout_start: 0,
             cutout_count: 0,
@@ -270,7 +268,7 @@ mod tests {
     }
 
     fn rect_profile_doc() -> GeometryDocument<u32, ()> {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
         let outer_path = doc.push_path(
             GeometryPath::unpainted(BBox::empty()),
             [
@@ -296,8 +294,6 @@ mod tests {
             bbox: BBox::empty(),
         });
         doc.profiles.push(StepProfile {
-            source_step_ref: 0,
-            transform: Affine2::identity(),
             outer_path,
             cutout_start: 0,
             cutout_count: 1,

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -46,6 +46,36 @@ struct ProfileRange {
     bbox: BBox,
 }
 
+struct LayoutBuildContext<'a> {
+    ipc: &'a Ipc2581,
+    steps: &'a [Step],
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LayoutParent<'a> {
+    step: &'a Step,
+    transform: Affine2,
+    layout_step: u32,
+    instance: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LayoutInstanceSpec {
+    repeat: u32,
+    parent_instance: Option<u32>,
+    child_step: u32,
+    source_step_ref: Symbol,
+    parent_step_ref: Symbol,
+    transform: Affine2,
+    repeat_index_x: u32,
+    repeat_index_y: u32,
+    repeat_count_x: u32,
+    repeat_count_y: u32,
+    repeat_pitch_x: f64,
+    repeat_pitch_y: f64,
+    profiles: ProfileRange,
+}
+
 struct ExtractContext<'a> {
     ipc: &'a Ipc2581,
     padstacks: HashMap<Symbol, &'a ipc2581::types::PadStackDef>,
@@ -475,24 +505,9 @@ fn append_layout_geometry(
 
 fn append_step_only_layout_geometry(doc: &mut GeometryDocument, primary_step: &Step) {
     if is_panel_step(primary_step) {
-        let profiles = append_step_profile(
-            doc,
-            primary_step,
-            Affine2::identity(),
-            BoardProfileKind::PanelDefinition,
-        );
+        let profiles = append_step_profile(doc, primary_step, Affine2::identity());
         let step = push_or_update_layout_step(doc, primary_step, profiles);
         doc.layout.root_step = Some(step);
-        doc.panels.push(PanelGeometry {
-            step_ref: primary_step.name,
-            profile_start: profiles.start,
-            profile_count: profiles.count,
-            profile_bbox: profiles.bbox,
-            board_instance_start: doc.board_instances.len() as u32,
-            board_instance_count: 0,
-            instance_bbox: BBox::empty(),
-            bbox: profiles.bbox,
-        });
     } else if is_board_step(primary_step) {
         doc.layout.root_step = Some(ensure_layout_step_for_step(doc, primary_step));
     }
@@ -504,81 +519,52 @@ fn append_panel_geometry(
     steps: &[Step],
     panel_step: &Step,
 ) -> Result<()> {
-    let panel_profiles = append_step_profile(
-        doc,
-        panel_step,
-        Affine2::identity(),
-        BoardProfileKind::PanelDefinition,
-    );
+    let panel_profiles = append_step_profile(doc, panel_step, Affine2::identity());
     let root_layout_step = push_or_update_layout_step(doc, panel_step, panel_profiles);
     doc.layout.root_step = Some(root_layout_step);
-    let board_instance_start = doc.board_instances.len() as u32;
-    let mut stack = vec![panel_step.name];
-    append_board_instances_from_repeats(
-        doc,
-        ipc,
-        steps,
-        panel_step,
-        Affine2::identity(),
-        &mut stack,
-        root_layout_step,
-        None,
-    )?;
-    let board_instance_count = doc.board_instances.len() as u32 - board_instance_start;
-    let instance_bbox = board_instances_bbox(doc, board_instance_start, board_instance_count);
-    let bbox = if !panel_profiles.bbox.is_empty() {
-        panel_profiles.bbox
-    } else {
-        instance_bbox
+    let context = LayoutBuildContext { ipc, steps };
+    let parent = LayoutParent {
+        step: panel_step,
+        transform: Affine2::identity(),
+        layout_step: root_layout_step,
+        instance: None,
     };
-
-    doc.panels.push(PanelGeometry {
-        step_ref: panel_step.name,
-        profile_start: panel_profiles.start,
-        profile_count: panel_profiles.count,
-        profile_bbox: panel_profiles.bbox,
-        board_instance_start,
-        board_instance_count,
-        instance_bbox,
-        bbox,
-    });
+    let mut stack = vec![panel_step.name];
+    append_layout_repeats(doc, &context, parent, &mut stack)?;
 
     Ok(())
 }
 
-fn append_board_instances_from_repeats(
+fn append_layout_repeats(
     doc: &mut GeometryDocument,
-    ipc: &Ipc2581,
-    steps: &[Step],
-    parent_step: &Step,
-    parent_transform: Affine2,
+    context: &LayoutBuildContext<'_>,
+    parent: LayoutParent<'_>,
     stack: &mut Vec<Symbol>,
-    parent_layout_step: u32,
-    parent_instance: Option<u32>,
 ) -> Result<()> {
-    for repeat in &parent_step.step_repeats {
-        let source_step = steps
+    for repeat in &parent.step.step_repeats {
+        let source_step = context
+            .steps
             .iter()
             .find(|step| step.name == repeat.step_ref)
             .with_context(|| {
                 format!(
                     "StepRepeat references unknown Step '{}'",
-                    ipc.resolve(repeat.step_ref)
+                    context.ipc.resolve(repeat.step_ref)
                 )
             })?;
 
         if stack.contains(&source_step.name) {
             bail!(
                 "StepRepeat cycle references Step '{}'",
-                ipc.resolve(source_step.name)
+                context.ipc.resolve(source_step.name)
             );
         }
 
         let child_layout_step = ensure_layout_step_for_step(doc, source_step);
         let layout_repeat = push_layout_repeat(
             doc,
-            parent_layout_step,
-            parent_instance,
+            parent.layout_step,
+            parent.instance,
             child_layout_step,
             source_step.name,
             repeat,
@@ -587,147 +573,52 @@ fn append_board_instances_from_repeats(
         let mut pending_panel_instances = Vec::new();
         for iy in 0..repeat.ny {
             for ix in 0..repeat.nx {
-                let transform = parent_transform.concat(step_repeat_transform(repeat, ix, iy));
+                let transform = parent
+                    .transform
+                    .concat(step_repeat_transform(repeat, ix, iy));
+                let profiles = append_step_profile(doc, source_step, transform);
+                let layout_instance = push_layout_instance(
+                    doc,
+                    LayoutInstanceSpec {
+                        repeat: layout_repeat,
+                        parent_instance: parent.instance,
+                        child_step: child_layout_step,
+                        source_step_ref: source_step.name,
+                        parent_step_ref: parent.step.name,
+                        transform,
+                        repeat_index_x: ix,
+                        repeat_index_y: iy,
+                        repeat_count_x: repeat.nx,
+                        repeat_count_y: repeat.ny,
+                        repeat_pitch_x: repeat.dx,
+                        repeat_pitch_y: repeat.dy,
+                        profiles,
+                    },
+                );
                 if is_panel_step(source_step) {
-                    let profiles = append_step_profile(
-                        doc,
-                        source_step,
-                        transform,
-                        BoardProfileKind::PanelInstance,
-                    );
-                    let layout_instance = push_layout_instance(
-                        doc,
-                        layout_repeat,
-                        parent_instance,
-                        child_layout_step,
-                        source_step.name,
-                        parent_step.name,
-                        repeat,
-                        ix,
-                        iy,
-                        transform,
-                        profiles,
-                    );
                     pending_panel_instances.push((source_step, transform, layout_instance));
-                } else if is_board_step(source_step) {
-                    let profiles = append_board_instance(
-                        doc,
-                        parent_step,
-                        source_step,
-                        repeat,
-                        ix,
-                        iy,
-                        transform,
-                    );
-                    push_layout_instance(
-                        doc,
-                        layout_repeat,
-                        parent_instance,
-                        child_layout_step,
-                        source_step.name,
-                        parent_step.name,
-                        repeat,
-                        ix,
-                        iy,
-                        transform,
-                        profiles,
-                    );
-                } else {
-                    let profiles = append_step_profile(
-                        doc,
-                        source_step,
-                        transform,
-                        BoardProfileKind::StepInstance,
-                    );
-                    push_layout_instance(
-                        doc,
-                        layout_repeat,
-                        parent_instance,
-                        child_layout_step,
-                        source_step.name,
-                        parent_step.name,
-                        repeat,
-                        ix,
-                        iy,
-                        transform,
-                        profiles,
-                    );
                 }
             }
         }
 
         for (source_step, transform, layout_instance) in pending_panel_instances {
             stack.push(source_step.name);
-            append_board_instances_from_repeats(
+            append_layout_repeats(
                 doc,
-                ipc,
-                steps,
-                source_step,
-                transform,
+                context,
+                LayoutParent {
+                    step: source_step,
+                    transform,
+                    layout_step: child_layout_step,
+                    instance: Some(layout_instance),
+                },
                 stack,
-                child_layout_step,
-                Some(layout_instance),
             )?;
             stack.pop();
         }
     }
 
     Ok(())
-}
-
-fn append_board_instance(
-    doc: &mut GeometryDocument,
-    parent_step: &Step,
-    board_step: &Step,
-    repeat: &StepRepeat,
-    ix: u32,
-    iy: u32,
-    transform: Affine2,
-) -> ProfileRange {
-    let board_index = ensure_board_geometry(doc, board_step);
-    let profiles = append_step_profile(doc, board_step, transform, BoardProfileKind::BoardInstance);
-
-    doc.board_instances.push(BoardInstance {
-        board_index,
-        source_step_ref: board_step.name,
-        parent_step_ref: parent_step.name,
-        transform,
-        repeat_index_x: ix,
-        repeat_index_y: iy,
-        repeat_count_x: repeat.nx,
-        repeat_count_y: repeat.ny,
-        repeat_pitch_x: repeat.dx,
-        repeat_pitch_y: repeat.dy,
-        profile_start: profiles.start,
-        profile_count: profiles.count,
-        bbox: profiles.bbox,
-    });
-    profiles
-}
-
-fn ensure_board_geometry(doc: &mut GeometryDocument, step: &Step) -> u32 {
-    if let Some(index) = doc
-        .boards
-        .iter()
-        .position(|board| board.step_ref == step.name)
-    {
-        return index as u32;
-    }
-
-    let profiles = append_step_profile(
-        doc,
-        step,
-        Affine2::identity(),
-        BoardProfileKind::BoardDefinition,
-    );
-    let board_index = doc.boards.len() as u32;
-    doc.boards.push(BoardGeometry {
-        step_ref: step.name,
-        profile_start: profiles.start,
-        profile_count: profiles.count,
-        bbox: profiles.bbox,
-    });
-    board_index
 }
 
 fn ensure_layout_step_for_step(doc: &mut GeometryDocument, step: &Step) -> u32 {
@@ -740,26 +631,7 @@ fn ensure_layout_step_for_step(doc: &mut GeometryDocument, step: &Step) -> u32 {
         return index as u32;
     }
 
-    if is_board_step(step) {
-        let board_index = ensure_board_geometry(doc, step);
-        let board = &doc.boards[board_index as usize];
-        return push_or_update_layout_step(
-            doc,
-            step,
-            ProfileRange {
-                start: board.profile_start,
-                count: board.profile_count,
-                bbox: board.bbox,
-            },
-        );
-    }
-
-    let profiles = append_step_profile(
-        doc,
-        step,
-        Affine2::identity(),
-        BoardProfileKind::StepDefinition,
-    );
+    let profiles = append_step_profile(doc, step, Affine2::identity());
     push_or_update_layout_step(doc, step, profiles)
 }
 
@@ -828,42 +700,30 @@ fn push_layout_repeat(
     repeat_index
 }
 
-fn push_layout_instance(
-    doc: &mut GeometryDocument,
-    repeat_index: u32,
-    parent_instance: Option<u32>,
-    child_step: u32,
-    source_step_ref: Symbol,
-    parent_step_ref: Symbol,
-    repeat: &StepRepeat,
-    ix: u32,
-    iy: u32,
-    transform: Affine2,
-    profiles: ProfileRange,
-) -> u32 {
+fn push_layout_instance(doc: &mut GeometryDocument, spec: LayoutInstanceSpec) -> u32 {
     let instance_index = doc.layout.instances.len() as u32;
-    let repeat_record = &mut doc.layout.repeats[repeat_index as usize];
+    let repeat_record = &mut doc.layout.repeats[spec.repeat as usize];
     if repeat_record.instance_count == 0 {
         repeat_record.instance_start = instance_index;
     }
     repeat_record.instance_count += 1;
 
     doc.layout.instances.push(LayoutInstance {
-        repeat: repeat_index,
-        parent_instance,
-        child_step,
-        source_step_ref,
-        parent_step_ref,
-        transform,
-        repeat_index_x: ix,
-        repeat_index_y: iy,
-        repeat_count_x: repeat.nx,
-        repeat_count_y: repeat.ny,
-        repeat_pitch_x: repeat.dx,
-        repeat_pitch_y: repeat.dy,
-        profile_start: profiles.start,
-        profile_count: profiles.count,
-        bbox: profiles.bbox,
+        repeat: spec.repeat,
+        parent_instance: spec.parent_instance,
+        child_step: spec.child_step,
+        source_step_ref: spec.source_step_ref,
+        parent_step_ref: spec.parent_step_ref,
+        transform: spec.transform,
+        repeat_index_x: spec.repeat_index_x,
+        repeat_index_y: spec.repeat_index_y,
+        repeat_count_x: spec.repeat_count_x,
+        repeat_count_y: spec.repeat_count_y,
+        repeat_pitch_x: spec.repeat_pitch_x,
+        repeat_pitch_y: spec.repeat_pitch_y,
+        profile_start: spec.profiles.start,
+        profile_count: spec.profiles.count,
+        bbox: spec.profiles.bbox,
     });
     instance_index
 }
@@ -876,13 +736,6 @@ fn layout_step_kind(step: &Step) -> LayoutStepKind {
         None if !step.step_repeats.is_empty() => LayoutStepKind::Panel,
         None => LayoutStepKind::Board,
     }
-}
-
-fn board_instances_bbox(doc: &GeometryDocument, start: u32, count: u32) -> BBox {
-    doc.board_instances[start as usize..(start + count) as usize]
-        .iter()
-        .map(|instance| instance.bbox)
-        .fold(BBox::empty(), BBox::union)
 }
 
 fn is_panel_step(step: &Step) -> bool {
@@ -1364,7 +1217,6 @@ fn append_step_profile(
     doc: &mut GeometryDocument,
     step: &Step,
     transform: Affine2,
-    kind: BoardProfileKind,
 ) -> ProfileRange {
     let start = doc.profiles.len() as u32;
     let Some(profile) = &step.profile else {
@@ -1379,15 +1231,14 @@ fn append_step_profile(
     let cutout_start = doc.profile_cutouts.len() as u32;
     for cutout in &profile.cutouts {
         let path = push_profile_polygon(doc, cutout, transform);
-        doc.profile_cutouts.push(BoardProfileCutout {
+        doc.profile_cutouts.push(StepProfileCutout {
             path,
             bbox: doc.paths[path as usize].bbox,
         });
     }
     let cutout_count = doc.profile_cutouts.len() as u32 - cutout_start;
     let bbox = doc.paths[outer_path as usize].bbox;
-    doc.profiles.push(BoardProfile {
-        kind,
+    doc.profiles.push(StepProfile {
         source_step_ref: step.name,
         transform,
         outer_path,
@@ -2939,18 +2790,20 @@ mod tests {
         assert_eq!(features[2].source.set_index, 2);
         assert_eq!(layer.bbox.min, Point::new(11.5, 4.5));
         assert_eq!(layer.bbox.max, Point::new(40.5, 23.5));
-        assert_eq!(doc.boards.len(), 1);
-        assert_eq!(doc.panels.len(), 1);
-        assert_eq!(doc.board_instances.len(), 2);
-        assert_eq!(doc.boards[0].bbox.min, Point::new(0.0, 0.0));
-        assert_eq!(doc.boards[0].bbox.max, Point::new(10.0, 5.0));
-        assert_eq!(doc.panels[0].profile_bbox.min, Point::new(0.0, 0.0));
-        assert_eq!(doc.panels[0].profile_bbox.max, Point::new(100.0, 80.0));
-        assert_eq!(doc.panels[0].board_instance_count, 2);
-        assert_eq!(doc.board_instances[0].bbox.min, Point::new(10.0, 20.0));
-        assert_eq!(doc.board_instances[0].bbox.max, Point::new(20.0, 25.0));
-        assert_eq!(doc.board_instances[1].bbox.min, Point::new(25.0, 20.0));
-        assert_eq!(doc.board_instances[1].bbox.max, Point::new(35.0, 25.0));
+        assert_eq!(board_step_count(&doc), 1);
+        assert_eq!(panel_step_count(&doc), 1);
+        assert_eq!(board_instance_count(&doc), 2);
+        assert_eq!(board_bbox(&doc).unwrap().min, Point::new(0.0, 0.0));
+        assert_eq!(board_bbox(&doc).unwrap().max, Point::new(10.0, 5.0));
+        assert_eq!(panel_profile_bbox(&doc).unwrap().min, Point::new(0.0, 0.0));
+        assert_eq!(
+            panel_profile_bbox(&doc).unwrap().max,
+            Point::new(100.0, 80.0)
+        );
+        assert_eq!(doc.layout.instances[0].bbox.min, Point::new(10.0, 20.0));
+        assert_eq!(doc.layout.instances[0].bbox.max, Point::new(20.0, 25.0));
+        assert_eq!(doc.layout.instances[1].bbox.min, Point::new(25.0, 20.0));
+        assert_eq!(doc.layout.instances[1].bbox.max, Point::new(35.0, 25.0));
         assert_eq!(doc.layout.steps.len(), 2);
         assert_eq!(doc.layout.repeats.len(), 1);
         assert_eq!(doc.layout.instances.len(), 2);
@@ -2985,7 +2838,7 @@ mod tests {
         assert_eq!(doc.layout.steps.len(), 2);
         assert_eq!(doc.layout.repeats.len(), 1);
         assert_eq!(doc.layout.instances.len(), 2);
-        assert_eq!(doc.board_instances.len(), 2);
+        assert_eq!(board_instance_count(&doc), 2);
     }
 
     #[test]
@@ -3008,8 +2861,8 @@ mod tests {
         assert_eq!(doc.layout.steps.len(), 1);
         assert!(doc.layout.repeats.is_empty());
         assert!(doc.layout.instances.is_empty());
-        assert!(doc.board_instances.is_empty());
-        assert_eq!(doc.panels[0].board_instance_count, 0);
+        assert_eq!(board_instance_count(&doc), 0);
+        assert_eq!(panel_step_count(&doc), 1);
     }
 
     #[test]
@@ -3023,8 +2876,8 @@ mod tests {
         assert_eq!(doc.layout.steps.len(), 2);
         assert_eq!(doc.layout.repeats.len(), 1);
         assert_eq!(doc.layout.instances.len(), 2);
-        assert_eq!(doc.panels.len(), 1);
-        assert_eq!(doc.board_instances.len(), 2);
+        assert_eq!(panel_step_count(&doc), 1);
+        assert_eq!(board_instance_count(&doc), 2);
     }
 
     #[test]
@@ -3036,7 +2889,7 @@ mod tests {
         assert_eq!(doc.layout.steps.len(), 3);
         assert_eq!(doc.layout.repeats.len(), 3);
         assert_eq!(doc.layout.instances.len(), 6);
-        assert_eq!(doc.board_instances.len(), 4);
+        assert_eq!(board_instance_count(&doc), 4);
         assert_eq!(doc.layout.repeats[0].instance_start, 0);
         assert_eq!(doc.layout.repeats[0].instance_count, 2);
         assert_eq!(doc.layout.repeats[1].instance_start, 2);
@@ -3093,14 +2946,13 @@ mod tests {
 
         assert_eq!(doc.profiles.len(), 1);
         assert_eq!(doc.profile_cutouts.len(), 1);
-        assert_eq!(doc.boards.len(), 1);
-        assert!(doc.panels.is_empty());
-        assert!(doc.board_instances.is_empty());
-        assert_eq!(doc.profiles[0].kind, BoardProfileKind::BoardDefinition);
-        assert_eq!(doc.boards[0].profile_start, 0);
-        assert_eq!(doc.boards[0].profile_count, 1);
-        assert_eq!(doc.boards[0].bbox.min, Point::new(0.0, 0.0));
-        assert_eq!(doc.boards[0].bbox.max, Point::new(20.0, 10.0));
+        assert_eq!(board_step_count(&doc), 1);
+        assert_eq!(panel_step_count(&doc), 0);
+        assert_eq!(board_instance_count(&doc), 0);
+        assert_eq!(doc.layout.steps[0].profile_start, 0);
+        assert_eq!(doc.layout.steps[0].profile_count, 1);
+        assert_eq!(board_bbox(&doc).unwrap().min, Point::new(0.0, 0.0));
+        assert_eq!(board_bbox(&doc).unwrap().max, Point::new(20.0, 10.0));
         assert_eq!(doc.profiles[0].bbox.min, Point::new(0.0, 0.0));
         assert_eq!(doc.profiles[0].bbox.max, Point::new(20.0, 10.0));
         assert!(doc.layers[0].bbox.is_empty());

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -8,6 +8,7 @@ use ipc2581::types::{
 };
 use ipc2581::{Ipc2581, Symbol};
 
+use crate::LayoutTarget;
 use crate::steps;
 use pcb_ir::common::*;
 use pcb_ir::dialects::ipc::*;
@@ -109,6 +110,53 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
     extract_layer_with_options(ipc, layer_name, &LayerExtractionOptions::default())
 }
 
+pub fn extract_layer_for_layout_target(
+    ipc: &Ipc2581,
+    layer_name: &str,
+    layout_target: LayoutTarget,
+) -> Result<GeometryDocument> {
+    let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
+    let layer = ecad
+        .cad_data
+        .layers
+        .iter()
+        .find(|layer| ipc.resolve(layer.name) == layer_name)
+        .with_context(|| format!("IPC-2581 layer '{layer_name}' was not found"))?;
+    let primary_step = steps::primary_step(ipc, &ecad.cad_data.steps)
+        .context("IPC-2581 ECAD section has no Step")?;
+
+    let step = match layout_target {
+        LayoutTarget::Board => canonical_board_step(ipc, &ecad.cad_data.steps, primary_step)?,
+        LayoutTarget::Panel | LayoutTarget::Layout => primary_step,
+    };
+
+    let mut doc = match layout_target {
+        LayoutTarget::Board => {
+            extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)?
+        }
+        LayoutTarget::Panel | LayoutTarget::Layout if is_panel_step(step) => extract_panel_layer(
+            ipc,
+            &ecad.cad_data.steps,
+            &ecad.cad_data.layers,
+            step,
+            layer,
+            layer_name,
+        )?,
+        LayoutTarget::Panel | LayoutTarget::Layout => {
+            extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)?
+        }
+    };
+
+    match layout_target {
+        LayoutTarget::Board => append_step_only_layout_geometry(&mut doc, step),
+        LayoutTarget::Panel | LayoutTarget::Layout => {
+            append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?
+        }
+    }
+    pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
+    Ok(doc)
+}
+
 pub fn extract_layer_with_options(
     ipc: &Ipc2581,
     layer_name: &str,
@@ -144,6 +192,67 @@ pub fn extract_layer_with_options(
     }
     pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
     Ok(doc)
+}
+
+fn canonical_board_step<'a>(
+    ipc: &Ipc2581,
+    steps: &'a [Step],
+    primary_step: &'a Step,
+) -> Result<&'a Step> {
+    if is_board_step(primary_step) {
+        return Ok(primary_step);
+    }
+
+    let mut stack = vec![primary_step.name];
+    if let Some(step) = first_reachable_board_step(ipc, steps, primary_step, &mut stack)? {
+        return Ok(step);
+    }
+
+    bail!(
+        "IPC-2581 primary step '{}' does not reference a board step",
+        ipc.resolve(primary_step.name)
+    )
+}
+
+fn first_reachable_board_step<'a>(
+    ipc: &Ipc2581,
+    steps: &'a [Step],
+    parent_step: &Step,
+    stack: &mut Vec<Symbol>,
+) -> Result<Option<&'a Step>> {
+    for repeat in &parent_step.step_repeats {
+        let source_step = steps
+            .iter()
+            .find(|step| step.name == repeat.step_ref)
+            .with_context(|| {
+                format!(
+                    "StepRepeat references unknown Step '{}'",
+                    ipc.resolve(repeat.step_ref)
+                )
+            })?;
+
+        if is_board_step(source_step) {
+            return Ok(Some(source_step));
+        }
+        if !is_panel_step(source_step) {
+            continue;
+        }
+        if stack.contains(&source_step.name) {
+            bail!(
+                "StepRepeat cycle references Step '{}'",
+                ipc.resolve(source_step.name)
+            );
+        }
+
+        stack.push(source_step.name);
+        let board_step = first_reachable_board_step(ipc, steps, source_step, stack)?;
+        stack.pop();
+        if board_step.is_some() {
+            return Ok(board_step);
+        }
+    }
+
+    Ok(None)
 }
 
 pub fn extract_layout(ipc: &Ipc2581) -> Result<GeometryDocument> {
@@ -2753,6 +2862,46 @@ mod tests {
         assert_eq!(doc.layout.instances[0].repeat_index_x, 0);
         assert_eq!(doc.layout.instances[1].repeat_index_x, 1);
         assert_eq!(doc.layout.instances[1].transform.m02, 25.0);
+    }
+
+    #[test]
+    fn extracts_layer_for_layout_target_board_or_panel() {
+        let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
+            .expect("synthetic panel fixture should parse");
+
+        let board = extract_layer_for_layout_target(&ipc, "TOP", LayoutTarget::Board)
+            .expect("board layer should extract");
+        let board_layer = &board.layers[0];
+        let board_features = &board.features[board_layer.feature_start as usize
+            ..(board_layer.feature_start + board_layer.feature_count) as usize];
+
+        assert_eq!(board_features.len(), 1);
+        assert_eq!(board_features[0].center, Point::new(2.0, 3.0));
+        assert_eq!(board.layout.steps.len(), 1);
+        assert_eq!(board.layout.root_step, Some(0));
+        assert_eq!(board.layout.steps[0].kind, LayoutStepKind::Board);
+        assert!(board.layout.instances.is_empty());
+        assert_eq!(
+            profile_occurrences_for(&board, ProfileSet::BoardOutlines).len(),
+            1
+        );
+
+        let panel = extract_layer_for_layout_target(&ipc, "TOP", LayoutTarget::Panel)
+            .expect("panel layer should extract");
+        let panel_layer = &panel.layers[0];
+        let panel_features = &panel.features[panel_layer.feature_start as usize
+            ..(panel_layer.feature_start + panel_layer.feature_count) as usize];
+
+        assert_eq!(panel_features.len(), 3);
+        assert_eq!(panel_features[0].center, Point::new(40.0, 5.0));
+        assert_eq!(panel_features[1].center, Point::new(12.0, 23.0));
+        assert_eq!(panel_features[2].center, Point::new(27.0, 23.0));
+        assert_eq!(panel.layout.steps.len(), 2);
+        assert_eq!(panel.layout.instances.len(), 2);
+        assert_eq!(
+            profile_occurrences_for(&panel, ProfileSet::FabricationOutlines).len(),
+            3
+        );
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -73,7 +73,6 @@ struct LayoutInstanceSpec {
     repeat_count_y: u32,
     repeat_pitch_x: f64,
     repeat_pitch_y: f64,
-    profiles: ProfileRange,
 }
 
 struct ExtractContext<'a> {
@@ -501,7 +500,7 @@ fn append_layout_geometry(
 
 fn append_step_only_layout_geometry(doc: &mut GeometryDocument, primary_step: &Step) {
     if is_panel_step(primary_step) {
-        let profiles = append_step_profile(doc, primary_step, Affine2::identity());
+        let profiles = append_step_profile(doc, primary_step);
         let step = push_or_update_layout_step(doc, primary_step, profiles);
         doc.layout.root_step = Some(step);
     } else if is_board_step(primary_step) {
@@ -515,7 +514,7 @@ fn append_panel_geometry(
     steps: &[Step],
     panel_step: &Step,
 ) -> Result<()> {
-    let panel_profiles = append_step_profile(doc, panel_step, Affine2::identity());
+    let panel_profiles = append_step_profile(doc, panel_step);
     let root_layout_step = push_or_update_layout_step(doc, panel_step, panel_profiles);
     doc.layout.root_step = Some(root_layout_step);
     let context = LayoutBuildContext { ipc, steps };
@@ -572,7 +571,6 @@ fn append_layout_repeats(
                 let transform = parent
                     .transform
                     .concat(step_repeat_transform(repeat, ix, iy));
-                let profiles = append_step_profile(doc, source_step, transform);
                 let layout_instance = push_layout_instance(
                     doc,
                     LayoutInstanceSpec {
@@ -588,7 +586,6 @@ fn append_layout_repeats(
                         repeat_count_y: repeat.ny,
                         repeat_pitch_x: repeat.dx,
                         repeat_pitch_y: repeat.dy,
-                        profiles,
                     },
                 );
                 if is_panel_step(source_step) {
@@ -627,7 +624,7 @@ fn ensure_layout_step_for_step(doc: &mut GeometryDocument, step: &Step) -> u32 {
         return index as u32;
     }
 
-    let profiles = append_step_profile(doc, step, Affine2::identity());
+    let profiles = append_step_profile(doc, step);
     push_or_update_layout_step(doc, step, profiles)
 }
 
@@ -717,9 +714,7 @@ fn push_layout_instance(doc: &mut GeometryDocument, spec: LayoutInstanceSpec) ->
         repeat_count_y: spec.repeat_count_y,
         repeat_pitch_x: spec.repeat_pitch_x,
         repeat_pitch_y: spec.repeat_pitch_y,
-        profile_start: spec.profiles.start,
-        profile_count: spec.profiles.count,
-        bbox: spec.profiles.bbox,
+        bbox: BBox::empty(),
     });
     instance_index
 }
@@ -1209,11 +1204,7 @@ fn extract_polygon(
     feature
 }
 
-fn append_step_profile(
-    doc: &mut GeometryDocument,
-    step: &Step,
-    transform: Affine2,
-) -> ProfileRange {
+fn append_step_profile(doc: &mut GeometryDocument, step: &Step) -> ProfileRange {
     let start = doc.profiles.len() as u32;
     let Some(profile) = &step.profile else {
         return ProfileRange {
@@ -1223,10 +1214,10 @@ fn append_step_profile(
         };
     };
 
-    let outer_path = push_profile_polygon(doc, &profile.polygon, transform);
+    let outer_path = push_profile_polygon(doc, &profile.polygon);
     let cutout_start = doc.profile_cutouts.len() as u32;
     for cutout in &profile.cutouts {
-        let path = push_profile_polygon(doc, cutout, transform);
+        let path = push_profile_polygon(doc, cutout);
         doc.profile_cutouts.push(StepProfileCutout {
             path,
             bbox: doc.paths[path as usize].bbox,
@@ -1247,12 +1238,8 @@ fn append_step_profile(
     }
 }
 
-fn push_profile_polygon(
-    doc: &mut GeometryDocument,
-    polygon: &ipc2581::types::Polygon,
-    transform: Affine2,
-) -> u32 {
-    let (bbox, cmds) = polygon_contour(polygon, transform);
+fn push_profile_polygon(doc: &mut GeometryDocument, polygon: &ipc2581::types::Polygon) -> u32 {
+    let (bbox, cmds) = polygon_contour(polygon, Affine2::identity());
     doc.push_path(GeometryPath::unpainted(bbox), cmds)
 }
 
@@ -2279,48 +2266,7 @@ fn transform_path_cmds(
     cmds: impl IntoIterator<Item = PathCmd>,
     transform: Affine2,
 ) -> (BBox, Vec<PathCmd>) {
-    let mut bbox = BBox::empty();
-    let mut current = Point::default();
-    let mut transformed_cmds = Vec::new();
-
-    for cmd in cmds {
-        let start = current;
-        let mut transformed = cmd;
-        transformed.p0 = transform.transform_point(cmd.p0);
-        transformed.p1 = transform.transform_point(cmd.p1);
-        if cmd.op != PathOp::ArcTo {
-            transformed.p2 = transform.transform_point(cmd.p2);
-        } else if transform.determinant() < 0.0 {
-            transformed.clockwise = !cmd.clockwise;
-        }
-
-        match cmd.op {
-            PathOp::MoveTo | PathOp::LineTo => {
-                current = cmd.p0;
-                bbox.include_point(transformed.p0);
-            }
-            PathOp::ArcTo => {
-                bbox.include_circular_arc(
-                    transform.transform_point(start),
-                    transformed.p0,
-                    transformed.p1,
-                    transformed.clockwise,
-                );
-                current = cmd.p0;
-            }
-            PathOp::CubicTo => {
-                bbox.include_point(transformed.p0);
-                bbox.include_point(transformed.p1);
-                bbox.include_point(transformed.p2);
-                current = cmd.p2;
-            }
-            PathOp::Close => {}
-        }
-
-        transformed_cmds.push(transformed);
-    }
-
-    (bbox, transformed_cmds)
+    pcb_ir::dialects::path::transform_cmds(cmds, transform)
 }
 
 fn push_donut_path(
@@ -2877,7 +2823,38 @@ mod tests {
         let ipc = ipc2581::Ipc2581::parse(nested_panel_fixture())
             .expect("synthetic nested panel fixture should parse");
         let doc = extract_layout(&ipc).expect("layout should extract");
+        let fabrication_profiles = profile_occurrences_for(&doc, ProfileSet::FabricationOutlines);
+        let layout_boundaries = profile_occurrences_for(&doc, ProfileSet::LayoutBoundaries);
 
+        assert_eq!(doc.profiles.len(), 3);
+        assert_eq!(fabrication_profiles.len(), 5);
+        assert_eq!(layout_boundaries.len(), 7);
+        assert_eq!(
+            fabrication_profiles
+                .iter()
+                .filter(|profile| profile.role == ProfileOccurrenceRole::RootPanel)
+                .count(),
+            1
+        );
+        assert_eq!(
+            fabrication_profiles
+                .iter()
+                .filter(|profile| profile.role == ProfileOccurrenceRole::BoardInstance)
+                .count(),
+            4
+        );
+        assert!(
+            fabrication_profiles
+                .iter()
+                .all(|profile| profile.role != ProfileOccurrenceRole::PanelInstance)
+        );
+        assert_eq!(
+            layout_boundaries
+                .iter()
+                .filter(|profile| profile.role == ProfileOccurrenceRole::PanelInstance)
+                .count(),
+            2
+        );
         assert_eq!(doc.layout.steps.len(), 3);
         assert_eq!(doc.layout.repeats.len(), 3);
         assert_eq!(doc.layout.instances.len(), 6);

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -106,6 +106,136 @@ enum PrimitivePaint {
     Void,
 }
 
+fn populate_ipc_specs(doc: &mut GeometryDocument, ipc: &Ipc2581) {
+    let Some(ecad) = ipc.ecad() else {
+        return;
+    };
+
+    doc.specs.clear();
+    doc.spec_items.clear();
+    doc.spec_properties.clear();
+
+    let mut specs = ecad.cad_header.specs.values().collect::<Vec<_>>();
+    specs.sort_by(|left, right| ipc.resolve(left.name).cmp(ipc.resolve(right.name)));
+
+    for spec in specs {
+        let item_start = doc.spec_items.len() as u32;
+        for item in &spec.items {
+            let property_start = doc.spec_properties.len() as u32;
+            doc.spec_properties
+                .extend(item.properties.iter().map(|property| IpcSpecProperty {
+                    value: property.value,
+                    text: property.text,
+                    unit: property.unit,
+                    plus_tol: property.plus_tol,
+                    minus_tol: property.minus_tol,
+                    tol_percent: property.tol_percent,
+                }));
+            doc.spec_items.push(IpcSpecItem {
+                element: item.element,
+                kind: map_spec_item_kind(item.kind),
+                item_type: item.item_type,
+                comment: item.comment,
+                property_start,
+                property_count: doc.spec_properties.len() as u32 - property_start,
+            });
+        }
+        doc.specs.push(IpcSpec {
+            name: spec.name,
+            item_start,
+            item_count: doc.spec_items.len() as u32 - item_start,
+        });
+    }
+}
+
+fn map_spec_item_kind(kind: ipc2581::types::ecad::SpecItemKind) -> IpcSpecItemKind {
+    match kind {
+        ipc2581::types::ecad::SpecItemKind::General => IpcSpecItemKind::General,
+        ipc2581::types::ecad::SpecItemKind::Dielectric => IpcSpecItemKind::Dielectric,
+        ipc2581::types::ecad::SpecItemKind::Conductor => IpcSpecItemKind::Conductor,
+        ipc2581::types::ecad::SpecItemKind::SurfaceFinish => IpcSpecItemKind::SurfaceFinish,
+        ipc2581::types::ecad::SpecItemKind::VCut => IpcSpecItemKind::VCut,
+        ipc2581::types::ecad::SpecItemKind::Other => IpcSpecItemKind::Other,
+    }
+}
+
+fn push_spec_refs(doc: &mut GeometryDocument, spec_refs: &[Symbol]) -> (u32, u32) {
+    let start = doc.spec_refs.len() as u32;
+    doc.spec_refs
+        .extend(spec_refs.iter().copied().map(|spec| IpcSpecRef { spec }));
+    (start, doc.spec_refs.len() as u32 - start)
+}
+
+fn push_feature_set_record(
+    doc: &mut GeometryDocument,
+    layer: u32,
+    source_set_index: u32,
+    set: &ipc2581::types::FeatureSet,
+    polarity: GeometryPolarity,
+) -> u32 {
+    let (spec_ref_start, spec_ref_count) = push_spec_refs(doc, &set.spec_refs);
+    let set_id = doc.feature_sets.len() as u32;
+    doc.feature_sets.push(GeometryFeatureSet {
+        layer,
+        source_set_index,
+        net: set.net,
+        polarity,
+        spec_ref_start,
+        spec_ref_count,
+        feature_start: doc.features.len() as u32,
+        feature_count: 0,
+        bbox: BBox::empty(),
+    });
+    set_id
+}
+
+fn push_extracted_feature(
+    doc: &mut GeometryDocument,
+    set_id: u32,
+    source_layer_ref: Symbol,
+    mut feature: GeometryFeature,
+    layer_bbox: &mut BBox,
+) {
+    feature.source_layer_ref = Some(source_layer_ref);
+    feature.set = Some(set_id);
+    let bbox = feature.bbox;
+    *layer_bbox = layer_bbox.union(bbox);
+    let set = &mut doc.feature_sets[set_id as usize];
+    set.bbox = set.bbox.union(bbox);
+    set.feature_count += 1;
+    doc.features.push(feature);
+}
+
+fn semantic_for_feature(
+    layer_function: LayerFunction,
+    feature: &GeometryFeature,
+) -> FeatureSemantic {
+    if matches!(feature.semantic, FeatureSemantic::Fiducial(_)) {
+        return feature.semantic;
+    }
+
+    match layer_function {
+        LayerFunction::VCut => FeatureSemantic::VCut,
+        LayerFunction::Score => FeatureSemantic::Score,
+        LayerFunction::Rout => FeatureSemantic::Route,
+        LayerFunction::BoardOutline => FeatureSemantic::BoardOutline,
+        _ => semantic_for_bucket(feature.bucket),
+    }
+}
+
+fn semantic_for_bucket(bucket: FeatureBucket) -> FeatureSemantic {
+    match bucket {
+        FeatureBucket::Smd => FeatureSemantic::SmdPad,
+        FeatureBucket::Pth => FeatureSemantic::ComponentPad,
+        FeatureBucket::Via => FeatureSemantic::ViaPad,
+        FeatureBucket::Trace | FeatureBucket::Fill => FeatureSemantic::CopperConductor,
+        FeatureBucket::Fiducial
+        | FeatureBucket::Cutout
+        | FeatureBucket::Thermal
+        | FeatureBucket::Antipad => FeatureSemantic::Other,
+    }
+}
+
 pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument> {
     extract_layer_with_options(ipc, layer_name, &LayerExtractionOptions::default())
 }
@@ -153,6 +283,7 @@ pub fn extract_layer_for_layout_target(
             append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?
         }
     }
+    populate_ipc_specs(&mut doc, ipc);
     pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
     Ok(doc)
 }
@@ -190,6 +321,7 @@ pub fn extract_layer_with_options(
             append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?
         }
     }
+    populate_ipc_specs(&mut doc, ipc);
     pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
     Ok(doc)
 }
@@ -261,6 +393,7 @@ pub fn extract_layout(ipc: &Ipc2581) -> Result<GeometryDocument> {
         .context("IPC-2581 ECAD section has no Step")?;
     let mut doc = GeometryDocument::new();
     append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?;
+    populate_ipc_specs(&mut doc, ipc);
     pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
     Ok(doc)
 }
@@ -275,6 +408,7 @@ fn extract_panel_layer(
 ) -> Result<GeometryDocument> {
     let mut doc = GeometryDocument::new();
     let feature_start = doc.features.len() as u32;
+    let set_start = doc.feature_sets.len() as u32;
     let mut layer_bbox = BBox::empty();
     let mut append_state = LayerAppendState::default();
 
@@ -315,10 +449,16 @@ fn extract_panel_layer(
     }
 
     let feature_count = doc.features.len() as u32 - feature_start;
+    let set_count = doc.feature_sets.len() as u32 - set_start;
+    let (spec_ref_start, spec_ref_count) = push_spec_refs(&mut doc, &layer.spec_refs);
     doc.layers.push(GeometryLayer {
         name: layer_name.to_string(),
         source_layer_ref: layer.name,
         layer_function: layer.layer_function,
+        spec_ref_start,
+        spec_ref_count,
+        set_start,
+        set_count,
         feature_start,
         feature_count,
         bbox: layer_bbox,
@@ -364,6 +504,22 @@ fn extract_step_layer(
 
     let mut doc = GeometryDocument::new();
     let feature_start = doc.features.len() as u32;
+    let set_start = doc.feature_sets.len() as u32;
+    let (spec_ref_start, spec_ref_count) = push_spec_refs(&mut doc, &layer.spec_refs);
+    let layer_index = doc.layers.len() as u32;
+    doc.layers.push(GeometryLayer {
+        name: layer_name.to_string(),
+        source_layer_ref: layer.name,
+        layer_function: layer.layer_function,
+        spec_ref_start,
+        spec_ref_count,
+        set_start,
+        set_count: 0,
+        feature_start,
+        feature_count: 0,
+        bbox: BBox::empty(),
+    });
+
     let mut layer_bbox = BBox::empty();
     let layer_polarity = map_polarity(layer.polarity.unwrap_or(Polarity::Positive));
 
@@ -374,6 +530,8 @@ fn extract_step_layer(
     {
         for (set_index, set) in layer_feature.sets.iter().enumerate() {
             let polarity = set.polarity.map(map_polarity).unwrap_or(layer_polarity);
+            let set_id =
+                push_feature_set_record(&mut doc, layer_index, set_index as u32, set, polarity);
 
             for (feature_index, set_feature) in set.features.iter().enumerate() {
                 let source = SourceRef {
@@ -384,6 +542,9 @@ fn extract_step_layer(
                     SetFeature::Pad(pad) => extract_pad(
                         &context, layer.name, set.net, polarity, source, pad, &mut doc,
                     )?,
+                    SetFeature::Fiducial(fiducial) => {
+                        extract_fiducial(&context, set.net, polarity, source, fiducial, &mut doc)?
+                    }
                     SetFeature::Trace(trace) => {
                         extract_trace(&context, set.net, polarity, source, trace, &mut doc)
                     }
@@ -421,9 +582,14 @@ fn extract_step_layer(
                 };
 
                 if let Some(mut feature) = feature {
-                    feature.source_layer_ref = Some(layer_feature.layer_ref);
-                    layer_bbox = layer_bbox.union(feature.bbox);
-                    doc.features.push(feature);
+                    feature.semantic = semantic_for_feature(layer.layer_function, &feature);
+                    push_extracted_feature(
+                        &mut doc,
+                        set_id,
+                        layer_feature.layer_ref,
+                        feature,
+                        &mut layer_bbox,
+                    );
                 }
             }
         }
@@ -437,13 +603,16 @@ fn extract_step_layer(
             continue;
         };
         let is_drill_layer = source_layer.layer_function == LayerFunction::Drill;
-        let is_routing_layer = source_layer.layer_function == LayerFunction::Rout;
+        let is_fabrication_layer = source_layer.layer_function.is_fabrication();
 
         for (set_index, set) in layer_feature.sets.iter().enumerate() {
+            let polarity = set.polarity.map(map_polarity).unwrap_or(layer_polarity);
+            let mut emitted = Vec::new();
+
             if is_drill_layer && layer_span_applies_to_layer(source_layer, layer, layers) {
                 for (feature_index, set_feature) in set.features.iter().enumerate() {
                     if let SetFeature::Hole(hole) = set_feature {
-                        let mut feature = extract_hole(
+                        let feature = extract_hole(
                             SourceRef {
                                 set_index: set_index as u32,
                                 feature_index: feature_index as u32,
@@ -451,19 +620,17 @@ fn extract_step_layer(
                             hole,
                             &mut doc,
                         );
-                        feature.source_layer_ref = Some(layer_feature.layer_ref);
-                        layer_bbox = layer_bbox.union(feature.bbox);
-                        doc.features.push(feature);
+                        emitted.push(feature);
                     }
                 }
             }
 
-            if is_drill_layer || is_routing_layer {
+            if is_fabrication_layer {
                 for (feature_index, set_feature) in set.features.iter().enumerate() {
                     if let SetFeature::Slot(slot) = set_feature
                         && slot_applies_to_layer(source_layer, layer, layers, slot)
                     {
-                        let mut feature = extract_slot(
+                        let feature = extract_slot(
                             &context,
                             SourceRef {
                                 set_index: set_index as u32,
@@ -472,24 +639,32 @@ fn extract_step_layer(
                             slot,
                             &mut doc,
                         )?;
-                        feature.source_layer_ref = Some(layer_feature.layer_ref);
-                        layer_bbox = layer_bbox.union(feature.bbox);
-                        doc.features.push(feature);
+                        emitted.push(feature);
                     }
+                }
+            }
+
+            if !emitted.is_empty() {
+                let set_id =
+                    push_feature_set_record(&mut doc, layer_index, set_index as u32, set, polarity);
+                for mut feature in emitted {
+                    feature.semantic = semantic_for_feature(source_layer.layer_function, &feature);
+                    push_extracted_feature(
+                        &mut doc,
+                        set_id,
+                        layer_feature.layer_ref,
+                        feature,
+                        &mut layer_bbox,
+                    );
                 }
             }
         }
     }
 
-    let feature_count = doc.features.len() as u32 - feature_start;
-    doc.layers.push(GeometryLayer {
-        name: layer_name.to_string(),
-        source_layer_ref: layer.name,
-        layer_function: layer.layer_function,
-        feature_start,
-        feature_count,
-        bbox: layer_bbox,
-    });
+    let layer = &mut doc.layers[layer_index as usize];
+    layer.feature_count = doc.features.len() as u32 - feature_start;
+    layer.set_count = doc.feature_sets.len() as u32 - set_start;
+    layer.bbox = layer_bbox;
 
     Ok(doc)
 }
@@ -534,23 +709,16 @@ impl LayerAppendState {
 fn source_layer_set_span(source: &GeometryDocument, layer_index: usize) -> Result<u32> {
     let layer = &source.layers[layer_index];
     let mut span = 0;
-    for feature in source_layer_features(source, layer) {
-        let set_end = feature
-            .source
-            .set_index
+    for set in
+        &source.feature_sets[layer.set_start as usize..(layer.set_start + layer.set_count) as usize]
+    {
+        let set_end = set
+            .source_set_index
             .checked_add(1)
             .context("Source feature set index overflow")?;
         span = span.max(set_end);
     }
     Ok(span)
-}
-
-fn source_layer_features<'a>(
-    source: &'a GeometryDocument,
-    layer: &GeometryLayer,
-) -> &'a [GeometryFeature] {
-    &source.features
-        [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
 }
 
 fn append_transformed_layer(
@@ -563,29 +731,71 @@ fn append_transformed_layer(
     let layer = &source.layers[layer_index];
     let mut layer_bbox = BBox::empty();
 
-    for feature in source_layer_features(source, layer) {
-        let path_start = target.paths.len() as u32;
-        for path in &source.paths
-            [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
-        {
-            append_transformed_path(target, source, path, transform);
-        }
-        let path_count = target.paths.len() as u32 - path_start;
-        let bbox = paths_bbox(target, path_start, path_count);
+    for source_set_index in layer.set_start..layer.set_start + layer.set_count {
+        let source_set = &source.feature_sets[source_set_index as usize];
+        let spec_ref_start = target.spec_refs.len() as u32;
+        target.spec_refs.extend(
+            source.spec_refs[source_set.spec_ref_start as usize
+                ..(source_set.spec_ref_start + source_set.spec_ref_count) as usize]
+                .iter()
+                .cloned(),
+        );
+        let target_set = target.feature_sets.len() as u32;
+        target.feature_sets.push(GeometryFeatureSet {
+            layer: 0,
+            source_set_index: source_set
+                .source_set_index
+                .checked_add(source_set_offset)
+                .context("Panel source feature set index overflow")?,
+            net: source_set.net,
+            polarity: source_set.polarity,
+            spec_ref_start,
+            spec_ref_count: target.spec_refs.len() as u32 - spec_ref_start,
+            feature_start: target.features.len() as u32,
+            feature_count: 0,
+            bbox: BBox::empty(),
+        });
 
-        let mut feature = feature.clone();
-        feature.transform = transform.concat(feature.transform);
-        feature.bbox = bbox;
-        feature.path_start = path_start;
-        feature.path_count = path_count;
-        feature.center = transform.transform_point(feature.center);
-        feature.source.set_index = feature
-            .source
-            .set_index
-            .checked_add(source_set_offset)
-            .context("Panel source feature set index overflow")?;
-        target.features.push(feature);
-        layer_bbox = layer_bbox.union(bbox);
+        for feature in &source.features[source_set.feature_start as usize
+            ..(source_set.feature_start + source_set.feature_count) as usize]
+        {
+            let path_start = target.paths.len() as u32;
+            for path in &source.paths
+                [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
+            {
+                append_transformed_path(target, source, path, transform);
+            }
+            let path_count = target.paths.len() as u32 - path_start;
+            let bbox = paths_bbox(target, path_start, path_count);
+
+            let mut feature = feature.clone();
+            feature.transform = transform.concat(feature.transform);
+            feature.bbox = bbox;
+            feature.path_start = path_start;
+            feature.path_count = path_count;
+            feature.center = transform.transform_point(feature.center);
+            feature.set = Some(target_set);
+            feature.source.set_index = feature
+                .source
+                .set_index
+                .checked_add(source_set_offset)
+                .context("Panel source feature set index overflow")?;
+            if feature.pin_ref_count > 0 {
+                let pin_ref_start = target.pin_refs.len() as u32;
+                target.pin_refs.extend(
+                    source.pin_refs[feature.pin_ref_start as usize
+                        ..(feature.pin_ref_start + feature.pin_ref_count) as usize]
+                        .iter()
+                        .cloned(),
+                );
+                feature.pin_ref_start = pin_ref_start;
+            }
+            target.features.push(feature);
+            let target_set_record = &mut target.feature_sets[target_set as usize];
+            target_set_record.feature_count += 1;
+            target_set_record.bbox = target_set_record.bbox.union(bbox);
+            layer_bbox = layer_bbox.union(bbox);
+        }
     }
 
     Ok(layer_bbox)
@@ -1152,6 +1362,101 @@ fn extract_feature_primitive(
     feature.path_count = path_count;
     feature.flags.lowered_to_paths = true;
     Ok(Some(feature))
+}
+
+fn extract_fiducial(
+    context: &ExtractContext<'_>,
+    net: Option<Symbol>,
+    polarity: GeometryPolarity,
+    source: SourceRef,
+    fiducial: &ipc2581::types::ecad::Fiducial,
+    doc: &mut GeometryDocument,
+) -> Result<Option<GeometryFeature>> {
+    let xform = fiducial.xform.unwrap_or_default();
+    let offset = Affine2::transform_vector(
+        xform.rotation,
+        xform.mirror,
+        xform.scale,
+        Point::new(xform.x_offset, xform.y_offset),
+    );
+    let center = Point::new(
+        fiducial.location.x + offset.x,
+        fiducial.location.y + offset.y,
+    );
+    let transform = Affine2::placement(center, xform.rotation, xform.mirror, xform.scale);
+
+    let path_start = doc.paths.len() as u32;
+    let (paint, primitive_ref) = match &fiducial.shape {
+        ipc2581::types::ecad::FiducialShape::Primitive(primitive) => (
+            lower_standard_primitive(context, doc, primitive, transform, FeatureBucket::Fiducial)?,
+            None,
+        ),
+        ipc2581::types::ecad::FiducialShape::StandardPrimitiveRef(primitive_ref) => {
+            let Some(primitive) = context.standard_primitives.get(primitive_ref).copied() else {
+                doc.warn(format!(
+                    "Skipping fiducial because standard primitive '{}' is missing",
+                    context.ipc.resolve(*primitive_ref)
+                ));
+                return Ok(None);
+            };
+            (
+                lower_standard_primitive(
+                    context,
+                    doc,
+                    primitive,
+                    transform,
+                    FeatureBucket::Fiducial,
+                )?,
+                Some(*primitive_ref),
+            )
+        }
+    };
+
+    let path_count = doc.paths.len() as u32 - path_start;
+    if path_count == 0 {
+        return Ok(None);
+    }
+
+    let mut feature = GeometryFeature::new(
+        FeatureKind::Primitive,
+        FeatureBucket::Fiducial,
+        if paint == PrimitivePaint::Void {
+            GeometryPolarity::Negative
+        } else {
+            polarity
+        },
+    );
+    feature.net = net;
+    feature.source = source;
+    feature.semantic = FeatureSemantic::Fiducial(map_fiducial_kind(fiducial.kind));
+    feature.transform = transform;
+    feature.bbox = paths_bbox(doc, path_start, path_count);
+    feature.path_start = path_start;
+    feature.path_count = path_count;
+    feature.center = center;
+    feature.rotation_degrees = xform.rotation;
+    feature.scale = xform.scale;
+    feature.primitive_ref = primitive_ref;
+    feature.flags.lowered_to_paths = true;
+    if let Some(pin_ref) = &fiducial.pin_ref {
+        feature.pin_ref_start = doc.pin_refs.len() as u32;
+        doc.pin_refs.push(IpcPinRef {
+            component_ref: pin_ref.component_ref,
+            pin: pin_ref.pin,
+            title: pin_ref.title,
+        });
+        feature.pin_ref_count = 1;
+    }
+    Ok(Some(feature))
+}
+
+fn map_fiducial_kind(kind: ipc2581::types::ecad::FiducialKind) -> FiducialKind {
+    match kind {
+        ipc2581::types::ecad::FiducialKind::BadBoardMark => FiducialKind::BadBoard,
+        ipc2581::types::ecad::FiducialKind::Global => FiducialKind::Global,
+        ipc2581::types::ecad::FiducialKind::GoodPanelMark => FiducialKind::GoodPanel,
+        ipc2581::types::ecad::FiducialKind::Local => FiducialKind::Local,
+    }
 }
 
 fn extract_trace(
@@ -2545,6 +2850,79 @@ mod tests {
     use super::*;
 
     #[test]
+    fn carries_spec_refs_fiducials_and_vcut_semantics() {
+        let ipc = Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="Panel"/>
+    <LayerRef name="TOP"/>
+    <LayerRef name="VCUT"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER">
+      <Spec name="VCut_1">
+        <V_Cut type="ANGLE">
+          <Property value="90" unit="DEGREES"/>
+        </V_Cut>
+      </Spec>
+    </CadHeader>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE">
+        <SpecRef id="VCut_1"/>
+      </Layer>
+      <Layer name="VCUT" layerFunction="V_CUT" side="ALL" polarity="POSITIVE">
+        <SpecRef id="VCut_1"/>
+      </Layer>
+      <Step name="Panel" type="PALLET">
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <SpecRef id="VCut_1"/>
+            <GlobalFiducial>
+              <Location x="1" y="2"/>
+              <Circle diameter="1"/>
+              <PinRef componentRef="U1" pin="1"/>
+            </GlobalFiducial>
+          </Set>
+        </LayerFeature>
+        <LayerFeature layerRef="VCUT">
+          <Set>
+            <SpecRef id="VCut_1"/>
+            <Features>
+              <Line startX="0" startY="5" endX="10" endY="5">
+                <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
+              </Line>
+            </Features>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+
+        let top = extract_layer_for_layout_target(&ipc, "TOP", LayoutTarget::Panel).unwrap();
+        assert_eq!(top.specs.len(), 1);
+        assert_eq!(top.layers[0].spec_ref_count, 1);
+        assert_eq!(top.feature_sets.len(), 1);
+        assert_eq!(top.feature_sets[0].spec_ref_count, 1);
+        assert_eq!(top.features[0].bucket, FeatureBucket::Fiducial);
+        assert_eq!(
+            top.features[0].semantic,
+            FeatureSemantic::Fiducial(FiducialKind::Global)
+        );
+        assert_eq!(top.features[0].pin_ref_count, 1);
+        assert_eq!(ipc.resolve(top.pin_refs[0].pin), "1");
+
+        let vcut = extract_layer_for_layout_target(&ipc, "VCUT", LayoutTarget::Panel).unwrap();
+        assert_eq!(vcut.layers[0].spec_ref_count, 1);
+        assert_eq!(vcut.feature_sets[0].spec_ref_count, 1);
+        assert_eq!(vcut.features[0].semantic, FeatureSemantic::VCut);
+    }
+
+    #[test]
     fn lowers_moire_as_rings_and_crosshair() {
         let mut doc = GeometryDocument::new();
 
@@ -3162,6 +3540,7 @@ mod tests {
             side: None,
             polarity: None,
             span,
+            spec_refs: Vec::new(),
             profile: None,
         }
     }

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -16,6 +16,29 @@ type GeometryDocument = pcb_ir::dialects::ipc::GeometryDocument<Symbol, LayerFun
 type GeometryLayer = pcb_ir::dialects::ipc::GeometryLayer<Symbol, LayerFunction>;
 type GeometryFeature = pcb_ir::dialects::ipc::GeometryFeature<Symbol>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlacementPolicy {
+    /// Extract only the primary step's own layer features and profile.
+    StepOnly,
+    /// Extract the primary step's own layer features and carry the panel graph sidecar.
+    PanelSymbolic,
+    /// Extract panel-local features and materialize repeated child step features.
+    PanelFlattened,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LayerExtractionOptions {
+    pub placement: PlacementPolicy,
+}
+
+impl Default for LayerExtractionOptions {
+    fn default() -> Self {
+        Self {
+            placement: PlacementPolicy::PanelFlattened,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ProfileRange {
     start: u32,
@@ -54,6 +77,14 @@ enum PrimitivePaint {
 }
 
 pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument> {
+    extract_layer_with_options(ipc, layer_name, &LayerExtractionOptions::default())
+}
+
+pub fn extract_layer_with_options(
+    ipc: &Ipc2581,
+    layer_name: &str,
+    options: &LayerExtractionOptions,
+) -> Result<GeometryDocument> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let layer = ecad
         .cad_data
@@ -64,25 +95,29 @@ pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument
     let step = steps::primary_step(ipc, &ecad.cad_data.steps)
         .context("IPC-2581 ECAD section has no Step")?;
 
-    let mut doc = if is_panel_step(step) {
-        extract_panel_layer(
+    let mut doc = match (is_panel_step(step), options.placement) {
+        (true, PlacementPolicy::PanelFlattened) => extract_panel_layer(
             ipc,
             &ecad.cad_data.steps,
             &ecad.cad_data.layers,
             step,
             layer,
             layer_name,
-        )?
-    } else {
-        extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)?
+        )?,
+        _ => extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)?,
     };
 
-    append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?;
+    match options.placement {
+        PlacementPolicy::StepOnly => append_step_only_layout_geometry(&mut doc, step),
+        PlacementPolicy::PanelSymbolic | PlacementPolicy::PanelFlattened => {
+            append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?
+        }
+    }
     pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
     Ok(doc)
 }
 
-pub fn extract_profiles(ipc: &Ipc2581) -> Result<GeometryDocument> {
+pub fn extract_layout(ipc: &Ipc2581) -> Result<GeometryDocument> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let step = steps::primary_step(ipc, &ecad.cad_data.steps)
         .context("IPC-2581 ECAD section has no Step")?;
@@ -90,6 +125,10 @@ pub fn extract_profiles(ipc: &Ipc2581) -> Result<GeometryDocument> {
     append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?;
     pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
     Ok(doc)
+}
+
+pub fn extract_profiles(ipc: &Ipc2581) -> Result<GeometryDocument> {
+    extract_layout(ipc)
 }
 
 fn extract_panel_layer(
@@ -427,10 +466,35 @@ fn append_layout_geometry(
     if is_panel_step(primary_step) {
         append_panel_geometry(doc, ipc, steps, primary_step)
     } else if is_board_step(primary_step) {
-        ensure_board_geometry(doc, primary_step);
+        doc.layout.root_step = Some(ensure_layout_step_for_step(doc, primary_step));
         Ok(())
     } else {
         Ok(())
+    }
+}
+
+fn append_step_only_layout_geometry(doc: &mut GeometryDocument, primary_step: &Step) {
+    if is_panel_step(primary_step) {
+        let profiles = append_step_profile(
+            doc,
+            primary_step,
+            Affine2::identity(),
+            BoardProfileKind::PanelDefinition,
+        );
+        let step = push_or_update_layout_step(doc, primary_step, profiles);
+        doc.layout.root_step = Some(step);
+        doc.panels.push(PanelGeometry {
+            step_ref: primary_step.name,
+            profile_start: profiles.start,
+            profile_count: profiles.count,
+            profile_bbox: profiles.bbox,
+            board_instance_start: doc.board_instances.len() as u32,
+            board_instance_count: 0,
+            instance_bbox: BBox::empty(),
+            bbox: profiles.bbox,
+        });
+    } else if is_board_step(primary_step) {
+        doc.layout.root_step = Some(ensure_layout_step_for_step(doc, primary_step));
     }
 }
 
@@ -446,6 +510,8 @@ fn append_panel_geometry(
         Affine2::identity(),
         BoardProfileKind::PanelDefinition,
     );
+    let root_layout_step = push_or_update_layout_step(doc, panel_step, panel_profiles);
+    doc.layout.root_step = Some(root_layout_step);
     let board_instance_start = doc.board_instances.len() as u32;
     let mut stack = vec![panel_step.name];
     append_board_instances_from_repeats(
@@ -455,6 +521,8 @@ fn append_panel_geometry(
         panel_step,
         Affine2::identity(),
         &mut stack,
+        root_layout_step,
+        None,
     )?;
     let board_instance_count = doc.board_instances.len() as u32 - board_instance_start;
     let instance_bbox = board_instances_bbox(doc, board_instance_start, board_instance_count);
@@ -485,6 +553,8 @@ fn append_board_instances_from_repeats(
     parent_step: &Step,
     parent_transform: Affine2,
     stack: &mut Vec<Symbol>,
+    parent_layout_step: u32,
+    parent_instance: Option<u32>,
 ) -> Result<()> {
     for repeat in &parent_step.step_repeats {
         let source_step = steps
@@ -504,24 +574,101 @@ fn append_board_instances_from_repeats(
             );
         }
 
+        let child_layout_step = ensure_layout_step_for_step(doc, source_step);
+        let layout_repeat = push_layout_repeat(
+            doc,
+            parent_layout_step,
+            parent_instance,
+            child_layout_step,
+            source_step.name,
+            repeat,
+        );
+
+        let mut pending_panel_instances = Vec::new();
         for iy in 0..repeat.ny {
             for ix in 0..repeat.nx {
                 let transform = parent_transform.concat(step_repeat_transform(repeat, ix, iy));
                 if is_panel_step(source_step) {
-                    stack.push(source_step.name);
-                    append_board_instances_from_repeats(
+                    let profiles = append_step_profile(
                         doc,
-                        ipc,
-                        steps,
                         source_step,
                         transform,
-                        stack,
-                    )?;
-                    stack.pop();
+                        BoardProfileKind::PanelInstance,
+                    );
+                    let layout_instance = push_layout_instance(
+                        doc,
+                        layout_repeat,
+                        parent_instance,
+                        child_layout_step,
+                        source_step.name,
+                        parent_step.name,
+                        repeat,
+                        ix,
+                        iy,
+                        transform,
+                        profiles,
+                    );
+                    pending_panel_instances.push((source_step, transform, layout_instance));
                 } else if is_board_step(source_step) {
-                    append_board_instance(doc, parent_step, source_step, repeat, ix, iy, transform);
+                    let profiles = append_board_instance(
+                        doc,
+                        parent_step,
+                        source_step,
+                        repeat,
+                        ix,
+                        iy,
+                        transform,
+                    );
+                    push_layout_instance(
+                        doc,
+                        layout_repeat,
+                        parent_instance,
+                        child_layout_step,
+                        source_step.name,
+                        parent_step.name,
+                        repeat,
+                        ix,
+                        iy,
+                        transform,
+                        profiles,
+                    );
+                } else {
+                    let profiles = append_step_profile(
+                        doc,
+                        source_step,
+                        transform,
+                        BoardProfileKind::StepInstance,
+                    );
+                    push_layout_instance(
+                        doc,
+                        layout_repeat,
+                        parent_instance,
+                        child_layout_step,
+                        source_step.name,
+                        parent_step.name,
+                        repeat,
+                        ix,
+                        iy,
+                        transform,
+                        profiles,
+                    );
                 }
             }
+        }
+
+        for (source_step, transform, layout_instance) in pending_panel_instances {
+            stack.push(source_step.name);
+            append_board_instances_from_repeats(
+                doc,
+                ipc,
+                steps,
+                source_step,
+                transform,
+                stack,
+                child_layout_step,
+                Some(layout_instance),
+            )?;
+            stack.pop();
         }
     }
 
@@ -536,7 +683,7 @@ fn append_board_instance(
     ix: u32,
     iy: u32,
     transform: Affine2,
-) {
+) -> ProfileRange {
     let board_index = ensure_board_geometry(doc, board_step);
     let profiles = append_step_profile(doc, board_step, transform, BoardProfileKind::BoardInstance);
 
@@ -555,6 +702,7 @@ fn append_board_instance(
         profile_count: profiles.count,
         bbox: profiles.bbox,
     });
+    profiles
 }
 
 fn ensure_board_geometry(doc: &mut GeometryDocument, step: &Step) -> u32 {
@@ -580,6 +728,154 @@ fn ensure_board_geometry(doc: &mut GeometryDocument, step: &Step) -> u32 {
         bbox: profiles.bbox,
     });
     board_index
+}
+
+fn ensure_layout_step_for_step(doc: &mut GeometryDocument, step: &Step) -> u32 {
+    if let Some(index) = doc
+        .layout
+        .steps
+        .iter()
+        .position(|layout_step| layout_step.source_step_ref == step.name)
+    {
+        return index as u32;
+    }
+
+    if is_board_step(step) {
+        let board_index = ensure_board_geometry(doc, step);
+        let board = &doc.boards[board_index as usize];
+        return push_or_update_layout_step(
+            doc,
+            step,
+            ProfileRange {
+                start: board.profile_start,
+                count: board.profile_count,
+                bbox: board.bbox,
+            },
+        );
+    }
+
+    let profiles = append_step_profile(
+        doc,
+        step,
+        Affine2::identity(),
+        BoardProfileKind::StepDefinition,
+    );
+    push_or_update_layout_step(doc, step, profiles)
+}
+
+fn push_or_update_layout_step(
+    doc: &mut GeometryDocument,
+    step: &Step,
+    profiles: ProfileRange,
+) -> u32 {
+    if let Some(index) = doc
+        .layout
+        .steps
+        .iter()
+        .position(|layout_step| layout_step.source_step_ref == step.name)
+    {
+        let layout_step = &mut doc.layout.steps[index];
+        if layout_step.profile_count == 0 && profiles.count > 0 {
+            layout_step.profile_start = profiles.start;
+            layout_step.profile_count = profiles.count;
+            layout_step.bbox = profiles.bbox;
+        }
+        return index as u32;
+    }
+
+    let index = doc.layout.steps.len() as u32;
+    doc.layout.steps.push(LayoutStep {
+        source_step_ref: step.name,
+        kind: layout_step_kind(step),
+        datum: step
+            .datum
+            .map(|datum| Point::new(datum.x, datum.y))
+            .unwrap_or_default(),
+        profile_start: profiles.start,
+        profile_count: profiles.count,
+        bbox: profiles.bbox,
+    });
+    index
+}
+
+fn push_layout_repeat(
+    doc: &mut GeometryDocument,
+    parent_step: u32,
+    parent_instance: Option<u32>,
+    child_step: u32,
+    source_step_ref: Symbol,
+    repeat: &StepRepeat,
+) -> u32 {
+    let repeat_index = doc.layout.repeats.len() as u32;
+
+    doc.layout.repeats.push(LayoutRepeat {
+        parent_step,
+        parent_instance,
+        child_step,
+        source_step_ref,
+        x: repeat.x,
+        y: repeat.y,
+        nx: repeat.nx,
+        ny: repeat.ny,
+        dx: repeat.dx,
+        dy: repeat.dy,
+        angle: repeat.angle,
+        mirror: repeat.mirror,
+        instance_start: doc.layout.instances.len() as u32,
+        instance_count: 0,
+        bbox: BBox::empty(),
+    });
+    repeat_index
+}
+
+fn push_layout_instance(
+    doc: &mut GeometryDocument,
+    repeat_index: u32,
+    parent_instance: Option<u32>,
+    child_step: u32,
+    source_step_ref: Symbol,
+    parent_step_ref: Symbol,
+    repeat: &StepRepeat,
+    ix: u32,
+    iy: u32,
+    transform: Affine2,
+    profiles: ProfileRange,
+) -> u32 {
+    let instance_index = doc.layout.instances.len() as u32;
+    let repeat_record = &mut doc.layout.repeats[repeat_index as usize];
+    if repeat_record.instance_count == 0 {
+        repeat_record.instance_start = instance_index;
+    }
+    repeat_record.instance_count += 1;
+
+    doc.layout.instances.push(LayoutInstance {
+        repeat: repeat_index,
+        parent_instance,
+        child_step,
+        source_step_ref,
+        parent_step_ref,
+        transform,
+        repeat_index_x: ix,
+        repeat_index_y: iy,
+        repeat_count_x: repeat.nx,
+        repeat_count_y: repeat.ny,
+        repeat_pitch_x: repeat.dx,
+        repeat_pitch_y: repeat.dy,
+        profile_start: profiles.start,
+        profile_count: profiles.count,
+        bbox: profiles.bbox,
+    });
+    instance_index
+}
+
+fn layout_step_kind(step: &Step) -> LayoutStepKind {
+    match step.step_type {
+        Some(StepType::Board) => LayoutStepKind::Board,
+        Some(StepType::Pallet) => LayoutStepKind::Panel,
+        Some(StepType::Ic) => LayoutStepKind::Ic,
+        None if !step.step_repeats.is_empty() => LayoutStepKind::Panel,
+        None => LayoutStepKind::Board,
+    }
 }
 
 fn board_instances_bbox(doc: &GeometryDocument, start: u32, count: u32) -> BBox {
@@ -2655,6 +2951,118 @@ mod tests {
         assert_eq!(doc.board_instances[0].bbox.max, Point::new(20.0, 25.0));
         assert_eq!(doc.board_instances[1].bbox.min, Point::new(25.0, 20.0));
         assert_eq!(doc.board_instances[1].bbox.max, Point::new(35.0, 25.0));
+        assert_eq!(doc.layout.steps.len(), 2);
+        assert_eq!(doc.layout.repeats.len(), 1);
+        assert_eq!(doc.layout.instances.len(), 2);
+        assert_eq!(doc.layout.root_step, Some(0));
+        assert_eq!(doc.layout.steps[0].kind, LayoutStepKind::Panel);
+        assert_eq!(doc.layout.steps[1].kind, LayoutStepKind::Board);
+        assert_eq!(doc.layout.repeats[0].instance_start, 0);
+        assert_eq!(doc.layout.repeats[0].instance_count, 2);
+        assert_eq!(doc.layout.instances[0].repeat_index_x, 0);
+        assert_eq!(doc.layout.instances[1].repeat_index_x, 1);
+        assert_eq!(doc.layout.instances[1].transform.m02, 25.0);
+    }
+
+    #[test]
+    fn symbolic_panel_extraction_carries_repeats_without_child_features() {
+        let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
+            .expect("synthetic panel fixture should parse");
+        let doc = extract_layer_with_options(
+            &ipc,
+            "TOP",
+            &LayerExtractionOptions {
+                placement: PlacementPolicy::PanelSymbolic,
+            },
+        )
+        .expect("panel layer should extract");
+        let layer = &doc.layers[0];
+        let features = &doc.features
+            [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize];
+
+        assert_eq!(features.len(), 1);
+        assert_eq!(features[0].center, Point::new(40.0, 5.0));
+        assert_eq!(doc.layout.steps.len(), 2);
+        assert_eq!(doc.layout.repeats.len(), 1);
+        assert_eq!(doc.layout.instances.len(), 2);
+        assert_eq!(doc.board_instances.len(), 2);
+    }
+
+    #[test]
+    fn step_only_panel_extraction_omits_repeat_graph_expansion() {
+        let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
+            .expect("synthetic panel fixture should parse");
+        let doc = extract_layer_with_options(
+            &ipc,
+            "TOP",
+            &LayerExtractionOptions {
+                placement: PlacementPolicy::StepOnly,
+            },
+        )
+        .expect("panel layer should extract");
+        let layer = &doc.layers[0];
+        let features = &doc.features
+            [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize];
+
+        assert_eq!(features.len(), 1);
+        assert_eq!(doc.layout.steps.len(), 1);
+        assert!(doc.layout.repeats.is_empty());
+        assert!(doc.layout.instances.is_empty());
+        assert!(doc.board_instances.is_empty());
+        assert_eq!(doc.panels[0].board_instance_count, 0);
+    }
+
+    #[test]
+    fn extract_layout_builds_sidecar_without_layer_features() {
+        let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
+            .expect("synthetic panel fixture should parse");
+        let doc = extract_layout(&ipc).expect("layout should extract");
+
+        assert!(doc.layers.is_empty());
+        assert!(doc.features.is_empty());
+        assert_eq!(doc.layout.steps.len(), 2);
+        assert_eq!(doc.layout.repeats.len(), 1);
+        assert_eq!(doc.layout.instances.len(), 2);
+        assert_eq!(doc.panels.len(), 1);
+        assert_eq!(doc.board_instances.len(), 2);
+    }
+
+    #[test]
+    fn nested_panel_layout_keeps_symbolic_parent_instances() {
+        let ipc = ipc2581::Ipc2581::parse(nested_panel_fixture())
+            .expect("synthetic nested panel fixture should parse");
+        let doc = extract_layout(&ipc).expect("layout should extract");
+
+        assert_eq!(doc.layout.steps.len(), 3);
+        assert_eq!(doc.layout.repeats.len(), 3);
+        assert_eq!(doc.layout.instances.len(), 6);
+        assert_eq!(doc.board_instances.len(), 4);
+        assert_eq!(doc.layout.repeats[0].instance_start, 0);
+        assert_eq!(doc.layout.repeats[0].instance_count, 2);
+        assert_eq!(doc.layout.repeats[1].instance_start, 2);
+        assert_eq!(doc.layout.repeats[1].instance_count, 2);
+        assert_eq!(doc.layout.repeats[2].instance_start, 4);
+        assert_eq!(doc.layout.repeats[2].instance_count, 2);
+        assert_eq!(doc.layout.instances[0].parent_instance, None);
+        assert_eq!(doc.layout.instances[1].parent_instance, None);
+        assert_eq!(doc.layout.instances[2].parent_instance, Some(0));
+        assert_eq!(doc.layout.instances[3].parent_instance, Some(0));
+        assert_eq!(doc.layout.instances[4].parent_instance, Some(1));
+        assert_eq!(doc.layout.instances[5].parent_instance, Some(1));
+    }
+
+    #[test]
+    fn nested_panel_instance_bbox_includes_child_repeats_without_profile() {
+        let ipc = ipc2581::Ipc2581::parse(nested_panel_without_subpanel_profile_fixture())
+            .expect("synthetic nested panel fixture should parse");
+        let doc = extract_layout(&ipc).expect("layout should extract");
+
+        assert_eq!(doc.layout.instances[0].bbox.min, Point::new(5.0, 5.0));
+        assert_eq!(doc.layout.instances[0].bbox.max, Point::new(30.0, 10.0));
+        assert_eq!(doc.layout.instances[1].bbox.min, Point::new(5.0, 25.0));
+        assert_eq!(doc.layout.instances[1].bbox.max, Point::new(30.0, 30.0));
+        assert_eq!(doc.layout.repeats[0].bbox.min, Point::new(5.0, 5.0));
+        assert_eq!(doc.layout.repeats[0].bbox.max, Point::new(30.0, 30.0));
     }
 
     #[test]
@@ -2899,6 +3307,96 @@ mod tests {
       </Step>
       <Step name="panel" type="PALLET">
         <StepRepeat stepRef="board" x="0" y="0" nx="2" ny="1" dx="20" dy="0"/>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#
+    }
+
+    fn nested_panel_fixture() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="panel"/>
+    <LayerRef name="TOP"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="5"/>
+            <PolyStepSegment x="0" y="5"/>
+          </Polygon>
+        </Profile>
+      </Step>
+      <Step name="subpanel" type="PALLET">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="30" y="0"/>
+            <PolyStepSegment x="30" y="10"/>
+            <PolyStepSegment x="0" y="10"/>
+          </Polygon>
+        </Profile>
+        <StepRepeat stepRef="board" x="0" y="0" nx="2" ny="1" dx="15" dy="0"/>
+      </Step>
+      <Step name="panel" type="PALLET">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="40" y="0"/>
+            <PolyStepSegment x="40" y="40"/>
+            <PolyStepSegment x="0" y="40"/>
+          </Polygon>
+        </Profile>
+        <StepRepeat stepRef="subpanel" x="5" y="5" nx="1" ny="2" dx="0" dy="20"/>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#
+    }
+
+    fn nested_panel_without_subpanel_profile_fixture() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="panel"/>
+    <LayerRef name="TOP"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="5"/>
+            <PolyStepSegment x="0" y="5"/>
+          </Polygon>
+        </Profile>
+      </Step>
+      <Step name="subpanel" type="PALLET">
+        <StepRepeat stepRef="board" x="0" y="0" nx="2" ny="1" dx="15" dy="0"/>
+      </Step>
+      <Step name="panel" type="PALLET">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="40" y="0"/>
+            <PolyStepSegment x="40" y="40"/>
+            <PolyStepSegment x="0" y="40"/>
+          </Polygon>
+        </Profile>
+        <StepRepeat stepRef="subpanel" x="5" y="5" nx="1" ny="2" dx="0" dy="20"/>
       </Step>
     </CadData>
   </Ecad>

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -151,14 +151,10 @@ pub fn extract_layout(ipc: &Ipc2581) -> Result<GeometryDocument> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let step = steps::primary_step(ipc, &ecad.cad_data.steps)
         .context("IPC-2581 ECAD section has no Step")?;
-    let mut doc = GeometryDocument::new(ipc.resolve(step.name).to_string());
+    let mut doc = GeometryDocument::new();
     append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?;
     pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
     Ok(doc)
-}
-
-pub fn extract_profiles(ipc: &Ipc2581) -> Result<GeometryDocument> {
-    extract_layout(ipc)
 }
 
 fn extract_panel_layer(
@@ -169,7 +165,7 @@ fn extract_panel_layer(
     layer: &Layer,
     layer_name: &str,
 ) -> Result<GeometryDocument> {
-    let mut doc = GeometryDocument::new(ipc.resolve(panel.name).to_string());
+    let mut doc = GeometryDocument::new();
     let feature_start = doc.features.len() as u32;
     let mut layer_bbox = BBox::empty();
     let mut append_state = LayerAppendState::default();
@@ -258,7 +254,7 @@ fn extract_step_layer(
             .collect(),
     };
 
-    let mut doc = GeometryDocument::new(ipc.resolve(step.name).to_string());
+    let mut doc = GeometryDocument::new();
     let feature_start = doc.features.len() as u32;
     let mut layer_bbox = BBox::empty();
     let layer_polarity = map_polarity(layer.polarity.unwrap_or(Polarity::Positive));
@@ -1239,8 +1235,6 @@ fn append_step_profile(
     let cutout_count = doc.profile_cutouts.len() as u32 - cutout_start;
     let bbox = doc.paths[outer_path as usize].bbox;
     doc.profiles.push(StepProfile {
-        source_step_ref: step.name,
-        transform,
         outer_path,
         cutout_start,
         cutout_count,
@@ -2497,7 +2491,7 @@ mod tests {
 
     #[test]
     fn lowers_moire_as_rings_and_crosshair() {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
 
         push_moire_path(
             &mut doc,
@@ -2550,7 +2544,7 @@ mod tests {
 
     #[test]
     fn lowers_trace_poly_step_curves_as_arcs() {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
         let trace = ipc2581::types::Trace {
             line_desc_ref: None,
             points: vec![
@@ -2582,7 +2576,7 @@ mod tests {
 
     #[test]
     fn lowers_feature_poly_step_curves_as_arcs() {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
         let polyline = ipc2581::types::ecad::FeaturePolyline {
             begin: ipc2581::types::Point { x: 1.0, y: 0.0 },
             steps: vec![PolyStep::Curve(ipc2581::types::PolyStepCurve {
@@ -2621,7 +2615,7 @@ mod tests {
 
     #[test]
     fn lowers_hollow_user_circle_as_stroked_path() {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
         let primitive = UserPrimitive::UserSpecial(ipc2581::types::UserSpecial {
             shapes: vec![ipc2581::types::UserShape {
                 shape: UserShapeType::Circle(ipc2581::types::Circle { diameter: 1.4 }),
@@ -2684,7 +2678,7 @@ mod tests {
             standard_primitives: HashMap::new(),
             user_primitives: HashMap::new(),
         };
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
         let primitive = UserPrimitive::UserSpecial(ipc2581::types::UserSpecial {
             shapes: vec![
                 ipc2581::types::UserShape {
@@ -2723,7 +2717,7 @@ mod tests {
 
     #[test]
     fn lowers_butterfly_with_removed_quadrants() {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
 
         push_butterfly_path(
             &mut doc,
@@ -2746,7 +2740,7 @@ mod tests {
 
     #[test]
     fn lowers_thermal_as_spokes_without_redundant_ring() {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
 
         push_thermal_path(&mut doc, Affine2::identity(), 10.0, 6.0, 2.0, 4, 0.0);
 
@@ -2762,7 +2756,7 @@ mod tests {
 
     #[test]
     fn lowers_spokeless_thermal_as_donut() {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
 
         push_thermal_path(&mut doc, Affine2::identity(), 10.0, 6.0, 2.0, 0, 0.0);
 
@@ -2780,7 +2774,8 @@ mod tests {
         let features = &doc.features
             [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize];
 
-        assert_eq!(doc.board_name, "panel");
+        let (_, root_step) = root_step(&doc).unwrap();
+        assert_eq!(root_step.kind, LayoutStepKind::Panel);
         assert_eq!(features.len(), 3);
         assert_eq!(features[0].center, Point::new(40.0, 5.0));
         assert_eq!(features[1].center, Point::new(12.0, 23.0));
@@ -2795,11 +2790,8 @@ mod tests {
         assert_eq!(board_instance_count(&doc), 2);
         assert_eq!(board_bbox(&doc).unwrap().min, Point::new(0.0, 0.0));
         assert_eq!(board_bbox(&doc).unwrap().max, Point::new(10.0, 5.0));
-        assert_eq!(panel_profile_bbox(&doc).unwrap().min, Point::new(0.0, 0.0));
-        assert_eq!(
-            panel_profile_bbox(&doc).unwrap().max,
-            Point::new(100.0, 80.0)
-        );
+        assert_eq!(panel_bbox(&doc).unwrap().min, Point::new(0.0, 0.0));
+        assert_eq!(panel_bbox(&doc).unwrap().max, Point::new(100.0, 80.0));
         assert_eq!(doc.layout.instances[0].bbox.min, Point::new(10.0, 20.0));
         assert_eq!(doc.layout.instances[0].bbox.max, Point::new(20.0, 25.0));
         assert_eq!(doc.layout.instances[1].bbox.min, Point::new(25.0, 20.0));
@@ -2966,7 +2958,7 @@ mod tests {
 
     #[test]
     fn chamfered_rect_respects_corner_flags() {
-        let mut doc = GeometryDocument::new("test".to_string());
+        let mut doc = GeometryDocument::new();
 
         push_chamfered_rect_path(
             &mut doc,

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -4,5 +4,5 @@ pub mod render;
 
 pub use extract::{
     LayerExtractionOptions, PlacementPolicy, extract_layer, extract_layer_with_options,
-    extract_layout, extract_profiles,
+    extract_layout,
 };

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -2,4 +2,7 @@ pub mod dxf;
 mod extract;
 pub mod render;
 
-pub use extract::{extract_layer, extract_profiles};
+pub use extract::{
+    LayerExtractionOptions, PlacementPolicy, extract_layer, extract_layer_with_options,
+    extract_layout, extract_profiles,
+};

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -3,6 +3,6 @@ mod extract;
 pub mod render;
 
 pub use extract::{
-    LayerExtractionOptions, PlacementPolicy, extract_layer, extract_layer_with_options,
-    extract_layout,
+    LayerExtractionOptions, PlacementPolicy, extract_layer, extract_layer_for_layout_target,
+    extract_layer_with_options, extract_layout,
 };

--- a/crates/pcb-ipc2581-tools/src/geometry/render.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/render.rs
@@ -6,13 +6,17 @@ use pcb_ir::dialects::mask::MaskDocument;
 
 type GeometryDocument = pcb_ir::dialects::ipc::GeometryDocument<Symbol, LayerFunction>;
 
-pub fn render_layer_svg(geometry: &GeometryDocument, include_profiles: bool) -> String {
-    let mask = layer_mask(geometry, include_profiles);
+pub fn render_layer_svg(
+    geometry: &GeometryDocument,
+    include_profiles: bool,
+    profile_set: ProfileSet,
+) -> String {
+    let mask = layer_mask(geometry, include_profiles, profile_set);
     pcb_ir::dialects::mask::render_svg_all(&mask)
 }
 
 fn layer_has_content(geometry: &GeometryDocument) -> bool {
-    let mask = layer_mask(geometry, false);
+    let mask = layer_mask(geometry, false, ProfileSet::RootOnly);
     mask.layers
         .first()
         .map(|layer| layer.shape_count > 0 && !layer.bbox.is_empty())
@@ -46,6 +50,7 @@ pub fn layer_has_native_content(geometry: &GeometryDocument) -> bool {
 pub fn layer_mask(
     geometry: &GeometryDocument,
     include_profiles: bool,
+    profile_set: ProfileSet,
 ) -> MaskDocument<LayerFunction> {
     let layer = &geometry.layers[0];
     let geom = if include_profiles {
@@ -54,7 +59,7 @@ pub fn layer_mask(
             0,
             layer_role(layer.layer_function),
             Side::None,
-            ProfileSet::LayoutBoundaries,
+            profile_set,
         )
     } else {
         pcb_ir::dialects::ipc::lower_layer_to_geom(

--- a/crates/pcb-ipc2581-tools/src/geometry/render.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/render.rs
@@ -1,6 +1,7 @@
 use ipc2581::Symbol;
 use ipc2581::types::LayerFunction;
 use pcb_ir::common::{LayerRole, Side};
+use pcb_ir::dialects::ipc::ProfileSet;
 use pcb_ir::dialects::mask::MaskDocument;
 
 type GeometryDocument = pcb_ir::dialects::ipc::GeometryDocument<Symbol, LayerFunction>;
@@ -48,11 +49,12 @@ pub fn layer_mask(
 ) -> MaskDocument<LayerFunction> {
     let layer = &geometry.layers[0];
     let geom = if include_profiles {
-        pcb_ir::dialects::ipc::lower_layer_with_profiles_to_geom(
+        pcb_ir::dialects::ipc::lower_layer_with_profile_set_to_geom(
             geometry,
             0,
             layer_role(layer.layer_function),
             Side::None,
+            ProfileSet::LayoutBoundaries,
         )
     } else {
         pcb_ir::dialects::ipc::lower_layer_to_geom(

--- a/crates/pcb-ipc2581-tools/src/gerber/artwork.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/artwork.rs
@@ -1,7 +1,17 @@
-pub type ArtworkLayer = pcb_ir::dialects::artwork::ArtworkDocument<Vec<String>, ObjectAttributes>;
+pub type ArtworkLayer =
+    pcb_ir::dialects::artwork::ArtworkDocument<LayerAttributes, ObjectAttributes>;
+
+#[derive(Debug, Clone, Default)]
+pub struct LayerAttributes {
+    pub file_function: Vec<String>,
+    pub part: Option<Vec<String>>,
+    pub file_polarity: Option<String>,
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct ObjectAttributes {
-    pub aperture_function: Option<String>,
+    pub aperture_function: Option<Vec<String>>,
     pub net: Option<String>,
+    pub component: Option<String>,
+    pub pin: Option<String>,
 }

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -296,12 +296,27 @@ fn profile_artwork_from_profiles(
         bbox: BBox::empty(),
         meta: vec!["Profile".into(), "NP".into()],
     });
-    for profile in pcb_ir::dialects::ipc::render_profiles(doc) {
-        push_profile_artwork_object(&mut artwork, artwork_layer, doc, profile.outer_path);
-        for cutout in &doc.profile_cutouts
-            [profile.cutout_start as usize..(profile.cutout_start + profile.cutout_count) as usize]
+    for occurrence in pcb_ir::dialects::ipc::profile_occurrences_for(
+        doc,
+        pcb_ir::dialects::ipc::ProfileSet::FabricationOutlines,
+    ) {
+        push_profile_artwork_object(
+            &mut artwork,
+            artwork_layer,
+            doc,
+            occurrence.profile.outer_path,
+            occurrence.transform,
+        );
+        for cutout in &doc.profile_cutouts[occurrence.profile.cutout_start as usize
+            ..(occurrence.profile.cutout_start + occurrence.profile.cutout_count) as usize]
         {
-            push_profile_artwork_object(&mut artwork, artwork_layer, doc, cutout.path);
+            push_profile_artwork_object(
+                &mut artwork,
+                artwork_layer,
+                doc,
+                cutout.path,
+                occurrence.transform,
+            );
         }
     }
     Ok(artwork)
@@ -376,10 +391,13 @@ fn push_profile_artwork_object(
     artwork_layer: u32,
     doc: &pcb_ir::dialects::ipc::GeometryDocument<ipc2581::Symbol, LayerFunction>,
     path_index: u32,
+    transform: pcb_ir::common::Affine2,
 ) {
-    let path = &doc.paths[path_index as usize];
     let artwork_path = ArtworkPath::stroked(PROFILE_STROKE_WIDTH, LineCap::Round, LineJoin::Round);
-    let path_id = push_artwork_path(artwork, artwork_path, doc, path);
+    let path_id = artwork.push_path(
+        artwork_path,
+        pcb_ir::dialects::ipc::transformed_path_payloads(doc, path_index, transform),
+    );
     artwork.push_object(
         artwork_layer,
         ArtworkObject {

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -7,7 +7,7 @@ use ipc2581::types::{LayerFunction, Side, ecad::Layer};
 
 use super::artwork::{ArtworkLayer, ObjectAttributes};
 use super::lower::lower_artwork_layer;
-use crate::{geometry, ipc2581 as ipc};
+use crate::{LayoutTarget, geometry, ipc2581 as ipc};
 use pcb_ir::common::{BBox, LayerRole, LineCap, LineJoin, PaintPolarity, Unit};
 use pcb_ir::dialects::artwork::{ArtworkGeometry, ArtworkObject, ArtworkPath};
 use pcb_ir::dialects::ipc::{FeatureBucket, GeometryPath};
@@ -16,6 +16,7 @@ use pcb_ir::dialects::path as common_path;
 #[derive(Debug, Clone)]
 pub struct GerberExportOptions {
     pub output_dir: PathBuf,
+    pub layout_target: LayoutTarget,
 }
 
 #[derive(Debug, Clone)]
@@ -31,6 +32,10 @@ pub struct GerberExportFile {
 }
 
 pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<GerberExportSet> {
+    if options.layout_target == LayoutTarget::Layout {
+        bail!("Gerber export does not support --layout-target layout; use board or panel");
+    }
+
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let mut files = Vec::new();
     let mut first_doc = None;
@@ -39,8 +44,9 @@ pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<
     for plan in &plans {
         let source_layer = plan.layer;
         let layer_name = ipc.resolve(source_layer.name);
-        let mut doc = geometry::extract_layer(ipc, layer_name)
-            .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
+        let mut doc =
+            geometry::extract_layer_for_layout_target(ipc, layer_name, options.layout_target)
+                .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
         pcb_ir::dialects::ipc::process::process_document(&mut doc);
         if first_doc.is_none() {
             first_doc = Some(doc.clone());
@@ -62,7 +68,7 @@ pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<
     }
 
     if let Some(doc) = first_doc {
-        let profile = profile_artwork_from_profiles(&doc)?;
+        let profile = profile_artwork_from_profiles(&doc, options.layout_target)?;
         if !profile.objects.is_empty() {
             let layer = lower_artwork_layer(&profile)?;
             let contents = write_layer(&layer)?;
@@ -285,6 +291,7 @@ const PROFILE_STROKE_WIDTH: f64 = 0.1;
 
 fn profile_artwork_from_profiles(
     doc: &pcb_ir::dialects::ipc::GeometryDocument<ipc2581::Symbol, LayerFunction>,
+    layout_target: LayoutTarget,
 ) -> Result<ArtworkLayer> {
     let mut artwork = ArtworkLayer::new(Unit::Millimeter);
     let artwork_layer = artwork.push_layer(pcb_ir::dialects::artwork::ArtworkLayer {
@@ -296,10 +303,9 @@ fn profile_artwork_from_profiles(
         bbox: BBox::empty(),
         meta: vec!["Profile".into(), "NP".into()],
     });
-    for occurrence in pcb_ir::dialects::ipc::profile_occurrences_for(
-        doc,
-        pcb_ir::dialects::ipc::ProfileSet::FabricationOutlines,
-    ) {
+    for occurrence in
+        pcb_ir::dialects::ipc::profile_occurrences_for(doc, layout_target.profile_set())
+    {
         push_profile_artwork_object(
             &mut artwork,
             artwork_layer,
@@ -429,14 +435,22 @@ fn artwork_contours(
 }
 
 pub fn execute_file(input_file: &Path, output_dir: &Path) -> Result<GerberExportSet> {
-    let content = crate::utils::file::load_ipc_file(input_file)?;
-    let ipc = ipc::Ipc2581::parse(&content)?;
-    export_gerber_x2(
-        &ipc,
+    execute_file_with_options(
+        input_file,
         &GerberExportOptions {
             output_dir: output_dir.to_path_buf(),
+            layout_target: LayoutTarget::Board,
         },
     )
+}
+
+pub fn execute_file_with_options(
+    input_file: &Path,
+    options: &GerberExportOptions,
+) -> Result<GerberExportSet> {
+    let content = crate::utils::file::load_ipc_file(input_file)?;
+    let ipc = ipc::Ipc2581::parse(&content)?;
+    export_gerber_x2(&ipc, options)
 }
 
 #[cfg(test)]
@@ -490,7 +504,14 @@ mod tests {
             std::env::temp_dir().join(format!("pcb-ipc-gerber-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&output_dir);
 
-        let set = export_gerber_x2(&ipc, &GerberExportOptions { output_dir }).unwrap();
+        let set = export_gerber_x2(
+            &ipc,
+            &GerberExportOptions {
+                output_dir,
+                layout_target: LayoutTarget::Board,
+            },
+        )
+        .unwrap();
 
         assert!(set.files.iter().any(|file| file.filename == "F_Cu.gtl"));
         assert!(set.files.iter().any(|file| file.filename == "profile.gbr"));
@@ -507,6 +528,36 @@ mod tests {
     }
 
     #[test]
+    fn gerber_export_rejects_symbolic_layout_target() {
+        let ipc = ipc::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+  </Content>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let output_dir =
+            std::env::temp_dir().join(format!("pcb-ipc-gerber-layout-test-{}", std::process::id()));
+
+        let error = export_gerber_x2(
+            &ipc,
+            &GerberExportOptions {
+                output_dir,
+                layout_target: LayoutTarget::Layout,
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Gerber export does not support --layout-target layout")
+        );
+    }
+
+    #[test]
     fn real_board_export_parseback_and_svg_paths_smoke() {
         let compressed = include_bytes!("../../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
         let content = zstd::decode_all(Cursor::new(compressed)).unwrap();
@@ -519,6 +570,7 @@ mod tests {
             &ipc,
             &GerberExportOptions {
                 output_dir: output_dir.clone(),
+                layout_target: LayoutTarget::Board,
             },
         )
         .unwrap();

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -5,12 +5,14 @@ use gerberx2::{GerberLayer, write_layer};
 use ipc2581::Ipc2581;
 use ipc2581::types::{LayerFunction, Side, ecad::Layer};
 
-use super::artwork::{ArtworkLayer, ObjectAttributes};
+use super::artwork::{ArtworkLayer, LayerAttributes, ObjectAttributes};
 use super::lower::lower_artwork_layer;
 use crate::{LayoutTarget, geometry, ipc2581 as ipc};
 use pcb_ir::common::{BBox, LayerRole, LineCap, LineJoin, PaintPolarity, Unit};
 use pcb_ir::dialects::artwork::{ArtworkGeometry, ArtworkObject, ArtworkPath};
-use pcb_ir::dialects::ipc::{FeatureBucket, GeometryPath};
+use pcb_ir::dialects::ipc::{
+    FeatureBucket, FeatureSemantic, FiducialKind, GeometryFeature, GeometryPath,
+};
 use pcb_ir::dialects::path as common_path;
 
 #[derive(Debug, Clone)]
@@ -56,7 +58,7 @@ pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<
             &doc,
             0,
             plan.role.ir_role(),
-            plan.file_function.clone(),
+            layer_attributes(plan.file_function.clone(), options.layout_target),
         )?;
         let layer = lower_artwork_layer(&artwork)?;
         let contents = write_layer(&layer)?;
@@ -114,6 +116,8 @@ enum GerberLayerRole {
     Soldermask,
     Legend,
     Profile,
+    Vcut,
+    Score,
 }
 
 fn export_layer_plans(layers: &[Layer]) -> Vec<ExportLayerPlan<'_>> {
@@ -155,6 +159,8 @@ fn gerber_layer_role(function: LayerFunction) -> Option<GerberLayerRole> {
         LayerFunction::Soldermask => Some(GerberLayerRole::Soldermask),
         LayerFunction::Silkscreen | LayerFunction::Legend => Some(GerberLayerRole::Legend),
         LayerFunction::Rout | LayerFunction::BoardOutline => Some(GerberLayerRole::Profile),
+        LayerFunction::VCut => Some(GerberLayerRole::Vcut),
+        LayerFunction::Score => Some(GerberLayerRole::Score),
         _ => None,
     }
 }
@@ -166,7 +172,9 @@ impl GerberLayerRole {
             GerberLayerRole::Paste => LayerRole::Paste,
             GerberLayerRole::Soldermask => LayerRole::Soldermask,
             GerberLayerRole::Legend => LayerRole::Legend,
-            GerberLayerRole::Profile => LayerRole::Profile,
+            GerberLayerRole::Profile | GerberLayerRole::Vcut | GerberLayerRole::Score => {
+                LayerRole::Profile
+            }
         }
     }
 }
@@ -213,6 +221,30 @@ fn layer_output(
             "Edge_Cuts.gm1".to_string(),
             vec!["Profile".into(), "NP".into()],
         ),
+        GerberLayerRole::Vcut => vcut_layer_output("V_Cut.gbr", side),
+        GerberLayerRole::Score => vcut_layer_output("Score.gbr", side),
+    }
+}
+
+fn vcut_layer_output(filename: &str, side: Option<Side>) -> (String, Vec<String>) {
+    let mut file_function = vec!["Vcut".to_string()];
+    match side {
+        Some(Side::Top) => file_function.push("Top".to_string()),
+        Some(Side::Bottom) => file_function.push("Bot".to_string()),
+        Some(Side::Both) | Some(Side::All) => file_function.push("Top/Bot".to_string()),
+        _ => {}
+    }
+    (filename.to_string(), file_function)
+}
+
+fn layer_attributes(file_function: Vec<String>, layout_target: LayoutTarget) -> LayerAttributes {
+    LayerAttributes {
+        file_function,
+        part: Some(vec![match layout_target {
+            LayoutTarget::Board => "Single".to_string(),
+            LayoutTarget::Panel | LayoutTarget::Layout => "Array".to_string(),
+        }]),
+        file_polarity: None,
     }
 }
 
@@ -251,7 +283,7 @@ fn artwork_from_processed_layer(
     doc: &pcb_ir::dialects::ipc::GeometryDocument<ipc2581::Symbol, LayerFunction>,
     layer_index: usize,
     role: LayerRole,
-    file_function: Vec<String>,
+    meta: LayerAttributes,
 ) -> Result<ArtworkLayer> {
     let layer = &doc.layers[layer_index];
     let mut artwork = ArtworkLayer::new(Unit::Millimeter);
@@ -262,7 +294,7 @@ fn artwork_from_processed_layer(
         object_start: 0,
         object_count: 0,
         bbox: layer.bbox,
-        meta: file_function,
+        meta,
     });
     for feature in &doc.features
         [layer.feature_start as usize..(layer.feature_start + layer.feature_count) as usize]
@@ -270,16 +302,13 @@ fn artwork_from_processed_layer(
         for path in &doc.paths
             [feature.path_start as usize..(feature.path_start + feature.path_count) as usize]
         {
-            let aperture_function = path
-                .flags
-                .stroked
-                .then(|| aperture_function(feature.bucket).to_string());
+            let aperture_function = path.flags.stroked.then(|| aperture_function(feature));
             push_artwork_object(
                 &mut artwork,
                 artwork_layer,
                 doc,
                 path,
-                object_attributes(ipc, feature.net, aperture_function),
+                object_attributes(ipc, doc, feature, aperture_function),
                 &layer.name,
             )?;
         }
@@ -301,7 +330,7 @@ fn profile_artwork_from_profiles(
         object_start: 0,
         object_count: 0,
         bbox: BBox::empty(),
-        meta: vec!["Profile".into(), "NP".into()],
+        meta: layer_attributes(vec!["Profile".into(), "NP".into()], layout_target),
     });
     for occurrence in
         pcb_ir::dialects::ipc::profile_occurrences_for(doc, layout_target.profile_set())
@@ -330,25 +359,53 @@ fn profile_artwork_from_profiles(
 
 fn object_attributes(
     ipc: &Ipc2581,
-    net: Option<ipc2581::Symbol>,
-    aperture_function: Option<String>,
+    doc: &pcb_ir::dialects::ipc::GeometryDocument<ipc2581::Symbol, LayerFunction>,
+    feature: &GeometryFeature<ipc2581::Symbol>,
+    aperture_function: Option<Vec<String>>,
 ) -> ObjectAttributes {
+    let pin_ref = (feature.pin_ref_count > 0)
+        .then(|| doc.pin_refs.get(feature.pin_ref_start as usize))
+        .flatten();
     ObjectAttributes {
         aperture_function,
-        net: net.map(|symbol| ipc.resolve(symbol).to_string()),
+        net: feature.net.map(|symbol| ipc.resolve(symbol).to_string()),
+        component: pin_ref
+            .and_then(|pin_ref| pin_ref.component_ref)
+            .map(|symbol| ipc.resolve(symbol).to_string()),
+        pin: pin_ref.map(|pin_ref| ipc.resolve(pin_ref.pin).to_string()),
     }
 }
 
-fn aperture_function(bucket: FeatureBucket) -> &'static str {
-    match bucket {
-        FeatureBucket::Smd => "SMDPad",
-        FeatureBucket::Pth => "ComponentPad",
-        FeatureBucket::Via => "ViaPad",
-        FeatureBucket::Trace => "Conductor",
-        FeatureBucket::Fill => "Conductor",
-        FeatureBucket::Cutout => "Other",
-        FeatureBucket::Thermal => "ThermalRelief",
-        FeatureBucket::Antipad => "AntiPad",
+fn aperture_function(feature: &GeometryFeature<ipc2581::Symbol>) -> Vec<String> {
+    match feature.semantic {
+        FeatureSemantic::Fiducial(kind) => {
+            let kind = match kind {
+                FiducialKind::Local => "Local",
+                FiducialKind::Global => "Global",
+                FiducialKind::Panel | FiducialKind::GoodPanel => "Panel",
+                FiducialKind::BadBoard => {
+                    return vec!["Other".to_string(), "BadBoardMark".to_string()];
+                }
+            };
+            vec!["FiducialPad".to_string(), kind.to_string()]
+        }
+        FeatureSemantic::SmdPad => vec!["SMDPad".to_string()],
+        FeatureSemantic::ComponentPad => vec!["ComponentPad".to_string()],
+        FeatureSemantic::ViaPad => vec!["ViaPad".to_string()],
+        FeatureSemantic::VCut | FeatureSemantic::Score => {
+            vec!["Other".to_string(), "Vcut".to_string()]
+        }
+        FeatureSemantic::Route | FeatureSemantic::BoardOutline => vec!["Profile".to_string()],
+        _ => match feature.bucket {
+            FeatureBucket::Smd => vec!["SMDPad".to_string()],
+            FeatureBucket::Pth => vec!["ComponentPad".to_string()],
+            FeatureBucket::Via => vec!["ViaPad".to_string()],
+            FeatureBucket::Fiducial => vec!["FiducialPad".to_string()],
+            FeatureBucket::Trace | FeatureBucket::Fill => vec!["Conductor".to_string()],
+            FeatureBucket::Cutout => vec!["Other".to_string()],
+            FeatureBucket::Thermal => vec!["ThermalRelief".to_string()],
+            FeatureBucket::Antipad => vec!["AntiPad".to_string()],
+        },
     }
 }
 
@@ -412,8 +469,10 @@ fn push_profile_artwork_object(
             net: None,
             bbox: artwork.paths[path_id as usize].bbox,
             meta: ObjectAttributes {
-                aperture_function: Some("Profile".to_string()),
+                aperture_function: Some(vec!["Profile".to_string()]),
                 net: None,
+                component: None,
+                pin: None,
             },
         },
     );
@@ -555,6 +614,99 @@ mod tests {
                 .to_string()
                 .contains("Gerber export does not support --layout-target layout")
         );
+    }
+
+    #[test]
+    fn gerber_export_carries_vcut_and_fiducial_x2_metadata() {
+        let ipc = ipc::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="Panel"/>
+    <LayerRef name="TOP"/>
+    <LayerRef name="VCUT"/>
+    <DictionaryLineDesc units="MILLIMETER">
+      <EntryLineDesc id="fidline">
+        <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
+      </EntryLineDesc>
+    </DictionaryLineDesc>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER">
+      <Spec name="VCut_1">
+        <V_Cut type="ANGLE">
+          <Property value="90" unit="DEGREES"/>
+        </V_Cut>
+      </Spec>
+    </CadHeader>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Layer name="VCUT" layerFunction="V_CUT" side="ALL" polarity="POSITIVE">
+        <SpecRef id="VCut_1"/>
+      </Layer>
+      <Step name="Panel" type="PALLET">
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <GlobalFiducial>
+              <Location x="1" y="2"/>
+              <Circle diameter="1">
+                <FillDesc fillProperty="HOLLOW"/>
+                <LineDescRef id="fidline"/>
+              </Circle>
+              <PinRef componentRef="U1" pin="1"/>
+            </GlobalFiducial>
+          </Set>
+        </LayerFeature>
+        <LayerFeature layerRef="VCUT">
+          <Set>
+            <Features>
+              <Line startX="0" startY="5" endX="10" endY="5">
+                <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
+              </Line>
+            </Features>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let output_dir =
+            std::env::temp_dir().join(format!("pcb-ipc-gerber-x2-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&output_dir);
+
+        let set = export_gerber_x2(
+            &ipc,
+            &GerberExportOptions {
+                output_dir,
+                layout_target: LayoutTarget::Panel,
+            },
+        )
+        .unwrap();
+
+        let top = set
+            .files
+            .iter()
+            .find(|file| file.filename == "F_Cu.gtl")
+            .unwrap();
+        assert!(top.contents.contains("%TF.Part,Array*%"));
+        assert!(
+            top.contents
+                .contains("%TA.AperFunction,FiducialPad,Global*%")
+        );
+        assert!(top.contents.contains("%TO.C,U1*%"));
+        assert!(top.contents.contains("%TO.P,1*%"));
+
+        let vcut = set
+            .files
+            .iter()
+            .find(|file| file.filename == "V_Cut.gbr")
+            .unwrap();
+        assert!(vcut.contents.contains("%TF.FileFunction,Vcut,Top/Bot*%"));
+        assert!(vcut.contents.contains("%TF.Part,Array*%"));
+        assert!(vcut.contents.contains("%TA.AperFunction,Other,Vcut*%"));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -53,12 +53,13 @@ pub fn export_gerber_x2(ipc: &Ipc2581, options: &GerberExportOptions) -> Result<
         if first_doc.is_none() {
             first_doc = Some(doc.clone());
         }
+        let part = gerber_part_for_doc(&doc);
         let artwork = artwork_from_processed_layer(
             ipc,
             &doc,
             0,
             plan.role.ir_role(),
-            layer_attributes(plan.file_function.clone(), options.layout_target),
+            layer_attributes(plan.file_function.clone(), part),
         )?;
         let layer = lower_artwork_layer(&artwork)?;
         let contents = write_layer(&layer)?;
@@ -246,13 +247,35 @@ fn fabrication_line_layer_output(
     (filename.to_string(), file_function)
 }
 
-fn layer_attributes(file_function: Vec<String>, layout_target: LayoutTarget) -> LayerAttributes {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GerberPart {
+    Single,
+    Array,
+}
+
+impl GerberPart {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Single => "Single",
+            Self::Array => "Array",
+        }
+    }
+}
+
+fn gerber_part_for_doc(
+    doc: &pcb_ir::dialects::ipc::GeometryDocument<ipc2581::Symbol, LayerFunction>,
+) -> GerberPart {
+    if pcb_ir::dialects::ipc::root_panel_step(doc).is_some() {
+        GerberPart::Array
+    } else {
+        GerberPart::Single
+    }
+}
+
+fn layer_attributes(file_function: Vec<String>, part: GerberPart) -> LayerAttributes {
     LayerAttributes {
         file_function,
-        part: Some(vec![match layout_target {
-            LayoutTarget::Board => "Single".to_string(),
-            LayoutTarget::Panel | LayoutTarget::Layout => "Array".to_string(),
-        }]),
+        part: Some(vec![part.as_str().to_string()]),
         file_polarity: None,
     }
 }
@@ -339,7 +362,10 @@ fn profile_artwork_from_profiles(
         object_start: 0,
         object_count: 0,
         bbox: BBox::empty(),
-        meta: layer_attributes(vec!["Profile".into(), "NP".into()], layout_target),
+        meta: layer_attributes(
+            vec!["Profile".into(), "NP".into()],
+            gerber_part_for_doc(doc),
+        ),
     });
     for occurrence in
         pcb_ir::dialects::ipc::profile_occurrences_for(doc, layout_target.profile_set())
@@ -591,7 +617,30 @@ mod tests {
             .find(|file| file.filename == "F_Cu.gtl")
             .unwrap();
         assert!(copper.contents.contains("%TF.FileFunction,Copper,L1,Top*%"));
+        assert!(copper.contents.contains("%TF.Part,Single*%"));
         assert!(copper.contents.contains("%TO.N,N1*%"));
+
+        let panel_output_dir = std::env::temp_dir().join(format!(
+            "pcb-ipc-gerber-panel-target-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&panel_output_dir);
+        let panel_target_set = export_gerber_x2(
+            &ipc,
+            &GerberExportOptions {
+                output_dir: panel_output_dir,
+                layout_target: LayoutTarget::Panel,
+            },
+        )
+        .unwrap();
+
+        let panel_target_copper = panel_target_set
+            .files
+            .iter()
+            .find(|file| file.filename == "F_Cu.gtl")
+            .unwrap();
+        assert!(panel_target_copper.contents.contains("%TF.Part,Single*%"));
+        assert!(!panel_target_copper.contents.contains("%TF.Part,Array*%"));
     }
 
     #[test]
@@ -716,7 +765,7 @@ mod tests {
                 .contains("%TA.AperFunction,FiducialPad,Global*%")
         );
         assert!(top.contents.contains("%TO.C,U1*%"));
-        assert!(top.contents.contains("%TO.P,1*%"));
+        assert!(top.contents.contains("%TO.P,U1,1*%"));
 
         let vcut = set
             .files

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -221,13 +221,22 @@ fn layer_output(
             "Edge_Cuts.gm1".to_string(),
             vec!["Profile".into(), "NP".into()],
         ),
-        GerberLayerRole::Vcut => vcut_layer_output("V_Cut.gbr", side),
-        GerberLayerRole::Score => vcut_layer_output("Score.gbr", side),
+        GerberLayerRole::Vcut => fabrication_line_layer_output("V_Cut.gbr", &["Vcut"], side),
+        GerberLayerRole::Score => {
+            fabrication_line_layer_output("Score.gbr", &["Other", "Score"], side)
+        }
     }
 }
 
-fn vcut_layer_output(filename: &str, side: Option<Side>) -> (String, Vec<String>) {
-    let mut file_function = vec!["Vcut".to_string()];
+fn fabrication_line_layer_output(
+    filename: &str,
+    function: &[&str],
+    side: Option<Side>,
+) -> (String, Vec<String>) {
+    let mut file_function = function
+        .iter()
+        .map(|field| (*field).to_string())
+        .collect::<Vec<_>>();
     match side {
         Some(Side::Top) => file_function.push("Top".to_string()),
         Some(Side::Bottom) => file_function.push("Bot".to_string()),
@@ -392,9 +401,8 @@ fn aperture_function(feature: &GeometryFeature<ipc2581::Symbol>) -> Vec<String> 
         FeatureSemantic::SmdPad => vec!["SMDPad".to_string()],
         FeatureSemantic::ComponentPad => vec!["ComponentPad".to_string()],
         FeatureSemantic::ViaPad => vec!["ViaPad".to_string()],
-        FeatureSemantic::VCut | FeatureSemantic::Score => {
-            vec!["Other".to_string(), "Vcut".to_string()]
-        }
+        FeatureSemantic::VCut => vec!["Other".to_string(), "Vcut".to_string()],
+        FeatureSemantic::Score => vec!["Other".to_string(), "Score".to_string()],
         FeatureSemantic::Route | FeatureSemantic::BoardOutline => vec!["Profile".to_string()],
         _ => match feature.bucket {
             FeatureBucket::Smd => vec!["SMDPad".to_string()],
@@ -626,6 +634,7 @@ mod tests {
     <StepRef name="Panel"/>
     <LayerRef name="TOP"/>
     <LayerRef name="VCUT"/>
+    <LayerRef name="SCORE"/>
     <DictionaryLineDesc units="MILLIMETER">
       <EntryLineDesc id="fidline">
         <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
@@ -645,6 +654,7 @@ mod tests {
       <Layer name="VCUT" layerFunction="V_CUT" side="ALL" polarity="POSITIVE">
         <SpecRef id="VCut_1"/>
       </Layer>
+      <Layer name="SCORE" layerFunction="SCORE" side="ALL" polarity="POSITIVE"/>
       <Step name="Panel" type="PALLET">
         <LayerFeature layerRef="TOP">
           <Set>
@@ -662,6 +672,15 @@ mod tests {
           <Set>
             <Features>
               <Line startX="0" startY="5" endX="10" endY="5">
+                <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
+              </Line>
+            </Features>
+          </Set>
+        </LayerFeature>
+        <LayerFeature layerRef="SCORE">
+          <Set>
+            <Features>
+              <Line startX="0" startY="7" endX="10" endY="7">
                 <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
               </Line>
             </Features>
@@ -707,6 +726,20 @@ mod tests {
         assert!(vcut.contents.contains("%TF.FileFunction,Vcut,Top/Bot*%"));
         assert!(vcut.contents.contains("%TF.Part,Array*%"));
         assert!(vcut.contents.contains("%TA.AperFunction,Other,Vcut*%"));
+
+        let score = set
+            .files
+            .iter()
+            .find(|file| file.filename == "Score.gbr")
+            .unwrap();
+        assert!(
+            score
+                .contents
+                .contains("%TF.FileFunction,Other,Score,Top/Bot*%")
+        );
+        assert!(score.contents.contains("%TF.Part,Array*%"));
+        assert!(score.contents.contains("%TA.AperFunction,Other,Score*%"));
+        assert!(!score.contents.contains("Vcut"));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/gerber/lower.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/lower.rs
@@ -10,12 +10,12 @@ use pcb_ir::dialects::artwork::{ArtworkGeometry, ArtworkPath};
 use pcb_ir::dialects::gerber::Polarity;
 use pcb_ir::dialects::path::{PathCmd, PathOp};
 
-use super::artwork::{ArtworkLayer, ObjectAttributes};
+use super::artwork::{ArtworkLayer, LayerAttributes, ObjectAttributes};
 
 pub fn lower_artwork_layer(layer: &ArtworkLayer) -> Result<GerberLayer> {
     let mut apertures = ApertureTable::default();
     let mut objects = Vec::new();
-    let file_function = layer
+    let layer_attributes = layer
         .layers
         .first()
         .map(|layer| layer.meta.clone())
@@ -33,14 +33,13 @@ pub fn lower_artwork_layer(layer: &ArtworkLayer) -> Result<GerberLayer> {
             }),
             ArtworkGeometry::Stroke { path } => {
                 let artwork_path = &layer.paths[path as usize];
-                let aperture = apertures.circle(
-                    artwork_path.stroke_width,
-                    object
-                        .meta
-                        .aperture_function
-                        .as_deref()
-                        .unwrap_or("Conductor"),
-                )?;
+                let default_function = vec!["Conductor".to_string()];
+                let aperture_function = object
+                    .meta
+                    .aperture_function
+                    .as_deref()
+                    .unwrap_or(default_function.as_slice());
+                let aperture = apertures.circle(artwork_path.stroke_width, aperture_function)?;
                 for contour in path_contours(layer, artwork_path) {
                     for segment in contour_segments(&contour.cmds)? {
                         objects.push(WriterObject {
@@ -79,10 +78,7 @@ pub fn lower_artwork_layer(layer: &ArtworkLayer) -> Result<GerberLayer> {
     }
 
     Ok(GerberLayer {
-        file_attributes: vec![AttributeValue::new(
-            ".FileFunction",
-            file_function.iter().cloned(),
-        )],
+        file_attributes: lower_layer_attributes(&layer_attributes),
         apertures: apertures.into_apertures(),
         objects,
         ..GerberLayer::default()
@@ -99,17 +95,17 @@ struct ApertureTable {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ApertureKey {
     diameter_nm: i64,
-    function: String,
+    function: Vec<String>,
 }
 
 impl ApertureTable {
-    fn circle(&mut self, diameter: f64, function: &str) -> Result<i32> {
+    fn circle(&mut self, diameter: f64, function: &[String]) -> Result<i32> {
         if diameter <= 0.0 {
             bail!("cannot export non-positive Gerber stroke aperture diameter {diameter}");
         }
         let key = ApertureKey {
             diameter_nm: quantize_mm(diameter),
-            function: function.to_string(),
+            function: function.to_vec(),
         };
         if let Some(code) = self.by_key.get(&key) {
             return Ok(*code);
@@ -128,7 +124,10 @@ impl ApertureTable {
                 diameter,
                 hole_diameter: None,
             },
-            attributes: vec![AttributeValue::new(".AperFunction", [function.to_string()])],
+            attributes: vec![AttributeValue::new(
+                ".AperFunction",
+                function.iter().cloned(),
+            )],
         });
         Ok(code)
     }
@@ -136,6 +135,23 @@ impl ApertureTable {
     fn into_apertures(self) -> Vec<WriterAperture> {
         self.apertures
     }
+}
+
+fn lower_layer_attributes(attributes: &LayerAttributes) -> Vec<AttributeValue> {
+    let mut values = vec![AttributeValue::new(
+        ".FileFunction",
+        attributes.file_function.iter().cloned(),
+    )];
+    if let Some(part) = &attributes.part {
+        values.push(AttributeValue::new(".Part", part.iter().cloned()));
+    }
+    if let Some(file_polarity) = &attributes.file_polarity {
+        values.push(AttributeValue::new(
+            ".FilePolarity",
+            [file_polarity.clone()],
+        ));
+    }
+    values
 }
 
 fn lower_region_contours(layer: &ArtworkLayer, path: u32) -> Result<Vec<Contour>> {
@@ -260,11 +276,20 @@ fn contour_segments(cmds: &[PathCmd]) -> Result<Vec<Segment>> {
 }
 
 fn lower_object_attributes(attributes: &ObjectAttributes) -> Vec<AttributeValue> {
-    attributes
-        .net
-        .as_ref()
-        .map(|net| vec![AttributeValue::new(".N", [sanitize_attribute_field(net)])])
-        .unwrap_or_default()
+    let mut values = Vec::new();
+    if let Some(component) = &attributes.component {
+        values.push(AttributeValue::new(
+            ".C",
+            [sanitize_attribute_field(component)],
+        ));
+    }
+    if let Some(pin) = &attributes.pin {
+        values.push(AttributeValue::new(".P", [sanitize_attribute_field(pin)]));
+    }
+    if let Some(net) = &attributes.net {
+        values.push(AttributeValue::new(".N", [sanitize_attribute_field(net)]));
+    }
+    values
 }
 
 fn lower_polarity(paint: PaintPolarity) -> Polarity {
@@ -312,6 +337,8 @@ mod tests {
         let attributes = lower_object_attributes(&ObjectAttributes {
             aperture_function: None,
             net: Some("PWR_RST*,A%B".to_string()),
+            component: None,
+            pin: None,
         });
 
         assert_eq!(attributes[0].name, ".N");

--- a/crates/pcb-ipc2581-tools/src/gerber/lower.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/lower.rs
@@ -283,8 +283,14 @@ fn lower_object_attributes(attributes: &ObjectAttributes) -> Vec<AttributeValue>
             [sanitize_attribute_field(component)],
         ));
     }
-    if let Some(pin) = &attributes.pin {
-        values.push(AttributeValue::new(".P", [sanitize_attribute_field(pin)]));
+    if let (Some(component), Some(pin)) = (&attributes.component, &attributes.pin) {
+        values.push(AttributeValue::new(
+            ".P",
+            [
+                sanitize_attribute_field(component),
+                sanitize_attribute_field(pin),
+            ],
+        ));
     }
     if let Some(net) = &attributes.net {
         values.push(AttributeValue::new(".N", [sanitize_attribute_field(net)]));
@@ -343,5 +349,32 @@ mod tests {
 
         assert_eq!(attributes[0].name, ".N");
         assert_eq!(attributes[0].fields, ["PWR_RST__A_B"]);
+    }
+
+    #[test]
+    fn lowers_pin_attribute_with_component_context() {
+        let attributes = lower_object_attributes(&ObjectAttributes {
+            aperture_function: None,
+            net: None,
+            component: Some("U1".to_string()),
+            pin: Some("1".to_string()),
+        });
+
+        assert_eq!(attributes[0].name, ".C");
+        assert_eq!(attributes[0].fields, ["U1"]);
+        assert_eq!(attributes[1].name, ".P");
+        assert_eq!(attributes[1].fields, ["U1", "1"]);
+    }
+
+    #[test]
+    fn skips_pin_attribute_without_component_context() {
+        let attributes = lower_object_attributes(&ObjectAttributes {
+            aperture_function: None,
+            net: None,
+            component: None,
+            pin: Some("1".to_string()),
+        });
+
+        assert!(attributes.is_empty());
     }
 }

--- a/crates/pcb-ipc2581-tools/src/gerber/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/mod.rs
@@ -3,5 +3,6 @@ mod export;
 mod lower;
 
 pub use export::{
-    GerberExportFile, GerberExportOptions, GerberExportSet, execute_file, export_gerber_x2,
+    GerberExportFile, GerberExportOptions, GerberExportSet, execute_file,
+    execute_file_with_options, export_gerber_x2,
 };

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -31,6 +31,23 @@ pub enum UnitFormat {
     Inch,
 }
 
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutTarget {
+    Board,
+    Panel,
+    Layout,
+}
+
+impl LayoutTarget {
+    pub fn profile_set(self) -> pcb_ir::dialects::ipc::ProfileSet {
+        match self {
+            Self::Board => pcb_ir::dialects::ipc::ProfileSet::BoardOutlines,
+            Self::Panel => pcb_ir::dialects::ipc::ProfileSet::FabricationOutlines,
+            Self::Layout => pcb_ir::dialects::ipc::ProfileSet::LayoutBoundaries,
+        }
+    }
+}
+
 #[derive(ValueEnum, Debug, Clone, Copy)]
 pub enum ViewMode {
     Bom,

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -212,6 +212,8 @@ pub fn panel_step_count<Symbol, LayerFunction>(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProfileSet {
+    /// The canonical board step profile only.
+    BoardOutlines,
     /// Physical outlines for manufacturing exports.
     ///
     /// For a panel root, this means the root panel profile plus final board
@@ -230,6 +232,7 @@ pub enum ProfileOccurrenceRole {
     RootBoard,
     RootPanel,
     RootStep,
+    BoardDefinition,
     BoardInstance,
     PanelInstance,
     StepInstance,
@@ -254,6 +257,10 @@ pub fn profile_occurrences_for<Symbol, LayerFunction>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
     profile_set: ProfileSet,
 ) -> Vec<ProfileOccurrence<'_>> {
+    if profile_set == ProfileSet::BoardOutlines {
+        return board_profile_occurrences(doc);
+    }
+
     let Some((root_index, root)) = root_step(doc) else {
         return doc
             .profiles
@@ -357,8 +364,36 @@ fn include_instance_profiles(
             root_kind == LayoutStepKind::Panel && child_kind == LayoutStepKind::Board
         }
         ProfileSet::LayoutBoundaries => true,
-        ProfileSet::RootOnly => false,
+        ProfileSet::BoardOutlines | ProfileSet::RootOnly => false,
     }
+}
+
+fn board_profile_occurrences<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+) -> Vec<ProfileOccurrence<'_>> {
+    let Some((step_index, step)) = layout_steps_by_kind(doc, LayoutStepKind::Board).next() else {
+        return Vec::new();
+    };
+    let role = if root_step(doc).is_some_and(|(root_index, _)| root_index == step_index) {
+        ProfileOccurrenceRole::RootBoard
+    } else {
+        ProfileOccurrenceRole::BoardDefinition
+    };
+    let mut occurrences = Vec::new();
+    push_profile_occurrences(
+        &mut occurrences,
+        doc,
+        ProfileOccurrenceSpec {
+            start: step.profile_start,
+            count: step.profile_count,
+            step: Some(step_index),
+            instance: None,
+            transform: Affine2::identity(),
+            role,
+            depth: 0,
+        },
+    );
+    occurrences
 }
 
 fn root_profile_role(kind: LayoutStepKind) -> ProfileOccurrenceRole {

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -8,7 +8,13 @@ pub struct GeometryDocument<Symbol, LayerFunction> {
     pub layers: Vec<GeometryLayer<Symbol, LayerFunction>>,
     pub profiles: Vec<StepProfile>,
     pub profile_cutouts: Vec<StepProfileCutout>,
+    pub specs: Vec<IpcSpec<Symbol>>,
+    pub spec_items: Vec<IpcSpecItem<Symbol>>,
+    pub spec_properties: Vec<IpcSpecProperty<Symbol>>,
+    pub spec_refs: Vec<IpcSpecRef<Symbol>>,
+    pub feature_sets: Vec<GeometryFeatureSet<Symbol>>,
     pub features: Vec<GeometryFeature<Symbol>>,
+    pub pin_refs: Vec<IpcPinRef<Symbol>>,
     pub paths: Vec<GeometryPath>,
     pub contours: Vec<GeometryContour>,
     pub path_cmds: Vec<PathCmd>,
@@ -90,7 +96,13 @@ impl<Symbol, LayerFunction> Default for GeometryDocument<Symbol, LayerFunction> 
             layers: Vec::new(),
             profiles: Vec::new(),
             profile_cutouts: Vec::new(),
+            specs: Vec::new(),
+            spec_items: Vec::new(),
+            spec_properties: Vec::new(),
+            spec_refs: Vec::new(),
+            feature_sets: Vec::new(),
             features: Vec::new(),
+            pin_refs: Vec::new(),
             paths: Vec::new(),
             contours: Vec::new(),
             path_cmds: Vec::new(),
@@ -743,10 +755,69 @@ pub struct StepProfileCutout {
 }
 
 #[derive(Debug, Clone)]
+pub struct IpcSpec<Symbol> {
+    pub name: Symbol,
+    pub item_start: u32,
+    pub item_count: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct IpcSpecItem<Symbol> {
+    pub element: Symbol,
+    pub kind: IpcSpecItemKind,
+    pub item_type: Option<Symbol>,
+    pub comment: Option<Symbol>,
+    pub property_start: u32,
+    pub property_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpcSpecItemKind {
+    General,
+    Dielectric,
+    Conductor,
+    SurfaceFinish,
+    VCut,
+    Other,
+}
+
+#[derive(Debug, Clone)]
+pub struct IpcSpecProperty<Symbol> {
+    pub value: Option<f64>,
+    pub text: Option<Symbol>,
+    pub unit: Option<Symbol>,
+    pub plus_tol: Option<f64>,
+    pub minus_tol: Option<f64>,
+    pub tol_percent: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IpcSpecRef<Symbol> {
+    pub spec: Symbol,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryFeatureSet<Symbol> {
+    pub layer: u32,
+    pub source_set_index: u32,
+    pub net: Option<Symbol>,
+    pub polarity: GeometryPolarity,
+    pub spec_ref_start: u32,
+    pub spec_ref_count: u32,
+    pub feature_start: u32,
+    pub feature_count: u32,
+    pub bbox: BBox,
+}
+
+#[derive(Debug, Clone)]
 pub struct GeometryLayer<Symbol, LayerFunction> {
     pub name: String,
     pub source_layer_ref: Symbol,
     pub layer_function: LayerFunction,
+    pub spec_ref_start: u32,
+    pub spec_ref_count: u32,
+    pub set_start: u32,
+    pub set_count: u32,
     pub feature_start: u32,
     pub feature_count: u32,
     pub bbox: BBox,
@@ -759,7 +830,9 @@ pub struct GeometryFeature<Symbol> {
     pub polarity: GeometryPolarity,
     pub net: Option<Symbol>,
     pub source_layer_ref: Option<Symbol>,
+    pub set: Option<u32>,
     pub source: SourceRef,
+    pub semantic: FeatureSemantic,
     pub transform: Affine2,
     pub bbox: BBox,
     pub path_start: u32,
@@ -779,6 +852,8 @@ pub struct GeometryFeature<Symbol> {
     pub fill_rule: FillRule,
     pub padstack_ref: Option<Symbol>,
     pub primitive_ref: Option<Symbol>,
+    pub pin_ref_start: u32,
+    pub pin_ref_count: u32,
     pub flags: FeatureFlags,
 }
 
@@ -790,7 +865,9 @@ impl<Symbol> GeometryFeature<Symbol> {
             polarity,
             net: None,
             source_layer_ref: None,
+            set: None,
             source: SourceRef::default(),
+            semantic: FeatureSemantic::None,
             transform: Affine2::identity(),
             bbox: BBox::empty(),
             path_start: 0,
@@ -808,9 +885,18 @@ impl<Symbol> GeometryFeature<Symbol> {
             fill_rule: FillRule::NonZero,
             padstack_ref: None,
             primitive_ref: None,
+            pin_ref_start: 0,
+            pin_ref_count: 0,
             flags: FeatureFlags::default(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct IpcPinRef<Symbol> {
+    pub component_ref: Option<Symbol>,
+    pub pin: Symbol,
+    pub title: Option<Symbol>,
 }
 
 #[derive(Debug, Clone)]
@@ -891,11 +977,36 @@ pub enum FeatureBucket {
     Smd,
     Pth,
     Via,
+    Fiducial,
     Trace,
     Fill,
     Cutout,
     Thermal,
     Antipad,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureSemantic {
+    None,
+    CopperConductor,
+    SmdPad,
+    ComponentPad,
+    ViaPad,
+    Fiducial(FiducialKind),
+    VCut,
+    Score,
+    Route,
+    BoardOutline,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FiducialKind {
+    Local,
+    Global,
+    Panel,
+    BadBoard,
+    GoodPanel,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -4,10 +4,9 @@ use crate::dialects::{geom, path as common_path};
 
 #[derive(Debug, Clone)]
 pub struct GeometryDocument<Symbol, LayerFunction> {
-    pub board_name: String,
     pub layout: LayoutGraph<Symbol>,
     pub layers: Vec<GeometryLayer<Symbol, LayerFunction>>,
-    pub profiles: Vec<StepProfile<Symbol>>,
+    pub profiles: Vec<StepProfile>,
     pub profile_cutouts: Vec<StepProfileCutout>,
     pub features: Vec<GeometryFeature<Symbol>>,
     pub paths: Vec<GeometryPath>,
@@ -17,19 +16,8 @@ pub struct GeometryDocument<Symbol, LayerFunction> {
 }
 
 impl<Symbol, LayerFunction> GeometryDocument<Symbol, LayerFunction> {
-    pub fn new(board_name: String) -> Self {
-        Self {
-            board_name,
-            layout: LayoutGraph::new(),
-            layers: Vec::new(),
-            profiles: Vec::new(),
-            profile_cutouts: Vec::new(),
-            features: Vec::new(),
-            paths: Vec::new(),
-            contours: Vec::new(),
-            path_cmds: Vec::new(),
-            diagnostics: Vec::new(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn push_path(
@@ -95,16 +83,23 @@ impl<Symbol, LayerFunction> GeometryDocument<Symbol, LayerFunction> {
     }
 }
 
-const PROFILE_STROKE_WIDTH: f64 = 0.1;
-
-pub fn profiles_bbox<Symbol, LayerFunction>(
-    doc: &GeometryDocument<Symbol, LayerFunction>,
-) -> Option<BBox> {
-    render_profiles(doc)
-        .map(|profile| profile.bbox)
-        .reduce(BBox::union)
-        .filter(|bbox| !bbox.is_empty())
+impl<Symbol, LayerFunction> Default for GeometryDocument<Symbol, LayerFunction> {
+    fn default() -> Self {
+        Self {
+            layout: LayoutGraph::new(),
+            layers: Vec::new(),
+            profiles: Vec::new(),
+            profile_cutouts: Vec::new(),
+            features: Vec::new(),
+            paths: Vec::new(),
+            contours: Vec::new(),
+            path_cmds: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
 }
+
+const PROFILE_STROKE_WIDTH: f64 = 0.1;
 
 pub fn board_bbox<Symbol, LayerFunction>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
@@ -243,25 +238,6 @@ fn rendered_profile_indices<Symbol, LayerFunction>(
     indices
 }
 
-fn profile_range_bbox<Symbol, LayerFunction>(
-    doc: &GeometryDocument<Symbol, LayerFunction>,
-    start: u32,
-    count: u32,
-) -> BBox {
-    doc.profiles[start as usize..(start + count) as usize]
-        .iter()
-        .map(|profile| profile.bbox)
-        .fold(BBox::empty(), BBox::union)
-}
-
-pub fn panel_profile_bbox<Symbol, LayerFunction>(
-    doc: &GeometryDocument<Symbol, LayerFunction>,
-) -> Option<BBox> {
-    root_panel_step(doc)
-        .map(|(_, panel)| profile_range_bbox(doc, panel.profile_start, panel.profile_count))
-        .filter(|bbox| !bbox.is_empty())
-}
-
 pub fn lower_layer_to_geom<Symbol: Clone, LayerFunction: Clone>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
     layer_index: usize,
@@ -338,7 +314,7 @@ pub fn lower_layer_with_profiles_to_geom<Symbol: Clone, LayerFunction: Clone>(
 
 pub fn render_profiles<Symbol, LayerFunction>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
-) -> impl Iterator<Item = &StepProfile<Symbol>> {
+) -> impl Iterator<Item = &StepProfile> {
     let indices = if has_panel_layout(doc) {
         rendered_profile_indices(doc)
     } else if let Some((_, root)) = root_step(doc) {
@@ -524,9 +500,7 @@ pub struct LayoutInstance<Symbol> {
 }
 
 #[derive(Debug, Clone)]
-pub struct StepProfile<Symbol> {
-    pub source_step_ref: Symbol,
-    pub transform: Affine2,
+pub struct StepProfile {
     pub outer_path: u32,
     pub cutout_start: u32,
     pub cutout_count: u32,

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -210,32 +210,198 @@ pub fn panel_step_count<Symbol, LayerFunction>(
     layout_steps_by_kind(doc, LayoutStepKind::Panel).count()
 }
 
-fn has_panel_layout<Symbol, LayerFunction>(doc: &GeometryDocument<Symbol, LayerFunction>) -> bool {
-    panel_step_count(doc) > 0
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileSet {
+    /// Physical outlines for manufacturing exports.
+    ///
+    /// For a panel root, this means the root panel profile plus final board
+    /// instance profiles. Nested panel boundaries are intentionally excluded.
+    FabricationOutlines,
+    /// Every placed profile boundary in the layout graph, including nested
+    /// panel/subpanel boundaries.
+    LayoutBoundaries,
+    /// Only the root step profile.
+    RootOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileOccurrenceRole {
+    Unplaced,
+    RootBoard,
+    RootPanel,
+    RootStep,
+    BoardInstance,
+    PanelInstance,
+    StepInstance,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProfileOccurrence<'a> {
+    pub profile_index: u32,
+    pub profile: &'a StepProfile,
+    pub step: Option<u32>,
+    pub instance: Option<u32>,
+    pub transform: Affine2,
+    pub role: ProfileOccurrenceRole,
+    pub depth: u32,
 }
 
 fn profile_range_indices(start: u32, count: u32) -> impl Iterator<Item = u32> {
     start..start + count
 }
 
-fn rendered_profile_indices<Symbol, LayerFunction>(
+pub fn profile_occurrences_for<Symbol, LayerFunction>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
-) -> Vec<u32> {
-    let Some((_, root)) = root_step(doc) else {
-        return (0..doc.profiles.len() as u32).collect();
+    profile_set: ProfileSet,
+) -> Vec<ProfileOccurrence<'_>> {
+    let Some((root_index, root)) = root_step(doc) else {
+        return doc
+            .profiles
+            .iter()
+            .enumerate()
+            .map(|(profile_index, profile)| ProfileOccurrence {
+                profile_index: profile_index as u32,
+                profile,
+                step: None,
+                instance: None,
+                transform: Affine2::identity(),
+                role: ProfileOccurrenceRole::Unplaced,
+                depth: 0,
+            })
+            .collect();
     };
 
-    let mut indices =
-        profile_range_indices(root.profile_start, root.profile_count).collect::<Vec<_>>();
-    if root.kind == LayoutStepKind::Panel {
-        for instance in &doc.layout.instances {
-            indices.extend(profile_range_indices(
-                instance.profile_start,
-                instance.profile_count,
-            ));
-        }
+    let mut occurrences = Vec::new();
+    push_profile_occurrences(
+        &mut occurrences,
+        doc,
+        ProfileOccurrenceSpec {
+            start: root.profile_start,
+            count: root.profile_count,
+            step: Some(root_index),
+            instance: None,
+            transform: Affine2::identity(),
+            role: root_profile_role(root.kind),
+            depth: 0,
+        },
+    );
+
+    if profile_set == ProfileSet::RootOnly {
+        return occurrences;
     }
-    indices
+
+    for (instance_index, instance) in doc.layout.instances.iter().enumerate() {
+        let Some(step) = doc.layout.steps.get(instance.child_step as usize) else {
+            continue;
+        };
+        if !include_instance_profiles(profile_set, root.kind, step.kind) {
+            continue;
+        }
+
+        push_profile_occurrences(
+            &mut occurrences,
+            doc,
+            ProfileOccurrenceSpec {
+                start: step.profile_start,
+                count: step.profile_count,
+                step: Some(instance.child_step),
+                instance: Some(instance_index as u32),
+                transform: instance.transform,
+                role: instance_profile_role(step.kind),
+                depth: instance_depth(doc, instance_index as u32),
+            },
+        );
+    }
+    occurrences
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProfileOccurrenceSpec {
+    start: u32,
+    count: u32,
+    step: Option<u32>,
+    instance: Option<u32>,
+    transform: Affine2,
+    role: ProfileOccurrenceRole,
+    depth: u32,
+}
+
+fn push_profile_occurrences<'a, Symbol, LayerFunction>(
+    occurrences: &mut Vec<ProfileOccurrence<'a>>,
+    doc: &'a GeometryDocument<Symbol, LayerFunction>,
+    spec: ProfileOccurrenceSpec,
+) {
+    for profile_index in profile_range_indices(spec.start, spec.count) {
+        let Some(profile) = doc.profiles.get(profile_index as usize) else {
+            continue;
+        };
+        occurrences.push(ProfileOccurrence {
+            profile_index,
+            profile,
+            step: spec.step,
+            instance: spec.instance,
+            transform: spec.transform,
+            role: spec.role,
+            depth: spec.depth,
+        });
+    }
+}
+
+fn include_instance_profiles(
+    profile_set: ProfileSet,
+    root_kind: LayoutStepKind,
+    child_kind: LayoutStepKind,
+) -> bool {
+    match profile_set {
+        ProfileSet::FabricationOutlines => {
+            root_kind == LayoutStepKind::Panel && child_kind == LayoutStepKind::Board
+        }
+        ProfileSet::LayoutBoundaries => true,
+        ProfileSet::RootOnly => false,
+    }
+}
+
+fn root_profile_role(kind: LayoutStepKind) -> ProfileOccurrenceRole {
+    match kind {
+        LayoutStepKind::Board => ProfileOccurrenceRole::RootBoard,
+        LayoutStepKind::Panel => ProfileOccurrenceRole::RootPanel,
+        _ => ProfileOccurrenceRole::RootStep,
+    }
+}
+
+fn instance_profile_role(kind: LayoutStepKind) -> ProfileOccurrenceRole {
+    match kind {
+        LayoutStepKind::Board => ProfileOccurrenceRole::BoardInstance,
+        LayoutStepKind::Panel => ProfileOccurrenceRole::PanelInstance,
+        _ => ProfileOccurrenceRole::StepInstance,
+    }
+}
+
+fn instance_depth<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+    instance_index: u32,
+) -> u32 {
+    let mut depth = 1;
+    let mut remaining = doc.layout.instances.len();
+    let mut parent = doc
+        .layout
+        .instances
+        .get(instance_index as usize)
+        .and_then(|instance| instance.parent_instance);
+
+    while let Some(parent_index) = parent {
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        depth += 1;
+        parent = doc
+            .layout
+            .instances
+            .get(parent_index as usize)
+            .and_then(|instance| instance.parent_instance);
+    }
+    depth
 }
 
 pub fn lower_layer_to_geom<Symbol: Clone, LayerFunction: Clone>(
@@ -282,11 +448,12 @@ pub fn lower_layer_to_geom<Symbol: Clone, LayerFunction: Clone>(
     geom
 }
 
-pub fn lower_layer_with_profiles_to_geom<Symbol: Clone, LayerFunction: Clone>(
+pub fn lower_layer_with_profile_set_to_geom<Symbol: Clone, LayerFunction: Clone>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
     layer_index: usize,
     role: LayerRole,
     side: Side,
+    profile_set: ProfileSet,
 ) -> geom::GeomDocument<LayerFunction, Option<Symbol>> {
     let mut geom = lower_layer_to_geom(doc, layer_index, role, side);
     let layer = &doc.layers[layer_index];
@@ -300,32 +467,28 @@ pub fn lower_layer_with_profiles_to_geom<Symbol: Clone, LayerFunction: Clone>(
         meta: layer.layer_function.clone(),
     });
 
-    for profile in render_profiles(doc) {
-        push_profile_path_to_geom(&mut geom, outline_layer, doc, profile.outer_path);
-        for cutout in &doc.profile_cutouts
-            [profile.cutout_start as usize..(profile.cutout_start + profile.cutout_count) as usize]
+    for occurrence in profile_occurrences_for(doc, profile_set) {
+        push_profile_path_to_geom(
+            &mut geom,
+            outline_layer,
+            doc,
+            occurrence.profile.outer_path,
+            occurrence.transform,
+        );
+        for cutout in &doc.profile_cutouts[occurrence.profile.cutout_start as usize
+            ..(occurrence.profile.cutout_start + occurrence.profile.cutout_count) as usize]
         {
-            push_profile_path_to_geom(&mut geom, outline_layer, doc, cutout.path);
+            push_profile_path_to_geom(
+                &mut geom,
+                outline_layer,
+                doc,
+                cutout.path,
+                occurrence.transform,
+            );
         }
     }
 
     geom
-}
-
-pub fn render_profiles<Symbol, LayerFunction>(
-    doc: &GeometryDocument<Symbol, LayerFunction>,
-) -> impl Iterator<Item = &StepProfile> {
-    let indices = if has_panel_layout(doc) {
-        rendered_profile_indices(doc)
-    } else if let Some((_, root)) = root_step(doc) {
-        profile_range_indices(root.profile_start, root.profile_count).collect()
-    } else {
-        (0..doc.profiles.len() as u32).collect()
-    };
-
-    indices
-        .into_iter()
-        .filter_map(move |index| doc.profiles.get(index as usize))
 }
 
 fn push_profile_path_to_geom<Symbol, LayerFunction>(
@@ -333,22 +496,24 @@ fn push_profile_path_to_geom<Symbol, LayerFunction>(
     layer_id: u32,
     doc: &GeometryDocument<Symbol, LayerFunction>,
     path_index: u32,
+    transform: Affine2,
 ) {
-    let path = &doc.paths[path_index as usize];
+    let payloads = transformed_path_payloads(doc, path_index, transform);
     let path_id = geom.push_path(
         geom::GeomPath::stroked(PROFILE_STROKE_WIDTH, LineCap::Round, LineJoin::Round),
-        path_payloads(doc, path),
+        payloads,
     );
+    let bbox = geom.paths[path_id as usize].bbox;
     geom.push_object(
         layer_id,
         geom::GeomObject {
             paint: PaintPolarity::Dark,
             path: path_id,
-            bbox: path.bbox,
+            bbox,
             meta: None,
         },
     );
-    geom.layers[layer_id as usize].bbox = geom.layers[layer_id as usize].bbox.union(path.bbox);
+    geom.layers[layer_id as usize].bbox = geom.layers[layer_id as usize].bbox.union(bbox);
 }
 
 fn lower_path_kind(path: &GeometryPath) -> Option<geom::GeomPath> {
@@ -378,6 +543,37 @@ fn path_payloads<Symbol, LayerFunction>(
                 .to_vec(),
         })
         .collect()
+}
+
+pub fn transformed_path_payloads<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+    path_index: u32,
+    transform: Affine2,
+) -> Vec<common_path::PathPayload> {
+    let path = &doc.paths[path_index as usize];
+    doc.contours[path.contour_start as usize..(path.contour_start + path.contour_count) as usize]
+        .iter()
+        .map(|contour| {
+            common_path::transform_cmds(
+                doc.path_cmds
+                    [contour.cmd_start as usize..(contour.cmd_start + contour.cmd_count) as usize]
+                    .iter()
+                    .copied(),
+                transform,
+            )
+            .into()
+        })
+        .collect()
+}
+
+pub fn transformed_path_bbox<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+    path_index: u32,
+    transform: Affine2,
+) -> BBox {
+    transformed_path_payloads(doc, path_index, transform)
+        .iter()
+        .fold(BBox::empty(), |bbox, payload| bbox.union(payload.bbox))
 }
 
 fn paint_polarity(polarity: GeometryPolarity) -> PaintPolarity {
@@ -494,8 +690,6 @@ pub struct LayoutInstance<Symbol> {
     pub repeat_count_y: u32,
     pub repeat_pitch_x: f64,
     pub repeat_pitch_y: f64,
-    pub profile_start: u32,
-    pub profile_count: u32,
     pub bbox: BBox,
 }
 

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -7,11 +7,8 @@ pub struct GeometryDocument<Symbol, LayerFunction> {
     pub board_name: String,
     pub layout: LayoutGraph<Symbol>,
     pub layers: Vec<GeometryLayer<Symbol, LayerFunction>>,
-    pub boards: Vec<BoardGeometry<Symbol>>,
-    pub panels: Vec<PanelGeometry<Symbol>>,
-    pub board_instances: Vec<BoardInstance<Symbol>>,
-    pub profiles: Vec<BoardProfile<Symbol>>,
-    pub profile_cutouts: Vec<BoardProfileCutout>,
+    pub profiles: Vec<StepProfile<Symbol>>,
+    pub profile_cutouts: Vec<StepProfileCutout>,
     pub features: Vec<GeometryFeature<Symbol>>,
     pub paths: Vec<GeometryPath>,
     pub contours: Vec<GeometryContour>,
@@ -25,9 +22,6 @@ impl<Symbol, LayerFunction> GeometryDocument<Symbol, LayerFunction> {
             board_name,
             layout: LayoutGraph::new(),
             layers: Vec::new(),
-            boards: Vec::new(),
-            panels: Vec::new(),
-            board_instances: Vec::new(),
             profiles: Vec::new(),
             profile_cutouts: Vec::new(),
             features: Vec::new(),
@@ -115,19 +109,157 @@ pub fn profiles_bbox<Symbol, LayerFunction>(
 pub fn board_bbox<Symbol, LayerFunction>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
 ) -> Option<BBox> {
-    doc.boards
-        .iter()
-        .map(|board| board.bbox)
+    layout_steps_by_kind(doc, LayoutStepKind::Board)
+        .map(|(_, step)| step.bbox)
         .find(|bbox| !bbox.is_empty())
 }
 
 pub fn panel_bbox<Symbol, LayerFunction>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
 ) -> Option<BBox> {
-    doc.panels
+    root_panel_step(doc)
+        .map(|(_, step)| step.bbox)
+        .filter(|bbox| !bbox.is_empty())
+        .or_else(|| {
+            layout_steps_by_kind(doc, LayoutStepKind::Panel)
+                .map(|(_, step)| step.bbox)
+                .find(|bbox| !bbox.is_empty())
+        })
+}
+
+pub fn root_step<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+) -> Option<(u32, &LayoutStep<Symbol>)> {
+    let index = doc.layout.root_step?;
+    doc.layout
+        .steps
+        .get(index as usize)
+        .map(|step| (index, step))
+}
+
+pub fn root_panel_step<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+) -> Option<(u32, &LayoutStep<Symbol>)> {
+    root_step(doc).filter(|(_, step)| step.kind == LayoutStepKind::Panel)
+}
+
+pub fn layout_steps_by_kind<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+    kind: LayoutStepKind,
+) -> impl Iterator<Item = (u32, &LayoutStep<Symbol>)> {
+    doc.layout
+        .steps
         .iter()
-        .map(|panel| panel.bbox)
-        .find(|bbox| !bbox.is_empty())
+        .enumerate()
+        .filter_map(move |(index, step)| (step.kind == kind).then_some((index as u32, step)))
+}
+
+pub fn layout_instances_by_kind<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+    kind: LayoutStepKind,
+) -> impl Iterator<Item = (u32, &LayoutInstance<Symbol>)> {
+    doc.layout
+        .instances
+        .iter()
+        .enumerate()
+        .filter_map(move |(index, instance)| {
+            let step = doc.layout.steps.get(instance.child_step as usize)?;
+            (step.kind == kind).then_some((index as u32, instance))
+        })
+}
+
+pub fn layout_child_repeats<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+    parent_step: u32,
+    parent_instance: Option<u32>,
+) -> impl Iterator<Item = (u32, &LayoutRepeat<Symbol>)> {
+    doc.layout
+        .repeats
+        .iter()
+        .enumerate()
+        .filter_map(move |(index, repeat)| {
+            (repeat.parent_step == parent_step && repeat.parent_instance == parent_instance)
+                .then_some((index as u32, repeat))
+        })
+}
+
+pub fn layout_repeat_instances<'a, Symbol, LayerFunction>(
+    doc: &'a GeometryDocument<Symbol, LayerFunction>,
+    repeat: &LayoutRepeat<Symbol>,
+) -> impl Iterator<Item = (u32, &'a LayoutInstance<Symbol>)> {
+    let start = repeat.instance_start;
+    let end = repeat.instance_start + repeat.instance_count;
+    (start..end).filter_map(move |index| {
+        doc.layout
+            .instances
+            .get(index as usize)
+            .map(|instance| (index, instance))
+    })
+}
+
+pub fn board_step_count<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+) -> usize {
+    layout_steps_by_kind(doc, LayoutStepKind::Board).count()
+}
+
+pub fn board_instance_count<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+) -> usize {
+    layout_instances_by_kind(doc, LayoutStepKind::Board).count()
+}
+
+pub fn panel_step_count<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+) -> usize {
+    layout_steps_by_kind(doc, LayoutStepKind::Panel).count()
+}
+
+fn has_panel_layout<Symbol, LayerFunction>(doc: &GeometryDocument<Symbol, LayerFunction>) -> bool {
+    panel_step_count(doc) > 0
+}
+
+fn profile_range_indices(start: u32, count: u32) -> impl Iterator<Item = u32> {
+    start..start + count
+}
+
+fn rendered_profile_indices<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+) -> Vec<u32> {
+    let Some((_, root)) = root_step(doc) else {
+        return (0..doc.profiles.len() as u32).collect();
+    };
+
+    let mut indices =
+        profile_range_indices(root.profile_start, root.profile_count).collect::<Vec<_>>();
+    if root.kind == LayoutStepKind::Panel {
+        for instance in &doc.layout.instances {
+            indices.extend(profile_range_indices(
+                instance.profile_start,
+                instance.profile_count,
+            ));
+        }
+    }
+    indices
+}
+
+fn profile_range_bbox<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+    start: u32,
+    count: u32,
+) -> BBox {
+    doc.profiles[start as usize..(start + count) as usize]
+        .iter()
+        .map(|profile| profile.bbox)
+        .fold(BBox::empty(), BBox::union)
+}
+
+pub fn panel_profile_bbox<Symbol, LayerFunction>(
+    doc: &GeometryDocument<Symbol, LayerFunction>,
+) -> Option<BBox> {
+    root_panel_step(doc)
+        .map(|(_, panel)| profile_range_bbox(doc, panel.profile_start, panel.profile_count))
+        .filter(|bbox| !bbox.is_empty())
 }
 
 pub fn lower_layer_to_geom<Symbol: Clone, LayerFunction: Clone>(
@@ -206,21 +338,18 @@ pub fn lower_layer_with_profiles_to_geom<Symbol: Clone, LayerFunction: Clone>(
 
 pub fn render_profiles<Symbol, LayerFunction>(
     doc: &GeometryDocument<Symbol, LayerFunction>,
-) -> impl Iterator<Item = &BoardProfile<Symbol>> {
-    let has_panel = !doc.panels.is_empty();
-    doc.profiles.iter().filter(move |profile| {
-        if has_panel {
-            matches!(
-                profile.kind,
-                BoardProfileKind::PanelDefinition
-                    | BoardProfileKind::PanelInstance
-                    | BoardProfileKind::BoardInstance
-                    | BoardProfileKind::StepInstance
-            )
-        } else {
-            matches!(profile.kind, BoardProfileKind::BoardDefinition)
-        }
-    })
+) -> impl Iterator<Item = &StepProfile<Symbol>> {
+    let indices = if has_panel_layout(doc) {
+        rendered_profile_indices(doc)
+    } else if let Some((_, root)) = root_step(doc) {
+        profile_range_indices(root.profile_start, root.profile_count).collect()
+    } else {
+        (0..doc.profiles.len() as u32).collect()
+    };
+
+    indices
+        .into_iter()
+        .filter_map(move |index| doc.profiles.get(index as usize))
 }
 
 fn push_profile_path_to_geom<Symbol, LayerFunction>(
@@ -282,11 +411,23 @@ fn paint_polarity(polarity: GeometryPolarity) -> PaintPolarity {
     }
 }
 
+/// Canonical IPC layout graph.
+///
+/// IPC-2581 stores panelization as reusable `Step` definitions plus
+/// `StepRepeat` placements. This graph mirrors that model directly: `steps`
+/// are reusable definitions, `repeats` are compact placement edges, and
+/// `instances` are the materialized placements generated by each repeat.
+/// Flattened board or panel geometry is a derived export/rendering view, not
+/// independent IR state.
 #[derive(Debug, Clone)]
 pub struct LayoutGraph<Symbol> {
+    /// Root step selected by IPC Content/StepRef or by parser fallback.
     pub root_step: Option<u32>,
+    /// Reusable step definitions. Indices are referenced by repeats and instances.
     pub steps: Vec<LayoutStep<Symbol>>,
+    /// Compact parent-to-child repeat records. Instances for one repeat are contiguous.
     pub repeats: Vec<LayoutRepeat<Symbol>>,
+    /// Materialized placements. Nested panel children reference their parent instance.
     pub instances: Vec<LayoutInstance<Symbol>>,
 }
 
@@ -314,6 +455,10 @@ impl<Symbol> Default for LayoutGraph<Symbol> {
     }
 }
 
+/// Reusable IPC step definition.
+///
+/// A step owns its local profile/layer features. A board array is represented
+/// by a panel step with child board instances, not by duplicating board data.
 #[derive(Debug, Clone)]
 pub struct LayoutStep<Symbol> {
     pub source_step_ref: Symbol,
@@ -334,6 +479,7 @@ pub enum LayoutStepKind {
     Unknown,
 }
 
+/// Compact placement edge from a parent step or parent instance to a child step.
 #[derive(Debug, Clone)]
 pub struct LayoutRepeat<Symbol> {
     pub parent_step: u32,
@@ -353,6 +499,11 @@ pub struct LayoutRepeat<Symbol> {
     pub bbox: BBox,
 }
 
+/// One materialized placement of a child step.
+///
+/// `transform` maps from the child step's local coordinate system into the
+/// root layout coordinate system. Repeated boards, subpanels, coupons, and
+/// tooling steps are all represented by this same structure.
 #[derive(Debug, Clone)]
 pub struct LayoutInstance<Symbol> {
     pub repeat: u32,
@@ -373,55 +524,7 @@ pub struct LayoutInstance<Symbol> {
 }
 
 #[derive(Debug, Clone)]
-pub struct BoardGeometry<Symbol> {
-    pub step_ref: Symbol,
-    pub profile_start: u32,
-    pub profile_count: u32,
-    pub bbox: BBox,
-}
-
-#[derive(Debug, Clone)]
-pub struct PanelGeometry<Symbol> {
-    pub step_ref: Symbol,
-    pub profile_start: u32,
-    pub profile_count: u32,
-    pub profile_bbox: BBox,
-    pub board_instance_start: u32,
-    pub board_instance_count: u32,
-    pub instance_bbox: BBox,
-    pub bbox: BBox,
-}
-
-#[derive(Debug, Clone)]
-pub struct BoardInstance<Symbol> {
-    pub board_index: u32,
-    pub source_step_ref: Symbol,
-    pub parent_step_ref: Symbol,
-    pub transform: Affine2,
-    pub repeat_index_x: u32,
-    pub repeat_index_y: u32,
-    pub repeat_count_x: u32,
-    pub repeat_count_y: u32,
-    pub repeat_pitch_x: f64,
-    pub repeat_pitch_y: f64,
-    pub profile_start: u32,
-    pub profile_count: u32,
-    pub bbox: BBox,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BoardProfileKind {
-    BoardDefinition,
-    PanelDefinition,
-    StepDefinition,
-    BoardInstance,
-    PanelInstance,
-    StepInstance,
-}
-
-#[derive(Debug, Clone)]
-pub struct BoardProfile<Symbol> {
-    pub kind: BoardProfileKind,
+pub struct StepProfile<Symbol> {
     pub source_step_ref: Symbol,
     pub transform: Affine2,
     pub outer_path: u32,
@@ -431,7 +534,7 @@ pub struct BoardProfile<Symbol> {
 }
 
 #[derive(Debug, Clone)]
-pub struct BoardProfileCutout {
+pub struct StepProfileCutout {
     pub path: u32,
     pub bbox: BBox,
 }

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -5,6 +5,7 @@ use crate::dialects::{geom, path as common_path};
 #[derive(Debug, Clone)]
 pub struct GeometryDocument<Symbol, LayerFunction> {
     pub board_name: String,
+    pub layout: LayoutGraph<Symbol>,
     pub layers: Vec<GeometryLayer<Symbol, LayerFunction>>,
     pub boards: Vec<BoardGeometry<Symbol>>,
     pub panels: Vec<PanelGeometry<Symbol>>,
@@ -22,6 +23,7 @@ impl<Symbol, LayerFunction> GeometryDocument<Symbol, LayerFunction> {
     pub fn new(board_name: String) -> Self {
         Self {
             board_name,
+            layout: LayoutGraph::new(),
             layers: Vec::new(),
             boards: Vec::new(),
             panels: Vec::new(),
@@ -210,7 +212,10 @@ pub fn render_profiles<Symbol, LayerFunction>(
         if has_panel {
             matches!(
                 profile.kind,
-                BoardProfileKind::PanelDefinition | BoardProfileKind::BoardInstance
+                BoardProfileKind::PanelDefinition
+                    | BoardProfileKind::PanelInstance
+                    | BoardProfileKind::BoardInstance
+                    | BoardProfileKind::StepInstance
             )
         } else {
             matches!(profile.kind, BoardProfileKind::BoardDefinition)
@@ -278,6 +283,96 @@ fn paint_polarity(polarity: GeometryPolarity) -> PaintPolarity {
 }
 
 #[derive(Debug, Clone)]
+pub struct LayoutGraph<Symbol> {
+    pub root_step: Option<u32>,
+    pub steps: Vec<LayoutStep<Symbol>>,
+    pub repeats: Vec<LayoutRepeat<Symbol>>,
+    pub instances: Vec<LayoutInstance<Symbol>>,
+}
+
+impl<Symbol> LayoutGraph<Symbol> {
+    pub fn new() -> Self {
+        Self {
+            root_step: None,
+            steps: Vec::new(),
+            repeats: Vec::new(),
+            instances: Vec::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.root_step.is_none()
+            && self.steps.is_empty()
+            && self.repeats.is_empty()
+            && self.instances.is_empty()
+    }
+}
+
+impl<Symbol> Default for LayoutGraph<Symbol> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LayoutStep<Symbol> {
+    pub source_step_ref: Symbol,
+    pub kind: LayoutStepKind,
+    pub datum: Point,
+    pub profile_start: u32,
+    pub profile_count: u32,
+    pub bbox: BBox,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutStepKind {
+    Board,
+    Panel,
+    Coupon,
+    Tooling,
+    Ic,
+    Unknown,
+}
+
+#[derive(Debug, Clone)]
+pub struct LayoutRepeat<Symbol> {
+    pub parent_step: u32,
+    pub parent_instance: Option<u32>,
+    pub child_step: u32,
+    pub source_step_ref: Symbol,
+    pub x: f64,
+    pub y: f64,
+    pub nx: u32,
+    pub ny: u32,
+    pub dx: f64,
+    pub dy: f64,
+    pub angle: f64,
+    pub mirror: bool,
+    pub instance_start: u32,
+    pub instance_count: u32,
+    pub bbox: BBox,
+}
+
+#[derive(Debug, Clone)]
+pub struct LayoutInstance<Symbol> {
+    pub repeat: u32,
+    pub parent_instance: Option<u32>,
+    pub child_step: u32,
+    pub source_step_ref: Symbol,
+    pub parent_step_ref: Symbol,
+    pub transform: Affine2,
+    pub repeat_index_x: u32,
+    pub repeat_index_y: u32,
+    pub repeat_count_x: u32,
+    pub repeat_count_y: u32,
+    pub repeat_pitch_x: f64,
+    pub repeat_pitch_y: f64,
+    pub profile_start: u32,
+    pub profile_count: u32,
+    pub bbox: BBox,
+}
+
+#[derive(Debug, Clone)]
 pub struct BoardGeometry<Symbol> {
     pub step_ref: Symbol,
     pub profile_start: u32,
@@ -318,7 +413,10 @@ pub struct BoardInstance<Symbol> {
 pub enum BoardProfileKind {
     BoardDefinition,
     PanelDefinition,
+    StepDefinition,
     BoardInstance,
+    PanelInstance,
+    StepInstance,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -155,10 +155,12 @@ pub fn normalize_bounds<S, L>(doc: &mut GeometryDocument<S, L>) {
     }
 
     for instance_index in 0..doc.layout.instances.len() {
-        let profile_start = doc.layout.instances[instance_index].profile_start;
-        let profile_count = doc.layout.instances[instance_index].profile_count;
+        let step_index = doc.layout.instances[instance_index].child_step;
+        let profile_start = doc.layout.steps[step_index as usize].profile_start;
+        let profile_count = doc.layout.steps[step_index as usize].profile_count;
+        let transform = doc.layout.instances[instance_index].transform;
         doc.layout.instances[instance_index].bbox =
-            profiles_range_bbox(doc, profile_start, profile_count);
+            transformed_profiles_range_bbox(doc, profile_start, profile_count, transform);
     }
 
     for repeat_index in (0..doc.layout.repeats.len()).rev() {
@@ -197,6 +199,18 @@ fn profiles_range_bbox<S, L>(doc: &GeometryDocument<S, L>, start: u32, count: u3
     doc.profiles[start as usize..(start + count) as usize]
         .iter()
         .map(|profile| profile.bbox)
+        .fold(BBox::empty(), BBox::union)
+}
+
+fn transformed_profiles_range_bbox<S, L>(
+    doc: &GeometryDocument<S, L>,
+    start: u32,
+    count: u32,
+    transform: Affine2,
+) -> BBox {
+    doc.profiles[start as usize..(start + count) as usize]
+        .iter()
+        .map(|profile| transformed_path_bbox(doc, profile.outer_path, transform))
         .fold(BBox::empty(), BBox::union)
 }
 

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -183,6 +183,36 @@ pub fn normalize_bounds<S, L>(doc: &mut GeometryDocument<S, L>) {
         };
     }
 
+    for instance_index in 0..doc.layout.instances.len() {
+        let profile_start = doc.layout.instances[instance_index].profile_start;
+        let profile_count = doc.layout.instances[instance_index].profile_count;
+        doc.layout.instances[instance_index].bbox =
+            profiles_range_bbox(doc, profile_start, profile_count);
+    }
+
+    for repeat_index in (0..doc.layout.repeats.len()).rev() {
+        let instance_start = doc.layout.repeats[repeat_index].instance_start;
+        let instance_count = doc.layout.repeats[repeat_index].instance_count;
+        let bbox = layout_instances_range_bbox(doc, instance_start, instance_count);
+        doc.layout.repeats[repeat_index].bbox = bbox;
+        if let Some(parent_instance) = doc.layout.repeats[repeat_index].parent_instance {
+            let instance_bbox = doc.layout.instances[parent_instance as usize].bbox;
+            doc.layout.instances[parent_instance as usize].bbox = instance_bbox.union(bbox);
+        }
+    }
+
+    for step_index in 0..doc.layout.steps.len() {
+        let profile_start = doc.layout.steps[step_index].profile_start;
+        let profile_count = doc.layout.steps[step_index].profile_count;
+        let profile_bbox = profiles_range_bbox(doc, profile_start, profile_count);
+        let repeat_bbox = layout_step_repeats_bbox(doc, step_index as u32);
+        doc.layout.steps[step_index].bbox = if !profile_bbox.is_empty() {
+            profile_bbox
+        } else {
+            repeat_bbox
+        };
+    }
+
     for feature_index in 0..doc.features.len() {
         doc.features[feature_index].bbox = feature_bbox(doc, feature_index);
     }
@@ -203,6 +233,22 @@ fn board_instances_range_bbox<S, L>(doc: &GeometryDocument<S, L>, start: u32, co
     doc.board_instances[start as usize..(start + count) as usize]
         .iter()
         .map(|instance| instance.bbox)
+        .fold(BBox::empty(), BBox::union)
+}
+
+fn layout_instances_range_bbox<S, L>(doc: &GeometryDocument<S, L>, start: u32, count: u32) -> BBox {
+    doc.layout.instances[start as usize..(start + count) as usize]
+        .iter()
+        .map(|instance| instance.bbox)
+        .fold(BBox::empty(), BBox::union)
+}
+
+fn layout_step_repeats_bbox<S, L>(doc: &GeometryDocument<S, L>, step_index: u32) -> BBox {
+    doc.layout
+        .repeats
+        .iter()
+        .filter(|repeat| repeat.parent_step == step_index && repeat.parent_instance.is_none())
+        .map(|repeat| repeat.bbox)
         .fold(BBox::empty(), BBox::union)
 }
 

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -709,7 +709,7 @@ mod tests {
 
     #[test]
     fn composes_compatible_stroked_feature_paths() {
-        let mut doc = TestDoc::new("test".to_string());
+        let mut doc = TestDoc::new();
         let bbox = BBox {
             min: Point::new(0.0, 0.0),
             max: Point::new(10.0, 0.0),
@@ -749,7 +749,7 @@ mod tests {
 
     #[test]
     fn process_prunes_unpainted_feature_paths_and_preserves_profile_paths() {
-        let mut doc = TestDoc::new("test".to_string());
+        let mut doc = TestDoc::new();
         doc.layers.push(GeometryLayer {
             name: "TOP".to_string(),
             source_layer_ref: 0,
@@ -795,8 +795,6 @@ mod tests {
             bbox: BBox::empty(),
         });
         doc.profiles.push(StepProfile {
-            source_step_ref: 0,
-            transform: Affine2::identity(),
             outer_path: outer_profile_path,
             cutout_start: 0,
             cutout_count: 1,
@@ -818,7 +816,7 @@ mod tests {
 
     #[test]
     fn coalesces_related_trace_features_inside_one_source_set() {
-        let mut doc = TestDoc::new("test".to_string());
+        let mut doc = TestDoc::new();
         doc.push_path(
             GeometryPath::filled(FillRule::NonZero, BBox::empty()),
             rect_cmds(0.0, 0.0, 2.0, 1.0),
@@ -887,7 +885,7 @@ mod tests {
 
     #[test]
     fn resolves_negative_polarity_as_layer_subtraction() {
-        let mut doc = TestDoc::new("test".to_string());
+        let mut doc = TestDoc::new();
         doc.push_path(
             GeometryPath::filled(FillRule::NonZero, BBox::empty()),
             rect_cmds(0.0, 0.0, 4.0, 4.0),
@@ -929,7 +927,7 @@ mod tests {
 
     #[test]
     fn subtracts_cutouts_after_trace_union() {
-        let mut doc = TestDoc::new("test".to_string());
+        let mut doc = TestDoc::new();
         doc.push_path(
             GeometryPath::stroked(1.0, LineCap::Round, BBox::empty()),
             [
@@ -972,7 +970,7 @@ mod tests {
 
     #[test]
     fn flattens_processed_layer_features_to_single_mask() {
-        let mut doc = TestDoc::new("test".to_string());
+        let mut doc = TestDoc::new();
         doc.push_path(
             GeometryPath::filled(FillRule::NonZero, BBox::empty()),
             rect_cmds(0.0, 0.0, 2.0, 1.0),

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -43,7 +43,7 @@ pub fn prune_unpainted_paths<S, L>(doc: &mut GeometryDocument<S, L>) {
         feature.path_count = path_count;
     }
 
-    // Board profiles are physical geometry, not painted layer features, and are
+    // Step profiles are physical geometry, not painted layer features, and are
     // intentionally allowed to use unpainted paths.
 }
 
@@ -154,35 +154,6 @@ pub fn normalize_bounds<S, L>(doc: &mut GeometryDocument<S, L>) {
         doc.profiles[profile_index].bbox = doc.paths[outer_path as usize].bbox;
     }
 
-    for board_index in 0..doc.boards.len() {
-        let profile_start = doc.boards[board_index].profile_start;
-        let profile_count = doc.boards[board_index].profile_count;
-        doc.boards[board_index].bbox = profiles_range_bbox(doc, profile_start, profile_count);
-    }
-
-    for instance_index in 0..doc.board_instances.len() {
-        let profile_start = doc.board_instances[instance_index].profile_start;
-        let profile_count = doc.board_instances[instance_index].profile_count;
-        doc.board_instances[instance_index].bbox =
-            profiles_range_bbox(doc, profile_start, profile_count);
-    }
-
-    for panel_index in 0..doc.panels.len() {
-        let profile_start = doc.panels[panel_index].profile_start;
-        let profile_count = doc.panels[panel_index].profile_count;
-        let instance_start = doc.panels[panel_index].board_instance_start;
-        let instance_count = doc.panels[panel_index].board_instance_count;
-        let profile_bbox = profiles_range_bbox(doc, profile_start, profile_count);
-        let instance_bbox = board_instances_range_bbox(doc, instance_start, instance_count);
-        doc.panels[panel_index].profile_bbox = profile_bbox;
-        doc.panels[panel_index].instance_bbox = instance_bbox;
-        doc.panels[panel_index].bbox = if !profile_bbox.is_empty() {
-            profile_bbox
-        } else {
-            instance_bbox
-        };
-    }
-
     for instance_index in 0..doc.layout.instances.len() {
         let profile_start = doc.layout.instances[instance_index].profile_start;
         let profile_count = doc.layout.instances[instance_index].profile_count;
@@ -226,13 +197,6 @@ fn profiles_range_bbox<S, L>(doc: &GeometryDocument<S, L>, start: u32, count: u3
     doc.profiles[start as usize..(start + count) as usize]
         .iter()
         .map(|profile| profile.bbox)
-        .fold(BBox::empty(), BBox::union)
-}
-
-fn board_instances_range_bbox<S, L>(doc: &GeometryDocument<S, L>, start: u32, count: u32) -> BBox {
-    doc.board_instances[start as usize..(start + count) as usize]
-        .iter()
-        .map(|instance| instance.bbox)
         .fold(BBox::empty(), BBox::union)
 }
 
@@ -826,12 +790,11 @@ mod tests {
                 PathCmd::line_to(Point::new(1.0, 1.0)),
             ],
         );
-        doc.profile_cutouts.push(BoardProfileCutout {
+        doc.profile_cutouts.push(StepProfileCutout {
             path: cutout_path,
             bbox: BBox::empty(),
         });
-        doc.profiles.push(BoardProfile {
-            kind: BoardProfileKind::BoardDefinition,
+        doc.profiles.push(StepProfile {
             source_step_ref: 0,
             transform: Affine2::identity(),
             outer_path: outer_profile_path,

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -190,6 +190,10 @@ pub fn normalize_bounds<S, L>(doc: &mut GeometryDocument<S, L>) {
         doc.features[feature_index].bbox = feature_bbox(doc, feature_index);
     }
 
+    for set_index in 0..doc.feature_sets.len() {
+        doc.feature_sets[set_index].bbox = feature_set_bbox(doc, set_index);
+    }
+
     for layer_index in 0..doc.layers.len() {
         doc.layers[layer_index].bbox = layer_bbox(doc, layer_index);
     }
@@ -230,6 +234,31 @@ fn layout_step_repeats_bbox<S, L>(doc: &GeometryDocument<S, L>, step_index: u32)
         .fold(BBox::empty(), BBox::union)
 }
 
+fn feature_set_bbox<S, L>(doc: &GeometryDocument<S, L>, set_index: usize) -> BBox {
+    let set_id = set_index as u32;
+    let linked_bbox = doc
+        .features
+        .iter()
+        .filter(|feature| feature.set == Some(set_id))
+        .map(|feature| feature.bbox)
+        .fold(BBox::empty(), BBox::union);
+    if !linked_bbox.is_empty() {
+        return linked_bbox;
+    }
+
+    let set = &doc.feature_sets[set_index];
+    let start = set.feature_start as usize;
+    let end = (set.feature_start + set.feature_count).min(doc.features.len() as u32) as usize;
+    if start >= end {
+        return BBox::empty();
+    }
+
+    doc.features[start..end]
+        .iter()
+        .map(|feature| feature.bbox)
+        .fold(BBox::empty(), BBox::union)
+}
+
 pub fn compose_feature_paths<S: Clone, L>(doc: &mut GeometryDocument<S, L>) {
     let feature_count = doc.features.len();
     for feature_index in 0..feature_count {
@@ -262,7 +291,7 @@ pub fn outline_stroked_paths<S: Clone, L>(doc: &mut GeometryDocument<S, L>) {
     let feature_count = doc.features.len();
     for feature_index in 0..feature_count {
         let feature = doc.features[feature_index].clone();
-        if feature.bucket != FeatureBucket::Trace {
+        if !is_copper_trace_feature(&feature) {
             continue;
         }
 
@@ -297,7 +326,7 @@ pub fn union_feature_filled_paths<S: Clone, L>(doc: &mut GeometryDocument<S, L>)
     let feature_count = doc.features.len();
     for feature_index in 0..feature_count {
         let feature = doc.features[feature_index].clone();
-        if feature.bucket != FeatureBucket::Trace {
+        if !is_copper_trace_feature(&feature) {
             continue;
         }
 
@@ -343,9 +372,7 @@ where
         for feature_index in layer.feature_start..layer.feature_start + layer.feature_count {
             let feature_index = feature_index as usize;
             let feature = &doc.features[feature_index];
-            if feature.bucket != FeatureBucket::Trace
-                || feature.polarity != GeometryPolarity::Positive
-            {
+            if !is_copper_trace_feature(feature) || feature.polarity != GeometryPolarity::Positive {
                 continue;
             }
 
@@ -403,6 +430,14 @@ where
             }
         }
     }
+}
+
+fn is_copper_trace_feature<S>(feature: &GeometryFeature<S>) -> bool {
+    feature.bucket == FeatureBucket::Trace
+        && matches!(
+            feature.semantic,
+            FeatureSemantic::None | FeatureSemantic::CopperConductor
+        )
 }
 
 pub fn resolve_set_voids<S: Clone, L: Clone>(doc: &mut GeometryDocument<S, L>) {
@@ -768,6 +803,10 @@ mod tests {
             name: "TOP".to_string(),
             source_layer_ref: 0,
             layer_function: (),
+            spec_ref_start: 0,
+            spec_ref_count: 0,
+            set_start: 0,
+            set_count: 0,
             feature_start: 0,
             feature_count: 1,
             bbox: BBox::empty(),
@@ -1032,6 +1071,10 @@ mod tests {
             name: "F.Cu".to_string(),
             source_layer_ref: 100,
             layer_function: (),
+            spec_ref_start: 0,
+            spec_ref_count: 0,
+            set_start: 0,
+            set_count: 0,
             feature_start,
             feature_count,
             bbox: BBox::empty(),

--- a/crates/pcb-ir/src/dialects/path.rs
+++ b/crates/pcb-ir/src/dialects/path.rs
@@ -206,6 +206,54 @@ pub fn contour_bbox(cmds: &[PathCmd]) -> BBox {
     bbox
 }
 
+pub fn transform_cmds(
+    cmds: impl IntoIterator<Item = PathCmd>,
+    transform: Affine2,
+) -> (BBox, Vec<PathCmd>) {
+    let mut bbox = BBox::empty();
+    let mut current = Point::default();
+    let mut transformed_cmds = Vec::new();
+
+    for cmd in cmds {
+        let start = current;
+        let mut transformed = cmd;
+        transformed.p0 = transform.transform_point(cmd.p0);
+        transformed.p1 = transform.transform_point(cmd.p1);
+        if cmd.op != PathOp::ArcTo {
+            transformed.p2 = transform.transform_point(cmd.p2);
+        } else if transform.determinant() < 0.0 {
+            transformed.clockwise = !cmd.clockwise;
+        }
+
+        match cmd.op {
+            PathOp::MoveTo | PathOp::LineTo => {
+                current = cmd.p0;
+                bbox.include_point(transformed.p0);
+            }
+            PathOp::ArcTo => {
+                bbox.include_circular_arc(
+                    transform.transform_point(start),
+                    transformed.p0,
+                    transformed.p1,
+                    transformed.clockwise,
+                );
+                current = cmd.p0;
+            }
+            PathOp::CubicTo => {
+                bbox.include_point(transformed.p0);
+                bbox.include_point(transformed.p1);
+                bbox.include_point(transformed.p2);
+                current = cmd.p2;
+            }
+            PathOp::Close => {}
+        }
+
+        transformed_cmds.push(transformed);
+    }
+
+    (bbox, transformed_cmds)
+}
+
 pub fn outline_stroke(
     payloads: &[PathPayload],
     width: f64,

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
 use pcb_ipc2581_tools::{
-    OutputFormat, RenderFormat, UnitFormat, ViewMode, commands, gerber, utils,
+    LayoutTarget, OutputFormat, RenderFormat, UnitFormat, ViewMode, commands, gerber, utils,
 };
 
 #[derive(Args)]
@@ -61,11 +61,14 @@ enum Commands {
         #[arg(short, long, default_value = "mm")]
         units: UnitFormat,
     },
-    /// Export the board outline as a KiCad-importable DXF
+    /// Export IPC-2581 outlines as a KiCad-importable DXF
     Outline {
         /// IPC-2581 XML file to export from
         #[arg(value_hint = clap::ValueHint::FilePath)]
         file: PathBuf,
+        /// Layout target to export
+        #[arg(long, default_value = "board")]
+        layout_target: LayoutTarget,
         /// Output DXF file path
         #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
         output: PathBuf,
@@ -84,6 +87,9 @@ enum Commands {
         /// Render format. Auto infers SVG/PNG from the output extension or uses terminal graphics.
         #[arg(short, long, default_value = "auto")]
         format: RenderFormat,
+        /// Layout target to render
+        #[arg(long, default_value = "layout")]
+        layout_target: LayoutTarget,
         /// Flatten the layer into a single Gerber-style mask before rendering.
         #[arg(long)]
         flat: bool,
@@ -93,6 +99,9 @@ enum Commands {
         /// IPC-2581 XML file to export from
         #[arg(value_hint = clap::ValueHint::FilePath)]
         file: PathBuf,
+        /// Layout target to export. Gerber supports board or panel.
+        #[arg(long, default_value = "board")]
+        layout_target: LayoutTarget,
         /// Output directory for generated Gerber files
         #[arg(short, long, value_hint = clap::ValueHint::DirPath)]
         output: PathBuf,
@@ -147,14 +156,23 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             output,
             units,
         } => commands::html_export::execute(&file, output.as_deref(), units),
-        Commands::Outline { file, output } => {
-            commands::outline::execute(&file, &commands::outline::OutlineOptions { output })
-        }
+        Commands::Outline {
+            file,
+            layout_target,
+            output,
+        } => commands::outline::execute(
+            &file,
+            &commands::outline::OutlineOptions {
+                output,
+                layout_target,
+            },
+        ),
         Commands::Render {
             file,
             layer,
             output,
             format,
+            layout_target,
             flat,
         } => commands::render::execute(
             &file,
@@ -162,11 +180,22 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 layer,
                 output,
                 format,
+                layout_target,
                 flat,
             },
         ),
-        Commands::Gerber { file, output } => {
-            let set = gerber::execute_file(&file, &output)?;
+        Commands::Gerber {
+            file,
+            layout_target,
+            output,
+        } => {
+            let set = gerber::execute_file_with_options(
+                &file,
+                &gerber::GerberExportOptions {
+                    output_dir: output.clone(),
+                    layout_target,
+                },
+            )?;
             println!(
                 "✓ IPC-2581 exported {} Gerber X2 file(s) to {}",
                 set.files.len(),


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of IPC geometry IR and manufacturing export paths (Gerber, outlines, panel flattening); behavior changes are broad but covered by extensive new tests.
> 
> **Overview**
> Introduces a **canonical IPC layout graph** (`LayoutGraph` with steps, repeats, and instances) in `pcb-ir`, replacing the older boards/panels/board-instances profile model. Profiles are now **step-local** and selected via **`ProfileSet`** (board, fabrication, layout boundaries, root-only) through **`profile_occurrences_for`**, with transforms applied at export/render time.
> 
> The **IPC-2581 parser** gains typed **`Spec` items** (including `V_Cut` properties), **`SpecRef`** on layers and sets, **fiducial** marks in sets, and looser **`PinRef`** fields. Geometry extraction carries **feature sets**, **spec refs**, **pin refs**, **feature semantics** (V-cut, score, fiducials), and supports **`LayoutTarget`** / **placement policies** (step-only, symbolic panel, flattened panel), plus **`extract_layout`** for outline-only sidecars.
> 
> **pcb-ipc2581-tools** wires this through: **`--layout-target`** on render/outline/Gerber, panel-aware **HTML** summary and layer SVGs, **DXF** via transformed profile occurrences, and **Gerber X2** updates (V-cut/score layers, `.Part`, fiducial/component/pin attributes). **`PinRef.component_ref`** is now optional—callers that assumed it was always present need to handle `Option`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f444c8ae5a52e3f36ed1cf6316b2c583225969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->