### PR TITLE
Flatten layers through the artwork compositor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
-
-- Flattened IPC-2581 layer renders no longer drop stroked features such as plane-layer traces.
-
 ### Changed
 
 - Board-array balancing now certifies per-layer regions and reduces density and stack imbalance with variable voids.
@@ -21,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Board-array creation now emits fiducials on both declared copper and solder-mask surfaces.
+- Flattened IPC-2581 layer renders no longer drop stroked features such as plane-layer traces.
 
 ## [0.4.17] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Flattened IPC-2581 layer renders no longer drop stroked features such as plane-layer traces.
+
 ### Changed
 
 - Board-array balancing now certifies per-layer regions and reduces density and stack imbalance with variable voids.

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -285,10 +285,10 @@ fn board_array_creation_accepts_no_source_copper_layers() {
 #[test]
 fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_layers() {
     let input = large_board_fixture_mm();
-    let ipc = Ipc2581::parse(&input).unwrap();
+    let ipc = Ipc2581::parse(input).unwrap();
     let (options, validation_mode, panelization) = auto_board_array_options(&ipc, None).unwrap();
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization).unwrap();
-    let provisional_xml = write_board_array_xml(&input, &spec).unwrap();
+    let provisional_xml = write_board_array_xml(input, &spec).unwrap();
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
     let balance = generate_automatic_board_array_copper_balance(&provisional).unwrap();
     let top = balance

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -322,6 +322,13 @@ pub fn expand_native_geometry_to_regions<LayerMeta, ObjectMeta>(
 }
 
 /// Compose ordered dark/clear objects into final positive per-layer images.
+///
+/// Objects paint stage by stage — [`PaintStage::Base`], then
+/// [`PaintStage::Overlay`], then [`PaintStage::FinalCutout`] — preserving
+/// paint order within each stage, so overlay objects survive base-stage
+/// clears and final cutouts remove painted material. A layer containing only
+/// final-cutout objects, such as a drill or rout document, images the
+/// removals themselves.
 pub fn compose_to_mask<LayerMeta: Clone, ObjectMeta: Clone>(
     doc: &Document<LayerMeta, ObjectMeta>,
 ) -> mask::Document<LayerMeta> {
@@ -340,13 +347,23 @@ pub fn compose_to_mask<LayerMeta: Clone, ObjectMeta: Clone>(
     }
 
     for (layer_index, layer) in doc.layers.iter().enumerate() {
+        let mut objects = layer.objects.slice(&doc.objects).iter().collect::<Vec<_>>();
+        objects.sort_by_key(|object| object.order.stage);
+        let has_material = objects
+            .iter()
+            .any(|object| object.order.stage != PaintStage::FinalCutout);
         let mut composer = region::PaintComposer::default();
-        for object in layer.objects.slice(&doc.objects) {
+        for object in objects {
             let image = object_image_rings(&doc, object);
             if image.is_empty() {
                 continue;
             }
-            composer.push(object.polarity, image);
+            let polarity = if object.order.stage == PaintStage::FinalCutout && has_material {
+                Polarity::Clear
+            } else {
+                object.polarity
+            };
+            composer.push(polarity, image);
         }
 
         let contours = region::rings_to_contours(composer.finish());
@@ -524,6 +541,67 @@ mod tests {
         assert_eq!(mask.layers[0].shapes.len(), 1);
         assert!(!mask.layers[0].bbox.is_empty());
         mask.validate().unwrap();
+    }
+
+    #[test]
+    fn composition_stages_overlays_over_base_clears_and_final_cutouts_last() {
+        let mut doc = Document::<(), ()>::new();
+        let layer = doc.push_layer(Layer::new("F.Cu", LayerRole::Copper, Side::Top));
+        let rect = |doc: &mut Document<(), ()>, x0: f64, y0: f64, x1: f64, y1: f64| {
+            doc.push_path(
+                Paint::Fill {
+                    rule: FillRule::NonZero,
+                },
+                vec![ContourBuf::new(vec![
+                    PathCmd::move_to(Point::new(x0, y0)),
+                    PathCmd::line_to(Point::new(x1, y0)),
+                    PathCmd::line_to(Point::new(x1, y1)),
+                    PathCmd::line_to(Point::new(x0, y1)),
+                    PathCmd::close(),
+                ])],
+            )
+        };
+        let stage_object = |polarity, path, stage| {
+            let mut object = Object::new(polarity, Geometry::Region { path });
+            object.order = PaintOrder { stage };
+            object
+        };
+
+        // Painted out of stage order: overlay trace first, then the base pour
+        // with a clear, then a dark-drawn final cutout.
+        let overlay = rect(&mut doc, 4.0, 4.0, 6.0, 6.0);
+        doc.push_object(
+            layer,
+            stage_object(Polarity::Dark, overlay, PaintStage::Overlay),
+        );
+        let base = rect(&mut doc, 0.0, 0.0, 10.0, 10.0);
+        doc.push_object(layer, stage_object(Polarity::Dark, base, PaintStage::Base));
+        let base_clear = rect(&mut doc, 3.0, 3.0, 7.0, 7.0);
+        doc.push_object(
+            layer,
+            stage_object(Polarity::Clear, base_clear, PaintStage::Base),
+        );
+        let cutout = rect(&mut doc, 0.0, 0.0, 1.0, 1.0);
+        doc.push_object(
+            layer,
+            stage_object(Polarity::Dark, cutout, PaintStage::FinalCutout),
+        );
+
+        let mask = compose_to_mask(&doc);
+        let shape = mask.layers[0].shapes.slice(&mask.arena.paths)[0];
+        let image = region::ContourSet::from_contours(
+            &mask.arena.path_contours(&shape),
+            FillRule::NonZero,
+            crate::geom::tol::REGION_MM,
+        );
+
+        // Overlay survives the base-stage clear painted after it.
+        assert!(image.contains_point(Point::new(5.0, 5.0)));
+        // The base clear still removes material around the overlay.
+        assert!(!image.contains_point(Point::new(3.5, 5.0)));
+        // The dark-drawn final cutout removes material.
+        assert!(!image.contains_point(Point::new(0.5, 0.5)));
+        assert!(image.contains_point(Point::new(9.0, 9.0)));
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -1222,6 +1222,49 @@ mod tests {
     }
 
     #[test]
+    fn flattening_keeps_layer_cutouts_clear() {
+        // Cutout features keep their dark-drawn geometry after composition;
+        // flattening must subtract it, not union it back over the clearance.
+        let mut doc = TestDoc::new();
+        doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            [rect_contour(0.0, 0.0, 4.0, 4.0)],
+        );
+        doc.features.push(Feature {
+            paths: Span::new(0, 1),
+            ..Feature::new(FeatureKind::Polygon, Polarity::Dark)
+        });
+        doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            [rect_contour(1.0, 1.0, 3.0, 3.0)],
+        );
+        let mut cutout = Feature::new(FeatureKind::Polygon, Polarity::Dark);
+        cutout.bucket = FeatureBucket::Cutout;
+        doc.features.push(Feature {
+            paths: Span::new(1, 1),
+            ..cutout
+        });
+        doc.layers.push(test_layer(Span::new(0, 2)));
+
+        compose_for_rendering(&mut doc);
+        flatten_layers_to_masks(&mut doc);
+
+        assert_eq!(doc.features[0].kind, FeatureKind::FlattenedBucket);
+        let path = &doc.arena.paths[doc.features[0].paths.start as usize];
+        let image = ContourSet::from_contours(
+            &doc.arena.path_contours(path),
+            FillRule::NonZero,
+            tol::REGION_MM,
+        );
+        assert!(image.contains_point(Point::new(0.5, 0.5)));
+        assert!(!image.contains_point(Point::new(2.0, 2.0)));
+    }
+
+    #[test]
     fn compact_reclaims_orphaned_paths() {
         let mut doc = TestDoc::new();
         doc.push_path(

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -225,7 +225,12 @@ fn remap_span(span: Span, mapping: &[Option<u32>]) -> Span {
     Span::new(start, span.count)
 }
 
-/// Flatten every layer's positive features into one unioned fill mask.
+/// Flatten every layer's ordered paint into one unioned fill mask.
+///
+/// Each layer is lowered to artwork and composed with the same machinery as
+/// rendering and Gerber export, so strokes, flashes, and polarity sequencing
+/// flatten exactly as they manufacture instead of through a second
+/// composition implementation.
 pub fn flatten_layers_to_masks<S, L>(doc: &mut Document<S, L>)
 where
     S: Copy + Eq + Hash,
@@ -237,28 +242,29 @@ where
             continue;
         }
 
-        let feature_indices = layer.features.range().collect::<Vec<_>>();
-        let rings = feature_indices
-            .iter()
-            .flat_map(|&feature_index| {
-                let feature = &doc.features[feature_index];
-                if feature.bucket == FeatureBucket::Cutout || feature.polarity != Polarity::Dark {
-                    Vec::new()
-                } else {
-                    feature_filled_rings(doc, feature)
-                }
+        let artwork = super::lower_layer_to_artwork(
+            doc,
+            layer_index,
+            crate::dialects::LayerRole::Other,
+            crate::dialects::Side::None,
+        );
+        let mask = crate::dialects::artwork::compose_to_mask(&artwork);
+        let contours = mask
+            .layers
+            .first()
+            .map(|mask_layer| {
+                mask.shapes(mask_layer)
+                    .iter()
+                    .flat_map(|shape| mask.arena.path_contours(shape))
+                    .collect::<Vec<_>>()
             })
-            .collect::<Vec<_>>();
+            .unwrap_or_default();
 
+        let feature_indices = layer.features.range().collect::<Vec<_>>();
         for &feature_index in &feature_indices {
             clear_feature_paths(doc, feature_index);
         }
 
-        if rings.is_empty() {
-            continue;
-        }
-
-        let contours = region::rings_to_contours(region::union_rings(rings, FillRule::NonZero));
         if contours.is_empty() {
             continue;
         }
@@ -1177,6 +1183,42 @@ mod tests {
         assert_eq!(path.bbox.max, Point::new(3.0, 1.0));
         assert_eq!(doc.layers[0].bbox.min, Point::new(0.0, 0.0));
         assert_eq!(doc.layers[0].bbox.max, Point::new(3.0, 1.0));
+    }
+
+    #[test]
+    fn flattening_expands_strokes_that_composition_left_unexpanded() {
+        // Only copper-trace features expand strokes during composition;
+        // primitive strokes reach the flattener as strokes and must still
+        // contribute their swept copper to the mask.
+        let mut doc = TestDoc::new();
+        doc.push_path(
+            Paint::Stroke(StrokeStyle::new(1.0, LineCap::Round)),
+            [ContourBuf::new(vec![
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(5.0, 0.0)),
+            ])],
+        );
+        doc.features.push(Feature {
+            paths: Span::new(0, 1),
+            ..Feature::new(FeatureKind::Primitive, Polarity::Dark)
+        });
+        doc.layers.push(test_layer(Span::new(0, 1)));
+
+        compose_for_rendering(&mut doc);
+        let path = &doc.arena.paths[doc.features[0].paths.start as usize];
+        assert!(
+            path.stroke().is_some(),
+            "precondition: stroke survives composition"
+        );
+
+        flatten_layers_to_masks(&mut doc);
+
+        assert_eq!(doc.features[0].kind, FeatureKind::FlattenedBucket);
+        assert_eq!(doc.features[0].paths.len(), 1);
+        let path = &doc.arena.paths[doc.features[0].paths.start as usize];
+        assert!(path.is_filled());
+        assert_eq!(path.bbox.min, Point::new(-0.5, -0.5));
+        assert_eq!(path.bbox.max, Point::new(5.5, 0.5));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes shared IPC geometry flattening and artwork composition used by `pcb ipc2581 render --flat` and Gerber export; incorrect paint ordering or stroke expansion would show up as wrong copper/mask images.
> 
> **Overview**
> IPC layer flattening for **flat** renders and related export no longer unions dark fills with a separate code path. Each layer is lowered to artwork and run through **`compose_to_mask`**, matching Gerber export and normal rendering so strokes, flashes, polarity, and cutouts flatten the same way.
> 
> **`compose_to_mask`** now composes in **`PaintStage`** order (Base → Overlay → FinalCutout). Overlay geometry survives base-stage clears, and final-cutout objects subtract from painted copper when the layer also has material.
> 
> Documented in the changelog: flattened IPC-2581 layer output no longer drops **stroked** features (e.g. plane-layer traces). Regression tests cover staged composition, primitive strokes after `compose_for_rendering`, and cutout subtraction during flattening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77e052dee17b17baa63a0bd9baf394811604689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->