### PR TITLE
ENG-60 Support page-range datasheet scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `pcb scan` supports page ranges with `--pages START-END`.
+
 ## [0.4.8] - 2026-07-22
 
 ### Changed

--- a/crates/pcb-diode-api/src/datasheet.rs
+++ b/crates/pcb-diode-api/src/datasheet.rs
@@ -11,7 +11,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::scan::{
-    DatasheetScanOutcome, DatasheetScanResponse, build_scan_client, calculate_sha256,
+    DatasheetScanOutcome, DatasheetScanResponse, PageRange, build_scan_client, calculate_sha256,
     create_datasheet_from_pdf, create_datasheet_from_url, datasheet_id_for_sha256, download_file,
     download_scan_artifacts, extract_zip, scan_datasheet,
 };
@@ -129,30 +129,31 @@ pub fn parse_resolve_request(args: Option<&Value>) -> Result<ResolveDatasheetInp
 pub fn resolve_datasheet(
     auth_token: Option<&str>,
     input: &ResolveDatasheetInput,
+    page_range: Option<PageRange>,
 ) -> Result<ResolveDatasheetResponse> {
     let client = build_scan_client()?;
 
     match input {
         ResolveDatasheetInput::DatasheetUrl(url) => {
             let canonical_url = canonicalize_url(url)?;
-            resolve_source_url_datasheet(&client, auth_token, canonical_url)
+            resolve_source_url_datasheet(&client, auth_token, canonical_url, page_range)
         }
         ResolveDatasheetInput::PdfPath(path) => {
             let pdf_path = path.clone();
             let execution = ResolveExecution::from_pdf_path(pdf_path, None)?;
-            execute_resolve_execution(&client, auth_token, execution)
+            execute_resolve_execution(&client, auth_token, execution, page_range)
         }
         ResolveDatasheetInput::KicadSymPath { path, symbol_name } => {
             let reference =
                 extract_datasheet_reference_from_kicad_sym(path, symbol_name.as_deref())?;
             if is_http_datasheet_url(&reference) {
                 let canonical_url = canonicalize_url(&reference)?;
-                resolve_source_url_datasheet(&client, auth_token, canonical_url)
+                resolve_source_url_datasheet(&client, auth_token, canonical_url, page_range)
             } else {
                 let pdf_path = resolve_local_datasheet_path_from_kicad_sym(path, &reference)?;
                 validate_local_pdf(&pdf_path)?;
                 let execution = ResolveExecution::from_pdf_path(pdf_path, None)?;
-                execute_resolve_execution(&client, auth_token, execution)
+                execute_resolve_execution(&client, auth_token, execution, page_range)
             }
         }
     }
@@ -162,10 +163,11 @@ fn resolve_source_url_datasheet(
     client: &Client,
     auth_token: Option<&str>,
     canonical_url: String,
+    page_range: Option<PageRange>,
 ) -> Result<ResolveDatasheetResponse> {
     let pdf_path = ensure_url_pdf_cached(client, auth_token, &canonical_url)?;
     let execution = ResolveExecution::from_pdf_path(pdf_path, Some(canonical_url))?;
-    execute_resolve_execution(client, auth_token, execution)
+    execute_resolve_execution(client, auth_token, execution, page_range)
 }
 
 /// Ensure the PDF behind a datasheet URL is present in the local URL cache,
@@ -195,10 +197,13 @@ fn execute_resolve_execution(
     client: &Client,
     auth_token: Option<&str>,
     execution: ResolveExecution,
+    page_range: Option<PageRange>,
 ) -> Result<ResolveDatasheetResponse> {
-    let materialization_id = materialization_id_for_key(&execution.pdf_sha256)?;
+    let materialization_id =
+        materialization_id_for_key(&materialization_key(&execution.pdf_sha256, page_range))?;
     let materialized_dir = materialized_dir(&materialization_id);
-    let markdown_path = materialized_dir.join(inferred_markdown_filename(&execution.pdf_path));
+    let markdown_path =
+        materialized_dir.join(inferred_markdown_filename(&execution.pdf_path, page_range));
     let cached_markdown_path = first_valid_file_in_dir(
         &materialized_dir,
         Some(&markdown_path),
@@ -224,7 +229,7 @@ fn execute_resolve_execution(
     }
     reset_materialized_cache(&materialized_dir, &images_dir, &complete_marker);
 
-    let scan = ensure_datasheet_scanned(client, auth_token, &execution)?;
+    let scan = ensure_datasheet_scanned(client, auth_token, &execution, page_range)?;
 
     materialize_scan_outputs(
         client,
@@ -271,16 +276,18 @@ fn ensure_datasheet_scanned(
     client: &Client,
     auth_token: Option<&str>,
     execution: &ResolveExecution,
+    page_range: Option<PageRange>,
 ) -> Result<DatasheetScanResponse> {
     let datasheet_id = datasheet_id_for_sha256(&execution.pdf_sha256);
-    if let DatasheetScanOutcome::Scanned(scan) = scan_datasheet(client, auth_token, &datasheet_id)?
+    if let DatasheetScanOutcome::Scanned(scan) =
+        scan_datasheet(client, auth_token, &datasheet_id, page_range)?
     {
         return Ok(scan);
     }
 
     // The backend has no PDF cached under this content hash yet — upload ours, then scan.
     let datasheet = create_datasheet_from_pdf(client, auth_token, &execution.pdf_path)?;
-    match scan_datasheet(client, auth_token, &datasheet.id)? {
+    match scan_datasheet(client, auth_token, &datasheet.id, page_range)? {
         DatasheetScanOutcome::Scanned(scan) => Ok(scan),
         DatasheetScanOutcome::NotCached => {
             anyhow::bail!("Datasheet {} not found after upload", datasheet.id)
@@ -525,10 +532,24 @@ fn inferred_pdf_filename(path: &Path) -> String {
         .unwrap_or_else(|| "datasheet.pdf".to_string())
 }
 
-fn inferred_markdown_filename(pdf_path: &Path) -> String {
+fn inferred_markdown_filename(pdf_path: &Path, page_range: Option<PageRange>) -> String {
     let mut filename = PathBuf::from(inferred_pdf_filename(pdf_path));
+    if let Some(range) = page_range {
+        let stem = filename
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("datasheet");
+        return format!("{stem}.pages-{:04}-{:04}.md", range.start(), range.end());
+    }
     filename.set_extension("md");
     filename.to_string_lossy().into_owned()
+}
+
+fn materialization_key(pdf_sha256: &str, page_range: Option<PageRange>) -> String {
+    match page_range {
+        Some(range) => format!("{pdf_sha256}:pages/{}-{}", range.start(), range.end()),
+        None => pdf_sha256.to_string(),
+    }
 }
 
 fn build_resolve_response(
@@ -718,8 +739,27 @@ mod tests {
 
     #[test]
     fn test_inferred_markdown_filename_matches_pdf_stem() {
-        let name = inferred_markdown_filename(Path::new("/tmp/LM1117-3.3.pdf"));
+        let name = inferred_markdown_filename(Path::new("/tmp/LM1117-3.3.pdf"), None);
         assert_eq!(name, "LM1117-3.3.md");
+    }
+
+    #[test]
+    fn test_inferred_markdown_filename_includes_page_range() {
+        let range = "1-1000".parse().unwrap();
+        let name = inferred_markdown_filename(Path::new("/tmp/UM11126.pdf"), Some(range));
+        assert_eq!(name, "UM11126.pages-0001-1000.md");
+    }
+
+    #[test]
+    fn test_materialization_key_separates_ranges_and_preserves_full_key() {
+        let first = "1-50".parse().unwrap();
+        let second = "51-100".parse().unwrap();
+
+        assert_eq!(materialization_key("abc123", None), "abc123");
+        assert_ne!(
+            materialization_key("abc123", Some(first)),
+            materialization_key("abc123", Some(second))
+        );
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -8,7 +8,10 @@ use sha2::{Digest, Sha256};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use url::Url;
+
+const MAX_SCAN_PAGES: u32 = 1_000;
 
 #[derive(Serialize)]
 struct CreateDatasheetRequest {
@@ -30,6 +33,75 @@ pub(crate) struct DatasheetScanResponse {
     pub(crate) markdown_url: String,
     #[serde(rename = "imagesZipUrl")]
     pub(crate) images_zip_url: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct PageRange {
+    start: u32,
+    end: u32,
+}
+
+impl PageRange {
+    pub(crate) fn start(self) -> u32 {
+        self.start
+    }
+
+    pub(crate) fn end(self) -> u32 {
+        self.end
+    }
+
+    fn page_count(self) -> u32 {
+        self.end - self.start + 1
+    }
+}
+
+impl std::fmt::Display for PageRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}", self.start, self.end)
+    }
+}
+
+impl FromStr for PageRange {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        let (start, end) = value.split_once('-').ok_or_else(|| {
+            "page range must use START-END with one-based inclusive page numbers".to_string()
+        })?;
+        let start = start.parse::<u32>().map_err(|_| {
+            "page range must use START-END with one-based inclusive page numbers".to_string()
+        })?;
+        let end = end.parse::<u32>().map_err(|_| {
+            "page range must use START-END with one-based inclusive page numbers".to_string()
+        })?;
+
+        if start == 0 || end == 0 {
+            return Err(
+                "page range uses one-based page numbers; START and END must be at least 1"
+                    .to_string(),
+            );
+        }
+        if end < start {
+            return Err("page range END must be greater than or equal to START".to_string());
+        }
+
+        let range = Self { start, end };
+        if range.page_count() > MAX_SCAN_PAGES {
+            return Err(format!(
+                "page range selects {} pages; at most {MAX_SCAN_PAGES} pages can be scanned",
+                range.page_count()
+            ));
+        }
+
+        Ok(range)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ScanDatasheetRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page_range: Option<PageRange>,
 }
 
 pub(crate) enum DatasheetScanOutcome {
@@ -129,6 +201,7 @@ pub(crate) fn scan_datasheet(
     client: &Client,
     token: Option<&str>,
     datasheet_id: &str,
+    page_range: Option<PageRange>,
 ) -> Result<DatasheetScanOutcome> {
     let endpoint = format!(
         "{}/api/datasheets/{}/scan",
@@ -137,7 +210,7 @@ pub(crate) fn scan_datasheet(
     );
 
     let response = crate::auth::apply_bearer_auth(client.post(&endpoint), token)
-        .json(&serde_json::json!({}))
+        .json(&ScanDatasheetRequest { page_range })
         .send()?;
 
     if response.status() == reqwest::StatusCode::NOT_FOUND {
@@ -257,6 +330,10 @@ pub struct ScanArgs {
 
     #[arg(short, long, value_name = "DIR")]
     pub output: Option<PathBuf>,
+
+    /// Scan a one-based, inclusive page range (for example, 1-1000)
+    #[arg(long, value_name = "START-END")]
+    pages: Option<PageRange>,
 }
 
 pub fn execute(args: ScanArgs) -> Result<()> {
@@ -274,7 +351,8 @@ pub fn execute(args: ScanArgs) -> Result<()> {
         ),
     };
     let spinner = Spinner::builder("Resolving datasheet...").start();
-    let response = crate::datasheet::resolve_datasheet(token.as_deref(), &resolve_input)?;
+    let response =
+        crate::datasheet::resolve_datasheet(token.as_deref(), &resolve_input, args.pages)?;
     let pdf_path = input_pdf_path
         .unwrap_or_else(|| PathBuf::from(&response.pdf_path))
         .display()
@@ -289,6 +367,12 @@ pub fn execute(args: ScanArgs) -> Result<()> {
     spinner.finish();
 
     println!("PDF: {pdf_path}");
+    println!(
+        "Pages: {}",
+        args.pages
+            .map(|range| range.to_string())
+            .unwrap_or_else(|| "all".to_string())
+    );
     println!("Markdown: {markdown_path}");
 
     Ok(())
@@ -346,5 +430,48 @@ mod tests {
         }
 
         fs::remove_file(file).unwrap();
+    }
+
+    #[test]
+    fn page_range_is_one_based_inclusive() {
+        let range = "1-1000".parse::<PageRange>().unwrap();
+        assert_eq!(range.start(), 1);
+        assert_eq!(range.end(), 1000);
+        assert_eq!(range.page_count(), 1000);
+    }
+
+    #[test]
+    fn page_range_rejects_invalid_ranges() {
+        for value in ["1", "a-b", "0-1", "2-1", "1-1001"] {
+            assert!(
+                value.parse::<PageRange>().is_err(),
+                "expected {value:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn scan_request_omits_page_range_for_full_scan() {
+        let request = ScanDatasheetRequest { page_range: None };
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
+    fn scan_request_serializes_page_range() {
+        let request = ScanDatasheetRequest {
+            page_range: Some("7-12".parse().unwrap()),
+        };
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            serde_json::json!({
+                "pageRange": {
+                    "start": 7,
+                    "end": 12
+                }
+            })
+        );
     }
 }

--- a/crates/pcbc/src/lsp.rs
+++ b/crates/pcbc/src/lsp.rs
@@ -19,7 +19,7 @@ fn handle_custom_request(
 
     let input = pcb_diode_api::datasheet::parse_resolve_request(Some(params))?;
     let token = pcb_diode_api::auth::get_api_token()?;
-    let response = pcb_diode_api::datasheet::resolve_datasheet(token.as_deref(), &input)?;
+    let response = pcb_diode_api::datasheet::resolve_datasheet(token.as_deref(), &input, None)?;
     Ok(Some(serde_json::to_value(response)?))
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the datasheet scan API payload and cache keying; behavior stays backward-compatible when no range is set, but wrong range handling could yield incomplete or duplicated cached outputs.
> 
> **Overview**
> Adds **optional partial datasheet scans** so users can limit OCR/markdown generation to a slice of a PDF instead of always processing the whole document.
> 
> `pcb scan` gains `--pages START-END` (one-based, inclusive, max 1000 pages). The range is parsed into a new `PageRange` type, validated at the CLI, and passed through `resolve_datasheet` into `POST /api/datasheets/{id}/scan` as optional camelCase `pageRange` in the JSON body; full scans still send `{}`.
> 
> **Caching** is range-aware: materialization IDs and markdown filenames incorporate the page span (e.g. `UM11126.pages-0001-1000.md`), so different ranges for the same PDF do not share cached markdown/images. LSP `pcb/resolveDatasheet` continues to resolve with `None` (full document).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870a1031299835594a266238dbf10128c3117930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->