### PR TITLE
Update pcb-version examples to 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Updated user-facing `pcb-version` examples and current-lane test fixtures to `0.4`.
+
 ## [0.4.1] - 2026-06-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Create `blinky.zen`:
 ```python
 # ```pcb
 # [workspace]
-# pcb-version = "0.3"
+# pcb-version = "0.4"
 # ```
 
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -113,7 +113,7 @@ Board repository `pcb.toml`:
 ```toml
 [workspace]
 repository = "github.com/myorg/MyBoard"
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [board]
 name = "MyBoard"
@@ -145,7 +145,7 @@ Registry `pcb.toml`:
 ```toml
 [workspace]
 repository = "github.com/myorg/registry"
-pcb-version = "0.3"
+pcb-version = "0.4"
 ```
 
 ## Common Commands

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -125,7 +125,7 @@ impl PcbToml {
             && parse_pcb_version(version).is_none()
         {
             anyhow::bail!(
-                "invalid `pcb-version`: expected \"major.minor\" like \"0.3\", got \"{}\"",
+                "invalid `pcb-version`: expected \"major.minor\" like \"0.4\", got \"{}\"",
                 version
             );
         }
@@ -189,7 +189,7 @@ impl PcbToml {
     /// ```text
     /// # ```pcb
     /// # [workspace]
-    /// # pcb-version = "0.3"
+    /// # pcb-version = "0.4"
     /// # ```
     /// ```
     ///
@@ -263,7 +263,7 @@ pub struct WorkspaceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 
-    /// Minimum compatible toolchain release series (e.g., "0.3")
+    /// Minimum compatible toolchain release series (e.g., "0.4")
     /// V2 only. Indicates breaking changes requiring newer compiler.
     #[serde(skip_serializing_if = "Option::is_none", rename = "pcb-version")]
     pub pcb_version: Option<String>,
