### PR TITLE
Update Starlark runtime to 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Legacy Registry references now prefer the canonical DiodeHub identity while remaining compatible with legacy workspace identities.
+- Updated the embedded Starlark runtime to the rebased starlark-rust 0.14.2 APIs.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,11 +41,12 @@ dependencies = [
 [[package]]
 name = "allocative"
 version = "0.3.6"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "allocative_derive",
  "bumpalo",
  "ctor",
+ "dashmap",
  "hashbrown 0.16.1",
  "num-bigint",
 ]
@@ -53,7 +54,7 @@ dependencies = [
 [[package]]
 name = "allocative_derive"
 version = "0.3.6"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -139,7 +140,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -150,7 +151,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -222,15 +223,6 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
 
 [[package]]
 name = "assert-json-diff"
@@ -1190,7 +1182,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
 ]
 
@@ -1239,7 +1231,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 
 [[package]]
 name = "cobs"
@@ -1274,7 +1266,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1625,12 +1617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,7 +1715,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.118",
 ]
 
@@ -1892,12 +1878,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,16 +1916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,19 +1923,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
+ "redox_users",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1983,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "either",
  "indenter",
@@ -2036,35 +1995,15 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "dupe"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
- "dupe_derive 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "dupe"
-version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
-dependencies = [
- "dupe_derive 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
+ "dupe_derive",
 ]
 
 [[package]]
 name = "dupe_derive"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "dupe_derive"
-version = "0.9.1"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2094,15 +2033,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "ena"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
-dependencies = [
- "log",
-]
 
 [[package]]
 name = "encode_unicode"
@@ -2181,7 +2111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2250,7 +2180,7 @@ checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2352,6 +2282,15 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "fnv"
@@ -2706,7 +2645,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3417,7 +3356,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -3477,7 +3416,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3495,15 +3434,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3691,37 +3621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
-name = "lalrpop"
-version = "0.19.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "diff",
- "ena",
- "is-terminal",
- "itertools 0.10.5",
- "lalrpop-util",
- "petgraph 0.6.5",
- "regex",
- "regex-syntax 0.6.29",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.19.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "lazy-regex"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3894,7 +3793,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.11",
+ "regex-syntax",
  "rustc_version",
  "syn 2.0.118",
 ]
@@ -3947,6 +3846,19 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
 ]
 
 [[package]]
@@ -4049,15 +3961,6 @@ name = "memo-map"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "memoffset"
@@ -4199,12 +4102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,7 +4132,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -4306,7 +4203,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4569,7 +4466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4580,8 +4477,8 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "pagable"
-version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+version = "0.4.1"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "allocative",
  "anyhow",
@@ -4589,10 +4486,12 @@ dependencies = [
  "blake3",
  "bytemuck",
  "dashmap",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
+ "dupe",
  "either",
  "erased-serde 0.4.10",
  "fancy-regex 0.16.2",
+ "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "indexmap",
  "inventory",
  "num-bigint",
@@ -4605,17 +4504,19 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "sorted_vector_map",
  "static_assertions",
  "static_interner",
  "strong_hash",
  "take_mut",
+ "thiserror 2.0.18",
  "triomphe",
 ]
 
 [[package]]
 name = "pagable_derive"
