### PR TITLE
Add read-only `pcb order` command group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New read-only `pcb order` command group (`list`, `show`, `bom`) for inspecting a
+  board's fabrication orders. Board identity resolves from `workspace.repository`
+  and is overridable with `--workspace`/`--board`. `pcb order bom` joins the order's
+  offer selections with the BOM (order override beats line default), supports
+  `--mismatches-only`, and all subcommands support `-f table|json`.
+
 ### Changed
 
 - `--layout-target` now takes `board` or `board-array` on every command, and defaults to `board-array`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - New read-only `pcb order` command group (`list`, `show`, `bom`) for inspecting a
-  board's fabrication orders. Board identity resolves from `workspace.repository`
-  and is overridable with `--workspace`/`--board`. `pcb order bom` joins the order's
-  offer selections with the BOM (order override beats line default), supports
-  `--mismatches-only`, and all subcommands support `-f table|json`.
+  board's fabrication orders. Board identity resolves from `workspace.name` and
+  `workspace.repository` and is overridable with `--workspace`/`--board`. `pcb order
+  bom` joins the order's offer selections with the BOM (order override beats line
+  default), supports `--mismatches-only`, and all subcommands support `-f table|json`.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,6 +4171,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "comfy-table",
  "crossterm",
  "dirs",
  "fslock",

--- a/README.md
+++ b/README.md
@@ -183,6 +183,22 @@ pcb layout <FILE>                            # Generate layout files
 pcb import <KICAD_SCH|KICAD_PRO> <OUTPUT_DIR> # Import a KiCad schematic or project
 ```
 
+### Orders (read-only)
+
+Inspect fabrication orders for a board. The board identity is resolved from
+`workspace.repository` and can be overridden with `--workspace <slug>` and
+`--board <name>`. All subcommands accept `-f table|json` (default `table`).
+
+```bash
+pcb order list
+pcb order show <ORDER_ID>
+pcb order bom <ORDER_ID>
+pcb order bom <ORDER_ID> --mismatches-only
+```
+
+For `pcb order bom`, an order selection overrides the BOM line default; lines
+without either have no effective selection. JSON output includes full offer detail.
+
 Run `pcb help` or `pcb help <command>` for the full command reference.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ pcb import <KICAD_SCH|KICAD_PRO> <OUTPUT_DIR> # Import a KiCad schematic or proj
 ### Orders (read-only)
 
 Inspect fabrication orders for a board. The board identity is resolved from
-`workspace.repository` and can be overridden with `--workspace <slug>` and
-`--board <name>`. All subcommands accept `-f table|json` (default `table`).
+`workspace.name` (when set) and `workspace.repository`, and can be overridden
+with `--workspace <slug>` and `--board <name>`. All subcommands accept
+`-f table|json` (default `table`).
 
 ```bash
 pcb order list

--- a/crates/pcb-diode-api/Cargo.toml
+++ b/crates/pcb-diode-api/Cargo.toml
@@ -18,6 +18,7 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
+comfy-table = { workspace = true }
 crossterm = { workspace = true }
 dirs = { workspace = true }
 fslock = { workspace = true }

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -11,6 +11,7 @@ mod download_support;
 mod endpoint;
 mod git_auth;
 pub mod kicad_symbols;
+pub mod order;
 pub mod registry;
 pub mod release;
 pub mod routing;
@@ -29,6 +30,7 @@ pub use component_api::{ComponentArgs, execute_component};
 pub use diode_uri::{DiodeUri, DiodeUriParseError, SandboxFileUri, is_diode_uri};
 pub use endpoint::WorkspaceContext;
 pub use kicad_symbols::KicadSymbolsClient;