@@ -421,7 +421,7 @@ pub struct ManifestPart {
 /// ```text
 /// # ```pcb
 /// # [workspace]
-/// # pcb-version = "0.3"
+/// # pcb-version = "0.4"
 /// # ```
 /// ```
 ///
@@ -619,7 +619,7 @@ members = ["boards/*"]
     fn test_parse_v2_package() {
         let content = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [board]
 name = "WV0002"
@@ -630,7 +630,7 @@ description = "Power Regulator Board"
         let config = PcbToml::parse(content).unwrap();
 
         let workspace = config.workspace.as_ref().unwrap();
-        assert_eq!(workspace.pcb_version.as_deref(), Some("0.3"));
+        assert_eq!(workspace.pcb_version.as_deref(), Some("0.4"));
 
         let board = config.board.as_ref().unwrap();
         assert_eq!(board.name, "WV0002");
@@ -642,7 +642,7 @@ description = "Power Regulator Board"
     fn test_parse_v2_workspace() {
         let content = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [access]
 allow = ["*@weaverobots.com"]
@@ -652,7 +652,7 @@ allow = ["*@weaverobots.com"]
         assert!(config.is_workspace());
 
         let workspace = config.workspace.as_ref().unwrap();
-        assert_eq!(workspace.pcb_version.as_deref(), Some("0.3"));
+        assert_eq!(workspace.pcb_version.as_deref(), Some("0.4"));
 
         let access = config.access.as_ref().unwrap();
         assert_eq!(access.allow, vec!["*@weaverobots.com"]);
@@ -662,7 +662,7 @@ allow = ["*@weaverobots.com"]
     fn test_parse_v2_dependencies() {
         let content = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [board]
 name = "Test"
@@ -766,7 +766,7 @@ path = "test.zen"
     fn test_parse_v2_patch() {
         let content = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [board]
 name = "Test"
@@ -787,7 +787,7 @@ path = "test.zen"
     fn test_parse_workspace_bom_config() {
         let content = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [workspace.bom]
 strict = true
@@ -803,7 +803,7 @@ strict = true
     fn test_parse_v2_patch_branch() {
         let content = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [board]
 name = "Test"
@@ -829,7 +829,7 @@ path = "test.zen"
     fn test_parse_v2_patch_rev() {
         let content = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [board]
 name = "Test"
@@ -855,7 +855,7 @@ path = "test.zen"
     fn test_v2_workspace_and_board() {
         let content = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [board]
 name = "RootBoard"
@@ -912,7 +912,7 @@ name = "TestBoard"
         let err = PcbToml::parse(
             r#"
 [workspace]
-pcb-version = "0.3.71"
+pcb-version = "0.4.1"
 "#,
         )
         .expect_err("expected patch pcb-version to be rejected at parse time");
@@ -933,7 +933,7 @@ pcb-version = "0.3.71"
 #
 # ```pcb
 # [workspace]
-# pcb-version = "0.3"
+# pcb-version = "0.4"
 #
 # [dependencies]
 # ```
@@ -945,7 +945,7 @@ load("@stdlib/units.zen", "Voltage")
         assert!(result.is_some());
         let toml = result.unwrap();
         assert!(toml.contains("[workspace]"));
-        assert!(toml.contains("pcb-version = \"0.3\""));
+        assert!(toml.contains("pcb-version = \"0.4\""));
         assert!(toml.contains("[dependencies]"));
     }
 
@@ -953,7 +953,7 @@ load("@stdlib/units.zen", "Voltage")
     fn test_extract_inline_manifest_no_shebang() {
         let zen_content = r#"# ```pcb
 # [workspace]
-# pcb-version = "0.3"
+# pcb-version = "0.4"
 # ```
 
 load("foo.zen", "Bar")
@@ -977,7 +977,7 @@ load("foo.zen", "Bar")
     fn test_extract_inline_manifest_unclosed() {
         let zen_content = r#"# ```pcb
 # [workspace]
-# pcb-version = "0.3"
+# pcb-version = "0.4"
 # Missing closing marker
 
 load("foo.zen", "Bar")
@@ -992,7 +992,7 @@ load("foo.zen", "Bar")
     fn test_from_zen_content() {
         let zen_content = r#"# ```pcb
 # [workspace]
-# pcb-version = "0.3"
+# pcb-version = "0.4"
 # ```
 
 load("foo.zen", "Bar")

--- a/crates/pcb-zen-core/src/workspace.rs
+++ b/crates/pcb-zen-core/src/workspace.rs
@@ -580,7 +580,7 @@ mod tests {
                 "/repo/pcb.toml".to_string(),
                 r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 "#
                 .to_string(),
             ),
@@ -588,7 +588,7 @@ pcb-version = "0.3"
                 "/repo/boards/demo/pcb.toml".to_string(),
                 r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 "#
                 .to_string(),
             ),
@@ -611,7 +611,7 @@ pcb-version = "0.3"
                 "/repo/pcb.toml".to_string(),
                 r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 "#
                 .to_string(),
             ),
@@ -623,7 +623,7 @@ pcb-version = "0.3"
                 "/repo/boards/demo/.pcb/edit/github.com/example/dep/pcb.toml".to_string(),
                 r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 "#
                 .to_string(),
             ),
@@ -643,7 +643,7 @@ pcb-version = "0.3"
                 "/repo/pcb.toml".to_string(),
                 r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 exclude = ["modules/ignored/**"]
 "#
                 .to_string(),
@@ -658,7 +658,7 @@ exclude = ["modules/ignored/**"]
             ),
             (
                 "/repo/modules/ignored/nested/pcb.toml".to_string(),
-                "[workspace]\npcb-version = \"0.3\"\n".to_string(),
+                "[workspace]\npcb-version = \"0.4\"\n".to_string(),
             ),
         ]);
         let provider = InMemoryFileProvider::new(files);
@@ -675,7 +675,7 @@ exclude = ["modules/ignored/**"]
         let files = HashMap::from([
             (
                 "/repo/pcb.toml".to_string(),
-                "[workspace]\npcb-version = \"0.3\"\n".to_string(),
+                "[workspace]\npcb-version = \"0.4\"\n".to_string(),
             ),
             (
                 "/repo/a/b/c/d/e/f/g/h/pcb.toml".to_string(),
@@ -700,7 +700,7 @@ exclude = ["modules/ignored/**"]
             "/repo/pcb.toml".to_string(),
             r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [patch]
 stdlib = { path = "third_party/stdlib" }
@@ -722,7 +722,7 @@ stdlib = { path = "third_party/stdlib" }
             "/repo/pcb.toml".to_string(),
             r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [patch]
 "github.com/diodeinc/stdlib" = { path = "../stdlib-fork" }
@@ -745,7 +745,7 @@ pcb-version = "0.3"
                 "/repo/pcb.toml".to_string(),
                 r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 preferred = ["components/preferred-part"]
 "#
                 .to_string(),

--- a/crates/pcbc/src/publish.rs
+++ b/crates/pcbc/src/publish.rs
@@ -1379,12 +1379,12 @@ mod tests {
 
     const TEST_WORKSPACE_PCB_TOML: &str = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 "#;
 
     const TEST_REPOSITORY_WORKSPACE_PCB_TOML: &str = r#"
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 repository = "github.com/example/workspace"
 "#;
 

--- a/docs/pages/antenna_matching_network.mdx
+++ b/docs/pages/antenna_matching_network.mdx
@@ -44,7 +44,7 @@ The root `pcb.toml` can be as small as:
 
 ```toml
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 
 [board]
 name = "AntennaDemo"

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -114,7 +114,7 @@ looks up to eight directory levels deep and treats each descendant directory wit
 
 ```toml
 [workspace]
-pcb-version = "0.3"
+pcb-version = "0.4"
 exclude = ["scratch/**", "experiments/old-board"]
 ```
 

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -106,7 +106,7 @@ Use `pcb new package <path>` to add modules or components inside the board repos
 ```toml
 [workspace]
 repository = "github.com/myorg/MainBoard"
-pcb-version = "0.3"
+pcb-version = "0.4"
 endpoint = "diode.computer"
 
 [board]
@@ -150,7 +150,7 @@ Registry manifests include `[workspace]` but do not include `[board]`:
 ```toml
 [workspace]
 repository = "github.com/myorg/registry"
-pcb-version = "0.3"
+pcb-version = "0.4"
 ```
 
 **Package manifest** (e.g., `modules/PowerSupply/pcb.toml`):

--- a/examples/blinky.zen
+++ b/examples/blinky.zen
@@ -1,6 +1,6 @@
 # ```pcb
 # [workspace]
-# pcb-version = "0.3"
+# pcb-version = "0.4"
 # ```
 
 Resistor = Module("@stdlib/generics/Resistor.zen")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String and fixture updates only; no changes to version parsing logic or toolchain selection behavior.
> 
> **Overview**
> Aligns documentation, examples, and tests with the **0.4** toolchain lane by replacing **`pcb-version = "0.3"`** (and related **`0.3`** wording) with **`0.4`** across user-facing surfaces.
> 
> **CHANGELOG** records the change under Unreleased. **README**, **docs** (`spec`, `packages`, antenna guide), and **`examples/blinky.zen`** now show **`pcb-version = "0.4"`** in inline and sample manifests. **`pcb-zen-core`** updates validation error text, doc comments, and **`config` / `workspace`** test fixtures; **`pcbc` publish** tests use the same version. No runtime parsing or MVS behavior changes beyond the illustrative strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f58b714570bf781ed7aff60f356de57d71c832b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->