### PR TITLE
Balance board array copper spatially across layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Board-array balancing now uses independent 1 mm filled-region and void-gap regularization, trimming narrow gaps locally instead of discarding whole regions.
+- Board-array copper balancing now varies rounded-hex void sizes to reduce local density and through-stack imbalance while preserving each layer's total copper target.
 
 ## [0.4.17] - 2026-07-31
 

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -20,6 +20,10 @@ alias provides the same commands.
 
 Run `pcb ipc2581 <command> --help` for arguments and output options.
 
+The mathematical and geometric strategy for automatically balancing board
+arrays is documented in
+[`docs/board-array-copper-balancing.md`](docs/board-array-copper-balancing.md).
+
 `edit bom` modifies the input file when `--output` is omitted. Specify an output
 path when the source document must remain unchanged.
 

--- a/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
+++ b/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
@@ -1,0 +1,209 @@
+# Board-array copper balancing
+
+This document defines copper balancing for an assembly panel created by
+`board-array create`. Fabrication-panel balancing is a later, independent pass.
+
+## Motivation and scope
+
+The immutable board images can leave the surrounding array rails much more or
+less copper-dense than the boards. Generated, non-functional copper should:
+
+- reduce spatial copper-density changes that make etching and plating less
+  uniform;
+- avoid adding asymmetric copper volume that increases bow or twist during
+  fabrication and assembly heating; and
+- remain simple, deterministic, and manufacturable.
+
+Board copper is never changed. Generated copper is confined to the certified
+safe region. The result is best effort because copper can only be added and the
+safe region, tooling, routing, and minimum-feature rules limit the feasible
+area.
+
+## Existing area and geometry model
+
+For copper layer `l`, let:
+
+- `P` be the retained assembly-panel region with area `A_P`;
+- `B` be the union of repeated board footprints with area `A_B`;
+- `C_l` be the fixed copper region;
+- `S_l` be the initially empty safe region; and
+- `d_l = area(C_l intersect B) / A_B` be the board-density target.
+
+The requested generated area is:
+
+```text
+A*_l = d_l A_P - area(C_l)
+```
+
+The solver first projects `A*_l` onto the area attainable by no fill, solid
+fill, or a perforated fill. Perforated copper uses a common 1.35 mm
+triangular lattice of slightly rounded hexagonal voids. Void radii stay between
+0.20 and 0.65 mm. The lattice and radius bound preserve at least 0.20 mm between
+voids; clipping preserves a 0.20 mm copper web at the safe-region boundary.
+
+The spatial solve keeps the per-layer attainable area selected by this first
+projection, but replaces the single interior radius with one radius field.
+
+## Local density field
+
+Use the void lattice as a shared sampling grid on every copper layer. At panel
+lattice site `j`, sample the fixed-copper indicator:
+
+```text
+c_lj = 1 when x_j is in C_l, otherwise 0
+```
+
+This is midpoint quadrature over the lattice's equal-area hexagonal Voronoi
+cells. Smooth the samples with a normalized Gaussian with `sigma = 5 mm`,
+truncated at `3 sigma`:
+
+```text
+rho_fixed_li =
+    sum_j K(distance(x_i, x_j)) c_lj
+    --------------------------------
+    sum_j K(distance(x_i, x_j))
+```
+
+The denominator normalizes panel edges instead of treating space outside the
+panel as empty copper area. The resulting field varies over about 10-15 mm,
+not at trace or 1.35 mm lattice scale. The kernel is a fixed manufacturing
+profile value, not a user-facing board-array option.
+
+The local deficit is:
+
+```text
+q_li = d_l - rho_fixed_li
+```
+
+A positive value requests more generated copper near `x_i`; a negative value
+requests less. The deficit is non-uniform when the fixed board copper or panel
+shape is non-uniform. The constrained solution can also become non-uniform
+when tooling, routing, or other protected features remove balancing area from
+one rail.
+
+## Through-stack metric
+
+The IPC-2581 physical stackup supplies the ordered layer thicknesses. Let:
+
+- `t_l` be conductor thickness;
+- `z_l` be the signed distance from the stack mid-plane to the conductor
+  layer's center; and
+- `w_l = z_l t_l`.
+
+Layer positions are the cumulative centers of the ordered physical stackup.
+The metric requires positive conductor thicknesses and enough layer thickness
+data to locate every conductor. When those data are absent, all stack weights
+are zero: the same solver still optimizes local density, but it does not invent
+nominal copper weights or equal layer spacing.
+
+For a proposed generated fill, let `rho_li` be the modeled final local density
+and:
+
+```text
+e_li = rho_li - d_l
+m_i  = sum_l w_l e_li
+```
+
+`m_i` is a first-moment proxy for the stack asymmetry introduced by
+panelization at `x_i`. Equal residual density on mirrored layers cancels;
+thicker copper and copper farther from the mid-plane contribute more. Normalize
+the RMS metric by `W = sum_l abs(w_l)`:
+
+```text
+E_stack = sqrt(weighted_mean_i(m_i^2)) / W
+```
+
+The reference is the board's own per-layer density, not zero copper moment.
+The optimizer therefore avoids adding new stack asymmetry without trying to
+repair immutable board content from the rails. The per-layer report exposes
+the physical stack weight when it is available.
+
+## One spatial solve
+
+For every full interior void, use squared radius `x_li = r_li^2` as the solver
+variable. This is the natural coordinate because the rounded hexagons are
+self-similar. Let `s_i` be the smoothed safe-region indicator at the site. If
+`a_h` is the rounded-hex area factor and `A_cell` is lattice-cell area, the
+local generated-copper model is affine:
+
+```text
+g_li = s_i (1 - a_h x_li / A_cell)
+rho_li = rho_fixed_li + g_li
+```
+
+The field varies only over the 5 mm kernel scale, so this uses the local radius
+as constant within that kernel. `s_i` prevents fixed copper near a safe-region
+boundary and generated copper from both claiming the same neighborhood area.
+
+Choose every layer's field together by minimizing the dimensionless convex
+energy:
+
+```text
+J(x) = sum_l mean_i(e_li^2)
+     + mean_i((m_i / W)^2)
+```
+
+subject to one box constraint and one equality per perforated layer:
+
+```text
+sum_i x_li = X_l
+r_min^2 <= x_li <= r_max^2
+```
+
+`X_l` is computed from the selected total void area after subtracting the
+already-clipped edge-fragment area. The equality therefore redistributes the
+full-void area without changing the layer-density result. Edge fragments keep
+their projected geometry; they are boundary constraints, not optimizer
+variables.
+
+The objective is a convex quadratic. A fixed-count projected-gradient solve
+uses its analytic gradient, then projects each layer onto the intersection of
+the box and sum constraints with one-dimensional bisection. A constant-radius
+pattern is the result when the measured fields and constraints are spatially
+symmetric; it is not a separate mode or fallback.
+
+## Fill-to-geometry map
+
+The rounded hexagons are self-similar because their corner radius is a fixed
+fraction `k = 0.15` of hexagon radius `r`. A full void has area:
+
+```text
+A_void(r) = [3 sqrt(3) / 2 - (2 sqrt(3) - pi) k^2] r^2
+```
+
+The full-cell area equality is therefore exact in squared-radius space. Edge
+sites use the projected common radius, intersect the rounded hexagon with the
+boundary-web region, and retain the existing fragment qualification that
+rejects clipped voids unable to contain the minimum disk.
+
+All layers use the same lattice origin and sites. Per-site radii may differ by
+layer. The existing maximum radius continues to guarantee the inter-void web
+for every neighboring radius pair.
+
+## Implementation boundaries
+
+Keep the numerical and geometric core independent of IPC-2581:
+
+```text
+stackup -> physical conductor weights
+fixed contours + lattice -> smoothed density fields
+fields + required areas + weights -> bounded fill fields
+fill fields + safe geometry -> rounded-hex void contours
+```
+
+These should be deterministic functions over immutable inputs in `pcb-ir`.
+The IPC-2581 board-array adapter should only extract stackup and copper
+geometry, invoke the core, serialize contours, and report metrics.
+
+Initial verification should cover:
+
+- constant density produces constant radii;
+- a left-to-right density gradient produces the opposite smooth radius
+  gradient without changing generated area;
+- equal mirrored layers cancel in `E_stack`;
+- conductor thickness and mid-plane distance scale the metric correctly;
+- translation and reflection preserve objective values; and
+- clipped edge voids preserve the existing web and minimum-fragment rules.
+
+Fabrication-panel layout and balancing, electroplating simulation, laminate
+material stiffness, and changes inside a board footprint are out of scope.

