### PR TITLE
Cache PCB Git credentials in Git

### DIFF
--- a/crates/pcb-diode-api/src/auth.rs
+++ b/crates/pcb-diode-api/src/auth.rs
@@ -62,7 +62,7 @@ impl WorkspaceContext {
     }
 }
 
-fn get_auth_dir() -> Result<PathBuf> {
+pub(crate) fn get_auth_dir() -> Result<PathBuf> {
     let pcb_dir = if let Ok(config_dir) = std::env::var("PCB_CONFIG_DIR") {
         PathBuf::from(config_dir)
     } else {
@@ -312,6 +312,7 @@ pub fn login_with_context(ctx: &WorkspaceContext) -> Result<()> {
         tokens.expires_at,
         tokens.email.as_deref(),
     )?;
+    crate::git_auth::clear_credential_cache();
 
     println!("✓ Authentication successful!");
     if let Some(email) = &tokens.email {
@@ -327,6 +328,7 @@ pub fn login() -> Result<()> {
 }
 
 pub fn logout_with_context(ctx: &WorkspaceContext) -> Result<()> {
+    crate::git_auth::clear_credential_cache();
     clear_tokens_with_context(ctx)?;
     aws_auth::clear_service_token(ctx)?;
     println!("✓ Logged out successfully");

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -2,7 +2,9 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
 use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
@@ -14,6 +16,7 @@ const DIODEHUB_CREDENTIAL_HELPER_CONFIG: &str = "credential.https://code.diode.c
 const DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG: &str =
     "credential.https://code.diode.computer.useHttpPath";
 const DIODEHUB_CREDENTIAL_HELPER: &str = "!pcb auth git";
+const DIODEHUB_CREDENTIAL_CACHE_TIMEOUT_SECONDS: u64 = 55 * 60;
 const DIODEHUB_HOST: &str = "code.diode.computer";
 const GIT_CONFIG_NOT_FOUND: i32 = 5;
 const MAX_CREDENTIAL_LINE_BYTES: usize = 65_535;
@@ -67,6 +70,11 @@ enum GitCredentialScheme {
     Bearer,
 }
 
+struct MintedGitCredential {
+    token: String,
+    expires_at: u64,
+}
+
 pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
     let stdin = io::stdin();
     let mut stdout = io::stdout().lock();
@@ -98,7 +106,9 @@ pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
 }
 
 fn configure() -> Result<()> {
+    let cache_helper = credential_cache_helper()?;
     run_git_config(&["--replace-all", DIODEHUB_CREDENTIAL_HELPER_CONFIG, ""])?;
+    run_git_config(&["--add", DIODEHUB_CREDENTIAL_HELPER_CONFIG, &cache_helper])?;
     run_git_config(&[
         "--add",
         DIODEHUB_CREDENTIAL_HELPER_CONFIG,
@@ -112,8 +122,56 @@ fn configure() -> Result<()> {
 }
 
 fn unconfigure() -> Result<()> {
+    clear_credential_cache();
     unset_git_config(DIODEHUB_CREDENTIAL_HELPER_CONFIG)?;
     unset_git_config(DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG)
+}
+
+fn credential_cache_socket() -> Result<PathBuf> {
+    let config_dir = crate::auth::get_auth_dir()?;
+    let config_dir = if config_dir.is_absolute() {
+        config_dir
+    } else {
+        std::env::current_dir()
+            .context("Failed to resolve PCB config directory")?
+            .join(config_dir)
+    };
+    Ok(config_dir.join("git-credential-cache").join("socket"))
+}
+
+fn credential_cache_helper() -> Result<String> {
+    let socket = credential_cache_socket()?;
+    let socket = socket
+        .to_str()
+        .context("PCB config directory is not valid UTF-8")?;
+    Ok(format!(
+        "cache --timeout={DIODEHUB_CREDENTIAL_CACHE_TIMEOUT_SECONDS} --socket={}",
+        shell_quote(socket)
+    ))
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn stop_credential_cache() -> Result<()> {
+    let socket = credential_cache_socket()?;
+    let mut socket_argument = OsString::from("--socket=");
+    socket_argument.push(socket);
+    let output = Command::new("git")
+        .arg("credential-cache")
+        .arg(socket_argument)
+        .arg("exit")
+        .output()
+        .context("Failed to stop Git credential cache")?;
+    if !output.status.success() {
+        bail!("`git credential-cache exit` failed with {}", output.status);
+    }
+    Ok(())
+}
+
+pub(crate) fn clear_credential_cache() {
+    let _ = stop_credential_cache();
 }
 
 fn run_git_config(args: &[&str]) -> Result<()> {
@@ -170,15 +228,19 @@ fn provide_credential(
 
     writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
     writeln!(output, "authtype=Bearer")?;
-    writeln!(output, "credential={credential}")?;
-    writeln!(output, "ephemeral=true")?;
+    writeln!(output, "credential={}", credential.token)?;
+    writeln!(output, "password_expiry_utc={}", credential.expires_at)?;
     writeln!(output)?;
     output.flush()?;
 
     Ok(())
 }
 
-fn exchange_credential(ctx: &WorkspaceContext, host: &str, path: &str) -> Result<String> {
+fn exchange_credential(
+    ctx: &WorkspaceContext,
+    host: &str,
+    path: &str,
+) -> Result<MintedGitCredential> {
     let api_token = ctx
         .token()
         .context("Failed to get a valid Diode API token")?;
@@ -224,7 +286,7 @@ fn exchange_credential(ctx: &WorkspaceContext, host: &str, path: &str) -> Result
         bail!("Git credential exchange returned an invalid credential");
     }
 
-    Ok(token)
+    Ok(MintedGitCredential { token, expires_at })
 }
 
 fn read_credential_request(mut input: impl BufRead) -> Result<CredentialRequest> {
@@ -299,6 +361,14 @@ mod tests {
         .unwrap();
 
         assert_eq!(request.capabilities, [b"state".to_vec()]);
+    }
+
+    #[test]
+    fn quotes_credential_cache_socket_for_the_shell() {
+        assert_eq!(
+            shell_quote("/tmp/PCB's cache/socket"),
+            "'/tmp/PCB'\\''s cache/socket'"
+        );
     }
 
     #[test]

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -15,6 +15,7 @@ const GIT_USE_HTTP_PATH_CONFIG: &str = "credential.https://code.diode.computer.u
 const REPOSITORY_PATH: &str = "acme/boards/widget.git";
 const USER_ACCESS_TOKEN: &str = "user-access-token";
 const REPOSITORY_TOKEN: &str = "repository-token";
+const REPOSITORY_TOKEN_EXPIRES_AT: u64 = 4_102_444_800;
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
 struct TestContext {
@@ -84,6 +85,21 @@ impl TestContext {
         command
     }
 
+    fn git_credential_cache(&self, action: &str) -> Command {
+        let mut command = Command::new("git");
+        command
+            .arg("credential-cache")
+            .arg(format!("--socket={}", self.cache_socket().display()))
+            .arg("--timeout=3300")
+            .arg(action);
+        self.configure_environment(&mut command);
+        command
+    }
+
+    fn cache_socket(&self) -> PathBuf {
+        self.config_dir.join("git-credential-cache/socket")
+    }
+
     fn run_git_config(&self, args: &[&str]) -> Output {
         self.git()
             .args(["config", "--global"])
@@ -124,6 +140,12 @@ impl TestContext {
             .env("no_proxy", "127.0.0.1,localhost")
             .env("PATH", &self.path)
             .env_remove("RUST_LOG");
+    }
+}
+
+impl Drop for TestContext {
+    fn drop(&mut self) {
+        let _ = self.git_credential_cache("exit").output();
     }
 }
 
@@ -203,7 +225,7 @@ fn mock_exchange<'a>(server: &'a MockServer, status: u16) -> Mock<'a> {
                     "scheme": "Bearer",
                     "token": REPOSITORY_TOKEN,
                 },
-                "expiresAt": 4102444800u64,
+                "expiresAt": REPOSITORY_TOKEN_EXPIRES_AT,
             }));
         } else {
             then.status(status);
@@ -253,10 +275,12 @@ fn configure_is_idempotent_and_preserves_unrelated_global_config() {
     assert_clean_success(&context.run_config_command("configure"));
     assert_clean_success(&context.run_config_command("configure"));
 
-    assert_eq!(
-        context.git_config_values(GIT_HELPER_CONFIG),
-        ["", "!pcb auth git"]
-    );
+    let helpers = context.git_config_values(GIT_HELPER_CONFIG);
+    assert_eq!(helpers.len(), 3);
+    assert_eq!(helpers[0], "");
+    assert!(helpers[1].starts_with("cache --timeout=3300 --socket="));
+    assert!(helpers[1].contains(context.cache_socket().to_str().unwrap()));
+    assert_eq!(helpers[2], "!pcb auth git");
     assert_eq!(
         context.git_config_values(GIT_USE_HTTP_PATH_CONFIG),
         ["true"]
@@ -283,10 +307,26 @@ fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
         "developer",
     ]));
     assert_clean_success(&context.run_config_command("configure"));
+    let cached_credential = format!(
+        "capability[]=authtype\n\
+         protocol=https\n\
+         host={GIT_HOST}\n\
+         path={REPOSITORY_PATH}\n\
+         authtype=Bearer\n\
+         credential={REPOSITORY_TOKEN}\n\
+         password_expiry_utc={REPOSITORY_TOKEN_EXPIRES_AT}\n\
+         \n"
+    );
+    assert_clean_success(&run_with_input(
+        context.git_credential_cache("store"),
+        &cached_credential,
+    ));
+    assert!(context.cache_socket().exists());
 
     assert_clean_success(&context.run_config_command("unconfigure"));
     assert_clean_success(&context.run_config_command("unconfigure"));
 
+    assert!(!context.cache_socket().exists());
     assert!(context.git_config_values(GIT_HELPER_CONFIG).is_empty());
     assert!(
         context
@@ -304,7 +344,7 @@ fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
 }
 
 #[test]
-fn modern_git_fill_receives_an_ephemeral_bearer_credential() {
+fn modern_git_fill_caches_the_bearer_credential_until_rejected() {
     let server = MockServer::start();
     let exchange = mock_exchange(&server, 200);
     let context = TestContext::new(server.base_url());
@@ -319,10 +359,11 @@ fn modern_git_fill_receives_an_ephemeral_bearer_credential() {
     assert_eq!(lines.first(), Some(&"capability[]=authtype"));
     assert!(lines.contains(&"authtype=Bearer"));
     assert!(lines.contains(&format!("credential={REPOSITORY_TOKEN}").as_str()));
-    assert!(lines.contains(&"ephemeral=1"));
+    assert!(lines.contains(&format!("password_expiry_utc={REPOSITORY_TOKEN_EXPIRES_AT}").as_str()));
     assert!(lines.contains(&"protocol=https"));
     assert!(lines.contains(&format!("host={GIT_HOST}").as_str()));
     assert!(lines.contains(&format!("path={REPOSITORY_PATH}").as_str()));
+    assert!(!credential.contains("ephemeral="));
     assert!(!credential.contains("username="));
     assert!(!credential.contains("password="));
     exchange.assert_calls(1);
@@ -332,10 +373,76 @@ fn modern_git_fill_receives_an_ephemeral_bearer_credential() {
     assert!(approve.stdout.is_empty());
     assert!(approve.stderr.is_empty());
 
-    let reject = run_with_input(context.git_credential("reject"), &credential);
+    let cached_fill = run_with_input(context.git_credential("fill"), &credential_request());
+    assert_success(&cached_fill);
+    assert!(cached_fill.stderr.is_empty());
+    let cached_credential = String::from_utf8(cached_fill.stdout).unwrap();
+    assert_eq!(cached_credential, credential);
+    exchange.assert_calls(1);
+
+    let reject = run_with_input(context.git_credential("reject"), &cached_credential);
     assert_success(&reject);
     assert!(reject.stdout.is_empty());
     assert!(reject.stderr.is_empty());
+
+    let refreshed_fill = run_with_input(context.git_credential("fill"), &credential_request());
+    assert_success(&refreshed_fill);
+    assert!(refreshed_fill.stderr.is_empty());
+    exchange.assert_calls(2);
+}
+
+#[test]
+fn modern_git_ignores_an_expired_cached_bearer_credential() {
+    let server = MockServer::start();
+    let exchange = mock_exchange(&server, 200);
+    let context = TestContext::new(server.base_url());
+    assert_clean_success(&context.run_config_command("configure"));
+    let expired_credential = format!(
+        "capability[]=authtype\n\
+         protocol=https\n\
+         host={GIT_HOST}\n\
+         path={REPOSITORY_PATH}\n\
+         authtype=Bearer\n\
+         credential=expired-repository-token\n\
+         password_expiry_utc=1\n\
+         \n"
+    );
+    assert_clean_success(&run_with_input(
+        context.git_credential_cache("store"),
+        &expired_credential,
+    ));
+
+    let fill = run_with_input(context.git_credential("fill"), &credential_request());
+    assert_success(&fill);
+    assert!(fill.stderr.is_empty());
+    let credential = String::from_utf8(fill.stdout).unwrap();
+    assert!(credential.contains(&format!("credential={REPOSITORY_TOKEN}")));
+    assert!(!credential.contains("expired-repository-token"));
+    exchange.assert_calls(1);
+}
+
+#[test]
+fn auth_logout_stops_the_git_credential_cache() {
+    let server = MockServer::start();
+    let exchange = mock_exchange(&server, 200);
+    let context = TestContext::new(server.base_url());
+    assert_clean_success(&context.run_config_command("configure"));
+
+    let fill = run_with_input(context.git_credential("fill"), &credential_request());
+    assert_success(&fill);
+    assert_clean_success(&run_with_input(
+        context.git_credential("approve"),
+        &String::from_utf8(fill.stdout).unwrap(),
+    ));
+    assert!(context.cache_socket().exists());
+
+    let logout = context
+        .pcbc()
+        .args(["auth", "logout"])
+        .output()
+        .expect("run pcb auth logout");
+    assert_success(&logout);
+    assert!(!context.cache_socket().exists());
     exchange.assert_calls(1);
 }
 

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -279,7 +279,6 @@ fn configure_is_idempotent_and_preserves_unrelated_global_config() {
     assert_eq!(helpers.len(), 3);
     assert_eq!(helpers[0], "");
     assert!(helpers[1].starts_with("cache --timeout=3300 --socket="));
-    assert!(helpers[1].contains(context.cache_socket().to_str().unwrap()));
     assert_eq!(helpers[2], "!pcb auth git");
     assert_eq!(
         context.git_config_values(GIT_USE_HTTP_PATH_CONFIG),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication and Git credential handling; mis-cached or uncleared tokens could affect repo access until reject/logout, but behavior is covered by integration tests.
> 
> **Overview**
> **Git configure** now chains Git’s built-in `credential-cache` (55-minute timeout, socket under the PCB config dir) ahead of `!pcb auth git`, so repeated `fill` calls reuse minted bearer tokens instead of hitting the credentials API every time.
> 
> The credential helper **stops marking tokens ephemeral** and instead returns **`password_expiry_utc`** from the exchange response so Git can treat cached credentials as expired when appropriate. **Login**, **logout**, and **`pcb auth git unconfigure`** all **stop the credential-cache daemon** so stale repository tokens aren’t left in memory after auth changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61645855e01ae0765f27e1f9839a147dd0122811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->