### PR TITLE
Emit board-array fiducials on both surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Board-array balancing now certifies per-layer regions and reduces density and stack imbalance with variable voids.
 
+### Fixed
+
+- Board-array creation now emits fiducials on both declared copper and solder-mask surfaces.
+
 ## [0.4.17] - 2026-07-31
 
 ### Fixed

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -54,8 +54,6 @@ const KICAD_VCUT_LABEL_GLYPHS: [&str; 5] = [
     "G]LFLWMYNZP[T[VZWYXWXF",
     "JZLFXF RR[RF",
 ];
-const TOP_COPPER_LAYER_BASE_NAME: &str = "F.Cu";
-const TOP_SOLDERMASK_LAYER_BASE_NAME: &str = "F.Mask";
 const TOOLING_HOLE_LAYER_BASE_NAME: &str = "Board_Array_Drill";
 const GENERATED_HOLE_NAME_PREFIX: &str = "array_tooling_hole";
 const FIDUCIAL_COPPER_DIAMETER_MM: f64 = 1.0;
@@ -750,18 +748,17 @@ fn build_board_array_spec(
             array_width_mm: array_width,
             array_height_mm: array_height,
         },
-    );
+    )?;
     add_board_cell_fiducials(
         &mut generated_geometry,
         ipc,
         ecad,
-        &mut used_layer_names,
         BoardCellFiducialSpec {
             board_width_mm: board_width,
             board_height_mm: board_height,
             board_margin,
         },
-    );
+    )?;
     let board_outline_layer_names = board_outline_layer_names(ipc, ecad);
     let content_step_refs = content_step_refs(ipc, &array_name, &board_cell_name, &board_name);
     let content_layer_refs =
@@ -1002,42 +999,6 @@ fn board_outline_layer_names(ipc: &Ipc2581, ecad: &ipc2581::types::Ecad) -> Vec<
         .collect()
 }
 
-fn ensure_top_copper_layer_name(
-    generated_geometry: &mut BoardArrayGeneratedGeometry,
-    ipc: &Ipc2581,
-    ecad: &ipc2581::types::Ecad,
-    used_layer_names: &mut HashSet<String>,
-) -> String {
-    top_copper_layer_name(ipc, ecad).unwrap_or_else(|| {
-        let layer_name = reserve_unique_name(used_layer_names, TOP_COPPER_LAYER_BASE_NAME);
-        generated_geometry.add_layer(GeneratedLayer::new(
-            layer_name.clone(),
-            LayerFunction::Signal,
-            Some(Side::Top),
-            Some(Polarity::Positive),
-        ));
-        layer_name
-    })
-}
-
-fn ensure_top_soldermask_layer_name(
-    generated_geometry: &mut BoardArrayGeneratedGeometry,
-    ipc: &Ipc2581,
-    ecad: &ipc2581::types::Ecad,
-    used_layer_names: &mut HashSet<String>,
-) -> String {
-    top_soldermask_layer_name(ipc, ecad).unwrap_or_else(|| {
-        let layer_name = reserve_unique_name(used_layer_names, TOP_SOLDERMASK_LAYER_BASE_NAME);
-        generated_geometry.add_layer(GeneratedLayer::new(
-            layer_name.clone(),
-            LayerFunction::Soldermask,
-            Some(Side::Top),
-            Some(Polarity::Positive),
-        ));
-        layer_name
-    })
-}
-
 fn ensure_tooling_hole_layer_name(
     generated_geometry: &mut BoardArrayGeneratedGeometry,
     used_layer_names: &mut HashSet<String>,
@@ -1057,26 +1018,6 @@ fn ensure_tooling_hole_layer_name(
         Some(Polarity::Positive),
     ));
     layer_name
