### PR TITLE
fix(ipc2581): fall back to RefDes for BOM selections (ENG-563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- IPC-2581 BOM selections now fall back to an explicit reference designator when the stable Path is unavailable.
+
 ## [0.4.16] - 2026-07-31
 
 ### Added

--- a/crates/pcb-ipc2581-tools/src/commands/bom_edit.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/bom_edit.rs
@@ -11,13 +11,16 @@ use crate::utils::file as file_utils;
 #[serde(deny_unknown_fields)]
 struct Selection {
     path: String,
+    refdes: Option<String>,
     manufacturer: String,
     mpn: String,
 }
 
+#[derive(Debug)]
 struct ResolvedSelection<'a> {
     selection: &'a Selection,
     oem_design_number: String,
+    used_refdes_fallback: bool,
 }
 
 type AlternativesMap = HashMap<String, HashMap<VmpnKey, ipc2581::types::AvlVmpn>>;
@@ -112,6 +115,14 @@ fn load_selections(path: &Path) -> Result<Vec<Selection>> {
                 anyhow::bail!("Selection {name} must not have leading or trailing whitespace");
             }
         }
+        if let Some(refdes) = &selection.refdes {
+            if refdes.is_empty() {
+                anyhow::bail!("Selection refdes must not be empty");
+            }
+            if refdes.trim() != refdes {
+                anyhow::bail!("Selection refdes must not have leading or trailing whitespace");
+            }
+        }
 
         if !paths.insert(selection.path.as_str()) {
             anyhow::bail!("Duplicate selection path: {}", selection.path);
@@ -130,7 +141,7 @@ fn resolve_selections<'a>(
     let resolved = selections
         .iter()
         .map(|selection| {
-            let matches: Vec<_> = bom
+            let path_matches: Vec<_> = bom
                 .items
                 .iter()
                 .filter(|item| {
@@ -147,12 +158,40 @@ fn resolve_selections<'a>(
                 })
                 .collect();
 
-            match matches.as_slice() {
+            match path_matches.as_slice() {
                 [item] => Ok(ResolvedSelection {
                     selection,
                     oem_design_number: ipc.resolve(item.oem_design_number_ref).to_string(),
+                    used_refdes_fallback: false,
                 }),
-                [] => anyhow::bail!("Selection path not found: {}", selection.path),
+                [] => {
+                    let Some(refdes) = selection.refdes.as_deref() else {
+                        anyhow::bail!("Selection path not found: {}", selection.path);
+                    };
+                    let refdes_matches: Vec<_> = bom
+                        .items
+                        .iter()
+                        .filter(|item| {
+                            item.ref_des_list
+                                .iter()
+                                .any(|item_refdes| ipc.resolve(item_refdes.name) == refdes)
+                        })
+                        .collect();
+
+                    match refdes_matches.as_slice() {
+                        [item] => Ok(ResolvedSelection {
+                            selection,
+                            oem_design_number: ipc.resolve(item.oem_design_number_ref).to_string(),
+                            used_refdes_fallback: true,
+                        }),
+                        [] => anyhow::bail!(
+                            "Selection path not found and fallback RefDes not found: {} ({})",
+                            selection.path,
+                            refdes
+                        ),
+                        _ => anyhow::bail!("Selection fallback RefDes is ambiguous: {refdes}"),
+                    }
+                }
                 _ => anyhow::bail!("Selection path is ambiguous: {}", selection.path),
             }
         })
@@ -516,6 +555,17 @@ pub fn execute_selections(file: &Path, selections_file: &Path, output: &Path) ->
     }
 
     let resolved = resolve_selections(&ipc, &selections)?;
+    let fallback_count = resolved
+        .iter()
+        .filter(|selection| selection.used_refdes_fallback)
+        .count();
+    if fallback_count > 0 {
+        eprintln!(
+            "Warning: resolved {} BOM selection{} by RefDes because Path was unavailable",
+            fallback_count,
+            if fallback_count == 1 { "" } else { "s" }
+        );
+    }
 
     let mut interner = ipc2581::Interner::new();
     let mut enterprise_registry = EnterpriseRegistry::from_ipc(&ipc);
@@ -673,6 +723,42 @@ fn avl_section_edit(doc: &ipc2581::edit::Doc, new_avl_xml: String) -> Result<ipc
 mod tests {
     use super::*;
 
+    fn parse_selection_test_ipc(extra_item: &str) -> ipc2581::Ipc2581 {
+        ipc2581::Ipc2581::parse(&format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="ASSEMBLY"/>
+  </Content>
+  <Bom name="TestBOM">
+    <BomHeader assembly="Test Design" revision="1.0"/>
+    <BomItem OEMDesignNumberRef="PATH_PART" quantity="1" category="ELECTRICAL">
+      <RefDes name="R1" packageRef="R0402" populate="true" layerRef="F.Cu"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual definitionSource="pcb" textualCharacteristicName="Path" textualCharacteristicValue="Power.R1"/>
+      </Characteristics>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="GROUPED_PART" quantity="2" category="ELECTRICAL">
+      <RefDes name="C1" packageRef="C0201" populate="true" layerRef="F.Cu"/>
+      <RefDes name="C2" packageRef="C0201" populate="true" layerRef="B.Cu"/>
+      <Characteristics category="ELECTRICAL"/>
+    </BomItem>
+    {extra_item}
+  </Bom>
+</IPC-2581>"#
+        ))
+        .unwrap()
+    }
+
+    fn selection(path: &str, refdes: Option<&str>) -> Selection {
+        Selection {
+            path: path.to_string(),
+            refdes: refdes.map(str::to_string),
+            manufacturer: "Example Manufacturer".to_string(),
+            mpn: "EXAMPLE-MPN".to_string(),
+        }
+    }
+
     fn patch_avl(original: &str, new_avl: &str) -> String {
         let doc = ipc2581::edit::Doc::parse(original).unwrap();
         let edit = avl_section_edit(&doc, new_avl.to_string()).unwrap();
@@ -714,5 +800,45 @@ mod tests {
         assert!(result.contains("OEMDesignNumber=\"NEW\""));
         assert!(!result.contains("OEMDesignNumber=\"OLD\""));
         assert!(result.contains("<Bom/>"));
+    }
+
+    #[test]
+    fn selection_path_remains_authoritative() {
+        let ipc = parse_selection_test_ipc("");
+        let selections = [selection("Power.R1", Some("C1"))];
+
+        let resolved = resolve_selections(&ipc, &selections).unwrap();
+
+        assert_eq!(resolved[0].oem_design_number, "PATH_PART");
+        assert!(!resolved[0].used_refdes_fallback);
+    }
+
+    #[test]
+    fn selection_falls_back_to_refdes_for_grouped_bom_item() {
+        let ipc = parse_selection_test_ipc("");
+        let selections = [selection("kicad::C2", Some("C2"))];
+
+        let resolved = resolve_selections(&ipc, &selections).unwrap();
+
+        assert_eq!(resolved[0].oem_design_number, "GROUPED_PART");
+        assert!(resolved[0].used_refdes_fallback);
+    }
+
+    #[test]
+    fn selection_rejects_ambiguous_refdes_fallback() {
+        let ipc = parse_selection_test_ipc(
+            r#"<BomItem OEMDesignNumberRef="OTHER_PART" quantity="1" category="ELECTRICAL">
+      <RefDes name="C2" packageRef="C0201" populate="true" layerRef="F.Cu"/>
+      <Characteristics category="ELECTRICAL"/>
+    </BomItem>"#,
+        );
+        let selections = [selection("kicad::C2", Some("C2"))];
+
+        let error = resolve_selections(&ipc, &selections).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Selection fallback RefDes is ambiguous: C2"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- keep exact IPC-2581 `Path` matching authoritative
- when a Path has no match, resolve an explicitly supplied `refdes` against the unique containing `BomItem`
- reject missing and ambiguous RefDes fallbacks with clear errors
- report how many selections used the fallback

## Why

The SN0001 and SN0002 v4.0.0 KiCad-derived IPC-2581 artifacts contain grouped BOM items with reference designators but no `Path` characteristics. The backend still has a stable Path for the BOM edit request, so these releases currently fail with `Selection path not found` even though their RefDes values identify the correct grouped item.

This does not infer RefDes from a path and does not special-case KiCad path syntax. Callers must include the optional `refdes` field; Path wins whenever it resolves.

Linear: [ENG-563](https://linear.app/diodeinc/issue/ENG-563/fall-back-to-refdes-when-ipc-2581-bom-path-is-unavailable)

## Validation

- `cargo +1.97.1 fmt --check`
- `cargo +1.97.1 test -p pcb-ipc2581-tools` — 154 passed
- `cargo +1.97.1 clippy -p pcb-ipc2581-tools --lib -- -D warnings`
- exact SN0001 production IPC: fallback selected `C1`, output remained parseable with 72 BOM items and 229 RefDes entries
- exact SN0002 production IPC: fallback selected `C1`, output remained parseable with 75 BOM items and 431 RefDes entries

The repository-wide all-targets clippy hook is currently blocked on unchanged `html_export.rs` by `clippy::items_after_test_module` under Rust 1.95/1.97; the changed library target passes clippy.