### PR TITLE
ENG-473 Avoid duplicate netlist updates on didSave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Avoid duplicate LSP netlist updates for unchanged state.
+- Prevent `textDocument/didSave` from republishing an open-buffer netlist already emitted by `textDocument/didChange`.
 
 ## [0.4.9] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - E-series helpers now consider the nearest value in the adjacent decade without changing exact E-series inputs.
 - IPC-2581 board-array output now uses schema-valid history changes and one feature per generated geometry container.
+- Prevent `textDocument/didSave` from republishing an open-buffer netlist already emitted by `textDocument/didChange`.
 
 ## [0.4.11] - 2026-07-23
 
@@ -39,7 +40,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Avoid duplicate LSP netlist updates for unchanged state.
-- Prevent `textDocument/didSave` from republishing an open-buffer netlist already emitted by `textDocument/didChange`.
 
 ## [0.4.9] - 2026-07-23
 

--- a/crates/pcb-starlark-lsp/src/server.rs
+++ b/crates/pcb-starlark-lsp/src/server.rs
@@ -730,7 +730,6 @@ impl<T: LspContext> Backend<T> {
         diagnostics.extend(sim_diagnostics);
 
         self.publish_grouped_diagnostics(&lsp_url, diagnostics, None);
-        self.maybe_publish_netlist_update(&lsp_url)?;
         self.propagate_change(&lsp_url)?;
 
         // Save is the explicit "refresh now" signal; force a full sweep so
@@ -2422,6 +2421,51 @@ mod tests {
         assert!(
             !notification.diagnostics.is_empty(),
             "expected diagnostics after didSave revalidation"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn did_save_does_not_republish_changed_document_netlist() -> anyhow::Result<()> {
+        if is_wasm() {
+            return Ok(());
+        }
+
+        let uri = temp_file_uri("file.star");
+        let mut server = TestServer::new()?;
+        server.open_file(uri.clone(), "x = 1\n".to_owned())?;
+
+        let subscribe = Request {
+            id: RequestId::from(1001),
+            method: "test/subscribeNetlist".to_owned(),
+            params: serde_json::Value::Null,
+        };
+        let subscribe_id = server.send_request(subscribe)?;
+        server.get_response::<bool>(subscribe_id)?;
+
+        let changed = "x = 2\n".to_owned();
+        server.set_file_contents(&uri, changed.clone())?;
+        server.change_file(uri.clone(), changed)?;
+        server.send_notification(new_notification::<DidSaveTextDocument>(
+            DidSaveTextDocumentParams {
+                text_document: TextDocumentIdentifier { uri },
+                text: None,
+            },
+        ))?;
+
+        // A request acts as a barrier for the preceding change and save notifications.
+        let barrier = Request {
+            id: RequestId::from(1002),
+            method: "starlark/echo".to_owned(),
+            params: serde_json::json!("done"),
+        };
+        let barrier_id = server.send_request(barrier)?;
+        server.get_response::<String>(barrier_id)?;
+
+        assert_eq!(
+            server.notification_count("zener/netlistUpdated"),
+            1,
+            "didChange should own netlist publication for the updated open buffer"
         );
         Ok(())
     }

--- a/crates/pcb-starlark-lsp/src/test.rs
+++ b/crates/pcb-starlark-lsp/src/test.rs
@@ -23,6 +23,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use dupe::Dupe;
@@ -123,6 +126,8 @@ struct TestServerContext {
     dirs: Arc<RwLock<HashSet<PathBuf>>>,
     builtin_docs: Arc<HashMap<LspUrl, String>>,
     builtin_symbols: Arc<HashMap<String, LspUrl>>,
+    netlist_subscribed: AtomicBool,
+    netlist_update_counter: AtomicU64,
 }
 
 impl LspContext for TestServerContext {
@@ -313,9 +318,28 @@ impl LspContext for TestServerContext {
                 result: Some(serde_json::to_value(format!("echo:{payload}")).unwrap()),
                 error: None,
             })
+        } else if req.method == "test/subscribeNetlist" {
+            self.netlist_subscribed.store(true, Ordering::Relaxed);
+            Some(lsp_server::Response {
+                id: req.id.clone(),
+                result: Some(serde_json::Value::Bool(true)),
+                error: None,
+            })
         } else {
             None
         }
+    }
+
+    fn netlist_update(&self, _uri: &LspUrl) -> anyhow::Result<Option<serde_json::Value>> {
+        if !self.netlist_subscribed.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+
+        let evaluator_id = self.netlist_update_counter.fetch_add(1, Ordering::Relaxed);
+        Ok(Some(serde_json::json!({
+            "contentHash": "unchanged",
+            "evaluatorId": evaluator_id,
+        })))
     }
 
     fn watched_file_changed(&self, uri: &LspUrl) -> bool {
@@ -464,6 +488,8 @@ impl TestServer {
             dirs: dirs.dupe(),
             builtin_docs: builtin_docs.dupe(),
             builtin_symbols,
+            netlist_subscribed: AtomicBool::new(false),
+            netlist_update_counter: AtomicU64::new(0),
         };
 
         let server_thread = std::thread::spawn(|| {
@@ -595,6 +621,13 @@ impl TestServer {
             "Did not get a notification of type `{}` in 10 retries",
             T::METHOD
         ))
+    }
+
+    pub fn notification_count(&self, method: &str) -> usize {
+        self.notifications
+            .iter()
+            .filter(|notification| notification.method == method)
+            .count()
     }
 
     /// Attempt to receive a message and either put it in the `responses` map if it's a


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow LSP behavior change: clients that relied on save-only netlist refresh may need to depend on didChange; save-time revalidation and diagnostics are unchanged.
> 
> **Overview**
> Fixes duplicate **`zener/netlistUpdated`** notifications when an open buffer is edited and then saved.
> 
> **`did_save`** no longer calls **`maybe_publish_netlist_update`** after revalidation; netlist publication stays on **`didChange`** (via **`validate`** / **`quick_validate`**). Save still merges save-time diagnostics, propagates dependency updates, and runs the full tracked-document revalidation sweep.
> 
> Adds LSP test support (**`test/subscribeNetlist`**, **`notification_count`**, mock **`netlist_update`**) and a test asserting change + save yields a single netlist notification. Changelog updated under **Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 439252a19937d1d04ec3f3c264a512b2854cfe7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->