### PR TITLE
Add PCB Git credential helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added `pcb auth git` as a Git credential helper that exchanges PCB authentication for short-lived DiodeHub Bearer credentials.
 - Added `pcb ipc2581 fab-panel create` to tile up to 32 assembly panels with identical stackups into a fixed 18 by 24 inch fabrication panel.
 - Added read-only `pcb component search` and `pcb component download` commands with pretty and raw JSON output.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,6 +5130,7 @@ dependencies = [
  "env_logger",
  "gerberx2",
  "glam",
+ "httpmock",
  "ignore",
  "inquire",
  "insta",

--- a/crates/pcb-diode-api/src/auth.rs
+++ b/crates/pcb-diode-api/src/auth.rs
@@ -456,6 +456,8 @@ pub enum AuthCommand {
     Refresh,
     /// Print a valid access token to stdout (refreshes if expired)
     Token,
+    /// Provide Git credentials using PCB authentication
+    Git(crate::git_auth::GitAuthArgs),
 }
 
 pub fn token_with_context(ctx: &WorkspaceContext) -> Result<()> {
@@ -476,6 +478,7 @@ pub fn execute(args: AuthArgs, ctx: &WorkspaceContext) -> Result<()> {
         Some(AuthCommand::Status) => status_with_context(ctx),
         Some(AuthCommand::Refresh) => refresh_with_context(ctx),
         Some(AuthCommand::Token) => token_with_context(ctx),
+        Some(AuthCommand::Git(args)) => crate::git_auth::execute(args, ctx),
     }
 }
 

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -1,0 +1,274 @@
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use std::io::{self, BufRead, Write};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+use crate::WorkspaceContext;
+
+const AUTHTYPE_CAPABILITY: &str = "authtype";
+const MAX_CREDENTIAL_LINE_BYTES: usize = 65_535;
+
+#[derive(Args, Debug)]
+#[command(about = "Provide Git credentials using PCB authentication")]
+pub struct GitAuthArgs {
+    /// Git credential helper operation
+    operation: String,
+}
+
+#[derive(Debug, Default)]
+struct CredentialRequest {
+    protocol: Option<Vec<u8>>,
+    host: Option<Vec<u8>>,
+    path: Option<Vec<u8>>,
+    capabilities: Vec<Vec<u8>>,
+}
+
+#[derive(Serialize)]
+struct GitCredentialExchangeRequest<'a> {
+    host: &'a str,
+    path: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitCredentialExchangeResponse {
+    repository_id: String,
+    #[serde(rename = "provider")]
+    _provider: GitProvider,
+    credential: GitCredential,
+    expires_at: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum GitProvider {
+    Diodehub,
+}
+
+#[derive(Deserialize)]
+struct GitCredential {
+    #[serde(rename = "scheme")]
+    _scheme: GitCredentialScheme,
+    token: String,
+}
+
+#[derive(Deserialize)]
+enum GitCredentialScheme {
+    Bearer,
+}
+
+pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+
+    match args.operation.as_str() {
+        "capability" => {
+            writeln!(stdout, "version 0")?;
+            writeln!(stdout, "capability {AUTHTYPE_CAPABILITY}")?;
+        }
+        "get" => {
+            let result = read_credential_request(stdin.lock())
+                .and_then(|request| provide_credential(ctx, request, &mut stdout));
+            if let Err(error) = result {
+                writeln!(stdout, "quit=true")?;
+                writeln!(stdout)?;
+                stdout.flush()?;
+                eprintln!("pcb auth git: {error:#}");
+            }
+        }
+        "store" | "erase" => {
+            read_credential_request(stdin.lock())?;
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn provide_credential(
+    ctx: &WorkspaceContext,
+    request: CredentialRequest,
+    output: &mut impl Write,
+) -> Result<()> {
+    if request.protocol.as_deref() != Some(b"https") {
+        return Ok(());
+    }
+
+    let Some(host) = request.host.as_deref().filter(|host| !host.is_empty()) else {
+        return Ok(());
+    };
+    let Some(path) = request.path.as_deref().filter(|path| !path.is_empty()) else {
+        return Ok(());
+    };
+
+    if !request
+        .capabilities
+        .iter()
+        .any(|capability| capability == AUTHTYPE_CAPABILITY.as_bytes())
+    {
+        bail!("Git did not advertise the `authtype` credential capability");
+    }
+
+    let host = std::str::from_utf8(host).context("Git credential host is not UTF-8")?;
+    let path = std::str::from_utf8(path).context("Git credential path is not UTF-8")?;
+    let credential = exchange_credential(ctx, host, path)?;
+
+    writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
+    writeln!(output, "authtype=Bearer")?;
+    writeln!(output, "credential={credential}")?;
+    writeln!(output, "ephemeral=true")?;
+    writeln!(output)?;
+    output.flush()?;
+
+    Ok(())
+}
+
+fn exchange_credential(ctx: &WorkspaceContext, host: &str, path: &str) -> Result<String> {
+    let api_token = ctx
+        .token()
+        .context("Failed to get a valid Diode API token")?;
+    let url = format!("{}/api/git/credentials", ctx.api_base_url());
+    let client = Client::builder()
+        .user_agent(format!("diode-pcb/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("Failed to create Git credential HTTP client")?;
+
+    let response = client
+        .post(url)
+        .bearer_auth(api_token)
+        .json(&GitCredentialExchangeRequest { host, path })
+        .send()
+        .context("Failed to exchange Diode authentication for a Git credential")?;
+
+    if !response.status().is_success() {
+        bail!("Git credential exchange failed: {}", response.status());
+    }
+
+    let response: GitCredentialExchangeResponse = response
+        .json()
+        .context("Failed to parse Git credential exchange response")?;
+    let GitCredentialExchangeResponse {
+        repository_id,
+        _provider: _,
+        credential,
+        expires_at,
+    } = response;
+    let GitCredential { _scheme: _, token } = credential;
+    Uuid::parse_str(&repository_id)
+        .context("Git credential exchange returned an invalid repository ID")?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("System clock is before the Unix epoch")?
+        .as_secs();
+
+    if expires_at <= now {
+        bail!("Git credential exchange returned an expired credential");
+    }
+    if token.is_empty() || token.contains(['\r', '\n', '\0']) {
+        bail!("Git credential exchange returned an invalid credential");
+    }
+
+    Ok(token)
+}
+
+fn read_credential_request(mut input: impl BufRead) -> Result<CredentialRequest> {
+    let mut request = CredentialRequest::default();
+    let mut line = Vec::new();
+
+    loop {
+        line.clear();
+        let bytes_read = input
+            .read_until(b'\n', &mut line)
+            .context("Failed to read Git credential request")?;
+        if bytes_read == 0 {
+            break;
+        }
+        if line.len() > MAX_CREDENTIAL_LINE_BYTES {
+            bail!("Git credential request line exceeds 65535 bytes");
+        }
+        if line.last() == Some(&b'\n') {
+            line.pop();
+        }
+        if line.is_empty() {
+            break;
+        }
+        if line.contains(&b'\0') {
+            bail!("Git credential request contains a NUL byte");
+        }
+
+        let Some(separator) = line.iter().position(|byte| *byte == b'=') else {
+            bail!("Invalid Git credential request line");
+        };
+        let (key, value) = (&line[..separator], &line[separator + 1..]);
+
+        match key {
+            b"protocol" => request.protocol = Some(value.to_vec()),
+            b"host" => request.host = Some(value.to_vec()),
+            b"path" => request.path = Some(value.to_vec()),
+            b"capability[]" if value.is_empty() => request.capabilities.clear(),
+            b"capability[]" => request.capabilities.push(value.to_vec()),
+            _ => {}
+        }
+    }
+
+    Ok(request)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn parses_known_attributes_and_ignores_extensions() {
+        let request = read_credential_request(Cursor::new(
+            b"capability[]=authtype\nprotocol=https\nhost=code.diode.computer\npath=acme/widget.git\nwwwauth[]=Bearer\n\n",
+        ))
+        .unwrap();
+
+        assert_eq!(request.protocol.as_deref(), Some(b"https".as_slice()));
+        assert_eq!(
+            request.host.as_deref(),
+            Some(b"code.diode.computer".as_slice())
+        );
+        assert_eq!(request.path.as_deref(), Some(b"acme/widget.git".as_slice()));
+        assert_eq!(request.capabilities, [b"authtype".to_vec()]);
+    }
+
+    #[test]
+    fn empty_capability_resets_the_capability_list() {
+        let request = read_credential_request(Cursor::new(
+            b"capability[]=authtype\ncapability[]=\ncapability[]=state\n\n",
+        ))
+        .unwrap();
+
+        assert_eq!(request.capabilities, [b"state".to_vec()]);
+    }
+
+    #[test]
+    fn accepts_a_line_at_the_protocol_limit() {
+        let mut input = b"extension=".to_vec();
+        input.resize(MAX_CREDENTIAL_LINE_BYTES - 1, b'x');
+        input.push(b'\n');
+
+        let request = read_credential_request(Cursor::new(input)).unwrap();
+
+        assert!(request.protocol.is_none());
+    }
+
+    #[test]
+    fn rejects_lines_longer_than_the_protocol_limit() {
+        let input = vec![b'x'; MAX_CREDENTIAL_LINE_BYTES + 1];
+        let error = read_credential_request(Cursor::new(input)).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Git credential request line exceeds 65535 bytes")
+        );
+    }
+}

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::WorkspaceContext;
 
 const AUTHTYPE_CAPABILITY: &str = "authtype";
+const DIODEHUB_HOST: &str = "code.diode.computer";
 const MAX_CREDENTIAL_LINE_BYTES: usize = 65_535;
 
 #[derive(Args, Debug)]
@@ -93,13 +94,12 @@ fn provide_credential(
     request: CredentialRequest,
     output: &mut impl Write,
 ) -> Result<()> {
-    if request.protocol.as_deref() != Some(b"https") {
+    if request.protocol.as_deref() != Some(b"https")
+        || request.host.as_deref() != Some(DIODEHUB_HOST.as_bytes())
+    {
         return Ok(());
     }
 
-    let Some(host) = request.host.as_deref().filter(|host| !host.is_empty()) else {
-        return Ok(());
-    };
     let Some(path) = request.path.as_deref().filter(|path| !path.is_empty()) else {
         return Ok(());
     };
@@ -112,9 +112,8 @@ fn provide_credential(
         bail!("Git did not advertise the `authtype` credential capability");
     }
 
-    let host = std::str::from_utf8(host).context("Git credential host is not UTF-8")?;
     let path = std::str::from_utf8(path).context("Git credential path is not UTF-8")?;
-    let credential = exchange_credential(ctx, host, path)?;
+    let credential = exchange_credential(ctx, DIODEHUB_HOST, path)?;
 
     writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
     writeln!(output, "authtype=Bearer")?;

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -10,6 +10,7 @@ pub mod datasheet;
 pub mod diode_uri;
 mod download_support;
 mod endpoint;
+mod git_auth;
 pub mod kicad_symbols;
 pub mod registry;
 pub mod release;

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -73,6 +73,7 @@ mimalloc = { workspace = true, optional = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+httpmock = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
 pcb-test-utils = { workspace = true }

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -72,7 +72,8 @@ impl TestContext {
             .env("PCB_CONFIG_DIR", &self.config_dir)
             .env("DIODE_API_URL", &self.api_url)
             .env("NO_PROXY", "127.0.0.1,localhost")
-            .env("no_proxy", "127.0.0.1,localhost");
+            .env("no_proxy", "127.0.0.1,localhost")
+            .env_remove("RUST_LOG");
     }
 }
 

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -80,7 +80,7 @@ impl TestContext {
             .arg("-c")
             .arg(format!(
                 "credential.helper=store --file={}",
-                credential_file.display()
+                credential_file.display().to_string().replace('\\', "/")
             ))
             .args(["-c", "credential.useHttpPath=true"])
             .args(["credential", "fill"]);

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -1,0 +1,251 @@
+use httpmock::Mock;
+use httpmock::prelude::*;
+use serde_json::json;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+const GIT_HOST: &str = "code.diode.computer";
+const REPOSITORY_PATH: &str = "acme/boards/widget.git";
+const USER_ACCESS_TOKEN: &str = "user-access-token";
+const REPOSITORY_TOKEN: &str = "repository-token";
+
+struct TestContext {
+    _tempdir: tempfile::TempDir,
+    config_dir: PathBuf,
+    api_url: String,
+}
+
+impl TestContext {
+    fn new(api_url: String) -> Self {
+        let tempdir = tempfile::tempdir().expect("create test directory");
+        let config_dir = tempdir.path().join("pcb");
+        let auth_dir = config_dir.join("auth");
+        fs::create_dir_all(&auth_dir).expect("create auth directory");
+        fs::write(
+            auth_dir.join(format!("{}.toml", auth_scope_slug(&api_url))),
+            format!(
+                "access_token = \"{USER_ACCESS_TOKEN}\"\n\
+                 refresh_token = \"refresh-token\"\n\
+                 expires_at = 4102444800\n"
+            ),
+        )
+        .expect("write auth tokens");
+
+        Self {
+            _tempdir: tempdir,
+            config_dir,
+            api_url,
+        }
+    }
+
+    fn pcbc(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_pcbc"));
+        self.configure_environment(&mut command);
+        command
+    }
+
+    fn git_credential(&self, action: &str) -> Command {
+        let helper = format!(
+            "!\"{}\" auth git",
+            env!("CARGO_BIN_EXE_pcbc").replace('\\', "/")
+        );
+        let credential_context = format!("credential.https://{GIT_HOST}");
+
+        let mut command = Command::new("git");
+        command
+            .arg("-c")
+            .arg(format!("{credential_context}.helper="))
+            .arg("-c")
+            .arg(format!("{credential_context}.helper={helper}"))
+            .arg("-c")
+            .arg(format!("{credential_context}.useHttpPath=true"))
+            .args(["credential", action]);
+        self.configure_environment(&mut command);
+        command
+    }
+
+    fn configure_environment(&self, command: &mut Command) {
+        command
+            .current_dir(self._tempdir.path())
+            .env("PCB_CONFIG_DIR", &self.config_dir)
+            .env("DIODE_API_URL", &self.api_url)
+            .env("NO_PROXY", "127.0.0.1,localhost")
+            .env("no_proxy", "127.0.0.1,localhost");
+    }
+}
+
+fn auth_scope_slug(api_url: &str) -> String {
+    let mut slug = String::with_capacity(api_url.len());
+    let mut last_was_separator = false;
+
+    for character in api_url.chars() {
+        if character.is_ascii_alphanumeric() {
+            slug.push(character.to_ascii_lowercase());
+            last_was_separator = false;
+        } else if !last_was_separator {
+            slug.push('_');
+            last_was_separator = true;
+        }
+    }
+
+    slug.trim_matches('_').to_string()
+}
+
+fn credential_request() -> String {
+    format!(
+        "capability[]=authtype\n\
+         protocol=https\n\
+         host={GIT_HOST}\n\
+         path={REPOSITORY_PATH}\n\
+         \n"
+    )
+}
+
+fn run_with_input(mut command: Command, input: &str) -> Output {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn command");
+    child
+        .stdin
+        .take()
+        .expect("open command stdin")
+        .write_all(input.as_bytes())
+        .expect("write command input");
+    child.wait_with_output().expect("wait for command")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn mock_exchange<'a>(server: &'a MockServer, status: u16) -> Mock<'a> {
+    server.mock(move |when, then| {
+        when.method(POST)
+            .path("/api/git/credentials")
+            .header("authorization", format!("Bearer {USER_ACCESS_TOKEN}"))
+            .json_body(json!({
+                "host": GIT_HOST,
+                "path": REPOSITORY_PATH,
+            }));
+        if status == 200 {
+            then.status(200).json_body(json!({
+                "repositoryId": "617882ea-14f6-40b4-bf52-cc1d3c7f67d4",
+                "provider": "diodehub",
+                "credential": {
+                    "scheme": "Bearer",
+                    "token": REPOSITORY_TOKEN,
+                },
+                "expiresAt": 4102444800u64,
+            }));
+        } else {
+            then.status(status);
+        }
+    })
+}
+
+#[test]
+fn advertises_authtype_and_ignores_unknown_operations() {
+    let context = TestContext::new("http://127.0.0.1:1".to_string());
+
+    let capability = context
+        .pcbc()
+        .args(["auth", "git", "capability"])
+        .output()
+        .expect("run helper capability operation");
+    assert_success(&capability);
+    assert_eq!(
+        String::from_utf8(capability.stdout).unwrap(),
+        "version 0\ncapability authtype\n"
+    );
+    assert!(capability.stderr.is_empty());
+
+    let unknown = context
+        .pcbc()
+        .args(["auth", "git", "future-operation"])
+        .output()
+        .expect("run unknown helper operation");
+    assert_success(&unknown);
+    assert!(unknown.stdout.is_empty());
+    assert!(unknown.stderr.is_empty());
+}
+
+#[test]
+fn modern_git_fill_receives_an_ephemeral_bearer_credential() {
+    let server = MockServer::start();
+    let exchange = mock_exchange(&server, 200);
+    let context = TestContext::new(server.base_url());
+
+    let fill = run_with_input(context.git_credential("fill"), &credential_request());
+    assert_success(&fill);
+    assert!(fill.stderr.is_empty());
+
+    let credential = String::from_utf8(fill.stdout).unwrap();
+    let lines: Vec<&str> = credential.lines().collect();
+    assert_eq!(lines.first(), Some(&"capability[]=authtype"));
+    assert!(lines.contains(&"authtype=Bearer"));
+    assert!(lines.contains(&format!("credential={REPOSITORY_TOKEN}").as_str()));
+    assert!(lines.contains(&"ephemeral=1"));
+    assert!(lines.contains(&"protocol=https"));
+    assert!(lines.contains(&format!("host={GIT_HOST}").as_str()));
+    assert!(lines.contains(&format!("path={REPOSITORY_PATH}").as_str()));
+    assert!(!credential.contains("username="));
+    assert!(!credential.contains("password="));
+    exchange.assert_calls(1);
+
+    let approve = run_with_input(context.git_credential("approve"), &credential);
+    assert_success(&approve);
+    assert!(approve.stdout.is_empty());
+    assert!(approve.stderr.is_empty());
+
+    let reject = run_with_input(context.git_credential("reject"), &credential);
+    assert_success(&reject);
+    assert!(reject.stdout.is_empty());
+    assert!(reject.stderr.is_empty());
+    exchange.assert_calls(1);
+}
+
+#[test]
+fn modern_git_honors_quit_when_the_exchange_fails() {
+    let server = MockServer::start();
+    let exchange = mock_exchange(&server, 403);
+    let context = TestContext::new(server.base_url());
+
+    let fill = run_with_input(context.git_credential("fill"), &credential_request());
+    assert!(!fill.status.success());
+    assert!(!String::from_utf8_lossy(&fill.stdout).contains("credential="));
+
+    let stderr = String::from_utf8_lossy(&fill.stderr);
+    assert!(stderr.contains("pcb auth git: Git credential exchange failed: 403 Forbidden"));
+    assert!(stderr.contains("credential helper"));
+    assert!(stderr.contains("told us to quit"));
+    exchange.assert_calls(1);
+}
+
+#[test]
+fn store_and_erase_are_silent_without_exchanging_credentials() {
+    let context = TestContext::new("http://127.0.0.1:1".to_string());
+
+    for operation in ["store", "erase"] {
+        let output = run_with_input(
+            {
+                let mut command = context.pcbc();
+                command.args(["auth", "git", operation]);
+                command
+            },
+            &credential_request(),
+        );
+        assert_success(&output);
+        assert!(output.stdout.is_empty());
+        assert!(output.stderr.is_empty());
+    }
+}

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -66,6 +66,28 @@ impl TestContext {
         command
     }
 
+    fn git_credential_with_fallback(&self, credential_file: &std::path::Path) -> Command {
+        let helper = format!(
+            "!\"{}\" auth git",
+            env!("CARGO_BIN_EXE_pcbc").replace('\\', "/")
+        );
+
+        let mut command = Command::new("git");
+        command
+            .args(["-c", "credential.helper="])
+            .arg("-c")
+            .arg(format!("credential.helper={helper}"))
+            .arg("-c")
+            .arg(format!(
+                "credential.helper=store --file={}",
+                credential_file.display()
+            ))
+            .args(["-c", "credential.useHttpPath=true"])
+            .args(["credential", "fill"]);
+        self.configure_environment(&mut command);
+        command
+    }
+
     fn configure_environment(&self, command: &mut Command) {
         command
             .current_dir(self._tempdir.path())
@@ -230,6 +252,32 @@ fn modern_git_honors_quit_when_the_exchange_fails() {
     assert!(stderr.contains("credential helper"));
     assert!(stderr.contains("told us to quit"));
     exchange.assert_calls(1);
+}
+
+#[test]
+fn global_helper_ignores_unrelated_hosts() {
+    let context = TestContext::new("http://127.0.0.1:1".to_string());
+    let credential_file = context._tempdir.path().join("credentials");
+    fs::write(
+        &credential_file,
+        "https://fallback-user:fallback-password@github.com/acme/widget.git\n",
+    )
+    .expect("write fallback credentials");
+
+    let fill = run_with_input(
+        context.git_credential_with_fallback(&credential_file),
+        "capability[]=authtype\n\
+         protocol=https\n\
+         host=github.com\n\
+         path=acme/widget.git\n\
+         \n",
+    );
+    assert_success(&fill);
+    assert!(fill.stderr.is_empty());
+
+    let credential = String::from_utf8(fill.stdout).unwrap();
+    assert!(credential.contains("username=fallback-user"));
+    assert!(credential.contains("password=fallback-password"));
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication and issues repo-scoped Git credentials, but scope is limited to DiodeHub HTTPS, tokens are validated and ephemeral, and failures avoid leaking credentials in stdout.
> 
> **Overview**
> Adds **`pcb auth git`** as a Git credential helper so HTTPS clones/fetches against **`code.diode.computer`** can use existing PCB login instead of long-lived passwords.
> 
> For matching `https` requests with the `authtype` capability, the helper POSTs **`/api/git/credentials`** with the user’s Diode API token and returns a short-lived **Bearer** token marked **ephemeral**. Other hosts, missing paths, and `store`/`erase` are no-ops so a global helper chain can fall through to other helpers. Failed exchanges signal **`quit=true`** to Git and log errors on stderr.
> 
> Wiring is through **`AuthCommand::Git`** in `pcb-diode-api`; integration tests exercise capability advertisement, `git credential fill`, exchange failures, unrelated hosts, and silent store/erase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0edc45bad7720b57ca8cab977a565d5bbd427293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->