### PR TITLE
Add no-auth Diode API mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `pcb sync --check` to fail CI when hydrated `pcb.toml` manifests or vendored package versions are out of sync. The check covers the whole workspace regardless of the current directory.
+- Added `DIODE_API_AUTH=none` to send Diode API requests without attaching client auth, for proxy-injected authentication.
 
 ### Changed
 

--- a/crates/pcb-diode-api/src/auth.rs
+++ b/crates/pcb-diode-api/src/auth.rs
@@ -3,7 +3,7 @@ use atomicwrites::{AtomicFile, OverwriteBehavior};
 use clap::{Args, Subcommand};
 use fslock::LockFile;
 use rand::Rng;
-use reqwest::blocking::Client;
+use reqwest::blocking::{Client, RequestBuilder};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
@@ -14,6 +14,7 @@ use crate::WorkspaceContext;
 use crate::aws_auth::{self, AwsDiodeToken};
 
 const NOT_AUTHENTICATED_MESSAGE: &str = "Not authenticated. Run `pcb auth login` to authenticate.";
+const DIODE_API_AUTH_NONE: &str = "none";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthTokens {
@@ -227,6 +228,44 @@ pub fn get_valid_token() -> Result<String> {
     get_valid_token_with_context(&ctx)
 }
 
+pub(crate) fn api_auth_disabled() -> bool {
+    std::env::var("DIODE_API_AUTH")
+        .is_ok_and(|value| value.eq_ignore_ascii_case(DIODE_API_AUTH_NONE))
+}
+
+pub fn get_api_token_with_context(ctx: &WorkspaceContext) -> Result<Option<String>> {
+    if api_auth_disabled() {
+        Ok(None)
+    } else {
+        get_valid_token_with_context(ctx).map(Some)
+    }
+}
+
+pub fn get_api_token() -> Result<Option<String>> {
+    let ctx = WorkspaceContext::from_cwd().unwrap_or_default();
+    get_api_token_with_context(&ctx)
+}
+
+pub(crate) fn apply_bearer_auth(request: RequestBuilder, token: Option<&str>) -> RequestBuilder {
+    if api_auth_disabled() {
+        request
+    } else if let Some(token) = token {
+        request.bearer_auth(token)
+    } else {
+        request
+    }
+}
+
+pub(crate) fn apply_api_auth_with_context(
+    ctx: &WorkspaceContext,
+    request: RequestBuilder,
+) -> Result<RequestBuilder> {
+    Ok(apply_bearer_auth(
+        request,
+        get_api_token_with_context(ctx)?.as_deref(),
+    ))
+}
+
 pub fn login_with_context(ctx: &WorkspaceContext) -> Result<()> {
     let code: String = rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)
@@ -304,6 +343,12 @@ pub fn logout() -> Result<()> {
 
 pub fn status_with_context(ctx: &WorkspaceContext) -> Result<()> {
     println!("Authentication Status:");
+    if api_auth_disabled() {
+        println!("  Status: API auth disabled");
+        println!("  Method: DIODE_API_AUTH=none");
+        return Ok(());
+    }
+
     match load_tokens_with_context(ctx)? {
         Some(tokens) => {
             println!("  Status: Logged in");
@@ -457,6 +502,14 @@ mod tests {
             }
             Self { key, previous }
         }
+
+        fn set_str(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
     }
 
     impl Drop for EnvGuard {
@@ -515,6 +568,15 @@ mod tests {
         assert_eq!(token, "aws-service-token");
         assert_eq!(refresh_calls.get(), 0);
         assert_eq!(aws_calls.get(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn api_auth_none_returns_no_api_token() {
+        let (_tempdir, _config_guard, ctx) = isolated_context();
+        let _auth_guard = EnvGuard::set_str("DIODE_API_AUTH", "none");
+
+        assert_eq!(get_api_token_with_context(&ctx).unwrap(), None);
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -251,7 +251,7 @@ fn build_availability_summary(
 /// Call the BOM match API and return parsed response
 fn call_bom_match_api(
     ctx: &WorkspaceContext,
-    auth_token: &str,
+    auth_token: Option<&str>,
     bom_entries: &[serde_json::Value],
     timeout_secs: u64,
     strict: bool,
@@ -263,9 +263,7 @@ fn call_bom_match_api(
         .build()?;
     let request_body = bom_match_request_body(bom_entries, strict);
 
-    let response = client
-        .post(&url)
-        .bearer_auth(auth_token)
+    let response = crate::auth::apply_bearer_auth(client.post(&url), auth_token)
         .json(&request_body)
         .send()
         .context("Failed to send BOM match request")?;
@@ -294,7 +292,7 @@ fn bom_match_request_body(bom_entries: &[serde_json::Value], strict: bool) -> se
 
 /// Fetch BOM matching results from the API and populate availability data
 pub fn fetch_and_populate_availability(
-    auth_token: &str,
+    auth_token: Option<&str>,
     bom: &mut pcb_sch::bom::Bom,
 ) -> Result<()> {
     let ctx = WorkspaceContext::from_cwd().unwrap_or_default();
@@ -303,7 +301,7 @@ pub fn fetch_and_populate_availability(
 
 pub fn fetch_and_populate_availability_with_context(
     ctx: &WorkspaceContext,
-    auth_token: &str,
+    auth_token: Option<&str>,
     bom: &mut pcb_sch::bom::Bom,
     strict: bool,
 ) -> Result<()> {
@@ -423,7 +421,7 @@ pub fn has_search_availability(availability: &Availability) -> bool {
 
 /// Fetch pricing for multiple components in a single batch request
 pub fn fetch_pricing_batch(
-    auth_token: &str,
+    auth_token: Option<&str>,
     components: &[ComponentKey],
 ) -> Result<Vec<Availability>> {
     fetch_pricing_in_chunks(components, |chunk| {
@@ -433,7 +431,7 @@ pub fn fetch_pricing_batch(
 
 /// Fetch pricing for grouped alternate components, combining all offers per group.
 pub fn fetch_pricing_grouped_batch(
-    auth_token: &str,
+    auth_token: Option<&str>,
     groups: &[Vec<ComponentKey>],
 ) -> Result<Vec<Availability>> {
     fetch_pricing_in_chunks(groups, |chunk| {
@@ -478,7 +476,7 @@ fn fetch_pricing_in_chunks<T: Clone>(
 }
 
 fn fetch_pricing_grouped_batch_once(
-    auth_token: &str,
+    auth_token: Option<&str>,
     groups: &[Vec<ComponentKey>],
 ) -> Result<Vec<Availability>> {
     if groups.is_empty() {
@@ -553,7 +551,7 @@ fn fetch_pricing_grouped_batch_once(
 }
 
 fn fetch_pricing_batch_once(
-    auth_token: &str,
+    auth_token: Option<&str>,
     components: &[ComponentKey],
 ) -> Result<Vec<Availability>> {
     if components.is_empty() {

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -91,15 +91,16 @@ struct DownloadResponseMetadata {
     manufacturer: Option<String>,
 }
 
-pub fn search_components(auth_token: &str, mpn: &str) -> Result<Vec<ComponentSearchResult>> {
+pub fn search_components(
+    auth_token: Option<&str>,
+    mpn: &str,
+) -> Result<Vec<ComponentSearchResult>> {
     let api_base_url = crate::get_api_base_url();
     let url = format!("{}/api/component/search", api_base_url);
 
     let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
 
-    let response = client
-        .post(&url)
-        .bearer_auth(auth_token)
+    let response = crate::auth::apply_bearer_auth(client.post(&url), auth_token)
         .json(&SearchRequest {
             mpn: mpn.to_string(),
         })
@@ -112,15 +113,16 @@ pub fn search_components(auth_token: &str, mpn: &str) -> Result<Vec<ComponentSea
     Ok(response.json()?)
 }
 
-pub fn download_component(auth_token: &str, component_id: &str) -> Result<ComponentDownloadResult> {
+pub fn download_component(
+    auth_token: Option<&str>,
+    component_id: &str,
+) -> Result<ComponentDownloadResult> {
     let api_base_url = crate::get_api_base_url();
     let url = format!("{}/api/component/download", api_base_url);
 
     let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
 
-    let response = client
-        .post(&url)
-        .bearer_auth(auth_token)
+    let response = crate::auth::apply_bearer_auth(client.post(&url), auth_token)
         .json(&DownloadRequest {
             component_id: component_id.to_string(),
         })
@@ -434,7 +436,7 @@ fn process_component_datasheet(
 }
 
 pub fn add_component_to_workspace(
-    auth_token: &str,
+    auth_token: Option<&str>,
     component_id: &str,
     part_number: Option<&str>,
     workspace_root: &std::path::Path,
@@ -1276,9 +1278,9 @@ fn add_component_with_feedback(
     part_number: Option<&str>,
     manufacturer: Option<&str>,
 ) -> Result<()> {
-    let token = crate::auth::get_valid_token()?;
+    let token = crate::auth::get_api_token()?;
     let result = add_component_to_workspace(
-        &token,
+        token.as_deref(),
         component_id,
         part_number,
         workspace_root,
@@ -1763,10 +1765,11 @@ fn registry_symbol_search_availability(
         return std::collections::HashMap::new();
     }
 
-    let Ok(token) = crate::auth::get_valid_token() else {
+    let Ok(token) = crate::auth::get_api_token() else {
         return std::collections::HashMap::new();
     };
-    let pricing = crate::bom::fetch_pricing_grouped_batch(&token, &groups).unwrap_or_default();
+    let pricing =
+        crate::bom::fetch_pricing_grouped_batch(token.as_deref(), &groups).unwrap_or_default();
 
     pricing
         .into_iter()
@@ -1787,10 +1790,11 @@ fn kicad_symbol_search_availability(
         return std::collections::HashMap::new();
     }
 
-    let Ok(token) = crate::auth::get_valid_token() else {
+    let Ok(token) = crate::auth::get_api_token() else {
         return std::collections::HashMap::new();
     };
-    let pricing = crate::bom::fetch_pricing_grouped_batch(&token, &groups).unwrap_or_default();
+    let pricing =
+        crate::bom::fetch_pricing_grouped_batch(token.as_deref(), &groups).unwrap_or_default();
 
     let mut map = std::collections::HashMap::new();
     for (result_idx, availability) in pricing.into_iter().enumerate() {
@@ -1835,7 +1839,7 @@ pub struct ComponentResult {
 
 /// Search for components and fetch availability data in batch
 pub fn search_components_with_availability(
-    auth_token: &str,
+    auth_token: Option<&str>,
     query: &str,
 ) -> Result<Vec<ComponentResult>> {
     let results = filter_component_search_results(search_components(auth_token, query)?);
@@ -1908,8 +1912,8 @@ fn filter_component_search_results(
 fn execute_web_search(query: &str, json: bool) -> Result<()> {
     use crate::registry::tui::display::WebComponentDisplay;
 
-    let token = crate::auth::get_valid_token()?;
-    let results = search_components_with_availability(&token, query)?;
+    let token = crate::auth::get_api_token()?;
+    let results = search_components_with_availability(token.as_deref(), query)?;
 
     if results.is_empty() {
         if json {

--- a/crates/pcb-diode-api/src/datasheet.rs
+++ b/crates/pcb-diode-api/src/datasheet.rs
@@ -126,7 +126,7 @@ pub fn parse_resolve_request(args: Option<&Value>) -> Result<ResolveDatasheetInp
 }
 
 pub fn resolve_datasheet(
-    auth_token: &str,
+    auth_token: Option<&str>,
     input: &ResolveDatasheetInput,
 ) -> Result<ResolveDatasheetResponse> {
     let client = build_scan_client()?;
@@ -159,7 +159,7 @@ pub fn resolve_datasheet(
 
 fn resolve_source_url_datasheet(
     client: &Client,
-    auth_token: &str,
+    auth_token: Option<&str>,
     canonical_url: String,
 ) -> Result<ResolveDatasheetResponse> {
     let url_cache_dir = url_pdf_cache_dir(&canonical_url)?;
@@ -181,7 +181,7 @@ fn resolve_source_url_datasheet(
 
 fn execute_resolve_execution(
     client: &Client,
-    auth_token: &str,
+    auth_token: Option<&str>,
     execution: ResolveExecution,
     prefetched_process: Option<crate::scan::ProcessResponse>,
 ) -> Result<ResolveDatasheetResponse> {
@@ -249,7 +249,7 @@ fn execute_resolve_execution(
 
 fn fetch_url_pdf_via_backend(
     client: &Client,
-    auth_token: &str,
+    auth_token: Option<&str>,
     canonical_url: &str,
     url_cache_dir: &Path,
 ) -> Result<(crate::scan::ProcessResponse, PathBuf)> {

--- a/crates/pcb-diode-api/src/kicad_symbols/download.rs
+++ b/crates/pcb-diode-api/src/kicad_symbols/download.rs
@@ -52,14 +52,12 @@ fn download_index_response(
 
 /// Fetch KiCad symbols index metadata without downloading the file.
 pub fn fetch_kicad_symbols_index_metadata() -> Result<KicadSymbolsIndexMetadata> {
-    let token = crate::auth::get_valid_token().context("Auth failed")?;
+    let token = crate::auth::get_api_token().context("Auth failed")?;
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
     let url = format!("{api_url}{KICAD_SYMBOLS_INDEX_ROUTE}");
 
-    let resp = client
-        .get(&url)
-        .bearer_auth(&token)
+    let resp = crate::auth::apply_bearer_auth(client.get(&url), token.as_deref())
         .send()
         .with_context(|| format!("Request to {url} failed"))?
         .error_for_status()
@@ -79,15 +77,13 @@ pub enum KicadSymbolsAccessResult {
 
 /// Check if KiCad symbols index download is allowed.
 pub fn check_kicad_symbols_access() -> Result<KicadSymbolsAccessResult> {
-    let token = crate::auth::get_valid_token()
+    let token = crate::auth::get_api_token()
         .context("Authentication required. Run `pcb auth` to log in.")?;
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
     let url = format!("{api_url}{KICAD_SYMBOLS_INDEX_ROUTE}");
 
-    let resp = client
-        .get(&url)
-        .bearer_auth(&token)
+    let resp = crate::auth::apply_bearer_auth(client.get(&url), token.as_deref())
         .send()
         .with_context(|| format!("Request to {url} failed"))?;
 
@@ -167,22 +163,21 @@ pub fn download_kicad_symbols_index_with_progress(
 
 /// Download KiCad symbols index (blocking, prints to stderr).
 pub fn download_kicad_symbols_index(dest_path: &Path) -> Result<()> {
-    let token = crate::auth::get_valid_token()
+    let token = crate::auth::get_api_token()
         .context("Authentication required. Run `pcb auth login` first.")?;
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
     let url = format!("{api_url}{KICAD_SYMBOLS_INDEX_ROUTE}");
 
     eprintln!("Fetching KiCad symbols index URL...");
-    let index_metadata: KicadSymbolsIndexMetadata = client
-        .get(&url)
-        .bearer_auth(&token)
-        .send()
-        .context("Failed to fetch KiCad symbols index URL")?
-        .error_for_status()
-        .context("API returned error when fetching KiCad symbols index URL")?
-        .json()
-        .context("Failed to parse KiCad symbols index response")?;
+    let index_metadata: KicadSymbolsIndexMetadata =
+        crate::auth::apply_bearer_auth(client.get(&url), token.as_deref())
+            .send()
+            .context("Failed to fetch KiCad symbols index URL")?
+            .error_for_status()
+            .context("API returned error when fetching KiCad symbols index URL")?
+            .json()
+            .context("Failed to parse KiCad symbols index response")?;
 
     ensure_parent_dir(dest_path, "KiCad symbols")?;
 

--- a/crates/pcb-diode-api/src/registry/download.rs
+++ b/crates/pcb-diode-api/src/registry/download.rs
@@ -155,14 +155,12 @@ pub fn save_local_version(db_path: &Path, version: &str) -> Result<()> {
 
 /// Fetch registries visible to the current user.
 pub fn fetch_registries() -> Result<Vec<RegistryInfo>> {
-    let token = crate::auth::get_valid_token().context("Auth failed")?;
+    let token = crate::auth::get_api_token().context("Auth failed")?;
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
     let url = format!("{api_url}{REGISTRIES_ROUTE}");
 
-    let resp = client
-        .get(&url)
-        .bearer_auth(&token)
+    let resp = crate::auth::apply_bearer_auth(client.get(&url), token.as_deref())
         .send()
         .with_context(|| format!("Request to {url} failed"))?
         .error_for_status()
@@ -525,15 +523,13 @@ fn registry_index_route(registry: &RegistryInfo) -> String {
 
 /// Fetch registry index metadata without downloading the file.
 pub fn fetch_registry_index_metadata(registry: &RegistryInfo) -> Result<RegistryIndexMetadata> {
-    let token = crate::auth::get_valid_token().context("Auth failed")?;
+    let token = crate::auth::get_api_token().context("Auth failed")?;
     let client = http_client()?;
     let api_url = crate::get_api_base_url();
     let url = reqwest::Url::parse(&format!("{api_url}{}", registry_index_route(registry)))
         .context("Invalid registry index URL")?;
 
-    let resp = client
-        .get(url.clone())
-        .bearer_auth(&token)
+    let resp = crate::auth::apply_bearer_auth(client.get(url.clone()), token.as_deref())
         .send()
         .with_context(|| format!("Request to {url} failed"))?
         .error_for_status()

--- a/crates/pcb-diode-api/src/registry/embeddings.rs
+++ b/crates/pcb-diode-api/src/registry/embeddings.rs
@@ -20,7 +20,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use std::sync::LazyLock;
 
-use crate::auth::get_valid_token;
 use crate::get_api_base_url;
 
 // ============================================================================
@@ -113,14 +112,12 @@ fn save_aws_creds_to_disk(creds: &AwsCredentials) -> Result<()> {
 
 /// Fetch fresh AWS credentials from Diode API
 fn fetch_aws_creds_from_api() -> Result<AwsCredentials> {
-    let token = get_valid_token()?;
+    let token = crate::auth::get_api_token()?;
 
     let api_url = get_api_base_url();
     let url = format!("{}/api/bedrock/embed/credentials", api_url);
 
-    let response = HTTP_CLIENT
-        .post(&url)
-        .bearer_auth(&token)
+    let response = crate::auth::apply_bearer_auth(HTTP_CLIENT.post(&url), token.as_deref())
         .send()
         .context("Failed to fetch AWS credentials")?;
 

--- a/crates/pcb-diode-api/src/registry/tui/app.rs
+++ b/crates/pcb-diode-api/src/registry/tui/app.rs
@@ -1704,7 +1704,7 @@ pub fn run_with_mode_and_registry_index(
 /// Run the TUI in WebComponents mode only (for pcb new component)
 pub fn run_web_components_only() -> Result<TuiResult> {
     // Check authentication first
-    crate::auth::get_valid_token()?;
+    crate::auth::get_api_token()?;
 
     run_with_preflight(Preflight::web_only())
 }

--- a/crates/pcb-diode-api/src/registry/tui/image.rs
+++ b/crates/pcb-diode-api/src/registry/tui/image.rs
@@ -189,8 +189,8 @@ fn load_or_fetch_registry_image(client: &Client, sha256: &str) -> Result<ImageRe
         return Ok(ImageResult::Ready(bytes));
     }
 
-    let token = crate::auth::get_valid_token().context("image auth failed")?;
-    let Some(url) = resolve_registry_image_url(client, &token, &sha256)? else {
+    let token = crate::auth::get_api_token().context("image auth failed")?;
+    let Some(url) = resolve_registry_image_url(client, token.as_deref(), &sha256)? else {
         return Ok(ImageResult::Missing);
     };
 
@@ -260,16 +260,14 @@ struct SignedImageResponse {
 
 fn resolve_registry_image_url(
     client: &Client,
-    token: &str,
+    token: Option<&str>,
     sha256: &str,
 ) -> Result<Option<String>> {
     let endpoint = format!(
         "{}/api/registries/images/{sha256}",
         crate::get_api_base_url()
     );
-    let response = client
-        .get(endpoint)
-        .bearer_auth(token)
+    let response = crate::auth::apply_bearer_auth(client.get(endpoint), token)
         .send()
         .context("failed to resolve registry image URL")?;
 

--- a/crates/pcb-diode-api/src/registry/tui/search.rs
+++ b/crates/pcb-diode-api/src/registry/tui/search.rs
@@ -852,14 +852,14 @@ pub fn spawn_worker(
 /// Spawn the component search worker thread (online API search)
 ///
 /// This worker handles searches for new components from online sources.
-/// It caches the auth token lazily on first request.
+/// It caches API auth lazily on first request.
 pub fn spawn_component_worker(
     query_rx: Receiver<ComponentSearchQuery>,
     result_tx: Sender<ComponentSearchResults>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
-        // Cache auth token (fetched lazily on first request)
         let mut auth_token: Option<String> = None;
+        let mut auth_checked = false;
 
         while let Ok(mut query) = query_rx.recv() {
             // Coalesce rapid queries - keep only the latest
@@ -880,10 +880,9 @@ pub fn spawn_component_worker(
                 continue;
             }
 
-            // Get auth token (lazy)
-            if auth_token.is_none() {
-                match crate::auth::get_valid_token() {
-                    Ok(token) => auth_token = Some(token),
+            if !auth_checked {
+                match crate::auth::get_api_token() {
+                    Ok(token) => auth_token = token,
                     Err(e) => {
                         let _ = result_tx.send(ComponentSearchResults {
                             query_id: query.id,
@@ -894,13 +893,13 @@ pub fn spawn_component_worker(
                         continue;
                     }
                 }
+                auth_checked = true;
             }
-
-            let token = auth_token.as_ref().unwrap();
 
             // Execute search
             let start = Instant::now();
-            let search_result = crate::component::search_components(token, query_text);
+            let search_result =
+                crate::component::search_components(auth_token.as_deref(), query_text);
             let duration = start.elapsed();
 
             let (results, error) = match search_result {
@@ -915,6 +914,7 @@ pub fn spawn_component_worker(
                 Err(e) => {
                     // Clear cached token on auth errors so we retry
                     if e.to_string().contains("401") || e.to_string().contains("403") {
+                        auth_checked = false;
                         auth_token = None;
                     }
                     (Vec::new(), Some(e.to_string()))
@@ -966,6 +966,7 @@ pub fn spawn_availability_worker(
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         let mut auth_token: Option<String> = None;
+        let mut auth_checked = false;
         while let Ok(mut queue) = req_rx.recv() {
             while let Ok(next) = req_rx.try_recv() {
                 queue = next;
@@ -975,11 +976,12 @@ pub fn spawn_availability_worker(
                 let chunk_len = queue.len().min(AVAILABILITY_WORKER_CHUNK_SIZE);
                 let chunk: Vec<_> = queue.drain(..chunk_len).collect();
 
-                let response = if auth_token.is_none() {
-                    match crate::auth::get_valid_token() {
+                let response = if !auth_checked {
+                    match crate::auth::get_api_token() {
                         Ok(token) => {
-                            auth_token = Some(token);
-                            fetch_pricing_chunk(auth_token.as_deref().unwrap(), &chunk)
+                            auth_token = token;
+                            auth_checked = true;
+                            fetch_pricing_chunk(auth_token.as_deref(), &chunk)
                         }
                         Err(e) => {
                             log::warn!("Pricing auth failed: {}", e);
@@ -990,7 +992,7 @@ pub fn spawn_availability_worker(
                         }
                     }
                 } else {
-                    fetch_pricing_chunk(auth_token.as_deref().unwrap(), &chunk)
+                    fetch_pricing_chunk(auth_token.as_deref(), &chunk)
                 };
 
                 let _ = resp_tx.send(response);
@@ -1003,7 +1005,7 @@ pub fn spawn_availability_worker(
     })
 }
 
-fn fetch_pricing_chunk(auth_token: &str, chunk: &[AvailabilityRequest]) -> PricingResponse {
+fn fetch_pricing_chunk(auth_token: Option<&str>, chunk: &[AvailabilityRequest]) -> PricingResponse {
     let groups: Vec<_> = chunk
         .iter()
         .map(|request| request.lookups.clone())

--- a/crates/pcb-diode-api/src/release.rs
+++ b/crates/pcb-diode-api/src/release.rs
@@ -39,12 +39,12 @@ struct UploadContext {
     client: Client,
     base_url: String,
     web_base_url: String,
-    token: String,
+    token: Option<String>,
     sha256_hex: String,
 }
 
 fn prepare_upload(ctx: &WorkspaceContext, zip_path: &Path) -> Result<UploadContext> {
-    let token = ctx.token()?;
+    let token = crate::auth::get_api_token_with_context(ctx)?;
     let base_url = ctx.api_base_url().to_string();
 
     let client = Client::builder()
@@ -56,7 +56,7 @@ fn prepare_upload(ctx: &WorkspaceContext, zip_path: &Path) -> Result<UploadConte
     stage_artifact(
         &client,
         &base_url,
-        &token,
+        token.as_deref(),
         zip_path,
         &sha256_hex,
         &sha256_b64,
@@ -81,7 +81,7 @@ pub fn upload_release(
     create_release(
         &upload.client,
         &upload.base_url,
-        &upload.token,
+        upload.token.as_deref(),
         workspace,
         &upload.sha256_hex,
     )
@@ -94,7 +94,7 @@ pub fn upload_preview(zip_path: &Path, ctx: &WorkspaceContext) -> Result<Preview
         &upload.client,
         &upload.base_url,
         &upload.web_base_url,
-        &upload.token,
+        upload.token.as_deref(),
         &upload.sha256_hex,
     )
 }
@@ -120,15 +120,13 @@ fn calculate_sha256(path: &Path) -> Result<(String, String)> {
 fn stage_artifact(
     client: &Client,
     base_url: &str,
-    token: &str,
+    token: Option<&str>,
     zip_path: &Path,
     sha256_hex: &str,
     sha256_b64: &str,
 ) -> Result<()> {
     let url = format!("{}/api/file/{}", base_url, sha256_hex);
-    let resp = client
-        .post(&url)
-        .bearer_auth(token)
+    let resp = crate::auth::apply_bearer_auth(client.post(&url), token)
         .send()
         .context("Failed to connect to Diode API")?;
 
@@ -161,7 +159,7 @@ fn stage_artifact(
 fn create_release(
     client: &Client,
     base_url: &str,
-    token: &str,
+    token: Option<&str>,
     workspace: &str,
     sha256_hex: &str,
 ) -> Result<ReleaseResult> {
@@ -171,9 +169,7 @@ fn create_release(
         urlencoding::encode(workspace)
     );
 
-    let resp = client
-        .post(&url)
-        .bearer_auth(token)
+    let resp = crate::auth::apply_bearer_auth(client.post(&url), token)
         .json(&serde_json::json!({ "artifactHash": sha256_hex }))
         .send()
         .context("Failed to connect to Diode API")?;
@@ -210,14 +206,12 @@ fn create_preview(
     client: &Client,
     base_url: &str,
     web_base_url: &str,
-    token: &str,
+    token: Option<&str>,
     sha256_hex: &str,
 ) -> Result<PreviewResult> {
     let url = format!("{}/api/previews", base_url);
 
-    let resp = client
-        .post(&url)
-        .bearer_auth(token)
+    let resp = crate::auth::apply_bearer_auth(client.post(&url), token)
         .json(&serde_json::json!({ "artifactHash": sha256_hex }))
         .send()
         .context("Failed to connect to Diode API")?;

--- a/crates/pcb-diode-api/src/routing.rs
+++ b/crates/pcb-diode-api/src/routing.rs
@@ -90,7 +90,7 @@ pub fn start_routing(
     project_path: &Path,
     request: &StartRoutingRequest,
 ) -> Result<String> {
-    let token = ctx.token()?;
+    let token = crate::auth::get_api_token_with_context(ctx)?;
     let url = format!("{}/api/routing", ctx.api_base_url());
 
     // Build multipart form
@@ -106,9 +106,7 @@ pub fn start_routing(
     }
 
     let client = create_client()?;
-    let response = client
-        .post(&url)
-        .bearer_auth(&token)
+    let response = crate::auth::apply_bearer_auth(client.post(&url), token.as_deref())
         .multipart(form)
         .send()
         .context("Failed to send routing request")?;
@@ -134,13 +132,11 @@ pub fn start_routing(
 /// # Returns
 /// Current job status including routing statistics
 pub fn get_routing_status(ctx: &WorkspaceContext, job_id: &str) -> Result<RoutingJob> {
-    let token = ctx.token()?;
+    let token = crate::auth::get_api_token_with_context(ctx)?;
     let url = format!("{}/api/routing/{}", ctx.api_base_url(), job_id);
 
     let client = create_client()?;
-    let response = client
-        .get(&url)
-        .bearer_auth(&token)
+    let response = crate::auth::apply_bearer_auth(client.get(&url), token.as_deref())
         .send()
         .context("Failed to get routing status")?;
 
@@ -163,7 +159,7 @@ pub fn get_routing_status(ctx: &WorkspaceContext, job_id: &str) -> Result<Routin
 /// # Returns
 /// The SES file contents as bytes
 pub fn download_routing_result(ctx: &WorkspaceContext, job_id: &str) -> Result<Vec<u8>> {
-    let token = ctx.token()?;
+    let token = crate::auth::get_api_token_with_context(ctx)?;
     let url = format!(
         "{}/api/routing/{}/download?format=ses",
         ctx.api_base_url(),
@@ -171,9 +167,7 @@ pub fn download_routing_result(ctx: &WorkspaceContext, job_id: &str) -> Result<V
     );
 
     let client = create_client()?;
-    let response = client
-        .get(&url)
-        .bearer_auth(&token)
+    let response = crate::auth::apply_bearer_auth(client.get(&url), token.as_deref())
         .send()
         .context("Failed to download routing result")?;
 
@@ -192,13 +186,11 @@ pub fn download_routing_result(ctx: &WorkspaceContext, job_id: &str) -> Result<V
 ///
 /// The best result found so far remains available for download.
 pub fn stop_routing(ctx: &WorkspaceContext, job_id: &str) -> Result<()> {
-    let token = ctx.token()?;
+    let token = crate::auth::get_api_token_with_context(ctx)?;
     let url = format!("{}/api/routing/{}/stop", ctx.api_base_url(), job_id);
 
     let client = create_client()?;
-    let response = client
-        .post(&url)
-        .bearer_auth(&token)
+    let response = crate::auth::apply_bearer_auth(client.post(&url), token.as_deref())
         .send()
         .context("Failed to stop routing")?;
 

--- a/crates/pcb-diode-api/src/sandbox.rs
+++ b/crates/pcb-diode-api/src/sandbox.rs
@@ -186,7 +186,7 @@ pub struct SandboxLockGuard {
 
 impl SandboxClient {
     pub fn new(ctx: WorkspaceContext) -> Result<Self> {
-        ctx.token()?;
+        crate::auth::get_api_token_with_context(&ctx)?;
         let api_base_url = ctx.api_base_url().trim_end_matches('/').to_string();
         Ok(Self {
             api_base_url,
@@ -230,9 +230,7 @@ impl SandboxClient {
             encoded_absolute_path(path)?
         ));
         let response = self
-            .http
-            .get(url)
-            .bearer_auth(self.auth_token()?)
+            .authenticated(self.http.get(url))?
             .send()
             .context("Failed to read sandbox file")?;
         let response = self.ensure_success(response)?;
@@ -241,13 +239,11 @@ impl SandboxClient {
 
     pub fn write_file(&self, sandbox_id: &str, path: &str, bytes: &[u8]) -> Result<()> {
         let response = self
-            .http
-            .put(self.url(&format!(
+            .authenticated(self.http.put(self.url(&format!(
                 "/api/sandboxes/{}/fs/write{}",
                 encode_segment(sandbox_id),
                 encoded_absolute_path(path)?
-            )))
-            .bearer_auth(self.auth_token()?)
+            ))))?
             .header(CONTENT_TYPE, "application/octet-stream")
             .body(bytes.to_vec())
             .send()
@@ -330,9 +326,7 @@ impl SandboxClient {
 
     fn get_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T> {
         let response = self
-            .http
-            .get(self.url(path))
-            .bearer_auth(self.auth_token()?)
+            .authenticated(self.http.get(self.url(path)))?
             .send()
             .context("Sandbox GET request failed")?;
         self.ensure_success(response)?
@@ -346,9 +340,7 @@ impl SandboxClient {
         body: &B,
     ) -> Result<T> {
         let response = self
-            .http
-            .post(self.url(path))
-            .bearer_auth(self.auth_token()?)
+            .authenticated(self.http.post(self.url(path)))?
             .json(body)
             .send()
             .context("Sandbox POST request failed")?;
@@ -377,8 +369,11 @@ impl SandboxClient {
         format!("{}{}", self.api_base_url, path)
     }
 
-    fn auth_token(&self) -> Result<String> {
-        self.ctx.token()
+    fn authenticated(
+        &self,
+        request: reqwest::blocking::RequestBuilder,
+    ) -> Result<reqwest::blocking::RequestBuilder> {
+        crate::auth::apply_api_auth_with_context(&self.ctx, request)
     }
 }
 
@@ -535,13 +530,11 @@ fn write_lock_file(client: &SandboxClient, sandbox_id: &str, lock: &SandboxLockF
 
 fn delete_lock_file(client: &SandboxClient, sandbox_id: &str) -> Result<()> {
     let response = client
-        .http
-        .delete(client.url(&format!(
+        .authenticated(client.http.delete(client.url(&format!(
             "/api/sandboxes/{}/fs/file{}",
             encode_segment(sandbox_id),
             encoded_absolute_path(SANDBOX_LOCK_FILE_PATH)?
-        )))
-        .bearer_auth(client.auth_token()?)
+        ))))?
         .send()
         .context("Failed to delete sandbox lock file")?;
     if response.status() == StatusCode::NOT_FOUND {
@@ -557,13 +550,11 @@ fn read_file_if_exists(
     path: &str,
 ) -> Result<Option<Vec<u8>>> {
     let response = client
-        .http
-        .get(client.url(&format!(
+        .authenticated(client.http.get(client.url(&format!(
             "/api/sandboxes/{}/fs/file{}",
             encode_segment(sandbox_id),
             encoded_absolute_path(path)?
-        )))
-        .bearer_auth(client.auth_token()?)
+        ))))?
         .send()
         .context("Failed to read sandbox file")?;
     if response.status() == StatusCode::NOT_FOUND {

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -117,16 +117,14 @@ pub(crate) fn calculate_sha256(path: &Path) -> Result<String> {
 
 pub(crate) fn request_upload_url(
     client: &Client,
-    token: &str,
+    token: Option<&str>,
     base_url: &str,
     sha256: &str,
     filename: &str,
 ) -> Result<UploadUrlResponse> {
     let url = format!("{}/api/scan/upload-url", base_url);
 
-    let response = client
-        .post(&url)
-        .bearer_auth(token)
+    let response = crate::auth::apply_bearer_auth(client.post(&url), token)
         .json(&UploadUrlRequest {
             sha256: sha256.to_string(),
             filename: filename.to_string(),
@@ -142,7 +140,7 @@ pub(crate) fn request_upload_url(
 
 pub(crate) fn process_local_pdf(
     client: &Client,
-    auth_token: &str,
+    auth_token: Option<&str>,
     file_path: &Path,
     file_sha256: Option<&str>,
     model: Option<&str>,
@@ -190,7 +188,7 @@ pub(crate) fn upload_pdf(client: &Client, upload_url: &str, file_path: &Path) ->
 
 pub(crate) fn request_process(
     client: &Client,
-    token: &str,
+    token: Option<&str>,
     base_url: &str,
     source_path: Option<&str>,
     source_url: Option<&str>,
@@ -202,9 +200,7 @@ pub(crate) fn request_process(
 
     let url = format!("{}/api/scan/process", base_url);
 
-    let response = client
-        .post(&url)
-        .bearer_auth(token)
+    let response = crate::auth::apply_bearer_auth(client.post(&url), token)
         .json(&ProcessRequest {
             source_path: source_path.map(ToOwned::to_owned),
             source_url: source_url.map(ToOwned::to_owned),
@@ -365,7 +361,7 @@ pub struct ScanArgs {
 pub fn execute(args: ScanArgs) -> Result<()> {
     let input = parse_scan_input(&args.input)?;
 
-    let token = crate::auth::get_valid_token()?;
+    let token = crate::auth::get_api_token()?;
     let (resolve_input, input_pdf_path) = match input {
         ScanInput::LocalPdf(file) => (
             crate::datasheet::ResolveDatasheetInput::PdfPath(file.clone()),
@@ -377,7 +373,7 @@ pub fn execute(args: ScanArgs) -> Result<()> {
         ),
     };
     let spinner = Spinner::builder("Resolving datasheet...").start();
-    let response = crate::datasheet::resolve_datasheet(&token, &resolve_input)?;
+    let response = crate::datasheet::resolve_datasheet(token.as_deref(), &resolve_input)?;
     let pdf_path = input_pdf_path
         .unwrap_or_else(|| PathBuf::from(&response.pdf_path))
         .display()

--- a/crates/pcb-ipc2581-tools/src/commands/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/bom.rs
@@ -73,12 +73,14 @@ pub fn execute(file: &Path, format: OutputFormat, offline: bool) -> Result<()> {
         let spinner = Spinner::builder(format!("{file_name}: Fetching availability")).start();
         let ctx = pcb_diode_api::WorkspaceContext::from_path(file);
 
-        let token = ctx
-            .token()
+        let token = pcb_diode_api::auth::get_api_token_with_context(&ctx)
             .context("Not authenticated. Run `pcb auth login` to authenticate.")?;
 
         if let Err(e) = pcb_diode_api::fetch_and_populate_availability_with_context(
-            &ctx, &token, &mut bom, false,
+            &ctx,
+            token.as_deref(),
+            &mut bom,
+            false,
         ) {
             log::warn!("Failed to fetch availability data: {}", e);
         }

--- a/crates/pcbc/src/bom.rs
+++ b/crates/pcbc/src/bom.rs
@@ -128,11 +128,14 @@ pub fn execute(args: BomArgs) -> Result<()> {
 
     if !args.offline {
         let ctx = pcb_diode_api::WorkspaceContext::from_path(&args.file);
-        match ctx.token() {
+        match pcb_diode_api::auth::get_api_token_with_context(&ctx) {
             Ok(token) => {
                 spinner.set_message(format!("{file_name}: Fetching availability"));
                 if let Err(e) = pcb_diode_api::fetch_and_populate_availability_with_context(
-                    &ctx, &token, &mut bom, strict,
+                    &ctx,
+                    token.as_deref(),
+                    &mut bom,
+                    strict,
                 ) {
                     log::warn!("Failed to fetch availability data: {}", e);
                 }

--- a/crates/pcbc/src/lsp.rs
+++ b/crates/pcbc/src/lsp.rs
@@ -18,8 +18,8 @@ fn handle_custom_request(
     }
 
     let input = pcb_diode_api::datasheet::parse_resolve_request(Some(params))?;
-    let token = pcb_diode_api::auth::get_valid_token()?;
-    let response = pcb_diode_api::datasheet::resolve_datasheet(&token, &input)?;
+    let token = pcb_diode_api::auth::get_api_token()?;
+    let response = pcb_diode_api::datasheet::resolve_datasheet(token.as_deref(), &input)?;
     Ok(Some(serde_json::to_value(response)?))
 }
 


### PR DESCRIPTION
`DIODE_API_TOKEN=` is ambiguous: empty could mean “unset”, “clear token”, or “send no auth”.