### PR TITLE
[ENG-472] Fix IPC-2581 board-array schema output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - E-series helpers now consider the nearest value in the adjacent decade without changing exact E-series inputs.
+- IPC-2581 board-array output now uses schema-valid history changes and one feature per generated geometry container.
 
 ## [0.4.11] - 2026-07-23
 

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -253,6 +253,32 @@ mod tests {
     }
 
     #[test]
+    fn rejects_multiple_file_revisions_in_history_record() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+  </Content>
+  <HistoryRecord number="2" origination="2026-01-01T00:00:00Z" software="pcb" lastChange="2026-01-02T00:00:00Z">
+    <FileRevision fileRevisionId="1" comment="Initial">
+      <SoftwarePackage name="pcb" revision="1" vendor="Diode">
+        <Certification certificationStatus="SELFTEST"/>
+      </SoftwarePackage>
+    </FileRevision>
+    <FileRevision fileRevisionId="2" comment="Invalid second revision">
+      <SoftwarePackage name="pcb" revision="1" vendor="Diode">
+        <Certification certificationStatus="SELFTEST"/>
+      </SoftwarePackage>
+    </FileRevision>
+  </HistoryRecord>
+</IPC-2581>"#;
+
+        let error =
+            Ipc2581::parse(xml).expect_err("multiple FileRevision children must be rejected");
+        assert!(error.to_string().contains("exactly one FileRevision"));
+    }
+
+    #[test]
     fn validate_reports_schema_errors() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -478,6 +504,8 @@ mod tests {
                 <PolyStepSegment x="1" y="1"/>
                 <PolyStepSegment x="0" y="0"/>
               </Polygon>
+            </Features>
+            <Features>
               <UserSpecial>
                 <Line startX="0" startY="0" endX="0" endY="1">
                   <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
@@ -516,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    fn skips_invalid_inline_user_special_inside_features() {
+    fn rejects_multiple_features_inside_features() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="Owner">
@@ -543,15 +571,8 @@ mod tests {
   </Ecad>
 </IPC-2581>"#;
 
-        let doc = Ipc2581::parse(xml).expect("parse IPC-2581");
-        let set = &doc.ecad().unwrap().cad_data.steps[0].layer_features[0].sets[0];
-
-        assert_eq!(set.features.len(), 2);
-        assert!(
-            set.features
-                .iter()
-                .all(|feature| matches!(feature, ecad::SetFeature::Line(_)))
-        );
+        let error = Ipc2581::parse(xml).expect_err("multiple Features children must be rejected");
+        assert!(error.to_string().contains("exactly one Feature"));
     }
 
     #[test]
@@ -618,6 +639,9 @@ mod tests {
                 <PolyStepCurve x="0" y="1" centerX="0" centerY="0" clockwise="false"/>
                 <PolyStepSegment x="0" y="0"/>
               </Polygon>
+            </Features>
+            <Features>
+              <Location x="10" y="20"/>
               <UserSpecial>
                 <Contour>
                   <Polygon>

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -642,15 +642,13 @@ mod tests {
             </Features>
             <Features>
               <Location x="10" y="20"/>
-              <UserSpecial>
-                <Contour>
-                  <Polygon>
-                    <PolyBegin x="2" y="0"/>
-                    <PolyStepSegment x="3" y="0"/>
-                    <PolyStepSegment x="2" y="0"/>
-                  </Polygon>
-                </Contour>
-              </UserSpecial>
+              <Contour>
+                <Polygon>
+                  <PolyBegin x="2" y="0"/>
+                  <PolyStepSegment x="3" y="0"/>
+                  <PolyStepSegment x="2" y="0"/>
+                </Polygon>
+              </Contour>
             </Features>
           </Set>
         </LayerFeature>

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -2286,6 +2286,9 @@ impl<'a> Parser<'a> {
                         self.parse_feature_arc(&child, units, offset.x, offset.y)?,
                     ));
                 }
+                "Contour" => {
+                    feature = Some(self.parse_contour_feature(&child, units, offset)?);
+                }
                 "UserSpecial" => {
                     feature = Some(ecad::SetFeature::UserPrimitive(
                         ecad::FeatureUserPrimitive {
@@ -2324,6 +2327,36 @@ impl<'a> Parser<'a> {
         Ok(vec![feature.ok_or(Ipc2581Error::MissingElement(
             "Feature in Features",
         ))?])
+    }
+
+    fn parse_contour_feature(
+        &mut self,
+        node: &Node,
+        units: Units,
+        offset: Point,
+    ) -> Result<ecad::SetFeature> {
+        let contour = self.parse_contour(node, units)?;
+        let style_node = self
+            .element_children(node)
+            .find(|child| self.name(child) == "Polygon")
+            .unwrap_or(*node);
+        let (line_desc, line_desc_ref, fill_desc) =
+            self.parse_user_shape_style(&style_node, units)?;
+
+        Ok(ecad::SetFeature::UserPrimitive(
+            ecad::FeatureUserPrimitive {
+                primitive: UserPrimitive::UserSpecial(UserSpecial {
+                    shapes: vec![UserShape {
+                        shape: UserShapeType::Contour(contour),
+                        line_desc,
+                        line_desc_ref,
+                        fill_desc,
+                    }],
+                }),
+                x: offset.x,
+                y: offset.y,
+            },
+        ))
     }
 
     fn translate_polygon(mut polygon: Polygon, offset: Point) -> Polygon {
@@ -3331,6 +3364,7 @@ fn is_features_feature_name(name: &str) -> bool {
             | "Polyline"
             | "Line"
             | "Arc"
+            | "Contour"
             | "UserSpecial"
             | "StandardPrimitiveRef"
             | "UserPrimitiveRef"

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1063,22 +1063,74 @@ impl<'a> Parser<'a> {
         let software = self.optional_attr(node, "software");
         let last_change = self.required_attr(node, "lastChange", "HistoryRecord")?;
 
-        // Parse FileRevision child element
+        // HistoryRecordType is FileRevision followed by zero or more ChangeRec
+        // elements. Keep the typed parser strict here so it cannot silently
+        // accept the invalid repeated-FileRevision structure emitted by older
+        // writers.
         let mut file_revision = None;
+        let mut saw_change_record = false;
         for child in self.element_children(node) {
-            if self.name(&child) == "FileRevision" {
-                file_revision = Some(self.parse_file_revision(&child)?);
-                break;
+            match self.name(&child) {
+                "FileRevision" => {
+                    if saw_change_record {
+                        return Err(Ipc2581Error::InvalidStructure(
+                            "FileRevision must precede ChangeRec in HistoryRecord".to_string(),
+                        ));
+                    }
+                    if file_revision.is_some() {
+                        return Err(Ipc2581Error::InvalidStructure(
+                            "HistoryRecord allows exactly one FileRevision".to_string(),
+                        ));
+                    }
+                    file_revision = Some(self.parse_file_revision(&child)?);
+                }
+                "ChangeRec" => {
+                    if file_revision.is_none() {
+                        return Err(Ipc2581Error::InvalidStructure(
+                            "ChangeRec must follow FileRevision in HistoryRecord".to_string(),
+                        ));
+                    }
+                    self.validate_change_record(&child)?;
+                    saw_change_record = true;
+                }
+                name => {
+                    return Err(Ipc2581Error::InvalidStructure(format!(
+                        "Unexpected {name} in HistoryRecord"
+                    )));
+                }
             }
         }
+        let file_revision = file_revision.ok_or(Ipc2581Error::MissingElement(
+            "FileRevision in HistoryRecord",
+        ))?;
 
         Ok(HistoryRecord {
             number,
             origination,
             software,
             last_change,
-            file_revision,
+            file_revision: Some(file_revision),
         })
+    }
+
+    fn validate_change_record(&mut self, node: &Node) -> Result<()> {
+        self.required_attr(node, "datetime", "ChangeRec")?;
+        self.required_attr(node, "personRef", "ChangeRec")?;
+        self.required_attr(node, "application", "ChangeRec")?;
+        self.required_attr(node, "change", "ChangeRec")?;
+
+        for child in self.element_children(node) {
+            if self.name(&child) != "Approval" {
+                return Err(Ipc2581Error::InvalidStructure(format!(
+                    "Unexpected {} in ChangeRec",
+                    self.name(&child)
+                )));
+            }
+            self.required_attr(&child, "datetime", "Approval")?;
+            self.required_attr(&child, "personRef", "Approval")?;
+        }
+
+        Ok(())
     }
 
     fn parse_file_revision(&mut self, node: &Node) -> Result<metadata::FileRevision> {
@@ -2175,101 +2227,103 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_features(&mut self, features_node: &Node) -> Result<Vec<ecad::SetFeature>> {
-        let mut features = Vec::new();
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
-        let offset = self.parse_features_location(features_node, units);
+        let mut offset = Point { x: 0.0, y: 0.0 };
+        let mut xform_seen = false;
+        let mut location_seen = false;
+        let mut feature = None;
 
         for child in self.element_children(features_node) {
-            match self.name(&child) {
-                "Polygon" => {
-                    if let Some(feature) = self.parse_feature_polygon(&child, units, offset) {
-                        features.push(feature);
+            let child_name = self.name(&child);
+            if is_features_feature_name(child_name) && feature.is_some() {
+                return Err(Ipc2581Error::InvalidStructure(
+                    "Features allows exactly one Feature child".to_string(),
+                ));
+            }
+
+            match child_name {
+                "Xform" => {
+                    if xform_seen || location_seen || feature.is_some() {
+                        return Err(Ipc2581Error::InvalidStructure(
+                            "Xform must be the first child of Features".to_string(),
+                        ));
                     }
+                    xform_seen = true;
+                }
+                "Location" => {
+                    if feature.is_some() {
+                        return Err(Ipc2581Error::InvalidStructure(
+                            "Location must precede the Feature in Features".to_string(),
+                        ));
+                    }
+                    let location = Point {
+                        x: self.parse_f64_attr_with_units(&child, "x", "Location", units)?,
+                        y: self.parse_f64_attr_with_units(&child, "y", "Location", units)?,
+                    };
+                    if !location_seen {
+                        offset = location;
+                    }
+                    location_seen = true;
+                }
+                "Polygon" => {
+                    let polygon = self.parse_polygon(&child, units)?;
+                    feature = Some(ecad::SetFeature::Polygon(Self::translate_polygon(
+                        polygon, offset,
+                    )));
                 }
                 "Polyline" => {
-                    if let Ok(polyline) =
-                        self.parse_feature_polyline(&child, units, offset.x, offset.y)
-                    {
-                        features.push(ecad::SetFeature::Polyline(polyline));
-                    }
+                    feature = Some(ecad::SetFeature::Polyline(
+                        self.parse_feature_polyline(&child, units, offset.x, offset.y)?,
+                    ));
                 }
                 "Line" => {
-                    if let Ok(line) = self.parse_line(&child, units, offset.x, offset.y) {
-                        features.push(ecad::SetFeature::Line(line));
-                    }
+                    feature = Some(ecad::SetFeature::Line(
+                        self.parse_line(&child, units, offset.x, offset.y)?,
+                    ));
                 }
                 "Arc" => {
-                    if let Ok(arc) = self.parse_feature_arc(&child, units, offset.x, offset.y) {
-                        features.push(ecad::SetFeature::Arc(arc));
-                    }
+                    feature = Some(ecad::SetFeature::Arc(
+                        self.parse_feature_arc(&child, units, offset.x, offset.y)?,
+                    ));
                 }
                 "UserSpecial" => {
-                    if let Ok(primitive) = self.parse_user_special(&child, units) {
-                        features.push(ecad::SetFeature::UserPrimitive(
-                            ecad::FeatureUserPrimitive {
-                                primitive,
-                                x: offset.x,
-                                y: offset.y,
-                            },
-                        ));
-                    }
+                    feature = Some(ecad::SetFeature::UserPrimitive(
+                        ecad::FeatureUserPrimitive {
+                            primitive: self.parse_user_special(&child, units)?,
+                            x: offset.x,
+                            y: offset.y,
+                        },
+                    ));
                 }
                 "StandardPrimitiveRef" => {
-                    if let Some(id) = self.attr(&child, "id") {
-                        features.push(ecad::SetFeature::StandardPrimitiveRef(
-                            ecad::FeaturePrimitiveRef {
-                                id: self.interner.intern(id),
-                                x: offset.x,
-                                y: offset.y,
-                            },
-                        ));
-                    }
+                    feature = Some(ecad::SetFeature::StandardPrimitiveRef(
+                        ecad::FeaturePrimitiveRef {
+                            id: self.required_attr(&child, "id", "StandardPrimitiveRef")?,
+                            x: offset.x,
+                            y: offset.y,
+                        },
+                    ));
                 }
                 "UserPrimitiveRef" => {
-                    if let Some(id) = self.attr(&child, "id") {
-                        features.push(ecad::SetFeature::UserPrimitiveRef(
-                            ecad::FeaturePrimitiveRef {
-                                id: self.interner.intern(id),
-                                x: offset.x,
-                                y: offset.y,
-                            },
-                        ));
-                    }
+                    feature = Some(ecad::SetFeature::UserPrimitiveRef(
+                        ecad::FeaturePrimitiveRef {
+                            id: self.required_attr(&child, "id", "UserPrimitiveRef")?,
+                            x: offset.x,
+                            y: offset.y,
+                        },
+                    ));
                 }
-                _ => {}
+                name => {
+                    return Err(Ipc2581Error::InvalidStructure(format!(
+                        "Unexpected {name} in Features"
+                    )));
+                }
             }
         }
 
-        Ok(features)
-    }
-
-    fn parse_features_location(&self, features_node: &Node, units: Units) -> Point {
-        self.element_children(features_node)
-            .find(|child| self.name(child) == "Location")
-            .map(|location| Point {
-                x: self
-                    .attr(&location, "x")
-                    .and_then(|s| s.parse::<f64>().ok())
-                    .map(|v| crate::units::to_mm(v, units))
-                    .unwrap_or(0.0),
-                y: self
-                    .attr(&location, "y")
-                    .and_then(|s| s.parse::<f64>().ok())
-                    .map(|v| crate::units::to_mm(v, units))
-                    .unwrap_or(0.0),
-            })
-            .unwrap_or(Point { x: 0.0, y: 0.0 })
-    }
-
-    fn parse_feature_polygon(
-        &mut self,
-        node: &Node,
-        units: Units,
-        offset: Point,
-    ) -> Option<ecad::SetFeature> {
-        self.parse_polygon(node, units)
-            .ok()
-            .map(|polygon| ecad::SetFeature::Polygon(Self::translate_polygon(polygon, offset)))
+        Ok(vec![feature.ok_or(Ipc2581Error::MissingElement(
+            "Feature in Features",
+        ))?])
     }
 
     fn translate_polygon(mut polygon: Polygon, offset: Point) -> Polygon {
@@ -3267,6 +3321,19 @@ fn is_standard_primitive_name(name: &str) -> bool {
             | "RectRound"
             | "Thermal"
             | "Triangle"
+    )
+}
+
+fn is_features_feature_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Polygon"
+            | "Polyline"
+            | "Line"
+            | "Arc"
+            | "UserSpecial"
+            | "StandardPrimitiveRef"
+            | "UserPrimitiveRef"
     )
 }
 

--- a/crates/pcb-ipc2581-tools/src/board_array.rs
+++ b/crates/pcb-ipc2581-tools/src/board_array.rs
@@ -791,6 +791,8 @@ mod tests {
               <Line startX="5" startY="0" endX="5" endY="24">
                 <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
               </Line>
+            </Features>
+            <Features>
               <Line startX="0" startY="5.5" endX="44" endY="5.5">
                 <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
               </Line>
@@ -876,12 +878,18 @@ mod tests {
               <Line startX="5" startY="0" endX="5" endY="20">
                 <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
               </Line>
+            </Features>
+            <Features>
               <Line startX="15" startY="0" endX="15" endY="20">
                 <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
               </Line>
+            </Features>
+            <Features>
               <Line startX="0" startY="5" endX="20" endY="5">
                 <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
               </Line>
+            </Features>
+            <Features>
               <Line startX="0" startY="15" endX="20" endY="15">
                 <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
               </Line>

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -151,6 +151,31 @@ fn board_array_creation_adds_history_record() {
 }
 
 #[test]
+fn generated_board_array_xml_validates_with_existing_history_and_callouts() {
+    let input = schema_valid_board_fixture_mm();
+    let xml = create_board_array_xml(
+        &input,
+        &BoardArrayCreateOptions {
+            columns: 6,
+            rows: 6,
+            board_margin_mm: board_margin(5.0, 5.0),
+            edge_rail_mm: BoardMarginMm::all(5.0),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(xml.matches("<FileRevision").count(), 1);
+    assert_eq!(xml.matches("<ChangeRec").count(), 1);
+    assert!(xml.matches("<Line ").count() > 1);
+    assert_eq!(
+        xml.matches("<Features>").count(),
+        xml.matches("<Line ").count()
+    );
+
+    crate::ipc2581::validate(&xml).expect("generated board array XML should validate");
+}
+
+#[test]
 fn auto_create_projects_board_to_a7_array() {
     let xml = create_auto_board_array_xml(board_fixture_mm()).unwrap();
 
@@ -1409,6 +1434,25 @@ fn board_fixture_mm() -> &'static str {
 </CadData>
   </Ecad>
 </IPC-2581>"#
+}
+
+fn schema_valid_board_fixture_mm() -> String {
+    board_fixture_mm().replace(
+        "  <Ecad>",
+        r#"  <LogisticHeader>
+    <Role id="Owner" roleFunction="SENDER"/>
+    <Enterprise id="UNKNOWN" code="NONE"/>
+    <Person name="UNKNOWN" enterpriseRef="UNKNOWN" roleRef="Owner"/>
+  </LogisticHeader>
+  <HistoryRecord number="1" origination="2026-01-01T00:00:00Z" software="KiCad EDA" lastChange="2026-01-01T00:00:00Z">
+    <FileRevision fileRevisionId="1" comment="Initial export">
+      <SoftwarePackage name="KiCad" revision="10.0.4" vendor="KiCad EDA">
+        <Certification certificationStatus="SELFTEST"/>
+      </SoftwarePackage>
+    </FileRevision>
+  </HistoryRecord>
+  <Ecad name="board">"#,
+    )
 }
 
 fn rounded_corner_board_fixture_mm() -> &'static str {

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
@@ -305,36 +305,23 @@ pub(super) fn write_set_features(
     features: &[SetFeature],
     names: &mut GeneratedNameState,
 ) -> Result<()> {
-    let mut features_open = false;
     for feature in features {
         match feature {
             SetFeature::Line(line) => {
-                if !features_open {
-                    writer.start_element("Features", &[]);
-                    features_open = true;
-                }
+                writer.start_element("Features", &[]);
                 write::line(writer, units, line)?;
+                writer.end_element("Features");
             }
             SetFeature::Fiducial(fiducial) => {
-                close_features_element(writer, &mut features_open);
                 write::fiducial(writer, units, fiducial)?;
             }
             SetFeature::Hole(hole) => {
-                close_features_element(writer, &mut features_open);
                 write::hole(writer, units, hole, &names.next_hole_name());
             }
             _ => bail!("generated board array layer feature has unsupported feature kind"),
         }
     }
-    close_features_element(writer, &mut features_open);
     Ok(())
-}
-
-pub(super) fn close_features_element(writer: &mut XmlWriter, features_open: &mut bool) {
-    if *features_open {
-        writer.end_element("Features");
-        *features_open = false;
-    }
 }
 
 pub(super) fn rectangle_polygon(width_mm: f64, height_mm: f64) -> Polygon {

--- a/crates/pcb-ipc2581-tools/src/commands/view.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/view.rs
@@ -76,7 +76,7 @@ pub fn execute(input: &Path, mode: ViewMode, output: &Path) -> Result<()> {
     let content = file_utils::load_ipc_file(input)?;
     let mut filtered_xml = filter_by_mode(&content, mode)?;
 
-    // Append FileRevision to HistoryRecord per IPC-2581C spec
+    // Append a schema-valid history change to HistoryRecord.
     let comment = format!("Filtered to {} view", mode.as_str());
     filtered_xml = crate::utils::history::append_file_revision(&filtered_xml, &comment)?;
 

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1572,6 +1572,8 @@ mod tests {
               <Line startX="4.2" startY="4.6" endX="5.8" endY="4.6">
                 <LineDesc lineWidth="0.5" lineEnd="ROUND"/>
               </Line>
+            </Features>
+            <Features>
               <Line startX="4.2" startY="5.4" endX="5.8" endY="5.4">
                 <LineDesc lineWidth="0.5" lineEnd="ROUND"/>
               </Line>

--- a/crates/pcb-ipc2581-tools/src/utils/history.rs
+++ b/crates/pcb-ipc2581-tools/src/utils/history.rs
@@ -20,6 +20,7 @@ const PCB_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// - Preserves HistoryRecord/@origination
 /// - Creates a HistoryRecord if the file does not already have one
 /// - Creates the initial FileRevision when the record is empty
+/// - Migrates legacy extra FileRevision elements to ChangeRec entries
 /// - Appends a ChangeRec when the record already contains its FileRevision
 pub fn append_file_revision(original_xml: &str, comment: &str) -> Result<String> {
     let doc = Doc::parse(original_xml)?;
@@ -32,6 +33,7 @@ pub fn append_file_revision(original_xml: &str, comment: &str) -> Result<String>
 pub fn file_revision_edits(doc: &Doc, comment: &str) -> Result<Vec<Edit>> {
     let now = jiff::Timestamp::now().to_string();
     let root = doc.root()?;
+    let (person_ref, mut edits) = ensure_history_person(doc, root)?;
 
     let edits = match doc.child(root, "HistoryRecord") {
         // A childless record is expanded in place, keeping its attributes.
@@ -40,30 +42,45 @@ pub fn file_revision_edits(doc: &Doc, comment: &str) -> Result<Vec<Edit>> {
             writer.start_element_with("HistoryRecord", initial_history_attrs(doc, record, &now));
             write_file_revision(&mut writer, 1, comment);
             writer.end_element("HistoryRecord");
-            vec![doc.replace(record, writer.into_string())]
+            edits.push(doc.replace(record, writer.into_string()));
+            edits
         }
         Some(record) => {
-            let file_revision_count = doc
+            let file_revisions = doc
                 .children(record)
                 .into_iter()
                 .filter(|&child| doc.name(child) == "FileRevision")
-                .count();
-            match file_revision_count {
-                0 => bail!("HistoryRecord has no FileRevision"),
-                1 => {}
-                _ => bail!(
-                    "HistoryRecord contains multiple FileRevision elements; IPC-2581C allows exactly one"
-                ),
+                .collect::<Vec<_>>();
+            if file_revisions.is_empty() {
+                bail!("HistoryRecord has no FileRevision");
             }
 
             let mut start_tag = XmlWriter::new();
             start_tag.start_element_with("HistoryRecord", updated_history_attrs(doc, record, &now));
-            let mut change = XmlWriter::new();
-            write_change_record(&mut change, &now, &history_person_ref(doc, root), comment);
-            vec![
-                doc.replace_start_tag(record, start_tag.into_string()),
-                doc.append_inside(record, change.into_string()),
-            ]
+            let mut changes = XmlWriter::new();
+            let legacy_datetime = doc.attr(record, "lastChange").unwrap_or(&now);
+            for revision in file_revisions.iter().skip(1) {
+                let package = doc.child(*revision, "SoftwarePackage");
+                let application = package
+                    .and_then(|package| doc.attr(package, "name"))
+                    .unwrap_or("pcb");
+                let change = legacy_revision_change(doc, *revision, package);
+                write_change_record(
+                    &mut changes,
+                    legacy_datetime,
+                    &person_ref,
+                    application,
+                    &change,
+                );
+            }
+            write_change_record(&mut changes, &now, &person_ref, "pcb", comment);
+
+            edits.push(doc.replace_start_tag(record, start_tag.into_string()));
+            for revision in file_revisions.iter().skip(1) {
+                edits.push(doc.delete(*revision));
+            }
+            edits.push(doc.append_inside(record, changes.into_string()));
+            edits
         }
         None => {
             let mut writer = XmlWriter::new();
@@ -84,9 +101,10 @@ pub fn file_revision_edits(doc: &Doc, comment: &str) -> Result<Vec<Edit>> {
                 .into_iter()
                 .find(|&child| !matches!(doc.name(child), "Content" | "LogisticHeader"));
             match anchor {
-                Some(node) => vec![doc.insert_before(node, writer.into_string())],
-                None => vec![doc.append_inside(root, writer.into_string())],
+                Some(node) => edits.push(doc.insert_before(node, writer.into_string())),
+                None => edits.push(doc.append_inside(root, writer.into_string())),
             }
+            edits
         }
     };
 
@@ -148,28 +166,107 @@ fn write_file_revision(writer: &mut XmlWriter, revision_id: u32, comment: &str) 
     writer.end_element("FileRevision");
 }
 
-fn write_change_record(writer: &mut XmlWriter, datetime: &str, person_ref: &str, comment: &str) {
+fn write_change_record(
+    writer: &mut XmlWriter,
+    datetime: &str,
+    person_ref: &str,
+    application: &str,
+    comment: &str,
+) {
     writer.empty_element(
         "ChangeRec",
         &[
             ("datetime", datetime),
             ("personRef", person_ref),
-            ("application", "pcb"),
+            ("application", application),
             ("change", comment),
         ],
     );
 }
 
-fn history_person_ref(doc: &Doc, root: Node) -> String {
-    doc.child(root, "LogisticHeader")
-        .and_then(|header| {
-            doc.children(header)
-                .into_iter()
-                .find(|&child| doc.name(child) == "Person")
+fn legacy_revision_change(doc: &Doc, revision: Node, package: Option<Node>) -> String {
+    if let Some(comment) = doc.attr(revision, "comment") {
+        return comment.to_string();
+    }
+
+    let id = doc.attr(revision, "fileRevisionId").unwrap_or("unknown");
+    let package_details = package
+        .map(|package| {
+            let name = doc.attr(package, "name").unwrap_or("unknown");
+            let revision = doc.attr(package, "revision").unwrap_or("unknown");
+            format!("{name} revision {revision}")
         })
-        .and_then(|person| doc.attr(person, "name"))
-        .unwrap_or("pcb")
-        .to_string()
+        .unwrap_or_else(|| "unknown application".to_string());
+    format!("Legacy FileRevision {id} ({package_details})")
+}
+
+fn ensure_history_person(doc: &Doc, root: Node) -> Result<(String, Vec<Edit>)> {
+    const PERSON_NAME: &str = "pcb";
+
+    if let Some(header) = doc.child(root, "LogisticHeader") {
+        if let Some(person) = doc
+            .children(header)
+            .into_iter()
+            .find(|&child| doc.name(child) == "Person")
+        {
+            if let Some(name) = doc.attr(person, "name") {
+                return Ok((name.to_string(), Vec::new()));
+            }
+        }
+
+        let role_ref = doc
+            .children(header)
+            .into_iter()
+            .find(|&child| doc.name(child) == "Role")
+            .and_then(|role| doc.attr(role, "id"))
+            .ok_or_else(|| anyhow::anyhow!("LogisticHeader has no Role for history Person"))?;
+        let enterprise_ref = doc
+            .children(header)
+            .into_iter()
+            .find(|&child| doc.name(child) == "Enterprise")
+            .and_then(|enterprise| doc.attr(enterprise, "id"))
+            .ok_or_else(|| {
+                anyhow::anyhow!("LogisticHeader has no Enterprise for history Person")
+            })?;
+
+        let mut writer = XmlWriter::new();
+        writer.empty_element(
+            "Person",
+            &[
+                ("name", PERSON_NAME),
+                ("enterpriseRef", enterprise_ref),
+                ("roleRef", role_ref),
+            ],
+        );
+        return Ok((
+            PERSON_NAME.to_string(),
+            vec![doc.append_inside(header, writer.into_string())],
+        ));
+    }
+
+    let mut writer = XmlWriter::new();
+    writer.start_element("LogisticHeader", &[]);
+    writer.empty_element("Role", &[("id", PERSON_NAME), ("roleFunction", "SENDER")]);
+    writer.empty_element("Enterprise", &[("id", PERSON_NAME), ("code", "NONE")]);
+    writer.empty_element(
+        "Person",
+        &[
+            ("name", PERSON_NAME),
+            ("enterpriseRef", PERSON_NAME),
+            ("roleRef", PERSON_NAME),
+        ],
+    );
+    writer.end_element("LogisticHeader");
+
+    let anchor = doc
+        .children(root)
+        .into_iter()
+        .find(|&child| doc.name(child) != "Content");
+    let edit = match anchor {
+        Some(node) => doc.insert_before(node, writer.into_string()),
+        None => doc.append_inside(root, writer.into_string()),
+    };
+    Ok((PERSON_NAME.to_string(), vec![edit]))
 }
 
 #[cfg(test)]
@@ -239,6 +336,38 @@ mod tests {
         // New edit appended as a third ChangeRec.
         assert_eq!(result.matches("<ChangeRec").count(), 3);
         assert!(result.contains("change=\"Third edit\""));
+    }
+
+    #[test]
+    fn test_migrates_legacy_file_revisions() {
+        let original = r#"<?xml version="1.0"?>
+<IPC-2581>
+  <Content roleRef="Owner"/>
+  <HistoryRecord number="3" origination="2025-10-23T16:30:12Z" software="pcb" lastChange="2025-11-17T20:00:00Z">
+    <FileRevision fileRevisionId="1" comment="Initial" label="">
+      <SoftwarePackage name="KiCad" revision="9.0.5" vendor="KiCad EDA"/>
+    </FileRevision>
+    <FileRevision fileRevisionId="2" comment="First edit" label="">
+      <SoftwarePackage name="pcb" revision="0.2.25" vendor="Diode"/>
+    </FileRevision>
+    <FileRevision fileRevisionId="3" comment="Second edit" label="">
+      <SoftwarePackage name="pcb" revision="0.2.26" vendor="Diode"/>
+    </FileRevision>
+  </HistoryRecord>
+  <Ecad/>
+</IPC-2581>"#;
+
+        let result = append_file_revision(original, "Third edit").unwrap();
+
+        assert_eq!(result.matches("<FileRevision").count(), 1);
+        assert_eq!(result.matches("<ChangeRec").count(), 3);
+        assert!(!result.contains("fileRevisionId=\"2\""));
+        assert!(!result.contains("fileRevisionId=\"3\""));
+        assert!(result.contains("datetime=\"2025-11-17T20:00:00Z\""));
+        assert!(result.contains("application=\"pcb\" change=\"First edit\""));
+        assert!(result.contains("application=\"pcb\" change=\"Second edit\""));
+        assert!(result.contains("change=\"Third edit\""));
+        assert!(result.contains("<Person name=\"pcb\""));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/utils/history.rs
+++ b/crates/pcb-ipc2581-tools/src/utils/history.rs
@@ -1,29 +1,26 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use ipc2581::XmlWriter;
 use ipc2581::edit::{self, Doc, Edit, Node};
 
 /// PCB tool version from Cargo.toml
 const PCB_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Append a FileRevision entry to HistoryRecord per IPC-2581C spec
+/// Append a schema-valid history entry to HistoryRecord per IPC-2581C spec.
 ///
 /// Per IPC-2581C Section 6.1 & 6.2:
 /// - HistoryRecord number must be incremented on every modification
 /// - lastChange must be updated to current timestamp
-/// - FileRevision elements track the sequence of changes and tools used
-/// - ALL previous FileRevision elements must be preserved (audit trail)
+/// - HistoryRecord contains one FileRevision followed by ChangeRec entries
+/// - ChangeRec entries preserve the audit trail for subsequent modifications
 ///
 /// This function:
 /// - Increments HistoryRecord/@number
 /// - Updates HistoryRecord/@lastChange to current timestamp
 /// - Updates HistoryRecord/@software to "pcb"
 /// - Preserves HistoryRecord/@origination
-/// - Preserves ALL existing FileRevision elements (untouched bytes)
 /// - Creates a HistoryRecord if the file does not already have one
-/// - Appends NEW FileRevision element with:
-///   - Incremented fileRevisionId
-///   - Descriptive comment about what changed
-///   - SoftwarePackage element with pcb version info
+/// - Creates the initial FileRevision when the record is empty
+/// - Appends a ChangeRec when the record already contains its FileRevision
 pub fn append_file_revision(original_xml: &str, comment: &str) -> Result<String> {
     let doc = Doc::parse(original_xml)?;
     let edits = file_revision_edits(&doc, comment)?;
@@ -46,21 +43,26 @@ pub fn file_revision_edits(doc: &Doc, comment: &str) -> Result<Vec<Edit>> {
             vec![doc.replace(record, writer.into_string())]
         }
         Some(record) => {
-            let next_id = doc
+            let file_revision_count = doc
                 .children(record)
                 .into_iter()
                 .filter(|&child| doc.name(child) == "FileRevision")
-                .filter_map(|child| doc.attr(child, "fileRevisionId")?.parse::<u32>().ok())
-                .map(|id| id + 1)
-                .max()
-                .unwrap_or(1);
+                .count();
+            match file_revision_count {
+                0 => bail!("HistoryRecord has no FileRevision"),
+                1 => {}
+                _ => bail!(
+                    "HistoryRecord contains multiple FileRevision elements; IPC-2581C allows exactly one"
+                ),
+            }
+
             let mut start_tag = XmlWriter::new();
             start_tag.start_element_with("HistoryRecord", updated_history_attrs(doc, record, &now));
-            let mut revision = XmlWriter::new();
-            write_file_revision(&mut revision, next_id, comment);
+            let mut change = XmlWriter::new();
+            write_change_record(&mut change, &now, &history_person_ref(doc, root), comment);
             vec![
                 doc.replace_start_tag(record, start_tag.into_string()),
-                doc.append_inside(record, revision.into_string()),
+                doc.append_inside(record, change.into_string()),
             ]
         }
         None => {
@@ -141,9 +143,33 @@ fn write_file_revision(writer: &mut XmlWriter, revision_id: u32, comment: &str) 
             ("vendor", "Diode"),
         ],
     );
-    writer.empty_element("Certification", &[("certificationStatus", "NONE")]);
+    writer.empty_element("Certification", &[("certificationStatus", "SELFTEST")]);
     writer.end_element("SoftwarePackage");
     writer.end_element("FileRevision");
+}
+
+fn write_change_record(writer: &mut XmlWriter, datetime: &str, person_ref: &str, comment: &str) {
+    writer.empty_element(
+        "ChangeRec",
+        &[
+            ("datetime", datetime),
+            ("personRef", person_ref),
+            ("application", "pcb"),
+            ("change", comment),
+        ],
+    );
+}
+
+fn history_person_ref(doc: &Doc, root: Node) -> String {
+    doc.child(root, "LogisticHeader")
+        .and_then(|header| {
+            doc.children(header)
+                .into_iter()
+                .find(|&child| doc.name(child) == "Person")
+        })
+        .and_then(|person| doc.attr(person, "name"))
+        .unwrap_or("pcb")
+        .to_string()
 }
 
 #[cfg(test)]
@@ -177,27 +203,24 @@ mod tests {
         assert!(result.contains("Initial export"));
         assert!(result.contains("KiCad"));
 
-        // New FileRevision appended
-        assert!(result.contains("fileRevisionId=\"2\""));
-        assert!(result.contains("BOM alternatives added"));
-        assert!(result.contains("name=\"pcb\""));
-        assert!(result.contains("vendor=\"Diode\""));
+        // A subsequent edit is recorded as ChangeRec; HistoryRecord allows
+        // only one FileRevision.
+        assert_eq!(result.matches("<FileRevision").count(), 1);
+        assert!(result.contains("<ChangeRec"));
+        assert!(result.contains("application=\"pcb\""));
+        assert!(result.contains("change=\"BOM alternatives added\""));
     }
 
     #[test]
-    fn test_multiple_revisions_preserved() {
+    fn test_existing_change_records_preserved() {
         let original = r#"<?xml version="1.0"?>
 <IPC-2581>
   <HistoryRecord number="3" origination="2025-10-23T16:30:12" software="pcb" lastChange="2025-11-17T20:00:00">
     <FileRevision fileRevisionId="1" comment="Initial" label="">
       <SoftwarePackage name="KiCad" revision="9.0.5" vendor="KiCad EDA"/>
     </FileRevision>
-    <FileRevision fileRevisionId="2" comment="First edit" label="">
-      <SoftwarePackage name="pcb" revision="0.2.25" vendor="Diode"/>
-    </FileRevision>
-    <FileRevision fileRevisionId="3" comment="Second edit" label="">
-      <SoftwarePackage name="pcb" revision="0.2.26" vendor="Diode"/>
-    </FileRevision>
+    <ChangeRec datetime="2025-11-01T20:00:00Z" personRef="pcb" application="pcb" change="First edit"/>
+    <ChangeRec datetime="2025-11-10T20:00:00Z" personRef="pcb" application="pcb" change="Second edit"/>
   </HistoryRecord>
 </IPC-2581>"#;
 
@@ -206,17 +229,16 @@ mod tests {
         // Number incremented from 3 to 4
         assert!(result.contains("number=\"4\""));
 
-        // All three previous revisions preserved
+        // The original revision and both existing changes are preserved.
+        assert_eq!(result.matches("<FileRevision").count(), 1);
         assert!(result.contains("fileRevisionId=\"1\""));
         assert!(result.contains("Initial"));
-        assert!(result.contains("fileRevisionId=\"2\""));
         assert!(result.contains("First edit"));
-        assert!(result.contains("fileRevisionId=\"3\""));
         assert!(result.contains("Second edit"));
 
-        // New revision appended as ID 4
-        assert!(result.contains("fileRevisionId=\"4\""));
-        assert!(result.contains("Third edit"));
+        // New edit appended as a third ChangeRec.
+        assert_eq!(result.matches("<ChangeRec").count(), 3);
+        assert!(result.contains("change=\"Third edit\""));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/utils/history.rs
+++ b/crates/pcb-ipc2581-tools/src/utils/history.rs
@@ -208,10 +208,9 @@ fn ensure_history_person(doc: &Doc, root: Node) -> Result<(String, Vec<Edit>)> {
             .children(header)
             .into_iter()
             .find(|&child| doc.name(child) == "Person")
+            && let Some(name) = doc.attr(person, "name")
         {
-            if let Some(name) = doc.attr(person, "name") {
-                return Ok((name.to_string(), Vec::new()));
-            }
+            return Ok((name.to_string(), Vec::new()));
         }
 
         let role_ref = doc


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes IPC-2581 parse strictness and XML shape for history and layer features; files that relied on lenient parsing or old multi-FileRevision writers may fail parse or need migration on next edit.
> 
> **Overview**
> Fixes **IPC-2581C schema compliance** for board-array and related tooling so generated XML validates and matches stricter parsing rules.
> 
> **History:** `append_file_revision` no longer stacks multiple `<FileRevision>` elements. It keeps a single `FileRevision`, records later edits as `<ChangeRec>`, migrates legacy extra `FileRevision` nodes into `ChangeRec`, and ensures a `Person` (and `LogisticHeader` when needed) for `personRef`. The parser rejects multiple `FileRevision` children and validates `ChangeRec` structure and ordering.
> 
> **Geometry:** Board-array (and similar) writers emit **one `<Features>` block per line** instead of multiple primitives in one container. The `Features` parser now enforces **exactly one feature** per container (with ordered `Xform`/`Location`) and surfaces parse errors instead of dropping invalid siblings.
> 
> Adds regression tests including full schema validation on generated board-array XML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0321e83193c2c009d2813d7271635d0c085a788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->