### PR TITLE
feat(pcb): add native KiCad URL launcher

### DIFF
--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -143,6 +143,7 @@ jobs:
             export CFLAGS="-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
           fi
           cargo build --profile dist -p pcb --bin pcb --target "$TARGET"
+          cargo build --profile dist -p pcb-launcher --bin pcb-launcher --target "$TARGET"
 
       - name: Prepare artifacts
         shell: bash
@@ -151,19 +152,21 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          exe=pcb
-          artifact="pcb-$TARGET"
-          if [[ "$TARGET" == *windows* ]]; then
-            exe=pcb.exe
-            artifact="$artifact.exe"
-          fi
-          cp "target/$TARGET/dist/$exe" "artifacts/$artifact"
-          zstd -q -f -3 "artifacts/$artifact" -o "artifacts/$artifact.zst"
-          if command -v shasum >/dev/null; then
-            shasum -a 256 "artifacts/$artifact" > "artifacts/$artifact.sha256"
-          else
-            sha256sum "artifacts/$artifact" > "artifacts/$artifact.sha256"
-          fi
+          for binary in pcb pcb-launcher; do
+            exe="$binary"
+            artifact="$binary-$TARGET"
+            if [[ "$TARGET" == *windows* ]]; then
+              exe="$exe.exe"
+              artifact="$artifact.exe"
+            fi
+            cp "target/$TARGET/dist/$exe" "artifacts/$artifact"
+            zstd -q -f -3 "artifacts/$artifact" -o "artifacts/$artifact.zst"
+            if command -v shasum >/dev/null; then
+              shasum -a 256 "artifacts/$artifact" > "artifacts/$artifact.sha256"
+            else
+              sha256sum "artifacts/$artifact" > "artifacts/$artifact.sha256"
+            fi
+          done
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -139,6 +139,7 @@ jobs:
             export CFLAGS="-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
           fi
           cargo build --profile dist -p pcb --bin pcb --target "$TARGET"
+          cargo build --profile dist -p pcb-launcher --bin pcb-launcher --target "$TARGET"
 
       - name: Prepare artifacts
         shell: bash
@@ -147,19 +148,21 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          exe=pcb
-          artifact="pcb-$TARGET"
-          if [[ "$TARGET" == *windows* ]]; then
-            exe=pcb.exe
-            artifact="$artifact.exe"
-          fi
-          cp "target/$TARGET/dist/$exe" "artifacts/$artifact"
-          zstd -q -f -3 "artifacts/$artifact" -o "artifacts/$artifact.zst"
-          if command -v shasum >/dev/null; then
-            shasum -a 256 "artifacts/$artifact" > "artifacts/$artifact.sha256"
-          else
-            sha256sum "artifacts/$artifact" > "artifacts/$artifact.sha256"
-          fi
+          for binary in pcb pcb-launcher; do
+            exe="$binary"
+            artifact="$binary-$TARGET"
+            if [[ "$TARGET" == *windows* ]]; then
+              exe="$exe.exe"
+              artifact="$artifact.exe"
+            fi
+            cp "target/$TARGET/dist/$exe" "artifacts/$artifact"
+            zstd -q -f -3 "artifacts/$artifact" -o "artifacts/$artifact.zst"
+            if command -v shasum >/dev/null; then
+              shasum -a 256 "artifacts/$artifact" > "artifacts/$artifact.sha256"
+            else
+              sha256sum "artifacts/$artifact" > "artifacts/$artifact.sha256"
+            fi
+          done
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Browser-launched KiCad recovery now asks whether to restore the local backup or open the current sandbox version.
+- Added cross-platform `diode://` links that open sandbox layouts in KiCad with live sync and native recovery prompts.
 - The interposer mate constellation is S13: uniform 2×3 blocks with corner mate-detect loops.
 
 ## [0.4.37] - 2026-08-26
@@ -218,14 +218,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added AEC-Q200-qualified Vishay D/CRCW e3 parts as 0402 generic resistor matches through 10 MΩ.
-- The `pcb` installer and self-updater now manage a cross-platform `diode://` launcher for opening sandbox layouts directly in KiCad.
-
-### Fixed
-
-- Launcher installation and updates now remain recoverable when release artifacts or desktop registration are unavailable.
-- Browser-launched KiCad opens now report failures, retain a bounded diagnostic log, and reject untrusted API hosts.
-- Remote sandbox layouts now open in the KiCad PCB Editor on Linux and Windows.
-- Interrupted remote sandbox syncs now leave KiCad open so unsaved edits are preserved.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Browser-launched KiCad recovery now asks whether to restore the local backup or open the current sandbox version.
 - The interposer mate constellation is S13: uniform 2×3 blocks with corner mate-detect loops.
 
 ## [0.4.37] - 2026-08-26
@@ -217,6 +218,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added AEC-Q200-qualified Vishay D/CRCW e3 parts as 0402 generic resistor matches through 10 MΩ.
+- The `pcb` installer and self-updater now manage a cross-platform `diode://` launcher for opening sandbox layouts directly in KiCad.
+
+### Fixed
+
+- Launcher installation and updates now remain recoverable when release artifacts or desktop registration are unavailable.
+- Browser-launched KiCad opens now report failures, retain a bounded diagnostic log, and reject untrusted API hosts.
+- Remote sandbox layouts now open in the KiCad PCB Editor on Linux and Windows.
+- Interrupted remote sandbox syncs now leave KiCad open so unsaved edits are preserved.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Browser-launched KiCad recovery now asks whether to restore the local backup or open the current sandbox version.
+- Added cross-platform `diode://` links that open sandbox layouts in KiCad with live sync and native recovery prompts.
 
 ## [0.4.28] - 2026-08-11
 
@@ -95,14 +95,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added AEC-Q200-qualified Vishay D/CRCW e3 parts as 0402 generic resistor matches through 10 MΩ.
-- The `pcb` installer and self-updater now manage a cross-platform `diode://` launcher for opening sandbox layouts directly in KiCad.
-
-### Fixed
-
-- Launcher installation and updates now remain recoverable when release artifacts or desktop registration are unavailable.
-- Browser-launched KiCad opens now report failures, retain a bounded diagnostic log, and reject untrusted API hosts.
-- Remote sandbox layouts now open in the KiCad PCB Editor on Linux and Windows.
-- Interrupted remote sandbox syncs now leave KiCad open so unsaved edits are preserved.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Browser-launched KiCad recovery now asks whether to restore the local backup or open the current sandbox version.
+
 ## [0.4.28] - 2026-08-11
 
 ### Changed
@@ -91,6 +95,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added AEC-Q200-qualified Vishay D/CRCW e3 parts as 0402 generic resistor matches through 10 MΩ.
+- The `pcb` installer and self-updater now manage a cross-platform `diode://` launcher for opening sandbox layouts directly in KiCad.
+
+### Fixed
+
+- Launcher installation and updates now remain recoverable when release artifacts or desktop registration are unavailable.
+- Browser-launched KiCad opens now report failures, retain a bounded diagnostic log, and reject untrusted API hosts.
+- Remote sandbox layouts now open in the KiCad PCB Editor on Linux and Windows.
+- Interrupted remote sandbox syncs now leave KiCad open so unsaved edits are preserved.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4184,6 +4184,7 @@ dependencies = [
  "md-5",
  "open",
  "pcb-component-gen",
+ "pcb-diode-uri",
  "pcb-eda",
  "pcb-fmt",
  "pcb-kicad",
@@ -4211,6 +4212,15 @@ dependencies = [
  "walkdir",
  "zip",
  "zstd",
+]
+
+[[package]]
+name = "pcb-diode-uri"
+version = "0.4.37"
+dependencies = [
+ "thiserror 2.0.19",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -4354,7 +4364,8 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "url",
+ "pcb-diode-uri",
+ "pcb-native-dialog",
 ]
 
 [[package]]
@@ -4380,6 +4391,13 @@ dependencies = [
  "starlark",
  "tempfile",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "pcb-native-dialog"
+version = "0.4.37"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]
@@ -4625,6 +4643,7 @@ dependencies = [
  "pcb-kicad",
  "pcb-kicad-sch",
  "pcb-layout",
+ "pcb-native-dialog",
  "pcb-sch",
  "pcb-sexpr",
  "pcb-sim",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,6 +4346,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcb-launcher"
+version = "0.4.37"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "url",
+]
+
+[[package]]
 name = "pcb-layout"
 version = "0.4.37"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4329,6 +4329,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcb-launcher"
+version = "0.4.28"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "url",
+]
+
+[[package]]
 name = "pcb-layout"
 version = "0.4.28"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ pcb-fmt = { path = "crates/pcb-fmt" }
 pcb-test-utils = { path = "crates/pcb-test-utils" }
 pcb-sim = { path = "crates/pcb-sim" }
 pcb-diode-api = { path = "crates/pcb-diode-api" }
+pcb-diode-uri = { path = "crates/pcb-diode-uri" }
+pcb-native-dialog = { path = "crates/pcb-native-dialog" }
 pcb-ipc2581-tools = { path = "crates/pcb-ipc2581-tools" }
 pcb-docgen = { path = "crates/pcb-docgen" }
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ The Unix installer writes `pcb` to `$HOME/.local/bin` by default. The Windows
 installer writes `pcb.exe` to `%USERPROFILE%\.pcb\bin` by default. Set
 `PCB_INSTALL_DIR` to choose a different directory.
 
+The installer also registers the `diode://` URL scheme for the current user.
+Registry can use these links to open sandbox layouts in KiCad without a
+terminal. `pcb self update` updates and re-registers the launcher together with
+the `pcb` shim. If a browser-launched open fails, the launcher displays the
+error and records command output in `~/.pcb/pcb-launcher.log` (or
+`%USERPROFILE%\.pcb\pcb-launcher.log` on Windows).
+
 KiCad 10.x is required only for generating and editing layouts. Building and
 validating Zener files does not require KiCad.
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ installer writes `pcb.exe` to `%USERPROFILE%\.pcb\bin` by default. Set
 `PCB_INSTALL_DIR` to choose a different directory.
 
 The installer also registers the `diode://` URL scheme for the current user.
-Registry can use these links to open sandbox layouts in KiCad without a
-terminal. `pcb self update` updates and re-registers the launcher together with
+The Diode registry can use these links to open sandbox layouts in KiCad
+without a terminal. `pcb self update` updates and re-registers the launcher together with
 the `pcb` shim. If a browser-launched open fails, the launcher displays the
 error and records command output in `~/.pcb/pcb-launcher.log` (or
 `%USERPROFILE%\.pcb\pcb-launcher.log` on Windows).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ cargo build -p pcb -p pcbc
 ./install.sh --local
 ```
 
+Local installation registers `diode://` links against the local toolchain.
+Installing or self-updating a release registers them against `latest` again.
+
 Repository maintenance scripts are run by their explicit path, such as
 `./bin/embed-readme --check README.md`; no shell environment activation is needed.
 

--- a/crates/pcb-diode-api/Cargo.toml
+++ b/crates/pcb-diode-api/Cargo.toml
@@ -30,6 +30,7 @@ md-5 = { workspace = true }
 open = { workspace = true }
 pcb-eda = { workspace = true }
 pcb-component-gen = { workspace = true }
+pcb-diode-uri = { workspace = true }
 pcb-fmt = { workspace = true }
 pcb-kicad = { workspace = true }
 pcb-sch = { workspace = true }

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -7,7 +7,7 @@ mod cache;
 pub mod component;
 mod component_api;
 pub mod datasheet;
-pub mod diode_uri;
+pub use pcb_diode_uri as diode_uri;
 mod download_support;
 mod endpoint;
 mod git_auth;

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -7,7 +7,6 @@ mod cache;
 pub mod component;
 mod component_api;
 pub mod datasheet;
-pub use pcb_diode_uri as diode_uri;
 mod download_support;
 mod endpoint;
 mod git_auth;
@@ -25,9 +24,9 @@ pub use bom::{
 };
 pub use component::{SearchArgs, execute as execute_search, execute_component_from_local_dir};
 pub use component_api::{ComponentArgs, execute_component};
-pub use diode_uri::{DiodeUri, DiodeUriParseError, SandboxFileUri, is_diode_uri};
 pub use endpoint::WorkspaceContext;
 pub use kicad_symbols::KicadSymbolsClient;
+pub use pcb_diode_uri::{DiodeUri, DiodeUriParseError, SandboxFileUri, is_diode_uri};
 pub use registry::{
     DigikeyClassifications, DigikeyData, DigikeyPriceBreak, ModuleRelations, ParsedQuery,
     RegistryClient, RegistryInfo, RegistryModule, RegistryModuleDependency,

--- a/crates/pcb-diode-uri/Cargo.toml
+++ b/crates/pcb-diode-uri/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pcb-diode-uri"
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+description = "Parsing and trust policy for diode:// URIs"
+homepage = { workspace = true }
+authors = { workspace = true }
+
+[dependencies]
+thiserror = { workspace = true }
+url = { workspace = true }
+urlencoding = { workspace = true }

--- a/crates/pcb-diode-uri/src/lib.rs
+++ b/crates/pcb-diode-uri/src/lib.rs
@@ -204,23 +204,15 @@ fn host_api_base_url(host: &str) -> String {
 }
 
 /// Whether a parsed [`SandboxFileUri::host`] (host, plus `:port` when present)
-/// is a Diode API endpoint that browser-launched opens may talk to.
+/// is a Diode API endpoint that browser-launched opens may talk to. Release
+/// builds trust only `*.diode.computer`; debug builds trust every host so
+/// local API stacks work.
 pub fn is_trusted_api_host(host: &str) -> bool {
-    let host = host.to_ascii_lowercase();
-    host == "localhost:3001"
-        || host == "127.0.0.1:3001"
-        || host == "api.diode.computer"
-        || host == "api.gov.diode.computer"
-        || is_preview_api_host(&host)
+    cfg!(debug_assertions) || is_diode_computer_host(host)
 }
 
-fn is_preview_api_host(host: &str) -> bool {
-    let Some(pr) = host.strip_suffix(".preview.api.diode.computer") else {
-        return false;
-    };
-    pr.strip_prefix("pr-").is_some_and(|number| {
-        !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit())
-    })
+fn is_diode_computer_host(host: &str) -> bool {
+    host.to_ascii_lowercase().ends_with(".diode.computer")
 }
 
 #[cfg(test)]
@@ -326,20 +318,16 @@ mod tests {
     }
 
     #[test]
-    fn trusts_only_diode_api_hosts() {
-        assert!(is_trusted_api_host("api.diode.computer"));
-        assert!(is_trusted_api_host("api.gov.diode.computer"));
-        assert!(is_trusted_api_host("pr-983.preview.api.diode.computer"));
-        assert!(is_trusted_api_host("localhost:3001"));
-        assert!(is_trusted_api_host("127.0.0.1:3001"));
-        assert!(!is_trusted_api_host("127.0.0.2:3001"));
-        assert!(!is_trusted_api_host("[::1]:3001"));
-        assert!(!is_trusted_api_host("localhost:8080"));
-        assert!(!is_trusted_api_host("localhost"));
-        assert!(!is_trusted_api_host("api.diode.computer:443"));
-        assert!(!is_trusted_api_host("preview.api.diode.computer"));
-        assert!(!is_trusted_api_host("evil.diode.computer"));
-        assert!(!is_trusted_api_host("pr-main.preview.api.diode.computer"));
+    fn release_trust_is_limited_to_diode_computer_hosts() {
+        assert!(is_diode_computer_host("api.diode.computer"));
+        assert!(is_diode_computer_host("api.gov.diode.computer"));
+        assert!(is_diode_computer_host("pr-983.preview.api.diode.computer"));
+        assert!(is_diode_computer_host("API.DIODE.COMPUTER"));
+        assert!(!is_diode_computer_host("diode.computer"));
+        assert!(!is_diode_computer_host("evil-diode.computer"));
+        assert!(!is_diode_computer_host("diode.computer.attacker.example"));
+        assert!(!is_diode_computer_host("api.diode.computer:443"));
+        assert!(!is_diode_computer_host("localhost:3001"));
     }
 
     #[test]

--- a/crates/pcb-diode-uri/src/lib.rs
+++ b/crates/pcb-diode-uri/src/lib.rs
@@ -203,6 +203,26 @@ fn host_api_base_url(host: &str) -> String {
     format!("{scheme}://{host}")
 }
 
+/// Whether a parsed [`SandboxFileUri::host`] (host, plus `:port` when present)
+/// is a Diode API endpoint that browser-launched opens may talk to.
+pub fn is_trusted_api_host(host: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    host == "localhost:3001"
+        || host == "127.0.0.1:3001"
+        || host == "api.diode.computer"
+        || host == "api.gov.diode.computer"
+        || is_preview_api_host(&host)
+}
+
+fn is_preview_api_host(host: &str) -> bool {
+    let Some(pr) = host.strip_suffix(".preview.api.diode.computer") else {
+        return false;
+    };
+    pr.strip_prefix("pr-").is_some_and(|number| {
+        !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -303,6 +323,23 @@ mod tests {
             .unwrap_err(),
             DiodeUriParseError::UnsafeSandboxPath
         );
+    }
+
+    #[test]
+    fn trusts_only_diode_api_hosts() {
+        assert!(is_trusted_api_host("api.diode.computer"));
+        assert!(is_trusted_api_host("api.gov.diode.computer"));
+        assert!(is_trusted_api_host("pr-983.preview.api.diode.computer"));
+        assert!(is_trusted_api_host("localhost:3001"));
+        assert!(is_trusted_api_host("127.0.0.1:3001"));
+        assert!(!is_trusted_api_host("127.0.0.2:3001"));
+        assert!(!is_trusted_api_host("[::1]:3001"));
+        assert!(!is_trusted_api_host("localhost:8080"));
+        assert!(!is_trusted_api_host("localhost"));
+        assert!(!is_trusted_api_host("api.diode.computer:443"));
+        assert!(!is_trusted_api_host("preview.api.diode.computer"));
+        assert!(!is_trusted_api_host("evil.diode.computer"));
+        assert!(!is_trusted_api_host("pr-main.preview.api.diode.computer"));
     }
 
     #[test]

--- a/crates/pcb-interposer/src/pattern.rs
+++ b/crates/pcb-interposer/src/pattern.rs
@@ -326,7 +326,7 @@ mod tests {
             pairs.entry(land.block).or_default().push(land);
         }
         assert_eq!(pairs.len(), 4);
-        for (_, pair) in &pairs {
+        for pair in pairs.values() {
             assert_eq!(pair.len(), 2);
             let d = ((pair[0].xy[0] - pair[1].xy[0]).powi(2)
                 + (pair[0].xy[1] - pair[1].xy[1]).powi(2))

--- a/crates/pcb-kicad/src/lib.rs
+++ b/crates/pcb-kicad/src/lib.rs
@@ -89,6 +89,7 @@ fn discover_path(env_var: &str, command: Option<&str>, candidates: &[&str]) -> S
         .unwrap_or_else(|| expand_home(candidates[0]))
 }
 
+#[cfg(target_os = "macos")]
 fn pcbnew_app_bundle_path(pcbnew_path: &str) -> Result<String> {
     let path = Path::new(pcbnew_path);
 
@@ -249,7 +250,6 @@ pub fn open_pcbnew(pcb_path: impl AsRef<Path>) -> Result<()> {
 
 pub struct PcbnewSession {
     child: Child,
-    pcbnew_app: String,
 }
 
 impl PcbnewSession {
@@ -258,33 +258,31 @@ impl PcbnewSession {
             .try_wait()
             .context("Failed while checking KiCad PCB Editor status")
     }
-
-    pub fn terminate(&mut self) -> Result<()> {
-        if self.try_wait()?.is_some() {
-            return Ok(());
-        }
-        request_pcbnew_shutdown(self)?;
-        self.child
-            .wait()
-            .context("Failed while waiting for KiCad PCB Editor to terminate")?;
-        Ok(())
-    }
 }
 
 /// Open a KiCad board in a process that can be waited on.
 pub fn open_pcbnew_session(pcb_path: impl AsRef<Path>) -> Result<PcbnewSession> {
     let pcb_path = pcb_path.as_ref();
     let pcbnew_path = require_pcbnew_launch(pcb_path)?;
-    let pcbnew_app = pcbnew_app_bundle_path(&pcbnew_path)?;
 
-    let mut cmd = Command::new("open");
-    cmd.arg("-n")
-        .arg("-W")
-        .arg("-a")
-        .arg(&pcbnew_app)
-        .arg(pcb_path);
-    spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path)
-        .map(|child| PcbnewSession { child, pcbnew_app })
+    #[cfg(target_os = "macos")]
+    {
+        let pcbnew_app = pcbnew_app_bundle_path(&pcbnew_path)?;
+        let mut cmd = Command::new("open");
+        cmd.arg("-n")
+            .arg("-W")
+            .arg("-a")
+            .arg(&pcbnew_app)
+            .arg(pcb_path);
+        spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path).map(|child| PcbnewSession { child })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let mut cmd = Command::new(&pcbnew_path);
+        cmd.arg(pcb_path);
+        spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path).map(|child| PcbnewSession { child })
+    }
 }
 
 fn require_pcbnew_launch(pcb_path: &Path) -> Result<String> {
@@ -315,29 +313,6 @@ fn spawn_pcbnew_command(mut cmd: Command, pcbnew_path: &str, pcb_path: &Path) ->
                 pcb_path.display()
             )
         })
-}
-
-fn request_pcbnew_shutdown(session: &mut PcbnewSession) -> Result<()> {
-    quit_macos_app(&session.pcbnew_app)
-}
-
-fn quit_macos_app(app_path: &str) -> Result<()> {
-    let script = format!("tell application {} to quit", applescript_string(app_path));
-    let status = Command::new("osascript")
-        .arg("-e")
-        .arg(script)
-        .status()
-        .with_context(|| format!("Failed to ask macOS to quit KiCad PCB Editor at {app_path}"))?;
-    if !status.success() {
-        return Err(anyhow!(
-            "macOS failed to quit KiCad PCB Editor at {app_path}"
-        ));
-    }
-    Ok(())
-}
-
-fn applescript_string(value: &str) -> String {
-    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 /// Builder for KiCad CLI commands

--- a/crates/pcb-kicad/src/lib.rs
+++ b/crates/pcb-kicad/src/lib.rs
@@ -253,6 +253,10 @@ pub struct PcbnewSession {
 }
 
 impl PcbnewSession {
+    pub fn id(&self) -> u32 {
+        self.child.id()
+    }
+
     pub fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>> {
         self.child
             .try_wait()

--- a/crates/pcb-kicad/src/lib.rs
+++ b/crates/pcb-kicad/src/lib.rs
@@ -223,27 +223,36 @@ pub fn ensure_board_compatible_with_installed_kicad(pcb_path: &Path) -> Result<(
     Ok(())
 }
 
+/// Build the per-platform command that opens a board in the KiCad GUI. On
+/// macOS `waitable` launches a dedicated app instance through `open -n -W`
+/// so the returned child tracks the editor's lifetime.
+fn pcbnew_launch_command(pcbnew_path: &str, pcb_path: &Path, waitable: bool) -> Result<Command> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut cmd = Command::new("open");
+        if waitable {
+            cmd.arg("-n").arg("-W");
+        }
+        cmd.arg("-a")
+            .arg(pcbnew_app_bundle_path(pcbnew_path)?)
+            .arg(pcb_path);
+        Ok(cmd)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = waitable;
+        let mut cmd = Command::new(pcbnew_path);
+        cmd.arg(pcb_path);
+        Ok(cmd)
+    }
+}
+
 /// Open a KiCad board in the GUI that matches this toolchain's discovered install.
 pub fn open_pcbnew(pcb_path: impl AsRef<Path>) -> Result<()> {
     let pcb_path = pcb_path.as_ref();
     let pcbnew_path = require_pcbnew_launch(pcb_path)?;
-
-    #[cfg(target_os = "macos")]
-    let cmd = {
-        let mut cmd = Command::new("open");
-        cmd.arg("-a")
-            .arg(pcbnew_app_bundle_path(&pcbnew_path)?)
-            .arg(pcb_path);
-        cmd
-    };
-
-    #[cfg(not(target_os = "macos"))]
-    let cmd = {
-        let mut cmd = Command::new(&pcbnew_path);
-        cmd.arg(pcb_path);
-        cmd
-    };
-
+    let cmd = pcbnew_launch_command(&pcbnew_path, pcb_path, false)?;
     spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path)?;
     Ok(())
 }
@@ -268,25 +277,8 @@ impl PcbnewSession {
 pub fn open_pcbnew_session(pcb_path: impl AsRef<Path>) -> Result<PcbnewSession> {
     let pcb_path = pcb_path.as_ref();
     let pcbnew_path = require_pcbnew_launch(pcb_path)?;
-
-    #[cfg(target_os = "macos")]
-    {
-        let pcbnew_app = pcbnew_app_bundle_path(&pcbnew_path)?;
-        let mut cmd = Command::new("open");
-        cmd.arg("-n")
-            .arg("-W")
-            .arg("-a")
-            .arg(&pcbnew_app)
-            .arg(pcb_path);
-        spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path).map(|child| PcbnewSession { child })
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        let mut cmd = Command::new(&pcbnew_path);
-        cmd.arg(pcb_path);
-        spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path).map(|child| PcbnewSession { child })
-    }
+    let cmd = pcbnew_launch_command(&pcbnew_path, pcb_path, true)?;
+    spawn_pcbnew_command(cmd, &pcbnew_path, pcb_path).map(|child| PcbnewSession { child })
 }
 
 fn require_pcbnew_launch(pcb_path: &Path) -> Result<String> {

--- a/crates/pcb-launcher/Cargo.toml
+++ b/crates/pcb-launcher/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "pcb-launcher"
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+description = "Native diode URL launcher for the pcb toolchain"
+homepage = { workspace = true }
+authors = { workspace = true }
+
+[[bin]]
+name = "pcb-launcher"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+dirs = { workspace = true }
+url = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
+    "NSApplication",
+    "NSResponder",
+    "NSRunningApplication",
+] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+    "NSArray",
+    "NSEnumerator",
+    "NSObject",
+    "NSString",
+    "NSURL",
+] }

