### PR TITLE
Use DiodeHub Registry defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- PCB search and new-board defaults now use the DiodeHub Registry identity.
 - Board-array balancing now certifies per-layer regions and reduces density and stack imbalance with variable voids.
 - Board-array creation now prints a per-layer copper-balance summary and warns when stackup data is missing.
 - Board-array balancing now keeps clear of stray panel-frame copper instead of failing.

--- a/crates/pcb-diode-api/src/registry/download.rs
+++ b/crates/pcb-diode-api/src/registry/download.rs
@@ -15,7 +15,7 @@ use std::sync::mpsc::Sender;
 use std::thread;
 
 const REGISTRIES_ROUTE: &str = "/api/registries";
-pub const DEFAULT_REGISTRY_URL: &str = "github.com/diodeinc/registry";
+pub const DEFAULT_REGISTRY_URL: &str = pcb_zen_core::package_url::CANONICAL_REGISTRY_REPOSITORY;
 
 #[derive(Debug, Clone, Deserialize, serde::Serialize, PartialEq, Eq)]
 pub struct RegistryInfo {
@@ -37,13 +37,13 @@ impl RegistryInfo {
     pub fn default_registry() -> Self {
         Self {
             id: "default".to_string(),
-            workspace: "diodeinc".to_string(),
-            name: "registry".to_string(),
-            provider: "github".to_string(),
-            owner: "diodeinc".to_string(),
-            repo: "registry".to_string(),
+            workspace: "diode".to_string(),
+            name: "default".to_string(),
+            provider: "diodehub".to_string(),
+            owner: "git".to_string(),
+            repo: "diode/registry".to_string(),
             registry_url: DEFAULT_REGISTRY_URL.to_string(),
-            default_branch: None,
+            default_branch: Some("main".to_string()),
             updated_at: None,
         }
     }
@@ -781,19 +781,10 @@ mod tests {
     }
 
     #[test]
-    fn registry_scope_matches_registry_url() {
-        let registries = vec![registry(
-            "reg_1",
-            "diode",
-            "registry",
-            "github.com/diodeinc/registry",
-        )];
+    fn registry_scope_matches_diodehub_registry_url() {
+        let registries = vec![registry("reg_1", "diode", "registry", DEFAULT_REGISTRY_URL)];
 
-        let scoped = resolve_registry_scope(
-            registries,
-            &["https://github.com/diodeinc/registry.git".into()],
-        )
-        .unwrap();
+        let scoped = resolve_registry_scope(registries, &[DEFAULT_REGISTRY_URL.into()]).unwrap();
 
         assert_eq!(scoped.len(), 1);
         assert_eq!(scoped[0].id, "reg_1");
@@ -809,8 +800,9 @@ mod tests {
             Some("code.diode.computer/revel/registry")
         );
         assert_eq!(
-            registry_url_from_package_url("github.com/diodeinc/registry/modules/foo").as_deref(),
-            Some("github.com/diodeinc/registry")
+            registry_url_from_package_url("code.diode.computer/diode/registry/modules/foo")
+                .as_deref(),
+            Some(DEFAULT_REGISTRY_URL)
         );
     }
 
@@ -830,12 +822,7 @@ mod tests {
     #[test]
     fn default_scope_selects_public_and_workspace_registries() {
         let registries = vec![
-            registry(
-                "public",
-                "diode",
-                "registry",
-                "github.com/diodeinc/registry",
-            ),
+            registry("public", "diode", "registry", DEFAULT_REGISTRY_URL),
             registry(
                 "workspace",
                 "weave",
@@ -853,6 +840,22 @@ mod tests {
             .map(|registry| registry.id.as_str())
             .collect::<Vec<_>>();
         assert_eq!(ids, vec!["public", "workspace"]);
+    }
+
+    #[test]
+    fn cached_default_scope_uses_diodehub_registry_metadata() {
+        let fallback = RegistryInfo::default_registry();
+        assert_eq!(fallback.workspace, "diode");
+        assert_eq!(fallback.name, "default");
+        assert_eq!(fallback.provider, "diodehub");
+        assert_eq!(fallback.owner, "git");
+        assert_eq!(fallback.repo, "diode/registry");
+        assert_eq!(fallback.registry_url, DEFAULT_REGISTRY_URL);
+        assert_eq!(fallback.default_branch.as_deref(), Some("main"));
+
+        let selected = default_registry_scope_for_prefix(vec![fallback], None);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].registry_url, DEFAULT_REGISTRY_URL);
     }
 
     #[test]
@@ -908,18 +911,13 @@ repository = "code.diode.computer/wildwestsystems"
 
     #[test]
     fn registry_scope_rejects_unknown_selector() {
-        let registries = vec![registry(
-            "reg_1",
-            "diode",
-            "registry",
-            "github.com/diodeinc/registry",
-        )];
+        let registries = vec![registry("reg_1", "diode", "registry", DEFAULT_REGISTRY_URL)];
 
         let err = resolve_registry_scope(registries, &["github.com/acme/parts".into()])
             .unwrap_err()
             .to_string();
 
         assert!(err.contains("github.com/acme/parts"));
-        assert!(err.contains("github.com/diodeinc/registry"));
+        assert!(err.contains(DEFAULT_REGISTRY_URL));
     }
 }

--- a/crates/pcb-diode-api/src/registry/tui/ui.rs
+++ b/crates/pcb-diode-api/src/registry/tui/ui.rs
@@ -1643,7 +1643,7 @@ fn render_dependency_tree(lines: &mut Vec<Line>, deps: &[RegistryModuleDependenc
     let count = deps.len();
 
     for dep in deps.iter().take(max_shown) {
-        // Split URL into parts: "github.com/diodeinc/registry" / rest
+        // Split URL into parts: "code.diode.computer/diode/registry" / rest
         let parts: Vec<_> = dep.url.split('/').collect();
         let registry_prefix = if parts.len() >= 3 {
             format!("{}/{}/{}/", parts[0], parts[1], parts[2])

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -234,7 +234,7 @@ impl PcbToml {
     ///
     /// Takes the last path segment as the alias key. Only creates alias if unique (no collisions).
     /// Examples:
-    /// - "github.com/diodeinc/registry/reference/XAL7070-562MEx" → "@XAL7070-562MEx"
+    /// - "code.diode.computer/diode/registry/reference/XAL7070-562MEx" → "@XAL7070-562MEx"
     pub fn auto_generated_aliases(&self) -> HashMap<String, String> {
         let mut aliases = HashMap::new();
         let mut seen_names: HashMap<String, usize> = HashMap::new();
@@ -293,7 +293,7 @@ pub struct WorkspaceConfig {
     pub name: Option<String>,
 
     /// Repository URL for workspace (V2 only, required for V2 multi-package workspaces)
-    /// Example: "github.com/diodeinc/registry"
+    /// Example: "code.diode.computer/diode/registry"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repository: Option<String>,
 
@@ -323,7 +323,7 @@ pub struct WorkspaceConfig {
     pub default_board: Option<String>,
 
     /// Patterns for dependencies to auto-vendor during build (supports globs)
-    /// Example: ["github.com/diodeinc/registry/*"]
+    /// Example: ["code.diode.computer/diode/registry/*"]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub vendor: Vec<String>,
 

--- a/crates/pcb-zen-core/src/load_spec.rs
+++ b/crates/pcb-zen-core/src/load_spec.rs
@@ -92,7 +92,7 @@ impl LoadSpec {
     ///
     /// • **Package URI** – `"package://<url>/<path>"`.
     ///   A stable, machine-independent reference to a file within a resolved package.
-    ///   Example: `"package://github.com/diodeinc/registry/reference/TPS54331/TPS54331.zen"`.
+    ///   Example: `"package://code.diode.computer/diode/registry/reference/TPS54331/TPS54331.zen"`.
     ///
     /// • **Stdlib package URI** – `"package://stdlib/<path>"`.
     ///   A stable reference to a toolchain-managed stdlib file.

--- a/crates/pcbc/src/new.rs
+++ b/crates/pcbc/src/new.rs
@@ -504,22 +504,6 @@ mod tests {
     }
 
     #[test]
-    fn test_board_template_uses_diodehub_registry_vendor() {
-        let rendered = create_template_env()
-            .get_template("board_pcb_toml")
-            .unwrap()
-            .render(context! {
-                board => "MainBoard",
-                repository => "code.diode.computer/acme/MainBoard",
-                pcb_version => "0.4",
-            })
-            .unwrap();
-
-        assert!(rendered.contains("vendor = [\"code.diode.computer/diode/registry/**\"]"));
-        assert!(!rendered.contains("github.com/diodeinc/registry"));
-    }
-
-    #[test]
     fn test_component_accepts_optional_directory() {
         let parsed = TestCli::try_parse_from(["pcb", "component"]).unwrap();
         assert!(matches!(

--- a/crates/pcbc/src/new.rs
+++ b/crates/pcbc/src/new.rs
@@ -504,6 +504,22 @@ mod tests {
     }
 
     #[test]
+    fn test_board_template_uses_diodehub_registry_vendor() {
+        let rendered = create_template_env()
+            .get_template("board_pcb_toml")
+            .unwrap()
+            .render(context! {
+                board => "MainBoard",
+                repository => "code.diode.computer/acme/MainBoard",
+                pcb_version => "0.4",
+            })
+            .unwrap();
+
+        assert!(rendered.contains("vendor = [\"code.diode.computer/diode/registry/**\"]"));
+        assert!(!rendered.contains("github.com/diodeinc/registry"));
+    }
+
+    #[test]
     fn test_component_accepts_optional_directory() {
         let parsed = TestCli::try_parse_from(["pcb", "component"]).unwrap();
         assert!(matches!(

--- a/crates/pcbc/src/templates/board_pcb_toml.jinja
+++ b/crates/pcbc/src/templates/board_pcb_toml.jinja
@@ -1,7 +1,7 @@
 [workspace]
 {% if repository %}repository = "{{ repository }}"
 {% endif %}pcb-version = "{{ pcb_version }}"
-vendor = ["github.com/diodeinc/registry/**"]
+vendor = ["code.diode.computer/diode/registry/**"]
 
 [board]
 name = "{{ board }}"

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -152,7 +152,7 @@ each package to use:
 
 ```toml
 [dependencies]
-"github.com/diodeinc/registry/components/ti/tps54331" = "1.0"
+"code.diode.computer/diode/registry/components/ti/tps54331" = "1.0"
 ```
 
 This separation keeps import statements stable across upgrades and confines
@@ -168,11 +168,11 @@ Workspaces store resolved dependency state in `pcb.toml`. `pcb sync` updates:
 
 ```toml
 [dependencies]
-"github.com/diodeinc/registry/modules/Regulator" = "1.0"
+"code.diode.computer/diode/registry/modules/Regulator" = "1.0"
 
 [dependencies.indirect]
-"github.com/diodeinc/registry/components/TPS54331@1" = "1.0.2"
-"github.com/diodeinc/registry/modules/Feedback@1" = "1.1.0"
+"code.diode.computer/diode/registry/components/TPS54331@1" = "1.0.2"
+"code.diode.computer/diode/registry/modules/Feedback@1" = "1.1.0"
 ```
 
 The `@1` suffix is a compatibility lane. It allows multiple
@@ -246,7 +246,7 @@ which uses fuzzy matching.
 Registry-backed `pcb search` searches the public Diode registry and the
 registries configured by `[workspace].repository`.
 
-- `pcb search --registry github.com/diodeinc/registry ...` overrides the default
+- `pcb search --registry code.diode.computer/diode/registry ...` overrides the default
   scope for that invocation.
 - Repeat `--registry` to search more than one registry.
 

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -47,7 +47,7 @@ load("@stdlib/interfaces.zen", "Spi")
 
 # Remote packages (version declared in pcb.toml)
 Resistor = Module("@stdlib/generics/Resistor.zen")
-TPS54331 = Module("github.com/diodeinc/registry/components/TPS54331/TPS54331.zen")
+TPS54331 = Module("code.diode.computer/diode/registry/components/TPS54331/TPS54331.zen")
 ```
 
 The toolchain supplies the virtual `@stdlib` package. Do not declare it in
@@ -58,7 +58,7 @@ statements remain stable across upgrades:
 
 ```toml
 [dependencies]
-"github.com/diodeinc/registry/components/TPS54331" = "1.0"
+"code.diode.computer/diode/registry/components/TPS54331" = "1.0"
 ```
 
 ### Dependency resolution
@@ -150,7 +150,7 @@ pcb-version = "0.4"
 
 ```toml
 [dependencies]
-"github.com/diodeinc/registry/components/TPS54331" = "1.0"
+"code.diode.computer/diode/registry/components/TPS54331" = "1.0"
 
 parts = [
   { mpn = "TPS54331DR", symbol = "TPS54331.kicad_sym", symbol_name = "TPS54331", manufacturer = "Texas Instruments", qualifications = ["Preferred"] },
@@ -448,7 +448,7 @@ Modules are reusable subcircuits — `.zen` files that declare their electrical 
 
 ```python
 PowerSupply = Module("./modules/PowerSupply.zen")
-TPS54331 = Module("github.com/diodeinc/registry/components/TPS54331/TPS54331.zen")
+TPS54331 = Module("code.diode.computer/diode/registry/components/TPS54331/TPS54331.zen")
 ```
 
 Instantiation takes a required `name` and passes remaining arguments as inputs to the module's `io()` and `config()` declarations:


### PR DESCRIPTION
PCB still used the GitHub Registry identity for default search scope and new board templates while production moves to DiodeHub. This change makes the DiodeHub Registry canonical for search, cached metadata, templates, and documentation, with coverage for online, explicit, and offline selection.