### PR TITLE
Split pcb and pcbc Nix packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Split the Nix flake's `pcb` shim and `pcbc` compiler into independent package outputs.
+
 ## [0.4.15] - 2026-07-29
 
 ### Added

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,25 +16,36 @@
         "aarch64-darwin"
       ];
       forAllSystems = lib.genAttrs systems;
-      workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      workspaceCargo = lib.importTOML ./Cargo.toml;
+      pcbCargo = lib.importTOML ./crates/pcb/Cargo.toml;
+      pcbcCargo = lib.importTOML ./crates/pcbc/Cargo.toml;
+      versionFor =
+        cargo:
+        let
+          version = cargo.package.version;
+        in
+        if builtins.isAttrs version && (version.workspace or false) then
+          workspaceCargo.workspace.package.version
+        else
+          version;
       pkgsFor =
         system:
         import nixpkgs {
           inherit system;
-          config.problems.handlers =
-            lib.optionalAttrs (lib.hasSuffix "-darwin" system)
-              {
-                kicad-base.broken = "warn";
-              };
         };
 
-      packageFor =
+      packagesFor =
         system:
         let
           pkgs = pkgsFor system;
           craneLib = crane.mkLib pkgs;
 
-          src = lib.fileset.toSource {
+          cargoSrc = lib.fileset.toSource {
+            root = ./.;
+            fileset = craneLib.fileset.commonCargoSources ./.;
+          };
+
+          pcbcSrc = lib.fileset.toSource {
             root = ./.;
             fileset = lib.fileset.unions [
               (craneLib.fileset.commonCargoSources ./.)
@@ -49,71 +60,89 @@
             ];
           };
 
-          commonArgs = {
+          pcbArgs = {
             pname = "pcb";
-            version = workspaceCargo.workspace.package.version;
-            inherit src;
+            version = versionFor pcbCargo;
+            src = cargoSrc;
             strictDeps = true;
             doCheck = false;
-            cargoExtraArgs = "-p pcb -p pcbc";
+            cargoExtraArgs = "-p pcb";
+          };
 
-            nativeBuildInputs = with pkgs; [
-              makeWrapper
-              pkg-config
+          pcbcArgs = {
+            pname = "pcbc";
+            version = versionFor pcbcCargo;
+            src = pcbcSrc;
+            strictDeps = true;
+            doCheck = false;
+            cargoExtraArgs = "-p pcbc";
+            nativeBuildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+              pkgs.makeWrapper
             ];
-
-            buildInputs = with pkgs; [
-              openssl
-              python312
-              python312Packages.kicad
+            buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+              pkgs.python312
+              pkgs.python312Packages.kicad
             ];
           };
 
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-        in
-        craneLib.buildPackage (
-          commonArgs
-          // {
-            inherit cargoArtifacts;
+          pcbCargoArtifacts = craneLib.buildDepsOnly pcbArgs;
+          pcbcCargoArtifacts = craneLib.buildDepsOnly pcbcArgs;
 
-            postInstall = ''
-              mkdir -p "$out/lib"
-              cp -R ${src}/lib/std "$out/lib/std"
-              chmod -R u+w "$out/lib/std"
-            '';
+          pcb = craneLib.buildPackage (
+            pcbArgs
+            // {
+              cargoArtifacts = pcbCargoArtifacts;
 
-            postFixup = ''
-              for binary in pcb pcbc; do
-                wrapProgram "$out/bin/$binary" \
+              meta = with lib; {
+                description = pcbCargo.package.description;
+                homepage = "https://github.com/diodeinc/pcb";
+                license = licenses.mit;
+                mainProgram = "pcb";
+                platforms = platforms.unix;
+              };
+            }
+          );
+
+          pcbc = craneLib.buildPackage (
+            pcbcArgs
+            // {
+              cargoArtifacts = pcbcCargoArtifacts;
+
+              postInstall = ''
+                mkdir -p "$out/lib"
+                cp -R ${pcbcSrc}/lib/std "$out/lib/std"
+                chmod -R u+w "$out/lib/std"
+              '';
+
+              postFixup = lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+                wrapProgram "$out/bin/pcbc" \
                   --set KICAD_PYTHON_SITE_PACKAGES "${pkgs.python312Packages.kicad}/${pkgs.python312.sitePackages}" \
                   --set KICAD_PYTHON_INTERPRETER "${pkgs.python312}/bin/python"
-              done
-            '';
+              '';
 
-            meta = with lib; {
-              description = "CLI for circuit board design";
-              homepage = "https://github.com/diodeinc/pcb";
-              license = licenses.mit;
-              mainProgram = "pcb";
-              platforms = platforms.unix;
-            };
-          }
-        );
+              meta = with lib; {
+                description = pcbcCargo.package.description;
+                homepage = "https://github.com/diodeinc/pcb";
+                license = licenses.mit;
+                mainProgram = "pcbc";
+                platforms = platforms.unix;
+              };
+            }
+          );
+        in
+        {
+          inherit pcb pcbc;
+        };
     in
     {
       packages = forAllSystems (
         system:
         let
-          pcb = packageFor system;
-          pcbc = pcb // {
-            meta = pcb.meta // {
-              mainProgram = "pcbc";
-            };
-          };
+          packages = packagesFor system;
         in
         {
-          default = pcb;
-          inherit pcb pcbc;
+          default = packages.pcb;
+          inherit (packages) pcb pcbc;
         }
       );
 
