### PR TITLE
Speed up build performance CI

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Build head pcbc
         run: |
+          cargo clean --release --workspace \
+            --target-dir "$GITHUB_WORKSPACE/target"
           cargo build --release -p pcbc \
             --target-dir "$GITHUB_WORKSPACE/target"
           mkdir -p "$HEAD_TOOLCHAIN/lib"

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build_perf:
     name: pcb build performance
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
@@ -49,39 +49,53 @@ jobs:
           wget -q https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine_1.20.0_amd64.deb
           sudo dpkg -i hyperfine_1.20.0_amd64.deb
 
+      - name: Prepare benchmark revisions
+        run: |
+          merge_base="$(git merge-base HEAD "${{ github.event.pull_request.base.sha }}")"
+          echo "BASE_DIR=$RUNNER_TEMP/pcb-base" >> "$GITHUB_ENV"
+          echo "BASE_TOOLCHAIN=$RUNNER_TEMP/pcb-base-toolchain" >> "$GITHUB_ENV"
+          echo "BASE_DATA=$RUNNER_TEMP/pcb-base-data" >> "$GITHUB_ENV"
+          echo "HEAD_TOOLCHAIN=$RUNNER_TEMP/pcb-head-toolchain" >> "$GITHUB_ENV"
+          echo "HEAD_DATA=$RUNNER_TEMP/pcb-head-data" >> "$GITHUB_ENV"
+          git worktree add --detach "$RUNNER_TEMP/pcb-base" "$merge_base"
+
+      - name: Build base pcbc
+        run: |
+          cargo build --release -p pcbc \
+            --manifest-path "$BASE_DIR/Cargo.toml" \
+            --target-dir "$GITHUB_WORKSPACE/target"
+          mkdir -p "$BASE_TOOLCHAIN/lib"
+          install -m 755 target/release/pcbc "$BASE_TOOLCHAIN/pcbc"
+          cp -R "$BASE_DIR/lib/std" "$BASE_TOOLCHAIN/lib/std"
+
+      - name: Build head pcbc
+        run: |
+          cargo build --release -p pcbc \
+            --target-dir "$GITHUB_WORKSPACE/target"
+          mkdir -p "$HEAD_TOOLCHAIN/lib"
+          install -m 755 target/release/pcbc "$HEAD_TOOLCHAIN/pcbc"
+          cp -R lib/std "$HEAD_TOOLCHAIN/lib/std"
+
       - name: Run performance benchmarks
         run: |
           mkdir -p perf
-          merge_base="$(git merge-base HEAD "${{ github.event.pull_request.base.sha }}")"
-          base_dir="$RUNNER_TEMP/pcb-base"
-          base_bin="$RUNNER_TEMP/pcb-base-bin"
-          base_data="$RUNNER_TEMP/pcb-base-data"
-          base_shim="$base_bin/pcb"
-          head_bin="$RUNNER_TEMP/pcb-head-bin"
-          head_data="$RUNNER_TEMP/pcb-head-data"
-          head_shim="$head_bin/pcb"
           workspaces="Demeter DM0001 DM0002 DM0003 Feign Renfield Seward Nano unoQ"
 
           bench() {
             suffix="$1"
-            shim="$2"
+            pcbc="$2"
             data_home="$3"
             for workspace in $workspaces; do
               XDG_DATA_HOME="$data_home" python3 bin/pcb-build-perf \
-                --pcb "$shim" \
-                --pcb-arg +local \
+                --pcbc "$pcbc" \
                 --workspace "workspaces/$workspace" \
                 --suppress bom \
                 --output "perf/$workspace-$suffix.json"
             done
           }
 
-          git worktree add --detach "$base_dir" "$merge_base"
-          XDG_DATA_HOME="$base_data" PCB_INSTALL_DIR="$base_bin" "$base_dir/install.sh" --local
-
-          XDG_DATA_HOME="$head_data" PCB_INSTALL_DIR="$head_bin" ./install.sh --local
-          bench base "$base_shim" "$base_data"
-          bench head "$head_shim" "$head_data"
+          bench base "$BASE_TOOLCHAIN/pcbc" "$BASE_DATA"
+          bench head "$HEAD_TOOLCHAIN/pcbc" "$HEAD_DATA"
 
       - name: Create PR comment body
         id: perf_comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,10 +122,7 @@ jobs:
       - name: Verify KiCad installation (Windows)
         if: matrix.config.name == 'Windows'
         shell: pwsh
