### PR TITLE
fix(api): use pcb auth login in auth failures

### DIFF
--- a/crates/pcb-diode-api/src/release.rs
+++ b/crates/pcb-diode-api/src/release.rs
@@ -16,6 +16,9 @@ use std::time::Duration;
 
 use crate::WorkspaceContext;
 
+const AUTHENTICATION_FAILED_MESSAGE: &str =
+    "Authentication failed. Run `pcb auth login` to sign in.";
+
 /// Response from creating a release.
 #[derive(Debug)]
 pub struct ReleaseResult {
@@ -130,7 +133,7 @@ fn stage_artifact(
         .context("Failed to connect to Diode API")?;
 
     let resp = check_response(resp, |status, msg| match status {
-        StatusCode::UNAUTHORIZED => "Authentication failed. Run `pcb login` to sign in.".into(),
+        StatusCode::UNAUTHORIZED => AUTHENTICATION_FAILED_MESSAGE.into(),
         StatusCode::BAD_REQUEST => format!("Invalid request: {msg}"),
         _ => format!("Failed to get upload URL ({status}): {msg}"),
     })?;
@@ -176,7 +179,7 @@ fn create_release(
         .context("Failed to connect to Diode API")?;
 
     let resp = check_response(resp, |status, msg| match status {
-        StatusCode::UNAUTHORIZED => "Authentication failed. Run `pcb login` to sign in.".into(),
+        StatusCode::UNAUTHORIZED => AUTHENTICATION_FAILED_MESSAGE.into(),
         StatusCode::NOT_FOUND if msg.contains("artifact") => {
             "Staged artifact not found. The upload may have expired.".into()
         }
@@ -220,7 +223,7 @@ fn create_preview(
         .context("Failed to connect to Diode API")?;
 
     let resp = check_response(resp, |status, msg| match status {
-        StatusCode::UNAUTHORIZED => "Authentication failed. Run `pcb login` to sign in.".into(),
+        StatusCode::UNAUTHORIZED => AUTHENTICATION_FAILED_MESSAGE.into(),
         StatusCode::NOT_FOUND if msg.contains("artifact") => {
             "Staged artifact not found. The upload may have expired.".into()
         }


### PR DESCRIPTION
## Summary
- Centralize the Diode API authentication failure message in `release.rs`
- Update release upload, release creation, and preview creation errors to point to `pcb auth login`

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text only; no auth logic or API behavior changes.
> 
> **Overview**
> **Diode release/preview API errors** now tell users to run **`pcb auth login`** instead of the outdated **`pcb login`** when the API returns **401 Unauthorized**.
> 
> The message is centralized in a new **`AUTHENTICATION_FAILED_MESSAGE`** constant in `release.rs` and reused for artifact staging, release creation, and preview creation—matching wording already used in `auth.rs` and other API clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 226e1a24ded060653255014c55ad40489d17e1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->