### PR TITLE
Regularize board array balancing regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Board-array creation now automatically adds best-effort copper balancing that matches each layer's placed-board copper density.
 - IPC-2581 fabrication views and panels now omit non-manufacturing data.
+- Board-array balancing regions now enforce 2 mm minimum copper and gap widths with disk morphology, removing sharp corners, slivers, and narrow void corridors.
 - Split the Nix flake's `pcb` shim and `pcbc` compiler into independent package outputs.
 
 ## [0.4.15] - 2026-07-29

--- a/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
+++ b/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
@@ -74,6 +74,14 @@ Exact segment distance with bounding-box pruning finds graph edges without
 retaining every component dilation in memory. On a detected conflict only, the
 harness constructs the overlapping dilations as debug geometry.
 
+The final optimized union is not a monotone set-valued function of clearance,
+feature radius, gap radius, or obstacle additions. Those changes shrink the
+pre-selection geometry, but can split components or change the maximum-area
+independent set. Equal-area coordinate tie breaks likewise mean rotations and
+reflections preserve the objective value and certificate, not necessarily the
+chosen union. Correctness is defined by the certificate, not by nesting outputs
+from different parameter values.
+
 The independent safety certificate is:
 
 ```text
@@ -408,9 +416,8 @@ Production calls can consume only `safe_region`; tests and diagnostics retain
 the full bundle. The renderer does not recompute intermediate regions.
 
 The reusable library boundary, fail-closed collector, certificate, tests, and
-debug-harness adapter are implemented. Wiring this API into board-array
-creation or a copper-balancing command, and emitting the safe geometry into an
-IPC/manufacturing artifact, are intentionally left out.
+debug-harness adapter are implemented. Automatic board-array creation consumes
+the certified region before balance copper is emitted.
 
 ## Validation plan
 
@@ -432,23 +439,25 @@ Use analytic shapes with known behavior:
 
 For generated valid regions:
 
-- increasing clearance cannot increase `safe`;
-- increasing minimum-feature radius cannot increase `safe`;
-- increasing minimum-gap radius cannot increase `safe`;
-- adding obstacles cannot increase `safe`;
-- rigid translation, rotation, and mirroring commute with the result;
+- increasing construction clearance or adding obstacles cannot enlarge
+  `maximal_safe`;
+- increasing the feature-disk radius cannot enlarge `opened_safe` for a fixed
+  `maximal_safe`;
+- rigid translation commutes with the result;
 - `safe ⊆ panel_keep_in`;
 - `safe ⊆ maximal_safe`;
 - `safe ∩ obstacle_clearance = ∅`;
 - `safe ∩ obstacle_gap_envelope = ∅`;
-- every connected component of `safe` survives erosion by the minimum-feature
-  radius;
-- disk closing by the minimum-gap radius adds no geometric material;
+- `safe \ open(safe, q) = ∅`;
+- radius-`v` dilations of every pair of distinct `safe` components are
+  disjoint;
 - `(safe ⊕ disk(r)) \ P = ∅`;
 - `(safe ⊕ disk(r)) ∩ O = ∅`.
 
-The last two are the acceptance certificate. Retain violation geometry on
-failure; a Boolean alone is not enough to debug a numerical case.
+These required checks form the acceptance certificate. Broader disk-closing
+additions remain diagnostic-only because they also include notches within one
+component. Retain violation geometry on failure; a Boolean alone is not enough
+to debug a numerical case.
 
 ### IPC integration fixtures
 

--- a/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
+++ b/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
@@ -1,7 +1,7 @@
 # Board-array copper-balancing region
 
-Status: implementation proposal plus a development harness. This does not add
-copper or expose a user-facing CLI contract.
+Status: reusable safe-region implementation plus a development harness. This
+does not add copper or expose a user-facing CLI contract.
 
 ## Geometry contract
 
@@ -22,32 +22,78 @@ millimeters:
   same-layer documentation such as arrows and labels.
 - `O = B ∪ M ∪ G`: every obstacle.
 - `r = 0.5 mm`: the nominal required clearance.
+- `q = 1.0 mm`: the minimum-feature radius used to regularize the result.
+- `v = 1.0 mm`: the minimum-gap radius that must fit between safe regions.
 - `e`: a conservative numerical error budget for polygonization and offsets.
 
 The result is:
 
 ```text
 construction_clearance = r + e
-panel_keep_in           = P ⊖ disk(construction_clearance)
+construction_gap       = max(r, v) + e
+panel_clearance_keep_in = P ⊖ disk(construction_clearance)
+panel_keep_in           = P ⊖ disk(construction_gap)
 obstacle_clearance      = O ⊕ disk(construction_clearance)
-safe                    = panel_keep_in \ obstacle_clearance
+obstacle_gap_envelope   = O ⊕ disk(construction_gap)
+maximal_safe            = panel_keep_in \ obstacle_gap_envelope
+regularization_core     = maximal_safe ⊖ disk(q)
+opened_safe             = (regularization_core ⊕ disk(q)) ∩ maximal_safe
+
+H = graph whose vertices are the connected components of opened_safe,
+    with an edge (i, j) exactly when distance(component_i, component_j) < 2v
+
+x*                      = arg max Σ area(component_i) x_i
+                          subject to x_i + x_j ≤ 1 for every edge (i, j) in H
+                          and x_i ∈ {0, 1}
+safe                    = union of component_i for which x*_i = 1
+removed_by_opening      = maximal_safe \ opened_safe
+removed_for_gap         = opened_safe \ safe
 ```
 
-This is deliberately expressed as two offsets and one Boolean difference. It
-does not contain geometric recognition rules for tooling holes, fiducials,
-V-scores, annotations, or individual shapes.
+The last two offsets are a morphological opening by a disk. They round convex
+tips, break necks narrower than the disk diameter, and remove components unable
+to contain the disk without geometric recognition rules or topology heuristics.
+The intersection makes the opening explicitly anti-extensive despite
+polygon-offset approximation: regularization can only remove clearance-safe
+material, never add material outside `maximal_safe`.
+
+The gap envelope is the dual construction. The outside of the panel and the
+obstacle union are treated as one hard forbidden phase: the panel is eroded
+and the obstacles are dilated by the same construction gap. This prevents
+diagonal shortcuts where an obstacle envelope meets a panel edge. For a
+line-like obstacle, the default creates a 2.05 mm corridor instead of the
+1.05 mm corridor produced by clearance alone.
+
+Opening removes copper slivers, but it cannot choose which side of a narrow
+gap should survive. That is a topology choice rather than another local
+offset. The component graph makes the choice explicit and order-independent:
+retain the conflict-free subset with maximum total area. Each connected
+conflict cluster is solved exactly by branch-and-bound; disconnected clusters
+are independent, and equal-area optima use the stable area/bounding-box order.
+Exact segment distance with bounding-box pruning finds graph edges without
+retaining every component dilation in memory. On a detected conflict only, the
+harness constructs the overlapping dilations as debug geometry.
 
 The independent safety certificate is:
 
 ```text
 C = safe ⊕ disk(r)
 
+safe \ maximal_safe = ∅
 C \ P = ∅
 C ∩ O = ∅
+safe \ open(safe, q) = ∅
+for every pair of distinct components i, j:
+    (component_i ⊕ disk(v)) ∩ (component_j ⊕ disk(v)) = ∅
 ```
 
 The certificate uses the nominal 0.5 mm, not the construction clearance. Its
-two violation regions are retained as first-class debug output.
+feature and pairwise-gap checks use the nominal radii. Numerical offset-only
+fragments are removed with an opening by `e`; geometric violations survive
+that filter and are retained as first-class debug output. The broader
+`close(safe, v) \ safe` is also emitted as a non-gating diagnostic: it finds
+concave notches within one component as well as gaps between components, so it
+is deliberately not the minimum-intercomponent-gap contract.
 
 ## Development harness
 
@@ -65,6 +111,8 @@ Useful options:
 
 ```text
 --clearance-mm <mm>                 nominal requirement; default 0.5
+--minimum-feature-radius-mm <mm>    disk-opening radius; default 1.0
+--minimum-gap-radius-mm <mm>        void disk radius; default 1.0
 --numerical-guard-mm <mm>           construction guard; default 0.025
 --check-area-tolerance-mm2 <mm²>    validation threshold; default 0.0001
 --require-a-series-auto             reject manual and minimum-fallback arrays
@@ -101,11 +149,21 @@ Each run overwrites a deterministic artifact set:
 | `20-material-removal.svg` | Fabrication material removal `M` |
 | `30-support-features.svg` | Cross-layer support footprint `G` |
 | `40-raw-obstacles.svg` | Union `O` |
-| `50-panel-keep-in.svg` | Eroded panel |
+| `50-panel-clearance-keep-in.svg` | Panel eroded by the construction clearance |
+| `55-panel-gap-keep-in.svg` | Panel eroded by the construction gap radius |
 | `60-obstacle-clearance.svg` | Dilated obstacles |
-| `70-safe-region.svg` | Final safe region |
-| `80-clearance-certificate.svg` | `safe` dilated by nominal clearance |
-| `90-validation-violations.svg` | Certificate leaks and overlaps |
+| `65-obstacle-gap-envelope.svg` | Obstacles dilated to the minimum-gap radius |
+| `70-maximal-safe-region.svg` | Maximal clearance-safe set before regularization |
+| `75-regularization-core.svg` | Centers where the minimum-feature disk fits |
+| `78-opened-safe-region.svg` | Result after minimum-feature opening |
+| `80-removed-by-opening.svg` | Material removed by the disk opening |
+| `85-removed-by-gap-separation.svg` | Whole components removed to enforce pairwise gaps |
+| `88-removed-by-regularization.svg` | All material removed by both stages |
+| `90-safe-region.svg` | Final regularized safe region |
+| `100-clearance-certificate.svg` | `safe` dilated by nominal clearance |
+| `105-minimum-gap-violations.svg` | Overlap between nominal dilations of distinct components |
+| `106-void-closing-additions.svg` | Non-gating broad closing diagnostic, including internal notches |
+| `110-validation-violations.svg` | Subset, clearance, feature, and gap violations |
 | `support-layers/*.svg` | Non-empty support footprints by source layer |
 | `regions.json` | Every ring, bounding box, included/excluded count, and check |
 
@@ -177,13 +235,18 @@ Current A-series results all have complete support-path coverage:
 
 | Case | Sheet | Boards | Safe area | Safe fraction | Certificate |
 |---|---|---:|---:|---:|---|
-| Auto Icarus | A7 | 2 | 4951.798 mm² | 63.8% | pass |
-| MicFlex | A7 | 4 | 5012.865 mm² | 64.6% | pass |
-| Blackstar | A6 | 1 | 9588.610 mm² | 61.7% | pass |
-| ControlHub | A5 | 1 | 15168.215 mm² | 48.8% | pass |
+| Auto Icarus | A7 | 2 | 4877.093 mm² | 62.8% | pass |
+| MicFlex | A7 | 4 | 4897.722 mm² | 63.1% | pass |
+| Blackstar | A6 | 1 | 9538.244 mm² | 61.4% | pass |
+| ControlHub | A5 | 1 | 15111.933 mm² | 48.6% | pass |
 
-These values are useful as investigation baselines, not long-lived golden
-numbers until the offset backend and error budget are finalized.
+Across the 20-array auto-panelizer corpus, both regularization stages retained
+90.18% to 99.88% of the maximal safe area and discarded 276 gap-conflicting
+components. Every final component passed a second independent 1.0 mm erosion;
+the smallest component was 60.441 mm² and the smallest component bounding-box
+span was 6.284 mm. Every subset, nominal-clearance, minimum-feature, and
+pairwise-gap certificate passed. These values are useful as investigation
+baselines, not long-lived golden numbers.
 
 ## Fast iteration loop
 
