### PR TITLE
Add pcb sync check mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added `pcb sync --check` to fail CI when hydrated `pcb.toml` manifests or `vendor/` are out of sync.
+
+### Removed
+
+- Removed `pcb sync --offline`; use `pcb build --offline` with a synced manifest for offline reproducibility.
+
 ## [0.4.3] - 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added `pcb sync --check` to fail CI when hydrated `pcb.toml` manifests or `vendor/` are out of sync.
+- Added `pcb sync --check` to fail CI when hydrated `pcb.toml` manifests or vendored package versions are out of sync. The check covers the whole workspace regardless of the current directory.
+
+### Changed
+
+- `pcb sync` now applies manifest and vendor updates only after the whole workspace resolves; a resolution failure no longer leaves partially hydrated manifests.
+- `pcb sync` and `pcb vendor` no longer create an empty `vendor/` directory when no packages match the vendor patterns.
 
 ### Removed
 

--- a/crates/pcb-zen/src/package_resolver/materialize.rs
+++ b/crates/pcb-zen/src/package_resolver/materialize.rs
@@ -60,3 +60,11 @@ pub fn vendor_selected(
     crate::resolve::vendor_package_roots(workspace, package_roots, &[], None, prune)?;
     Ok(())
 }
+
+pub fn plan_vendor_selected(
+    workspace: &crate::WorkspaceInfo,
+    package_roots: &BTreeSet<(String, String)>,
+    prune: bool,
+) -> Result<crate::resolve::VendorPlan> {
+    crate::resolve::plan_vendor_package_roots(workspace, package_roots, &[], None, prune)
+}

--- a/crates/pcb-zen/src/package_resolver/materialize.rs
+++ b/crates/pcb-zen/src/package_resolver/materialize.rs
@@ -52,15 +52,6 @@ fn ensure_remote_package_materialized(
     Ok(())
 }
 