--- a/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
+++ b/crates/pcb-ipc2581-tools/examples/board-array-balancing-region.md
@@ -4,6 +4,9 @@ Status: reusable `pcb-ir` computation plus a development harness. Board-array
 creation consumes the result before it emits balancing copper. The harness does
 not define a user-facing CLI contract.
 
+The balancing objective and generated copper geometry are documented in
+[`../docs/board-array-copper-balancing.md`](../docs/board-array-copper-balancing.md).
+
 ## Geometry contract
 
 All geometry is a filled planar point set in panel coordinates, in millimeters:

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -245,6 +245,11 @@ pub fn generate_automatic_board_array_copper_balance(
             })
         })
         .collect::<Result<Vec<_>>>()?;
+    let existing_copper_union = prepared.iter().fold(
+        ContourSet::empty(common_safe_region.tolerance),
+        |existing, layer| existing.union(&layer.existing_copper),
+    );
+    let common_safe_region = common_safe_region.difference(&existing_copper_union);
     let spatial_layers = prepared
         .iter()
         .map(|layer| SpatialCopperBalanceLayerRequest {

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -5,6 +5,8 @@
 //! low-level adapter remains available for callers that already have explicit
 //! geometry and area inputs.
 
+use std::collections::HashMap;
+
 use anyhow::{Context, Result, bail};
 use ipc2581::types::{
     LayerFunction,
@@ -20,7 +22,8 @@ use pcb_ir::dialects::ipc::{
 };
 use pcb_ir::geom::copper_balance::{
     DenseCopperBalanceMode, DenseCopperBalanceProfile, DenseCopperBalanceRequest,
-    DenseCopperBalanceResult, generate_dense_copper_balance, rounded_hexagonal_void,
+    DenseCopperBalanceResult, SpatialCopperBalanceLayerRequest, SpatialCopperBalanceRequest,
+    generate_dense_copper_balance, generate_spatial_dense_copper_balance, rounded_hexagonal_void,
 };
 use pcb_ir::geom::path::transform_cmds;
 use pcb_ir::geom::region::simplify_shapes;
@@ -38,6 +41,7 @@ pub struct AutomaticBoardArrayLayerBalance {
     pub layer_name: String,
     /// Copper density measured inside the repeated board footprints.
     pub board_target_density: f64,
+    pub stack_weight_mm2: Option<f64>,
     pub existing_copper: ContourSet,
     pub safe_region: ContourSet,
     pub result: DenseCopperBalanceResult,
@@ -60,6 +64,9 @@ pub struct AutomaticBoardArrayLayerBalanceReport {
     pub layer_name: String,
     pub mode: AutomaticBoardArrayCopperBalanceMode,
     pub void_radius_mm: Option<f64>,
+    pub min_void_radius_mm: Option<f64>,
+    pub max_void_radius_mm: Option<f64>,
+    pub stack_weight_mm2: Option<f64>,
     pub target_density: f64,
     pub initial_density: f64,
     pub achieved_density: f64,
@@ -120,10 +127,17 @@ impl AutomaticBoardArrayCopperBalance {
                             Some(void_radius_mm),
                         ),
                     };
+                    let (min_void_radius_mm, max_void_radius_mm) = layer
+                        .result
+                        .full_void_radius_range_mm()
+                        .map_or((None, None), |(min, max)| (Some(min), Some(max)));
                     AutomaticBoardArrayLayerBalanceReport {
                         layer_name: layer.layer_name.clone(),
                         mode,
                         void_radius_mm,
+                        min_void_radius_mm,
+                        max_void_radius_mm,
+                        stack_weight_mm2: layer.stack_weight_mm2,
                         target_density: solution.target_density,
                         initial_density: solution.initial_density,
                         achieved_density: solution.achieved_density,
@@ -207,45 +221,71 @@ pub fn generate_automatic_board_array_copper_balance(
     let retained_area_mm2 = panel_outer.area();
     let board_area_mm2 = board_footprints.area();
     let lattice_origin = panel_outer.bbox.min;
-    let mut layers = Vec::new();
-
-    for layer in ecad
+    let stack_weights = physical_copper_stack_weights(ipc);
+    let prepared = ecad
         .cad_data
         .layers
         .iter()
         .filter(|layer| crate::layers::is_copper(layer.layer_function))
-    {
-        let layer_name = ipc.resolve(layer.name).to_string();
-        let existing_copper = composed_copper_image(ipc, &layer_name)?.intersection(&panel_outer);
-        let board_target_density = (existing_copper.intersection(&board_footprints).area()
-            / board_area_mm2)
-            .clamp(0.0, 1.0);
-        // This is normally redundant because panel-root copper features are
-        // already support obstacles, but makes the solver's disjoint-input
-        // contract explicit and robust to sub-tolerance extraction overlap.
-        let safe_region = common_safe_region.difference(&existing_copper);
-        let (result, features) = generate_board_array_copper_balance(
-            DenseCopperBalanceProfile::V1,
-            DenseCopperBalanceRequest {
-                safe_region: &safe_region,
-                retained_area_mm2,
-                existing_copper_area_mm2: existing_copper.area(),
-                target_density: board_target_density,
-                lattice_origin,
-            },
-        )
-        .with_context(|| {
-            format!("failed to generate copper balance geometry for layer '{layer_name}'")
-        })?;
-        layers.push(AutomaticBoardArrayLayerBalance {
-            layer_name,
-            board_target_density,
-            existing_copper,
-            safe_region,
-            result,
-            features,
-        });
-    }
+        .map(|layer| {
+            let layer_name = ipc.resolve(layer.name).to_string();
+            let existing_copper =
+                composed_copper_image(ipc, &layer_name)?.intersection(&panel_outer);
+            let board_target_density = (existing_copper.intersection(&board_footprints).area()
+                / board_area_mm2)
+                .clamp(0.0, 1.0);
+            let stack_weight_mm2 = stack_weights
+                .as_ref()
+                .and_then(|weights| weights.get(&layer_name).copied());
+            Ok(PreparedLayerBalance {
+                layer_name,
+                board_target_density,
+                stack_weight_mm2,
+                existing_copper,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let spatial_layers = prepared
+        .iter()
+        .map(|layer| SpatialCopperBalanceLayerRequest {
+            existing_copper: &layer.existing_copper,
+            existing_copper_area_mm2: layer.existing_copper.area(),
+            target_density: layer.board_target_density,
+            stack_weight_mm2: layer.stack_weight_mm2.unwrap_or(0.0),
+        })
+        .collect::<Vec<_>>();
+    let results = generate_spatial_dense_copper_balance(
+        DenseCopperBalanceProfile::V1,
+        SpatialCopperBalanceRequest {
+            panel_region: &panel_outer,
+            safe_region: &common_safe_region,
+            retained_area_mm2,
+            lattice_origin,
+            layers: &spatial_layers,
+        },
+    )
+    .context("failed to generate spatial board-array copper balance")?;
+    let layers = prepared
+        .into_iter()
+        .zip(results)
+        .map(|(layer, result)| {
+            let features = match result.solution.mode {
+                DenseCopperBalanceMode::None => Vec::new(),
+                DenseCopperBalanceMode::Solid | DenseCopperBalanceMode::Perforated { .. } => {
+                    ipc_contour_features(&result)?
+                }
+            };
+            Ok(AutomaticBoardArrayLayerBalance {
+                layer_name: layer.layer_name,
+                board_target_density: layer.board_target_density,
+                stack_weight_mm2: layer.stack_weight_mm2,
+                existing_copper: layer.existing_copper,
+                safe_region: common_safe_region.clone(),
+                result,
+                features,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(AutomaticBoardArrayCopperBalance {
         panel_outer,
@@ -254,6 +294,13 @@ pub fn generate_automatic_board_array_copper_balance(
         retained_area_mm2,
         layers,
     })
+}
+
+struct PreparedLayerBalance {
+    layer_name: String,
+    board_target_density: f64,
+    stack_weight_mm2: Option<f64>,
+    existing_copper: ContourSet,
 }
 
 /// Solve and convert one layer's explicit safe region to positive IPC contours.
@@ -287,6 +334,52 @@ fn composed_copper_image(ipc: &Ipc2581, layer_name: &str) -> Result<ContourSet> 
     ))
 }
 
+fn physical_copper_stack_weights(ipc: &Ipc2581) -> Option<HashMap<String, f64>> {
+    let ecad = ipc.ecad()?;
+    let stackup = ecad.cad_data.stackups.first()?;
+    let mut layers = stackup.layers.iter().collect::<Vec<_>>();
+    if layers.iter().all(|layer| layer.layer_number.is_some()) {
+        layers.sort_by_key(|layer| layer.layer_number);
+    }
+
+    let mut cursor_mm = 0.0;
+    let mut copper = Vec::new();
+    for stack_layer in layers {
+        let thickness_mm = stack_layer.thickness?;
+        if !thickness_mm.is_finite() || thickness_mm < 0.0 {
+            return None;
+        }
+        let center_mm = cursor_mm + thickness_mm / 2.0;
+        let name = ipc.resolve(stack_layer.layer_ref);
+        if ecad.cad_data.layers.iter().any(|layer| {
+            ipc.resolve(layer.name) == name && crate::layers::is_copper(layer.layer_function)
+        }) {
+            if thickness_mm <= 0.0 {
+                return None;
+            }
+            copper.push((name.to_string(), center_mm, thickness_mm));
+        }
+        cursor_mm += thickness_mm;
+    }
+
+    let expected = ecad
+        .cad_data
+        .layers
+        .iter()
+        .filter(|layer| crate::layers::is_copper(layer.layer_function))
+        .count();
+    if copper.len() != expected || cursor_mm <= 0.0 {
+        return None;
+    }
+    let midplane_mm = cursor_mm / 2.0;
+    Some(
+        copper
+            .into_iter()
+            .map(|(name, center_mm, thickness_mm)| (name, (midplane_mm - center_mm) * thickness_mm))
+            .collect(),
+    )
+}
+
 struct IpcCopperComponent {
     region: ContourSet,
     outer: ContourBuf,
@@ -307,15 +400,18 @@ fn ipc_contour_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeat
         })
         .collect::<Vec<_>>();
 
-    if let DenseCopperBalanceMode::Perforated { void_radius_mm } = result.solution.mode {
-        let template = rounded_hexagonal_void(void_radius_mm)
-            .context("generated copper balance has an invalid rounded-hex void radius")?;
-        for center in &result.full_void_centers {
-            let component = containing_component(&mut components, *center)
+    if matches!(
+        result.solution.mode,
+        DenseCopperBalanceMode::Perforated { .. }
+    ) {
+        for void in &result.full_voids {
+            let template = rounded_hexagonal_void(void.radius_mm)
+                .context("generated copper balance has an invalid rounded-hex void radius")?;
+            let component = containing_component(&mut components, void.center)
                 .context("generated full copper void lies outside the usable region")?;
             component.cutouts.push(transform_cmds(
                 template.cmds.iter().copied(),
-                Affine2::translation(*center),
+                Affine2::translation(void.center),
             ));
         }
     }
@@ -462,7 +558,7 @@ mod tests {
             result.solution
         );
         assert!(result.solution.generated_area_mm2 > 0.0);
-        assert!(!result.full_void_centers.is_empty());
+        assert!(!result.full_voids.is_empty());
         assert!(!result.partial_voids.is_empty());
         assert!(
             features
@@ -498,5 +594,43 @@ mod tests {
                 .flat_map(|polygon| &polygon.steps)
                 .any(|step| matches!(step, PolyStep::Curve(_)))
         );
+    }
+
+    #[test]
+    fn derives_signed_stack_weights_from_physical_layer_centers() {
+        let ipc = Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="F.Cu"/>
+    <LayerRef name="B.Cu"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="F.Cu" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Layer name="B.Cu" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+      <Stackup name="Primary" overallThickness="1.6">
+        <StackupGroup name="Primary_Group">
+          <StackupLayer layerOrGroupRef="COATING_TOP" thickness="0" sequence="0"/>
+          <StackupLayer layerOrGroupRef="F.Cu" thickness="0.035" sequence="1"/>
+          <StackupLayer layerOrGroupRef="CORE" thickness="1.53" sequence="2"/>
+          <StackupLayer layerOrGroupRef="B.Cu" thickness="0.035" sequence="3"/>
+          <StackupLayer layerOrGroupRef="COATING_BOTTOM" thickness="0" sequence="4"/>
+        </StackupGroup>
+      </Stackup>
+      <Step name="board" type="BOARD"><Datum x="0" y="0"/></Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let weights = physical_copper_stack_weights(&ipc).unwrap();
+
+        assert!((weights["F.Cu"] + weights["B.Cu"]).abs() <= 1e-12);
+        assert!(weights["F.Cu"] > 0.0);
+        assert!(weights["B.Cu"] < 0.0);
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -903,7 +903,8 @@ fn explicit_copper_balance_region_round_trips_as_positive_panel_geometry() {
 
     assert!(!round_trip.is_empty());
     assert!(
-        (round_trip.area() - balance.solution.generated_area_mm2).abs() <= 0.10,
+        (round_trip.area() - balance.solution.generated_area_mm2).abs()
+            <= balance.solution.generated_area_mm2 * 5e-4,
         "IPC area {}, source area {}",
         round_trip.area(),
         balance.solution.generated_area_mm2

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -241,6 +241,12 @@ fn board_array_creation_automatically_balances_every_copper_layer() {
     assert!(bottom.features.is_empty());
 
     for layer in &balance.layers {
+        assert!(
+            layer
+                .safe_region
+                .intersection(&layer.existing_copper)
+                .is_empty()
+        );
         let expected_target = layer
             .existing_copper
             .intersection(&balance.board_footprints)
@@ -278,6 +284,17 @@ fn board_array_creation_automatically_balances_every_copper_layer() {
     let xml = creation.xml;
     assert!(!xml.contains(r#"<Set polarity="NEGATIVE">"#));
     assert!(xml.matches("<Contour>").count() > 0);
+}
+
+#[test]
+fn board_array_creation_accepts_no_source_copper_layers() {
+    let input = board_fixture_mm().replace(
+        r#"<Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>"#,
+        r#"<Layer name="TOP" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>"#,
+    );
+    let creation = create_auto_board_array(&input, None).unwrap();
+
+    assert!(creation.copper_balance.layers.is_empty());
 }
 
 #[test]

--- a/crates/pcb-ir/src/geom/copper_balance.rs
+++ b/crates/pcb-ir/src/geom/copper_balance.rs
@@ -5,7 +5,7 @@
 //! per-layer areas; the solver chooses the closest manufacturable copper area
 //! and generates a deterministic perforated plane.
 
-use std::f64::consts::PI;
+use std::{collections::HashMap, f64::consts::PI};
 
 use crate::geom::path::transform_cmds;
 use crate::geom::{Affine2, BBox, ContourBuf, ContourSet, FillRule, PathCmd, Point, tol};
@@ -13,11 +13,12 @@ use crate::geom::{Affine2, BBox, ContourBuf, ContourSet, FillRule, PathCmd, Poin
 const NUMERIC_EPSILON: f64 = 1e-9;
 const RADIUS_SOLVE_TOLERANCE_MM: f64 = 1e-4;
 const AREA_SOLVE_TOLERANCE_MM2: f64 = 1e-3;
+const SPATIAL_SOLVE_ITERATIONS: usize = 64;
+const DENSITY_KERNEL_TRUNCATION: f64 = 3.0;
 const SQRT_3: f64 = 1.732_050_807_568_877_2;
 const HEXAGON_CORNER_RADIUS_RATIO: f64 = 0.15;
 // A sharp regular hexagon has area 3√3 R² / 2. Rounding each 120° corner
 // inward by fillet radius kR removes (2√3 - π)k²R² across all six corners.
-#[cfg(test)]
 const ROUNDED_HEXAGON_AREA_FACTOR: f64 = 3.0 * SQRT_3 / 2.0
     - (2.0 * SQRT_3 - PI) * HEXAGON_CORNER_RADIUS_RATIO * HEXAGON_CORNER_RADIUS_RATIO;
 
@@ -29,6 +30,7 @@ pub struct DenseCopperBalanceProfile {
     pub max_void_radius_mm: f64,
     pub min_copper_web_mm: f64,
     pub boundary_web_mm: f64,
+    pub density_sigma_mm: f64,
 }
 
 impl DenseCopperBalanceProfile {
@@ -39,6 +41,7 @@ impl DenseCopperBalanceProfile {
         max_void_radius_mm: 0.65,
         min_copper_web_mm: 0.20,
         boundary_web_mm: 0.20,
+        density_sigma_mm: 5.0,
     };
 
     pub fn lattice_column_pitch_mm(self) -> f64 {
@@ -68,6 +71,7 @@ impl DenseCopperBalanceProfile {
             ("maximum void radius", self.max_void_radius_mm),
             ("minimum copper web", self.min_copper_web_mm),
             ("boundary copper web", self.boundary_web_mm),
+            ("density smoothing sigma", self.density_sigma_mm),
         ] {
             if !value.is_finite() || value <= 0.0 {
                 return Err(DenseCopperBalanceError::InvalidProfile(format!(
@@ -97,16 +101,15 @@ impl Default for DenseCopperBalanceProfile {
     }
 }
 
-/// The selected topology and, for a perforated plane, its analytic radius.
+/// The selected topology and, for a perforated plane, its equivalent radius.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DenseCopperBalanceMode {
     None,
     Solid,
     /// A solid fill perforated by slightly rounded regular flat-top hexagons.
     ///
-    /// The radius is the rounded-hex circumradius of every interior void.
-    /// A clipped edge void may use a larger radius when that is the minimum
-    /// needed for the fragment to reach the manufacturable width.
+    /// A spatial result can use different per-site radii. This value is the
+    /// root-mean-square radius, which preserves their total analytic area.
     Perforated {
         void_radius_mm: f64,
     },
@@ -137,6 +140,33 @@ pub struct DenseCopperBalanceRequest<'a> {
     pub lattice_origin: Point,
 }
 
+/// One layer in a joint spatial copper-balance solve.
+#[derive(Debug, Clone, Copy)]
+pub struct SpatialCopperBalanceLayerRequest<'a> {
+    pub existing_copper: &'a ContourSet,
+    pub existing_copper_area_mm2: f64,
+    pub target_density: f64,
+    /// Signed first-moment weight `z * thickness` from the physical stackup.
+    pub stack_weight_mm2: f64,
+}
+
+/// Geometry shared by all layers in a joint spatial copper-balance solve.
+#[derive(Debug, Clone, Copy)]
+pub struct SpatialCopperBalanceRequest<'a> {
+    pub panel_region: &'a ContourSet,
+    pub safe_region: &'a ContourSet,
+    pub retained_area_mm2: f64,
+    pub lattice_origin: Point,
+    pub layers: &'a [SpatialCopperBalanceLayerRequest<'a>],
+}
+
+/// One full, unclipped rounded-hex void.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DenseCopperVoid {
+    pub center: Point,
+    pub radius_mm: f64,
+}
+
 /// Selected density solution plus its canonical copper geometry.
 #[derive(Debug, Clone)]
 pub struct DenseCopperBalanceResult {
@@ -144,14 +174,28 @@ pub struct DenseCopperBalanceResult {
     /// Safe, initially empty region available for generated copper.
     pub usable: ContourSet,
     /// Interior voids that retain the exact rounded-hex template.
-    pub full_void_centers: Vec<Point>,
+    pub full_voids: Vec<DenseCopperVoid>,
     /// Edge voids that require clipping to the boundary web.
     pub partial_voids: ContourSet,
 }
 
 impl DenseCopperBalanceResult {
     pub fn void_count(&self) -> usize {
-        self.full_void_centers.len() + self.partial_voids.connected_components().len()
+        self.full_voids.len() + self.partial_voids.connected_components().len()
+    }
+
+    pub fn full_void_radius_range_mm(&self) -> Option<(f64, f64)> {
+        let min = self
+            .full_voids
+            .iter()
+            .map(|void| void.radius_mm)
+            .min_by(f64::total_cmp)?;
+        let max = self
+            .full_voids
+            .iter()
+            .map(|void| void.radius_mm)
+            .max_by(f64::total_cmp)?;
+        Some((min, max))
     }
 }
 
@@ -181,9 +225,21 @@ pub fn generate_dense_copper_balance(
     validate_request(request)?;
 
     let usable = request.safe_region.clone();
-    let usable_area_mm2 = usable.area();
     let voidable = usable.disk_erode(profile.boundary_web_mm);
     let lattice = LatticeCandidates::new(&voidable, request.lattice_origin, profile);
+    Ok(generate_dense_copper_balance_with_lattice(
+        profile, request, usable, &voidable, &lattice,
+    ))
+}
+
+fn generate_dense_copper_balance_with_lattice(
+    profile: DenseCopperBalanceProfile,
+    request: DenseCopperBalanceRequest<'_>,
+    usable: ContourSet,
+    voidable: &ContourSet,
+    lattice: &LatticeCandidates,
+) -> DenseCopperBalanceResult {
+    let usable_area_mm2 = usable.area();
     let desired_added_area_mm2 =
         request.target_density * request.retained_area_mm2 - request.existing_copper_area_mm2;
     let initial_density = request.existing_copper_area_mm2 / request.retained_area_mm2;
@@ -196,18 +252,25 @@ pub fn generate_dense_copper_balance(
 
     if !lattice.is_empty() {
         best.consider(project_perforated_geometry(
-            &lattice,
+            lattice,
             profile,
-            &voidable,
+            voidable,
             usable_area_mm2,
             desired_added_area_mm2,
         ));
     }
 
-    let (full_void_centers, partial_voids) = match best.mode {
+    let (full_voids, partial_voids) = match best.mode {
         DenseCopperBalanceMode::Perforated { void_radius_mm } => (
-            lattice.full_centers.clone(),
-            lattice.partial_voids(&voidable, void_radius_mm, profile),
+            lattice
+                .full_centers
+                .iter()
+                .map(|center| DenseCopperVoid {
+                    center: *center,
+                    radius_mm: void_radius_mm,
+                })
+                .collect(),
+            lattice.partial_voids(voidable, void_radius_mm, profile),
         ),
         DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => {
             (Vec::new(), ContourSet::empty(usable.tolerance))
@@ -228,12 +291,408 @@ pub fn generate_dense_copper_balance(
         solution.residual_error
             <= (solution.initial_density - request.target_density).abs() + NUMERIC_EPSILON
     );
-    Ok(DenseCopperBalanceResult {
+    DenseCopperBalanceResult {
         solution,
         usable,
-        full_void_centers,
+        full_voids,
         partial_voids,
-    })
+    }
+}
+
+/// Jointly distribute each layer's already-selected copper area in space.
+///
+/// The solver uses squared void radius as its variable. It minimizes local
+/// density error plus the signed through-stack first moment, then projects
+/// every layer back onto its original total void area and radius bounds.
+pub fn generate_spatial_dense_copper_balance(
+    profile: DenseCopperBalanceProfile,
+    request: SpatialCopperBalanceRequest<'_>,
+) -> Result<Vec<DenseCopperBalanceResult>, DenseCopperBalanceError> {
+    profile.validate()?;
+    validate_spatial_request(request)?;
+
+    let voidable = request.safe_region.disk_erode(profile.boundary_web_mm);
+    let lattice = LatticeCandidates::new(&voidable, request.lattice_origin, profile);
+    let uniform = request
+        .layers
+        .iter()
+        .map(|layer| {
+            generate_dense_copper_balance_with_lattice(
+                profile,
+                DenseCopperBalanceRequest {
+                    safe_region: request.safe_region,
+                    retained_area_mm2: request.retained_area_mm2,
+                    existing_copper_area_mm2: layer.existing_copper_area_mm2,
+                    target_density: layer.target_density,
+                    lattice_origin: request.lattice_origin,
+                },
+                request.safe_region.clone(),
+                &voidable,
+                &lattice,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if lattice.is_empty() {
+        return Ok(uniform);
+    }
+
+    let centers = &lattice.full_centers;
+    if centers.is_empty() {
+        return Ok(uniform);
+    }
+    let panel_samples =
+        hex_aligned_lattice_centers(request.panel_region.bbox, request.lattice_origin, profile)
+            .into_iter()
+            .filter(|point| request.panel_region.contains_point(*point))
+            .collect::<Vec<_>>();
+    let density_kernel =
+        LatticeDensityKernel::new(&panel_samples, centers, request.lattice_origin, profile);
+    let fixed_density = request
+        .layers
+        .iter()
+        .map(|layer| {
+            density_kernel.smooth(&scanline_indicator(&panel_samples, layer.existing_copper))
+        })
+        .collect::<Vec<_>>();
+    let available_density =
+        density_kernel.smooth(&scanline_indicator(&panel_samples, request.safe_region));
+
+    let lower = vec![profile.min_void_radius_mm.powi(2); centers.len()];
+    let upper = vec![profile.max_void_radius_mm.powi(2); centers.len()];
+    let squared_radius_sums = uniform
+        .iter()
+        .map(|result| match result.solution.mode {
+            DenseCopperBalanceMode::Perforated { .. } => {
+                let target_full_void_area_mm2 = result.usable.area()
+                    - result.solution.generated_area_mm2
+                    - result.partial_voids.area();
+                (target_full_void_area_mm2 / ROUNDED_HEXAGON_AREA_FACTOR)
+                    .clamp(lower.iter().sum(), upper.iter().sum())
+            }
+            DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => 0.0,
+        })
+        .collect::<Vec<_>>();
+    let mut squared_radii = uniform
+        .iter()
+        .enumerate()
+        .map(|(layer_index, result)| match result.solution.mode {
+            DenseCopperBalanceMode::Perforated { void_radius_mm } => project_box_sum(
+                &vec![void_radius_mm.powi(2); centers.len()],
+                &lower,
+                &upper,
+                squared_radius_sums[layer_index],
+            ),
+            DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => Vec::new(),
+        })
+        .collect::<Vec<Vec<f64>>>();
+    let cell_area_mm2 = SQRT_3 * profile.pitch_mm.powi(2) / 2.0;
+    let void_fraction_per_radius_squared = ROUNDED_HEXAGON_AREA_FACTOR / cell_area_mm2;
+    let normalized_stack_weights = normalized_stack_weights(request.layers);
+    let step = 0.5 / void_fraction_per_radius_squared;
+
+    for _ in 0..SPATIAL_SOLVE_ITERATIONS {
+        let error = request
+            .layers
+            .iter()
+            .enumerate()
+            .map(|(layer_index, layer)| {
+                centers
+                    .iter()
+                    .enumerate()
+                    .map(|(site_index, _)| {
+                        let generated_density = match uniform[layer_index].solution.mode {
+                            DenseCopperBalanceMode::None => 0.0,
+                            DenseCopperBalanceMode::Solid => available_density[site_index],
+                            DenseCopperBalanceMode::Perforated { .. } => {
+                                available_density[site_index]
+                                    * (1.0
+                                        - void_fraction_per_radius_squared
+                                            * squared_radii[layer_index][site_index])
+                                        .clamp(0.0, 1.0)
+                            }
+                        };
+                        fixed_density[layer_index][site_index] + generated_density
+                            - layer.target_density
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let stack_error = (0..centers.len())
+            .map(|site_index| {
+                normalized_stack_weights
+                    .iter()
+                    .enumerate()
+                    .map(|(layer_index, weight)| weight * error[layer_index][site_index])
+                    .sum::<f64>()
+            })
+            .collect::<Vec<_>>();
+
+        for layer_index in 0..request.layers.len() {
+            if squared_radii[layer_index].is_empty() {
+                continue;
+            }
+            let proposed = squared_radii[layer_index]
+                .iter()
+                .enumerate()
+                .map(|(site_index, radius_squared)| {
+                    radius_squared
+                        + step
+                            * available_density[site_index]
+                            * (error[layer_index][site_index]
+                                + normalized_stack_weights[layer_index] * stack_error[site_index])
+                })
+                .collect::<Vec<_>>();
+            squared_radii[layer_index] =
+                project_box_sum(&proposed, &lower, &upper, squared_radius_sums[layer_index]);
+        }
+    }
+
+    Ok(uniform
+        .into_iter()
+        .enumerate()
+        .map(|(layer_index, baseline)| {
+            if squared_radii[layer_index].is_empty() {
+                return baseline;
+            }
+            spatial_result_from_squared_radii(
+                centers,
+                &squared_radii[layer_index],
+                baseline,
+                request.layers[layer_index],
+                request.retained_area_mm2,
+            )
+        })
+        .collect())
+}
+
+fn validate_spatial_request(
+    request: SpatialCopperBalanceRequest<'_>,
+) -> Result<(), DenseCopperBalanceError> {
+    if request.layers.is_empty() {
+        return Err(DenseCopperBalanceError::InvalidInput(
+            "spatial copper balance requires at least one layer".to_string(),
+        ));
+    }
+    if !request.panel_region.bbox.is_valid() || request.panel_region.is_empty() {
+        return Err(DenseCopperBalanceError::InvalidInput(
+            "panel region must be non-empty and have valid bounds".to_string(),
+        ));
+    }
+    for layer in request.layers {
+        if !layer.stack_weight_mm2.is_finite() {
+            return Err(DenseCopperBalanceError::InvalidInput(
+                "stack weights must be finite".to_string(),
+            ));
+        }
+        validate_request(DenseCopperBalanceRequest {
+            safe_region: request.safe_region,
+            retained_area_mm2: request.retained_area_mm2,
+            existing_copper_area_mm2: layer.existing_copper_area_mm2,
+            target_density: layer.target_density,
+            lattice_origin: request.lattice_origin,
+        })?;
+    }
+    Ok(())
+}
+
+fn normalized_stack_weights(layers: &[SpatialCopperBalanceLayerRequest<'_>]) -> Vec<f64> {
+    let scale = layers
+        .iter()
+        .map(|layer| layer.stack_weight_mm2.abs())
+        .sum::<f64>();
+    layers
+        .iter()
+        .map(|layer| {
+            if scale > NUMERIC_EPSILON {
+                layer.stack_weight_mm2 / scale
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+struct LatticeDensityKernel {
+    samples: HashMap<(i64, i64), usize>,
+    evaluation_sites: Vec<(i64, i64)>,
+    offsets: [Vec<(i64, i64, f64)>; 2],
+}
+
+impl LatticeDensityKernel {
+    fn new(
+        samples: &[Point],
+        evaluation_points: &[Point],
+        origin: Point,
+        profile: DenseCopperBalanceProfile,
+    ) -> Self {
+        let index = |point| lattice_index(point, origin, profile);
+        let samples = samples
+            .iter()
+            .enumerate()
+            .map(|(sample_index, point)| (index(*point), sample_index))
+            .collect();
+        let evaluation_sites = evaluation_points
+            .iter()
+            .map(|point| index(*point))
+            .collect();
+        let support_mm = DENSITY_KERNEL_TRUNCATION * profile.density_sigma_mm;
+        let inverse_two_sigma_squared = 0.5 / profile.density_sigma_mm.powi(2);
+        let column_span = (support_mm / profile.lattice_column_pitch_mm()).ceil() as i64;
+        let row_span = (support_mm / profile.pitch_mm).ceil() as i64 + 1;
+        let offsets = [0_i64, 1_i64].map(|parity| {
+            (-column_span..=column_span)
+                .flat_map(|column| {
+                    (-row_span..=row_span).filter_map(move |row| {
+                        let neighbor_parity = (parity + column).rem_euclid(2);
+                        let dx = column as f64 * profile.lattice_column_pitch_mm();
+                        let dy = (row as f64 + (neighbor_parity - parity) as f64 / 2.0)
+                            * profile.pitch_mm;
+                        let distance_squared = dx * dx + dy * dy;
+                        (distance_squared <= support_mm.powi(2)).then(|| {
+                            (
+                                column,
+                                row,
+                                (-distance_squared * inverse_two_sigma_squared).exp(),
+                            )
+                        })
+                    })
+                })
+                .collect()
+        });
+        Self {
+            samples,
+            evaluation_sites,
+            offsets,
+        }
+    }
+
+    fn smooth(&self, values: &[f64]) -> Vec<f64> {
+        self.evaluation_sites
+            .iter()
+            .map(|&(column, row)| {
+                let (weighted_sum, weight_sum) = self.offsets[column.rem_euclid(2) as usize]
+                    .iter()
+                    .filter_map(|&(column_offset, row_offset, weight)| {
+                        let sample_index = self
+                            .samples
+                            .get(&(column + column_offset, row + row_offset))?;
+                        Some((weight * values[*sample_index], weight))
+                    })
+                    .fold((0.0, 0.0), |(sum, weights), (value, weight)| {
+                        (sum + value, weights + weight)
+                    });
+                if weight_sum > 0.0 {
+                    weighted_sum / weight_sum
+                } else {
+                    0.0
+                }
+            })
+            .collect()
+    }
+}
+
+fn lattice_index(point: Point, origin: Point, profile: DenseCopperBalanceProfile) -> (i64, i64) {
+    let column = ((point.x - origin.x) / profile.lattice_column_pitch_mm()).round() as i64;
+    let column_offset = column.rem_euclid(2) as f64 * profile.pitch_mm / 2.0;
+    let row = ((point.y - origin.y - column_offset) / profile.pitch_mm).round() as i64;
+    (column, row)
+}
+
+fn scanline_indicator(points: &[Point], region: &ContourSet) -> Vec<f64> {
+    let mut result = vec![0.0; points.len()];
+    let mut by_y = (0..points.len()).collect::<Vec<_>>();
+    by_y.sort_by(|left, right| {
+        points[*left]
+            .y
+            .total_cmp(&points[*right].y)
+            .then_with(|| points[*left].x.total_cmp(&points[*right].x))
+    });
+    let edges = region
+        .rings
+        .iter()
+        .flat_map(|ring| {
+            ring.iter()
+                .copied()
+                .zip(ring.iter().copied().cycle().skip(1))
+                .take(ring.len())
+        })
+        .collect::<Vec<_>>();
+
+    let mut first = 0;
+    while first < by_y.len() {
+        let y = points[by_y[first]].y;
+        let mut last = first + 1;
+        while last < by_y.len() && (points[by_y[last]].y - y).abs() <= NUMERIC_EPSILON {
+            last += 1;
+        }
+        let mut crossings = edges
+            .iter()
+            .filter_map(|([x0, y0], [x1, y1])| {
+                let direction = if *y0 <= y && y < *y1 {
+                    1
+                } else if *y1 <= y && y < *y0 {
+                    -1
+                } else {
+                    return None;
+                };
+                let x = x0 + (y - y0) * (x1 - x0) / (y1 - y0);
+                Some((x, direction))
+            })
+            .collect::<Vec<_>>();
+        crossings.sort_by(|left, right| left.0.total_cmp(&right.0));
+        let mut crossing_index = 0;
+        let mut winding = 0;
+        for &point_index in &by_y[first..last] {
+            while crossing_index < crossings.len()
+                && crossings[crossing_index].0 <= points[point_index].x
+            {
+                winding += crossings[crossing_index].1;
+                crossing_index += 1;
+            }
+            result[point_index] = (winding != 0) as u8 as f64;
+        }
+        first = last;
+    }
+    result
+}
+
+fn project_box_sum(values: &[f64], lower: &[f64], upper: &[f64], target: f64) -> Vec<f64> {
+    debug_assert_eq!(values.len(), lower.len());
+    debug_assert_eq!(values.len(), upper.len());
+    let mut low_shift = values
+        .iter()
+        .zip(upper)
+        .map(|(value, bound)| value - bound)
+        .min_by(f64::total_cmp)
+        .unwrap_or(0.0);
+    let mut high_shift = values
+        .iter()
+        .zip(lower)
+        .map(|(value, bound)| value - bound)
+        .max_by(f64::total_cmp)
+        .unwrap_or(0.0);
+    for _ in 0..64 {
+        let shift = (low_shift + high_shift) / 2.0;
+        let sum = values
+            .iter()
+            .zip(lower)
+            .zip(upper)
+            .map(|((value, lower), upper)| (value - shift).clamp(*lower, *upper))
+            .sum::<f64>();
+        if sum > target {
+            low_shift = shift;
+        } else {
+            high_shift = shift;
+        }
+    }
+    let shift = (low_shift + high_shift) / 2.0;
+    values
+        .iter()
+        .zip(lower)
+        .zip(upper)
+        .map(|((value, lower), upper)| (value - shift).clamp(*lower, *upper))
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -458,6 +917,48 @@ impl LatticeCandidates {
     ) -> f64 {
         self.full_void_area(radius, voidable.tolerance)
             + self.partial_voids(voidable, radius, profile).area()
+    }
+}
+
+fn spatial_result_from_squared_radii(
+    centers: &[Point],
+    squared_radii: &[f64],
+    baseline: DenseCopperBalanceResult,
+    layer: SpatialCopperBalanceLayerRequest<'_>,
+    retained_area_mm2: f64,
+) -> DenseCopperBalanceResult {
+    let full_voids = centers
+        .iter()
+        .zip(squared_radii)
+        .map(|(center, radius_squared)| DenseCopperVoid {
+            center: *center,
+            radius_mm: radius_squared.sqrt(),
+        })
+        .collect::<Vec<_>>();
+    let full_void_area_mm2 = ROUNDED_HEXAGON_AREA_FACTOR * squared_radii.iter().sum::<f64>();
+    let partial_voids = baseline.partial_voids;
+    let void_area_mm2 = full_void_area_mm2 + partial_voids.area();
+    let generated_area_mm2 = (baseline.usable.area() - void_area_mm2).max(0.0);
+    let achieved_density =
+        (layer.existing_copper_area_mm2 + generated_area_mm2) / retained_area_mm2;
+    let equivalent_radius_mm =
+        (squared_radii.iter().sum::<f64>() / squared_radii.len() as f64).sqrt();
+    let solution = DenseCopperBalanceSolution {
+        mode: DenseCopperBalanceMode::Perforated {
+            void_radius_mm: equivalent_radius_mm,
+        },
+        desired_added_area_mm2: baseline.solution.desired_added_area_mm2,
+        generated_area_mm2,
+        initial_density: baseline.solution.initial_density,
+        achieved_density,
+        target_density: layer.target_density,
+        residual_error: (achieved_density - layer.target_density).abs(),
+    };
+    DenseCopperBalanceResult {
+        solution,
+        usable: baseline.usable,
+        full_voids,
+        partial_voids,
     }
 }
 
@@ -728,11 +1229,15 @@ mod tests {
     use crate::geom::{BBox, PathOp, Point, tol};
 
     fn result_voids(result: &DenseCopperBalanceResult) -> ContourSet {
-        let radius = match result.solution.mode {
-            DenseCopperBalanceMode::Perforated { void_radius_mm } => void_radius_mm,
+        match result.solution.mode {
+            DenseCopperBalanceMode::Perforated { .. } => {}
             _ => return ContourSet::empty(result.usable.tolerance),
-        };
-        let candidates = uniform_candidates(&result.full_void_centers, radius);
+        }
+        let candidates = result
+            .full_voids
+            .iter()
+            .map(|void| (void.center, void.radius_mm))
+            .collect::<Vec<_>>();
         let mut rings = hexagon_set_with_radii(&candidates, result.usable.tolerance).rings;
         rings.extend(result.partial_voids.rings.clone());
         ContourSet::new(rings, FillRule::NonZero, result.usable.tolerance)
@@ -829,6 +1334,166 @@ mod tests {
                 .any(|void| (void.bbox.max.y - voidable.bbox.max.y).abs() <= 2.0 * tol::FLATTEN_MM),
         ];
         assert!(touches_each_boundary.into_iter().all(|touches| touches));
+    }
+
+    #[test]
+    fn spatial_solver_keeps_constant_fields_uniform() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(24.0, 16.0)),
+            tol::REGION_MM,
+        );
+        let existing = ContourSet::empty(tol::REGION_MM);
+        let layers = [SpatialCopperBalanceLayerRequest {
+            existing_copper: &existing,
+            existing_copper_area_mm2: 0.0,
+            target_density: 0.5,
+            stack_weight_mm2: 0.0,
+        }];
+        let result = generate_spatial_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            SpatialCopperBalanceRequest {
+                panel_region: &panel,
+                safe_region: &panel,
+                retained_area_mm2: panel.area(),
+                lattice_origin: Point::ZERO,
+                layers: &layers,
+            },
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+
+        let (min, max) = result.full_void_radius_range_mm().unwrap();
+        assert!(max - min <= 1e-9);
+        assert!((result.solution.achieved_density - 0.5).abs() <= 5e-3);
+    }
+
+    #[test]
+    fn spatial_solver_opposes_a_fixed_copper_gradient_without_changing_total_area() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let existing = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let safe = ContourSet::rectangle(
+            BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let layer = SpatialCopperBalanceLayerRequest {
+            existing_copper: &existing,
+            existing_copper_area_mm2: existing.area(),
+            target_density: 0.75,
+            stack_weight_mm2: 0.0,
+        };
+        let baseline = generate_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            DenseCopperBalanceRequest {
+                safe_region: &safe,
+                retained_area_mm2: panel.area(),
+                existing_copper_area_mm2: existing.area(),
+                target_density: layer.target_density,
+                lattice_origin: Point::ZERO,
+            },
+        )
+        .unwrap();
+        let result = generate_spatial_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            SpatialCopperBalanceRequest {
+                panel_region: &panel,
+                safe_region: &safe,
+                retained_area_mm2: panel.area(),
+                lattice_origin: Point::ZERO,
+                layers: &[layer],
+            },
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+        let mean_radius = |minimum_x: f64, maximum_x: f64| {
+            let radii = result
+                .full_voids
+                .iter()
+                .filter(|void| (minimum_x..maximum_x).contains(&void.center.x))
+                .map(|void| void.radius_mm)
+                .collect::<Vec<_>>();
+            radii.iter().sum::<f64>() / radii.len() as f64
+        };
+
+        assert!(mean_radius(20.0, 25.0) > mean_radius(35.0, 40.0));
+        assert!(
+            (result.solution.generated_area_mm2 - baseline.solution.generated_area_mm2).abs()
+                <= AREA_SOLVE_TOLERANCE_MM2
+        );
+    }
+
+    #[test]
+    fn spatial_solver_uses_signed_stack_weights() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let safe = ContourSet::rectangle(
+            BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let top_copper = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let bottom_copper = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 10.0)),
+            tol::REGION_MM,
+        );
+        let solve = |stack_weight_mm2: f64| {
+            generate_spatial_dense_copper_balance(
+                DenseCopperBalanceProfile::V1,
+                SpatialCopperBalanceRequest {
+                    panel_region: &panel,
+                    safe_region: &safe,
+                    retained_area_mm2: panel.area(),
+                    lattice_origin: Point::ZERO,
+                    layers: &[
+                        SpatialCopperBalanceLayerRequest {
+                            existing_copper: &top_copper,
+                            existing_copper_area_mm2: top_copper.area(),
+                            target_density: 0.75,
+                            stack_weight_mm2,
+                        },
+                        SpatialCopperBalanceLayerRequest {
+                            existing_copper: &bottom_copper,
+                            existing_copper_area_mm2: bottom_copper.area(),
+                            target_density: 0.50,
+                            stack_weight_mm2: -stack_weight_mm2,
+                        },
+                    ],
+                },
+            )
+            .unwrap()
+        };
+        let independent = solve(0.0);
+        let stack_aware = solve(1.0);
+        let radius_difference = independent
+            .iter()
+            .zip(&stack_aware)
+            .flat_map(|(independent, stack_aware)| {
+                independent
+                    .full_voids
+                    .iter()
+                    .zip(&stack_aware.full_voids)
+                    .map(|(independent, stack_aware)| {
+                        (independent.radius_mm - stack_aware.radius_mm).abs()
+                    })
+            })
+            .sum::<f64>();
+
+        assert!(radius_difference > 0.01);
+        assert!(independent.iter().zip(&stack_aware).all(|(left, right)| {
+            (left.solution.generated_area_mm2 - right.solution.generated_area_mm2).abs()
+                <= AREA_SOLVE_TOLERANCE_MM2
+        }));
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/copper_balance.rs
+++ b/crates/pcb-ir/src/geom/copper_balance.rs
@@ -753,9 +753,9 @@ fn project_perforated_geometry(
     while high_radius - low_radius > RADIUS_SOLVE_TOLERANCE_MM
         && best.error_mm2 > AREA_SOLVE_TOLERANCE_MM2
     {
-        // Interior hex area is approximately linear in r² after flattening.
-        // Interpolate there, with a midpoint fallback that keeps convergence
-        // bracketed when clipped edge area dominates.
+        // Interior hex area is linear in r². Interpolate there, with a
+        // midpoint fallback that keeps convergence bracketed when clipped
+        // edge area dominates.
         let low_squared = low_radius.powi(2);
         let high_squared = high_radius.powi(2);
         let fraction = (target_void_area_mm2 - low_area) / (high_area - low_area);
@@ -885,9 +885,8 @@ impl LatticeCandidates {
         self.full_centers.is_empty() && self.edge_candidates.is_empty()
     }
 
-    fn full_void_area(&self, radius: f64, tolerance: f64) -> f64 {
-        let template = hexagon_set_with_radii(&[(Point::ZERO, radius)], tolerance);
-        self.full_centers.len() as f64 * template.area()
+    fn full_void_area(&self, radius: f64) -> f64 {
+        self.full_centers.len() as f64 * ROUNDED_HEXAGON_AREA_FACTOR * radius.powi(2)
     }
 
     fn partial_voids(
@@ -910,8 +909,7 @@ impl LatticeCandidates {
         radius: f64,
         profile: DenseCopperBalanceProfile,
     ) -> f64 {
-        self.full_void_area(radius, voidable.tolerance)
-            + self.partial_voids(voidable, radius, profile).area()
+        self.full_void_area(radius) + self.partial_voids(voidable, radius, profile).area()
     }
 }
 
@@ -1350,6 +1348,62 @@ mod tests {
         .unwrap();
 
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn spatial_solver_preserves_minimum_radius_area() {
+        let profile = DenseCopperBalanceProfile::V1;
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(24.0, 16.0)),
+            tol::REGION_MM,
+        );
+        let voidable = panel.disk_erode(profile.boundary_web_mm);
+        let lattice = LatticeCandidates::new(&voidable, Point::ZERO, profile);
+        let target_density = (panel.area()
+            - lattice.void_area(&voidable, profile.min_void_radius_mm, profile))
+            / panel.area();
+        let existing = ContourSet::empty(tol::REGION_MM);
+        let layer = SpatialCopperBalanceLayerRequest {
+            existing_copper: &existing,
+            existing_copper_area_mm2: 0.0,
+            target_density,
+            stack_weight_mm2: 0.0,
+        };
+        let baseline = generate_dense_copper_balance(
+            profile,
+            DenseCopperBalanceRequest {
+                safe_region: &panel,
+                retained_area_mm2: panel.area(),
+                existing_copper_area_mm2: 0.0,
+                target_density,
+                lattice_origin: Point::ZERO,
+            },
+        )
+        .unwrap();
+        let result = generate_spatial_dense_copper_balance(
+            profile,
+            SpatialCopperBalanceRequest {
+                panel_region: &panel,
+                safe_region: &panel,
+                retained_area_mm2: panel.area(),
+                lattice_origin: Point::ZERO,
+                layers: &[layer],
+            },
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+
+        assert_eq!(
+            baseline.solution.mode,
+            DenseCopperBalanceMode::Perforated {
+                void_radius_mm: profile.min_void_radius_mm
+            }
+        );
+        assert!(
+            (result.solution.generated_area_mm2 - baseline.solution.generated_area_mm2).abs()
+                <= AREA_SOLVE_TOLERANCE_MM2
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/copper_balance.rs
+++ b/crates/pcb-ir/src/geom/copper_balance.rs
@@ -469,11 +469,6 @@ pub fn generate_spatial_dense_copper_balance(
 fn validate_spatial_request(
     request: SpatialCopperBalanceRequest<'_>,
 ) -> Result<(), DenseCopperBalanceError> {
-    if request.layers.is_empty() {
-        return Err(DenseCopperBalanceError::InvalidInput(
-            "spatial copper balance requires at least one layer".to_string(),
-        ));
-    }
     if !request.panel_region.bbox.is_valid() || request.panel_region.is_empty() {
         return Err(DenseCopperBalanceError::InvalidInput(
             "panel region must be non-empty and have valid bounds".to_string(),
@@ -1334,6 +1329,27 @@ mod tests {
                 .any(|void| (void.bbox.max.y - voidable.bbox.max.y).abs() <= 2.0 * tol::FLATTEN_MM),
         ];
         assert!(touches_each_boundary.into_iter().all(|touches| touches));
+    }
+
+    #[test]
+    fn spatial_solver_accepts_no_layers() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(24.0, 16.0)),
+            tol::REGION_MM,
+        );
+        let result = generate_spatial_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            SpatialCopperBalanceRequest {
+                panel_region: &panel,
+                safe_region: &panel,
+                retained_area_mm2: panel.area(),
+                lattice_origin: Point::ZERO,
+                layers: &[],
+            },
+        )
+        .unwrap();
+
+        assert!(result.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Board-array rails can add local copper-density changes and stack asymmetry. This change varies rounded-hex void sizes to smooth each layer and coordinate the physical stack, while it preserves each layer's copper target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fabrication geometry generation and a new numerical optimizer for all board-array copper layers; mitigated by preserved per-layer area targets, safe-region constraints, and broad unit/integration tests.
> 
> **Overview**
> **Board-array automatic copper balancing** no longer uses one uniform rounded-hex void radius per layer. It runs a **joint spatial solve** over all copper layers: per-lattice-site radii smooth local density from fixed copper and coordinate **through-stack asymmetry** using IPC stackup-derived signed weights, while keeping each layer’s prior total generated copper (area projection unchanged).
> 
> In **`pcb-ir`**, `generate_spatial_dense_copper_balance` adds Gaussian-smoothed density fields, a projected-gradient optimizer on squared radii, and **`DenseCopperVoid`** (center + radius) instead of **`full_void_centers`**. Perforated mode’s reported radius is an RMS equivalent when radii vary.
> 
> The **IPC board-array adapter** prepares all layers, derives **`physical_copper_stack_weights`**, subtracts the union of existing copper from the shared safe region, emits IPC contours per void radius, and extends balance **reports** with min/max void radius and **`stack_weight_mm2`**.
> 
> **Docs/changelog**: new **`board-array-copper-balancing.md`**, README cross-links, and an unreleased changelog line. **Tests** cover stack weights, spatial gradients, stack-aware radii, empty copper layers, and safe-region disjointness from existing copper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3ccd150b64d14e3a20c518ba5248345acffef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->