### PR TITLE
Make pcb --version show toolchain versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- `pcb --version` now aliases `pcb toolchain show` and reports both shim and active `pcbc` versions.
 - `NotConnected` is now an open-net constructor, not a net type.
 
 ## [0.4.1] - 2026-06-22

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -140,7 +140,7 @@ fn is_help_request(args: &[OsString]) -> bool {
 fn is_shim_command(args: &[OsString]) -> bool {
     matches!(
         args.first().and_then(|arg| arg.to_str()),
-        Some("self" | "toolchain")
+        Some("self" | "toolchain" | "--version" | "-V")
     )
 }
 
@@ -172,6 +172,7 @@ fn parse_shim_command(args: &[OsString]) -> Result<ShimCommand> {
         .collect::<Result<_>>()?;
 
     match strings.as_slice() {
+        ["--version" | "-V"] => Ok(ShimCommand::ToolchainShow),
         ["self", "update"] => Ok(ShimCommand::SelfUpdate),
         ["toolchain", "list"] => Ok(ShimCommand::ToolchainList),
         ["toolchain", "show"] => Ok(ShimCommand::ToolchainShow),
@@ -984,6 +985,10 @@ fn toolchain_list() -> Result<()> {
 fn toolchain_show() -> Result<()> {
     println!("shim: {}", env!("CARGO_PKG_VERSION"));
     let selection = select_toolchain(None, false, false)?;
+    let pcbc_version = pcbc_version(&selection.binary)
+        .map(|version| version.to_string())
+        .unwrap_or_else(|| selection.label.clone());
+    println!("pcbc: {pcbc_version}");
     println!("active: {}", selection.label);
     println!("reason: {}", selection.reason);
     println!("binary: {}", selection.binary.display());
@@ -1403,6 +1408,18 @@ mod tests {
 
     fn args(values: &[&str]) -> Vec<OsString> {
         values.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn version_flags_are_shim_toolchain_show_aliases() {
+        for flag in ["--version", "-V"] {
+            let argv = args(&[flag]);
+            assert!(is_shim_command(&argv));
+            assert!(matches!(
+                parse_shim_command(&argv).unwrap(),
+                ShimCommand::ToolchainShow
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat `pcb --version` and `pcb -V` as shim aliases for `pcb toolchain show`
- Include the active `pcbc` version in toolchain output
- Add regression coverage and changelog entry

## Tests
- `cargo fmt`
- `cargo test -p pcb`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI routing and display change in the pcb shim; no auth, data, or build-evaluation behavior changes.
> 
> **Overview**
> **`pcb --version`** and **`pcb -V`** are handled by the shim like **`pcb toolchain show`** instead of being forwarded to the selected `pcbc` binary.
> 
> **`toolchain show`** output (and thus the version flags) now includes a **`pcbc:`** line with the semver from the active toolchain binary’s `--version`, falling back to the selection label when that probe fails. The existing **`shim:`**, **`active:`**, **`reason:`**, and **`binary:`** lines are unchanged.
> 
> Changelog and a unit test assert that **`--version`** / **`-V`** are shim commands that resolve to **`ToolchainShow`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22acb050cf40a78af97b4d60e68e95ee761ccf0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->