-}
-
-fn top_copper_layer_name(ipc: &Ipc2581, ecad: &ipc2581::types::Ecad) -> Option<String> {
-    ecad.cad_data
-        .layers
-        .iter()
-        .find(|layer| {
-            layer.side == Some(Side::Top) && crate::layers::is_copper(layer.layer_function)
-        })
-        .map(|layer| ipc.resolve(layer.name).to_string())
-}
-
-fn top_soldermask_layer_name(ipc: &Ipc2581, ecad: &ipc2581::types::Ecad) -> Option<String> {
-    ecad.cad_data
-        .layers
-        .iter()
-        .find(|layer| {
-            layer.side == Some(Side::Top) && layer.layer_function == LayerFunction::Soldermask
-        })
-        .map(|layer| ipc.resolve(layer.name).to_string())
 }
 
 fn reserve_unique_name(used_names: &mut HashSet<String>, base: &str) -> String {

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -4,7 +4,7 @@ use super::balance::{
 use super::*;
 use crate::accessors::IpcAccessor;
 use crate::ipc2581::types::LayerFunction;
-use crate::manufacturing::build_manufacturing_package;
+use crate::manufacturing::{ManufacturingPackage, build_manufacturing_package};
 use pcb_ir::dialects::ipc::{
     BalancingRegionOptions, BoardArraySupportDocument, BoardArraySupportLayerPolicy, FeatureBucket,
     FeatureDomain, FeatureIntent, FeatureKind, FeatureOperation, FeatureRole, FeatureSpan,
@@ -306,18 +306,8 @@ fn board_array_creation_accepts_no_source_copper_layers() {
 }
 
 #[test]
-fn automatic_balancing_regions_scope_panel_fiducials_to_top_copper() {
-    let input = large_board_fixture_mm()
-        .replace(
-            r#"<LayerRef name="TOP"/>"#,
-            r#"<LayerRef name="TOP"/>
-<LayerRef name="BOTTOM"/>"#,
-        )
-        .replace(
-            r#"<Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>"#,
-            r#"<Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
-  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>"#,
-        );
+fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_layers() {
+    let input = large_board_fixture_mm();
     let ipc = Ipc2581::parse(&input).unwrap();
     let (options, validation_mode, panelization) = auto_board_array_options(&ipc, None).unwrap();
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization).unwrap();
@@ -336,8 +326,8 @@ fn automatic_balancing_regions_scope_panel_fiducials_to_top_copper() {
         .unwrap();
 
     assert!(
-        bottom.result.usable.area() > top.result.usable.area(),
-        "top-only fiducials and mask openings should reserve only top-copper area: top {:.6} mm², bottom {:.6} mm²",
+        (bottom.result.usable.area() - top.result.usable.area()).abs() <= 1e-6,
+        "two-sided fiducials and mask openings should reserve equal surface-copper area: top {:.6} mm², bottom {:.6} mm²",
         top.result.usable.area(),
         bottom.result.usable.area(),
     );
@@ -982,26 +972,18 @@ fn board_array_creation_adds_default_tooling_at_single_column_min_width() {
 
     let ipc = Ipc2581::parse(&xml).unwrap();
     let step = array_step(&ipc);
-    let top_fiducials = fiducials_on_layer(&ipc, step, "TOP");
-    let mask_fiducials = fiducials_on_layer(&ipc, step, "F.Mask");
     let tooling_holes = holes_on_layer(&ipc, step, TOOLING_HOLE_LAYER_BASE_NAME);
     let corner_holes = holes_with_diameter(&tooling_holes, CORNER_TOOLING_HOLE_DIAMETER_MM);
     let rail_holes = holes_with_diameter(&tooling_holes, TOOLING_HOLE_DIAMETER_MM);
 
-    assert_eq!(top_fiducials.len(), 4);
-    assert_eq!(mask_fiducials.len(), 4);
+    assert_two_sided_fiducials(
+        &ipc,
+        step,
+        IpcFiducialKind::Global,
+        &[(29.0, 66.15), (41.0, 66.15), (33.0, 3.85), (37.0, 3.85)],
+    );
     assert_eq!(corner_holes.len(), 4);
     assert_eq!(rail_holes.len(), 4);
-    assert!(
-        top_fiducials
-            .iter()
-            .all(|fiducial| close(fiducial_diameter(fiducial), 1.0))
-    );
-    assert!(
-        mask_fiducials
-            .iter()
-            .all(|fiducial| close(fiducial_diameter(fiducial), 2.0))
-    );
     assert!(
         tooling_holes
             .iter()
@@ -1009,13 +991,67 @@ fn board_array_creation_adds_default_tooling_at_single_column_min_width() {
     );
     assert_corner_holes(&corner_holes, 70.0, 70.0);
     assert_points_close(
-        fiducial_points(&top_fiducials),
-        vec![(29.0, 66.15), (41.0, 66.15), (33.0, 3.85), (37.0, 3.85)],
-    );
-    assert_points_close(
         hole_points(&rail_holes),
         vec![(23.5, 67.5), (46.5, 67.5), (27.5, 2.5), (42.5, 2.5)],
     );
+
+    let package = build_manufacturing_package(&ipc, View::ArrayFlattened).unwrap();
+    assert_fiducial_gerbers(&package, "Global");
+}
+
+#[test]
+fn board_array_creation_rejects_missing_bottom_soldermask_for_fiducials() {
+    let input = board_fixture_with_mask_bbox_mm(40.0, 30.0).replace(
+        r#"  <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
+"#,
+        "",
+    );
+    let error = create_board_array_xml(
+        &input,
+        &BoardArrayCreateOptions {
+            columns: 1,
+            rows: 1,
+            board_margin_mm: board_margin(5.0, 5.0),
+            edge_rail_mm: BoardMarginMm::all(20.0),
+        },
+    )
+    .unwrap_err();
+
+    assert!(
+        format!("{error:#}")
+            .contains("missing bottom solder-mask layer required for two-sided surface features"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn board_array_creation_uses_declared_surface_layers_regardless_of_name() {
+    let input = board_fixture_with_mask_bbox_mm(40.0, 30.0)
+        .replace(r#"name="TOP""#, r#"name="front-signal""#)
+        .replace(r#"name="F.Mask""#, r#"name="front-coating""#)
+        .replace(r#"name="BOTTOM""#, r#"name="rear-signal""#)
+        .replace(r#"name="B.Mask""#, r#"name="rear-coating""#);
+    let xml = create_board_array_xml(
+        &input,
+        &BoardArrayCreateOptions {
+            columns: 1,
+            rows: 1,
+            board_margin_mm: board_margin(5.0, 5.0),
+            edge_rail_mm: BoardMarginMm::all(20.0),
+        },
+    )
+    .unwrap();
+
+    let ipc = Ipc2581::parse(&xml).unwrap();
+    let step = array_step(&ipc);
+    for layer_name in [
+        "front-signal",
+        "front-coating",
+        "rear-signal",
+        "rear-coating",
+    ] {
+        assert_eq!(fiducials_on_layer(&ipc, step, layer_name).len(), 4);
+    }
 }
 
 #[test]
@@ -1159,29 +1195,11 @@ fn board_array_creation_adds_board_cell_fiducials_on_top_bottom_margins() {
 
     let ipc = Ipc2581::parse(&xml).unwrap();
     let cell = board_cell_step(&ipc);
-    let top_fiducials = fiducials_on_layer(&ipc, cell, "TOP");
-    let mask_fiducials = fiducials_on_layer(&ipc, cell, "F.Mask");
-
-    assert_eq!(top_fiducials.len(), 4);
-    assert_eq!(mask_fiducials.len(), 4);
-    assert!(
-        top_fiducials
-            .iter()
-            .all(|fiducial| fiducial.kind == IpcFiducialKind::Local)
-    );
-    assert!(
-        top_fiducials
-            .iter()
-            .all(|fiducial| close(fiducial_diameter(fiducial), 1.0))
-    );
-    assert!(
-        mask_fiducials
-            .iter()
-            .all(|fiducial| close(fiducial_diameter(fiducial), 2.0))
-    );
-    assert_points_close(
-        fiducial_points(&top_fiducials),
-        vec![(3.0, 38.0), (37.0, 38.0), (7.0, 2.0), (33.0, 2.0)],
+    assert_two_sided_fiducials(
+        &ipc,
+        cell,
+        IpcFiducialKind::Local,
+        &[(3.0, 38.0), (37.0, 38.0), (7.0, 2.0), (33.0, 2.0)],
     );
 
     let top = geometry::extract_layer_for_view(&ipc, "TOP", View::ArrayFlattened).unwrap();
@@ -1194,15 +1212,7 @@ fn board_array_creation_adds_board_cell_fiducials_on_top_bottom_margins() {
     );
 
     let package = build_manufacturing_package(&ipc, View::ArrayFlattened).unwrap();
-    let top = package
-        .files
-        .iter()
-        .find(|file| file.filename == "F_Cu.gtl")
-        .unwrap();
-    assert!(
-        top.contents
-            .contains("%TA.AperFunction,FiducialPad,Local*%")
-    );
+    assert_fiducial_gerbers(&package, "Local");
 }
 
 #[test]
@@ -1645,6 +1655,45 @@ fn fiducials_on_layer<'a>(
         .collect()
 }
 
+fn assert_two_sided_fiducials(
+    ipc: &Ipc2581,
+    step: &ipc2581::types::ecad::Step,
+    kind: IpcFiducialKind,
+    expected_points: &[(f64, f64)],
+) {
+    for (layer_name, diameter_mm) in [
+        ("TOP", FIDUCIAL_COPPER_DIAMETER_MM),
+        ("F.Mask", FIDUCIAL_MASK_OPENING_DIAMETER_MM),
+        ("BOTTOM", FIDUCIAL_COPPER_DIAMETER_MM),
+        ("B.Mask", FIDUCIAL_MASK_OPENING_DIAMETER_MM),
+    ] {
+        let fiducials = fiducials_on_layer(ipc, step, layer_name);
+        assert_eq!(fiducials.len(), expected_points.len());
+        assert!(fiducials.iter().all(|fiducial| fiducial.kind == kind));
+        assert!(
+            fiducials
+                .iter()
+                .all(|fiducial| close(fiducial_diameter(fiducial), diameter_mm))
+        );
+        assert_points_close(fiducial_points(&fiducials), expected_points.to_vec());
+    }
+}
+
+fn assert_fiducial_gerbers(package: &ManufacturingPackage, kind: &str) {
+    let attribute = format!("%TA.AperFunction,FiducialPad,{kind}*%");
+    for filename in ["F_Cu.gtl", "F_Mask.gts", "B_Cu.gbl", "B_Mask.gbs"] {
+        let file = package
+            .files
+            .iter()
+            .find(|file| file.filename == filename)
+            .unwrap();
+        assert!(
+            file.contents.contains(&attribute),
+            "{filename} is missing {kind} fiducial metadata"
+        );
+    }
+}
+
 fn holes_on_layer<'a>(
     ipc: &'a Ipc2581,
     step: &'a ipc2581::types::ecad::Step,
@@ -1810,6 +1859,8 @@ fn board_fixture_with_mask_bbox_mm(width_mm: f64, height_mm: f64) -> String {
 <CadData>
   <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
   <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+  <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
   <Step name="board" type="BOARD">
     <Datum x="0" y="0"/>
     <Profile>
@@ -1997,6 +2048,9 @@ fn board_fixture_with_edge_cuts_layer_mm() -> &'static str {
 <CadHeader units="MILLIMETER"/>
 <CadData>
   <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+  <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+  <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
   <Layer name="Edge.Cuts" layerFunction="BOARD_OUTLINE" side="ALL" polarity="POSITIVE"/>
   <Step name="board" type="BOARD">
     <Datum x="0" y="0"/>
@@ -2045,6 +2099,9 @@ fn board_fixture_inch() -> &'static str {
 <CadHeader units="INCH"/>
 <CadData>
   <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+  <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+  <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
   <Step name="board" type="BOARD">
     <Datum x="0" y="0"/>
     <Profile>
@@ -2074,6 +2131,9 @@ fn large_board_fixture_mm() -> &'static str {
 <CadHeader units="MILLIMETER"/>
 <CadData>
   <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+  <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+  <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
   <Step name="board" type="BOARD">
     <Datum x="0" y="0"/>
     <Profile>

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tooling.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tooling.rs
@@ -39,7 +39,7 @@ pub(super) fn add_board_array_tooling(
     ecad: &ipc2581::types::Ecad,
     used_layer_names: &mut HashSet<String>,
     spec: BoardArrayToolingSpec,
-) {
+) -> Result<()> {
     let (span_count, board_span) = match spec.orientation {
         BoardArrayToolingOrientation::TopBottom => (spec.columns, spec.board_width_mm),
         BoardArrayToolingOrientation::LeftRight => (spec.rows, spec.board_height_mm),
@@ -50,43 +50,29 @@ pub(super) fn add_board_array_tooling(
         MULTI_BOARD_TOOLING_MIN_SPAN_MM
     };
     if board_span + EPSILON < min_span {
-        return;
+        return Ok(());
     }
 
-    let top_copper_layer_name =
-        ensure_top_copper_layer_name(generated_geometry, ipc, ecad, used_layer_names);
-    let top_soldermask_layer_name =
-        ensure_top_soldermask_layer_name(generated_geometry, ipc, ecad, used_layer_names);
     let tooling_hole_layer_name =
         ensure_tooling_hole_layer_name(generated_geometry, used_layer_names);
 
     let fiducials = board_array_tooling_fiducials(&spec);
-    generated_geometry.add_layer_feature(
+    add_two_sided_fiducials(
+        generated_geometry,
+        ipc,
+        ecad,
         GeneratedFeatureScope::Array,
-        top_copper_layer_name,
-        Polarity::Positive,
-        round_fiducial_features(
-            IpcFiducialKind::Global,
-            fiducials,
-            FIDUCIAL_COPPER_DIAMETER_MM,
-        ),
-    );
-    generated_geometry.add_layer_feature(
-        GeneratedFeatureScope::Array,
-        top_soldermask_layer_name,
-        Polarity::Positive,
-        round_fiducial_features(
-            IpcFiducialKind::Global,
-            fiducials,
-            FIDUCIAL_MASK_OPENING_DIAMETER_MM,
-        ),
-    );
+        IpcFiducialKind::Global,
+        fiducials,
+    )
+    .context("cannot add global board-array fiducials")?;
     generated_geometry.add_layer_feature(
         GeneratedFeatureScope::Array,
         tooling_hole_layer_name,
         Polarity::Positive,
         round_nonplated_hole_features(board_array_tooling_holes(&spec), TOOLING_HOLE_DIAMETER_MM),
     );
+    Ok(())
 }
 
 pub(super) fn add_board_array_corner_tooling(
@@ -118,38 +104,46 @@ pub(super) fn add_board_cell_fiducials(
     generated_geometry: &mut BoardArrayGeneratedGeometry,
     ipc: &Ipc2581,
     ecad: &ipc2581::types::Ecad,
-    used_layer_names: &mut HashSet<String>,
     spec: BoardCellFiducialSpec,
-) {
+) -> Result<()> {
     let Some(fiducials) = board_cell_fiducials(&spec) else {
-        return;
+        return Ok(());
     };
 
-    let top_copper_layer_name =
-        ensure_top_copper_layer_name(generated_geometry, ipc, ecad, used_layer_names);
-    let top_soldermask_layer_name =
-        ensure_top_soldermask_layer_name(generated_geometry, ipc, ecad, used_layer_names);
+    add_two_sided_fiducials(
+        generated_geometry,
+        ipc,
+        ecad,
+        GeneratedFeatureScope::BoardCell,
+        IpcFiducialKind::Local,
+        fiducials,
+    )
+    .context("cannot add local board-cell fiducials")
+}
 
-    generated_geometry.add_layer_feature(
-        GeneratedFeatureScope::BoardCell,
-        top_copper_layer_name,
-        Polarity::Positive,
-        round_fiducial_features(
-            IpcFiducialKind::Local,
-            fiducials,
-            FIDUCIAL_COPPER_DIAMETER_MM,
-        ),
-    );
-    generated_geometry.add_layer_feature(
-        GeneratedFeatureScope::BoardCell,
-        top_soldermask_layer_name,
-        Polarity::Positive,
-        round_fiducial_features(
-            IpcFiducialKind::Local,
-            fiducials,
-            FIDUCIAL_MASK_OPENING_DIAMETER_MM,
-        ),
-    );
+fn add_two_sided_fiducials(
+    generated_geometry: &mut BoardArrayGeneratedGeometry,
+    ipc: &Ipc2581,
+    ecad: &ipc2581::types::Ecad,
+    scope: GeneratedFeatureScope,
+    kind: IpcFiducialKind,
+    points: [(f64, f64); 4],
+) -> Result<()> {
+    let layers = crate::layers::two_sided_surface_layers(ecad)?;
+    for (layer, diameter_mm) in [
+        (layers.top_copper, FIDUCIAL_COPPER_DIAMETER_MM),
+        (layers.top_soldermask, FIDUCIAL_MASK_OPENING_DIAMETER_MM),
+        (layers.bottom_copper, FIDUCIAL_COPPER_DIAMETER_MM),
+        (layers.bottom_soldermask, FIDUCIAL_MASK_OPENING_DIAMETER_MM),
+    ] {
+        generated_geometry.add_layer_feature(
+            scope,
+            ipc.resolve(layer),
+            Polarity::Positive,
+            round_fiducial_features(kind, points, diameter_mm),
+        );
+    }
+    Ok(())
 }
 
 /// Place board array tooling on the shorter pair of array rails.

--- a/crates/pcb-ipc2581-tools/src/layers.rs
+++ b/crates/pcb-ipc2581-tools/src/layers.rs
@@ -4,7 +4,10 @@ use ipc2581::{
     Symbol,
     types::{Ecad, LayerFunction, Side as IpcSide},
 };
-use pcb_ir::dialects::ipc::BoardArrayCopperLayer;
+use pcb_ir::dialects::ipc::{
+    BoardArrayCopperLayer, PhysicalLayer, SurfaceLayerError, TwoSidedSurfaceLayers,
+    resolve_two_sided_surface_layers,
+};
 use pcb_ir::dialects::{LayerRole, Side};
 
 /// True for layer functions that carry copper imagery.
@@ -28,6 +31,19 @@ pub fn copper_layers(ecad: &Ecad) -> Vec<BoardArrayCopperLayer<Symbol>> {
         .filter(|layer| is_copper(layer.layer_function))
         .map(|layer| BoardArrayCopperLayer::new(layer.name, ir_side(layer.side)))
         .collect()
+}
+
+/// Resolve existing outer copper and solder-mask layers for two-sided features.
+pub fn two_sided_surface_layers(
+    ecad: &Ecad,
+) -> Result<TwoSidedSurfaceLayers<Symbol>, SurfaceLayerError> {
+    resolve_two_sided_surface_layers(ecad.cad_data.layers.iter().map(|layer| {
+        PhysicalLayer::new(
+            layer.name,
+            layer_role(layer.layer_function),
+            ir_side(layer.side),
+        )
+    }))
 }
 
 fn ir_side(side: Option<IpcSide>) -> Side {

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -15,6 +15,7 @@ pub mod lower;
 pub mod process;
 pub mod relief;
 pub mod spec;
+pub mod surface_layers;
 pub mod validate;
 
 pub use analysis::{
@@ -48,4 +49,7 @@ pub use lower::{
     board_array_fabrication_profile, lower_layer_to_artwork, lower_to_nc,
 };
 pub use spec::{Spec, SpecItem, SpecItemKind, SpecProperty, SpecRef};
+pub use surface_layers::{
+    PhysicalLayer, SurfaceLayerError, TwoSidedSurfaceLayers, resolve_two_sided_surface_layers,
+};
 pub use validate::{validate_artwork_ready, validate_homogeneous_features};

--- a/crates/pcb-ir/src/dialects/ipc/surface_layers.rs
+++ b/crates/pcb-ir/src/dialects/ipc/surface_layers.rs
@@ -1,0 +1,185 @@
+//! Semantic surface-layer resolution for physical board features.
+
+use std::fmt;
+
+use crate::dialects::{LayerRole, Side};
+
+/// One declared physical layer, classified independently of its source name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PhysicalLayer<Symbol> {
+    pub name: Symbol,
+    pub role: LayerRole,
+    pub side: Side,
+}
+
+impl<Symbol> PhysicalLayer<Symbol> {
+    pub fn new(name: Symbol, role: LayerRole, side: Side) -> Self {
+        Self { name, role, side }
+    }
+}
+
+/// The four declared artwork layers needed for two-sided fiducials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TwoSidedSurfaceLayers<Symbol> {
+    pub top_copper: Symbol,
+    pub top_soldermask: Symbol,
+    pub bottom_copper: Symbol,
+    pub bottom_soldermask: Symbol,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceLayerError {
+    Missing {
+        role: LayerRole,
+        side: Side,
+    },
+    Ambiguous {
+        role: LayerRole,
+        side: Side,
+        count: usize,
+    },
+}
+
+impl fmt::Display for SurfaceLayerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing { role, side } => write!(
+                f,
+                "missing {} {} layer required for two-sided surface features",
+                side_name(*side),
+                role_name(*role),
+            ),
+            Self::Ambiguous { role, side, count } => write!(
+                f,
+                "found {count} {} {} layers; expected exactly one for two-sided surface features",
+                side_name(*side),
+                role_name(*role),
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SurfaceLayerError {}
+
+/// Resolve the declared outer copper and solder-mask layers by semantics.
+///
+/// Physical layers are never inferred or created. Every required role and side
+/// must have exactly one declaration, regardless of its source layer name.
+pub fn resolve_two_sided_surface_layers<Symbol: Copy>(
+    layers: impl IntoIterator<Item = PhysicalLayer<Symbol>>,
+) -> Result<TwoSidedSurfaceLayers<Symbol>, SurfaceLayerError> {
+    let layers = layers.into_iter().collect::<Vec<_>>();
+    Ok(TwoSidedSurfaceLayers {
+        top_copper: resolve_one(&layers, LayerRole::Copper, Side::Top)?,
+        top_soldermask: resolve_one(&layers, LayerRole::Soldermask, Side::Top)?,
+        bottom_copper: resolve_one(&layers, LayerRole::Copper, Side::Bottom)?,
+        bottom_soldermask: resolve_one(&layers, LayerRole::Soldermask, Side::Bottom)?,
+    })
+}
+
+fn resolve_one<Symbol: Copy>(
+    layers: &[PhysicalLayer<Symbol>],
+    role: LayerRole,
+    side: Side,
+) -> Result<Symbol, SurfaceLayerError> {
+    let mut matches = layers
+        .iter()
+        .filter(|layer| layer.role == role && layer.side == side);
+    let Some(layer) = matches.next() else {
+        return Err(SurfaceLayerError::Missing { role, side });
+    };
+    let count = 1 + matches.count();
+    if count > 1 {
+        return Err(SurfaceLayerError::Ambiguous { role, side, count });
+    }
+    Ok(layer.name)
+}
+
+fn role_name(role: LayerRole) -> &'static str {
+    match role {
+        LayerRole::Copper => "copper",
+        LayerRole::Soldermask => "solder-mask",
+        LayerRole::Paste => "paste",
+        LayerRole::Legend => "legend",
+        LayerRole::Profile => "profile",
+        LayerRole::Drill => "drill",
+        LayerRole::Mechanical => "mechanical",
+        LayerRole::Other => "other",
+    }
+}
+
+fn side_name(side: Side) -> &'static str {
+    match side {
+        Side::Top => "top",
+        Side::Bottom => "bottom",
+        Side::Inner => "inner",
+        Side::None => "side-neutral",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_two_sided_layers_by_role_and_side_not_name() {
+        let resolved = resolve_two_sided_surface_layers([
+            PhysicalLayer::new(10, LayerRole::Soldermask, Side::Bottom),
+            PhysicalLayer::new(20, LayerRole::Copper, Side::Top),
+            PhysicalLayer::new(30, LayerRole::Other, Side::Top),
+            PhysicalLayer::new(40, LayerRole::Copper, Side::Bottom),
+            PhysicalLayer::new(50, LayerRole::Soldermask, Side::Top),
+            PhysicalLayer::new(60, LayerRole::Copper, Side::Inner),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            resolved,
+            TwoSidedSurfaceLayers {
+                top_copper: 20,
+                top_soldermask: 50,
+                bottom_copper: 40,
+                bottom_soldermask: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_a_missing_surface_layer() {
+        let error = resolve_two_sided_surface_layers([
+            PhysicalLayer::new(10, LayerRole::Copper, Side::Top),
+            PhysicalLayer::new(20, LayerRole::Soldermask, Side::Top),
+            PhysicalLayer::new(30, LayerRole::Copper, Side::Bottom),
+        ])
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            SurfaceLayerError::Missing {
+                role: LayerRole::Soldermask,
+                side: Side::Bottom,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_an_ambiguous_surface_layer() {
+        let error = resolve_two_sided_surface_layers([
+            PhysicalLayer::new(10, LayerRole::Copper, Side::Top),
+            PhysicalLayer::new(11, LayerRole::Copper, Side::Top),
+            PhysicalLayer::new(20, LayerRole::Soldermask, Side::Top),
+            PhysicalLayer::new(30, LayerRole::Copper, Side::Bottom),
+            PhysicalLayer::new(40, LayerRole::Soldermask, Side::Bottom),
+        ])
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            SurfaceLayerError::Ambiguous {
+                role: LayerRole::Copper,
+                side: Side::Top,
+                count: 2,
+            }
+        );
+    }
+}


### PR DESCRIPTION
Board-array creation emitted fiducials only on the top copper and solder-mask layers, which left two-sided panels without bottom-side registration features. This change resolves the declared surface layers in pcb-ir, rejects incomplete or ambiguous layer sets, and emits matching global and local fiducials on both sides; `cargo test -p pcb-ir` and `cargo test -p pcb-ipc2581-tools` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default panelization output and tightens prerequisites (full two-sided surface layer set), which can break board-array create on IPC files that previously succeeded with top-only layers.
> 
> **Overview**
> Board-array **global** and **local** fiducials are now written on all four declared surface layers—top/bottom copper and solder mask—instead of only top copper and top mask.
> 
> Layer targeting no longer relies on KiCad-style names or auto-created `F.Cu` / `F.Mask`. **pcb-ir** adds `resolve_two_sided_surface_layers`, which picks exactly one layer per copper/mask role and side from IPC declarations; **pcb-ipc2581-tools** routes fiducial placement through that helper. Incomplete stacks (e.g. missing bottom mask) fail at create time with a clear error.
> 
> Copper-balancing tests expect fiducial keepouts on both outer copper layers. Manufacturing/Gerber coverage asserts fiducial metadata on `F_Cu`, `F_Mask`, `B_Cu`, and `B_Mask`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19164fa4afc543b85c4786ed0ea2ed272c946e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->