### PR TITLE
Document stdlib files from any workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Gerber regions no longer connect holes with board-length cut-in slivers.
 - Reference designators derived from instance-name hints now honor 4-digit (1000-series) numbers such as `R1000`, `R1500`, and `LED1001` instead of silently auto-renumbering them.
+- `pcb doc @stdlib/...` now works from inside any workspace.
 
 ## [0.4.4] - 2026-07-03
 

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -914,6 +914,17 @@ impl ResolutionResult {
     }
 
     pub fn frozen_root_for_file(&self, file: &Path) -> Option<(&str, &FrozenResolutionMap)> {
+        // Stdlib files are owned by the synthetic stdlib package in every map,
+        // never by a map's own root package; they root at the stdlib
+        // resolution when one was requested (e.g. `pcb doc @stdlib`). Both
+        // `file` and the workspace root are canonical, so a prefix check works.
+        if file.starts_with(self.workspace_info.workspace_stdlib_dir()) {
+            return self
+                .resolution
+                .get_key_value(STDLIB_MODULE_PATH)
+                .map(|(root_package, resolution)| (root_package.as_str(), resolution));
+        }
+
         // A resolution map is a candidate only when its own longest match for
         // `file` is its root workspace package; the longest such root wins.
         // Walk the file's ancestors (longest first) over the precomputed

--- a/crates/pcb-zen/src/package_resolver/resolve.rs
+++ b/crates/pcb-zen/src/package_resolver/resolve.rs
@@ -9,11 +9,11 @@ use anyhow::{Context, Result, bail};
 use ignore::WalkBuilder;
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use pcb_zen_core::file_extensions;
-use pcb_zen_core::is_stdlib_module_path;
 use pcb_zen_core::resolution::{
     FrozenPackage, FrozenPackageIdentity, FrozenResolutionMap, FrozenResolutionSet,
     ResolutionResult, selected_remote_from_hydrated_manifest,
 };
+use pcb_zen_core::{STDLIB_MODULE_PATH, is_stdlib_module_path};
 use semver::Version;
 
 use super::ResolvedDepId;
@@ -33,6 +33,12 @@ enum PackageNode {
 
 pub fn target_package_urls_for_path(workspace: &WorkspaceInfo, path: &Path) -> Result<Vec<String>> {
     let path = path.canonicalize()?;
+    // The materialized stdlib lives inside the workspace tree but is never a
+    // workspace package; resolve it as the stdlib root.
+    if path.starts_with(canonicalize(&workspace.workspace_stdlib_dir())) {
+        return Ok(vec![STDLIB_MODULE_PATH.to_string()]);
+    }
+
     if workspace.packages.is_empty() {
         return Ok(vec![STANDALONE_PACKAGE_URL.to_string()]);
     }
@@ -64,12 +70,36 @@ pub fn build_frozen_resolution_maps(
     let mut builder = FrozenResolutionBuilder::new(workspace.clone(), offline)?;
     let mut resolutions = BTreeMap::new();
     for package_url in package_urls {
-        let resolution = builder
-            .build(&package_url)
-            .with_context(|| format!("while resolving dependencies for {package_url}"))?;
+        // The stdlib has no manifest to hydrate; its resolution is the
+        // stdlib package alone.
+        let resolution = if is_stdlib_module_path(&package_url) {
+            stdlib_resolution_map(workspace)
+        } else {
+            builder
+                .build(&package_url)
+                .with_context(|| format!("while resolving dependencies for {package_url}"))?
+        };
         resolutions.insert(package_url, resolution);
     }
     Ok(resolutions)
+}
+
+fn stdlib_frozen_package() -> FrozenPackage {
+    FrozenPackage {
+        identity: FrozenPackageIdentity::Stdlib,
+        deps: BTreeMap::new(),
+        parts: Vec::new(),
+    }
+}
+
+fn stdlib_resolution_map(workspace: &WorkspaceInfo) -> FrozenResolutionMap {
+    FrozenResolutionMap {
+        selected_remote: BTreeMap::new(),
+        packages: BTreeMap::from([(
+            canonicalize(&workspace.workspace_stdlib_dir()),
+            stdlib_frozen_package(),
+        )]),
+    }
 }
 
 pub fn resolve_workspace_dependencies(
@@ -316,11 +346,7 @@ impl FrozenResolutionBuilder {
     fn add_stdlib_package(&mut self) -> Result<()> {
         self.packages.insert(
             canonicalize(&self.workspace.workspace_stdlib_dir()),
-            FrozenPackage {
-                identity: FrozenPackageIdentity::Stdlib,
-                deps: BTreeMap::new(),
-                parts: Vec::new(),
-            },
+            stdlib_frozen_package(),
         );
         Ok(())
     }
@@ -431,4 +457,86 @@ fn local_path_dependency_root(package_root: &Path, spec: &DependencySpec) -> Opt
         return None;
     };
     detail.path.as_ref().map(|path| package_root.join(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::WorkspacePackage;
+
+    fn workspace_with_package(root: &Path) -> WorkspaceInfo {
+        WorkspaceInfo {
+            root: root.to_path_buf(),
+            cache_dir: PathBuf::new(),
+            config: None,
+            packages: BTreeMap::from([(
+                "github.com/acme/pkg".to_string(),
+                WorkspacePackage {
+                    rel_path: PathBuf::from("pkg"),
+                    config: PcbToml::default(),
+                    version: None,
+                    published_at: None,
+                    preferred: false,
+                    dirty: false,
+                    entrypoints: Vec::new(),
+                    symbol_files: Vec::new(),
+                },
+            )]),
+            errors: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn stdlib_path_resolves_as_stdlib_root() {
+        let temp = tempfile::tempdir().unwrap();
+        // Workspace roots are canonical in real discovery; mirror that here so
+        // the stdlib prefix checks compare canonical paths.
+        let root = temp.path().canonicalize().unwrap();
+        let stdlib = root.join(".pcb/stdlib");
+        let pin_header = stdlib.join("generics/PinHeader.zen");
+        std::fs::create_dir_all(pin_header.parent().unwrap()).unwrap();
+        std::fs::write(&pin_header, "").unwrap();
+        let workspace = workspace_with_package(&root);
+
+        let targets = target_package_urls_for_path(&workspace, &stdlib).unwrap();
+        assert_eq!(targets, vec![STDLIB_MODULE_PATH.to_string()]);
+
+        let frozen = build_frozen_resolution_maps(&workspace, targets, true).unwrap();
+        let stdlib_resolution = frozen
+            .get(STDLIB_MODULE_PATH)
+            .expect("stdlib root resolution should exist");
+        assert_eq!(stdlib_resolution.packages.len(), 1);
+
+        let package = stdlib_resolution
+            .packages
+            .get(&stdlib)
+            .expect("stdlib package should be registered");
+        assert!(matches!(package.identity, FrozenPackageIdentity::Stdlib));
+
+        let resolution = ResolutionResult::frozen(workspace, frozen, HashMap::new());
+        let (root_package, _) = resolution
+            .frozen_root_for_file(&pin_header)
+            .expect("stdlib files should select the stdlib root package");
+        assert_eq!(root_package, STDLIB_MODULE_PATH);
+    }
+
+    #[test]
+    fn stdlib_file_has_no_root_without_stdlib_resolution() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let stdlib = root.join(".pcb/stdlib");
+        std::fs::create_dir_all(&stdlib).unwrap();
+        let workspace = workspace_with_package(&root);
+
+        // A resolution set without a stdlib root (the build/LSP flows) must
+        // keep returning None for stdlib files rather than misattributing
+        // them to a workspace package.
+        let resolution =
+            ResolutionResult::frozen(workspace, FrozenResolutionSet::default(), HashMap::new());
+        assert!(
+            resolution
+                .frozen_root_for_file(&stdlib.join("interfaces.zen"))
+                .is_none()
+        );
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to stdlib path routing and synthetic resolution maps, with tests covering doc success and build/LSP non-misattribution.
> 
> **Overview**
> **`pcb doc @stdlib/...` now works from inside any workspace** by treating the materialized `.pcb/stdlib` tree as the synthetic `@stdlib` package instead of a workspace member.
> 
> Resolution picks `@stdlib` when the target path is under the workspace stdlib directory, builds a **manifest-free frozen map** (stdlib identity only), and **`frozen_root_for_file`** routes stdlib `.zen` files to that root when a stdlib resolution was requested. If the frozen set has no stdlib entry (typical **build/LSP** flows), stdlib files still return **no root** so they are not attributed to a workspace package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf200daa2b65756ad783be814d2e0c4965d7e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->