### PR TITLE
Migrate CI to Blacksmith ARM macOS runners

### DIFF
--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -10,4 +10,5 @@
   if: runner.os != 'Windows'
   uses: actions-rust-lang/setup-rust-toolchain@v1
   with:
+    toolchain: stable
     cache-bin: false

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build_perf:
     name: pcb build performance
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           cache-bin: false
 
       - name: Checkout benchmark workspace

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
 
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
 
       - name: Cache KiCad (macOS)
         if: matrix.config.name == 'macOS'
@@ -93,7 +93,7 @@ jobs:
 
       - name: Checkout kicad-test-fixtures
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v5
+        uses: useblacksmith/checkout@v1
         with:
           repository: diodeinc/kicad-test-fixtures
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,14 +51,20 @@ jobs:
       - name: Install KiCad (macOS)
         if: matrix.config.name == 'macOS' && steps.cache-kicad-mac.outputs.cache-hit != 'true'
         run: |
-          brew update
           brew uninstall --cask kicad 2>/dev/null || true
           rm -rf /Applications/KiCad 2>/dev/null || true
-          brew install --cask kicad
+          dmg="$RUNNER_TEMP/kicad.dmg"
+          mount_point="$RUNNER_TEMP/kicad-mount"
+          curl -fL "https://github.com/KiCad/kicad-source-mirror/releases/download/${KICAD_VERSION}/kicad-unified-universal-${KICAD_VERSION}.dmg" -o "$dmg"
+          mkdir -p "$mount_point"
+          hdiutil attach "$dmg" -mountpoint "$mount_point" -nobrowse
+          trap 'hdiutil detach "$mount_point"' EXIT
+          cp -R "$mount_point/KiCad" /Applications/KiCad
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           cache-bin: false
 
       - name: Install local pcb toolchain

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
               image: ghcr.io/diodeinc/kicad:10.0.4
