### PR TITLE
fix spice generation for unit like Mohms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "allocative"
 version = "0.3.6"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "allocative_derive",
  "bumpalo",
@@ -53,7 +53,7 @@ dependencies = [
 [[package]]
 name = "allocative_derive"
 version = "0.3.6"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1222,7 +1222,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 
 [[package]]
 name = "cobs"
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "either",
  "indenter",
@@ -2017,9 +2017,9 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
- "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
+ "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
 ]
 
 [[package]]
@@ -2036,7 +2036,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4553,7 +4553,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "pagable"
 version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "allocative",
  "anyhow",
@@ -4561,7 +4561,7 @@ dependencies = [
  "blake3",
  "bytemuck",
  "dashmap",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
  "either",
  "erased-serde 0.4.10",
  "fancy-regex 0.16.2",
@@ -4587,7 +4587,7 @@ dependencies = [
 [[package]]
 name = "pagable_derive"
 version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7180,7 +7180,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "starlark"
 version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "allocative",
  "anyhow",
@@ -7192,7 +7192,7 @@ dependencies = [
  "derivative",
  "derive_more 1.0.0",
  "display_container",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
  "either",
  "erased-serde 0.3.31",
  "hashbrown 0.16.1",
@@ -7225,9 +7225,9 @@ dependencies = [
 [[package]]
 name = "starlark_derive"
 version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7236,10 +7236,10 @@ dependencies = [
 [[package]]
 name = "starlark_map"
 version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "allocative",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
  "equivalent",
  "fxhash",
  "hashbrown 0.16.1",
@@ -7251,14 +7251,14 @@ dependencies = [
 [[package]]
 name = "starlark_syntax"
 version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "allocative",
  "annotate-snippets",
  "anyhow",
  "derivative",
  "derive_more 1.0.0",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662)",
+ "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -7351,7 +7351,7 @@ dependencies = [
 [[package]]
 name = "strong_hash"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "ref-cast",
  "strong_hash_derive",
@@ -7360,7 +7360,7 @@ dependencies = [
 [[package]]
 name = "strong_hash_derive"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=0a73b696d5f72085d85b04fc065d35e56eb32662#0a73b696d5f72085d85b04fc065d35e56eb32662"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
 dependencies = [
  "quote",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ authors = ["Diode Computers, Inc. <founders@diode.computer>"]
 
 [workspace.dependencies]
 glam = "0.33"
-starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
-starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
-starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
-allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
-pagable = { git = "https://github.com/diodeinc/starlark-rust", rev = "0a73b696d5f72085d85b04fc065d35e56eb32662", default-features = false }
+starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
+starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
+starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
+allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
+pagable = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
 
 ruff_python_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.20" }
 ruff_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.20" }

--- a/crates/pcb-sch/src/physical.rs
+++ b/crates/pcb-sch/src/physical.rs
@@ -390,6 +390,7 @@ impl PhysicalValue {
         let diff_param_spec = single_param_spec(PhysicalValue::get_type_starlark_repr());
         let matches_param_spec = single_param_spec(Ty::any());
         let abs_param_spec = no_param_spec();
+        let spice_param_spec = no_param_spec();
         let within_param_spec = single_param_spec(Ty::any()); // Accepts any type like is_in()
 
         SortedMap::from_iter([
@@ -402,6 +403,10 @@ impl PhysicalValue {
             (
                 "__str__".to_string(),
                 Ty::callable(str_param_spec, Ty::string()),
+            ),
+            (
+                "spice".to_string(),
+                Ty::callable(spice_param_spec, Ty::string()),
             ),
             (
                 "with_tolerance".to_string(),
@@ -1099,6 +1104,33 @@ fn scale_to_si(raw: Decimal) -> (Decimal, &'static str) {
     (raw, "")
 }
 
+const NGSPICE_PREFIXES: [(i32, &str); 10] = [
+    (12, "T"),
+    (9, "G"),
+    (6, "meg"),
+    (3, "k"),
+    (0, ""),
+    (-3, "m"),
+    (-6, "u"),
+    (-9, "n"),
+    (-12, "p"),
+    (-15, "f"),
+];
+
+fn scale_to_ngspice(raw: Decimal) -> (Decimal, &'static str) {
+    if raw.is_zero() {
+        return (raw, "");
+    }
+    for &(exp, sym) in &NGSPICE_PREFIXES {
+        let factor = pow10(exp);
+        if raw.abs() >= factor {
+            return (raw / factor, sym);
+        }
+    }
+    // Smaller than femto: emit the raw decimal; ngspice reads the bare number.
+    (raw, "")
+}
+
 fn fmt_significant(x: Decimal) -> String {
     let formatted = format!("{}", x);
 
@@ -1568,6 +1600,12 @@ impl std::fmt::Display for PhysicalValue {
 }
 
 impl PhysicalValue {
+    /// Format with ngspice-compatible suffixes (like "meg" for mega)
+    pub fn to_spice_string(&self) -> String {
+        let (scaled, prefix) = scale_to_ngspice(self.nominal);
+        format!("{}{}", fmt_significant(scaled), prefix)
+    }
+
     /// Format as point value (no tolerance suffix)
     fn fmt_point_value(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.fmt_point_value_with_suffix(f, "")
@@ -1725,6 +1763,11 @@ fn physical_value_methods(methods: &mut MethodsBuilder) {
         #[starlark(require = pos)] _arg: Value<'v>,
     ) -> starlark::Result<String> {
         Ok(this.to_string())
+    }
+
+    /// Format the nominal value for a SPICE netlist (ngspice scale factors)
+    fn spice<'v>(this: &PhysicalValue) -> starlark::Result<String> {
+        Ok(this.to_spice_string())
     }
 
     /// Returns a new PhysicalValue with symmetric tolerance applied to nominal
@@ -2429,6 +2472,29 @@ mod tests {
         assert!(
             (result.nominal - Decimal::from_f64(expected_val).unwrap()).abs() < Decimal::new(1, 6)
         );
+    }
+
+    #[test]
+    fn test_spice_format() {
+        // ngspice netlist formatting: number + ngspice scale factor, no unit.
+        // Crucially, mega must be "meg" (ngspice reads 'M'/'m' as milli).
+        for (input, expected) in [
+            ("2MOhm", "2meg"),
+            ("10kOhm", "10k"),
+            ("50mOhm", "50m"),
+            ("0.5nH", "500p"),
+            ("0.05pF", "50f"),
+            ("1F", "1"),
+            ("100nF", "100n"),
+            ("4.7uF", "4.7u"),
+            ("0", "0"),
+        ] {
+            assert_eq!(
+                PhysicalValue::from_str(input).unwrap().to_spice_string(),
+                expected,
+                "input={input}"
+            );
+        }
     }
 
     #[test]

--- a/crates/pcb-zen-core/src/lang/spice_model.rs
+++ b/crates/pcb-zen-core/src/lang/spice_model.rs
@@ -20,6 +20,7 @@ use starlark::{
 use crate::lang::evaluator_ext::EvaluatorExt;
 
 use anyhow::anyhow;
+use pcb_sch::physical::PhysicalValue;
 
 /// SpiceModel reprents a sub circuit
 #[derive(Clone, Trace, Coerce, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
@@ -145,12 +146,15 @@ where
                             starlark::Error::new_other(anyhow!("parameter names must be strings"))
                         })?
                         .to_owned();
-                    let v_str = v_val
-                        .unpack_str()
-                        .ok_or_else(|| {
-                            starlark::Error::new_other(anyhow!("parameter values must be strings"))
-                        })?
-                        .to_owned();
+                    let v_str = if let Some(s) = v_val.unpack_str() {
+                        s.to_owned()
+                    } else if let Some(pv) = v_val.downcast_ref::<PhysicalValue>() {
+                        pv.to_spice_string()
+                    } else {
+                        return Err(starlark::Error::new_other(anyhow!(
+                            "parameter values must be a string or PhysicalValue"
+                        )));
+                    };
                     args.insert(param_name, v_str);
                 }
 

--- a/crates/pcb-zen/tests/snapshots/spice_model__snapshot_sim_divider_physical_value.snap
+++ b/crates/pcb-zen/tests/snapshots/spice_model__snapshot_sim_divider_physical_value.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pcb-zen/tests/spice_model.rs
+expression: result
+---
+
+
+.SUBCKT my_resistor p n PARAMS: RVAL={0}
+R1 p n {RVAL}
+.ENDS my_resistor
+XR1 vin vout my_resistor RVAL=10k
+XR2 vout gnd my_resistor RVAL=20k

--- a/crates/pcb-zen/tests/spice_model.rs
+++ b/crates/pcb-zen/tests/spice_model.rs
@@ -453,3 +453,85 @@ builtin.set_sim_setup(content=".tran 1u 10m")
         diag_text
     );
 }
+
+// Same as snapshot_sim_divider but passes the PhysicalValue directly into
+// `args` (no `.spice()` / `str()`); SpiceModel formats it to ngspice scale
+// factors, so RVAL comes out as `10k` / `20k` instead of `10000.0`.
+#[test]
+fn snapshot_sim_divider_physical_value() {
+    let env = TestProject::new();
+    add_resistor_artifacts(&env);
+
+    env.add_file(
+        "r.lib",
+        r#"
+.SUBCKT my_resistor p n PARAMS: RVAL={0}
+R1 p n {RVAL}
+.ENDS my_resistor
+"#,
+    );
+
+    env.add_file(
+        "myresistor.zen",
+        r#"
+load("@stdlib/units.zen", "Resistance", "Voltage")
+load("@stdlib/utils.zen", "format_value")
+
+Package = enum("0201", "0402", "0603", "0805", "1206", "1210", "2010", "2512")
+
+package = config(Package, default = Package("0603"))
+value = config(Resistance)
+
+voltage = config(Voltage, optional = True)
+
+properties = {
+    "value": format_value(value, voltage),
+    "package": package,
+    "resistance": value,
+    "voltage": voltage,
+}
+
+P1 = io(Net)
+P2 = io(Net)
+
+Component(
+    name = "R",
+    symbol = Symbol(library = "Device_R.kicad_sym", name="R"),
+    footprint = File("R_0201_0603Metric.kicad_mod"),
+    prefix = "R",
+    skip_bom = True,
+    spice_model = SpiceModel('./r.lib', 'my_resistor',
+        nets=[P1, P2],
+        args={"RVAL": value}),
+    pins = {
+        "1": P1,
+        "2": P2,
+    },
+    properties = properties,
+)
+"#,
+    );
+
+    env.add_file(
+        "divider.zen",
+        r#"
+load("@stdlib/interfaces.zen", "Analog")
+Resistor = Module("myresistor.zen")
+
+# Configuration parameters
+r1_value = config(str, default="10kohms", optional=True)
+r2_value = config(str, default="20kohms", optional=True)
+
+# IO ports
+vin = io(Power)
+vout = io(Analog)
+gnd = io(Ground)
+
+# Create the voltage divider
+Resistor(name="R1", value=r1_value, package="0603", P1=vin, P2=vout)
+Resistor(name="R2", value=r2_value, package="0603", P1=vout, P2=gnd)
+"#,
+    );
+
+    sim_snapshot!(env, "divider.zen");
+}

--- a/crates/pcbc/tests/snapshots/release__publish_full.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_full.snap
@@ -118,7 +118,7 @@ Designator,Val,Package,Mid X,Mid Y,Rotation,Layer
     "user": "<USER>"
   }
 }
-=== netlist.json <75342 bytes, sha256: 45a8069>
+=== netlist.json <75334 bytes, sha256: a232edf>
 === src/boards/TestBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcbc/tests/snapshots/release__publish_source_only.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_source_only.snap
@@ -44,7 +44,7 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <75342 bytes, sha256: 45a8069>
+=== netlist.json <75334 bytes, sha256: a232edf>
 === src/boards/TestBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcbc/tests/snapshots/release__publish_with_description.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_with_description.snap
@@ -45,7 +45,7 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <75342 bytes, sha256: 53bd154>
+=== netlist.json <75334 bytes, sha256: 3003da1>
 === src/boards/DescBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcbc/tests/snapshots/release__publish_with_version.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_with_version.snap
@@ -44,7 +44,7 @@ expression: sb.snapshot_dir(staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <74624 bytes, sha256: 3cf3e83>
+=== netlist.json <74616 bytes, sha256: 31176f0>
 === src/boards/TB0001.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -425,7 +425,7 @@ Use `.matches(other)` when you want coercive comparisons against strings or scal
 
 **String formatting**: Point values → `"3.3V"`. Symmetric tolerances → `"10k 5%"`. Ranges → `"11–26V (16V nom.)"`.
 
-**SPICE formatting**: `.spice()` → ngspice-safe string (`meg` for mega, no unit suffix, e.g. `Resistance("2MOhm").spice()` → `"2meg"`). Use it instead of `str()` when embedding a unit value in a SPICE simulation block.
+**SPICE formatting**: Pass a `PhysicalValue` directly or use `.spice()` to emit an ngspice-safe string (`meg` for mega, no unit suffix, e.g. `Resistance("2MOhm")` → `2meg`).
 
 ### Generic Components
 

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -417,13 +417,15 @@ SI base symbols are resolved in the context of the declared type, so `Length("1m
 
 **Properties**: `.value` (alias for `.nominal`), `.nominal`, `.min`, `.max`, `.tolerance`, `.unit`
 
-**Methods**: `.with_tolerance(t)`, `.with_value(v)`, `.with_unit(u)`, `.abs()`, `.diff(other)`, `.within(other)`, `.matches(other)`
+**Methods**: `.with_tolerance(t)`, `.with_value(v)`, `.with_unit(u)`, `.abs()`, `.diff(other)`, `.within(other)`, `.matches(other)`, `.spice()`
 
 **Operators**: `+`, `-`, `*`, `/` (with unit tracking), `<`, `>`, `<=`, `>=`, `==` (strict equality against another `PhysicalValue`), unary `-`
 
 Use `.matches(other)` when you want coercive comparisons against strings or scalars such as `Voltage("5V").matches("5V")`.
 
 **String formatting**: Point values → `"3.3V"`. Symmetric tolerances → `"10k 5%"`. Ranges → `"11–26V (16V nom.)"`.
+
+**SPICE formatting**: `.spice()` → ngspice-safe string (`meg` for mega, no unit suffix, e.g. `Resistance("2MOhm").spice()` → `"2meg"`). Use it instead of `str()` when embedding a unit value in a SPICE simulation block.
 
 ### Generic Components
 

--- a/lib/std/generics/Capacitor.zen
+++ b/lib/std/generics/Capacitor.zen
@@ -114,9 +114,9 @@ def _spice_args(value, package, esr=None, esl=None):
     }
 
     return {
-        "CVAL": str(value),
-        "ESR": str(esr or esr_table.get(package, Resistance("50mOhm"))),
-        "ESL": str(esl or esl_table.get(package, Inductance("0.5nH"))),
+        "CVAL": value.spice(),
+        "ESR": (esr or esr_table.get(package, Resistance("50mOhm"))).spice(),
+        "ESL": (esl or esl_table.get(package, Inductance("0.5nH"))).spice(),
     }
 
 

--- a/lib/std/generics/Capacitor.zen
+++ b/lib/std/generics/Capacitor.zen
@@ -114,9 +114,9 @@ def _spice_args(value, package, esr=None, esl=None):
     }
 
     return {
-        "CVAL": value.spice(),
-        "ESR": (esr or esr_table.get(package, Resistance("50mOhm"))).spice(),
-        "ESL": (esl or esl_table.get(package, Inductance("0.5nH"))).spice(),
+        "CVAL": value,
+        "ESR": esr or esr_table.get(package, Resistance("50mOhm")),
+        "ESL": esl or esl_table.get(package, Inductance("0.5nH")),
     }
 
 

--- a/lib/std/generics/FerriteBead.zen
+++ b/lib/std/generics/FerriteBead.zen
@@ -71,19 +71,19 @@ def _spice_args(impedance, frequency, dcr):
 
     if rac <= 0 or freq <= 0:
         return {
-            "RDC": rdc.spice(),
+            "RDC": rdc,
             "L": "0",
-            "RAC": rac.spice(),
+            "RAC": rac,
             "CP": "0",
         }
 
     l_val = rac / (2 * pi * freq)
     cp_val = 1.0 / (2 * pi * freq * rac)
     return {
-        "RDC": rdc.spice(),
-        "L": l_val.spice(),
-        "RAC": rac.spice(),
-        "CP": cp_val.spice(),
+        "RDC": rdc,
+        "L": l_val,
+        "RAC": rac,
+        "CP": cp_val,
     }
 
 

--- a/lib/std/generics/FerriteBead.zen
+++ b/lib/std/generics/FerriteBead.zen
@@ -71,19 +71,19 @@ def _spice_args(impedance, frequency, dcr):
 
     if rac <= 0 or freq <= 0:
         return {
-            "RDC": str(rdc),
+            "RDC": rdc.spice(),
             "L": "0",
-            "RAC": str(rac),
+            "RAC": rac.spice(),
             "CP": "0",
         }
 
     l_val = rac / (2 * pi * freq)
     cp_val = 1.0 / (2 * pi * freq * rac)
     return {
-        "RDC": str(rdc),
-        "L": str(l_val),
-        "RAC": str(rac),
-        "CP": str(cp_val),
+        "RDC": rdc.spice(),
+        "L": l_val.spice(),
+        "RAC": rac.spice(),
+        "CP": cp_val.spice(),
     }
 
 

--- a/lib/std/generics/Inductor.zen
+++ b/lib/std/generics/Inductor.zen
@@ -91,9 +91,9 @@ def _spice_args(value, package, dcr=None):
         cp_val = Capacitance("100pF")
 
     return {
-        "LVAL": str(lval),
-        "RDC": str(rdc_val),
-        "CP": str(cp_val),
+        "LVAL": lval.spice(),
+        "RDC": rdc_val.spice(),
+        "CP": cp_val.spice(),
     }
 
 

--- a/lib/std/generics/Inductor.zen
+++ b/lib/std/generics/Inductor.zen
@@ -91,9 +91,9 @@ def _spice_args(value, package, dcr=None):
         cp_val = Capacitance("100pF")
 
     return {
-        "LVAL": lval.spice(),
-        "RDC": rdc_val.spice(),
-        "CP": cp_val.spice(),
+        "LVAL": lval,
+        "RDC": rdc_val,
+        "CP": cp_val,
     }
 
 

--- a/lib/std/generics/Resistor.zen
+++ b/lib/std/generics/Resistor.zen
@@ -90,9 +90,9 @@ def _spice_args(value, package, esl=None, cp=None):
     }
 
     return {
-        "RVAL": str(value),
-        "ESL": str(esl or esl_table.get(package, Inductance("0.5nH"))),
-        "CP": str(cp or cp_table.get(package, Capacitance("0.05pF"))),
+        "RVAL": value.spice(),
+        "ESL": (esl or esl_table.get(package, Inductance("0.5nH"))).spice(),
+        "CP": (cp or cp_table.get(package, Capacitance("0.05pF"))).spice(),
     }
 
 

--- a/lib/std/generics/Resistor.zen
+++ b/lib/std/generics/Resistor.zen
@@ -90,9 +90,9 @@ def _spice_args(value, package, esl=None, cp=None):
     }
 
     return {
-        "RVAL": value.spice(),
-        "ESL": (esl or esl_table.get(package, Inductance("0.5nH"))).spice(),
-        "CP": (cp or cp_table.get(package, Capacitance("0.05pF"))).spice(),
+        "RVAL": value,
+        "ESL": esl or esl_table.get(package, Inductance("0.5nH")),
+        "CP": cp or cp_table.get(package, Capacitance("0.05pF")),
     }
 
 

--- a/lib/std/generics/Thermistor.zen
+++ b/lib/std/generics/Thermistor.zen
@@ -82,9 +82,9 @@ def _spice_args(value, package):
     }
 
     return {
-        "RVAL": value.spice(),
-        "ESL": esl_table.get(package, Inductance("0.5nH")).spice(),
-        "CP": cp_table.get(package, Capacitance("0.05pF")).spice(),
+        "RVAL": value,
+        "ESL": esl_table.get(package, Inductance("0.5nH")),
+        "CP": cp_table.get(package, Capacitance("0.05pF")),
     }
 
 

--- a/lib/std/generics/Thermistor.zen
+++ b/lib/std/generics/Thermistor.zen
@@ -82,9 +82,9 @@ def _spice_args(value, package):
     }
 
     return {
-        "RVAL": str(value),
-        "ESL": str(esl_table.get(package, Inductance("0.5nH"))),
-        "CP": str(cp_table.get(package, Capacitance("0.05pF"))),
+        "RVAL": value.spice(),
+        "ESL": esl_table.get(package, Inductance("0.5nH")).spice(),
+        "CP": cp_table.get(package, Capacitance("0.05pF")).spice(),
     }
 
 


### PR DESCRIPTION
Hi, 

first PR here, I am not sure if you are open to external contribution. Feel free to close if not !

Spice simulation was broken for Mohm resistors as it generates "1M" value which spice interpret as milliohm

I added a spice function to PhysicalValue to generate correct spice notation. It seems the least invasive fix but another way is to accept PhysicalValue directly as a parameter (I do not know enough the codebase to judge if this would have been a better way).

Disclaimer : i have used Opus to help be understand the codebase. I saw an Agent.md so I think this is ok but no policy about AI-helped PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how physical values are written into SPICE netlists across generics and SpiceModel; incorrect formatting would skew simulation results, but scope is narrow and covered by new unit and snapshot tests.
> 
> **Overview**
> Fixes incorrect SPICE netlist values for large resistances (e.g. Mohm) where human-oriented `str()` / SI prefixes emit **`M`**, which ngspice treats as **milli**.
> 
> **`PhysicalValue`** now exposes ngspice-oriented formatting via **`to_spice_string()`** and a Starlark **`.spice()`** method, using a dedicated scale table (notably **`meg`** for mega, no unit suffix). **`SpiceModel`** **`args`** accept **`PhysicalValue`** values and serialize them with that formatter instead of requiring pre-stringified values.
> 
> Stdlib generic components (**Resistor**, **Capacitor**, **Inductor**, etc.) pass typed values straight into spice **`args`** so simulations pick up correct notation automatically. Docs and integration/snapshot tests cover divider netlists (`10k` / `20k`) and publish netlist hashes reflect the updated output.
> 
> The workspace also pins **`starlark-rust`** to a newer git revision in **`Cargo.toml`** / **`Cargo.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 242f49018e07e820f4f8ec21f701902ba094d898. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->