### PR TITLE
Simplify net kind registration

### DIFF
--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -2,7 +2,7 @@ use crate::lang::r#enum::EnumValue;
 use crate::lang::interface::FrozenInterfaceValue;
 use crate::lang::io_direction::IoDirection;
 use crate::lang::module::{ModulePath, find_moved_span};
-use crate::lang::net::{merge_canonical_net_kind_name, net_kind_requires_name};
+use crate::lang::net::net_kind_requires_name;
 use crate::lang::part::PartValue;
 use crate::lang::symbol::SymbolValue;
 use crate::lang::type_info::TypeInfo;
@@ -34,7 +34,7 @@ struct NetInfo {
     ports: Vec<InstanceRef>,
     /// Aggregated properties for this net.
     properties: HashMap<String, AttributeValue>,
-    /// Canonical Starlark net kind, if observed.
+    /// Starlark net kind, if observed during conversion.
     kind: Option<String>,
 }
 
@@ -640,9 +640,7 @@ impl ModuleConverter {
             }
 
             let info = self.net_info_mut(*net_id);
-            if let Some(kind) = introduced_net.kind.as_deref() {
-                merge_canonical_net_kind_name(&mut info.kind, kind);
-            }
+            info.kind.get_or_insert_with(|| introduced_net.kind.clone());
         }
 
         // Add direct child components
