### PR TITLE
ENG-350: Remove repository metadata from Git credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Git authentication now leaves repository authorization to DiodeHub.
+
 ### Fixed
 
 - Corrected house TVS ratings and clamping-voltage range matching.

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -4,7 +4,6 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use uuid::Uuid;
 
 use crate::WorkspaceContext;
 
@@ -36,7 +35,6 @@ struct GitCredentialExchangeRequest<'a> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GitCredentialExchangeResponse {
-    repository_id: String,
     #[serde(rename = "provider")]
     _provider: GitProvider,
     credential: GitCredential,
@@ -162,14 +160,11 @@ fn exchange_credential(
         .json()
         .context("Failed to parse Git credential exchange response")?;
     let GitCredentialExchangeResponse {
-        repository_id,
         _provider: _,
         credential,
         expires_at,
     } = response;
     let GitCredential { _scheme: _, token } = credential;
-    Uuid::parse_str(&repository_id)
-        .context("Git credential exchange returned an invalid repository ID")?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("System clock is before the Unix epoch")?

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -219,7 +219,6 @@ fn mock_exchange<'a>(server: &'a MockServer, status: u16) -> Mock<'a> {
             }));
         if status == 200 {
             then.status(200).json_body(json!({
-                "repositoryId": "617882ea-14f6-40b4-bf52-cc1d3c7f67d4",
                 "provider": "diodehub",
                 "credential": {
                     "scheme": "Bearer",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small auth client/API contract change with no new credential logic; behavior shifts from local repo-ID validation to trusting DiodeHub for access control.
> 
> **Overview**
> Aligns the PCB Git credential helper with an API that no longer returns **repository metadata** on `/api/git/credentials`.
> 
> The client drops `repositoryId` from the exchange response model and removes **UUID parsing/validation** that previously ran after a successful exchange. Credential minting still uses host, path, Bearer token, and expiry checks only. Integration tests and **CHANGELOG** are updated to match: Git auth now leaves **repository authorization to DiodeHub**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1cdb32b414c151c029e07baadd6902555b69ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->