### PR TITLE
fix(pcbc): reject unsynced workspace dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Net kind merging now promotes empty or `NotConnected` placeholders to observed concrete kinds.
 - Stdlib TVS matching now includes the `SP3022-01ETG-NM` SOD-882 peak pulse power rating.
+- `pcb build` now rejects relative imports into undeclared nested workspace packages and asks users to run `pcb sync`.
 
 ## [0.4.0] - 2026-06-17
 

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -708,7 +708,27 @@ impl EvalContextConfig {
                 .expect("try_resolve_workspace called with non-URL spec")
         };
 
-        let (matched_dep, root_path) = match scope.resolve_package_url(&full_url) {
+        let resolved = scope.resolve_package_url(&full_url);
+        let is_declared_dependency = matches!(
+            resolved.as_ref(),
+            Some(PackageUrlResolution::Dependency { .. })
+        );
+        if let Some(target_package_url) = self
+            .resolution
+            .workspace_info
+            .package_url_for_url(&full_url)
+            && scope.package_url() != Some(target_package_url)
+            && !is_declared_dependency
+        {
+            anyhow::bail!(
+                "No declared dependency matches '{}' required by '{}'\n  \
+                Run `pcb sync` to update [dependencies] in pcb.toml",
+                target_package_url,
+                full_url
+            );
+        }
+
+        let (matched_dep, root_path) = match resolved {
             Some(PackageUrlResolution::OwnPackage) => anyhow::bail!(
                 "{} uses package URL '{}' that points into its own package '{}'; use a relative path instead",
                 context.current_file.display(),
@@ -805,6 +825,18 @@ impl EvalContextConfig {
                 .canonicalize(target_scope.root())
                 .unwrap_or_else(|_| target_scope.root().to_path_buf());
             crosses_package_boundary = target_root != canonical_root;
+        }
+        if !crosses_package_boundary
+            && let (Some(current_url), Some(target_url)) = (
+                self.resolution
+                    .workspace_info
+                    .package_url_for_path(self.file_provider(), &context.current_file),
+                self.resolution
+                    .workspace_info
+                    .package_url_for_path(self.file_provider(), &canonical_resolved),
+            )
+        {
+            crosses_package_boundary = current_url != target_url;
         }
 
         if crosses_package_boundary {

--- a/crates/pcb-zen-core/src/workspace.rs
+++ b/crates/pcb-zen-core/src/workspace.rs
@@ -219,6 +219,38 @@ impl WorkspaceInfo {
             .is_some_and(|base| package_url_covers(base, url))
     }
 
+    /// Return the most specific workspace package URL that contains `url`.
+    pub fn package_url_for_url(&self, url: &str) -> Option<&str> {
+        self.packages
+            .keys()
+            .filter(|package_url| package_url_covers(package_url, url))
+            .max_by_key(|package_url| package_url.len())
+            .map(String::as_str)
+    }
+
+    /// Return the most specific workspace package URL that owns `path`.
+    pub fn package_url_for_path(
+        &self,
+        file_provider: &dyn FileProvider,
+        path: &Path,
+    ) -> Option<&str> {
+        let canonical_path = file_provider
+            .canonicalize(path)
+            .unwrap_or_else(|_| path.to_path_buf());
+
+        self.packages
+            .iter()
+            .filter_map(|(url, pkg)| {
+                let root = pkg.dir(&self.root);
+                let canonical_root = file_provider.canonicalize(&root).unwrap_or(root);
+                canonical_path
+                    .starts_with(&canonical_root)
+                    .then(|| (url.as_str(), canonical_root.as_os_str().len()))
+            })
+            .max_by_key(|(_, root_len)| *root_len)
+            .map(|(url, _)| url)
+    }
+
     /// Get optional subpath within repository
     pub fn path(&self) -> Option<&str> {
         self.config

--- a/crates/pcb-zen-core/tests/cross_package_load.rs
+++ b/crates/pcb-zen-core/tests/cross_package_load.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 fn setup_cross_package_workspace(
     repository: Option<&str>,
     board_deps: BTreeMap<String, pcb_zen_core::config::DependencySpec>,
+    include_target_in_frozen_resolution: bool,
 ) -> (Arc<dyn FileProvider>, ResolutionResult, PathBuf) {
     let workspace_root = PathBuf::from("/workspace");
     let stdlib_root = pcb_zen_core::workspace_stdlib_root(&workspace_root);
@@ -115,52 +116,54 @@ check(LedValue == "hello from Led", "should load from Led")
         board_deps_map.insert(led_url.clone(), PathBuf::from("/workspace/modules/Led"));
     }
 
+    let mut frozen_packages = BTreeMap::from([
+        (
+            PathBuf::from("/workspace/boards/Main"),
+            pcb_zen_core::resolution::FrozenPackage {
+                identity: pcb_zen_core::resolution::FrozenPackageIdentity::Workspace(
+                    board_url.clone(),
+                ),
+                deps: board_deps_map,
+                parts: Vec::new(),
+            },
+        ),
+        (
+            stdlib_root,
+            pcb_zen_core::resolution::FrozenPackage {
+                identity: pcb_zen_core::resolution::FrozenPackageIdentity::Stdlib,
+                deps: BTreeMap::new(),
+                parts: Vec::new(),
+            },
+        ),
+        (
+            workspace_root.clone(),
+            pcb_zen_core::resolution::FrozenPackage {
+                identity: pcb_zen_core::resolution::FrozenPackageIdentity::Workspace(
+                    "github.com/myorg/project".to_string(),
+                ),
+                deps: BTreeMap::new(),
+                parts: Vec::new(),
+            },
+        ),
+    ]);
+    if include_target_in_frozen_resolution {
+        frozen_packages.insert(
+            PathBuf::from("/workspace/modules/Led"),
+            pcb_zen_core::resolution::FrozenPackage {
+                identity: pcb_zen_core::resolution::FrozenPackageIdentity::Workspace(led_url),
+                deps: BTreeMap::new(),
+                parts: Vec::new(),
+            },
+        );
+    }
+
     let resolution = ResolutionResult::frozen(
         workspace_info,
         BTreeMap::from([(
             board_url.clone(),
             pcb_zen_core::resolution::FrozenResolutionMap {
                 selected_remote: BTreeMap::new(),
-                packages: BTreeMap::from([
-                    (
-                        PathBuf::from("/workspace/boards/Main"),
-                        pcb_zen_core::resolution::FrozenPackage {
-                            identity: pcb_zen_core::resolution::FrozenPackageIdentity::Workspace(
-                                board_url,
-                            ),
-                            deps: board_deps_map,
-                            parts: Vec::new(),
-                        },
-                    ),
-                    (
-                        PathBuf::from("/workspace/modules/Led"),
-                        pcb_zen_core::resolution::FrozenPackage {
-                            identity: pcb_zen_core::resolution::FrozenPackageIdentity::Workspace(
-                                led_url,
-                            ),
-                            deps: BTreeMap::new(),
-                            parts: Vec::new(),
-                        },
-                    ),
-                    (
-                        stdlib_root,
-                        pcb_zen_core::resolution::FrozenPackage {
-                            identity: pcb_zen_core::resolution::FrozenPackageIdentity::Stdlib,
-                            deps: BTreeMap::new(),
-                            parts: Vec::new(),
-                        },
-                    ),
-                    (
-                        workspace_root,
-                        pcb_zen_core::resolution::FrozenPackage {
-                            identity: pcb_zen_core::resolution::FrozenPackageIdentity::Workspace(
-                                "github.com/myorg/project".to_string(),
-                            ),
-                            deps: BTreeMap::new(),
-                            parts: Vec::new(),
-                        },
-                    ),
-                ]),
+                packages: frozen_packages,
             },
         )]),
         HashMap::new(),
@@ -179,7 +182,7 @@ fn cross_package_relative_load_with_repository() {
     )]);
 
     let (file_provider, resolution, main_path) =
-        setup_cross_package_workspace(Some("github.com/myorg/project"), deps);
+        setup_cross_package_workspace(Some("github.com/myorg/project"), deps, true);
 
     let result = EvalContext::new(file_provider, resolution)
         .set_source_path(main_path)
@@ -204,7 +207,7 @@ fn cross_package_relative_load_without_repository() {
         pcb_zen_core::config::DependencySpec::Version("0.1.0".to_string()),
     )]);
 
-    let (file_provider, resolution, main_path) = setup_cross_package_workspace(None, deps);
+    let (file_provider, resolution, main_path) = setup_cross_package_workspace(None, deps, true);
 
     let result = EvalContext::new(file_provider, resolution)
         .set_source_path(main_path)
@@ -228,7 +231,7 @@ fn cross_package_relative_load_undeclared_dependency() {
     let deps = BTreeMap::new();
 
     let (file_provider, resolution, main_path) =
-        setup_cross_package_workspace(Some("github.com/myorg/project"), deps);
+        setup_cross_package_workspace(Some("github.com/myorg/project"), deps, true);
 
     let result = EvalContext::new(file_provider, resolution)
         .set_source_path(main_path)
@@ -246,6 +249,32 @@ fn cross_package_relative_load_undeclared_dependency() {
     assert!(
         has_dep_error,
         "Should get 'No declared dependency matches' error, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn cross_package_relative_load_undeclared_dependency_missing_from_frozen_resolution() {
+    let deps = BTreeMap::new();
+
+    let (file_provider, resolution, main_path) =
+        setup_cross_package_workspace(Some("github.com/myorg/project"), deps, false);
+
+    let result = EvalContext::new(file_provider, resolution)
+        .set_source_path(main_path)
+        .eval();
+
+    assert!(
+        !result.is_success(),
+        "Cross-package load should fail even when stale resolution omitted the target package"
+    );
+
+    let errors: Vec<String> = result.diagnostics.iter().map(|d| d.to_string()).collect();
+    let has_sync_error = errors.iter().any(|e| e.contains("Run `pcb sync`"));
+    assert!(
+        has_sync_error,
+        "Should ask the user to run `pcb sync`, got: {:?}",
         errors
     );
 }

--- a/crates/pcb-zen/src/package_resolver/scan.rs
+++ b/crates/pcb-zen/src/package_resolver/scan.rs
@@ -37,7 +37,7 @@ pub(crate) fn scan_package_direct_deps(
             .ok_or_else(|| anyhow::anyhow!("Failed to parse {}", zen_path.display()))?;
 
         for url in extracted.urls {
-            if let Some(workspace_package_url) = workspace_package_for_url(workspace_info, &url) {
+            if let Some(workspace_package_url) = workspace_info.package_url_for_url(&url) {
                 if workspace_package_url == package_url {
                     anyhow::bail!(
                         "{} uses package URL '{}' that points into its own package '{}'; use a relative path instead",
@@ -157,16 +157,4 @@ fn existing_manifest_dep(url: &str, config: &PcbToml) -> Option<(String, Depende
         .filter(|(module_path, _)| package_url_covers(module_path, url))
         .max_by_key(|(module_path, _)| module_path.len())
         .map(|(module_path, spec)| (module_path.clone(), spec.clone()))
-}
-
-fn workspace_package_for_url<'a>(
-    workspace_info: &'a crate::WorkspaceInfo,
-    url: &str,
-) -> Option<&'a str> {
-    workspace_info
-        .packages
-        .keys()
-        .filter(|package_url| package_url_covers(package_url, url))
-        .max_by_key(|package_url| package_url.len())
-        .map(|package_url| package_url.as_str())
 }

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -71,13 +71,9 @@ impl WorkspaceInfoExt for WorkspaceInfo {
     }
 
     fn package_url_for_zen(&self, zen_path: &Path) -> Option<String> {
-        let canon_zen = zen_path.canonicalize().ok()?;
-        // Longest prefix match: find most specific package containing this path
-        self.packages
-            .iter()
-            .filter(|(_, pkg)| canon_zen.starts_with(pkg.dir(&self.root)))
-            .max_by_key(|(_, pkg)| pkg.rel_path.as_os_str().len())
-            .map(|(url, _)| url.clone())
+        let file_provider = DefaultFileProvider::new();
+        self.package_url_for_path(&file_provider, zen_path)
+            .map(str::to_string)
     }
 }
 

--- a/crates/pcbc/src/doc.rs
+++ b/crates/pcbc/src/doc.rs
@@ -117,20 +117,19 @@ fn resolve_local_workspace_package_url(pkg: &str) -> Option<(PathBuf, String, Op
     let workspace_info = pcb_zen::get_workspace_info(&file_provider, &cwd).ok()?;
 
     workspace_info
-        .packages
-        .iter()
-        .filter(|(package_url, _)| pcb_zen_core::workspace::package_url_covers(package_url, pkg))
-        .max_by_key(|(package_url, _)| package_url.len())
-        .map(|(package_url, package)| {
-            let filter = pkg
-                .strip_prefix(package_url)
-                .and_then(|rest| rest.strip_prefix('/'))
-                .map(str::to_string);
-            (
-                package.dir(&workspace_info.root),
-                package_url.clone(),
-                filter,
-            )
+        .package_url_for_url(pkg)
+        .and_then(|package_url| {
+            workspace_info.packages.get(package_url).map(|package| {
+                let filter = pkg
+                    .strip_prefix(package_url)
+                    .and_then(|rest| rest.strip_prefix('/'))
+                    .map(str::to_string);
+                (
+                    package.dir(&workspace_info.root),
+                    package_url.to_string(),
+                    filter,
+                )
+            })
         })
 }
 

--- a/crates/pcbc/tests/sync.rs
+++ b/crates/pcbc/tests/sync.rs
@@ -224,6 +224,59 @@ gnd = Net("GND")
 }
 
 #[test]
+fn test_build_rejects_unsynced_cross_package_relative_load() {
+    let mut sandbox = Sandbox::new();
+
+    sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.4"
+repository = "github.com/example/demo"
+
+[board]
+name = "Main"
+path = "board.zen"
+"#,
+        )
+        .write(
+            "board.zen",
+            r#"
+load("modules/Lib/Lib.zen", "Marker")
+
+check(Marker == "ok", "loaded marker")
+"#,
+        )
+        .write("modules/Lib/pcb.toml", "[dependencies]\n")
+        .write(
+            "modules/Lib/Lib.zen",
+            r#"
+Marker = "ok"
+"#,
+        );
+
+    let build_before_sync = run_pcbc_unchecked(&mut sandbox, ["build", "board.zen"]);
+    let output_before_sync = command_output(&build_before_sync);
+    assert!(
+        !build_before_sync.status.success(),
+        "expected unsynced build to fail:\n{output_before_sync}"
+    );
+    assert!(
+        output_before_sync.contains("Run `pcb sync`"),
+        "expected build to point at pcb sync:\n{output_before_sync}"
+    );
+
+    sandbox.run("pcbc", ["sync"]).run().unwrap();
+
+    let build_after_sync = run_pcbc_unchecked(&mut sandbox, ["build", "board.zen"]);
+    let output_after_sync = command_output(&build_after_sync);
+    assert!(
+        build_after_sync.status.success(),
+        "expected synced build to succeed:\n{output_after_sync}"
+    );
+}
+
+#[test]
 fn test_same_package_url_rejected() {
     let mut sandbox = Sandbox::new();
 


### PR DESCRIPTION
## Summary
- detect relative imports that cross into discovered workspace packages even when stale dependency resolution omitted the target package
- add shared `WorkspaceInfo` helpers for longest-prefix package ownership by URL/path and reuse them in eval, sync scanning, docs, and native workspace lookup
- add regressions for stale frozen resolution and the CLI build-before/after-sync flow

## Root Cause
`pcb build` only used the frozen resolution map to decide whether a relative import crossed a package boundary. If `pcb.toml` was stale, the nested workspace package was absent from that frozen map, so build treated the file as part of the root package. Source bundling for publish still excluded nested package roots, which made publish fail later when validating staged sources.

## Impact
Unsynced workspaces now fail early with guidance to run `pcb sync` instead of letting build succeed and publish fail later.

## Validation
- `cargo test -p pcb-zen-core --test cross_package_load`
- `cargo test -p pcbc --test sync test_build_rejects_unsynced_cross_package_relative_load`
- `cargo test -p pcbc --test sync test_sync_adds_workspace_dependency_for_cross_package_relative_load`
- `cargo test -p pcbc --test doc test_pcb_doc_shows_allowed_values_for_config`
- `cargo fmt`
- `git diff --check`
- manual repro on a disposable workspace copy: unsynced build and source-only publish now fail with the `pcb sync` guidance; after sync, build succeeds and source-only publish validates staged sources up to the release confirmation prompt

Note: pre-commit `clippy` was attempted and failed on an existing `clippy::items-after-test-module` issue in `crates/pcb-ipc2581-tools/src/commands/html_export.rs`, unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency and cross-package load validation in the eval/build path; incorrect boundary detection could break valid workspace imports or still allow bad ones.
> 
> **Overview**
> **`pcb build` now fails early** when a relative import targets another discovered workspace package that is not a declared dependency in `pcb.toml`, including when stale frozen resolution omitted that package from the dependency map. The error tells users to run **`pcb sync`** instead of succeeding at build and failing later on publish.
> 
> **`WorkspaceInfo`** gains shared **`package_url_for_url`** and **`package_url_for_path`** helpers (longest-prefix package ownership). Eval uses them to detect cross-package relative loads via package URL comparison and to reject undeclared workspace targets before resolution; sync scanning, docs, and native zen lookup reuse the same helpers instead of duplicating logic.
> 
> Tests cover stale frozen resolution and the CLI build-before/after-sync flow; the changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ee6600a08b945cb757f2fcaeb750a09432546d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->