### PR TITLE
Use KiCad 10.0.4 workflow image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  KICAD_VERSION: 10.0.0
+  KICAD_VERSION: 10.0.4
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,16 +29,16 @@ jobs:
           - name: Ubuntu
             runs-on: ubicloud-standard-16
             container:
-              image: ghcr.io/diodeinc/kicad:10.0.0
+              image: ghcr.io/diodeinc/kicad:10.0.4
               options: --user root
     steps:
-      - uses: actions/checkout@v5
-
       - name: Install Dependencies (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
         run: |
           apt-get update
-          apt-get install -y curl build-essential pkg-config libssl-dev
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
+
+      - uses: actions/checkout@v5
 
       - name: Cache KiCad (macOS)
         if: matrix.config.name == 'macOS'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_TEST_DEBUG: 0
-  KICAD_VERSION: 10.0.0  # Update container image below when changing this
+  KICAD_VERSION: 10.0.4  # Update container image below when changing this
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -64,16 +64,16 @@ jobs:
           - name: Ubuntu
             runs-on: ubicloud-standard-16
             container:
-              image: ghcr.io/diodeinc/kicad:10.0.0  # Keep in sync with KICAD_VERSION
+              image: ghcr.io/diodeinc/kicad:10.0.4  # Keep in sync with KICAD_VERSION
               options: --user root
     steps:
-      - uses: actions/checkout@v5
-
       - name: Install Dependencies (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
         run: |
           apt-get update
-          apt-get install -y curl build-essential pkg-config libssl-dev
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
+
+      - uses: actions/checkout@v5
 
       - name: Cache KiCad (macOS)
         if: contains(matrix.config.name, 'macOS')

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  KICAD_VERSION: 10.0.0
+  KICAD_VERSION: 10.0.4
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,16 +19,16 @@ jobs:
     name: Evaluate publish bundles
     runs-on: ubicloud-standard-16
     container:
-      image: ghcr.io/diodeinc/kicad:10.0.0
+      image: ghcr.io/diodeinc/kicad:10.0.4
       options: --user root
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y curl build-essential pkg-config libssl-dev jq git openssh-client zstd
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd
+
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions configuration; no application or runtime code is modified.
> 
> **Overview**
> Bumps CI from KiCad **10.0.0** to **10.0.4** across `e2e.yml`, `test.yml`, and `wasm.yml`, keeping `KICAD_VERSION` and `ghcr.io/diodeinc/kicad` container tags aligned (including the Windows installer tag in the test matrix).
> 
> On Ubuntu container jobs, **checkout** now runs after an `apt-get install` step that adds **`ca-certificates`** alongside the existing build deps, instead of checking out the repo first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81f2d22383c93282cbfd9055fbeb0535639b721c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->