@@ -121,9 +150,26 @@
         system:
         let
           pkgs = pkgsFor system;
+          pcb = self.packages.${system}.pcb;
           pcbc = self.packages.${system}.pcbc;
         in
         {
+          pcb-package = pkgs.runCommand "pcb-package" { } ''
+            export HOME="$TMPDIR/home"
+            test -x "${pcb}/bin/pcb"
+            test ! -e "${pcb}/bin/pcbc"
+            "${pcb}/bin/pcb" toolchain show --offline | grep -Fqx "shim: ${pcb.version}"
+            touch "$out"
+          '';
+
+          pcbc-package = pkgs.runCommand "pcbc-package" { } ''
+            test -x "${pcbc}/bin/pcbc"
+            test ! -e "${pcbc}/bin/pcb"
+            test -f "${pcbc}/lib/std/pcb.toml"
+            test "$("${pcbc}/bin/pcbc" --version)" = "pcbc ${pcbc.version}"
+            touch "$out"
+          '';
+
           pcbc-stdlib-installed = pkgs.runCommand "pcbc-stdlib-installed" { } ''
             test -f "${pcbc}/lib/std/pcb.toml"
             touch "$out"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only changes to the Nix flake and lockfile; no application runtime or auth logic is modified.
> 
> **Overview**
> **Splits the Nix flake so `pcb` (shim) and `pcbc` (compiler) are separate build outputs** instead of one Crane build that installed both binaries and aliased `pcbc` via metadata on the same store path.
> 
> The flake now builds each crate with its own `cargoExtraArgs`, dependency artifacts, and package metadata. **`pcb`** uses minimal Cargo sources only; **`pcbc`** adds templates, IPC/layout assets, and `lib/std`, with KiCad/Python wrapping limited to Linux. Versions come from each crate’s `Cargo.toml` via a shared `versionFor` helper (replacing a single workspace TOML read). Darwin-specific `kicad-base.broken` nixpkgs overrides were removed, and **nixpkgs** was bumped in `flake.lock`.
> 
> **New flake checks** assert isolation: `pcb` has no `pcbc` binary and reports the expected shim version offline; `pcbc` has no `pcb`, ships stdlib, and matches `--version`. Changelog documents the packaging change under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3bfd8fb34598e43bab3598ea96aa9bec708df44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->