@@ -194,8 +257,17 @@ numbers until the offset backend and error budget are finalized.
    cargo test -p pcb-ir geom::region
    ```
 
-3. Regenerate auto Icarus A7, MicFlex A7, Blackstar A6, and ControlHub A5 into
-   the same output directories. Always pass `--require-a-series-auto`.
+3. Build the harness once in release mode, then regenerate auto Icarus A7,
+   MicFlex A7, Blackstar A6, and ControlHub A5 into the same output
+   directories. Always pass `--require-a-series-auto` and put a bounded timeout
+   around each corpus case:
+
+   ```bash
+   cargo build --release -p pcb-ipc2581-tools \
+     --example board_array_balancing_region
+   gtimeout 20s target/release/examples/board_array_balancing_region \
+     path/to/array.xml --output path/to/report --require-a-series-auto
+   ```
 4. Check the command summary for:
 
    - complete painted-path coverage;
@@ -211,8 +283,10 @@ numbers until the offset backend and error budget are finalized.
      on the rails;
    - V-cut support contains physical score lines but no callout arrows or text;
    - obstacle clearance is round and continuous at corners;
+   - the minimum-gap envelope creates visibly usable void corridors;
    - the green safe region is confined to true non-board support material;
-   - violation layers are empty.
+   - pink discarded components explain every minimum-gap topology choice;
+   - minimum-feature and minimum-gap violation layers are empty.
 
 6. Compare `regions.json` before and after. Area, ring count, vertex count, and
    per-layer contributions usually locate an unintended change faster than an
@@ -233,17 +307,20 @@ The generic operations belong in `pcb-ir`, independent of IPC:
 
 - construct a footprint from painted paths;
 - union, intersection, and difference of `ContourSet`s;
-- disk dilation and erosion;
+- disk dilation, erosion, opening, and closing;
 - compute and retain certificate violation regions.
 
 `ContourSet` provides `from_painted_paths` and
-`ContourSet::disk_erode`. Dilation and erosion use `i_overlay`'s
-topology-aware outline offset over canonical rings. Its sign-aware builders
-offset outer contours and holes in opposite directions, after which the result
-is regularized through the existing Boolean kernel. Round-join segmentation is
-derived from `STROKE_OUTLINE_MM`, giving the arc approximation an explicit
-sagitta bound. Union is an actual `OverlayRule::Union`, so overlap cannot
-cancel filled material through winding arithmetic.
+`ContourSet::disk_open` and `ContourSet::disk_close`. Dilation and erosion use
+`i_overlay`'s topology-aware outline offset over canonical rings. Its
+sign-aware builders offset outer contours and holes in opposite directions,
+after which the result is regularized through the existing Boolean kernel.
+Round-join segmentation is derived from `STROKE_OUTLINE_MM`, giving the arc
+approximation an explicit sagitta bound. Union is an actual
+`OverlayRule::Union`, so overlap cannot cancel filled material through winding
+arithmetic. Opening clips its dilation back to the source and closing unions
+its erosion with the source, preserving their subset and superset guarantees
+at polygon tolerance.
 
 The construction guard and nominal-clearance certificate remain separate.
 That makes approximation error conservative and testable: construct with
@@ -267,6 +344,8 @@ pub struct BoardArrayBalancingInput {
 
 pub struct BalancingRegionOptions {
     pub clearance_mm: f64,
+    pub minimum_feature_radius_mm: f64,
+    pub minimum_gap_radius_mm: f64,
     pub numerical_guard_mm: f64,
 }
 
@@ -314,12 +393,15 @@ browser viewers, Clap, or the source IPC parser.
 
 The versioned internal debug schema retains:
 
-- nominal clearance, error budget, and construction clearance;
+- nominal clearance, feature radius, gap radius, error budget, and both
+  construction radii;
 - source-layer feature/path counts and unsupported-path diagnostics;
 - all four semantic inputs;
-- both offset results;
+- the clearance and minimum-gap obstacle envelopes;
+- maximal safe region, opening core, and material removed by regularization;
 - final safe region;
-- certificate footprint and violation regions;
+- certificate footprint plus clearance, minimum-feature, and minimum-gap
+  violation regions;
 - geometry-kernel tolerance/scale metadata.
 
 Production calls can consume only `safe_region`; tests and diagnostics retain
@@ -351,10 +433,17 @@ Use analytic shapes with known behavior:
 For generated valid regions:
 
 - increasing clearance cannot increase `safe`;
+- increasing minimum-feature radius cannot increase `safe`;
+- increasing minimum-gap radius cannot increase `safe`;
 - adding obstacles cannot increase `safe`;
 - rigid translation, rotation, and mirroring commute with the result;
 - `safe ⊆ panel_keep_in`;
+- `safe ⊆ maximal_safe`;
 - `safe ∩ obstacle_clearance = ∅`;
+- `safe ∩ obstacle_gap_envelope = ∅`;
+- every connected component of `safe` survives erosion by the minimum-feature
+  radius;
+- disk closing by the minimum-gap radius adds no geometric material;
 - `(safe ⊕ disk(r)) \ P = ∅`;
 - `(safe ⊕ disk(r)) ∩ O = ∅`.
 
@@ -394,6 +483,8 @@ The safe-region implementation is ready for a copper-balancing consumer when:
 - the fixed-grid/offset error budget is explicit and tested;
 - the nominal 0.5 mm certificate passes on the A7, A6, and A5 auto-panel
   baselines, all compact fixtures, and the wider survey topology suite;
+- the 2 mm minimum-feature and minimum-gap certificates pass on the same
+  corpus;
 - auto Icarus, MicFlex, Blackstar, ControlHub, complex, nested, and
   empty-region visual reviews are clean;
 - the result is deterministic and fast enough to regenerate during ordinary

--- a/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
+++ b/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
@@ -19,13 +19,14 @@ use pcb_ir::dialects::ipc::{
     BalancingRegionOptions, BoardArrayBalancingCollection, BoardArrayBalancingInput,
     BoardArrayBalancingResult, BoardArraySupportDocument, BoardArraySupportLayerGeometry,
     BoardArraySupportLayerPolicy, DEFAULT_BALANCING_CLEARANCE_MM,
+    DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM, DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM,
     DEFAULT_BALANCING_NUMERICAL_GUARD_MM, View, board_array_balancing_region,
     inspect_board_array_balancing_input, root_panel_step,
 };
 use pcb_ir::geom::{BBox, ContourSet};
 use serde::Serialize;
 
-const SCHEMA: &str = "pcb-ir.board-array-balancing-debug.v1";
+const SCHEMA: &str = "pcb-ir.board-array-balancing-debug.v3";
 const DEFAULT_CHECK_AREA_TOLERANCE_MM2: f64 = 1e-4;
 const SVG_PADDING_MM: f64 = 2.0;
 const SVG_STROKE_MM: f64 = 0.12;
@@ -47,6 +48,14 @@ struct Args {
     /// Required Euclidean clearance from the panel boundary and every obstacle.
     #[arg(long, default_value_t = DEFAULT_BALANCING_CLEARANCE_MM)]
     clearance_mm: f64,
+
+    /// Radius used to round tips and remove safe regions too small to contain the disk.
+    #[arg(long, default_value_t = DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM)]
+    minimum_feature_radius_mm: f64,
+
+    /// Radius that must fit in every gap between balancing regions.
+    #[arg(long, default_value_t = DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM)]
+    minimum_gap_radius_mm: f64,
 
     /// Extra construction clearance reserved for polygonization/offset error.
     #[arg(long, default_value_t = DEFAULT_BALANCING_NUMERICAL_GUARD_MM)]
@@ -89,12 +98,26 @@ struct Regions {
     material_removal: ContourSet,
     support_features: ContourSet,
     raw_obstacles: ContourSet,
+    panel_clearance_keep_in: ContourSet,
     panel_keep_in: ContourSet,
     obstacle_clearance: ContourSet,
+    obstacle_gap_envelope: ContourSet,
+    maximal_safe_region: ContourSet,
+    regularization_core: ContourSet,
+    opened_safe_region: ContourSet,
+    removed_by_opening: ContourSet,
+    removed_by_gap_separation: ContourSet,
+    removed_by_regularization: ContourSet,
     safe_region: ContourSet,
+    undersized_final_components: ContourSet,
     clearance_certificate: ContourSet,
+    safe_outside_maximal_region: ContourSet,
     safe_outside_keep_in: ContourSet,
     safe_inside_obstacle_clearance: ContourSet,
+    safe_inside_obstacle_gap_envelope: ContourSet,
+    minimum_feature_violations: ContourSet,
+    minimum_gap_violations: ContourSet,
+    void_closing_additions: ContourSet,
     certificate_outside_panel: ContourSet,
     certificate_obstacle_overlap: ContourSet,
 }
@@ -106,12 +129,16 @@ struct DebugArtifact {
     passed: bool,
     input: String,
     nominal_clearance_mm: f64,
+    minimum_feature_radius_mm: f64,
+    minimum_gap_radius_mm: f64,
     numerical_guard_mm: f64,
     construction_clearance_mm: f64,
+    construction_gap_radius_mm: f64,
     check_area_tolerance_mm2: f64,
     panelization: PanelizationJson,
     counts: CountsJson,
     coverage: CoverageJson,
+    regularization: RegularizationJson,
     checks: ChecksJson,
     support_layers: Vec<SupportLayerJson>,
     regions: RegionsJson,
@@ -170,10 +197,34 @@ struct CoverageJson {
 #[serde(rename_all = "camelCase")]
 struct ChecksJson {
     passed: bool,
+    safe_outside_maximal_region_area_mm2: f64,
     safe_outside_keep_in_area_mm2: f64,
     safe_inside_obstacle_clearance_area_mm2: f64,
+    safe_inside_obstacle_gap_envelope_area_mm2: f64,
+    minimum_feature_violation_area_mm2: f64,
+    minimum_gap_violation_area_mm2: f64,
+    void_closing_addition_area_mm2: f64,
     certificate_outside_panel_area_mm2: f64,
     certificate_obstacle_overlap_area_mm2: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RegularizationJson {
+    maximal_safe_area_mm2: f64,
+    final_safe_area_mm2: f64,
+    removed_area_mm2: f64,
+    removed_by_opening_area_mm2: f64,
+    removed_by_gap_separation_area_mm2: f64,
+    retained_fraction: f64,
+    maximal_component_count: usize,
+    core_component_count: usize,
+    opened_component_count: usize,
+    final_component_count: usize,
+    discarded_for_gap_component_count: usize,
+    smallest_final_component_area_mm2: Option<f64>,
+    minimum_final_component_bbox_span_mm: Option<f64>,
+    undersized_final_component_count: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -198,12 +249,26 @@ struct RegionsJson {
     material_removal: RegionJson,
     support_features: RegionJson,
     raw_obstacles: RegionJson,
+    panel_clearance_keep_in: RegionJson,
     panel_keep_in: RegionJson,
     obstacle_clearance: RegionJson,
+    obstacle_gap_envelope: RegionJson,
+    maximal_safe_region: RegionJson,
+    regularization_core: RegionJson,
+    opened_safe_region: RegionJson,
+    removed_by_opening: RegionJson,
+    removed_by_gap_separation: RegionJson,
+    removed_by_regularization: RegionJson,
     safe_region: RegionJson,
+    undersized_final_components: RegionJson,
     clearance_certificate: RegionJson,
+    safe_outside_maximal_region: RegionJson,
     safe_outside_keep_in: RegionJson,
     safe_inside_obstacle_clearance: RegionJson,
+    safe_inside_obstacle_gap_envelope: RegionJson,
+    minimum_feature_violations: RegionJson,
+    minimum_gap_violations: RegionJson,
+    void_closing_additions: RegionJson,
     certificate_outside_panel: RegionJson,
     certificate_obstacle_overlap: RegionJson,
 }
@@ -240,10 +305,24 @@ impl From<&ContourSet> for RegionJson {
     }
 }
 
+fn component_areas(region: &ContourSet) -> Vec<f64> {
+    region
+        .connected_components()
+        .into_iter()
+        .map(|component| component.area())
+        .collect()
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
     if !args.clearance_mm.is_finite() || args.clearance_mm <= 0.0 {
         bail!("--clearance-mm must be a finite positive number");
+    }
+    if !args.minimum_feature_radius_mm.is_finite() || args.minimum_feature_radius_mm <= 0.0 {
+        bail!("--minimum-feature-radius-mm must be a finite positive number");
+    }
+    if !args.minimum_gap_radius_mm.is_finite() || args.minimum_gap_radius_mm <= 0.0 {
+        bail!("--minimum-gap-radius-mm must be a finite positive number");
     }
     if !args.numerical_guard_mm.is_finite() || args.numerical_guard_mm < 0.0 {
         bail!("--numerical-guard-mm must be a finite non-negative number");
@@ -290,11 +369,15 @@ fn main() -> Result<()> {
         &collection.input,
         BalancingRegionOptions {
             clearance_mm: args.clearance_mm,
+            minimum_feature_radius_mm: args.minimum_feature_radius_mm,
+            minimum_gap_radius_mm: args.minimum_gap_radius_mm,
             numerical_guard_mm: args.numerical_guard_mm,
         },
     )
     .context("failed to compute board-array balancing region")?;
     let construction_clearance_mm = args.clearance_mm + args.numerical_guard_mm;
+    let construction_gap_radius_mm =
+        args.clearance_mm.max(args.minimum_gap_radius_mm) + args.numerical_guard_mm;
     let certificate_passed = result.certificate.passes(args.check_area_tolerance_mm2);
     let BoardArrayBalancingCollection {
         input:
@@ -317,42 +400,119 @@ fn main() -> Result<()> {
         intermediates,
         certificate,
     } = result;
+    let final_components = safe_region.connected_components();
+    let undersized_final_components = final_components
+        .iter()
+        .filter(|component| {
+            component
+                .disk_erode(args.minimum_feature_radius_mm)
+                .is_empty()
+        })
+        .cloned()
+        .fold(
+            ContourSet::empty(safe_region.tolerance),
+            |undersized, component| undersized.union(&component),
+        );
     let regions = Regions {
         panel_outer,
         board_footprints,
         material_removal,
         support_features,
         raw_obstacles: intermediates.raw_obstacles,
+        panel_clearance_keep_in: intermediates.panel_clearance_keep_in,
         panel_keep_in: intermediates.panel_keep_in,
         obstacle_clearance: intermediates.obstacle_clearance,
+        obstacle_gap_envelope: intermediates.obstacle_gap_envelope,
+        maximal_safe_region: intermediates.maximal_safe_region,
+        regularization_core: intermediates.regularization_core,
+        opened_safe_region: intermediates.opened_safe_region,
+        removed_by_opening: intermediates.removed_by_opening,
+        removed_by_gap_separation: intermediates.removed_by_gap_separation,
+        removed_by_regularization: intermediates.removed_by_regularization,
         safe_region,
+        undersized_final_components,
         clearance_certificate: certificate.swept_safe_region,
+        safe_outside_maximal_region: certificate.safe_outside_maximal_region,
         safe_outside_keep_in: certificate.safe_outside_keep_in,
         safe_inside_obstacle_clearance: certificate.safe_inside_obstacle_clearance,
+        safe_inside_obstacle_gap_envelope: certificate.safe_inside_obstacle_gap_envelope,
+        minimum_feature_violations: certificate.minimum_feature_violations,
+        minimum_gap_violations: certificate.minimum_gap_violations,
+        void_closing_additions: certificate.void_closing_additions,
         certificate_outside_panel: certificate.outside_panel,
         certificate_obstacle_overlap: certificate.obstacle_overlap,
     };
 
     let checks = ChecksJson {
         passed: certificate_passed,
+        safe_outside_maximal_region_area_mm2: regions.safe_outside_maximal_region.area(),
         safe_outside_keep_in_area_mm2: regions.safe_outside_keep_in.area(),
         safe_inside_obstacle_clearance_area_mm2: regions.safe_inside_obstacle_clearance.area(),
+        safe_inside_obstacle_gap_envelope_area_mm2: regions
+            .safe_inside_obstacle_gap_envelope
+            .area(),
+        minimum_feature_violation_area_mm2: regions.minimum_feature_violations.area(),
+        minimum_gap_violation_area_mm2: regions.minimum_gap_violations.area(),
+        void_closing_addition_area_mm2: regions.void_closing_additions.area(),
         certificate_outside_panel_area_mm2: regions.certificate_outside_panel.area(),
         certificate_obstacle_overlap_area_mm2: regions.certificate_obstacle_overlap.area(),
+    };
+    let maximal_component_areas = component_areas(&regions.maximal_safe_region);
+    let core_component_areas = component_areas(&regions.regularization_core);
+    let opened_component_areas = component_areas(&regions.opened_safe_region);
+    let final_component_areas = final_components
+        .iter()
+        .map(ContourSet::area)
+        .collect::<Vec<_>>();
+    let minimum_final_component_bbox_span_mm = final_components
+        .iter()
+        .map(|component| component.bbox.width().min(component.bbox.height()))
+        .reduce(f64::min);
+    let maximal_safe_area_mm2 = regions.maximal_safe_region.area();
+    let final_safe_area_mm2 = regions.safe_region.area();
+    let regularization = RegularizationJson {
+        maximal_safe_area_mm2,
+        final_safe_area_mm2,
+        removed_area_mm2: regions.removed_by_regularization.area(),
+        removed_by_opening_area_mm2: regions.removed_by_opening.area(),
+        removed_by_gap_separation_area_mm2: regions.removed_by_gap_separation.area(),
+        retained_fraction: if maximal_safe_area_mm2 > 0.0 {
+            final_safe_area_mm2 / maximal_safe_area_mm2
+        } else {
+            1.0
+        },
+        maximal_component_count: maximal_component_areas.len(),
+        core_component_count: core_component_areas.len(),
+        opened_component_count: opened_component_areas.len(),
+        final_component_count: final_component_areas.len(),
+        discarded_for_gap_component_count: opened_component_areas
+            .len()
+            .saturating_sub(final_component_areas.len()),
+        smallest_final_component_area_mm2: final_component_areas.into_iter().reduce(f64::min),
+        minimum_final_component_bbox_span_mm,
+        undersized_final_component_count: regions
+            .undersized_final_components
+            .connected_components()
+            .len(),
     };
 
     let unpainted_support_paths = support_layers
         .iter()
         .map(|layer| layer.unpainted_path_count)
         .sum::<usize>();
-    let passed = checks.passed && unpainted_support_paths == 0;
+    let passed = checks.passed
+        && unpainted_support_paths == 0
+        && regularization.undersized_final_component_count == 0;
     let artifact = DebugArtifact {
         schema: SCHEMA,
         passed,
         input: input.display().to_string(),
         nominal_clearance_mm: args.clearance_mm,
+        minimum_feature_radius_mm: args.minimum_feature_radius_mm,
+        minimum_gap_radius_mm: args.minimum_gap_radius_mm,
         numerical_guard_mm: args.numerical_guard_mm,
         construction_clearance_mm,
+        construction_gap_radius_mm,
         check_area_tolerance_mm2: args.check_area_tolerance_mm2,
         panelization,
         counts: CountsJson {
@@ -380,6 +540,7 @@ fn main() -> Result<()> {
             unpainted_support_paths,
             note: "Every painted ArraySupport path is treated as an obstacle except same-layer V-cut documentation. V-cut inclusion is limited to features referencing a V_Cut process specification, which keeps physical score lines and excludes callout arrows and labels. Unpainted included paths have no defined physical envelope and are reported as incomplete coverage.",
         },
+        regularization,
         checks,
         support_layers: support_layers
             .iter()
@@ -401,28 +562,36 @@ fn main() -> Result<()> {
             material_removal: RegionJson::from(&regions.material_removal),
             support_features: RegionJson::from(&regions.support_features),
             raw_obstacles: RegionJson::from(&regions.raw_obstacles),
+            panel_clearance_keep_in: RegionJson::from(&regions.panel_clearance_keep_in),
             panel_keep_in: RegionJson::from(&regions.panel_keep_in),
             obstacle_clearance: RegionJson::from(&regions.obstacle_clearance),
+            obstacle_gap_envelope: RegionJson::from(&regions.obstacle_gap_envelope),
+            maximal_safe_region: RegionJson::from(&regions.maximal_safe_region),
+            regularization_core: RegionJson::from(&regions.regularization_core),
+            opened_safe_region: RegionJson::from(&regions.opened_safe_region),
+            removed_by_opening: RegionJson::from(&regions.removed_by_opening),
+            removed_by_gap_separation: RegionJson::from(&regions.removed_by_gap_separation),
+            removed_by_regularization: RegionJson::from(&regions.removed_by_regularization),
             safe_region: RegionJson::from(&regions.safe_region),
+            undersized_final_components: RegionJson::from(&regions.undersized_final_components),
             clearance_certificate: RegionJson::from(&regions.clearance_certificate),
+            safe_outside_maximal_region: RegionJson::from(&regions.safe_outside_maximal_region),
             safe_outside_keep_in: RegionJson::from(&regions.safe_outside_keep_in),
             safe_inside_obstacle_clearance: RegionJson::from(
                 &regions.safe_inside_obstacle_clearance,
             ),
+            safe_inside_obstacle_gap_envelope: RegionJson::from(
+                &regions.safe_inside_obstacle_gap_envelope,
+            ),
+            minimum_feature_violations: RegionJson::from(&regions.minimum_feature_violations),
+            minimum_gap_violations: RegionJson::from(&regions.minimum_gap_violations),
+            void_closing_additions: RegionJson::from(&regions.void_closing_additions),
             certificate_outside_panel: RegionJson::from(&regions.certificate_outside_panel),
             certificate_obstacle_overlap: RegionJson::from(&regions.certificate_obstacle_overlap),
         },
     };
 
-    write_artifacts(
-        &args.output,
-        &input,
-        args.clearance_mm,
-        args.numerical_guard_mm,
-        &regions,
-        &support_layers,
-        &artifact,
-    )?;
+    write_artifacts(&args.output, &input, &regions, &support_layers, &artifact)?;
 
     println!("wrote {}", args.output.join("index.html").display());
     println!(
@@ -430,6 +599,18 @@ fn main() -> Result<()> {
         regions.safe_region.area(),
         100.0 * regions.safe_region.area() / regions.panel_outer.area(),
         regions.panel_outer.area()
+    );
+    println!(
+        "regularization: {:.3} mm radius retained {:.3} / {:.3} mm² ({:.1}%, {} -> {} opened -> {} final components, {} gap-conflicting components discarded, {} undersized)",
+        artifact.minimum_feature_radius_mm,
+        artifact.regularization.final_safe_area_mm2,
+        artifact.regularization.maximal_safe_area_mm2,
+        100.0 * artifact.regularization.retained_fraction,
+        artifact.regularization.maximal_component_count,
+        artifact.regularization.opened_component_count,
+        artifact.regularization.final_component_count,
+        artifact.regularization.discarded_for_gap_component_count,
+        artifact.regularization.undersized_final_component_count,
     );
     println!(
         "coverage: {} ({} unpainted support paths)",
@@ -441,14 +622,17 @@ fn main() -> Result<()> {
         artifact.coverage.unpainted_support_paths
     );
     println!(
-        "certificate: {} (outside panel {:.6} mm², obstacle overlap {:.6} mm²)",
+        "certificate: {} (outside panel {:.6} mm², obstacle overlap {:.6} mm², feature violations {:.6} mm², inter-component gap violations {:.6} mm²; broader closing diagnostic {:.6} mm²)",
         if artifact.checks.passed {
             "PASS"
         } else {
             "FAIL"
         },
         artifact.checks.certificate_outside_panel_area_mm2,
-        artifact.checks.certificate_obstacle_overlap_area_mm2
+        artifact.checks.certificate_obstacle_overlap_area_mm2,
+        artifact.checks.minimum_feature_violation_area_mm2,
+        artifact.checks.minimum_gap_violation_area_mm2,
+        artifact.checks.void_closing_addition_area_mm2,
     );
 
     if !artifact.passed {
@@ -518,8 +702,6 @@ fn generated_metadata_value(xml: &str, name: &str) -> Option<String> {
 fn write_artifacts(
     output: &Path,
     input: &Path,
-    clearance_mm: f64,
-    numerical_guard_mm: f64,
     regions: &Regions,
     support_layers: &[SupportLayer],
     artifact: &DebugArtifact,
@@ -528,13 +710,15 @@ fn write_artifacts(
         .with_context(|| format!("failed to create output directory {}", output.display()))?;
 
     let title = format!(
-        "{} — {:.3} mm copper-balancing clearance (+{:.3} mm geometry guard)",
+        "{} — {:.3} mm clearance, {:.3} mm feature radius, {:.3} mm gap radius (+{:.3} mm geometry guard)",
         input
             .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or("board array"),
-        clearance_mm,
-        numerical_guard_mm
+        artifact.nominal_clearance_mm,
+        artifact.minimum_feature_radius_mm,
+        artifact.minimum_gap_radius_mm,
+        artifact.numerical_guard_mm
     );
     let overview = render_overview_svg(&title, regions);
     write_file(output.join("overview.svg"), &overview)?;
@@ -576,11 +760,18 @@ fn write_artifacts(
             stroke: "#b91c1c",
         },
         Stage {
-            filename: "50-panel-keep-in.svg",
+            filename: "50-panel-clearance-keep-in.svg",
             title: "50 — panel outer region eroded by construction clearance",
-            region: &regions.panel_keep_in,
+            region: &regions.panel_clearance_keep_in,
             fill: "#67e8f9",
             stroke: "#0e7490",
+        },
+        Stage {
+            filename: "55-panel-gap-keep-in.svg",
+            title: "55 — panel outer region eroded by construction minimum-gap radius",
+            region: &regions.panel_keep_in,
+            fill: "#a5b4fc",
+            stroke: "#4338ca",
         },
         Stage {
             filename: "60-obstacle-clearance.svg",
@@ -590,18 +781,81 @@ fn write_artifacts(
             stroke: "#dc2626",
         },
         Stage {
-            filename: "70-safe-region.svg",
-            title: "70 — final balancing-safe region",
+            filename: "65-obstacle-gap-envelope.svg",
+            title: "65 — raw obstacles dilated by construction minimum-gap radius",
+            region: &regions.obstacle_gap_envelope,
+            fill: "#f9a8d4",
+            stroke: "#be185d",
+        },
+        Stage {
+            filename: "70-maximal-safe-region.svg",
+            title: "70 — maximal clearance-safe region before regularization",
+            region: &regions.maximal_safe_region,
+            fill: "#fde68a",
+            stroke: "#b45309",
+        },
+        Stage {
+            filename: "75-regularization-core.svg",
+            title: "75 — centers where the minimum-feature disk fits",
+            region: &regions.regularization_core,
+            fill: "#67e8f9",
+            stroke: "#0e7490",
+        },
+        Stage {
+            filename: "78-opened-safe-region.svg",
+            title: "78 — minimum-feature disk opening before gap separation",
+            region: &regions.opened_safe_region,
+            fill: "#86efac",
+            stroke: "#16a34a",
+        },
+        Stage {
+            filename: "80-removed-by-opening.svg",
+            title: "80 — sharp, narrow, and small geometry removed by disk opening",
+            region: &regions.removed_by_opening,
+            fill: "#fb923c",
+            stroke: "#c2410c",
+        },
+        Stage {
+            filename: "85-removed-by-gap-separation.svg",
+            title: "85 — components excluded by maximum-area gap selection",
+            region: &regions.removed_by_gap_separation,
+            fill: "#f472b6",
+            stroke: "#be185d",
+        },
+        Stage {
+            filename: "88-removed-by-regularization.svg",
+            title: "88 — all geometry removed by opening and gap separation",
+            region: &regions.removed_by_regularization,
+            fill: "#fb923c",
+            stroke: "#c2410c",
+        },
+        Stage {
+            filename: "90-safe-region.svg",
+            title: "90 — final regularized balancing-safe region",
             region: &regions.safe_region,
             fill: "#4ade80",
             stroke: "#15803d",
         },
         Stage {
-            filename: "80-clearance-certificate.svg",
-            title: "80 — safe region dilated by nominal clearance",
+            filename: "100-clearance-certificate.svg",
+            title: "100 — final safe region dilated by nominal clearance",
             region: &regions.clearance_certificate,
             fill: "#60a5fa",
             stroke: "#1d4ed8",
+        },
+        Stage {
+            filename: "105-minimum-gap-violations.svg",
+            title: "105 — gaps where minimum-gap component dilations overlap",
+            region: &regions.minimum_gap_violations,
+            fill: "#c026d3",
+            stroke: "#701a75",
+        },
+        Stage {
+            filename: "106-void-closing-additions.svg",
+            title: "106 — broader void notches filled by disk closing (diagnostic)",
+            region: &regions.void_closing_additions,
+            fill: "#818cf8",
+            stroke: "#3730a3",
         },
     ];
     for stage in &stages {
@@ -611,12 +865,10 @@ fn write_artifacts(
         )?;
     }
     write_file(
-        output.join("90-validation-violations.svg"),
+        output.join("110-validation-violations.svg"),
         &render_validation_svg(
-            "90 — clearance-certificate violations",
-            &regions.panel_outer,
-            &regions.certificate_outside_panel,
-            &regions.certificate_obstacle_overlap,
+            "110 — regularization and clearance-certificate violations",
+            regions,
         ),
     )?;
 
@@ -695,33 +947,57 @@ fn render_stage_svg(title: &str, panel: &ContourSet, stage: &Stage<'_>) -> Strin
     svg
 }
 
-fn render_validation_svg(
-    title: &str,
-    panel: &ContourSet,
-    outside_panel: &ContourSet,
-    obstacle_overlap: &ContourSet,
-) -> String {
-    let bbox = panel
+fn render_validation_svg(title: &str, regions: &Regions) -> String {
+    let bbox = regions
+        .panel_outer
         .bbox
-        .union(outside_panel.bbox)
-        .union(obstacle_overlap.bbox);
+        .union(regions.safe_outside_maximal_region.bbox)
+        .union(regions.undersized_final_components.bbox)
+        .union(regions.minimum_feature_violations.bbox)
+        .union(regions.minimum_gap_violations.bbox)
+        .union(regions.certificate_outside_panel.bbox)
+        .union(regions.certificate_obstacle_overlap.bbox);
     let mut svg = svg_start(title, bbox);
     write_region(
         &mut svg,
         "panel-context",
-        panel,
+        &regions.panel_outer,
         "fill='#f8fafc' stroke='#475569' fill-opacity='1'",
     );
     write_region(
         &mut svg,
+        "safe-outside-maximal-region",
+        &regions.safe_outside_maximal_region,
+        "fill='#e11d48' stroke='#881337' fill-opacity='0.9'",
+    );
+    write_region(
+        &mut svg,
+        "undersized-final-components",
+        &regions.undersized_final_components,
+        "fill='#db2777' stroke='#831843' fill-opacity='0.9'",
+    );
+    write_region(
+        &mut svg,
+        "minimum-feature-violations",
+        &regions.minimum_feature_violations,
+        "fill='#7c3aed' stroke='#4c1d95' fill-opacity='0.9'",
+    );
+    write_region(
+        &mut svg,
+        "minimum-gap-violations",
+        &regions.minimum_gap_violations,
+        "fill='#c026d3' stroke='#701a75' fill-opacity='0.9'",
+    );
+    write_region(
+        &mut svg,
         "certificate-outside-panel",
-        outside_panel,
+        &regions.certificate_outside_panel,
         "fill='#dc2626' stroke='#7f1d1d' fill-opacity='0.9'",
     );
     write_region(
         &mut svg,
         "certificate-obstacle-overlap",
-        obstacle_overlap,
+        &regions.certificate_obstacle_overlap,
         "fill='#f59e0b' stroke='#92400e' fill-opacity='0.9'",
     );
     svg.push_str("  </g>\n</svg>\n");
@@ -749,9 +1025,57 @@ fn render_overview_svg(title: &str, regions: &Regions) -> String {
     );
     write_region(
         &mut svg,
+        "obstacle-gap-envelope",
+        &regions.obstacle_gap_envelope,
+        "fill='#f9a8d4' stroke='#be185d' fill-opacity='0.42'",
+    );
+    write_region(
+        &mut svg,
+        "panel-clearance-keep-in",
+        &regions.panel_clearance_keep_in,
+        "fill='none' stroke='#0891b2' stroke-dasharray='0.6 0.5'",
+    );
+    write_region(
+        &mut svg,
         "panel-keep-in",
         &regions.panel_keep_in,
-        "fill='none' stroke='#0891b2' stroke-dasharray='0.6 0.5'",
+        "fill='none' stroke='#4338ca' stroke-dasharray='0.6 0.5'",
+    );
+    write_region(
+        &mut svg,
+        "maximal-safe-region",
+        &regions.maximal_safe_region,
+        "fill='#fde68a' stroke='#b45309' fill-opacity='0.24'",
+    );
+    write_region(
+        &mut svg,
+        "regularization-core",
+        &regions.regularization_core,
+        "fill='none' stroke='#0891b2' stroke-dasharray='0.3 0.3' stroke-opacity='0.7'",
+    );
+    write_region(
+        &mut svg,
+        "opened-safe-region",
+        &regions.opened_safe_region,
+        "fill='#86efac' stroke='#16a34a' fill-opacity='0.24'",
+    );
+    write_region(
+        &mut svg,
+        "removed-by-opening",
+        &regions.removed_by_opening,
+        "fill='#fb923c' stroke='#c2410c' fill-opacity='0.82'",
+    );
+    write_region(
+        &mut svg,
+        "removed-by-gap-separation",
+        &regions.removed_by_gap_separation,
+        "fill='#f472b6' stroke='#be185d' fill-opacity='0.88'",
+    );
+    write_region(
+        &mut svg,
+        "removed-by-regularization",
+        &regions.removed_by_regularization,
+        "fill='none' stroke='#c2410c' stroke-opacity='0.72'",
     );
     write_region(
         &mut svg,
@@ -782,6 +1106,36 @@ fn render_overview_svg(title: &str, regions: &Regions) -> String {
         "clearance-certificate",
         &regions.clearance_certificate,
         "fill='none' stroke='#2563eb' stroke-dasharray='0.4 0.4' stroke-opacity='0.72'",
+    );
+    write_region(
+        &mut svg,
+        "undersized-final-components",
+        &regions.undersized_final_components,
+        "fill='#db2777' stroke='#831843' fill-opacity='0.95'",
+    );
+    write_region(
+        &mut svg,
+        "minimum-feature-violations",
+        &regions.minimum_feature_violations,
+        "fill='#7c3aed' stroke='#4c1d95' fill-opacity='0.95'",
+    );
+    write_region(
+        &mut svg,
+        "minimum-gap-violations",
+        &regions.minimum_gap_violations,
+        "fill='#c026d3' stroke='#701a75' fill-opacity='0.95'",
+    );
+    write_region(
+        &mut svg,
+        "void-closing-additions",
+        &regions.void_closing_additions,
+        "fill='#818cf8' stroke='#3730a3' fill-opacity='0.9'",
+    );
+    write_region(
+        &mut svg,
+        "safe-outside-maximal-region",
+        &regions.safe_outside_maximal_region,
+        "fill='#e11d48' stroke='#881337' fill-opacity='0.95'",
     );
     write_region(
         &mut svg,
@@ -890,7 +1244,7 @@ fn render_index_html(
         .unwrap();
     }
     stage_links.push_str(
-        "<li><a href='90-validation-violations.svg'>90 — clearance-certificate violations</a></li>",
+        "<li><a href='110-validation-violations.svg'>110 — regularization and clearance-certificate violations</a></li>",
     );
 
     let mut support_links = String::new();
@@ -947,23 +1301,52 @@ fn render_index_html(
       <fieldset>
         <legend>Geometry</legend>
         <label><input type="checkbox" data-layer="panel-outer"{panel_outer}><span class="swatch" style="background:#e2e8f0"></span>panel outer</label>
-        <label><input type="checkbox" data-layer="panel-keep-in"{panel_keep_in}><span class="swatch" style="background:#22d3ee"></span>eroded keep-in</label>
+        <label><input type="checkbox" data-layer="panel-clearance-keep-in"{panel_clearance_keep_in}><span class="swatch" style="background:#22d3ee"></span>clearance keep-in</label>
+        <label><input type="checkbox" data-layer="panel-keep-in"{panel_keep_in}><span class="swatch" style="background:#a5b4fc"></span>minimum-gap keep-in</label>
         <label><input type="checkbox" data-layer="obstacle-clearance"{obstacle_clearance}><span class="swatch" style="background:#fecaca"></span>obstacle clearance</label>
-        <label><input type="checkbox" data-layer="safe-region"{safe_region}><span class="swatch" style="background:#4ade80"></span>safe region</label>
+        <label><input type="checkbox" data-layer="obstacle-gap-envelope"{obstacle_gap_envelope}><span class="swatch" style="background:#f9a8d4"></span>minimum-gap envelope</label>
+        <label><input type="checkbox" data-layer="maximal-safe-region"{maximal_safe_region}><span class="swatch" style="background:#fde68a"></span>maximal safe region</label>
+        <label><input type="checkbox" data-layer="regularization-core"{regularization_core}><span class="swatch" style="background:#22d3ee"></span>regularization core</label>
+        <label><input type="checkbox" data-layer="opened-safe-region"{opened_safe_region}><span class="swatch" style="background:#86efac"></span>opened region before gap separation</label>
+        <label><input type="checkbox" data-layer="removed-by-opening"{removed_by_opening}><span class="swatch" style="background:#fb923c"></span>discarded by opening</label>
+        <label><input type="checkbox" data-layer="removed-by-gap-separation"{removed_by_gap_separation}><span class="swatch" style="background:#f472b6"></span>discarded for minimum gap</label>
+        <label><input type="checkbox" data-layer="removed-by-regularization"{removed_by_regularization}><span class="swatch" style="background:#c2410c"></span>all discarded geometry</label>
+        <label><input type="checkbox" data-layer="safe-region"{safe_region}><span class="swatch" style="background:#4ade80"></span>regularized safe region</label>
         <label><input type="checkbox" data-layer="board-footprints"{board_footprints}><span class="swatch" style="background:#fb7185"></span>board footprints</label>
         <label><input type="checkbox" data-layer="material-removal"{material_removal}><span class="swatch" style="background:#fb923c"></span>material removal</label>
         <label><input type="checkbox" data-layer="support-features"{support_features}><span class="swatch" style="background:#a78bfa"></span>support features</label>
         <label><input type="checkbox" data-layer="clearance-certificate"{certificate}><span class="swatch" style="background:#60a5fa"></span>clearance certificate</label>
+        <label><input type="checkbox" data-layer="undersized-final-components"{violations}><span class="swatch" style="background:#db2777"></span>undersized-final violation</label>
+        <label><input type="checkbox" data-layer="minimum-feature-violations"{violations}><span class="swatch" style="background:#7c3aed"></span>minimum-feature violation</label>
+        <label><input type="checkbox" data-layer="minimum-gap-violations"{violations}><span class="swatch" style="background:#c026d3"></span>minimum-gap violation</label>
+        <label><input type="checkbox" data-layer="void-closing-additions"{diagnostics}><span class="swatch" style="background:#818cf8"></span>all closing additions (diagnostic)</label>
+        <label><input type="checkbox" data-layer="safe-outside-maximal-region"{violations}><span class="swatch" style="background:#e11d48"></span>outside-maximal violation</label>
         <label><input type="checkbox" data-layer="certificate-outside-panel"{violations}><span class="swatch" style="background:#dc2626"></span>outside-panel violation</label>
         <label><input type="checkbox" data-layer="certificate-obstacle-overlap"{violations}><span class="swatch" style="background:#f59e0b"></span>obstacle-overlap violation</label>
       </fieldset>
       <dl>
         <dt>Panel area</dt><dd>{panel_area:.3} mm²</dd>
         <dt>Obstacle area</dt><dd>{obstacle_area:.3} mm²</dd>
-        <dt>Safe area</dt><dd>{safe_area:.3} mm²</dd>
+        <dt>Maximal safe area</dt><dd>{maximal_safe_area:.3} mm²</dd>
+        <dt>Regularized safe area</dt><dd>{safe_area:.3} mm²</dd>
+        <dt>Removed area</dt><dd>{removed_area:.3} mm²</dd>
+        <dt>Removed by opening</dt><dd>{removed_by_opening_area:.3} mm²</dd>
+        <dt>Removed for gap</dt><dd>{removed_for_gap_area:.3} mm²</dd>
+        <dt>Retained</dt><dd>{retained_fraction:.1}%</dd>
         <dt>Safe fraction</dt><dd>{safe_fraction:.1}%</dd>
         <dt>Nominal clearance</dt><dd>{nominal_clearance:.3} mm</dd>
+        <dt>Minimum-feature radius</dt><dd>{minimum_feature_radius:.3} mm</dd>
+        <dt>Minimum-gap radius</dt><dd>{minimum_gap_radius:.3} mm</dd>
+        <dt>Construction gap radius</dt><dd>{construction_gap_radius:.3} mm</dd>
         <dt>Geometry guard</dt><dd>{geometry_guard:.3} mm</dd>
+        <dt>Feature violation area</dt><dd>{feature_violation_area:.6} mm²</dd>
+        <dt>Gap violation area</dt><dd>{gap_violation_area:.6} mm²</dd>
+        <dt>All closing additions</dt><dd>{void_closing_addition_area:.6} mm²</dd>
+        <dt>Components</dt><dd>{maximal_components} → {opened_components} → {final_components}</dd>
+        <dt>Gap-conflicting discarded</dt><dd>{gap_discarded_components}</dd>
+        <dt>Smallest component</dt><dd>{smallest_component}</dd>
+        <dt>Minimum component span</dt><dd>{minimum_component_span}</dd>
+        <dt>Undersized components</dt><dd>{undersized_components}</dd>
         <dt>Panelizer</dt><dd>{panelizer}</dd>
         <dt>Board instances</dt><dd>{board_instances}</dd>
         <dt>Support features</dt><dd>{support_count}</dd>
@@ -998,20 +1381,55 @@ fn render_index_html(
 "#,
         title = escape_html(title),
         panel_outer = checked(true),
+        panel_clearance_keep_in = checked(false),
         panel_keep_in = checked(true),
-        obstacle_clearance = checked(true),
+        obstacle_clearance = checked(false),
+        obstacle_gap_envelope = checked(true),
+        maximal_safe_region = checked(false),
+        regularization_core = checked(false),
+        opened_safe_region = checked(false),
+        removed_by_opening = checked(false),
+        removed_by_gap_separation = checked(true),
+        removed_by_regularization = checked(false),
         safe_region = checked(true),
         board_footprints = checked(true),
         material_removal = checked(true),
         support_features = checked(true),
         certificate = checked(false),
         violations = checked(true),
+        diagnostics = checked(false),
         panel_area = regions.panel_outer.area(),
         obstacle_area = regions.raw_obstacles.area(),
+        maximal_safe_area = artifact.regularization.maximal_safe_area_mm2,
         safe_area = regions.safe_region.area(),
+        removed_area = artifact.regularization.removed_area_mm2,
+        removed_by_opening_area = artifact.regularization.removed_by_opening_area_mm2,
+        removed_for_gap_area = artifact.regularization.removed_by_gap_separation_area_mm2,
+        retained_fraction = 100.0 * artifact.regularization.retained_fraction,
         safe_fraction = 100.0 * regions.safe_region.area() / regions.panel_outer.area(),
         nominal_clearance = artifact.nominal_clearance_mm,
+        minimum_feature_radius = artifact.minimum_feature_radius_mm,
+        minimum_gap_radius = artifact.minimum_gap_radius_mm,
+        construction_gap_radius = artifact.construction_gap_radius_mm,
         geometry_guard = artifact.numerical_guard_mm,
+        feature_violation_area = artifact.checks.minimum_feature_violation_area_mm2,
+        gap_violation_area = artifact.checks.minimum_gap_violation_area_mm2,
+        void_closing_addition_area = artifact.checks.void_closing_addition_area_mm2,
+        maximal_components = artifact.regularization.maximal_component_count,
+        opened_components = artifact.regularization.opened_component_count,
+        final_components = artifact.regularization.final_component_count,
+        gap_discarded_components = artifact.regularization.discarded_for_gap_component_count,
+        smallest_component = artifact
+            .regularization
+            .smallest_final_component_area_mm2
+            .map(|area| format!("{area:.3} mm²"))
+            .unwrap_or_else(|| "none".to_string()),
+        minimum_component_span = artifact
+            .regularization
+            .minimum_final_component_bbox_span_mm
+            .map(|span| format!("{span:.3} mm"))
+            .unwrap_or_else(|| "none".to_string()),
+        undersized_components = artifact.regularization.undersized_final_component_count,
         panelizer = escape_html(&format!(
             "{} {}",
             artifact.panelization.mode.as_deref().unwrap_or("unknown"),

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -142,7 +142,13 @@ fn creates_rounded_panel_step_from_board_bbox() {
 
 #[test]
 fn generated_board_array_has_a_certified_safe_balancing_region() {
-    let xml = create_auto_board_array_xml(board_fixture_mm()).unwrap();
+    let input = board_fixture_mm();
+    let source = Ipc2581::parse(input).unwrap();
+    let (options, validation_mode, panelization) = auto_board_array_options(&source, None).unwrap();
+    let spec = build_board_array_spec(&source, &options, validation_mode, panelization).unwrap();
+    // Safe-region discovery runs on the completed but not-yet-balanced array;
+    // otherwise the generated balance copper becomes its own obstacle.
+    let xml = write_board_array_xml(input, &spec).unwrap();
     let ipc = Ipc2581::parse(&xml).unwrap();
     let layout = geometry::extract_layout(&ipc).unwrap();
     let score_lines = geometry::board_array_vscore_lines(&ipc).unwrap();

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -301,6 +301,11 @@ impl std::error::Error for BalancingRegionError {}
 /// This makes the unavoidable topology choice order-independent and preserves
 /// the greatest possible area without recognizing board features or encoding
 /// special cases.
+///
+/// The optimized final union is not necessarily nested when options or
+/// obstacles change: shrinking or splitting the opened components can change
+/// which independent set is optimal. Callers should rely on the returned
+/// certificate, not cross-parameter set monotonicity.
 pub fn board_array_balancing_region(
     input: &BoardArrayBalancingInput,
     options: BalancingRegionOptions,
@@ -597,7 +602,7 @@ mod tests {
     }
 
     #[test]
-    fn increasing_clearance_cannot_increase_safe_region() {
+    fn larger_clearance_shrinks_maximal_region_for_simple_fixture() {
         let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
         let smaller = board_array_balancing_region(
             &input,
@@ -620,17 +625,23 @@ mod tests {
         )
         .unwrap();
 
-        let larger_outside_smaller = larger.safe_region.difference(&smaller.safe_region);
+        let larger_outside_smaller = larger
+            .intermediates
+            .maximal_safe_region
+            .difference(&smaller.intermediates.maximal_safe_region);
         assert!(
             larger_outside_smaller.is_empty(),
-            "larger opening added {:.9} mm²",
+            "larger clearance added {:.9} mm² to the maximal region",
             larger_outside_smaller.area()
         );
-        assert!(larger.safe_region.area() < smaller.safe_region.area());
+        assert!(
+            larger.intermediates.maximal_safe_region.area()
+                < smaller.intermediates.maximal_safe_region.area()
+        );
     }
 
     #[test]
-    fn increasing_minimum_feature_radius_cannot_increase_safe_region() {
+    fn larger_feature_disk_shrinks_opened_region_for_simple_fixture() {
         let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
         let smaller = board_array_balancing_region(
             &input,
@@ -653,13 +664,19 @@ mod tests {
         )
         .unwrap();
 
-        let larger_outside_smaller = larger.safe_region.difference(&smaller.safe_region);
+        let larger_outside_smaller = larger
+            .intermediates
+            .opened_safe_region
+            .difference(&smaller.intermediates.opened_safe_region);
         assert!(
             larger_outside_smaller.is_empty(),
-            "larger opening added {:.9} mm²",
+            "larger feature disk added {:.9} mm² to the opened region",
             larger_outside_smaller.area()
         );
-        assert!(larger.safe_region.area() < smaller.safe_region.area());
+        assert!(
+            larger.intermediates.opened_safe_region.area()
+                < smaller.intermediates.opened_safe_region.area()
+        );
     }
 
     #[test]
@@ -692,9 +709,15 @@ mod tests {
         .unwrap();
 
         assert!(
-            wide.safe_region.difference(&narrow.safe_region).is_empty(),
-            "wider gap envelope added {:.9} mm²",
-            wide.safe_region.difference(&narrow.safe_region).area()
+            wide.intermediates
+                .maximal_safe_region
+                .difference(&narrow.intermediates.maximal_safe_region)
+                .is_empty(),
+            "wider gap envelope added {:.9} mm² to the maximal region",
+            wide.intermediates
+                .maximal_safe_region
+                .difference(&narrow.intermediates.maximal_safe_region)
+                .area()
         );
         assert!(wide.certificate.minimum_gap_violations.is_empty());
 
@@ -712,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn adding_an_obstacle_cannot_increase_safe_region() {
+    fn adding_an_obstacle_shrinks_maximal_region_for_simple_fixture() {
         let baseline_input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
         let added_obstacle = ContourSet::rectangle(bbox(10.0, 1.0, 11.0, 9.0), tol::REGION_MM);
         let blocked_input = balancing_input(0.0, added_obstacle);
@@ -723,11 +746,15 @@ mod tests {
 
         assert!(
             blocked
-                .safe_region
-                .difference(&baseline.safe_region)
+                .intermediates
+                .maximal_safe_region
+                .difference(&baseline.intermediates.maximal_safe_region)
                 .is_empty()
         );
-        assert!(blocked.safe_region.area() < baseline.safe_region.area());
+        assert!(
+            blocked.intermediates.maximal_safe_region.area()
+                < baseline.intermediates.maximal_safe_region.area()
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -4,6 +4,25 @@
 //! callers provide the canonical layout document, its fabrication profile, and
 //! the already-extracted `ArraySupport` layer documents. The resulting input
 //! is then handled entirely as regularized [`ContourSet`] geometry.
+//!
+//! For panel material `P`, obstacle union `O`, construction gap radius `g`,
+//! minimum-feature radius `q`, and minimum-gap radius `v`, the construction is:
+//!
+//! ```text
+//! M = (P ⊖ disk(g)) \ (O ⊕ disk(g))
+//! A = ((M ⊖ disk(q)) ⊕ disk(q)) ∩ M
+//! ```
+//!
+//! `M` is the clearance-safe set. Treating the outside of `P` and `O` as one
+//! forbidden phase prevents narrow diagonal gaps where an obstacle meets the
+//! panel edge. `A` is a disk opening: the union of all radius-`q` disks that
+//! fit in `M`, which removes copper slivers and rounds outward corners.
+//!
+//! Finally, the connected components of `A` form a proximity graph with an
+//! edge when `distance(C_i, C_j) < 2v`. The exact maximum-area independent set
+//! is retained. Thus distinct output components are separated by at least `2v`
+//! while preserving the greatest possible area from the opened components,
+//! without feature-specific rules or traversal-order policy.
 
 use std::fmt;
 
