### PR TITLE
Refine board array copper balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Board-array creation now automatically adds best-effort copper balancing that matches each layer's placed-board copper density.
-- Board-array balancing now uses a finer 1.5 mm rounded-hex lattice with 0.2 mm minimum copper webs and exposes compact per-layer balance reports.
+- Board-array balancing now uses a finer 1.35 mm rounded-hex lattice with 0.2 mm minimum copper webs and exposes compact per-layer balance reports.
 - IPC-2581 fabrication views and panels now omit non-manufacturing data.
 - Board-array balancing regions now enforce 2 mm minimum copper and gap widths with disk morphology, removing sharp corners, slivers, and narrow void corridors.
 - Split the Nix flake's `pcb` shim and `pcbc` compiler into independent package outputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Board-array creation now automatically adds best-effort copper balancing that matches each layer's placed-board copper density.
+- Board-array balancing now uses a finer 1.5 mm rounded-hex lattice with 0.2 mm minimum copper webs and exposes compact per-layer balance reports.
 - IPC-2581 fabrication views and panels now omit non-manufacturing data.
 - Board-array balancing regions now enforce 2 mm minimum copper and gap widths with disk morphology, removing sharp corners, slivers, and narrow void corridors.
 - Split the Nix flake's `pcb` shim and `pcbc` compiler into independent package outputs.

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -25,6 +25,7 @@ use pcb_ir::geom::copper_balance::{
 use pcb_ir::geom::path::transform_cmds;
 use pcb_ir::geom::region::simplify_shapes;
 use pcb_ir::geom::{Affine2, ContourBuf, ContourSet, FillRule, PathOp, Point, tol};
+use serde::Serialize;
 
 use crate::geometry;
 use crate::ipc2581::Ipc2581;
@@ -51,6 +52,96 @@ pub struct AutomaticBoardArrayCopperBalance {
     pub common_safe_region: ContourSet,
     pub retained_area_mm2: f64,
     pub layers: Vec<AutomaticBoardArrayLayerBalance>,
+}
+
+/// Compact, serializable accounting for one layer's automatic balance.
+#[derive(Debug, Clone, Serialize)]
+pub struct AutomaticBoardArrayLayerBalanceReport {
+    pub layer_name: String,
+    pub mode: AutomaticBoardArrayCopperBalanceMode,
+    pub void_radius_mm: Option<f64>,
+    pub target_density: f64,
+    pub initial_density: f64,
+    pub achieved_density: f64,
+    pub residual_error: f64,
+    pub existing_copper_area_mm2: f64,
+    pub desired_added_area_mm2: f64,
+    pub generated_area_mm2: f64,
+    pub safe_area_mm2: f64,
+    pub usable_area_mm2: f64,
+    pub fixed_empty_area_mm2: f64,
+    pub lattice_center_count: usize,
+    pub eligible_component_count: usize,
+}
+
+/// Topology selected for one layer's automatic balance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomaticBoardArrayCopperBalanceMode {
+    None,
+    Solid,
+    Perforated,
+}
+
+/// Compact, serializable accounting for a completed automatic balance plan.
+#[derive(Debug, Clone, Serialize)]
+pub struct AutomaticBoardArrayCopperBalanceReport {
+    pub retained_area_mm2: f64,
+    pub board_footprint_area_mm2: f64,
+    pub common_safe_area_mm2: f64,
+    pub layers: Vec<AutomaticBoardArrayLayerBalanceReport>,
+}
+
+impl AutomaticBoardArrayCopperBalance {
+    /// Discard heavy geometry while retaining enough data to audit the result.
+    pub fn report(&self) -> AutomaticBoardArrayCopperBalanceReport {
+        AutomaticBoardArrayCopperBalanceReport {
+            retained_area_mm2: self.retained_area_mm2,
+            board_footprint_area_mm2: self.board_footprints.area(),
+            common_safe_area_mm2: self.common_safe_region.area(),
+            layers: self
+                .layers
+                .iter()
+                .map(|layer| {
+                    let solution = layer.result.solution;
+                    let existing_copper_area_mm2 = layer.existing_copper.area();
+                    let fixed_empty_area_mm2 = (self.retained_area_mm2
+                        - existing_copper_area_mm2
+                        - layer.result.usable_area_mm2)
+                        .max(0.0);
+                    let (mode, void_radius_mm) = match solution.mode {
+                        DenseCopperBalanceMode::None => {
+                            (AutomaticBoardArrayCopperBalanceMode::None, None)
+                        }
+                        DenseCopperBalanceMode::Solid => {
+                            (AutomaticBoardArrayCopperBalanceMode::Solid, None)
+                        }
+                        DenseCopperBalanceMode::Perforated { void_radius_mm } => (
+                            AutomaticBoardArrayCopperBalanceMode::Perforated,
+                            Some(void_radius_mm),
+                        ),
+                    };
+                    AutomaticBoardArrayLayerBalanceReport {
+                        layer_name: layer.layer_name.clone(),
+                        mode,
+                        void_radius_mm,
+                        target_density: solution.target_density,
+                        initial_density: solution.initial_density,
+                        achieved_density: solution.achieved_density,
+                        residual_error: solution.residual_error,
+                        existing_copper_area_mm2,
+                        desired_added_area_mm2: solution.desired_added_area_mm2,
+                        generated_area_mm2: solution.generated_area_mm2,
+                        safe_area_mm2: layer.safe_region.area(),
+                        usable_area_mm2: layer.result.usable_area_mm2,
+                        fixed_empty_area_mm2,
+                        lattice_center_count: layer.result.lattice_centers.len(),
+                        eligible_component_count: layer.result.eligible_component_count,
+                    }
+                })
+                .collect(),
+        }
+    }
 }
 
 /// Plan best-effort copper balancing for every copper layer in a board array.

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -184,6 +184,13 @@ pub struct BoardArrayCreateOptions {
     pub edge_rail_mm: BoardMarginMm,
 }
 