@@ -665,7 +663,9 @@ impl ModuleConverter {
     fn update_net(&mut self, net: &FrozenNetValue, instance_ref: &InstanceRef) {
         let net_info = self.net_info_mut(net.id());
         net_info.ports.push(instance_ref.clone());
-        merge_canonical_net_kind_name(&mut net_info.kind, net.net_kind_name());
+        net_info
+            .kind
+            .get_or_insert_with(|| net.net_kind_name().to_string());
 
         // For unnamed NotConnected nets, use a stable port-derived name when possible.
         if net_info.kind.as_deref() == Some("NotConnected")

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -1548,9 +1548,7 @@ impl EvalContext {
                         .expect("extra value should be a FrozenContextValue");
 
                     for (_id, net_info) in extra.module.introduced_nets() {
-                        if net_info.kind.as_deref() != Some("NotConnected")
-                            && net_info.name.is_pending_inference()
-                        {
+                        if net_info.kind != "NotConnected" && net_info.name.is_pending_inference() {
                             diagnostics.push(anyhow!("Net is unnamed").into());
                             return WithDiagnostics {
                                 output: None,

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -59,8 +59,7 @@ macro_rules! downcast_frozen_module {
 
 use super::net::{
     FrozenNetType, FrozenNetValue, NetId, NetType, NetValue, generate_net_id,
-    merge_canonical_net_kind_name, net_kind_requires_name, net_matches_type_name,
-    net_type_name_from_value,
+    net_kind_requires_name, net_matches_type_name, net_type_name_from_value,
 };
 use crate::lang::context::FrozenContextValue;
 use starlark::errors::EvalMessage;
@@ -69,8 +68,8 @@ use starlark::errors::EvalMessage;
 #[derive(Clone, Debug, Trace, Allocative, Freeze)]
 pub struct IntroducedNet {
     pub name: IntroducedNetName,
-    /// Canonical kind evidence, if this module introduced any.
-    pub kind: Option<String>,
+    /// Starlark net kind introduced by this module.
+    pub kind: String,
 }
 
 #[derive(Clone, Debug, Trace, Allocative, Freeze)]
@@ -814,60 +813,30 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
         id: NetId,
         local_name: String,
         assignment_inferable: bool,
-        observed_kind: String,
+        kind: String,
     ) -> anyhow::Result<String> {
         let base_name = local_name;
 
         if let Some(existing) = self.introduced_nets.get(&id).cloned() {
-            let mut merged_kind = existing.kind.clone();
-            merge_canonical_net_kind_name(&mut merged_kind, &observed_kind);
-
             let has_name_evidence = assignment_inferable || !base_name.trim().is_empty();
-            if merged_kind == existing.kind && !has_name_evidence {
+            if !has_name_evidence {
                 return Ok(existing.name.as_str().to_string());
             }
 
-            let (name, returned_name) = if has_name_evidence {
-                self.record_net_name(
-                    id,
-                    &base_name,
-                    assignment_inferable,
-                    merged_kind.as_deref().unwrap_or("Net"),
-                )?;
-                (
-                    Self::registration_name(&base_name, assignment_inferable),
-                    base_name,
-                )
-            } else if existing.name.as_str().is_empty() {
-                return Ok(existing.name.as_str().to_string());
-            } else {
-                self.record_net_name(
-                    id,
-                    existing.name.as_str(),
-                    false,
-                    merged_kind.as_deref().unwrap_or("Net"),
-                )?;
-                (existing.name.clone(), existing.name.as_str().to_string())
-            };
+            self.record_net_name(id, &base_name, assignment_inferable, &existing.kind)?;
+            let name = Self::registration_name(&base_name, assignment_inferable);
 
             self.introduced_nets.insert(
                 id,
                 IntroducedNet {
                     name,
-                    kind: merged_kind,
+                    kind: existing.kind,
                 },
             );
-            return Ok(returned_name);
+            return Ok(base_name);
         }
 
-        let mut kind = None;
-        merge_canonical_net_kind_name(&mut kind, &observed_kind);
-        self.record_net_name(
-            id,
-            &base_name,
-            assignment_inferable,
-            kind.as_deref().unwrap_or("Net"),
-        )?;
+        self.record_net_name(id, &base_name, assignment_inferable, &kind)?;
         let name = Self::registration_name(&base_name, assignment_inferable);
         self.introduced_nets
             .insert(id, IntroducedNet { name, kind });
@@ -885,12 +854,7 @@ impl<'v, V: ValueLike<'v>> ModuleValueGen<V> {
             return Ok(existing.name.as_str().to_string());
         }
 
-        self.record_net_name(
-            id,
-            &inferred_name,
-            false,
-            existing.kind.as_deref().unwrap_or("Net"),
-        )?;
+        self.record_net_name(id, &inferred_name, false, &existing.kind)?;
         self.introduced_nets.insert(
             id,
             IntroducedNet {

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -62,38 +62,9 @@ pub(crate) fn net_kind_requires_name(kind: &str) -> bool {
     kind != "NotConnected"
 }
 
-pub(crate) fn merge_canonical_net_kind_name(current: &mut Option<String>, observed: &str) {
-    if current.is_none() {
-        *current = Some(observed.to_string());
-    }
-}
-
 #[cfg(test)]
-mod net_kind_merge_tests {
-    use super::{compatible_net_type_view, merge_canonical_net_kind_name};
-
-    #[test]
-    fn merge_canonical_net_kind_name_only_fills_empty() {
-        let mut kind = None;
-        for (observed, expected) in [
-            ("NotConnected", Some("NotConnected")),
-            ("Net", Some("NotConnected")),
-            ("Power", Some("NotConnected")),
-        ] {
-            merge_canonical_net_kind_name(&mut kind, observed);
-            assert_eq!(kind.as_deref(), expected);
-        }
-
-        let mut kind = None;
-        for (observed, expected) in [
-            ("Power", Some("Power")),
-            ("NotConnected", Some("Power")),
-            ("Net", Some("Power")),
-        ] {
-            merge_canonical_net_kind_name(&mut kind, observed);
-            assert_eq!(kind.as_deref(), expected);
-        }
-    }
+mod net_type_view_tests {
+    use super::compatible_net_type_view;
 
     #[test]
     fn compatible_net_type_view_is_not_canonical_promotion() {


### PR DESCRIPTION
This just drops the pretend merge path and keeps the “kind might be missing” logic only where that can actually happen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes net naming/kind semantics on re-registration and schematic conversion; wrong assumptions about conflicting kinds could surface as different schematic net kinds or diagnostics, though scope is limited to zen-core net registration paths.
> 
> **Overview**
> **Simplifies how Starlark net kinds are recorded** by dropping `merge_canonical_net_kind_name` and the tests that enforced “only fill empty” merging.
> 
> **Module registration** now treats `IntroducedNet.kind` as a required `String` set on first `register_net`; repeat registrations for the same net id update naming only and **keep the existing kind** instead of reconciling multiple observed kinds.
> 
> **Schematic conversion** (`ModuleConverter`) sets net kind with `get_or_insert_with` from introduced nets or port connections, so optional kind handling remains only where a net might not have been classified yet—not via a merge helper.
> 
> **Freeze-time validation** in `eval.rs` compares `net_info.kind` directly to `"NotConnected"` when flagging unnamed nets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ae6796d64a60d1a47f54e0bfcee80006655722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->