-              options: --user root
+              options: --user root --privileged -v /dev:/dev
     steps:
       - name: Install Dependencies (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
@@ -38,7 +38,15 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
 
-      - uses: actions/checkout@v5
+      - name: Checkout with Blacksmith cache
+        if: matrix.config.name == 'Ubuntu'
+        uses: useblacksmith/checkout@v1.1
+        with:
+          allow-inside-container: true
+
+      - name: Checkout
+        if: matrix.config.name != 'Ubuntu'
+        uses: actions/checkout@v5
 
       - name: Cache KiCad (macOS)
         if: matrix.config.name == 'macOS'
@@ -91,8 +99,17 @@ jobs:
       - name: Test stdlib builds
         run: pcb +local build lib/std/ -S bom
 
+      - name: Checkout kicad-test-fixtures with Blacksmith cache
+        if: matrix.config.name == 'Ubuntu' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: useblacksmith/checkout@v1.1
+        with:
+          repository: diodeinc/kicad-test-fixtures
+          token: ${{ secrets.DIODE_ROBOT_TOKEN }}
+          path: kicad-test-fixtures
+          allow-inside-container: true
+
       - name: Checkout kicad-test-fixtures
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: matrix.config.name != 'Ubuntu' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/checkout@v5
         with:
           repository: diodeinc/kicad-test-fixtures

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  KICAD_VERSION: 10.0.4
+  KICAD_VERSION: 10.0.5
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,7 +29,7 @@ jobs:
           - name: Ubuntu
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
-              image: ghcr.io/diodeinc/kicad:10.0.4
+              image: ghcr.io/diodeinc/kicad:10.0.5
               options: --user root
     steps:
       - name: Install Dependencies (Ubuntu)
@@ -51,15 +51,10 @@ jobs:
       - name: Install KiCad (macOS)
         if: matrix.config.name == 'macOS' && steps.cache-kicad-mac.outputs.cache-hit != 'true'
         run: |
+          brew update
           brew uninstall --cask kicad 2>/dev/null || true
           rm -rf /Applications/KiCad 2>/dev/null || true
-          dmg="$RUNNER_TEMP/kicad.dmg"
-          mount_point="$RUNNER_TEMP/kicad-mount"
-          curl -fL "https://github.com/KiCad/kicad-source-mirror/releases/download/${KICAD_VERSION}/kicad-unified-universal-${KICAD_VERSION}.dmg" -o "$dmg"
-          mkdir -p "$mount_point"
-          hdiutil attach "$dmg" -mountpoint "$mount_point" -nobrowse
-          trap 'hdiutil detach "$mount_point"' EXIT
-          cp -R "$mount_point/KiCad" /Applications/KiCad
+          brew install --cask kicad
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
 
-      - uses: useblacksmith/checkout@v1
+      - uses: actions/checkout@v5
 
       - name: Cache KiCad (macOS)
         if: matrix.config.name == 'macOS'
@@ -93,7 +93,7 @@ jobs:
 
       - name: Checkout kicad-test-fixtures
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: useblacksmith/checkout@v1
+        uses: actions/checkout@v5
         with:
           repository: diodeinc/kicad-test-fixtures
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,25 +30,15 @@ jobs:
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
               image: ghcr.io/diodeinc/kicad:10.0.4
-              options: --user root --privileged -v /dev:/dev
+              options: --user root
     steps:
       - name: Install Dependencies (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
         run: |
           apt-get update
-          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev e2fsprogs
-          git config --global --add safe.directory /blacksmith-git-mirror/diodeinc/pcb/v1/diodeinc-pcb.git
-          git config --global --add safe.directory /blacksmith-git-mirror/diodeinc/kicad-test-fixtures/v1/diodeinc-kicad-test-fixtures.git
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
 
-      - name: Checkout with Blacksmith cache
-        if: matrix.config.name == 'Ubuntu'
-        uses: useblacksmith/checkout@v1.1
-        with:
-          allow-inside-container: true
-
-      - name: Checkout
-        if: matrix.config.name != 'Ubuntu'
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
 
       - name: Cache KiCad (macOS)
         if: matrix.config.name == 'macOS'
@@ -101,17 +91,8 @@ jobs:
       - name: Test stdlib builds
         run: pcb +local build lib/std/ -S bom
 
-      - name: Checkout kicad-test-fixtures with Blacksmith cache
-        if: matrix.config.name == 'Ubuntu' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: useblacksmith/checkout@v1.1
-        with:
-          repository: diodeinc/kicad-test-fixtures
-          token: ${{ secrets.DIODE_ROBOT_TOKEN }}
-          path: kicad-test-fixtures
-          allow-inside-container: true
-
       - name: Checkout kicad-test-fixtures
-        if: matrix.config.name != 'Ubuntu' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v5
         with:
           repository: diodeinc/kicad-test-fixtures

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,9 @@ jobs:
         if: matrix.config.name == 'Ubuntu'
         run: |
           apt-get update
-          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev e2fsprogs
+          git config --global --add safe.directory /blacksmith-git-mirror/diodeinc/pcb/v1/diodeinc-pcb.git
+          git config --global --add safe.directory /blacksmith-git-mirror/diodeinc/kicad-test-fixtures/v1/diodeinc-kicad-test-fixtures.git
 
       - name: Checkout with Blacksmith cache
         if: matrix.config.name == 'Ubuntu'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
           - name: Ubuntu
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
-              image: ghcr.io/diodeinc/kicad:10.0.4
+              image: ghcr.io/diodeinc/kicad:10.0.5
               options: --user root
     steps:
       - name: Install Dependencies (Ubuntu)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
           - name: Ubuntu
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
-              image: ghcr.io/diodeinc/kicad:10.0.5
+              image: ghcr.io/diodeinc/kicad:10.0.4
               options: --user root
     steps:
       - name: Install Dependencies (Ubuntu)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,9 +25,9 @@ jobs:
       matrix:
         config:
           - name: macOS
-            runs-on: macos-15-xlarge
+            runs-on: blacksmith-6vcpu-macos-15
           - name: Ubuntu
-            runs-on: ubicloud-standard-16
+            runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
               image: ghcr.io/diodeinc/kicad:10.0.4
               options: --user root

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           cache-bin: false
 
       - id: release

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
@@ -72,17 +72,17 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            runner: macos-15-xlarge
+            runner: blacksmith-6vcpu-macos-15
           - target: aarch64-unknown-linux-gnu
-            runner: ubicloud-standard-16-arm
+            runner: blacksmith-16vcpu-ubuntu-2404-arm
           - target: aarch64-unknown-linux-musl
-            runner: ubicloud-standard-16-arm
+            runner: blacksmith-16vcpu-ubuntu-2404-arm
           - target: x86_64-unknown-linux-gnu
-            runner: ubicloud-standard-16
+            runner: blacksmith-16vcpu-ubuntu-2404
           - target: x86_64-unknown-linux-musl
-            runner: ubicloud-standard-16
+            runner: blacksmith-16vcpu-ubuntu-2404
           - target: x86_64-pc-windows-msvc
-            runner: diode-windows
+            runner: blacksmith-16vcpu-windows-2025
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Enable Windows long paths
@@ -173,7 +173,7 @@ jobs:
     needs:
       - prepare
       - build
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
           submodules: recursive
@@ -90,16 +90,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - name: Checkout with Blacksmith cache
-        if: runner.os == 'Linux'
-        uses: useblacksmith/checkout@v1.1
-        with:
-          ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
-          submodules: recursive
-
-      - name: Checkout
-        if: runner.os != 'Linux'
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive
@@ -185,7 +176,7 @@ jobs:
       - build
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
 

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -73,8 +73,6 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             runner: macos-15-xlarge
-          - target: x86_64-apple-darwin
-            runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
             runner: ubicloud-standard-16-arm
           - target: aarch64-unknown-linux-musl

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -90,7 +90,16 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: useblacksmith/checkout@v1
+      - name: Checkout with Blacksmith cache
+        if: runner.os == 'Linux'
+        uses: useblacksmith/checkout@v1
+        with:
+          ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
+          submodules: recursive
+
+      - name: Checkout
+        if: runner.os != 'Linux'
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
           submodules: recursive
@@ -90,7 +90,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive
@@ -176,7 +176,7 @@ jobs:
       - build
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
 

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
           submodules: recursive
@@ -92,7 +92,7 @@ jobs:
 
       - name: Checkout with Blacksmith cache
         if: runner.os == 'Linux'
-        uses: useblacksmith/checkout@v1
+        uses: useblacksmith/checkout@v1.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive
@@ -185,7 +185,7 @@ jobs:
       - build
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
 

--- a/.github/workflows/pcb-version-bump.yml
+++ b/.github/workflows/pcb-version-bump.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   bump:
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/pcb-version-bump.yml
+++ b/.github/workflows/pcb-version-bump.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           cache-bin: false
 
       - name: Update pcb shim version

--- a/.github/workflows/pcb-version-bump.yml
+++ b/.github/workflows/pcb-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
   bump:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/pcb-version-bump.yml
+++ b/.github/workflows/pcb-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
   bump:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/pcb-version-bump.yml
+++ b/.github/workflows/pcb-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
   bump:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -25,7 +25,7 @@ jobs:
       tag: ${{ steps.nightly.outputs.tag }}
       base_url: ${{ steps.nightly.outputs.base_url }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
           submodules: recursive
@@ -106,7 +106,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ needs.prepare.outputs.sha }}
           submodules: recursive

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -25,7 +25,7 @@ jobs:
       tag: ${{ steps.nightly.outputs.tag }}
       base_url: ${{ steps.nightly.outputs.base_url }}
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
           submodules: recursive
@@ -108,7 +108,7 @@ jobs:
 
       - name: Checkout with Blacksmith cache
         if: runner.os == 'Linux'
-        uses: useblacksmith/checkout@v1
+        uses: useblacksmith/checkout@v1.1
         with:
           ref: ${{ needs.prepare.outputs.sha }}
           submodules: recursive

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -106,7 +106,16 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: useblacksmith/checkout@v1
+      - name: Checkout with Blacksmith cache
+        if: runner.os == 'Linux'
+        uses: useblacksmith/checkout@v1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          submodules: recursive
+
+      - name: Checkout
+        if: runner.os != 'Linux'
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.sha }}
           submodules: recursive

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     outputs:
       should_build: ${{ steps.nightly.outputs.should_build }}
       sha: ${{ steps.nightly.outputs.sha }}
