### PR TITLE
ENG-357 Make schematic position edits atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- LSP schematic position edits can combine updates and deletions in one optimistic-concurrency request while retaining deprecated legacy position requests during client migration.
+- LSP schematic position writes support atomic updates and deletions while remaining compatible with legacy clients.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb scan` supports page ranges with `--pages START-END`.
 
+### Changed
+
+- LSP schematic position edits can combine updates and deletions in one optimistic-concurrency request while retaining deprecated legacy position requests during client migration.
+
 ### Fixed
 
 - `[workspace.bom] strict = true` now selects the API's strict BOM matcher instead of sending an ignored request-body field.

--- a/crates/pcb-sch/src/position.rs
+++ b/crates/pcb-sch/src/position.rs
@@ -127,32 +127,39 @@ pub fn update_position_comments(
     content: &str,
     new_positions: &BTreeMap<String, Position>,
 ) -> (usize, String) {
-    // Get existing positions and block start
-    let (mut existing_positions, block_start) = parse_position_comments(content);
+    edit_position_comments(content, new_positions, &[])
+}
 
-    // Merge new positions (overriding existing ones)
+/// Apply position updates and deletions after parsing the position block once.
+/// Updates take precedence when the same symbol appears in both collections.
+pub fn edit_position_comments(
+    content: &str,
+    new_positions: &BTreeMap<String, Position>,
+    symbol_ids_to_remove: &[String],
+) -> (usize, String) {
+    let (mut positions, block_start) = parse_position_comments(content);
+
+    for symbol_id in symbol_ids_to_remove {
+        positions.remove(&NaturalString::from(symbol_id.clone()));
+    }
     for (element_id, position) in new_positions {
-        existing_positions.insert(NaturalString::from(element_id.clone()), position.clone());
+        positions.insert(NaturalString::from(element_id.clone()), position.clone());
     }
 
-    // Check if we need a blank line before positions
     let content_before = &content[..block_start];
-    let needs_blank_line = !content_before.is_empty() && !content_before.ends_with("\n\n");
-
-    // Generate position comments
     let mut position_comments = String::new();
-    if needs_blank_line {
-        if content_before.ends_with('\n') {
-            position_comments.push('\n'); // Add one more to create blank line
-        } else {
-            position_comments.push_str("\n\n"); // Add newline + blank line
+    if !positions.is_empty() {
+        if !content_before.is_empty() && !content_before.ends_with("\n\n") {
+            position_comments.push_str(if content_before.ends_with('\n') {
+                "\n"
+            } else {
+                "\n\n"
+            });
         }
-    }
 
-    // BTreeMap with NaturalString keys automatically sorts naturally
-    for (element_id, position) in &existing_positions {
-        let comment = format_position_comment(element_id, position);
-        position_comments.push_str(&comment);
+        for (element_id, position) in &positions {
+            position_comments.push_str(&format_position_comment(element_id, position));
+        }
     }
 
     (block_start, position_comments)
@@ -164,35 +171,7 @@ pub fn update_position_comments(
 /// position block starts and the replacement text for everything from that
 /// offset to the end of the content.
 pub fn remove_position_comments(content: &str, symbol_ids_to_remove: &[String]) -> (usize, String) {
-    // Parse existing positions
-    let (mut existing_positions, block_start) = parse_position_comments(content);
-
-    // Remove the specified symbols
-    for symbol_id in symbol_ids_to_remove {
-        existing_positions.remove(&NaturalString::from(symbol_id.clone()));
-    }
-
-    // Regenerate position comments
-    let content_before = &content[..block_start];
-    let needs_blank_line = !content_before.is_empty() && !content_before.ends_with("\n\n");
-
-    let mut position_comments = String::new();
-    if !existing_positions.is_empty() {
-        if needs_blank_line {
-            if content_before.ends_with('\n') {
-                position_comments.push('\n');
-            } else {
-                position_comments.push_str("\n\n");
-            }
-        }
-
-        for (element_id, position) in &existing_positions {
-            let comment = format_position_comment(element_id, position);
-            position_comments.push_str(&comment);
-        }
-    }
-
-    (block_start, position_comments)
+    edit_position_comments(content, &BTreeMap::new(), symbol_ids_to_remove)
 }
 
 /// Truncate `file_path` at `block_start` and append `position_comments`.

--- a/crates/pcb-sch/src/position.rs
+++ b/crates/pcb-sch/src/position.rs
@@ -123,13 +123,6 @@ pub fn parse_position_comments(content: &str) -> (BTreeMap<NaturalString, Positi
     (positions, block_start)
 }
 
-pub fn update_position_comments(
-    content: &str,
-    new_positions: &BTreeMap<String, Position>,
-) -> (usize, String) {
-    edit_position_comments(content, new_positions, &[])
-}
-
 /// Apply position updates and deletions after parsing the position block once.
 /// Updates take precedence when the same symbol appears in both collections.
 pub fn edit_position_comments(
@@ -165,15 +158,6 @@ pub fn edit_position_comments(
     (block_start, position_comments)
 }
 
-/// Remove positions for specific symbol IDs from document content.
-///
-/// Pure counterpart of [`remove_positions`]: returns the byte offset where the
-/// position block starts and the replacement text for everything from that
-/// offset to the end of the content.
-pub fn remove_position_comments(content: &str, symbol_ids_to_remove: &[String]) -> (usize, String) {
-    edit_position_comments(content, &BTreeMap::new(), symbol_ids_to_remove)
-}
-
 /// Truncate `file_path` at `block_start` and append `position_comments`.
 fn write_position_block<P: AsRef<Path>>(
     file_path: P,
@@ -197,7 +181,7 @@ pub fn replace_pcb_sch_comments<P: AsRef<Path>>(
     positions: &BTreeMap<String, Position>,
 ) -> std::io::Result<()> {
     let content = std::fs::read_to_string(&file_path)?;
-    let (block_start, position_comments) = update_position_comments(&content, positions);
+    let (block_start, position_comments) = edit_position_comments(&content, positions, &[]);
     write_position_block(&file_path, block_start, &position_comments)
 }
 
@@ -214,7 +198,8 @@ pub fn remove_positions<P: AsRef<Path>>(
     }
 
     let content = std::fs::read_to_string(&file_path)?;
-    let (block_start, position_comments) = remove_position_comments(&content, symbol_ids_to_remove);
+    let (block_start, position_comments) =
+        edit_position_comments(&content, &BTreeMap::new(), symbol_ids_to_remove);
     write_position_block(&file_path, block_start, &position_comments)
 }
 
@@ -255,7 +240,7 @@ load("@stdlib/interfaces.zen", "Power")
     }
 
     #[test]
-    fn test_update_position_comments() {
+    fn test_edit_position_comments() {
         let original_content = r#"load("@stdlib/interfaces.zen", "Power")
 
 # Old position comment
@@ -273,7 +258,7 @@ load("@stdlib/interfaces.zen", "Power")
         );
 
         let (truncate_pos, position_comments) =
-            update_position_comments(original_content, &positions);
+            edit_position_comments(original_content, &positions, &[]);
         let updated_content = format!("{}{}", &original_content[..truncate_pos], position_comments);
 
         // Old position comment should be preserved (merge behavior)
@@ -304,7 +289,7 @@ load("@stdlib/interfaces.zen", "Power")
         );
 
         let (truncate_pos, position_comments) =
-            update_position_comments(original_content, &positions);
+            edit_position_comments(original_content, &positions, &[]);
         let updated_content = format!("{}{}", &original_content[..truncate_pos], position_comments);
 
         // Should not add extra blank lines when updating existing position comments
@@ -381,7 +366,7 @@ load("@stdlib/interfaces.zen", "Power")
 
         // Test 3: Update function should preserve valid positions and add new ones
         let (truncate_pos, position_comments) =
-            update_position_comments(original_content, &new_positions);
+            edit_position_comments(original_content, &new_positions, &[]);
         let updated_content = format!("{}{}", &original_content[..truncate_pos], position_comments);
 
         // Should preserve valid positions from anywhere in file
@@ -429,7 +414,7 @@ load("@stdlib/interfaces.zen", "Power")
         ); // Add C
 
         let (content_before, position_comments) =
-            update_position_comments(original_content, &new_positions);
+            edit_position_comments(original_content, &new_positions, &[]);
         let updated_content = format!("{content_before}{position_comments}");
 
         // Should have 3 elements: updated A, preserved B, new C
@@ -535,7 +520,8 @@ Resistor("R1", "10kOhm", "0603", P1=vcc.NET, P2=gnd.NET)
             },
         ); // Add
 
-        let (truncate_pos, position_comments) = update_position_comments(content, &new_positions);
+        let (truncate_pos, position_comments) =
+            edit_position_comments(content, &new_positions, &[]);
         let updated_content = format!("{}{}", &content[..truncate_pos], position_comments);
 
         // Should preserve all scattered positions + new ones (5 total: EARLY, MIDDLE, FINAL_A, FINAL_B, NEW)
@@ -623,7 +609,7 @@ Resistor = Module("@stdlib/generics/Resistor.zen")"#;
     }
 
     #[test]
-    fn test_update_position_comments_writes_mirror() {
+    fn test_edit_position_comments_writes_mirror() {
         let content = "";
         let mut positions = std::collections::BTreeMap::new();
         positions.insert(
@@ -645,7 +631,7 @@ Resistor = Module("@stdlib/generics/Resistor.zen")"#;
             },
         );
 
-        let (_, position_comments) = update_position_comments(content, &positions);
+        let (_, position_comments) = edit_position_comments(content, &positions, &[]);
         assert!(position_comments.contains("# pcb:sch MIRRORED x=1.0000 y=2.0000 rot=90 mirror=x"));
         assert!(position_comments.contains("# pcb:sch PLAIN x=3.0000 y=4.0000 rot=180\n"));
     }
@@ -680,7 +666,8 @@ Resistor = Module("@stdlib/generics/Resistor.zen")"#;
             },
         );
 
-        let (truncate_pos, position_comments) = update_position_comments(content, &new_positions);
+        let (truncate_pos, position_comments) =
+            edit_position_comments(content, &new_positions, &[]);
         let updated_content = format!("{}{}", &content[..truncate_pos], position_comments);
 
         // Should handle file without trailing newline
@@ -789,7 +776,8 @@ Resistor("R1", "10kOhm", "0603", P1=vcc.NET, P2=gnd.NET)"#;
             },
         );
 
-        let (truncate_pos, position_comments) = update_position_comments(content, &new_positions);
+        let (truncate_pos, position_comments) =
+            edit_position_comments(content, &new_positions, &[]);
         let updated_content = format!("{}{}", &content[..truncate_pos], position_comments);
 
         println!("Updated content: '{updated_content}'");
@@ -841,7 +829,7 @@ Resistor("R1", "10kOhm", "0603", P1=vcc.NET, P2=gnd.NET)"#;
             },
         );
 
-        let (_, position_comments) = update_position_comments(content, &positions);
+        let (_, position_comments) = edit_position_comments(content, &positions, &[]);
         println!("Position comments order:\n{position_comments}");
 
         // Should sort numerically: 2, 9, 10, 11
@@ -886,7 +874,7 @@ Resistor("R1", "10kOhm", "0603", P1=vcc.NET, P2=gnd.NET)"#;
     }
 
     #[test]
-    fn test_remove_position_comments_pure() {
+    fn test_edit_position_comments_removes_positions() {
         let content = r#"load("@stdlib/interfaces.zen", "Power")
 
 # pcb:sch R1 x=100.0 y=200.0 rot=0
@@ -894,7 +882,7 @@ Resistor("R1", "10kOhm", "0603", P1=vcc.NET, P2=gnd.NET)"#;
 # pcb:sch R2 x=700.0 y=800.0 rot=180"#;
 
         let (block_start, position_comments) =
-            remove_position_comments(content, &["C1".to_string()]);
+            edit_position_comments(content, &BTreeMap::new(), &["C1".to_string()]);
         let updated = format!("{}{}", &content[..block_start], position_comments);
 
         assert!(updated.contains("R1"));
@@ -902,8 +890,9 @@ Resistor("R1", "10kOhm", "0603", P1=vcc.NET, P2=gnd.NET)"#;
         assert!(!updated.contains("C1"));
 
         // Removing every position leaves no trailing block (and no stray blank line).
-        let (block_start, position_comments) = remove_position_comments(
+        let (block_start, position_comments) = edit_position_comments(
             content,
+            &BTreeMap::new(),
             &["R1".to_string(), "C1".to_string(), "R2".to_string()],
         );
         assert!(position_comments.is_empty());

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -7,8 +7,8 @@ use lsp_types::{
     WorkDoneProgressOptions, request::Request,
 };
 use pcb_sch::position::{
-    Position, remove_position_comments, remove_positions, replace_pcb_sch_comments,
-    symbol_id_to_comment_key, update_position_comments,
+    Position, edit_position_comments, remove_position_comments, remove_positions,
+    replace_pcb_sch_comments, symbol_id_to_comment_key,
 };
 use pcb_starlark_lsp::server::{
     self, CompletionMeta, LspContext, LspEvalResult, LspUrl, Response, StringLiteralResult,
@@ -1229,8 +1229,9 @@ impl LspContext for LspEvalContext {
                 Ok(params) => {
                     let file_path = &params.file_path;
                     info!(
-                        "Saving {} symbol positions to file: {}",
+                        "Saving {} position updates and {} deletions to file: {}",
                         params.symbol_positions.len(),
+                        params.deleted_symbol_ids.len(),
                         file_path
                     );
 
@@ -1251,24 +1252,52 @@ impl LspContext for LspEvalContext {
                         flat_positions.insert(comment_name, position);
                     }
 
-                    // Buffer-first path: the client applies the returned edit
-                    // to its own buffer and mirrors it to disk; the server
-                    // touches neither.
+                    let mut deleted_comment_names = Vec::new();
+                    for symbol_id in params.deleted_symbol_ids {
+                        let Some(comment_name) = symbol_id_to_comment_key(&symbol_id) else {
+                            return Some(Response {
+                                id: req.id.clone(),
+                                result: None,
+                                error: Some(ResponseError {
+                                    code: INVALID_PARAMS,
+                                    message: format!("Invalid symbol ID format: {symbol_id}"),
+                                    data: None,
+                                }),
+                            });
+                        };
+                        deleted_comment_names.push(comment_name);
+                    }
+
                     if let Some(base_hash) = &params.base_hash {
                         let result = self.position_block_edit(file_path, base_hash, |content| {
-                            update_position_comments(content, &flat_positions)
+                            edit_position_comments(content, &flat_positions, &deleted_comment_names)
                         });
                         return Some(position_edit_result_to_response(req.id.clone(), result));
                     }
 
-                    // Legacy path (no baseHash): write the file directly; the
-                    // client rediscovers the change through its file watcher.
+                    if !deleted_comment_names.is_empty() {
+                        return Some(Response {
+                            id: req.id.clone(),
+                            result: None,
+                            error: Some(ResponseError {
+                                code: INVALID_PARAMS,
+                                message: "baseHash is required when deletedSymbolIds is non-empty"
+                                    .to_string(),
+                                data: None,
+                            }),
+                        });
+                    }
+
+                    // DEPRECATED: Legacy clients expect this request to write
+                    // directly to disk and return null when baseHash is absent.
+                    // TODO(ENG-357): Remove this path once all Diode clients
+                    // send baseHash and apply the returned text edit.
                     match replace_pcb_sch_comments(file_path, &flat_positions) {
                         Ok(()) => {
                             info!("Successfully wrote positions to file");
                             return Some(Response {
                                 id: req.id.clone(),
-                                result: Some(serde_json::Value::Null), // null indicates success
+                                result: Some(serde_json::Value::Null),
                                 error: None,
                             });
                         }
@@ -1299,13 +1328,14 @@ impl LspContext for LspEvalContext {
             }
         }
 
-        // Handle pcb/removePosition requests
+        // DEPRECATED: Legacy clients send deletions as separate requests. New
+        // clients use deletedSymbolIds in the atomic pcb/savePositions request.
+        // TODO(ENG-357): Remove this handler once all Diode clients use the
+        // atomic pcb/savePositions request.
         if req.method == "pcb/removePosition" {
             match serde_json::from_value::<PcbRemovePositionParams>(req.params.clone()) {
                 Ok(params) => {
                     let file_path = &params.file_path;
-
-                    // Translate symbol_id to comment key used in pcb:sch lines
                     let Some(comment_key) = symbol_id_to_comment_key(&params.symbol_id) else {
                         return Some(Response {
                             id: req.id.clone(),
@@ -1318,7 +1348,6 @@ impl LspContext for LspEvalContext {
                         });
                     };
 
-                    // Buffer-first path: see pcb/savePositions above.
                     if let Some(base_hash) = &params.base_hash {
                         let result = self.position_block_edit(file_path, base_hash, |content| {
                             remove_position_comments(content, &[comment_key])
@@ -1326,7 +1355,6 @@ impl LspContext for LspEvalContext {
                         return Some(position_edit_result_to_response(req.id.clone(), result));
                     }
 
-                    // Legacy path (no baseHash): write the file directly.
                     if let Err(e) = remove_positions(file_path, &[comment_key]) {
                         return Some(Response {
                             id: req.id.clone(),
@@ -1622,30 +1650,33 @@ struct DiagnosticInfo {
 struct PcbSavePositionsParams {
     file_path: String,
     symbol_positions: BTreeMap<String, Position>,
+    /// Optional only for compatibility with clients predating atomic writes.
+    /// TODO(ENG-357): Make this field required after all clients migrate.
+    #[serde(default)]
+    deleted_symbol_ids: Vec<String>,
     /// Content hash of the document the positions were computed against.
-    /// When present, the server responds with a text edit for the client to
-    /// apply instead of writing the file itself.
+    /// Omitting this field selects the deprecated direct-to-disk path.
+    /// TODO(ENG-357): Make this field required after all clients migrate.
     #[serde(default)]
     base_hash: Option<String>,
 }
 
+/// Deprecated request shape retained for pre-atomic Diode clients.
+/// TODO(ENG-357): Remove after all clients send deletions through
+/// `PcbSavePositionsParams::deleted_symbol_ids`.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct PcbRemovePositionParams {
     file_path: String,
-    /// Symbol ID in the same format used by pcb/savePositions keys
-    /// (e.g. "comp:R1" or "sym:NET#1")
     symbol_id: String,
-    /// See [`PcbSavePositionsParams::base_hash`].
     #[serde(default)]
     base_hash: Option<String>,
 }
 
-/// Response to `pcb/savePositions` / `pcb/removePosition` requests that carry
-/// a `baseHash`: the edit is applied by the client to its own buffer (and
-/// mirrored to disk by the client); the server touches neither. `resultHash`
-/// is the content hash after applying the edit, which the client can verify
-/// and use to correlate the subsequent evaluation.
+/// Response to `pcb/savePositions`: the edit is applied by the client to its
+/// own buffer (and mirrored to disk by the client); the server touches neither.
+/// `resultHash` is the content hash after applying the edit, which the client
+/// can verify and use to correlate the subsequent evaluation.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct PcbPositionEditResponse {
@@ -1859,16 +1890,15 @@ pcb-version = "0.4"
         format!("{}{}{}", &content[..start], edit.new_text, &content[end..])
     }
 
-    fn save_positions_request(id: i32, path: &std::path::Path, base_hash: Option<&str>) -> Request {
-        let mut params = json!({
+    fn save_positions_request(id: i32, path: &std::path::Path, base_hash: &str) -> Request {
+        let params = json!({
             "filePath": path.to_str().unwrap(),
+            "baseHash": base_hash,
             "symbolPositions": {
                 "comp:R1": { "x": 12.5, "y": 30.0, "rotation": 90.0 }
             },
+            "deletedSymbolIds": ["comp:C1"],
         });
-        if let Some(base_hash) = base_hash {
-            params["baseHash"] = json!(base_hash);
-        }
         Request {
             id: RequestId::from(id),
             method: "pcb/savePositions".to_string(),
@@ -1882,7 +1912,10 @@ pcb-version = "0.4"
         let zen_path = dir.path().canonicalize()?.join("main.zen");
         let disk_contents = "x = 1\n";
         // Buffer diverges from disk: the edit must be computed from the buffer.
-        let buffer_contents = "x = 1\n\n# pcb:sch C1 x=1.0000 y=2.0000 rot=0\n";
+        // No trailing newline exercises combined edits without reparsing a
+        // regenerated position block at a different byte offset.
+        let buffer_contents =
+            "x = 1\n\n# pcb:sch C1 x=1.0000 y=2.0000 rot=0\n# pcb:sch C2 x=3.0000 y=4.0000 rot=0";
         fs::write(&zen_path, disk_contents)?;
 
         let ctx = LspEvalContext::default();
@@ -1891,7 +1924,7 @@ pcb-version = "0.4"
         let base_hash = super::content_hash(buffer_contents);
         let response = ctx
             .handle_custom_request(
-                &save_positions_request(1, &zen_path, Some(&base_hash)),
+                &save_positions_request(1, &zen_path, &base_hash),
                 &lsp_types::InitializeParams::default(),
             )
             .expect("request should be handled");
@@ -1903,7 +1936,8 @@ pcb-version = "0.4"
         let edit: lsp_types::TextEdit = serde_json::from_value(result["edit"].clone())?;
         let updated = apply_text_edit(buffer_contents, &edit);
         assert!(updated.contains("# pcb:sch R1 x=12.5000 y=30.0000 rot=90"));
-        assert!(updated.contains("# pcb:sch C1 x=1.0000 y=2.0000 rot=0"));
+        assert!(!updated.contains("# pcb:sch C1"));
+        assert!(updated.contains("# pcb:sch C2 x=3.0000 y=4.0000 rot=0"));
         assert_eq!(result["resultHash"], json!(super::content_hash(&updated)));
 
         // Neither disk nor the overlay was touched.
@@ -1925,7 +1959,7 @@ pcb-version = "0.4"
         let ctx = LspEvalContext::default();
         let response = ctx
             .handle_custom_request(
-                &save_positions_request(1, &zen_path, Some(&super::content_hash("stale"))),
+                &save_positions_request(1, &zen_path, &super::content_hash("stale")),
                 &lsp_types::InitializeParams::default(),
             )
             .expect("request should be handled");
@@ -1939,23 +1973,51 @@ pcb-version = "0.4"
     }
 
     #[test]
+    fn save_positions_with_base_hash_defaults_missing_deletions() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let zen_path = dir.path().canonicalize()?.join("main.zen");
+        let contents = "x = 1\n\n# pcb:sch C1 x=1.0000 y=2.0000 rot=0\n";
+        fs::write(&zen_path, contents)?;
+
+        let ctx = LspEvalContext::default();
+        let mut request = save_positions_request(1, &zen_path, &super::content_hash(contents));
+        request
+            .params
+            .as_object_mut()
+            .unwrap()
+            .remove("deletedSymbolIds");
+        let response = ctx
+            .handle_custom_request(&request, &lsp_types::InitializeParams::default())
+            .expect("request should be handled");
+
+        assert!(response.error.is_none(), "error: {:?}", response.error);
+        let result = response.result.unwrap();
+        let edit: lsp_types::TextEdit = serde_json::from_value(result["edit"].clone())?;
+        let updated = apply_text_edit(contents, &edit);
+        assert!(updated.contains("# pcb:sch C1 x=1.0000 y=2.0000 rot=0"));
+        assert!(updated.contains("# pcb:sch R1 x=12.5000 y=30.0000 rot=90"));
+
+        Ok(())
+    }
+
+    #[test]
     fn save_positions_without_base_hash_writes_file() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let zen_path = dir.path().canonicalize()?.join("main.zen");
         fs::write(&zen_path, "x = 1\n")?;
 
         let ctx = LspEvalContext::default();
+        let mut request = save_positions_request(1, &zen_path, "unused");
+        let params = request.params.as_object_mut().unwrap();
+        params.remove("baseHash");
+        params.remove("deletedSymbolIds");
         let response = ctx
-            .handle_custom_request(
-                &save_positions_request(1, &zen_path, None),
-                &lsp_types::InitializeParams::default(),
-            )
+            .handle_custom_request(&request, &lsp_types::InitializeParams::default())
             .expect("request should be handled");
 
         assert!(response.error.is_none(), "error: {:?}", response.error);
         assert_eq!(response.result, Some(serde_json::Value::Null));
-        let updated = fs::read_to_string(&zen_path)?;
-        assert!(updated.contains("# pcb:sch R1 x=12.5000 y=30.0000 rot=90"));
+        assert!(fs::read_to_string(&zen_path)?.contains("# pcb:sch R1 x=12.5000 y=30.0000 rot=90"));
 
         Ok(())
     }
@@ -1969,7 +2031,6 @@ pcb-version = "0.4"
         fs::write(&zen_path, contents)?;
 
         let ctx = LspEvalContext::default();
-        let base_hash = super::content_hash(contents);
         let response = ctx
             .handle_custom_request(
                 &Request {
@@ -1978,7 +2039,7 @@ pcb-version = "0.4"
                     params: json!({
                         "filePath": zen_path.to_str().unwrap(),
                         "symbolId": "comp:C1",
-                        "baseHash": base_hash,
+                        "baseHash": super::content_hash(contents),
                     }),
                 },
                 &lsp_types::InitializeParams::default(),
@@ -1992,9 +2053,39 @@ pcb-version = "0.4"
         assert!(!updated.contains("C1"));
         assert!(updated.contains("# pcb:sch R1 x=3.0000 y=4.0000 rot=0"));
         assert_eq!(result["resultHash"], json!(super::content_hash(&updated)));
-
-        // Disk untouched.
         assert_eq!(fs::read_to_string(&zen_path)?, contents);
+
+        Ok(())
+    }
+
+    #[test]
+    fn remove_position_without_base_hash_writes_file() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let zen_path = dir.path().canonicalize()?.join("main.zen");
+        let contents =
+            "x = 1\n\n# pcb:sch C1 x=1.0000 y=2.0000 rot=0\n# pcb:sch R1 x=3.0000 y=4.0000 rot=0\n";
+        fs::write(&zen_path, contents)?;
+
+        let ctx = LspEvalContext::default();
+        let response = ctx
+            .handle_custom_request(
+                &Request {
+                    id: RequestId::from(1),
+                    method: "pcb/removePosition".to_string(),
+                    params: json!({
+                        "filePath": zen_path.to_str().unwrap(),
+                        "symbolId": "comp:C1",
+                    }),
+                },
+                &lsp_types::InitializeParams::default(),
+            )
+            .expect("request should be handled");
+
+        assert!(response.error.is_none(), "error: {:?}", response.error);
+        assert_eq!(response.result, Some(serde_json::Value::Null));
+        let updated = fs::read_to_string(&zen_path)?;
+        assert!(!updated.contains("C1"));
+        assert!(updated.contains("# pcb:sch R1 x=3.0000 y=4.0000 rot=0"));
 
         Ok(())
     }

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -7,8 +7,8 @@ use lsp_types::{
     WorkDoneProgressOptions, request::Request,
 };
 use pcb_sch::position::{
-    Position, edit_position_comments, remove_position_comments, remove_positions,
-    replace_pcb_sch_comments, symbol_id_to_comment_key,
+    Position, edit_position_comments, remove_positions, replace_pcb_sch_comments,
+    symbol_id_to_comment_key,
 };
 use pcb_starlark_lsp::server::{
     self, CompletionMeta, LspContext, LspEvalResult, LspUrl, Response, StringLiteralResult,
@@ -1350,7 +1350,7 @@ impl LspContext for LspEvalContext {
 
                     if let Some(base_hash) = &params.base_hash {
                         let result = self.position_block_edit(file_path, base_hash, |content| {
-                            remove_position_comments(content, &[comment_key])
+                            edit_position_comments(content, &BTreeMap::new(), &[comment_key])
                         });
                         return Some(position_edit_result_to_response(req.id.clone(), result));
                     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes LSP contract and `.zen` position-block rewriting used by the schematic editor; legacy paths are preserved but new clients must send `baseHash` for deletions.
> 
> **Overview**
> **Schematic position edits are now atomic:** a single `pcb/savePositions` call can update symbol positions and remove deleted symbols in one pass, instead of splitting moves and deletions across separate requests.
> 
> In `pcb-sch`, `update_position_comments` and `remove_position_comments` are replaced by **`edit_position_comments`**, which parses the `# pcb:sch` block once, applies removals then updates (updates win on duplicate keys), and regenerates the trailing position block.
> 
> The LSP handler accepts optional **`deletedSymbolIds`** on `pcb/savePositions`. With **`baseHash`**, updates and deletions are combined into one buffer-first text edit via `edit_position_comments`; deletions without `baseHash` are rejected. Legacy behavior remains: no `baseHash` still writes updates-only to disk, and **`pcb/removePosition`** is kept for older clients (marked deprecated, ENG-357).
> 
> Changelog and LSP tests cover combined update/delete edits, default-empty deletions, and legacy disk-write paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166b958c743be798596247cdb28c2ce989522564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->