### PR TITLE
feat(pcbc): infer board publish bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added board release support for `pcb publish <board.zen> --bump=infer`.
+
 ## [0.4.6] - 2026-07-08
 
 ### Changed

--- a/crates/pcbc/src/publish.rs
+++ b/crates/pcbc/src/publish.rs
@@ -516,13 +516,17 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
     let tag_prefix = tags::compute_tag_prefix(Some(&pkg_rel_path), workspace.path());
     let all_tags = git::list_all_tags(&workspace.root).unwrap_or_default();
     let current = tags::find_latest_version(&all_tags, &tag_prefix);
+    let latest_tag = tags::find_latest_tag(&all_tags, &tag_prefix);
 
     // Resolve bump type (interactive prompt if --bump was passed without a value)
     let bump = match args.bump.unwrap() {
         BumpType::Interactive => prompt_single_bump(&board_name, current.as_ref())?,
-        BumpType::Infer => {
-            bail!("--bump=infer is only supported when publishing packages.");
-        }
+        BumpType::Infer => infer_board_bump(
+            &workspace,
+            current.as_ref(),
+            latest_tag.as_deref(),
+            &pkg_rel_path,
+        ),
         b => b
             .release()
             .expect("explicit board bump must be a release bump"),
@@ -1093,6 +1097,24 @@ fn infer_self_bump(
     .into_iter()
     .map(|subject| ReleaseBump::infer_from_commit(&subject, current))
     .max()
+}
+
+fn infer_board_bump(
+    workspace: &WorkspaceInfo,
+    current: Option<&Version>,
+    latest_tag: Option<&str>,
+    pkg_rel_path: &Path,
+) -> ReleaseBump {
+    let Some(current) = current else {
+        return ReleaseBump::Minor;
+    };
+
+    let range = latest_tag.map(|tag| format!("{tag}..HEAD"));
+    git::log_subjects(&workspace.root, range.as_deref(), Some(pkg_rel_path))
+        .into_iter()
+        .map(|subject| ReleaseBump::infer_from_commit(&subject, current))
+        .max()
+        .unwrap_or(ReleaseBump::Patch)
 }
 
 fn current_package_version(

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -155,6 +155,134 @@ fn find_staging_dir(sb: &Sandbox, board_name: &str) -> String {
     format!(".pcb/releases/{}", staging_dir_name)
 }
 
+fn setup_board_publish_infer_workspace(sb: &mut Sandbox) {
+    sb.cwd("src")
+        .write(".gitignore", ".pcb\n")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write("boards/modules/LedModule.zen", LED_MODULE_ZEN)
+        .write("boards/TestBoard.zen", TEST_BOARD_ZEN)
+        .hash_globs(["*.kicad_mod", "**/diodeinc/stdlib/*.zen", "**/netlist.json"])
+        .ignore_globs(["layout/*", "**/vendor/**", "**/build/**"])
+        .init_git()
+        .commit("chore: initial workspace")
+        .sync();
+
+    sb.run("pcbc", ["build", "boards/TestBoard.zen"])
+        .run()
+        .expect("build failed");
+    sb.commit("chore: hydrate manifests");
+}
+
+fn publish_board_infer(sb: &mut Sandbox) {
+    let mut args = source_only_args("boards/TestBoard.zen");
+    args.push("--bump=infer");
+    sb.run("pcbc", &args).run().expect("publish failed");
+}
+
+fn assert_publish_git_version(sb: &Sandbox, version: &str) {
+    let staging_dir = format!(".pcb/releases/TestBoard-{version}");
+    let metadata_file = File::open(
+        sb.root_path()
+            .join("src")
+            .join(&staging_dir)
+            .join("metadata.json"),
+    )
+    .unwrap();
+    let metadata_json: Value = serde_json::from_reader(metadata_file).unwrap();
+    assert_eq!(
+        metadata_json["release"]["git_version"].as_str(),
+        Some(version)
+    );
+}
+
+#[test]
+fn test_publish_board_infer_first_release() {
+    let mut sb = Sandbox::new();
+    setup_board_publish_infer_workspace(&mut sb);
+
+    publish_board_infer(&mut sb);
+
+    assert_publish_git_version(&sb, "v0.1.0");
+}
+
+#[test]
+fn test_publish_board_infer_pre_1_0_feat_is_patch() {
+    let mut sb = Sandbox::new();
+    setup_board_publish_infer_workspace(&mut sb);
+    sb.tag("boards/v0.1.0")
+        .write(
+            "boards/TestBoard.zen",
+            format!("{TEST_BOARD_ZEN}\n# add connector\n"),
+        )
+        .commit("feat: add connector");
+
+    publish_board_infer(&mut sb);
+
+    assert_publish_git_version(&sb, "v0.1.1");
+}
+
+#[test]
+fn test_publish_board_infer_pre_1_0_breaking_is_minor() {
+    let mut sb = Sandbox::new();
+    setup_board_publish_infer_workspace(&mut sb);
+    sb.tag("boards/v0.1.0")
+        .write(
+            "boards/TestBoard.zen",
+            format!("{TEST_BOARD_ZEN}\n# reroute board\n"),
+        )
+        .commit("feat!: reroute board");
+
+    publish_board_infer(&mut sb);
+
+    assert_publish_git_version(&sb, "v0.2.0");
+}
+
+#[test]
+fn test_publish_board_infer_post_1_0_feat_is_minor() {
+    let mut sb = Sandbox::new();
+    setup_board_publish_infer_workspace(&mut sb);
+    sb.tag("boards/v1.0.0")
+        .write(
+            "boards/TestBoard.zen",
+            format!("{TEST_BOARD_ZEN}\n# add connector\n"),
+        )
+        .commit("feat: add connector");
+
+    publish_board_infer(&mut sb);
+
+    assert_publish_git_version(&sb, "v1.1.0");
+}
+
+#[test]
+fn test_publish_board_infer_post_1_0_breaking_is_major() {
+    let mut sb = Sandbox::new();
+    setup_board_publish_infer_workspace(&mut sb);
+    sb.tag("boards/v1.0.0")
+        .write(
+            "boards/TestBoard.zen",
+            format!("{TEST_BOARD_ZEN}\n# reroute board\n"),
+        )
+        .commit("feat!: reroute board");
+
+    publish_board_infer(&mut sb);
+
+    assert_publish_git_version(&sb, "v2.0.0");
+}
+
+#[test]
+fn test_publish_board_infer_scopes_commit_history_to_board_path() {
+    let mut sb = Sandbox::new();
+    setup_board_publish_infer_workspace(&mut sb);
+    sb.tag("boards/v1.0.0")
+        .write("README.md", "outside board path\n")
+        .commit("feat!: outside breaking change");
+
+    publish_board_infer(&mut sb);
+
+    assert_publish_git_version(&sb, "v1.0.1");
+}
+
 #[test]
 fn test_publish_board_source_only() {
     let mut sb = Sandbox::new();


### PR DESCRIPTION
This PR supports board release version inference by applying the existing conventional-commit bump rules to path-scoped board history. It enables `pcb publish <board.zen> --bump=infer` without changing package inference behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds board-only versioning logic that mirrors existing package inference; behavior is covered by integration tests and does not alter package publish paths.
> 
> **Overview**
> **Board releases** can use **`pcb publish <board.zen> --bump=infer`**, which was previously rejected for boards only.
> 
> Inference reuses the same **conventional-commit → semver bump** rules as package publish (`ReleaseBump::infer_from_commit`). Commits since the **latest board tag** are read from git history **scoped to the board package path**, so unrelated repo changes do not affect the bump. With no prior tag, the inferred first release is **0.1.0**; if there are no qualifying commits in range, it defaults to **patch**.
> 
> Package publish inference is unchanged. **CHANGELOG** documents the feature, and **integration tests** cover first release, pre-1.0 vs post-1.0 feat/breaking behavior, and path scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c997bc81d5df0ff68ee264a8c68f51d237b2a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->