@@ -15,6 +34,12 @@ use crate::geom::{ContourSet, FillRule, Paint, tol};
 
 /// Default Euclidean clearance from every protected feature.
 pub const DEFAULT_BALANCING_CLEARANCE_MM: f64 = 0.5;
+
+/// Default rolling-disk radius; surviving copper can accommodate this disk.
+pub const DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM: f64 = 1.0;
+
+/// Half the default minimum Euclidean gap between distinct safe components.
+pub const DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM: f64 = 1.0;
 
 /// Conservative allowance for curve flattening and round-offset construction.
 pub const DEFAULT_BALANCING_NUMERICAL_GUARD_MM: f64 =
@@ -38,6 +63,11 @@ pub struct BoardArrayBalancingInput {
 pub struct BalancingRegionOptions {
     /// Required Euclidean clearance from the panel boundary and all obstacles.
     pub clearance_mm: f64,
+    /// Radius `q` of the disk opening. The opened result is the union of all
+    /// radius-`q` disks contained in the pre-regularized safe set.
+    pub minimum_feature_radius_mm: f64,
+    /// Gap radius `v`; distinct final components must be at least `2v` apart.
+    pub minimum_gap_radius_mm: f64,
     /// Additional conservative allowance for numerical approximation.
     pub numerical_guard_mm: f64,
 }
@@ -46,14 +76,25 @@ impl Default for BalancingRegionOptions {
     fn default() -> Self {
         Self {
             clearance_mm: DEFAULT_BALANCING_CLEARANCE_MM,
+            minimum_feature_radius_mm: DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM,
+            minimum_gap_radius_mm: DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM,
             numerical_guard_mm: DEFAULT_BALANCING_NUMERICAL_GUARD_MM,
         }
     }
 }
 
 impl BalancingRegionOptions {
+    /// `clearance_mm + numerical_guard_mm`.
     pub fn construction_clearance_mm(self) -> f64 {
         self.clearance_mm + self.numerical_guard_mm
+    }
+
+    /// `max(clearance_mm, minimum_gap_radius_mm) + numerical_guard_mm`.
+    ///
+    /// Applying the same radius as a panel erosion and obstacle dilation makes
+    /// the entire forbidden phase obey one construction-gap rule.
+    pub fn construction_gap_radius_mm(self) -> f64 {
+        self.clearance_mm.max(self.minimum_gap_radius_mm) + self.numerical_guard_mm
     }
 }
 
@@ -62,10 +103,26 @@ impl BalancingRegionOptions {
 pub struct BoardArrayBalancingIntermediates {
     /// `board_footprints ∪ material_removal ∪ support_features`.
     pub raw_obstacles: ContourSet,
-    /// Panel region eroded by the construction clearance.
+    /// `panel_outer ⊖ disk(construction_clearance)`.
+    pub panel_clearance_keep_in: ContourSet,
+    /// `panel_outer ⊖ disk(construction_gap_radius)`.
     pub panel_keep_in: ContourSet,
-    /// Raw obstacles dilated by the construction clearance.
+    /// `raw_obstacles ⊕ disk(construction_clearance)`.
     pub obstacle_clearance: ContourSet,
+    /// `raw_obstacles ⊕ disk(construction_gap_radius)`.
+    pub obstacle_gap_envelope: ContourSet,
+    /// `panel_keep_in \ obstacle_gap_envelope`.
+    pub maximal_safe_region: ContourSet,
+    /// `maximal_safe_region ⊖ disk(minimum_feature_radius)`.
+    pub regularization_core: ContourSet,
+    /// Disk opening of `maximal_safe_region`, before component separation.
+    pub opened_safe_region: ContourSet,
+    /// Material removed from the maximal set by the disk opening alone.
+    pub removed_by_opening: ContourSet,
+    /// Whole components excluded by the maximum-area independent set.
+    pub removed_by_gap_separation: ContourSet,
+    /// Total material removed by opening and component separation.
+    pub removed_by_regularization: ContourSet,
 }
 
 /// Independent proof geometry for a computed safe region.
@@ -73,10 +130,26 @@ pub struct BoardArrayBalancingIntermediates {
 pub struct ClearanceCertificate {
     /// Safe region dilated by the nominal requested clearance.
     pub swept_safe_region: ContourSet,
+    /// Regularized safe material outside the maximal pre-regularization set.
+    pub safe_outside_maximal_region: ContourSet,
     /// Internal consistency violation: safe material outside `panel_keep_in`.
     pub safe_outside_keep_in: ContourSet,
     /// Internal consistency violation: safe material inside cleared obstacles.
     pub safe_inside_obstacle_clearance: ContourSet,
+    /// Internal consistency violation: safe material inside the minimum-gap
+    /// obstacle envelope.
+    pub safe_inside_obstacle_gap_envelope: ContourSet,
+    /// `safe_region \ open(safe_region, q)`, after numerical denoising.
+    pub minimum_feature_violations: ContourSet,
+    /// `((C_i ⊕ disk(v)) ∩ (C_j ⊕ disk(v))) \ safe_region`, unioned over
+    /// distinct components. Non-empty geometry proves `distance(C_i, C_j) <
+    /// 2v` within polygon tolerance.
+    pub minimum_gap_violations: ContourSet,
+    /// Broader diagnostic geometry that disk closing would fill. This includes
+    /// narrow notches in a single component as well as inter-component gaps,
+    /// so it is retained for inspection but is not an inter-component
+    /// separation failure.
+    pub void_closing_additions: ContourSet,
     /// Nominal-clearance sweep outside the raw panel.
     pub outside_panel: ContourSet,
     /// Nominal-clearance sweep intersecting raw obstacles.
@@ -84,13 +157,22 @@ pub struct ClearanceCertificate {
 }
 
 impl ClearanceCertificate {
-    /// Whether every violation region is below the supplied area tolerance.
+    /// Whether all required subset, clearance, rolling-disk, and pairwise-gap
+    /// violations are below the supplied area tolerance.
+    ///
+    /// [`Self::void_closing_additions`] is intentionally diagnostic-only:
+    /// closing also fills concave notches within a single component, whereas
+    /// the enforced gap contract concerns distinct components.
     pub fn passes(&self, area_tolerance_mm2: f64) -> bool {
         area_tolerance_mm2.is_finite()
             && area_tolerance_mm2 >= 0.0
             && [
+                &self.safe_outside_maximal_region,
                 &self.safe_outside_keep_in,
                 &self.safe_inside_obstacle_clearance,
+                &self.safe_inside_obstacle_gap_envelope,
+                &self.minimum_feature_violations,
+                &self.minimum_gap_violations,
                 &self.outside_panel,
                 &self.obstacle_overlap,
             ]
@@ -102,6 +184,8 @@ impl ClearanceCertificate {
 /// Safe region plus all data required to inspect and certify it.
 #[derive(Debug, Clone)]
 pub struct BoardArrayBalancingResult {
+    /// Final subset whose local copper scale is at least the rolling-disk scale
+    /// and whose distinct components are separated by the requested gap.
     pub safe_region: ContourSet,
     pub intermediates: BoardArrayBalancingIntermediates,
     pub certificate: ClearanceCertificate,
@@ -156,6 +240,8 @@ pub struct BoardArrayBalancingCollection {
 #[derive(Debug, Clone, PartialEq)]
 pub enum BalancingRegionError {
     InvalidClearance(f64),
+    InvalidMinimumFeatureRadius(f64),
+    InvalidMinimumGapRadius(f64),
     InvalidNumericalGuard(f64),
     EmptyPanelOutline,
     EmptyBoardFootprints,
@@ -168,6 +254,14 @@ impl fmt::Display for BalancingRegionError {
             Self::InvalidClearance(value) => write!(
                 f,
                 "balancing-region clearance must be finite and positive; got {value}"
+            ),
+            Self::InvalidMinimumFeatureRadius(value) => write!(
+                f,
+                "balancing-region minimum feature radius must be finite and positive; got {value}"
+            ),
+            Self::InvalidMinimumGapRadius(value) => write!(
+                f,
+                "balancing-region minimum gap radius must be finite and positive; got {value}"
             ),
             Self::InvalidNumericalGuard(value) => write!(
                 f,
@@ -189,8 +283,24 @@ impl fmt::Display for BalancingRegionError {
 
 impl std::error::Error for BalancingRegionError {}
 
-/// Compute the region in which copper can be added with the requested
-/// clearance from the panel boundary and every obstacle.
+/// Compute a clearance-safe, minimum-feature, minimum-gap copper region.
+///
+/// Let `P` be [`BoardArrayBalancingInput::panel_outer`], `O` the union of the
+/// three obstacle inputs, `g` [`BalancingRegionOptions::construction_gap_radius_mm`],
+/// `q` [`BalancingRegionOptions::minimum_feature_radius_mm`], and `v`
+/// [`BalancingRegionOptions::minimum_gap_radius_mm`]. The geometric stages are:
+///
+/// ```text
+/// maximal = (P ⊖ disk(g)) \ (O ⊕ disk(g))
+/// opened  = ((maximal ⊖ disk(q)) ⊕ disk(q)) ∩ maximal
+/// ```
+///
+/// For each connected component `C_i` of `opened`, choose `x_i ∈ {0, 1}` to
+/// maximize `Σ area(C_i) x_i`, subject to `x_i + x_j ≤ 1` whenever
+/// `distance(C_i, C_j) < 2v`. Independent conflict clusters are solved exactly.
+/// This makes the unavoidable topology choice order-independent and preserves
+/// the greatest possible area without recognizing board features or encoding
+/// special cases.
 pub fn board_array_balancing_region(
     input: &BoardArrayBalancingInput,
     options: BalancingRegionOptions,
@@ -208,16 +318,42 @@ pub fn board_array_balancing_region(
         .union(&input.material_removal)
         .union(&input.support_features);
     let construction_clearance_mm = options.construction_clearance_mm();
-    let panel_keep_in = input.panel_outer.disk_erode(construction_clearance_mm);
+    let construction_gap_radius_mm = options.construction_gap_radius_mm();
+    let panel_clearance_keep_in = input.panel_outer.disk_erode(construction_clearance_mm);
+    let panel_keep_in = input.panel_outer.disk_erode(construction_gap_radius_mm);
     let obstacle_clearance = raw_obstacles.disk_dilate(construction_clearance_mm);
-    let safe_region = panel_keep_in.difference(&obstacle_clearance);
+    let obstacle_gap_envelope = raw_obstacles.disk_dilate(construction_gap_radius_mm);
+    let maximal_safe_region = panel_keep_in.difference(&obstacle_gap_envelope);
+    let regularization_core = maximal_safe_region.disk_erode(options.minimum_feature_radius_mm);
+    let opened_safe_region = regularization_core
+        .disk_dilate(options.minimum_feature_radius_mm)
+        .intersection(&maximal_safe_region);
+    let removed_by_opening = maximal_safe_region.difference(&opened_safe_region);
+    let (safe_region, removed_by_gap_separation) =
+        opened_safe_region.disk_separate_components(options.minimum_gap_radius_mm);
+    let removed_by_regularization = maximal_safe_region.difference(&safe_region);
 
     // Certify against the nominal requirement, independently of the
     // construction guard used above.
     let swept_safe_region = safe_region.disk_dilate(options.clearance_mm);
+    let minimum_feature_violations = safe_region
+        .difference(&safe_region.disk_open(options.minimum_feature_radius_mm))
+        .disk_open(options.numerical_guard_mm);
+    let minimum_gap_violations = safe_region
+        .disk_inter_component_gap_violations(options.minimum_gap_radius_mm)
+        .disk_open(options.numerical_guard_mm);
+    let void_closing_additions = safe_region
+        .disk_close(options.minimum_gap_radius_mm)
+        .difference(&safe_region)
+        .disk_open(options.numerical_guard_mm);
     let certificate = ClearanceCertificate {
+        safe_outside_maximal_region: safe_region.difference(&maximal_safe_region),
         safe_outside_keep_in: safe_region.difference(&panel_keep_in),
         safe_inside_obstacle_clearance: safe_region.intersection(&obstacle_clearance),
+        safe_inside_obstacle_gap_envelope: safe_region.intersection(&obstacle_gap_envelope),
+        minimum_feature_violations,
+        minimum_gap_violations,
+        void_closing_additions,
         outside_panel: swept_safe_region.difference(&input.panel_outer),
         obstacle_overlap: swept_safe_region.intersection(&raw_obstacles),
         swept_safe_region,
@@ -227,8 +363,16 @@ pub fn board_array_balancing_region(
         safe_region,
         intermediates: BoardArrayBalancingIntermediates {
             raw_obstacles,
+            panel_clearance_keep_in,
             panel_keep_in,
             obstacle_clearance,
+            obstacle_gap_envelope,
+            maximal_safe_region,
+            regularization_core,
+            opened_safe_region,
+            removed_by_opening,
+            removed_by_gap_separation,
+            removed_by_regularization,
         },
         certificate,
     })
@@ -380,6 +524,16 @@ fn validate_options(options: BalancingRegionOptions) -> Result<(), BalancingRegi
     if !options.clearance_mm.is_finite() || options.clearance_mm <= 0.0 {
         return Err(BalancingRegionError::InvalidClearance(options.clearance_mm));
     }
+    if !options.minimum_feature_radius_mm.is_finite() || options.minimum_feature_radius_mm <= 0.0 {
+        return Err(BalancingRegionError::InvalidMinimumFeatureRadius(
+            options.minimum_feature_radius_mm,
+        ));
+    }
+    if !options.minimum_gap_radius_mm.is_finite() || options.minimum_gap_radius_mm <= 0.0 {
+        return Err(BalancingRegionError::InvalidMinimumGapRadius(
+            options.minimum_gap_radius_mm,
+        ));
+    }
     if !options.numerical_guard_mm.is_finite() || options.numerical_guard_mm < 0.0 {
         return Err(BalancingRegionError::InvalidNumericalGuard(
             options.numerical_guard_mm,
@@ -409,7 +563,25 @@ mod tests {
             board_array_balancing_region(&input, BalancingRegionOptions::default()).unwrap();
 
         assert!(!result.safe_region.is_empty());
-        assert!(result.certificate.passes(1e-4));
+        assert!(
+            result.certificate.passes(1e-4),
+            "outside maximal {:.9}, outside keep-in {:.9}, inside obstacle clearance {:.9}, inside gap envelope {:.9}, feature violations {:.9}, gap violations {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
+            result.certificate.safe_outside_maximal_region.area(),
+            result.certificate.safe_outside_keep_in.area(),
+            result.certificate.safe_inside_obstacle_clearance.area(),
+            result.certificate.safe_inside_obstacle_gap_envelope.area(),
+            result.certificate.minimum_feature_violations.area(),
+            result.certificate.minimum_gap_violations.area(),
+            result.certificate.outside_panel.area(),
+            result.certificate.obstacle_overlap.area(),
+        );
+        assert!(
+            result
+                .safe_region
+                .difference(&result.intermediates.maximal_safe_region)
+                .is_empty()
+        );
+        assert!(result.intermediates.removed_by_regularization.area() > 0.0);
         assert!(
             result
                 .safe_region
@@ -431,6 +603,8 @@ mod tests {
             &input,
             BalancingRegionOptions {
                 clearance_mm: 0.25,
+                minimum_feature_radius_mm: 0.5,
+                minimum_gap_radius_mm: 0.5,
                 numerical_guard_mm: 0.0,
             },
         )
@@ -439,18 +613,102 @@ mod tests {
             &input,
             BalancingRegionOptions {
                 clearance_mm: 1.0,
+                minimum_feature_radius_mm: 0.5,
+                minimum_gap_radius_mm: 0.5,
                 numerical_guard_mm: 0.0,
             },
         )
         .unwrap();
 
+        let larger_outside_smaller = larger.safe_region.difference(&smaller.safe_region);
         assert!(
-            larger
-                .safe_region
-                .difference(&smaller.safe_region)
-                .is_empty()
+            larger_outside_smaller.is_empty(),
+            "larger opening added {:.9} mm²",
+            larger_outside_smaller.area()
         );
         assert!(larger.safe_region.area() < smaller.safe_region.area());
+    }
+
+    #[test]
+    fn increasing_minimum_feature_radius_cannot_increase_safe_region() {
+        let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
+        let smaller = board_array_balancing_region(
+            &input,
+            BalancingRegionOptions {
+                clearance_mm: 0.5,
+                minimum_feature_radius_mm: 0.25,
+                minimum_gap_radius_mm: 0.5,
+                numerical_guard_mm: 0.0,
+            },
+        )
+        .unwrap();
+        let larger = board_array_balancing_region(
+            &input,
+            BalancingRegionOptions {
+                clearance_mm: 0.5,
+                minimum_feature_radius_mm: 1.0,
+                minimum_gap_radius_mm: 0.5,
+                numerical_guard_mm: 0.0,
+            },
+        )
+        .unwrap();
+
+        let larger_outside_smaller = larger.safe_region.difference(&smaller.safe_region);
+        assert!(
+            larger_outside_smaller.is_empty(),
+            "larger opening added {:.9} mm²",
+            larger_outside_smaller.area()
+        );
+        assert!(larger.safe_region.area() < smaller.safe_region.area());
+    }
+
+    #[test]
+    fn minimum_gap_radius_widens_corridors_around_line_obstacles() {
+        let input = BoardArrayBalancingInput {
+            panel_outer: ContourSet::rectangle(bbox(0.0, 0.0, 30.0, 20.0), tol::REGION_MM),
+            board_footprints: ContourSet::rectangle(bbox(2.0, 2.0, 4.0, 4.0), tol::REGION_MM),
+            material_removal: ContourSet::empty(tol::REGION_MM),
+            support_features: ContourSet::rectangle(bbox(14.95, 0.0, 15.05, 20.0), tol::REGION_MM),
+        };
+        let narrow = board_array_balancing_region(
+            &input,
+            BalancingRegionOptions {
+                clearance_mm: 0.5,
+                minimum_feature_radius_mm: 0.5,
+                minimum_gap_radius_mm: 0.5,
+                numerical_guard_mm: 0.025,
+            },
+        )
+        .unwrap();
+        let wide = board_array_balancing_region(
+            &input,
+            BalancingRegionOptions {
+                clearance_mm: 0.5,
+                minimum_feature_radius_mm: 0.5,
+                minimum_gap_radius_mm: 1.0,
+                numerical_guard_mm: 0.025,
+            },
+        )
+        .unwrap();
+
+        assert!(
+            wide.safe_region.difference(&narrow.safe_region).is_empty(),
+            "wider gap envelope added {:.9} mm²",
+            wide.safe_region.difference(&narrow.safe_region).area()
+        );
+        assert!(wide.certificate.minimum_gap_violations.is_empty());
+
+        let mut components = wide.safe_region.connected_components();
+        components.sort_by(|left, right| left.bbox.min.x.total_cmp(&right.bbox.min.x));
+        assert_eq!(
+            components.len(),
+            2,
+            "rings {}, bbox {:?}",
+            wide.safe_region.rings.len(),
+            wide.safe_region.bbox
+        );
+        let gap = components[1].bbox.min.x - components[0].bbox.max.x;
+        assert!(gap >= 2.0, "expected a 2 mm gap, got {gap:.9} mm");
     }
 
     #[test]
@@ -487,8 +745,20 @@ mod tests {
             (translated.safe_region.bbox.min.x - original.safe_region.bbox.min.x - 37.0).abs()
                 <= 1e-9
         );
-        assert!(original.certificate.passes(1e-4));
-        assert!(translated.certificate.passes(1e-4));
+        assert!(
+            original.certificate.passes(1e-4),
+            "original outside maximal {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
+            original.certificate.safe_outside_maximal_region.area(),
+            original.certificate.outside_panel.area(),
+            original.certificate.obstacle_overlap.area(),
+        );
+        assert!(
+            translated.certificate.passes(1e-4),
+            "translated outside maximal {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
+            translated.certificate.safe_outside_maximal_region.area(),
+            translated.certificate.outside_panel.area(),
+            translated.certificate.obstacle_overlap.area(),
+        );
     }
 
     #[test]
@@ -516,6 +786,8 @@ mod tests {
                 &input,
                 BalancingRegionOptions {
                     clearance_mm: 0.0,
+                    minimum_feature_radius_mm: 0.5,
+                    minimum_gap_radius_mm: 0.5,
                     numerical_guard_mm: 0.0,
                 }
             )
@@ -527,6 +799,34 @@ mod tests {
                 &input,
                 BalancingRegionOptions {
                     clearance_mm: 0.5,
+                    minimum_feature_radius_mm: 0.0,
+                    minimum_gap_radius_mm: 0.5,
+                    numerical_guard_mm: 0.0,
+                }
+            )
+            .unwrap_err(),
+            BalancingRegionError::InvalidMinimumFeatureRadius(0.0)
+        );
+        assert_eq!(
+            board_array_balancing_region(
+                &input,
+                BalancingRegionOptions {
+                    clearance_mm: 0.5,
+                    minimum_feature_radius_mm: 0.5,
+                    minimum_gap_radius_mm: 0.0,
+                    numerical_guard_mm: 0.0,
+                }
+            )
+            .unwrap_err(),
+            BalancingRegionError::InvalidMinimumGapRadius(0.0)
+        );
+        assert_eq!(
+            board_array_balancing_region(
+                &input,
+                BalancingRegionOptions {
+                    clearance_mm: 0.5,
+                    minimum_feature_radius_mm: 0.5,
+                    minimum_gap_radius_mm: 0.5,
                     numerical_guard_mm: -0.1,
                 }
             )

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -27,9 +27,10 @@ pub use balancing_region::{
     BalancingRegionError, BalancingRegionOptions, BoardArrayBalancingCollection,
     BoardArrayBalancingInput, BoardArrayBalancingIntermediates, BoardArrayBalancingResult,
     BoardArraySupportDocument, BoardArraySupportLayerGeometry, BoardArraySupportLayerPolicy,
-    ClearanceCertificate, DEFAULT_BALANCING_CLEARANCE_MM, DEFAULT_BALANCING_NUMERICAL_GUARD_MM,
-    board_array_balancing_region, collect_board_array_balancing_input,
-    inspect_board_array_balancing_input,
+    ClearanceCertificate, DEFAULT_BALANCING_CLEARANCE_MM,
+    DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM, DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM,
+    DEFAULT_BALANCING_NUMERICAL_GUARD_MM, board_array_balancing_region,
+    collect_board_array_balancing_input, inspect_board_array_balancing_input,
 };
 pub use document::{Document, Layer};
 pub use feature::{

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -347,6 +347,162 @@ impl ContourSet {
         self.disk_offset(-radius)
     }
 
+    /// Morphological opening by a disk: `(self ⊖ D_radius) ⊕ D_radius`.
+    ///
+    /// Equivalently, this is the union of every radius-sized disk contained in
+    /// the source region. It is therefore a subset of the source that removes
+    /// tips and islands too small to accommodate the disk while rounding the
+    /// surviving outward corners.
+    pub fn disk_open(&self, radius: f64) -> Self {
+        if self.is_empty() || radius <= 0.0 {
+            return self.clone();
+        }
+
+        // Round-offset tessellation approximates the mathematical disks. Clip
+        // the regrown result to the source so the operation retains its
+        // defining anti-extensive property at polygon tolerance.
+        self.disk_erode(radius)
+            .disk_dilate(radius)
+            .intersection(self)
+    }
+
+    /// Morphological closing by a disk: `(self ⊕ D_radius) ⊖ D_radius`.
+    ///
+    /// Equivalently, the complement of the result is the union of every
+    /// radius-sized disk contained in the source complement. Closing therefore
+    /// fills void tips and gaps too small to accommodate the disk while
+    /// rounding the surviving inward corners.
+    pub fn disk_close(&self, radius: f64) -> Self {
+        if self.is_empty() || radius <= 0.0 {
+            return self.clone();
+        }
+
+        // Round-offset tessellation approximates the mathematical disks. Union
+        // the contracted result with the source so the operation retains its
+        // defining extensive property at polygon tolerance.
+        self.disk_dilate(radius).disk_erode(radius).union(self)
+    }
+
+    /// Diagnose distinct components whose Euclidean separation is less than
+    /// the disk diameter `2 * radius`.
+    ///
+    /// For connected components `C_i`, returns
+    /// `⋃_{i<j} (((C_i ⊕ D_r) ∩ (C_j ⊕ D_r)) \ self)` for pairs with
+    /// `distance(C_i, C_j) < 2r`. Subtracting `self` localizes the diagnostic
+    /// to the intervening void. Bounding-box pruning and segment distance avoid
+    /// constructing dilations for non-conflicting pairs.
+    pub fn disk_inter_component_gap_violations(&self, radius: f64) -> Self {
+        if self.is_empty() || radius <= 0.0 {
+            return Self::empty(self.tolerance);
+        }
+
+        let components = self.connected_components();
+        let mut violations = Self::empty(self.tolerance);
+        for (index, left) in components.iter().enumerate() {
+            for right in &components[index + 1..] {
+                if !regions_within_distance(left, right, 2.0 * radius) {
+                    continue;
+                }
+                let overlap = left
+                    .disk_dilate(radius)
+                    .intersection(&right.disk_dilate(radius))
+                    .difference(self);
+                violations = violations.union(&overlap);
+            }
+        }
+        violations
+    }
+
+    /// Retain a maximum-area subset of connected components with pairwise
+    /// Euclidean separation at least `2 * radius`.
+    ///
+    /// Components form a graph with edge `(i, j)` when
+    /// `distance(C_i, C_j) < 2r`, equivalently when their radius-`r` dilations
+    /// overlap. With component area as vertex weight, the retained components
+    /// are an exact maximum-weight independent set:
+    ///
+    /// ```text
+    /// maximize  Σ area(C_i) x_i
+    /// subject to x_i + x_j ≤ 1  for every conflict edge (i, j)
+    ///            x_i ∈ {0, 1}
+    /// ```
+    ///
+    /// Disconnected conflict clusters are solved independently. Equal-area
+    /// optima prefer the deterministic component order: descending area, then
+    /// bounding-box coordinates. The return value is `(kept, removed)`.
+    pub fn disk_separate_components(&self, radius: f64) -> (Self, Self) {
+        if self.is_empty() || radius <= 0.0 {
+            return (self.clone(), Self::empty(self.tolerance));
+        }
+
+        let mut candidates = self
+            .connected_components()
+            .into_iter()
+            .map(|component| (component.area(), component))
+            .collect::<Vec<_>>();
+        candidates.sort_by(|(left_area, left), (right_area, right)| {
+            right_area
+                .total_cmp(left_area)
+                .then_with(|| left.bbox.min.x.total_cmp(&right.bbox.min.x))
+                .then_with(|| left.bbox.min.y.total_cmp(&right.bbox.min.y))
+                .then_with(|| left.bbox.max.x.total_cmp(&right.bbox.max.x))
+                .then_with(|| left.bbox.max.y.total_cmp(&right.bbox.max.y))
+        });
+
+        let mut conflicts = vec![Vec::new(); candidates.len()];
+        for left in 0..candidates.len() {
+            for right in left + 1..candidates.len() {
+                if regions_within_distance(&candidates[left].1, &candidates[right].1, 2.0 * radius)
+                {
+                    conflicts[left].push(right);
+                    conflicts[right].push(left);
+                }
+            }
+        }
+
+        if conflicts.iter().all(Vec::is_empty) {
+            return (self.clone(), Self::empty(self.tolerance));
+        }
+
+        let weights = candidates.iter().map(|(area, _)| *area).collect::<Vec<_>>();
+        let mut visited = vec![false; candidates.len()];
+        let mut kept_indices = Vec::new();
+        for start in 0..candidates.len() {
+            if visited[start] {
+                continue;
+            }
+            let mut cluster = Vec::new();
+            let mut pending = vec![start];
+            visited[start] = true;
+            while let Some(vertex) = pending.pop() {
+                cluster.push(vertex);
+                for &neighbor in &conflicts[vertex] {
+                    if !visited[neighbor] {
+                        visited[neighbor] = true;
+                        pending.push(neighbor);
+                    }
+                }
+            }
+            cluster.sort_unstable();
+            kept_indices.extend(maximum_weight_independent_set(
+                &cluster, &conflicts, &weights,
+            ));
+        }
+
+        if kept_indices.len() == candidates.len() {
+            return (self.clone(), Self::empty(self.tolerance));
+        }
+        kept_indices.sort_unstable();
+        let kept = kept_indices
+            .into_iter()
+            .fold(Self::empty(self.tolerance), |region, index| {
+                region.union(&candidates[index].1)
+            })
+            .intersection(self);
+        let removed = self.difference(&kept);
+        (kept, removed)
+    }
+
     pub fn to_contours(&self) -> Vec<ContourBuf> {
         rings_to_contours(self.rings.clone())
     }
@@ -541,6 +697,144 @@ fn point_segment_distance(point: Point, start: Point, end: Point) -> f64 {
     point.distance_to(start + segment * t)
 }
 
+fn maximum_weight_independent_set(
+    cluster: &[usize],
+    conflicts: &[Vec<usize>],
+    weights: &[f64],
+) -> Vec<usize> {
+    let mut greedy = Vec::new();
+    for &vertex in cluster {
+        if greedy
+            .iter()
+            .all(|kept| conflicts[vertex].binary_search(kept).is_err())
+        {
+            greedy.push(vertex);
+        }
+    }
+    let best_weight = greedy.iter().map(|&vertex| weights[vertex]).sum();
+    let mut search = MaximumWeightIndependentSetSearch {
+        conflicts,
+        weights,
+        best: greedy,
+        best_weight,
+    };
+    search.visit(cluster.to_vec(), &mut Vec::new(), 0.0);
+    search.best
+}
+
+struct MaximumWeightIndependentSetSearch<'a> {
+    conflicts: &'a [Vec<usize>],
+    weights: &'a [f64],
+    best: Vec<usize>,
+    best_weight: f64,
+}
+
+impl MaximumWeightIndependentSetSearch<'_> {
+    fn visit(&mut self, remaining: Vec<usize>, selected: &mut Vec<usize>, selected_weight: f64) {
+        let upper_bound = selected_weight
+            + remaining
+                .iter()
+                .map(|&vertex| self.weights[vertex])
+                .sum::<f64>();
+        if upper_bound.total_cmp(&self.best_weight).is_lt() {
+            return;
+        }
+        if remaining.is_empty() {
+            let mut candidate = selected.clone();
+            candidate.sort_unstable();
+            if selected_weight.total_cmp(&self.best_weight).is_gt()
+                || (selected_weight.total_cmp(&self.best_weight).is_eq() && candidate < self.best)
+            {
+                self.best = candidate;
+                self.best_weight = selected_weight;
+            }
+            return;
+        }
+
+        let pivot = *remaining
+            .iter()
+            .max_by(|&&left, &&right| {
+                let left_degree = remaining
+                    .iter()
+                    .filter(|&&other| self.conflicts[left].binary_search(&other).is_ok())
+                    .count();
+                let right_degree = remaining
+                    .iter()
+                    .filter(|&&other| self.conflicts[right].binary_search(&other).is_ok())
+                    .count();
+                left_degree
+                    .cmp(&right_degree)
+                    .then_with(|| self.weights[left].total_cmp(&self.weights[right]))
+                    .then_with(|| right.cmp(&left))
+            })
+            .expect("non-empty remaining vertex set");
+
+        let include_remaining = remaining
+            .iter()
+            .copied()
+            .filter(|&vertex| {
+                vertex != pivot && self.conflicts[pivot].binary_search(&vertex).is_err()
+            })
+            .collect();
+        selected.push(pivot);
+        self.visit(
+            include_remaining,
+            selected,
+            selected_weight + self.weights[pivot],
+        );
+        selected.pop();
+
+        let exclude_remaining = remaining
+            .into_iter()
+            .filter(|&vertex| vertex != pivot)
+            .collect();
+        self.visit(exclude_remaining, selected, selected_weight);
+    }
+}
+
+fn regions_within_distance(left: &ContourSet, right: &ContourSet, distance: f64) -> bool {
+    if !left.bbox.expand(distance).intersects(right.bbox) {
+        return false;
+    }
+    let threshold = distance + left.tolerance.max(right.tolerance);
+    for left_ring in &left.rings {
+        for left_index in 0..left_ring.len() {
+            let [left_start_x, left_start_y] = left_ring[left_index];
+            let [left_end_x, left_end_y] = left_ring[(left_index + 1) % left_ring.len()];
+            let left_start = Point::new(left_start_x, left_start_y);
+            let left_end = Point::new(left_end_x, left_end_y);
+            let left_bbox = segment_bbox(left_start, left_end).expand(threshold);
+            for right_ring in &right.rings {
+                for right_index in 0..right_ring.len() {
+                    let [right_start_x, right_start_y] = right_ring[right_index];
+                    let [right_end_x, right_end_y] =
+                        right_ring[(right_index + 1) % right_ring.len()];
+                    let right_start = Point::new(right_start_x, right_start_y);
+                    let right_end = Point::new(right_end_x, right_end_y);
+                    if !left_bbox.intersects(segment_bbox(right_start, right_end)) {
+                        continue;
+                    }
+                    let separation = point_segment_distance(left_start, right_start, right_end)
+                        .min(point_segment_distance(left_end, right_start, right_end))
+                        .min(point_segment_distance(right_start, left_start, left_end))
+                        .min(point_segment_distance(right_end, left_start, left_end));
+                    if separation <= threshold {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+fn segment_bbox(start: Point, end: Point) -> BBox {
+    BBox::new(
+        Point::new(start.x.min(end.x), start.y.min(end.y)),
+        Point::new(start.x.max(end.x), start.y.max(end.y)),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -664,6 +958,182 @@ mod tests {
         let eroded = region.disk_erode(0.5);
 
         assert!(eroded.is_empty());
+    }
+
+    #[test]
+    fn disk_opening_rounds_corners_and_stays_inside_source() {
+        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+
+        let opened = region.disk_open(0.5);
+
+        assert!(opened.difference(&region).is_empty());
+        assert!((opened.bbox.min.x - 0.0).abs() <= 1e-9);
+        assert!((opened.bbox.min.y - 0.0).abs() <= 1e-9);
+        assert!((opened.bbox.max.x - 10.0).abs() <= 1e-9);
+        assert!((opened.bbox.max.y - 10.0).abs() <= 1e-9);
+        assert!((opened.area() - (99.0 + std::f64::consts::PI / 4.0)).abs() <= 2e-2);
+        assert!(
+            opened
+                .to_contours_with_arcs()
+                .iter()
+                .flat_map(|contour| &contour.cmds)
+                .any(|cmd| cmd.op == crate::geom::PathOp::ArcTo)
+        );
+    }
+
+    #[test]
+    fn disk_opening_removes_sub_diameter_slivers_and_small_islands() {
+        let body = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let sliver = ContourSet::rectangle(rect(12.0, 0.0, 20.0, 0.8), tol::REGION_MM);
+        let island = ContourSet::rectangle(rect(22.0, 0.0, 22.8, 0.8), tol::REGION_MM);
+        let region = body.union(&sliver).union(&island);
+
+        let opened = region.disk_open(0.5);
+
+        assert_eq!(opened.connected_components().len(), 1);
+        assert!(opened.intersection(&body).area() > 99.0);
+        assert!(opened.intersection(&sliver).is_empty());
+        assert!(opened.intersection(&island).is_empty());
+    }
+
+    #[test]
+    fn disk_opening_is_idempotent_within_offset_tolerance() {
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let notch = ContourSet::rectangle(rect(4.0, 8.0, 6.0, 10.0), tol::REGION_MM);
+        let region = outer.difference(&notch);
+
+        let once = region.disk_open(0.5);
+        let twice = once.disk_open(0.5);
+        let symmetric_difference = once.difference(&twice).union(&twice.difference(&once));
+
+        assert!(
+            symmetric_difference.area() <= 2e-2,
+            "opening changed by {:.9} mm² on repetition",
+            symmetric_difference.area()
+        );
+    }
+
+    #[test]
+    fn disk_closing_fills_sub_diameter_gaps_and_stays_outside_source() {
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
+        let right = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let region = left.union(&right);
+
+        let closed = region.disk_close(0.5);
+        let middle = ContourSet::rectangle(rect(4.0, 1.0, 4.8, 9.0), tol::REGION_MM);
+
+        assert!(region.difference(&closed).is_empty());
+        assert!(closed.intersection(&middle).area() > 6.3);
+    }
+
+    #[test]
+    fn disk_closing_preserves_wide_gaps() {
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
+        let right = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let region = left.union(&right);
+
+        let closed = region.disk_close(0.5);
+        let middle = ContourSet::rectangle(rect(4.0, 1.0, 5.2, 9.0), tol::REGION_MM);
+
+        assert!(closed.intersection(&middle).is_empty());
+    }
+
+    #[test]
+    fn disk_gap_violations_only_report_close_distinct_components() {
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
+        let close = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let wide = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), tol::REGION_MM);
+
+        let close_violations = left.union(&close).disk_inter_component_gap_violations(0.5);
+        let wide_violations = left.union(&wide).disk_inter_component_gap_violations(0.5);
+
+        assert!(close_violations.area() > 1.5);
+        assert!(wide_violations.is_empty());
+        assert!(left.disk_inter_component_gap_violations(0.5).is_empty());
+    }
+
+    #[test]
+    fn disk_component_separation_discards_smaller_conflicting_islands() {
+        let large = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let small = ContourSet::rectangle(rect(10.8, 4.0, 11.6, 4.8), tol::REGION_MM);
+        let distant = ContourSet::rectangle(rect(14.0, 0.0, 20.0, 10.0), tol::REGION_MM);
+        let region = large.union(&small).union(&distant);
+
+        let (separated, removed) = region.disk_separate_components(0.5);
+
+        assert_eq!(separated.connected_components().len(), 2);
+        assert_eq!(removed.connected_components().len(), 1);
+        assert!(separated.difference(&region).is_empty());
+        assert!((removed.area() - small.area()).abs() <= 1e-6);
+        assert!(
+            separated
+                .disk_inter_component_gap_violations(0.5)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn disk_component_separation_maximizes_total_retained_area() {
+        let large = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM);
+        let right = ContourSet::rectangle(rect(4.8, 0.0, 7.8, 3.0), tol::REGION_MM);
+        let upper = ContourSet::rectangle(rect(0.0, 4.8, 3.0, 7.8), tol::REGION_MM);
+        let region = large.union(&right).union(&upper);
+
+        let (separated, removed) = region.disk_separate_components(0.5);
+
+        assert!((separated.area() - right.area() - upper.area()).abs() <= 1e-6);
+        assert!((removed.area() - large.area()).abs() <= 1e-6);
+        assert!(separated.intersection(&large).is_empty());
+        assert!(
+            separated
+                .disk_inter_component_gap_violations(0.5)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn exact_component_selection_matches_exhaustive_search() {
+        const VERTICES: usize = 5;
+        let cluster = (0..VERTICES).collect::<Vec<_>>();
+        let weights = [1.0, 2.0, 4.0, 8.0, 16.0];
+        let possible_edges = (0..VERTICES)
+            .flat_map(|left| (left + 1..VERTICES).map(move |right| (left, right)))
+            .collect::<Vec<_>>();
+
+        for graph_mask in 0..1_usize << possible_edges.len() {
+            let mut conflicts = vec![Vec::new(); VERTICES];
+            for (edge_index, &(left, right)) in possible_edges.iter().enumerate() {
+                if graph_mask & (1 << edge_index) != 0 {
+                    conflicts[left].push(right);
+                    conflicts[right].push(left);
+                }
+            }
+
+            let selected = maximum_weight_independent_set(&cluster, &conflicts, &weights);
+            let actual_weight = selected.iter().map(|&vertex| weights[vertex]).sum::<f64>();
+            let mut expected_weight: f64 = 0.0;
+            for selection_mask in 0..1_usize << VERTICES {
+                let independent = possible_edges.iter().all(|&(left, right)| {
+                    selection_mask & (1 << left) == 0
+                        || selection_mask & (1 << right) == 0
+                        || conflicts[left].binary_search(&right).is_err()
+                });
+                if independent {
+                    let weight = (0..VERTICES)
+                        .filter(|&vertex| selection_mask & (1 << vertex) != 0)
+                        .map(|vertex| weights[vertex])
+                        .sum::<f64>();
+                    expected_weight = expected_weight.max(weight);
+                }
+            }
+            assert_eq!(actual_weight, expected_weight, "graph mask {graph_mask}");
+        }
+
+        assert_eq!(
+            maximum_weight_independent_set(&[0, 1], &[vec![1], vec![0]], &[1.0, 1.0]),
+            vec![0],
+            "equal-weight optima should prefer the stable component order"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core planar geometry for automatic board-array copper balancing and shrinks safe areas versus clearance-only output; correctness relies on new certificates and tests rather than a simple monotone clearance model.
> 
> **Overview**
> Board-array **copper-balancing safe regions** are no longer a single clearance Boolean; they go through **disk morphology** and **gap-aware component selection** so manufacturable copper stays rounded, wide enough, and separated.
> 
> **`pcb-ir`** extends `board_array_balancing_region` with default **1 mm minimum-feature** and **minimum-gap** radii (2 mm copper width and void corridors). Construction uses a shared **gap envelope** on panel erosion and obstacle dilation, then **disk opening** on the maximal safe set, then an exact **maximum-area independent set** over conflicting opened components so pairwise gaps are at least **2v** without order-dependent heuristics. **`ContourSet`** gains `disk_open`, `disk_close`, gap-violation diagnostics, and `disk_separate_components`. **`ClearanceCertificate`** and intermediates expose the new stages and checks (subset of maximal safe, minimum-feature, pairwise gap).
> 
> The **debug harness** (`board_array_balancing_region` example, schema v3) adds CLI flags, SVG/HTML stages, regularization metrics, and stricter pass criteria (including no undersized final components). **Board-array tests** certify the safe region on XML written **before** balance copper is applied. Docs and changelog describe the geometry contract and updated A-series baselines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d382b2b2b5b3cc3269aa1afd8e8f5eda05ff4b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->