### PR TITLE
fix(sch): use serde_jcs for canonical JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,18 +987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
-name = "canon-json"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ae9f90437d2e2efba2a6c75b8279aa6b8f2f4017e0a4aeb64a76cd9d3a2bab"
-dependencies = [
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,7 +4698,6 @@ version = "0.4.5"
 dependencies = [
  "allocative",
  "anyhow",
- "canon-json",
  "colored",
  "comfy-table",
  "csv",
@@ -4721,6 +4708,7 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
+ "serde_jcs",
  "serde_json",
  "starlark",
  "starlark_map",
@@ -6419,6 +6407,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
 name = "safe_arch"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6652,6 +6646,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/pcb-sch/Cargo.toml
+++ b/crates/pcb-sch/Cargo.toml
@@ -8,7 +8,7 @@ authors = { workspace = true }
 description = "Schematic handling for PCB design"
 
 [dependencies]
-canon-json = "0.2"
+serde_jcs = "0.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/pcb-sch/src/lib.rs
+++ b/crates/pcb-sch/src/lib.rs
@@ -764,11 +764,7 @@ impl Schematic {
     /// Serialize the schematic to canonical (deterministic) JSON string.
     /// Uses RFC 8785 canonical JSON format with sorted keys.
     pub fn to_json(&self) -> anyhow::Result<String> {
-        let mut buf = Vec::new();
-        let mut ser =
-            serde_json::Serializer::with_formatter(&mut buf, canon_json::CanonicalFormatter::new());
-        serde::Serialize::serialize(self, &mut ser)?;
-        Ok(String::from_utf8(buf)?)
+        Ok(serde_jcs::to_string(self)?)
     }
 
     /// Insert (or replace) an instance.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Canonical JSON output may differ in edge cases from the previous `canon-json` formatter, which could affect hashes or diffs of serialized schematics even though the public API is unchanged.
> 
> **Overview**
> **Canonical schematic JSON** in `pcb-sch` now goes through **`serde_jcs`** instead of **`canon-json`**. `Schematic::to_json` is reduced to `serde_jcs::to_string(self)` while still targeting **RFC 8785** (deterministic, sorted keys) per the existing docs.
> 
> Dependency wiring: **`canon-json` removed**, **`serde_jcs`** added in `Cargo.toml` with matching **`Cargo.lock`** updates (including transitive **`ryu-js`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56e04cf52005d213f4fbc79457b8383a316e8ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->