-        run: |
-          if (-not (Test-Path "C:\Program Files\KiCad\10.0\bin\kicad-cli.exe")) {
-            throw "KiCad CLI was not restored or installed"
-          }
+        run: '& "C:\Program Files\KiCad\10.0\bin\kicad-cli.exe" version --format about'
 
       - name: Install Rust (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,10 @@ jobs:
       - name: Verify KiCad installation (Windows)
         if: matrix.config.name == 'Windows'
         shell: pwsh
-        run: '& "C:\Program Files\KiCad\10.0\bin\kicad-cli.exe" version --format about'
+        run: |
+          if (-not (Test-Path "C:\Program Files\KiCad\10.0\bin\kicad-cli.exe")) {
+            throw "KiCad CLI was not restored or installed"
+          }
 
       - name: Install Rust (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,10 +119,13 @@ jobs:
           Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $installer
           Start-Process -FilePath $installer -ArgumentList '/S', '/allusers' -Wait
 
-      - name: Verify KiCad (Windows)
+      - name: Verify KiCad installation (Windows)
         if: matrix.config.name == 'Windows'
         shell: pwsh
-        run: '& "C:\Program Files\KiCad\10.0\bin\kicad-cli.exe" --version'
+        run: |
+          if (-not (Test-Path "C:\Program Files\KiCad\10.0\bin\kicad-cli.exe")) {
+            throw "KiCad CLI was not restored or installed"
+          }
 
       - name: Install Rust (Windows)
         if: runner.os == 'Windows'

--- a/bin/pcb-build-perf
+++ b/bin/pcb-build-perf
@@ -95,15 +95,9 @@ def main() -> int:
         help="Path to workspace root (contains pcb.toml).",
     )
     parser.add_argument(
-        "--pcb",
-        default="pcb",
-        help="Path to pcb binary (default: pcb in PATH).",
-    )
-    parser.add_argument(
-        "--pcb-arg",
-        action="append",
-        default=[],
-        help="Extra argument before the pcb subcommand (repeatable).",
+        "--pcbc",
+        default="pcbc",
+        help="Path to pcbc binary (default: pcbc in PATH).",
     )
     parser.add_argument(
         "--output",
@@ -137,14 +131,13 @@ def main() -> int:
     if not os.path.isdir(workspace):
         raise SystemExit(f"Workspace directory not found: {workspace}")
 
-    pcb_path = (
-        os.path.abspath(args.pcb)
-        if not args.pcb.startswith("/") and args.pcb != "pcb"
-        else args.pcb
+    pcbc_path = (
+        os.path.abspath(args.pcbc)
+        if not args.pcbc.startswith("/") and args.pcbc != "pcbc"
+        else args.pcbc
     )
-    pcb_cmd = [pcb_path, *args.pcb_arg]
 
-    info = run_json([*pcb_cmd, "info", "-f", "json", workspace], cwd=None)
+    info = run_json([pcbc_path, "info", "-f", "json", workspace], cwd=None)
     boards = collect_boards(info)
     if not boards:
         raise SystemExit(f"No boards found in workspace: {workspace}")
@@ -163,7 +156,7 @@ def main() -> int:
     board_results = []
     for board in boards:
         zen_path = board["zen_path"]
-        cmd = [*pcb_cmd, "build", *build_flags, zen_path]
+        cmd = [pcbc_path, "build", *build_flags, zen_path]
 
         hf = run_hyperfine(cmd, cwd=workspace, warmup=args.warmup)
 


### PR DESCRIPTION
## Summary

- run the build-performance job on a 32-vCPU Blacksmith runner
- compile base and head `pcbc` binaries in separate steps using a shared cached Cargo target directory
- clean workspace release artifacts before head so local crates rebuild while third-party dependencies remain cached
- benchmark `pcbc` directly instead of building and dispatching through the `pcb` shim
- stop building unrelated toolchain binaries
- cache the installed Windows KiCad tree and skip the installer on cache hits

## Validation

- all PR checks pass
- build-performance CI completes in 2m52s with correct base/head rebuilds, down from 5m44s on PR #966
- Windows CI completes in 3m19s on a KiCad cache hit, down from 4m47s on PR #966
- the 791 MiB KiCad cache restores in 52s and the restored installation passes the Windows test suite
- reproduced Cargo's stale cross-worktree artifact behavior and verified `cargo clean --release --workspace` produces the correct head binary
- parsed the benchmark helper CLI and checked Python syntax
- ran `git diff --check`