### PR TITLE
Fix large-workspace build regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - IPC-2581 mutations now create a history record when the source file does not already have one, including board array creation.
+- Fixed a `pcb build` performance regression in large workspaces with many packages.
 
 ## [0.4.2] - 2026-06-26
 

--- a/crates/pcb-zen-core/src/workspace.rs
+++ b/crates/pcb-zen-core/src/workspace.rs
@@ -234,21 +234,21 @@ impl WorkspaceInfo {
         file_provider: &dyn FileProvider,
         path: &Path,
     ) -> Option<&str> {
+        let canonical_workspace_root = file_provider
+            .canonicalize(&self.root)
+            .unwrap_or_else(|_| self.root.clone());
         let canonical_path = file_provider
             .canonicalize(path)
             .unwrap_or_else(|_| path.to_path_buf());
+        let workspace_relative = canonical_path
+            .strip_prefix(&canonical_workspace_root)
+            .ok()?;
 
         self.packages
             .iter()
-            .filter_map(|(url, pkg)| {
-                let root = pkg.dir(&self.root);
-                let canonical_root = file_provider.canonicalize(&root).unwrap_or(root);
-                canonical_path
-                    .starts_with(&canonical_root)
-                    .then(|| (url.as_str(), canonical_root.as_os_str().len()))
-            })
-            .max_by_key(|(_, root_len)| *root_len)
-            .map(|(url, _)| url)
+            .filter(|(_, pkg)| workspace_relative.starts_with(&pkg.rel_path))
+            .max_by_key(|(_, pkg)| pkg.rel_path.as_os_str().len())
+            .map(|(url, _)| url.as_str())
     }
 
     /// Get optional subpath within repository
@@ -724,6 +724,44 @@ exclude = ["modules/ignored/**"]
         assert!(info.errors.is_empty());
         assert!(info.packages.contains_key("a/b/c/d/e/f/g/h"));
         assert!(!info.packages.contains_key("a/b/c/d/e/f/g/h/i"));
+    }
+
+    #[test]
+    fn test_package_url_for_path_uses_most_specific_package() {
+        let files = HashMap::from([
+            (
+                "/repo/pcb.toml".to_string(),
+                "[workspace]\npcb-version = \"0.4\"\n".to_string(),
+            ),
+            (
+                "/repo/modules/parent/pcb.toml".to_string(),
+                "[dependencies]\n".to_string(),
+            ),
+            (
+                "/repo/modules/parent/child/pcb.toml".to_string(),
+                "[dependencies]\n".to_string(),
+            ),
+            (
+                "/repo/modules/parent/child/board.zen".to_string(),
+                "".to_string(),
+            ),
+        ]);
+        let provider = InMemoryFileProvider::new(files);
+
+        let info = get_workspace_info(&provider, Path::new("/repo")).unwrap();
+
+        assert_eq!(
+            info.package_url_for_path(&provider, Path::new("/repo/modules/parent/child/board.zen")),
+            Some("modules/parent/child")
+        );
+        assert_eq!(
+            info.package_url_for_path(&provider, Path::new("/repo/modules/parent/local.zen")),
+            Some("modules/parent")
+        );
+        assert_eq!(
+            info.package_url_for_path(&provider, Path::new("/repo/modules/parental/board.zen")),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized lookup optimization with a focused regression test; no API or build-output behavior change intended beyond performance.
> 
> **Overview**
> Fixes a **`pcb build`** slowdown in workspaces with many packages by rewriting **`package_url_for_path`** so it no longer canonicalizes every package directory on each lookup.
> 
> The path is canonicalized once, converted to a workspace-relative path, and matched against each package’s stored **`rel_path`** (longest prefix wins). Behavior for nested packages and paths outside any package is covered by a new unit test; the unreleased changelog notes the regression fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52be2d2de25bc51e93b00726daf8fc2e6ca537d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->