### PR TITLE
Add IPC-2581 fabrication panel generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added `pcb ipc2581 fab-panel create` to tile up to 32 assembly panels into a fixed 18 by 24 inch fabrication panel.
+- Added `pcb ipc2581 fab-panel create` to tile up to 32 assembly panels with identical stackups into a fixed 18 by 24 inch fabrication panel.
 
 ## [0.4.12] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added `pcb ipc2581 fab-panel create` to tile up to 32 assembly panels into a fixed 18 by 24 inch fabrication panel.
+
 ## [0.4.12] - 2026-07-24
 
 ### Changed

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -15,12 +15,26 @@ alias provides the same commands.
 | `gerber` | Export fabrication layers and drill files. |
 | `view` | Export a filtered IPC-2581 document. |
 | `board-array create` | Create a rectangular board array. |
+| `fab-panel create` | Tile assembly panels into an 18 by 24 inch fabrication panel. |
 | `edit bom` | Add approved alternatives to BOM entries. |
 
 Run `pcb ipc2581 <command> --help` for arguments and output options.
 
 `edit bom` modifies the input file when `--output` is omitted. Specify an output
 path when the source document must remain unchanged.
+
+`fab-panel create` uses a 5 mm edge rail and a 5 mm gap between assembly
+panels. Repeat an input path to request more than one copy:
+
+```bash
+pcb ipc2581 fab-panel create \
+  --output fabrication-panel.xml \
+  assembly-a.xml assembly-a.xml assembly-b.xml
+```
+
+The command supports up to 32 assembly panels. Packing more than 16 panels can
+require a larger slicing-layout search and produces a warning. The command
+fails without writing an output when it cannot find a layout.
 
 ```bash
 cargo test -p pcb-ipc2581-tools

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -24,7 +24,9 @@ Run `pcb ipc2581 <command> --help` for arguments and output options.
 path when the source document must remain unchanged.
 
 `fab-panel create` uses a 5 mm edge rail and a 5 mm gap between assembly
-panels. Repeat an input path to request more than one copy:
+panels. All inputs must have identical physical stackups. The first input
+provides the fab panel stackup and canonical physical layer definitions.
+Repeat an input path to request more than one copy:
 
 ```bash
 pcb ipc2581 fab-panel create \

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -34,9 +34,8 @@ pcb ipc2581 fab-panel create \
   assembly-a.xml assembly-a.xml assembly-b.xml
 ```
 
-The command supports up to 32 assembly panels. Packing more than 16 panels can
-require a larger slicing-layout search and produces a warning. The command
-fails without writing an output when it cannot find a layout.
+The command supports up to 32 assembly panels and fails without writing an
+output when it cannot find a layout.
 
 ```bash
 cargo test -p pcb-ipc2581-tools

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -1,0 +1,181 @@
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use ipc2581::Ipc2581;
+use ipc2581::types::Units;
+use pcb_ir::dialects::ipc::{LayoutStepKind, root_step};
+use pcb_ir::geom::BBox;
+
+use crate::geometry;
+use crate::utils::file as file_utils;
+
+mod packing;
+mod xml;
+
+use packing::{MAX_ITEM_COUNT, SOFT_ITEM_LIMIT, Size, pack};
+
+const FAB_PANEL_WIDTH_MM: f64 = 18.0 * 25.4;
+const FAB_PANEL_HEIGHT_MM: f64 = 24.0 * 25.4;
+const EDGE_RAIL_MM: f64 = 5.0;
+const PANEL_GAP_MM: f64 = 5.0;
+const MICROMETERS_PER_MM: f64 = 1_000.0;
+
+const USABLE_FAB_PANEL: Size = Size {
+    width: 447_200,
+    height: 599_600,
+};
+const PANEL_GAP_UM: u32 = 5_000;
+
+#[derive(Debug)]
+struct SourcePanel {
+    namespaced_xml: String,
+    root_step_name: String,
+    bbox: BBox,
+    units: Units,
+    revision: String,
+}
+
+pub fn execute(inputs: &[PathBuf], output: &Path) -> Result<()> {
+    if inputs.is_empty() {
+        bail!("at least one assembly panel IPC-2581 file is required");
+    }
+    if inputs.len() > MAX_ITEM_COUNT {
+        bail!(
+            "at most {MAX_ITEM_COUNT} assembly panels are supported; got {}",
+            inputs.len()
+        );
+    }
+    if inputs.len() > SOFT_ITEM_LIMIT {
+        eprintln!(
+            "warning: packing {} assembly panels exceeds the recommended limit of {SOFT_ITEM_LIMIT}",
+            inputs.len()
+        );
+    }
+
+    let mut source_by_path = HashMap::<PathBuf, usize>::new();
+    let mut source_xml = Vec::new();
+    let mut occurrences = Vec::with_capacity(inputs.len());
+    for input in inputs {
+        let canonical = std::fs::canonicalize(input)
+            .with_context(|| format!("Failed to resolve input file: {}", input.display()))?;
+        let source_index = match source_by_path.get(&canonical) {
+            Some(source_index) => *source_index,
+            None => {
+                let source_index = source_xml.len();
+                source_xml.push(file_utils::load_ipc_file(input)?);
+                source_by_path.insert(canonical, source_index);
+                source_index
+            }
+        };
+        occurrences.push(source_index);
+    }
+
+    let generated = create_fab_panel_xml(&source_xml, &occurrences)?;
+    if output.as_os_str() == "-" {
+        io::stdout().lock().write_all(generated.as_bytes())?;
+        eprintln!("✓ Created IPC-2581 fabrication panel on stdout");
+    } else {
+        file_utils::save_ipc_file(output, &generated)?;
+        eprintln!(
+            "✓ Created IPC-2581 fabrication panel at {}",
+            output.display()
+        );
+    }
+    Ok(())
+}
+
+fn create_fab_panel_xml(source_xml: &[String], occurrences: &[usize]) -> Result<String> {
+    if occurrences.is_empty() {
+        bail!("at least one assembly panel is required");
+    }
+
+    let sources = source_xml
+        .iter()
+        .enumerate()
+        .map(|(source_index, xml)| prepare_source_panel(xml, source_index))
+        .collect::<Result<Vec<_>>>()?;
+    let first = sources
+        .first()
+        .context("at least one assembly panel source is required")?;
+    for source in &sources[1..] {
+        if source.units != first.units {
+            bail!("all assembly panel IPC-2581 files must use the same units");
+        }
+        if source.revision != first.revision {
+            bail!("all assembly panel IPC-2581 files must use the same revision");
+        }
+    }
+
+    let items = occurrences
+        .iter()
+        .map(|source_index| {
+            let source = sources
+                .get(*source_index)
+                .with_context(|| format!("invalid assembly panel source index {source_index}"))?;
+            Ok(Size {
+                width: dimension_um(source.bbox.width())?,
+                height: dimension_um(source.bbox.height())?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let placements = pack(&items, USABLE_FAB_PANEL, PANEL_GAP_UM)?;
+
+    xml::write_fab_panel_xml(&sources, occurrences, &placements)
+}
+
+fn prepare_source_panel(xml: &str, source_index: usize) -> Result<SourcePanel> {
+    let ipc = Ipc2581::parse(xml)
+        .with_context(|| format!("Failed to parse assembly panel input {}", source_index + 1))?;
+    let ecad = ipc.ecad().with_context(|| {
+        format!(
+            "assembly panel input {} has no ECAD section",
+            source_index + 1
+        )
+    })?;
+    let layout = geometry::extract_layout(&ipc).with_context(|| {
+        format!(
+            "failed to extract layout from assembly panel input {}",
+            source_index + 1
+        )
+    })?;
+    let (_, root) = root_step(&layout).with_context(|| {
+        format!(
+            "assembly panel input {} has no layout root",
+            source_index + 1
+        )
+    })?;
+    if root.kind != LayoutStepKind::Panel {
+        bail!(
+            "assembly panel input {} has a board layout root; expected a board array",
+            source_index + 1
+        );
+    }
+    if root.bbox.is_empty() || root.bbox.width() <= 0.0 || root.bbox.height() <= 0.0 {
+        bail!(
+            "assembly panel input {} has no non-empty root Profile",
+            source_index + 1
+        );
+    }
+
+    let prefix = format!("fab_{source_index}_");
+    Ok(SourcePanel {
+        namespaced_xml: xml::namespace_source(xml, &prefix)?,
+        root_step_name: format!("{prefix}{}", ipc.resolve(root.source_step_ref)),
+        bbox: root.bbox,
+        units: ecad.cad_header.units,
+        revision: ipc.revision().to_string(),
+    })
+}
+
+fn dimension_um(value_mm: f64) -> Result<u32> {
+    let value = (value_mm * MICROMETERS_PER_MM).ceil();
+    if !value.is_finite() || value <= 0.0 || value > f64::from(u32::MAX) {
+        bail!("assembly panel dimension {value_mm} mm is outside the supported range");
+    }
+    Ok(value as u32)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -1,10 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use ipc2581::Ipc2581;
-use ipc2581::types::Units;
+use ipc2581::edit::{Doc, Node};
+use ipc2581::types::{Spec, Units};
 use pcb_ir::dialects::ipc::{LayoutStepKind, root_step};
 use pcb_ir::geom::BBox;
 
@@ -35,6 +36,69 @@ struct SourcePanel {
     bbox: BBox,
     units: Units,
     revision: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PhysicalStackup {
+    attributes: Vec<(String, String)>,
+    group_attributes: Vec<Vec<(String, String)>>,
+    layers: Vec<PhysicalStackupLayer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PhysicalStackupLayer {
+    name: String,
+    layer_function: String,
+    side: Option<String>,
+    polarity: Option<String>,
+    span: Option<(Option<String>, Option<String>)>,
+    thickness: Option<u64>,
+    tol_plus: Option<u64>,
+    tol_minus: Option<u64>,
+    material: Option<String>,
+    dielectric_constant: Option<u64>,
+    loss_tangent: Option<u64>,
+    layer_number: Option<u32>,
+    specs: Vec<SpecSignature>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SpecSignature {
+    items: Vec<SpecItemSignature>,
+    material: Option<String>,
+    dielectric_constant: Option<u64>,
+    loss_tangent: Option<u64>,
+    properties: Vec<String>,
+    surface_finish: Option<SurfaceFinishSignature>,
+    copper_weight_oz: Option<u64>,
+    color_term: Option<String>,
+    color_rgb: Option<(u8, u8, u8)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SpecItemSignature {
+    element: String,
+    kind: String,
+    item_type: Option<String>,
+    comment: Option<String>,
+    properties: Vec<SpecPropertySignature>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SpecPropertySignature {
+    value: Option<u64>,
+    text: Option<String>,
+    unit: Option<String>,
+    plus_tol: Option<u64>,
+    minus_tol: Option<u64>,
+    tol_percent: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SurfaceFinishSignature {
+    finish_type: String,
+    comment: Option<String>,
+    products: Vec<(String, Option<String>)>,
 }
 
 pub fn execute(inputs: &[PathBuf], output: &Path) -> Result<()> {
@@ -91,10 +155,27 @@ fn create_fab_panel_xml(source_xml: &[String], occurrences: &[usize]) -> Result<
         bail!("at least one assembly panel is required");
     }
 
+    let stackups = source_xml
+        .iter()
+        .enumerate()
+        .map(|(source_index, xml)| physical_stackup(xml, source_index))
+        .collect::<Result<Vec<_>>>()?;
+    let first_stackup = stackups
+        .first()
+        .context("at least one assembly panel source is required")?;
+    for (source_index, stackup) in stackups.iter().enumerate().skip(1) {
+        require_identical_stackup(first_stackup, stackup, source_index)?;
+    }
+    let shared_stackup_layers = first_stackup
+        .layers
+        .iter()
+        .map(|layer| layer.name.clone())
+        .collect::<HashSet<_>>();
+
     let sources = source_xml
         .iter()
         .enumerate()
-        .map(|(source_index, xml)| prepare_source_panel(xml, source_index))
+        .map(|(source_index, xml)| prepare_source_panel(xml, source_index, &shared_stackup_layers))
         .collect::<Result<Vec<_>>>()?;
     let first = sources
         .first()
@@ -122,10 +203,14 @@ fn create_fab_panel_xml(source_xml: &[String], occurrences: &[usize]) -> Result<
         .collect::<Result<Vec<_>>>()?;
     let placements = pack(&items, USABLE_FAB_PANEL, PANEL_GAP_UM)?;
 
-    xml::write_fab_panel_xml(&sources, occurrences, &placements)
+    xml::write_fab_panel_xml(&sources, occurrences, &placements, &shared_stackup_layers)
 }
 
-fn prepare_source_panel(xml: &str, source_index: usize) -> Result<SourcePanel> {
+fn prepare_source_panel(
+    xml: &str,
+    source_index: usize,
+    shared_stackup_layers: &HashSet<String>,
+) -> Result<SourcePanel> {
     let ipc = Ipc2581::parse(xml)
         .with_context(|| format!("Failed to parse assembly panel input {}", source_index + 1))?;
     let ecad = ipc.ecad().with_context(|| {
@@ -161,12 +246,225 @@ fn prepare_source_panel(xml: &str, source_index: usize) -> Result<SourcePanel> {
 
     let prefix = format!("fab_{source_index}_");
     Ok(SourcePanel {
-        namespaced_xml: xml::namespace_source(xml, &prefix)?,
+        namespaced_xml: xml::namespace_source(xml, &prefix, shared_stackup_layers)?,
         root_step_name: format!("{prefix}{}", ipc.resolve(root.source_step_ref)),
         bbox: root.bbox,
         units: ecad.cad_header.units,
         revision: ipc.revision().to_string(),
     })
+}
+
+fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
+    let input_number = source_index + 1;
+    let ipc = Ipc2581::parse(xml)
+        .with_context(|| format!("Failed to parse assembly panel input {input_number}"))?;
+    let ecad = ipc
+        .ecad()
+        .with_context(|| format!("assembly panel input {input_number} has no ECAD section"))?;
+    if ecad.cad_data.stackups.len() != 1 {
+        bail!(
+            "assembly panel input {input_number} must contain exactly one physical stackup; found {}",
+            ecad.cad_data.stackups.len()
+        );
+    }
+    let stackup = &ecad.cad_data.stackups[0];
+
+    let doc = Doc::parse(xml)?;
+    let stackup_nodes = doc.find_all("Stackup");
+    if stackup_nodes.len() != 1 {
+        bail!(
+            "assembly panel input {input_number} must contain exactly one Stackup element; found {}",
+            stackup_nodes.len()
+        );
+    }
+    let stackup_node = stackup_nodes[0];
+    let attributes = sorted_attributes(&doc, stackup_node, &["name"]);
+    let group_attributes = doc
+        .children(stackup_node)
+        .into_iter()
+        .filter(|child| doc.name(*child) == "StackupGroup")
+        .map(|group| sorted_attributes(&doc, group, &["name"]))
+        .collect::<Vec<_>>();
+
+    let layers = stackup
+        .layers
+        .iter()
+        .enumerate()
+        .map(|(layer_index, stackup_layer)| {
+            let name = ipc.resolve(stackup_layer.layer_ref).to_string();
+            let layer = ecad
+                .cad_data
+                .layers
+                .iter()
+                .find(|layer| ipc.resolve(layer.name) == name)
+                .with_context(|| {
+                    format!(
+                        "assembly panel input {input_number} stackup layer {} references missing layer '{name}'",
+                        layer_index + 1
+                    )
+                })?;
+            let mut specs = layer
+                .spec_refs
+                .iter()
+                .filter_map(|spec_ref| ecad.cad_header.specs.get(spec_ref))
+                .map(|spec| spec_signature(&ipc, spec))
+                .collect::<Vec<_>>();
+            if let Some(spec_ref) = stackup_layer.spec_ref
+                && !layer.spec_refs.contains(&spec_ref)
+                && let Some(spec) = ecad.cad_header.specs.get(&spec_ref)
+            {
+                specs.push(spec_signature(&ipc, spec));
+            }
+
+            Ok(PhysicalStackupLayer {
+                name,
+                layer_function: layer.layer_function.as_str().to_string(),
+                side: layer.side.map(|side| side.as_str().to_string()),
+                polarity: layer.polarity.map(|polarity| format!("{polarity:?}")),
+                span: layer.span.map(|span| {
+                    (
+                        span.from_layer
+                            .map(|layer| ipc.resolve(layer).to_string()),
+                        span.to_layer.map(|layer| ipc.resolve(layer).to_string()),
+                    )
+                }),
+                thickness: float_bits(stackup_layer.thickness),
+                tol_plus: float_bits(stackup_layer.tol_plus),
+                tol_minus: float_bits(stackup_layer.tol_minus),
+                material: stackup_layer
+                    .material
+                    .map(|material| ipc.resolve(material).to_string()),
+                dielectric_constant: float_bits(stackup_layer.dielectric_constant),
+                loss_tangent: float_bits(stackup_layer.loss_tangent),
+                layer_number: stackup_layer.layer_number,
+                specs,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(PhysicalStackup {
+        attributes,
+        group_attributes,
+        layers,
+    })
+}
+
+fn require_identical_stackup(
+    first: &PhysicalStackup,
+    candidate: &PhysicalStackup,
+    source_index: usize,
+) -> Result<()> {
+    let input_number = source_index + 1;
+    if candidate.attributes != first.attributes
+        || candidate.group_attributes != first.group_attributes
+    {
+        bail!(
+            "assembly panel input {input_number} has stackup attributes that differ from assembly panel input 1"
+        );
+    }
+    if candidate.layers.len() != first.layers.len() {
+        bail!(
+            "assembly panel input {input_number} has {} stackup layers; assembly panel input 1 has {}",
+            candidate.layers.len(),
+            first.layers.len()
+        );
+    }
+    for (layer_index, (expected, actual)) in first.layers.iter().zip(&candidate.layers).enumerate()
+    {
+        if actual.name != expected.name {
+            bail!(
+                "assembly panel input {input_number} stackup layer {} is '{}'; assembly panel input 1 uses '{}'",
+                layer_index + 1,
+                actual.name,
+                expected.name
+            );
+        }
+        if actual != expected {
+            bail!(
+                "assembly panel input {input_number} stackup layer {} ('{}') differs from assembly panel input 1",
+                layer_index + 1,
+                expected.name
+            );
+        }
+    }
+    Ok(())
+}
+
+fn sorted_attributes(doc: &Doc<'_>, node: Node, excluded: &[&str]) -> Vec<(String, String)> {
+    let mut attributes = doc
+        .attrs(node)
+        .filter(|(name, _)| !excluded.contains(name))
+        .map(|(name, value)| (name.to_string(), value.to_string()))
+        .collect::<Vec<_>>();
+    attributes.sort();
+    attributes
+}
+
+fn spec_signature(ipc: &Ipc2581, spec: &Spec) -> SpecSignature {
+    SpecSignature {
+        items: spec
+            .items
+            .iter()
+            .map(|item| SpecItemSignature {
+                element: ipc.resolve(item.element).to_string(),
+                kind: format!("{:?}", item.kind),
+                item_type: item
+                    .item_type
+                    .map(|item_type| ipc.resolve(item_type).to_string()),
+                comment: item.comment.map(|comment| ipc.resolve(comment).to_string()),
+                properties: item
+                    .properties
+                    .iter()
+                    .map(|property| SpecPropertySignature {
+                        value: float_bits(property.value),
+                        text: property.text.map(|text| ipc.resolve(text).to_string()),
+                        unit: property.unit.map(|unit| ipc.resolve(unit).to_string()),
+                        plus_tol: float_bits(property.plus_tol),
+                        minus_tol: float_bits(property.minus_tol),
+                        tol_percent: property.tol_percent,
+                    })
+                    .collect(),
+            })
+            .collect(),
+        material: spec
+            .material
+            .map(|material| ipc.resolve(material).to_string()),
+        dielectric_constant: float_bits(spec.dielectric_constant),
+        loss_tangent: float_bits(spec.loss_tangent),
+        properties: spec
+            .properties
+            .iter()
+            .map(|property| ipc.resolve(*property).to_string())
+            .collect(),
+        surface_finish: spec
+            .surface_finish
+            .as_ref()
+            .map(|finish| SurfaceFinishSignature {
+                finish_type: format!("{:?}", finish.finish_type),
+                comment: finish
+                    .comment
+                    .map(|comment| ipc.resolve(comment).to_string()),
+                products: finish
+                    .products
+                    .iter()
+                    .map(|product| {
+                        (
+                            ipc.resolve(product.name).to_string(),
+                            product.criteria.map(|criteria| format!("{criteria:?}")),
+                        )
+                    })
+                    .collect(),
+            }),
+        copper_weight_oz: float_bits(spec.copper_weight_oz),
+        color_term: spec
+            .color_term
+            .map(|color_term| ipc.resolve(color_term).to_string()),
+        color_rgb: spec.color_rgb,
+    }
+}
+
+fn float_bits(value: Option<f64>) -> Option<u64> {
+    value.map(f64::to_bits)
 }
 
 fn dimension_um(value_mm: f64) -> Result<u32> {

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -15,7 +15,7 @@ use crate::utils::file as file_utils;
 mod packing;
 mod xml;
 
-use packing::{MAX_ITEM_COUNT, SOFT_ITEM_LIMIT, Size, pack};
+use packing::{MAX_ITEM_COUNT, Size, pack};
 
 const FAB_PANEL_WIDTH_MM: f64 = 18.0 * 25.4;
 const FAB_PANEL_HEIGHT_MM: f64 = 24.0 * 25.4;
@@ -111,13 +111,6 @@ pub fn execute(inputs: &[PathBuf], output: &Path) -> Result<()> {
             inputs.len()
         );
     }
-    if inputs.len() > SOFT_ITEM_LIMIT {
-        eprintln!(
-            "warning: packing {} assembly panels exceeds the recommended limit of {SOFT_ITEM_LIMIT}",
-            inputs.len()
-        );
-    }
-
     let mut source_by_path = HashMap::<PathBuf, usize>::new();
     let mut source_xml = Vec::new();
     let mut occurrences = Vec::with_capacity(inputs.len());

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/packing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/packing.rs
@@ -5,7 +5,7 @@ pub const SOFT_ITEM_LIMIT: usize = 16;
 pub const MAX_ITEM_COUNT: usize = 32;
 
 const SOFT_LIMIT_SEARCH_WORK: usize = 100_000_000;
-const EXTENDED_SEARCH_WORK: usize = 20_000_000;
+const EXTENDED_SEARCH_WORK: usize = 100_000_000;
 const SPLITS_PER_STATE_LIMIT: usize = 200_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -578,6 +578,48 @@ mod tests {
             };
             MAX_ITEM_COUNT
         ];
+        let placements = pack(&items, USABLE_FAB_PANEL, GAP).unwrap();
+        assert_valid(&items, &placements);
+    }
+
+    #[test]
+    fn packs_heterogeneous_shapes_above_the_soft_limit() {
+        let items = [
+            (
+                Size {
+                    width: 40_000,
+                    height: 60_000,
+                },
+                5,
+            ),
+            (
+                Size {
+                    width: 50_000,
+                    height: 70_000,
+                },
+                4,
+            ),
+            (
+                Size {
+                    width: 60_000,
+                    height: 80_000,
+                },
+                4,
+            ),
+            (
+                Size {
+                    width: 70_000,
+                    height: 90_000,
+                },
+                4,
+            ),
+        ]
+        .into_iter()
+        .flat_map(|(size, count)| std::iter::repeat_n(size, count))
+        .collect::<Vec<_>>();
+
+        assert!(items.len() > SOFT_ITEM_LIMIT);
+        assert!(EXTENDED_SEARCH_WORK >= SOFT_LIMIT_SEARCH_WORK);
         let placements = pack(&items, USABLE_FAB_PANEL, GAP).unwrap();
         assert_valid(&items, &placements);
     }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/packing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/packing.rs
@@ -1,0 +1,639 @@
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+
+pub const SOFT_ITEM_LIMIT: usize = 16;
+pub const MAX_ITEM_COUNT: usize = 32;
+
+const SOFT_LIMIT_SEARCH_WORK: usize = 100_000_000;
+const EXTENDED_SEARCH_WORK: usize = 20_000_000;
+const SPLITS_PER_STATE_LIMIT: usize = 200_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Size {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Size {
+    fn area(self) -> u64 {
+        u64::from(self.width) * u64::from(self.height)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Placement {
+    pub item_index: usize,
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+    pub rotated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackError {
+    Empty,
+    InvalidBin,
+    InvalidItem { item_index: usize },
+    TooManyItems { count: usize, max: usize },
+    NoLayout,
+    SearchLimitExceeded,
+}
+
+impl fmt::Display for PackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "at least one assembly panel is required"),
+            Self::InvalidBin => write!(f, "the usable fabrication panel size must be positive"),
+            Self::InvalidItem { item_index } => {
+                write!(f, "assembly panel {} has an empty profile", item_index + 1)
+            }
+            Self::TooManyItems { count, max } => {
+                write!(
+                    f,
+                    "at most {max} assembly panels are supported; got {count}"
+                )
+            }
+            Self::NoLayout => write!(
+                f,
+                "no slicing layout fits the requested assembly panels in the fabrication panel"
+            ),
+            Self::SearchLimitExceeded => write!(
+                f,
+                "no layout was found before the slicing-layout search limit was reached"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PackError {}
+
+#[derive(Debug, Clone)]
+struct Shape {
+    size: Size,
+    item_indices: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Candidate {
+    size: Size,
+    node: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PlanNode {
+    Leaf {
+        shape_index: usize,
+        size: Size,
+    },
+    Join {
+        axis: Axis,
+        first: Candidate,
+        second: Candidate,
+        size: Size,
+    },
+}
+
+struct Solver {
+    bin: Size,
+    gap: u32,
+    shapes: Vec<Shape>,
+    memo: HashMap<Vec<u8>, Vec<Candidate>>,
+    nodes: Vec<PlanNode>,
+    work: usize,
+    work_limit: usize,
+}
+
+pub fn pack(items: &[Size], bin: Size, gap: u32) -> Result<Vec<Placement>, PackError> {
+    if items.is_empty() {
+        return Err(PackError::Empty);
+    }
+    if items.len() > MAX_ITEM_COUNT {
+        return Err(PackError::TooManyItems {
+            count: items.len(),
+            max: MAX_ITEM_COUNT,
+        });
+    }
+    if bin.width == 0 || bin.height == 0 {
+        return Err(PackError::InvalidBin);
+    }
+    if let Some((item_index, _)) = items
+        .iter()
+        .enumerate()
+        .find(|(_, size)| size.width == 0 || size.height == 0)
+    {
+        return Err(PackError::InvalidItem { item_index });
+    }
+
+    let shapes = group_shapes(items);
+    let full_state = shapes
+        .iter()
+        .map(|shape| shape.item_indices.len() as u8)
+        .collect::<Vec<_>>();
+    let item_area = items.iter().map(|size| size.area()).sum::<u64>();
+    if item_area > bin.area() {
+        return Err(PackError::NoLayout);
+    }
+
+    let mut solver = Solver {
+        bin,
+        gap,
+        shapes,
+        memo: HashMap::new(),
+        nodes: Vec::new(),
+        work: 0,
+        work_limit: if items.len() <= SOFT_ITEM_LIMIT {
+            SOFT_LIMIT_SEARCH_WORK
+        } else {
+            EXTENDED_SEARCH_WORK
+        },
+    };
+    let frontier = solver.solve(&full_state)?;
+    let best = frontier
+        .into_iter()
+        .min_by_key(|candidate| {
+            (
+                candidate.size.area(),
+                candidate.size.width + candidate.size.height,
+                candidate.size.width,
+                candidate.size.height,
+            )
+        })
+        .ok_or(PackError::NoLayout)?;
+
+    let origin_x = (bin.width - best.size.width) / 2;
+    let origin_y = (bin.height - best.size.height) / 2;
+    let mut next_item_in_shape = vec![0; solver.shapes.len()];
+    let mut placements = Vec::with_capacity(items.len());
+    solver.place(
+        best,
+        origin_x,
+        origin_y,
+        items,
+        &mut next_item_in_shape,
+        &mut placements,
+    );
+    placements.sort_by_key(|placement| placement.item_index);
+    Ok(placements)
+}
+
+fn group_shapes(items: &[Size]) -> Vec<Shape> {
+    let mut groups = BTreeMap::<(u32, u32), Vec<usize>>::new();
+    for (item_index, item) in items.iter().enumerate() {
+        let key = if item.width <= item.height {
+            (item.width, item.height)
+        } else {
+            (item.height, item.width)
+        };
+        groups.entry(key).or_default().push(item_index);
+    }
+    groups
+        .into_iter()
+        .map(|((width, height), item_indices)| Shape {
+            size: Size { width, height },
+            item_indices,
+        })
+        .collect()
+}
+
+impl Solver {
+    fn solve(&mut self, state: &[u8]) -> Result<Vec<Candidate>, PackError> {
+        if let Some(frontier) = self.memo.get(state) {
+            return Ok(frontier.clone());
+        }
+
+        let item_count = state.iter().map(|count| usize::from(*count)).sum::<usize>();
+        let frontier = if item_count == 1 {
+            self.leaf_frontier(state)
+        } else {
+            self.join_frontier(state)?
+        };
+        self.memo.insert(state.to_vec(), frontier.clone());
+        Ok(frontier)
+    }
+
+    fn leaf_frontier(&mut self, state: &[u8]) -> Vec<Candidate> {
+        let shape_index = state
+            .iter()
+            .position(|count| *count == 1)
+            .expect("single-item state has one shape");
+        let size = self.shapes[shape_index].size;
+        let mut frontier = Vec::with_capacity(2);
+        self.add_leaf_candidate(&mut frontier, shape_index, size);
+        if size.width != size.height {
+            self.add_leaf_candidate(
+                &mut frontier,
+                shape_index,
+                Size {
+                    width: size.height,
+                    height: size.width,
+                },
+            );
+        }
+        frontier
+    }
+
+    fn add_leaf_candidate(
+        &mut self,
+        frontier: &mut Vec<Candidate>,
+        shape_index: usize,
+        size: Size,
+    ) {
+        if size.width > self.bin.width || size.height > self.bin.height {
+            return;
+        }
+        let node = self.nodes.len();
+        self.nodes.push(PlanNode::Leaf { shape_index, size });
+        insert_pareto(frontier, Candidate { size, node });
+    }
+
+    fn join_frontier(&mut self, state: &[u8]) -> Result<Vec<Candidate>, PackError> {
+        let mut splits = Vec::new();
+        let mut left = vec![0; state.len()];
+        self.collect_splits(state, 0, &mut left, &mut splits)?;
+        let total_count = state.iter().map(|count| usize::from(*count)).sum::<usize>();
+        splits.sort_by(|first, second| {
+            let first_count = first.iter().map(|count| usize::from(*count)).sum::<usize>();
+            let second_count = second
+                .iter()
+                .map(|count| usize::from(*count))
+                .sum::<usize>();
+            total_count
+                .abs_diff(first_count * 2)
+                .cmp(&total_count.abs_diff(second_count * 2))
+                .then_with(|| first.cmp(second))
+        });
+
+        let mut frontier = Vec::new();
+        for left_state in splits {
+            let right_state = state
+                .iter()
+                .zip(&left_state)
+                .map(|(total, left)| total - left)
+                .collect::<Vec<_>>();
+            let left_frontier = self.solve(&left_state)?;
+            if left_frontier.is_empty() {
+                continue;
+            }
+            let right_frontier = self.solve(&right_state)?;
+            if right_frontier.is_empty() {
+                continue;
+            }
+            for first in &left_frontier {
+                for second in &right_frontier {
+                    self.tick()?;
+                    self.add_join_candidate(&mut frontier, Axis::Horizontal, *first, *second);
+                    self.add_join_candidate(&mut frontier, Axis::Vertical, *first, *second);
+                }
+            }
+        }
+        Ok(frontier)
+    }
+
+    fn collect_splits(
+        &mut self,
+        state: &[u8],
+        index: usize,
+        left: &mut [u8],
+        splits: &mut Vec<Vec<u8>>,
+    ) -> Result<(), PackError> {
+        if index == state.len() {
+            self.tick()?;
+            if left.iter().all(|count| *count == 0) || left == state {
+                return Ok(());
+            }
+            let right = state
+                .iter()
+                .zip(left.iter())
+                .map(|(total, left)| total - left)
+                .collect::<Vec<_>>();
+            if &*left <= right.as_slice() {
+                if splits.len() == SPLITS_PER_STATE_LIMIT {
+                    return Err(PackError::SearchLimitExceeded);
+                }
+                splits.push(left.to_vec());
+            }
+            return Ok(());
+        }
+
+        for count in 0..=state[index] {
+            left[index] = count;
+            self.collect_splits(state, index + 1, left, splits)?;
+        }
+        Ok(())
+    }
+
+    fn add_join_candidate(
+        &mut self,
+        frontier: &mut Vec<Candidate>,
+        axis: Axis,
+        first: Candidate,
+        second: Candidate,
+    ) {
+        let size = match axis {
+            Axis::Horizontal => {
+                let Some(width) = first
+                    .size
+                    .width
+                    .checked_add(self.gap)
+                    .and_then(|width| width.checked_add(second.size.width))
+                else {
+                    return;
+                };
+                Size {
+                    width,
+                    height: first.size.height.max(second.size.height),
+                }
+            }
+            Axis::Vertical => {
+                let Some(height) = first
+                    .size
+                    .height
+                    .checked_add(self.gap)
+                    .and_then(|height| height.checked_add(second.size.height))
+                else {
+                    return;
+                };
+                Size {
+                    width: first.size.width.max(second.size.width),
+                    height,
+                }
+            }
+        };
+        if size.width > self.bin.width || size.height > self.bin.height {
+            return;
+        }
+        if frontier
+            .iter()
+            .any(|candidate| dominates(candidate.size, size))
+        {
+            return;
+        }
+        frontier.retain(|candidate| !dominates(size, candidate.size));
+        let node = self.nodes.len();
+        self.nodes.push(PlanNode::Join {
+            axis,
+            first,
+            second,
+            size,
+        });
+        frontier.push(Candidate { size, node });
+    }
+
+    fn tick(&mut self) -> Result<(), PackError> {
+        self.work += 1;
+        if self.work > self.work_limit {
+            Err(PackError::SearchLimitExceeded)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn place(
+        &self,
+        candidate: Candidate,
+        x: u32,
+        y: u32,
+        items: &[Size],
+        next_item_in_shape: &mut [usize],
+        placements: &mut Vec<Placement>,
+    ) {
+        match self.nodes[candidate.node] {
+            PlanNode::Leaf { shape_index, size } => {
+                let item_slot = next_item_in_shape[shape_index];
+                let item_index = self.shapes[shape_index].item_indices[item_slot];
+                next_item_in_shape[shape_index] += 1;
+                let original = items[item_index];
+                placements.push(Placement {
+                    item_index,
+                    x,
+                    y,
+                    width: size.width,
+                    height: size.height,
+                    rotated: size.width != original.width || size.height != original.height,
+                });
+            }
+            PlanNode::Join {
+                axis,
+                first,
+                second,
+                size,
+            } => match axis {
+                Axis::Horizontal => {
+                    self.place(
+                        first,
+                        x,
+                        y + (size.height - first.size.height) / 2,
+                        items,
+                        next_item_in_shape,
+                        placements,
+                    );
+                    self.place(
+                        second,
+                        x + first.size.width + self.gap,
+                        y + (size.height - second.size.height) / 2,
+                        items,
+                        next_item_in_shape,
+                        placements,
+                    );
+                }
+                Axis::Vertical => {
+                    self.place(
+                        first,
+                        x + (size.width - first.size.width) / 2,
+                        y,
+                        items,
+                        next_item_in_shape,
+                        placements,
+                    );
+                    self.place(
+                        second,
+                        x + (size.width - second.size.width) / 2,
+                        y + first.size.height + self.gap,
+                        items,
+                        next_item_in_shape,
+                        placements,
+                    );
+                }
+            },
+        }
+    }
+}
+
+fn dominates(first: Size, second: Size) -> bool {
+    first.width <= second.width && first.height <= second.height
+}
+
+fn insert_pareto(frontier: &mut Vec<Candidate>, candidate: Candidate) {
+    if frontier
+        .iter()
+        .any(|existing| dominates(existing.size, candidate.size))
+    {
+        return;
+    }
+    frontier.retain(|existing| !dominates(candidate.size, existing.size));
+    frontier.push(candidate);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const USABLE_FAB_PANEL: Size = Size {
+        width: 447_200,
+        height: 599_600,
+    };
+    const GAP: u32 = 5_000;
+
+    fn assert_valid(items: &[Size], placements: &[Placement]) {
+        assert_eq!(items.len(), placements.len());
+        for placement in placements {
+            assert!(placement.x + placement.width <= USABLE_FAB_PANEL.width);
+            assert!(placement.y + placement.height <= USABLE_FAB_PANEL.height);
+            let original = items[placement.item_index];
+            assert!(
+                (placement.width == original.width && placement.height == original.height)
+                    || (placement.width == original.height && placement.height == original.width)
+            );
+        }
+        for (index, first) in placements.iter().enumerate() {
+            for second in &placements[index + 1..] {
+                let separated = first.x + first.width + GAP <= second.x
+                    || second.x + second.width + GAP <= first.x
+                    || first.y + first.height + GAP <= second.y
+                    || second.y + second.height + GAP <= first.y;
+                assert!(separated, "{first:?} overlaps {second:?}");
+            }
+        }
+
+        let min_x = placements.iter().map(|item| item.x).min().unwrap();
+        let max_x = placements
+            .iter()
+            .map(|item| item.x + item.width)
+            .max()
+            .unwrap();
+        let min_y = placements.iter().map(|item| item.y).min().unwrap();
+        let max_y = placements
+            .iter()
+            .map(|item| item.y + item.height)
+            .max()
+            .unwrap();
+        assert!((min_x as i64 - (USABLE_FAB_PANEL.width - max_x) as i64).abs() <= 1);
+        assert!((min_y as i64 - (USABLE_FAB_PANEL.height - max_y) as i64).abs() <= 1);
+    }
+
+    #[test]
+    fn packs_four_a4_panels() {
+        let items = vec![
+            Size {
+                width: 210_000,
+                height: 297_000,
+            };
+            4
+        ];
+        let placements = pack(&items, USABLE_FAB_PANEL, GAP).unwrap();
+        assert_valid(&items, &placements);
+    }
+
+    #[test]
+    fn packs_heterogeneous_a_series_panels() {
+        let items = vec![
+            Size {
+                width: 210_000,
+                height: 297_000,
+            },
+            Size {
+                width: 148_000,
+                height: 210_000,
+            },
+            Size {
+                width: 105_000,
+                height: 148_000,
+            },
+            Size {
+                width: 74_000,
+                height: 105_000,
+            },
+            Size {
+                width: 74_000,
+                height: 105_000,
+            },
+        ];
+        let placements = pack(&items, USABLE_FAB_PANEL, GAP).unwrap();
+        assert_valid(&items, &placements);
+    }
+
+    #[test]
+    fn repeated_shapes_scale_to_the_hard_limit() {
+        let items = vec![
+            Size {
+                width: 50_000,
+                height: 50_000,
+            };
+            MAX_ITEM_COUNT
+        ];
+        let placements = pack(&items, USABLE_FAB_PANEL, GAP).unwrap();
+        assert_valid(&items, &placements);
+    }
+
+    #[test]
+    fn rejects_more_than_the_hard_limit() {
+        let items = vec![
+            Size {
+                width: 1,
+                height: 1,
+            };
+            MAX_ITEM_COUNT + 1
+        ];
+        assert_eq!(
+            pack(&items, USABLE_FAB_PANEL, GAP),
+            Err(PackError::TooManyItems {
+                count: MAX_ITEM_COUNT + 1,
+                max: MAX_ITEM_COUNT,
+            })
+        );
+    }
+
+    #[test]
+    fn returns_no_layout_when_panels_do_not_fit() {
+        let items = vec![
+            Size {
+                width: USABLE_FAB_PANEL.width,
+                height: USABLE_FAB_PANEL.height,
+            };
+            2
+        ];
+        assert_eq!(
+            pack(&items, USABLE_FAB_PANEL, GAP),
+            Err(PackError::NoLayout)
+        );
+    }
+
+    #[test]
+    fn packing_is_deterministic() {
+        let items = vec![
+            Size {
+                width: 100_000,
+                height: 200_000,
+            },
+            Size {
+                width: 120_000,
+                height: 80_000,
+            },
+            Size {
+                width: 100_000,
+                height: 200_000,
+            },
+        ];
+        assert_eq!(
+            pack(&items, USABLE_FAB_PANEL, GAP).unwrap(),
+            pack(&items, USABLE_FAB_PANEL, GAP).unwrap()
+        );
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/packing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/packing.rs
@@ -1,11 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
-pub const SOFT_ITEM_LIMIT: usize = 16;
 pub const MAX_ITEM_COUNT: usize = 32;
 
-const SOFT_LIMIT_SEARCH_WORK: usize = 100_000_000;
-const EXTENDED_SEARCH_WORK: usize = 100_000_000;
+const SEARCH_WORK_LIMIT: usize = 100_000_000;
 const SPLITS_PER_STATE_LIMIT: usize = 200_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -148,11 +146,7 @@ pub fn pack(items: &[Size], bin: Size, gap: u32) -> Result<Vec<Placement>, PackE
         memo: HashMap::new(),
         nodes: Vec::new(),
         work: 0,
-        work_limit: if items.len() <= SOFT_ITEM_LIMIT {
-            SOFT_LIMIT_SEARCH_WORK
-        } else {
-            EXTENDED_SEARCH_WORK
-        },
+        work_limit: SEARCH_WORK_LIMIT,
     };
     let frontier = solver.solve(&full_state)?;
     let best = frontier
@@ -570,7 +564,7 @@ mod tests {
     }
 
     #[test]
-    fn repeated_shapes_scale_to_the_hard_limit() {
+    fn repeated_shapes_scale_to_the_limit() {
         let items = vec![
             Size {
                 width: 50_000,
@@ -583,7 +577,20 @@ mod tests {
     }
 
     #[test]
-    fn packs_heterogeneous_shapes_above_the_soft_limit() {
+    fn packs_twenty_nine_a7_panels() {
+        let items = vec![
+            Size {
+                width: 105_000,
+                height: 74_000,
+            };
+            29
+        ];
+        let placements = pack(&items, USABLE_FAB_PANEL, GAP).unwrap();
+        assert_valid(&items, &placements);
+    }
+
+    #[test]
+    fn packs_seventeen_heterogeneous_panels() {
         let items = [
             (
                 Size {
@@ -618,14 +625,13 @@ mod tests {
         .flat_map(|(size, count)| std::iter::repeat_n(size, count))
         .collect::<Vec<_>>();
 
-        assert!(items.len() > SOFT_ITEM_LIMIT);
-        assert!(EXTENDED_SEARCH_WORK >= SOFT_LIMIT_SEARCH_WORK);
+        assert_eq!(items.len(), 17);
         let placements = pack(&items, USABLE_FAB_PANEL, GAP).unwrap();
         assert_valid(&items, &placements);
     }
 
     #[test]
-    fn rejects_more_than_the_hard_limit() {
+    fn rejects_more_than_the_limit() {
         let items = vec![
             Size {
                 width: 1,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -1,0 +1,157 @@
+use ipc2581::edit::Doc;
+use pcb_ir::dialects::ipc::root_step;
+
+use super::*;
+
+fn assembly_panel_xml(width_mm: f64, height_mm: f64) -> String {
+    assembly_panel_xml_at(0.0, 0.0, width_mm, height_mm)
+}
+
+fn assembly_panel_xml_at(min_x: f64, min_y: f64, width_mm: f64, height_mm: f64) -> String {
+    let max_x = min_x + width_mm;
+    let max_y = min_y + height_mm;
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="designer">
+    <FunctionMode mode="ASSEMBLY"/>
+    <StepRef name="panel"/>
+    <LayerRef name="TOP"/>
+  </Content>
+  <LogisticHeader>
+    <Role id="designer" roleFunction="DESIGNER"/>
+    <Enterprise id="enterprise" name="Example" code="EXAMPLE"/>
+    <Person name="designer" enterpriseRef="enterprise" roleRef="designer"/>
+  </LogisticHeader>
+  <HistoryRecord number="1" origination="2026-07-24T00:00:00Z" software="test" lastChange="2026-07-24T00:00:00Z">
+    <FileRevision fileRevisionId="1" comment="Test input" label="">
+      <SoftwarePackage name="test" vendor="test" revision="1">
+        <Certification certificationStatus="SELFTEST"/>
+      </SoftwarePackage>
+    </FileRevision>
+  </HistoryRecord>
+  <Ecad name="assembly">
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+      <Step name="panel" type="PALLET">
+        <Datum x="0" y="0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="{min_x}" y="{min_y}"/>
+            <PolyStepSegment x="{max_x}" y="{min_y}"/>
+            <PolyStepSegment x="{max_x}" y="{max_y}"/>
+            <PolyStepSegment x="{min_x}" y="{max_y}"/>
+          </Polygon>
+        </Profile>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#
+    )
+}
+
+#[test]
+fn merges_colliding_source_names_and_builds_full_fab_profile() {
+    let sources = vec![
+        assembly_panel_xml_at(10.0, 20.0, 100.0, 80.0),
+        assembly_panel_xml_at(-15.0, 7.0, 120.0, 90.0),
+    ];
+    let generated = create_fab_panel_xml(&sources, &[0, 1]).unwrap();
+
+    assert!(generated.contains(r#"<Step name="fab_0_panel" type="PALLET">"#));
+    assert!(generated.contains(r#"<Step name="fab_1_panel" type="PALLET">"#));
+    assert!(generated.contains(r#"<Layer name="fab_0_TOP""#));
+    assert!(generated.contains(r#"<Layer name="fab_1_TOP""#));
+    assert!(generated.contains(r#"stepRef="fab_0_panel""#));
+    assert!(generated.contains(r#"stepRef="fab_1_panel""#));
+
+    Ipc2581::validate(&generated).unwrap();
+    let parsed = Ipc2581::parse(&generated).unwrap();
+    let layout = geometry::extract_layout(&parsed).unwrap();
+    let (_, root) = root_step(&layout).unwrap();
+    assert!((root.bbox.width() - FAB_PANEL_WIDTH_MM).abs() < 1e-9);
+    assert!((root.bbox.height() - FAB_PANEL_HEIGHT_MM).abs() < 1e-9);
+
+    let instances = layout
+        .layout
+        .instances
+        .iter()
+        .filter(|instance| {
+            instance.parent_instance.is_none()
+                && layout.layout.steps[instance.child_step as usize].kind == LayoutStepKind::Panel
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(instances.len(), 2);
+    for instance in &instances {
+        assert!(instance.bbox.min.x >= EDGE_RAIL_MM - 1e-9);
+        assert!(instance.bbox.min.y >= EDGE_RAIL_MM - 1e-9);
+        assert!(instance.bbox.max.x <= FAB_PANEL_WIDTH_MM - EDGE_RAIL_MM + 1e-9);
+        assert!(instance.bbox.max.y <= FAB_PANEL_HEIGHT_MM - EDGE_RAIL_MM + 1e-9);
+    }
+    let first = instances[0].bbox;
+    let second = instances[1].bbox;
+    let separated = first.max.x + PANEL_GAP_MM <= second.min.x + 1e-9
+        || second.max.x + PANEL_GAP_MM <= first.min.x + 1e-9
+        || first.max.y + PANEL_GAP_MM <= second.min.y + 1e-9
+        || second.max.y + PANEL_GAP_MM <= first.min.y + 1e-9;
+    assert!(separated);
+}
+
+#[test]
+fn repeating_an_input_reuses_its_definitions_and_adds_placements() {
+    let sources = vec![assembly_panel_xml(100.0, 80.0)];
+    let generated = create_fab_panel_xml(&sources, &[0, 0, 0]).unwrap();
+    let doc = Doc::parse(&generated).unwrap();
+
+    let imported_steps = doc
+        .find_all("Step")
+        .into_iter()
+        .filter(|step| doc.attr(*step, "name") == Some("fab_0_panel"))
+        .count();
+    let imported_layers = doc
+        .find_all("Layer")
+        .into_iter()
+        .filter(|layer| doc.attr(*layer, "name") == Some("fab_0_TOP"))
+        .count();
+    let placements = doc
+        .find_all("StepRepeat")
+        .into_iter()
+        .filter(|repeat| doc.attr(*repeat, "stepRef") == Some("fab_0_panel"))
+        .count();
+
+    assert_eq!(imported_steps, 1);
+    assert_eq!(imported_layers, 1);
+    assert_eq!(placements, 3);
+}
+
+#[test]
+fn rotates_and_translates_a_nonzero_source_profile() {
+    let sources = vec![assembly_panel_xml_at(10.0, 20.0, 500.0, 400.0)];
+    let generated = create_fab_panel_xml(&sources, &[0]).unwrap();
+    let parsed = Ipc2581::parse(&generated).unwrap();
+    let layout = geometry::extract_layout(&parsed).unwrap();
+    let instance = layout
+        .layout
+        .instances
+        .iter()
+        .find(|instance| instance.parent_instance.is_none())
+        .unwrap();
+
+    assert!((instance.bbox.width() - 400.0).abs() < 1e-9);
+    assert!((instance.bbox.height() - 500.0).abs() < 1e-9);
+    assert!(instance.bbox.min.x >= EDGE_RAIL_MM - 1e-9);
+    assert!(instance.bbox.min.y >= EDGE_RAIL_MM - 1e-9);
+    assert!(instance.bbox.max.x <= FAB_PANEL_WIDTH_MM - EDGE_RAIL_MM + 1e-9);
+    assert!(instance.bbox.max.y <= FAB_PANEL_HEIGHT_MM - EDGE_RAIL_MM + 1e-9);
+}
+
+#[test]
+fn rejects_a_board_instead_of_an_assembly_panel() {
+    let board = assembly_panel_xml(100.0, 80.0).replace(
+        r#"<Step name="panel" type="PALLET">"#,
+        r#"<Step name="panel" type="BOARD">"#,
+    );
+    let error = create_fab_panel_xml(&[board], &[0]).unwrap_err();
+    assert!(error.to_string().contains("expected a board array"));
+}

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -34,6 +34,11 @@ fn assembly_panel_xml_at(min_x: f64, min_y: f64, width_mm: f64, height_mm: f64) 
     <CadHeader units="MILLIMETER"/>
     <CadData>
       <Layer name="TOP" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+      <Stackup name="Primary" overallThickness="0.035" tolPlus="0" tolMinus="0" whereMeasured="METAL" stackupStatus="PROPOSED">
+        <StackupGroup name="Primary_Group" thickness="0.035" tolPlus="0" tolMinus="0">
+          <StackupLayer layerOrGroupRef="TOP" thickness="0.035" tolPlus="0" tolMinus="0" sequence="0"/>
+        </StackupGroup>
+      </Stackup>
       <Step name="panel" type="PALLET">
         <Datum x="0" y="0"/>
         <Profile>
@@ -44,6 +49,15 @@ fn assembly_panel_xml_at(min_x: f64, min_y: f64, width_mm: f64, height_mm: f64) 
             <PolyStepSegment x="{min_x}" y="{max_y}"/>
           </Polygon>
         </Profile>
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <Features>
+              <Line startX="{min_x}" startY="{min_y}" endX="{max_x}" endY="{min_y}">
+                <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
+              </Line>
+            </Features>
+          </Set>
+        </LayerFeature>
       </Step>
     </CadData>
   </Ecad>
@@ -52,7 +66,7 @@ fn assembly_panel_xml_at(min_x: f64, min_y: f64, width_mm: f64, height_mm: f64) 
 }
 
 #[test]
-fn merges_colliding_source_names_and_builds_full_fab_profile() {
+fn shares_the_first_stackup_across_sources_and_builds_full_fab_profile() {
     let sources = vec![
         assembly_panel_xml_at(10.0, 20.0, 100.0, 80.0),
         assembly_panel_xml_at(-15.0, 7.0, 120.0, 90.0),
@@ -61,8 +75,22 @@ fn merges_colliding_source_names_and_builds_full_fab_profile() {
 
     assert!(generated.contains(r#"<Step name="fab_0_panel" type="PALLET">"#));
     assert!(generated.contains(r#"<Step name="fab_1_panel" type="PALLET">"#));
-    assert!(generated.contains(r#"<Layer name="fab_0_TOP""#));
-    assert!(generated.contains(r#"<Layer name="fab_1_TOP""#));
+    assert_eq!(generated.matches(r#"<Layer name="TOP""#).count(), 1);
+    assert!(!generated.contains(r#"<Layer name="fab_0_TOP""#));
+    assert!(!generated.contains(r#"<Layer name="fab_1_TOP""#));
+    assert_eq!(
+        generated
+            .matches(r#"<Stackup name="fab_0_Primary""#)
+            .count(),
+        1
+    );
+    assert!(!generated.contains(r#"<Stackup name="fab_1_Primary""#));
+    assert_eq!(
+        generated
+            .matches(r#"<LayerFeature layerRef="TOP">"#)
+            .count(),
+        2
+    );
     assert!(generated.contains(r#"stepRef="fab_0_panel""#));
     assert!(generated.contains(r#"stepRef="fab_1_panel""#));
 
@@ -112,7 +140,7 @@ fn repeating_an_input_reuses_its_definitions_and_adds_placements() {
     let imported_layers = doc
         .find_all("Layer")
         .into_iter()
-        .filter(|layer| doc.attr(*layer, "name") == Some("fab_0_TOP"))
+        .filter(|layer| doc.attr(*layer, "name") == Some("TOP"))
         .count();
     let placements = doc
         .find_all("StepRepeat")
@@ -123,6 +151,45 @@ fn repeating_an_input_reuses_its_definitions_and_adds_placements() {
     assert_eq!(imported_steps, 1);
     assert_eq!(imported_layers, 1);
     assert_eq!(placements, 3);
+}
+
+#[test]
+fn rejects_a_stackup_that_differs_from_the_first_input() {
+    let first = assembly_panel_xml(100.0, 80.0);
+    let second = assembly_panel_xml(120.0, 90.0).replace(
+        r#"thickness="0.035" tolPlus="0" tolMinus="0" sequence="0""#,
+        r#"thickness="0.070" tolPlus="0" tolMinus="0" sequence="0""#,
+    );
+
+    let error = create_fab_panel_xml(&[first, second], &[0, 1]).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("stackup layer 1 ('TOP') differs from assembly panel input 1")
+    );
+}
+
+#[test]
+fn rejects_an_input_without_exactly_one_stackup() {
+    let first = assembly_panel_xml(100.0, 80.0);
+    let second = assembly_panel_xml(120.0, 90.0).replace(
+        r#"      <Stackup name="Primary" overallThickness="0.035" tolPlus="0" tolMinus="0" whereMeasured="METAL" stackupStatus="PROPOSED">
+        <StackupGroup name="Primary_Group" thickness="0.035" tolPlus="0" tolMinus="0">
+          <StackupLayer layerOrGroupRef="TOP" thickness="0.035" tolPlus="0" tolMinus="0" sequence="0"/>
+        </StackupGroup>
+      </Stackup>
+"#,
+        "",
+    );
+
+    let error = create_fab_panel_xml(&[first, second], &[0, 1]).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("assembly panel input 2 must contain exactly one physical stackup")
+    );
 }
 
 #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
@@ -1,0 +1,566 @@
+use anyhow::{Context, Result, bail};
+use ipc2581::edit::{self, Doc, Edit, Node};
+use ipc2581::types::Units;
+use ipc2581::{Ipc2581, XmlWriter};
+
+use super::{EDGE_RAIL_MM, FAB_PANEL_HEIGHT_MM, FAB_PANEL_WIDTH_MM, PANEL_GAP_MM, SourcePanel};
+use crate::commands::fab_panel::packing::Placement;
+
+const FAB_STEP_NAME: &str = "fab_panel";
+const FAB_AVL_NAME: &str = "fab_panel_avl";
+const FAB_ROLE_ID: &str = "fab_panel_role";
+const FAB_ENTERPRISE_ID: &str = "fab_panel_enterprise";
+const FAB_PERSON_NAME: &str = "pcb";
+
+pub(super) fn namespace_source(xml: &str, prefix: &str) -> Result<String> {
+    let doc = Doc::parse(xml)?;
+    let root = doc.root()?;
+    let mut edits = Vec::new();
+    collect_namespace_edits(&doc, root, prefix, &mut edits);
+    Ok(edit::apply(xml, edits)?)
+}
+
+fn collect_namespace_edits(doc: &Doc, node: Node, prefix: &str, edits: &mut Vec<Edit>) {
+    let element = doc.name(node);
+    let mut changed = false;
+    let attrs = doc
+        .attrs(node)
+        .map(|(name, value)| {
+            let value = if should_namespace_attr(element, name) {
+                changed = true;
+                format!("{prefix}{value}")
+            } else {
+                value.to_string()
+            };
+            (name.to_string(), value)
+        })
+        .collect::<Vec<_>>();
+
+    if changed {
+        let mut writer = XmlWriter::new();
+        if doc.source(node).ends_with("/>") {
+            writer.empty_element_with(element, attrs);
+        } else {
+            writer.start_element_with(element, attrs);
+        }
+        edits.push(doc.replace_start_tag(node, writer.into_string()));
+    }
+
+    for child in doc.children(node) {
+        collect_namespace_edits(doc, child, prefix, edits);
+    }
+}
+
+fn should_namespace_attr(element: &str, attr: &str) -> bool {
+    if matches!(
+        attr,
+        "enterpriseRef"
+            | "personRef"
+            | "roleRef"
+            | "stepRef"
+            | "packageRef"
+            | "layerRef"
+            | "layerRefTopside"
+            | "secondaryLayerRef"
+            | "fromLayer"
+            | "toLayer"
+            | "startCutLayer"
+            | "layerId"
+            | "modelRef"
+            | "componentRef"
+            | "compRef"
+            | "specRef"
+            | "firmwareRef"
+            | "padstackDefRef"
+            | "netRef"
+            | "stackupRef"
+            | "bomRef"
+            | "layerOrGroupRef"
+            | "portName"
+            | "matDes"
+            | "refDes"
+            | "net"
+            | "netPair"
+            | "part"
+            | "OEMDesignNumber"
+            | "OEMDesignNumberRef"
+            | "dfxMeasurementRef"
+    ) {
+        return true;
+    }
+
+    match attr {
+        "name" => matches!(
+            element,
+            "Step"
+                | "StepRef"
+                | "Package"
+                | "Bom"
+                | "BomRef"
+                | "Person"
+                | "Avl"
+                | "AvlRef"
+                | "Layer"
+                | "LayerRef"
+                | "RefDes"
+                | "MatDes"
+                | "Stackup"
+                | "StackupGroup"
+                | "Spec"
+                | "Port"
+                | "NetRef"
+                | "LogicalNet"
+                | "PhyNet"
+                | "PhyNetGroup"
+                | "PadStackDef"
+                | "Model"
+                | "SlotCavity"
+                | "StackupZone"
+        ),
+        "id" => matches!(
+            element,
+            "Role"
+                | "Enterprise"
+                | "EntryColor"
+                | "ColorRef"
+                | "EntryStandard"
+                | "StandardPrimitiveRef"
+                | "EntryUser"
+                | "UserPrimitiveRef"
+                | "EntryFirmware"
+                | "FirmwareRef"
+                | "EntryFont"
+                | "FontRef"
+                | "EntryLineDesc"
+                | "LineDescRef"
+                | "EntryFillDesc"
+                | "FillDescRef"
+                | "SpecRef"
+                | "SlotCavityRef"
+                | "StackupZoneRef"
+                | "DfxMeasurement"
+        ),
+        _ => false,
+    }
+}
+
+pub(super) fn write_fab_panel_xml(
+    sources: &[SourcePanel],
+    occurrences: &[usize],
+    placements: &[Placement],
+) -> Result<String> {
+    let docs = sources
+        .iter()
+        .map(|source| Doc::parse(&source.namespaced_xml))
+        .collect::<ipc2581::Result<Vec<_>>>()?;
+    let first = sources
+        .first()
+        .context("at least one assembly panel source is required")?;
+    let has_avl = docs.iter().any(|doc| {
+        doc.root()
+            .ok()
+            .and_then(|root| doc.child(root, "Avl"))
+            .is_some()
+    });
+
+    let mut writer = XmlWriter::new();
+    writer.write_declaration();
+    writer.start_element(
+        "IPC-2581",
+        &[
+            ("revision", first.revision.as_str()),
+            ("xmlns", "http://webstds.ipc.org/2581"),
+        ],
+    );
+    write_content(&mut writer, &docs, has_avl)?;
+    write_logistic_header(&mut writer, &docs)?;
+    write_history_record(&mut writer);
+    write_boms(&mut writer, &docs)?;
+    write_ecad(
+        &mut writer,
+        sources,
+        &docs,
+        occurrences,
+        placements,
+        first.units,
+    )?;
+    if has_avl {
+        write_avl(&mut writer, &docs)?;
+    }
+    writer.end_element("IPC-2581");
+
+    let xml = crate::utils::format::reformat_xml(&writer.into_string())?;
+    Ipc2581::parse(&xml).context("Generated IPC-2581 fabrication panel XML did not parse")?;
+    Ok(xml)
+}
+
+fn write_content(writer: &mut XmlWriter, docs: &[Doc<'_>], has_avl: bool) -> Result<()> {
+    writer.start_element("Content", &[("roleRef", FAB_ROLE_ID)]);
+    writer.empty_element("FunctionMode", &[("mode", "FABRICATION")]);
+    writer.empty_element("StepRef", &[("name", FAB_STEP_NAME)]);
+
+    for doc in docs {
+        let cad_data = cad_data(doc)?;
+        for layer in children_named(doc, cad_data, "Layer") {
+            let name = doc
+                .attr(layer, "name")
+                .context("IPC-2581 Layer has no name")?;
+            writer.empty_element("LayerRef", &[("name", name)]);
+        }
+    }
+    for doc in docs {
+        let root = doc.root()?;
+        for bom in children_named(doc, root, "Bom") {
+            let name = doc.attr(bom, "name").context("IPC-2581 Bom has no name")?;
+            writer.empty_element("BomRef", &[("name", name)]);
+        }
+    }
+    if has_avl {
+        writer.empty_element("AvlRef", &[("name", FAB_AVL_NAME)]);
+    }
+
+    for dictionary in [
+        "DictionaryColor",
+        "DictionaryLineDesc",
+        "DictionaryFillDesc",
+        "DictionaryFont",
+        "DictionaryStandard",
+        "DictionaryUser",
+        "DictionaryFirmware",
+    ] {
+        write_merged_container(writer, docs, dictionary)?;
+    }
+    writer.end_element("Content");
+    Ok(())
+}
+
+fn write_merged_container(
+    writer: &mut XmlWriter,
+    docs: &[Doc<'_>],
+    element_name: &str,
+) -> Result<()> {
+    let mut attrs: Option<Vec<(String, String)>> = None;
+    let mut children = Vec::new();
+    for doc in docs {
+        let root = doc.root()?;
+        let Some(content) = doc.child(root, "Content") else {
+            continue;
+        };
+        let Some(container) = doc.child(content, element_name) else {
+            continue;
+        };
+        let container_attrs = doc
+            .attrs(container)
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect::<Vec<_>>();
+        match &attrs {
+            Some(first_attrs) if first_attrs != &container_attrs => {
+                bail!("assembly panel inputs use incompatible {element_name} attributes")
+            }
+            None => attrs = Some(container_attrs),
+            _ => {}
+        }
+        children.extend(
+            doc.children(container)
+                .into_iter()
+                .map(|child| doc.source(child).to_string()),
+        );
+    }
+    if children.is_empty() {
+        return Ok(());
+    }
+
+    writer.start_element_with(element_name, attrs.unwrap_or_default());
+    for child in children {
+        writer.raw(&child);
+    }
+    writer.end_element(element_name);
+    Ok(())
+}
+
+fn write_logistic_header(writer: &mut XmlWriter, docs: &[Doc<'_>]) -> Result<()> {
+    writer.start_element("LogisticHeader", &[]);
+    writer.empty_element("Role", &[("id", FAB_ROLE_ID), ("roleFunction", "DESIGNER")]);
+    write_logistic_children(writer, docs, "Role")?;
+
+    writer.empty_element(
+        "Enterprise",
+        &[
+            ("id", FAB_ENTERPRISE_ID),
+            ("name", "Diode"),
+            ("code", "DIODE"),
+        ],
+    );
+    write_logistic_children(writer, docs, "Enterprise")?;
+
+    writer.empty_element(
+        "Person",
+        &[
+            ("name", FAB_PERSON_NAME),
+            ("enterpriseRef", FAB_ENTERPRISE_ID),
+            ("roleRef", FAB_ROLE_ID),
+        ],
+    );
+    write_logistic_children(writer, docs, "Person")?;
+    writer.end_element("LogisticHeader");
+    Ok(())
+}
+
+fn write_logistic_children(
+    writer: &mut XmlWriter,
+    docs: &[Doc<'_>],
+    child_name: &str,
+) -> Result<()> {
+    for doc in docs {
+        let root = doc.root()?;
+        let Some(logistic) = doc.child(root, "LogisticHeader") else {
+            continue;
+        };
+        for child in children_named(doc, logistic, child_name) {
+            writer.raw(doc.source(child));
+        }
+    }
+    Ok(())
+}
+
+fn write_history_record(writer: &mut XmlWriter) {
+    let now = jiff::Timestamp::now().to_string();
+    writer.start_element(
+        "HistoryRecord",
+        &[
+            ("number", "1"),
+            ("origination", now.as_str()),
+            ("software", "pcb"),
+            ("lastChange", now.as_str()),
+        ],
+    );
+    writer.start_element(
+        "FileRevision",
+        &[
+            ("fileRevisionId", "1"),
+            ("comment", "Created fabrication panel"),
+            ("label", ""),
+        ],
+    );
+    writer.start_element(
+        "SoftwarePackage",
+        &[
+            ("name", "pcb"),
+            ("vendor", "Diode"),
+            ("revision", env!("CARGO_PKG_VERSION")),
+        ],
+    );
+    writer.empty_element("Certification", &[("certificationStatus", "SELFTEST")]);
+    writer.end_element("SoftwarePackage");
+    writer.end_element("FileRevision");
+    writer.end_element("HistoryRecord");
+}
+
+fn write_boms(writer: &mut XmlWriter, docs: &[Doc<'_>]) -> Result<()> {
+    for doc in docs {
+        let root = doc.root()?;
+        for bom in children_named(doc, root, "Bom") {
+            writer.raw(doc.source(bom));
+        }
+    }
+    Ok(())
+}
+
+fn write_ecad(
+    writer: &mut XmlWriter,
+    sources: &[SourcePanel],
+    docs: &[Doc<'_>],
+    occurrences: &[usize],
+    placements: &[Placement],
+    units: Units,
+) -> Result<()> {
+    writer.start_element("Ecad", &[("name", FAB_STEP_NAME)]);
+    writer.start_element("CadHeader", &[("units", units_attr(units))]);
+    for doc in docs {
+        let cad_header = cad_header(doc)?;
+        for spec in children_named(doc, cad_header, "Spec") {
+            writer.raw(doc.source(spec));
+        }
+    }
+    writer.end_element("CadHeader");
+
+    writer.start_element("CadData", &[]);
+    for doc in docs {
+        let cad_data = cad_data(doc)?;
+        for layer in children_named(doc, cad_data, "Layer") {
+            writer.raw(doc.source(layer));
+        }
+    }
+    for doc in docs {
+        let cad_data = cad_data(doc)?;
+        for stackup in children_named(doc, cad_data, "Stackup") {
+            writer.raw(doc.source(stackup));
+        }
+    }
+    for doc in docs {
+        let cad_data = cad_data(doc)?;
+        for step in children_named(doc, cad_data, "Step") {
+            writer.raw(doc.source(step));
+        }
+    }
+    write_fab_step(writer, sources, occurrences, placements, units)?;
+    writer.end_element("CadData");
+    writer.end_element("Ecad");
+    Ok(())
+}
+
+fn write_fab_step(
+    writer: &mut XmlWriter,
+    sources: &[SourcePanel],
+    occurrences: &[usize],
+    placements: &[Placement],
+    units: Units,
+) -> Result<()> {
+    writer.start_element("Step", &[("name", FAB_STEP_NAME), ("type", "PALLET")]);
+    write_metadata(writer, "diode.fab_panel.schema_version", "INTEGER", "1");
+    write_metadata(
+        writer,
+        "diode.fab_panel.width_mm",
+        "DOUBLE",
+        &ipc2581::write::fmt_num(FAB_PANEL_WIDTH_MM),
+    );
+    write_metadata(
+        writer,
+        "diode.fab_panel.height_mm",
+        "DOUBLE",
+        &ipc2581::write::fmt_num(FAB_PANEL_HEIGHT_MM),
+    );
+    write_metadata(
+        writer,
+        "diode.fab_panel.edge_rail_mm",
+        "DOUBLE",
+        &ipc2581::write::fmt_num(EDGE_RAIL_MM),
+    );
+    write_metadata(
+        writer,
+        "diode.fab_panel.gap_mm",
+        "DOUBLE",
+        &ipc2581::write::fmt_num(PANEL_GAP_MM),
+    );
+    write_metadata(
+        writer,
+        "diode.fab_panel.panel_count",
+        "INTEGER",
+        &occurrences.len().to_string(),
+    );
+
+    ipc2581::write::location(writer, "Datum", 0.0, 0.0, units);
+    writer.start_element("Profile", &[]);
+    writer.start_element("Polygon", &[]);
+    ipc2581::write::location(writer, "PolyBegin", 0.0, 0.0, units);
+    ipc2581::write::location(writer, "PolyStepSegment", FAB_PANEL_WIDTH_MM, 0.0, units);
+    ipc2581::write::location(
+        writer,
+        "PolyStepSegment",
+        FAB_PANEL_WIDTH_MM,
+        FAB_PANEL_HEIGHT_MM,
+        units,
+    );
+    ipc2581::write::location(writer, "PolyStepSegment", 0.0, FAB_PANEL_HEIGHT_MM, units);
+    writer.end_element("Polygon");
+    writer.end_element("Profile");
+
+    for placement in placements {
+        let source_index = occurrences[placement.item_index];
+        let source = &sources[source_index];
+        let target_x_mm = EDGE_RAIL_MM + f64::from(placement.x) / 1_000.0;
+        let target_y_mm = EDGE_RAIL_MM + f64::from(placement.y) / 1_000.0;
+        let (x_mm, y_mm, angle) = if placement.rotated {
+            (
+                target_x_mm + source.bbox.max.y,
+                target_y_mm - source.bbox.min.x,
+                "90",
+            )
+        } else {
+            (
+                target_x_mm - source.bbox.min.x,
+                target_y_mm - source.bbox.min.y,
+                "0",
+            )
+        };
+        let x = ipc2581::write::fmt_units(x_mm, units);
+        let y = ipc2581::write::fmt_units(y_mm, units);
+        writer.empty_element(
+            "StepRepeat",
+            &[
+                ("stepRef", source.root_step_name.as_str()),
+                ("x", x.as_str()),
+                ("y", y.as_str()),
+                ("nx", "1"),
+                ("ny", "1"),
+                ("dx", "0"),
+                ("dy", "0"),
+                ("angle", angle),
+                ("mirror", "false"),
+            ],
+        );
+    }
+    writer.end_element("Step");
+    Ok(())
+}
+
+fn write_metadata(writer: &mut XmlWriter, name: &str, property_type: &str, value: &str) {
+    writer.empty_element(
+        "NonstandardAttribute",
+        &[("name", name), ("type", property_type), ("value", value)],
+    );
+}
+
+fn write_avl(writer: &mut XmlWriter, docs: &[Doc<'_>]) -> Result<()> {
+    writer.start_element("Avl", &[("name", FAB_AVL_NAME)]);
+    let mut wrote_header = false;
+    for doc in docs {
+        let root = doc.root()?;
+        let Some(avl) = doc.child(root, "Avl") else {
+            continue;
+        };
+        if !wrote_header && let Some(header) = doc.child(avl, "AvlHeader") {
+            writer.raw(doc.source(header));
+            wrote_header = true;
+        }
+        for item in children_named(doc, avl, "AvlItem") {
+            writer.raw(doc.source(item));
+        }
+    }
+    writer.end_element("Avl");
+    Ok(())
+}
+
+fn cad_header<'a>(doc: &'a Doc<'a>) -> Result<Node> {
+    let root = doc.root()?;
+    let ecad = doc
+        .child(root, "Ecad")
+        .context("assembly panel IPC-2581 has no Ecad element")?;
+    doc.child(ecad, "CadHeader")
+        .context("assembly panel IPC-2581 has no CadHeader element")
+}
+
+fn cad_data<'a>(doc: &'a Doc<'a>) -> Result<Node> {
+    let root = doc.root()?;
+    let ecad = doc
+        .child(root, "Ecad")
+        .context("assembly panel IPC-2581 has no Ecad element")?;
+    doc.child(ecad, "CadData")
+        .context("assembly panel IPC-2581 has no CadData element")
+}
+
+fn children_named<'a>(doc: &'a Doc<'a>, parent: Node, name: &'a str) -> Vec<Node> {
+    doc.children(parent)
+        .into_iter()
+        .filter(|child| doc.name(*child) == name)
+        .collect()
+}
+
+fn units_attr(units: Units) -> &'static str {
+    match units {
+        Units::Millimeter => "MILLIMETER",
+        Units::Inch => "INCH",
+        Units::Micron => "MICRON",
+        Units::Mils => "MILS",
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::{Context, Result, bail};
 use ipc2581::edit::{self, Doc, Edit, Node};
 use ipc2581::types::Units;
@@ -12,21 +14,31 @@ const FAB_ROLE_ID: &str = "fab_panel_role";
 const FAB_ENTERPRISE_ID: &str = "fab_panel_enterprise";
 const FAB_PERSON_NAME: &str = "pcb";
 
-pub(super) fn namespace_source(xml: &str, prefix: &str) -> Result<String> {
+pub(super) fn namespace_source(
+    xml: &str,
+    prefix: &str,
+    shared_stackup_layers: &HashSet<String>,
+) -> Result<String> {
     let doc = Doc::parse(xml)?;
     let root = doc.root()?;
     let mut edits = Vec::new();
-    collect_namespace_edits(&doc, root, prefix, &mut edits);
+    collect_namespace_edits(&doc, root, prefix, shared_stackup_layers, &mut edits);
     Ok(edit::apply(xml, edits)?)
 }
 
-fn collect_namespace_edits(doc: &Doc, node: Node, prefix: &str, edits: &mut Vec<Edit>) {
+fn collect_namespace_edits(
+    doc: &Doc,
+    node: Node,
+    prefix: &str,
+    shared_stackup_layers: &HashSet<String>,
+    edits: &mut Vec<Edit>,
+) {
     let element = doc.name(node);
     let mut changed = false;
     let attrs = doc
         .attrs(node)
         .map(|(name, value)| {
-            let value = if should_namespace_attr(element, name) {
+            let value = if should_namespace_attr(element, name, value, shared_stackup_layers) {
                 changed = true;
                 format!("{prefix}{value}")
             } else {
@@ -47,11 +59,31 @@ fn collect_namespace_edits(doc: &Doc, node: Node, prefix: &str, edits: &mut Vec<
     }
 
     for child in doc.children(node) {
-        collect_namespace_edits(doc, child, prefix, edits);
+        collect_namespace_edits(doc, child, prefix, shared_stackup_layers, edits);
     }
 }
 
-fn should_namespace_attr(element: &str, attr: &str) -> bool {
+fn should_namespace_attr(
+    element: &str,
+    attr: &str,
+    value: &str,
+    shared_stackup_layers: &HashSet<String>,
+) -> bool {
+    let is_layer_reference = matches!(
+        attr,
+        "layerRef"
+            | "layerRefTopside"
+            | "secondaryLayerRef"
+            | "fromLayer"
+            | "toLayer"
+            | "startCutLayer"
+            | "layerId"
+            | "layerOrGroupRef"
+    ) || (attr == "name" && matches!(element, "Layer" | "LayerRef"));
+    if is_layer_reference && shared_stackup_layers.contains(value) {
+        return false;
+    }
+
     if matches!(
         attr,
         "enterpriseRef"
@@ -148,6 +180,7 @@ pub(super) fn write_fab_panel_xml(
     sources: &[SourcePanel],
     occurrences: &[usize],
     placements: &[Placement],
+    shared_stackup_layers: &HashSet<String>,
 ) -> Result<String> {
     let docs = sources
         .iter()
@@ -172,7 +205,7 @@ pub(super) fn write_fab_panel_xml(
             ("xmlns", "http://webstds.ipc.org/2581"),
         ],
     );
-    write_content(&mut writer, &docs, has_avl)?;
+    write_content(&mut writer, &docs, has_avl, shared_stackup_layers)?;
     write_logistic_header(&mut writer, &docs)?;
     write_history_record(&mut writer);
     write_boms(&mut writer, &docs)?;
@@ -183,6 +216,7 @@ pub(super) fn write_fab_panel_xml(
         occurrences,
         placements,
         first.units,
+        shared_stackup_layers,
     )?;
     if has_avl {
         write_avl(&mut writer, &docs)?;
@@ -194,17 +228,25 @@ pub(super) fn write_fab_panel_xml(
     Ok(xml)
 }
 
-fn write_content(writer: &mut XmlWriter, docs: &[Doc<'_>], has_avl: bool) -> Result<()> {
+fn write_content(
+    writer: &mut XmlWriter,
+    docs: &[Doc<'_>],
+    has_avl: bool,
+    shared_stackup_layers: &HashSet<String>,
+) -> Result<()> {
     writer.start_element("Content", &[("roleRef", FAB_ROLE_ID)]);
     writer.empty_element("FunctionMode", &[("mode", "FABRICATION")]);
     writer.empty_element("StepRef", &[("name", FAB_STEP_NAME)]);
 
-    for doc in docs {
+    for (doc_index, doc) in docs.iter().enumerate() {
         let cad_data = cad_data(doc)?;
         for layer in children_named(doc, cad_data, "Layer") {
             let name = doc
                 .attr(layer, "name")
                 .context("IPC-2581 Layer has no name")?;
+            if doc_index > 0 && shared_stackup_layers.contains(name) {
+                continue;
+            }
             writer.empty_element("LayerRef", &[("name", name)]);
         }
     }
@@ -373,6 +415,7 @@ fn write_ecad(
     occurrences: &[usize],
     placements: &[Placement],
     units: Units,
+    shared_stackup_layers: &HashSet<String>,
 ) -> Result<()> {
     writer.start_element("Ecad", &[("name", FAB_STEP_NAME)]);
     writer.start_element("CadHeader", &[("units", units_attr(units))]);
@@ -385,17 +428,24 @@ fn write_ecad(
     writer.end_element("CadHeader");
 
     writer.start_element("CadData", &[]);
-    for doc in docs {
+    for (doc_index, doc) in docs.iter().enumerate() {
         let cad_data = cad_data(doc)?;
         for layer in children_named(doc, cad_data, "Layer") {
+            let name = doc
+                .attr(layer, "name")
+                .context("IPC-2581 Layer has no name")?;
+            if doc_index > 0 && shared_stackup_layers.contains(name) {
+                continue;
+            }
             writer.raw(doc.source(layer));
         }
     }
-    for doc in docs {
-        let cad_data = cad_data(doc)?;
-        for stackup in children_named(doc, cad_data, "Stackup") {
-            writer.raw(doc.source(stackup));
-        }
+    let first_doc = docs
+        .first()
+        .context("at least one assembly panel source is required")?;
+    let first_cad_data = cad_data(first_doc)?;
+    for stackup in children_named(first_doc, first_cad_data, "Stackup") {
+        writer.raw(first_doc.source(stackup));
     }
     for doc in docs {
         let cad_data = cad_data(doc)?;

--- a/crates/pcb-ipc2581-tools/src/commands/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod bom;
 pub mod bom_edit;
 pub mod cpl;
 pub mod dfm;
+pub mod fab_panel;
 pub mod html_export;
 pub mod info;
 pub mod outline;

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -60,6 +60,11 @@ enum Commands {
         #[command(subcommand)]
         command: BoardArrayCommands,
     },
+    /// Tile assembly panels into a fixed 18 by 24 inch fabrication panel
+    FabPanel {
+        #[command(subcommand)]
+        command: FabPanelCommands,
+    },
     /// Export a filtered view of an IPC-2581 file for a specific mode
     View {
         /// Input IPC-2581 XML file
@@ -214,6 +219,24 @@ enum BoardArrayCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum FabPanelCommands {
+    /// Create a fabrication panel with 5 mm edge rails and 5 mm panel gaps
+    Create {
+        /// Assembly panel IPC-2581 files. Repeat a path to request multiple copies.
+        #[arg(
+            required = true,
+            num_args = 1..=32,
+            value_name = "ASSEMBLY_PANEL",
+            value_hint = clap::ValueHint::FilePath
+        )]
+        inputs: Vec<PathBuf>,
+        /// Output IPC-2581 XML file, or '-' for stdout
+        #[arg(short, long, value_hint = clap::ValueHint::AnyPath)]
+        output: PathBuf,
+    },
+}
+
 #[derive(ValueEnum, Debug, Clone, Copy)]
 enum GerberLayoutTarget {
     Board,
@@ -327,6 +350,11 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                         },
                     )
                 }
+            }
+        },
+        Commands::FabPanel { command } => match command {
+            FabPanelCommands::Create { inputs, output } => {
+                commands::fab_panel::execute(&inputs, &output)
             }
         },
         Commands::View {


### PR DESCRIPTION
Very alpha slop implementation. Needs a whole bunch of things that I'm unclear on how to do (e.g. copper balancing, indicating board array outlines, etc).

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New manufacturing export path with strict stackup validation and complex XML merging; mistakes could produce invalid or mis-placed fab data, but scope is isolated to the new command with tests.
> 
> **Overview**
> Adds **`pcb ipc2581 fab-panel create`**, which merges up to 32 assembly-panel IPC-2581 files into one **18×24 inch** fabrication document with **5 mm** edge rails and **5 mm** gaps between panels.
> 
> Inputs must be **panel** (board-array) roots with matching **physical stackup**, units, and revision. The first file defines the shared stackup and layer definitions; duplicate paths request extra copies. A new **slicing packer** (rotation, gaps, centered layout) places panels in the usable area; if nothing fits, the command errors **without** writing output.
> 
> Implementation namespaces and merges source XML, emits a `fab_panel` step with `StepRepeat` placements (including 90° rotation and profile offset), and validates the result. Docs and changelog are updated; **`pcbc`** wires the new subcommand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd02dec56131ad921f818b07ae082089fe53f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->