+/// Generated board-array IPC plus compact per-layer copper-balance accounting.
+#[derive(Debug, Clone)]
+pub struct BoardArrayCreation {
+    pub xml: String,
+    pub copper_balance: balance::AutomaticBoardArrayCopperBalanceReport,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BoardArrayValidationMode {
     Manual,
@@ -379,15 +386,15 @@ struct VcutLine {
 
 pub fn execute(input: &Path, output: &Path, options: &BoardArrayCreateOptions) -> Result<()> {
     let content = file_utils::load_ipc_file(input)?;
-    let updated_xml = create_board_array_xml(&content, options)?;
-    write_board_array_output(output, &updated_xml)?;
+    let creation = create_board_array(&content, options)?;
+    write_board_array_output(output, &creation.xml)?;
     Ok(())
 }
 
 pub fn execute_auto(input: &Path, output: &Path, sheet: Option<AutoSheetSize>) -> Result<()> {
     let content = file_utils::load_ipc_file(input)?;
-    let updated_xml = create_auto_board_array_xml_with_sheet(&content, sheet)?;
-    write_board_array_output(output, &updated_xml)?;
+    let creation = create_auto_board_array(&content, sheet)?;
+    write_board_array_output(output, &creation.xml)?;
     Ok(())
 }
 
@@ -403,7 +410,11 @@ fn write_board_array_output(output: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
-fn create_board_array_xml(xml: &str, options: &BoardArrayCreateOptions) -> Result<String> {
+/// Create a manually configured board array and return its balance accounting.
+pub fn create_board_array(
+    xml: &str,
+    options: &BoardArrayCreateOptions,
+) -> Result<BoardArrayCreation> {
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
     let spec = build_board_array_spec(
         &ipc,
@@ -419,18 +430,32 @@ fn create_board_array_xml(xml: &str, options: &BoardArrayCreateOptions) -> Resul
 }
 
 #[cfg(test)]
+fn create_board_array_xml(xml: &str, options: &BoardArrayCreateOptions) -> Result<String> {
+    Ok(create_board_array(xml, options)?.xml)
+}
+
+#[cfg(test)]
 fn create_auto_board_array_xml(xml: &str) -> Result<String> {
     create_auto_board_array_xml_with_sheet(xml, None)
 }
 
-fn create_auto_board_array_xml_with_sheet(
+/// Create an automatically sized board array and return its balance accounting.
+pub fn create_auto_board_array(
     xml: &str,
     sheet: Option<AutoSheetSize>,
-) -> Result<String> {
+) -> Result<BoardArrayCreation> {
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
     let (options, validation_mode, panelization) = auto_board_array_options(&ipc, sheet)?;
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization)?;
     write_balanced_board_array_xml(xml, spec)
+}
+
+#[cfg(test)]
+fn create_auto_board_array_xml_with_sheet(
+    xml: &str,
+    sheet: Option<AutoSheetSize>,
+) -> Result<String> {
+    Ok(create_auto_board_array(xml, sheet)?.xml)
 }
 
 fn auto_board_array_options(
@@ -557,11 +582,15 @@ fn write_board_array_xml(xml: &str, spec: &BoardArraySpec) -> Result<String> {
     Ok(xml)
 }
 
-fn write_balanced_board_array_xml(xml: &str, mut spec: BoardArraySpec) -> Result<String> {
+fn write_balanced_board_array_xml(
+    xml: &str,
+    mut spec: BoardArraySpec,
+) -> Result<BoardArrayCreation> {
     let provisional_xml = write_board_array_xml(xml, &spec)?;
     let provisional = Ipc2581::parse(&provisional_xml)
         .context("Failed to parse provisional IPC-2581 board array")?;
     let balance = balance::generate_automatic_board_array_copper_balance(&provisional)?;
+    let copper_balance = balance.report();
 
     for layer in balance.layers {
         if layer.features.is_empty() {
@@ -575,7 +604,10 @@ fn write_balanced_board_array_xml(xml: &str, mut spec: BoardArraySpec) -> Result
         );
     }
 
-    write_board_array_xml(xml, &spec)
+    Ok(BoardArrayCreation {
+        xml: write_board_array_xml(xml, &spec)?,
+        copper_balance,
+    })
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -258,7 +258,24 @@ fn board_array_creation_automatically_balances_every_copper_layer() {
         );
     }
 
-    let xml = create_auto_board_array_xml(&input).unwrap();
+    let creation = create_auto_board_array(&input, None).unwrap();
+    assert_eq!(creation.copper_balance.layers.len(), 2);
+    for report in &creation.copper_balance.layers {
+        assert!(
+            (report.existing_copper_area_mm2
+                + report.usable_area_mm2
+                + report.fixed_empty_area_mm2
+                - creation.copper_balance.retained_area_mm2)
+                .abs()
+                <= 1e-6
+        );
+        assert!(
+            report.residual_error <= (report.initial_density - report.target_density).abs() + 1e-9
+        );
+    }
+    assert!(serde_json::to_value(&creation.copper_balance).unwrap()["layers"].is_array());
+
+    let xml = creation.xml;
     assert!(!xml.contains(r#"<Set polarity="NEGATIVE">"#));
     assert!(xml.matches("<Contour>").count() > 0);
 }

--- a/crates/pcb-ir/src/geom/copper_balance.rs
+++ b/crates/pcb-ir/src/geom/copper_balance.rs
@@ -32,11 +32,11 @@ pub struct DenseCopperBalanceProfile {
 impl DenseCopperBalanceProfile {
     /// Conservative first-party defaults for conventional rigid boards.
     pub const V1: Self = Self {
-        pitch_mm: 2.30,
-        min_void_radius_mm: 0.25,
-        max_void_radius_mm: 1.00,
-        min_copper_web_mm: 0.30,
-        boundary_web_mm: 0.30,
+        pitch_mm: 1.50,
+        min_void_radius_mm: 0.20,
+        max_void_radius_mm: 0.65,
+        min_copper_web_mm: 0.20,
+        boundary_web_mm: 0.20,
         min_centers_per_component: 4,
     };
 
@@ -564,15 +564,15 @@ mod tests {
     #[test]
     fn solves_continuous_hexagon_circumradius_exactly() {
         let solution =
-            solve_dense_copper_balance(DenseCopperBalanceProfile::V1, areas(0.60)).unwrap();
+            solve_dense_copper_balance(DenseCopperBalanceProfile::V1, areas(0.85)).unwrap();
 
         let DenseCopperBalanceMode::Perforated { void_radius_mm } = solution.mode else {
             panic!("expected perforated balance");
         };
-        let expected_radius = (400.0 / (200.0 * ROUNDED_HEXAGON_AREA_FACTOR)).sqrt();
+        let expected_radius = (150.0 / (200.0 * ROUNDED_HEXAGON_AREA_FACTOR)).sqrt();
         assert!((void_radius_mm - expected_radius).abs() <= 1e-12);
-        assert!((solution.generated_area_mm2 - 600.0).abs() <= 1e-9);
-        assert!((solution.achieved_density - 0.60).abs() <= 1e-12);
+        assert!((solution.generated_area_mm2 - 850.0).abs() <= 1e-9);
+        assert!((solution.achieved_density - 0.85).abs() <= 1e-12);
         assert!(solution.residual_error <= 1e-12);
     }
 
@@ -582,14 +582,14 @@ mod tests {
         assert_eq!(none.mode, DenseCopperBalanceMode::None);
 
         let bounded =
-            solve_dense_copper_balance(DenseCopperBalanceProfile::V1, areas(0.30)).unwrap();
+            solve_dense_copper_balance(DenseCopperBalanceProfile::V1, areas(0.70)).unwrap();
         assert_eq!(
             bounded.mode,
             DenseCopperBalanceMode::Perforated {
-                void_radius_mm: 1.0
+                void_radius_mm: 0.65
             }
         );
-        assert!(bounded.residual_error < 0.30);
+        assert!(bounded.residual_error < 0.70);
     }
 
     #[test]
@@ -618,6 +618,54 @@ mod tests {
 
         assert_eq!(solution.mode, DenseCopperBalanceMode::None);
         assert_eq!(solution.initial_density, solution.achieved_density);
+    }
+
+    #[test]
+    fn analytic_projection_never_worsens_a_dense_target_sweep() {
+        for existing_copper_area_mm2 in [0.0, 100.0, 400.0, 800.0] {
+            for usable_area_mm2 in [0.0, 100.0, 1_000.0 - existing_copper_area_mm2] {
+                let void_count = if usable_area_mm2 >= 100.0 { 20 } else { 0 };
+                for target_step in 0..=100 {
+                    let target_density = target_step as f64 / 100.0;
+                    let solution = solve_dense_copper_balance(
+                        DenseCopperBalanceProfile::V1,
+                        DenseCopperBalanceAreas {
+                            retained_area_mm2: 1_000.0,
+                            existing_copper_area_mm2,
+                            target_density,
+                            usable_area_mm2,
+                            void_count,
+                        },
+                    )
+                    .unwrap();
+
+                    let initial_error = (solution.initial_density - target_density).abs();
+                    assert!(solution.residual_error <= initial_error + NUMERIC_EPSILON);
+                    assert!(
+                        (-NUMERIC_EPSILON..=usable_area_mm2 + NUMERIC_EPSILON)
+                            .contains(&solution.generated_area_mm2)
+                    );
+                    match solution.mode {
+                        DenseCopperBalanceMode::None => {
+                            assert!(solution.generated_area_mm2.abs() <= NUMERIC_EPSILON);
+                        }
+                        DenseCopperBalanceMode::Solid => {
+                            assert!(
+                                (solution.generated_area_mm2 - usable_area_mm2).abs()
+                                    <= NUMERIC_EPSILON
+                            );
+                        }
+                        DenseCopperBalanceMode::Perforated { void_radius_mm } => {
+                            assert!(
+                                (DenseCopperBalanceProfile::V1.min_void_radius_mm
+                                    ..=DenseCopperBalanceProfile::V1.max_void_radius_mm)
+                                    .contains(&void_radius_mm)
+                            );
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[test]
@@ -661,7 +709,7 @@ mod tests {
         let DenseCopperBalanceMode::Perforated { void_radius_mm } = result.solution.mode else {
             panic!("expected perforated balance");
         };
-        assert!((0.25..=1.0).contains(&void_radius_mm));
+        assert!((0.20..=0.65).contains(&void_radius_mm));
         assert_eq!(result.eligible_component_count, 1);
         assert!(result.lattice_centers.len() >= 4);
         assert!((result.solution.achieved_density - 0.75).abs() <= 2e-3);
@@ -688,9 +736,12 @@ mod tests {
             }
         }
         assert!(
-            (DenseCopperBalanceProfile::V1.nearest_neighbor_web_mm() - (2.30 - SQRT_3)).abs()
+            (DenseCopperBalanceProfile::V1.nearest_neighbor_web_mm() - (1.50 - SQRT_3 * 0.65))
+                .abs()
                 <= 1e-12
         );
+        assert_eq!(DenseCopperBalanceProfile::V1.min_copper_web_mm, 0.20);
+        assert_eq!(DenseCopperBalanceProfile::V1.boundary_web_mm, 0.20);
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/copper_balance.rs
+++ b/crates/pcb-ir/src/geom/copper_balance.rs
@@ -32,7 +32,7 @@ pub struct DenseCopperBalanceProfile {
 impl DenseCopperBalanceProfile {
     /// Conservative first-party defaults for conventional rigid boards.
     pub const V1: Self = Self {
-        pitch_mm: 1.50,
+        pitch_mm: 1.35,
         min_void_radius_mm: 0.20,
         max_void_radius_mm: 0.65,
         min_copper_web_mm: 0.20,
@@ -736,7 +736,7 @@ mod tests {
             }
         }
         assert!(
-            (DenseCopperBalanceProfile::V1.nearest_neighbor_web_mm() - (1.50 - SQRT_3 * 0.65))
+            (DenseCopperBalanceProfile::V1.nearest_neighbor_web_mm() - (1.35 - SQRT_3 * 0.65))
                 .abs()
                 <= 1e-12
         );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default panel copper-balance geometry and manufacturability constraints; incorrect tuning could affect fab yield, but scope is limited to board-array balancing and covered by updated tests.
> 
> **Overview**
> Tightens **default dense copper balancing** (`DenseCopperBalanceProfile::V1`): **1.35 mm** hex pitch (was 2.30 mm), void radius **0.20–0.65 mm** (was 0.25–1.00 mm), and **0.2 mm** minimum copper/boundary webs (was 0.30 mm). Board-array auto-balance therefore produces a denser perforated fill pattern on panel safe regions.
> 
> Adds **serializable per-layer balance accounting** via `AutomaticBoardArrayCopperBalance::report()` and exposes it on **`BoardArrayCreation`** (`xml` + `copper_balance`) from `create_board_array` / `create_auto_board_array`. CLI `execute` paths still write only IPC XML; the report is for programmatic callers and tests (JSON-serializable densities, areas, mode, lattice counts).
> 
> Extends **`pcb-ir`** tests with a sweep asserting analytic projection never worsens residual error vs. initial density; existing unit tests are updated for the new profile bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13ddc4d6e84a4eeb7d0e07741e3ff51a0d057a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->