+pub use order::{OrderArgs, OrderCommand, execute as execute_order};
 pub use registry::{
     DigikeyClassifications, DigikeyData, DigikeyPriceBreak, ModuleRelations, ParsedQuery,
     RegistryClient, RegistryInfo, RegistryModule, RegistryModuleDependency,

--- a/crates/pcb-diode-api/src/order.rs
+++ b/crates/pcb-diode-api/src/order.rs
@@ -1,0 +1,982 @@
+//! Read-only `pcb order` command group.
+//!
+//! Three subcommands, all backed by existing authenticated API endpoints:
+//!
+//! * `pcb order list`            -> `GET /api/boards/:workspace/:name/orders`
+//! * `pcb order show <id>`       -> `GET /api/boards/:workspace/:name/orders/:orderId`
+//! * `pcb order bom  <id>`       -> `GET /api/boms/:bomId` joined with
+//!   `GET /api/boards/:workspace/:name/orders/:orderId/selections`
+//!
+//! Board identity is resolved from the workspace config (`workspace.repository`,
+//! e.g. `code.diode.computer/demo/b/DM0002` -> workspace `demo`, board `DM0002`),
+//! and can be overridden with `--workspace`/`--board`.
+//!
+//! All subcommands are strictly read-only. Order-mutating flows (create, select)
+//! deliberately live in a separate change.
+
+use anyhow::{Result, anyhow, bail};
+use clap::{Args, Subcommand, ValueEnum};
+use colored::Colorize;
+use comfy_table::{Cell, ContentArrangement, Table, presets};
+use reqwest::StatusCode;
+use reqwest::blocking::{Client, Response};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use crate::auth::get_valid_token;
+use crate::get_api_base_url;
+
+// ---------------------------------------------------------------------------
+// Board identity resolution
+// ---------------------------------------------------------------------------
+
+/// A resolved (`workspace`, `board`) pair used to build API paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoardIdentity {
+    pub workspace: String,
+    pub board: String,
+}
+
+/// Parse a workspace `repository` string into `(workspace, board)`.
+///
+/// The board repository format is `<host>/<workspace>/b/<board>`, e.g.
+/// `code.diode.computer/demo/b/DM0002` -> `("demo", "DM0002")`. We anchor on the
+/// `b` marker so that hosts with extra path segments still resolve correctly.
+///
+/// Returns `None` when the string does not describe a board repository.
+pub fn parse_board_repository(repository: &str) -> Option<(String, String)> {
+    let segments: Vec<&str> = repository.split('/').filter(|s| !s.is_empty()).collect();
+    let b_idx = segments.iter().position(|s| *s == "b")?;
+    // Need a segment before ("workspace") and after ("board") the `b` marker.
+    if b_idx == 0 {
+        return None;
+    }
+    let workspace = *segments.get(b_idx - 1)?;
+    let board = *segments.get(b_idx + 1)?;
+    if workspace.is_empty() || board.is_empty() {
+        return None;
+    }
+    Some((workspace.to_string(), board.to_string()))
+}
+
+/// Resolve the board identity from the workspace repository plus optional
+/// `--workspace`/`--board` overrides.
+///
+/// Flags take precedence over the inferred values. When neither flags nor the
+/// workspace repository provide a value, we fail with a clear, actionable error.
+pub fn resolve_board_identity(
+    repository: Option<&str>,
+    workspace_flag: Option<&str>,
+    board_flag: Option<&str>,
+) -> Result<BoardIdentity> {
+    let parsed = repository.and_then(parse_board_repository);
+
+    let workspace = workspace_flag
+        .map(str::to_string)
+        .or_else(|| parsed.as_ref().map(|(w, _)| w.clone()));
+    let board = board_flag
+        .map(str::to_string)
+        .or_else(|| parsed.as_ref().map(|(_, b)| b.clone()));
+
+    match (workspace, board) {
+        (Some(workspace), Some(board)) => Ok(BoardIdentity { workspace, board }),
+        _ => bail!(
+            "Could not determine which board to use.\n\
+             Run this command from inside a board workspace (see `pcb info`), \
+             or pass both --workspace <slug> and --board <name>."
+        ),
+    }
+}
+
+/// Read the current workspace repository (if any) starting from the CWD.
+///
+/// Any discovery error is swallowed to `None` so that explicit
+/// `--workspace`/`--board` flags keep working outside a workspace.
+fn current_workspace_repository() -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    let file_provider = pcb_zen_core::DefaultFileProvider::new();
+    let ws = pcb_zen::get_workspace_info(&file_provider, &cwd).ok()?;
+    ws.repository().map(|s| s.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// MPN normalization (mirrors backend `normalizeBomLookupMpn`)
+// ---------------------------------------------------------------------------
+
+/// Normalize an MPN for comparison: trim, uppercase, then strip every character
+/// except `A-Z`, `0-9`, and `.`.
+///
+/// This mirrors the backend's `normalizeBomLookupMpn` so that mismatch detection
+/// on the client agrees with server-side matching.
+pub fn normalize_bom_lookup_mpn(mpn: &str) -> String {
+    mpn.trim()
+        .to_uppercase()
+        .chars()
+        .filter(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || *c == '.')
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// API response models
+// ---------------------------------------------------------------------------
+
+/// A single order as returned by the list endpoint.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderSummary {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub quantity: Option<i64>,
+    #[serde(default)]
+    pub release_version: Option<String>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+}
+
+/// A quote summary attached to an order, when present.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteSummary {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub currency: Option<String>,
+    #[serde(default)]
+    pub unit_price: Option<f64>,
+    #[serde(default)]
+    pub total: Option<f64>,
+    #[serde(default)]
+    pub lead_time_days: Option<i64>,
+}
+
+/// A single entry in an order's status timeline.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineEntry {
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub timestamp: Option<String>,
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+/// The full order detail as returned by the show endpoint.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderDetail {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub quantity: Option<i64>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub release_id: Option<String>,
+    #[serde(default)]
+    pub release_version: Option<String>,
+    #[serde(default)]
+    pub bom_id: Option<String>,
+    #[serde(default)]
+    pub quote: Option<QuoteSummary>,
+    #[serde(default)]
+    pub timeline: Vec<TimelineEntry>,
+    #[serde(default)]
+    pub shipping_location_id: Option<String>,
+}
+
+/// A declared alternative part on a BOM line.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Alternative {
+    #[serde(default)]
+    pub mpn: Option<String>,
+    #[serde(default)]
+    pub manufacturer: Option<String>,
+}
+
+/// A candidate distributor offer for a BOM line.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Offer {
+    pub id: String,
+    #[serde(default)]
+    pub mpn: Option<String>,
+    #[serde(default)]
+    pub manufacturer: Option<String>,
+    #[serde(default)]
+    pub distributor: Option<String>,
+    #[serde(default)]
+    pub stock: Option<i64>,
+    #[serde(default)]
+    pub price: Option<f64>,
+}
+
+/// A single line of a BOM as returned by `GET /api/boms/:bomId`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BomLine {
+    pub id: String,
+    #[serde(default)]
+    pub mpn: Option<String>,
+    #[serde(default)]
+    pub manufacturer: Option<String>,
+    #[serde(default)]
+    pub package: Option<String>,
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub designator: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub alternatives: Vec<Alternative>,
+    #[serde(default)]
+    pub match_status: Option<String>,
+    #[serde(default)]
+    pub offers: Vec<Offer>,
+    #[serde(default)]
+    pub selected_offer_id: Option<String>,
+}
+
+/// The BOM document returned by `GET /api/boms/:bomId`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bom {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub lines: Vec<BomLine>,
+}
+
+// ---------------------------------------------------------------------------
+// Joined `order bom` output model
+// ---------------------------------------------------------------------------
+
+/// Where the effective selection for a BOM line came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SelectionSource {
+    /// The order's selections map overrode the line default.
+    OrderOverride,
+    /// The line's own `selectedOfferId` default was used.
+    Default,
+    /// Neither an override nor a default was present.
+    None,
+}
+
+/// The design-side view of a BOM line.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DesignEntry {
+    pub mpn: Option<String>,
+    pub manufacturer: Option<String>,
+    pub package: Option<String>,
+    pub value: Option<String>,
+    pub designator: Option<String>,
+    pub path: Option<String>,
+    pub alternatives: Vec<Alternative>,
+}
+
+/// One fully joined BOM line: design entry + candidate offers + effective selection.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderBomRow {
+    pub bom_line_id: String,
+    pub design: DesignEntry,
+    pub match_status: Option<String>,
+    pub offers: Vec<Offer>,
+    pub selected_offer_id: Option<String>,
+    pub selection_source: SelectionSource,
+    pub selected_mpn: Option<String>,
+    pub selected_manufacturer: Option<String>,
+}
+
+impl OrderBomRow {
+    /// True when both the design MPN and selected MPN are present and differ
+    /// under [`normalize_bom_lookup_mpn`]. Lines with no selection or no design
+    /// MPN are never mismatches.
+    pub fn is_mpn_mismatch(&self) -> bool {
+        match (self.design.mpn.as_deref(), self.selected_mpn.as_deref()) {
+            (Some(design), Some(selected)) => {
+                normalize_bom_lookup_mpn(design) != normalize_bom_lookup_mpn(selected)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// The full `order bom` report, serialized in JSON mode.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderBomReport {
+    pub order_id: String,
+    pub bom_id: String,
+    pub rows: Vec<OrderBomRow>,
+}
+
+/// Resolve the BOM id an order points at, failing clearly when the order has no BOM.
+pub fn resolve_order_bom_id(order: &OrderDetail) -> Result<&str> {
+    order
+        .bom_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow!("Order '{}' has no BOM.", order.id))
+}
+
+/// Join a BOM with the order's selections map into per-line rows.
+///
+/// Effective selection precedence per line:
+/// 1. `selections[bomLineId]` (order override), else
+/// 2. `line.selectedOfferId` (default), else
+/// 3. none.
+///
+/// This is a pure function so the join precedence can be tested directly.
+pub fn build_order_bom_rows(bom: &Bom, selections: &BTreeMap<String, String>) -> Vec<OrderBomRow> {
+    bom.lines
+        .iter()
+        .map(|line| {
+            let (selected_offer_id, selection_source) = match selections.get(&line.id) {
+                Some(offer_id) => (Some(offer_id.clone()), SelectionSource::OrderOverride),
+                None => match &line.selected_offer_id {
+                    Some(offer_id) => (Some(offer_id.clone()), SelectionSource::Default),
+                    None => (None, SelectionSource::None),
+                },
+            };
+
+            // Resolve the selected offer (if any) to convenience MPN/manufacturer.
+            let selected_offer = selected_offer_id
+                .as_deref()
+                .and_then(|id| line.offers.iter().find(|o| o.id == id));
+
+            OrderBomRow {
+                bom_line_id: line.id.clone(),
+                design: DesignEntry {
+                    mpn: line.mpn.clone(),
+                    manufacturer: line.manufacturer.clone(),
+                    package: line.package.clone(),
+                    value: line.value.clone(),
+                    designator: line.designator.clone(),
+                    path: line.path.clone(),
+                    alternatives: line.alternatives.clone(),
+                },
+                match_status: line.match_status.clone(),
+                offers: line.offers.clone(),
+                selected_mpn: selected_offer.and_then(|o| o.mpn.clone()),
+                selected_manufacturer: selected_offer.and_then(|o| o.manufacturer.clone()),
+                selected_offer_id,
+                selection_source,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client + error handling
+// ---------------------------------------------------------------------------
+
+fn create_client() -> Result<Client> {
+    Client::builder()
+        .user_agent(format!("diode-pcb/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs(60))
+        .build()
+        .map_err(|e| anyhow!("Failed to create HTTP client: {e}"))
+}
+
+/// Describes what a request was fetching, so 404s can be disambiguated.
+struct RequestTarget<'a> {
+    workspace: &'a str,
+    board: &'a str,
+    order_id: Option<&'a str>,
+    bom_id: Option<&'a str>,
+}
+
+/// Extract a human-readable `error` message from a JSON error body, if any.
+fn extract_error_message(body: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()?
+        .get("error")?
+        .as_str()
+        .map(String::from)
+}
+
+/// Map a non-success HTTP response into a uniform, actionable error.
+fn map_error_response(resp: Response, target: &RequestTarget) -> anyhow::Error {
+    let status = resp.status();
+    let body = resp.text().unwrap_or_default();
+    let msg = extract_error_message(&body).unwrap_or_default();
+
+    match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+            anyhow!("Not authorized. Run `pcb auth login` to authenticate.")
+        }
+        StatusCode::NOT_FOUND => {
+            let lower = msg.to_lowercase();
+            if let Some(bom_id) = target.bom_id
+                && lower.contains("bom")
+            {
+                return anyhow!("BOM '{bom_id}' not found.");
+            }
+            match target.order_id {
+                // Order-scoped request: could be an unknown board or unknown order.
+                Some(order_id) => {
+                    if lower.contains("board") {
+                        anyhow!(
+                            "Board '{}' not found in workspace '{}'.",
+                            target.board,
+                            target.workspace
+                        )
+                    } else {
+                        anyhow!(
+                            "Order '{order_id}' not found for board '{}' in workspace '{}'.",
+                            target.board,
+                            target.workspace
+                        )
+                    }
+                }
+                // Board-scoped request: the board must be unknown.
+                None => anyhow!(
+                    "Board '{}' not found in workspace '{}'.",
+                    target.board,
+                    target.workspace
+                ),
+            }
+        }
+        other => {
+            if msg.is_empty() {
+                anyhow!("Diode API request failed ({other}).")
+            } else {
+                anyhow!("Diode API request failed ({other}): {msg}")
+            }
+        }
+    }
+}
+
+/// Perform a GET request and return the response body as text, mapping errors.
+fn get_text(client: &Client, token: &str, url: &str, target: &RequestTarget) -> Result<String> {
+    let resp = client
+        .get(url)
+        .bearer_auth(token)
+        .send()
+        .map_err(|e| anyhow!("Network error contacting Diode API: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(map_error_response(resp, target));
+    }
+
+    resp.text()
+        .map_err(|e| anyhow!("Failed to read Diode API response: {e}"))
+}
+
+/// Fetch the orders list for a board.
+pub fn fetch_orders(
+    client: &Client,
+    token: &str,
+    identity: &BoardIdentity,
+) -> Result<Vec<OrderSummary>> {
+    let url = format!(
+        "{}/api/boards/{}/{}/orders",
+        get_api_base_url(),
+        urlencoding::encode(&identity.workspace),
+        urlencoding::encode(&identity.board),
+    );
+    let target = RequestTarget {
+        workspace: &identity.workspace,
+        board: &identity.board,
+        order_id: None,
+        bom_id: None,
+    };
+    let body = get_text(client, token, &url, &target)?;
+    parse_orders_list(&body)
+}
+
+/// Fetch a single order's detail.
+pub fn fetch_order(
+    client: &Client,
+    token: &str,
+    identity: &BoardIdentity,
+    order_id: &str,
+) -> Result<OrderDetail> {
+    let url = format!(
+        "{}/api/boards/{}/{}/orders/{}",
+        get_api_base_url(),
+        urlencoding::encode(&identity.workspace),
+        urlencoding::encode(&identity.board),
+        urlencoding::encode(order_id),
+    );
+    let target = RequestTarget {
+        workspace: &identity.workspace,
+        board: &identity.board,
+        order_id: Some(order_id),
+        bom_id: None,
+    };
+    let body = get_text(client, token, &url, &target)?;
+    serde_json::from_str(&body).map_err(|e| anyhow!("Failed to parse order response: {e}"))
+}
+
+/// Fetch a BOM document by id.
+pub fn fetch_bom(
+    client: &Client,
+    token: &str,
+    identity: &BoardIdentity,
+    order_id: &str,
+    bom_id: &str,
+) -> Result<Bom> {
+    let url = format!(
+        "{}/api/boms/{}",
+        get_api_base_url(),
+        urlencoding::encode(bom_id),
+    );
+    let target = RequestTarget {
+        workspace: &identity.workspace,
+        board: &identity.board,
+        order_id: Some(order_id),
+        bom_id: Some(bom_id),
+    };
+    let body = get_text(client, token, &url, &target)?;
+    serde_json::from_str(&body).map_err(|e| anyhow!("Failed to parse BOM response: {e}"))
+}
+
+/// Fetch the order's selections map (`{bomLineId -> offerId}`).
+pub fn fetch_selections(
+    client: &Client,
+    token: &str,
+    identity: &BoardIdentity,
+    order_id: &str,
+) -> Result<BTreeMap<String, String>> {
+    let url = format!(
+        "{}/api/boards/{}/{}/orders/{}/selections",
+        get_api_base_url(),
+        urlencoding::encode(&identity.workspace),
+        urlencoding::encode(&identity.board),
+        urlencoding::encode(order_id),
+    );
+    let target = RequestTarget {
+        workspace: &identity.workspace,
+        board: &identity.board,
+        order_id: Some(order_id),
+        bom_id: None,
+    };
+    let body = get_text(client, token, &url, &target)?;
+    parse_selections(&body)
+}
+
+/// Parse the orders list response, tolerating either a bare array or an object
+/// with an `orders` array.
+fn parse_orders_list(body: &str) -> Result<Vec<OrderSummary>> {
+    let value: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| anyhow!("Failed to parse orders response: {e}"))?;
+    let array = if value.is_array() {
+        value
+    } else {
+        value
+            .get("orders")
+            .cloned()
+            .ok_or_else(|| anyhow!("Unexpected orders response shape"))?
+    };
+    serde_json::from_value(array).map_err(|e| anyhow!("Failed to parse orders response: {e}"))
+}
+
+/// Parse the selections response, tolerating either a bare map or an object with
+/// a `selections` map.
+fn parse_selections(body: &str) -> Result<BTreeMap<String, String>> {
+    let value: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| anyhow!("Failed to parse selections response: {e}"))?;
+    let map = value.get("selections").cloned().unwrap_or(value);
+    if map.is_null() {
+        return Ok(BTreeMap::new());
+    }
+    serde_json::from_value(map).map_err(|e| anyhow!("Failed to parse selections response: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+const NONE: &str = "—";
+
+fn opt(value: &Option<String>) -> &str {
+    value.as_deref().filter(|s| !s.is_empty()).unwrap_or(NONE)
+}
+
+fn opt_i64(value: Option<i64>) -> String {
+    value.map(|v| v.to_string()).unwrap_or_else(|| NONE.into())
+}
+
+fn fmt_price(currency: Option<&str>, price: Option<f64>) -> String {
+    match price {
+        Some(p) => match currency {
+            Some(c) if !c.is_empty() => format!("{p:.2} {c}"),
+            _ => format!("${p:.2}"),
+        },
+        None => NONE.into(),
+    }
+}
+
+/// Render a date-ish string, trimming an ISO timestamp to `YYYY-MM-DD HH:MM` when possible.
+fn fmt_date(value: &Option<String>) -> String {
+    let Some(raw) = value.as_deref().filter(|s| !s.is_empty()) else {
+        return NONE.into();
+    };
+    match chrono::DateTime::parse_from_rfc3339(raw) {
+        Ok(dt) => dt.format("%Y-%m-%d %H:%M").to_string(),
+        Err(_) => raw.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Renderers
+// ---------------------------------------------------------------------------
+
+fn render_orders_table(orders: &[OrderSummary]) {
+    if orders.is_empty() {
+        println!("No orders found.");
+        return;
+    }
+
+    let mut table = Table::new();
+    table
+        .load_preset(presets::UTF8_FULL_CONDENSED)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec![
+        Cell::new("ID"),
+        Cell::new("Name"),
+        Cell::new("Status"),
+        Cell::new("Qty"),
+        Cell::new("Release"),
+        Cell::new("Provider"),
+        Cell::new("Created"),
+    ]);
+
+    for o in orders {
+        table.add_row(vec![
+            Cell::new(&o.id),
+            Cell::new(opt(&o.name)),
+            Cell::new(opt(&o.status)),
+            Cell::new(opt_i64(o.quantity)),
+            Cell::new(opt(&o.release_version)),
+            Cell::new(opt(&o.provider)),
+            Cell::new(fmt_date(&o.created_at)),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+fn render_order_detail(order: &OrderDetail) {
+    let mut table = Table::new();
+    table
+        .load_preset(presets::UTF8_BORDERS_ONLY)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+
+    table.add_row(vec![Cell::new("ID"), Cell::new(&order.id)]);
+    table.add_row(vec![Cell::new("Name"), Cell::new(opt(&order.name))]);
+    table.add_row(vec![Cell::new("Status"), Cell::new(opt(&order.status))]);
+    table.add_row(vec![
+        Cell::new("Quantity"),
+        Cell::new(opt_i64(order.quantity)),
+    ]);
+    table.add_row(vec![Cell::new("Provider"), Cell::new(opt(&order.provider))]);
+    table.add_row(vec![
+        Cell::new("Created"),
+        Cell::new(fmt_date(&order.created_at)),
+    ]);
+    table.add_row(vec![
+        Cell::new("Release ID"),
+        Cell::new(opt(&order.release_id)),
+    ]);
+    table.add_row(vec![
+        Cell::new("Release Version"),
+        Cell::new(opt(&order.release_version)),
+    ]);
+    table.add_row(vec![Cell::new("BOM ID"), Cell::new(opt(&order.bom_id))]);
+    table.add_row(vec![
+        Cell::new("Shipping Location ID"),
+        Cell::new(opt(&order.shipping_location_id)),
+    ]);
+
+    println!("{}", "Order".bold());
+    println!("{table}");
+
+    if let Some(quote) = &order.quote {
+        println!();
+        println!("{}", "Quote".bold());
+        let mut q = Table::new();
+        q.load_preset(presets::UTF8_BORDERS_ONLY)
+            .set_content_arrangement(ContentArrangement::Dynamic);
+        q.add_row(vec![Cell::new("Quote ID"), Cell::new(opt(&quote.id))]);
+        q.add_row(vec![Cell::new("Status"), Cell::new(opt(&quote.status))]);
+        q.add_row(vec![
+            Cell::new("Unit Price"),
+            Cell::new(fmt_price(quote.currency.as_deref(), quote.unit_price)),
+        ]);
+        q.add_row(vec![
+            Cell::new("Total"),
+            Cell::new(fmt_price(quote.currency.as_deref(), quote.total)),
+        ]);
+        q.add_row(vec![
+            Cell::new("Lead Time (days)"),
+            Cell::new(opt_i64(quote.lead_time_days)),
+        ]);
+        println!("{q}");
+    }
+
+    if !order.timeline.is_empty() {
+        println!();
+        println!("{}", "Timeline".bold());
+        let mut t = Table::new();
+        t.load_preset(presets::UTF8_FULL_CONDENSED)
+            .set_content_arrangement(ContentArrangement::Dynamic);
+        t.set_header(vec![
+            Cell::new("Status"),
+            Cell::new("When"),
+            Cell::new("Note"),
+        ]);
+        for entry in &order.timeline {
+            t.add_row(vec![
+                Cell::new(opt(&entry.status)),
+                Cell::new(fmt_date(&entry.timestamp)),
+                Cell::new(opt(&entry.note)),
+            ]);
+        }
+        println!("{t}");
+    }
+}
+
+fn render_order_bom_table(report: &OrderBomReport) {
+    if report.rows.is_empty() {
+        println!("No BOM lines found.");
+        return;
+    }
+
+    let mut table = Table::new();
+    table
+        .load_preset(presets::UTF8_FULL_CONDENSED)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+    // Compact row: full offer detail is reserved for JSON mode.
+    table.set_header(vec![
+        Cell::new("Designator"),
+        Cell::new("Design MPN"),
+        Cell::new("Selected MPN"),
+        Cell::new("Match"),
+        Cell::new("Selection"),
+    ]);
+
+    for row in &report.rows {
+        let designator = row
+            .design
+            .designator
+            .clone()
+            .or_else(|| row.design.path.clone());
+        let selection = match row.selection_source {
+            SelectionSource::OrderOverride => "order_override",
+            SelectionSource::Default => "default",
+            SelectionSource::None => "none",
+        };
+        table.add_row(vec![
+            Cell::new(opt(&designator)),
+            Cell::new(opt(&row.design.mpn)),
+            Cell::new(opt(&row.selected_mpn)),
+            Cell::new(opt(&row.match_status)),
+            Cell::new(selection),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CLI definition
+// ---------------------------------------------------------------------------
+
+/// Output format for `pcb order` subcommands.
+#[derive(ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OrderFormat {
+    /// Human-readable table (default).
+    #[default]
+    Table,
+    /// Machine-readable JSON.
+    Json,
+}
+
+impl std::fmt::Display for OrderFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrderFormat::Table => write!(f, "table"),
+            OrderFormat::Json => write!(f, "json"),
+        }
+    }
+}
+
+/// Board selection flags shared by all `pcb order` subcommands.
+#[derive(Args, Debug, Clone)]
+pub struct BoardSelector {
+    /// Workspace slug (overrides the workspace inferred from pcb.toml)
+    #[arg(long, value_name = "SLUG")]
+    pub workspace: Option<String>,
+
+    /// Board name (overrides the board inferred from pcb.toml)
+    #[arg(long, value_name = "NAME")]
+    pub board: Option<String>,
+}
+
+impl BoardSelector {
+    fn resolve(&self) -> Result<BoardIdentity> {
+        let repository = current_workspace_repository();
+        resolve_board_identity(
+            repository.as_deref(),
+            self.workspace.as_deref(),
+            self.board.as_deref(),
+        )
+    }
+}
+
+#[derive(Args, Debug)]
+#[command(about = "Inspect fabrication orders for a board (read-only)")]
+pub struct OrderArgs {
+    #[command(subcommand)]
+    pub command: OrderCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum OrderCommand {
+    /// List orders for a board
+    List(OrderListArgs),
+    /// Show a single order by id
+    Show(OrderShowArgs),
+    /// Show the resolved BOM (with selections) for an order
+    Bom(OrderBomArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct OrderListArgs {
+    #[command(flatten)]
+    pub board: BoardSelector,
+
+    /// Output format
+    #[arg(short = 'f', long, value_enum, default_value_t = OrderFormat::Table)]
+    pub format: OrderFormat,
+}
+
+#[derive(Args, Debug)]
+pub struct OrderShowArgs {
+    /// Order id
+    #[arg(value_name = "ORDER_ID")]
+    pub order_id: String,
+
+    #[command(flatten)]
+    pub board: BoardSelector,
+
+    /// Output format
+    #[arg(short = 'f', long, value_enum, default_value_t = OrderFormat::Table)]
+    pub format: OrderFormat,
+}
+
+#[derive(Args, Debug)]
+pub struct OrderBomArgs {
+    /// Order id
+    #[arg(value_name = "ORDER_ID")]
+    pub order_id: String,
+
+    #[command(flatten)]
+    pub board: BoardSelector,
+
+    /// Output format
+    #[arg(short = 'f', long, value_enum, default_value_t = OrderFormat::Table)]
+    pub format: OrderFormat,
+
+    /// Only show lines where the selected MPN differs from the design MPN
+    #[arg(long)]
+    pub mismatches_only: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Command entry points
+// ---------------------------------------------------------------------------
+
+pub fn execute(args: OrderArgs) -> Result<()> {
+    match args.command {
+        OrderCommand::List(args) => execute_list(args),
+        OrderCommand::Show(args) => execute_show(args),
+        OrderCommand::Bom(args) => execute_bom(args),
+    }
+}
+
+fn execute_list(args: OrderListArgs) -> Result<()> {
+    let identity = args.board.resolve()?;
+    let token = get_valid_token()?;
+    let client = create_client()?;
+
+    let orders = fetch_orders(&client, &token, &identity)?;
+
+    match args.format {
+        OrderFormat::Table => render_orders_table(&orders),
+        OrderFormat::Json => print_json(&orders)?,
+    }
+    Ok(())
+}
+
+fn execute_show(args: OrderShowArgs) -> Result<()> {
+    let identity = args.board.resolve()?;
+    let token = get_valid_token()?;
+    let client = create_client()?;
+
+    let order = fetch_order(&client, &token, &identity, &args.order_id)?;
+
+    match args.format {
+        OrderFormat::Table => render_order_detail(&order),
+        OrderFormat::Json => print_json(&order)?,
+    }
+    Ok(())
+}
+
+fn execute_bom(args: OrderBomArgs) -> Result<()> {
+    let identity = args.board.resolve()?;
+    let token = get_valid_token()?;
+    let client = create_client()?;
+
+    let order = fetch_order(&client, &token, &identity, &args.order_id)?;
+    let bom_id = resolve_order_bom_id(&order)?;
+
+    let bom = fetch_bom(&client, &token, &identity, &args.order_id, bom_id)?;
+    let selections = fetch_selections(&client, &token, &identity, &args.order_id)?;
+
+    let mut rows = build_order_bom_rows(&bom, &selections);
+    if args.mismatches_only {
+        rows.retain(OrderBomRow::is_mpn_mismatch);
+    }
+
+    let report = OrderBomReport {
+        order_id: args.order_id.clone(),
+        bom_id: bom_id.to_string(),
+        rows,
+    };
+
+    match args.format {
+        OrderFormat::Table => render_order_bom_table(&report),
+        OrderFormat::Json => print_json(&report)?,
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pcb-diode-api/src/order.rs
+++ b/crates/pcb-diode-api/src/order.rs
@@ -425,12 +425,13 @@ fn map_error_response(resp: Response, target: &RequestTarget) -> anyhow::Error {
             anyhow!("Not authorized. Run `pcb auth login` to authenticate.")
         }
         StatusCode::NOT_FOUND => {
-            let lower = msg.to_lowercase();
-            if let Some(bom_id) = target.bom_id
-                && lower.contains("bom")
-            {
+            // `bom_id` is only set for `GET /api/boms/:bomId`, which is neither
+            // board- nor order-scoped: a 404 there can only mean the BOM itself
+            // is missing (the order was already fetched successfully).
+            if let Some(bom_id) = target.bom_id {
                 return anyhow!("BOM '{bom_id}' not found.");
             }
+            let lower = msg.to_lowercase();
             match target.order_id {
                 // Order-scoped request: could be an unknown board or unknown order.
                 Some(order_id) => {

--- a/crates/pcb-diode-api/src/order.rs
+++ b/crates/pcb-diode-api/src/order.rs
@@ -24,8 +24,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use crate::auth::get_valid_token;
-use crate::get_api_base_url;
+use crate::WorkspaceContext;
+use crate::auth::{apply_bearer_auth, get_api_token_with_context};
 
 // ---------------------------------------------------------------------------
 // Board identity resolution
@@ -89,14 +89,14 @@ pub fn resolve_board_identity(
     }
 }
 
-/// Read the current workspace repository (if any) starting from the CWD.
+/// Read the selected workspace's repository (if any).
 ///
 /// Any discovery error is swallowed to `None` so that explicit
 /// `--workspace`/`--board` flags keep working outside a workspace.
-fn current_workspace_repository() -> Option<String> {
-    let cwd = std::env::current_dir().ok()?;
+fn current_workspace_repository(ctx: &WorkspaceContext) -> Option<String> {
+    let workspace_root = ctx.workspace_root()?;
     let file_provider = pcb_zen_core::DefaultFileProvider::new();
-    let ws = pcb_zen::get_workspace_info(&file_provider, &cwd).ok()?;
+    let ws = pcb_zen::get_workspace_info(&file_provider, workspace_root).ok()?;
     ws.repository().map(|s| s.to_string())
 }
 
@@ -468,10 +468,13 @@ fn map_error_response(resp: Response, target: &RequestTarget) -> anyhow::Error {
 }
 
 /// Perform a GET request and return the response body as text, mapping errors.
-fn get_text(client: &Client, token: &str, url: &str, target: &RequestTarget) -> Result<String> {
-    let resp = client
-        .get(url)
-        .bearer_auth(token)
+fn get_text(
+    client: &Client,
+    token: Option<&str>,
+    url: &str,
+    target: &RequestTarget,
+) -> Result<String> {
+    let resp = apply_bearer_auth(client.get(url), token)
         .send()
         .map_err(|e| anyhow!("Network error contacting Diode API: {e}"))?;
 
@@ -486,12 +489,13 @@ fn get_text(client: &Client, token: &str, url: &str, target: &RequestTarget) -> 
 /// Fetch the orders list for a board.
 pub fn fetch_orders(
     client: &Client,
-    token: &str,
+    token: Option<&str>,
+    api_base_url: &str,
     identity: &BoardIdentity,
 ) -> Result<Vec<OrderSummary>> {
     let url = format!(
         "{}/api/boards/{}/{}/orders",
-        get_api_base_url(),
+        api_base_url,
         urlencoding::encode(&identity.workspace),
         urlencoding::encode(&identity.board),
     );
@@ -508,13 +512,14 @@ pub fn fetch_orders(
 /// Fetch a single order's detail.
 pub fn fetch_order(
     client: &Client,
-    token: &str,
+    token: Option<&str>,
+    api_base_url: &str,
     identity: &BoardIdentity,
     order_id: &str,
 ) -> Result<OrderDetail> {
     let url = format!(
         "{}/api/boards/{}/{}/orders/{}",
-        get_api_base_url(),
+        api_base_url,
         urlencoding::encode(&identity.workspace),
         urlencoding::encode(&identity.board),
         urlencoding::encode(order_id),
@@ -532,16 +537,13 @@ pub fn fetch_order(
 /// Fetch a BOM document by id.
 pub fn fetch_bom(
     client: &Client,
-    token: &str,
+    token: Option<&str>,
+    api_base_url: &str,
     identity: &BoardIdentity,
     order_id: &str,
     bom_id: &str,
 ) -> Result<Bom> {
-    let url = format!(
-        "{}/api/boms/{}",
-        get_api_base_url(),
-        urlencoding::encode(bom_id),
-    );
+    let url = format!("{}/api/boms/{}", api_base_url, urlencoding::encode(bom_id),);
     let target = RequestTarget {
         workspace: &identity.workspace,
         board: &identity.board,
@@ -555,13 +557,14 @@ pub fn fetch_bom(
 /// Fetch the order's selections map (`{bomLineId -> offerId}`).
 pub fn fetch_selections(
     client: &Client,
-    token: &str,
+    token: Option<&str>,
+    api_base_url: &str,
     identity: &BoardIdentity,
     order_id: &str,
 ) -> Result<BTreeMap<String, String>> {
     let url = format!(
         "{}/api/boards/{}/{}/orders/{}/selections",
-        get_api_base_url(),
+        api_base_url,
         urlencoding::encode(&identity.workspace),
         urlencoding::encode(&identity.board),
         urlencoding::encode(order_id),
@@ -841,8 +844,8 @@ pub struct BoardSelector {
 }
 
 impl BoardSelector {
-    fn resolve(&self) -> Result<BoardIdentity> {
-        let repository = current_workspace_repository();
+    fn resolve(&self, ctx: &WorkspaceContext) -> Result<BoardIdentity> {
+        let repository = current_workspace_repository(ctx);
         resolve_board_identity(
             repository.as_deref(),
             self.workspace.as_deref(),
@@ -914,20 +917,20 @@ pub struct OrderBomArgs {
 // Command entry points
 // ---------------------------------------------------------------------------
 
-pub fn execute(args: OrderArgs) -> Result<()> {
+pub fn execute(args: OrderArgs, ctx: &WorkspaceContext) -> Result<()> {
     match args.command {
-        OrderCommand::List(args) => execute_list(args),
-        OrderCommand::Show(args) => execute_show(args),
-        OrderCommand::Bom(args) => execute_bom(args),
+        OrderCommand::List(args) => execute_list(args, ctx),
+        OrderCommand::Show(args) => execute_show(args, ctx),
+        OrderCommand::Bom(args) => execute_bom(args, ctx),
     }
 }
 
-fn execute_list(args: OrderListArgs) -> Result<()> {
-    let identity = args.board.resolve()?;
-    let token = get_valid_token()?;
+fn execute_list(args: OrderListArgs, ctx: &WorkspaceContext) -> Result<()> {
+    let identity = args.board.resolve(ctx)?;
+    let token = get_api_token_with_context(ctx)?;
     let client = create_client()?;
 
-    let orders = fetch_orders(&client, &token, &identity)?;
+    let orders = fetch_orders(&client, token.as_deref(), ctx.api_base_url(), &identity)?;
 
     match args.format {
         OrderFormat::Table => render_orders_table(&orders),
@@ -936,12 +939,18 @@ fn execute_list(args: OrderListArgs) -> Result<()> {
     Ok(())
 }
 
-fn execute_show(args: OrderShowArgs) -> Result<()> {
-    let identity = args.board.resolve()?;
-    let token = get_valid_token()?;
+fn execute_show(args: OrderShowArgs, ctx: &WorkspaceContext) -> Result<()> {
+    let identity = args.board.resolve(ctx)?;
+    let token = get_api_token_with_context(ctx)?;
     let client = create_client()?;
 
-    let order = fetch_order(&client, &token, &identity, &args.order_id)?;
+    let order = fetch_order(
+        &client,
+        token.as_deref(),
+        ctx.api_base_url(),
+        &identity,
+        &args.order_id,
+    )?;
 
     match args.format {
         OrderFormat::Table => render_order_detail(&order),
@@ -950,16 +959,35 @@ fn execute_show(args: OrderShowArgs) -> Result<()> {
     Ok(())
 }
 
-fn execute_bom(args: OrderBomArgs) -> Result<()> {
-    let identity = args.board.resolve()?;
-    let token = get_valid_token()?;
+fn execute_bom(args: OrderBomArgs, ctx: &WorkspaceContext) -> Result<()> {
+    let identity = args.board.resolve(ctx)?;
+    let token = get_api_token_with_context(ctx)?;
     let client = create_client()?;
 
-    let order = fetch_order(&client, &token, &identity, &args.order_id)?;
+    let order = fetch_order(
+        &client,
+        token.as_deref(),
+        ctx.api_base_url(),
+        &identity,
+        &args.order_id,
+    )?;
     let bom_id = resolve_order_bom_id(&order)?;
 
-    let bom = fetch_bom(&client, &token, &identity, &args.order_id, bom_id)?;
-    let selections = fetch_selections(&client, &token, &identity, &args.order_id)?;
+    let bom = fetch_bom(
+        &client,
+        token.as_deref(),
+        ctx.api_base_url(),
+        &identity,
+        &args.order_id,
+        bom_id,
+    )?;
+    let selections = fetch_selections(
+        &client,
+        token.as_deref(),
+        ctx.api_base_url(),
+        &identity,
+        &args.order_id,
+    )?;
 
     let mut rows = build_order_bom_rows(&bom, &selections);
     if args.mismatches_only {

--- a/crates/pcb-diode-api/src/order.rs
+++ b/crates/pcb-diode-api/src/order.rs
@@ -7,9 +7,9 @@
 //! * `pcb order bom  <id>`       -> `GET /api/boms/:bomId` joined with
 //!   `GET /api/boards/:workspace/:name/orders/:orderId/selections`
 //!
-//! Board identity is resolved from the workspace config (`workspace.repository`,
-//! e.g. `code.diode.computer/demo/b/DM0002` -> workspace `demo`, board `DM0002`),
-//! and can be overridden with `--workspace`/`--board`.
+//! Board identity is resolved from the workspace config (`workspace.name` and
+//! `workspace.repository`, e.g. `code.diode.computer/demo/b/DM0002` -> workspace
+//! `demo`, board `DM0002`) and can be overridden with `--workspace`/`--board`.
 //!
 //! All subcommands are strictly read-only. Order-mutating flows (create, select)
 //! deliberately live in a separate change.
@@ -60,13 +60,15 @@ pub fn parse_board_repository(repository: &str) -> Option<(String, String)> {
     Some((workspace.to_string(), board.to_string()))
 }
 
-/// Resolve the board identity from the workspace repository plus optional
+/// Resolve the board identity from workspace configuration plus optional
 /// `--workspace`/`--board` overrides.
 ///
-/// Flags take precedence over the inferred values. When neither flags nor the
-/// workspace repository provide a value, we fail with a clear, actionable error.
+/// The workspace flag takes precedence over `[workspace].name`, which takes
+/// precedence over the repository-derived workspace. The board flag takes
+/// precedence over the repository-derived board.
 pub fn resolve_board_identity(
     repository: Option<&str>,
+    configured_workspace: Option<&str>,
     workspace_flag: Option<&str>,
     board_flag: Option<&str>,
 ) -> Result<BoardIdentity> {
@@ -74,6 +76,12 @@ pub fn resolve_board_identity(
 
     let workspace = workspace_flag
         .map(str::to_string)
+        .or_else(|| {
+            configured_workspace
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+        })
         .or_else(|| parsed.as_ref().map(|(w, _)| w.clone()));
     let board = board_flag
         .map(str::to_string)
@@ -89,15 +97,25 @@ pub fn resolve_board_identity(
     }
 }
 
-/// Read the selected workspace's repository (if any).
+/// Read the selected workspace's configured name and repository, if available.
 ///
 /// Any discovery error is swallowed to `None` so that explicit
 /// `--workspace`/`--board` flags keep working outside a workspace.
-fn current_workspace_repository(ctx: &WorkspaceContext) -> Option<String> {
-    let workspace_root = ctx.workspace_root()?;
+fn current_workspace_identity(ctx: &WorkspaceContext) -> (Option<String>, Option<String>) {
+    let Some(workspace_root) = ctx.workspace_root() else {
+        return (None, None);
+    };
     let file_provider = pcb_zen_core::DefaultFileProvider::new();
-    let ws = pcb_zen::get_workspace_info(&file_provider, workspace_root).ok()?;
-    ws.repository().map(|s| s.to_string())
+    let Ok(ws) = pcb_zen::get_workspace_info(&file_provider, workspace_root) else {
+        return (None, None);
+    };
+    let configured_workspace = ws
+        .config
+        .as_ref()
+        .and_then(|config| config.workspace.as_ref())
+        .and_then(|workspace| workspace.name.clone());
+    let repository = ws.repository().map(str::to_string);
+    (configured_workspace, repository)
 }
 
 // ---------------------------------------------------------------------------
@@ -761,9 +779,13 @@ fn render_order_detail(order: &OrderDetail) {
     }
 }
 
-fn render_order_bom_table(report: &OrderBomReport) {
+fn render_order_bom_table(report: &OrderBomReport, mismatches_only: bool) {
     if report.rows.is_empty() {
-        println!("No BOM lines found.");
+        if mismatches_only {
+            println!("No mismatched BOM lines found.");
+        } else {
+            println!("No BOM lines found.");
+        }
         return;
     }
 
@@ -845,9 +867,10 @@ pub struct BoardSelector {
 
 impl BoardSelector {
     fn resolve(&self, ctx: &WorkspaceContext) -> Result<BoardIdentity> {
-        let repository = current_workspace_repository(ctx);
+        let (configured_workspace, repository) = current_workspace_identity(ctx);
         resolve_board_identity(
             repository.as_deref(),
+            configured_workspace.as_deref(),
             self.workspace.as_deref(),
             self.board.as_deref(),
         )
@@ -1001,7 +1024,7 @@ fn execute_bom(args: OrderBomArgs, ctx: &WorkspaceContext) -> Result<()> {
     };
 
     match args.format {
-        OrderFormat::Table => render_order_bom_table(&report),
+        OrderFormat::Table => render_order_bom_table(&report, args.mismatches_only),
         OrderFormat::Json => print_json(&report)?,
     }
     Ok(())

--- a/crates/pcb-diode-api/src/order.rs
+++ b/crates/pcb-diode-api/src/order.rs
@@ -46,6 +46,8 @@ pub struct BoardIdentity {
 ///
 /// Returns `None` when the string does not describe a board repository.
 pub fn parse_board_repository(repository: &str) -> Option<(String, String)> {
+    let repository = pcb_zen::git::parse_remote_url(repository)
+        .unwrap_or_else(|_| repository.trim().to_string());
     let segments: Vec<&str> = repository.split('/').filter(|s| !s.is_empty()).collect();
     let b_idx = segments.iter().position(|s| *s == "b")?;
     // Need a segment before ("workspace") and after ("board") the `b` marker.
@@ -53,7 +55,10 @@ pub fn parse_board_repository(repository: &str) -> Option<(String, String)> {
         return None;
     }
     let workspace = *segments.get(b_idx - 1)?;
-    let board = *segments.get(b_idx + 1)?;
+    let board = segments
+        .get(b_idx + 1)?
+        .strip_suffix(".git")
+        .unwrap_or(segments[b_idx + 1]);
     if workspace.is_empty() || board.is_empty() {
         return None;
     }

--- a/crates/pcb-diode-api/src/order/snapshots/pcb_diode_api__order__tests__snapshot_order_bom_report_json.snap
+++ b/crates/pcb-diode-api/src/order/snapshots/pcb_diode_api__order__tests__snapshot_order_bom_report_json.snap
@@ -1,0 +1,95 @@
+---
+source: crates/pcb-diode-api/src/order/tests.rs
+expression: report
+---
+{
+  "orderId": "ord_abc123",
+  "bomId": "bom_555",
+  "rows": [
+    {
+      "bomLineId": "line_override",
+      "design": {
+        "mpn": "STM32F407VGT6",
+        "manufacturer": "STMicroelectronics",
+        "package": "LQFP-100",
+        "value": null,
+        "designator": "U1",
+        "path": "root.U1",
+        "alternatives": [
+          {
+            "mpn": "STM32F407VGT7",
+            "manufacturer": "ST"
+          }
+        ]
+      },
+      "matchStatus": "matched",
+      "offers": [
+        {
+          "id": "offer_default",
+          "mpn": "STM32F407VGT6",
+          "manufacturer": "STMicroelectronics",
+          "distributor": "lcsc",
+          "stock": 1200,
+          "price": 8.5
+        },
+        {
+          "id": "offer_override",
+          "mpn": "STM32F407VET6",
+          "manufacturer": "STMicroelectronics",
+          "distributor": "digikey",
+          "stock": 50,
+          "price": 9.1
+        }
+      ],
+      "selectedOfferId": "offer_override",
+      "selectionSource": "order_override",
+      "selectedMpn": "STM32F407VET6",
+      "selectedManufacturer": "STMicroelectronics"
+    },
+    {
+      "bomLineId": "line_default",
+      "design": {
+        "mpn": "GRM188R71H104KA93D",
+        "manufacturer": "Murata",
+        "package": "0603",
+        "value": "100nF",
+        "designator": "C1",
+        "path": "root.C1",
+        "alternatives": []
+      },
+      "matchStatus": "matched",
+      "offers": [
+        {
+          "id": "offer_c1",
+          "mpn": "GRM188R71H104KA93D",
+          "manufacturer": "Murata",
+          "distributor": "lcsc",
+          "stock": 500000,
+          "price": 0.01
+        }
+      ],
+      "selectedOfferId": "offer_c1",
+      "selectionSource": "default",
+      "selectedMpn": "GRM188R71H104KA93D",
+      "selectedManufacturer": "Murata"
+    },
+    {
+      "bomLineId": "line_none",
+      "design": {
+        "mpn": "XYZ-UNMATCHED",
+        "manufacturer": null,
+        "package": null,
+        "value": null,
+        "designator": "J1",
+        "path": "root.J1",
+        "alternatives": []
+      },
+      "matchStatus": "unmatched",
+      "offers": [],
+      "selectedOfferId": null,
+      "selectionSource": "none",
+      "selectedMpn": null,
+      "selectedManufacturer": null
+    }
+  ]
+}

--- a/crates/pcb-diode-api/src/order/snapshots/pcb_diode_api__order__tests__snapshot_order_bom_report_mismatches_only_json.snap
+++ b/crates/pcb-diode-api/src/order/snapshots/pcb_diode_api__order__tests__snapshot_order_bom_report_mismatches_only_json.snap
@@ -1,0 +1,50 @@
+---
+source: crates/pcb-diode-api/src/order/tests.rs
+expression: report
+---
+{
+  "orderId": "ord_abc123",
+  "bomId": "bom_555",
+  "rows": [
+    {
+      "bomLineId": "line_override",
+      "design": {
+        "mpn": "STM32F407VGT6",
+        "manufacturer": "STMicroelectronics",
+        "package": "LQFP-100",
+        "value": null,
+        "designator": "U1",
+        "path": "root.U1",
+        "alternatives": [
+          {
+            "mpn": "STM32F407VGT7",
+            "manufacturer": "ST"
+          }
+        ]
+      },
+      "matchStatus": "matched",
+      "offers": [
+        {
+          "id": "offer_default",
+          "mpn": "STM32F407VGT6",
+          "manufacturer": "STMicroelectronics",
+          "distributor": "lcsc",
+          "stock": 1200,
+          "price": 8.5
+        },
+        {
+          "id": "offer_override",
+          "mpn": "STM32F407VET6",
+          "manufacturer": "STMicroelectronics",
+          "distributor": "digikey",
+          "stock": 50,
+          "price": 9.1
+        }
+      ],
+      "selectedOfferId": "offer_override",
+      "selectionSource": "order_override",
+      "selectedMpn": "STM32F407VET6",
+      "selectedManufacturer": "STMicroelectronics"
+    }
+  ]
+}

--- a/crates/pcb-diode-api/src/order/snapshots/pcb_diode_api__order__tests__snapshot_order_detail_json.snap
+++ b/crates/pcb-diode-api/src/order/snapshots/pcb_diode_api__order__tests__snapshot_order_detail_json.snap
@@ -1,0 +1,41 @@
+---
+source: crates/pcb-diode-api/src/order/tests.rs
+expression: order
+---
+{
+  "id": "ord_abc123",
+  "name": "Prototype run",
+  "status": "in_production",
+  "quantity": 10,
+  "provider": "jlcpcb",
+  "createdAt": "2024-05-01T12:30:00Z",
+  "releaseId": "rel_789",
+  "releaseVersion": "v1.2.3",
+  "bomId": "bom_555",
+  "quote": {
+    "id": "quote_1",
+    "status": "accepted",
+    "currency": "USD",
+    "unitPrice": 12.34,
+    "total": 123.4,
+    "leadTimeDays": 14
+  },
+  "timeline": [
+    {
+      "status": "created",
+      "timestamp": "2024-05-01T12:30:00Z",
+      "note": null
+    },
+    {
+      "status": "quoted",
+      "timestamp": "2024-05-02T08:00:00Z",
+      "note": "auto-quoted"
+    },
+    {
+      "status": "in_production",
+      "timestamp": "2024-05-03T10:15:00Z",
+      "note": null
+    }
+  ],
+  "shippingLocationId": "loc_42"
+}

--- a/crates/pcb-diode-api/src/order/snapshots/pcb_diode_api__order__tests__snapshot_orders_list_json.snap
+++ b/crates/pcb-diode-api/src/order/snapshots/pcb_diode_api__order__tests__snapshot_orders_list_json.snap
@@ -1,0 +1,24 @@
+---
+source: crates/pcb-diode-api/src/order/tests.rs
+expression: orders
+---
+[
+  {
+    "id": "ord_abc123",
+    "name": "Prototype run",
+    "status": "in_production",
+    "quantity": 10,
+    "releaseVersion": "v1.2.3",
+    "provider": "jlcpcb",
+    "createdAt": "2024-05-01T12:30:00Z"
+  },
+  {
+    "id": "ord_def456",
+    "name": null,
+    "status": "quoted",
+    "quantity": 100,
+    "releaseVersion": null,
+    "provider": "pcbway",
+    "createdAt": "2024-06-15T09:00:00Z"
+  }
+]

--- a/crates/pcb-diode-api/src/order/tests.rs
+++ b/crates/pcb-diode-api/src/order/tests.rs
@@ -1,0 +1,550 @@
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Board-identity resolution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parses_standard_board_repository() {
+    assert_eq!(
+        parse_board_repository("code.diode.computer/demo/b/DM0002"),
+        Some(("demo".to_string(), "DM0002".to_string()))
+    );
+}
+
+#[test]
+fn parses_repository_with_extra_host_segments() {
+    // Anchoring on the `b` marker keeps resolution correct with nested paths.
+    assert_eq!(
+        parse_board_repository("code.diode.computer/org/team/b/DM9999"),
+        Some(("team".to_string(), "DM9999".to_string()))
+    );
+}
+
+#[test]
+fn rejects_repository_without_board_marker() {
+    assert_eq!(parse_board_repository("github.com/diodeinc/registry"), None);
+    assert_eq!(parse_board_repository("b/DM0002"), None); // no workspace before `b`
+    assert_eq!(parse_board_repository("demo/b"), None); // no board after `b`
+}
+
+#[test]
+fn resolves_identity_from_repository() {
+    let id = resolve_board_identity(Some("code.diode.computer/demo/b/DM0002"), None, None).unwrap();
+    assert_eq!(id.workspace, "demo");
+    assert_eq!(id.board, "DM0002");
+}
+
+#[test]
+fn flags_override_repository() {
+    let id = resolve_board_identity(
+        Some("code.diode.computer/demo/b/DM0002"),
+        Some("other-ws"),
+        Some("DM1234"),
+    )
+    .unwrap();
+    assert_eq!(id.workspace, "other-ws");
+    assert_eq!(id.board, "DM1234");
+}
+
+#[test]
+fn single_flag_overrides_only_that_field() {
+    let id = resolve_board_identity(
+        Some("code.diode.computer/demo/b/DM0002"),
+        None,
+        Some("DM1234"),
+    )
+    .unwrap();
+    assert_eq!(id.workspace, "demo");
+    assert_eq!(id.board, "DM1234");
+}
+
+#[test]
+fn both_flags_work_without_a_repository() {
+    let id = resolve_board_identity(None, Some("demo"), Some("DM0002")).unwrap();
+    assert_eq!(id.workspace, "demo");
+    assert_eq!(id.board, "DM0002");
+}
+
+#[test]
+fn errors_outside_workspace_with_no_flags() {
+    let err = resolve_board_identity(None, None, None).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("--workspace"), "message was: {msg}");
+    assert!(msg.contains("--board"), "message was: {msg}");
+}
+
+#[test]
+fn errors_when_partial_flag_cannot_be_completed() {
+    // Only workspace flag, no repository to supply the board.
+    assert!(resolve_board_identity(None, Some("demo"), None).is_err());
+    // Only board flag, no repository to supply the workspace.
+    assert!(resolve_board_identity(None, None, Some("DM0002")).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// MPN normalization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn normalization_matches_backend_rules() {
+    assert_eq!(normalize_bom_lookup_mpn("  stm32f407 "), "STM32F407");
+    assert_eq!(normalize_bom_lookup_mpn("GRM188R71H"), "GRM188R71H");
+    // Only A-Z, 0-9 and `.` survive.
+    assert_eq!(normalize_bom_lookup_mpn("PESD2CAN,215"), "PESD2CAN215");
+    assert_eq!(normalize_bom_lookup_mpn("AT86RF212B.ZU"), "AT86RF212B.ZU");
+    assert_eq!(normalize_bom_lookup_mpn("mc34063a/d"), "MC34063AD");
+    assert_eq!(normalize_bom_lookup_mpn("part number 42"), "PARTNUMBER42");
+}
+
+// ---------------------------------------------------------------------------
+// Selection-join precedence
+// ---------------------------------------------------------------------------
+
+fn sample_bom() -> Bom {
+    Bom {
+        id: Some("bom_1".into()),
+        lines: vec![
+            // Line with a default selection AND an override -> override wins.
+            BomLine {
+                id: "line_override".into(),
+                mpn: Some("STM32F407VGT6".into()),
+                manufacturer: Some("STMicroelectronics".into()),
+                package: Some("LQFP-100".into()),
+                value: None,
+                designator: Some("U1".into()),
+                path: Some("root.U1".into()),
+                alternatives: vec![Alternative {
+                    mpn: Some("STM32F407VGT7".into()),
+                    manufacturer: Some("ST".into()),
+                }],
+                match_status: Some("matched".into()),
+                offers: vec![
+                    Offer {
+                        id: "offer_default".into(),
+                        mpn: Some("STM32F407VGT6".into()),
+                        manufacturer: Some("STMicroelectronics".into()),
+                        distributor: Some("lcsc".into()),
+                        stock: Some(1200),
+                        price: Some(8.50),
+                    },
+                    Offer {
+                        id: "offer_override".into(),
+                        mpn: Some("STM32F407VET6".into()),
+                        manufacturer: Some("STMicroelectronics".into()),
+                        distributor: Some("digikey".into()),
+                        stock: Some(50),
+                        price: Some(9.10),
+                    },
+                ],
+                selected_offer_id: Some("offer_default".into()),
+            },
+            // Line with only a default selection.
+            BomLine {
+                id: "line_default".into(),
+                mpn: Some("GRM188R71H104KA93D".into()),
+                manufacturer: Some("Murata".into()),
+                package: Some("0603".into()),
+                value: Some("100nF".into()),
+                designator: Some("C1".into()),
+                path: Some("root.C1".into()),
+                alternatives: vec![],
+                match_status: Some("matched".into()),
+                offers: vec![Offer {
+                    id: "offer_c1".into(),
+                    mpn: Some("GRM188R71H104KA93D".into()),
+                    manufacturer: Some("Murata".into()),
+                    distributor: Some("lcsc".into()),
+                    stock: Some(500000),
+                    price: Some(0.01),
+                }],
+                selected_offer_id: Some("offer_c1".into()),
+            },
+            // Line with no selection at all.
+            BomLine {
+                id: "line_none".into(),
+                mpn: Some("XYZ-UNMATCHED".into()),
+                manufacturer: None,
+                package: None,
+                value: None,
+                designator: Some("J1".into()),
+                path: Some("root.J1".into()),
+                alternatives: vec![],
+                match_status: Some("unmatched".into()),
+                offers: vec![],
+                selected_offer_id: None,
+            },
+        ],
+    }
+}
+
+fn sample_selections() -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    map.insert("line_override".to_string(), "offer_override".to_string());
+    map
+}
+
+#[test]
+fn override_beats_default() {
+    let rows = build_order_bom_rows(&sample_bom(), &sample_selections());
+    let row = &rows[0];
+    assert_eq!(row.selection_source, SelectionSource::OrderOverride);
+    assert_eq!(row.selected_offer_id.as_deref(), Some("offer_override"));
+    assert_eq!(row.selected_mpn.as_deref(), Some("STM32F407VET6"));
+}
+
+#[test]
+fn default_used_when_no_override() {
+    let rows = build_order_bom_rows(&sample_bom(), &sample_selections());
+    let row = &rows[1];
+    assert_eq!(row.selection_source, SelectionSource::Default);
+    assert_eq!(row.selected_offer_id.as_deref(), Some("offer_c1"));
+    assert_eq!(row.selected_mpn.as_deref(), Some("GRM188R71H104KA93D"));
+}
+
+#[test]
+fn none_when_neither_override_nor_default() {
+    let rows = build_order_bom_rows(&sample_bom(), &sample_selections());
+    let row = &rows[2];
+    assert_eq!(row.selection_source, SelectionSource::None);
+    assert!(row.selected_offer_id.is_none());
+    assert!(row.selected_mpn.is_none());
+    assert!(row.selected_manufacturer.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// BOM id resolution ("order has no BOM")
+// ---------------------------------------------------------------------------
+
+fn order_with_bom(bom_id: Option<&str>) -> OrderDetail {
+    OrderDetail {
+        id: "ord_1".into(),
+        name: None,
+        status: None,
+        quantity: None,
+        provider: None,
+        created_at: None,
+        release_id: None,
+        release_version: None,
+        bom_id: bom_id.map(str::to_string),
+        quote: None,
+        timeline: vec![],
+        shipping_location_id: None,
+    }
+}
+
+#[test]
+fn resolves_present_bom_id() {
+    let order = order_with_bom(Some("bom_555"));
+    assert_eq!(resolve_order_bom_id(&order).unwrap(), "bom_555");
+}
+
+#[test]
+fn errors_when_order_has_no_bom() {
+    for missing in [order_with_bom(None), order_with_bom(Some(""))] {
+        let err = resolve_order_bom_id(&missing).unwrap_err();
+        assert!(err.to_string().contains("has no BOM"), "was: {err}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// --mismatches-only normalization edge cases
+// ---------------------------------------------------------------------------
+
+fn row_with(design_mpn: Option<&str>, selected_mpn: Option<&str>) -> OrderBomRow {
+    OrderBomRow {
+        bom_line_id: "line".into(),
+        design: DesignEntry {
+            mpn: design_mpn.map(str::to_string),
+            manufacturer: None,
+            package: None,
+            value: None,
+            designator: Some("U1".into()),
+            path: None,
+            alternatives: vec![],
+        },
+        match_status: None,
+        offers: vec![],
+        selected_offer_id: selected_mpn.map(|_| "offer".to_string()),
+        selection_source: if selected_mpn.is_some() {
+            SelectionSource::Default
+        } else {
+            SelectionSource::None
+        },
+        selected_mpn: selected_mpn.map(str::to_string),
+        selected_manufacturer: None,
+    }
+}
+
+#[test]
+fn case_only_difference_is_not_a_mismatch() {
+    assert!(!row_with(Some("stm32f407"), Some("STM32F407")).is_mpn_mismatch());
+}
+
+#[test]
+fn punctuation_only_difference_is_not_a_mismatch() {
+    // Comma / slash / dash are stripped by normalization.
+    assert!(!row_with(Some("PESD2CAN,215"), Some("PESD2CAN215")).is_mpn_mismatch());
+    assert!(!row_with(Some("MC34063A/D"), Some("MC34063AD")).is_mpn_mismatch());
+}
+
+#[test]
+fn genuinely_different_mpn_is_a_mismatch() {
+    assert!(row_with(Some("STM32F407VGT6"), Some("STM32F407VET6")).is_mpn_mismatch());
+}
+
+#[test]
+fn missing_selection_is_excluded_from_mismatches() {
+    assert!(!row_with(Some("STM32F407VGT6"), None).is_mpn_mismatch());
+}
+
+#[test]
+fn missing_design_mpn_is_excluded_from_mismatches() {
+    assert!(!row_with(None, Some("STM32F407VGT6")).is_mpn_mismatch());
+}
+
+#[test]
+fn mismatches_only_filter_keeps_only_true_mismatches() {
+    let bom = Bom {
+        id: Some("bom".into()),
+        lines: vec![
+            // Genuine mismatch (override to a different part).
+            BomLine {
+                id: "l1".into(),
+                mpn: Some("STM32F407VGT6".into()),
+                manufacturer: None,
+                package: None,
+                value: None,
+                designator: Some("U1".into()),
+                path: None,
+                alternatives: vec![],
+                match_status: None,
+                offers: vec![Offer {
+                    id: "o1".into(),
+                    mpn: Some("STM32F407VET6".into()),
+                    manufacturer: None,
+                    distributor: None,
+                    stock: None,
+                    price: None,
+                }],
+                selected_offer_id: None,
+            },
+            // Punctuation-only difference -> not a mismatch.
+            BomLine {
+                id: "l2".into(),
+                mpn: Some("MC34063A/D".into()),
+                manufacturer: None,
+                package: None,
+                value: None,
+                designator: Some("U2".into()),
+                path: None,
+                alternatives: vec![],
+                match_status: None,
+                offers: vec![Offer {
+                    id: "o2".into(),
+                    mpn: Some("MC34063AD".into()),
+                    manufacturer: None,
+                    distributor: None,
+                    stock: None,
+                    price: None,
+                }],
+                selected_offer_id: Some("o2".into()),
+            },
+        ],
+    };
+    let mut selections = BTreeMap::new();
+    selections.insert("l1".to_string(), "o1".to_string());
+
+    let mut rows = build_order_bom_rows(&bom, &selections);
+    rows.retain(OrderBomRow::is_mpn_mismatch);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].bom_line_id, "l1");
+}
+
+// ---------------------------------------------------------------------------
+// JSON snapshot output against recorded / mocked API responses
+// ---------------------------------------------------------------------------
+
+const ORDERS_LIST_FIXTURE: &str = r#"{
+  "orders": [
+    {
+      "id": "ord_abc123",
+      "name": "Prototype run",
+      "status": "in_production",
+      "quantity": 10,
+      "releaseVersion": "v1.2.3",
+      "provider": "jlcpcb",
+      "createdAt": "2024-05-01T12:30:00Z"
+    },
+    {
+      "id": "ord_def456",
+      "status": "quoted",
+      "quantity": 100,
+      "provider": "pcbway",
+      "createdAt": "2024-06-15T09:00:00Z"
+    }
+  ]
+}"#;
+
+const ORDER_DETAIL_FIXTURE: &str = r#"{
+  "id": "ord_abc123",
+  "name": "Prototype run",
+  "status": "in_production",
+  "quantity": 10,
+  "provider": "jlcpcb",
+  "createdAt": "2024-05-01T12:30:00Z",
+  "releaseId": "rel_789",
+  "releaseVersion": "v1.2.3",
+  "bomId": "bom_555",
+  "quote": {
+    "id": "quote_1",
+    "status": "accepted",
+    "currency": "USD",
+    "unitPrice": 12.34,
+    "total": 123.40,
+    "leadTimeDays": 14
+  },
+  "timeline": [
+    { "status": "created", "timestamp": "2024-05-01T12:30:00Z" },
+    { "status": "quoted", "timestamp": "2024-05-02T08:00:00Z", "note": "auto-quoted" },
+    { "status": "in_production", "timestamp": "2024-05-03T10:15:00Z" }
+  ],
+  "shippingLocationId": "loc_42"
+}"#;
+
+const BOM_FIXTURE: &str = r#"{
+  "id": "bom_555",
+  "lines": [
+    {
+      "id": "line_override",
+      "mpn": "STM32F407VGT6",
+      "manufacturer": "STMicroelectronics",
+      "package": "LQFP-100",
+      "designator": "U1",
+      "path": "root.U1",
+      "alternatives": [{ "mpn": "STM32F407VGT7", "manufacturer": "ST" }],
+      "matchStatus": "matched",
+      "selectedOfferId": "offer_default",
+      "offers": [
+        {
+          "id": "offer_default",
+          "mpn": "STM32F407VGT6",
+          "manufacturer": "STMicroelectronics",
+          "distributor": "lcsc",
+          "stock": 1200,
+          "price": 8.5
+        },
+        {
+          "id": "offer_override",
+          "mpn": "STM32F407VET6",
+          "manufacturer": "STMicroelectronics",
+          "distributor": "digikey",
+          "stock": 50,
+          "price": 9.1
+        }
+      ]
+    },
+    {
+      "id": "line_default",
+      "mpn": "GRM188R71H104KA93D",
+      "manufacturer": "Murata",
+      "package": "0603",
+      "value": "100nF",
+      "designator": "C1",
+      "path": "root.C1",
+      "matchStatus": "matched",
+      "selectedOfferId": "offer_c1",
+      "offers": [
+        {
+          "id": "offer_c1",
+          "mpn": "GRM188R71H104KA93D",
+          "manufacturer": "Murata",
+          "distributor": "lcsc",
+          "stock": 500000,
+          "price": 0.01
+        }
+      ]
+    },
+    {
+      "id": "line_none",
+      "mpn": "XYZ-UNMATCHED",
+      "designator": "J1",
+      "path": "root.J1",
+      "matchStatus": "unmatched",
+      "offers": []
+    }
+  ]
+}"#;
+
+const SELECTIONS_FIXTURE: &str = r#"{ "selections": { "line_override": "offer_override" } }"#;
+
+#[test]
+fn parses_orders_list_object_wrapper() {
+    let orders = parse_orders_list(ORDERS_LIST_FIXTURE).unwrap();
+    assert_eq!(orders.len(), 2);
+    assert_eq!(orders[0].id, "ord_abc123");
+    assert_eq!(orders[1].release_version, None);
+}
+
+#[test]
+fn parses_orders_list_bare_array() {
+    let orders = parse_orders_list(r#"[{"id":"ord_1"}]"#).unwrap();
+    assert_eq!(orders.len(), 1);
+    assert_eq!(orders[0].id, "ord_1");
+}
+
+#[test]
+fn parses_selections_object_and_bare_map() {
+    let wrapped = parse_selections(SELECTIONS_FIXTURE).unwrap();
+    assert_eq!(
+        wrapped.get("line_override").map(String::as_str),
+        Some("offer_override")
+    );
+
+    let bare = parse_selections(r#"{ "line_a": "offer_a" }"#).unwrap();
+    assert_eq!(bare.get("line_a").map(String::as_str), Some("offer_a"));
+
+    let empty = parse_selections("null").unwrap();
+    assert!(empty.is_empty());
+}
+
+#[test]
+fn snapshot_orders_list_json() {
+    let orders = parse_orders_list(ORDERS_LIST_FIXTURE).unwrap();
+    insta::assert_json_snapshot!(orders);
+}
+
+#[test]
+fn snapshot_order_detail_json() {
+    let order: OrderDetail = serde_json::from_str(ORDER_DETAIL_FIXTURE).unwrap();
+    insta::assert_json_snapshot!(order);
+}
+
+#[test]
+fn snapshot_order_bom_report_json() {
+    let bom: Bom = serde_json::from_str(BOM_FIXTURE).unwrap();
+    let selections = parse_selections(SELECTIONS_FIXTURE).unwrap();
+    let rows = build_order_bom_rows(&bom, &selections);
+    let report = OrderBomReport {
+        order_id: "ord_abc123".into(),
+        bom_id: bom.id.clone().unwrap(),
+        rows,
+    };
+    insta::assert_json_snapshot!(report);
+}
+
+#[test]
+fn snapshot_order_bom_report_mismatches_only_json() {
+    let bom: Bom = serde_json::from_str(BOM_FIXTURE).unwrap();
+    let selections = parse_selections(SELECTIONS_FIXTURE).unwrap();
+    let mut rows = build_order_bom_rows(&bom, &selections);
+    rows.retain(OrderBomRow::is_mpn_mismatch);
+    let report = OrderBomReport {
+        order_id: "ord_abc123".into(),
+        bom_id: bom.id.clone().unwrap(),
+        rows,
+    };
+    // Only line_override is a real mismatch (VGT6 -> VET6).
+    assert_eq!(report.rows.len(), 1);
+    insta::assert_json_snapshot!(report);
+}

--- a/crates/pcb-diode-api/src/order/tests.rs
+++ b/crates/pcb-diode-api/src/order/tests.rs
@@ -22,6 +22,23 @@ fn parses_repository_with_extra_host_segments() {
 }
 
 #[test]
+fn parses_git_remote_url_forms() {
+    let expected = Some(("demo".to_string(), "DM0002".to_string()));
+    assert_eq!(
+        parse_board_repository("https://code.diode.computer/demo/b/DM0002.git"),
+        expected
+    );
+    assert_eq!(
+        parse_board_repository("git@code.diode.computer:demo/b/DM0002.git"),
+        expected
+    );
+    assert_eq!(
+        parse_board_repository("code.diode.computer/demo/b/DM0002.git"),
+        expected
+    );
+}
+
+#[test]
 fn rejects_repository_without_board_marker() {
     assert_eq!(parse_board_repository("github.com/diodeinc/registry"), None);
     assert_eq!(parse_board_repository("b/DM0002"), None); // no workspace before `b`

--- a/crates/pcb-diode-api/src/order/tests.rs
+++ b/crates/pcb-diode-api/src/order/tests.rs
@@ -30,7 +30,8 @@ fn rejects_repository_without_board_marker() {
 
 #[test]
 fn resolves_identity_from_repository() {
-    let id = resolve_board_identity(Some("code.diode.computer/demo/b/DM0002"), None, None).unwrap();
+    let id = resolve_board_identity(Some("code.diode.computer/demo/b/DM0002"), None, None, None)
+        .unwrap();
     assert_eq!(id.workspace, "demo");
     assert_eq!(id.board, "DM0002");
 }
@@ -39,6 +40,7 @@ fn resolves_identity_from_repository() {
 fn flags_override_repository() {
     let id = resolve_board_identity(
         Some("code.diode.computer/demo/b/DM0002"),
+        None,
         Some("other-ws"),
         Some("DM1234"),
     )
@@ -52,6 +54,7 @@ fn single_flag_overrides_only_that_field() {
     let id = resolve_board_identity(
         Some("code.diode.computer/demo/b/DM0002"),
         None,
+        None,
         Some("DM1234"),
     )
     .unwrap();
@@ -60,15 +63,65 @@ fn single_flag_overrides_only_that_field() {
 }
 
 #[test]
+fn configured_workspace_name_overrides_repository() {
+    let id = resolve_board_identity(
+        Some("code.diode.computer/demo/b/DM0002"),
+        Some("custom"),
+        None,
+        None,
+    )
+    .unwrap();
+    assert_eq!(id.workspace, "custom");
+    assert_eq!(id.board, "DM0002");
+}
+
+#[test]
+fn workspace_flag_overrides_configured_workspace_name() {
+    let id = resolve_board_identity(
+        Some("code.diode.computer/demo/b/DM0002"),
+        Some("custom"),
+        Some("flagged"),
+        None,
+    )
+    .unwrap();
+    assert_eq!(id.workspace, "flagged");
+    assert_eq!(id.board, "DM0002");
+}
+
+#[test]
+fn reads_workspace_name_and_repository_from_workspace_context() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("pcb.toml"),
+        r#"
+[workspace]
+name = "custom"
+repository = "code.diode.computer/demo/b/DM0002"
+pcb-version = "0.4"
+"#,
+    )
+    .unwrap();
+
+    let ctx = WorkspaceContext::from_workspace_root(dir.path());
+    assert_eq!(
+        current_workspace_identity(&ctx),
+        (
+            Some("custom".to_string()),
+            Some("code.diode.computer/demo/b/DM0002".to_string())
+        )
+    );
+}
+
+#[test]
 fn both_flags_work_without_a_repository() {
-    let id = resolve_board_identity(None, Some("demo"), Some("DM0002")).unwrap();
+    let id = resolve_board_identity(None, None, Some("demo"), Some("DM0002")).unwrap();
     assert_eq!(id.workspace, "demo");
     assert_eq!(id.board, "DM0002");
 }
 
 #[test]
 fn errors_outside_workspace_with_no_flags() {
-    let err = resolve_board_identity(None, None, None).unwrap_err();
+    let err = resolve_board_identity(None, None, None, None).unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("--workspace"), "message was: {msg}");
     assert!(msg.contains("--board"), "message was: {msg}");
@@ -77,9 +130,9 @@ fn errors_outside_workspace_with_no_flags() {
 #[test]
 fn errors_when_partial_flag_cannot_be_completed() {
     // Only workspace flag, no repository to supply the board.
-    assert!(resolve_board_identity(None, Some("demo"), None).is_err());
+    assert!(resolve_board_identity(None, None, Some("demo"), None).is_err());
     // Only board flag, no repository to supply the workspace.
-    assert!(resolve_board_identity(None, None, Some("DM0002")).is_err());
+    assert!(resolve_board_identity(None, None, None, Some("DM0002")).is_err());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pcbc/src/main.rs
+++ b/crates/pcbc/src/main.rs
@@ -141,6 +141,9 @@ enum Commands {
     /// Build and upload a preview release for a board
     Preview(preview::PreviewArgs),
 
+    /// Inspect fabrication orders for a board (read-only)
+    Order(pcb_diode_api::OrderArgs),
+
     /// Vendor external dependencies
     Vendor(vendor::VendorArgs),
 
@@ -237,6 +240,7 @@ fn run() -> anyhow::Result<()> {
         Commands::Open(args) => open::execute(args),
         Commands::Publish(args) => publish::execute(args),
         Commands::Preview(args) => preview::execute(args),
+        Commands::Order(args) => pcb_diode_api::execute_order(args),
         Commands::Vendor(args) => vendor::execute(args),
         Commands::Fork => {
             println!("`pcb fork` is a reserved subcommand for future use.");

--- a/crates/pcbc/src/main.rs
+++ b/crates/pcbc/src/main.rs
@@ -240,7 +240,10 @@ fn run() -> anyhow::Result<()> {
         Commands::Open(args) => open::execute(args),
         Commands::Publish(args) => publish::execute(args),
         Commands::Preview(args) => preview::execute(args),
-        Commands::Order(args) => pcb_diode_api::execute_order(args),
+        Commands::Order(args) => {
+            let ctx = pcb_diode_api::WorkspaceContext::from_cwd()?;
+            pcb_diode_api::execute_order(args, &ctx)
+        }
         Commands::Vendor(args) => vendor::execute(args),
         Commands::Fork => {
             println!("`pcb fork` is a reserved subcommand for future use.");

--- a/crates/pcbc/tests/snapshots/simple__help.snap
+++ b/crates/pcbc/tests/snapshots/simple__help.snap
@@ -30,6 +30,7 @@ Commands:
   open        Open PCB layout files
   publish     Publish packages and boards by creating version tags
   preview     Build and upload a preview release for a board
+  order       Inspect fabrication orders for a board (read-only)
   vendor      Vendor external dependencies
   fork        Reserved subcommand for future use
   embed-step  Embed a STEP model into a KiCad footprint


### PR DESCRIPTION
## Summary

Adds a read-only `pcb order` command group with three subcommands, all backed by **existing** authenticated API endpoints (reusing the `pcb-diode-api` client and `pcb auth` bearer-token infra used by `search`/`scan`/`preview`). No new backend routes.

- **`pcb order list`** → `GET /api/boards/:workspace/:name/orders` — renders id, name, status, quantity, release version, provider, created date.
- **`pcb order show <order-id>`** → `GET /api/boards/:workspace/:name/orders/:orderId` — renders the full order (release id/version, bom id, quote summary if present, timeline, shipping location id).
- **`pcb order bom <order-id>`** → fetches the order, then `GET /api/boms/:bomId` (fails clearly with "order has no BOM" if `bomId` is null) and `GET /api/boards/:workspace/:name/orders/:orderId/selections`, joined client-side.

## Board identity

Resolves from `workspace.repository` (e.g. `code.diode.computer/demo/b/DM0002` → workspace `demo`, board `DM0002`, as surfaced by `pcb info`), overridable with `--workspace <slug>` / `--board <name>`. Errors clearly when run outside a workspace with no flags.

## `order bom` join

One row per BOM line: bomLineId, design entry (mpn, manufacturer, package, value, designator/path, declared alternatives), match status, candidate offers (id, mpn, manufacturer, distributor, stock, price), and the **effective selection**:

- order's selections map (`{bomLineId → offerId}`) if present, else
- the line's default `selectedOfferId`, else
- none

surfaced as `selectionSource` (`order_override` | `default` | `none`) plus convenience `selectedMpn`/`selectedManufacturer`.

`--mismatches-only` filters to lines where the selected MPN differs from the design MPN under the backend's `normalizeBomLookupMpn` normalization (trim, uppercase, strip everything except `A–Z`, `0–9`, `.`). Lines with no selection or no design MPN are excluded. Table mode stays compact (designator, design MPN, selected MPN, match, selection source); full offer detail is reserved for `-f json`.

## Output & errors

- All subcommands support `-f table|json` (table default), following `pcb bom` conventions.
- 401/403 → prompt to run `pcb auth login`; 404 → distinguishes unknown board from unknown order id; network failures → single-line error, non-zero exit.

## Tests

- Board-identity resolution (parsing, flag overrides, out-of-workspace error, partial flags).
- Selection-join precedence (override beats default; none when neither).
- `--mismatches-only` normalization edge cases (case, punctuation, missing MPNs).
- JSON snapshot output for list/show/bom (+ mismatches-only) against mocked API responses.

## Out of scope

Order-mutating subcommands (`create`, `select`) intentionally land in a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only GETs against existing APIs; no mutations or auth changes beyond reusing `pcb auth` tokens.
> 
> **Overview**
> Adds a **read-only** `pcb order` CLI group (`list`, `show`, `bom`) wired through `pcb-diode-api` and the existing authenticated Diode API client—no new backend routes.
> 
> Board targeting resolves from `pcb.toml` (`workspace.name`, `workspace.repository` with `/b/` parsing) or `--workspace` / `--board`. Subcommands support **`-f table|json`**; table output uses **comfy-table**.
> 
> **`pcb order bom`** loads the order BOM and order selections, joins them client-side with precedence **order override → line default → none**, and exposes `selectionSource` plus selected MPN fields. **`--mismatches-only`** filters lines where design vs selected MPN differ after backend-aligned MPN normalization.
> 
> Docs and changelog are updated; tests cover identity resolution, join logic, mismatch rules, and JSON snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c31d9cdf890a6b8b044b199eac357c2af4e418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->