--- a/crates/pcb-launcher/Cargo.toml
+++ b/crates/pcb-launcher/Cargo.toml
@@ -14,7 +14,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 dirs = { workspace = true }
-url = { workspace = true }
+pcb-diode-uri = { workspace = true }
+pcb-native-dialog = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"

--- a/crates/pcb-launcher/src/main.rs
+++ b/crates/pcb-launcher/src/main.rs
@@ -1,0 +1,742 @@
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+
+use anyhow::{Context, Result, bail};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use url::Url;
+
+const PCB_TOOLCHAIN: &str = "+latest";
+const LAUNCHER_LOG_MAX_BYTES: u64 = 1024 * 1024;
+
+fn main() {
+    if let Some(result) = run_from_args() {
+        if let Err(error) = result {
+            eprintln!("pcb-launcher failed: {error:#}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    macos::run();
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        eprintln!("pcb-launcher failed: expected --install or a diode:// sandbox file URI");
+        std::process::exit(1);
+    }
+}
+
+fn run_from_args() -> Option<Result<()>> {
+    let mut args = std::env::args_os();
+    let _program = args.next();
+    let first = args.next()?;
+    if args.next().is_some() {
+        return Some(Err(anyhow::anyhow!(
+            "expected --install or exactly one diode:// sandbox file URI"
+        )));
+    }
+    if first == "--install" {
+        let result = install_protocol_handler();
+        if let Err(error) = &result {
+            append_launcher_error(error);
+        }
+        Some(result)
+    } else {
+        Some(launch_pcb(first.to_string_lossy().as_ref()))
+    }
+}
+
+fn install_protocol_handler() -> Result<()> {
+    let launcher = std::env::current_exe().context("failed to locate pcb-launcher")?;
+    let pcb = sibling_pcb_executable()?;
+    platform::install(&launcher, &pcb)
+}
+
+fn launch_pcb(uri: &str) -> Result<()> {
+    let result = launch_pcb_inner(uri);
+    if let Err(error) = &result {
+        report_launch_error(error);
+    }
+    result
+}
+
+fn report_launch_error(error: &anyhow::Error) {
+    append_launcher_error(error);
+    platform::show_error(error, &launcher_log_path());
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_uri_worker(uri: &str) -> Result<()> {
+    let launcher = std::env::current_exe().context("failed to locate pcb-launcher")?;
+    Command::new(&launcher)
+        .arg(uri)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to start {}", launcher.display()))?;
+    Ok(())
+}
+
+fn launch_pcb_inner(uri: &str) -> Result<()> {
+    validate_uri(uri)?;
+    let pcb = sibling_pcb_executable()?;
+    let mut log = open_launcher_log()?;
+    writeln!(
+        log,
+        "\n--- pcb-launcher invocation at {:?} ---",
+        std::time::SystemTime::now()
+    )
+    .context("failed to write the launcher log")?;
+    let stdout = log
+        .try_clone()
+        .context("failed to clone the launcher log handle")?;
+    let mut command = Command::new(&pcb);
+    command
+        .arg(PCB_TOOLCHAIN)
+        .arg("open")
+        .arg(uri)
+        .env("PCB_URL_LAUNCHER", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(log));
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to start {}", pcb.display()))?;
+    // Keep the protocol handler alive while pcb opens KiCad. This preserves
+    // browser-launched children on Windows and lets every platform surface a
+    // non-zero exit instead of silently discarding it.
+    let status = child
+        .wait()
+        .with_context(|| format!("failed to wait for {}", pcb.display()))?;
+    if !status.success() {
+        bail!("{} failed: {status}", pcb.display());
+    }
+
+    Ok(())
+}
+
+fn validate_uri(uri: &str) -> Result<()> {
+    let url = Url::parse(uri).context("invalid diode URI")?;
+    if url.scheme() != "diode" {
+        bail!("expected a diode:// sandbox file URI");
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        bail!("diode URI must not include user info");
+    }
+    if url.fragment().is_some() {
+        bail!("diode URI must not include a fragment");
+    }
+
+    let host = url.host_str().context("diode URI must include a host")?;
+    if !is_trusted_api_host(host, url.port()) {
+        bail!("refusing untrusted diode API host: {host}");
+    }
+
+    let segments: Vec<_> = url.path().split('/').skip(1).collect();
+    if segments.len() != 4
+        || segments[0] != "sandboxes"
+        || segments[1].is_empty()
+        || segments[2] != "fs"
+        || segments[3] != "read"
+    {
+        bail!("expected /sandboxes/{{sandboxId}}/fs/read");
+    }
+
+    let mut query = url.query_pairs();
+    let Some((key, path)) = query.next() else {
+        bail!("diode URI must include one path query parameter");
+    };
+    if key != "path" || query.next().is_some() {
+        bail!("diode URI must include only one path query parameter");
+    }
+    if !path.starts_with('/')
+        || path
+            .split('/')
+            .skip(1)
+            .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        bail!("diode URI path must be a safe absolute sandbox path");
+    }
+    Ok(())
+}
+
+fn is_trusted_api_host(host: &str, port: Option<u16>) -> bool {
+    let host = host.to_ascii_lowercase();
+    if host == "localhost" || host == "127.0.0.1" {
+        return port == Some(3001);
+    }
+    port.is_none()
+        && (host == "api.diode.computer"
+            || host == "api.gov.diode.computer"
+            || is_preview_api_host(&host))
+}
+
+fn is_preview_api_host(host: &str) -> bool {
+    let Some(pr) = host.strip_suffix(".preview.api.diode.computer") else {
+        return false;
+    };
+    pr.strip_prefix("pr-").is_some_and(|number| {
+        !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
+fn launcher_log_path() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join(".pcb/pcb-launcher.log"))
+        .unwrap_or_else(|| std::env::temp_dir().join("pcb-launcher.log"))
+}
+
+fn open_launcher_log() -> Result<File> {
+    let path = launcher_log_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    secure_launcher_log_permissions(&path)?;
+    if path
+        .metadata()
+        .is_ok_and(|metadata| metadata.len() >= LAUNCHER_LOG_MAX_BYTES)
+    {
+        let rotated = path.with_extension("log.old");
+        let _ = fs::remove_file(&rotated);
+        let _ = fs::rename(&path, rotated);
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options
+        .open(&path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    secure_launcher_log_permissions(&path)?;
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn secure_launcher_log_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if path.exists() {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to secure {}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn secure_launcher_log_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn append_launcher_error(error: &anyhow::Error) {
+    if let Ok(mut log) = open_launcher_log() {
+        let _ = writeln!(log, "pcb-launcher failed: {error:#}");
+    }
+}
+
+fn sibling_pcb_executable() -> Result<PathBuf> {
+    let current = std::env::current_exe().context("failed to locate pcb-launcher")?;
+    let parent = current
+        .parent()
+        .context("pcb-launcher has no parent directory")?;
+
+    #[cfg(target_os = "macos")]
+    if let Some(contents) = parent.parent() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let pcb_path = contents.join("Resources/pcb-path");
+        if pcb_path.is_file() {
+            let pcb = PathBuf::from(OsString::from_vec(
+                std::fs::read(&pcb_path)
+                    .with_context(|| format!("failed to read {}", pcb_path.display()))?,
+            ));
+            if !pcb.is_file() {
+                bail!(
+                    "pcb executable not found at bundled path: {}",
+                    pcb.display()
+                );
+            }
+            return Ok(pcb);
+        }
+    }
+
+    let name = if cfg!(target_os = "windows") {
+        "pcb.exe"
+    } else {
+        "pcb"
+    };
+    let pcb = parent.join(name);
+    if !pcb.is_file() {
+        bail!(
+            "pcb executable not found beside launcher: {}",
+            pcb.display()
+        );
+    }
+    Ok(pcb)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn escape_desktop_exec_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "\\\\\\\\")
+        .replace('"', "\\\\\"")
+        .replace('`', "\\\\`")
+        .replace('$', "\\\\$")
+        .replace('%', "%%")
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn run_checked(command: &mut Command, description: &str) -> Result<()> {
+    let status = command
+        .status()
+        .with_context(|| format!("failed to {description}"))?;
+    if !status.success() {
+        bail!("failed to {description}: {status}");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::*;
+    use std::fs;
+    use std::os::unix::ffi::OsStrExt;
+
+    const INFO_PLIST: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key><string>Diode PCB Launcher</string>
+  <key>CFBundleExecutable</key><string>pcb-launcher</string>
+  <key>CFBundleIdentifier</key><string>computer.diode.pcb-launcher</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleName</key><string>Diode PCB Launcher</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleURLTypes</key>
+  <array><dict>
+    <key>CFBundleURLName</key><string>Diode sandbox file</string>
+    <key>CFBundleURLSchemes</key><array><string>diode</string></array>
+  </dict></array>
+  <key>LSBackgroundOnly</key><true/>
+</dict>
+</plist>
+"#;
+
+    struct StagedAppCleanup(PathBuf);
+
+    impl Drop for StagedAppCleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    pub fn install(launcher: &Path, pcb: &Path) -> Result<()> {
+        let home = dirs::home_dir().context("could not locate the home directory")?;
+        let applications = home.join("Applications");
+        fs::create_dir_all(&applications)
+            .with_context(|| format!("failed to create {}", applications.display()))?;
+        let app = applications.join("Diode PCB Launcher.app");
+        let staged_app = applications.join(format!(
+            ".Diode PCB Launcher-{}.app.tmp",
+            std::process::id()
+        ));
+        let backup_app = applications.join(format!(
+            ".Diode PCB Launcher-{}.app.old",
+            std::process::id()
+        ));
+        remove_dir_if_exists(&staged_app)?;
+        remove_dir_if_exists(&backup_app)?;
+        let _staged_app_cleanup = StagedAppCleanup(staged_app.clone());
+
+        let contents = staged_app.join("Contents");
+        let macos = contents.join("MacOS");
+        let resources = contents.join("Resources");
+        fs::create_dir_all(&macos)
+            .with_context(|| format!("failed to create {}", macos.display()))?;
+        fs::create_dir_all(&resources)
+            .with_context(|| format!("failed to create {}", resources.display()))?;
+        fs::copy(launcher, macos.join("pcb-launcher"))
+            .context("failed to install the macOS launcher executable")?;
+        let pcb =
+            fs::canonicalize(pcb).context("failed to resolve the installed pcb executable")?;
+        fs::write(resources.join("pcb-path"), pcb.as_os_str().as_bytes())
+            .context("failed to store the installed pcb path")?;
+        fs::write(contents.join("Info.plist"), INFO_PLIST)
+            .context("failed to write the macOS launcher Info.plist")?;
+
+        if let Err(error) = run_checked(
+            Command::new("codesign")
+                .args(["--force", "--deep", "--sign", "-"])
+                .arg(&staged_app),
+            "sign the macOS launcher app",
+        ) {
+            let _ = fs::remove_dir_all(&staged_app);
+            return Err(error);
+        }
+
+        let had_app = app.exists();
+        if had_app {
+            fs::rename(&app, &backup_app)
+                .context("failed to back up the existing macOS launcher app")?;
+        }
+        if let Err(error) = fs::rename(&staged_app, &app) {
+            if had_app {
+                fs::rename(&backup_app, &app)
+                    .context("failed to restore the existing macOS launcher app")?;
+            }
+            return Err(error).context("failed to install the macOS launcher app");
+        }
+
+        let lsregister = Path::new(
+            "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
+        );
+        if lsregister.is_file()
+            && let Err(error) = run_checked(
+                Command::new(lsregister).arg("-f").arg(&app),
+                "register the macOS launcher app",
+            )
+        {
+            fs::remove_dir_all(&app)
+                .context("failed to remove the unregistered macOS launcher app")?;
+            if had_app {
+                fs::rename(&backup_app, &app)
+                    .context("failed to restore the existing macOS launcher app")?;
+                let _ = Command::new(lsregister).arg("-f").arg(&app).status();
+            }
+            return Err(error);
+        }
+        if had_app && let Err(error) = fs::remove_dir_all(&backup_app) {
+            eprintln!(
+                "warning: failed to remove macOS launcher backup {}: {error}",
+                backup_app.display()
+            );
+        }
+        Ok(())
+    }
+
+    pub fn show_error(error: &anyhow::Error, log_path: &Path) {
+        let message = format!("{error:#}\n\nDetails: {}", log_path.display());
+        let _ = Command::new("osascript")
+            .args([
+                "-e",
+                "on run argv",
+                "-e",
+                "display alert \"Open in KiCad failed\" message (item 1 of argv) as critical",
+                "-e",
+                "end run",
+                "--",
+            ])
+            .arg(message)
+            .status();
+    }
+
+    fn remove_dir_if_exists(path: &Path) -> Result<()> {
+        if path.exists() {
+            fs::remove_dir_all(path)
+                .with_context(|| format!("failed to remove stale {}", path.display()))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::*;
+    use std::fs;
+
+    pub fn install(launcher: &Path, _pcb: &Path) -> Result<()> {
+        let data_home = std::env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|home| home.join(".local/share")))
+            .context("could not locate the user data directory")?;
+        let applications = data_home.join("applications");
+        fs::create_dir_all(&applications)
+            .with_context(|| format!("failed to create {}", applications.display()))?;
+        let escaped = escape_desktop_exec_path(launcher);
+        let desktop = format!(
+            "[Desktop Entry]\nType=Application\nName=Diode PCB Launcher\nNoDisplay=true\nTerminal=false\nExec=\"{escaped}\" %u\nMimeType=x-scheme-handler/diode;\n"
+        );
+        fs::write(applications.join("diode-pcb-launcher.desktop"), desktop)
+            .context("failed to write the Linux desktop entry")?;
+
+        run_optional(
+            Command::new("update-desktop-database").arg(&applications),
+            "update the desktop database",
+        )?;
+        let status = Command::new("xdg-mime")
+            .args([
+                "default",
+                "diode-pcb-launcher.desktop",
+                "x-scheme-handler/diode",
+            ])
+            .status()
+            .context("failed to run xdg-mime to register the diode URL handler")?;
+        if !status.success() {
+            bail!("xdg-mime failed to register the diode URL handler: {status}");
+        }
+        Ok(())
+    }
+
+    pub fn show_error(error: &anyhow::Error, log_path: &Path) {
+        let message = format!("{error:#}\n\nDetails: {}", log_path.display());
+        let shown = Command::new("zenity")
+            .args(["--error", "--title=Open in KiCad failed", "--text"])
+            .arg(&message)
+            .status()
+            .is_ok_and(|status| status.success());
+        if !shown {
+            let _ = Command::new("kdialog")
+                .args(["--title", "Open in KiCad failed", "--error"])
+                .arg(message)
+                .status();
+        }
+    }
+
+    fn run_optional(command: &mut Command, description: &str) -> Result<()> {
+        match command.status() {
+            Ok(status) if status.success() => Ok(()),
+            Ok(status) => {
+                eprintln!("warning: failed to {description}: {status}");
+                Ok(())
+            }
+            Err(error) => {
+                eprintln!("warning: failed to {description}: {error}");
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use super::*;
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    pub fn install(launcher: &Path, _pcb: &Path) -> Result<()> {
+        let command = format!("\"{}\" \"%1\"", launcher.display());
+        reg_add(
+            r"HKCU\Software\Classes\diode",
+            None,
+            "URL:Diode PCB Launcher",
+        )?;
+        reg_add(r"HKCU\Software\Classes\diode", Some("URL Protocol"), "")?;
+        reg_add(
+            r"HKCU\Software\Classes\diode\shell\open\command",
+            None,
+            &command,
+        )?;
+        Ok(())
+    }
+
+    pub fn show_error(error: &anyhow::Error, log_path: &Path) {
+        let message = format!("{error:#}\n\nDetails: {}", log_path.display());
+        let mut command = Command::new("powershell.exe");
+        command.creation_flags(CREATE_NO_WINDOW);
+        let _ = command
+            .env("PCB_LAUNCHER_ERROR", &message)
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Add-Type -AssemblyName PresentationFramework; [System.Windows.MessageBox]::Show($env:PCB_LAUNCHER_ERROR, 'Open in KiCad failed', 'OK', 'Error')",
+            ])
+            .status();
+    }
+
+    fn reg_add(key: &str, name: Option<&str>, value: &str) -> Result<()> {
+        let mut command = Command::new("reg.exe");
+        command.creation_flags(CREATE_NO_WINDOW);
+        command.args(["ADD", key]);
+        match name {
+            Some(name) => command.args(["/v", name]),
+            None => command.arg("/ve"),
+        };
+        command.args(["/t", "REG_SZ", "/d", value, "/f"]);
+        run_checked(&mut command, "register the Windows diode URL handler")
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use objc2::rc::Retained;
+    use objc2::runtime::ProtocolObject;
+    use objc2::{MainThreadOnly, define_class, msg_send};
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate};
+    use objc2_foundation::{MainThreadMarker, NSArray, NSObject, NSObjectProtocol, NSURL};
+
+    static RECEIVED_URL: AtomicBool = AtomicBool::new(false);
+
+    define_class!(
+        #[unsafe(super = NSObject)]
+        #[thread_kind = MainThreadOnly]
+        #[ivars = ()]
+        struct LauncherDelegate;
+
+        unsafe impl NSObjectProtocol for LauncherDelegate {}
+
+        unsafe impl NSApplicationDelegate for LauncherDelegate {
+            #[unsafe(method(application:openURLs:))]
+            fn application_open_urls(&self, application: &NSApplication, urls: &NSArray<NSURL>) {
+                RECEIVED_URL.store(true, Ordering::Release);
+                for url in urls {
+                    if let Some(value) = url.absoluteString()
+                        && let Err(error) = super::spawn_uri_worker(&value.to_string())
+                    {
+                        super::report_launch_error(&error);
+                        eprintln!("Failed to open in KiCad: {error:#}");
+                    }
+                }
+                application.terminate(None);
+            }
+        }
+    );
+
+    impl LauncherDelegate {
+        fn new(mtm: MainThreadMarker) -> Retained<Self> {
+            let this = Self::alloc(mtm).set_ivars(());
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    pub fn run() {
+        let mtm = MainThreadMarker::new().expect("pcb-launcher must run on the main thread");
+        let application = NSApplication::sharedApplication(mtm);
+        application.setActivationPolicy(NSApplicationActivationPolicy::Prohibited);
+        let delegate = LauncherDelegate::new(mtm);
+        application.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+
+        // LaunchServices may start the app bundle without delivering an open-URL
+        // event, so bound the lifetime after the application is ready to receive it.
+        std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            if !RECEIVED_URL.load(Ordering::Acquire) {
+                std::process::exit(0);
+            }
+        });
+
+        application.run();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{escape_desktop_exec_path, is_trusted_api_host, validate_uri};
+    use std::path::Path;
+
+    #[test]
+    fn accepts_diode_uri() {
+        validate_uri(
+            "diode://api.diode.computer/sandboxes/sandbox/fs/read?path=%2Fworkspace%2Flayout.kicad_pcb",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_other_schemes() {
+        assert!(validate_uri("https://example.com/layout.kicad_pcb").is_err());
+    }
+
+    #[test]
+    fn rejects_untrusted_api_hosts() {
+        assert!(
+            validate_uri(
+                "diode://attacker.example/sandboxes/sandbox/fs/read?path=%2Fworkspace%2Flayout.kicad_pcb",
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn accepts_diode_preview_and_loopback_hosts() {
+        assert!(is_trusted_api_host(
+            "pr-983.preview.api.diode.computer",
+            None
+        ));
+        assert!(is_trusted_api_host("api.gov.diode.computer", None));
+        assert!(is_trusted_api_host("localhost", Some(3001)));
+        assert!(is_trusted_api_host("127.0.0.1", Some(3001)));
+        assert!(!is_trusted_api_host("127.0.0.2", Some(3001)));
+        assert!(!is_trusted_api_host("[::1]", Some(3001)));
+        assert!(!is_trusted_api_host("localhost", Some(8080)));
+        assert!(!is_trusted_api_host("preview.api.diode.computer", None));
+        assert!(!is_trusted_api_host("evil.diode.computer", None));
+        assert!(!is_trusted_api_host(
+            "pr-main.preview.api.diode.computer",
+            None
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_sandbox_file_uris() {
+        assert!(
+            validate_uri(
+                "diode://api.diode.computer/sandboxes/sandbox/fs/write?path=%2Fworkspace%2Flayout.kicad_pcb",
+            )
+            .is_err()
+        );
+        assert!(
+            validate_uri(
+                "diode://api.diode.computer/sandboxes/sandbox/fs/read?path=%2Fworkspace%2F..%2Flayout.kicad_pcb",
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn escapes_linux_desktop_exec_paths() {
+        assert_eq!(
+            escape_desktop_exec_path(Path::new("/tmp/a\\b\"c`d$e%f")),
+            "/tmp/a\\\\\\\\b\\\\\"c\\\\`d\\\\$e%%f"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secures_existing_launcher_log() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "pcb-launcher-permissions-{}-{nonce}.log",
+            std::process::id()
+        ));
+        fs::write(&path, "sandbox output").expect("write log");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("set permissions");
+
+        super::secure_launcher_log_permissions(&path).expect("secure log");
+
+        let mode = fs::metadata(&path)
+            .expect("log metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        fs::remove_file(path).expect("remove log");
+    }
+}

--- a/crates/pcb-launcher/src/main.rs
+++ b/crates/pcb-launcher/src/main.rs
@@ -7,8 +7,45 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use url::Url;
 
-const PCB_TOOLCHAIN: &str = "+latest";
 const LAUNCHER_LOG_MAX_BYTES: u64 = 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LauncherToolchain {
+    Latest,
+    Local,
+}
+
+impl LauncherToolchain {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "latest" => Ok(Self::Latest),
+            "local" => Ok(Self::Local),
+            _ => bail!("expected launcher toolchain `latest` or `local`"),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Latest => "latest",
+            Self::Local => "local",
+        }
+    }
+
+    fn override_arg(self) -> &'static str {
+        match self {
+            Self::Latest => "+latest",
+            Self::Local => "+local",
+        }
+    }
+}
+
+enum LauncherCommand {
+    Install(LauncherToolchain),
+    Open {
+        toolchain: LauncherToolchain,
+        uri: String,
+    },
+}
 
 fn main() {
     if let Some(result) = run_from_args() {
@@ -30,33 +67,55 @@ fn main() {
 }
 
 fn run_from_args() -> Option<Result<()>> {
-    let mut args = std::env::args_os();
-    let _program = args.next();
-    let first = args.next()?;
-    if args.next().is_some() {
-        return Some(Err(anyhow::anyhow!(
-            "expected --install or exactly one diode:// sandbox file URI"
-        )));
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    if args.is_empty() {
+        return None;
     }
-    if first == "--install" {
-        let result = install_protocol_handler();
-        if let Err(error) = &result {
-            append_launcher_error(error);
+    Some(
+        parse_launcher_args(&args).and_then(|command| match command {
+            LauncherCommand::Install(toolchain) => {
+                let result = install_protocol_handler(toolchain);
+                if let Err(error) = &result {
+                    append_launcher_error(error);
+                }
+                result
+            }
+            LauncherCommand::Open { toolchain, uri } => launch_pcb(&uri, toolchain),
+        }),
+    )
+}
+
+fn parse_launcher_args(args: &[std::ffi::OsString]) -> Result<LauncherCommand> {
+    let values: Vec<_> = args.iter().map(|arg| arg.to_string_lossy()).collect();
+    match values.as_slice() {
+        [install] if install == "--install" => {
+            Ok(LauncherCommand::Install(LauncherToolchain::Latest))
         }
-        Some(result)
-    } else {
-        Some(launch_pcb(first.to_string_lossy().as_ref()))
+        [install, option, toolchain] if install == "--install" && option == "--toolchain" => Ok(
+            LauncherCommand::Install(LauncherToolchain::parse(toolchain)?),
+        ),
+        [option, toolchain, uri] if option == "--toolchain" => Ok(LauncherCommand::Open {
+            toolchain: LauncherToolchain::parse(toolchain)?,
+            uri: uri.to_string(),
+        }),
+        [uri] => Ok(LauncherCommand::Open {
+            toolchain: LauncherToolchain::Latest,
+            uri: uri.to_string(),
+        }),
+        _ => bail!(
+            "expected --install [--toolchain latest|local] or [--toolchain latest|local] <diode URI>"
+        ),
     }
 }
 
-fn install_protocol_handler() -> Result<()> {
+fn install_protocol_handler(toolchain: LauncherToolchain) -> Result<()> {
     let launcher = std::env::current_exe().context("failed to locate pcb-launcher")?;
     let pcb = sibling_pcb_executable()?;
-    platform::install(&launcher, &pcb)
+    platform::install(&launcher, &pcb, toolchain)
 }
 
-fn launch_pcb(uri: &str) -> Result<()> {
-    let result = launch_pcb_inner(uri);
+fn launch_pcb(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
+    let result = launch_pcb_inner(uri, toolchain);
     if let Err(error) = &result {
         report_launch_error(error);
     }
@@ -69,10 +128,10 @@ fn report_launch_error(error: &anyhow::Error) {
 }
 
 #[cfg(target_os = "macos")]
-fn spawn_uri_worker(uri: &str) -> Result<()> {
+fn spawn_uri_worker(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
     let launcher = std::env::current_exe().context("failed to locate pcb-launcher")?;
     Command::new(&launcher)
-        .arg(uri)
+        .args(["--toolchain", toolchain.name(), uri])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -81,7 +140,7 @@ fn spawn_uri_worker(uri: &str) -> Result<()> {
     Ok(())
 }
 
-fn launch_pcb_inner(uri: &str) -> Result<()> {
+fn launch_pcb_inner(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
     validate_uri(uri)?;
     let pcb = sibling_pcb_executable()?;
     let mut log = open_launcher_log()?;
@@ -96,7 +155,7 @@ fn launch_pcb_inner(uri: &str) -> Result<()> {
         .context("failed to clone the launcher log handle")?;
     let mut command = Command::new(&pcb);
     command
-        .arg(PCB_TOOLCHAIN)
+        .arg(toolchain.override_arg())
         .arg("open")
         .arg(uri)
         .env("PCB_URL_LAUNCHER", "1")
@@ -292,6 +351,19 @@ fn sibling_pcb_executable() -> Result<PathBuf> {
     Ok(pcb)
 }
 
+#[cfg(target_os = "macos")]
+fn bundled_launcher_toolchain() -> Result<LauncherToolchain> {
+    let launcher = std::env::current_exe().context("failed to locate pcb-launcher")?;
+    let contents = launcher
+        .parent()
+        .and_then(Path::parent)
+        .context("bundled pcb-launcher has no Contents directory")?;
+    let path = contents.join("Resources/pcb-toolchain");
+    let value =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    LauncherToolchain::parse(value.trim())
+}
+
 #[cfg(any(target_os = "linux", test))]
 fn escape_desktop_exec_path(path: &Path) -> String {
     path.to_string_lossy()
@@ -349,7 +421,7 @@ mod platform {
         }
     }
 
-    pub fn install(launcher: &Path, pcb: &Path) -> Result<()> {
+    pub fn install(launcher: &Path, pcb: &Path, toolchain: LauncherToolchain) -> Result<()> {
         let home = dirs::home_dir().context("could not locate the home directory")?;
         let applications = home.join("Applications");
         fs::create_dir_all(&applications)
@@ -380,6 +452,8 @@ mod platform {
             fs::canonicalize(pcb).context("failed to resolve the installed pcb executable")?;
         fs::write(resources.join("pcb-path"), pcb.as_os_str().as_bytes())
             .context("failed to store the installed pcb path")?;
+        fs::write(resources.join("pcb-toolchain"), toolchain.name())
+            .context("failed to store the launcher toolchain")?;
         fs::write(contents.join("Info.plist"), INFO_PLIST)
             .context("failed to write the macOS launcher Info.plist")?;
 
@@ -463,7 +537,7 @@ mod platform {
     use super::*;
     use std::fs;
 
-    pub fn install(launcher: &Path, _pcb: &Path) -> Result<()> {
+    pub fn install(launcher: &Path, _pcb: &Path, toolchain: LauncherToolchain) -> Result<()> {
         let data_home = std::env::var_os("XDG_DATA_HOME")
             .map(PathBuf::from)
             .or_else(|| dirs::home_dir().map(|home| home.join(".local/share")))
@@ -473,7 +547,8 @@ mod platform {
             .with_context(|| format!("failed to create {}", applications.display()))?;
         let escaped = escape_desktop_exec_path(launcher);
         let desktop = format!(
-            "[Desktop Entry]\nType=Application\nName=Diode PCB Launcher\nNoDisplay=true\nTerminal=false\nExec=\"{escaped}\" %u\nMimeType=x-scheme-handler/diode;\n"
+            "[Desktop Entry]\nType=Application\nName=Diode PCB Launcher\nNoDisplay=true\nTerminal=false\nExec=\"{escaped}\" --toolchain {} %u\nMimeType=x-scheme-handler/diode;\n",
+            toolchain.name()
         );
         fs::write(applications.join("diode-pcb-launcher.desktop"), desktop)
             .context("failed to write the Linux desktop entry")?;
@@ -533,8 +608,12 @@ mod platform {
 
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-    pub fn install(launcher: &Path, _pcb: &Path) -> Result<()> {
-        let command = format!("\"{}\" \"%1\"", launcher.display());
+    pub fn install(launcher: &Path, _pcb: &Path, toolchain: LauncherToolchain) -> Result<()> {
+        let command = format!(
+            "\"{}\" --toolchain {} \"%1\"",
+            launcher.display(),
+            toolchain.name()
+        );
         reg_add(
             r"HKCU\Software\Classes\diode",
             None,
@@ -601,9 +680,17 @@ mod macos {
             #[unsafe(method(application:openURLs:))]
             fn application_open_urls(&self, application: &NSApplication, urls: &NSArray<NSURL>) {
                 RECEIVED_URL.store(true, Ordering::Release);
+                let toolchain = match super::bundled_launcher_toolchain() {
+                    Ok(toolchain) => toolchain,
+                    Err(error) => {
+                        super::report_launch_error(&error);
+                        application.terminate(None);
+                        return;
+                    }
+                };
                 for url in urls {
                     if let Some(value) = url.absoluteString()
-                        && let Err(error) = super::spawn_uri_worker(&value.to_string())
+                        && let Err(error) = super::spawn_uri_worker(&value.to_string(), toolchain)
                     {
                         super::report_launch_error(&error);
                         eprintln!("Failed to open in KiCad: {error:#}");
@@ -643,7 +730,11 @@ mod macos {
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_desktop_exec_path, is_trusted_api_host, validate_uri};
+    use super::{
+        LauncherCommand, LauncherToolchain, escape_desktop_exec_path, is_trusted_api_host,
+        parse_launcher_args, validate_uri,
+    };
+    use std::ffi::OsString;
     use std::path::Path;
 
     #[test]
@@ -703,6 +794,32 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn parses_explicit_install_and_open_toolchains() {
+        let install = [
+            OsString::from("--install"),
+            OsString::from("--toolchain"),
+            OsString::from("local"),
+        ];
+        assert!(matches!(
+            parse_launcher_args(&install).unwrap(),
+            LauncherCommand::Install(LauncherToolchain::Local)
+        ));
+
+        let open = [
+            OsString::from("--toolchain"),
+            OsString::from("latest"),
+            OsString::from("diode://api.diode.computer/sandboxes/s/fs/read?path=%2Fa"),
+        ];
+        assert!(matches!(
+            parse_launcher_args(&open).unwrap(),
+            LauncherCommand::Open {
+                toolchain: LauncherToolchain::Latest,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/pcb-launcher/src/main.rs
+++ b/crates/pcb-launcher/src/main.rs
@@ -645,23 +645,10 @@ mod tests {
     }
 
     #[test]
-    fn rejects_untrusted_api_hosts() {
-        assert!(
-            validate_uri(
-                "diode://attacker.example/sandboxes/sandbox/fs/read?path=%2Fworkspace%2Flayout.kicad_pcb",
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn accepts_diode_preview_and_loopback_hosts() {
-        assert!(
-            validate_uri("diode://pr-983.preview.api.diode.computer/sandboxes/s/fs/read?path=%2Fa")
-                .is_ok()
-        );
-        assert!(validate_uri("diode://localhost:3001/sandboxes/s/fs/read?path=%2Fa").is_ok());
-        assert!(validate_uri("diode://localhost:8080/sandboxes/s/fs/read?path=%2Fa").is_err());
+    fn rejects_untrusted_api_hosts_in_release_builds() {
+        let untrusted = "diode://attacker.example/sandboxes/sandbox/fs/read?path=%2Fworkspace%2Flayout.kicad_pcb";
+        // Debug builds trust every host so local API stacks work.
+        assert_eq!(validate_uri(untrusted).is_ok(), cfg!(debug_assertions));
     }
 
     #[test]

--- a/crates/pcb-launcher/src/main.rs
+++ b/crates/pcb-launcher/src/main.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 use anyhow::{Context, Result, bail};
+use pcb_diode_uri::{SandboxFileUri, is_trusted_api_host};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use url::Url;
 
 const LAUNCHER_LOG_MAX_BYTES: u64 = 1024 * 1024;
 
@@ -124,7 +124,8 @@ fn launch_pcb(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
 
 fn report_launch_error(error: &anyhow::Error) {
     append_launcher_error(error);
-    platform::show_error(error, &launcher_log_path());
+    let message = format!("{error:#}\n\nDetails: {}", launcher_log_path().display());
+    pcb_native_dialog::show_error("Open in KiCad failed", &message);
 }
 
 #[cfg(target_os = "macos")]
@@ -144,12 +145,12 @@ fn launch_pcb_inner(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
     validate_uri(uri)?;
     let pcb = sibling_pcb_executable()?;
     let mut log = open_launcher_log()?;
-    writeln!(
-        log,
-        "\n--- pcb-launcher invocation at {:?} ---",
-        std::time::SystemTime::now()
-    )
-    .context("failed to write the launcher log")?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or_default();
+    writeln!(log, "\n--- pcb-launcher invocation at unix {now} ---")
+        .context("failed to write the launcher log")?;
     let stdout = log
         .try_clone()
         .context("failed to clone the launcher log handle")?;
@@ -188,68 +189,11 @@ fn launch_pcb_inner(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
 }
 
 fn validate_uri(uri: &str) -> Result<()> {
-    let url = Url::parse(uri).context("invalid diode URI")?;
-    if url.scheme() != "diode" {
-        bail!("expected a diode:// sandbox file URI");
-    }
-    if !url.username().is_empty() || url.password().is_some() {
-        bail!("diode URI must not include user info");
-    }
-    if url.fragment().is_some() {
-        bail!("diode URI must not include a fragment");
-    }
-
-    let host = url.host_str().context("diode URI must include a host")?;
-    if !is_trusted_api_host(host, url.port()) {
-        bail!("refusing untrusted diode API host: {host}");
-    }
-
-    let segments: Vec<_> = url.path().split('/').skip(1).collect();
-    if segments.len() != 4
-        || segments[0] != "sandboxes"
-        || segments[1].is_empty()
-        || segments[2] != "fs"
-        || segments[3] != "read"
-    {
-        bail!("expected /sandboxes/{{sandboxId}}/fs/read");
-    }
-
-    let mut query = url.query_pairs();
-    let Some((key, path)) = query.next() else {
-        bail!("diode URI must include one path query parameter");
-    };
-    if key != "path" || query.next().is_some() {
-        bail!("diode URI must include only one path query parameter");
-    }
-    if !path.starts_with('/')
-        || path
-            .split('/')
-            .skip(1)
-            .any(|segment| segment.is_empty() || segment == "." || segment == "..")
-    {
-        bail!("diode URI path must be a safe absolute sandbox path");
+    let parsed = SandboxFileUri::parse(uri).context("expected a diode:// sandbox file URI")?;
+    if !is_trusted_api_host(&parsed.host) {
+        bail!("refusing untrusted diode API host: {}", parsed.host);
     }
     Ok(())
-}
-
-fn is_trusted_api_host(host: &str, port: Option<u16>) -> bool {
-    let host = host.to_ascii_lowercase();
-    if host == "localhost" || host == "127.0.0.1" {
-        return port == Some(3001);
-    }
-    port.is_none()
-        && (host == "api.diode.computer"
-            || host == "api.gov.diode.computer"
-            || is_preview_api_host(&host))
-}
-
-fn is_preview_api_host(host: &str) -> bool {
-    let Some(pr) = host.strip_suffix(".preview.api.diode.computer") else {
-        return false;
-    };
-    pr.strip_prefix("pr-").is_some_and(|number| {
-        !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit())
-    })
 }
 
 fn launcher_log_path() -> PathBuf {
@@ -264,7 +208,6 @@ fn open_launcher_log() -> Result<File> {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
-    secure_launcher_log_permissions(&path)?;
     if path
         .metadata()
         .is_ok_and(|metadata| metadata.len() >= LAUNCHER_LOG_MAX_BYTES)
@@ -457,15 +400,12 @@ mod platform {
         fs::write(contents.join("Info.plist"), INFO_PLIST)
             .context("failed to write the macOS launcher Info.plist")?;
 
-        if let Err(error) = run_checked(
+        run_checked(
             Command::new("codesign")
                 .args(["--force", "--deep", "--sign", "-"])
                 .arg(&staged_app),
             "sign the macOS launcher app",
-        ) {
-            let _ = fs::remove_dir_all(&staged_app);
-            return Err(error);
-        }
+        )?;
 
         let had_app = app.exists();
         if had_app {
@@ -505,22 +445,6 @@ mod platform {
             );
         }
         Ok(())
-    }
-
-    pub fn show_error(error: &anyhow::Error, log_path: &Path) {
-        let message = format!("{error:#}\n\nDetails: {}", log_path.display());
-        let _ = Command::new("osascript")
-            .args([
-                "-e",
-                "on run argv",
-                "-e",
-                "display alert \"Open in KiCad failed\" message (item 1 of argv) as critical",
-                "-e",
-                "end run",
-                "--",
-            ])
-            .arg(message)
-            .status();
     }
 
     fn remove_dir_if_exists(path: &Path) -> Result<()> {
@@ -571,21 +495,6 @@ mod platform {
         Ok(())
     }
 
-    pub fn show_error(error: &anyhow::Error, log_path: &Path) {
-        let message = format!("{error:#}\n\nDetails: {}", log_path.display());
-        let shown = Command::new("zenity")
-            .args(["--error", "--title=Open in KiCad failed", "--text"])
-            .arg(&message)
-            .status()
-            .is_ok_and(|status| status.success());
-        if !shown {
-            let _ = Command::new("kdialog")
-                .args(["--title", "Open in KiCad failed", "--error"])
-                .arg(message)
-                .status();
-        }
-    }
-
     fn run_optional(command: &mut Command, description: &str) -> Result<()> {
         match command.status() {
             Ok(status) if status.success() => Ok(()),
@@ -626,21 +535,6 @@ mod platform {
             &command,
         )?;
         Ok(())
-    }
-
-    pub fn show_error(error: &anyhow::Error, log_path: &Path) {
-        let message = format!("{error:#}\n\nDetails: {}", log_path.display());
-        let mut command = Command::new("powershell.exe");
-        command.creation_flags(CREATE_NO_WINDOW);
-        let _ = command
-            .env("PCB_LAUNCHER_ERROR", &message)
-            .args([
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                "Add-Type -AssemblyName PresentationFramework; [System.Windows.MessageBox]::Show($env:PCB_LAUNCHER_ERROR, 'Open in KiCad failed', 'OK', 'Error')",
-            ])
-            .status();
     }
 
     fn reg_add(key: &str, name: Option<&str>, value: &str) -> Result<()> {
@@ -731,8 +625,8 @@ mod macos {
 #[cfg(test)]
 mod tests {
     use super::{
-        LauncherCommand, LauncherToolchain, escape_desktop_exec_path, is_trusted_api_host,
-        parse_launcher_args, validate_uri,
+        LauncherCommand, LauncherToolchain, escape_desktop_exec_path, parse_launcher_args,
+        validate_uri,
     };
     use std::ffi::OsString;
     use std::path::Path;
@@ -762,22 +656,12 @@ mod tests {
 
     #[test]
     fn accepts_diode_preview_and_loopback_hosts() {
-        assert!(is_trusted_api_host(
-            "pr-983.preview.api.diode.computer",
-            None
-        ));
-        assert!(is_trusted_api_host("api.gov.diode.computer", None));
-        assert!(is_trusted_api_host("localhost", Some(3001)));
-        assert!(is_trusted_api_host("127.0.0.1", Some(3001)));
-        assert!(!is_trusted_api_host("127.0.0.2", Some(3001)));
-        assert!(!is_trusted_api_host("[::1]", Some(3001)));
-        assert!(!is_trusted_api_host("localhost", Some(8080)));
-        assert!(!is_trusted_api_host("preview.api.diode.computer", None));
-        assert!(!is_trusted_api_host("evil.diode.computer", None));
-        assert!(!is_trusted_api_host(
-            "pr-main.preview.api.diode.computer",
-            None
-        ));
+        assert!(
+            validate_uri("diode://pr-983.preview.api.diode.computer/sandboxes/s/fs/read?path=%2Fa")
+                .is_ok()
+        );
+        assert!(validate_uri("diode://localhost:3001/sandboxes/s/fs/read?path=%2Fa").is_ok());
+        assert!(validate_uri("diode://localhost:8080/sandboxes/s/fs/read?path=%2Fa").is_err());
     }
 
     #[test]

--- a/crates/pcb-native-dialog/Cargo.toml
+++ b/crates/pcb-native-dialog/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pcb-native-dialog"
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+description = "Minimal native message dialogs for the pcb toolchain"
+homepage = { workspace = true }
+authors = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }

--- a/crates/pcb-native-dialog/src/lib.rs
+++ b/crates/pcb-native-dialog/src/lib.rs
@@ -1,0 +1,318 @@
+//! Minimal native message dialogs (macOS / Linux / Windows) shared by the
+//! pcb tools that run without a terminal, such as browser-launched opens.
+
+use anyhow::{Result, bail};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Choice {
+    Confirm,
+    Decline,
+    Cancel,
+}
+
+/// A three-way native dialog: a default confirm button, an alternative
+/// decline button, and Cancel.
+pub struct ConfirmDialog<'a> {
+    pub title: &'a str,
+    pub message: &'a str,
+    pub confirm_label: &'a str,
+    pub decline_label: &'a str,
+}
+
+impl ConfirmDialog<'_> {
+    pub fn show(&self) -> Result<Choice> {
+        platform::show_confirm(self)
+    }
+
+    fn parse_choice(&self, value: &str) -> Result<Choice> {
+        match value.trim() {
+            value if value == self.confirm_label || value == "Yes" => Ok(Choice::Confirm),
+            value if value == self.decline_label || value == "No" => Ok(Choice::Decline),
+            "Cancel" => Ok(Choice::Cancel),
+            value => bail!("native dialog returned an unexpected choice: {value:?}"),
+        }
+    }
+
+    #[cfg(any(target_os = "linux", test))]
+    fn parse_zenity_choice(
+        &self,
+        status_success: bool,
+        status_code: Option<i32>,
+        stdout: &str,
+    ) -> Result<Choice> {
+        if !stdout.trim().is_empty() {
+            return self.parse_choice(stdout);
+        }
+        if status_success {
+            return Ok(Choice::Confirm);
+        }
+        if status_code == Some(1) {
+            return Ok(Choice::Cancel);
+        }
+        bail!("zenity dialog failed with exit code {status_code:?}")
+    }
+}
+
+/// Show a best-effort native error alert; failures to display are ignored.
+pub fn show_error(title: &str, message: &str) {
+    platform::show_error(title, message);
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn applescript_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::*;
+    use anyhow::Context;
+    use std::process::Command;
+
+    pub fn show_confirm(dialog: &ConfirmDialog) -> Result<Choice> {
+        let confirm = applescript_string(dialog.confirm_label);
+        let show_dialog = format!(
+            "set dialogResult to display dialog (item 1 of argv) buttons {{\"Cancel\", {}, {confirm}}} default button {confirm} cancel button \"Cancel\" with title {} with icon caution",
+            applescript_string(dialog.decline_label),
+            applescript_string(dialog.title),
+        );
+        let output = Command::new("osascript")
+            .args([
+                "-e",
+                "on run argv",
+                "-e",
+                "try",
+                "-e",
+                &show_dialog,
+                "-e",
+                "return button returned of dialogResult",
+                "-e",
+                "on error number -128",
+                "-e",
+                "return \"Cancel\"",
+                "-e",
+                "end try",
+                "-e",
+                "end run",
+                "--",
+            ])
+            .arg(dialog.message)
+            .output()
+            .context("failed to show the macOS dialog")?;
+        if !output.status.success() {
+            bail!(
+                "macOS dialog failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        dialog.parse_choice(&String::from_utf8_lossy(&output.stdout))
+    }
+
+    pub fn show_error(title: &str, message: &str) {
+        let show_alert = format!(
+            "display alert {} message (item 1 of argv) as critical",
+            applescript_string(title)
+        );
+        let _ = Command::new("osascript")
+            .args([
+                "-e",
+                "on run argv",
+                "-e",
+                &show_alert,
+                "-e",
+                "end run",
+                "--",
+            ])
+            .arg(message)
+            .status();
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::*;
+    use anyhow::Context;
+    use std::process::Command;
+
+    pub fn show_confirm(dialog: &ConfirmDialog) -> Result<Choice> {
+        match show_zenity(dialog) {
+            Ok(choice) => Ok(choice),
+            Err(zenity_error) => show_kdialog(dialog).with_context(|| {
+                format!("failed to show dialog with zenity ({zenity_error:#}) or kdialog")
+            }),
+        }
+    }
+
+    fn show_zenity(dialog: &ConfirmDialog) -> Result<Choice> {
+        let output = Command::new("zenity")
+            .arg("--question")
+            .arg(format!("--title={}", dialog.title))
+            .arg(format!("--ok-label={}", dialog.confirm_label))
+            .arg("--cancel-label=Cancel")
+            .arg(format!("--extra-button={}", dialog.decline_label))
+            .arg("--text")
+            .arg(dialog.message)
+            .output()
+            .context("failed to run zenity")?;
+        dialog
+            .parse_zenity_choice(
+                output.status.success(),
+                output.status.code(),
+                &String::from_utf8_lossy(&output.stdout),
+            )
+            .with_context(|| {
+                format!(
+                    "zenity dialog failed: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                )
+            })
+    }
+
+    fn show_kdialog(dialog: &ConfirmDialog) -> Result<Choice> {
+        let status = Command::new("kdialog")
+            .args([
+                "--title",
+                dialog.title,
+                "--yesnocancel",
+                dialog.message,
+                "--yes-label",
+                dialog.confirm_label,
+                "--no-label",
+                dialog.decline_label,
+                "--cancel-label",
+                "Cancel",
+            ])
+            .status()
+            .context("failed to run kdialog")?;
+        match status.code() {
+            Some(0) => Ok(Choice::Confirm),
+            Some(1) => Ok(Choice::Decline),
+            Some(2) => Ok(Choice::Cancel),
+            code => bail!("kdialog dialog failed with exit code {code:?}"),
+        }
+    }
+
+    pub fn show_error(title: &str, message: &str) {
+        let shown = Command::new("zenity")
+            .arg("--error")
+            .arg(format!("--title={title}"))
+            .arg("--text")
+            .arg(message)
+            .status()
+            .is_ok_and(|status| status.success());
+        if !shown {
+            let _ = Command::new("kdialog")
+                .args(["--title", title, "--error", message])
+                .status();
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use super::*;
+    use anyhow::Context;
+    use std::os::windows::process::CommandExt;
+    use std::process::Command;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    fn message_box(title: &str, message: &str, buttons: &str, icon: &str) -> Command {
+        let mut command = Command::new("powershell.exe");
+        command
+            .creation_flags(CREATE_NO_WINDOW)
+            .env("PCB_DIALOG_TITLE", title)
+            .env("PCB_DIALOG_MESSAGE", message)
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &format!(
+                    "Add-Type -AssemblyName PresentationFramework; [System.Windows.MessageBox]::Show($env:PCB_DIALOG_MESSAGE, $env:PCB_DIALOG_TITLE, '{buttons}', '{icon}')"
+                ),
+            ]);
+        command
+    }
+
+    pub fn show_confirm(dialog: &ConfirmDialog) -> Result<Choice> {
+        let message = format!(
+            "{}\n\nYes \u{2014} {}\nNo \u{2014} {}",
+            dialog.message, dialog.confirm_label, dialog.decline_label
+        );
+        let output = message_box(dialog.title, &message, "YesNoCancel", "Warning")
+            .output()
+            .context("failed to show the Windows dialog")?;
+        if !output.status.success() {
+            bail!(
+                "Windows dialog failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        dialog.parse_choice(&String::from_utf8_lossy(&output.stdout))
+    }
+
+    pub fn show_error(title: &str, message: &str) {
+        let _ = message_box(title, message, "OK", "Error").status();
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+mod platform {
+    use super::*;
+
+    pub fn show_confirm(_dialog: &ConfirmDialog) -> Result<Choice> {
+        bail!("native dialogs are not supported on this platform")
+    }
+
+    pub fn show_error(title: &str, message: &str) {
+        eprintln!("{title}: {message}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dialog() -> ConfirmDialog<'static> {
+        ConfirmDialog {
+            title: "Restore local KiCad backup?",
+            message: "message",
+            confirm_label: "Restore Backup",
+            decline_label: "Open Sandbox Version",
+        }
+    }
+
+    #[test]
+    fn parses_native_dialog_choices() {
+        assert_eq!(
+            dialog().parse_choice("Restore Backup\n").unwrap(),
+            Choice::Confirm
+        );
+        assert_eq!(dialog().parse_choice("No\r\n").unwrap(), Choice::Decline);
+        assert_eq!(dialog().parse_choice("Cancel").unwrap(), Choice::Cancel);
+        assert!(dialog().parse_choice("Maybe").is_err());
+    }
+
+    #[test]
+    fn parses_zenity_extra_button_before_exit_code() {
+        assert_eq!(
+            dialog()
+                .parse_zenity_choice(false, Some(1), "Open Sandbox Version\n")
+                .unwrap(),
+            Choice::Decline
+        );
+        assert_eq!(
+            dialog().parse_zenity_choice(false, Some(1), "").unwrap(),
+            Choice::Cancel
+        );
+        assert_eq!(
+            dialog().parse_zenity_choice(true, Some(0), "").unwrap(),
+            Choice::Confirm
+        );
+    }
+
+    #[test]
+    fn escapes_applescript_strings() {
+        assert_eq!(applescript_string(r#"a\b"c"#), r#""a\\b\"c""#);
+    }
+}

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -28,6 +28,7 @@ const MAX_DOWNLOAD_BYTES: u64 = 512 * 1024 * 1024;
 const RELEASE_LIST_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const NIGHTLY_RELEASE_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 const SELF_UPDATE_REEXEC_ENV: &str = "PCB_SELF_UPDATE_REEXEC";
+const SELF_UPDATE_RELEASE_ENV: &str = "PCB_SELF_UPDATE_RELEASE";
 
 #[derive(Parser)]
 #[command(name = "pcb")]
@@ -105,7 +106,7 @@ struct InstallReceipt {
     installed_at: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct LatestRelease {
     version: Version,
     tag: String,
@@ -1711,20 +1712,34 @@ fn self_update() -> Result<()> {
     let current_version = Version::parse(env!("CARGO_PKG_VERSION"))?;
     let mut failures = Vec::new();
     let mut shim_status = format!("pcb shim {current_version}: current");
-    if std::env::var_os(SELF_UPDATE_REEXEC_ENV).is_none() {
-        match fetch_latest_release() {
-            Ok(latest) if latest.version > current_version => {
+    let latest_release = match self_update_latest_release() {
+        Ok(latest) => {
+            if std::env::var_os(SELF_UPDATE_REEXEC_ENV).is_none()
+                && latest.version > current_version
+            {
                 let version = latest.version.clone();
                 let shim = install_shim_update(&latest)?;
-                reexec_self_update(&shim, &current_version, &version)?;
+                reexec_self_update(&shim, &current_version, &version, &latest)?;
             }
-            Ok(_) => {}
-            Err(err) => {
-                shim_status = format!("pcb shim {current_version}: update check failed");
-                failures.push(format!("failed to check latest pcb shim release: {err}"));
-            }
+            Some(latest)
         }
-    }
+        Err(err) => {
+            shim_status = format!("pcb shim {current_version}: update check failed");
+            failures.push(format!("failed to check latest pcb shim release: {err}"));
+            None
+        }
+    };
+
+    let launcher_status = match latest_release.as_ref() {
+        Some(latest) => match install_shim_launcher(latest) {
+            Ok(()) => "pcb launcher: current".to_string(),
+            Err(err) => {
+                eprintln!("Warning: failed to update the optional pcb launcher: {err}");
+                "pcb launcher: update skipped".to_string()
+            }
+        },
+        None => "pcb launcher: update skipped".to_string(),
+    };
 
     let mut requests = BTreeSet::new();
     let stable_result: Result<Vec<(Version, Version, PathBuf)>> = (|| {
@@ -1798,6 +1813,7 @@ fn self_update() -> Result<()> {
     };
 
     println!("{shim_status}");
+    println!("{launcher_status}");
     println!(
         "stable toolchains: {}",
         if stable_result.is_ok() {
@@ -1821,7 +1837,31 @@ fn finish_self_update(failures: Vec<String>) -> Result<()> {
 
 fn fetch_latest_release() -> Result<LatestRelease> {
     let content = download_text(&http_client(METADATA_TIMEOUT)?, SHIM_LATEST_RELEASE_URL)?;
-    Ok(serde_json::from_str(&content)?)
+    parse_latest_release(&content)
+}
+
+fn parse_latest_release(content: &str) -> Result<LatestRelease> {
+    let release: LatestRelease = serde_json::from_str(content)?;
+    let expected_tag = format!("pcb/v{}", release.version);
+    anyhow::ensure!(
+        release.tag == expected_tag,
+        "invalid pcb release tag {:?}; expected {expected_tag:?}",
+        release.tag
+    );
+    Ok(release)
+}
+
+fn self_update_latest_release() -> Result<LatestRelease> {
+    if std::env::var_os(SELF_UPDATE_REEXEC_ENV).is_none() {
+        return fetch_latest_release();
+    }
+
+    let release = match std::env::var(SELF_UPDATE_RELEASE_ENV) {
+        Ok(release) => release,
+        Err(std::env::VarError::NotPresent) => return fetch_latest_release(),
+        Err(error) => return Err(error.into()),
+    };
+    parse_latest_release(&release)
 }
 
 fn fetch_nightly_release(force_refresh: bool) -> Result<NightlyRelease> {
@@ -1889,13 +1929,173 @@ fn install_shim_update(latest: &LatestRelease) -> Result<PathBuf> {
     Ok(installed_shim)
 }
 
-fn reexec_self_update(shim: &Path, from: &Version, to: &Version) -> Result<()> {
+fn install_shim_launcher(latest: &LatestRelease) -> Result<()> {
+    ensure_supported_target()?;
+
+    let installed_shim =
+        std::env::current_exe().context("failed to locate current pcb shim executable")?;
+    let install_dir = installed_shim
+        .parent()
+        .context("current pcb shim has no parent directory")?;
+    let installed_launcher = install_dir.join(executable_name("pcb-launcher"));
+    let client = http_client(ARCHIVE_TIMEOUT)?;
+    let mut download = None;
+    let mut launcher_is_current = false;
+    for target in download_target_triples().iter().copied() {
+        let binary_name = binary_artifact_name_for("pcb-launcher", target);
+        let binary_url = format!("{RELEASE_BASE_URL}/{}/{}", latest.tag, binary_name);
+        let checksum_url = format!("{binary_url}.sha256");
+        let expected_sha256 = download_optional(&client, &checksum_url)?
+            .map(|bytes| {
+                let checksum = String::from_utf8(bytes)
+                    .with_context(|| format!("checksum is not UTF-8: {checksum_url}"))?;
+                parse_sha256(&checksum)
+            })
+            .transpose()?;
+
+        if let Some(expected_sha256) = expected_sha256.as_deref()
+            && installed_launcher.is_file()
+            && sha256_file(&installed_launcher)? == expected_sha256
+        {
+            launcher_is_current = true;
+            break;
+        }
+
+        if let Some(bytes) = download_optional_artifact(&client, &binary_url)? {
+            let expected_sha256 = expected_sha256.with_context(|| {
+                format!("missing checksum for pcb launcher artifact: {binary_url}")
+            })?;
+            let actual_sha256 = sha256_hex(&bytes);
+            anyhow::ensure!(
+                actual_sha256 == expected_sha256,
+                "checksum mismatch for {binary_url}: expected {expected_sha256}, got {actual_sha256}"
+            );
+            download = Some(bytes);
+            break;
+        }
+    }
+    if !launcher_is_current && download.is_none() {
+        anyhow::bail!(
+            "no pcb launcher binary found for {} on {}",
+            latest.tag,
+            target_triple()
+        );
+    }
+
+    if let Some(bytes) = download {
+        let temporary_launcher =
+            install_dir.join(format!(".pcb-launcher-{}.tmp", std::process::id()));
+        let install_result: Result<()> = (|| {
+            fs::write(&temporary_launcher, bytes).with_context(|| {
+                format!(
+                    "failed to stage pcb launcher at {}",
+                    temporary_launcher.display()
+                )
+            })?;
+            copy_executable_permissions(&temporary_launcher, &temporary_launcher)?;
+
+            #[cfg(windows)]
+            {
+                let backup_launcher =
+                    install_dir.join(format!(".pcb-launcher-{}.old", std::process::id()));
+                if backup_launcher.exists() {
+                    fs::remove_file(&backup_launcher).with_context(|| {
+                        format!(
+                            "failed to remove stale pcb launcher backup {}",
+                            backup_launcher.display()
+                        )
+                    })?;
+                }
+                let had_installed_launcher = installed_launcher.exists();
+                if had_installed_launcher {
+                    fs::rename(&installed_launcher, &backup_launcher).with_context(|| {
+                        format!(
+                            "failed to back up existing pcb launcher {}",
+                            installed_launcher.display()
+                        )
+                    })?;
+                }
+                if let Err(install_error) = fs::rename(&temporary_launcher, &installed_launcher) {
+                    if had_installed_launcher {
+                        fs::rename(&backup_launcher, &installed_launcher).with_context(|| {
+                        format!(
+                            "failed to restore pcb launcher {} after update failed: {install_error}",
+                            installed_launcher.display()
+                        )
+                    })?;
+                    }
+                    return Err(install_error).with_context(|| {
+                        format!(
+                            "failed to install pcb launcher at {}",
+                            installed_launcher.display()
+                        )
+                    });
+                }
+                if had_installed_launcher {
+                    if let Err(error) = fs::remove_file(&backup_launcher) {
+                        eprintln!(
+                            "Warning: failed to remove pcb launcher backup {}: {error}",
+                            backup_launcher.display()
+                        );
+                    }
+                }
+            }
+            #[cfg(not(windows))]
+            fs::rename(&temporary_launcher, &installed_launcher).with_context(|| {
+                format!(
+                    "failed to install pcb launcher at {}",
+                    installed_launcher.display()
+                )
+            })?;
+
+            Ok(())
+        })();
+        if let Err(error) = install_result {
+            if let Err(cleanup_error) = fs::remove_file(&temporary_launcher)
+                && cleanup_error.kind() != std::io::ErrorKind::NotFound
+            {
+                eprintln!(
+                    "Warning: failed to remove staged pcb launcher {}: {cleanup_error}",
+                    temporary_launcher.display()
+                );
+            }
+            return Err(error);
+        }
+    }
+
+    let status = Command::new(&installed_launcher)
+        .arg("--install")
+        .status()
+        .with_context(|| {
+            format!(
+                "failed to run pcb launcher registration at {}",
+                installed_launcher.display()
+            )
+        })?;
+    let launcher_log = dirs::home_dir()
+        .map(|home| home.join(".pcb/pcb-launcher.log"))
+        .unwrap_or_else(|| std::env::temp_dir().join("pcb-launcher.log"));
+    anyhow::ensure!(
+        status.success(),
+        "pcb launcher registration failed with {status}; see {}",
+        launcher_log.display()
+    );
+    Ok(())
+}
+
+fn reexec_self_update(
+    shim: &Path,
+    from: &Version,
+    to: &Version,
+    latest: &LatestRelease,
+) -> Result<()> {
     println!("Updated pcb {from} → {to}; continuing with updated shim");
 
     let mut command = Command::new(shim);
     command
         .args(["self", "update"])
-        .env(SELF_UPDATE_REEXEC_ENV, "1");
+        .env(SELF_UPDATE_REEXEC_ENV, "1")
+        .env(SELF_UPDATE_RELEASE_ENV, serde_json::to_string(latest)?);
 
     #[cfg(unix)]
     {
@@ -2308,6 +2508,18 @@ mod tests {
                 Version::parse("0.4.0-beta.1").unwrap(),
             ]
         );
+    }
+
+    #[test]
+    fn latest_release_requires_canonical_tag() {
+        let release = parse_latest_release(r#"{"version":"0.4.17","tag":"pcb/v0.4.17"}"#).unwrap();
+        assert_eq!(release.tag, "pcb/v0.4.17");
+
+        let error =
+            parse_latest_release(r#"{"version":"0.4.17","tag":"pcb/v0.4.17/../../attacker"}"#)
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("invalid pcb release tag"));
     }
 
     #[test]

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -2064,7 +2064,7 @@ fn install_shim_launcher(latest: &LatestRelease) -> Result<()> {
     }
 
     let status = Command::new(&installed_launcher)
-        .arg("--install")
+        .args(["--install", "--toolchain", "latest"])
         .status()
         .with_context(|| {
             format!(

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -1938,129 +1938,10 @@ fn install_shim_launcher(latest: &LatestRelease) -> Result<()> {
         .parent()
         .context("current pcb shim has no parent directory")?;
     let installed_launcher = install_dir.join(executable_name("pcb-launcher"));
-    let client = http_client(ARCHIVE_TIMEOUT)?;
-    let mut download = None;
-    let mut launcher_is_current = false;
-    for target in download_target_triples().iter().copied() {
-        let binary_name = binary_artifact_name_for("pcb-launcher", target);
-        let binary_url = format!("{RELEASE_BASE_URL}/{}/{}", latest.tag, binary_name);
-        let checksum_url = format!("{binary_url}.sha256");
-        let expected_sha256 = download_optional(&client, &checksum_url)?
-            .map(|bytes| {
-                let checksum = String::from_utf8(bytes)
-                    .with_context(|| format!("checksum is not UTF-8: {checksum_url}"))?;
-                parse_sha256(&checksum)
-            })
-            .transpose()?;
 
-        if let Some(expected_sha256) = expected_sha256.as_deref()
-            && installed_launcher.is_file()
-            && sha256_file(&installed_launcher)? == expected_sha256
-        {
-            launcher_is_current = true;
-            break;
-        }
-
-        if let Some(bytes) = download_optional_artifact(&client, &binary_url)? {
-            let expected_sha256 = expected_sha256.with_context(|| {
-                format!("missing checksum for pcb launcher artifact: {binary_url}")
-            })?;
-            let actual_sha256 = sha256_hex(&bytes);
-            anyhow::ensure!(
-                actual_sha256 == expected_sha256,
-                "checksum mismatch for {binary_url}: expected {expected_sha256}, got {actual_sha256}"
-            );
-            download = Some(bytes);
-            break;
-        }
-    }
-    if !launcher_is_current && download.is_none() {
-        anyhow::bail!(
-            "no pcb launcher binary found for {} on {}",
-            latest.tag,
-            target_triple()
-        );
-    }
-
-    if let Some(bytes) = download {
-        let temporary_launcher =
-            install_dir.join(format!(".pcb-launcher-{}.tmp", std::process::id()));
-        let install_result: Result<()> = (|| {
-            fs::write(&temporary_launcher, bytes).with_context(|| {
-                format!(
-                    "failed to stage pcb launcher at {}",
-                    temporary_launcher.display()
-                )
-            })?;
-            copy_executable_permissions(&temporary_launcher, &temporary_launcher)?;
-
-            #[cfg(windows)]
-            {
-                let backup_launcher =
-                    install_dir.join(format!(".pcb-launcher-{}.old", std::process::id()));
-                if backup_launcher.exists() {
-                    fs::remove_file(&backup_launcher).with_context(|| {
-                        format!(
-                            "failed to remove stale pcb launcher backup {}",
-                            backup_launcher.display()
-                        )
-                    })?;
-                }
-                let had_installed_launcher = installed_launcher.exists();
-                if had_installed_launcher {
-                    fs::rename(&installed_launcher, &backup_launcher).with_context(|| {
-                        format!(
-                            "failed to back up existing pcb launcher {}",
-                            installed_launcher.display()
-                        )
-                    })?;
-                }
-                if let Err(install_error) = fs::rename(&temporary_launcher, &installed_launcher) {
-                    if had_installed_launcher {
-                        fs::rename(&backup_launcher, &installed_launcher).with_context(|| {
-                        format!(
-                            "failed to restore pcb launcher {} after update failed: {install_error}",
-                            installed_launcher.display()
-                        )
-                    })?;
-                    }
-                    return Err(install_error).with_context(|| {
-                        format!(
-                            "failed to install pcb launcher at {}",
-                            installed_launcher.display()
-                        )
-                    });
-                }
-                if had_installed_launcher {
-                    if let Err(error) = fs::remove_file(&backup_launcher) {
-                        eprintln!(
-                            "Warning: failed to remove pcb launcher backup {}: {error}",
-                            backup_launcher.display()
-                        );
-                    }
-                }
-            }
-            #[cfg(not(windows))]
-            fs::rename(&temporary_launcher, &installed_launcher).with_context(|| {
-                format!(
-                    "failed to install pcb launcher at {}",
-                    installed_launcher.display()
-                )
-            })?;
-
-            Ok(())
-        })();
-        if let Err(error) = install_result {
-            if let Err(cleanup_error) = fs::remove_file(&temporary_launcher)
-                && cleanup_error.kind() != std::io::ErrorKind::NotFound
-            {
-                eprintln!(
-                    "Warning: failed to remove staged pcb launcher {}: {cleanup_error}",
-                    temporary_launcher.display()
-                );
-            }
-            return Err(error);
-        }
+    if let Some(bytes) = fetch_launcher_update(latest, &installed_launcher)? {
+        let staged_launcher = install_dir.join(format!(".pcb-launcher-{}.tmp", std::process::id()));
+        install_staged_executable(&staged_launcher, &installed_launcher, &bytes)?;
     }
 
     let status = Command::new(&installed_launcher)
@@ -2081,6 +1962,113 @@ fn install_shim_launcher(latest: &LatestRelease) -> Result<()> {
         launcher_log.display()
     );
     Ok(())
+}
+
+/// Download the launcher binary for this release, or return `None` when the
+/// installed launcher already matches the release checksum.
+fn fetch_launcher_update(
+    latest: &LatestRelease,
+    installed_launcher: &Path,
+) -> Result<Option<Vec<u8>>> {
+    let client = http_client(ARCHIVE_TIMEOUT)?;
+    for target in download_target_triples().iter().copied() {
+        let binary_name = binary_artifact_name_for("pcb-launcher", target);
+        let binary_url = format!("{RELEASE_BASE_URL}/{}/{}", latest.tag, binary_name);
+        let checksum_url = format!("{binary_url}.sha256");
+        let expected_sha256 = download_optional(&client, &checksum_url)?
+            .map(|bytes| {
+                let checksum = String::from_utf8(bytes)
+                    .with_context(|| format!("checksum is not UTF-8: {checksum_url}"))?;
+                parse_sha256(&checksum)
+            })
+            .transpose()?;
+
+        if let Some(expected_sha256) = expected_sha256.as_deref()
+            && installed_launcher.is_file()
+            && sha256_file(installed_launcher)? == expected_sha256
+        {
+            return Ok(None);
+        }
+
+        if let Some(bytes) = download_optional_artifact(&client, &binary_url)? {
+            let expected_sha256 = expected_sha256.with_context(|| {
+                format!("missing checksum for pcb launcher artifact: {binary_url}")
+            })?;
+            let actual_sha256 = sha256_hex(&bytes);
+            anyhow::ensure!(
+                actual_sha256 == expected_sha256,
+                "checksum mismatch for {binary_url}: expected {expected_sha256}, got {actual_sha256}"
+            );
+            return Ok(Some(bytes));
+        }
+    }
+    anyhow::bail!(
+        "no pcb launcher binary found for {} on {}",
+        latest.tag,
+        target_triple()
+    )
+}
+
+/// Write `bytes` to `staged` and move it over `installed`, cleaning up the
+/// staged file on failure.
+fn install_staged_executable(staged: &Path, installed: &Path, bytes: &[u8]) -> Result<()> {
+    let result = (|| {
+        fs::write(staged, bytes)
+            .with_context(|| format!("failed to stage {}", staged.display()))?;
+        copy_executable_permissions(staged, staged)?;
+        replace_executable_with_backup(staged, installed)
+    })();
+    if result.is_err()
+        && let Err(cleanup_error) = fs::remove_file(staged)
+        && cleanup_error.kind() != std::io::ErrorKind::NotFound
+    {
+        eprintln!(
+            "Warning: failed to remove staged {}: {cleanup_error}",
+            staged.display()
+        );
+    }
+    result
+}
+
+/// Move `staged` over `installed`. Windows cannot replace a running or
+/// locked executable in place, so the existing binary is moved aside first
+/// and restored when the swap fails.
+fn replace_executable_with_backup(staged: &Path, installed: &Path) -> Result<()> {
+    #[cfg(windows)]
+    {
+        let backup = installed.with_extension(format!("{}.old", std::process::id()));
+        if backup.exists() {
+            fs::remove_file(&backup)
+                .with_context(|| format!("failed to remove stale backup {}", backup.display()))?;
+        }
+        let had_installed = installed.exists();
+        if had_installed {
+            fs::rename(installed, &backup)
+                .with_context(|| format!("failed to back up {}", installed.display()))?;
+        }
+        if let Err(install_error) = fs::rename(staged, installed) {
+            if had_installed {
+                fs::rename(&backup, installed).with_context(|| {
+                    format!(
+                        "failed to restore {} after update failed: {install_error}",
+                        installed.display()
+                    )
+                })?;
+            }
+            return Err(install_error)
+                .with_context(|| format!("failed to install {}", installed.display()));
+        }
+        if had_installed && let Err(error) = fs::remove_file(&backup) {
+            eprintln!(
+                "Warning: failed to remove backup {}: {error}",
+                backup.display()
+            );
+        }
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    fs::rename(staged, installed)
+        .with_context(|| format!("failed to install {}", installed.display()))
 }
 
 fn reexec_self_update(

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -44,6 +44,7 @@ dirs = { workspace = true }
 env_logger = { workspace = true }
 colored = { workspace = true }
 pcb-kicad = { workspace = true }
+pcb-native-dialog = { workspace = true }
 pcb-command-runner = { workspace = true }
 pcb-kicad-sch = { workspace = true }
 open = { workspace = true }

--- a/crates/pcbc/src/main.rs
+++ b/crates/pcbc/src/main.rs
@@ -40,6 +40,7 @@ mod open;
 #[path = "mod/mod.rs"]
 mod pcb_mod;
 mod publish;
+mod recovery_dialog;
 mod release;
 mod remote_sandbox;
 mod route;

--- a/crates/pcbc/src/main.rs
+++ b/crates/pcbc/src/main.rs
@@ -38,6 +38,7 @@ mod open;
 mod pcb_mod;
 mod preview;
 mod publish;
+mod recovery_dialog;
 mod release;
 mod remote_sandbox;
 mod route;

--- a/crates/pcbc/src/recovery_dialog.rs
+++ b/crates/pcbc/src/recovery_dialog.rs
@@ -1,8 +1,8 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use chrono::{DateTime, Local};
+use pcb_native_dialog::{Choice, ConfirmDialog};
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 pub const URL_LAUNCHER_ENV: &str = "PCB_URL_LAUNCHER";
 
@@ -24,7 +24,18 @@ pub fn choose(layout_file: &Path) -> Result<RecoveryChoice> {
             )
         })?;
     let message = recovery_message(layout_file, DateTime::<Local>::from(modified));
-    platform::show(&message)
+    let choice = ConfirmDialog {
+        title: "Restore local KiCad backup?",
+        message: &message,
+        confirm_label: "Restore Backup",
+        decline_label: "Open Sandbox Version",
+    }
+    .show()?;
+    Ok(match choice {
+        Choice::Confirm => RecoveryChoice::Restore,
+        Choice::Decline => RecoveryChoice::Discard,
+        Choice::Cancel => RecoveryChoice::Cancel,
+    })
 }
 
 fn recovery_message<Tz>(layout_file: &Path, updated_at: DateTime<Tz>) -> String
@@ -44,177 +55,6 @@ where
     )
 }
 
-fn parse_choice(value: &str) -> Result<RecoveryChoice> {
-    match value.trim() {
-        "Restore Backup" | "Yes" => Ok(RecoveryChoice::Restore),
-        "Open Sandbox Version" | "No" => Ok(RecoveryChoice::Discard),
-        "Cancel" => Ok(RecoveryChoice::Cancel),
-        value => bail!("recovery dialog returned an unexpected choice: {value:?}"),
-    }
-}
-
-#[cfg(any(target_os = "linux", test))]
-fn parse_zenity_choice(
-    status_success: bool,
-    status_code: Option<i32>,
-    stdout: &str,
-) -> Result<RecoveryChoice> {
-    if !stdout.trim().is_empty() {
-        return parse_choice(stdout);
-    }
-    if status_success {
-        return Ok(RecoveryChoice::Restore);
-    }
-    if status_code == Some(1) {
-        return Ok(RecoveryChoice::Cancel);
-    }
-    bail!("zenity recovery dialog failed with exit code {status_code:?}")
-}
-
-#[cfg(target_os = "macos")]
-mod platform {
-    use super::*;
-
-    pub fn show(message: &str) -> Result<RecoveryChoice> {
-        let output = Command::new("osascript")
-            .args([
-                "-e",
-                "on run argv",
-                "-e",
-                "try",
-                "-e",
-                "set dialogResult to display dialog (item 1 of argv) buttons {\"Cancel\", \"Open Sandbox Version\", \"Restore Backup\"} default button \"Restore Backup\" cancel button \"Cancel\" with title \"Restore local KiCad backup?\" with icon caution",
-                "-e",
-                "return button returned of dialogResult",
-                "-e",
-                "on error number -128",
-                "-e",
-                "return \"Cancel\"",
-                "-e",
-                "end try",
-                "-e",
-                "end run",
-                "--",
-            ])
-            .arg(message)
-            .output()
-            .context("failed to show the macOS recovery dialog")?;
-        if !output.status.success() {
-            bail!(
-                "macOS recovery dialog failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
-        parse_choice(&String::from_utf8_lossy(&output.stdout))
-    }
-}
-
-#[cfg(target_os = "linux")]
-mod platform {
-    use super::*;
-
-    pub fn show(message: &str) -> Result<RecoveryChoice> {
-        match show_zenity(message) {
-            Ok(choice) => Ok(choice),
-            Err(zenity_error) => show_kdialog(message).with_context(|| {
-                format!("failed to show recovery dialog with zenity ({zenity_error:#}) or kdialog")
-            }),
-        }
-    }
-
-    fn show_zenity(message: &str) -> Result<RecoveryChoice> {
-        let output = Command::new("zenity")
-            .args([
-                "--question",
-                "--title=Restore local KiCad backup?",
-                "--ok-label=Restore Backup",
-                "--cancel-label=Cancel",
-                "--extra-button=Open Sandbox Version",
-                "--text",
-            ])
-            .arg(message)
-            .output()
-            .context("failed to run zenity")?;
-        parse_zenity_choice(
-            output.status.success(),
-            output.status.code(),
-            &String::from_utf8_lossy(&output.stdout),
-        )
-        .with_context(|| {
-            format!(
-                "zenity recovery dialog failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            )
-        })
-    }
-
-    fn show_kdialog(message: &str) -> Result<RecoveryChoice> {
-        let status = Command::new("kdialog")
-            .args([
-                "--title",
-                "Restore local KiCad backup?",
-                "--yesnocancel",
-                message,
-                "--yes-label",
-                "Restore Backup",
-                "--no-label",
-                "Open Sandbox Version",
-                "--cancel-label",
-                "Cancel",
-            ])
-            .status()
-            .context("failed to run kdialog")?;
-        match status.code() {
-            Some(0) => Ok(RecoveryChoice::Restore),
-            Some(1) => Ok(RecoveryChoice::Discard),
-            Some(2) => Ok(RecoveryChoice::Cancel),
-            code => bail!("kdialog recovery dialog failed with exit code {code:?}"),
-        }
-    }
-}
-
-#[cfg(target_os = "windows")]
-mod platform {
-    use super::*;
-    use std::os::windows::process::CommandExt;
-
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-
-    pub fn show(message: &str) -> Result<RecoveryChoice> {
-        let message = format!(
-            "{message}\n\nYes — Restore Backup\nNo — Open Sandbox Version\nCancel — Don't open"
-        );
-        let mut command = Command::new("powershell.exe");
-        command.creation_flags(CREATE_NO_WINDOW);
-        let output = command
-            .env("PCB_RECOVERY_MESSAGE", message)
-            .args([
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                "Add-Type -AssemblyName PresentationFramework; $choice = [System.Windows.MessageBox]::Show($env:PCB_RECOVERY_MESSAGE, 'Restore local KiCad backup?', 'YesNoCancel', 'Warning'); Write-Output $choice",
-            ])
-            .output()
-            .context("failed to show the Windows recovery dialog")?;
-        if !output.status.success() {
-            bail!(
-                "Windows recovery dialog failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
-        parse_choice(&String::from_utf8_lossy(&output.stdout))
-    }
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-mod platform {
-    use super::*;
-
-    pub fn show(_message: &str) -> Result<RecoveryChoice> {
-        bail!("native recovery dialogs are not supported on this platform")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,32 +71,5 @@ mod tests {
         assert!(message.contains("KiCad didn’t finish syncing power-board.kicad_pcb."));
         assert!(message.contains("Backup saved Aug 11, 2026 at 2:37 PM -04:00."));
         assert!(message.contains("open the current sandbox version"));
-    }
-
-    #[test]
-    fn parses_native_dialog_choices() {
-        assert_eq!(
-            parse_choice("Restore Backup\n").unwrap(),
-            RecoveryChoice::Restore
-        );
-        assert_eq!(parse_choice("No\r\n").unwrap(), RecoveryChoice::Discard);
-        assert_eq!(parse_choice("Cancel").unwrap(), RecoveryChoice::Cancel);
-        assert!(parse_choice("Maybe").is_err());
-    }
-
-    #[test]
-    fn parses_zenity_extra_button_before_exit_code() {
-        assert_eq!(
-            parse_zenity_choice(false, Some(1), "Open Sandbox Version\n").unwrap(),
-            RecoveryChoice::Discard
-        );
-        assert_eq!(
-            parse_zenity_choice(false, Some(1), "").unwrap(),
-            RecoveryChoice::Cancel
-        );
-        assert_eq!(
-            parse_zenity_choice(true, Some(0), "").unwrap(),
-            RecoveryChoice::Restore
-        );
     }
 }

--- a/crates/pcbc/src/recovery_dialog.rs
+++ b/crates/pcbc/src/recovery_dialog.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Local};
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -12,8 +13,17 @@ pub enum RecoveryChoice {
     Cancel,
 }
 
-pub fn choose(layout_file: &Path, updated_at: DateTime<Utc>) -> Result<RecoveryChoice> {
-    let message = recovery_message(layout_file, updated_at.with_timezone(&Local));
+pub fn choose(layout_file: &Path) -> Result<RecoveryChoice> {
+    let modified = fs::metadata(layout_file)
+        .with_context(|| format!("failed to inspect recovery file {}", layout_file.display()))?
+        .modified()
+        .with_context(|| {
+            format!(
+                "failed to read recovery file modification time {}",
+                layout_file.display()
+            )
+        })?;
+    let message = recovery_message(layout_file, DateTime::<Local>::from(modified));
     platform::show(&message)
 }
 
@@ -41,6 +51,24 @@ fn parse_choice(value: &str) -> Result<RecoveryChoice> {
         "Cancel" => Ok(RecoveryChoice::Cancel),
         value => bail!("recovery dialog returned an unexpected choice: {value:?}"),
     }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_zenity_choice(
+    status_success: bool,
+    status_code: Option<i32>,
+    stdout: &str,
+) -> Result<RecoveryChoice> {
+    if !stdout.trim().is_empty() {
+        return parse_choice(stdout);
+    }
+    if status_success {
+        return Ok(RecoveryChoice::Restore);
+    }
+    if status_code == Some(1) {
+        return Ok(RecoveryChoice::Cancel);
+    }
+    bail!("zenity recovery dialog failed with exit code {status_code:?}")
 }
 
 #[cfg(target_os = "macos")]
@@ -107,21 +135,17 @@ mod platform {
             .arg(message)
             .output()
             .context("failed to run zenity")?;
-        let choice = String::from_utf8_lossy(&output.stdout);
-        if output.status.success() {
-            if choice.trim().is_empty() {
-                Ok(RecoveryChoice::Restore)
-            } else {
-                parse_choice(&choice)
-            }
-        } else if output.status.code() == Some(1) {
-            Ok(RecoveryChoice::Cancel)
-        } else {
-            bail!(
+        parse_zenity_choice(
+            output.status.success(),
+            output.status.code(),
+            &String::from_utf8_lossy(&output.stdout),
+        )
+        .with_context(|| {
+            format!(
                 "zenity recovery dialog failed: {}",
                 String::from_utf8_lossy(&output.stderr).trim()
             )
-        }
+        })
     }
 
     fn show_kdialog(message: &str) -> Result<RecoveryChoice> {
@@ -218,5 +242,21 @@ mod tests {
         assert_eq!(parse_choice("No\r\n").unwrap(), RecoveryChoice::Discard);
         assert_eq!(parse_choice("Cancel").unwrap(), RecoveryChoice::Cancel);
         assert!(parse_choice("Maybe").is_err());
+    }
+
+    #[test]
+    fn parses_zenity_extra_button_before_exit_code() {
+        assert_eq!(
+            parse_zenity_choice(false, Some(1), "Open Sandbox Version\n").unwrap(),
+            RecoveryChoice::Discard
+        );
+        assert_eq!(
+            parse_zenity_choice(false, Some(1), "").unwrap(),
+            RecoveryChoice::Cancel
+        );
+        assert_eq!(
+            parse_zenity_choice(true, Some(0), "").unwrap(),
+            RecoveryChoice::Restore
+        );
     }
 }

--- a/crates/pcbc/src/recovery_dialog.rs
+++ b/crates/pcbc/src/recovery_dialog.rs
@@ -1,0 +1,222 @@
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Local, Utc};
+use std::path::Path;
+use std::process::Command;
+
+pub const URL_LAUNCHER_ENV: &str = "PCB_URL_LAUNCHER";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryChoice {
+    Restore,
+    Discard,
+    Cancel,
+}
+
+pub fn choose(layout_file: &Path, updated_at: DateTime<Utc>) -> Result<RecoveryChoice> {
+    let message = recovery_message(layout_file, updated_at.with_timezone(&Local));
+    platform::show(&message)
+}
+
+fn recovery_message<Tz>(layout_file: &Path, updated_at: DateTime<Tz>) -> String
+where
+    Tz: chrono::TimeZone,
+    Tz::Offset: std::fmt::Display,
+{
+    let board = layout_file
+        .file_name()
+        .unwrap_or(layout_file.as_os_str())
+        .to_string_lossy();
+    format!(
+        "KiCad didn’t finish syncing {board}.\n\n\
+         Backup saved {}.\n\n\
+         Restore it, or open the current sandbox version?",
+        updated_at.format("%b %-d, %Y at %-I:%M %p %Z")
+    )
+}
+
+fn parse_choice(value: &str) -> Result<RecoveryChoice> {
+    match value.trim() {
+        "Restore Backup" | "Yes" => Ok(RecoveryChoice::Restore),
+        "Open Sandbox Version" | "No" => Ok(RecoveryChoice::Discard),
+        "Cancel" => Ok(RecoveryChoice::Cancel),
+        value => bail!("recovery dialog returned an unexpected choice: {value:?}"),
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::*;
+
+    pub fn show(message: &str) -> Result<RecoveryChoice> {
+        let output = Command::new("osascript")
+            .args([
+                "-e",
+                "on run argv",
+                "-e",
+                "try",
+                "-e",
+                "set dialogResult to display dialog (item 1 of argv) buttons {\"Cancel\", \"Open Sandbox Version\", \"Restore Backup\"} default button \"Restore Backup\" cancel button \"Cancel\" with title \"Restore local KiCad backup?\" with icon caution",
+                "-e",
+                "return button returned of dialogResult",
+                "-e",
+                "on error number -128",
+                "-e",
+                "return \"Cancel\"",
+                "-e",
+                "end try",
+                "-e",
+                "end run",
+                "--",
+            ])
+            .arg(message)
+            .output()
+            .context("failed to show the macOS recovery dialog")?;
+        if !output.status.success() {
+            bail!(
+                "macOS recovery dialog failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        parse_choice(&String::from_utf8_lossy(&output.stdout))
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::*;
+
+    pub fn show(message: &str) -> Result<RecoveryChoice> {
+        match show_zenity(message) {
+            Ok(choice) => Ok(choice),
+            Err(zenity_error) => show_kdialog(message).with_context(|| {
+                format!("failed to show recovery dialog with zenity ({zenity_error:#}) or kdialog")
+            }),
+        }
+    }
+
+    fn show_zenity(message: &str) -> Result<RecoveryChoice> {
+        let output = Command::new("zenity")
+            .args([
+                "--question",
+                "--title=Restore local KiCad backup?",
+                "--ok-label=Restore Backup",
+                "--cancel-label=Cancel",
+                "--extra-button=Open Sandbox Version",
+                "--text",
+            ])
+            .arg(message)
+            .output()
+            .context("failed to run zenity")?;
+        let choice = String::from_utf8_lossy(&output.stdout);
+        if output.status.success() {
+            if choice.trim().is_empty() {
+                Ok(RecoveryChoice::Restore)
+            } else {
+                parse_choice(&choice)
+            }
+        } else if output.status.code() == Some(1) {
+            Ok(RecoveryChoice::Cancel)
+        } else {
+            bail!(
+                "zenity recovery dialog failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    }
+
+    fn show_kdialog(message: &str) -> Result<RecoveryChoice> {
+        let status = Command::new("kdialog")
+            .args([
+                "--title",
+                "Restore local KiCad backup?",
+                "--yesnocancel",
+                message,
+                "--yes-label",
+                "Restore Backup",
+                "--no-label",
+                "Open Sandbox Version",
+                "--cancel-label",
+                "Cancel",
+            ])
+            .status()
+            .context("failed to run kdialog")?;
+        match status.code() {
+            Some(0) => Ok(RecoveryChoice::Restore),
+            Some(1) => Ok(RecoveryChoice::Discard),
+            Some(2) => Ok(RecoveryChoice::Cancel),
+            code => bail!("kdialog recovery dialog failed with exit code {code:?}"),
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use super::*;
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    pub fn show(message: &str) -> Result<RecoveryChoice> {
+        let message = format!(
+            "{message}\n\nYes — Restore Backup\nNo — Open Sandbox Version\nCancel — Don't open"
+        );
+        let mut command = Command::new("powershell.exe");
+        command.creation_flags(CREATE_NO_WINDOW);
+        let output = command
+            .env("PCB_RECOVERY_MESSAGE", message)
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Add-Type -AssemblyName PresentationFramework; $choice = [System.Windows.MessageBox]::Show($env:PCB_RECOVERY_MESSAGE, 'Restore local KiCad backup?', 'YesNoCancel', 'Warning'); Write-Output $choice",
+            ])
+            .output()
+            .context("failed to show the Windows recovery dialog")?;
+        if !output.status.success() {
+            bail!(
+                "Windows recovery dialog failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        parse_choice(&String::from_utf8_lossy(&output.stdout))
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+mod platform {
+    use super::*;
+
+    pub fn show(_message: &str) -> Result<RecoveryChoice> {
+        bail!("native recovery dialogs are not supported on this platform")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{FixedOffset, TimeZone};
+
+    #[test]
+    fn recovery_message_has_board_and_local_save_time() {
+        let saved_at = FixedOffset::west_opt(4 * 60 * 60)
+            .unwrap()
+            .with_ymd_and_hms(2026, 8, 11, 14, 37, 0)
+            .unwrap();
+        let message = recovery_message(Path::new("/tmp/power-board.kicad_pcb"), saved_at);
+
+        assert!(message.contains("KiCad didn’t finish syncing power-board.kicad_pcb."));
+        assert!(message.contains("Backup saved Aug 11, 2026 at 2:37 PM -04:00."));
+        assert!(message.contains("open the current sandbox version"));
+    }
+
+    #[test]
+    fn parses_native_dialog_choices() {
+        assert_eq!(
+            parse_choice("Restore Backup\n").unwrap(),
+            RecoveryChoice::Restore
+        );
+        assert_eq!(parse_choice("No\r\n").unwrap(), RecoveryChoice::Discard);
+        assert_eq!(parse_choice("Cancel").unwrap(), RecoveryChoice::Cancel);
+        assert!(parse_choice("Maybe").is_err());
+    }
+}

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -477,9 +477,10 @@ fn sync_layout_down(
         && let Some(session) = latest_recoverable_session(&cache_root)?
     {
         match prompt_restore_recovery(status, &session)? {
-            RecoveryChoice::Restore => recovered_session = Some(session),
-            RecoveryChoice::Discard => mark_recoverable_sessions_prompt_seen(&cache_root),
-            RecoveryChoice::Cancel => return Ok(None),
+            Some(RecoveryChoice::Restore) => recovered_session = Some(session),
+            Some(RecoveryChoice::Discard) => mark_recoverable_sessions_prompt_seen(&cache_root),
+            Some(RecoveryChoice::Cancel) => return Ok(None),
+            None => {}
         }
     }
 
@@ -782,17 +783,18 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
 fn prompt_restore_recovery(
     status: &pcb_ui::Spinner,
     session: &SyncSession,
-) -> Result<RecoveryChoice> {
+) -> Result<Option<RecoveryChoice>> {
     if !crate::tty::is_interactive() {
         if std::env::var_os(URL_LAUNCHER_ENV).is_some() {
             return status.suspend(|| {
-                crate::recovery_dialog::choose(
-                    &session.manifest.layout_file,
-                    session.manifest.updated_at,
-                )
+                crate::recovery_dialog::choose(&session.manifest.layout_file).map(Some)
             });
         }
-        return Ok(RecoveryChoice::Restore);
+        eprintln!(
+            "Found local recovery file for this remote layout at {}. Re-run interactively to restore it.",
+            session.manifest.layout_file.display()
+        );
+        return Ok(None);
     }
     let prompt = format!(
         "Restore previous local KiCad recovery file from {}?",
@@ -804,11 +806,11 @@ fn prompt_restore_recovery(
             .prompt()
             .unwrap_or(false)
     };
-    Ok(if status.suspend(ask) {
+    Ok(Some(if status.suspend(ask) {
         RecoveryChoice::Restore
     } else {
         RecoveryChoice::Discard
-    })
+    }))
 }
 
 fn mark_recoverable_sessions_prompt_seen(cache_root: &Path) {

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -162,6 +162,8 @@ struct SyncSessionManifest {
     layout_file: PathBuf,
     state: SyncSessionState,
     stop_reason: Option<RecoverableStopReason>,
+    #[serde(default)]
+    editor_pid: Option<u32>,
     prompt_seen: bool,
     started_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
@@ -206,7 +208,6 @@ fn open_layout_and_sync(
                 local.pcb_file.display()
             )
         })?;
-    sync_session.mark_active()?;
     let running = install_shutdown_flag()?;
     status.set_message(format!("Opening {}...", local.pcb_file.display()));
     let watcher = LocalLayoutWatcher::new(&local.local_layout_dir)?;
@@ -217,6 +218,7 @@ fn open_layout_and_sync(
             return Err(err);
         }
     };
+    sync_session.mark_active(session.id())?;
     status.set_message(format!(
         "Watching {} for KiCad changes...",
         local.local_layout_dir.display()
@@ -694,6 +696,7 @@ impl SyncSession {
                 layout_file,
                 state: SyncSessionState::Active,
                 stop_reason: None,
+                editor_pid: None,
                 prompt_seen: false,
                 started_at: now,
                 updated_at: now,
@@ -715,9 +718,10 @@ impl SyncSession {
         })
     }
 
-    fn mark_active(&mut self) -> Result<()> {
+    fn mark_active(&mut self, editor_pid: u32) -> Result<()> {
         self.manifest.state = SyncSessionState::Active;
         self.manifest.stop_reason = None;
+        self.manifest.editor_pid = Some(editor_pid);
         self.manifest.updated_at = Utc::now();
         self.save()
     }
@@ -725,6 +729,7 @@ impl SyncSession {
     fn mark_complete(&mut self) -> Result<()> {
         self.manifest.state = SyncSessionState::Complete;
         self.manifest.stop_reason = None;
+        self.manifest.editor_pid = None;
         self.manifest.prompt_seen = true;
         self.manifest.updated_at = Utc::now();
         self.save()
@@ -769,6 +774,16 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
         };
         if !is_recovery_candidate(&session.manifest) {
             continue;
+        }
+        if session
+            .manifest
+            .editor_pid
+            .is_some_and(editor_process_is_running)
+        {
+            bail!(
+                "KiCad is still open for {}. Close that KiCad window before opening this board again.",
+                session.manifest.layout_file.display()
+            );
         }
         if latest
             .as_ref()
@@ -857,6 +872,42 @@ fn is_recovery_candidate(manifest: &SyncSessionManifest) -> bool {
         SyncSessionState::Active | SyncSessionState::Recoverable
     ) && !manifest.prompt_seen
         && manifest.layout_file.is_file()
+}
+
+#[cfg(unix)]
+fn editor_process_is_running(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(windows)]
+fn editor_process_is_running(pid: u32) -> bool {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let mut command = std::process::Command::new("tasklist.exe");
+    command.creation_flags(CREATE_NO_WINDOW).args([
+        "/FI",
+        &format!("PID eq {pid}"),
+        "/FO",
+        "CSV",
+        "/NH",
+    ]);
+    command.output().is_ok_and(|output| {
+        output.status.success()
+            && String::from_utf8_lossy(&output.stdout)
+                .split(',')
+                .any(|field| field.trim_matches([' ', '\r', '\n', '"']) == pid.to_string())
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn editor_process_is_running(_pid: u32) -> bool {
+    false
 }
 
 fn prune_old_layout_sessions(cache_root: &Path, retention: Duration) -> Result<()> {
@@ -987,4 +1038,41 @@ fn shell_command(args: &[String]) -> String {
 
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refuses_recovery_while_tracked_editor_is_running() {
+        let cache = tempfile::tempdir().unwrap();
+        let local_layout_dir = cache.path().join("session");
+        fs::create_dir(&local_layout_dir).unwrap();
+        let layout_file = local_layout_dir.join("layout.kicad_pcb");
+        fs::write(&layout_file, "").unwrap();
+        let now = Utc::now();
+        let manifest = SyncSessionManifest {
+            version: 1,
+            uri: "diode://api.diode.computer/sandboxes/test/fs/read?path=%2Flayout.kicad_pcb"
+                .to_string(),
+            remote_layout_dir: "/".to_string(),
+            local_layout_dir: local_layout_dir.clone(),
+            layout_file,
+            state: SyncSessionState::Recoverable,
+            stop_reason: Some(RecoverableStopReason::SyncFailed),
+            editor_pid: Some(std::process::id()),
+            prompt_seen: false,
+            started_at: now,
+            updated_at: now,
+        };
+        fs::write(
+            local_layout_dir.join(SESSION_MANIFEST),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let error = latest_recoverable_session(cache.path()).unwrap_err();
+        assert!(error.to_string().contains("KiCad is still open"));
+    }
 }

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -772,18 +772,19 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
         let Ok(session) = SyncSession::load(entry.path()) else {
             continue;
         };
-        if !is_recovery_candidate(&session.manifest) {
-            continue;
-        }
-        if session
-            .manifest
-            .editor_pid
-            .is_some_and(editor_process_is_running)
+        if session.manifest.state == SyncSessionState::Active
+            && session
+                .manifest
+                .editor_pid
+                .is_some_and(editor_process_is_running)
         {
             bail!(
                 "KiCad is still open for {}. Close that KiCad window before opening this board again.",
                 session.manifest.layout_file.display()
             );
+        }
+        if !is_recovery_candidate(&session.manifest) {
+            continue;
         }
         if latest
             .as_ref()
@@ -1045,7 +1046,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn refuses_recovery_while_tracked_editor_is_running() {
+    fn refuses_open_for_restored_session_while_tracked_editor_is_running() {
         let cache = tempfile::tempdir().unwrap();
         let local_layout_dir = cache.path().join("session");
         fs::create_dir(&local_layout_dir).unwrap();
@@ -1059,10 +1060,10 @@ mod tests {
             remote_layout_dir: "/".to_string(),
             local_layout_dir: local_layout_dir.clone(),
             layout_file,
-            state: SyncSessionState::Recoverable,
-            stop_reason: Some(RecoverableStopReason::SyncFailed),
+            state: SyncSessionState::Active,
+            stop_reason: None,
             editor_pid: Some(std::process::id()),
-            prompt_seen: false,
+            prompt_seen: true,
             started_at: now,
             updated_at: now,
         };

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 
 use crate::layout::{LayoutArgs, LayoutOutputFormat};
 use crate::open::OpenArgs;
+use crate::recovery_dialog::{RecoveryChoice, URL_LAUNCHER_ENV};
 
 const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const WATCH_DEBOUNCE: Duration = Duration::from_millis(150);
@@ -51,7 +52,11 @@ pub fn execute_layout(uri: SandboxFileUri, args: LayoutArgs) -> Result<()> {
     let result = run_remote_layout(&client, &uri, &args)?;
     status.set_message("Downloading layout from sandbox...");
     let restore_status = should_open.then_some(&status);
-    let local = sync_layout_down(&client, &uri, &result, restore_status)?;
+    let Some(local) = sync_layout_down(&client, &uri, &result, restore_status)? else {
+        lock.release()?;
+        status.finish();
+        return Ok(());
+    };
     if should_open {
         return open_layout_and_sync(&client, &uri, &local, lock, status);
     }
@@ -91,11 +96,17 @@ pub fn execute_open(uri: SandboxFileUri, args: OpenArgs) -> Result<()> {
         status.set_message("Downloading layout from sandbox...");
         sync_layout_down(&client, &uri, &result, Some(&status))?
     };
+    let Some(local) = local else {
+        lock.release()?;
+        status.finish();
+        return Ok(());
+    };
 
     open_layout_and_sync(&client, &uri, &local, lock, status)
 }
 
 struct LocalLayout {
+    cache_root: PathBuf,
     remote_layout_dir: String,
     local_layout_dir: PathBuf,
     pcb_file: PathBuf,
@@ -188,12 +199,13 @@ fn open_layout_and_sync(
         .sync_session
         .clone()
         .context("Remote sync session was not initialized")?;
-    restore_recovered_layout_if_needed(client, uri, local, &status).with_context(|| {
-        format!(
-            "Failed to restore local recovery file {}",
-            local.pcb_file.display()
-        )
-    })?;
+    restore_recovered_layout_if_needed(client, uri, local, &mut sync_session, &status)
+        .with_context(|| {
+            format!(
+                "Failed to restore local recovery file {}",
+                local.pcb_file.display()
+            )
+        })?;
     sync_session.mark_active()?;
     let running = install_shutdown_flag()?;
     status.set_message(format!("Opening {}...", local.pcb_file.display()));
@@ -237,16 +249,9 @@ fn open_layout_and_sync(
                 "Remote sync stopped; local recovery file is {}",
                 local.pcb_file.display()
             ));
-            let terminate_result = session.terminate();
+            // Leave KiCad open so an interrupted sync cannot discard unsaved
+            // edits or close another concurrent editor session.
             let release_result = lock.release();
-            if let Err(terminate_err) = terminate_result {
-                return Err(error).with_context(|| {
-                    format!(
-                        "Remote sync stopped. Local recovery file: {}. Also failed to quit KiCad: {terminate_err:#}",
-                        local.pcb_file.display()
-                    )
-                });
-            }
             if let Err(release_err) = release_result {
                 return Err(error).with_context(|| {
                     format!(
@@ -440,7 +445,7 @@ fn sync_remote_pcb_file_down(
     client: &SandboxClient,
     uri: &SandboxFileUri,
     status: Option<&pcb_ui::Spinner>,
-) -> Result<LocalLayout> {
+) -> Result<Option<LocalLayout>> {
     let result = RemoteLayoutResult {
         layout_dir: Some(remote_parent_dir(&uri.sandbox_path)?),
         pcb_file: Some(uri.sandbox_path.clone()),
@@ -453,7 +458,7 @@ fn sync_layout_down(
     uri: &SandboxFileUri,
     result: &RemoteLayoutResult,
     restore_status: Option<&pcb_ui::Spinner>,
-) -> Result<LocalLayout> {
+) -> Result<Option<LocalLayout>> {
     let remote_layout_dir = result
         .layout_dir
         .as_ref()
@@ -470,11 +475,11 @@ fn sync_layout_down(
     let mut recovered_session = None;
     if let Some(status) = restore_status
         && let Some(session) = latest_recoverable_session(&cache_root)?
-        && let Some(restore) = prompt_restore_recovery(status, &session)
     {
-        mark_recoverable_sessions_prompt_seen(&cache_root);
-        if restore {
-            recovered_session = Some(session);
+        match prompt_restore_recovery(status, &session)? {
+            RecoveryChoice::Restore => recovered_session = Some(session),
+            RecoveryChoice::Discard => mark_recoverable_sessions_prompt_seen(&cache_root),
+            RecoveryChoice::Cancel => return Ok(None),
         }
     }
 
@@ -506,19 +511,21 @@ fn sync_layout_down(
             (local_layout_dir, pcb_file, sync_session, false)
         };
 
-    Ok(LocalLayout {
+    Ok(Some(LocalLayout {
+        cache_root,
         remote_layout_dir,
         local_layout_dir,
         pcb_file,
         sync_session,
         restored_from_recovery,
-    })
+    }))
 }
 
 fn restore_recovered_layout_if_needed(
     client: &SandboxClient,
     uri: &SandboxFileUri,
     local: &LocalLayout,
+    sync_session: &mut SyncSession,
     status: &pcb_ui::Spinner,
 ) -> Result<()> {
     if !local.restored_from_recovery {
@@ -529,6 +536,8 @@ fn restore_recovered_layout_if_needed(
         local.pcb_file.display()
     ));
     let stats = sync_layout_up_with_retry(client, uri, local)?;
+    mark_recoverable_sessions_prompt_seen(&local.cache_root);
+    sync_session.mark_prompt_seen()?;
     status.set_message(format!(
         "Restored recovery file ({} uploaded, {} removed).",
         stats.uploaded, stats.removed
@@ -770,13 +779,20 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
     Ok(latest)
 }
 
-fn prompt_restore_recovery(status: &pcb_ui::Spinner, session: &SyncSession) -> Option<bool> {
+fn prompt_restore_recovery(
+    status: &pcb_ui::Spinner,
+    session: &SyncSession,
+) -> Result<RecoveryChoice> {
     if !crate::tty::is_interactive() {
-        eprintln!(
-            "Found local recovery file for this remote layout at {}. Re-run interactively to restore it.",
-            session.manifest.layout_file.display()
-        );
-        return None;
+        if std::env::var_os(URL_LAUNCHER_ENV).is_some() {
+            return status.suspend(|| {
+                crate::recovery_dialog::choose(
+                    &session.manifest.layout_file,
+                    session.manifest.updated_at,
+                )
+            });
+        }
+        return Ok(RecoveryChoice::Restore);
     }
     let prompt = format!(
         "Restore previous local KiCad recovery file from {}?",
@@ -788,7 +804,11 @@ fn prompt_restore_recovery(status: &pcb_ui::Spinner, session: &SyncSession) -> O
             .prompt()
             .unwrap_or(false)
     };
-    Some(status.suspend(ask))
+    Ok(if status.suspend(ask) {
+        RecoveryChoice::Restore
+    } else {
+        RecoveryChoice::Discard
+    })
 }
 
 fn mark_recoverable_sessions_prompt_seen(cache_root: &Path) {

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -53,9 +53,7 @@ pub fn execute_layout(uri: SandboxFileUri, args: LayoutArgs) -> Result<()> {
     status.set_message("Downloading layout from sandbox...");
     let restore_status = should_open.then_some(&status);
     let Some(local) = sync_layout_down(&client, &uri, &result, restore_status)? else {
-        lock.release()?;
-        status.finish();
-        return Ok(());
+        return finish_cancelled(lock, status);
     };
     if should_open {
         return open_layout_and_sync(&client, &uri, &local, lock, status);
@@ -97,12 +95,17 @@ pub fn execute_open(uri: SandboxFileUri, args: OpenArgs) -> Result<()> {
         sync_layout_down(&client, &uri, &result, Some(&status))?
     };
     let Some(local) = local else {
-        lock.release()?;
-        status.finish();
-        return Ok(());
+        return finish_cancelled(lock, status);
     };
 
     open_layout_and_sync(&client, &uri, &local, lock, status)
+}
+
+/// Wind down cleanly after the user cancels the recovery prompt.
+fn finish_cancelled(lock: SandboxLockGuard, status: pcb_ui::Spinner) -> Result<()> {
+    lock.release()?;
+    status.finish();
+    Ok(())
 }
 
 struct LocalLayout {
@@ -772,11 +775,13 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
         let Ok(session) = SyncSession::load(entry.path()) else {
             continue;
         };
-        if session.manifest.state == SyncSessionState::Active
-            && session
-                .manifest
-                .editor_pid
-                .is_some_and(editor_process_is_running)
+        if matches!(
+            session.manifest.state,
+            SyncSessionState::Active | SyncSessionState::Recoverable
+        ) && session
+            .manifest
+            .editor_pid
+            .is_some_and(editor_process_is_running)
         {
             bail!(
                 "KiCad is still open for {}. Close that KiCad window before opening this board again.",
@@ -875,14 +880,18 @@ fn is_recovery_candidate(manifest: &SyncSessionManifest) -> bool {
         && manifest.layout_file.is_file()
 }
 
+/// Best-effort check that `pid` is still the editor process this session
+/// launched (`open` on macOS, pcbnew elsewhere). Matching the process name
+/// keeps a recycled pid from permanently blocking the board.
 #[cfg(unix)]
 fn editor_process_is_running(pid: u32) -> bool {
-    std::process::Command::new("kill")
-        .args(["-0", &pid.to_string()])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
+    std::process::Command::new("ps")
+        .args(["-o", "comm=", "-p", &pid.to_string()])
+        .output()
+        .is_ok_and(|output| {
+            output.status.success()
+                && is_editor_process_name(&String::from_utf8_lossy(&output.stdout))
+        })
 }
 
 #[cfg(windows)]
@@ -901,14 +910,26 @@ fn editor_process_is_running(pid: u32) -> bool {
     command.output().is_ok_and(|output| {
         output.status.success()
             && String::from_utf8_lossy(&output.stdout)
-                .split(',')
-                .any(|field| field.trim_matches([' ', '\r', '\n', '"']) == pid.to_string())
+                .lines()
+                .filter_map(|line| line.split(',').next())
+                .any(is_editor_process_name)
     })
 }
 
 #[cfg(not(any(unix, windows)))]
 fn editor_process_is_running(_pid: u32) -> bool {
     false
+}
+
+#[cfg(any(unix, windows))]
+fn is_editor_process_name(raw: &str) -> bool {
+    let name = raw.trim().trim_matches('"');
+    let name = name
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(name)
+        .to_ascii_lowercase();
+    name == "open" || name.contains("pcbnew") || name.contains("kicad")
 }
 
 fn prune_old_layout_sessions(cache_root: &Path, retention: Duration) -> Result<()> {
@@ -1045,10 +1066,8 @@ fn shell_quote(value: &str) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn refuses_open_for_restored_session_while_tracked_editor_is_running() {
-        let cache = tempfile::tempdir().unwrap();
-        let local_layout_dir = cache.path().join("session");
+    fn write_session_manifest(cache_root: &Path, state: SyncSessionState, editor_pid: Option<u32>) {
+        let local_layout_dir = cache_root.join("session");
         fs::create_dir(&local_layout_dir).unwrap();
         let layout_file = local_layout_dir.join("layout.kicad_pcb");
         fs::write(&layout_file, "").unwrap();
@@ -1060,10 +1079,10 @@ mod tests {
             remote_layout_dir: "/".to_string(),
             local_layout_dir: local_layout_dir.clone(),
             layout_file,
-            state: SyncSessionState::Active,
+            state,
             stop_reason: None,
-            editor_pid: Some(std::process::id()),
-            prompt_seen: true,
+            editor_pid,
+            prompt_seen: false,
             started_at: now,
             updated_at: now,
         };
@@ -1072,8 +1091,58 @@ mod tests {
             serde_json::to_vec(&manifest).unwrap(),
         )
         .unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_open_while_tracked_editor_is_running() {
+        let cache = tempfile::tempdir().unwrap();
+        let sleep = ["/bin/sleep", "/usr/bin/sleep"]
+            .into_iter()
+            .find(|path| Path::new(path).is_file())
+            .expect("sleep binary");
+        let editor = cache.path().join("pcbnew");
+        fs::copy(sleep, &editor).unwrap();
+        let mut editor = std::process::Command::new(&editor)
+            .arg("30")
+            .spawn()
+            .unwrap();
+        write_session_manifest(
+            cache.path(),
+            SyncSessionState::Recoverable,
+            Some(editor.id()),
+        );
 
         let error = latest_recoverable_session(cache.path()).unwrap_err();
+        let _ = editor.kill();
+        let _ = editor.wait();
         assert!(error.to_string().contains("KiCad is still open"));
+    }
+
+    #[test]
+    fn recycled_editor_pid_does_not_block_recovery() {
+        let cache = tempfile::tempdir().unwrap();
+        // A live pid that is not a KiCad editor process: pid reuse must not
+        // permanently block the board.
+        write_session_manifest(
+            cache.path(),
+            SyncSessionState::Recoverable,
+            Some(std::process::id()),
+        );
+
+        let session = latest_recoverable_session(cache.path()).unwrap();
+        assert!(session.is_some());
+    }
+
+    #[test]
+    fn matches_only_editor_process_names() {
+        assert!(is_editor_process_name("/usr/bin/open\n"));
+        assert!(is_editor_process_name("pcbnew"));
+        assert!(is_editor_process_name("\"kicad.exe\""));
+        assert!(is_editor_process_name(
+            "/Applications/KiCad/KiCad.app/Contents/MacOS/pcbnew"
+        ));
+        assert!(!is_editor_process_name("cargo"));
+        assert!(!is_editor_process_name("INFO: No tasks are running"));
     }
 }

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -161,6 +161,8 @@ struct SyncSessionManifest {
     layout_file: PathBuf,
     state: SyncSessionState,
     stop_reason: Option<RecoverableStopReason>,
+    #[serde(default)]
+    editor_pid: Option<u32>,
     prompt_seen: bool,
     started_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
@@ -205,7 +207,6 @@ fn open_layout_and_sync(
                 local.pcb_file.display()
             )
         })?;
-    sync_session.mark_active()?;
     let running = install_shutdown_flag()?;
     status.set_message(format!("Opening {}...", local.pcb_file.display()));
     let watcher = LocalLayoutWatcher::new(&local.local_layout_dir)?;
@@ -216,6 +217,7 @@ fn open_layout_and_sync(
             return Err(err);
         }
     };
+    sync_session.mark_active(session.id())?;
     status.set_message(format!(
         "Watching {} for KiCad changes...",
         local.local_layout_dir.display()
@@ -690,6 +692,7 @@ impl SyncSession {
                 layout_file,
                 state: SyncSessionState::Active,
                 stop_reason: None,
+                editor_pid: None,
                 prompt_seen: false,
                 started_at: now,
                 updated_at: now,
@@ -711,9 +714,10 @@ impl SyncSession {
         })
     }
 
-    fn mark_active(&mut self) -> Result<()> {
+    fn mark_active(&mut self, editor_pid: u32) -> Result<()> {
         self.manifest.state = SyncSessionState::Active;
         self.manifest.stop_reason = None;
+        self.manifest.editor_pid = Some(editor_pid);
         self.manifest.updated_at = Utc::now();
         self.save()
     }
@@ -721,6 +725,7 @@ impl SyncSession {
     fn mark_complete(&mut self) -> Result<()> {
         self.manifest.state = SyncSessionState::Complete;
         self.manifest.stop_reason = None;
+        self.manifest.editor_pid = None;
         self.manifest.prompt_seen = true;
         self.manifest.updated_at = Utc::now();
         self.save()
@@ -765,6 +770,16 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
         };
         if !is_recovery_candidate(&session.manifest) {
             continue;
+        }
+        if session
+            .manifest
+            .editor_pid
+            .is_some_and(editor_process_is_running)
+        {
+            bail!(
+                "KiCad is still open for {}. Close that KiCad window before opening this board again.",
+                session.manifest.layout_file.display()
+            );
         }
         if latest
             .as_ref()
@@ -853,6 +868,42 @@ fn is_recovery_candidate(manifest: &SyncSessionManifest) -> bool {
         SyncSessionState::Active | SyncSessionState::Recoverable
     ) && !manifest.prompt_seen
         && manifest.layout_file.is_file()
+}
+
+#[cfg(unix)]
+fn editor_process_is_running(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(windows)]
+fn editor_process_is_running(pid: u32) -> bool {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let mut command = std::process::Command::new("tasklist.exe");
+    command.creation_flags(CREATE_NO_WINDOW).args([
+        "/FI",
+        &format!("PID eq {pid}"),
+        "/FO",
+        "CSV",
+        "/NH",
+    ]);
+    command.output().is_ok_and(|output| {
+        output.status.success()
+            && String::from_utf8_lossy(&output.stdout)
+                .split(',')
+                .any(|field| field.trim_matches([' ', '\r', '\n', '"']) == pid.to_string())
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn editor_process_is_running(_pid: u32) -> bool {
+    false
 }
 
 fn prune_old_layout_sessions(cache_root: &Path, retention: Duration) -> Result<()> {
@@ -983,4 +1034,41 @@ fn shell_command(args: &[String]) -> String {
 
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refuses_recovery_while_tracked_editor_is_running() {
+        let cache = tempfile::tempdir().unwrap();
+        let local_layout_dir = cache.path().join("session");
+        fs::create_dir(&local_layout_dir).unwrap();
+        let layout_file = local_layout_dir.join("layout.kicad_pcb");
+        fs::write(&layout_file, "").unwrap();
+        let now = Utc::now();
+        let manifest = SyncSessionManifest {
+            version: 1,
+            uri: "diode://api.diode.computer/sandboxes/test/fs/read?path=%2Flayout.kicad_pcb"
+                .to_string(),
+            remote_layout_dir: "/".to_string(),
+            local_layout_dir: local_layout_dir.clone(),
+            layout_file,
+            state: SyncSessionState::Recoverable,
+            stop_reason: Some(RecoverableStopReason::SyncFailed),
+            editor_pid: Some(std::process::id()),
+            prompt_seen: false,
+            started_at: now,
+            updated_at: now,
+        };
+        fs::write(
+            local_layout_dir.join(SESSION_MANIFEST),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let error = latest_recoverable_session(cache.path()).unwrap_err();
+        assert!(error.to_string().contains("KiCad is still open"));
+    }
 }

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -768,18 +768,19 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
         let Ok(session) = SyncSession::load(entry.path()) else {
             continue;
         };
-        if !is_recovery_candidate(&session.manifest) {
-            continue;
-        }
-        if session
-            .manifest
-            .editor_pid
-            .is_some_and(editor_process_is_running)
+        if session.manifest.state == SyncSessionState::Active
+            && session
+                .manifest
+                .editor_pid
+                .is_some_and(editor_process_is_running)
         {
             bail!(
                 "KiCad is still open for {}. Close that KiCad window before opening this board again.",
                 session.manifest.layout_file.display()
             );
+        }
+        if !is_recovery_candidate(&session.manifest) {
+            continue;
         }
         if latest
             .as_ref()
@@ -1041,7 +1042,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn refuses_recovery_while_tracked_editor_is_running() {
+    fn refuses_open_for_restored_session_while_tracked_editor_is_running() {
         let cache = tempfile::tempdir().unwrap();
         let local_layout_dir = cache.path().join("session");
         fs::create_dir(&local_layout_dir).unwrap();
@@ -1055,10 +1056,10 @@ mod tests {
             remote_layout_dir: "/".to_string(),
             local_layout_dir: local_layout_dir.clone(),
             layout_file,
-            state: SyncSessionState::Recoverable,
-            stop_reason: Some(RecoverableStopReason::SyncFailed),
+            state: SyncSessionState::Active,
+            stop_reason: None,
             editor_pid: Some(std::process::id()),
-            prompt_seen: false,
+            prompt_seen: true,
             started_at: now,
             updated_at: now,
         };

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 
 use crate::layout::{LayoutArgs, LayoutOutputFormat};
 use crate::open::OpenArgs;
+use crate::recovery_dialog::{RecoveryChoice, URL_LAUNCHER_ENV};
 
 const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const WATCH_DEBOUNCE: Duration = Duration::from_millis(150);
@@ -51,7 +52,11 @@ pub fn execute_layout(uri: SandboxFileUri, args: LayoutArgs) -> Result<()> {
     let result = run_remote_layout(&client, &uri, &args)?;
     status.set_message("Downloading layout from sandbox...");
     let restore_status = should_open.then_some(&status);
-    let local = sync_layout_down(&client, &uri, &result, restore_status)?;
+    let Some(local) = sync_layout_down(&client, &uri, &result, restore_status)? else {
+        lock.release()?;
+        status.finish();
+        return Ok(());
+    };
     if should_open {
         return open_layout_and_sync(&client, &uri, &local, lock, status);
     }
@@ -90,11 +95,17 @@ pub fn execute_open(uri: SandboxFileUri, args: OpenArgs) -> Result<()> {
         status.set_message("Downloading layout from sandbox...");
         sync_layout_down(&client, &uri, &result, Some(&status))?
     };
+    let Some(local) = local else {
+        lock.release()?;
+        status.finish();
+        return Ok(());
+    };
 
     open_layout_and_sync(&client, &uri, &local, lock, status)
 }
 
 struct LocalLayout {
+    cache_root: PathBuf,
     remote_layout_dir: String,
     local_layout_dir: PathBuf,
     pcb_file: PathBuf,
@@ -187,12 +198,13 @@ fn open_layout_and_sync(
         .sync_session
         .clone()
         .context("Remote sync session was not initialized")?;
-    restore_recovered_layout_if_needed(client, uri, local, &status).with_context(|| {
-        format!(
-            "Failed to restore local recovery file {}",
-            local.pcb_file.display()
-        )
-    })?;
+    restore_recovered_layout_if_needed(client, uri, local, &mut sync_session, &status)
+        .with_context(|| {
+            format!(
+                "Failed to restore local recovery file {}",
+                local.pcb_file.display()
+            )
+        })?;
     sync_session.mark_active()?;
     let running = install_shutdown_flag()?;
     status.set_message(format!("Opening {}...", local.pcb_file.display()));
@@ -236,16 +248,9 @@ fn open_layout_and_sync(
                 "Remote sync stopped; local recovery file is {}",
                 local.pcb_file.display()
             ));
-            let terminate_result = session.terminate();
+            // Leave KiCad open so an interrupted sync cannot discard unsaved
+            // edits or close another concurrent editor session.
             let release_result = lock.release();
-            if let Err(terminate_err) = terminate_result {
-                return Err(error).with_context(|| {
-                    format!(
-                        "Remote sync stopped. Local recovery file: {}. Also failed to quit KiCad: {terminate_err:#}",
-                        local.pcb_file.display()
-                    )
-                });
-            }
             if let Err(release_err) = release_result {
                 return Err(error).with_context(|| {
                     format!(
@@ -436,7 +441,7 @@ fn sync_remote_pcb_file_down(
     client: &SandboxClient,
     uri: &SandboxFileUri,
     status: Option<&pcb_ui::Spinner>,
-) -> Result<LocalLayout> {
+) -> Result<Option<LocalLayout>> {
     let result = RemoteLayoutResult {
         layout_dir: Some(remote_parent_dir(&uri.sandbox_path)?),
         pcb_file: Some(uri.sandbox_path.clone()),
@@ -449,7 +454,7 @@ fn sync_layout_down(
     uri: &SandboxFileUri,
     result: &RemoteLayoutResult,
     restore_status: Option<&pcb_ui::Spinner>,
-) -> Result<LocalLayout> {
+) -> Result<Option<LocalLayout>> {
     let remote_layout_dir = result
         .layout_dir
         .as_ref()
@@ -466,11 +471,11 @@ fn sync_layout_down(
     let mut recovered_session = None;
     if let Some(status) = restore_status
         && let Some(session) = latest_recoverable_session(&cache_root)?
-        && let Some(restore) = prompt_restore_recovery(status, &session)
     {
-        mark_recoverable_sessions_prompt_seen(&cache_root);
-        if restore {
-            recovered_session = Some(session);
+        match prompt_restore_recovery(status, &session)? {
+            RecoveryChoice::Restore => recovered_session = Some(session),
+            RecoveryChoice::Discard => mark_recoverable_sessions_prompt_seen(&cache_root),
+            RecoveryChoice::Cancel => return Ok(None),
         }
     }
 
@@ -502,19 +507,21 @@ fn sync_layout_down(
             (local_layout_dir, pcb_file, sync_session, false)
         };
 
-    Ok(LocalLayout {
+    Ok(Some(LocalLayout {
+        cache_root,
         remote_layout_dir,
         local_layout_dir,
         pcb_file,
         sync_session,
         restored_from_recovery,
-    })
+    }))
 }
 
 fn restore_recovered_layout_if_needed(
     client: &SandboxClient,
     uri: &SandboxFileUri,
     local: &LocalLayout,
+    sync_session: &mut SyncSession,
     status: &pcb_ui::Spinner,
 ) -> Result<()> {
     if !local.restored_from_recovery {
@@ -525,6 +532,8 @@ fn restore_recovered_layout_if_needed(
         local.pcb_file.display()
     ));
     let stats = sync_layout_up_with_retry(client, uri, local)?;
+    mark_recoverable_sessions_prompt_seen(&local.cache_root);
+    sync_session.mark_prompt_seen()?;
     status.set_message(format!(
         "Restored recovery file ({} uploaded, {} removed).",
         stats.uploaded, stats.removed
@@ -766,13 +775,20 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
     Ok(latest)
 }
 
-fn prompt_restore_recovery(status: &pcb_ui::Spinner, session: &SyncSession) -> Option<bool> {
+fn prompt_restore_recovery(
+    status: &pcb_ui::Spinner,
+    session: &SyncSession,
+) -> Result<RecoveryChoice> {
     if !crate::tty::is_interactive() {
-        eprintln!(
-            "Found local recovery file for this remote layout at {}. Re-run interactively to restore it.",
-            session.manifest.layout_file.display()
-        );
-        return None;
+        if std::env::var_os(URL_LAUNCHER_ENV).is_some() {
+            return status.suspend(|| {
+                crate::recovery_dialog::choose(
+                    &session.manifest.layout_file,
+                    session.manifest.updated_at,
+                )
+            });
+        }
+        return Ok(RecoveryChoice::Restore);
     }
     let prompt = format!(
         "Restore previous local KiCad recovery file from {}?",
@@ -784,7 +800,11 @@ fn prompt_restore_recovery(status: &pcb_ui::Spinner, session: &SyncSession) -> O
             .prompt()
             .unwrap_or(false)
     };
-    Some(status.suspend(ask))
+    Ok(if status.suspend(ask) {
+        RecoveryChoice::Restore
+    } else {
+        RecoveryChoice::Discard
+    })
 }
 
 fn mark_recoverable_sessions_prompt_seen(cache_root: &Path) {

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -473,9 +473,10 @@ fn sync_layout_down(
         && let Some(session) = latest_recoverable_session(&cache_root)?
     {
         match prompt_restore_recovery(status, &session)? {
-            RecoveryChoice::Restore => recovered_session = Some(session),
-            RecoveryChoice::Discard => mark_recoverable_sessions_prompt_seen(&cache_root),
-            RecoveryChoice::Cancel => return Ok(None),
+            Some(RecoveryChoice::Restore) => recovered_session = Some(session),
+            Some(RecoveryChoice::Discard) => mark_recoverable_sessions_prompt_seen(&cache_root),
+            Some(RecoveryChoice::Cancel) => return Ok(None),
+            None => {}
         }
     }
 
@@ -778,17 +779,18 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
 fn prompt_restore_recovery(
     status: &pcb_ui::Spinner,
     session: &SyncSession,
-) -> Result<RecoveryChoice> {
+) -> Result<Option<RecoveryChoice>> {
     if !crate::tty::is_interactive() {
         if std::env::var_os(URL_LAUNCHER_ENV).is_some() {
             return status.suspend(|| {
-                crate::recovery_dialog::choose(
-                    &session.manifest.layout_file,
-                    session.manifest.updated_at,
-                )
+                crate::recovery_dialog::choose(&session.manifest.layout_file).map(Some)
             });
         }
-        return Ok(RecoveryChoice::Restore);
+        eprintln!(
+            "Found local recovery file for this remote layout at {}. Re-run interactively to restore it.",
+            session.manifest.layout_file.display()
+        );
+        return Ok(None);
     }
     let prompt = format!(
         "Restore previous local KiCad recovery file from {}?",
@@ -800,11 +802,11 @@ fn prompt_restore_recovery(
             .prompt()
             .unwrap_or(false)
     };
-    Ok(if status.suspend(ask) {
+    Ok(Some(if status.suspend(ask) {
         RecoveryChoice::Restore
     } else {
         RecoveryChoice::Discard
-    })
+    }))
 }
 
 fn mark_recoverable_sessions_prompt_seen(cache_root: &Path) {

--- a/install.ps1
+++ b/install.ps1
@@ -33,20 +33,20 @@ function Add-InstallDirToPath($dir) {
 }
 
 $latest = Invoke-RestMethod "$baseUrl/pcb-latest.json"
-$artifact = "pcb-x86_64-pc-windows-msvc.exe"
+$zstd = Get-Command zstd -ErrorAction SilentlyContinue
 $tmp = New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName()))
 
-try {
-    $binary = Join-Path $tmp "pcb.exe"
-    $sum = Join-Path $tmp "pcb.exe.sha256"
-    $launcherArtifact = "pcb-launcher-x86_64-pc-windows-msvc.exe"
-    $launcherBinary = Join-Path $tmp "pcb-launcher.exe"
-    $launcherSum = Join-Path $tmp "pcb-launcher.exe.sha256"
+# Download and checksum-verify one release binary into $tmp, preferring the
+# zstd-compressed artifact when zstd is available. Returns the local path.
+function Get-ReleaseBinary($name) {
+    $artifact = "$name-x86_64-pc-windows-msvc.exe"
+    $binary = Join-Path $tmp "$name.exe"
+    $sum = Join-Path $tmp "$name.exe.sha256"
     Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact.sha256" -OutFile $sum
-    $zstd = Get-Command zstd -ErrorAction SilentlyContinue
+
     $downloadedCompressed = $false
     if ($zstd) {
-        $compressedPath = Join-Path $tmp "pcb.exe.zst"
+        $compressedPath = Join-Path $tmp "$name.exe.zst"
         try {
             Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact.zst" -OutFile $compressedPath
             $downloadedCompressed = $true
@@ -54,7 +54,6 @@ try {
             $downloadedCompressed = $false
         }
     }
-
     if ($downloadedCompressed) {
         & $zstd.Source -q -d -f $compressedPath -o $binary
         if ($LASTEXITCODE -ne 0) {
@@ -65,60 +64,39 @@ try {
         Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact" -OutFile $binary
     }
 
-    $launcherDownloaded = $false
+    $expected = ((Get-Content $sum -Raw) -split "\s+")[0].ToLowerInvariant()
+    $actual = (Get-FileHash -Algorithm SHA256 $binary).Hash.ToLowerInvariant()
+    if ($actual -ne $expected) {
+        throw "$name checksum mismatch"
+    }
+    return $binary
+}
+
+try {
+    $binary = Get-ReleaseBinary "pcb"
+
+    $launcherBinary = $null
     try {
-        Invoke-WebRequest "$baseUrl/$($latest.tag)/$launcherArtifact.sha256" -OutFile $launcherSum
-        $launcherDownloadedCompressed = $false
-        if ($zstd) {
-            $launcherCompressedPath = Join-Path $tmp "pcb-launcher.exe.zst"
-            try {
-                Invoke-WebRequest "$baseUrl/$($latest.tag)/$launcherArtifact.zst" -OutFile $launcherCompressedPath
-                $launcherDownloadedCompressed = $true
-            } catch {
-                $launcherDownloadedCompressed = $false
-            }
-        }
-        if ($launcherDownloadedCompressed) {
-            & $zstd.Source -q -d -f $launcherCompressedPath -o $launcherBinary
-            if ($LASTEXITCODE -ne 0) {
-                Remove-Item -Force -ErrorAction SilentlyContinue $launcherBinary
-                Invoke-WebRequest "$baseUrl/$($latest.tag)/$launcherArtifact" -OutFile $launcherBinary
-            }
-        } else {
-            Invoke-WebRequest "$baseUrl/$($latest.tag)/$launcherArtifact" -OutFile $launcherBinary
-        }
-
-        $launcherExpected = ((Get-Content $launcherSum -Raw) -split "\s+")[0].ToLowerInvariant()
-        $launcherActual = (Get-FileHash -Algorithm SHA256 $launcherBinary).Hash.ToLowerInvariant()
-        if ($launcherActual -ne $launcherExpected) {
-            throw "pcb-launcher checksum mismatch"
-        }
-
-        $launcherDownloaded = $true
+        $launcherBinary = Get-ReleaseBinary "pcb-launcher"
     } catch {
         Write-Warning "Skipping optional pcb-launcher for $($latest.tag): $_"
     }
 
-    $expected = ((Get-Content $sum -Raw) -split "\s+")[0].ToLowerInvariant()
-    $actual = (Get-FileHash -Algorithm SHA256 $binary).Hash.ToLowerInvariant()
-    if ($actual -ne $expected) {
-        throw "checksum mismatch"
-    }
     New-Item -ItemType Directory -Force $installDir | Out-Null
     $installedPcb = Join-Path $installDir "pcb.exe"
     $installedLauncher = Join-Path $installDir "pcb-launcher.exe"
     Move-Item -Force $binary $installedPcb
 
-    if ($launcherDownloaded) {
+    if ($launcherBinary) {
         try {
             Move-Item -Force $launcherBinary $installedLauncher
         } catch {
-            $launcherDownloaded = $false
+            $launcherBinary = $null
             Write-Warning "Installed pcb, but could not install the Diode URL launcher: $_"
         }
     }
 
-    if ($launcherDownloaded) {
+    if ($launcherBinary) {
         # pcb-launcher uses the Windows GUI subsystem, so invoke it through a
         # process handle to wait for registration and read the correct exit code.
         try {
@@ -134,7 +112,7 @@ try {
     Add-InstallDirToPath $installDir
 
     Write-Host "Installed pcb to $installedPcb"
-    if ($launcherDownloaded) {
+    if ($launcherBinary) {
         Write-Host "Installed Diode URL launcher to $installedLauncher"
     }
 } finally {

--- a/install.ps1
+++ b/install.ps1
@@ -39,6 +39,9 @@ $tmp = New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) 
 try {
     $binary = Join-Path $tmp "pcb.exe"
     $sum = Join-Path $tmp "pcb.exe.sha256"
+    $launcherArtifact = "pcb-launcher-x86_64-pc-windows-msvc.exe"
+    $launcherBinary = Join-Path $tmp "pcb-launcher.exe"
+    $launcherSum = Join-Path $tmp "pcb-launcher.exe.sha256"
     Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact.sha256" -OutFile $sum
     $zstd = Get-Command zstd -ErrorAction SilentlyContinue
     $downloadedCompressed = $false
@@ -54,8 +57,46 @@ try {
 
     if ($downloadedCompressed) {
         & $zstd.Source -q -d -f $compressedPath -o $binary
+        if ($LASTEXITCODE -ne 0) {
+            Remove-Item -Force -ErrorAction SilentlyContinue $binary
+            Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact" -OutFile $binary
+        }
     } else {
         Invoke-WebRequest "$baseUrl/$($latest.tag)/$artifact" -OutFile $binary
+    }
+
+    $launcherDownloaded = $false
+    try {
+        Invoke-WebRequest "$baseUrl/$($latest.tag)/$launcherArtifact.sha256" -OutFile $launcherSum
+        $launcherDownloadedCompressed = $false
+        if ($zstd) {
+            $launcherCompressedPath = Join-Path $tmp "pcb-launcher.exe.zst"
+            try {
+                Invoke-WebRequest "$baseUrl/$($latest.tag)/$launcherArtifact.zst" -OutFile $launcherCompressedPath
+                $launcherDownloadedCompressed = $true
+            } catch {
+                $launcherDownloadedCompressed = $false
+            }
+        }
+        if ($launcherDownloadedCompressed) {
+            & $zstd.Source -q -d -f $launcherCompressedPath -o $launcherBinary
+            if ($LASTEXITCODE -ne 0) {
+                Remove-Item -Force -ErrorAction SilentlyContinue $launcherBinary
+                Invoke-WebRequest "$baseUrl/$($latest.tag)/$launcherArtifact" -OutFile $launcherBinary
+            }
+        } else {
+            Invoke-WebRequest "$baseUrl/$($latest.tag)/$launcherArtifact" -OutFile $launcherBinary
+        }
+
+        $launcherExpected = ((Get-Content $launcherSum -Raw) -split "\s+")[0].ToLowerInvariant()
+        $launcherActual = (Get-FileHash -Algorithm SHA256 $launcherBinary).Hash.ToLowerInvariant()
+        if ($launcherActual -ne $launcherExpected) {
+            throw "pcb-launcher checksum mismatch"
+        }
+
+        $launcherDownloaded = $true
+    } catch {
+        Write-Warning "Skipping optional pcb-launcher for $($latest.tag): $_"
     }
 
     $expected = ((Get-Content $sum -Raw) -split "\s+")[0].ToLowerInvariant()
@@ -63,13 +104,39 @@ try {
     if ($actual -ne $expected) {
         throw "checksum mismatch"
     }
-
     New-Item -ItemType Directory -Force $installDir | Out-Null
-    Move-Item -Force $binary (Join-Path $installDir "pcb.exe")
+    $installedPcb = Join-Path $installDir "pcb.exe"
+    $installedLauncher = Join-Path $installDir "pcb-launcher.exe"
+    Move-Item -Force $binary $installedPcb
+
+    if ($launcherDownloaded) {
+        try {
+            Move-Item -Force $launcherBinary $installedLauncher
+        } catch {
+            $launcherDownloaded = $false
+            Write-Warning "Installed pcb, but could not install the Diode URL launcher: $_"
+        }
+    }
+
+    if ($launcherDownloaded) {
+        # pcb-launcher uses the Windows GUI subsystem, so invoke it through a
+        # process handle to wait for registration and read the correct exit code.
+        try {
+            $launcherInstall = Start-Process -FilePath $installedLauncher -ArgumentList "--install" -Wait -PassThru
+            if ($launcherInstall.ExitCode -ne 0) {
+                Write-Warning "Installed pcb, but could not register the Diode URL launcher. See $HOME\.pcb\pcb-launcher.log for details"
+            }
+        } catch {
+            Write-Warning "Installed pcb, but could not register the Diode URL launcher: $_"
+        }
+    }
 
     Add-InstallDirToPath $installDir
 
-    Write-Host "Installed pcb to $(Join-Path $installDir "pcb.exe")"
+    Write-Host "Installed pcb to $installedPcb"
+    if ($launcherDownloaded) {
+        Write-Host "Installed Diode URL launcher to $installedLauncher"
+    }
 } finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
 }

--- a/install.ps1
+++ b/install.ps1
@@ -122,7 +122,7 @@ try {
         # pcb-launcher uses the Windows GUI subsystem, so invoke it through a
         # process handle to wait for registration and read the correct exit code.
         try {
-            $launcherInstall = Start-Process -FilePath $installedLauncher -ArgumentList "--install" -Wait -PassThru
+            $launcherInstall = Start-Process -FilePath $installedLauncher -ArgumentList "--install --toolchain latest" -Wait -PassThru
             if ($launcherInstall.ExitCode -ne 0) {
                 Write-Warning "Installed pcb, but could not register the Diode URL launcher. See $HOME\.pcb\pcb-launcher.log for details"
             }

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,12 @@ EOF
   echo "Added $install_dir to PATH. Restart your shell or run: $source_line"
 }
 
+register_url_launcher() {
+  if ! "$install_dir/pcb-launcher" --install; then
+    echo "Warning: installed pcb, but could not register the Diode URL launcher; see $HOME/.pcb/pcb-launcher.log" >&2
+  fi
+}
+
 install_local() {
   command -v cargo >/dev/null || { echo "missing required command: cargo" >&2; exit 1; }
 
@@ -69,7 +75,7 @@ install_local() {
   fi
 
   target_dir="$source_dir/target"
-  cargo build --release -p pcb -p pcbc -p rectify --manifest-path "$source_dir/Cargo.toml" --target-dir "$target_dir"
+  cargo build --release -p pcb -p pcb-launcher -p pcbc -p rectify --manifest-path "$source_dir/Cargo.toml" --target-dir "$target_dir"
 
   local_target_dir="$data_dir/toolchains/local/$target"
   stdlib_dir="$local_target_dir/lib/std"
@@ -78,6 +84,12 @@ install_local() {
 
   mkdir -p "$install_dir"
   install -m 755 "$target_dir/release/pcb" "$install_dir/pcb"
+  launcher_installed=""
+  if install -m 755 "$target_dir/release/pcb-launcher" "$install_dir/pcb-launcher"; then
+    launcher_installed="true"
+  else
+    echo "Warning: installed pcb, but could not install the Diode URL launcher" >&2
+  fi
 
   mkdir -p "$local_target_dir/lib"
   install -m 755 "$target_dir/release/pcbc" "$local_target_dir/pcbc"
@@ -87,8 +99,14 @@ install_local() {
   cp -R "$source_dir/lib/std" "$stdlib_dir"
 
   add_install_dir_to_path
+  if [ -n "$launcher_installed" ]; then
+    register_url_launcher
+  fi
 
   echo "Installed local pcb to $install_dir/pcb"
+  if [ -n "$launcher_installed" ]; then
+    echo "Installed Diode URL launcher to $install_dir/pcb-launcher"
+  fi
   echo "Installed local pcbc to $local_target_dir/pcbc"
   echo "Installed local pcb-rectify to $local_target_dir/pcb-rectify"
   echo "Installed local stdlib to $stdlib_dir"
@@ -117,40 +135,85 @@ tag="$(printf '%s' "$json" | sed -n 's/.*"tag"[[:space:]]*:[[:space:]]*"\([^"]*\
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-artifact=""
-downloaded=""
-for artifact_target in $download_targets; do
-  rm -f "$tmp/pcb" "$tmp/pcb.zst" "$tmp/pcb.sha256"
-  artifact="pcb-$artifact_target"
-  if ! curl -fsSL "$base_url/$tag/$artifact.sha256" -o "$tmp/pcb.sha256" 2>/dev/null; then
-    continue
-  fi
-  if command -v zstd >/dev/null \
-    && curl -fsSL "$base_url/$tag/$artifact.zst" -o "$tmp/pcb.zst" 2>/dev/null; then
-    zstd -q -d -f "$tmp/pcb.zst" -o "$tmp/pcb"
-  elif ! curl -fsSL "$base_url/$tag/$artifact" -o "$tmp/pcb" 2>/dev/null; then
-    continue
-  fi
-  downloaded="true"
-  break
-done
-[ -n "$downloaded" ] || { echo "could not find pcb release artifact for $target" >&2; exit 1; }
+download_binary() {
+  binary_name="$1"
+  downloaded=""
+  for artifact_target in $download_targets; do
+    output="$tmp/$binary_name"
+    compressed="$output.zst"
+    checksum="$output.sha256"
+    artifact="$binary_name-$artifact_target"
+    rm -f "$output" "$compressed" "$checksum"
+    if ! curl -fsSL "$base_url/$tag/$artifact.sha256" -o "$checksum" 2>/dev/null; then
+      continue
+    fi
+    if command -v zstd >/dev/null \
+      && curl -fsSL "$base_url/$tag/$artifact.zst" -o "$compressed" 2>/dev/null; then
+      if ! zstd -q -d -f "$compressed" -o "$output"; then
+        rm -f "$output"
+        if ! curl -fsSL "$base_url/$tag/$artifact" -o "$output" 2>/dev/null; then
+          continue
+        fi
+      fi
+    elif ! curl -fsSL "$base_url/$tag/$artifact" -o "$output" 2>/dev/null; then
+      continue
+    fi
 
-expected="$(sed 's/[[:space:]].*//' "$tmp/pcb.sha256")"
-if command -v shasum >/dev/null; then
-  actual="$(shasum -a 256 "$tmp/pcb" | sed 's/[[:space:]].*//')"
-elif command -v sha256sum >/dev/null; then
-  actual="$(sha256sum "$tmp/pcb" | sed 's/[[:space:]].*//')"
+    expected="$(sed 's/[[:space:]].*//' "$checksum")"
+    if command -v shasum >/dev/null; then
+      actual="$(shasum -a 256 "$output" | sed 's/[[:space:]].*//')"
+    elif command -v sha256sum >/dev/null; then
+      actual="$(sha256sum "$output" | sed 's/[[:space:]].*//')"
+    else
+      echo "missing shasum or sha256sum" >&2
+      exit 1
+    fi
+    [ "$actual" = "$expected" ] || { echo "checksum mismatch for $artifact" >&2; return 2; }
+    downloaded="true"
+    break
+  done
+  [ -n "$downloaded" ]
+}
+
+if download_binary pcb; then
+  :
 else
-  echo "missing shasum or sha256sum" >&2
-  exit 1
+  pcb_status="$?"
+  if [ "$pcb_status" -eq 1 ]; then
+    echo "could not find pcb release artifact for $target" >&2
+  fi
+  exit "$pcb_status"
 fi
-[ "$actual" = "$expected" ] || { echo "checksum mismatch" >&2; exit 1; }
+
+launcher_downloaded=""
+if download_binary pcb-launcher; then
+  launcher_downloaded="true"
+else
+  launcher_status="$?"
+  if [ "$launcher_status" -eq 1 ]; then
+    echo "Warning: pcb-launcher is not available for $tag; skipping Diode URL launcher install" >&2
+  else
+    echo "Warning: pcb-launcher failed integrity verification; skipping Diode URL launcher install" >&2
+  fi
+fi
 
 mkdir -p "$install_dir"
 chmod +x "$tmp/pcb"
 mv "$tmp/pcb" "$install_dir/pcb"
 
+if [ -n "$launcher_downloaded" ]; then
+  if ! chmod +x "$tmp/pcb-launcher" || ! mv "$tmp/pcb-launcher" "$install_dir/pcb-launcher"; then
+    echo "Warning: installed pcb, but could not install the Diode URL launcher" >&2
+    launcher_downloaded=""
+  fi
+fi
+
 add_install_dir_to_path
+if [ -n "$launcher_downloaded" ]; then
+  register_url_launcher
+fi
 
 echo "Installed pcb to $install_dir/pcb"
+if [ -n "$launcher_downloaded" ]; then
+  echo "Installed Diode URL launcher to $install_dir/pcb-launcher"
+fi

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,8 @@ EOF
 }
 
 register_url_launcher() {
-  if ! "$install_dir/pcb-launcher" --install; then
+  launcher_toolchain="$1"
+  if ! "$install_dir/pcb-launcher" --install --toolchain "$launcher_toolchain"; then
     echo "Warning: installed pcb, but could not register the Diode URL launcher; see $HOME/.pcb/pcb-launcher.log" >&2
   fi
 }
@@ -100,7 +101,7 @@ install_local() {
 
   add_install_dir_to_path
   if [ -n "$launcher_installed" ]; then
-    register_url_launcher
+    register_url_launcher local
   fi
 
   echo "Installed local pcb to $install_dir/pcb"
@@ -210,7 +211,7 @@ fi
 
 add_install_dir_to_path
 if [ -n "$launcher_downloaded" ]; then
-  register_url_launcher
+  register_url_launcher latest
 fi
 
 echo "Installed pcb to $install_dir/pcb"


### PR DESCRIPTION
## Summary

- add a small cross-platform `pcb-launcher` sidecar that handles `diode://` sandbox file URLs
- register the URL handler for the current user on macOS, Linux, and Windows
- bootstrap the launcher from the Unix and Windows installers
- update and re-register the launcher from `pcb self update`
- publish launcher artifacts alongside the `pcb` shim

## Why

Registry currently copies a `pcb open` command that users must paste into a terminal. A native protocol handler lets Registry open a sandbox board directly in KiCad while keeping `pcb.exe` a console application and using a GUI-subsystem launcher on Windows.

`pcb-rectify` remains a versioned toolchain sidecar because it must match the selected `pcbc` lane. The launcher instead follows the shim release lifecycle.

Linear: [ENG-286](https://linear.app/diodeinc/issue/ENG-286/registry-open-in-kicad)

## Validation

- `cargo test -p pcb-launcher -p pcb`
- `cargo clippy -p pcb-launcher -p pcb -- -D warnings`
- Windows MSVC and Linux musl cross-target clippy for `pcb-launcher`
- macOS release build and AppKit linkage inspection
- `bash -n install.sh`
- release workflow YAML parse
- installed and registered the launcher on macOS
- verified LaunchServices claims `diode://`
- verified the bundled `pcb` opens a board in KiCad PCB Editor

The full repository clippy hook reaches an unrelated existing `items_after_test_module` lint in `crates/pcb-ipc2581-tools/src/commands/html_export.rs`; the scoped changed crates pass clippy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OS URL-handler registration, external URI trust policy, and remote sync/recovery behavior where mistakes could block opens or mishandle local KiCad state.
> 
> **Overview**
> Adds a **`pcb-launcher`** sidecar that registers and handles the **`diode://`** URL scheme so Registry can open sandbox boards in KiCad without a terminal. The launcher validates sandbox file URIs (with release builds trusting only **`*.diode.computer`** hosts), runs **`pcb +latest|+local open`**, waits for completion, logs to **`~/.pcb/pcb-launcher.log`**, and shows native errors via new **`pcb-native-dialog`**.
> 
> URI parsing moves into **`pcb-diode-uri`** and is shared with **`pcb-diode-api`**. **Installers**, **`pcb self update`**, and the **release workflow** now ship, verify, and re-register **`pcb-launcher`** alongside **`pcb`**.
> 
> **Remote sandbox open** gains browser-friendly **recovery prompts** (restore backup / open sandbox / cancel), tracks **KiCad editor PID** to block duplicate opens, and **stops force-quitting KiCad** on recoverable sync failures. **`pcb-kicad`** unifies macOS waitable vs fire-and-forget **`open`** launches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9048225d91680ee031dccf4db1a468a678b77473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->