### PR TITLE
Refine pcb scan page output

### DIFF
--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -367,13 +367,10 @@ pub fn execute(args: ScanArgs) -> Result<()> {
     spinner.finish();
 
     println!("PDF: {pdf_path}");
-    println!(
-        "Pages: {}",
-        args.pages
-            .map(|range| range.to_string())
-            .unwrap_or_else(|| "all".to_string())
-    );
     println!("Markdown: {markdown_path}");
+    if let Some(pages) = args.pages {
+        println!("Pages: {pages}");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> User-facing CLI output only; no API or scan behavior changes.
> 
> **Overview**
> **`pcb scan` success output** no longer prints a `Pages:` line when the user did not pass `--pages` (full-document scan). Previously it always showed `Pages: all` in that case.
> 
> When `--pages START-END` is set, it still prints `Pages: {range}` using the same `PageRange` display format as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89011f9a865cc260f4beb4c7b4364d6082a60381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->