-pub fn vendor_selected(
-    workspace: &crate::WorkspaceInfo,
-    package_roots: &BTreeSet<(String, String)>,
-    prune: bool,
-) -> Result<()> {
-    crate::resolve::vendor_package_roots(workspace, package_roots, &[], None, prune)?;
-    Ok(())
-}
-
 pub fn plan_vendor_selected(
     workspace: &crate::WorkspaceInfo,
     package_roots: &BTreeSet<(String, String)>,

--- a/crates/pcb-zen/src/package_resolver/mod.rs
+++ b/crates/pcb-zen/src/package_resolver/mod.rs
@@ -7,7 +7,7 @@ mod resolve;
 mod scan;
 mod versions;
 
-pub use materialize::{plan_vendor_selected, vendor_selected};
+pub use materialize::plan_vendor_selected;
 pub use mvs::{DepGraph, DepGraphNode, PackageResolution, PackageResolver};
 pub use pcb_zen_core::resolution::{
     FrozenDepId as ResolvedDepId, compatibility_lane, parse_lane_qualified_key,

--- a/crates/pcb-zen/src/package_resolver/mod.rs
+++ b/crates/pcb-zen/src/package_resolver/mod.rs
@@ -7,7 +7,7 @@ mod resolve;
 mod scan;
 mod versions;
 
-pub use materialize::vendor_selected;
+pub use materialize::{plan_vendor_selected, vendor_selected};
 pub use mvs::{DepGraph, DepGraphNode, PackageResolution, PackageResolver};
 pub use pcb_zen_core::resolution::{
     FrozenDepId as ResolvedDepId, compatibility_lane, parse_lane_qualified_key,

--- a/crates/pcb-zen/src/package_resolver/mvs.rs
+++ b/crates/pcb-zen/src/package_resolver/mvs.rs
@@ -147,13 +147,13 @@ pub struct PackageResolver {
 }
 
 impl PackageResolver {
-    pub fn new(workspace: crate::WorkspaceInfo, offline: bool) -> Result<Self> {
+    pub fn new(workspace: crate::WorkspaceInfo) -> Result<Self> {
         let package_index = WorkspacePackageIndex::new(&workspace);
         Ok(Self {
             cache_index: CacheIndex::open()?,
-            manifest_loader: ManifestLoader::new(workspace.clone(), offline),
+            manifest_loader: ManifestLoader::new(workspace.clone(), false),
             workspace,
-            spec_resolver: SpecVersionResolver::new(offline),
+            spec_resolver: SpecVersionResolver::default(),
             package_index,
             package_states: BTreeMap::new(),
         })
@@ -208,12 +208,7 @@ impl PackageResolver {
         &self,
         selected_remote: impl IntoIterator<Item = (&'a ResolvedDepId, &'a Version)>,
     ) -> Result<BTreeSet<(String, String)>> {
-        materialize_selected(
-            &self.workspace,
-            selected_remote,
-            self.spec_resolver.is_offline(),
-            &self.cache_index,
-        )
+        materialize_selected(&self.workspace, selected_remote, false, &self.cache_index)
     }
 
     pub fn build_package_graph(&mut self, package_url: &str) -> Result<DepGraph> {
@@ -244,7 +239,6 @@ impl PackageResolver {
             &package_dir,
             &current_config,
             &self.cache_index,
-            self.spec_resolver.is_offline(),
         )
         .with_context(|| format!("while scanning package {}", package_url))?;
         if let Some(direct_overrides) = direct_overrides {

--- a/crates/pcb-zen/src/package_resolver/scan.rs
+++ b/crates/pcb-zen/src/package_resolver/scan.rs
@@ -24,7 +24,6 @@ pub(crate) fn scan_package_direct_deps(
     package_dir: &Path,
     current_config: &PcbToml,
     index: &CacheIndex,
-    offline: bool,
 ) -> Result<ScannedDirectDeps> {
     let file_provider = DefaultFileProvider::new();
     let mut scanned = ScannedDirectDeps::default();
@@ -50,7 +49,7 @@ pub(crate) fn scan_package_direct_deps(
                 continue;
             }
 
-            add_remote_dep(&mut scanned.remote, &url, current_config, index, offline)?;
+            add_remote_dep(&mut scanned.remote, &url, current_config, index)?;
         }
 
         for rel_path in extracted.relative_paths {
@@ -125,18 +124,10 @@ fn add_remote_dep(
     url: &str,
     current_config: &PcbToml,
     index: &CacheIndex,
-    offline: bool,
 ) -> Result<()> {
     if let Some((module_path, spec)) = existing_manifest_dep(url, current_config) {
         remote.entry(module_path).or_insert(spec);
         return Ok(());
-    }
-
-    if offline {
-        anyhow::bail!(
-            "Cannot discover package root for '{}' in offline mode; add it to [dependencies] first",
-            url
-        );
     }
 
     let Some(candidate) = index.find_remote_package(url)? else {

--- a/crates/pcb-zen/src/package_resolver/versions.rs
+++ b/crates/pcb-zen/src/package_resolver/versions.rs
@@ -10,23 +10,11 @@ use semver::Version;
 
 #[derive(Default)]
 pub struct SpecVersionResolver {
-    offline: bool,
     source_repos: BTreeMap<String, PathBuf>,
     base_versions: BTreeMap<String, BTreeMap<String, Version>>,
 }
 
 impl SpecVersionResolver {
-    pub fn new(offline: bool) -> Self {
-        Self {
-            offline,
-            ..Self::default()
-        }
-    }
-
-    pub(crate) fn is_offline(&self) -> bool {
-        self.offline
-    }
-
     pub(crate) fn resolve_spec(
         &mut self,
         module_path: &str,
@@ -39,14 +27,6 @@ impl SpecVersionResolver {
     }
 
     pub fn resolve_ref_or_branch(&mut self, module_path: &str, selector: &str) -> Result<Version> {
-        if self.offline {
-            bail!(
-                "Cannot resolve {}@{} in offline mode",
-                module_path,
-                selector
-            );
-        }
-
         match self.generate_pseudo_version(module_path, selector) {
             Ok(version) => Ok(version),
             Err(rev_err) => {

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -26,8 +26,6 @@ pub struct VendorResult {
 }
 
 pub struct VendorCopy {
-    pub module_path: String,
-    pub version: String,
     pub src: PathBuf,
     pub dst: PathBuf,
 }
@@ -36,7 +34,6 @@ pub struct VendorPlan {
     pub vendor_dir: PathBuf,
     pub copies: Vec<VendorCopy>,
     pub prunes: Vec<PathBuf>,
-    patterns_configured: bool,
 }
 
 impl VendorPlan {
@@ -45,11 +42,7 @@ impl VendorPlan {
     }
 
     pub fn apply(&self) -> Result<VendorResult> {
-        let mut package_count = 0;
         for copy in &self.copies {
-            if copy.dst.exists() {
-                continue;
-            }
             copy_canonical_files(
                 &copy.src,
                 &copy.dst,
@@ -57,22 +50,17 @@ impl VendorPlan {
                     exclude_nested_packages: true,
                 }),
             )?;
-            package_count += 1;
         }
 
-        let mut pruned_count = 0;
         for root in &self.prunes {
-            if !root.exists() {
-                continue;
-            }
+            log::debug!("Pruning stale vendor path: {}", root.display());
             fs::remove_dir_all(root)?;
-            pruned_count += 1;
             remove_empty_ancestors_until(&self.vendor_dir, root)?;
         }
 
         Ok(VendorResult {
-            package_count,
-            pruned_count,
+            package_count: self.copies.len(),
+            pruned_count: self.prunes.len(),
             vendor_dir: self.vendor_dir.clone(),
         })
     }
@@ -125,17 +113,14 @@ pub fn vendor_package_roots(
     target_vendor_dir: Option<&Path>,
     prune: bool,
 ) -> Result<VendorResult> {
-    let plan = plan_vendor_package_roots(
+    plan_vendor_package_roots(
         workspace_info,
         package_roots,
         additional_patterns,
         target_vendor_dir,
         prune,
-    )?;
-    if plan.patterns_configured {
-        fs::create_dir_all(&plan.vendor_dir)?;
-    }
-    plan.apply()
+    )?
+    .apply()
 }
 
 #[instrument(name = "plan_vendor_package_roots", skip_all)]
@@ -166,7 +151,6 @@ pub fn plan_vendor_package_roots(
             vendor_dir,
             copies: Vec::new(),
             prunes: Vec::new(),
-            patterns_configured: false,
         });
     }
     log::debug!("Vendor patterns: {:?}", patterns);
@@ -205,12 +189,7 @@ pub fn plan_vendor_package_roots(
             continue;
         };
 
-        copies.push(VendorCopy {
-            module_path: path.clone(),
-            version: version.clone(),
-            src,
-            dst,
-        });
+        copies.push(VendorCopy { src, dst });
     }
 
     let prunes = if prune {
@@ -223,7 +202,6 @@ pub fn plan_vendor_package_roots(
         vendor_dir,
         copies,
         prunes,
-        patterns_configured: true,
     })
 }
 
@@ -262,39 +240,6 @@ fn remove_empty_ancestors_until(base: &Path, removed_root: &Path) -> Result<()> 
         current = parent;
     }
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RemotePackageVendorStatus {
-    AlreadyPresent,
-    Copied,
-    MissingSource,
-}
-
-pub fn copy_remote_package_to_vendor(
-    workspace_vendor: &Path,
-    cache_dir: &Path,
-    module_path: &str,
-    version: &str,
-    dst: &Path,
-) -> Result<RemotePackageVendorStatus> {
-    if dst.exists() {
-        return Ok(RemotePackageVendorStatus::AlreadyPresent);
-    }
-
-    let Some(src) = remote_package_vendor_source(workspace_vendor, cache_dir, module_path, version)
-    else {
-        return Ok(RemotePackageVendorStatus::MissingSource);
-    };
-
-    copy_canonical_files(
-        &src,
-        dst,
-        Some(CanonicalTarOptions {
-            exclude_nested_packages: true,
-        }),
-    )?;
-    Ok(RemotePackageVendorStatus::Copied)
 }
 
 /// Recursively copy a directory, excluding hidden directories/files and symlinks.
@@ -391,8 +336,7 @@ fn collect_stale_dir(
             } else if ancestors.contains(&child_rel) {
                 collect_stale_dir(base, &child_rel, desired_roots, ancestors, stale_roots)?;
             } else {
-                // Not needed - prune entire subtree
-                log::debug!("Pruning stale vendor path: {}", child_rel.display());
+                // Not needed - stale root, prune entire subtree on apply
                 stale_roots.push(entry.path());
             }
         }

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -25,6 +25,59 @@ pub struct VendorResult {
     pub vendor_dir: PathBuf,
 }
 
+pub struct VendorCopy {
+    pub module_path: String,
+    pub version: String,
+    pub src: PathBuf,
+    pub dst: PathBuf,
+}
+
+pub struct VendorPlan {
+    pub vendor_dir: PathBuf,
+    pub copies: Vec<VendorCopy>,
+    pub prunes: Vec<PathBuf>,
+    patterns_configured: bool,
+}
+
+impl VendorPlan {
+    pub fn is_empty(&self) -> bool {
+        self.copies.is_empty() && self.prunes.is_empty()
+    }
+
+    pub fn apply(&self) -> Result<VendorResult> {
+        let mut package_count = 0;
+        for copy in &self.copies {
+            if copy.dst.exists() {
+                continue;
+            }
+            copy_canonical_files(
+                &copy.src,
+                &copy.dst,
+                Some(CanonicalTarOptions {
+                    exclude_nested_packages: true,
+                }),
+            )?;
+            package_count += 1;
+        }
+
+        let mut pruned_count = 0;
+        for root in &self.prunes {
+            if !root.exists() {
+                continue;
+            }
+            fs::remove_dir_all(root)?;
+            pruned_count += 1;
+            remove_empty_ancestors_until(&self.vendor_dir, root)?;
+        }
+
+        Ok(VendorResult {
+            package_count,
+            pruned_count,
+            vendor_dir: self.vendor_dir.clone(),
+        })
+    }
+}
+
 /// Vendor dependencies from cache to vendor directory
 ///
 /// Vendors package entries matching workspace.vendor patterns plus any additional_patterns.
@@ -72,6 +125,27 @@ pub fn vendor_package_roots(
     target_vendor_dir: Option<&Path>,
     prune: bool,
 ) -> Result<VendorResult> {
+    let plan = plan_vendor_package_roots(
+        workspace_info,
+        package_roots,
+        additional_patterns,
+        target_vendor_dir,
+        prune,
+    )?;
+    if plan.patterns_configured {
+        fs::create_dir_all(&plan.vendor_dir)?;
+    }
+    plan.apply()
+}
+
+#[instrument(name = "plan_vendor_package_roots", skip_all)]
+pub fn plan_vendor_package_roots(
+    workspace_info: &WorkspaceInfo,
+    package_roots: &BTreeSet<(String, String)>,
+    additional_patterns: &[String],
+    target_vendor_dir: Option<&Path>,
+    prune: bool,
+) -> Result<VendorPlan> {
     let vendor_dir = target_vendor_dir
         .map(PathBuf::from)
         .unwrap_or_else(|| workspace_info.root.join("vendor"));
@@ -88,10 +162,11 @@ pub fn vendor_package_roots(
     // No patterns = no-op
     if patterns.is_empty() {
         log::debug!("No vendor patterns configured, skipping vendoring");
-        return Ok(VendorResult {
-            package_count: 0,
-            pruned_count: 0,
+        return Ok(VendorPlan {
             vendor_dir,
+            copies: Vec::new(),
+            prunes: Vec::new(),
+            patterns_configured: false,
         });
     }
     log::debug!("Vendor patterns: {:?}", patterns);
@@ -106,13 +181,11 @@ pub fn vendor_package_roots(
     }
     let glob_set = builder.build()?;
 
-    fs::create_dir_all(&vendor_dir)?;
-
     // Track all desired {url}/{version-or-ref} roots for pruning stale entries
     let mut desired_roots: HashSet<PathBuf> = HashSet::new();
 
     // Copy matching packages from workspace vendor or cache (vendor takes precedence)
-    let mut package_count = 0;
+    let mut copies = Vec::new();
     for (path, version) in package_roots {
         if !glob_set.is_match(path) {
             continue;
@@ -123,26 +196,72 @@ pub fn vendor_package_roots(
         desired_roots.insert(rel_root);
 
         let dst = vendor_dir.join(path).join(version);
-        if matches!(
-            copy_remote_package_to_vendor(&workspace_vendor, cache, path, version, &dst)?,
-            RemotePackageVendorStatus::Copied
-        ) {
-            package_count += 1;
+        if dst.exists() {
+            continue;
         }
+
+        let Some(src) = remote_package_vendor_source(&workspace_vendor, cache, path, version)
+        else {
+            continue;
+        };
+
+        copies.push(VendorCopy {
+            module_path: path.clone(),
+            version: version.clone(),
+            src,
+            dst,
+        });
     }
 
-    // Prune stale {url}/{version-or-ref} directories not in the resolution
-    let pruned_count = if prune {
-        prune_stale_vendor_roots(&vendor_dir, &desired_roots)?
+    let prunes = if prune {
+        collect_stale_vendor_roots(&vendor_dir, &desired_roots)?
     } else {
-        0
+        Vec::new()
     };
 
-    Ok(VendorResult {
-        package_count,
-        pruned_count,
+    Ok(VendorPlan {
         vendor_dir,
+        copies,
+        prunes,
+        patterns_configured: true,
     })
+}
+
+fn remote_package_vendor_source(
+    workspace_vendor: &Path,
+    cache_dir: &Path,
+    module_path: &str,
+    version: &str,
+) -> Option<PathBuf> {
+    let vendor_src = workspace_vendor.join(module_path).join(version);
+    if vendor_src.exists() {
+        return Some(vendor_src);
+    }
+
+    let cache_src = cache_dir.join(module_path).join(version);
+    if cache_src.exists() {
+        Some(cache_src)
+    } else {
+        None
+    }
+}
+
+fn remove_empty_ancestors_until(base: &Path, removed_root: &Path) -> Result<()> {
+    let Some(mut current) = removed_root.parent().map(Path::to_path_buf) else {
+        return Ok(());
+    };
+
+    while current.starts_with(base) && current != base {
+        if current.read_dir()?.next().is_some() {
+            break;
+        }
+        fs::remove_dir(&current)?;
+        let Some(parent) = current.parent().map(Path::to_path_buf) else {
+            break;
+        };
+        current = parent;
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -163,16 +282,10 @@ pub fn copy_remote_package_to_vendor(
         return Ok(RemotePackageVendorStatus::AlreadyPresent);
     }
 
-    let vendor_src = workspace_vendor.join(module_path).join(version);
-    let cache_src = cache_dir.join(module_path).join(version);
-    let src = if vendor_src.exists() {
-        vendor_src
-    } else {
-        cache_src
-    };
-    if !src.exists() {
+    let Some(src) = remote_package_vendor_source(workspace_vendor, cache_dir, module_path, version)
+    else {
         return Ok(RemotePackageVendorStatus::MissingSource);
-    }
+    };
 
     copy_canonical_files(
         &src,
@@ -220,13 +333,16 @@ pub fn copy_dir_all(src: &Path, dst: &Path, excluded_roots: &HashSet<PathBuf>) -
     Ok(())
 }
 
-/// Prune stale {path}/{version} directories from vendor/
+/// Collect stale directories from vendor/
 ///
-/// Walks vendor/ recursively and removes directories not in desired_roots
-/// or on the path to a desired root. Returns the number of roots pruned.
-fn prune_stale_vendor_roots(vendor_dir: &Path, desired_roots: &HashSet<PathBuf>) -> Result<usize> {
+/// Walks vendor/ recursively and returns directories not in desired_roots
+/// or on the path to a desired root.
+fn collect_stale_vendor_roots(
+    vendor_dir: &Path,
+    desired_roots: &HashSet<PathBuf>,
+) -> Result<Vec<PathBuf>> {
     if !vendor_dir.exists() {
-        return Ok(0);
+        return Ok(Vec::new());
     }
 
     // Build set of ancestor paths (paths we must traverse to reach desired roots)
@@ -239,26 +355,28 @@ fn prune_stale_vendor_roots(vendor_dir: &Path, desired_roots: &HashSet<PathBuf>)
         }
     }
 
-    let mut pruned = 0;
-    prune_dir(
+    let mut stale_roots = Vec::new();
+    collect_stale_dir(
         vendor_dir,
         &PathBuf::new(),
         desired_roots,
         &ancestors,
-        &mut pruned,
+        &mut stale_roots,
     )?;
-    Ok(pruned)
+    Ok(stale_roots)
 }
 
-fn prune_dir(
+fn collect_stale_dir(
     base: &Path,
     rel: &Path,
     desired_roots: &HashSet<PathBuf>,
     ancestors: &HashSet<PathBuf>,
-    pruned: &mut usize,
+    stale_roots: &mut Vec<PathBuf>,
 ) -> Result<()> {
-    for entry in fs::read_dir(base.join(rel))? {
-        let entry = entry?;
+    let mut entries = fs::read_dir(base.join(rel))?.collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
         let name = entry.file_name();
         let child_rel = if rel.as_os_str().is_empty() {
             PathBuf::from(&name)
@@ -271,17 +389,11 @@ fn prune_dir(
                 // This is a desired root - keep everything inside it
                 continue;
             } else if ancestors.contains(&child_rel) {
-                // On path to a desired root - recurse to find what to prune
-                prune_dir(base, &child_rel, desired_roots, ancestors, pruned)?;
-                // Clean up if now empty
-                if entry.path().read_dir()?.next().is_none() {
-                    fs::remove_dir(entry.path())?;
-                }
+                collect_stale_dir(base, &child_rel, desired_roots, ancestors, stale_roots)?;
             } else {
                 // Not needed - prune entire subtree
                 log::debug!("Pruning stale vendor path: {}", child_rel.display());
-                fs::remove_dir_all(entry.path())?;
-                *pruned += 1;
+                stale_roots.push(entry.path());
             }
         }
         // Files at the root level of vendor/ shouldn't exist, ignore them

--- a/crates/pcbc/src/list.rs
+++ b/crates/pcbc/src/list.rs
@@ -62,7 +62,7 @@ fn list_updates() -> Result<()> {
         bail!("`pcb list -m -u` must be run from a package directory.");
     };
 
-    let mut resolver = PackageResolver::new(workspace.clone(), false)?;
+    let mut resolver = PackageResolver::new(workspace.clone())?;
     let resolution = resolver.resolve_package(&target.package_url)?;
 
     for dep_id in &resolution.direct_remote_ids {

--- a/crates/pcbc/src/mod/mod.rs
+++ b/crates/pcbc/src/mod/mod.rs
@@ -7,9 +7,10 @@ use clap::Args;
 use pcb_zen::WorkspaceInfo;
 use pcb_zen::cache_index::{CacheIndex, ensure_workspace_cache_symlink};
 use pcb_zen::package_resolver::{
-    DepGraph, DepGraphNode, PackageResolver, build_frozen_resolution_maps,
-    target_package_urls_for_path, vendor_selected,
+    DepGraph, DepGraphNode, PackageResolver, build_frozen_resolution_maps, plan_vendor_selected,
+    target_package_urls_for_path,
 };
+use pcb_zen::resolve::VendorPlan;
 use pcb_zen::resolve::ensure_package_manifest_in_cache;
 use pcb_zen::tags;
 use pcb_zen::workspace::get_workspace_info;
@@ -22,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 use self::request::resolve_direct_dependency_request;
 use self::target::{AddTarget, discover_add_targets, discover_package_target};
-use self::writeback::write_package_manifest;
+use self::writeback::{ManifestEdit, plan_package_manifest};
 
 type DirectOverrides = BTreeMap<String, DependencySpec>;
 
@@ -45,9 +46,9 @@ pub struct SyncArgs {
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
-    /// Do not use the network; only use already cached package data
-    #[arg(long = "offline")]
-    pub offline: bool,
+    /// Verify manifests and vendor/ are in sync; write nothing, exit non-zero on drift
+    #[arg(long = "check")]
+    pub check: bool,
 }
 
 #[derive(Args, Debug)]
@@ -95,7 +96,7 @@ pub fn execute_mod_add(args: ModAddArgs) -> Result<()> {
         false,
         Some((&target.package_url, &overrides)),
         false,
-        false,
+        SyncMode::Write,
     )
 }
 
@@ -109,12 +110,18 @@ pub(crate) fn execute_sync_from(cwd: &Path, args: SyncArgs) -> Result<()> {
     validate_workspace(&workspace)?;
 
     let targets = discover_add_targets(&workspace, cwd)?;
-    sync_targets(
+    let mode = if args.check {
+        SyncMode::Check
+    } else {
+        SyncMode::Write
+    };
+    run_resolution(
         &workspace,
         &targets,
         args.verbose,
+        None,
         is_workspace_root(&workspace, cwd),
-        args.offline,
+        mode,
     )
 }
 
@@ -403,9 +410,21 @@ pub(crate) fn sync_targets(
     targets: &[AddTarget],
     verbose: bool,
     prune_vendor: bool,
-    offline: bool,
 ) -> Result<()> {
-    run_resolution(workspace, targets, verbose, None, prune_vendor, offline)
+    run_resolution(
+        workspace,
+        targets,
+        verbose,
+        None,
+        prune_vendor,
+        SyncMode::Write,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SyncMode {
+    Write,
+    Check,
 }
 
 fn run_resolution(
@@ -414,11 +433,12 @@ fn run_resolution(
     verbose: bool,
     direct_overrides: Option<(&str, &DirectOverrides)>,
     prune_vendor: bool,
-    offline: bool,
+    mode: SyncMode,
 ) -> Result<()> {
     ensure_workspace_cache_symlink(&workspace.root)?;
-    let mut resolver = PackageResolver::new(workspace.clone(), offline)?;
+    let mut resolver = PackageResolver::new(workspace.clone(), false)?;
     let mut selected_remote = BTreeSet::new();
+    let mut manifest_edits = Vec::new();
 
     for target in targets {
         let overrides = direct_overrides
@@ -426,12 +446,8 @@ fn run_resolution(
             .map(|(_, overrides)| overrides);
         let resolution =
             resolver.resolve_package_with_direct_overrides(&target.package_url, overrides)?;
-        let summary = write_package_manifest(target, &resolution)?;
-        if verbose && summary.changed {
-            println!(
-                "pcb: updated {}",
-                workspace_relative_path(&workspace.root, &target.pcb_toml_path).display()
-            );
+        if let Some(edit) = plan_package_manifest(target, &resolution)? {
+            manifest_edits.push(edit);
         }
         selected_remote.extend(resolution.resolved_remote);
     }
@@ -441,9 +457,59 @@ fn run_resolution(
             .iter()
             .map(|(dep_id, version)| (dep_id, version)),
     )?;
-    vendor_selected(workspace, &package_roots, prune_vendor)?;
+    let vendor_plan = plan_vendor_selected(workspace, &package_roots, prune_vendor)?;
 
+    match mode {
+        SyncMode::Write => apply_sync_plan(workspace, manifest_edits, vendor_plan, verbose),
+        SyncMode::Check => report_sync_drift(workspace, &manifest_edits, &vendor_plan),
+    }
+}
+
+fn apply_sync_plan(
+    workspace: &WorkspaceInfo,
+    manifest_edits: Vec<ManifestEdit>,
+    vendor_plan: VendorPlan,
+    verbose: bool,
+) -> Result<()> {
+    for edit in manifest_edits {
+        edit.apply()?;
+        if verbose {
+            println!(
+                "pcb: updated {}",
+                workspace_relative_path(&workspace.root, &edit.path).display()
+            );
+        }
+    }
+    vendor_plan.apply()?;
     Ok(())
+}
+
+fn report_sync_drift(
+    workspace: &WorkspaceInfo,
+    manifest_edits: &[ManifestEdit],
+    vendor_plan: &VendorPlan,
+) -> Result<()> {
+    if manifest_edits.is_empty() && vendor_plan.is_empty() {
+        return Ok(());
+    }
+
+    for edit in manifest_edits {
+        println!(
+            "would update {}",
+            workspace_relative_path(&workspace.root, &edit.path).display()
+        );
+    }
+    for copy in &vendor_plan.copies {
+        println!("would vendor {}/{}", copy.module_path, copy.version);
+    }
+    for prune in &vendor_plan.prunes {
+        println!(
+            "would prune {}",
+            workspace_relative_path(&workspace.root, prune).display()
+        );
+    }
+
+    bail!("workspace is not synced; run `pcb sync` and commit the changes")
 }
 
 pub(crate) fn validate_workspace(workspace: &WorkspaceInfo) -> Result<()> {

--- a/crates/pcbc/src/mod/mod.rs
+++ b/crates/pcbc/src/mod/mod.rs
@@ -46,7 +46,8 @@ pub struct SyncArgs {
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
-    /// Verify manifests and vendor/ are in sync; write nothing, exit non-zero on drift
+    /// Verify pcb.toml and vendor/ are in sync across the whole workspace
+    /// without modifying them; exit non-zero on drift
     #[arg(long = "check")]
     pub check: bool,
 }
@@ -109,7 +110,9 @@ pub(crate) fn execute_sync_from(cwd: &Path, args: SyncArgs) -> Result<()> {
     let workspace = get_workspace_info(&DefaultFileProvider::new(), cwd)?;
     validate_workspace(&workspace)?;
 
-    let targets = discover_add_targets(&workspace, cwd)?;
+    // --check always verifies the whole workspace, regardless of cwd.
+    let scope = if args.check { &workspace.root } else { cwd };
+    let targets = discover_add_targets(&workspace, scope)?;
     let mode = if args.check {
         SyncMode::Check
     } else {
@@ -120,7 +123,7 @@ pub(crate) fn execute_sync_from(cwd: &Path, args: SyncArgs) -> Result<()> {
         &targets,
         args.verbose,
         None,
-        is_workspace_root(&workspace, cwd),
+        is_workspace_root(&workspace, scope),
         mode,
     )
 }
@@ -210,7 +213,7 @@ fn load_single_target_workspace(command_name: &str) -> Result<(WorkspaceInfo, Ad
 }
 
 fn build_target_graph(workspace: &WorkspaceInfo, target: &AddTarget) -> Result<DepGraph> {
-    let mut resolver = PackageResolver::new(workspace.clone(), false)?;
+    let mut resolver = PackageResolver::new(workspace.clone())?;
     resolver.build_package_graph(&target.package_url)
 }
 
@@ -435,8 +438,7 @@ fn run_resolution(
     prune_vendor: bool,
     mode: SyncMode,
 ) -> Result<()> {
-    ensure_workspace_cache_symlink(&workspace.root)?;
-    let mut resolver = PackageResolver::new(workspace.clone(), false)?;
+    let mut resolver = PackageResolver::new(workspace.clone())?;
     let mut selected_remote = BTreeSet::new();
     let mut manifest_edits = Vec::new();
 
@@ -494,16 +496,19 @@ fn report_sync_drift(
     }
 
     for edit in manifest_edits {
-        println!(
+        eprintln!(
             "would update {}",
             workspace_relative_path(&workspace.root, &edit.path).display()
         );
     }
     for copy in &vendor_plan.copies {
-        println!("would vendor {}/{}", copy.module_path, copy.version);
+        eprintln!(
+            "would vendor {}",
+            workspace_relative_path(&workspace.root, &copy.dst).display()
+        );
     }
     for prune in &vendor_plan.prunes {
-        println!(
+        eprintln!(
             "would prune {}",
             workspace_relative_path(&workspace.root, prune).display()
         );

--- a/crates/pcbc/src/mod/request.rs
+++ b/crates/pcbc/src/mod/request.rs
@@ -24,13 +24,9 @@ pub(crate) fn resolve_direct_dependency_request(
         .direct
         .get(module_path)
         .and_then(dependency_lane);
-    let version = resolve_requested_version(
-        module_path,
-        requested_version,
-        current_lane.as_deref(),
-        false,
-    )
-    .with_context(|| format!("Failed to resolve requested dependency {}", module_path))?;
+    let version =
+        resolve_requested_version(module_path, requested_version, current_lane.as_deref())
+            .with_context(|| format!("Failed to resolve requested dependency {}", module_path))?;
     Ok((
         module_path.to_string(),
         DependencySpec::Version(version.to_string()),
@@ -83,11 +79,10 @@ fn resolve_requested_version(
     module_path: &str,
     requested_version: RequestedVersion,
     current_lane: Option<&str>,
-    offline: bool,
 ) -> Result<Version> {
     match requested_version {
         RequestedVersion::RefOrBranch(selector) => {
-            SpecVersionResolver::new(offline).resolve_ref_or_branch(module_path, &selector)
+            SpecVersionResolver::default().resolve_ref_or_branch(module_path, &selector)
         }
         RequestedVersion::Latest => {
             let versions = available_versions_for_module(module_path)?;

--- a/crates/pcbc/src/mod/writeback.rs
+++ b/crates/pcbc/src/mod/writeback.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use pcb_zen::package_resolver::PackageResolution;
@@ -6,15 +7,23 @@ use pcb_zen_core::config::{DependencySpec, PcbToml};
 
 use super::target::AddTarget;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct WritebackSummary {
-    pub(crate) changed: bool,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ManifestEdit {
+    pub(crate) path: PathBuf,
+    pub(crate) rendered: String,
 }
 
-pub(crate) fn write_package_manifest(
+impl ManifestEdit {
+    pub(crate) fn apply(&self) -> Result<()> {
+        std::fs::write(&self.path, &self.rendered)
+            .with_context(|| format!("Failed to write {}", self.path.display()))
+    }
+}
+
+pub(crate) fn plan_package_manifest(
     target: &AddTarget,
     resolution: &PackageResolution,
-) -> Result<WritebackSummary> {
+) -> Result<Option<ManifestEdit>> {
     let original = std::fs::read_to_string(&target.pcb_toml_path)
         .with_context(|| format!("Failed to read {}", target.pcb_toml_path.display()))?;
     let mut config: PcbToml = toml::from_str(&original)
@@ -25,12 +34,14 @@ pub(crate) fn write_package_manifest(
 
     let rendered = render_manifest(&config)?;
     let changed = rendered != original;
-    if changed {
-        std::fs::write(&target.pcb_toml_path, rendered)
-            .with_context(|| format!("Failed to write {}", target.pcb_toml_path.display()))?;
+    if !changed {
+        return Ok(None);
     }
 
-    Ok(WritebackSummary { changed })
+    Ok(Some(ManifestEdit {
+        path: target.pcb_toml_path.clone(),
+        rendered,
+    }))
 }
 
 fn indirect_dependencies(resolution: &PackageResolution) -> BTreeMap<String, DependencySpec> {

--- a/crates/pcbc/src/publish.rs
+++ b/crates/pcbc/src/publish.rs
@@ -881,7 +881,7 @@ fn sync_dependency_wave(
 
     let had_commits = guard.has_commits;
     guard.has_commits = true;
-    sync_targets(workspace, &targets, false, false, false)?;
+    sync_targets(workspace, &targets, false, false)?;
     if !git::has_uncommitted_changes(&workspace.root)? {
         guard.has_commits = had_commits;
         return Ok(false);

--- a/crates/pcbc/tests/sync.rs
+++ b/crates/pcbc/tests/sync.rs
@@ -55,10 +55,18 @@ fn write_simple_resistor_package(repo: &mut FixtureRepo, module_source: &str) {
         .write("SimpleResistor/test.kicad_mod", TEST_KICAD_MOD);
 }
 
-fn seed_simple_resistor_repo(sandbox: &mut Sandbox, commit_message: &str) -> String {
+fn seed_simple_resistor_repo(
+    sandbox: &mut Sandbox,
+    commit_message: &str,
+    tag: Option<&str>,
+) -> String {
     let mut fixture = sandbox.git_fixture("https://github.com/mycompany/components.git");
     write_simple_resistor_package(&mut fixture, SIMPLE_RESISTOR_ZEN);
-    fixture.commit(commit_message).push_mirror();
+    fixture.commit(commit_message);
+    if let Some(tag) = tag {
+        fixture.tag(tag, false);
+    }
+    fixture.push_mirror();
     fixture.rev_parse_head()
 }
 
@@ -145,15 +153,6 @@ Lib(name = "X", P1 = Net("P1"))
     );
 }
 
-fn seed_tagged_simple_resistor_repo(sandbox: &mut Sandbox) {
-    let mut fixture = sandbox.git_fixture("https://github.com/mycompany/components.git");
-    write_simple_resistor_package(&mut fixture, SIMPLE_RESISTOR_ZEN);
-    fixture
-        .commit("Add SimpleResistor package")
-        .tag("SimpleResistor/v1.0.0", false)
-        .push_mirror();
-}
-
 fn write_vendored_simple_resistor_workspace(sandbox: &mut Sandbox) -> &mut Sandbox {
     sandbox
         .write(
@@ -190,7 +189,7 @@ x = kOhm(10)
 fn test_sync_pins_branch_dep_to_rev_and_builds() {
     let mut sandbox = Sandbox::new();
 
-    let head_rev = seed_simple_resistor_repo(&mut sandbox, "Add SimpleResistor package");
+    let head_rev = seed_simple_resistor_repo(&mut sandbox, "Add SimpleResistor package", None);
 
     let pcb_toml = r#"[workspace]
 pcb-version = "0.4"
@@ -548,7 +547,7 @@ P1 = io(Net)
 fn test_branch_only_dep_hydrates_before_read_only_and_offline() {
     let mut sandbox = Sandbox::new();
 
-    let head_rev = seed_simple_resistor_repo(&mut sandbox, "Add SimpleResistor package");
+    let head_rev = seed_simple_resistor_repo(&mut sandbox, "Add SimpleResistor package", None);
 
     let pcb_toml = r#"[workspace]
 pcb-version = "0.4"
@@ -743,7 +742,11 @@ fn test_sync_check_detects_manifest_drift() {
 fn test_sync_check_detects_vendor_drift() {
     let mut sandbox = Sandbox::new();
 
-    seed_tagged_simple_resistor_repo(&mut sandbox);
+    seed_simple_resistor_repo(
+        &mut sandbox,
+        "Add SimpleResistor package",
+        Some("SimpleResistor/v1.0.0"),
+    );
     write_vendored_simple_resistor_workspace(&mut sandbox).sync();
 
     let vendored = sandbox
@@ -760,8 +763,12 @@ fn test_sync_check_detects_vendor_drift() {
     );
     assert!(
         missing_output
-            .contains("would vendor github.com/mycompany/components/SimpleResistor/1.0.0"),
+            .contains("would vendor vendor/github.com/mycompany/components/SimpleResistor/1.0.0"),
         "expected missing vendor report:\n{missing_output}"
+    );
+    assert!(
+        !vendored.exists(),
+        "sync --check must not re-vendor the missing package"
     );
 
     sandbox.sync();
@@ -783,6 +790,10 @@ fn test_sync_check_detects_vendor_drift() {
             .contains("would prune vendor/github.com/mycompany/components/SimpleResistor/9.9.9"),
         "expected stale vendor report:\n{stale_output}"
     );
+    assert!(
+        stale.exists(),
+        "sync --check must not prune the stale package"
+    );
 
     sandbox.sync();
     let clean_result = run_sync_check(&mut sandbox);
@@ -790,6 +801,37 @@ fn test_sync_check_detects_vendor_drift() {
     assert!(
         clean_result.status.success(),
         "expected sync --check to pass after vendor sync:\n{clean_output}"
+    );
+}
+
+#[test]
+fn test_sync_check_from_subdirectory_checks_whole_workspace() {
+    let mut sandbox = Sandbox::new();
+
+    seed_simple_resistor_repo(
+        &mut sandbox,
+        "Add SimpleResistor package",
+        Some("SimpleResistor/v1.0.0"),
+    );
+    write_vendored_simple_resistor_workspace(&mut sandbox).sync();
+
+    let stale = sandbox
+        .default_cwd()
+        .join("vendor/github.com/mycompany/components/SimpleResistor/9.9.9");
+    std::fs::create_dir_all(&stale).expect("create stale vendored package");
+    std::fs::write(stale.join("pcb.toml"), "[dependencies]\n")
+        .expect("write stale vendored manifest");
+
+    sandbox.cwd("sub");
+    let result = run_sync_check(&mut sandbox);
+    let output = command_output(&result);
+    assert!(
+        !result.status.success(),
+        "expected sync --check from a subdirectory to detect workspace drift:\n{output}"
+    );
+    assert!(
+        output.contains("would prune vendor/github.com/mycompany/components/SimpleResistor/9.9.9"),
+        "expected stale vendor report from a subdirectory:\n{output}"
     );
 }
 

--- a/crates/pcbc/tests/sync.rs
+++ b/crates/pcbc/tests/sync.rs
@@ -92,6 +92,10 @@ where
         .expect("pcbc command should execute")
 }
 
+fn run_sync_check(sandbox: &mut Sandbox) -> Output {
+    run_pcbc_unchecked(sandbox, ["sync", "--check"])
+}
+
 fn hydrated_version(manifest: &str, package_name: &str) -> String {
     let needle = format!("{package_name}\" = \"");
     manifest
@@ -99,6 +103,70 @@ fn hydrated_version(manifest: &str, package_name: &str) -> String {
         .and_then(|(_, rest)| rest.split('"').next())
         .expect("hydrated manifest should pin package")
         .to_string()
+}
+
+fn write_local_lib_workspace(sandbox: &mut Sandbox) -> &mut Sandbox {
+    sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.4"
+repository = "github.com/example/demo"
+
+[board]
+name = "Main"
+path = "board.zen"
+"#,
+        )
+        .write(
+            "board.zen",
+            r#"
+vcc = Net("VCC")
+gnd = Net("GND")
+"#,
+        )
+        .write("modules/Lib/pcb.toml", "[dependencies]\n")
+        .write(
+            "modules/Lib/Lib.zen",
+            r#"
+P1 = io(Net)
+"#,
+        )
+}
+
+fn add_unsynced_local_lib_import(sandbox: &mut Sandbox) {
+    sandbox.write(
+        "board.zen",
+        r#"
+Lib = Module("github.com/example/demo/modules/Lib/Lib.zen")
+
+Lib(name = "X", P1 = Net("P1"))
+"#,
+    );
+}
+
+fn seed_tagged_simple_resistor_repo(sandbox: &mut Sandbox) {
+    let mut fixture = sandbox.git_fixture("https://github.com/mycompany/components.git");
+    write_simple_resistor_package(&mut fixture, SIMPLE_RESISTOR_ZEN);
+    fixture
+        .commit("Add SimpleResistor package")
+        .tag("SimpleResistor/v1.0.0", false)
+        .push_mirror();
+}
+
+fn write_vendored_simple_resistor_workspace(sandbox: &mut Sandbox) -> &mut Sandbox {
+    sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.4"
+vendor = ["github.com/mycompany/components/**"]
+
+[dependencies]
+"github.com/mycompany/components/SimpleResistor" = "1.0.0"
+"#,
+        )
+        .write("board.zen", BOARD_USING_SIMPLE_RESISTOR)
 }
 
 #[test]
@@ -605,6 +673,145 @@ pcb-version = "0.4"
     assert_eq!(
         first_toml, second_toml,
         "expected hydrated pcb.toml to be stable across syncs"
+    );
+}
+
+#[test]
+fn test_sync_check_clean_workspace() {
+    let mut sandbox = Sandbox::new();
+
+    write_local_lib_workspace(&mut sandbox).sync();
+
+    let before = sandbox.snapshot_dir(".");
+    let result = run_sync_check(&mut sandbox);
+    let output = command_output(&result);
+
+    assert!(
+        result.status.success(),
+        "expected sync --check to pass:\n{output}"
+    );
+    assert!(
+        output.trim().is_empty(),
+        "expected sync --check success to be quiet:\n{output}"
+    );
+    assert_eq!(
+        before,
+        sandbox.snapshot_dir("."),
+        "sync --check must not change a clean workspace"
+    );
+}
+
+#[test]
+fn test_sync_check_detects_manifest_drift() {
+    let mut sandbox = Sandbox::new();
+
+    write_local_lib_workspace(&mut sandbox).sync();
+    let manifest_before = read_root_manifest(&sandbox);
+    add_unsynced_local_lib_import(&mut sandbox);
+
+    let result = run_sync_check(&mut sandbox);
+    let output = command_output(&result);
+
+    assert!(
+        !result.status.success(),
+        "expected sync --check to fail on manifest drift:\n{output}"
+    );
+    assert!(
+        output.contains("would update pcb.toml"),
+        "expected drift report to name pcb.toml:\n{output}"
+    );
+    assert!(
+        output.contains("workspace is not synced; run `pcb sync`"),
+        "expected final sync guidance:\n{output}"
+    );
+    assert_eq!(
+        manifest_before,
+        read_root_manifest(&sandbox),
+        "sync --check must not rewrite the manifest"
+    );
+
+    sandbox.sync();
+    let clean_result = run_sync_check(&mut sandbox);
+    let clean_output = command_output(&clean_result);
+    assert!(
+        clean_result.status.success(),
+        "expected sync --check to pass after sync:\n{clean_output}"
+    );
+}
+
+#[test]
+fn test_sync_check_detects_vendor_drift() {
+    let mut sandbox = Sandbox::new();
+
+    seed_tagged_simple_resistor_repo(&mut sandbox);
+    write_vendored_simple_resistor_workspace(&mut sandbox).sync();
+
+    let vendored = sandbox
+        .default_cwd()
+        .join("vendor/github.com/mycompany/components/SimpleResistor/1.0.0");
+    assert!(vendored.exists(), "expected sync to vendor SimpleResistor");
+    std::fs::remove_dir_all(&vendored).expect("remove vendored package");
+
+    let missing_result = run_sync_check(&mut sandbox);
+    let missing_output = command_output(&missing_result);
+    assert!(
+        !missing_result.status.success(),
+        "expected sync --check to fail on missing vendored package:\n{missing_output}"
+    );
+    assert!(
+        missing_output
+            .contains("would vendor github.com/mycompany/components/SimpleResistor/1.0.0"),
+        "expected missing vendor report:\n{missing_output}"
+    );
+
+    sandbox.sync();
+    let stale = sandbox
+        .default_cwd()
+        .join("vendor/github.com/mycompany/components/SimpleResistor/9.9.9");
+    std::fs::create_dir_all(&stale).expect("create stale vendored package");
+    std::fs::write(stale.join("pcb.toml"), "[dependencies]\n")
+        .expect("write stale vendored manifest");
+
+    let stale_result = run_sync_check(&mut sandbox);
+    let stale_output = command_output(&stale_result);
+    assert!(
+        !stale_result.status.success(),
+        "expected sync --check to fail on stale vendored package:\n{stale_output}"
+    );
+    assert!(
+        stale_output
+            .contains("would prune vendor/github.com/mycompany/components/SimpleResistor/9.9.9"),
+        "expected stale vendor report:\n{stale_output}"
+    );
+
+    sandbox.sync();
+    let clean_result = run_sync_check(&mut sandbox);
+    let clean_output = command_output(&clean_result);
+    assert!(
+        clean_result.status.success(),
+        "expected sync --check to pass after vendor sync:\n{clean_output}"
+    );
+}
+
+#[test]
+fn test_sync_check_writes_nothing_on_drift() {
+    let mut sandbox = Sandbox::new();
+
+    write_local_lib_workspace(&mut sandbox).sync();
+    add_unsynced_local_lib_import(&mut sandbox);
+    let before = sandbox.snapshot_dir(".");
+
+    let result = run_sync_check(&mut sandbox);
+    let output = command_output(&result);
+
+    assert!(
+        !result.status.success(),
+        "expected sync --check to fail on drift:\n{output}"
+    );
+    assert_eq!(
+        before,
+        sandbox.snapshot_dir("."),
+        "sync --check must not write workspace files when reporting drift"
     );
 }
 

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -444,6 +444,11 @@ pcb sync -v                 # Print changed manifests
 The command also downloads selected packages into the cache and vendors packages
 matched by `[workspace].vendor`.
 
+`pcb sync --check` always verifies the whole workspace, regardless of the
+current directory, and writes neither `pcb.toml` nor `vendor/`. It detects
+missing or stale vendored package versions; it does not verify the contents of
+vendored versions that are already present.
+
 ### pcb add
 
 Adds or upgrades a direct dependency for the package in the current directory.

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -437,7 +437,7 @@ removing imports or changing dependency versions.
 
 ```bash
 pcb sync                    # Sync packages under the current workspace/package
-pcb sync --offline          # Use only already cached package data
+pcb sync --check            # CI guard: fail if pcb.toml or vendor/ is out of sync
 pcb sync -v                 # Print changed manifests
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default `pcb sync` write ordering and removes `sync --offline`, which can affect CI/scripts; core dependency resolution and vendor layout behavior are touched but covered by new integration tests.
> 
> **Overview**
> Adds **`pcb sync --check`** for CI: it resolves the **entire workspace** (even when run from a subdirectory), reports drift for hydrated `pcb.toml` files and `vendor/` copies/prunes, exits non-zero on mismatch, and **never writes** disk.
> 
> **`pcb sync` is now plan-then-apply.** Resolution and materialization run first; manifest updates (`ManifestEdit`) and vendoring (`VendorPlan`) apply only after the full workspace succeeds, so a failed resolve no longer leaves partially updated manifests. **`pcb sync --offline` is removed**; offline behavior is expected via a synced manifest and `pcb build --offline`.
> 
> Vendoring is refactored to **`plan_vendor_package_roots` + `apply`**: sync/check share the same plan, stale vendor trees are collected then removed (with empty parent cleanup), and **no empty `vendor/`** is created when nothing matches `[workspace].vendor` patterns. Check mode treats missing vendored versions and extra stale version dirs as drift but does not re-hash contents of versions already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea1b87eebcc8c71633305564e26299851540fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->