@@ -89,17 +89,17 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            runner: macos-15-xlarge
+            runner: blacksmith-6vcpu-macos-15
           - target: aarch64-unknown-linux-gnu
-            runner: ubicloud-standard-16-arm
+            runner: blacksmith-16vcpu-ubuntu-2404-arm
           - target: aarch64-unknown-linux-musl
-            runner: ubicloud-standard-16-arm
+            runner: blacksmith-16vcpu-ubuntu-2404-arm
           - target: x86_64-unknown-linux-gnu
-            runner: ubicloud-standard-16
+            runner: blacksmith-16vcpu-ubuntu-2404
           - target: x86_64-unknown-linux-musl
-            runner: ubicloud-standard-16
+            runner: blacksmith-16vcpu-ubuntu-2404
           - target: x86_64-pc-windows-msvc
-            runner: diode-windows
+            runner: blacksmith-16vcpu-windows-2025
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Enable Windows long paths
@@ -173,7 +173,7 @@ jobs:
       - prepare
       - build
     if: needs.prepare.outputs.should_build == 'true'
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -25,7 +25,7 @@ jobs:
       tag: ${{ steps.nightly.outputs.tag }}
       base_url: ${{ steps.nightly.outputs.base_url }}
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
           submodules: recursive
@@ -106,16 +106,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - name: Checkout with Blacksmith cache
-        if: runner.os == 'Linux'
-        uses: useblacksmith/checkout@v1.1
-        with:
-          ref: ${{ needs.prepare.outputs.sha }}
-          submodules: recursive
-
-      - name: Checkout
-        if: runner.os != 'Linux'
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.sha }}
           submodules: recursive

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -90,8 +90,6 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             runner: macos-15-xlarge
-          - target: x86_64-apple-darwin
-            runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
             runner: ubicloud-standard-16-arm
           - target: aarch64-unknown-linux-musl

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
@@ -89,17 +89,17 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            runner: macos-15-xlarge
+            runner: blacksmith-6vcpu-macos-15
           - target: aarch64-unknown-linux-gnu
