### PR TITLE
Add opt-in DiodeHub registry migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Added `pcb ipc2581 fab-panel create` to tile up to 32 assembly panels with identical stackups into a fixed 18 by 24 inch fabrication panel.
 
+- Added opt-in DiodeHub registry migration support.
+
 ## [0.4.12] - 2026-07-24
 
 ### Changed

--- a/crates/pcb-test-utils/src/sandbox.rs
+++ b/crates/pcb-test-utils/src/sandbox.rs
@@ -1,7 +1,7 @@
 //! git_sandbox.rs
 //!
 //! Hermetic, offline Git test sandbox for Rust tests.
-//! - Rewrites GitHub/GitLab URLs for fixture repos to local `file://` bare repos via a private `.gitconfig`
+//! - Rewrites supported remote URLs for fixture repos to local `file://` bare repos via a private `.gitconfig`
 //! - Disables all network protocols (whitelists `file` only)
 //! - Isolates cache directory via `DIODE_STAR_CACHE_DIR`
 //! - Lets you create fixture repos (files/commits/tags) and mirror-push them
@@ -69,6 +69,7 @@ pub struct Sandbox {
     pub gitconfig: PathBuf,
     pub mock_github: PathBuf,
     pub mock_gitlab: PathBuf,
+    pub mock_diodehub: PathBuf,
     pub cache_dir: PathBuf,
     fixture_rewrites: BTreeSet<RepoRewrite>,
     default_cwd: PathBuf,
@@ -92,11 +93,13 @@ impl Sandbox {
         let gitconfig = home.join(".gitconfig");
         let mock_github = root.child("mock/github").to_path_buf();
         let mock_gitlab = root.child("mock/gitlab").to_path_buf();
+        let mock_diodehub = root.child("mock/diodehub").to_path_buf();
         let cache_dir = root.child("cache").to_path_buf();
 
         fs::create_dir_all(&home).expect("create home dir");
         fs::create_dir_all(&mock_github).expect("create mock github dir");
         fs::create_dir_all(&mock_gitlab).expect("create mock gitlab dir");
+        fs::create_dir_all(&mock_diodehub).expect("create mock DiodeHub dir");
         fs::create_dir_all(&cache_dir).expect("create cache dir");
 
         let default_cwd = root.path().to_path_buf();
@@ -107,6 +110,7 @@ impl Sandbox {
             gitconfig,
             mock_github,
             mock_gitlab,
+            mock_diodehub,
             cache_dir,
             fixture_rewrites: BTreeSet::new(),
             default_cwd,
@@ -282,6 +286,7 @@ impl Sandbox {
         let base = match host {
             "github.com" => &self.mock_github,
             "gitlab.com" => &self.mock_gitlab,
+            "code.diode.computer" => &self.mock_diodehub,
             _ => panic!("unsupported host: {host}"),
         };
 
@@ -597,6 +602,7 @@ impl Sandbox {
             let base = match rewrite.host.as_str() {
                 "github.com" => &self.mock_github,
                 "gitlab.com" => &self.mock_gitlab,
+                "code.diode.computer" => &self.mock_diodehub,
                 other => panic!("unsupported host: {other}"),
             };
             let rel = ensure_dot_git(rewrite.repo.clone());
@@ -836,10 +842,10 @@ fn file_url(p: &Path) -> String {
     format!("file://{s}")
 }
 
-/// Parse minimal forms for GitHub/GitLab: https, ssh, scp.
+/// Parse minimal forms for supported fixture hosts: https, ssh, scp.
 /// Returns (host, "org/repo[.git]").
 fn parse_supported_url(url: &str) -> (&'static str, String) {
-    for host in ["github.com", "gitlab.com"] {
+    for host in ["github.com", "gitlab.com", "code.diode.computer"] {
         let https = format!("https://{host}/");
         if let Some(rest) = url.strip_prefix(&https) {
             return (host, rest.trim_start_matches('/').to_string());

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -112,9 +112,29 @@ pub fn pcb_version_is_older(current: &str, required: &str) -> Option<bool> {
 
 impl PcbToml {
     fn finish_parse(mut self) -> Result<Self> {
+        self.canonicalize_package_references()?;
         self.dependencies.remove_kicad_library_dependencies();
         self.validate_pcb_version()?;
         Ok(self)
+    }
+
+    fn canonicalize_package_references(&mut self) -> Result<()> {
+        canonicalize_map_keys(&mut self.dependencies.direct, "direct dependency")?;
+        canonicalize_map_keys(&mut self.dependencies.indirect, "indirect dependency")?;
+        canonicalize_map_keys(&mut self.patch, "patch")?;
+
+        if let Some(workspace) = &mut self.workspace {
+            if let Some(repository) = &mut workspace.repository {
+                *repository =
+                    crate::package_url::canonicalize_package_reference(repository).into_owned();
+            }
+
+            for pattern in &mut workspace.vendor {
+                *pattern = crate::package_url::canonicalize_package_reference(pattern).into_owned();
+            }
+        }
+
+        Ok(())
     }
 
     fn validate_pcb_version(&self) -> Result<()> {
@@ -241,6 +261,27 @@ impl PcbToml {
 
         aliases
     }
+}
+
+fn canonicalize_map_keys<T>(map: &mut BTreeMap<String, T>, label: &str) -> Result<()>
+where
+    T: PartialEq,
+{
+    let mut canonical = BTreeMap::new();
+    for (raw_key, value) in std::mem::take(map) {
+        let key = crate::package_url::canonicalize_package_reference(&raw_key).into_owned();
+        if let Some(existing) = canonical.get(&key) {
+            if existing != &value {
+                anyhow::bail!(
+                    "conflicting {label} entries map to the canonical package path '{key}'"
+                );
+            }
+            continue;
+        }
+        canonical.insert(key, value);
+    }
+    *map = canonical;
+    Ok(())
 }
 
 /// Workspace configuration
@@ -475,6 +516,22 @@ pub fn extract_inline_manifest(zen_content: &str) -> Option<String> {
 /// - "github.com/user/repo/pkg" -> ("github.com/user/repo", "pkg")
 /// - "github.com/user/repo/a/b/c" -> ("github.com/user/repo", "a/b/c")
 pub fn split_repo_and_subpath(module_path: &str) -> (&str, &str) {
+    let diode_registry = crate::package_url::CANONICAL_REGISTRY_REPOSITORY;
+    if module_path == diode_registry {
+        return (module_path, "");
+    }
+    if module_path.starts_with(diode_registry)
+        && module_path
+            .as_bytes()
+            .get(diode_registry.len())
+            .is_some_and(|separator| *separator == b'/')
+    {
+        return (
+            &module_path[..diode_registry.len()],
+            &module_path[diode_registry.len() + 1..],
+        );
+    }
+
     let parts: Vec<&str> = module_path.split('/').collect();
     if parts.is_empty() {
         return (module_path, "");
@@ -1035,6 +1092,10 @@ load("@stdlib/foo.zen", "Bar")
         assert_eq!(
             split_repo_and_subpath("github.com/user/repo/a/b/c"),
             ("github.com/user/repo", "a/b/c")
+        );
+        assert_eq!(
+            split_repo_and_subpath("code.diode.computer/diode/registry/components/Foo"),
+            ("code.diode.computer/diode/registry", "components/Foo")
         );
         // Non-github repos return full path as repo_url
         assert_eq!(

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -118,7 +118,8 @@ impl PcbToml {
         Ok(self)
     }
 
-    fn canonicalize_package_references(&mut self) -> Result<()> {
+    /// Apply enabled package-identity migrations without other parse finalization.
+    pub fn canonicalize_package_references(&mut self) -> Result<()> {
         canonicalize_map_keys(&mut self.dependencies.direct, "direct dependency")?;
         canonicalize_map_keys(&mut self.dependencies.indirect, "indirect dependency")?;
         canonicalize_map_keys(&mut self.patch, "patch")?;

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod graph;
 pub mod lang;
 pub mod load_spec;
 mod moved;
+pub mod package_url;
 pub mod passes;
 pub mod resolution;
 pub mod stdlib;

--- a/crates/pcb-zen-core/src/load_spec.rs
+++ b/crates/pcb-zen-core/src/load_spec.rs
@@ -108,7 +108,10 @@ impl LoadSpec {
             if uri.is_empty() {
                 return None;
             }
-            return Some(LoadSpec::PackageUri { uri: s.to_string() });
+            let uri = crate::package_url::canonicalize_package_reference(uri);
+            return Some(LoadSpec::PackageUri {
+                uri: format!("{}{uri}", pcb_sch::PACKAGE_URI_PREFIX),
+            });
         }
 
         if let Some(rest) = s.strip_prefix('@') {
@@ -147,7 +150,9 @@ impl LoadSpec {
                 path: PathBuf::from(rel_path),
             })
         } else if is_package_url(s) {
-            Some(LoadSpec::Url { url: s.to_string() })
+            Some(LoadSpec::Url {
+                url: crate::package_url::canonicalize_package_reference(s).into_owned(),
+            })
         } else {
             // Raw file path (relative or absolute)
             Some(LoadSpec::local_path(s))
@@ -162,7 +167,8 @@ impl LoadSpec {
             LoadSpec::Path { .. } => None,
             other => {
                 let url = other.to_string();
-                Some(url.strip_prefix('@').unwrap_or(&url).to_string())
+                let url = url.strip_prefix('@').unwrap_or(&url);
+                Some(crate::package_url::canonicalize_package_reference(url).into_owned())
             }
         }
     }

--- a/crates/pcb-zen-core/src/package_url.rs
+++ b/crates/pcb-zen-core/src/package_url.rs
@@ -1,0 +1,73 @@
+use std::borrow::Cow;
+
+/// Opt-in gate for the Diode registry package-identity migration.
+pub const REGISTRY_MIGRATION_ENV: &str = "PCB_REGISTRY_MIGRATION";
+/// Legacy package repository accepted while the registry moves to DiodeHub.
+pub const LEGACY_REGISTRY_REPOSITORY: &str = "github.com/diodeinc/registry";
+/// Canonical package repository used when the migration is enabled.
+pub const CANONICAL_REGISTRY_REPOSITORY: &str = "code.diode.computer/diode/registry";
+
+/// Whether the opt-in Diode registry migration is enabled for this process.
+pub fn registry_migration_enabled() -> bool {
+    std::env::var(REGISTRY_MIGRATION_ENV).as_deref() == Ok("1")
+}
+
+/// Canonicalize a package URL, dependency key, or package-prefix glob.
+///
+/// The rewrite is deliberately one-way and matches only the complete legacy
+/// repository path, a slash-delimited child path, or a version selector on the
+/// repository root.
+pub fn canonicalize_package_reference(value: &str) -> Cow<'_, str> {
+    if !registry_migration_enabled() {
+        return Cow::Borrowed(value);
+    }
+    canonicalize_registry_reference(value)
+}
+
+fn canonicalize_registry_reference(value: &str) -> Cow<'_, str> {
+    if value == LEGACY_REGISTRY_REPOSITORY {
+        return Cow::Borrowed(CANONICAL_REGISTRY_REPOSITORY);
+    }
+
+    let Some(suffix) = value.strip_prefix(LEGACY_REGISTRY_REPOSITORY) else {
+        return Cow::Borrowed(value);
+    };
+    if !suffix.starts_with('/') && !suffix.starts_with('@') {
+        return Cow::Borrowed(value);
+    }
+
+    Cow::Owned(format!("{CANONICAL_REGISTRY_REPOSITORY}{suffix}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_only_the_legacy_registry_boundary() {
+        assert_eq!(
+            canonicalize_registry_reference(LEGACY_REGISTRY_REPOSITORY),
+            CANONICAL_REGISTRY_REPOSITORY
+        );
+        assert_eq!(
+            canonicalize_registry_reference("github.com/diodeinc/registry/components/Foo/Foo.zen"),
+            "code.diode.computer/diode/registry/components/Foo/Foo.zen"
+        );
+        assert_eq!(
+            canonicalize_registry_reference("github.com/diodeinc/registry/components/Foo@0.4"),
+            "code.diode.computer/diode/registry/components/Foo@0.4"
+        );
+        assert_eq!(
+            canonicalize_registry_reference("github.com/diodeinc/registry@0.4"),
+            "code.diode.computer/diode/registry@0.4"
+        );
+        assert_eq!(
+            canonicalize_registry_reference("github.com/diodeinc/registry-old/components/Foo"),
+            "github.com/diodeinc/registry-old/components/Foo"
+        );
+        assert_eq!(
+            canonicalize_registry_reference("https://github.com/diodeinc/registry"),
+            "https://github.com/diodeinc/registry"
+        );
+    }
+}

--- a/crates/pcb-zen/src/import_scanner.rs
+++ b/crates/pcb-zen/src/import_scanner.rs
@@ -38,7 +38,7 @@ pub fn extract_imports(content: &str) -> Option<CollectedImports> {
 
 fn extract_from_load(s: &str, result: &mut CollectedImports) {
     if let Some(spec) = LoadSpec::parse(s) {
-        collect_spec(s, spec, result);
+        collect_spec(spec, result);
     }
 }
 
@@ -52,15 +52,15 @@ fn extract_from_literal(s: &str, result: &mut CollectedImports) {
     }
 
     if let Some(spec) = LoadSpec::parse(s) {
-        collect_spec(s, spec, result);
+        collect_spec(spec, result);
     }
 }
 
-fn collect_spec(s: &str, spec: LoadSpec, result: &mut CollectedImports) {
+fn collect_spec(spec: LoadSpec, result: &mut CollectedImports) {
     match spec {
         LoadSpec::Stdlib { .. } | LoadSpec::PackageUri { .. } | LoadSpec::Package { .. } => {}
-        LoadSpec::Url { .. } => {
-            result.urls.insert(s.to_string());
+        LoadSpec::Url { url } => {
+            result.urls.insert(url);
         }
         LoadSpec::Path { path, .. } => {
             result.relative_paths.push(path);

--- a/crates/pcbc/src/mod/mod.rs
+++ b/crates/pcbc/src/mod/mod.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 use self::request::resolve_direct_dependency_request;
 use self::target::{AddTarget, discover_add_targets, discover_package_target};
-use self::writeback::{ManifestEdit, plan_package_manifest};
+use self::writeback::{ManifestEdit, plan_canonical_manifest, plan_package_manifest};
 
 type DirectOverrides = BTreeMap<String, DependencySpec>;
 
@@ -445,6 +445,15 @@ fn run_resolution(
     let mut resolver = PackageResolver::new(workspace.clone())?;
     let mut selected_remote = BTreeSet::new();
     let mut manifest_edits = Vec::new();
+
+    let root_manifest = workspace.root.join("pcb.toml");
+    if !targets
+        .iter()
+        .any(|target| target.pcb_toml_path == root_manifest)
+        && let Some(edit) = plan_canonical_manifest(root_manifest)?
+    {
+        manifest_edits.push(edit);
+    }
 
     for target in targets {
         let overrides = direct_overrides

--- a/crates/pcbc/src/mod/writeback.rs
+++ b/crates/pcbc/src/mod/writeback.rs
@@ -26,8 +26,7 @@ pub(crate) fn plan_package_manifest(
 ) -> Result<Option<ManifestEdit>> {
     let original = std::fs::read_to_string(&target.pcb_toml_path)
         .with_context(|| format!("Failed to read {}", target.pcb_toml_path.display()))?;
-    let mut config: PcbToml = toml::from_str(&original)
-        .with_context(|| format!("Failed to parse {}", target.pcb_toml_path.display()))?;
+    let mut config = PcbToml::parse_with_path(&original, &target.pcb_toml_path)?;
 
     config.dependencies.direct = resolution.direct.clone();
     config.dependencies.indirect = indirect_dependencies(resolution);
@@ -42,6 +41,28 @@ pub(crate) fn plan_package_manifest(
         path: target.pcb_toml_path.clone(),
         rendered,
     }))
+}
+
+pub(crate) fn plan_canonical_manifest(path: PathBuf) -> Result<Option<ManifestEdit>> {
+    if !pcb_zen_core::package_url::registry_migration_enabled() {
+        return Ok(None);
+    }
+
+    let original = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    if !original.contains(pcb_zen_core::package_url::LEGACY_REGISTRY_REPOSITORY) {
+        return Ok(None);
+    }
+
+    let unmodified: PcbToml =
+        toml::from_str(&original).with_context(|| format!("Failed to parse {}", path.display()))?;
+    let canonical = PcbToml::parse_with_path(&original, &path)?;
+    if canonical == unmodified {
+        return Ok(None);
+    }
+
+    let rendered = render_manifest(&canonical)?;
+    Ok((rendered != original).then_some(ManifestEdit { path, rendered }))
 }
 
 fn indirect_dependencies(resolution: &PackageResolution) -> BTreeMap<String, DependencySpec> {

--- a/crates/pcbc/src/mod/writeback.rs
+++ b/crates/pcbc/src/mod/writeback.rs
@@ -50,13 +50,10 @@ pub(crate) fn plan_canonical_manifest(path: PathBuf) -> Result<Option<ManifestEd
 
     let original = std::fs::read_to_string(&path)
         .with_context(|| format!("Failed to read {}", path.display()))?;
-    if !original.contains(pcb_zen_core::package_url::LEGACY_REGISTRY_REPOSITORY) {
-        return Ok(None);
-    }
-
-    let unmodified: PcbToml =
+    let mut canonical: PcbToml =
         toml::from_str(&original).with_context(|| format!("Failed to parse {}", path.display()))?;
-    let canonical = PcbToml::parse_with_path(&original, &path)?;
+    let unmodified = canonical.clone();
+    canonical.canonicalize_package_references()?;
     if canonical == unmodified {
         return Ok(None);
     }

--- a/crates/pcbc/tests/sync.rs
+++ b/crates/pcbc/tests/sync.rs
@@ -987,3 +987,102 @@ pcb-version = "0.4"
         "expected covered import to skip remote discovery warning:\n{output}"
     );
 }
+
+#[test]
+fn test_registry_migration_rewrites_manifest_and_builds_legacy_import_from_tag_only_commit() {
+    const LEGACY_REPOSITORY: &str = "github.com/diodeinc/registry";
+    const CANONICAL_REPOSITORY: &str = "code.diode.computer/diode/registry";
+
+    let mut sandbox = Sandbox::new();
+    sandbox.env("PCB_REGISTRY_MIGRATION", "1");
+
+    let mut fixture = sandbox.git_fixture("https://code.diode.computer/diode/registry.git");
+    fixture.write("README.md", "main\n").commit("main");
+    fixture.with_branch("package-release", |repo| {
+        repo.write("components/Foo/pcb.toml", "[dependencies]\n")
+            .write("components/Foo/Foo.zen", SIMPLE_RESISTOR_ZEN)
+            .write("components/Foo/test.kicad_mod", TEST_KICAD_MOD)
+            .commit("tagged packages")
+            .tag("components/Foo/v1.0.0", true);
+    });
+    fixture.push_mirror();
+
+    let manifest = format!(
+        r#"[workspace]
+pcb-version = "0.4"
+vendor = ["{LEGACY_REPOSITORY}/**"]
+
+[board]
+name = "Main"
+path = "board.zen"
+
+[dependencies]
+"{LEGACY_REPOSITORY}/components/Foo" = "1.0.0"
+"#
+    );
+    let board = format!(
+        r#"
+Foo = Module("{LEGACY_REPOSITORY}/components/Foo/Foo.zen")
+
+Foo(name = "R1", value = "1kOhm", P1 = Net("P1"), P2 = Net("P2"))
+"#
+    );
+
+    sandbox
+        .write("pcb.toml", manifest)
+        .write("board.zen", &board)
+        .sync();
+
+    let migrated = read_root_manifest(&sandbox);
+    assert!(!migrated.contains(LEGACY_REPOSITORY));
+    assert!(migrated.contains(&format!(
+        "\"{CANONICAL_REPOSITORY}/components/Foo\" = \"1.0.0\""
+    )));
+    assert!(migrated.contains(&format!("vendor = [\"{CANONICAL_REPOSITORY}/**\"]")));
+    assert_eq!(read_sandbox_file(&sandbox, "board.zen"), board);
+    assert!(
+        sandbox
+            .default_cwd()
+            .join("vendor")
+            .join(CANONICAL_REPOSITORY)
+            .join("components/Foo/1.0.0/pcb.toml")
+            .exists()
+    );
+
+    let build = run_pcbc_unchecked(&mut sandbox, ["build", "board.zen"]);
+    assert!(
+        build.status.success(),
+        "expected migrated legacy import to build:\n{}",
+        command_output(&build)
+    );
+
+    let check = run_sync_check(&mut sandbox);
+    assert!(
+        check.status.success(),
+        "expected migrated workspace to pass sync --check:\n{}",
+        command_output(&check)
+    );
+}
+
+#[test]
+fn test_registry_migration_is_disabled_by_default() {
+    let mut sandbox = Sandbox::new();
+    sandbox
+        .write(
+            "pcb.toml",
+            r#"[workspace]
+pcb-version = "0.4"
+vendor = ["github.com/diodeinc/registry/**"]
+
+[board]
+name = "Main"
+path = "board.zen"
+"#,
+        )
+        .write("board.zen", "Net(\"P1\")\n")
+        .sync();
+
+    let manifest = read_root_manifest(&sandbox);
+    assert!(manifest.contains("github.com/diodeinc/registry/**"));
+    assert!(!manifest.contains("code.diode.computer/diode/registry"));
+}

--- a/crates/pcbc/tests/sync.rs
+++ b/crates/pcbc/tests/sync.rs
@@ -1010,11 +1010,17 @@ fn test_registry_migration_rewrites_manifest_and_builds_legacy_import_from_tag_o
     let manifest = format!(
         r#"[workspace]
 pcb-version = "0.4"
+repository = "github.com/example/demo"
 vendor = ["{LEGACY_REPOSITORY}/**"]
 
-[board]
+[dependencies]
+"gitlab.com/kicad/libraries/kicad-footprints" = "7.0.0"
+"#
+    );
+    let board_manifest = format!(
+        r#"[board]
 name = "Main"
-path = "board.zen"
+path = "Main.zen"
 
 [dependencies]
 "{LEGACY_REPOSITORY}/components/Foo" = "1.0.0"
@@ -1030,16 +1036,20 @@ Foo(name = "R1", value = "1kOhm", P1 = Net("P1"), P2 = Net("P2"))
 
     sandbox
         .write("pcb.toml", manifest)
-        .write("board.zen", &board)
+        .write("boards/Main/pcb.toml", board_manifest)
+        .write("boards/Main/Main.zen", &board)
         .sync();
 
-    let migrated = read_root_manifest(&sandbox);
-    assert!(!migrated.contains(LEGACY_REPOSITORY));
-    assert!(migrated.contains(&format!(
+    let root_manifest = read_root_manifest(&sandbox);
+    assert!(!root_manifest.contains(LEGACY_REPOSITORY));
+    assert!(root_manifest.contains(&format!("vendor = [\"{CANONICAL_REPOSITORY}/**\"]")));
+    assert!(root_manifest.contains("\"gitlab.com/kicad/libraries/kicad-footprints\" = \"7.0.0\""));
+
+    let migrated_board_manifest = read_sandbox_file(&sandbox, "boards/Main/pcb.toml");
+    assert!(migrated_board_manifest.contains(&format!(
         "\"{CANONICAL_REPOSITORY}/components/Foo\" = \"1.0.0\""
     )));
-    assert!(migrated.contains(&format!("vendor = [\"{CANONICAL_REPOSITORY}/**\"]")));
-    assert_eq!(read_sandbox_file(&sandbox, "board.zen"), board);
+    assert_eq!(read_sandbox_file(&sandbox, "boards/Main/Main.zen"), board);
     assert!(
         sandbox
             .default_cwd()
@@ -1049,7 +1059,7 @@ Foo(name = "R1", value = "1kOhm", P1 = Net("P1"), P2 = Net("P2"))
             .exists()
     );
 
-    let build = run_pcbc_unchecked(&mut sandbox, ["build", "board.zen"]);
+    let build = run_pcbc_unchecked(&mut sandbox, ["build", "boards/Main/Main.zen"]);
     assert!(
         build.status.success(),
         "expected migrated legacy import to build:\n{}",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how registry package identity is resolved and persisted in manifests/vendor paths, but it is gated, boundary-safe, and covered by sync/build tests.
> 
> **Overview**
> Adds an **opt-in** migration path (`PCB_REGISTRY_MIGRATION=1`) that rewrites legacy `github.com/diodeinc/registry` package references to `code.diode.computer/diode/registry` at parse and load time, without changing behavior when the env var is unset.
> 
> **Canonicalization** runs on `pcb.toml` dependency/patch keys and workspace `repository`/`vendor` patterns, on `LoadSpec` package URLs and `package://` URIs, and in `split_repo_and_subpath` for the canonical registry repo. Conflicting legacy keys that collapse to the same canonical path fail parse with a clear error.
> 
> **`pcb sync`** can rewrite the workspace root `pcb.toml` via `plan_canonical_manifest` when migration is enabled (even if the root is not a sync target). Package manifest planning now parses through `PcbToml::parse_with_path` so canonical keys apply consistently. Import scanning records **canonical** URLs from parsed specs.
> 
> **Tests:** Hermetic sandbox fixtures support `code.diode.computer`; integration tests cover full sync/build with legacy imports in `.zen` left unchanged while manifests and vendor paths migrate, and that migration stays off by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365d7e93d2334e490dd6db227bcfbdf525bebfe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->