### PR TITLE
[codex] Preserve empty manifests on sync

### DIFF
--- a/crates/pcbc/src/mod/writeback.rs
+++ b/crates/pcbc/src/mod/writeback.rs
@@ -49,7 +49,7 @@ fn indirect_dependencies(resolution: &PackageResolution) -> BTreeMap<String, Dep
 
 fn render_manifest(config: &PcbToml) -> Result<String> {
     let mut rendered = toml::to_string_pretty(config)?;
-    if !rendered.ends_with('\n') {
+    if !rendered.is_empty() && !rendered.ends_with('\n') {
         rendered.push('\n');
     }
     Ok(rendered)

--- a/crates/pcbc/tests/sync.rs
+++ b/crates/pcbc/tests/sync.rs
@@ -183,6 +183,25 @@ gnd = Net("GND")
 }
 
 #[test]
+fn test_sync_preserves_empty_package_manifest() {
+    let mut sandbox = Sandbox::new();
+
+    sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.4"
+repository = "github.com/example/demo"
+"#,
+        )
+        .write("modules/Empty/pcb.toml", "")
+        .write("modules/Empty/Empty.zen", "P1 = io(Net)\n")
+        .sync();
+
+    assert_eq!(read_sandbox_file(&sandbox, "modules/Empty/pcb.toml"), "");
+}
+
+#[test]
 fn test_sync_adds_workspace_dependency_for_cross_package_relative_load() {
     let mut sandbox = Sandbox::new();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small conditional change in manifest rendering plus a sync integration test; no auth, security, or broad behavioral surface beyond empty-file preservation.
> 
> **Overview**
> **`pcb sync` no longer rewrites truly empty package `pcb.toml` files** when dependency hydration would otherwise leave the manifest content unchanged.
> 
> `render_manifest` in writeback now only appends a trailing newline when the serialized TOML is **non-empty** and missing a final newline. Previously, an empty render (e.g. from an empty manifest parse/write cycle) could become a single newline, making `rendered != original` and forcing a disk write.
> 
> Adds **`test_sync_preserves_empty_package_manifest`** to assert `modules/Empty/pcb.toml` stays `""` after sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a053b20e47329ee56d89bdde54d46e1e9af4c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->