-            runner: ubicloud-standard-16-arm
+            runner: blacksmith-16vcpu-ubuntu-2404-arm
           - target: aarch64-unknown-linux-musl
-            runner: ubicloud-standard-16-arm
+            runner: blacksmith-16vcpu-ubuntu-2404-arm
           - target: x86_64-unknown-linux-gnu
-            runner: ubicloud-standard-16
+            runner: blacksmith-16vcpu-ubuntu-2404
           - target: x86_64-unknown-linux-musl
-            runner: ubicloud-standard-16
+            runner: blacksmith-16vcpu-ubuntu-2404
           - target: x86_64-pc-windows-msvc
-            runner: diode-windows
+            runner: blacksmith-16vcpu-windows-2025
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Enable Windows long paths
@@ -193,7 +193,7 @@ jobs:
     needs:
       - prepare
       - build
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           cache-bin: false
 
       - id: release

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
           submodules: recursive
@@ -107,16 +107,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - name: Checkout with Blacksmith cache
-        if: runner.os == 'Linux'
-        uses: useblacksmith/checkout@v1.1
-        with:
-          ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
-          submodules: recursive
-
-      - name: Checkout
-        if: runner.os != 'Linux'
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
           submodules: recursive
@@ -109,7 +109,7 @@ jobs:
 
       - name: Checkout with Blacksmith cache
         if: runner.os == 'Linux'
-        uses: useblacksmith/checkout@v1
+        uses: useblacksmith/checkout@v1.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -107,7 +107,16 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: useblacksmith/checkout@v1
+      - name: Checkout with Blacksmith cache
+        if: runner.os == 'Linux'
+        uses: useblacksmith/checkout@v1
+        with:
+          ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
+          submodules: recursive
+
+      - name: Checkout
+        if: runner.os != 'Linux'
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
           submodules: recursive
@@ -107,7 +107,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
           submodules: recursive

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -90,8 +90,6 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             runner: macos-15-xlarge
-          - target: x86_64-apple-darwin
-            runner: macos-15-large
           - target: aarch64-unknown-linux-gnu
             runner: ubicloud-standard-16-arm
           - target: aarch64-unknown-linux-musl

--- a/.github/workflows/pcbc-version-bump.yml
+++ b/.github/workflows/pcbc-version-bump.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   bump:
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/pcbc-version-bump.yml
+++ b/.github/workflows/pcbc-version-bump.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           cache-bin: false
 
       - name: Update changelog

--- a/.github/workflows/pcbc-version-bump.yml
+++ b/.github/workflows/pcbc-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
   bump:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/pcbc-version-bump.yml
+++ b/.github/workflows/pcbc-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
   bump:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/pcbc-version-bump.yml
+++ b/.github/workflows/pcbc-version-bump.yml
@@ -15,7 +15,7 @@ jobs:
   bump:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,8 @@ jobs:
         if: matrix.config.name == 'Ubuntu'
         run: |
           apt-get update
-          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev e2fsprogs
+          git config --global --add safe.directory /blacksmith-git-mirror/diodeinc/pcb/v1/diodeinc-pcb.git
 
       - name: Checkout with Blacksmith cache
         if: matrix.config.name == 'Ubuntu'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -74,7 +74,7 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
 
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
 
       - name: Cache KiCad (macOS)
         if: contains(matrix.config.name, 'macOS')
@@ -151,7 +151,7 @@ jobs:
       run:
         working-directory: crates/pcb-layout/src/scripts
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
       - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync
         working-directory: .
@@ -163,7 +163,7 @@ jobs:
     name: Check README Sync
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
 
       - name: Check README sync
         run: bin/embed-readme --check README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_TEST_DEBUG: 0
-  KICAD_VERSION: 10.0.5  # Update container image below when changing this
+  KICAD_VERSION: 10.0.5
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -65,7 +65,7 @@ jobs:
           - name: Ubuntu
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
-              image: ghcr.io/diodeinc/kicad:10.0.5  # Keep in sync with KICAD_VERSION
+              image: ghcr.io/diodeinc/kicad:10.0.4
               options: --user root
     steps:
       - name: Install Dependencies (Ubuntu)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           components: rustfmt, clippy
           cache-bin: false
 
@@ -86,13 +87,15 @@ jobs:
       - name: Install KiCad (macOS)
         if: contains(matrix.config.name, 'macOS') && steps.cache-kicad-mac.outputs.cache-hit != 'true'
         run: |
-          brew update
-          # Uninstall existing KiCad if present to avoid conflicts
           brew uninstall --cask kicad 2>/dev/null || true
-          # Remove any remaining KiCad installation
           rm -rf /Applications/KiCad 2>/dev/null || true