-version = "0.3.3"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+version = "0.4.1"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5002,10 +4903,10 @@ dependencies = [
  "anyhow",
  "derivative",
  "derive_more 2.1.1",
- "dupe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dupe",
  "itertools 0.15.0",
  "lsp-server",
- "lsp-types",
+ "lsp-types 0.94.1",
  "maplit",
  "regex",
  "serde",
@@ -5052,7 +4953,7 @@ dependencies = [
  "ariadne",
  "debugserver-types",
  "dirs",
- "dupe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dupe",
  "fslock",
  "globset",
  "hex",
@@ -5061,7 +4962,7 @@ dependencies = [
  "jiff",
  "log",
  "lsp-server",
- "lsp-types",
+ "lsp-types 0.94.1",
  "path-slash",
  "pcb-canonical",
  "pcb-sch",
@@ -5187,7 +5088,7 @@ dependencies = [
  "pcb-ui",
  "pcb-zen",
  "pcb-zen-core",
- "petgraph 0.8.3",
+ "petgraph",
  "rayon",
  "reqwest",
  "semver",
@@ -5255,16 +5156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap",
 ]
 
 [[package]]
@@ -5431,12 +5322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5554,6 +5439,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quickcheck"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.10.2",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5607,7 +5503,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5968,17 +5864,6 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -6017,7 +5902,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6028,7 +5913,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6036,12 +5921,6 @@ name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -6516,7 +6395,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6575,7 +6454,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7184,7 +7063,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "sorted_vector_map"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bf565ee1681b4473aa5a9d71d807347c28021bd1d8947cb626b02f42a0141f"
+dependencies = [
+ "itertools 0.14.0",
+ "quickcheck",
 ]
 
 [[package]]
@@ -7225,8 +7114,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starlark"
-version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+version = "0.14.2"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "allocative",
  "anyhow",
@@ -7238,7 +7127,7 @@ dependencies = [
  "derivative",
  "derive_more 1.0.0",
  "display_container",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
+ "dupe",
  "either",
  "erased-serde 0.3.31",
  "hashbrown 0.16.1",
@@ -7246,7 +7135,6 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "maplit",
- "memoffset 0.6.5",
  "num-bigint",
  "num-traits",
  "once_cell",
@@ -7254,7 +7142,6 @@ dependencies = [
  "paste",
  "ref-cast",
  "regex",
- "rust_decimal",
  "rustyline",
  "serde",
  "serde_json",
@@ -7263,17 +7150,17 @@ dependencies = [
  "starlark_syntax",
  "static_assertions",
  "strong_hash",
- "strsim 0.10.0",
+ "strsim",
  "textwrap 0.11.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "starlark_derive"
-version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+version = "0.14.2"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
+ "dupe",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7281,11 +7168,11 @@ dependencies = [
 
 [[package]]
 name = "starlark_map"
-version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+version = "0.14.2"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "allocative",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
+ "dupe",
  "equivalent",
  "fxhash",
  "hashbrown 0.16.1",
@@ -7296,19 +7183,17 @@ dependencies = [
 
 [[package]]
 name = "starlark_syntax"
-version = "0.14.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+version = "0.14.2"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "allocative",
  "annotate-snippets",
  "anyhow",
  "derivative",
  "derive_more 1.0.0",
- "dupe 0.9.1 (git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937)",
- "lalrpop",
- "lalrpop-util",
+ "dupe",
  "logos",
- "lsp-types",
+ "lsp-types 0.97.0",
  "memchr",
  "num-bigint",
  "num-traits",
@@ -7368,18 +7253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
 name = "stringmetrics"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7397,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "strong_hash"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "ref-cast",
  "strong_hash_derive",
@@ -7406,17 +7279,11 @@ dependencies = [
 [[package]]
 name = "strong_hash_derive"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/starlark-rust?rev=deba1116f93e97b4db3eb0631bae3a39c4f09937#deba1116f93e97b4db3eb0631bae3a39c4f09937"
+source = "git+https://github.com/diodeinc/starlark-rust?rev=c3d776bcd0bf074b00fc059d7700b82ab8dcc010#c3d776bcd0bf074b00fc059d7700b82ab8dcc010"
 dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -7538,7 +7405,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "onig",
- "regex-syntax 0.8.11",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "thiserror 2.0.18",
@@ -7604,21 +7471,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7647,7 +7503,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7663,7 +7519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7849,15 +7705,6 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -8700,7 +8547,7 @@ checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float 4.6.0",
- "strsim 0.11.1",
+ "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]
@@ -8761,7 +8608,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ authors = ["Diode Computers, Inc. <founders@diode.computer>"]
 
 [workspace.dependencies]
 glam = "0.33"
-starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
-starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
-starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
-allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
-pagable = { git = "https://github.com/diodeinc/starlark-rust", rev = "deba1116f93e97b4db3eb0631bae3a39c4f09937", default-features = false }
+starlark = { git = "https://github.com/diodeinc/starlark-rust", rev = "c3d776bcd0bf074b00fc059d7700b82ab8dcc010", default-features = false }
+starlark_map = { git = "https://github.com/diodeinc/starlark-rust", rev = "c3d776bcd0bf074b00fc059d7700b82ab8dcc010", default-features = false }
+starlark_syntax = { git = "https://github.com/diodeinc/starlark-rust", rev = "c3d776bcd0bf074b00fc059d7700b82ab8dcc010", default-features = false }
+allocative = { git = "https://github.com/diodeinc/starlark-rust", rev = "c3d776bcd0bf074b00fc059d7700b82ab8dcc010", default-features = false }
+pagable = { git = "https://github.com/diodeinc/starlark-rust", rev = "c3d776bcd0bf074b00fc059d7700b82ab8dcc010", default-features = false }
 
 ruff_python_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.20" }
 ruff_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.20" }
@@ -60,7 +60,7 @@ clap = { version = "4", features = ["derive", "wrap_help"] }
 colored = "3"
 derive_more = { version = "2.1.1", features = ["full"] }
 dirs = "6"
-dupe = "0.9.1"
+dupe = { git = "https://github.com/diodeinc/starlark-rust", rev = "c3d776bcd0bf074b00fc059d7700b82ab8dcc010" }
 duct = "1.1.1"
 env_logger = "0.11"
 indicatif = "0.18"

--- a/crates/pcb-sch/src/physical.rs
+++ b/crates/pcb-sch/src/physical.rs
@@ -13,7 +13,7 @@ use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use starlark::{
     any::ProvidesStaticType,
-    environment::{Methods, MethodsBuilder, MethodsStatic},
+    environment::{Methods, MethodsBuilder},
     eval::{Arguments, Evaluator, ParametersSpec, ParametersSpecParam},
     starlark_simple_value,
     typing::{
@@ -139,14 +139,17 @@ fn starlark_value_to_decimal(
 pub struct PhysicalValue {
     /// The nominal/typical value (always required)
     #[allocative(skip)]
+    #[freeze(identity)]
     #[serde(with = "rust_decimal::serde::str")]
     pub nominal: Decimal,
     /// Lower bound (can be asymmetric from nominal)
     #[allocative(skip)]
+    #[freeze(identity)]
     #[serde(with = "rust_decimal::serde::str")]
     pub min: Decimal,
     /// Upper bound (can be asymmetric from nominal)
     #[allocative(skip)]
+    #[freeze(identity)]
     #[serde(with = "rust_decimal::serde::str")]
     pub max: Decimal,
     /// Physical unit dimensions
@@ -1714,6 +1717,7 @@ impl<'v> StarlarkValue<'v> for PhysicalUnitDims {
 }
 
 starlark_simple_value!(PhysicalValue);
+starlark::methods_static!(PHYSICAL_VALUE_METHODS = physical_value_methods);
 
 #[starlark::starlark_module]
 fn physical_value_methods(methods: &mut MethodsBuilder) {
@@ -1868,8 +1872,7 @@ fn physical_value_methods(methods: &mut MethodsBuilder) {
 #[starlark_value(type = "PhysicalValue")]
 impl<'v> StarlarkValue<'v> for PhysicalValue {
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new("PhysicalValue", physical_value_methods);
-        Some(RES.methods())
+        Some(PHYSICAL_VALUE_METHODS.methods())
     }
 
     fn write_hash(&self, hasher: &mut StarlarkHasher) -> starlark::Result<()> {
@@ -2014,6 +2017,7 @@ impl Freeze for PhysicalValueType {
 }
 
 starlark_simple_value!(PhysicalValueType);
+starlark::methods_static!(PHYSICAL_VALUE_TYPE_METHODS = value_type_methods);
 
 impl fmt::Display for PhysicalValueType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -2342,8 +2346,7 @@ impl<'v> StarlarkValue<'v> for PhysicalValueType {
     }
 
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new("PhysicalValueType", value_type_methods);
-        Some(RES.methods())
+        Some(PHYSICAL_VALUE_TYPE_METHODS.methods())
     }
 }
 

--- a/crates/pcb-starlark-lsp/src/completion.rs
+++ b/crates/pcb-starlark-lsp/src/completion.rs
@@ -26,7 +26,6 @@ use lsp_types::CompletionTextEdit;
 use lsp_types::Documentation;
 use lsp_types::MarkupContent;
 use lsp_types::MarkupKind;
-use lsp_types::Range;
 use lsp_types::TextEdit;
 use starlark::codemap::ResolvedSpan;
 use starlark::docs::DocItem;
@@ -44,6 +43,7 @@ use crate::exported::SymbolKind as ExportedSymbolKind;
 use crate::server::Backend;
 use crate::server::LspContext;
 use crate::server::LspUrl;
+use crate::span::IntoLspRange;
 use crate::symbols::SymbolKind;
 use crate::symbols::find_symbols_at_location;
 
@@ -167,7 +167,7 @@ impl<T: LspContext> Backend<T> {
                     .map(|symbol| {
                         let mut item: CompletionItem = symbol.into();
                         item.text_edit = Some(CompletionTextEdit::Edit(TextEdit {
-                            range: current_span.into(),
+                            range: current_span.to_lsp_range(),
                             new_text: item.label.clone(),
                         }));
                         item
@@ -323,7 +323,7 @@ impl<T: LspContext> Backend<T> {
             .get_string_completion_options(document_uri, kind, current_value, workspace_root)?
             .into_iter()
             .map(|result| {
-                let mut range: Range = current_span.into();
+                let mut range = current_span.to_lsp_range();
                 range.start.character += result.insert_text_offset as u32;
 
                 CompletionItem {

--- a/crates/pcb-starlark-lsp/src/error.rs
+++ b/crates/pcb-starlark-lsp/src/error.rs
@@ -20,9 +20,11 @@ use lsp_types::Range;
 use starlark::analysis::EvalMessage;
 use starlark::analysis::EvalSeverity;
 
+use crate::span::IntoLspRange;
+
 pub fn eval_message_to_lsp_diagnostic(eval_message: EvalMessage) -> lsp_types::Diagnostic {
     let range = match eval_message.span {
-        Some(s) => s.into(),
+        Some(s) => s.to_lsp_range(),
         _ => Range::default(),
     };
     lsp_types::Diagnostic::new(

--- a/crates/pcb-starlark-lsp/src/lib.rs
+++ b/crates/pcb-starlark-lsp/src/lib.rs
@@ -30,6 +30,7 @@ mod exported;
 pub(crate) mod inspect;
 pub(crate) mod loaded;
 pub mod server;
+mod span;
 mod symbols;
 #[cfg(test)]
 mod test;

--- a/crates/pcb-starlark-lsp/src/server.rs
+++ b/crates/pcb-starlark-lsp/src/server.rs
@@ -122,6 +122,7 @@ use crate::definition::IdentifierDefinition;
 use crate::definition::LspModule;
 use crate::inspect::AstModuleInspect;
 use crate::inspect::AutocompleteType;
+use crate::span::IntoLspRange;
 use crate::symbols::find_symbols_at_location;
 
 const SERVER_NAME: &str = "pcbc";
@@ -821,16 +822,16 @@ impl<T: LspContext> Backend<T> {
     }
 
     /// Simple helper to generate `Some(LocationLink)` objects in `resolve_definition_location`
-    fn location_link<R: Into<Range> + Copy>(
+    fn location_link<R: IntoLspRange + Copy>(
         source: ResolvedSpan,
         uri: &LspUrl,
         target_range: R,
     ) -> anyhow::Result<Option<LocationLink>> {
         Ok(Some(LocationLink {
-            origin_selection_range: Some(source.into()),
+            origin_selection_range: Some(source.to_lsp_range()),
             target_uri: uri.try_into()?,
-            target_range: target_range.into(),
-            target_selection_range: target_range.into(),
+            target_range: target_range.to_lsp_range(),
+            target_selection_range: target_range.to_lsp_range(),
         }))
     }
 
@@ -1250,14 +1251,14 @@ impl<T: LspContext> Backend<T> {
                             contents: HoverContents::Array(vec![MarkedString::String(
                                 render_doc_item_no_link(&symbol.name, &docs),
                             )]),
-                            range: Some(source.into()),
+                            range: Some(source.to_lsp_range()),
                         })
                         .or_else(|| {
                             symbol.param.map(|(starred_name, doc)| Hover {
                                 contents: HoverContents::Array(vec![MarkedString::String(
                                     render_doc_param(starred_name, &doc),
                                 )]),
-                                range: Some(source.into()),
+                                range: Some(source.to_lsp_range()),
                             })
                         })
                 })
@@ -1283,7 +1284,7 @@ impl<T: LspContext> Backend<T> {
                             contents: HoverContents::Array(vec![MarkedString::String(
                                 render_doc_item_no_link(&symbol.name, &docs),
                             )]),
-                            range: Some(source.into()),
+                            range: Some(source.to_lsp_range()),
                         })
                     })
                 })
@@ -1319,7 +1320,7 @@ impl<T: LspContext> Backend<T> {
                                     value: module.ast.codemap().source_span(location).to_owned(),
                                 },
                             )]),
-                            range: Some(source.into()),
+                            range: Some(source.to_lsp_range()),
                         })
                     }
                     _ => None,
@@ -1336,7 +1337,7 @@ impl<T: LspContext> Backend<T> {
                         contents: HoverContents::Array(vec![MarkedString::String(
                             render_doc_item_no_link(&symbol.0, &symbol.1),
                         )]),
-                        range: Some(source.into()),
+                        range: Some(source.to_lsp_range()),
                     })
             }
             IdentifierDefinition::LoadPath { .. } | IdentifierDefinition::NotFound => None,
@@ -2178,6 +2179,7 @@ mod tests {
     use crate::server::StarlarkFileContentsRequest;
     use crate::server::StarlarkFileContentsResponse;
     use crate::server::new_notification;
+    use crate::span::IntoLspRange;
     use crate::test::TestServer;
 
     #[test]
@@ -2253,10 +2255,10 @@ mod tests {
         dest_span: ResolvedSpan,
     ) -> LocationLink {
         LocationLink {
-            origin_selection_range: Some(source_span.into()),
+            origin_selection_range: Some(source_span.to_lsp_range()),
             target_uri: uri,
-            target_range: dest_span.into(),
-            target_selection_range: dest_span.into(),
+            target_range: dest_span.to_lsp_range(),
+            target_selection_range: dest_span.to_lsp_range(),
         }
     }
 
@@ -2907,7 +2909,7 @@ mod tests {
         let foo = FixtureWithRanges::from_fixture(foo_uri.path(), &foo_contents)?;
 
         let expected_location = LocationLink {
-            origin_selection_range: Some(foo.resolved_span("bar_click").into()),
+            origin_selection_range: Some(foo.resolved_span("bar_click").to_lsp_range()),
             target_uri: bar_uri,
             target_range: Default::default(),
             target_selection_range: Default::default(),
@@ -3160,7 +3162,7 @@ mod tests {
         let response = goto_definition_response_location(&mut server, req_id)?;
 
         let expected = LocationLink {
-            origin_selection_range: Some(foo.resolved_span("bar").into()),
+            origin_selection_range: Some(foo.resolved_span("bar").to_lsp_range()),
             target_uri: bar_uri,
             target_range: Default::default(),
             target_selection_range: Default::default(),
@@ -3178,7 +3180,7 @@ mod tests {
         let response = goto_definition_response_location(&mut server, req_id)?;
 
         let expected = LocationLink {
-            origin_selection_range: Some(foo.resolved_span("baz").into()),
+            origin_selection_range: Some(foo.resolved_span("baz").to_lsp_range()),
             target_uri: baz_uri,
             target_range: Default::default(),
             target_selection_range: Default::default(),
@@ -3196,7 +3198,7 @@ mod tests {
         let response = goto_definition_response_location(&mut server, req_id)?;
 
         let expected = LocationLink {
-            origin_selection_range: Some(foo.resolved_span("dir1").into()),
+            origin_selection_range: Some(foo.resolved_span("dir1").to_lsp_range()),
             target_uri: dir1_uri,
             target_range: Default::default(),
             target_selection_range: Default::default(),
@@ -3215,7 +3217,7 @@ mod tests {
         let response = goto_definition_response_location(&mut server, req_id)?;
 
         let expected = LocationLink {
-            origin_selection_range: Some(foo.resolved_span("dir2").into()),
+            origin_selection_range: Some(foo.resolved_span("dir2").to_lsp_range()),
             target_uri: dir2_uri,
             target_range: Default::default(),
             target_selection_range: Default::default(),
@@ -3386,7 +3388,7 @@ mod tests {
 
         assert_eq!(
             n1_location.origin_selection_range,
-            Some(foo.resolved_span("click_n1").into())
+            Some(foo.resolved_span("click_n1").to_lsp_range())
         );
         assert_eq!(n1_location.target_uri, native_uri);
         let native_gen_code = server

--- a/crates/pcb-starlark-lsp/src/span.rs
+++ b/crates/pcb-starlark-lsp/src/span.rs
@@ -1,0 +1,21 @@
+use lsp_types::{Position, Range};
+use starlark::codemap::ResolvedSpan;
+
+pub(crate) trait IntoLspRange {
+    fn to_lsp_range(self) -> Range;
+}
+
+impl IntoLspRange for ResolvedSpan {
+    fn to_lsp_range(self) -> Range {
+        Range::new(
+            Position::new(self.begin.line as u32, self.begin.column as u32),
+            Position::new(self.end.line as u32, self.end.column as u32),
+        )
+    }
+}
+
+impl IntoLspRange for Range {
+    fn to_lsp_range(self) -> Range {
+        self
+    }
+}

--- a/crates/pcb-zen-core/src/lang/builtin.rs
+++ b/crates/pcb-zen-core/src/lang/builtin.rs
@@ -7,7 +7,7 @@ use starlark::{
     Error,
     any::ProvidesStaticType,
     collections::SmallMap,
-    environment::{GlobalsBuilder, Methods, MethodsBuilder, MethodsStatic},
+    environment::{GlobalsBuilder, Methods, MethodsBuilder},
     eval::{Arguments, Evaluator},
     starlark_module, starlark_simple_value,
     values::{
@@ -37,12 +37,12 @@ impl fmt::Display for Builtin {
 }
 
 starlark_simple_value!(Builtin);
+starlark::methods_static!(BUILTIN_METHODS = builtin_methods);
 
 #[starlark_value(type = "builtin")]
 impl<'v> StarlarkValue<'v> for Builtin {
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new("Builtin", builtin_methods);
-        Some(RES.methods())
+        Some(BUILTIN_METHODS.methods())
     }
 }
 

--- a/crates/pcb-zen-core/src/lang/enum.rs
+++ b/crates/pcb-zen-core/src/lang/enum.rs
@@ -2,7 +2,7 @@ use allocative::Allocative;
 use serde::{Deserialize, Serialize};
 use starlark::{
     any::ProvidesStaticType,
-    environment::{Methods, MethodsBuilder, MethodsStatic},
+    environment::{Methods, MethodsBuilder},
     eval::{Arguments, Evaluator},
     starlark_module, starlark_simple_value,
     typing::{ParamIsRequired, ParamSpec, Ty, TyCallable, TyStarlarkValue, TyUser, TyUserParams},
@@ -61,6 +61,7 @@ pub struct EnumType {
 }
 
 starlark_simple_value!(EnumType);
+starlark::methods_static!(ENUM_TYPE_METHODS = enum_type_methods);
 
 impl fmt::Display for EnumType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -183,8 +184,7 @@ impl<'v> StarlarkValue<'v> for EnumType {
     unsafe fn iter_stop(&self) {}
 
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new("EnumType", enum_type_methods);
-        Some(RES.methods())
+        Some(ENUM_TYPE_METHODS.methods())
     }
 
     fn eval_type(&self) -> Option<Ty> {
@@ -265,6 +265,7 @@ pub struct EnumValue {
 }
 
 starlark_simple_value!(EnumValue);
+starlark::methods_static!(ENUM_VALUE_METHODS = enum_value_methods);
 
 impl fmt::Display for EnumValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -345,8 +346,7 @@ impl<'v> StarlarkValue<'v> for EnumValue {
     }
 
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new("EnumValue", enum_value_methods);
-        Some(RES.methods())
+        Some(ENUM_VALUE_METHODS.methods())
     }
 }
 

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -1212,7 +1212,7 @@ impl EvalContext {
             .as_ref()
             .map(|path| path.display().to_string())
             .unwrap_or_else(|| "<unknown>".to_string());
-        FrozenHeapName::User(Box::new(format!("{}:{source}", self.config.module_path)))
+        FrozenHeapName::user(format!("{}:{source}", self.config.module_path))
     }
 
     /// Enable or disable eager workspace parsing.
@@ -1446,17 +1446,10 @@ impl EvalContext {
         self.json_inputs.extend(json_inputs);
     }
 
-    /// Parse Starlark source with this context's dialect, using the recursive
-    /// descent parser (same AST as the default LALRPOP parser, roughly half
-    /// the cost).
+    /// Parse Starlark source with this context's dialect.
     fn parse_ast(&self, filename: &str, contents: String) -> starlark::Result<AstModule> {
         let _span = info_span!("parse").entered();
-        AstModule::parse_with(
-            filename,
-            contents,
-            &self.dialect(),
-            starlark::syntax::ParserKind::Rd,
-        )
+        AstModule::parse(filename, contents, &self.dialect())
     }
 
     /// Contents + AST for the module being evaluated. Explicit contents (e.g.

--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -2,13 +2,13 @@ use allocative::Allocative;
 use starlark::collections::SmallMap;
 use starlark::environment::GlobalsBuilder;
 use starlark::eval::{Arguments, Evaluator, ParametersSpec, ParametersSpecParam};
-use starlark::starlark_complex_value;
 use starlark::starlark_module;
 use starlark::values::typing::TypeInstanceId;
 use starlark::values::{
     Coerce, Freeze, FrozenValue, Heap, NoSerialize, ProvidesStaticType, StarlarkValue, Trace,
     Value, ValueLike, starlark_value,
 };
+use starlark::{starlark_complex_value, starlark_complex_values};
 use std::cell::OnceCell;
 
 use std::collections::HashMap;
@@ -503,8 +503,7 @@ impl InterfaceCell for FrozenValue {
     }
 }
 
-#[derive(Clone, Debug, Trace, Coerce, ProvidesStaticType, NoSerialize, Allocative)]
-#[repr(C)]
+#[derive(Clone, Debug, Trace, ProvidesStaticType, NoSerialize, Allocative)]
 pub struct InterfaceFactoryGen<V: InterfaceCell> {
     id: TypeInstanceId,
     #[allocative(skip)]
@@ -515,7 +514,9 @@ pub struct InterfaceFactoryGen<V: InterfaceCell> {
     param_spec: ParametersSpec<FrozenValue>,
 }
 
-starlark_complex_value!(pub InterfaceFactory);
+pub type InterfaceFactory<'v> = InterfaceFactoryGen<Value<'v>>;
+pub type FrozenInterfaceFactory = InterfaceFactoryGen<FrozenValue>;
+starlark_complex_values!(InterfaceFactory);
 
 impl Freeze for InterfaceFactory<'_> {
     type Frozen = FrozenInterfaceFactory;
@@ -872,23 +873,6 @@ pub(crate) fn instantiate_interface<'v>(
         "internal error: unexpected value type in instantiate_interface: {} (expected InterfaceFactory or InterfaceValue)",
         spec.get_type()
     ).into())
-}
-
-impl<'v, V: ValueLike<'v> + InterfaceCell> InterfaceFactoryGen<V> {
-    /// Return the map of field specifications (field name -> type value) that
-    /// define this interface. This is primarily used by the input
-    /// deserialization logic to determine the expected type for nested
-    /// interface fields when reconstructing an instance from a serialised
-    /// `InputValue`.
-    #[inline]
-    pub fn fields(&self) -> &SmallMap<String, V> {
-        &self.fields
-    }
-
-    #[inline]
-    pub fn field(&self, name: &str) -> Option<&V> {
-        self.fields.get(name)
-    }
 }
 
 #[cfg(test)]

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -22,10 +22,10 @@ use starlark::{
     collections::SmallMap,
     environment::GlobalsBuilder,
     eval::{Arguments, Evaluator},
-    starlark_complex_value, starlark_module, starlark_simple_value,
+    starlark_complex_value, starlark_complex_values, starlark_module, starlark_simple_value,
     values::{
-        Coerce, Freeze, NoSerialize, StarlarkValue, Trace, Value, ValueLike, float::StarlarkFloat,
-        list::ListRef, starlark_value, tuple::TupleRef,
+        Coerce, Freeze, FrozenValue, NoSerialize, StarlarkValue, Trace, Value, ValueLike,
+        float::StarlarkFloat, list::ListRef, starlark_value, tuple::TupleRef,
     },
 };
 
@@ -275,8 +275,7 @@ impl From<MissingInputError> for starlark::Error {
 }
 
 /// Metadata for a module parameter (from io() or config() calls)
-#[derive(Clone, Debug, Coerce, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
-#[repr(C)]
+#[derive(Clone, Debug, Trace, Allocative, Freeze)]
 pub struct ParameterMetadataGen<V: ValueLifetimeless> {
     /// Parameter name
     pub name: String,
@@ -304,20 +303,6 @@ pub struct ParameterMetadataGen<V: ValueLifetimeless> {
     #[freeze(identity)]
     #[allocative(skip)]
     pub declaration_call_stack: starlark::eval::CallStack,
-}
-
-starlark_complex_value!(pub ParameterMetadata);
-
-#[starlark_value(type = "ParameterMetadata")]
-impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for ParameterMetadataGen<V> where
-    Self: ProvidesStaticType<'v>
-{
-}
-
-impl<'v, V: ValueLike<'v>> std::fmt::Display for ParameterMetadataGen<V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ParameterMetadata({})", self.name)
-    }
 }
 
 impl<'v, V: ValueLike<'v>> ParameterMetadataGen<V> {
@@ -467,8 +452,7 @@ pub(crate) fn io_declaration_site(eval: &Evaluator<'_, '_, '_>) -> DeclarationSi
     }
 }
 
-#[derive(Clone, Coerce, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
-#[repr(C)]
+#[derive(Clone, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
 pub struct ModuleValueGen<V: ValueLifetimeless> {
     path: ModulePath,
     source_path: String,
@@ -497,7 +481,9 @@ pub struct ModuleValueGen<V: ValueLifetimeless> {
     parent_component_modifiers: Vec<V>,
 }
 
-starlark_complex_value!(pub ModuleValue);
+pub type ModuleValue<'v> = ModuleValueGen<Value<'v>>;
+pub type FrozenModuleValue = ModuleValueGen<FrozenValue>;
+starlark_complex_values!(ModuleValue);
 
 #[starlark_value(type = "Module")]
 impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for ModuleValueGen<V>

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -7,7 +7,7 @@ use starlark::typing::TyUserFields;
 use starlark::{
     any::ProvidesStaticType,
     collections::SmallMap,
-    environment::{Methods, MethodsBuilder, MethodsStatic},
+    environment::{Methods, MethodsBuilder},
     eval::{Arguments, Evaluator, ParametersSpec, ParametersSpecParam},
     starlark_complex_value, starlark_module,
     typing::{ParamIsRequired, ParamSpec, Ty, TyCallable, TyStarlarkValue, TyUser, TyUserParams},
@@ -15,7 +15,7 @@ use starlark::{
     values::{
         Coerce, Freeze, FreezeResult, Freezer, FrozenValue, Heap, NoSerialize, StarlarkValue,
         Trace, Value, ValueLike,
-        record::field::FieldGen,
+        record::FieldGen,
         starlark_value,
         typing::{TypeCompiled, TypeInstanceId, TypeMatcher, TypeMatcherDyn, TypeMatcherFactory},
     },
@@ -207,6 +207,7 @@ pub struct NetValueGen<V> {
 }
 
 starlark_complex_value!(pub NetValue);
+starlark::methods_static!(NET_METHODS = builtin_net_methods);
 
 impl<V: std::fmt::Debug> std::fmt::Debug for NetValueGen<V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -235,8 +236,7 @@ where
     Self: ProvidesStaticType<'v>,
 {
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new("Net", builtin_net_methods);
-        Some(RES.methods())
+        Some(NET_METHODS.methods())
     }
 
     fn get_attr(&self, attribute: &str, heap: Heap<'v>) -> Option<Value<'v>> {
@@ -650,6 +650,7 @@ pub struct NetTypeGen<V> {
 }
 
 starlark_complex_value!(pub NetType);
+starlark::methods_static!(NET_TYPE_METHODS = net_type_methods);
 
 impl<'v> Freeze for NetType<'v> {
     type Frozen = FrozenNetType;
@@ -701,7 +702,7 @@ impl<'v> NetType<'v> {
             // This handles field(), direct types (str/int), and custom types (Enum/PhysicalValue) uniformly
             let type_compiled_result =
                 if let Some(field_gen) = field_value.downcast_ref::<FieldGen<Value<'v>>>() {
-                    Ok(*field_gen.typ())
+                    Ok(field_gen.typ)
                 } else {
                     TypeCompiled::new(field_value, eval.heap())
                 };
@@ -958,11 +959,11 @@ fn compile_field_type<'v>(
     heap: Heap<'v>,
 ) -> anyhow::Result<TypeCompiled<Value<'v>>> {
     if let Some(field_gen) = field_spec.downcast_ref::<FieldGen<Value<'v>>>() {
-        Ok(TypeCompiled::from_ty(field_gen.typ().as_ty(), heap))
+        Ok(TypeCompiled::from_ty(field_gen.typ.as_ty(), heap))
     } else if let Some(field_gen) = field_spec.downcast_ref::<FieldGen<FrozenValue>>() {
         // Loaded modules freeze field(...) specs, but we still want to honor
         // the original compiled matcher for validation and coercion.
-        Ok(TypeCompiled::from_ty(field_gen.typ().as_ty(), heap))
+        Ok(TypeCompiled::from_ty(field_gen.typ.as_ty(), heap))
     } else {
         TypeCompiled::new(field_spec, heap)
     }
@@ -985,9 +986,9 @@ pub(crate) fn validate_field<'v>(
 
     // Try to extract default from field() spec first (before type compilation)
     let default = if let Some(fg) = field_spec.downcast_ref::<FieldGen<Value>>() {
-        fg.default().map(|d| d.to_value())
+        fg.default.map(|d| d.to_value())
     } else if let Some(fg) = field_spec.downcast_ref::<FieldGen<FrozenValue>>() {
-        fg.default().map(|d| d.to_value())
+        fg.default.map(|d| d.to_value())
     } else {
         None
     };
@@ -1217,8 +1218,7 @@ where
     }
 
     fn get_methods() -> Option<&'static Methods> {
-        static RES: MethodsStatic = MethodsStatic::new("NetType", net_type_methods);
-        Some(RES.methods())
+        Some(NET_TYPE_METHODS.methods())
     }
 }
 


### PR DESCRIPTION
PCB used APIs and fork patches from the previous Starlark revision. This change updates starlark-rust to 0.14.2, adopts its current APIs, removes duplicate build dependencies, and verifies the migration with focused tests, strict Clippy, and a full workspace check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the core Starlark evaluator, type system, and language server across the whole toolchain; runtime or LSP regressions would affect every `.zen` build and IDE session.
> 
> **Overview**
> **Upgrades the embedded Starlark runtime** from the previous `starlark-rust` git pin to **0.14.2** (`c3d776…`), with a matching **CHANGELOG** note. Workspace `Cargo.toml` retargets `starlark`, `starlark_syntax`, `allocative`, `pagable`, and **`dupe`** to that single revision; **Cargo.lock** reflects upstream cleanup (e.g. dropping the old **lalrpop** parser chain, bumping **pagable** to 0.4.1, and pinning **lsp-types** 0.97 for `starlark_syntax` while PCB LSP crates stay on 0.94.1).
> 
> **Zen / schematic Starlark glue** is adjusted for 0.14.2: static method tables use **`starlark::methods_static!`** instead of hand-rolled `MethodsStatic`; complex values use **`starlark_complex_values!`** and updated **`FieldGen`** field access; **`PhysicalValue`** gets **`#[freeze(identity)]`** on decimal fields; evaluation uses **`FrozenHeapName::user(...)`** and **`AstModule::parse`** without the recursive-descent **`ParserKind::Rd`** path.
> 
> **pcb-starlark-lsp** no longer relies on implicit `Into<lsp_types::Range>` for **`ResolvedSpan`**; a local **`IntoLspRange`** trait maps spans explicitly for diagnostics, completion, hover, and go-to-definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f8b3334d52ed817df2d8dd148ef912b9e8cb18c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->