### PR TITLE
Fall back to SSH for Git dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Git dependency resolution now falls back to SSH when DiodeHub HTTPS authentication is unavailable.
+
 ## [0.4.18] - 2026-08-03
 
 ### Changed

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -17,7 +17,6 @@ const DIODEHUB_CREDENTIAL_HELPER: &str = "!pcb auth git";
 const DIODEHUB_CREDENTIAL_HELPER_CONFIG: &str = "credential.https://code.diode.computer.helper";
 const DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG: &str =
     "credential.https://code.diode.computer.useHttpPath";
-const DIODEHUB_HOST: &str = "code.diode.computer";
 const GIT_CONFIG_NOT_FOUND: i32 = 5;
 
 #[derive(Debug, Clone)]
@@ -634,12 +633,7 @@ pub fn push_branch_force(repo_root: &Path, branch: &str, remote: &str) -> anyhow
 /// Clone a repository with HTTPS, falling back to SSH
 pub fn clone_with_fallback(repo_url: &str, dest: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(dest.parent().unwrap_or(dest))?;
-    let https_url = format!("https://{}.git", repo_url);
-    match clone(&https_url, dest, false) {
-        Ok(()) => Ok(()),
-        Err(error) if is_diodehub_repo(repo_url) => Err(error),
-        Err(_) => clone(&format_ssh_url(repo_url), dest, true),
-    }
+    with_remote_fallback(repo_url, |url, prompt| clone(url, dest, prompt)).map(|_| ())
 }
 
 /// Create or reset a branch to point at a specific ref
@@ -780,10 +774,18 @@ pub fn format_ssh_url(module_path: &str) -> String {
     }
 }
 
