### PR TITLE
Never downgrade workspace dependency pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `pcb sync` no longer downgrades workspace dependency pins when local git tags are stale.
 - Gerber regions no longer connect holes with board-length cut-in slivers.
 - Reference designators derived from instance-name hints now honor 4-digit (1000-series) numbers such as `R1000`, `R1500`, and `LED1001` instead of silently auto-renumbering them.
 

--- a/crates/pcb-zen/src/package_resolver/mvs.rs
+++ b/crates/pcb-zen/src/package_resolver/mvs.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::cache_index::CacheIndex;
 use anyhow::{Context, Result};
 use pcb_zen_core::config::{DependencySpec, PcbToml};
-use pcb_zen_core::{initial_package_version, is_stdlib_module_path};
+use pcb_zen_core::{initial_package_version, is_stdlib_module_path, parse_relaxed_version};
 use semver::Version;
 
 use super::ResolvedDepId;
@@ -249,13 +249,17 @@ impl PackageResolver {
 
         let imported_workspace_floors = self.import_workspace_floors(&scanned)?;
 
-        self.run_remote_mvs(&scanned, &imported_workspace_floors)
-            .with_context(|| {
-                format!(
-                    "while resolving remote dependency closure for {}",
-                    package_url
-                )
-            })
+        self.run_remote_mvs(
+            &scanned,
+            &current_config.dependencies.direct,
+            &imported_workspace_floors,
+        )
+        .with_context(|| {
+            format!(
+                "while resolving remote dependency closure for {}",
+                package_url
+            )
+        })
     }
 
     fn populate_package_graph(
@@ -424,6 +428,7 @@ impl PackageResolver {
     fn run_remote_mvs(
         &mut self,
         scanned: &ScannedDirectDeps,
+        existing_direct: &BTreeMap<String, DependencySpec>,
         imported_workspace_floors: &BTreeMap<ResolvedDepId, Version>,
     ) -> Result<PackageResolution> {
         let mut selected = BTreeMap::<ResolvedDepId, Version>::new();
@@ -473,6 +478,7 @@ impl PackageResolver {
             direct: fold_direct_dependencies(
                 &self.workspace,
                 scanned,
+                existing_direct,
                 &selected,
                 &direct_remote_ids,
             )?,
@@ -505,6 +511,7 @@ impl PackageResolver {
 fn fold_direct_dependencies(
     workspace: &crate::WorkspaceInfo,
     scanned: &ScannedDirectDeps,
+    existing_direct: &BTreeMap<String, DependencySpec>,
     resolved_remote: &BTreeMap<ResolvedDepId, Version>,
     direct_remote_ids: &BTreeSet<ResolvedDepId>,
 ) -> Result<BTreeMap<String, DependencySpec>> {
@@ -526,7 +533,11 @@ fn fold_direct_dependencies(
     for module_path in &scanned.workspace {
         direct.insert(
             module_path.clone(),
-            DependencySpec::Version(workspace_package_version(workspace, module_path)?),
+            DependencySpec::Version(workspace_package_version(
+                workspace,
+                module_path,
+                existing_direct.get(module_path),
+            )?),
         );
     }
 
@@ -536,6 +547,7 @@ fn fold_direct_dependencies(
 fn workspace_package_version(
     workspace: &crate::WorkspaceInfo,
     package_url: &str,
+    existing_pin: Option<&DependencySpec>,
 ) -> Result<String> {
     let Some(pkg) = workspace.packages.get(package_url) else {
         anyhow::bail!(
@@ -543,10 +555,26 @@ fn workspace_package_version(
             package_url
         );
     };
-    Ok(pkg
+    let mut version = pkg
         .version
-        .clone()
-        .unwrap_or_else(|| initial_package_version().to_string()))
+        .as_deref()
+        .and_then(parse_relaxed_version)
+        .unwrap_or_else(initial_package_version);
+    // The tag-derived version lags reality whenever local tags haven't been
+    // fetched, so the existing manifest pin is a floor: sync never lowers it.
+    if let Some(pinned) = existing_pin.and_then(pinned_version) {
+        version = version.max(pinned);
+    }
+    Ok(version.to_string())
+}
+
+fn pinned_version(spec: &DependencySpec) -> Option<Version> {
+    match spec {
+        DependencySpec::Version(raw) => parse_relaxed_version(raw),
+        DependencySpec::Detailed(detail) => {
+            detail.version.as_deref().and_then(parse_relaxed_version)
+        }
+    }
 }
 
 fn merge_floor_version(

--- a/crates/pcb-zen/src/workspace.rs
+++ b/crates/pcb-zen/src/workspace.rs
@@ -238,15 +238,33 @@ pub fn get_workspace_info<F: FileProvider>(
     Ok(info)
 }
 
+/// Populate package `version` from the newest package tags merged into HEAD.
+/// Cheap subset of [`enrich_git_metadata`] for commands that only need
+/// versions (e.g. the workspace pins `pcb sync` writes back).
+#[instrument(name = "enrich_tag_versions", skip_all)]
+pub fn enrich_tag_versions(info: &mut WorkspaceInfo) {
+    apply_tag_versions(info);
+}
+
+/// For forked packages, version is already set from the fork path, so only
+/// update if we find a tag (don't overwrite with None).
+fn apply_tag_versions(info: &mut WorkspaceInfo) -> HashMap<String, PackageTagInfo> {
+    let all_tags = git::list_tags_merged_into(&info.root, "HEAD");
+    let latest_tags = latest_package_tags(info, &all_tags);
+    for (url, pkg) in info.packages.iter_mut() {
+        if let Some(tag_info) = latest_tags.get(url) {
+            pkg.version = Some(tag_info.version.to_string());
+        }
+    }
+    latest_tags
+}
+
 /// Populate package `version`, `published_at`, and `dirty` from git tags and
 /// working-tree status. Runs several git commands, so it is opt-in for the
 /// commands that actually display this metadata.
 #[instrument(name = "enrich_git_metadata", skip_all)]
 pub fn enrich_git_metadata(info: &mut WorkspaceInfo) {
-    // For forked packages, version is already set from the fork path, so only
-    // update if we find a tag (don't overwrite with None)
-    let all_tags = git::list_tags_merged_into(&info.root, "HEAD");
-    let latest_tags = latest_package_tags(info, &all_tags);
+    let latest_tags = apply_tag_versions(info);
     let workspace_subpath = git::get_repo_subpath(&info.root).ok().flatten();
 
     let latest_tag_names: Vec<_> = latest_tags.values().map(|info| info.tag.clone()).collect();
@@ -267,7 +285,6 @@ pub fn enrich_git_metadata(info: &mut WorkspaceInfo) {
 
     for (url, pkg) in info.packages.iter_mut() {
         if let Some(tag_info) = latest_tags.get(url) {
-            pkg.version = Some(tag_info.version.to_string());
             pkg.published_at = tag_metadata
                 .get(&tag_info.tag)
                 .map(|metadata| metadata.timestamp.clone());

--- a/crates/pcbc/src/mod/mod.rs
+++ b/crates/pcbc/src/mod/mod.rs
@@ -13,7 +13,7 @@ use pcb_zen::package_resolver::{
 use pcb_zen::resolve::VendorPlan;
 use pcb_zen::resolve::ensure_package_manifest_in_cache;
 use pcb_zen::tags;
-use pcb_zen::workspace::get_workspace_info;
+use pcb_zen::workspace::{enrich_tag_versions, get_workspace_info};
 use pcb_zen_core::DefaultFileProvider;
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::is_stdlib_module_path;
@@ -81,10 +81,18 @@ pub struct ModResolveArgs {
     pub path: Option<PathBuf>,
 }
 
+/// Load and validate the workspace for `pcb mod` / `pcb sync`, with package
+/// versions from git tags: they feed the workspace pins written to pcb.toml.
+fn load_workspace(start_path: &Path) -> Result<WorkspaceInfo> {
+    let mut workspace = get_workspace_info(&DefaultFileProvider::new(), start_path)?;
+    enrich_tag_versions(&mut workspace);
+    validate_workspace(&workspace)?;
+    Ok(workspace)
+}
+
 pub fn execute_mod_add(args: ModAddArgs) -> Result<()> {
     let cwd = std::env::current_dir()?;
-    let workspace = get_workspace_info(&DefaultFileProvider::new(), &cwd)?;
-    validate_workspace(&workspace)?;
+    let workspace = load_workspace(&cwd)?;
 
     let Some(target) = discover_package_target(&workspace, &cwd) else {
         bail!("must be run from a package directory.");
@@ -107,8 +115,7 @@ pub fn execute_sync(args: SyncArgs) -> Result<()> {
 }
 
 pub(crate) fn execute_sync_from(cwd: &Path, args: SyncArgs) -> Result<()> {
-    let workspace = get_workspace_info(&DefaultFileProvider::new(), cwd)?;
-    validate_workspace(&workspace)?;
+    let workspace = load_workspace(cwd)?;
 
     // --check always verifies the whole workspace, regardless of cwd.
     let scope = if args.check { &workspace.root } else { cwd };
@@ -130,8 +137,7 @@ pub(crate) fn execute_sync_from(cwd: &Path, args: SyncArgs) -> Result<()> {
 
 pub fn execute_mod_download(args: ModDownloadArgs) -> Result<()> {
     let cwd = std::env::current_dir()?;
-    let workspace = get_workspace_info(&DefaultFileProvider::new(), &cwd)?;
-    validate_workspace(&workspace)?;
+    let workspace = load_workspace(&cwd)?;
     ensure_workspace_cache_symlink(&workspace.root)?;
 
     if let Some(dependency) = args.dependency {
@@ -179,8 +185,7 @@ pub fn execute_mod_graph(_args: ModGraphArgs) -> Result<()> {
 pub fn execute_mod_resolve(args: ModResolveArgs) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let path = args.path.as_deref().unwrap_or(&cwd);
-    let workspace = get_workspace_info(&DefaultFileProvider::new(), path)?;
-    validate_workspace(&workspace)?;
+    let workspace = load_workspace(path)?;
 
     let package_urls = target_package_urls_for_path(&workspace, path)?;
     let resolutions = build_frozen_resolution_maps(&workspace, package_urls.clone(), false)?;
@@ -203,8 +208,7 @@ fn load_target_manifest(target: &AddTarget) -> Result<PcbToml> {
 
 fn load_single_target_workspace(command_name: &str) -> Result<(WorkspaceInfo, AddTarget)> {
     let cwd = std::env::current_dir()?;
-    let workspace = get_workspace_info(&DefaultFileProvider::new(), &cwd)?;
-    validate_workspace(&workspace)?;
+    let workspace = load_workspace(&cwd)?;
 
     let Some(target) = discover_package_target(&workspace, &cwd) else {
         bail!("`{command_name}` must be run from a package directory, not the workspace root.");

--- a/crates/pcbc/tests/sync.rs
+++ b/crates/pcbc/tests/sync.rs
@@ -458,6 +458,56 @@ P1 = io(Net)
     );
 }
 
+/// Workspace with a `libs/Helper` package tagged `v1.2.3`; returns the board
+/// pin for Helper after syncing a board whose manifest ends with `board_deps`.
+fn sync_tagged_helper_workspace(board_deps: &str) -> String {
+    let mut sandbox = Sandbox::new();
+    sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.4"
+repository = "github.com/example/demo"
+"#,
+        )
+        .write("libs/Helper/pcb.toml", "[dependencies]\n")
+        .write("libs/Helper/Helper.zen", "P1 = io(Net)\n")
+        .write(
+            "boards/Main/pcb.toml",
+            format!("[board]\nname = \"Main\"\npath = \"Main.zen\"\n{board_deps}"),
+        )
+        .write(
+            "boards/Main/Main.zen",
+            r#"
+Helper = Module("github.com/example/demo/libs/Helper/Helper.zen")
+
+Helper(name = "H", P1 = Net("P1"))
+"#,
+        )
+        .init_git()
+        .commit("init")
+        .tag("libs/Helper/v1.2.3")
+        .sync();
+
+    let board_pcb_toml = read_sandbox_file(&sandbox, "boards/Main/pcb.toml");
+    hydrated_version(&board_pcb_toml, "libs/Helper")
+}
+
+#[test]
+fn test_sync_pins_workspace_dependency_to_latest_tag() {
+    assert_eq!(sync_tagged_helper_workspace(""), "1.2.3");
+}
+
+#[test]
+fn test_sync_never_downgrades_workspace_pin() {
+    // A pin newer than the local tags means the tags simply haven't been
+    // fetched; sync must keep the pin rather than downgrade it.
+    let pin = sync_tagged_helper_workspace(
+        "\n[dependencies]\n\"github.com/example/demo/libs/Helper\" = \"2.0.0\"\n",
+    );
+    assert_eq!(pin, "2.0.0");
+}
+
 #[test]
 fn test_sync_preserves_pinned_dependency_version() {
     let mut sandbox = Sandbox::new();


### PR DESCRIPTION
This can happen if new pcb.toml manifests are fetched but not the tags. Should fix https://diodeinc.slack.com/archives/C08UH053Q5R/p1783299623954389.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency pin writeback during sync/mod resolution; behavior is conservative (semver max only) but affects manifest hydration across workspaces.
> 
> **Overview**
> **`pcb sync`** and related **`pcb mod`** commands now treat existing workspace dependency versions in **`pcb.toml`** as a **floor**: when hydrating pins for workspace packages, the written version is the **maximum** of the tag-derived version and what is already declared, so stale local git tags cannot lower a newer pin.
> 
> Resolution passes the target package’s current **`[dependencies]`** into MVS fold logic; workspace package versions are enriched from **git tags merged into HEAD** via a new **`enrich_tag_versions`** path (lighter than full git metadata) used when loading the workspace for sync/mod.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cda1f4d77dad5986f5acb8a5c696641e76989ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->