### PR TITLE
Fix Gerber compound region hole export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a manual KiCad SVG vs IPC-2581 to Gerber SVG raster diff script for checking copper export regressions.
+
 ### Fixed
 
 - IPC-2581 mutations now create a history record when the source file does not already have one, including board array creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - IPC-2581 mutations now create a history record when the source file does not already have one, including board array creation.
 - Fixed a `pcb build` performance regression in large workspaces with many packages.
+- IPC-2581 to Gerber export now emits compound region holes as local Gerber cut-ins.
 
 ## [0.4.2] - 2026-06-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4592,6 +4592,7 @@ dependencies = [
  "colored",
  "comfy-table",
  "gerberx2",
+ "i_overlay",
  "ipc2581",
  "jiff",
  "log",

--- a/bin/kicad_ipc_gerber_svg_diff.py
+++ b/bin/kicad_ipc_gerber_svg_diff.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pillow>=10"]
+# ///
+"""Compare KiCad F.Cu SVG against IPC-2581 -> Gerber -> SVG output."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import zipfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import NoReturn, cast
+from xml.etree import ElementTree as ET
+
+from PIL import Image, ImageChops, ImageDraw
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+DEFAULT_PX_PER_MM = 100
+DEFAULT_TOTAL_TOLERANCE_MM2 = 5.0
+DEFAULT_COMPONENT_TOLERANCE_MM2 = 0.5
+
+GERBER_BY_LAYER = {
+    "F.Cu": "F_Cu.gtl",
+    "B.Cu": "B_Cu.gbl",
+    "F.Mask": "F_Mask.gts",
+    "B.Mask": "B_Mask.gbs",
+    "F.Paste": "F_Paste.gtp",
+    "B.Paste": "B_Paste.gbp",
+    "F.SilkS": "F_SilkS.gto",
+    "B.SilkS": "B_SilkS.gbo",
+}
+
+
+def main() -> int:
+    args = parse_args()
+    layout = args.layout.resolve()
+    if not layout.is_file() or layout.suffix != ".kicad_pcb":
+        fail(f"expected a .kicad_pcb file, got {layout}")
+
+    kicad_cli = resolve_command(args.kicad_cli, "kicad-cli")
+    rsvg_convert = resolve_command(args.rsvg_convert, "rsvg-convert")
+    layer = cast(str, args.layer)
+    gerber_name = cast(str | None, args.gerber_file) or GERBER_BY_LAYER.get(layer)
+    if gerber_name is None:
+        fail(f"no default Gerber filename for layer {layer!r}; pass --gerber-file")
+
+    out_dir = (
+        args.output_dir
+        or Path.cwd() / "build" / "kicad-ipc-gerber-svg-diff" / layout.stem
+    ).resolve()
+    if out_dir.exists() and args.clean:
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    paths = OutputPaths(out_dir, layer, gerber_name)
+    run_kicad_svg(kicad_cli, layout, layer, paths.kicad_svg)
+    run_kicad_ipc(kicad_cli, layout, paths.ipc_xml)
+    run_pcbc(
+        args,
+        [
+            "ipc2581",
+            "gerber",
+            "--layout-target",
+            args.layout_target,
+            "--output",
+            str(paths.gerber_zip),
+            str(paths.ipc_xml),
+        ],
+    )
+    unzip_to(paths.gerber_zip, paths.gerber_dir)
+    gerber_layer = paths.gerber_dir / gerber_name
+    if not gerber_layer.is_file():
+        fail(f"Gerber export did not create {gerber_name}; see {paths.gerber_dir}")
+
+    run_pcbc(
+        args,
+        ["gerber", "render", "--output", str(paths.ipc_gerber_svg), str(gerber_layer)],
+    )
+    ensure_svg_size_from_viewbox(paths.ipc_gerber_svg, paths.ipc_gerber_sized_svg)
+
+    rasterize_svg(
+        rsvg_convert,
+        paths.kicad_svg,
+        paths.kicad_png,
+        args.px_per_mm,
+    )
+    rasterize_svg(
+        rsvg_convert,
+        paths.ipc_gerber_sized_svg,
+        paths.ipc_gerber_png,
+        args.px_per_mm,
+    )
+
+    report = compare_rasters(
+        paths.kicad_png,
+        paths.ipc_gerber_png,
+        paths,
+        args.alpha_threshold,
+        args.px_per_mm,
+    )
+    write_panel(paths.diff_panel_png, report)
+    print_report(paths, report, args)
+
+    failed = (
+        report.diff_mm2 > args.max_total_diff_mm2
+        or report.largest_component_mm2 > args.max_component_diff_mm2
+    )
+    if failed:
+        print("FAIL: SVG raster diff exceeds tolerance", file=sys.stderr)
+        return 1
+
+    print("PASS: SVG raster diff is within tolerance")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate KiCad SVG and IPC-2581 -> Gerber -> SVG output for a "
+            ".kicad_pcb file, rasterize both, and fail on significant copper diff."
+        )
+    )
+    parser.add_argument("layout", type=Path, help="Path to a .kicad_pcb file")
+    parser.add_argument("--layer", default="F.Cu", help="KiCad layer to compare")
+    parser.add_argument(
+        "--gerber-file",
+        help="Expected Gerber filename inside the IPC Gerber package; inferred for common layers",
+    )
+    parser.add_argument(
+        "--layout-target",
+        default="board",
+        choices=["board", "board-array"],
+        help="IPC Gerber export target",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for generated IPC, Gerber, SVG, PNG, and diff artifacts",
+    )
+    parser.add_argument(
+        "--px-per-mm",
+        type=int,
+        default=DEFAULT_PX_PER_MM,
+        help="Rasterization resolution; 100 means 10,000 pixels per mm^2",
+    )
+    parser.add_argument(
+        "--max-total-diff-mm2",
+        type=float,
+        default=DEFAULT_TOTAL_TOLERANCE_MM2,
+        help="Fail when total XOR area exceeds this value",
+    )
+    parser.add_argument(
+        "--max-component-diff-mm2",
+        type=float,
+        default=DEFAULT_COMPONENT_TOLERANCE_MM2,
+        help="Fail when the largest connected XOR component exceeds this value",
+    )
+    parser.add_argument(
+        "--alpha-threshold",
+        type=int,
+        default=8,
+        help="Alpha value above which a raster pixel counts as painted copper",
+    )
+    parser.add_argument(
+        "--kicad-cli",
+        default=os.environ.get("KICAD_CLI"),
+        help="Path to kicad-cli; defaults to KICAD_CLI or PATH lookup",
+    )
+    parser.add_argument(
+        "--rsvg-convert",
+        default=os.environ.get("RSVG_CONVERT"),
+        help="Path to rsvg-convert; defaults to RSVG_CONVERT or PATH lookup",
+    )
+    parser.add_argument(
+        "--pcbc-bin",
+        type=Path,
+        help="Use an existing pcbc binary instead of cargo run -p pcbc --",
+    )
+    parser.add_argument(
+        "--release",
+        action="store_true",
+        help="Use cargo run --release when --pcbc-bin is not set",
+    )
+    parser.add_argument(
+        "--keep-output",
+        dest="clean",
+        action="store_false",
+        help="Do not clear the output directory before running",
+    )
+    parser.set_defaults(clean=True)
+    return parser.parse_args()
+
+
+class OutputPaths:
+    def __init__(self, out_dir: Path, layer: str, gerber_file: str) -> None:
+        safe_layer = layer.replace(".", "_")
+        self.out_dir = out_dir
+        self.ipc_xml = out_dir / "layout.ipc2581.xml"
+        self.gerber_zip = out_dir / "ipc-gerbers.zip"
+        self.gerber_dir = out_dir / "ipc-gerbers"
+        self.kicad_svg = out_dir / f"kicad-{safe_layer}.svg"
+        self.kicad_png = out_dir / f"kicad-{safe_layer}.png"
+        self.kicad_mask_png = out_dir / f"kicad-{safe_layer}.mask.png"
+        self.ipc_gerber_svg = out_dir / f"ipc-gerber-{safe_layer}.svg"
+        self.ipc_gerber_sized_svg = out_dir / f"ipc-gerber-{safe_layer}.sized.svg"
+        self.ipc_gerber_png = out_dir / f"ipc-gerber-{safe_layer}.png"
+        self.ipc_gerber_mask_png = out_dir / f"ipc-gerber-{safe_layer}.mask.png"
+        self.diff_png = out_dir / f"kicad-vs-ipc-gerber-{safe_layer}.diff.png"
+        self.xor_png = out_dir / f"kicad-vs-ipc-gerber-{safe_layer}.xor.png"
+        self.diff_panel_png = out_dir / f"kicad-vs-ipc-gerber-{safe_layer}.panel.png"
+        self.gerber_file = gerber_file
+
+
+class DiffReport:
+    def __init__(
+        self,
+        *,
+        size: tuple[int, int],
+        reference_area_px: int,
+        candidate_area_px: int,
+        diff_px: int,
+        px_per_mm: int,
+        components: list[tuple[int, tuple[int, int, int, int]]],
+    ) -> None:
+        self.size = size
+        self.reference_area_px = reference_area_px
+        self.candidate_area_px = candidate_area_px
+        self.diff_px = diff_px
+        self.px_per_mm = px_per_mm
+        self.components = components
+
+    @property
+    def px_per_mm2(self) -> int:
+        return self.px_per_mm * self.px_per_mm
+
+    @property
+    def reference_area_mm2(self) -> float:
+        return self.reference_area_px / self.px_per_mm2
+
+    @property
+    def candidate_area_mm2(self) -> float:
+        return self.candidate_area_px / self.px_per_mm2
+
+    @property
+    def diff_mm2(self) -> float:
+        return self.diff_px / self.px_per_mm2
+
+    @property
+    def largest_component_px(self) -> int:
+        return self.components[0][0] if self.components else 0
+
+    @property
+    def largest_component_mm2(self) -> float:
+        return self.largest_component_px / self.px_per_mm2
+
+
+def run_kicad_svg(kicad_cli: str, layout: Path, layer: str, output: Path) -> None:
+    run(
+        [
+            kicad_cli,
+            "pcb",
+            "export",
+            "svg",
+            "--layers",
+            layer,
+            "--mode-single",
+            "--page-size-mode",
+            "2",
+            "--exclude-drawing-sheet",
+            "--check-zones",
+            "--output",
+            str(output),
+            str(layout),
+        ]
+    )
+
+
+def run_kicad_ipc(kicad_cli: str, layout: Path, output: Path) -> None:
+    run([kicad_cli, "pcb", "export", "ipc2581", "--output", str(output), str(layout)])
+
+
+def run_pcbc(args: argparse.Namespace, pcbc_args: Sequence[str]) -> None:
+    if args.pcbc_bin:
+        cmd = [str(args.pcbc_bin), *pcbc_args]
+    else:
+        cmd = ["cargo", "run"]
+        if args.release:
+            cmd.append("--release")
+        cmd.extend(["-p", "pcbc", "--", *pcbc_args])
+    run(cmd, cwd=REPO_ROOT)
+
+
+def unzip_to(zip_path: Path, output_dir: Path) -> None:
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+    with zipfile.ZipFile(zip_path) as archive:
+        archive.extractall(output_dir)
+
+
+def ensure_svg_size_from_viewbox(input_svg: Path, output_svg: Path) -> None:
+    text = input_svg.read_text()
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as error:
+        fail(f"invalid SVG XML in {input_svg}: {error}")
+
+    if root.tag.rsplit("}", 1)[-1] != "svg":
+        fail(f"expected SVG root in {input_svg}, got {root.tag!r}")
+
+    viewbox = root.attrib.get("viewBox")
+    if viewbox is None:
+        fail(f"SVG has no viewBox: {input_svg}")
+
+    if "width" in root.attrib and "height" in root.attrib:
+        output_svg.write_text(text)
+        return
+
+    values = [float(value) for value in viewbox.replace(",", " ").split()]
+    if len(values) != 4 or values[2] <= 0 or values[3] <= 0:
+        fail(f"invalid SVG viewBox in {input_svg}: {viewbox!r}")
+    width, height = values[2], values[3]
+    root.attrib["width"] = f"{width}mm"
+    root.attrib["height"] = f"{height}mm"
+    ET.register_namespace("", SVG_NAMESPACE)
+    output_svg.write_text(ET.tostring(root, encoding="unicode") + "\n")
+
+
+def rasterize_svg(
+    rsvg_convert: str, input_svg: Path, output_png: Path, px_per_mm: int
+) -> None:
+    dpi = px_per_mm * 25.4
+    run(
+        [
+            rsvg_convert,
+            "--dpi-x",
+            f"{dpi}",
+            "--dpi-y",
+            f"{dpi}",
+            str(input_svg),
+            "--output",
+            str(output_png),
+        ]
+    )
+
+
+def compare_rasters(
+    reference_png: Path,
+    candidate_png: Path,
+    paths: OutputPaths,
+    alpha_threshold: int,
+    px_per_mm: int,
+) -> DiffReport:
+    reference = trim_to_painted_bbox(alpha_mask(reference_png, alpha_threshold))
+    candidate = trim_to_painted_bbox(alpha_mask(candidate_png, alpha_threshold))
+    reference.save(paths.kicad_mask_png)
+    candidate.save(paths.ipc_gerber_mask_png)
+    if reference.size != candidate.size:
+        fail(
+            "trimmed raster sizes differ: "
+            f"KiCad {reference.size}, IPC Gerber {candidate.size}"
+        )
+
+    only_reference = ImageChops.subtract(reference, candidate)
+    only_candidate = ImageChops.subtract(candidate, reference)
+    common = ImageChops.multiply(reference, candidate)
+    xor = ImageChops.difference(reference, candidate).point(
+        lambda value: 255 if value else 0, "L"
+    )
+    xor.save(paths.xor_png)
+
+    diff = Image.new("RGB", reference.size, "white")
+    diff_pixels = diff.load()
+    ref_pixels = only_reference.load()
+    candidate_pixels = only_candidate.load()
+    common_pixels = common.load()
+    width, height = reference.size
+    for y in range(height):
+        for x in range(width):
+            if common_pixels[x, y]:
+                diff_pixels[x, y] = (18, 18, 18)
+            if ref_pixels[x, y]:
+                diff_pixels[x, y] = (220, 38, 38)
+            if candidate_pixels[x, y]:
+                diff_pixels[x, y] = (37, 99, 235)
+    diff.save(paths.diff_png)
+
+    components = connected_components(xor)
+    return DiffReport(
+        size=reference.size,
+        reference_area_px=count_painted(reference),
+        candidate_area_px=count_painted(candidate),
+        diff_px=count_painted(xor),
+        px_per_mm=px_per_mm,
+        components=components,
+    )
+
+
+def alpha_mask(png: Path, threshold: int) -> Image.Image:
+    image = Image.open(png).convert("RGBA")
+    return image.getchannel("A").point(
+        lambda value: 255 if value > threshold else 0, "L"
+    )
+
+
+def trim_to_painted_bbox(mask: Image.Image) -> Image.Image:
+    bbox = mask.getbbox()
+    if bbox is None:
+        fail("rasterized SVG contains no painted pixels")
+    return mask.crop(bbox)
+
+
+def count_painted(mask: Image.Image) -> int:
+    return sum(mask.histogram()[1:])
+
+
+def connected_components(
+    mask: Image.Image,
+) -> list[tuple[int, tuple[int, int, int, int]]]:
+    width, height = mask.size
+    pixels = mask.load()
+    seen = bytearray(width * height)
+    components: list[tuple[int, tuple[int, int, int, int]]] = []
+    for y in range(height):
+        for x in range(width):
+            start = y * width + x
+            if seen[start] or not pixels[x, y]:
+                continue
+            seen[start] = 1
+            stack = [(x, y)]
+            min_x = max_x = x
+            min_y = max_y = y
+            count = 0
+            while stack:
+                current_x, current_y = stack.pop()
+                count += 1
+                min_x = min(min_x, current_x)
+                max_x = max(max_x, current_x)
+                min_y = min(min_y, current_y)
+                max_y = max(max_y, current_y)
+                for next_y in range(max(0, current_y - 1), min(height, current_y + 2)):
+                    for next_x in range(
+                        max(0, current_x - 1), min(width, current_x + 2)
+                    ):
+                        if next_x == current_x and next_y == current_y:
+                            continue
+                        next_index = next_y * width + next_x
+                        if not seen[next_index] and pixels[next_x, next_y]:
+                            seen[next_index] = 1
+                            stack.append((next_x, next_y))
+            components.append((count, (min_x, min_y, max_x + 1, max_y + 1)))
+    components.sort(reverse=True)
+    return components
+
+
+def write_panel(output: Path, report: DiffReport) -> None:
+    diff = Image.open(
+        output.with_name(output.name.replace(".panel.", ".diff."))
+    ).convert("RGB")
+    max_width = 1600
+    scale = min(1.0, max_width / diff.size[0])
+    image_width = int(diff.size[0] * scale)
+    image_height = int(diff.size[1] * scale)
+    header_height = 96
+    legend_height = 48
+    panel = Image.new(
+        "RGB", (image_width, header_height + image_height + legend_height), "white"
+    )
+    draw = ImageDraw.Draw(panel)
+    draw.rectangle([0, 0, image_width, header_height], fill=(245, 245, 245))
+    draw.text((18, 14), "KiCad SVG vs IPC -> Gerber -> SVG", fill=(20, 20, 20))
+    draw.text(
+        (18, 42),
+        (
+            f"XOR {report.diff_mm2:.4f} mm^2; largest component "
+            f"{report.largest_component_mm2:.4f} mm^2; "
+            f"KiCad {report.reference_area_mm2:.4f} mm^2; "
+            f"candidate {report.candidate_area_mm2:.4f} mm^2"
+        ),
+        fill=(40, 40, 40),
+    )
+    panel.paste(
+        diff.resize((image_width, image_height), Image.Resampling.LANCZOS),
+        (0, header_height),
+    )
+    legend_y = header_height + image_height
+    legend = [
+        ((18, 18, 18), "common copper"),
+        ((220, 38, 38), "KiCad only / missing in candidate"),
+        ((37, 99, 235), "candidate only / extra copper"),
+    ]
+    x = 18
+    for color, label in legend:
+        draw.rectangle([x, legend_y + 14, x + 24, legend_y + 38], fill=color)
+        draw.text((x + 34, legend_y + 14), label, fill=(30, 30, 30))
+        x += 330
+    panel.save(output)
+
+
+def print_report(
+    paths: OutputPaths, report: DiffReport, args: argparse.Namespace
+) -> None:
+    print(f"Artifacts: {paths.out_dir}")
+    print(f"KiCad SVG: {paths.kicad_svg}")
+    print(f"IPC XML: {paths.ipc_xml}")
+    print(f"Gerber ZIP: {paths.gerber_zip}")
+    print(f"IPC Gerber SVG: {paths.ipc_gerber_svg}")
+    print(f"Diff panel: {paths.diff_panel_png}")
+    print(
+        "Areas: "
+        f"KiCad {report.reference_area_mm2:.6f} mm^2, "
+        f"candidate {report.candidate_area_mm2:.6f} mm^2, "
+        f"delta {report.candidate_area_mm2 - report.reference_area_mm2:.6f} mm^2"
+    )
+    print(
+        "Diff: "
+        f"total {report.diff_mm2:.6f} mm^2 "
+        f"({report.diff_px:,} px), "
+        f"largest component {report.largest_component_mm2:.6f} mm^2 "
+        f"({report.largest_component_px:,} px), "
+        f"components {len(report.components)}"
+    )
+    print(
+        "Tolerances: "
+        f"total <= {args.max_total_diff_mm2:.6f} mm^2, "
+        f"largest component <= {args.max_component_diff_mm2:.6f} mm^2"
+    )
+    for index, (pixels, bbox) in enumerate(report.components[:8], start=1):
+        print(
+            f"component {index}: {pixels / report.px_per_mm2:.6f} mm^2, "
+            f"bbox {bbox}, size {bbox[2] - bbox[0]}x{bbox[3] - bbox[1]} px"
+        )
+
+
+def resolve_command(value: str | None, fallback: str) -> str:
+    if value:
+        path = shutil.which(value) if os.sep not in value else value
+        if path and Path(path).exists():
+            return str(path)
+        fail(f"command not found: {value}")
+    path = shutil.which(fallback)
+    if path:
+        return path
+    if fallback == "kicad-cli":
+        mac_path = "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+        if Path(mac_path).exists():
+            return mac_path
+    fail(f"command not found: {fallback}")
+
+
+def run(command: Sequence[str], cwd: Path | None = None) -> None:
+    print("+ " + " ".join(command), flush=True)
+    try:
+        subprocess.run(command, cwd=cwd, check=True)
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(error.returncode) from error
+
+
+def fail(message: str) -> NoReturn:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/gerberx2/src/geometry/extract.rs
+++ b/crates/gerberx2/src/geometry/extract.rs
@@ -164,7 +164,7 @@ pub fn extract_document(gerber: &GerberX2) -> GerberArtworkDocument {
                     FeatureKind::Region,
                     classify_bucket(object, FeatureKind::Region),
                 );
-                push_feature_paths(&mut doc, layer, meta, vec![region_path(contours)]);
+                push_feature_paths(&mut doc, layer, meta, region_paths(contours));
             }
         }
     }
@@ -284,7 +284,10 @@ fn push_feature_paths(
 
     let mut composer = common_path::PaintComposer::default();
     for extracted in paths {
-        let contours = common_path::payloads_to_polygon_contours(&extracted.contours);
+        let contours = common_path::simplify_polygon_contours(
+            common_path::payloads_to_polygon_contours(&extracted.contours),
+            extracted.path.fill_rule,
+        );
         if contours.is_empty() {
             continue;
         }
@@ -450,13 +453,15 @@ fn sample_steps(length: f64) -> usize {
     (length / SWEEP_SAMPLE_MM).ceil().max(1.0) as usize
 }
 
-fn region_path(contours: &[gerber::Contour]) -> ExtractedPath {
-    let contours = contours.iter().map(region_contour).collect();
-    ExtractedPath {
-        paint: PaintPolarity::Dark,
-        path: ArtworkPath::filled(FillRule::NonZero),
-        contours,
-    }
+fn region_paths(contours: &[gerber::Contour]) -> Vec<ExtractedPath> {
+    contours
+        .iter()
+        .map(|contour| ExtractedPath {
+            paint: PaintPolarity::Dark,
+            path: ArtworkPath::filled(FillRule::EvenOdd),
+            contours: vec![region_contour(contour)],
+        })
+        .collect()
 }
 
 fn region_contour(contour: &gerber::Contour) -> common_path::PathPayload {

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -441,6 +441,22 @@ fn artwork_composition_applies_clear_polarity_cutouts() {
 }
 
 #[test]
+fn region_contour_orientation_does_not_create_holes() {
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%\n%MOMM*%\nG36*\nG01*\nX0Y0D02*\nX4000000Y0D01*\nX4000000Y4000000D01*\nX0Y4000000D01*\nX0Y0D01*\nX1000000Y1000000D02*\nX1000000Y3000000D01*\nX3000000Y3000000D01*\nX3000000Y1000000D01*\nX1000000Y1000000D01*\nG37*\nM02*\n",
+    )
+    .unwrap();
+
+    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let summary = pcb_ir::dialects::gerber::compare::summarize(&geometry);
+    assert!(
+        close(summary.area_mm2, 16.0),
+        "region contours are filled independently; area was {}",
+        summary.area_mm2
+    );
+}
+
+#[test]
 fn artwork_composition_keeps_clear_polarity_semantics_after_overlapping_dark_runs() {
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10R,4.0X4.0*%\n%ADD11R,2.0X2.0*%\nD10*\nX0Y0D03*\nX0Y0D03*\n%LPC*%\nD11*\nX0Y0D03*\nM02*\n",

--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -14,6 +14,7 @@ colored = { workspace = true }
 comfy-table = { workspace = true }
 ipc2581 = { workspace = true }
 gerberx2 = { workspace = true }
+i_overlay = { workspace = true }
 jiff = { workspace = true }
 log = { workspace = true }
 minijinja = { workspace = true }

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1518,7 +1518,7 @@ mod tests {
     }
 
     #[test]
-    fn gerber_export_places_pad_flashes_after_local_fill_clear_regions() {
+    fn gerber_export_places_pad_flashes_after_local_fill_cut_ins() {
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -1588,13 +1588,16 @@ mod tests {
                 .objects()
                 .iter()
                 .all(|object| object.polarity == pcb_ir::dialects::gerber::Polarity::Dark),
-            "compound region holes should stay object-local, not global clear polarity"
+            "positive compound region holes should not export as layer-global clear regions"
         );
         let region_index = parsed
             .objects()
             .iter()
-            .position(|object| matches!(object.kind, gerberx2::ObjectKind::Region { .. }))
-            .expect("compound fill should export as a region");
+            .position(|object| {
+                object.polarity == pcb_ir::dialects::gerber::Polarity::Dark
+                    && matches!(object.kind, gerberx2::ObjectKind::Region { .. })
+            })
+            .expect("compound fill should export as a dark local cut-in region");
         let pad_flash_index = parsed
             .objects()
             .iter()
@@ -1612,7 +1615,7 @@ mod tests {
     }
 
     #[test]
-    fn gerber_export_places_multi_contour_traces_after_local_fill_clear_regions() {
+    fn gerber_export_places_multi_contour_traces_after_local_fill_cut_ins() {
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -1676,7 +1679,7 @@ mod tests {
             .unwrap();
         assert!(
             !copper.contents.contains("%LPC*%"),
-            "compound region holes should stay object-local, not global clear polarity"
+            "positive compound region holes should not export as layer-global clear regions"
         );
         let fill_end_index = copper
             .contents
@@ -1945,7 +1948,7 @@ mod tests {
             .unwrap();
         assert!(
             !silk.contents.contains("%LPC*%"),
-            "compound region holes should stay object-local, not global clear polarity"
+            "positive compound region holes should not export as layer-global clear regions"
         );
         let parsed = gerberx2::GerberX2::parse(&silk.contents).unwrap();
         let geometry = gerberx2::geometry::extract_document(&parsed);

--- a/crates/pcb-ipc2581-tools/src/gerber/lower.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/lower.rs
@@ -5,7 +5,8 @@ use gerberx2::{
     AttributeValue, Contour, ContourSegment, GerberLayer, ObjectKind, Point as GerberPoint,
     WriterAperture, WriterApertureTemplate, WriterObject, sanitize_attribute_field,
 };
-use pcb_ir::common::{BBox, FillRule, PaintPolarity, Point};
+use i_overlay::float::simplify::SimplifyShape;
+use pcb_ir::common::{FillRule, PaintPolarity, Point};
 use pcb_ir::dialects::artwork::{ArtworkAperture, ArtworkGeometry, ArtworkPath, PaintStage};
 use pcb_ir::dialects::gerber::Polarity;
 use pcb_ir::dialects::path::{self as common_path, PathCmd, PathOp, PathPayload, PolygonContour};
@@ -442,67 +443,32 @@ fn lower_region_objects(
     let artwork_path = &layer.paths[path_index as usize];
     let payloads = path_contours(layer, artwork_path);
     let contours = lower_region_image_contours(&payloads, artwork_path.fill_rule)?;
-    if contours.is_empty() {
-        return Ok(Vec::new());
-    }
-    Ok(vec![WriterObject {
-        kind: ObjectKind::Region { contours },
-        polarity: lower_polarity(paint),
-        attributes: attributes.to_vec(),
-    }])
+    Ok(contours
+        .into_iter()
+        .map(|contour| WriterObject {
+            kind: ObjectKind::Region {
+                contours: vec![contour],
+            },
+            polarity: lower_polarity(paint),
+            attributes: attributes.to_vec(),
+        })
+        .collect())
 }
 
 fn lower_region_image_contours(
     payloads: &[PathPayload],
     fill_rule: FillRule,
 ) -> Result<Vec<Contour>> {
-    if fill_rule == FillRule::NonZero {
-        return payloads.iter().map(lower_region_contour).collect();
-    }
-
-    if let Some(contours) = lower_simple_compound_region_contours(payloads)? {
-        return Ok(contours);
-    }
-
     let contours = common_path::payloads_to_polygon_contours(payloads);
-    let contours = common_path::simplify_polygon_contours(contours, fill_rule);
-    let mut parts = contours
-        .into_iter()
-        .filter_map(region_part)
-        .collect::<Result<Vec<_>>>()?;
-    assign_region_depths(&mut parts);
-    parts.sort_by_key(|part| part.depth);
-
-    Ok(parts
-        .into_iter()
-        .map(oriented_region_part_contour)
-        .collect())
-}
-
-fn lower_simple_compound_region_contours(payloads: &[PathPayload]) -> Result<Option<Vec<Contour>>> {
-    let polygons = common_path::payloads_to_polygon_contours(payloads);
-    if polygons.len() != payloads.len() {
-        return Ok(None);
+    if payloads.len() == 1 && contours.len() == 1 {
+        return Ok(vec![lower_region_contour(&payloads[0])?]);
     }
 
-    let mut parts = payloads
-        .iter()
-        .zip(polygons)
-        .filter_map(|(payload, polygon)| original_region_part(payload, polygon))
-        .collect::<Result<Vec<_>>>()?;
-    if parts.len() != payloads.len() || !region_parts_are_nested_or_disjoint(&parts) {
-        return Ok(None);
-    }
-
-    assign_region_depths(&mut parts);
-    parts.sort_by_key(|part| part.depth);
-
-    Ok(Some(
-        parts
-            .into_iter()
-            .map(oriented_region_part_contour)
-            .collect(),
-    ))
+    let shapes = contours.simplify_shape(common_path::overlay_fill_rule(fill_rule));
+    shapes
+        .into_iter()
+        .filter_map(region_shape_contour)
+        .collect::<Result<Vec<_>>>()
 }
 
 fn lower_region_contour(contour: &PathPayload) -> Result<Contour> {
@@ -550,126 +516,86 @@ fn path_contours(
 
 #[derive(Debug)]
 struct RegionPart {
-    polygon: PolygonContour,
     contour: Contour,
-    bbox: BBox,
-    area: f64,
-    depth: usize,
+    signed_area: f64,
 }
 
 fn region_part(polygon: PolygonContour) -> Option<Result<RegionPart>> {
-    let payload = common_path::polygon_contours_to_payloads(vec![polygon.clone()])
-        .into_iter()
-        .next()?;
-    original_region_part(&payload, polygon)
-}
-
-fn original_region_part(
-    payload: &PathPayload,
-    polygon: PolygonContour,
-) -> Option<Result<RegionPart>> {
     if polygon.is_empty() {
         return None;
     }
-    let bbox = payload.bbox;
-    let area = polygon_area_abs(&polygon);
-    Some(lower_region_contour(payload).map(|contour| RegionPart {
-        polygon,
+    let payload = common_path::polygon_contours_to_payloads(vec![polygon.clone()])
+        .into_iter()
+        .next()?;
+    let signed_area = polygon_area_signed(&polygon);
+    Some(lower_region_contour(&payload).map(|contour| RegionPart {
         contour,
-        bbox,
-        area,
-        depth: 0,
+        signed_area,
     }))
 }
 
-fn region_parts_are_nested_or_disjoint(parts: &[RegionPart]) -> bool {
-    for left_index in 0..parts.len() {
-        for right_index in left_index + 1..parts.len() {
-            let left = &parts[left_index];
-            let right = &parts[right_index];
-            if !left.bbox.intersects(right.bbox) {
-                continue;
-            }
+fn region_shape_contour(shape: Vec<PolygonContour>) -> Option<Result<Contour>> {
+    let mut parts = match shape
+        .into_iter()
+        .filter_map(region_part)
+        .collect::<Result<Vec<_>>>()
+    {
+        Ok(parts) => parts,
+        Err(error) => return Some(Err(error)),
+    };
+    if parts.is_empty() {
+        return None;
+    }
+    let outer = parts.remove(0);
+    let holes = parts.iter().collect::<Vec<_>>();
+    Some(region_part_shape_contour(&outer, &holes))
+}
 
-            let left_contains_right = region_part_contains(left, right);
-            let right_contains_left = region_part_contains(right, left);
-            if left_contains_right == right_contains_left {
-                return false;
-            }
+fn region_part_shape_contour(outer: &RegionPart, holes: &[&RegionPart]) -> Result<Contour> {
+    let mut contour = outer.contour.clone();
+    let outer_start = match contour.segments.first() {
+        Some(ContourSegment::Line { start, .. } | ContourSegment::Arc { start, .. }) => *start,
+        None => bail!("compound Gerber region has empty outer"),
+    };
+    for hole in holes {
+        let mut hole_contour = hole.contour.clone();
+        if outer.signed_area.signum() == hole.signed_area.signum() {
+            hole_contour = reverse_contour(&hole_contour);
+        }
+        let hole_start = match hole_contour.segments.first() {
+            Some(ContourSegment::Line { start, .. } | ContourSegment::Arc { start, .. }) => *start,
+            None => bail!("compound Gerber region has empty hole"),
+        };
+        if (outer_start.x - hole_start.x).hypot(outer_start.y - hole_start.y) > 1e-9 {
+            contour.segments.push(ContourSegment::Line {
+                start: outer_start,
+                end: hole_start,
+            });
+        }
+        contour.segments.extend(hole_contour.segments);
+        if (outer_start.x - hole_start.x).hypot(outer_start.y - hole_start.y) > 1e-9 {
+            contour.segments.push(ContourSegment::Line {
+                start: hole_start,
+                end: outer_start,
+            });
         }
     }
-    true
+    Ok(contour)
 }
 
-fn region_part_contains(outer: &RegionPart, inner: &RegionPart) -> bool {
-    bbox_contains_bbox(outer.bbox, inner.bbox) && point_in_polygon(inner.polygon[0], &outer.polygon)
-}
-
-fn assign_region_depths(parts: &mut [RegionPart]) {
-    let parents = (0..parts.len())
-        .map(|index| region_parent(index, parts))
-        .collect::<Vec<_>>();
-    let mut depths = vec![None; parts.len()];
-    for (index, part) in parts.iter_mut().enumerate() {
-        part.depth = region_depth(index, &parents, &mut depths);
-    }
-}
-
-fn region_parent(index: usize, parts: &[RegionPart]) -> Option<usize> {
-    let point = parts[index].polygon[0];
-    let mut parent: Option<usize> = None;
-    for candidate in 0..parts.len() {
-        if candidate == index
-            || parts[candidate].area <= parts[index].area
-            || !bbox_contains_bbox(parts[candidate].bbox, parts[index].bbox)
-            || !point_in_polygon(point, &parts[candidate].polygon)
-        {
-            continue;
-        }
-        if let Some(current_parent) = parent
-            && parts[candidate].area >= parts[current_parent].area
-        {
-            continue;
-        }
-        parent = Some(candidate);
-    }
-    parent
-}
-
-fn region_depth(index: usize, parents: &[Option<usize>], depths: &mut [Option<usize>]) -> usize {
-    if let Some(depth) = depths[index] {
-        return depth;
-    }
-    let depth = parents[index]
-        .map(|parent| region_depth(parent, parents, depths) + 1)
-        .unwrap_or(0);
-    depths[index] = Some(depth);
-    depth
-}
-
-fn oriented_region_part_contour(part: RegionPart) -> Contour {
-    let signed_area = polygon_area_signed(&part.polygon);
-    let wants_positive = part.depth.is_multiple_of(2);
-    if (signed_area >= 0.0) == wants_positive {
-        part.contour
-    } else {
-        reverse_contour(part.contour)
-    }
-}
-
-fn reverse_contour(contour: Contour) -> Contour {
+fn reverse_contour(contour: &Contour) -> Contour {
     Contour {
         segments: contour
             .segments
-            .into_iter()
+            .iter()
             .rev()
-            .map(reverse_segment)
+            .map(reverse_contour_segment)
             .collect(),
     }
 }
 
-fn reverse_segment(segment: ContourSegment) -> ContourSegment {
-    match segment {
+fn reverse_contour_segment(segment: &ContourSegment) -> ContourSegment {
+    match *segment {
         ContourSegment::Line { start, end } => ContourSegment::Line {
             start: end,
             end: start,
@@ -680,7 +606,10 @@ fn reverse_segment(segment: ContourSegment) -> ContourSegment {
             center_offset,
             clockwise,
         } => {
-            let center = Point::new(start.x + center_offset.x, start.y + center_offset.y);
+            let center = GerberPoint {
+                x: start.x + center_offset.x,
+                y: start.y + center_offset.y,
+            };
             ContourSegment::Arc {
                 start: end,
                 end: start,
@@ -692,32 +621,6 @@ fn reverse_segment(segment: ContourSegment) -> ContourSegment {
             }
         }
     }
-}
-
-fn bbox_contains_bbox(outer: BBox, inner: BBox) -> bool {
-    !outer.is_empty()
-        && !inner.is_empty()
-        && outer.min.x <= inner.min.x
-        && outer.min.y <= inner.min.y
-        && outer.max.x >= inner.max.x
-        && outer.max.y >= inner.max.y
-}
-
-fn point_in_polygon(point: [f64; 2], polygon: &PolygonContour) -> bool {
-    let [x, y] = point;
-    let mut inside = false;
-    for index in 0..polygon.len() {
-        let [x0, y0] = polygon[index];
-        let [x1, y1] = polygon[(index + 1) % polygon.len()];
-        if ((y0 > y) != (y1 > y)) && x < (x1 - x0) * (y - y0) / (y1 - y0) + x0 {
-            inside = !inside;
-        }
-    }
-    inside
-}
-
-fn polygon_area_abs(polygon: &PolygonContour) -> f64 {
-    polygon_area_signed(polygon).abs()
 }
 
 fn polygon_area_signed(polygon: &PolygonContour) -> f64 {
@@ -868,7 +771,7 @@ fn quantize_mm(value: f64) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pcb_ir::common::{FillRule, LayerRole, Side, Unit};
+    use pcb_ir::common::{BBox, FillRule, LayerRole, Side, Unit};
     use pcb_ir::dialects::artwork::{ArtworkLayer as IrArtworkLayer, ArtworkObject, PaintOrder};
 
     #[test]
@@ -912,7 +815,7 @@ mod tests {
     }
 
     #[test]
-    fn lowers_compound_region_holes_as_object_local_contours() {
+    fn lowers_compound_region_holes_as_local_cut_ins() {
         let mut artwork = ArtworkLayer::new(Unit::Millimeter);
         let layer_id = artwork.push_layer(IrArtworkLayer {
             name: "F.SilkS".to_string(),
@@ -947,18 +850,23 @@ mod tests {
         assert_eq!(gerber.objects.len(), 1);
         assert_eq!(gerber.objects[0].polarity, Polarity::Dark);
         let ObjectKind::Region { contours } = &gerber.objects[0].kind else {
-            panic!("expected multi-contour region");
+            panic!("expected local cut-in region");
         };
-        assert_eq!(contours.len(), 2);
+        assert_eq!(contours.len(), 1);
+        assert_eq!(
+            contours[0].segments.len(),
+            10,
+            "outer rectangle plus inner rectangle should be connected by two cut-in segments"
+        );
     }
 
     #[test]
-    fn preserves_arcs_for_simple_compound_region_holes() {
+    fn deep_nested_even_odd_compound_regions_preserve_topology() {
         let mut artwork = ArtworkLayer::new(Unit::Millimeter);
         let layer_id = artwork.push_layer(IrArtworkLayer {
-            name: "F.SilkS".to_string(),
-            role: LayerRole::Legend,
-            side: Side::None,
+            name: "F.Cu".to_string(),
+            role: LayerRole::Copper,
+            side: Side::Top,
             object_start: 0,
             object_count: 0,
             bbox: BBox::empty(),
@@ -966,7 +874,12 @@ mod tests {
         });
         let path = artwork.push_path(
             ArtworkPath::filled(FillRule::EvenOdd),
-            vec![circle_payload(0.0, 0.0, 5.0), circle_payload(0.0, 0.0, 2.0)],
+            vec![
+                rect_payload(0.0, 0.0, 10.0, 10.0),
+                rect_payload(1.0, 1.0, 9.0, 9.0),
+                rect_payload(2.0, 2.0, 8.0, 8.0),
+                rect_payload(3.0, 3.0, 7.0, 7.0),
+            ],
         );
         artwork.push_object(
             layer_id,
@@ -982,17 +895,22 @@ mod tests {
 
         let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
 
-        assert_eq!(gerber.objects.len(), 1);
-        assert_eq!(gerber.objects[0].polarity, Polarity::Dark);
-        let ObjectKind::Region { contours } = &gerber.objects[0].kind else {
-            panic!("expected multi-contour region");
-        };
-        assert_eq!(contours.len(), 2);
+        assert_eq!(gerber.objects.len(), 2);
         assert!(
-            contours[1]
-                .segments
+            gerber
+                .objects
                 .iter()
-                .any(|segment| matches!(segment, ContourSegment::Arc { .. }))
+                .all(|object| object.polarity == Polarity::Dark
+                    && matches!(&object.kind, ObjectKind::Region { contours } if contours.len() == 1))
+        );
+        let contents = gerberx2::write_layer(&gerber).expect("write Gerber");
+        let parsed = gerberx2::GerberX2::parse(&contents).expect("parse Gerber");
+        let geometry = gerberx2::geometry::extract_document(&parsed);
+        let summary = pcb_ir::dialects::gerber::compare::summarize(&geometry);
+        assert!(
+            (summary.area_mm2 - 56.0).abs() < 0.001,
+            "deep even-odd topology exported wrong area: {}",
+            summary.area_mm2
         );
     }
 
@@ -1026,16 +944,88 @@ mod tests {
 
         let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
 
-        assert_eq!(gerber.objects.len(), 1);
         assert_eq!(gerber.objects[0].polarity, Polarity::Dark);
-        let ObjectKind::Region { contours } = &gerber.objects[0].kind else {
-            panic!("expected simplified multi-contour region");
-        };
-        assert!(!contours.is_empty());
+        assert!(
+            !gerber.objects.is_empty()
+                && gerber.objects.iter().all(|object| {
+                    matches!(&object.kind, ObjectKind::Region { contours } if contours.len() == 1)
+                }),
+            "fallback regions must be emitted as spec-compliant single-contour objects"
+        );
     }
 
     #[test]
-    fn keeps_object_local_holes_inside_base_region_before_overlay() {
+    fn local_compound_region_holes_do_not_clear_prior_base_copper() {
+        let mut artwork = ArtworkLayer::new(Unit::Millimeter);
+        let layer_id = artwork.push_layer(IrArtworkLayer {
+            name: "F.Cu".to_string(),
+            role: LayerRole::Copper,
+            side: Side::Top,
+            object_start: 0,
+            object_count: 0,
+            bbox: BBox::empty(),
+            meta: LayerAttributes::default(),
+        });
+        let base = artwork.push_path(
+            ArtworkPath::filled(FillRule::NonZero),
+            vec![rect_payload(0.0, 0.0, 10.0, 10.0)],
+        );
+        artwork.push_object(
+            layer_id,
+            ArtworkObject {
+                paint: PaintPolarity::Dark,
+                order: PaintOrder {
+                    stage: PaintStage::Base,
+                },
+                geometry: ArtworkGeometry::Region { path: base },
+                net: None,
+                bbox: artwork.paths[base as usize].bbox,
+                meta: ObjectAttributes::default(),
+            },
+        );
+        let donut = artwork.push_path(
+            ArtworkPath::filled(FillRule::EvenOdd),
+            vec![
+                rect_payload(2.0, 2.0, 8.0, 8.0),
+                rect_payload(4.0, 4.0, 6.0, 6.0),
+            ],
+        );
+        artwork.push_object(
+            layer_id,
+            ArtworkObject {
+                paint: PaintPolarity::Dark,
+                order: PaintOrder {
+                    stage: PaintStage::Base,
+                },
+                geometry: ArtworkGeometry::Region { path: donut },
+                net: None,
+                bbox: artwork.paths[donut as usize].bbox,
+                meta: ObjectAttributes::default(),
+            },
+        );
+
+        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+
+        assert!(
+            gerber
+                .objects
+                .iter()
+                .all(|object| object.polarity == Polarity::Dark),
+            "local holes must not lower to layer-global clear polarity"
+        );
+        let contents = gerberx2::write_layer(&gerber).expect("write Gerber");
+        let parsed = gerberx2::GerberX2::parse(&contents).expect("parse Gerber");
+        let geometry = gerberx2::geometry::extract_document(&parsed);
+        let summary = pcb_ir::dialects::gerber::compare::summarize(&geometry);
+        assert!(
+            (summary.area_mm2 - 100.0).abs() < 0.001,
+            "donut hole cleared prior base copper; area was {}",
+            summary.area_mm2
+        );
+    }
+
+    #[test]
+    fn places_compound_regions_before_overlay_objects() {
         let mut artwork = ArtworkLayer::new(Unit::Millimeter);
         let layer_id = artwork.push_layer(IrArtworkLayer {
             name: "F.Cu".to_string(),
@@ -1098,10 +1088,10 @@ mod tests {
             .position(|object| {
                 matches!(
                     &object.kind,
-                    ObjectKind::Region { contours } if contours.len() == 2
-                )
+                    ObjectKind::Region { contours } if contours.len() == 1
+                ) && object.polarity == Polarity::Dark
             })
-            .expect("base pour should stay one multi-contour region");
+            .expect("base pour should emit a dark region");
         let trace_index = gerber
             .objects
             .iter()
@@ -1115,12 +1105,6 @@ mod tests {
 
         assert!(pour_index < trace_index);
         assert!(
-            gerber
-                .objects
-                .iter()
-                .all(|object| object.polarity == Polarity::Dark)
-        );
-        assert!(
             gerber.objects[trace_index..]
                 .iter()
                 .filter(|object| {
@@ -1130,6 +1114,13 @@ mod tests {
                         .any(|attr| attr.name == ".N" && attr.fields == ["TRACE"])
                 })
                 .all(|object| object.polarity == Polarity::Dark)
+        );
+        assert!(
+            gerber
+                .objects
+                .iter()
+                .all(|object| object.polarity == Polarity::Dark),
+            "positive local holes must not become clear-polarity objects"
         );
     }
 
@@ -1179,31 +1170,6 @@ mod tests {
             });
         }
         cmds.push(PathCmd::close());
-        PathPayload { bbox, cmds }
-    }
-
-    fn circle_payload(cx: f64, cy: f64, radius: f64) -> PathPayload {
-        let center = Point::new(cx, cy);
-        let points = [
-            Point::new(cx + radius, cy),
-            Point::new(cx, cy + radius),
-            Point::new(cx - radius, cy),
-            Point::new(cx, cy - radius),
-            Point::new(cx + radius, cy),
-        ];
-        let mut bbox = BBox::empty();
-        bbox.include_circular_arc(points[0], points[1], center, false);
-        bbox.include_circular_arc(points[1], points[2], center, false);
-        bbox.include_circular_arc(points[2], points[3], center, false);
-        bbox.include_circular_arc(points[3], points[4], center, false);
-        let cmds = vec![
-            PathCmd::move_to(points[0]),
-            PathCmd::arc_to(points[1], center, false),
-            PathCmd::arc_to(points[2], center, false),
-            PathCmd::arc_to(points[3], center, false),
-            PathCmd::arc_to(points[4], center, false),
-            PathCmd::close(),
-        ];
         PathPayload { bbox, cmds }
     }
 }


### PR DESCRIPTION
<img width="1600" height="1528" alt="image" src="https://github.com/user-attachments/assets/bc297d47-d59e-4061-8d81-f272874713e2" />

^ regression fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fabrication Gerber geometry for compound fills and hole handling; risk is mitigated by focused export/extract tests and a manual visual diff script, but wrong copper still has high downstream impact.
> 
> **Overview**
> Fixes a **copper export regression** where IPC-2581 → Gerber turned compound region holes into layer-global clear polarity or multi-contour regions that cleared unrelated geometry and diverged from KiCad.
> 
> **IPC Gerber lowering** (`lower.rs`) now uses **`i_overlay`** to simplify even-odd compound fills, then emits **spec-compliant single-contour regions** with **bridge segments** connecting outer boundaries to holes (local cut-ins). Positive holes stay **dark polarity** instead of `%LPC*%` clear objects. Nested and deep even-odd topology is covered by expanded tests (area, ordering vs pads/traces).
> 
> **Gerber geometry extraction** (`gerberx2`) treats each region contour as its own **even-odd** fill path (so orientation alone does not punch holes) and applies **fill-rule-aware simplification** when composing multi-path features.
> 
> Adds **`bin/kicad_ipc_gerber_svg_diff.py`**, a manual pipeline that raster-compares KiCad layer SVG against IPC → Gerber → SVG with configurable mm² tolerances. **CHANGELOG** documents the fix and the new script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99889ca619c5eecc26dcc2bae90aaebceec9337d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->