### PR TITLE
Use the new datasheet APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - `pcb scan` now uses the datasheet cache API and skips re-uploading PDFs the backend already has.
+- `pcb new component` resolves symbol datasheet URLs through the datasheet cache API and keeps the URL in the symbol instead of vendoring a local PDF copy.
 
 ## [0.4.5] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `pcb scan` now uses the datasheet cache API and skips re-uploading PDFs the backend already has.
+
 ## [0.4.5] - 2026-07-07
 
 ### Added

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -194,6 +194,10 @@ fn write_validated_pdf(bytes: &[u8], output_path: &Path) -> Result<()> {
         );
     }
 
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
     std::fs::write(output_path, bytes)?;
     Ok(())
 }
@@ -334,7 +338,11 @@ fn resolve_component_identity(
     })
 }
 
-fn materialize_symbol_datasheet(symbol_path: &Path, output_path: &Path) -> Result<()> {
+fn materialize_symbol_datasheet(
+    auth_token: Option<&str>,
+    symbol_path: &Path,
+    output_path: &Path,
+) -> Result<DatasheetProcessingOutcome> {
     let symbol_lib = pcb_eda::SymbolLibrary::from_file(symbol_path).with_context(|| {
         format!(
             "Failed to parse KiCad symbol file {}",
@@ -348,12 +356,25 @@ fn materialize_symbol_datasheet(symbol_path: &Path, output_path: &Path) -> Resul
         .and_then(pcb_eda::usable_kicad_field_value)
         .ok_or_else(|| anyhow::anyhow!("No valid Datasheet found in {}", symbol_path.display()))?;
 
-    materialize_datasheet_pdf(datasheet_ref, symbol_path.parent(), output_path)
+    if datasheet_ref.starts_with("http://") || datasheet_ref.starts_with("https://") {
+        // Verify the URL resolves to a PDF through the backend datasheet
+        // cache (which also warms it for later `pcb scan` runs). The symbol
+        // keeps the original URL, so no docs/ copy is needed.
+        crate::datasheet::ensure_pdf_for_url(auth_token, datasheet_ref)?;
+        return Ok(DatasheetProcessingOutcome::SymbolUrlCached);
+    }
+
+    materialize_datasheet_pdf(datasheet_ref, symbol_path.parent(), output_path)?;
+    Ok(DatasheetProcessingOutcome::SymbolDownloaded)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DatasheetProcessingOutcome {
+    /// Symbol datasheet URL verified and cached; the symbol keeps the URL.
+    SymbolUrlCached,
+    /// Symbol's local datasheet reference copied into docs/.
     SymbolDownloaded,
+    /// Component-download fallback PDF downloaded into docs/.
     FallbackDownloaded,
     NotResolved,
 }
@@ -363,10 +384,6 @@ fn materialize_datasheet_pdf(
     relative_to_dir: Option<&Path>,
     output_path: &Path,
 ) -> Result<()> {
-    if datasheet_ref.starts_with("http://") || datasheet_ref.starts_with("https://") {
-        return download_pdf_file(datasheet_ref, output_path);
-    }
-
     let source_path = {
         let path = Path::new(datasheet_ref);
         if path.is_absolute() {
@@ -387,28 +404,16 @@ fn materialize_datasheet_pdf(
 }
 
 fn process_component_datasheet(
+    auth_token: Option<&str>,
     symbol_path: &Path,
     output_path: &Path,
     fallback_datasheet_url: Option<&str>,
 ) -> (DatasheetProcessingOutcome, Vec<String>) {
-    if let Some(parent) = output_path.parent()
-        && let Err(e) = fs::create_dir_all(parent)
-    {
-        return (
-            DatasheetProcessingOutcome::NotResolved,
-            vec![format!(
-                "datasheet setup: failed to create {}: {}",
-                parent.display(),
-                e
-            )],
-        );
-    }
-
     let mut symbol_error: Option<String> = None;
 
     if symbol_path.exists() {
-        match materialize_symbol_datasheet(symbol_path, output_path) {
-            Ok(()) => return (DatasheetProcessingOutcome::SymbolDownloaded, Vec::new()),
+        match materialize_symbol_datasheet(auth_token, symbol_path, output_path) {
+            Ok(outcome) => return (outcome, Vec::new()),
             Err(e) => symbol_error = Some(format!("symbol datasheet download: {e}")),
         }
     }
@@ -616,6 +621,7 @@ pub fn add_component_to_workspace(
     spinner.set_message("Downloading datasheet...");
 
     let (datasheet_outcome, datasheet_warnings) = process_component_datasheet(
+        auth_token,
         &files.symbol_path,
         &files.pdf_path,
         download.datasheet_url.as_deref(),
@@ -629,6 +635,9 @@ pub fn add_component_to_workspace(
     )
     .then(|| component_datasheet_ref(&files.sanitized_mpn));
     match datasheet_outcome {
+        DatasheetProcessingOutcome::SymbolUrlCached => {
+            eprintln!("{} Datasheet URL verified and cached", "✓".green());
+        }
         DatasheetProcessingOutcome::SymbolDownloaded => {
             eprintln!("{} Downloaded datasheet from symbol", "✓".green());
         }

--- a/crates/pcb-diode-api/src/datasheet.rs
+++ b/crates/pcb-diode-api/src/datasheet.rs
@@ -11,8 +11,9 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::scan::{
-    build_scan_client, calculate_sha256, download_file, download_process_artifacts, extract_zip,
-    process_local_pdf, request_process,
+    DatasheetScanOutcome, DatasheetScanResponse, build_scan_client, calculate_sha256,
+    create_datasheet_from_pdf, create_datasheet_from_url, datasheet_id_for_sha256, download_file,
+    download_scan_artifacts, extract_zip, scan_datasheet,
 };
 
 const DATASHEET_NAMESPACE_UUID: &str = "fe255507-b3f4-4ec0-98cb-9e3f90cfd8eb";
@@ -139,7 +140,7 @@ pub fn resolve_datasheet(
         ResolveDatasheetInput::PdfPath(path) => {
             let pdf_path = path.clone();
             let execution = ResolveExecution::from_pdf_path(pdf_path, None)?;
-            execute_resolve_execution(&client, auth_token, execution, None)
+            execute_resolve_execution(&client, auth_token, execution)
         }
         ResolveDatasheetInput::KicadSymPath { path, symbol_name } => {
             let reference =
@@ -151,7 +152,7 @@ pub fn resolve_datasheet(
                 let pdf_path = resolve_local_datasheet_path_from_kicad_sym(path, &reference)?;
                 validate_local_pdf(&pdf_path)?;
                 let execution = ResolveExecution::from_pdf_path(pdf_path, None)?;
-                execute_resolve_execution(&client, auth_token, execution, None)
+                execute_resolve_execution(&client, auth_token, execution)
             }
         }
     }
@@ -165,25 +166,22 @@ fn resolve_source_url_datasheet(
     let url_cache_dir = url_pdf_cache_dir(&canonical_url)?;
     fs::create_dir_all(&url_cache_dir)?;
 
-    let (pdf_path, prefetched_process) = if let Some(cached_pdf) =
+    let pdf_path = if let Some(cached_pdf) =
         first_valid_file_in_dir(&url_cache_dir, None, is_valid_cached_pdf)?
     {
-        (cached_pdf, None)
+        cached_pdf
     } else {
-        let (process, downloaded_pdf_path) =
-            fetch_url_pdf_via_backend(client, auth_token, &canonical_url, &url_cache_dir)?;
-        (downloaded_pdf_path, Some(process))
+        fetch_url_pdf_via_backend(client, auth_token, &canonical_url, &url_cache_dir)?
     };
 
     let execution = ResolveExecution::from_pdf_path(pdf_path, Some(canonical_url))?;
-    execute_resolve_execution(client, auth_token, execution, prefetched_process)
+    execute_resolve_execution(client, auth_token, execution)
 }
 
 fn execute_resolve_execution(
     client: &Client,
     auth_token: Option<&str>,
     execution: ResolveExecution,
-    prefetched_process: Option<crate::scan::ProcessResponse>,
 ) -> Result<ResolveDatasheetResponse> {
     let materialization_id = materialization_id_for_key(&execution.pdf_sha256)?;
     let materialized_dir = materialized_dir(&materialization_id);
@@ -213,25 +211,11 @@ fn execute_resolve_execution(
     }
     reset_materialized_cache(&materialized_dir, &images_dir, &complete_marker);
 
-    let process = if let Some(process) = prefetched_process {
-        process
-    } else {
-        if let Some(parent) = execution.pdf_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
+    let scan = ensure_datasheet_scanned(client, auth_token, &execution)?;
 
-        process_local_pdf(
-            client,
-            auth_token,
-            &execution.pdf_path,
-            Some(&execution.pdf_sha256),
-            None,
-        )?
-    };
-
-    materialize_process_outputs(
+    materialize_scan_outputs(
         client,
-        &process,
+        &scan,
         &materialized_dir,
         &markdown_path,
         &images_dir,
@@ -252,36 +236,48 @@ fn fetch_url_pdf_via_backend(
     auth_token: Option<&str>,
     canonical_url: &str,
     url_cache_dir: &Path,
-) -> Result<(crate::scan::ProcessResponse, PathBuf)> {
-    let api_base_url = crate::get_api_base_url();
-    let process = request_process(
-        client,
-        auth_token,
-        &api_base_url,
-        None,
-        Some(canonical_url),
-        None,
-    )?;
-    let source_pdf_url = process
-        .source_pdf_url
-        .as_deref()
-        .context("Scan API did not return sourcePdfUrl for URL input")?;
-    let filename = infer_source_pdf_filename(source_pdf_url)?;
-    let pdf_path = url_cache_dir.join(filename);
+) -> Result<PathBuf> {
+    let datasheet = create_datasheet_from_url(client, auth_token, canonical_url)?;
+    let pdf_path = url_cache_dir.join(cached_pdf_filename(&datasheet.filename));
 
-    download_file(client, source_pdf_url, &pdf_path)
-        .context("Failed to download source PDF output")?;
+    download_file(client, &datasheet.file_url, &pdf_path)
+        .context("Failed to download cached datasheet PDF")?;
     if !is_valid_cached_pdf(&pdf_path)? {
         let _ = fs::remove_file(&pdf_path);
         anyhow::bail!("Downloaded URL did not produce a valid PDF: {canonical_url}");
     }
+    if !calculate_sha256(&pdf_path)?.eq_ignore_ascii_case(&datasheet.sha256) {
+        let _ = fs::remove_file(&pdf_path);
+        anyhow::bail!("Downloaded datasheet PDF did not match its content hash: {canonical_url}");
+    }
 
-    Ok((process, pdf_path))
+    Ok(pdf_path)
 }
 
-fn materialize_process_outputs(
+fn ensure_datasheet_scanned(
     client: &Client,
-    process: &crate::scan::ProcessResponse,
+    auth_token: Option<&str>,
+    execution: &ResolveExecution,
+) -> Result<DatasheetScanResponse> {
+    let datasheet_id = datasheet_id_for_sha256(&execution.pdf_sha256);
+    if let DatasheetScanOutcome::Scanned(scan) = scan_datasheet(client, auth_token, &datasheet_id)?
+    {
+        return Ok(scan);
+    }
+
+    // The backend has no PDF cached under this content hash yet — upload ours, then scan.
+    let datasheet = create_datasheet_from_pdf(client, auth_token, &execution.pdf_path)?;
+    match scan_datasheet(client, auth_token, &datasheet.id)? {
+        DatasheetScanOutcome::Scanned(scan) => Ok(scan),
+        DatasheetScanOutcome::NotCached => {
+            anyhow::bail!("Datasheet {} not found after upload", datasheet.id)
+        }
+    }
+}
+
+fn materialize_scan_outputs(
+    client: &Client,
+    scan: &DatasheetScanResponse,
     materialized_dir: &Path,
     markdown_path: &Path,
     images_dir: &Path,
@@ -291,16 +287,15 @@ fn materialize_process_outputs(
     let _ = fs::remove_file(complete_marker);
 
     let zip_path = materialized_dir.join("images.zip");
-    download_process_artifacts(
+    download_scan_artifacts(
         client,
-        process,
+        scan,
         markdown_path,
-        None,
-        process.images_zip_url.as_ref().map(|_| zip_path.as_path()),
+        scan.images_zip_url.as_ref().map(|_| zip_path.as_path()),
     )
     .context("Failed to download datasheet outputs")?;
 
-    if process.images_zip_url.is_some() {
+    if scan.images_zip_url.is_some() {
         let temp_images_dir = materialized_dir.join(format!(".images-{}", Uuid::new_v4()));
 
         let extract_result = (|| -> Result<()> {
@@ -635,20 +630,14 @@ fn is_file_with_extension(path: &Path, extension: &str) -> bool {
             .is_some_and(|ext| ext.eq_ignore_ascii_case(extension))
 }
 
-fn infer_source_pdf_filename(source_pdf_url: &str) -> Result<String> {
-    let parsed = Url::parse(source_pdf_url)
-        .with_context(|| format!("Invalid sourcePdfUrl returned by scan API: {source_pdf_url}"))?;
-    let filename = parsed
-        .path_segments()
-        .and_then(|mut segments| segments.next_back())
-        .filter(|name| !name.is_empty())
-        .with_context(|| format!("sourcePdfUrl missing filename: {source_pdf_url}"))?;
-
-    if !filename.to_ascii_lowercase().ends_with(".pdf") {
-        anyhow::bail!("sourcePdfUrl filename must end with .pdf: {source_pdf_url}");
-    }
-
-    Ok(filename.to_string())
+/// Reduce the backend-reported filename to a safe local cache filename.
+fn cached_pdf_filename(filename: &str) -> String {
+    Path::new(filename)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| name.to_ascii_lowercase().ends_with(".pdf") && name.len() > ".pdf".len())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "datasheet.pdf".to_string())
 }
 
 fn is_non_empty_file(path: &Path) -> Result<bool> {
@@ -721,20 +710,22 @@ mod tests {
     }
 
     #[test]
-    fn test_infer_source_pdf_filename_extracts_pdf_name() {
-        let name =
-            infer_source_pdf_filename("https://example.com/scans/abc123/ad574a.pdf").unwrap();
-        assert_eq!(name, "ad574a.pdf");
+    fn test_cached_pdf_filename_keeps_valid_pdf_name() {
+        assert_eq!(cached_pdf_filename("ad574a.pdf"), "ad574a.pdf");
+        assert_eq!(cached_pdf_filename("AD574A.PDF"), "AD574A.PDF");
     }
 
     #[test]
-    fn test_infer_source_pdf_filename_rejects_empty_segment() {
-        assert!(infer_source_pdf_filename("https://example.com/scans/abc123/").is_err());
+    fn test_cached_pdf_filename_strips_path_components() {
+        assert_eq!(cached_pdf_filename("scans/abc123/ad574a.pdf"), "ad574a.pdf");
     }
 
     #[test]
-    fn test_infer_source_pdf_filename_rejects_non_pdf_name() {
-        assert!(infer_source_pdf_filename("https://example.com/scans/abc123/source").is_err());
+    fn test_cached_pdf_filename_defaults_for_unsafe_names() {
+        assert_eq!(cached_pdf_filename(""), "datasheet.pdf");
+        assert_eq!(cached_pdf_filename("source"), "datasheet.pdf");
+        assert_eq!(cached_pdf_filename(".pdf"), "datasheet.pdf");
+        assert_eq!(cached_pdf_filename("scans/abc123/"), "datasheet.pdf");
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/datasheet.rs
+++ b/crates/pcb-diode-api/src/datasheet.rs
@@ -163,19 +163,32 @@ fn resolve_source_url_datasheet(
     auth_token: Option<&str>,
     canonical_url: String,
 ) -> Result<ResolveDatasheetResponse> {
-    let url_cache_dir = url_pdf_cache_dir(&canonical_url)?;
-    fs::create_dir_all(&url_cache_dir)?;
-
-    let pdf_path = if let Some(cached_pdf) =
-        first_valid_file_in_dir(&url_cache_dir, None, is_valid_cached_pdf)?
-    {
-        cached_pdf
-    } else {
-        fetch_url_pdf_via_backend(client, auth_token, &canonical_url, &url_cache_dir)?
-    };
-
+    let pdf_path = ensure_url_pdf_cached(client, auth_token, &canonical_url)?;
     let execution = ResolveExecution::from_pdf_path(pdf_path, Some(canonical_url))?;
     execute_resolve_execution(client, auth_token, execution)
+}
+
+/// Ensure the PDF behind a datasheet URL is present in the local URL cache,
+/// fetching it through the backend datasheet cache on miss, and return its
+/// local path.
+pub(crate) fn ensure_pdf_for_url(auth_token: Option<&str>, url: &str) -> Result<PathBuf> {
+    let client = build_scan_client()?;
+    let canonical_url = canonicalize_url(url)?;
+    ensure_url_pdf_cached(&client, auth_token, &canonical_url)
+}
+
+fn ensure_url_pdf_cached(
+    client: &Client,
+    auth_token: Option<&str>,
+    canonical_url: &str,
+) -> Result<PathBuf> {
+    let url_cache_dir = url_pdf_cache_dir(canonical_url)?;
+    fs::create_dir_all(&url_cache_dir)?;
+
+    if let Some(cached_pdf) = first_valid_file_in_dir(&url_cache_dir, None, is_valid_cached_pdf)? {
+        return Ok(cached_pdf);
+    }
+    fetch_url_pdf_via_backend(client, auth_token, canonical_url, &url_cache_dir)
 }
 
 fn execute_resolve_execution(

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -38,7 +38,7 @@ pub use sandbox::{
     ExecSyncOutput, ExecSyncRequest, SandboxClient, SandboxDirEntry, SandboxListResponse,
     SandboxLockGuard, SandboxLockOptions,
 };
-pub use scan::{ScanArgs, ScanModel, ScanModelArg, execute as execute_scan};
+pub use scan::{ScanArgs, execute as execute_scan};
 
 pub fn get_api_base_url() -> String {
     WorkspaceContext::from_cwd()

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
-use clap::{Args, ValueEnum};
+use clap::Args;
 use pcb_ui::Spinner;
-use reqwest::blocking::Client;
+use reqwest::blocking::{Client, multipart};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File};
@@ -10,86 +10,50 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use url::Url;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ScanModel {
-    MistralOcr2512,
-    DatalabFast,
-    DatalabBalanced,
-    DatalabAccurate,
-}
-
-impl ScanModel {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::MistralOcr2512 => "mistral-ocr-2512",
-            Self::DatalabFast => "datalab-fast",
-            Self::DatalabBalanced => "datalab-balanced",
-            Self::DatalabAccurate => "datalab-accurate",
-        }
-    }
-}
-
-impl std::fmt::Display for ScanModel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl std::str::FromStr for ScanModel {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s {
-            "mistral-ocr-2512" => Ok(Self::MistralOcr2512),
-            "datalab-fast" => Ok(Self::DatalabFast),
-            "datalab-balanced" => Ok(Self::DatalabBalanced),
-            "datalab-accurate" => Ok(Self::DatalabAccurate),
-            _ => anyhow::bail!(
-                "Invalid model: {}. Valid options: mistral-ocr-2512, datalab-fast, datalab-balanced, datalab-accurate",
-                s
-            ),
-        }
-    }
-}
-
 #[derive(Serialize)]
-struct UploadUrlRequest {
-    sha256: String,
-    filename: String,
+struct CreateDatasheetRequest {
+    url: String,
 }
 
 #[derive(Deserialize)]
-pub(crate) struct UploadUrlResponse {
-    #[serde(rename = "uploadUrl")]
-    pub(crate) upload_url: Option<String>,
-    #[serde(rename = "sourcePath")]
-    pub(crate) source_path: String,
-}
-
-#[derive(Serialize)]
-struct ProcessRequest {
-    #[serde(rename = "sourcePath")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    source_path: Option<String>,
-    #[serde(rename = "sourceUrl")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    source_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    model: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    concurrency: Option<u32>,
+pub(crate) struct DatasheetResponse {
+    pub(crate) id: String,
+    #[serde(rename = "fileUrl")]
+    pub(crate) file_url: String,
+    pub(crate) sha256: String,
+    pub(crate) filename: String,
 }
 
 #[derive(Deserialize)]
-pub(crate) struct ProcessResponse {
+pub(crate) struct DatasheetScanResponse {
     #[serde(rename = "markdownUrl")]
     pub(crate) markdown_url: String,
-    #[serde(rename = "documentJsonUrl")]
-    pub(crate) document_json_url: Option<String>,
     #[serde(rename = "imagesZipUrl")]
     pub(crate) images_zip_url: Option<String>,
-    #[serde(rename = "sourcePdfUrl")]
-    pub(crate) source_pdf_url: Option<String>,
+}
+
+pub(crate) enum DatasheetScanOutcome {
+    Scanned(DatasheetScanResponse),
+    NotCached,
+}
+
+pub(crate) fn datasheet_id_for_sha256(sha256: &str) -> String {
+    format!("sha256:{sha256}")
+}
+
+fn api_error(context: &str, response: reqwest::blocking::Response) -> anyhow::Error {
+    #[derive(Deserialize)]
+    struct ApiError {
+        error: String,
+    }
+
+    let status = response.status();
+    match response.json::<ApiError>() {
+        Ok(body) if !body.error.is_empty() => {
+            anyhow::anyhow!("{context} failed ({status}): {}", body.error)
+        }
+        _ => anyhow::anyhow!("{context} failed: {status}"),
+    }
 }
 
 pub(crate) fn build_scan_client() -> Result<Client> {
@@ -115,105 +79,75 @@ pub(crate) fn calculate_sha256(path: &Path) -> Result<String> {
     Ok(hex::encode(hasher.finalize()))
 }
 
-pub(crate) fn request_upload_url(
+pub(crate) fn create_datasheet_from_url(
     client: &Client,
     token: Option<&str>,
-    base_url: &str,
-    sha256: &str,
-    filename: &str,
-) -> Result<UploadUrlResponse> {
-    let url = format!("{}/api/scan/upload-url", base_url);
+    url: &str,
+) -> Result<DatasheetResponse> {
+    let endpoint = format!("{}/api/datasheets", crate::get_api_base_url());
 
-    let response = crate::auth::apply_bearer_auth(client.post(&url), token)
-        .json(&UploadUrlRequest {
-            sha256: sha256.to_string(),
-            filename: filename.to_string(),
+    let response = crate::auth::apply_bearer_auth(client.post(&endpoint), token)
+        .json(&CreateDatasheetRequest {
+            url: url.to_string(),
         })
         .send()?;
 
     if !response.status().is_success() {
-        anyhow::bail!("API error: {}", response.status());
+        return Err(api_error("Datasheet download", response));
     }
 
     Ok(response.json()?)
 }
 
-pub(crate) fn process_local_pdf(
-    client: &Client,
-    auth_token: Option<&str>,
-    file_path: &Path,
-    file_sha256: Option<&str>,
-    model: Option<&str>,
-) -> Result<ProcessResponse> {
-    let api_base_url = crate::get_api_base_url();
-    let filename = file_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .context("Invalid filename")?;
-    let sha256 = match file_sha256 {
-        Some(sha256) => sha256.to_owned(),
-        None => calculate_sha256(file_path)?,
-    };
-
-    let upload = request_upload_url(client, auth_token, &api_base_url, &sha256, filename)?;
-    if let Some(upload_url) = upload.upload_url.as_deref() {
-        upload_pdf(client, upload_url, file_path)?;
-    }
-
-    request_process(
-        client,
-        auth_token,
-        &api_base_url,
-        Some(&upload.source_path),
-        None,
-        model,
-    )
-}
-
-pub(crate) fn upload_pdf(client: &Client, upload_url: &str, file_path: &Path) -> Result<()> {
-    let file_data = fs::read(file_path)?;
-
-    let response = client
-        .put(upload_url)
-        .header("Content-Type", "application/pdf")
-        .body(file_data)
-        .send()?;
-
-    if !response.status().is_success() {
-        anyhow::bail!("Upload failed: {}", response.status());
-    }
-
-    Ok(())
-}
-
-pub(crate) fn request_process(
+pub(crate) fn create_datasheet_from_pdf(
     client: &Client,
     token: Option<&str>,
-    base_url: &str,
-    source_path: Option<&str>,
-    source_url: Option<&str>,
-    model: Option<&str>,
-) -> Result<ProcessResponse> {
-    if source_path.is_none() && source_url.is_none() {
-        anyhow::bail!("Either source_path or source_url is required");
-    }
+    pdf_path: &Path,
+) -> Result<DatasheetResponse> {
+    let endpoint = format!("{}/api/datasheets", crate::get_api_base_url());
+    let form = multipart::Form::new()
+        .file("file", pdf_path)
+        .with_context(|| {
+            format!(
+                "Failed to read datasheet PDF for upload: {}",
+                pdf_path.display()
+            )
+        })?;
 
-    let url = format!("{}/api/scan/process", base_url);
-
-    let response = crate::auth::apply_bearer_auth(client.post(&url), token)
-        .json(&ProcessRequest {
-            source_path: source_path.map(ToOwned::to_owned),
-            source_url: source_url.map(ToOwned::to_owned),
-            model: model.map(|s| s.to_string()),
-            concurrency: None,
-        })
+    let response = crate::auth::apply_bearer_auth(client.post(&endpoint), token)
+        .multipart(form)
         .send()?;
 
     if !response.status().is_success() {
-        anyhow::bail!("API error: {}", response.status());
+        return Err(api_error("Datasheet upload", response));
     }
 
     Ok(response.json()?)
+}
+
+pub(crate) fn scan_datasheet(
+    client: &Client,
+    token: Option<&str>,
+    datasheet_id: &str,
+) -> Result<DatasheetScanOutcome> {
+    let endpoint = format!(
+        "{}/api/datasheets/{}/scan",
+        crate::get_api_base_url(),
+        datasheet_id
+    );
+
+    let response = crate::auth::apply_bearer_auth(client.post(&endpoint), token)
+        .json(&serde_json::json!({}))
+        .send()?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(DatasheetScanOutcome::NotCached);
+    }
+    if !response.status().is_success() {
+        return Err(api_error("Datasheet scan", response));
+    }
+
+    Ok(DatasheetScanOutcome::Scanned(response.json()?))
 }
 
 pub(crate) fn download_file(client: &Client, url: &str, path: &Path) -> Result<()> {
@@ -233,33 +167,23 @@ pub(crate) fn download_file(client: &Client, url: &str, path: &Path) -> Result<(
     Ok(())
 }
 
-pub(crate) fn download_process_artifacts(
+pub(crate) fn download_scan_artifacts(
     client: &Client,
-    process_response: &ProcessResponse,
+    scan_response: &DatasheetScanResponse,
     markdown_path: &Path,
-    document_json_path: Option<&Path>,
     images_zip_path: Option<&Path>,
 ) -> Result<()> {
     std::thread::scope(|s| -> Result<()> {
         let md_handle =
-            s.spawn(|| download_file(client, &process_response.markdown_url, markdown_path));
+            s.spawn(|| download_file(client, &scan_response.markdown_url, markdown_path));
 
-        let json_handle = process_response
-            .document_json_url
-            .as_ref()
-            .zip(document_json_path)
-            .map(|(url, path)| s.spawn(|| download_file(client, url, path)));
-
-        let images_handle = process_response
+        let images_handle = scan_response
             .images_zip_url
             .as_ref()
             .zip(images_zip_path)
             .map(|(url, path)| s.spawn(|| download_file(client, url, path)));
 
         md_handle.join().unwrap()?;
-        if let Some(h) = json_handle {
-            h.join().unwrap()?;
-        }
         if let Some(h) = images_handle {
             h.join().unwrap()?;
         }
@@ -293,29 +217,6 @@ pub(crate) fn extract_zip(zip_path: &Path, output_dir: &Path) -> Result<()> {
     }
 
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum ScanModelArg {
-    #[value(name = "mistral-ocr-2512")]
-    MistralOcr2512,
-    #[value(name = "datalab-fast")]
-    DatalabFast,
-    #[value(name = "datalab-balanced")]
-    DatalabBalanced,
-    #[value(name = "datalab-accurate")]
-    DatalabAccurate,
-}
-
-impl From<ScanModelArg> for ScanModel {
-    fn from(arg: ScanModelArg) -> Self {
-        match arg {
-            ScanModelArg::MistralOcr2512 => ScanModel::MistralOcr2512,
-            ScanModelArg::DatalabFast => ScanModel::DatalabFast,
-            ScanModelArg::DatalabBalanced => ScanModel::DatalabBalanced,
-            ScanModelArg::DatalabAccurate => ScanModel::DatalabAccurate,
-        }
-    }
 }
 
 enum ScanInput {


### PR DESCRIPTION
Also, don't copy datasheet to `docs/` if the url resolves (and is cached) such that `pcb scan` is guaranteed to work on the url.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated backend datasheet upload/scan and changes when components vendor PDFs vs keep URLs; failures affect scan and component import, but scope is limited to the diode API client.
> 
> **Overview**
> **Datasheet client** moves off `/api/scan/upload-url` and `/api/scan/process` to **`POST /api/datasheets`** (URL JSON or PDF multipart) and **`POST /api/datasheets/{id}/scan`**, keyed by `sha256:{hash}`. Resolve/scan first tries scan on the content hash and only uploads the local PDF when the backend returns not cached; URL PDFs are fetched via the cache API with **SHA-256 verification** after download.
> 
> **`pcb scan`** is wired through shared `resolve_datasheet` (no separate process path); **scan model CLI options are removed** from the public API.
> 
> **`pcb new component` / search add**: symbol **HTTP datasheet fields** are validated and warmed via `ensure_pdf_for_url` without copying into `docs/` or rewriting the symbol to a local path; local relative datasheets and API fallback URLs still materialize under `docs/` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d8ac44594fed886c913513c1f870ce4e39d229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->