### PR TITLE
fix: document stdlib files from any workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `pcb doc @stdlib/...` now documents stdlib files from any workspace without treating the materialized stdlib as an ordinary workspace package.
+
 ## [0.4.4] - 2026-07-03
 
 ### Added

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -842,6 +842,9 @@ impl ResolutionResult {
                     {
                         Some((root_package.as_str(), resolution, root.as_os_str().len()))
                     }
+                    FrozenPackageIdentity::Stdlib => {
+                        Some((root_package.as_str(), resolution, root.as_os_str().len()))
+                    }
                     _ => None,
                 }
             })

--- a/crates/pcb-zen/src/package_resolver/resolve.rs
+++ b/crates/pcb-zen/src/package_resolver/resolve.rs
@@ -9,11 +9,11 @@ use anyhow::{Context, Result, bail};
 use ignore::WalkBuilder;
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::file_extensions;
-use pcb_zen_core::is_stdlib_module_path;
 use pcb_zen_core::resolution::{
     FrozenPackage, FrozenPackageIdentity, FrozenResolutionMap, FrozenResolutionSet,
     ResolutionResult, selected_remote_from_hydrated_manifest,
 };
+use pcb_zen_core::{STDLIB_MODULE_PATH, is_stdlib_module_path};
 use semver::Version;
 
 use super::ResolvedDepId;
@@ -33,6 +33,10 @@ enum PackageNode {
 
 pub fn target_package_urls_for_path(workspace: &WorkspaceInfo, path: &Path) -> Result<Vec<String>> {
     let path = path.canonicalize()?;
+    if path.starts_with(canonicalize(&workspace.workspace_stdlib_dir())) {
+        return Ok(vec![STDLIB_MODULE_PATH.to_string()]);
+    }
+
     if workspace.packages.is_empty() {
         return Ok(vec![STANDALONE_PACKAGE_URL.to_string()]);
     }
@@ -178,6 +182,16 @@ impl FrozenResolutionBuilder {
     }
 
     fn build(&mut self, package_url: &str) -> Result<FrozenResolutionMap> {
+        if is_stdlib_module_path(package_url) {
+            self.selected_remote.clear();
+            self.packages.clear();
+            self.add_stdlib_package()?;
+            return Ok(FrozenResolutionMap {
+                selected_remote: BTreeMap::new(),
+                packages: std::mem::take(&mut self.packages),
+            });
+        }
+
         self.selected_remote = selected_remote_from_hydrated_manifest(&self.workspace, package_url)
             .with_context(|| format!("while reading resolved closure for {}", package_url))?;
 
@@ -431,4 +445,64 @@ fn local_path_dependency_root(package_root: &Path, spec: &DependencySpec) -> Opt
         return None;
     };
     detail.path.as_ref().map(|path| package_root.join(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::WorkspacePackage;
+
+    fn workspace_with_package(root: &Path) -> WorkspaceInfo {
+        WorkspaceInfo {
+            root: root.to_path_buf(),
+            cache_dir: PathBuf::new(),
+            config: None,
+            packages: BTreeMap::from([(
+                "github.com/acme/pkg".to_string(),
+                WorkspacePackage {
+                    rel_path: PathBuf::from("pkg"),
+                    config: PcbToml::default(),
+                    version: None,
+                    published_at: None,
+                    preferred: false,
+                    dirty: false,
+                    entrypoints: Vec::new(),
+                    symbol_files: Vec::new(),
+                },
+            )]),
+            errors: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn stdlib_path_builds_stdlib_root_resolution() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let stdlib = root.join(".pcb/stdlib");
+        let pin_header = stdlib.join("generics/PinHeader.zen");
+        std::fs::create_dir_all(pin_header.parent().unwrap()).unwrap();
+        std::fs::write(&pin_header, "").unwrap();
+        let workspace = workspace_with_package(root);
+
+        let targets = target_package_urls_for_path(&workspace, &stdlib).unwrap();
+        assert_eq!(targets, vec![STDLIB_MODULE_PATH.to_string()]);
+
+        let frozen = build_frozen_resolution_maps(&workspace, targets, true).unwrap();
+        let stdlib_resolution = frozen
+            .get(STDLIB_MODULE_PATH)
+            .expect("stdlib root resolution should exist");
+        assert_eq!(stdlib_resolution.packages.len(), 1);
+
+        let package = stdlib_resolution
+            .packages
+            .get(&stdlib.canonicalize().unwrap())
+            .expect("stdlib package should be registered");
+        assert!(matches!(package.identity, FrozenPackageIdentity::Stdlib));
+
+        let resolution = ResolutionResult::frozen(workspace, frozen, HashMap::new());
+        let (root_package, _) = resolution
+            .frozen_root_for_file(&pin_header.canonicalize().unwrap())
+            .expect("stdlib files should select a frozen root package");
+        assert_eq!(root_package, STDLIB_MODULE_PATH);
+    }
 }


### PR DESCRIPTION
## Summary
- Treat materialized stdlib paths as stdlib targets during doc resolution.
- Preserve frozen root lookup for stdlib files so `pcb doc @stdlib/...` works from any workspace.
- Add a regression test covering stdlib target resolution and frozen root selection.

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to package/doc resolution for stdlib paths with a regression test; no auth, sync, or build pipeline changes.
> 
> **Overview**
> Fixes **`pcb doc @stdlib/...`** when run from workspaces that also contain packages under `.pcb/stdlib`, by treating materialized stdlib as the **`@stdlib`** root instead of a normal workspace member.
> 
> **`target_package_urls_for_path`** now maps paths under the workspace stdlib directory to **`STDLIB_MODULE_PATH`** only. **`FrozenResolutionBuilder::build`** short-circuits for that target and builds a frozen map with a single **`FrozenPackageIdentity::Stdlib`** entry. **`frozen_root_for_file`** includes stdlib-owned files when picking the frozen root, so doc/eval can set **`active_root_package`** correctly.
> 
> Adds a regression test for stdlib target resolution and frozen root selection; changelog entry under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eff26347523f1820fbcf606e78008f6bad26a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->