### PR TITLE
fix(ipc2581): preserve multiple features in a Features block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fab panels now reserve configurable process margins.
+- IPC-2581 parsing now preserves multiple feature children emitted in one `Features` block.
 - Split fab-panel outlines and cutouts into separate Gerbers.
 
 ## [0.4.15] - 2026-07-29

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -544,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_multiple_features_inside_features() {
+    fn preserves_multiple_features_inside_features() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="Owner">
@@ -558,11 +558,14 @@ mod tests {
         <LayerFeature layerRef="F.Cu">
           <Set>
             <Features>
-              <Line startX="0" startY="0" endX="1" endY="0"/>
+              <Xform rotation="90"/>
+              <Location x="10" y="20"/>
               <UserSpecial>
-                <RectCenter height="1"/>
+                <Line startX="0" startY="0" endX="1" endY="0">
+                  <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
+                </Line>
               </UserSpecial>
-              <Line startX="0" startY="1" endX="1" endY="1"/>
+              <UserPrimitiveRef id="URECT_408"/>
             </Features>
           </Set>
         </LayerFeature>
@@ -571,8 +574,20 @@ mod tests {
   </Ecad>
 </IPC-2581>"#;
 
-        let error = Ipc2581::parse(xml).expect_err("multiple Features children must be rejected");
-        assert!(error.to_string().contains("exactly one Feature"));
+        let doc = Ipc2581::parse(xml).expect("parse multi-feature Features block");
+        let set = &doc.ecad().unwrap().cad_data.steps[0].layer_features[0].sets[0];
+
+        assert_eq!(set.features.len(), 2);
+        let ecad::SetFeature::UserPrimitive(user_primitive) = &set.features[0] else {
+            panic!("expected inline user primitive first");
+        };
+        assert_eq!((user_primitive.x, user_primitive.y), (10.0, 20.0));
+
+        let ecad::SetFeature::UserPrimitiveRef(primitive_ref) = &set.features[1] else {
+            panic!("expected user primitive reference second");
+        };
+        assert_eq!(doc.resolve(primitive_ref.id), "URECT_408");
+        assert_eq!((primitive_ref.x, primitive_ref.y), (10.0, 20.0));
     }
 
     #[test]

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -2231,19 +2231,16 @@ impl<'a> Parser<'a> {
         let mut offset = Point { x: 0.0, y: 0.0 };
         let mut xform_seen = false;
         let mut location_seen = false;
-        let mut feature = None;
+        // IPC-2581C specifies one Feature child, but KiCad emits multiple
+        // substitution-group children in a single Features container. Accept
+        // that de facto shape without relaxing the container's child ordering.
+        let mut features = Vec::new();
 
         for child in self.element_children(features_node) {
             let child_name = self.name(&child);
-            if is_features_feature_name(child_name) && feature.is_some() {
-                return Err(Ipc2581Error::InvalidStructure(
-                    "Features allows exactly one Feature child".to_string(),
-                ));
-            }
-
             match child_name {
                 "Xform" => {
-                    if xform_seen || location_seen || feature.is_some() {
+                    if xform_seen || location_seen || !features.is_empty() {
                         return Err(Ipc2581Error::InvalidStructure(
                             "Xform must be the first child of Features".to_string(),
                         ));
@@ -2251,7 +2248,7 @@ impl<'a> Parser<'a> {
                     xform_seen = true;
                 }
                 "Location" => {
-                    if feature.is_some() {
+                    if !features.is_empty() {
                         return Err(Ipc2581Error::InvalidStructure(
                             "Location must precede the Feature in Features".to_string(),
                         ));
@@ -2267,30 +2264,30 @@ impl<'a> Parser<'a> {
                 }
                 "Polygon" => {
                     let polygon = self.parse_polygon(&child, units)?;
-                    feature = Some(ecad::SetFeature::Polygon(Self::translate_polygon(
+                    features.push(ecad::SetFeature::Polygon(Self::translate_polygon(
                         polygon, offset,
                     )));
                 }
                 "Polyline" => {
-                    feature = Some(ecad::SetFeature::Polyline(
+                    features.push(ecad::SetFeature::Polyline(
                         self.parse_feature_polyline(&child, units, offset.x, offset.y)?,
                     ));
                 }
                 "Line" => {
-                    feature = Some(ecad::SetFeature::Line(
+                    features.push(ecad::SetFeature::Line(
                         self.parse_line(&child, units, offset.x, offset.y)?,
                     ));
                 }
                 "Arc" => {
-                    feature = Some(ecad::SetFeature::Arc(
+                    features.push(ecad::SetFeature::Arc(
                         self.parse_feature_arc(&child, units, offset.x, offset.y)?,
                     ));
                 }
                 "Contour" => {
-                    feature = Some(self.parse_contour_feature(&child, units, offset)?);
+                    features.push(self.parse_contour_feature(&child, units, offset)?);
                 }
                 "UserSpecial" => {
-                    feature = Some(ecad::SetFeature::UserPrimitive(
+                    features.push(ecad::SetFeature::UserPrimitive(
                         ecad::FeatureUserPrimitive {
                             primitive: self.parse_user_special(&child, units)?,
                             x: offset.x,
@@ -2299,7 +2296,7 @@ impl<'a> Parser<'a> {
                     ));
                 }
                 "StandardPrimitiveRef" => {
-                    feature = Some(ecad::SetFeature::StandardPrimitiveRef(
+                    features.push(ecad::SetFeature::StandardPrimitiveRef(
                         ecad::FeaturePrimitiveRef {
                             id: self.required_attr(&child, "id", "StandardPrimitiveRef")?,
                             x: offset.x,
@@ -2308,7 +2305,7 @@ impl<'a> Parser<'a> {
                     ));
                 }
                 "UserPrimitiveRef" => {
-                    feature = Some(ecad::SetFeature::UserPrimitiveRef(
+                    features.push(ecad::SetFeature::UserPrimitiveRef(
                         ecad::FeaturePrimitiveRef {
                             id: self.required_attr(&child, "id", "UserPrimitiveRef")?,
                             x: offset.x,
@@ -2324,9 +2321,11 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Ok(vec![feature.ok_or(Ipc2581Error::MissingElement(
-            "Feature in Features",
-        ))?])
+        if features.is_empty() {
+            return Err(Ipc2581Error::MissingElement("Feature in Features"));
+        }
+
+        Ok(features)
     }
 
     fn parse_contour_feature(
@@ -3354,20 +3353,6 @@ fn is_standard_primitive_name(name: &str) -> bool {
             | "RectRound"
             | "Thermal"
             | "Triangle"
-    )
-}
-
-fn is_features_feature_name(name: &str) -> bool {
-    matches!(
-        name,
-        "Polygon"
-            | "Polyline"
-            | "Line"
-            | "Arc"
-            | "Contour"
-            | "UserSpecial"
-            | "StandardPrimitiveRef"
-            | "UserPrimitiveRef"
     )
 }
 


### PR DESCRIPTION
## Summary

- Accept multiple feature children in a single IPC-2581 `Features` block.
- Preserve each parsed feature and apply shared `Xform` and `Location` offsets.
- Add regression coverage for inline and referenced user primitives.
- Document the parser fix in the changelog.

## Testing

- Added and updated IPC-2581 parser unit tests covering multiple feature children, offsets, and primitive references.
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized IPC-2581 parser behavior change with unit tests; no auth, security, or broader pipeline impact.
> 
> **Overview**
> **IPC-2581 `Features` parsing** no longer rejects KiCad exports that place several substitution-group children in one `Features` container. The parser now collects each geometry or primitive reference as its own `SetFeature` while still requiring `Xform`/`Location` before any features and keeping shared offset application.
> 
> **Regression coverage** replaces the old “exactly one Feature” test with a case that checks an inline `UserSpecial` and a `UserPrimitiveRef` both land in the set with the same translated coordinates. The unreleased changelog records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6da535f6dea2b71ca9e19ff8428d46c5a994fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->