### PR TITLE
ENG-445 Fix strict BOM API request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb scan` supports page ranges with `--pages START-END`.
 
+### Fixed
+
+- `[workspace.bom] strict = true` now selects the API's strict BOM matcher instead of sending an ignored request-body field.
+
 ## [0.4.8] - 2026-07-22
 
 ### Changed

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -105,8 +105,12 @@ struct DesignBomEntry {
 enum BomMatchStatus {
     #[serde(rename = "MATCH_EXACT")]
     Exact,
+    #[serde(rename = "MATCH_COMPATIBLE")]
+    Compatible,
     #[serde(rename = "MATCH_FUZZY")]
     Fuzzy,
+    #[serde(rename = "MATCH_NEEDS_RETRY")]
+    NeedsRetry,
     #[serde(rename = "MATCH_FAILED")]
     Failed,
 }
@@ -256,12 +260,12 @@ fn call_bom_match_api(
     timeout_secs: u64,
     strict: bool,
 ) -> Result<MatchBomResponse> {
-    let url = format!("{}/api/boms/match", ctx.api_base_url());
+    let url = bom_match_url(ctx.api_base_url(), strict);
 
     let client = Client::builder()
         .timeout(Duration::from_secs(timeout_secs))
         .build()?;
-    let request_body = bom_match_request_body(bom_entries, strict);
+    let request_body = bom_match_request_body(bom_entries);
 
     let response = crate::auth::apply_bearer_auth(client.post(&url), auth_token)
         .json(&request_body)
@@ -279,15 +283,16 @@ fn call_bom_match_api(
         .context("Failed to parse BOM match response")
 }
 
-fn bom_match_request_body(bom_entries: &[serde_json::Value], strict: bool) -> serde_json::Value {
-    let mut body = serde_json::json!({
+fn bom_match_url(api_base_url: &str, strict: bool) -> String {
+    let suffix = if strict { "?strict=true" } else { "" };
+    format!("{api_base_url}/api/boms/match{suffix}")
+}
+
+fn bom_match_request_body(bom_entries: &[serde_json::Value]) -> serde_json::Value {
+    serde_json::json!({
         "designBom": bom_entries,
         "format": "normalized",
-    });
-    if strict {
-        body["strict"] = serde_json::json!(true);
-    }
-    body
+    })
 }
 
 /// Fetch BOM matching results from the API and populate availability data
@@ -669,14 +674,31 @@ mod tests {
             Some(BomMatchStatus::Failed),
             vec!["offer-1".to_string()]
         )));
-        assert!(!bom_line_no_match(&bom_line(
-            Some(BomMatchStatus::Exact),
-            Vec::new()
-        )));
-        assert!(!bom_line_no_match(&bom_line(
-            Some(BomMatchStatus::Fuzzy),
-            Vec::new()
-        )));
+
+        for status in [
+            BomMatchStatus::Exact,
+            BomMatchStatus::Compatible,
+            BomMatchStatus::Fuzzy,
+            BomMatchStatus::NeedsRetry,
+        ] {
+            assert!(!bom_line_no_match(&bom_line(Some(status), Vec::new())));
+        }
+    }
+
+    #[test]
+    fn match_status_decodes_server_values() {
+        for (json, expected) in [
+            (r#""MATCH_EXACT""#, BomMatchStatus::Exact),
+            (r#""MATCH_COMPATIBLE""#, BomMatchStatus::Compatible),
+            (r#""MATCH_FUZZY""#, BomMatchStatus::Fuzzy),
+            (r#""MATCH_NEEDS_RETRY""#, BomMatchStatus::NeedsRetry),
+            (r#""MATCH_FAILED""#, BomMatchStatus::Failed),
+        ] {
+            assert_eq!(
+                serde_json::from_str::<BomMatchStatus>(json).unwrap(),
+                expected
+            );
+        }
     }
 
     #[test]
@@ -731,7 +753,7 @@ mod tests {
             "mpn": "ABC123",
         })];
 
-        let body = bom_match_request_body(&entries, false);
+        let body = bom_match_request_body(&entries);
 
         assert_eq!(body["format"], "normalized");
         assert_eq!(body["designBom"], serde_json::Value::Array(entries));
@@ -739,15 +761,14 @@ mod tests {
     }
 
     #[test]
-    fn bom_match_request_body_sends_strict_when_enabled() {
-        let entries = vec![serde_json::json!({
-            "path": "root.U1",
-            "designator": "U1",
-            "mpn": "ABC123",
-        })];
-
-        let body = bom_match_request_body(&entries, true);
-
-        assert_eq!(body["strict"], true);
+    fn bom_match_url_selects_strict_matching_when_enabled() {
+        assert_eq!(
+            bom_match_url("https://api.diode.computer", false),
+            "https://api.diode.computer/api/boms/match"
+        );
+        assert_eq!(
+            bom_match_url("https://api.diode.computer", true),
+            "https://api.diode.computer/api/boms/match?strict=true"
+        );
     }
 }

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -24,6 +24,7 @@ struct PriceBreak {
 #[serde(rename_all = "UPPERCASE")]
 enum Geography {
     Us,
+    Uk,
     Global,
 }
 
@@ -31,6 +32,7 @@ impl std::fmt::Display for Geography {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
             Self::Us => "US",
+            Self::Uk => "UK",
             Self::Global => "Global",
         })
     }
@@ -627,7 +629,11 @@ fn build_search_availability(offers: &[&ComponentOffer], no_match: bool) -> Avai
         us: summary_for(Geography::Us),
         global: summary_for(Geography::Global),
         no_match,
-        offers: offers.iter().map(|offer| offer.to_offer(1)).collect(),
+        offers: offers
+            .iter()
+            .filter(|offer| offer.geography != Geography::Uk)
+            .map(|offer| offer.to_offer(1))
+            .collect(),
     }
 }
 
@@ -699,6 +705,29 @@ mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    fn geography_decodes_server_values() {
+        for (json, expected) in [
+            (r#""US""#, Geography::Us),
+            (r#""UK""#, Geography::Uk),
+            (r#""GLOBAL""#, Geography::Global),
+        ] {
+            assert_eq!(serde_json::from_str::<Geography>(json).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn uk_offers_are_ignored() {
+        let mut uk_offer = offer("uk-offer", Some(1), &[(1, 1.0)]);
+        uk_offer.geography = Geography::Uk;
+
+        let availability = build_search_availability(&[&uk_offer], false);
+
+        assert!(availability.us.is_none());
+        assert!(availability.global.is_none());
+        assert!(availability.offers.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Send strict BOM selection through the API's `strict=true` query parameter.
- Decode the complete strict BOM match-status contract.
- Document the fix under `Unreleased`.

## Why

The PCB client sent `strict` in the request body, but the Diode API reads it from the query string. As a result, `[workspace.bom] strict = true` still used the default matcher. Strict responses can also contain `MATCH_COMPATIBLE` and `MATCH_NEEDS_RETRY`, which the client did not previously decode.

## Validation

- `cargo fmt --check`
- `cargo test -p pcb-diode-api` (117 tests)
- `pnpm -C projects/api test test/routes/boms.test.ts` in `../diode` (2 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized BOM API client changes with added tests; behavior change is that strict mode now takes effect as users intended.
> 
> **Overview**
> Fixes **`[workspace.bom] strict = true`** so it actually enables the API’s strict BOM matcher: **`strict` moves from the JSON body to `?strict=true` on `/api/boms/match`**, which is what the Diode API reads.
> 
> The client also **aligns with the strict match contract** by decoding **`MATCH_COMPATIBLE`** and **`MATCH_NEEDS_RETRY`**, adding **`UK`** geography (filtered out of US/global availability and offer lists like other non-target regions), and **expanding tests** for URL construction, status/geography JSON, and UK offer handling. The **Unreleased changelog** documents the strict-setting fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ce656fbd81cfcfd35ac2ff4c9bd9554d8feda9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->