-fn is_diodehub_repo(repo_url: &str) -> bool {
-    repo_url
-        .split_once('/')
-        .is_some_and(|(host, _)| host == DIODEHUB_HOST)
+fn with_remote_fallback<T>(
+    repo_url: &str,
+    mut operation: impl FnMut(&str, bool) -> anyhow::Result<T>,
+) -> anyhow::Result<(T, String)> {
+    let https_url = format!("https://{}.git", repo_url);
+    match operation(&https_url, false) {
+        Ok(value) => Ok((value, https_url)),
+        Err(_) => {
+            let ssh_url = format_ssh_url(repo_url);
+            operation(&ssh_url, true).map(|value| (value, ssh_url))
+        }
+    }
 }
 
 pub fn parse_remote_url(url: &str) -> anyhow::Result<String> {
@@ -808,32 +810,21 @@ pub fn ls_remote_with_fallback(
     refspec: &str,
 ) -> anyhow::Result<(String, String)> {
     let (repo_url, _) = split_repo_and_subpath(module_path);
-    let https_url = format!("https://{}.git", repo_url);
-    if let Some(commit) = ls_remote(&https_url, refspec, false)? {
-        return Ok((commit, https_url));
-    }
-
-    if !is_diodehub_repo(repo_url) {
-        let ssh_url = format_ssh_url(repo_url);
-        if let Some(commit) = ls_remote(&ssh_url, refspec, true)? {
-            return Ok((commit, ssh_url));
-        }
-    }
-
-    anyhow::bail!("Failed to ls-remote {} for {}", refspec, module_path)
+    with_remote_fallback(repo_url, |url, interactive| {
+        ls_remote(url, refspec, interactive)
+    })
+    .with_context(|| format!("Failed to ls-remote {} for {}", refspec, module_path))
 }
 
-fn ls_remote(url: &str, refspec: &str, interactive: bool) -> anyhow::Result<Option<String>> {
+fn ls_remote(url: &str, refspec: &str, interactive: bool) -> anyhow::Result<String> {
     let mut cmd = git_global_network_with_prompt(interactive)?;
-    let out = cmd.args(["ls-remote", url, refspec]).output()?;
-    if !out.status.success() {
-        return Ok(None);
-    }
-    Ok(String::from_utf8_lossy(&out.stdout)
-        .lines()
+    cmd.args(["ls-remote", url, refspec]);
+    let out = run_stdout(cmd)?;
+    out.lines()
         .next()
         .and_then(|line| line.split_whitespace().next())
-        .map(str::to_string))
+        .map(str::to_string)
+        .with_context(|| format!("No matching ref {refspec} at {url}"))
 }
 
 pub fn resolve_branch_head(module_path: &str, branch: &str) -> anyhow::Result<String> {
@@ -997,6 +988,36 @@ mod tests {
         assert_eq!(
             format_ssh_url("gitlab.com/group/project"),
             "git@gitlab.com:group/project.git"
+        );
+    }
+
+    #[test]
+    fn remote_fallback_uses_ssh_after_https_failure() {
+        let mut attempts = Vec::new();
+        let (value, url) =
+            with_remote_fallback("code.diode.computer/diode/registry", |url, interactive| {
+                attempts.push((url.to_string(), interactive));
+                if url.starts_with("https://") {
+                    anyhow::bail!("HTTPS unavailable");
+                }
+                Ok("fetched")
+            })
+            .unwrap();
+
+        assert_eq!(value, "fetched");
+        assert_eq!(url, "git@code.diode.computer:diode/registry.git");
+        assert_eq!(
+            attempts,
+            [
+                (
+                    "https://code.diode.computer/diode/registry.git".to_string(),
+                    false
+                ),
+                (
+                    "git@code.diode.computer:diode/registry.git".to_string(),
+                    true
+                ),
+            ]
         );
     }
 

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -810,21 +810,23 @@ pub fn ls_remote_with_fallback(
     refspec: &str,
 ) -> anyhow::Result<(String, String)> {
     let (repo_url, _) = split_repo_and_subpath(module_path);
-    with_remote_fallback(repo_url, |url, interactive| {
+    let (commit, url) = with_remote_fallback(repo_url, |url, interactive| {
         ls_remote(url, refspec, interactive)
     })
-    .with_context(|| format!("Failed to ls-remote {} for {}", refspec, module_path))
+    .with_context(|| format!("Failed to ls-remote {} for {}", refspec, module_path))?;
+    let commit = commit.with_context(|| format!("No matching ref {refspec} for {module_path}"))?;
+    Ok((commit, url))
 }
 
-fn ls_remote(url: &str, refspec: &str, interactive: bool) -> anyhow::Result<String> {
+fn ls_remote(url: &str, refspec: &str, interactive: bool) -> anyhow::Result<Option<String>> {
     let mut cmd = git_global_network_with_prompt(interactive)?;
     cmd.args(["ls-remote", url, refspec]);
     let out = run_stdout(cmd)?;
-    out.lines()
+    Ok(out
+        .lines()
         .next()
         .and_then(|line| line.split_whitespace().next())
-        .map(str::to_string)
-        .with_context(|| format!("No matching ref {refspec} at {url}"))
+        .map(str::to_string))
 }
 
 pub fn resolve_branch_head(module_path: &str, branch: &str) -> anyhow::Result<String> {
@@ -1019,6 +1021,19 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn remote_fallback_stops_after_https_success() {
+        let mut attempts = Vec::new();
+        let (value, _) = with_remote_fallback("code.diode.computer/diode/registry", |_, prompt| {
+            attempts.push(prompt);
+            Ok(None::<String>)
+        })
+        .unwrap();
+
+        assert_eq!(value, None);
+        assert_eq!(attempts, [false]);
     }
 
     #[test]


### PR DESCRIPTION
PCB stopped after DiodeHub HTTPS authentication failed, even when the same repository was available through SSH. This change removes the DiodeHub-only exception, uses one HTTPS-to-SSH fallback path for clone and `ls-remote`, and adds a regression test so SSH-enabled sandboxes can sync; `cargo test -p pcb-zen`, `cargo fmt --all`, and `git diff --check` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to remote git transport selection in pcb-zen; behavior is broader fallback with regression tests and no auth or data-model changes.
> 
> **Overview**
> Git dependency **clone** and **`ls-remote`** now share a single **HTTPS-then-SSH** path instead of treating DiodeHub (`code.diode.computer`) as HTTPS-only.
> 
> The old **`is_diodehub_repo`** guard is removed, so a failed DiodeHub HTTPS attempt (e.g. missing or invalid credential helper auth) can retry over SSH like other hosts. HTTPS still runs non-interactively first; SSH is tried with interactive prompting enabled.
> 
> **`ls_remote`** now surfaces command failures via **`run_stdout`** so HTTPS errors trigger fallback instead of being treated as “no ref.” **`ls_remote_with_fallback`** returns clearer errors when both transports fail or the ref is missing. Unit tests cover HTTPS failure → SSH and HTTPS success without a second attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e292cefe7ce47c9adbdb3ae600c3336cca163c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->