### PR TITLE
Regularize board-array balancing gaps locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Board-array balancing now uses independent 1 mm filled-region and void-gap regularization, trimming narrow gaps locally instead of discarding whole regions.
+
 ## [0.4.17] - 2026-07-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "boostvoronoi"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077839b66f949d7728595b25f9c24b6d6972e0fd3afbd35cf034de66dd1bdb34"
+dependencies = [
+ "approx",
+ "cpp_map",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.18",
+ "vob",
+]
+
+[[package]]
 name = "borsh"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1455,17 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
+name = "cpp_map"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1940c0c538b9de163cd9523bf2801fdea188bba1c5978c9b8750a8a9c7d500"
+dependencies = [
+ "rand 0.9.4",
+ "smallvec",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -4859,6 +4887,7 @@ name = "pcb-ir"
 version = "0.3.82"
 dependencies = [
  "base64",
+ "boostvoronoi",
  "i_overlay",
  "kurbo",
  "resvg",
@@ -5675,7 +5704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -5685,6 +5714,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -5710,6 +5740,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5723,6 +5763,9 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rand_core"
@@ -8436,6 +8479,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vob"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "vsimd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ comfy-table = { version = "7.2", features = ["custom_styling"] }
 url = "2.5"
 ignore = "0.4"
 i_overlay = "7"
+boostvoronoi = "0.12.1"
 sha2 = "0.11"
 semver = { version = "1.0", features = ["serde"] }
 kurbo = "0.13"

--- a/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
+++ b/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
@@ -51,16 +51,20 @@ N₀   = G_(v + e)(A)
 Γ₀   = source-boundary generalized Voronoi axis inside N₀
 S₀   = open(A \ (Γ₀ ⊕ disk(v + e)), disk(q))
 
-Vₖ   = open(G_v(Sₖ), disk(e))
-Sₖ₊₁ = open(Sₖ \ (Vₖ ⊕ disk(v + e)), disk(q))
+Rₖ   = G_v(Sₖ)
+Vₖ   = open(Rₖ, disk(e))
+Wₖ   = Vₖ if Vₖ is nonempty, otherwise Rₖ
+Sₖ₊₁ = open(Sₖ \ (Wₖ ⊕ disk(v + e)), disk(q))
 ```
 
 The Voronoi axis gives the least local first cut and treats competing sides
-symmetrically. Any meaningful certificate residual is swept directly, avoiding
-repeated Voronoi construction over Boolean-generated boundaries. Each pass only
-removes material, and the filled-region opening after every trim prevents new
-copper slivers. Iteration ends when `Vₖ` is empty or reports an error if a pass
-cannot make meaningful geometric progress.
+symmetrically. Meaningful residuals are denoised before sweeping. A residual too
+thin for that filter is swept raw rather than treated as safe. This avoids
+repeated Voronoi construction over Boolean-generated boundaries without letting
+an extremely tight real gap evade the proof. Each pass only removes material,
+and the filled-region opening after every trim prevents new copper slivers.
+Iteration ends when `Rₖ` is empty or reports an error if a pass cannot make
+meaningful geometric progress.
 
 The independent nominal certificate is:
 
@@ -69,7 +73,7 @@ C = safe ⊕ disk(r)
 
 safe \ F = ∅
 safe \ open(safe, disk(q)) = ∅, after numerical denoising
-G_v(safe) = ∅, after numerical denoising
+G_v(safe) = ∅
 C \ P = ∅
 C ∩ O = ∅
 ```

--- a/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
+++ b/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
@@ -1,346 +1,86 @@
 # Board-array copper-balancing region
 
-Status: reusable safe-region implementation plus a development harness. This
-does not add copper or expose a user-facing CLI contract.
+Status: reusable `pcb-ir` computation plus a development harness. Board-array
+creation consumes the result before it emits balancing copper. The harness does
+not define a user-facing CLI contract.
 
 ## Geometry contract
 
-All geometry is a filled planar point set in panel coordinates, measured in
-millimeters:
+All geometry is a filled planar point set in panel coordinates, in millimeters:
 
-- `P`: the filled outer profile of the root array/panel.
-- `B`: the union of the filled outer profiles of every final board instance.
-  Board-profile cutouts are deliberately ignored here, so the whole board
-  footprint remains protected.
-- `M`: physical material removal already derived for fabrication: root-profile
-  cutouts, board cutouts, and generated V-score route reliefs.
-- `G`: the geometric footprint of every painted physical `ArraySupport`
-  feature on every source layer. Filled paths use their native fill rule.
-  Stroked paths use their native width, cap, and join. Feature polarity does
-  not change the fact that its footprint is protected. V-cut layers use
-  process-spec references to retain score operations while excluding
-  same-layer documentation such as arrows and labels.
-- `O = B ∪ M ∪ G`: every obstacle.
-- `r = 0.5 mm`: the nominal required clearance.
-- `q = 1.0 mm`: the minimum-feature radius used to regularize the result.
-- `v = 1.0 mm`: the minimum-gap radius that must fit between safe regions.
-- `e`: a conservative numerical error budget for polygonization and offsets.
+- `P`: filled outer profile of the root panel.
+- `B`: union of every final board-instance profile. Board-profile holes remain
+  protected because copper balancing must not enter a board footprint.
+- `M`: fabrication material removal, including profile cutouts, board cutouts,
+  and generated V-score reliefs.
+- `G`: union of painted physical geometry on every `ArraySupport` layer.
+  V-cut layers include features tied to a `V_Cut` process and exclude callout
+  arrows and labels.
+- `O = B ∪ M ∪ G`: obstacle union.
+- `r = 0.5`: required feature and panel-edge clearance.
+- `q = 0.5`: filled-region rolling-disk radius.
+- `v = 0.5`: void-gap rolling-disk radius.
+- `e = 0.025`: numerical construction guard.
 
-The result is:
+Clearance and filled-region regularization are direct morphology:
 
 ```text
-construction_clearance = r + e
-construction_gap       = max(r, v) + e
-panel_clearance_keep_in = P ⊖ disk(construction_clearance)
-panel_keep_in           = P ⊖ disk(construction_gap)
-obstacle_clearance      = O ⊕ disk(construction_clearance)
-obstacle_gap_envelope   = O ⊕ disk(construction_gap)
-maximal_safe            = panel_keep_in \ obstacle_gap_envelope
-regularization_core     = maximal_safe ⊖ disk(q)
-opened_safe             = (regularization_core ⊕ disk(q)) ∩ maximal_safe
-
-H = graph whose vertices are the connected components of opened_safe,
-    with an edge (i, j) exactly when distance(component_i, component_j) < 2v
-
-x*                      = arg max Σ area(component_i) x_i
-                          subject to x_i + x_j ≤ 1 for every edge (i, j) in H
-                          and x_i ∈ {0, 1}
-safe                    = union of component_i for which x*_i = 1
-removed_by_opening      = maximal_safe \ opened_safe
-removed_for_gap         = opened_safe \ safe
+c = r + e
+F = (P ⊖ disk(c)) \ (O ⊕ disk(c))
+A = open(F, disk(q))
 ```
 
-The last two offsets are a morphological opening by a disk. They round convex
-tips, break necks narrower than the disk diameter, and remove components unable
-to contain the disk without geometric recognition rules or topology heuristics.
-The intersection makes the opening explicitly anti-extensive despite
-polygon-offset approximation: regularization can only remove clearance-safe
-material, never add material outside `maximal_safe`.
+`F` is the clearance-safe set. Treating the panel exterior and all obstacles as
+one forbidden phase covers corners and diagonal approaches without rules for
+individual feature types. `A` is the union of all radius-`q` disks contained in
+`F`. It rounds outward corners and removes tips, necks, slivers, or components
+that cannot contain that disk. There is no component-area threshold. With the
+defaults, both surviving filled regions and empty gaps use a 1 mm nominal
+scale, while clearance remains an independent 0.5 mm distance.
 
-The gap envelope is the dual construction. The outside of the panel and the
-obstacle union are treated as one hard forbidden phase: the panel is eroded
-and the obstacles are dilated by the same construction gap. This prevents
-diagonal shortcuts where an obstacle envelope meets a panel edge. For a
-line-like obstacle, the default creates a 2.05 mm corridor instead of the
-1.05 mm corridor produced by clearance alone.
+For any set `X`, define `G_t(X)` as the connected components of
+`close(X, disk(t)) \ X` that touch nonincident source-boundary branches with
+opposing tangents. This keeps genuine two-sided gaps—including gaps between
+components, hairpins, notches, and holes—and rejects the ordinary closing bite
+at an isolated concave corner.
 
-Opening removes copper slivers, but it cannot choose which side of a narrow
-gap should survive. That is a topology choice rather than another local
-offset. The component graph makes the choice explicit and order-independent:
-retain the conflict-free subset with maximum total area. Each connected
-conflict cluster is solved exactly by branch-and-bound; disconnected clusters
-are independent, and equal-area optima use the stable area/bounding-box order.
-Exact segment distance with bounding-box pruning finds graph edges without
-retaining every component dilation in memory. On a detected conflict only, the
-harness constructs the overlapping dilations as debug geometry.
+Gap regularization is a monotone local trim:
 
-The final optimized union is not a monotone set-valued function of clearance,
-feature radius, gap radius, or obstacle additions. Those changes shrink the
-pre-selection geometry, but can split components or change the maximum-area
-independent set. Equal-area coordinate tie breaks likewise mean rotations and
-reflections preserve the objective value and certificate, not necessarily the
-chosen union. Correctness is defined by the certificate, not by nesting outputs
-from different parameter values.
+```text
+N₀   = G_(v + e)(A)
+Γ₀   = source-boundary generalized Voronoi axis inside N₀
+S₀   = open(A \ (Γ₀ ⊕ disk(v + e)), disk(q))
 
-The independent safety certificate is:
+Vₖ   = open(G_v(Sₖ), disk(e))
+Sₖ₊₁ = open(Sₖ \ (Vₖ ⊕ disk(v + e)), disk(q))
+```
+
+The Voronoi axis gives the least local first cut and treats competing sides
+symmetrically. Any meaningful certificate residual is swept directly, avoiding
+repeated Voronoi construction over Boolean-generated boundaries. Each pass only
+removes material, and the filled-region opening after every trim prevents new
+copper slivers. Iteration ends when `Vₖ` is empty or reports an error if a pass
+cannot make meaningful geometric progress.
+
+The independent nominal certificate is:
 
 ```text
 C = safe ⊕ disk(r)
 
-safe \ maximal_safe = ∅
+safe \ F = ∅
+safe \ open(safe, disk(q)) = ∅, after numerical denoising
+G_v(safe) = ∅, after numerical denoising
 C \ P = ∅
 C ∩ O = ∅
-safe \ open(safe, q) = ∅
-for every pair of distinct components i, j:
-    (component_i ⊕ disk(v)) ∩ (component_j ⊕ disk(v)) = ∅
 ```
 
-The certificate uses the nominal 0.5 mm, not the construction clearance. Its
-feature and pairwise-gap checks use the nominal radii. Numerical offset-only
-fragments are removed with an opening by `e`; geometric violations survive
-that filter and are retained as first-class debug output. The broader
-`close(safe, v) \ safe` is also emitted as a non-gating diagnostic: it finds
-concave notches within one component as well as gaps between components, so it
-is deliberately not the minimum-intercomponent-gap contract.
+Construction uses the guard; certification uses the nominal requirements.
+Every violation remains available as geometry for debugging.
 
-## Development harness
+## IPC boundary
 
-The harness is
-`examples/board_array_balancing_region.rs`. Run it with:
-
-```bash
-cargo run -p pcb-ipc2581-tools \
-  --example board_array_balancing_region -- \
-  path/to/array.xml \
-  --output /tmp/balancing-region/case-name
-```
-
-Useful options:
-
-```text
---clearance-mm <mm>                 nominal requirement; default 0.5
---minimum-feature-radius-mm <mm>    disk-opening radius; default 1.0
---minimum-gap-radius-mm <mm>        void disk radius; default 1.0
---numerical-guard-mm <mm>           construction guard; default 0.025
---check-area-tolerance-mm2 <mm²>    validation threshold; default 0.0001
---require-a-series-auto             reject manual and minimum-fallback arrays
-```
-
-The current 0.025 mm guard is explicit and provisional. It is
-`2 * STROKE_OUTLINE_MM + FLATTEN_MM` from the present `pcb-ir` polygonization
-pipeline. A zero-guard Icarus run made the Boolean result look correct but the
-independent certificate exposed many tiny offset-approximation slivers. Keeping
-the guard separate makes that numerical decision visible in JSON and in the
-viewer.
-
-The auto A5 ControlHub case exposed a topology defect in the original
-boundary-stroke offset implementation. Signed winding cancellation created
-five microscopic holes inside the dilated obstacle region near connected
-V-score/relief geometry. The nominal certificate then expanded those false
-safe islands into 2.159 mm² of obstacle overlap. Increasing the guard through
-0.150 mm could not fix a topological error.
-
-`ContourSet` now uses `i_overlay`'s topology-aware outline offset directly.
-Outer contours and holes are offset according to their role, the result is
-regularized, and `ContourSet::union` performs an explicit Boolean union rather
-than relying on concatenated winding. The A5 certificate now has zero obstacle
-overlap.
-
-Each run overwrites a deterministic artifact set:
-
-| Artifact | Contents |
-|---|---|
-| `index.html` | Toggleable overlay, metrics, check status, and links |
-| `overview.svg` | Portable combined overlay |
-| `00-panel-outer.svg` | Raw root-panel region `P` |
-| `10-board-footprints.svg` | Final board-instance region `B` |
-| `20-material-removal.svg` | Fabrication material removal `M` |
-| `30-support-features.svg` | Cross-layer support footprint `G` |
-| `40-raw-obstacles.svg` | Union `O` |
-| `50-panel-clearance-keep-in.svg` | Panel eroded by the construction clearance |
-| `55-panel-gap-keep-in.svg` | Panel eroded by the construction gap radius |
-| `60-obstacle-clearance.svg` | Dilated obstacles |
-| `65-obstacle-gap-envelope.svg` | Obstacles dilated to the minimum-gap radius |
-| `70-maximal-safe-region.svg` | Maximal clearance-safe set before regularization |
-| `75-regularization-core.svg` | Centers where the minimum-feature disk fits |
-| `78-opened-safe-region.svg` | Result after minimum-feature opening |
-| `80-removed-by-opening.svg` | Material removed by the disk opening |
-| `85-removed-by-gap-separation.svg` | Whole components removed to enforce pairwise gaps |
-| `88-removed-by-regularization.svg` | All material removed by both stages |
-| `90-safe-region.svg` | Final regularized safe region |
-| `100-clearance-certificate.svg` | `safe` dilated by nominal clearance |
-| `105-minimum-gap-violations.svg` | Overlap between nominal dilations of distinct components |
-| `106-void-closing-additions.svg` | Non-gating broad closing diagnostic, including internal notches |
-| `110-validation-violations.svg` | Subset, clearance, feature, and gap violations |
-| `support-layers/*.svg` | Non-empty support footprints by source layer |
-| `regions.json` | Every ring, bounding box, included/excluded count, and check |
-
-`regions.json` is intentionally geometry-bearing rather than only a summary.
-When a Boolean result looks wrong, the exact input and output rings can be
-loaded into a small reproducer without parsing the original IPC again.
-Artifacts are written before validation is reported; incomplete path coverage
-or a failed certificate then makes the process exit nonzero.
-
-## Baseline suite
-
-The primary suite should contain only arrays generated by the A-series auto
-panelizer:
-
-1. Auto Icarus A7, 1 by 2: ordinary rigid board with real board-cell margins.
-2. MicFlex A7, 2 by 2: highly concave 196-segment flex outline and asymmetric
-   free space.
-3. Blackstar A6, 1 by 1: dense near-circular 481-segment boundary.
-4. ControlHub A5, 1 by 1: larger coordinate span and the offset-topology
-   regression case.
-
-For the local survey artifacts:
-
-```bash
-SURVEY_ROOT=/tmp/pcb-board-survey.oKwNKA
-BALANCE_OUT=/tmp/board-array-balancing
-mkdir -p "$BALANCE_OUT"
-
-cargo run -q -p pcbc -- ipc board-array create --auto \
-  "$SURVEY_ROOT/ipc/icarus_ir0001.xml" \
-  --output "$BALANCE_OUT/icarus-auto.xml"
-
-cargo run -q -p pcb-ipc2581-tools \
-  --example board_array_balancing_region -- \
-  "$BALANCE_OUT/icarus-auto.xml" \
-  --output "$BALANCE_OUT/icarus-auto" \
-  --require-a-series-auto
-
-cargo run -q -p pcb-ipc2581-tools \
-  --example board_array_balancing_region -- \
-  "$SURVEY_ROOT/arrays/micflex__auto.xml" \
-  --output "$BALANCE_OUT/micflex" \
-  --require-a-series-auto
-
-cargo run -q -p pcb-ipc2581-tools \
-  --example board_array_balancing_region -- \
-  "$SURVEY_ROOT/arrays/blackstar_mic__auto.xml" \
-  --output "$BALANCE_OUT/blackstar-a6" \
-  --require-a-series-auto
-
-cargo run -q -p pcb-ipc2581-tools \
-  --example board_array_balancing_region -- \
-  "$SURVEY_ROOT/arrays/impulse_controlhub__auto.xml" \
-  --output "$BALANCE_OUT/controlhub-a5" \
-  --require-a-series-auto
-```
-
-Then broaden the topology set:
-
-- Amoeba A7: complex curved boundary and generated reliefs.
-- Forced-sheet A7/A6/A5 cases for one identical source board, separating
-  topology changes from sheet-size and coordinate-span changes.
-- A nested high-mix fabrication panel: nested panel transforms, rotation, and
-  namespaced layers.
-- A synthetic no-free-space fixture: verifies that an empty safe region is a
-  valid result.
-
-Current A-series results all have complete support-path coverage:
-
-| Case | Sheet | Boards | Safe area | Safe fraction | Certificate |
-|---|---|---:|---:|---:|---|
-| Auto Icarus | A7 | 2 | 4877.093 mm² | 62.8% | pass |
-| MicFlex | A7 | 4 | 4897.722 mm² | 63.1% | pass |
-| Blackstar | A6 | 1 | 9538.244 mm² | 61.4% | pass |
-| ControlHub | A5 | 1 | 15111.933 mm² | 48.6% | pass |
-
-Across the 20-array auto-panelizer corpus, both regularization stages retained
-90.18% to 99.88% of the maximal safe area and discarded 276 gap-conflicting
-components. Every final component passed a second independent 1.0 mm erosion;
-the smallest component was 60.441 mm² and the smallest component bounding-box
-span was 6.284 mm. Every subset, nominal-clearance, minimum-feature, and
-pairwise-gap certificate passed. These values are useful as investigation
-baselines, not long-lived golden numbers.
-
-## Fast iteration loop
-
-1. Change one geometry or semantic stage.
-2. Run the focused geometry tests:
-
-   ```bash
-   cargo test -p pcb-ir geom::region
-   ```
-
-3. Build the harness once in release mode, then regenerate auto Icarus A7,
-   MicFlex A7, Blackstar A6, and ControlHub A5 into the same output
-   directories. Always pass `--require-a-series-auto` and put a bounded timeout
-   around each corpus case:
-
-   ```bash
-   cargo build --release -p pcb-ipc2581-tools \
-     --example board_array_balancing_region
-   gtimeout 20s target/release/examples/board_array_balancing_region \
-     path/to/array.xml --output path/to/report --require-a-series-auto
-   ```
-4. Check the command summary for:
-
-   - complete painted-path coverage;
-   - zero unpainted support paths;
-   - a passing nominal-clearance certificate.
-
-5. Open `index.html` and inspect in this order:
-
-   - board footprints cover every board but no intermediate panel-cell
-     boundary;
-   - material removal includes cutouts and relief pockets;
-   - support features include score, drill, copper, and mask geometry present
-     on the rails;
-   - V-cut support contains physical score lines but no callout arrows or text;
-   - obstacle clearance is round and continuous at corners;
-   - the minimum-gap envelope creates visibly usable void corridors;
-   - the green safe region is confined to true non-board support material;
-   - pink discarded components explain every minimum-gap topology choice;
-   - minimum-feature and minimum-gap violation layers are empty.
-
-6. Compare `regions.json` before and after. Area, ring count, vertex count, and
-   per-layer contributions usually locate an unintended change faster than an
-   image diff.
-7. Keep A5 as a required passing geometry regression gate: any nonzero
-   certificate overlap is a regression. Then run the complex, nested, and
-   empty cases.
-
-This loop keeps visual review diagnostic rather than authoritative: the viewer
-and automated checks are both projections of the same serialized
-`ContourSet`s.
-
-## Production architecture
-
-### 1. Keep the geometry kernel in `pcb-ir::geom`
-
-The generic operations belong in `pcb-ir`, independent of IPC:
-
-- construct a footprint from painted paths;
-- union, intersection, and difference of `ContourSet`s;
-- disk dilation, erosion, opening, and closing;
-- compute and retain certificate violation regions.
-
-`ContourSet` provides `from_painted_paths` and
-`ContourSet::disk_open` and `ContourSet::disk_close`. Dilation and erosion use
-`i_overlay`'s topology-aware outline offset over canonical rings. Its
-sign-aware builders offset outer contours and holes in opposite directions,
-after which the result is regularized through the existing Boolean kernel.
-Round-join segmentation is derived from `STROKE_OUTLINE_MM`, giving the arc
-approximation an explicit sagitta bound. Union is an actual
-`OverlayRule::Union`, so overlap cannot cancel filled material through winding
-arithmetic. Opening clips its dilation back to the source and closing unions
-its erosion with the source, preserving their subset and superset guarantees
-at polygon tolerance.
-
-The construction guard and nominal-clearance certificate remain separate.
-That makes approximation error conservative and testable: construct with
-`r + e`, but certify against `r`. Further manufacturing hardening can choose a
-panel-local fixed scale and conservative integer rounding, while retaining the
-same `ContourSet` API and Boolean kernel.
-
-### 2. IPC semantic collector
-
-`pcb_ir::dialects::ipc::balancing_region` consumes existing IR views and
-produces four semantic input regions without classifying individual IPC shape
-kinds:
+`pcb_ir::dialects::ipc::balancing_region` supplies only semantic collection and
+orchestration:
 
 ```rust
 pub struct BoardArrayBalancingInput {
@@ -352,149 +92,89 @@ pub struct BoardArrayBalancingInput {
 
 pub struct BalancingRegionOptions {
     pub clearance_mm: f64,
-    pub minimum_feature_radius_mm: f64,
-    pub minimum_gap_radius_mm: f64,
+    pub regularization_radius_mm: f64,
+    pub gap_radius_mm: f64,
     pub numerical_guard_mm: f64,
-}
-
-pub struct BoardArrayBalancingResult {
-    pub safe_region: ContourSet,
-    pub certificate: ClearanceCertificate,
-    pub intermediates: BoardArrayBalancingIntermediates,
 }
 ```
 
-The collector:
+The collector uses existing IR roles and painted paths. It does not recognize
+tooling holes, fiducials, score lines, or other features from their shape. A new
+physical support feature is covered automatically when it appears as painted
+`ArraySupport` geometry. An included path without paint has no physical
+envelope, so production collection fails closed instead of guessing.
 
-- obtains `panel_outer` from the root panel profile;
-- obtains `board_footprints` from occurrences whose existing role is
-  `BoardInstance`;
-- accepts the existing `BoardArrayFabricationProfile.material_removal`;
-- unions painted paths from every `ArraySupport` layer;
-- on V-cut layers, includes only features whose referenced process
-  specification contains a `V_Cut` item.
+Generic Boolean operations, disk morphology, gap classification, Voronoi-axis
+construction, and certificates remain in `pcb-ir::geom`. File parsing and
+debug rendering remain in `pcb-ipc2581-tools`.
 
-That is the entire IPC policy. The V-cut distinction is semantic metadata, not
-shape or coordinate recognition: generated score operations carry the process
-specification while callouts do not. A new tooling feature or fiducial shape
-is automatically covered because extraction yields another painted path. A
-path with no paint has no defined footprint; the production collector fails
-closed instead of guessing from `FeatureKind`. A separate inspection collector
-retains incomplete coverage for the debug harness, which still exits nonzero
-after writing its artifacts.
+## Development harness
 
-### 3. Keep orchestration in `pcb-ipc2581-tools`
+Run the harness in release mode for corpus iteration:
 
-The development harness now only:
+```bash
+cargo build --release -p pcb-ipc2581-tools \
+  --example board_array_balancing_region
 
-1. parse the document;
-2. call `extract_layout`;
-3. derive the existing fabrication profile and V-score reliefs;
-4. enumerate every IPC source layer with `View::ArraySupport`;
-5. feed those IR documents to the collector;
-6. serialize the returned safe region and debug bundle.
+gtimeout 60 target/release/examples/board_array_balancing_region \
+  path/to/array.xml \
+  --output /tmp/balancing-region/case-name \
+  --require-a-series-auto
+```
 
-SVG/HTML/JSON rendering stays here. `pcb-ir` should not know about files,
-browser viewers, Clap, or the source IPC parser.
+Options:
 
-### 4. Preserve debug data as a stable internal schema
+```text
+--clearance-mm <mm>                  nominal clearance; default 0.5
+--regularization-radius-mm <mm>      filled-region disk radius; default 0.5
+--gap-radius-mm <mm>                 void-gap disk radius; default 0.5
+--numerical-guard-mm <mm>            construction guard; default 0.025
+--check-area-tolerance-mm2 <mm²>     certificate threshold; default 0.0001
+--require-a-series-auto              reject non-A-series auto arrays
+```
 
-The versioned internal debug schema retains:
+Each run overwrites a deterministic artifact set:
 
-- nominal clearance, feature radius, gap radius, error budget, and both
-  construction radii;
-- source-layer feature/path counts and unsupported-path diagnostics;
-- all four semantic inputs;
-- the clearance and minimum-gap obstacle envelopes;
-- maximal safe region, opening core, and material removed by regularization;
-- final safe region;
-- certificate footprint plus clearance, minimum-feature, and minimum-gap
-  violation regions;
-- geometry-kernel tolerance/scale metadata.
+| Artifact | Contents |
+|---|---|
+| `index.html`, `overview.svg` | Interactive and portable combined views |
+| `00-panel-outer.svg` | Raw panel region `P` |
+| `10-board-footprints.svg` | Board-instance region `B` |
+| `20-material-removal.svg` | Fabrication removal `M` |
+| `30-support-features.svg` | Cross-layer support footprint `G` |
+| `40-raw-obstacles.svg` | Obstacle union `O` |
+| `50-panel-keep-in.svg` | Panel eroded by construction clearance |
+| `60-obstacle-keep-out.svg` | Obstacles dilated by construction clearance |
+| `70-clearance-safe-region.svg` | Clearance-safe set `F` |
+| `75-opened-candidates.svg` | Filled-region opening `A` |
+| `80-removed-by-opening.svg` | Material rejected by filled regularization |
+| `82-narrow-voids.svg` | Detected two-sided closing residuals |
+| `83-gap-separator-keep-out.svg` | Medial-axis and residual sweep tubes |
+| `85-removed-by-gap-regularization.svg` | Material locally trimmed around gaps |
+| `90-safe-region.svg` | Final balancing-safe region |
+| `100-clearance-certificate.svg` | Safe region swept by nominal clearance |
+| `105-gap-violations.svg` | Remaining nominal two-sided gap violations |
+| `110-validation-violations.svg` | Union of all certificate failures |
+| `support-layers/*.svg` | Physical support footprint by source layer |
+| `regions.json` | Metrics and exact rings for every intermediate |
 
-Production calls can consume only `safe_region`; tests and diagnostics retain
-the full bundle. The renderer does not recompute intermediate regions.
+Artifacts are written before a failed certificate exits nonzero. Exact rings
+make a failure reproducible without reparsing IPC.
 
-The reusable library boundary, fail-closed collector, certificate, tests, and
-debug-harness adapter are implemented. Automatic board-array creation consumes
-the certified region before balance copper is emitted.
+## Fast validation loop
 
-## Validation plan
+1. Run `cargo test -p pcb-ir geom::region`.
+2. Build the release harness once.
+3. Regenerate varied A7, A6, A5, and A4 auto-panelized arrays with a bounded
+   timeout.
+4. Require complete painted-path coverage, zero undersized components, and an
+   empty nominal certificate.
+5. Inspect board footprints, material removal, per-layer support, V-cut
+   inclusion, every regularization intermediate, and the final safe region.
+6. Compare `regions.json` area, component, ring, and vertex metrics.
+7. Parse every SVG and independently reconstruct the serialized regions with a
+   second geometry engine for area, subset, clearance, filled-disk, and
+   inter-component-gap checks.
 
-### Geometry unit tests
-
-Use analytic shapes with known behavior:
-
-- rectangle erosion and dilation;
-- a region with a hole, proving erosion expands the hole;
-- concave polygons and narrow necks that split or disappear;
-- disconnected islands;
-- nested rings under even-odd and non-zero fill rules;
-- native round, square, and butt-cap strokes;
-- arcs and full circles;
-- zero/negative radius identity behavior;
-- empty input and an entirely eroded result.
-
-### Metamorphic/property tests
-
-For generated valid regions:
-
-- increasing construction clearance or adding obstacles cannot enlarge
-  `maximal_safe`;
-- increasing the feature-disk radius cannot enlarge `opened_safe` for a fixed
-  `maximal_safe`;
-- rigid translation commutes with the result;
-- `safe ⊆ panel_keep_in`;
-- `safe ⊆ maximal_safe`;
-- `safe ∩ obstacle_clearance = ∅`;
-- `safe ∩ obstacle_gap_envelope = ∅`;
-- `safe \ open(safe, q) = ∅`;
-- radius-`v` dilations of every pair of distinct `safe` components are
-  disjoint;
-- `(safe ⊕ disk(r)) \ P = ∅`;
-- `(safe ⊕ disk(r)) ∩ O = ∅`.
-
-These required checks form the acceptance certificate. Broader disk-closing
-additions remain diagnostic-only because they also include notches within one
-component. Retain violation geometry on failure; a Boolean alone is not enough
-to debug a numerical case.
-
-### IPC integration fixtures
-
-Check in small, purpose-built IPC fixtures for deterministic tests:
-
-- direct board repeat with zero gap;
-- board-cell nesting whose intermediate profile must not block balancing;
-- tooling holes and fiducials on different layers;
-- clear-polarity support geometry;
-- routed cutout plus V-score relief;
-- rotated/mirrored nested panel;
-- missing or unpainted geometry, which must fail closed.
-
-Use the survey corpus as an opt-in developer suite because those files are
-large and external. Record summaries from the corpus, but keep correctness
-assertions on compact checked-in fixtures.
-
-### Performance and determinism
-
-Record elapsed time, input/output ring counts, and peak ring count per stage.
-Require deterministic ring serialization for identical inputs. Batch path
-footprints and perform one regularized union per layer, then one cross-layer
-union; do not repeatedly offset individual features.
-
-## Completion criteria
-
-The safe-region implementation is ready for a copper-balancing consumer when:
-
-- every source layer is successfully projected through `ArraySupport`;
-- every support feature has a defined painted footprint or produces a
-  fail-closed diagnostic;
-- the fixed-grid/offset error budget is explicit and tested;
-- the nominal 0.5 mm certificate passes on the A7, A6, and A5 auto-panel
-  baselines, all compact fixtures, and the wider survey topology suite;
-- the 2 mm minimum-feature and minimum-gap certificates pass on the same
-  corpus;
-- auto Icarus, MicFlex, Blackstar, ControlHub, complex, nested, and
-  empty-region visual reviews are clean;
-- the result is deterministic and fast enough to regenerate during ordinary
-  board-array iteration.
+The viewer explains failures; the set-theoretic certificate determines
+correctness.

--- a/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
+++ b/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
@@ -1004,12 +1004,6 @@ fn render_overview_svg(title: &str, regions: &Regions) -> String {
     );
     write_region(
         &mut svg,
-        "removed-by-regularization",
-        &regions.removed_by_regularization,
-        "fill='none' stroke='#c2410c' stroke-opacity='0.72'",
-    );
-    write_region(
-        &mut svg,
         "safe-region",
         &regions.safe_region,
         "fill='#4ade80' stroke='#15803d' fill-opacity='0.72'",

--- a/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
+++ b/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
@@ -18,15 +18,14 @@ use pcb_ipc2581_tools::utils::file::load_ipc_file;
 use pcb_ir::dialects::ipc::{
     BalancingRegionOptions, BoardArrayBalancingCollection, BoardArrayBalancingInput,
     BoardArrayBalancingResult, BoardArraySupportDocument, BoardArraySupportLayerGeometry,
-    BoardArraySupportLayerPolicy, DEFAULT_BALANCING_CLEARANCE_MM,
-    DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM, DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM,
-    DEFAULT_BALANCING_NUMERICAL_GUARD_MM, View, board_array_balancing_region,
-    inspect_board_array_balancing_input, root_panel_step,
+    BoardArraySupportLayerPolicy, DEFAULT_BALANCING_CLEARANCE_MM, DEFAULT_BALANCING_GAP_RADIUS_MM,
+    DEFAULT_BALANCING_NUMERICAL_GUARD_MM, DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM, View,
+    board_array_balancing_region, inspect_board_array_balancing_input, root_panel_step,
 };
 use pcb_ir::geom::{BBox, ContourSet};
 use serde::Serialize;
 
-const SCHEMA: &str = "pcb-ir.board-array-balancing-debug.v3";
+const SCHEMA: &str = "pcb-ir.board-array-balancing-debug.v7";
 const DEFAULT_CHECK_AREA_TOLERANCE_MM2: f64 = 1e-4;
 const SVG_PADDING_MM: f64 = 2.0;
 const SVG_STROKE_MM: f64 = 0.12;
@@ -49,13 +48,13 @@ struct Args {
     #[arg(long, default_value_t = DEFAULT_BALANCING_CLEARANCE_MM)]
     clearance_mm: f64,
 
-    /// Radius used to round tips and remove safe regions too small to contain the disk.
-    #[arg(long, default_value_t = DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM)]
-    minimum_feature_radius_mm: f64,
+    /// Disk radius used to round filled-region corners and reject small regions or slivers.
+    #[arg(long, default_value_t = DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM)]
+    regularization_radius_mm: f64,
 
-    /// Radius that must fit in every gap between balancing regions.
-    #[arg(long, default_value_t = DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM)]
-    minimum_gap_radius_mm: f64,
+    /// Rolling-disk radius for two-sided void gaps; minimum gap is twice this.
+    #[arg(long, default_value_t = DEFAULT_BALANCING_GAP_RADIUS_MM)]
+    gap_radius_mm: f64,
 
     /// Extra construction clearance reserved for polygonization/offset error.
     #[arg(long, default_value_t = DEFAULT_BALANCING_NUMERICAL_GUARD_MM)]
@@ -98,26 +97,21 @@ struct Regions {
     material_removal: ContourSet,
     support_features: ContourSet,
     raw_obstacles: ContourSet,
-    panel_clearance_keep_in: ContourSet,
     panel_keep_in: ContourSet,
-    obstacle_clearance: ContourSet,
-    obstacle_gap_envelope: ContourSet,
-    maximal_safe_region: ContourSet,
-    regularization_core: ContourSet,
-    opened_safe_region: ContourSet,
+    obstacle_keep_out: ContourSet,
+    clearance_safe_region: ContourSet,
+    opened_candidates: ContourSet,
     removed_by_opening: ContourSet,
-    removed_by_gap_separation: ContourSet,
+    narrow_voids: ContourSet,
+    gap_separator_keep_out: ContourSet,
+    removed_by_gap_regularization: ContourSet,
     removed_by_regularization: ContourSet,
     safe_region: ContourSet,
     undersized_final_components: ContourSet,
     clearance_certificate: ContourSet,
-    safe_outside_maximal_region: ContourSet,
-    safe_outside_keep_in: ContourSet,
-    safe_inside_obstacle_clearance: ContourSet,
-    safe_inside_obstacle_gap_envelope: ContourSet,
-    minimum_feature_violations: ContourSet,
-    minimum_gap_violations: ContourSet,
-    void_closing_additions: ContourSet,
+    safe_outside_clearance_region: ContourSet,
+    regularization_violations: ContourSet,
+    gap_violations: ContourSet,
     certificate_outside_panel: ContourSet,
     certificate_obstacle_overlap: ContourSet,
 }
@@ -129,11 +123,10 @@ struct DebugArtifact {
     passed: bool,
     input: String,
     nominal_clearance_mm: f64,
-    minimum_feature_radius_mm: f64,
-    minimum_gap_radius_mm: f64,
+    regularization_radius_mm: f64,
+    gap_radius_mm: f64,
     numerical_guard_mm: f64,
     construction_clearance_mm: f64,
-    construction_gap_radius_mm: f64,
     check_area_tolerance_mm2: f64,
     panelization: PanelizationJson,
     counts: CountsJson,
@@ -197,13 +190,9 @@ struct CoverageJson {
 #[serde(rename_all = "camelCase")]
 struct ChecksJson {
     passed: bool,
-    safe_outside_maximal_region_area_mm2: f64,
-    safe_outside_keep_in_area_mm2: f64,
-    safe_inside_obstacle_clearance_area_mm2: f64,
-    safe_inside_obstacle_gap_envelope_area_mm2: f64,
-    minimum_feature_violation_area_mm2: f64,
-    minimum_gap_violation_area_mm2: f64,
-    void_closing_addition_area_mm2: f64,
+    safe_outside_clearance_region_area_mm2: f64,
+    regularization_violation_area_mm2: f64,
+    gap_violation_area_mm2: f64,
     certificate_outside_panel_area_mm2: f64,
     certificate_obstacle_overlap_area_mm2: f64,
 }
@@ -211,17 +200,17 @@ struct ChecksJson {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RegularizationJson {
-    maximal_safe_area_mm2: f64,
+    clearance_safe_area_mm2: f64,
     final_safe_area_mm2: f64,
     removed_area_mm2: f64,
     removed_by_opening_area_mm2: f64,
-    removed_by_gap_separation_area_mm2: f64,
+    narrow_void_area_mm2: f64,
+    gap_separator_keep_out_area_mm2: f64,
+    removed_by_gap_regularization_area_mm2: f64,
     retained_fraction: f64,
-    maximal_component_count: usize,
-    core_component_count: usize,
+    clearance_safe_component_count: usize,
     opened_component_count: usize,
     final_component_count: usize,
-    discarded_for_gap_component_count: usize,
     smallest_final_component_area_mm2: Option<f64>,
     minimum_final_component_bbox_span_mm: Option<f64>,
     undersized_final_component_count: usize,
@@ -249,26 +238,21 @@ struct RegionsJson {
     material_removal: RegionJson,
     support_features: RegionJson,
     raw_obstacles: RegionJson,
-    panel_clearance_keep_in: RegionJson,
     panel_keep_in: RegionJson,
-    obstacle_clearance: RegionJson,
-    obstacle_gap_envelope: RegionJson,
-    maximal_safe_region: RegionJson,
-    regularization_core: RegionJson,
-    opened_safe_region: RegionJson,
+    obstacle_keep_out: RegionJson,
+    clearance_safe_region: RegionJson,
+    opened_candidates: RegionJson,
     removed_by_opening: RegionJson,
-    removed_by_gap_separation: RegionJson,
+    narrow_voids: RegionJson,
+    gap_separator_keep_out: RegionJson,
+    removed_by_gap_regularization: RegionJson,
     removed_by_regularization: RegionJson,
     safe_region: RegionJson,
     undersized_final_components: RegionJson,
     clearance_certificate: RegionJson,
-    safe_outside_maximal_region: RegionJson,
-    safe_outside_keep_in: RegionJson,
-    safe_inside_obstacle_clearance: RegionJson,
-    safe_inside_obstacle_gap_envelope: RegionJson,
-    minimum_feature_violations: RegionJson,
-    minimum_gap_violations: RegionJson,
-    void_closing_additions: RegionJson,
+    safe_outside_clearance_region: RegionJson,
+    regularization_violations: RegionJson,
+    gap_violations: RegionJson,
     certificate_outside_panel: RegionJson,
     certificate_obstacle_overlap: RegionJson,
 }
@@ -318,11 +302,11 @@ fn main() -> Result<()> {
     if !args.clearance_mm.is_finite() || args.clearance_mm <= 0.0 {
         bail!("--clearance-mm must be a finite positive number");
     }
-    if !args.minimum_feature_radius_mm.is_finite() || args.minimum_feature_radius_mm <= 0.0 {
-        bail!("--minimum-feature-radius-mm must be a finite positive number");
+    if !args.regularization_radius_mm.is_finite() || args.regularization_radius_mm <= 0.0 {
+        bail!("--regularization-radius-mm must be a finite positive number");
     }
-    if !args.minimum_gap_radius_mm.is_finite() || args.minimum_gap_radius_mm <= 0.0 {
-        bail!("--minimum-gap-radius-mm must be a finite positive number");
+    if !args.gap_radius_mm.is_finite() || args.gap_radius_mm <= 0.0 {
+        bail!("--gap-radius-mm must be a finite positive number");
     }
     if !args.numerical_guard_mm.is_finite() || args.numerical_guard_mm < 0.0 {
         bail!("--numerical-guard-mm must be a finite non-negative number");
@@ -369,15 +353,13 @@ fn main() -> Result<()> {
         &collection.input,
         BalancingRegionOptions {
             clearance_mm: args.clearance_mm,
-            minimum_feature_radius_mm: args.minimum_feature_radius_mm,
-            minimum_gap_radius_mm: args.minimum_gap_radius_mm,
+            regularization_radius_mm: args.regularization_radius_mm,
+            gap_radius_mm: args.gap_radius_mm,
             numerical_guard_mm: args.numerical_guard_mm,
         },
     )
     .context("failed to compute board-array balancing region")?;
     let construction_clearance_mm = args.clearance_mm + args.numerical_guard_mm;
-    let construction_gap_radius_mm =
-        args.clearance_mm.max(args.minimum_gap_radius_mm) + args.numerical_guard_mm;
     let certificate_passed = result.certificate.passes(args.check_area_tolerance_mm2);
     let BoardArrayBalancingCollection {
         input:
@@ -405,7 +387,7 @@ fn main() -> Result<()> {
         .iter()
         .filter(|component| {
             component
-                .disk_erode(args.minimum_feature_radius_mm)
+                .disk_erode(args.regularization_radius_mm)
                 .is_empty()
         })
         .cloned()
@@ -419,47 +401,35 @@ fn main() -> Result<()> {
         material_removal,
         support_features,
         raw_obstacles: intermediates.raw_obstacles,
-        panel_clearance_keep_in: intermediates.panel_clearance_keep_in,
         panel_keep_in: intermediates.panel_keep_in,
-        obstacle_clearance: intermediates.obstacle_clearance,
-        obstacle_gap_envelope: intermediates.obstacle_gap_envelope,
-        maximal_safe_region: intermediates.maximal_safe_region,
-        regularization_core: intermediates.regularization_core,
-        opened_safe_region: intermediates.opened_safe_region,
+        obstacle_keep_out: intermediates.obstacle_keep_out,
+        clearance_safe_region: intermediates.clearance_safe_region,
+        opened_candidates: intermediates.opened_candidates,
         removed_by_opening: intermediates.removed_by_opening,
-        removed_by_gap_separation: intermediates.removed_by_gap_separation,
+        narrow_voids: intermediates.narrow_voids,
+        gap_separator_keep_out: intermediates.gap_separator_keep_out,
+        removed_by_gap_regularization: intermediates.removed_by_gap_regularization,
         removed_by_regularization: intermediates.removed_by_regularization,
         safe_region,
         undersized_final_components,
         clearance_certificate: certificate.swept_safe_region,
-        safe_outside_maximal_region: certificate.safe_outside_maximal_region,
-        safe_outside_keep_in: certificate.safe_outside_keep_in,
-        safe_inside_obstacle_clearance: certificate.safe_inside_obstacle_clearance,
-        safe_inside_obstacle_gap_envelope: certificate.safe_inside_obstacle_gap_envelope,
-        minimum_feature_violations: certificate.minimum_feature_violations,
-        minimum_gap_violations: certificate.minimum_gap_violations,
-        void_closing_additions: certificate.void_closing_additions,
+        safe_outside_clearance_region: certificate.safe_outside_clearance_region,
+        regularization_violations: certificate.regularization_violations,
+        gap_violations: certificate.gap_violations,
         certificate_outside_panel: certificate.outside_panel,
         certificate_obstacle_overlap: certificate.obstacle_overlap,
     };
 
     let checks = ChecksJson {
         passed: certificate_passed,
-        safe_outside_maximal_region_area_mm2: regions.safe_outside_maximal_region.area(),
-        safe_outside_keep_in_area_mm2: regions.safe_outside_keep_in.area(),
-        safe_inside_obstacle_clearance_area_mm2: regions.safe_inside_obstacle_clearance.area(),
-        safe_inside_obstacle_gap_envelope_area_mm2: regions
-            .safe_inside_obstacle_gap_envelope
-            .area(),
-        minimum_feature_violation_area_mm2: regions.minimum_feature_violations.area(),
-        minimum_gap_violation_area_mm2: regions.minimum_gap_violations.area(),
-        void_closing_addition_area_mm2: regions.void_closing_additions.area(),
+        safe_outside_clearance_region_area_mm2: regions.safe_outside_clearance_region.area(),
+        regularization_violation_area_mm2: regions.regularization_violations.area(),
+        gap_violation_area_mm2: regions.gap_violations.area(),
         certificate_outside_panel_area_mm2: regions.certificate_outside_panel.area(),
         certificate_obstacle_overlap_area_mm2: regions.certificate_obstacle_overlap.area(),
     };
-    let maximal_component_areas = component_areas(&regions.maximal_safe_region);
-    let core_component_areas = component_areas(&regions.regularization_core);
-    let opened_component_areas = component_areas(&regions.opened_safe_region);
+    let clearance_safe_component_areas = component_areas(&regions.clearance_safe_region);
+    let opened_component_areas = component_areas(&regions.opened_candidates);
     let final_component_areas = final_components
         .iter()
         .map(ContourSet::area)
@@ -468,26 +438,24 @@ fn main() -> Result<()> {
         .iter()
         .map(|component| component.bbox.width().min(component.bbox.height()))
         .reduce(f64::min);
-    let maximal_safe_area_mm2 = regions.maximal_safe_region.area();
+    let clearance_safe_area_mm2 = regions.clearance_safe_region.area();
     let final_safe_area_mm2 = regions.safe_region.area();
     let regularization = RegularizationJson {
-        maximal_safe_area_mm2,
+        clearance_safe_area_mm2,
         final_safe_area_mm2,
         removed_area_mm2: regions.removed_by_regularization.area(),
         removed_by_opening_area_mm2: regions.removed_by_opening.area(),
-        removed_by_gap_separation_area_mm2: regions.removed_by_gap_separation.area(),
-        retained_fraction: if maximal_safe_area_mm2 > 0.0 {
-            final_safe_area_mm2 / maximal_safe_area_mm2
+        narrow_void_area_mm2: regions.narrow_voids.area(),
+        gap_separator_keep_out_area_mm2: regions.gap_separator_keep_out.area(),
+        removed_by_gap_regularization_area_mm2: regions.removed_by_gap_regularization.area(),
+        retained_fraction: if clearance_safe_area_mm2 > 0.0 {
+            final_safe_area_mm2 / clearance_safe_area_mm2
         } else {
             1.0
         },
-        maximal_component_count: maximal_component_areas.len(),
-        core_component_count: core_component_areas.len(),
+        clearance_safe_component_count: clearance_safe_component_areas.len(),
         opened_component_count: opened_component_areas.len(),
         final_component_count: final_component_areas.len(),
-        discarded_for_gap_component_count: opened_component_areas
-            .len()
-            .saturating_sub(final_component_areas.len()),
         smallest_final_component_area_mm2: final_component_areas.into_iter().reduce(f64::min),
         minimum_final_component_bbox_span_mm,
         undersized_final_component_count: regions
@@ -508,11 +476,10 @@ fn main() -> Result<()> {
         passed,
         input: input.display().to_string(),
         nominal_clearance_mm: args.clearance_mm,
-        minimum_feature_radius_mm: args.minimum_feature_radius_mm,
-        minimum_gap_radius_mm: args.minimum_gap_radius_mm,
+        regularization_radius_mm: args.regularization_radius_mm,
+        gap_radius_mm: args.gap_radius_mm,
         numerical_guard_mm: args.numerical_guard_mm,
         construction_clearance_mm,
-        construction_gap_radius_mm,
         check_area_tolerance_mm2: args.check_area_tolerance_mm2,
         panelization,
         counts: CountsJson {
@@ -562,30 +529,21 @@ fn main() -> Result<()> {
             material_removal: RegionJson::from(&regions.material_removal),
             support_features: RegionJson::from(&regions.support_features),
             raw_obstacles: RegionJson::from(&regions.raw_obstacles),
-            panel_clearance_keep_in: RegionJson::from(&regions.panel_clearance_keep_in),
             panel_keep_in: RegionJson::from(&regions.panel_keep_in),
-            obstacle_clearance: RegionJson::from(&regions.obstacle_clearance),
-            obstacle_gap_envelope: RegionJson::from(&regions.obstacle_gap_envelope),
-            maximal_safe_region: RegionJson::from(&regions.maximal_safe_region),
-            regularization_core: RegionJson::from(&regions.regularization_core),
-            opened_safe_region: RegionJson::from(&regions.opened_safe_region),
+            obstacle_keep_out: RegionJson::from(&regions.obstacle_keep_out),
+            clearance_safe_region: RegionJson::from(&regions.clearance_safe_region),
+            opened_candidates: RegionJson::from(&regions.opened_candidates),
             removed_by_opening: RegionJson::from(&regions.removed_by_opening),
-            removed_by_gap_separation: RegionJson::from(&regions.removed_by_gap_separation),
+            narrow_voids: RegionJson::from(&regions.narrow_voids),
+            gap_separator_keep_out: RegionJson::from(&regions.gap_separator_keep_out),
+            removed_by_gap_regularization: RegionJson::from(&regions.removed_by_gap_regularization),
             removed_by_regularization: RegionJson::from(&regions.removed_by_regularization),
             safe_region: RegionJson::from(&regions.safe_region),
             undersized_final_components: RegionJson::from(&regions.undersized_final_components),
             clearance_certificate: RegionJson::from(&regions.clearance_certificate),
-            safe_outside_maximal_region: RegionJson::from(&regions.safe_outside_maximal_region),
-            safe_outside_keep_in: RegionJson::from(&regions.safe_outside_keep_in),
-            safe_inside_obstacle_clearance: RegionJson::from(
-                &regions.safe_inside_obstacle_clearance,
-            ),
-            safe_inside_obstacle_gap_envelope: RegionJson::from(
-                &regions.safe_inside_obstacle_gap_envelope,
-            ),
-            minimum_feature_violations: RegionJson::from(&regions.minimum_feature_violations),
-            minimum_gap_violations: RegionJson::from(&regions.minimum_gap_violations),
-            void_closing_additions: RegionJson::from(&regions.void_closing_additions),
+            safe_outside_clearance_region: RegionJson::from(&regions.safe_outside_clearance_region),
+            regularization_violations: RegionJson::from(&regions.regularization_violations),
+            gap_violations: RegionJson::from(&regions.gap_violations),
             certificate_outside_panel: RegionJson::from(&regions.certificate_outside_panel),
             certificate_obstacle_overlap: RegionJson::from(&regions.certificate_obstacle_overlap),
         },
@@ -601,15 +559,15 @@ fn main() -> Result<()> {
         regions.panel_outer.area()
     );
     println!(
-        "regularization: {:.3} mm radius retained {:.3} / {:.3} mm² ({:.1}%, {} -> {} opened -> {} final components, {} gap-conflicting components discarded, {} undersized)",
-        artifact.minimum_feature_radius_mm,
+        "regularization: {:.3} mm region radius, {:.3} mm gap radius retained {:.3} / {:.3} mm² ({:.1}%, {} clearance-safe -> {} opened -> {} final components, {} undersized)",
+        artifact.regularization_radius_mm,
+        artifact.gap_radius_mm,
         artifact.regularization.final_safe_area_mm2,
-        artifact.regularization.maximal_safe_area_mm2,
+        artifact.regularization.clearance_safe_area_mm2,
         100.0 * artifact.regularization.retained_fraction,
-        artifact.regularization.maximal_component_count,
+        artifact.regularization.clearance_safe_component_count,
         artifact.regularization.opened_component_count,
         artifact.regularization.final_component_count,
-        artifact.regularization.discarded_for_gap_component_count,
         artifact.regularization.undersized_final_component_count,
     );
     println!(
@@ -622,17 +580,17 @@ fn main() -> Result<()> {
         artifact.coverage.unpainted_support_paths
     );
     println!(
-        "certificate: {} (outside panel {:.6} mm², obstacle overlap {:.6} mm², feature violations {:.6} mm², inter-component gap violations {:.6} mm²; broader closing diagnostic {:.6} mm²)",
+        "certificate: {} (outside clearance-safe region {:.6} mm², regularization violations {:.6} mm², void-gap violations {:.6} mm², outside panel {:.6} mm², obstacle overlap {:.6} mm²)",
         if artifact.checks.passed {
             "PASS"
         } else {
             "FAIL"
         },
+        artifact.checks.safe_outside_clearance_region_area_mm2,
+        artifact.checks.regularization_violation_area_mm2,
+        artifact.checks.gap_violation_area_mm2,
         artifact.checks.certificate_outside_panel_area_mm2,
         artifact.checks.certificate_obstacle_overlap_area_mm2,
-        artifact.checks.minimum_feature_violation_area_mm2,
-        artifact.checks.minimum_gap_violation_area_mm2,
-        artifact.checks.void_closing_addition_area_mm2,
     );
 
     if !artifact.passed {
@@ -710,14 +668,14 @@ fn write_artifacts(
         .with_context(|| format!("failed to create output directory {}", output.display()))?;
 
     let title = format!(
-        "{} — {:.3} mm clearance, {:.3} mm feature radius, {:.3} mm gap radius (+{:.3} mm geometry guard)",
+        "{} — {:.3} mm clearance, {:.3} mm region radius, {:.3} mm gap radius (+{:.3} mm geometry guard)",
         input
             .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or("board array"),
         artifact.nominal_clearance_mm,
-        artifact.minimum_feature_radius_mm,
-        artifact.minimum_gap_radius_mm,
+        artifact.regularization_radius_mm,
+        artifact.gap_radius_mm,
         artifact.numerical_guard_mm
     );
     let overview = render_overview_svg(&title, regions);
@@ -760,51 +718,30 @@ fn write_artifacts(
             stroke: "#b91c1c",
         },
         Stage {
-            filename: "50-panel-clearance-keep-in.svg",
+            filename: "50-panel-keep-in.svg",
             title: "50 — panel outer region eroded by construction clearance",
-            region: &regions.panel_clearance_keep_in,
+            region: &regions.panel_keep_in,
             fill: "#67e8f9",
             stroke: "#0e7490",
         },
         Stage {
-            filename: "55-panel-gap-keep-in.svg",
-            title: "55 — panel outer region eroded by construction minimum-gap radius",
-            region: &regions.panel_keep_in,
-            fill: "#a5b4fc",
-            stroke: "#4338ca",
-        },
-        Stage {
-            filename: "60-obstacle-clearance.svg",
+            filename: "60-obstacle-keep-out.svg",
             title: "60 — raw obstacles dilated by construction clearance",
-            region: &regions.obstacle_clearance,
+            region: &regions.obstacle_keep_out,
             fill: "#fca5a5",
             stroke: "#dc2626",
         },
         Stage {
-            filename: "65-obstacle-gap-envelope.svg",
-            title: "65 — raw obstacles dilated by construction minimum-gap radius",
-            region: &regions.obstacle_gap_envelope,
-            fill: "#f9a8d4",
-            stroke: "#be185d",
-        },
-        Stage {
-            filename: "70-maximal-safe-region.svg",
-            title: "70 — maximal clearance-safe region before regularization",
-            region: &regions.maximal_safe_region,
+            filename: "70-clearance-safe-region.svg",
+            title: "70 — clearance-safe region before regularization",
+            region: &regions.clearance_safe_region,
             fill: "#fde68a",
             stroke: "#b45309",
         },
         Stage {
-            filename: "75-regularization-core.svg",
-            title: "75 — centers where the minimum-feature disk fits",
-            region: &regions.regularization_core,
-            fill: "#67e8f9",
-            stroke: "#0e7490",
-        },
-        Stage {
-            filename: "78-opened-safe-region.svg",
-            title: "78 — minimum-feature disk opening before gap separation",
-            region: &regions.opened_safe_region,
+            filename: "75-opened-candidates.svg",
+            title: "75 — disk opening before void-gap regularization",
+            region: &regions.opened_candidates,
             fill: "#86efac",
             stroke: "#16a34a",
         },
@@ -816,18 +753,25 @@ fn write_artifacts(
             stroke: "#c2410c",
         },
         Stage {
-            filename: "85-removed-by-gap-separation.svg",
-            title: "85 — components excluded by maximum-area gap selection",
-            region: &regions.removed_by_gap_separation,
-            fill: "#f472b6",
-            stroke: "#be185d",
+            filename: "82-narrow-voids.svg",
+            title: "82 — two-sided voids rejected by the rolling-disk test",
+            region: &regions.narrow_voids,
+            fill: "#22d3ee",
+            stroke: "#0e7490",
         },
         Stage {
-            filename: "88-removed-by-regularization.svg",
-            title: "88 — all geometry removed by opening and gap separation",
-            region: &regions.removed_by_regularization,
-            fill: "#fb923c",
-            stroke: "#c2410c",
+            filename: "83-gap-separator-keep-out.svg",
+            title: "83 — medial-axis keep-out tubes through narrow voids",
+            region: &regions.gap_separator_keep_out,
+            fill: "#c084fc",
+            stroke: "#7e22ce",
+        },
+        Stage {
+            filename: "85-removed-by-gap-regularization.svg",
+            title: "85 — material trimmed to widen narrow void gaps",
+            region: &regions.removed_by_gap_regularization,
+            fill: "#f472b6",
+            stroke: "#be185d",
         },
         Stage {
             filename: "90-safe-region.svg",
@@ -844,18 +788,11 @@ fn write_artifacts(
             stroke: "#1d4ed8",
         },
         Stage {
-            filename: "105-minimum-gap-violations.svg",
-            title: "105 — gaps where minimum-gap component dilations overlap",
-            region: &regions.minimum_gap_violations,
+            filename: "105-gap-violations.svg",
+            title: "105 — two-sided void gaps narrower than the disk diameter",
+            region: &regions.gap_violations,
             fill: "#c026d3",
             stroke: "#701a75",
-        },
-        Stage {
-            filename: "106-void-closing-additions.svg",
-            title: "106 — broader void notches filled by disk closing (diagnostic)",
-            region: &regions.void_closing_additions,
-            fill: "#818cf8",
-            stroke: "#3730a3",
         },
     ];
     for stage in &stages {
@@ -951,10 +888,10 @@ fn render_validation_svg(title: &str, regions: &Regions) -> String {
     let bbox = regions
         .panel_outer
         .bbox
-        .union(regions.safe_outside_maximal_region.bbox)
+        .union(regions.safe_outside_clearance_region.bbox)
         .union(regions.undersized_final_components.bbox)
-        .union(regions.minimum_feature_violations.bbox)
-        .union(regions.minimum_gap_violations.bbox)
+        .union(regions.regularization_violations.bbox)
+        .union(regions.gap_violations.bbox)
         .union(regions.certificate_outside_panel.bbox)
         .union(regions.certificate_obstacle_overlap.bbox);
     let mut svg = svg_start(title, bbox);
@@ -966,8 +903,8 @@ fn render_validation_svg(title: &str, regions: &Regions) -> String {
     );
     write_region(
         &mut svg,
-        "safe-outside-maximal-region",
-        &regions.safe_outside_maximal_region,
+        "safe-outside-clearance-region",
+        &regions.safe_outside_clearance_region,
         "fill='#e11d48' stroke='#881337' fill-opacity='0.9'",
     );
     write_region(
@@ -978,14 +915,14 @@ fn render_validation_svg(title: &str, regions: &Regions) -> String {
     );
     write_region(
         &mut svg,
-        "minimum-feature-violations",
-        &regions.minimum_feature_violations,
+        "regularization-violations",
+        &regions.regularization_violations,
         "fill='#7c3aed' stroke='#4c1d95' fill-opacity='0.9'",
     );
     write_region(
         &mut svg,
-        "minimum-gap-violations",
-        &regions.minimum_gap_violations,
+        "gap-violations",
+        &regions.gap_violations,
         "fill='#c026d3' stroke='#701a75' fill-opacity='0.9'",
     );
     write_region(
@@ -1019,44 +956,26 @@ fn render_overview_svg(title: &str, regions: &Regions) -> String {
     );
     write_region(
         &mut svg,
-        "obstacle-clearance",
-        &regions.obstacle_clearance,
+        "obstacle-keep-out",
+        &regions.obstacle_keep_out,
         "fill='#fecaca' stroke='#ef4444' fill-opacity='0.62'",
-    );
-    write_region(
-        &mut svg,
-        "obstacle-gap-envelope",
-        &regions.obstacle_gap_envelope,
-        "fill='#f9a8d4' stroke='#be185d' fill-opacity='0.42'",
-    );
-    write_region(
-        &mut svg,
-        "panel-clearance-keep-in",
-        &regions.panel_clearance_keep_in,
-        "fill='none' stroke='#0891b2' stroke-dasharray='0.6 0.5'",
     );
     write_region(
         &mut svg,
         "panel-keep-in",
         &regions.panel_keep_in,
-        "fill='none' stroke='#4338ca' stroke-dasharray='0.6 0.5'",
+        "fill='none' stroke='#0891b2' stroke-dasharray='0.6 0.5'",
     );
     write_region(
         &mut svg,
-        "maximal-safe-region",
-        &regions.maximal_safe_region,
+        "clearance-safe-region",
+        &regions.clearance_safe_region,
         "fill='#fde68a' stroke='#b45309' fill-opacity='0.24'",
     );
     write_region(
         &mut svg,
-        "regularization-core",
-        &regions.regularization_core,
-        "fill='none' stroke='#0891b2' stroke-dasharray='0.3 0.3' stroke-opacity='0.7'",
-    );
-    write_region(
-        &mut svg,
-        "opened-safe-region",
-        &regions.opened_safe_region,
+        "opened-candidates",
+        &regions.opened_candidates,
         "fill='#86efac' stroke='#16a34a' fill-opacity='0.24'",
     );
     write_region(
@@ -1067,8 +986,20 @@ fn render_overview_svg(title: &str, regions: &Regions) -> String {
     );
     write_region(
         &mut svg,
-        "removed-by-gap-separation",
-        &regions.removed_by_gap_separation,
+        "narrow-voids",
+        &regions.narrow_voids,
+        "fill='#22d3ee' stroke='#0e7490' fill-opacity='0.42'",
+    );
+    write_region(
+        &mut svg,
+        "gap-separator-keep-out",
+        &regions.gap_separator_keep_out,
+        "fill='#c084fc' stroke='#7e22ce' fill-opacity='0.24'",
+    );
+    write_region(
+        &mut svg,
+        "removed-by-gap-regularization",
+        &regions.removed_by_gap_regularization,
         "fill='#f472b6' stroke='#be185d' fill-opacity='0.88'",
     );
     write_region(
@@ -1115,26 +1046,20 @@ fn render_overview_svg(title: &str, regions: &Regions) -> String {
     );
     write_region(
         &mut svg,
-        "minimum-feature-violations",
-        &regions.minimum_feature_violations,
+        "regularization-violations",
+        &regions.regularization_violations,
         "fill='#7c3aed' stroke='#4c1d95' fill-opacity='0.95'",
     );
     write_region(
         &mut svg,
-        "minimum-gap-violations",
-        &regions.minimum_gap_violations,
+        "gap-violations",
+        &regions.gap_violations,
         "fill='#c026d3' stroke='#701a75' fill-opacity='0.95'",
     );
     write_region(
         &mut svg,
-        "void-closing-additions",
-        &regions.void_closing_additions,
-        "fill='#818cf8' stroke='#3730a3' fill-opacity='0.9'",
-    );
-    write_region(
-        &mut svg,
-        "safe-outside-maximal-region",
-        &regions.safe_outside_maximal_region,
+        "safe-outside-clearance-region",
+        &regions.safe_outside_clearance_region,
         "fill='#e11d48' stroke='#881337' fill-opacity='0.95'",
     );
     write_region(
@@ -1301,49 +1226,45 @@ fn render_index_html(
       <fieldset>
         <legend>Geometry</legend>
         <label><input type="checkbox" data-layer="panel-outer"{panel_outer}><span class="swatch" style="background:#e2e8f0"></span>panel outer</label>
-        <label><input type="checkbox" data-layer="panel-clearance-keep-in"{panel_clearance_keep_in}><span class="swatch" style="background:#22d3ee"></span>clearance keep-in</label>
-        <label><input type="checkbox" data-layer="panel-keep-in"{panel_keep_in}><span class="swatch" style="background:#a5b4fc"></span>minimum-gap keep-in</label>
-        <label><input type="checkbox" data-layer="obstacle-clearance"{obstacle_clearance}><span class="swatch" style="background:#fecaca"></span>obstacle clearance</label>
-        <label><input type="checkbox" data-layer="obstacle-gap-envelope"{obstacle_gap_envelope}><span class="swatch" style="background:#f9a8d4"></span>minimum-gap envelope</label>
-        <label><input type="checkbox" data-layer="maximal-safe-region"{maximal_safe_region}><span class="swatch" style="background:#fde68a"></span>maximal safe region</label>
-        <label><input type="checkbox" data-layer="regularization-core"{regularization_core}><span class="swatch" style="background:#22d3ee"></span>regularization core</label>
-        <label><input type="checkbox" data-layer="opened-safe-region"{opened_safe_region}><span class="swatch" style="background:#86efac"></span>opened region before gap separation</label>
+        <label><input type="checkbox" data-layer="panel-keep-in"{panel_keep_in}><span class="swatch" style="background:#22d3ee"></span>clearance keep-in</label>
+        <label><input type="checkbox" data-layer="obstacle-keep-out"{obstacle_keep_out}><span class="swatch" style="background:#fecaca"></span>clearance keep-out</label>
+        <label><input type="checkbox" data-layer="clearance-safe-region"{clearance_safe_region}><span class="swatch" style="background:#fde68a"></span>clearance-safe region</label>
+        <label><input type="checkbox" data-layer="opened-candidates"{opened_candidates}><span class="swatch" style="background:#86efac"></span>disk-opened candidates</label>
         <label><input type="checkbox" data-layer="removed-by-opening"{removed_by_opening}><span class="swatch" style="background:#fb923c"></span>discarded by opening</label>
-        <label><input type="checkbox" data-layer="removed-by-gap-separation"{removed_by_gap_separation}><span class="swatch" style="background:#f472b6"></span>discarded for minimum gap</label>
-        <label><input type="checkbox" data-layer="removed-by-regularization"{removed_by_regularization}><span class="swatch" style="background:#c2410c"></span>all discarded geometry</label>
+        <label><input type="checkbox" data-layer="narrow-voids"{narrow_voids}><span class="swatch" style="background:#22d3ee"></span>narrow two-sided voids</label>
+        <label><input type="checkbox" data-layer="gap-separator-keep-out"{gap_separator_keep_out}><span class="swatch" style="background:#c084fc"></span>gap separator keep-out</label>
+        <label><input type="checkbox" data-layer="removed-by-gap-regularization"{removed_by_gap_regularization}><span class="swatch" style="background:#f472b6"></span>trimmed to widen gaps</label>
         <label><input type="checkbox" data-layer="safe-region"{safe_region}><span class="swatch" style="background:#4ade80"></span>regularized safe region</label>
         <label><input type="checkbox" data-layer="board-footprints"{board_footprints}><span class="swatch" style="background:#fb7185"></span>board footprints</label>
         <label><input type="checkbox" data-layer="material-removal"{material_removal}><span class="swatch" style="background:#fb923c"></span>material removal</label>
         <label><input type="checkbox" data-layer="support-features"{support_features}><span class="swatch" style="background:#a78bfa"></span>support features</label>
         <label><input type="checkbox" data-layer="clearance-certificate"{certificate}><span class="swatch" style="background:#60a5fa"></span>clearance certificate</label>
         <label><input type="checkbox" data-layer="undersized-final-components"{violations}><span class="swatch" style="background:#db2777"></span>undersized-final violation</label>
-        <label><input type="checkbox" data-layer="minimum-feature-violations"{violations}><span class="swatch" style="background:#7c3aed"></span>minimum-feature violation</label>
-        <label><input type="checkbox" data-layer="minimum-gap-violations"{violations}><span class="swatch" style="background:#c026d3"></span>minimum-gap violation</label>
-        <label><input type="checkbox" data-layer="void-closing-additions"{diagnostics}><span class="swatch" style="background:#818cf8"></span>all closing additions (diagnostic)</label>
-        <label><input type="checkbox" data-layer="safe-outside-maximal-region"{violations}><span class="swatch" style="background:#e11d48"></span>outside-maximal violation</label>
+        <label><input type="checkbox" data-layer="regularization-violations"{violations}><span class="swatch" style="background:#7c3aed"></span>regularization violation</label>
+        <label><input type="checkbox" data-layer="gap-violations"{violations}><span class="swatch" style="background:#c026d3"></span>void-gap violation</label>
+        <label><input type="checkbox" data-layer="safe-outside-clearance-region"{violations}><span class="swatch" style="background:#e11d48"></span>outside-clearance violation</label>
         <label><input type="checkbox" data-layer="certificate-outside-panel"{violations}><span class="swatch" style="background:#dc2626"></span>outside-panel violation</label>
         <label><input type="checkbox" data-layer="certificate-obstacle-overlap"{violations}><span class="swatch" style="background:#f59e0b"></span>obstacle-overlap violation</label>
       </fieldset>
       <dl>
         <dt>Panel area</dt><dd>{panel_area:.3} mm²</dd>
         <dt>Obstacle area</dt><dd>{obstacle_area:.3} mm²</dd>
-        <dt>Maximal safe area</dt><dd>{maximal_safe_area:.3} mm²</dd>
+        <dt>Clearance-safe area</dt><dd>{clearance_safe_area:.3} mm²</dd>
         <dt>Regularized safe area</dt><dd>{safe_area:.3} mm²</dd>
         <dt>Removed area</dt><dd>{removed_area:.3} mm²</dd>
         <dt>Removed by opening</dt><dd>{removed_by_opening_area:.3} mm²</dd>
-        <dt>Removed for gap</dt><dd>{removed_for_gap_area:.3} mm²</dd>
+        <dt>Narrow voids</dt><dd>{narrow_void_area:.3} mm²</dd>
+        <dt>Gap keep-out</dt><dd>{gap_separator_keep_out_area:.3} mm²</dd>
+        <dt>Trimmed to widen gaps</dt><dd>{removed_by_gap_regularization_area:.3} mm²</dd>
         <dt>Retained</dt><dd>{retained_fraction:.1}%</dd>
         <dt>Safe fraction</dt><dd>{safe_fraction:.1}%</dd>
         <dt>Nominal clearance</dt><dd>{nominal_clearance:.3} mm</dd>
-        <dt>Minimum-feature radius</dt><dd>{minimum_feature_radius:.3} mm</dd>
-        <dt>Minimum-gap radius</dt><dd>{minimum_gap_radius:.3} mm</dd>
-        <dt>Construction gap radius</dt><dd>{construction_gap_radius:.3} mm</dd>
+        <dt>Filled-region radius</dt><dd>{regularization_radius:.3} mm</dd>
+        <dt>Void-gap radius</dt><dd>{gap_radius:.3} mm ({gap_width:.3} mm nominal gap)</dd>
         <dt>Geometry guard</dt><dd>{geometry_guard:.3} mm</dd>
-        <dt>Feature violation area</dt><dd>{feature_violation_area:.6} mm²</dd>
-        <dt>Gap violation area</dt><dd>{gap_violation_area:.6} mm²</dd>
-        <dt>All closing additions</dt><dd>{void_closing_addition_area:.6} mm²</dd>
-        <dt>Components</dt><dd>{maximal_components} → {opened_components} → {final_components}</dd>
-        <dt>Gap-conflicting discarded</dt><dd>{gap_discarded_components}</dd>
+        <dt>Regularization violations</dt><dd>{regularization_violation_area:.6} mm²</dd>
+        <dt>Void-gap violations</dt><dd>{gap_violation_area:.6} mm²</dd>
+        <dt>Components</dt><dd>{clearance_safe_components} → {opened_components} → {final_components}</dd>
         <dt>Smallest component</dt><dd>{smallest_component}</dd>
         <dt>Minimum component span</dt><dd>{minimum_component_span}</dd>
         <dt>Undersized components</dt><dd>{undersized_components}</dd>
@@ -1381,44 +1302,43 @@ fn render_index_html(
 "#,
         title = escape_html(title),
         panel_outer = checked(true),
-        panel_clearance_keep_in = checked(false),
         panel_keep_in = checked(true),
-        obstacle_clearance = checked(false),
-        obstacle_gap_envelope = checked(true),
-        maximal_safe_region = checked(false),
-        regularization_core = checked(false),
-        opened_safe_region = checked(false),
+        obstacle_keep_out = checked(false),
+        clearance_safe_region = checked(false),
+        opened_candidates = checked(false),
         removed_by_opening = checked(false),
-        removed_by_gap_separation = checked(true),
-        removed_by_regularization = checked(false),
+        narrow_voids = checked(false),
+        gap_separator_keep_out = checked(false),
+        removed_by_gap_regularization = checked(true),
         safe_region = checked(true),
         board_footprints = checked(true),
         material_removal = checked(true),
         support_features = checked(true),
         certificate = checked(false),
         violations = checked(true),
-        diagnostics = checked(false),
         panel_area = regions.panel_outer.area(),
         obstacle_area = regions.raw_obstacles.area(),
-        maximal_safe_area = artifact.regularization.maximal_safe_area_mm2,
+        clearance_safe_area = artifact.regularization.clearance_safe_area_mm2,
         safe_area = regions.safe_region.area(),
         removed_area = artifact.regularization.removed_area_mm2,
         removed_by_opening_area = artifact.regularization.removed_by_opening_area_mm2,
-        removed_for_gap_area = artifact.regularization.removed_by_gap_separation_area_mm2,
+        narrow_void_area = artifact.regularization.narrow_void_area_mm2,
+        gap_separator_keep_out_area = artifact.regularization.gap_separator_keep_out_area_mm2,
+        removed_by_gap_regularization_area = artifact
+            .regularization
+            .removed_by_gap_regularization_area_mm2,
         retained_fraction = 100.0 * artifact.regularization.retained_fraction,
         safe_fraction = 100.0 * regions.safe_region.area() / regions.panel_outer.area(),
         nominal_clearance = artifact.nominal_clearance_mm,
-        minimum_feature_radius = artifact.minimum_feature_radius_mm,
-        minimum_gap_radius = artifact.minimum_gap_radius_mm,
-        construction_gap_radius = artifact.construction_gap_radius_mm,
+        regularization_radius = artifact.regularization_radius_mm,
+        gap_radius = artifact.gap_radius_mm,
+        gap_width = 2.0 * artifact.gap_radius_mm,
         geometry_guard = artifact.numerical_guard_mm,
-        feature_violation_area = artifact.checks.minimum_feature_violation_area_mm2,
-        gap_violation_area = artifact.checks.minimum_gap_violation_area_mm2,
-        void_closing_addition_area = artifact.checks.void_closing_addition_area_mm2,
-        maximal_components = artifact.regularization.maximal_component_count,
+        regularization_violation_area = artifact.checks.regularization_violation_area_mm2,
+        gap_violation_area = artifact.checks.gap_violation_area_mm2,
+        clearance_safe_components = artifact.regularization.clearance_safe_component_count,
         opened_components = artifact.regularization.opened_component_count,
         final_components = artifact.regularization.final_component_count,
-        gap_discarded_components = artifact.regularization.discarded_for_gap_component_count,
         smallest_component = artifact
             .regularization
             .smallest_final_component_area_mm2

--- a/crates/pcb-ir/Cargo.toml
+++ b/crates/pcb-ir/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["graphics", "rendering", "hardware-support"]
 
 [dependencies]
 base64 = { workspace = true }
+boostvoronoi = { workspace = true }
 i_overlay = { workspace = true }
 kurbo = { workspace = true }
 resvg = { workspace = true }

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -141,15 +141,15 @@ pub struct ClearanceCertificate {
 }
 
 impl ClearanceCertificate {
-    /// Whether all required subset, clearance, rolling-disk, and pairwise-gap
-    /// violations are below the supplied area tolerance.
+    /// Whether the two-sided gap set is empty and every other violation is
+    /// below the supplied area tolerance.
     pub fn passes(&self, area_tolerance_mm2: f64) -> bool {
         area_tolerance_mm2.is_finite()
             && area_tolerance_mm2 >= 0.0
+            && self.gap_violations.is_empty()
             && [
                 &self.safe_outside_clearance_region,
                 &self.regularization_violations,
-                &self.gap_violations,
                 &self.outside_panel,
                 &self.obstacle_overlap,
             ]
@@ -325,9 +325,7 @@ pub fn board_array_balancing_region(
     let regularization_violations = safe_region
         .difference(&safe_region.disk_open(options.regularization_radius_mm))
         .disk_open(options.numerical_guard_mm);
-    let gap_violations = safe_region
-        .disk_gap_violations(options.gap_radius_mm)
-        .disk_open(options.numerical_guard_mm);
+    let gap_violations = safe_region.disk_gap_violations(options.gap_radius_mm);
     let certificate = ClearanceCertificate {
         safe_outside_clearance_region: safe_region.difference(&clearance_safe_region),
         regularization_violations,
@@ -569,6 +567,21 @@ mod tests {
                 .intersection(&result.intermediates.obstacle_keep_out)
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn certificate_never_tolerates_a_nonempty_gap_violation() {
+        let empty = ContourSet::empty(tol::REGION_MM);
+        let certificate = ClearanceCertificate {
+            swept_safe_region: empty.clone(),
+            safe_outside_clearance_region: empty.clone(),
+            regularization_violations: empty.clone(),
+            gap_violations: ContourSet::rectangle(bbox(0.0, 0.0, 0.01, 0.01), tol::REGION_MM),
+            outside_panel: empty.clone(),
+            obstacle_overlap: empty,
+        };
+
+        assert!(!certificate.passes(1.0));
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -5,24 +5,28 @@
 //! the already-extracted `ArraySupport` layer documents. The resulting input
 //! is then handled entirely as regularized [`ContourSet`] geometry.
 //!
-//! For panel material `P`, obstacle union `O`, construction gap radius `g`,
-//! minimum-feature radius `q`, and minimum-gap radius `v`, the construction is:
+//! For panel material `P`, obstacle union `O`, construction clearance `c`,
+//! filled-region radius `q`, and void-gap radius `v`, the construction is:
 //!
 //! ```text
-//! M = (P ⊖ disk(g)) \ (O ⊕ disk(g))
-//! A = ((M ⊖ disk(q)) ⊕ disk(q)) ∩ M
+//! F = (P ⊖ disk(c)) \ (O ⊕ disk(c))
+//! A = open(F, disk(q))
 //! ```
 //!
-//! `M` is the clearance-safe set. Treating the outside of `P` and `O` as one
-//! forbidden phase prevents narrow diagonal gaps where an obstacle meets the
-//! panel edge. `A` is a disk opening: the union of all radius-`q` disks that
-//! fit in `M`, which removes copper slivers and rounds outward corners.
+//! `F` is the clearance-safe set: the complement of the clearance-dilated
+//! forbidden phase formed by the panel exterior and every physical obstacle.
+//! `A` is a disk opening, the union of all radius-`q` disks that fit in `F`;
+//! it removes copper slivers and rounds outward corners without inflating the
+//! safety clearance to the regularization scale.
 //!
-//! Finally, the connected components of `A` form a proximity graph with an
-//! edge when `distance(C_i, C_j) < 2v`. The exact maximum-area independent set
-//! is retained. Thus distinct output components are separated by at least `2v`
-//! while preserving the greatest possible area from the opened components,
-//! without feature-specific rules or traversal-order policy.
+//! Let `G_v(X)` retain the components of `close(X, disk(v)) \ X` that touch two
+//! nonincident, opposing boundary branches. This excludes the normal rounded
+//! bite at a single concave corner. Removing a radius-`v` tube around the
+//! medial axis of `G_v(A)`, then disk-opening, trims both sides of every narrow
+//! void locally. Any certified residual is swept by the same radius until
+//! `G_v(S)` is empty. Thus filled features admit a disk of radius `q`, while
+//! intervening void gaps admit a disk of radius `v`, without component ranking
+//! or feature-specific rules.
 
 use std::fmt;
 
@@ -35,11 +39,11 @@ use crate::geom::{ContourSet, FillRule, Paint, tol};
 /// Default Euclidean clearance from every protected feature.
 pub const DEFAULT_BALANCING_CLEARANCE_MM: f64 = 0.5;
 
-/// Default rolling-disk radius; surviving copper can accommodate this disk.
-pub const DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM: f64 = 1.0;
+/// Default rolling-disk radius for filled balancing regions.
+pub const DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM: f64 = 0.5;
 
-/// Half the default minimum Euclidean gap between distinct safe components.
-pub const DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM: f64 = 1.0;
+/// Half the default minimum width of a two-sided void gap.
+pub const DEFAULT_BALANCING_GAP_RADIUS_MM: f64 = 0.5;
 
 /// Conservative allowance for curve flattening and round-offset construction.
 pub const DEFAULT_BALANCING_NUMERICAL_GUARD_MM: f64 =
@@ -63,11 +67,12 @@ pub struct BoardArrayBalancingInput {
 pub struct BalancingRegionOptions {
     /// Required Euclidean clearance from the panel boundary and all obstacles.
     pub clearance_mm: f64,
-    /// Radius `q` of the disk opening. The opened result is the union of all
-    /// radius-`q` disks contained in the pre-regularized safe set.
-    pub minimum_feature_radius_mm: f64,
-    /// Gap radius `v`; distinct final components must be at least `2v` apart.
-    pub minimum_gap_radius_mm: f64,
+    /// Radius of the filled-feature opening. Surviving regions admit disks of
+    /// this radius.
+    pub regularization_radius_mm: f64,
+    /// Radius of the rolling-disk test for two-sided void gaps. The minimum
+    /// nominal gap width is twice this radius.
+    pub gap_radius_mm: f64,
     /// Additional conservative allowance for numerical approximation.
     pub numerical_guard_mm: f64,
 }
@@ -76,8 +81,8 @@ impl Default for BalancingRegionOptions {
     fn default() -> Self {
         Self {
             clearance_mm: DEFAULT_BALANCING_CLEARANCE_MM,
-            minimum_feature_radius_mm: DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM,
-            minimum_gap_radius_mm: DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM,
+            regularization_radius_mm: DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM,
+            gap_radius_mm: DEFAULT_BALANCING_GAP_RADIUS_MM,
             numerical_guard_mm: DEFAULT_BALANCING_NUMERICAL_GUARD_MM,
         }
     }
@@ -88,14 +93,6 @@ impl BalancingRegionOptions {
     pub fn construction_clearance_mm(self) -> f64 {
         self.clearance_mm + self.numerical_guard_mm
     }
-
-    /// `max(clearance_mm, minimum_gap_radius_mm) + numerical_guard_mm`.
-    ///
-    /// Applying the same radius as a panel erosion and obstacle dilation makes
-    /// the entire forbidden phase obey one construction-gap rule.
-    pub fn construction_gap_radius_mm(self) -> f64 {
-        self.clearance_mm.max(self.minimum_gap_radius_mm) + self.numerical_guard_mm
-    }
 }
 
 /// Set-theoretic intermediates retained for diagnostics and validation.
@@ -104,24 +101,22 @@ pub struct BoardArrayBalancingIntermediates {
     /// `board_footprints ∪ material_removal ∪ support_features`.
     pub raw_obstacles: ContourSet,
     /// `panel_outer ⊖ disk(construction_clearance)`.
-    pub panel_clearance_keep_in: ContourSet,
-    /// `panel_outer ⊖ disk(construction_gap_radius)`.
     pub panel_keep_in: ContourSet,
     /// `raw_obstacles ⊕ disk(construction_clearance)`.
-    pub obstacle_clearance: ContourSet,
-    /// `raw_obstacles ⊕ disk(construction_gap_radius)`.
-    pub obstacle_gap_envelope: ContourSet,
-    /// `panel_keep_in \ obstacle_gap_envelope`.
-    pub maximal_safe_region: ContourSet,
-    /// `maximal_safe_region ⊖ disk(minimum_feature_radius)`.
-    pub regularization_core: ContourSet,
-    /// Disk opening of `maximal_safe_region`, before component separation.
-    pub opened_safe_region: ContourSet,
-    /// Material removed from the maximal set by the disk opening alone.
+    pub obstacle_keep_out: ContourSet,
+    /// `panel_keep_in \ obstacle_keep_out`.
+    pub clearance_safe_region: ContourSet,
+    /// Disk opening of `clearance_safe_region`, before void-gap regularization.
+    pub opened_candidates: ContourSet,
+    /// Material removed from the clearance-safe set by the disk opening alone.
     pub removed_by_opening: ContourSet,
-    /// Whole components excluded by the maximum-area independent set.
-    pub removed_by_gap_separation: ContourSet,
-    /// Total material removed by opening and component separation.
+    /// Two-sided complement phase rejected by the rolling-disk gap test.
+    pub narrow_voids: ContourSet,
+    /// Initial medial-axis tube plus any directly swept certificate residuals.
+    pub gap_separator_keep_out: ContourSet,
+    /// Material locally trimmed to widen two-sided void gaps.
+    pub removed_by_gap_regularization: ContourSet,
+    /// Total material removed by filled-feature and void-gap regularization.
     pub removed_by_regularization: ContourSet,
 }
 
@@ -130,26 +125,15 @@ pub struct BoardArrayBalancingIntermediates {
 pub struct ClearanceCertificate {
     /// Safe region dilated by the nominal requested clearance.
     pub swept_safe_region: ContourSet,
-    /// Regularized safe material outside the maximal pre-regularization set.
-    pub safe_outside_maximal_region: ContourSet,
-    /// Internal consistency violation: safe material outside `panel_keep_in`.
-    pub safe_outside_keep_in: ContourSet,
-    /// Internal consistency violation: safe material inside cleared obstacles.
-    pub safe_inside_obstacle_clearance: ContourSet,
-    /// Internal consistency violation: safe material inside the minimum-gap
-    /// obstacle envelope.
-    pub safe_inside_obstacle_gap_envelope: ContourSet,
-    /// `safe_region \ open(safe_region, q)`, after numerical denoising.
-    pub minimum_feature_violations: ContourSet,
-    /// `((C_i ⊕ disk(v)) ∩ (C_j ⊕ disk(v))) \ safe_region`, unioned over
-    /// distinct components. Non-empty geometry proves `distance(C_i, C_j) <
-    /// 2v` within polygon tolerance.
-    pub minimum_gap_violations: ContourSet,
-    /// Broader diagnostic geometry that disk closing would fill. This includes
-    /// narrow notches in a single component as well as inter-component gaps,
-    /// so it is retained for inspection but is not an inter-component
-    /// separation failure.
-    pub void_closing_additions: ContourSet,
+    /// Regularized safe material outside the clearance-safe set.
+    pub safe_outside_clearance_region: ContourSet,
+    /// `safe_region \ open(safe_region, region_radius)`, after denoising.
+    pub regularization_violations: ContourSet,
+    /// Two-sided components of
+    /// `close(safe_region, disk(gap_radius)) \ safe_region`. Non-empty geometry
+    /// proves a void gap narrower than twice the gap radius, including within
+    /// one connected filled component.
+    pub gap_violations: ContourSet,
     /// Nominal-clearance sweep outside the raw panel.
     pub outside_panel: ContourSet,
     /// Nominal-clearance sweep intersecting raw obstacles.
@@ -159,20 +143,13 @@ pub struct ClearanceCertificate {
 impl ClearanceCertificate {
     /// Whether all required subset, clearance, rolling-disk, and pairwise-gap
     /// violations are below the supplied area tolerance.
-    ///
-    /// [`Self::void_closing_additions`] is intentionally diagnostic-only:
-    /// closing also fills concave notches within a single component, whereas
-    /// the enforced gap contract concerns distinct components.
     pub fn passes(&self, area_tolerance_mm2: f64) -> bool {
         area_tolerance_mm2.is_finite()
             && area_tolerance_mm2 >= 0.0
             && [
-                &self.safe_outside_maximal_region,
-                &self.safe_outside_keep_in,
-                &self.safe_inside_obstacle_clearance,
-                &self.safe_inside_obstacle_gap_envelope,
-                &self.minimum_feature_violations,
-                &self.minimum_gap_violations,
+                &self.safe_outside_clearance_region,
+                &self.regularization_violations,
+                &self.gap_violations,
                 &self.outside_panel,
                 &self.obstacle_overlap,
             ]
@@ -184,8 +161,8 @@ impl ClearanceCertificate {
 /// Safe region plus all data required to inspect and certify it.
 #[derive(Debug, Clone)]
 pub struct BoardArrayBalancingResult {
-    /// Final subset whose local copper scale is at least the rolling-disk scale
-    /// and whose distinct components are separated by the requested gap.
+    /// Final subset whose filled features and two-sided void gaps satisfy their
+    /// independently requested rolling-disk radii.
     pub safe_region: ContourSet,
     pub intermediates: BoardArrayBalancingIntermediates,
     pub certificate: ClearanceCertificate,
@@ -240,12 +217,13 @@ pub struct BoardArrayBalancingCollection {
 #[derive(Debug, Clone, PartialEq)]
 pub enum BalancingRegionError {
     InvalidClearance(f64),
-    InvalidMinimumFeatureRadius(f64),
-    InvalidMinimumGapRadius(f64),
+    InvalidRegularizationRadius(f64),
+    InvalidGapRadius(f64),
     InvalidNumericalGuard(f64),
     EmptyPanelOutline,
     EmptyBoardFootprints,
     UnpaintedSupportPaths(usize),
+    GapRegularization(String),
 }
 
 impl fmt::Display for BalancingRegionError {
@@ -255,13 +233,13 @@ impl fmt::Display for BalancingRegionError {
                 f,
                 "balancing-region clearance must be finite and positive; got {value}"
             ),
-            Self::InvalidMinimumFeatureRadius(value) => write!(
+            Self::InvalidRegularizationRadius(value) => write!(
                 f,
-                "balancing-region minimum feature radius must be finite and positive; got {value}"
+                "balancing-region regularization radius must be finite and positive; got {value}"
             ),
-            Self::InvalidMinimumGapRadius(value) => write!(
+            Self::InvalidGapRadius(value) => write!(
                 f,
-                "balancing-region minimum gap radius must be finite and positive; got {value}"
+                "balancing-region gap radius must be finite and positive; got {value}"
             ),
             Self::InvalidNumericalGuard(value) => write!(
                 f,
@@ -277,35 +255,35 @@ impl fmt::Display for BalancingRegionError {
                 f,
                 "board array has {count} support paths without a physical painted footprint"
             ),
+            Self::GapRegularization(message) => {
+                write!(f, "could not regularize balancing-region gaps: {message}")
+            }
         }
     }
 }
 
 impl std::error::Error for BalancingRegionError {}
 
-/// Compute a clearance-safe, minimum-feature, minimum-gap copper region.
+/// Compute a clearance-safe, radius-regularized copper region.
 ///
 /// Let `P` be [`BoardArrayBalancingInput::panel_outer`], `O` the union of the
-/// three obstacle inputs, `g` [`BalancingRegionOptions::construction_gap_radius_mm`],
-/// `q` [`BalancingRegionOptions::minimum_feature_radius_mm`], and `v`
-/// [`BalancingRegionOptions::minimum_gap_radius_mm`]. The geometric stages are:
+/// three obstacle inputs, `c`
+/// [`BalancingRegionOptions::construction_clearance_mm`], `q`
+/// [`BalancingRegionOptions::regularization_radius_mm`], and `v`
+/// [`BalancingRegionOptions::gap_radius_mm`]. The geometric stages are:
 ///
 /// ```text
-/// maximal = (P ⊖ disk(g)) \ (O ⊕ disk(g))
-/// opened  = ((maximal ⊖ disk(q)) ⊕ disk(q)) ∩ maximal
+/// clearance_safe = (P ⊖ disk(c)) \ (O ⊕ disk(c))
+/// candidates     = open(clearance_safe, disk(q))
 /// ```
 ///
-/// For each connected component `C_i` of `opened`, choose `x_i ∈ {0, 1}` to
-/// maximize `Σ area(C_i) x_i`, subject to `x_i + x_j ≤ 1` whenever
-/// `distance(C_i, C_j) < 2v`. Independent conflict clusters are solved exactly.
-/// This makes the unavoidable topology choice order-independent and preserves
-/// the greatest possible area without recognizing board features or encoding
-/// special cases.
-///
-/// The optimized final union is not necessarily nested when options or
-/// obstacles change: shrinking or splitting the opened components can change
-/// which independent set is optimal. Callers should rely on the returned
-/// certificate, not cross-parameter set monotonicity.
+/// The first pass removes a radius-`v + guard` tube around the portion of the
+/// candidates' boundary medial axis inside the two-sided subset of
+/// `close(candidates, disk(v + guard)) \ candidates`. If the nominal closing
+/// certificate finds a nontrivial two-sided residual after that cut, monotone
+/// set iteration sweeps that residual directly until the certificate is empty.
+/// It widens inter-component gaps, hairpins, notches, and internal voids
+/// locally without widening one-sided edge clearance.
 pub fn board_array_balancing_region(
     input: &BoardArrayBalancingInput,
     options: BalancingRegionOptions,
@@ -323,42 +301,37 @@ pub fn board_array_balancing_region(
         .union(&input.material_removal)
         .union(&input.support_features);
     let construction_clearance_mm = options.construction_clearance_mm();
-    let construction_gap_radius_mm = options.construction_gap_radius_mm();
-    let panel_clearance_keep_in = input.panel_outer.disk_erode(construction_clearance_mm);
-    let panel_keep_in = input.panel_outer.disk_erode(construction_gap_radius_mm);
-    let obstacle_clearance = raw_obstacles.disk_dilate(construction_clearance_mm);
-    let obstacle_gap_envelope = raw_obstacles.disk_dilate(construction_gap_radius_mm);
-    let maximal_safe_region = panel_keep_in.difference(&obstacle_gap_envelope);
-    let regularization_core = maximal_safe_region.disk_erode(options.minimum_feature_radius_mm);
-    let opened_safe_region = regularization_core
-        .disk_dilate(options.minimum_feature_radius_mm)
-        .intersection(&maximal_safe_region);
-    let removed_by_opening = maximal_safe_region.difference(&opened_safe_region);
-    let (safe_region, removed_by_gap_separation) =
-        opened_safe_region.disk_separate_components(options.minimum_gap_radius_mm);
-    let removed_by_regularization = maximal_safe_region.difference(&safe_region);
+    let panel_keep_in = input.panel_outer.disk_erode(construction_clearance_mm);
+    let obstacle_keep_out = raw_obstacles.disk_dilate(construction_clearance_mm);
+    let clearance_safe_region = panel_keep_in.difference(&obstacle_keep_out);
+    let opened_candidates = clearance_safe_region.disk_open(options.regularization_radius_mm);
+    let removed_by_opening = clearance_safe_region.difference(&opened_candidates);
+    let gap_regularization = opened_candidates
+        .disk_regularize_gaps(
+            options.gap_radius_mm,
+            options.regularization_radius_mm,
+            options.numerical_guard_mm,
+        )
+        .map_err(|error| BalancingRegionError::GapRegularization(error.to_string()))?;
+    let safe_region = gap_regularization.kept;
+    let narrow_voids = gap_regularization.narrow_voids;
+    let gap_separator_keep_out = gap_regularization.separator_keep_out;
+    let removed_by_gap_regularization = gap_regularization.removed;
+    let removed_by_regularization = clearance_safe_region.difference(&safe_region);
 
     // Certify against the nominal requirement, independently of the
     // construction guard used above.
     let swept_safe_region = safe_region.disk_dilate(options.clearance_mm);
-    let minimum_feature_violations = safe_region
-        .difference(&safe_region.disk_open(options.minimum_feature_radius_mm))
+    let regularization_violations = safe_region
+        .difference(&safe_region.disk_open(options.regularization_radius_mm))
         .disk_open(options.numerical_guard_mm);
-    let minimum_gap_violations = safe_region
-        .disk_inter_component_gap_violations(options.minimum_gap_radius_mm)
-        .disk_open(options.numerical_guard_mm);
-    let void_closing_additions = safe_region
-        .disk_close(options.minimum_gap_radius_mm)
-        .difference(&safe_region)
+    let gap_violations = safe_region
+        .disk_gap_violations(options.gap_radius_mm)
         .disk_open(options.numerical_guard_mm);
     let certificate = ClearanceCertificate {
-        safe_outside_maximal_region: safe_region.difference(&maximal_safe_region),
-        safe_outside_keep_in: safe_region.difference(&panel_keep_in),
-        safe_inside_obstacle_clearance: safe_region.intersection(&obstacle_clearance),
-        safe_inside_obstacle_gap_envelope: safe_region.intersection(&obstacle_gap_envelope),
-        minimum_feature_violations,
-        minimum_gap_violations,
-        void_closing_additions,
+        safe_outside_clearance_region: safe_region.difference(&clearance_safe_region),
+        regularization_violations,
+        gap_violations,
         outside_panel: swept_safe_region.difference(&input.panel_outer),
         obstacle_overlap: swept_safe_region.intersection(&raw_obstacles),
         swept_safe_region,
@@ -368,15 +341,14 @@ pub fn board_array_balancing_region(
         safe_region,
         intermediates: BoardArrayBalancingIntermediates {
             raw_obstacles,
-            panel_clearance_keep_in,
             panel_keep_in,
-            obstacle_clearance,
-            obstacle_gap_envelope,
-            maximal_safe_region,
-            regularization_core,
-            opened_safe_region,
+            obstacle_keep_out,
+            clearance_safe_region,
+            opened_candidates,
             removed_by_opening,
-            removed_by_gap_separation,
+            narrow_voids,
+            gap_separator_keep_out,
+            removed_by_gap_regularization,
             removed_by_regularization,
         },
         certificate,
@@ -529,14 +501,14 @@ fn validate_options(options: BalancingRegionOptions) -> Result<(), BalancingRegi
     if !options.clearance_mm.is_finite() || options.clearance_mm <= 0.0 {
         return Err(BalancingRegionError::InvalidClearance(options.clearance_mm));
     }
-    if !options.minimum_feature_radius_mm.is_finite() || options.minimum_feature_radius_mm <= 0.0 {
-        return Err(BalancingRegionError::InvalidMinimumFeatureRadius(
-            options.minimum_feature_radius_mm,
+    if !options.regularization_radius_mm.is_finite() || options.regularization_radius_mm <= 0.0 {
+        return Err(BalancingRegionError::InvalidRegularizationRadius(
+            options.regularization_radius_mm,
         ));
     }
-    if !options.minimum_gap_radius_mm.is_finite() || options.minimum_gap_radius_mm <= 0.0 {
-        return Err(BalancingRegionError::InvalidMinimumGapRadius(
-            options.minimum_gap_radius_mm,
+    if !options.gap_radius_mm.is_finite() || options.gap_radius_mm <= 0.0 {
+        return Err(BalancingRegionError::InvalidGapRadius(
+            options.gap_radius_mm,
         ));
     }
     if !options.numerical_guard_mm.is_finite() || options.numerical_guard_mm < 0.0 {
@@ -571,20 +543,17 @@ mod tests {
         assert!(!result.safe_region.is_empty());
         assert!(
             result.certificate.passes(1e-4),
-            "outside maximal {:.9}, outside keep-in {:.9}, inside obstacle clearance {:.9}, inside gap envelope {:.9}, feature violations {:.9}, gap violations {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
-            result.certificate.safe_outside_maximal_region.area(),
-            result.certificate.safe_outside_keep_in.area(),
-            result.certificate.safe_inside_obstacle_clearance.area(),
-            result.certificate.safe_inside_obstacle_gap_envelope.area(),
-            result.certificate.minimum_feature_violations.area(),
-            result.certificate.minimum_gap_violations.area(),
+            "outside clearance-safe {:.9}, filled-feature violations {:.9}, void-gap violations {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
+            result.certificate.safe_outside_clearance_region.area(),
+            result.certificate.regularization_violations.area(),
+            result.certificate.gap_violations.area(),
             result.certificate.outside_panel.area(),
             result.certificate.obstacle_overlap.area(),
         );
         assert!(
             result
                 .safe_region
-                .difference(&result.intermediates.maximal_safe_region)
+                .difference(&result.intermediates.clearance_safe_region)
                 .is_empty()
         );
         assert!(result.intermediates.removed_by_regularization.area() > 0.0);
@@ -597,20 +566,20 @@ mod tests {
         assert!(
             result
                 .safe_region
-                .intersection(&result.intermediates.obstacle_clearance)
+                .intersection(&result.intermediates.obstacle_keep_out)
                 .is_empty()
         );
     }
 
     #[test]
-    fn larger_clearance_shrinks_maximal_region_for_simple_fixture() {
+    fn larger_clearance_shrinks_clearance_safe_region_for_simple_fixture() {
         let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
         let smaller = board_array_balancing_region(
             &input,
             BalancingRegionOptions {
                 clearance_mm: 0.25,
-                minimum_feature_radius_mm: 0.5,
-                minimum_gap_radius_mm: 0.5,
+                regularization_radius_mm: 0.5,
+                gap_radius_mm: 0.5,
                 numerical_guard_mm: 0.0,
             },
         )
@@ -619,8 +588,8 @@ mod tests {
             &input,
             BalancingRegionOptions {
                 clearance_mm: 1.0,
-                minimum_feature_radius_mm: 0.5,
-                minimum_gap_radius_mm: 0.5,
+                regularization_radius_mm: 0.5,
+                gap_radius_mm: 0.5,
                 numerical_guard_mm: 0.0,
             },
         )
@@ -628,28 +597,28 @@ mod tests {
 
         let larger_outside_smaller = larger
             .intermediates
-            .maximal_safe_region
-            .difference(&smaller.intermediates.maximal_safe_region);
+            .clearance_safe_region
+            .difference(&smaller.intermediates.clearance_safe_region);
         assert!(
             larger_outside_smaller.is_empty(),
             "larger clearance added {:.9} mm² to the maximal region",
             larger_outside_smaller.area()
         );
         assert!(
-            larger.intermediates.maximal_safe_region.area()
-                < smaller.intermediates.maximal_safe_region.area()
+            larger.intermediates.clearance_safe_region.area()
+                < smaller.intermediates.clearance_safe_region.area()
         );
     }
 
     #[test]
-    fn larger_feature_disk_shrinks_opened_region_for_simple_fixture() {
+    fn larger_regularization_disk_shrinks_opened_region_for_simple_fixture() {
         let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
         let smaller = board_array_balancing_region(
             &input,
             BalancingRegionOptions {
                 clearance_mm: 0.5,
-                minimum_feature_radius_mm: 0.25,
-                minimum_gap_radius_mm: 0.5,
+                regularization_radius_mm: 0.25,
+                gap_radius_mm: 0.5,
                 numerical_guard_mm: 0.0,
             },
         )
@@ -658,8 +627,8 @@ mod tests {
             &input,
             BalancingRegionOptions {
                 clearance_mm: 0.5,
-                minimum_feature_radius_mm: 1.0,
-                minimum_gap_radius_mm: 0.5,
+                regularization_radius_mm: 1.0,
+                gap_radius_mm: 0.5,
                 numerical_guard_mm: 0.0,
             },
         )
@@ -667,76 +636,60 @@ mod tests {
 
         let larger_outside_smaller = larger
             .intermediates
-            .opened_safe_region
-            .difference(&smaller.intermediates.opened_safe_region);
+            .opened_candidates
+            .difference(&smaller.intermediates.opened_candidates);
         assert!(
             larger_outside_smaller.is_empty(),
             "larger feature disk added {:.9} mm² to the opened region",
             larger_outside_smaller.area()
         );
         assert!(
-            larger.intermediates.opened_safe_region.area()
-                < smaller.intermediates.opened_safe_region.area()
+            larger.intermediates.opened_candidates.area()
+                < smaller.intermediates.opened_candidates.area()
         );
     }
 
     #[test]
-    fn minimum_gap_radius_widens_corridors_around_line_obstacles() {
+    fn regularization_does_not_inflate_obstacle_clearance() {
         let input = BoardArrayBalancingInput {
             panel_outer: ContourSet::rectangle(bbox(0.0, 0.0, 30.0, 20.0), tol::REGION_MM),
             board_footprints: ContourSet::rectangle(bbox(2.0, 2.0, 4.0, 4.0), tol::REGION_MM),
             material_removal: ContourSet::empty(tol::REGION_MM),
             support_features: ContourSet::rectangle(bbox(14.95, 0.0, 15.05, 20.0), tol::REGION_MM),
         };
-        let narrow = board_array_balancing_region(
+        let result = board_array_balancing_region(
             &input,
             BalancingRegionOptions {
                 clearance_mm: 0.5,
-                minimum_feature_radius_mm: 0.5,
-                minimum_gap_radius_mm: 0.5,
-                numerical_guard_mm: 0.025,
-            },
-        )
-        .unwrap();
-        let wide = board_array_balancing_region(
-            &input,
-            BalancingRegionOptions {
-                clearance_mm: 0.5,
-                minimum_feature_radius_mm: 0.5,
-                minimum_gap_radius_mm: 1.0,
+                regularization_radius_mm: 1.0,
+                gap_radius_mm: 0.5,
                 numerical_guard_mm: 0.025,
             },
         )
         .unwrap();
 
-        assert!(
-            wide.intermediates
-                .maximal_safe_region
-                .difference(&narrow.intermediates.maximal_safe_region)
-                .is_empty(),
-            "wider gap envelope added {:.9} mm² to the maximal region",
-            wide.intermediates
-                .maximal_safe_region
-                .difference(&narrow.intermediates.maximal_safe_region)
-                .area()
-        );
-        assert!(wide.certificate.minimum_gap_violations.is_empty());
-
-        let mut components = wide.safe_region.connected_components();
+        let mut components = result
+            .intermediates
+            .clearance_safe_region
+            .connected_components();
         components.sort_by(|left, right| left.bbox.min.x.total_cmp(&right.bbox.min.x));
-        assert_eq!(
-            components.len(),
-            2,
-            "rings {}, bbox {:?}",
-            wide.safe_region.rings.len(),
-            wide.safe_region.bbox
-        );
+        assert_eq!(components.len(), 2);
         let gap = components[1].bbox.min.x - components[0].bbox.max.x;
-        assert!(gap >= 2.0, "expected a 2 mm gap, got {gap:.9} mm");
+        assert!(
+            (gap - 1.15).abs() <= 0.01,
+            "expected physical stroke plus two 0.525 mm clearances, got {gap:.9} mm"
+        );
+        assert_eq!(result.safe_region.connected_components().len(), 2);
+        assert!(
+            result.intermediates.removed_by_gap_regularization.area() <= 1e-4,
+            "unexpected gap trimming {:.9} mm²",
+            result.intermediates.removed_by_gap_regularization.area(),
+        );
+        assert!(result.certificate.gap_violations.is_empty());
     }
 
     #[test]
-    fn adding_an_obstacle_shrinks_maximal_region_for_simple_fixture() {
+    fn adding_an_obstacle_shrinks_clearance_safe_region_for_simple_fixture() {
         let baseline_input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
         let added_obstacle = ContourSet::rectangle(bbox(10.0, 1.0, 11.0, 9.0), tol::REGION_MM);
         let blocked_input = balancing_input(0.0, added_obstacle);
@@ -748,13 +701,13 @@ mod tests {
         assert!(
             blocked
                 .intermediates
-                .maximal_safe_region
-                .difference(&baseline.intermediates.maximal_safe_region)
+                .clearance_safe_region
+                .difference(&baseline.intermediates.clearance_safe_region)
                 .is_empty()
         );
         assert!(
-            blocked.intermediates.maximal_safe_region.area()
-                < baseline.intermediates.maximal_safe_region.area()
+            blocked.intermediates.clearance_safe_region.area()
+                < baseline.intermediates.clearance_safe_region.area()
         );
     }
 
@@ -775,15 +728,15 @@ mod tests {
         );
         assert!(
             original.certificate.passes(1e-4),
-            "original outside maximal {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
-            original.certificate.safe_outside_maximal_region.area(),
+            "original outside clearance-safe {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
+            original.certificate.safe_outside_clearance_region.area(),
             original.certificate.outside_panel.area(),
             original.certificate.obstacle_overlap.area(),
         );
         assert!(
             translated.certificate.passes(1e-4),
-            "translated outside maximal {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
-            translated.certificate.safe_outside_maximal_region.area(),
+            "translated outside clearance-safe {:.9}, outside panel {:.9}, obstacle overlap {:.9}",
+            translated.certificate.safe_outside_clearance_region.area(),
             translated.certificate.outside_panel.area(),
             translated.certificate.obstacle_overlap.area(),
         );
@@ -814,8 +767,8 @@ mod tests {
                 &input,
                 BalancingRegionOptions {
                     clearance_mm: 0.0,
-                    minimum_feature_radius_mm: 0.5,
-                    minimum_gap_radius_mm: 0.5,
+                    regularization_radius_mm: 0.5,
+                    gap_radius_mm: 0.5,
                     numerical_guard_mm: 0.0,
                 }
             )
@@ -827,34 +780,34 @@ mod tests {
                 &input,
                 BalancingRegionOptions {
                     clearance_mm: 0.5,
-                    minimum_feature_radius_mm: 0.0,
-                    minimum_gap_radius_mm: 0.5,
+                    regularization_radius_mm: 0.0,
+                    gap_radius_mm: 0.5,
                     numerical_guard_mm: 0.0,
                 }
             )
             .unwrap_err(),
-            BalancingRegionError::InvalidMinimumFeatureRadius(0.0)
+            BalancingRegionError::InvalidRegularizationRadius(0.0)
         );
         assert_eq!(
             board_array_balancing_region(
                 &input,
                 BalancingRegionOptions {
                     clearance_mm: 0.5,
-                    minimum_feature_radius_mm: 0.5,
-                    minimum_gap_radius_mm: 0.0,
+                    regularization_radius_mm: 1.0,
+                    gap_radius_mm: 0.0,
                     numerical_guard_mm: 0.0,
                 }
             )
             .unwrap_err(),
-            BalancingRegionError::InvalidMinimumGapRadius(0.0)
+            BalancingRegionError::InvalidGapRadius(0.0)
         );
         assert_eq!(
             board_array_balancing_region(
                 &input,
                 BalancingRegionOptions {
                     clearance_mm: 0.5,
-                    minimum_feature_radius_mm: 0.5,
-                    minimum_gap_radius_mm: 0.5,
+                    regularization_radius_mm: 0.5,
+                    gap_radius_mm: 0.5,
                     numerical_guard_mm: -0.1,
                 }
             )

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -27,10 +27,10 @@ pub use balancing_region::{
     BalancingRegionError, BalancingRegionOptions, BoardArrayBalancingCollection,
     BoardArrayBalancingInput, BoardArrayBalancingIntermediates, BoardArrayBalancingResult,
     BoardArraySupportDocument, BoardArraySupportLayerGeometry, BoardArraySupportLayerPolicy,
-    ClearanceCertificate, DEFAULT_BALANCING_CLEARANCE_MM,
-    DEFAULT_BALANCING_MINIMUM_FEATURE_RADIUS_MM, DEFAULT_BALANCING_MINIMUM_GAP_RADIUS_MM,
-    DEFAULT_BALANCING_NUMERICAL_GUARD_MM, board_array_balancing_region,
-    collect_board_array_balancing_input, inspect_board_array_balancing_input,
+    ClearanceCertificate, DEFAULT_BALANCING_CLEARANCE_MM, DEFAULT_BALANCING_GAP_RADIUS_MM,
+    DEFAULT_BALANCING_NUMERICAL_GUARD_MM, DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM,
+    board_array_balancing_region, collect_board_array_balancing_input,
+    inspect_board_array_balancing_input,
 };
 pub use document::{Document, Layer};
 pub use feature::{

--- a/crates/pcb-ir/src/geom/mod.rs
+++ b/crates/pcb-ir/src/geom/mod.rs
@@ -23,7 +23,7 @@ pub use arc::Arc;
 pub use bbox::BBox;
 pub use path::{ContourBuf, PathCmd, PathOp, Segment, StrokeToFillStyle};
 pub use point::{Mirror, Point};
-pub use region::{ContourSet, PaintComposer, Ring};
+pub use region::{ContourSet, DiskGapRegularization, GapRegularizationError, PaintComposer, Ring};
 pub(crate) use store::validate_bbox;
 pub use store::{Contour, Path, PathArena, Span};
 pub use style::{

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -520,7 +520,7 @@ impl ContourSet {
             if violations.is_empty() {
                 break;
             }
-            let pass_separator_keep_out = pass_narrow_voids.disk_dilate(tube_radius);
+            let pass_separator_keep_out = violations.disk_dilate(tube_radius);
             let next = kept
                 .difference(&pass_separator_keep_out)
                 .disk_open(filled_radius)

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -6,6 +6,14 @@
 //! dilation over filled point sets, shared by every dialect so IPC, Gerber,
 //! SVG, and comparison all use the same geometry semantics.
 
+use std::fmt;
+
+use boostvoronoi::prelude::{
+    Builder as VoronoiBuilder, CellIndex as VoronoiCellIndex, Diagram as VoronoiDiagram,
+    EdgeIndex as VoronoiEdgeIndex, Line as VoronoiLine, Point as VoronoiPoint, SourceCategory,
+    VoronoiVisualUtils,
+};
+use boostvoronoi::utils::visual_utils::SimpleAffine;
 use i_overlay::core::fill_rule::FillRule as OverlayFillRule;
 use i_overlay::core::overlay_rule::OverlayRule;
 use i_overlay::float::simplify::SimplifyShape;
@@ -128,6 +136,31 @@ pub struct ContourSet {
     pub rings: Vec<Ring>,
     pub tolerance: f64,
 }
+
+/// Result of enforcing a minimum width for every two-sided void gap.
+#[derive(Debug, Clone)]
+pub struct DiskGapRegularization {
+    /// Input material retained after local gap trimming and disk opening.
+    pub kept: ContourSet,
+    /// Two-sided components of `close(source, disk(radius)) \ source`.
+    pub narrow_voids: ContourSet,
+    /// Initial medial-axis tube plus any directly swept certificate residuals.
+    pub separator_keep_out: ContourSet,
+    /// `source \ kept`.
+    pub removed: ContourSet,
+}
+
+/// Failure to construct a narrow void's medial axis for gap regularization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GapRegularizationError(String);
+
+impl fmt::Display for GapRegularizationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for GapRegularizationError {}
 
 impl ContourSet {
     pub fn new(rings: Vec<Ring>, fill_rule: FillRule, tolerance: f64) -> Self {
@@ -413,94 +446,121 @@ impl ContourSet {
         violations
     }
 
-    /// Retain a maximum-area subset of connected components with pairwise
-    /// Euclidean separation at least `2 * radius`.
+    /// Enforce a diameter-`2 * gap_radius` minimum for every two-sided void gap.
     ///
-    /// Components form a graph with edge `(i, j)` when
-    /// `distance(C_i, C_j) < 2r`, equivalently when their radius-`r` dilations
-    /// overlap. With component area as vertex weight, the retained components
-    /// are an exact maximum-weight independent set:
+    /// First isolate the narrow complement phase `N`, then take its medial axis
+    /// `Γ_N` from the source boundary's primary generalized Voronoi branches:
     ///
     /// ```text
-    /// maximize  Σ area(C_i) x_i
-    /// subject to x_i + x_j ≤ 1  for every conflict edge (i, j)
-    ///            x_i ∈ {0, 1}
+    /// N₀     = G_(gap_radius + guard)(self)
+    /// S₀     = open(self \ (Γ_N₀ ⊕ disk(gap_radius + guard)), disk(filled_radius))
+    /// Vₖ     = open(G_gap_radius(Sₖ), disk(guard))
+    /// Sₖ₊₁   = open(Sₖ \ (Vₖ ⊕ disk(gap_radius + guard)), disk(filled_radius))
     /// ```
     ///
-    /// Disconnected conflict clusters are solved independently. Equal-area
-    /// optima prefer the deterministic component order: descending area, then
-    /// bounding-box coordinates. The return value is `(kept, removed)`.
-    pub fn disk_separate_components(&self, radius: f64) -> (Self, Self) {
-        if self.is_empty() || radius <= 0.0 {
-            return (self.clone(), Self::empty(self.tolerance));
-        }
-
-        let mut candidates = self
-            .connected_components()
-            .into_iter()
-            .map(|component| (component.area(), component))
-            .collect::<Vec<_>>();
-        candidates.sort_by(|(left_area, left), (right_area, right)| {
-            right_area
-                .total_cmp(left_area)
-                .then_with(|| left.bbox.min.x.total_cmp(&right.bbox.min.x))
-                .then_with(|| left.bbox.min.y.total_cmp(&right.bbox.min.y))
-                .then_with(|| left.bbox.max.x.total_cmp(&right.bbox.max.x))
-                .then_with(|| left.bbox.max.y.total_cmp(&right.bbox.max.y))
-        });
-
-        let mut conflicts = vec![Vec::new(); candidates.len()];
-        for left in 0..candidates.len() {
-            for right in left + 1..candidates.len() {
-                if regions_within_distance(&candidates[left].1, &candidates[right].1, 2.0 * radius)
-                {
-                    conflicts[left].push(right);
-                    conflicts[right].push(left);
-                }
-            }
-        }
-
-        if conflicts.iter().all(Vec::is_empty) {
-            return (self.clone(), Self::empty(self.tolerance));
-        }
-
-        let weights = candidates.iter().map(|(area, _)| *area).collect::<Vec<_>>();
-        let mut visited = vec![false; candidates.len()];
-        let mut kept_indices = Vec::new();
-        for start in 0..candidates.len() {
-            if visited[start] {
-                continue;
-            }
-            let mut cluster = Vec::new();
-            let mut pending = vec![start];
-            visited[start] = true;
-            while let Some(vertex) = pending.pop() {
-                cluster.push(vertex);
-                for &neighbor in &conflicts[vertex] {
-                    if !visited[neighbor] {
-                        visited[neighbor] = true;
-                        pending.push(neighbor);
-                    }
-                }
-            }
-            cluster.sort_unstable();
-            kept_indices.extend(maximum_weight_independent_set(
-                &cluster, &conflicts, &weights,
+    /// `G_r(X)` is the two-sided part of `close(X, disk(r)) \ X`, and `Γ_N₀` is
+    /// the source-boundary medial axis inside the initial narrow void
+    /// phase. It gives the least local first cut. Any residual `Vₖ` is swept
+    /// directly, so boolean-generated boundaries never require another Voronoi
+    /// diagram. Iteration stops when `Vₖ` is empty. The sequence is monotone
+    /// decreasing: every pass only trims the source. This covers distinct
+    /// components, hairpins, notches, and internal voids without treating
+    /// one-sided edge clearance as a gap.
+    pub fn disk_regularize_gaps(
+        &self,
+        gap_radius: f64,
+        filled_radius: f64,
+        guard: f64,
+    ) -> Result<DiskGapRegularization, GapRegularizationError> {
+        if !gap_radius.is_finite()
+            || gap_radius <= 0.0
+            || !filled_radius.is_finite()
+            || filled_radius <= 0.0
+        {
+            return Err(GapRegularizationError(
+                "gap and filled-region radii must be finite and positive".to_string(),
             ));
         }
-
-        if kept_indices.len() == candidates.len() {
-            return (self.clone(), Self::empty(self.tolerance));
+        if !guard.is_finite() || guard < 0.0 {
+            return Err(GapRegularizationError(
+                "gap-regularization guard must be finite and non-negative".to_string(),
+            ));
         }
-        kept_indices.sort_unstable();
-        let kept = kept_indices
-            .into_iter()
-            .fold(Self::empty(self.tolerance), |region, index| {
-                region.union(&candidates[index].1)
-            })
+        if self.is_empty() {
+            return Ok(DiskGapRegularization {
+                kept: self.clone(),
+                narrow_voids: Self::empty(self.tolerance),
+                separator_keep_out: Self::empty(self.tolerance),
+                removed: Self::empty(self.tolerance),
+            });
+        }
+
+        let tube_radius = gap_radius + guard;
+        let initial_narrow_voids = self.disk_gap_violations(tube_radius);
+        if initial_narrow_voids.is_empty() {
+            return Ok(DiskGapRegularization {
+                kept: self.clone(),
+                narrow_voids: Self::empty(self.tolerance),
+                separator_keep_out: Self::empty(self.tolerance),
+                removed: Self::empty(self.tolerance),
+            });
+        }
+        let initial_keep_out =
+            narrow_void_medial_axis_keep_out(self, &initial_narrow_voids, tube_radius)?;
+        let mut kept = self
+            .difference(&initial_keep_out)
+            .disk_open(filled_radius)
             .intersection(self);
+        let mut narrow_voids = initial_narrow_voids;
+        let mut separator_keep_out = initial_keep_out;
+        let certificate_guard = guard.max(self.tolerance);
+        loop {
+            let pass_narrow_voids = kept.disk_gap_violations(gap_radius);
+            let violations = pass_narrow_voids.disk_open(certificate_guard);
+            if violations.is_empty() {
+                break;
+            }
+            let pass_separator_keep_out = pass_narrow_voids.disk_dilate(tube_radius);
+            let next = kept
+                .difference(&pass_separator_keep_out)
+                .disk_open(filled_radius)
+                .intersection(&kept);
+            narrow_voids = narrow_voids.union(&pass_narrow_voids);
+            separator_keep_out = separator_keep_out.union(&pass_separator_keep_out);
+
+            if kept.difference(&next).area() <= self.tolerance * self.tolerance {
+                return Err(GapRegularizationError(format!(
+                    "gap regularization stalled with {:.9} mm² of void-gap violations",
+                    violations.area()
+                )));
+            }
+            kept = next;
+        }
         let removed = self.difference(&kept);
-        (kept, removed)
+        Ok(DiskGapRegularization {
+            kept,
+            narrow_voids,
+            separator_keep_out,
+            removed,
+        })
+    }
+
+    /// Unfilled material that violates the two-sided void-gap radius.
+    ///
+    /// The raw closing residual `close(self, disk(radius)) \ self` also contains
+    /// the rounded bite at an isolated concave corner. A residual component is
+    /// a gap only when it contacts nonincident source-boundary segments with
+    /// opposing tangents. An empty result proves no two facing boundary
+    /// branches fail the rolling-disk test.
+    pub fn disk_gap_violations(&self, radius: f64) -> Self {
+        if self.is_empty() || radius <= 0.0 {
+            return Self::empty(self.tolerance);
+        }
+        if !radius.is_finite() {
+            return Self::empty(self.tolerance);
+        }
+        let closing_residual = self.disk_close(radius).difference(self);
+        two_sided_gap_residual(self, &closing_residual)
     }
 
     pub fn to_contours(&self) -> Vec<ContourBuf> {
@@ -697,99 +757,448 @@ fn point_segment_distance(point: Point, start: Point, end: Point) -> f64 {
     point.distance_to(start + segment * t)
 }
 
-fn maximum_weight_independent_set(
-    cluster: &[usize],
-    conflicts: &[Vec<usize>],
-    weights: &[f64],
-) -> Vec<usize> {
-    let mut greedy = Vec::new();
-    for &vertex in cluster {
-        if greedy
-            .iter()
-            .all(|kept| conflicts[vertex].binary_search(kept).is_err())
-        {
-            greedy.push(vertex);
-        }
-    }
-    let best_weight = greedy.iter().map(|&vertex| weights[vertex]).sum();
-    let mut search = MaximumWeightIndependentSetSearch {
-        conflicts,
-        weights,
-        best: greedy,
-        best_weight,
-    };
-    search.visit(cluster.to_vec(), &mut Vec::new(), 0.0);
-    search.best
+const VORONOI_COORDINATES_PER_MM: f64 = 100_000.0;
+
+#[derive(Debug, Clone, Copy)]
+struct BoundarySegment {
+    ring: usize,
+    index: usize,
+    ring_len: usize,
 }
 
-struct MaximumWeightIndependentSetSearch<'a> {
-    conflicts: &'a [Vec<usize>],
-    weights: &'a [f64],
-    best: Vec<usize>,
-    best_weight: f64,
+#[derive(Debug, Clone, Copy)]
+struct OrientedBoundarySegment {
+    topology: BoundarySegment,
+    start: Point,
+    end: Point,
 }
 
-impl MaximumWeightIndependentSetSearch<'_> {
-    fn visit(&mut self, remaining: Vec<usize>, selected: &mut Vec<usize>, selected_weight: f64) {
-        let upper_bound = selected_weight
-            + remaining
+fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> ContourSet {
+    let source_segments = source
+        .rings
+        .iter()
+        .enumerate()
+        .flat_map(|(ring_id, ring)| {
+            (0..ring.len()).filter_map(move |index| {
+                let [start_x, start_y] = ring[index];
+                let [end_x, end_y] = ring[(index + 1) % ring.len()];
+                let start = Point::new(start_x, start_y);
+                let end = Point::new(end_x, end_y);
+                (start.distance_to(end) > source.tolerance).then_some(OrientedBoundarySegment {
+                    topology: BoundarySegment {
+                        ring: ring_id,
+                        index,
+                        ring_len: ring.len(),
+                    },
+                    start,
+                    end,
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    let contact_tolerance = source.tolerance.max(residual.tolerance);
+
+    residual
+        .connected_components()
+        .into_iter()
+        .filter(|component| {
+            let contacts = source_segments
                 .iter()
-                .map(|&vertex| self.weights[vertex])
-                .sum::<f64>();
-        if upper_bound.total_cmp(&self.best_weight).is_lt() {
-            return;
-        }
-        if remaining.is_empty() {
-            let mut candidate = selected.clone();
-            candidate.sort_unstable();
-            if selected_weight.total_cmp(&self.best_weight).is_gt()
-                || (selected_weight.total_cmp(&self.best_weight).is_eq() && candidate < self.best)
-            {
-                self.best = candidate;
-                self.best_weight = selected_weight;
-            }
-            return;
-        }
-
-        let pivot = *remaining
-            .iter()
-            .max_by(|&&left, &&right| {
-                let left_degree = remaining
-                    .iter()
-                    .filter(|&&other| self.conflicts[left].binary_search(&other).is_ok())
-                    .count();
-                let right_degree = remaining
-                    .iter()
-                    .filter(|&&other| self.conflicts[right].binary_search(&other).is_ok())
-                    .count();
-                left_degree
-                    .cmp(&right_degree)
-                    .then_with(|| self.weights[left].total_cmp(&self.weights[right]))
-                    .then_with(|| right.cmp(&left))
+                .filter(|segment| {
+                    segment_bbox(segment.start, segment.end)
+                        .expand(contact_tolerance)
+                        .intersects(component.bbox)
+                        && region_boundary_within_distance(
+                            component,
+                            segment.start,
+                            segment.end,
+                            contact_tolerance,
+                        )
+                })
+                .collect::<Vec<_>>();
+            contacts.iter().enumerate().any(|(index, left)| {
+                contacts[index + 1..].iter().any(|right| {
+                    let separation =
+                        segment_separation(left.start, left.end, right.start, right.end);
+                    !boundary_segments_are_incident(left.topology, right.topology)
+                        && boundary_tangents_oppose(left, right)
+                        && separation > contact_tolerance
+                })
             })
-            .expect("non-empty remaining vertex set");
+        })
+        .fold(ContourSet::empty(residual.tolerance), |gaps, component| {
+            gaps.union(&component)
+        })
+}
 
-        let include_remaining = remaining
-            .iter()
-            .copied()
-            .filter(|&vertex| {
-                vertex != pivot && self.conflicts[pivot].binary_search(&vertex).is_err()
-            })
-            .collect();
-        selected.push(pivot);
-        self.visit(
-            include_remaining,
-            selected,
-            selected_weight + self.weights[pivot],
-        );
-        selected.pop();
+fn region_boundary_within_distance(
+    region: &ContourSet,
+    start: Point,
+    end: Point,
+    distance: f64,
+) -> bool {
+    let expanded = segment_bbox(start, end).expand(distance);
+    region.rings.iter().any(|ring| {
+        (0..ring.len()).any(|index| {
+            let [other_start_x, other_start_y] = ring[index];
+            let [other_end_x, other_end_y] = ring[(index + 1) % ring.len()];
+            let other_start = Point::new(other_start_x, other_start_y);
+            let other_end = Point::new(other_end_x, other_end_y);
+            expanded.intersects(segment_bbox(other_start, other_end))
+                && segment_separation(start, end, other_start, other_end) <= distance
+        })
+    })
+}
 
-        let exclude_remaining = remaining
-            .into_iter()
-            .filter(|&vertex| vertex != pivot)
-            .collect();
-        self.visit(exclude_remaining, selected, selected_weight);
+fn segment_separation(
+    left_start: Point,
+    left_end: Point,
+    right_start: Point,
+    right_end: Point,
+) -> f64 {
+    point_segment_distance(left_start, right_start, right_end)
+        .min(point_segment_distance(left_end, right_start, right_end))
+        .min(point_segment_distance(right_start, left_start, left_end))
+        .min(point_segment_distance(right_end, left_start, left_end))
+}
+
+fn boundary_tangents_oppose(
+    left: &OrientedBoundarySegment,
+    right: &OrientedBoundarySegment,
+) -> bool {
+    let left_tangent = left.end - left.start;
+    let right_tangent = right.end - right.start;
+    left_tangent.x * right_tangent.x + left_tangent.y * right_tangent.y < 0.0
+}
+
+fn narrow_void_medial_axis_keep_out(
+    source: &ContourSet,
+    narrow_voids: &ContourSet,
+    radius: f64,
+) -> Result<ContourSet, GapRegularizationError> {
+    if narrow_voids.is_empty() {
+        return Ok(ContourSet::empty(source.tolerance));
     }
+    let origin = Point::new(source.bbox.min.x, source.bbox.min.y);
+    let mut segments = Vec::<VoronoiLine<i32>>::new();
+    let mut boundary_segments = Vec::new();
+    for (ring_id, ring) in source.rings.iter().enumerate() {
+        for index in 0..ring.len() {
+            let [start_x, start_y] = ring[index];
+            let [end_x, end_y] = ring[(index + 1) % ring.len()];
+            if (end_x - start_x).hypot(end_y - start_y) <= source.tolerance {
+                continue;
+            }
+            let start = quantize_voronoi_point(ring[index], origin)?;
+            let end = quantize_voronoi_point(ring[(index + 1) % ring.len()], origin)?;
+            if start == end {
+                continue;
+            }
+            segments.push(VoronoiLine::new(start, end));
+            boundary_segments.push(BoundarySegment {
+                ring: ring_id,
+                index,
+                ring_len: ring.len(),
+            });
+        }
+    }
+
+    let diagram = VoronoiBuilder::<i32>::default()
+        .with_segments(segments.iter())
+        .and_then(VoronoiBuilder::build)
+        .map_err(|error| {
+            GapRegularizationError(format!(
+                "could not construct boundary Voronoi diagram: {error}"
+            ))
+        })?;
+    let mut contours = Vec::new();
+    for edge in diagram.edges() {
+        let twin = edge.twin().map_err(gap_regularization_error)?;
+        if edge.id() > twin || !edge.is_primary() {
+            continue;
+        }
+        let left = diagram
+            .cell(edge.cell().map_err(gap_regularization_error)?)
+            .map_err(gap_regularization_error)?;
+        let right = diagram
+            .cell(
+                diagram
+                    .edge(twin)
+                    .and_then(|edge| edge.cell())
+                    .map_err(gap_regularization_error)?,
+            )
+            .map_err(gap_regularization_error)?;
+        let left_boundary = boundary_segments
+            .get(left.source_index().usize())
+            .ok_or_else(|| {
+                GapRegularizationError(
+                    "Voronoi cell references an unknown boundary segment".to_string(),
+                )
+            })?;
+        let right_boundary = boundary_segments
+            .get(right.source_index().usize())
+            .ok_or_else(|| {
+                GapRegularizationError(
+                    "Voronoi cell references an unknown boundary segment".to_string(),
+                )
+            })?;
+        if boundary_segments_are_incident(*left_boundary, *right_boundary) {
+            continue;
+        }
+        let samples = voronoi_edge_samples(&diagram, edge.id(), &segments, source, radius)?;
+        let mut commands = Vec::with_capacity(samples.len());
+        for sample in samples {
+            let point = Point::new(
+                sample[0] / VORONOI_COORDINATES_PER_MM + origin.x,
+                sample[1] / VORONOI_COORDINATES_PER_MM + origin.y,
+            );
+            if commands
+                .last()
+                .and_then(|command: &PathCmd| command.end_point())
+                .is_some_and(|previous| previous.distance_to(point) <= tol::EPSILON_MM)
+            {
+                continue;
+            }
+            commands.push(if commands.is_empty() {
+                PathCmd::move_to(point)
+            } else {
+                PathCmd::line_to(point)
+            });
+        }
+        if commands.len() >= 2 {
+            contours.push(ContourBuf::new(commands));
+        }
+    }
+
+    if contours.is_empty() {
+        return Ok(ContourSet::empty(source.tolerance));
+    }
+    // A narrow filled stroke makes the one-dimensional axis available to the
+    // existing set algebra. Intersecting with a slightly eroded narrow-void
+    // phase removes the finite stroke's boundary fringe and the exterior axis.
+    let axis_stroke_radius = tol::REGION_MM;
+    let mut arena = PathArena::default();
+    let path = arena.push_path(
+        Paint::Stroke(crate::geom::StrokeStyle::round(2.0 * axis_stroke_radius)),
+        contours,
+    );
+    let medial_axis = ContourSet::from_painted_paths(
+        &arena,
+        std::iter::once(&arena.paths[path as usize]),
+        source.tolerance,
+    );
+    let interior_axis =
+        medial_axis.intersection(&narrow_voids.disk_erode(2.0 * axis_stroke_radius));
+    let keep_out = interior_axis.disk_dilate(radius);
+    Ok(keep_out.intersection(&source.disk_dilate(radius)))
+}
+
+fn boundary_segments_are_incident(left: BoundarySegment, right: BoundarySegment) -> bool {
+    if left.ring != right.ring || left.ring_len != right.ring_len {
+        return false;
+    }
+    let distance = left.index.abs_diff(right.index);
+    distance.min(left.ring_len - distance) <= 1
+}
+
+fn quantize_voronoi_point(
+    [x, y]: [f64; 2],
+    origin: Point,
+) -> Result<VoronoiPoint<i32>, GapRegularizationError> {
+    fn coordinate(value: f64, origin: f64) -> Result<i32, GapRegularizationError> {
+        let scaled = ((value - origin) * VORONOI_COORDINATES_PER_MM).round();
+        if !scaled.is_finite() || scaled < i32::MIN as f64 || scaled > i32::MAX as f64 {
+            return Err(GapRegularizationError(
+                "component geometry exceeds the Voronoi coordinate range".to_string(),
+            ));
+        }
+        Ok(scaled as i32)
+    }
+
+    Ok(VoronoiPoint::new(
+        coordinate(x, origin.x)?,
+        coordinate(y, origin.y)?,
+    ))
+}
+
+fn gap_regularization_error(error: boostvoronoi::BvError) -> GapRegularizationError {
+    GapRegularizationError(format!("invalid boundary Voronoi diagram: {error}"))
+}
+
+fn voronoi_edge_samples(
+    diagram: &VoronoiDiagram,
+    edge_id: VoronoiEdgeIndex,
+    segments: &[VoronoiLine<i32>],
+    region: &ContourSet,
+    radius: f64,
+) -> Result<Vec<[f64; 2]>, GapRegularizationError> {
+    let edge = diagram.edge(edge_id).map_err(gap_regularization_error)?;
+    let affine = SimpleAffine::default();
+    let mut samples = if let (Some(start), Some(end)) = (
+        edge.vertex0(),
+        diagram
+            .edge_get_vertex1(edge_id)
+            .map_err(gap_regularization_error)?,
+    ) {
+        let start = diagram.vertex(start).map_err(gap_regularization_error)?;
+        let end = diagram.vertex(end).map_err(gap_regularization_error)?;
+        vec![
+            affine.transform(start.x(), start.y()),
+            affine.transform(end.x(), end.y()),
+        ]
+    } else {
+        clip_infinite_voronoi_edge(diagram, edge_id, segments, region, radius)?
+    };
+
+    if edge.is_curved() {
+        let cell = edge.cell().map_err(gap_regularization_error)?;
+        let twin_cell = diagram
+            .edge(edge.twin().map_err(gap_regularization_error)?)
+            .and_then(|edge| edge.cell())
+            .map_err(gap_regularization_error)?;
+        let (point_cell, segment_cell) = if diagram
+            .cell(cell)
+            .map_err(gap_regularization_error)?
+            .contains_point()
+        {
+            (cell, twin_cell)
+        } else {
+            (twin_cell, cell)
+        };
+        let point = voronoi_cell_point(diagram, point_cell, segments)?;
+        let segment = voronoi_cell_segment(diagram, segment_cell, segments)?;
+        VoronoiVisualUtils::discretize(
+            &point,
+            segment,
+            tol::FLATTEN_MM * VORONOI_COORDINATES_PER_MM,
+            &affine,
+            &mut samples,
+        );
+    }
+    Ok(samples)
+}
+
+fn clip_infinite_voronoi_edge(
+    diagram: &VoronoiDiagram,
+    edge_id: VoronoiEdgeIndex,
+    segments: &[VoronoiLine<i32>],
+    region: &ContourSet,
+    radius: f64,
+) -> Result<Vec<[f64; 2]>, GapRegularizationError> {
+    let edge = diagram.edge(edge_id).map_err(gap_regularization_error)?;
+    let cell = edge.cell().map_err(gap_regularization_error)?;
+    let twin_cell = diagram
+        .edge(edge.twin().map_err(gap_regularization_error)?)
+        .and_then(|edge| edge.cell())
+        .map_err(gap_regularization_error)?;
+    let left = diagram.cell(cell).map_err(gap_regularization_error)?;
+    let right = diagram.cell(twin_cell).map_err(gap_regularization_error)?;
+    let (origin, direction) = if left.contains_point() && right.contains_point() {
+        let left = voronoi_cell_point(diagram, cell, segments)?;
+        let right = voronoi_cell_point(diagram, twin_cell, segments)?;
+        (
+            [
+                (left.x as f64 + right.x as f64) * 0.5,
+                (left.y as f64 + right.y as f64) * 0.5,
+            ],
+            [
+                left.y as f64 - right.y as f64,
+                right.x as f64 - left.x as f64,
+            ],
+        )
+    } else {
+        let (point_cell, segment_cell) = if left.contains_segment() {
+            (twin_cell, cell)
+        } else {
+            (cell, twin_cell)
+        };
+        let point = voronoi_cell_point(diagram, point_cell, segments)?;
+        let segment = voronoi_cell_segment(diagram, segment_cell, segments)?;
+        let origin = [point.x as f64, point.y as f64];
+        let dx = segment.end.x - segment.start.x;
+        let dy = segment.end.y - segment.start.y;
+        let direction = if ([segment.start.x as f64, segment.start.y as f64] == origin)
+            ^ left.contains_point()
+        {
+            [dy as f64, -dx as f64]
+        } else {
+            [-dy as f64, dx as f64]
+        };
+        (origin, direction)
+    };
+    let reach =
+        (region.bbox.width().max(region.bbox.height()) + 4.0 * radius) * VORONOI_COORDINATES_PER_MM;
+    let direction_scale = direction[0].abs().max(direction[1].abs());
+    if direction_scale == 0.0 {
+        return Err(GapRegularizationError(
+            "infinite Voronoi edge has no direction".to_string(),
+        ));
+    }
+    let coefficient = reach / direction_scale;
+    let affine = SimpleAffine::default();
+    let start = edge
+        .vertex0()
+        .map(|vertex| {
+            diagram
+                .vertex(vertex)
+                .map(|vertex| affine.transform(vertex.x(), vertex.y()))
+        })
+        .transpose()
+        .map_err(gap_regularization_error)?
+        .unwrap_or([
+            origin[0] - direction[0] * coefficient,
+            origin[1] - direction[1] * coefficient,
+        ]);
+    let end = diagram
+        .edge_get_vertex1(edge_id)
+        .map_err(gap_regularization_error)?
+        .map(|vertex| {
+            diagram
+                .vertex(vertex)
+                .map(|vertex| affine.transform(vertex.x(), vertex.y()))
+        })
+        .transpose()
+        .map_err(gap_regularization_error)?
+        .unwrap_or([
+            origin[0] + direction[0] * coefficient,
+            origin[1] + direction[1] * coefficient,
+        ]);
+    Ok(vec![start, end])
+}
+
+fn voronoi_cell_point(
+    diagram: &VoronoiDiagram,
+    cell: VoronoiCellIndex,
+    segments: &[VoronoiLine<i32>],
+) -> Result<VoronoiPoint<i32>, GapRegularizationError> {
+    let cell = diagram.cell(cell).map_err(gap_regularization_error)?;
+    let segment = segments.get(cell.source_index().usize()).ok_or_else(|| {
+        GapRegularizationError("Voronoi point references an unknown segment".to_string())
+    })?;
+    Ok(match cell.source_category() {
+        SourceCategory::SegmentStart => segment.start,
+        SourceCategory::Segment | SourceCategory::SegmentEnd => segment.end,
+        SourceCategory::SinglePoint => {
+            return Err(GapRegularizationError(
+                "unexpected standalone point in component Voronoi diagram".to_string(),
+            ));
+        }
+    })
+}
+
+fn voronoi_cell_segment<'a>(
+    diagram: &VoronoiDiagram,
+    cell: VoronoiCellIndex,
+    segments: &'a [VoronoiLine<i32>],
+) -> Result<&'a VoronoiLine<i32>, GapRegularizationError> {
+    let index = diagram
+        .cell(cell)
+        .map_err(gap_regularization_error)?
+        .source_index()
+        .usize();
+    segments.get(index).ok_or_else(|| {
+        GapRegularizationError("Voronoi cell references an unknown segment".to_string())
+    })
 }
 
 fn regions_within_distance(left: &ContourSet, right: &ContourSet, distance: f64) -> bool {
@@ -1039,100 +1448,124 @@ mod tests {
     }
 
     #[test]
-    fn disk_gap_violations_only_report_close_distinct_components() {
+    fn disk_gap_violations_report_close_distinct_components() {
         let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
         let close = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), tol::REGION_MM);
         let wide = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), tol::REGION_MM);
 
-        let close_violations = left.union(&close).disk_inter_component_gap_violations(0.5);
-        let wide_violations = left.union(&wide).disk_inter_component_gap_violations(0.5);
+        let close_violations = left.union(&close).disk_gap_violations(0.5);
+        let wide_violations = left.union(&wide).disk_gap_violations(0.5);
 
         assert!(close_violations.area() > 1.5);
         assert!(wide_violations.is_empty());
-        assert!(left.disk_inter_component_gap_violations(0.5).is_empty());
+        assert!(left.disk_gap_violations(0.5).is_empty());
     }
 
     #[test]
-    fn disk_component_separation_discards_smaller_conflicting_islands() {
-        let large = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let small = ContourSet::rectangle(rect(10.8, 4.0, 11.6, 4.8), tol::REGION_MM);
-        let distant = ContourSet::rectangle(rect(14.0, 0.0, 20.0, 10.0), tol::REGION_MM);
-        let region = large.union(&small).union(&distant);
+    fn disk_gap_violations_exclude_isolated_void_corners() {
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let wide_hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), tol::REGION_MM);
+        let region = outer.difference(&wide_hole);
+        let raw_closing_residual = region.disk_close(0.5).difference(&region);
 
-        let (separated, removed) = region.disk_separate_components(0.5);
+        assert!(raw_closing_residual.area() > 0.1);
+        assert!(region.disk_gap_violations(0.5).is_empty());
+    }
 
-        assert_eq!(separated.connected_components().len(), 2);
-        assert_eq!(removed.connected_components().len(), 1);
-        assert!(separated.difference(&region).is_empty());
-        assert!((removed.area() - small.area()).abs() <= 1e-6);
+    #[test]
+    fn disk_gap_regularization_rejects_invalid_scales() {
+        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+
+        assert!(region.disk_regularize_gaps(0.0, 0.5, 0.025).is_err());
+        assert!(region.disk_regularize_gaps(0.5, f64::NAN, 0.025).is_err());
+        assert!(region.disk_regularize_gaps(0.5, 0.5, -0.025).is_err());
+    }
+
+    #[test]
+    fn disk_gap_regularization_trims_a_close_pair_locally() {
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let right = ContourSet::rectangle(rect(10.8, 0.0, 20.8, 10.0), tol::REGION_MM);
+        let distant = ContourSet::rectangle(rect(24.0, 0.0, 30.0, 10.0), tol::REGION_MM);
+        let region = left.union(&right).union(&distant);
+
+        let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
+
+        assert_eq!(result.kept.connected_components().len(), 3);
+        assert!(result.kept.difference(&region).is_empty());
         assert!(
-            separated
-                .disk_inter_component_gap_violations(0.5)
-                .is_empty()
+            result.removed.area() < 4.0,
+            "removed {:.9} mm²",
+            result.removed.area()
+        );
+        assert!(result.removed.intersection(&distant).area() <= 0.25);
+        let violations = result.kept.disk_gap_violations(0.5);
+        assert!(
+            violations.disk_open(0.025).area() <= 1e-4,
+            "remaining void-gap violation area {:.9} mm²",
+            violations.area()
         );
     }
 
     #[test]
-    fn disk_component_separation_maximizes_total_retained_area() {
-        let large = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM);
-        let right = ContourSet::rectangle(rect(4.8, 0.0, 7.8, 3.0), tol::REGION_MM);
-        let upper = ContourSet::rectangle(rect(0.0, 4.8, 3.0, 7.8), tol::REGION_MM);
-        let region = large.union(&right).union(&upper);
+    fn disk_gap_regularization_is_symmetric_at_a_three_way_conflict() {
+        let lower_left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM);
+        let lower_right = ContourSet::rectangle(rect(4.8, 0.0, 8.8, 4.0), tol::REGION_MM);
+        let upper = ContourSet::rectangle(rect(2.4, 4.8, 6.4, 8.8), tol::REGION_MM);
+        let region = lower_left.union(&lower_right).union(&upper);
 
-        let (separated, removed) = region.disk_separate_components(0.5);
+        let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
 
-        assert!((separated.area() - right.area() - upper.area()).abs() <= 1e-6);
-        assert!((removed.area() - large.area()).abs() <= 1e-6);
-        assert!(separated.intersection(&large).is_empty());
-        assert!(
-            separated
-                .disk_inter_component_gap_violations(0.5)
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn exact_component_selection_matches_exhaustive_search() {
-        const VERTICES: usize = 5;
-        let cluster = (0..VERTICES).collect::<Vec<_>>();
-        let weights = [1.0, 2.0, 4.0, 8.0, 16.0];
-        let possible_edges = (0..VERTICES)
-            .flat_map(|left| (left + 1..VERTICES).map(move |right| (left, right)))
-            .collect::<Vec<_>>();
-
-        for graph_mask in 0..1_usize << possible_edges.len() {
-            let mut conflicts = vec![Vec::new(); VERTICES];
-            for (edge_index, &(left, right)) in possible_edges.iter().enumerate() {
-                if graph_mask & (1 << edge_index) != 0 {
-                    conflicts[left].push(right);
-                    conflicts[right].push(left);
-                }
-            }
-
-            let selected = maximum_weight_independent_set(&cluster, &conflicts, &weights);
-            let actual_weight = selected.iter().map(|&vertex| weights[vertex]).sum::<f64>();
-            let mut expected_weight: f64 = 0.0;
-            for selection_mask in 0..1_usize << VERTICES {
-                let independent = possible_edges.iter().all(|&(left, right)| {
-                    selection_mask & (1 << left) == 0
-                        || selection_mask & (1 << right) == 0
-                        || conflicts[left].binary_search(&right).is_err()
-                });
-                if independent {
-                    let weight = (0..VERTICES)
-                        .filter(|&vertex| selection_mask & (1 << vertex) != 0)
-                        .map(|vertex| weights[vertex])
-                        .sum::<f64>();
-                    expected_weight = expected_weight.max(weight);
-                }
-            }
-            assert_eq!(actual_weight, expected_weight, "graph mask {graph_mask}");
+        assert_eq!(result.kept.connected_components().len(), 3);
+        for source in [&lower_left, &lower_right, &upper] {
+            assert!(result.kept.intersection(source).area() > 13.0);
         }
+        let violations = result.kept.disk_gap_violations(0.5);
+        let denoised = violations.disk_open(0.025);
+        assert!(
+            denoised.area() <= 1e-4,
+            "remaining void-gap violation area {:.9} mm²; denoised {:.9}",
+            violations.area(),
+            denoised.area(),
+        );
+    }
 
-        assert_eq!(
-            maximum_weight_independent_set(&[0, 1], &[vec![1], vec![0]], &[1.0, 1.0]),
-            vec![0],
-            "equal-weight optima should prefer the stable component order"
+    #[test]
+    fn disk_gap_regularization_widens_a_same_component_hairpin() {
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let narrow_notch = ContourSet::rectangle(rect(4.6, 3.0, 5.4, 10.0), tol::REGION_MM);
+        let hairpin = outer.difference(&narrow_notch);
+
+        let before = hairpin.disk_gap_violations(0.5);
+        let result = hairpin.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
+        let after = result.kept.disk_gap_violations(0.5);
+
+        assert_eq!(hairpin.connected_components().len(), 1);
+        assert!(before.area() > 1.0);
+        assert!(result.removed.area() > 1.0);
+        assert!(
+            after.disk_open(0.025).area() <= 1e-4,
+            "remaining hairpin-gap violation area {:.9} mm²",
+            after.area(),
+        );
+    }
+
+    #[test]
+    fn disk_gap_regularization_widens_a_narrow_internal_void() {
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let narrow_hole = ContourSet::rectangle(rect(4.6, 3.0, 5.4, 7.0), tol::REGION_MM);
+        let region = outer.difference(&narrow_hole);
+
+        let before = region.disk_gap_violations(0.5);
+        let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
+        let after = result.kept.disk_gap_violations(0.5);
+
+        assert!(before.area() > 3.0);
+        assert!(result.removed.area() > 1.0);
+        assert!(result.kept.contains_point(Point::new(2.0, 5.0)));
+        assert!(
+            after.disk_open(0.025).area() <= 1e-4,
+            "remaining internal-void violation area {:.9} mm²",
+            after.area(),
         );
     }
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -454,18 +454,21 @@ impl ContourSet {
     /// ```text
     /// N₀     = G_(gap_radius + guard)(self)
     /// S₀     = open(self \ (Γ_N₀ ⊕ disk(gap_radius + guard)), disk(filled_radius))
-    /// Vₖ     = open(G_gap_radius(Sₖ), disk(guard))
-    /// Sₖ₊₁   = open(Sₖ \ (Vₖ ⊕ disk(gap_radius + guard)), disk(filled_radius))
+    /// Rₖ     = G_gap_radius(Sₖ)
+    /// Vₖ     = open(Rₖ, disk(guard))
+    /// Wₖ     = Vₖ if Vₖ is nonempty, otherwise Rₖ
+    /// Sₖ₊₁   = open(Sₖ \ (Wₖ ⊕ disk(gap_radius + guard)), disk(filled_radius))
     /// ```
     ///
     /// `G_r(X)` is the two-sided part of `close(X, disk(r)) \ X`, and `Γ_N₀` is
     /// the source-boundary medial axis inside the initial narrow void
-    /// phase. It gives the least local first cut. Any residual `Vₖ` is swept
-    /// directly, so boolean-generated boundaries never require another Voronoi
-    /// diagram. Iteration stops when `Vₖ` is empty. The sequence is monotone
-    /// decreasing: every pass only trims the source. This covers distinct
-    /// components, hairpins, notches, and internal voids without treating
-    /// one-sided edge clearance as a gap.
+    /// phase. It gives the least local first cut. Meaningful residuals are
+    /// denoised before sweeping; a residual too thin for that filter is swept
+    /// raw rather than mistaken for a passing certificate. Boolean-generated
+    /// boundaries never require another Voronoi diagram. Iteration stops only
+    /// when `Rₖ` is empty. The sequence is monotone decreasing: every pass only
+    /// trims the source. This covers distinct components, hairpins, notches,
+    /// and internal voids without treating one-sided edge clearance as a gap.
     pub fn disk_regularize_gaps(
         &self,
         gap_radius: f64,
@@ -513,14 +516,19 @@ impl ContourSet {
             .intersection(self);
         let mut narrow_voids = initial_narrow_voids;
         let mut separator_keep_out = initial_keep_out;
-        let certificate_guard = guard.max(self.tolerance);
+        let denoise_radius = guard.max(self.tolerance);
         loop {
             let pass_narrow_voids = kept.disk_gap_violations(gap_radius);
-            let violations = pass_narrow_voids.disk_open(certificate_guard);
-            if violations.is_empty() {
+            if pass_narrow_voids.is_empty() {
                 break;
             }
-            let pass_separator_keep_out = violations.disk_dilate(tube_radius);
+            let denoised = pass_narrow_voids.disk_open(denoise_radius);
+            let sweep = if denoised.is_empty() {
+                &pass_narrow_voids
+            } else {
+                &denoised
+            };
+            let pass_separator_keep_out = sweep.disk_dilate(tube_radius);
             let next = kept
                 .difference(&pass_separator_keep_out)
                 .disk_open(filled_radius)
@@ -531,7 +539,7 @@ impl ContourSet {
             if kept.difference(&next).area() <= self.tolerance * self.tolerance {
                 return Err(GapRegularizationError(format!(
                     "gap regularization stalled with {:.9} mm² of void-gap violations",
-                    violations.area()
+                    pass_narrow_voids.area()
                 )));
             }
             kept = next;
@@ -771,6 +779,7 @@ struct OrientedBoundarySegment {
     topology: BoundarySegment,
     start: Point,
     end: Point,
+    bbox: BBox,
 }
 
 fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> ContourSet {
@@ -792,20 +801,22 @@ fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> Contour
                     },
                     start,
                     end,
+                    bbox: segment_bbox(start, end),
                 })
             })
         })
         .collect::<Vec<_>>();
     let contact_tolerance = source.tolerance.max(residual.tolerance);
 
-    residual
+    let rings = residual
         .connected_components()
         .into_iter()
         .filter(|component| {
             let contacts = source_segments
                 .iter()
                 .filter(|segment| {
-                    segment_bbox(segment.start, segment.end)
+                    segment
+                        .bbox
                         .expand(contact_tolerance)
                         .intersects(component.bbox)
                         && region_boundary_within_distance(
@@ -826,9 +837,9 @@ fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> Contour
                 })
             })
         })
-        .fold(ContourSet::empty(residual.tolerance), |gaps, component| {
-            gaps.union(&component)
-        })
+        .flat_map(|component| component.rings)
+        .collect();
+    ContourSet::new(rings, FillRule::NonZero, residual.tolerance)
 }
 
 fn region_boundary_within_distance(
@@ -1482,6 +1493,21 @@ mod tests {
     }
 
     #[test]
+    fn disk_gap_regularization_widens_a_gap_thinner_than_the_guard() {
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
+        let right = ContourSet::rectangle(rect(4.01, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let region = left.union(&right);
+
+        let before = region.disk_gap_violations(0.5);
+        let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
+
+        assert!(before.area() > 0.05);
+        assert!(before.disk_open(0.025).is_empty());
+        assert!(result.removed.area() > 0.0);
+        assert!(result.kept.disk_gap_violations(0.5).is_empty());
+    }
+
+    #[test]
     fn disk_gap_regularization_trims_a_close_pair_locally() {
         let left = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
         let right = ContourSet::rectangle(rect(10.8, 0.0, 20.8, 10.0), tol::REGION_MM);
@@ -1498,12 +1524,7 @@ mod tests {
             result.removed.area()
         );
         assert!(result.removed.intersection(&distant).area() <= 0.25);
-        let violations = result.kept.disk_gap_violations(0.5);
-        assert!(
-            violations.disk_open(0.025).area() <= 1e-4,
-            "remaining void-gap violation area {:.9} mm²",
-            violations.area()
-        );
+        assert!(result.kept.disk_gap_violations(0.5).is_empty());
     }
 
     #[test]
@@ -1520,12 +1541,10 @@ mod tests {
             assert!(result.kept.intersection(source).area() > 13.0);
         }
         let violations = result.kept.disk_gap_violations(0.5);
-        let denoised = violations.disk_open(0.025);
         assert!(
-            denoised.area() <= 1e-4,
-            "remaining void-gap violation area {:.9} mm²; denoised {:.9}",
+            violations.is_empty(),
+            "remaining void-gap violation area {:.9} mm²",
             violations.area(),
-            denoised.area(),
         );
     }
 
@@ -1543,9 +1562,9 @@ mod tests {
         assert!(before.area() > 1.0);
         assert!(result.removed.area() > 1.0);
         assert!(
-            after.disk_open(0.025).area() <= 1e-4,
-            "remaining hairpin-gap violation area {:.9} mm²",
-            after.area(),
+            after.is_empty(),
+            "remaining hairpin gap {:.9} mm²",
+            after.area()
         );
     }
 
@@ -1563,8 +1582,8 @@ mod tests {
         assert!(result.removed.area() > 1.0);
         assert!(result.kept.contains_point(Point::new(2.0, 5.0)));
         assert!(
-            after.disk_open(0.025).area() <= 1e-4,
-            "remaining internal-void violation area {:.9} mm²",
+            after.is_empty(),
+            "remaining internal-void gap {:.9} mm²",
             after.area(),
         );
     }


### PR DESCRIPTION
Board-array balancing discarded complete safe-region components and used a gap scale that was too conservative. This change uses independent 0.5 mm clearance and 1 mm filled-region and void-gap scales, trims narrow two-sided gaps locally with medial-axis geometry, and adds complete certificate and debug output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the core safe-region algorithm and default geometry scales used before balance copper is emitted in board-array creation; incorrect trimming or certificate gaps would affect fabrication copper placement.
> 
> **Overview**
> Replaces **whole-component gap selection** (maximum-area independent set on proximity graph) with **local void trimming** around narrow two-sided gaps. After clearance-safe morphology and filled-region disk opening, `disk_regularize_gaps` detects gap violations, builds a **boundary Voronoi medial axis** (`boostvoronoi`), and iteratively sweeps keep-out tubes until gaps meet the nominal rolling-disk test—covering inter-component corridors, hairpins, notches, and internal voids without dropping entire islands.
> 
> **Parameter model** decouples scales: defaults move to **0.5 mm** clearance, filled-region radius, and gap radius (1 mm nominal gap width), instead of 1 mm feature/gap radii and a shared **construction gap** that inflated obstacles and panel erosion together. Clearance-safe region is now `(P ⊖ c) \ (O ⊕ c)` with a single construction clearance `c`.
> 
> **Certificates and tooling** rename options (`regularization_radius_mm`, `gap_radius_mm`), add `GapRegularizationError`, require **empty** `gap_violations` for pass, and refresh the balancing debug harness to schema **v7** with new intermediates (narrow voids, gap separator keep-out, local trim). Changelog documents the behavior change for board-array balancing consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20809e3dd4da590194173ff703a8535cd527a3bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->