-          # Install KiCad fresh
-          brew install --cask kicad
+          dmg="$RUNNER_TEMP/kicad.dmg"
+          mount_point="$RUNNER_TEMP/kicad-mount"
+          curl -fL "https://github.com/KiCad/kicad-source-mirror/releases/download/${KICAD_VERSION}/kicad-unified-universal-${KICAD_VERSION}.dmg" -o "$dmg"
+          mkdir -p "$mount_point"
+          hdiutil attach "$dmg" -mountpoint "$mount_point" -nobrowse
+          trap 'hdiutil detach "$mount_point"' EXIT
+          cp -R "$mount_point/KiCad" /Applications/KiCad
 
       - name: Install KiCad (Windows)
         if: matrix.config.name == 'Windows'
@@ -126,6 +129,7 @@ jobs:
         if: runner.os != 'Windows'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           components: rustfmt, clippy
           cache-bin: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -66,7 +66,7 @@ jobs:
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
               image: ghcr.io/diodeinc/kicad:10.0.4
-              options: --user root
+              options: --user root --privileged -v /dev:/dev
     steps:
       - name: Install Dependencies (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
@@ -74,7 +74,15 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
 
-      - uses: actions/checkout@v5
+      - name: Checkout with Blacksmith cache
+        if: matrix.config.name == 'Ubuntu'
+        uses: useblacksmith/checkout@v1.1
+        with:
+          allow-inside-container: true
+
+      - name: Checkout
+        if: matrix.config.name != 'Ubuntu'
+        uses: actions/checkout@v5
 
       - name: Cache KiCad (macOS)
         if: contains(matrix.config.name, 'macOS')
@@ -151,7 +159,7 @@ jobs:
       run:
         working-directory: crates/pcb-layout/src/scripts
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
       - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync
         working-directory: .
@@ -163,7 +171,7 @@ jobs:
     name: Check README Sync
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@v1.1
 
       - name: Check README sync
         run: bin/embed-readme --check README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_TEST_DEBUG: 0
-  KICAD_VERSION: 10.0.4  # Update container image below when changing this
+  KICAD_VERSION: 10.0.5  # Update container image below when changing this
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -65,7 +65,7 @@ jobs:
           - name: Ubuntu
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
-              image: ghcr.io/diodeinc/kicad:10.0.4  # Keep in sync with KICAD_VERSION
+              image: ghcr.io/diodeinc/kicad:10.0.5  # Keep in sync with KICAD_VERSION
               options: --user root
     steps:
       - name: Install Dependencies (Ubuntu)
@@ -87,15 +87,10 @@ jobs:
       - name: Install KiCad (macOS)
         if: contains(matrix.config.name, 'macOS') && steps.cache-kicad-mac.outputs.cache-hit != 'true'
         run: |
+          brew update
           brew uninstall --cask kicad 2>/dev/null || true
           rm -rf /Applications/KiCad 2>/dev/null || true
-          dmg="$RUNNER_TEMP/kicad.dmg"
-          mount_point="$RUNNER_TEMP/kicad-mount"
-          curl -fL "https://github.com/KiCad/kicad-source-mirror/releases/download/${KICAD_VERSION}/kicad-unified-universal-${KICAD_VERSION}.dmg" -o "$dmg"
-          mkdir -p "$mount_point"
-          hdiutil attach "$dmg" -mountpoint "$mount_point" -nobrowse
-          trap 'hdiutil detach "$mount_point"' EXIT
-          cp -R "$mount_point/KiCad" /Applications/KiCad
+          brew install --cask kicad
 
       - name: Install KiCad (Windows)
         if: matrix.config.name == 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   lint:
     name: Lint and Check
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
@@ -58,11 +58,11 @@ jobs:
       matrix:
         config:
           - name: Windows
-            runs-on: diode-windows
+            runs-on: blacksmith-16vcpu-windows-2025
           - name: macOS
-            runs-on: macos-15-xlarge
+            runs-on: blacksmith-6vcpu-macos-15
           - name: Ubuntu
-            runs-on: ubicloud-standard-16
+            runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
               image: ghcr.io/diodeinc/kicad:10.0.4  # Keep in sync with KICAD_VERSION
               options: --user root
@@ -146,7 +146,7 @@ jobs:
 
   python-tests:
     name: Python Tests
-    runs-on: ubicloud-standard-4
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     defaults:
       run:
@@ -162,7 +162,7 @@ jobs:
 
   check_readme:
     name: Check README Sync
-    runs-on: ubicloud-standard-2
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
 
-      - uses: useblacksmith/checkout@v1
+      - uses: actions/checkout@v5
 
       - name: Cache KiCad (macOS)
         if: contains(matrix.config.name, 'macOS')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           - name: Ubuntu
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
-              image: ghcr.io/diodeinc/kicad:10.0.4
+              image: ghcr.io/diodeinc/kicad:10.0.5
               options: --user root
     steps:
       - name: Install Dependencies (Ubuntu)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -66,24 +66,15 @@ jobs:
             runs-on: blacksmith-16vcpu-ubuntu-2404
             container:
               image: ghcr.io/diodeinc/kicad:10.0.4
-              options: --user root --privileged -v /dev:/dev
+              options: --user root
     steps:
       - name: Install Dependencies (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
         run: |
           apt-get update
-          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev e2fsprogs
-          git config --global --add safe.directory /blacksmith-git-mirror/diodeinc/pcb/v1/diodeinc-pcb.git
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
 
-      - name: Checkout with Blacksmith cache
-        if: matrix.config.name == 'Ubuntu'
-        uses: useblacksmith/checkout@v1.1
-        with:
-          allow-inside-container: true
-
-      - name: Checkout
-        if: matrix.config.name != 'Ubuntu'
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
 
       - name: Cache KiCad (macOS)
         if: contains(matrix.config.name, 'macOS')
@@ -160,7 +151,7 @@ jobs:
       run:
         working-directory: crates/pcb-layout/src/scripts
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync
         working-directory: .
@@ -172,7 +163,7 @@ jobs:
     name: Check README Sync
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: useblacksmith/checkout@v1.1
+      - uses: actions/checkout@v5
 
       - name: Check README sync
         run: bin/embed-readme --check README.md

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd e2fsprogs
+          git config --global --add safe.directory /blacksmith-git-mirror/diodeinc/pcb/v1/diodeinc-pcb.git
 
       - uses: useblacksmith/checkout@v1.1
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     container:
       image: ghcr.io/diodeinc/kicad:10.0.4
-      options: --user root
+      options: --user root --privileged -v /dev:/dev
     timeout-minutes: 30
     steps:
       - name: Install dependencies
@@ -28,7 +28,9 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd
 
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1.1
+        with:
+          allow-inside-container: true
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,18 +20,15 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     container:
       image: ghcr.io/diodeinc/kicad:10.0.4
-      options: --user root --privileged -v /dev:/dev
+      options: --user root
     timeout-minutes: 30
     steps:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd e2fsprogs
-          git config --global --add safe.directory /blacksmith-git-mirror/diodeinc/pcb/v1/diodeinc-pcb.git
+          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd
 
-      - uses: useblacksmith/checkout@v1.1
-        with:
-          allow-inside-container: true
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -28,7 +28,7 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd
 
-      - uses: actions/checkout@v5
+      - uses: useblacksmith/checkout@v1
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           target: wasm32-unknown-unknown
           cache-bin: false
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -28,7 +28,7 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd
 
-      - uses: useblacksmith/checkout@v1
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  KICAD_VERSION: 10.0.4
+  KICAD_VERSION: 10.0.5
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +19,7 @@ jobs:
     name: Evaluate publish bundles
     runs-on: blacksmith-16vcpu-ubuntu-2404
     container:
-      image: ghcr.io/diodeinc/kicad:10.0.4
+      image: ghcr.io/diodeinc/kicad:10.0.5
       options: --user root
     timeout-minutes: 30
     steps:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   wasm:
     name: Evaluate publish bundles
-    runs-on: ubicloud-standard-16
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     container:
       image: ghcr.io/diodeinc/kicad:10.0.4
       options: --user root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - `pcb migrate` now rewrites legacy GitHub registry references to DiodeHub.
+- Dropped support for Intel Macs; macOS now requires Apple silicon.
 
 ## [0.4.13] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb migrate` now rewrites legacy GitHub registry references to DiodeHub.
 
+### Fixed
+
+- Fixed hierarchical layout placement with KiCad 10.0.5.
+
 ## [0.4.13] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb migrate` now rewrites legacy GitHub registry references to DiodeHub.
 
-### Fixed
-
-- Fixed hierarchical layout placement with KiCad 10.0.5.
-
 ## [0.4.13] - 2026-07-27
 
 ### Added

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -302,11 +302,11 @@ struct ComponentFilePaths {
 fn component_file_paths(component_dir: &Path, mpn: &str) -> ComponentFilePaths {
     let sanitized_mpn = pcb_component_gen::sanitize_mpn_for_path(mpn);
     ComponentFilePaths {
-        symbol_path: component_dir.join(format!("{}.kicad_sym", &sanitized_mpn)),
-        footprint_path: component_dir.join(format!("{}.kicad_mod", &sanitized_mpn)),
-        step_path: component_dir.join(format!("{}.step", &sanitized_mpn)),
-        pdf_path: component_docs_dir(component_dir).join(format!("{}.pdf", &sanitized_mpn)),
-        zen_path: component_dir.join(format!("{}.zen", &sanitized_mpn)),
+        symbol_path: component_dir.join(format!("{}.kicad_sym", sanitized_mpn)),
+        footprint_path: component_dir.join(format!("{}.kicad_mod", sanitized_mpn)),
+        step_path: component_dir.join(format!("{}.step", sanitized_mpn)),
+        pdf_path: component_docs_dir(component_dir).join(format!("{}.pdf", sanitized_mpn)),
+        zen_path: component_dir.join(format!("{}.zen", sanitized_mpn)),
         sanitized_mpn,
     }
 }
@@ -756,7 +756,7 @@ fn finalize_component(
     let content = generate_zen_file(
         &files.sanitized_mpn,
         symbol,
-        &format!("{}.kicad_sym", &files.sanitized_mpn),
+        &format!("{}.kicad_sym", files.sanitized_mpn),
     )?;
 
     write_component_files(&files.zen_path, component_dir, &content)?;
@@ -1181,32 +1181,32 @@ fn execute_from_dir(dir: &Path, workspace_root: &Path) -> Result<()> {
     );
 
     // Copy the selected symbol with standardized name
-    let sym_filename = format!("{}.kicad_sym", &component_files.sanitized_mpn);
+    let sym_filename = format!("{}.kicad_sym", component_files.sanitized_mpn);
     install_component_asset(&selected_symbol, &component_dir, &sym_filename, "Symbol")?;
 
     // Copy backup symbol files (*.orig.kicad_sym)
     for orig_sym in &files.orig_symbols {
-        let orig_filename = format!("{}.orig.kicad_sym", &component_files.sanitized_mpn);
+        let orig_filename = format!("{}.orig.kicad_sym", component_files.sanitized_mpn);
         install_component_asset(orig_sym, &component_dir, &orig_filename, "Backup")?;
     }
 
     // Copy first footprint if available
     let has_footprint = !files.footprints.is_empty();
     if let Some(fp) = files.footprints.first() {
-        let fp_filename = format!("{}.kicad_mod", &component_files.sanitized_mpn);
+        let fp_filename = format!("{}.kicad_mod", component_files.sanitized_mpn);
         install_component_asset(fp, &component_dir, &fp_filename, "Footprint")?;
     }
 
     // Copy first STEP file if available
     if let Some(sp) = files.steps.first() {
-        let step_filename = format!("{}.step", &component_files.sanitized_mpn);
+        let step_filename = format!("{}.step", component_files.sanitized_mpn);
         install_component_asset(sp, &component_dir, &step_filename, "3D Model")?;
     }
 
     // Copy first PDF with standardized name
     let has_datasheet = !files.pdfs.is_empty();
     if let Some(pdf) = files.pdfs.first() {
-        let pdf_filename = format!("{}.pdf", &component_files.sanitized_mpn);
+        let pdf_filename = format!("{}.pdf", component_files.sanitized_mpn);
         copy_file_to_dir(pdf, &component_docs_dir(&component_dir), &pdf_filename)?;
         println!(
             "  {} Datasheet: {} → {}",

--- a/crates/pcb-diode-api/src/release.rs
+++ b/crates/pcb-diode-api/src/release.rs
@@ -240,7 +240,7 @@ fn create_preview(
     let preview_url = if let Some(url) = json["previewUrl"].as_str() {
         url.to_string()
     } else {
-        format!("{}/preview/{}", web_base_url, &preview_id)
+        format!("{}/preview/{}", web_base_url, preview_id)
     };
 
     Ok(PreviewResult {

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -1108,10 +1108,7 @@ def _apply_fragment_routing(
 
     def _dup_and_add(src: Any, net_name: str = "") -> Any:
         """Duplicate item, offset it, set net, and add to board+group."""
-        try:
-            item = src.Duplicate()
-        except TypeError:
-            item = src.Duplicate(False).Cast()
+        item = pcbnew.BOARD_ITEM.Duplicate(src)
         if net_name:
             _set_net(item, net_name)
         kicad_board.Add(item)

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -1108,7 +1108,10 @@ def _apply_fragment_routing(
 
     def _dup_and_add(src: Any, net_name: str = "") -> Any:
         """Duplicate item, offset it, set net, and add to board+group."""
-        item = src.Duplicate(False)
+        try:
+            item = src.Duplicate(False)
+        except TypeError:
+            item = src.Duplicate()
         if net_name:
             _set_net(item, net_name)
         kicad_board.Add(item)

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -1108,7 +1108,7 @@ def _apply_fragment_routing(
 
     def _dup_and_add(src: Any, net_name: str = "") -> Any:
         """Duplicate item, offset it, set net, and add to board+group."""
-        item = src.Duplicate()
+        item = src.Duplicate(False)
         if net_name:
             _set_net(item, net_name)
         kicad_board.Add(item)

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -1109,9 +1109,9 @@ def _apply_fragment_routing(
     def _dup_and_add(src: Any, net_name: str = "") -> Any:
         """Duplicate item, offset it, set net, and add to board+group."""
         try:
-            item = src.Duplicate(False)
-        except TypeError:
             item = src.Duplicate()
+        except TypeError:
+            item = src.Duplicate(False).Cast()
         if net_name:
             _set_net(item, net_name)
         kicad_board.Add(item)

--- a/crates/pcb-sch/src/physical.rs
+++ b/crates/pcb-sch/src/physical.rs
@@ -1226,15 +1226,11 @@ fn parse_range_syntax(
         } else {
             nom_part
         };
-        if let Some(parts) = split_range(range_part.trim()) {
-            (parts.0, parts.1, Some(nom_str))
-        } else {
-            return None;
-        }
-    } else if let Some(parts) = split_range(s) {
-        (parts.0, parts.1, None)
+        let parts = split_range(range_part.trim())?;
+        (parts.0, parts.1, Some(nom_str))
     } else {
-        return None;
+        let parts = split_range(s)?;
+        (parts.0, parts.1, None)
     };
 
     // Parse left and right values

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -2051,7 +2051,6 @@ fn legacy_pcb_binary_name() -> &'static str {
 fn target_triple() -> &'static str {
     match (std::env::consts::OS, std::env::consts::ARCH) {
         ("macos", "aarch64") => "aarch64-apple-darwin",
-        ("macos", "x86_64") => "x86_64-apple-darwin",
         ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
         ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
         ("windows", "x86_64") => "x86_64-pc-windows-msvc",
@@ -2065,7 +2064,6 @@ fn download_target_triples() -> &'static [&'static str] {
         ("linux", "aarch64") => &["aarch64-unknown-linux-musl", "aarch64-unknown-linux-gnu"],
         ("linux", "x86_64") => &["x86_64-unknown-linux-musl", "x86_64-unknown-linux-gnu"],
         ("macos", "aarch64") => &["aarch64-apple-darwin"],
-        ("macos", "x86_64") => &["x86_64-apple-darwin"],
         ("windows", "x86_64") => &["x86_64-pc-windows-msvc"],
         _ => &["unsupported"],
     }

--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,6 @@ platform="$(uname -s)-$(uname -m)"
 download_targets=""
 case "$platform" in
   Darwin-arm64) target="aarch64-apple-darwin"; download_targets="$target"; data_dir="$HOME/Library/Application Support/pcb" ;;
-  Darwin-x86_64) target="x86_64-apple-darwin"; download_targets="$target"; data_dir="$HOME/Library/Application Support/pcb" ;;
   Linux-aarch64|Linux-arm64) target="aarch64-unknown-linux-gnu"; download_targets="aarch64-unknown-linux-musl $target"; data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/pcb" ;;
   Linux-x86_64) target="x86_64-unknown-linux-gnu"; download_targets="x86_64-unknown-linux-musl $target"; data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/pcb" ;;
   *) echo "unsupported platform: $platform" >&2; exit 1 ;;


### PR DESCRIPTION
## Summary
- drop Intel macOS release and nightly artifacts
- migrate Linux, ARM Linux, macOS, and Windows CI jobs to Blacksmith runners
- preserve existing runner CPU tiers where possible
- keep npm publishing on GitHub-hosted `ubuntu-latest` for trusted publishing/OIDC

## Validation
- parsed all workflow files as YAML
- verified no stale Ubicloud, custom Windows, or Intel macOS CI runner labels remain
- ran `git diff --check`

## Notes
The current release workflows are hand-maintained. The old cargo-dist configuration and generated release workflow were removed when pcb shim and pcbc releases were split, so there was no generated cargo-dist source to update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dropping Intel Mac binaries and changing all CI runners can break installs on x86_64 Macs and delay or fail pipelines until Blacksmith runners are stable; release artifact coverage is reduced.
> 
> **Overview**
> Moves GitHub Actions jobs from Ubicloud, GitHub-hosted macOS, and custom Windows runners to **Blacksmith** labels (Ubuntu, ARM Ubuntu, macOS 15, Windows 2025), and pins non-Windows Rust setup to **`toolchain: stable`** in shared build setup and workflows.
> 
> **Release and nightly** matrices no longer build **`x86_64-apple-darwin`**; macOS artifacts are **Apple silicon only**. **`install.sh`** and **`pcb` shim** download/target logic drop Intel Mac triples, and **CHANGELOG** documents that macOS requires Apple silicon.
> 
> **E2E, test, and WASM** bump **`KICAD_VERSION`** and container images to **10.0.5**. Minor code cleanups: redundant `&` on formatted strings in component paths, **`pcbnew.BOARD_ITEM.Duplicate`** in the lens KiCad adapter, and a small refactor in physical range parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0293b9f8ba7c9fdbfeaff556392fd18453a525a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->