### PR TITLE
ENG-584 Normalize Registry resolution through DiodeHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Legacy Registry references now normalize to the canonical DiodeHub identity before resolution.
+
 ### Fixed
 
 - Git dependency resolution now falls back to SSH when DiodeHub HTTPS authentication is unavailable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Legacy Registry references now normalize to the canonical DiodeHub identity before resolution.
+- Legacy Registry references now prefer the canonical DiodeHub identity while remaining compatible with legacy workspace identities.
 
 ### Fixed
 

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -625,7 +625,7 @@ name = "legacy"
         let err = PcbToml::parse(
             r#"
 [packages]
-registry = "github.com/diodeinc/registry"
+registry = "code.diode.computer/diode/registry"
 "#,
         )
         .expect_err("legacy [packages] should not parse");
@@ -727,7 +727,7 @@ path = "test.zen"
 
 [dependencies]
 "github.com/diodeinc/stdlib" = "0.3.2"
-"github.com/diodeinc/registry/reference/ti/tps54331" = { version = "^1.0.0" }
+"code.diode.computer/diode/registry/reference/ti/tps54331" = { version = "^1.0.0" }
 "github.com/user/custom" = { branch = "main" }
 "github.com/user/local" = { path = "../local" }
 "#;
@@ -750,7 +750,7 @@ path = "test.zen"
         match config
             .dependencies
             .direct
-            .get("github.com/diodeinc/registry/reference/ti/tps54331")
+            .get("code.diode.computer/diode/registry/reference/ti/tps54331")
             .unwrap()
         {
             DependencySpec::Detailed(d) => {
@@ -867,7 +867,7 @@ name = "Test"
 path = "test.zen"
 
 [patch]
-"github.com/diodeinc/registry/components/FOO" = { branch = "feature-branch" }
+"code.diode.computer/diode/registry/components/FOO" = { branch = "feature-branch" }
 "#;
 
         let config = PcbToml::parse(content).unwrap();
@@ -875,7 +875,7 @@ path = "test.zen"
 
         let patch = config
             .patch
-            .get("github.com/diodeinc/registry/components/FOO")
+            .get("code.diode.computer/diode/registry/components/FOO")
             .unwrap();
         assert_eq!(patch.branch.as_deref(), Some("feature-branch"));
         assert_eq!(patch.path, None);
@@ -893,7 +893,7 @@ name = "Test"
 path = "test.zen"
 
 [patch]
-"github.com/diodeinc/registry/components/BAR" = { rev = "abc123def456" }
+"code.diode.computer/diode/registry/components/BAR" = { rev = "abc123def456" }
 "#;
 
         let config = PcbToml::parse(content).unwrap();
@@ -901,7 +901,7 @@ path = "test.zen"
 
         let patch = config
             .patch
-            .get("github.com/diodeinc/registry/components/BAR")
+            .get("code.diode.computer/diode/registry/components/BAR")
             .unwrap();
         assert_eq!(patch.rev.as_deref(), Some("abc123def456"));
         assert_eq!(patch.path, None);

--- a/crates/pcb-zen-core/src/load_spec.rs
+++ b/crates/pcb-zen-core/src/load_spec.rs
@@ -292,12 +292,12 @@ mod tests {
     #[test]
     fn test_parse_load_spec_package_uri() {
         let spec = LoadSpec::parse(
-            "package://github.com/diodeinc/registry/reference/TPS54331/TPS54331.zen",
+            "package://code.diode.computer/diode/registry/reference/TPS54331/TPS54331.zen",
         );
         assert_eq!(
             spec,
             Some(LoadSpec::PackageUri {
-                uri: "package://github.com/diodeinc/registry/reference/TPS54331/TPS54331.zen"
+                uri: "package://code.diode.computer/diode/registry/reference/TPS54331/TPS54331.zen"
                     .to_string(),
             })
         );
@@ -384,7 +384,7 @@ mod tests {
             },
             LoadSpec::local_path("./relative/file.zen"),
             LoadSpec::PackageUri {
-                uri: "package://github.com/diodeinc/registry/reference/TPS54331/TPS54331.zen"
+                uri: "package://code.diode.computer/diode/registry/reference/TPS54331/TPS54331.zen"
                     .to_string(),
             },
         ];

--- a/crates/pcb-zen-core/src/package_url.rs
+++ b/crates/pcb-zen-core/src/package_url.rs
@@ -25,19 +25,12 @@ pub fn canonicalize_package_reference(value: &str) -> Cow<'_, str> {
     Cow::Owned(format!("{CANONICAL_REGISTRY_REPOSITORY}{suffix}"))
 }
 
-/// Resolve a package reference literally, then retry its canonical identity.
+/// Canonicalize a package reference before resolving it.
 pub fn resolve_package_reference<'a, T>(
     value: &'a str,
-    mut resolve: impl FnMut(&str) -> Option<T>,
+    resolve: impl FnOnce(&str) -> Option<T>,
 ) -> Option<(Cow<'a, str>, T)> {
-    if let Some(resolved) = resolve(value) {
-        return Some((Cow::Borrowed(value), resolved));
-    }
-
     let canonical = canonicalize_package_reference(value);
-    if canonical.as_ref() == value {
-        return None;
-    }
     resolve(&canonical).map(|resolved| (canonical, resolved))
 }
 
@@ -82,16 +75,10 @@ mod tests {
     }
 
     #[test]
-    fn resolves_literal_before_registry_alias() {
+    fn resolves_legacy_registry_reference_with_canonical_identity() {
         let legacy = "github.com/diodeinc/registry/components/Foo/Foo.zen";
         let canonical = "code.diode.computer/diode/registry/components/Foo/Foo.zen";
 
-        assert_eq!(
-            resolve_package_reference(legacy, |candidate| (candidate == legacy)
-                .then_some("literal"))
-            .map(|(matched, resolved)| (matched.into_owned(), resolved)),
-            Some((legacy.to_string(), "literal"))
-        );
         assert_eq!(
             resolve_package_reference(legacy, |candidate| {
                 (candidate == canonical).then_some("canonical")
@@ -99,10 +86,5 @@ mod tests {
             .map(|(matched, resolved)| (matched.into_owned(), resolved)),
             Some((canonical.to_string(), "canonical"))
         );
-        assert_eq!(
-            resolve_package_reference(canonical, |_| Some("literal")),
-            Some((Cow::Borrowed(canonical), "literal"))
-        );
-        assert_eq!(resolve_package_reference(canonical, |_| None::<()>), None);
     }
 }

--- a/crates/pcb-zen-core/src/package_url.rs
+++ b/crates/pcb-zen-core/src/package_url.rs
@@ -25,13 +25,21 @@ pub fn canonicalize_package_reference(value: &str) -> Cow<'_, str> {
     Cow::Owned(format!("{CANONICAL_REGISTRY_REPOSITORY}{suffix}"))
 }
 
-/// Canonicalize a package reference before resolving it.
+/// Resolve a package reference by preferring its canonical identity.
 pub fn resolve_package_reference<'a, T>(
     value: &'a str,
-    resolve: impl FnOnce(&str) -> Option<T>,
+    mut resolve: impl FnMut(&str) -> Option<T>,
 ) -> Option<(Cow<'a, str>, T)> {
     let canonical = canonicalize_package_reference(value);
-    resolve(&canonical).map(|resolved| (canonical, resolved))
+    if let Some(resolved) = resolve(&canonical) {
+        return Some((canonical, resolved));
+    }
+
+    if canonical != value {
+        return resolve(value).map(|resolved| (Cow::Borrowed(value), resolved));
+    }
+
+    None
 }
 
 /// Whether a package reference belongs to the canonical registry repository.
@@ -85,6 +93,14 @@ mod tests {
             })
             .map(|(matched, resolved)| (matched.into_owned(), resolved)),
             Some((canonical.to_string(), "canonical"))
+        );
+
+        assert_eq!(
+            resolve_package_reference(legacy, |candidate| {
+                (candidate == legacy).then_some("legacy")
+            })
+            .map(|(matched, resolved)| (matched.into_owned(), resolved)),
+            Some((legacy.to_string(), "legacy"))
         );
     }
 }

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -942,22 +942,15 @@ impl ResolutionResult {
 
     /// Resolve a package URI (`package://…`) to an absolute filesystem path.
     pub fn resolve_package_uri(&self, uri: &str) -> anyhow::Result<PathBuf> {
-        let original_error = match pcb_sch::resolve_package_uri(uri, &self.indexes.package_roots) {
-            Ok(path) => return Ok(path),
-            Err(error) => error,
-        };
-        let Some(reference) = uri.strip_prefix(pcb_sch::PACKAGE_URI_PREFIX) else {
-            return Err(original_error);
-        };
-
-        let canonical = crate::package_url::canonicalize_package_reference(reference);
-        if canonical == reference {
-            return Err(original_error);
+        if let Some(reference) = uri.strip_prefix(pcb_sch::PACKAGE_URI_PREFIX) {
+            let canonical = crate::package_url::canonicalize_package_reference(reference);
+            if canonical != reference {
+                let canonical_uri = format!("{}{canonical}", pcb_sch::PACKAGE_URI_PREFIX);
+                return pcb_sch::resolve_package_uri(&canonical_uri, &self.indexes.package_roots);
+            }
         }
 
-        let canonical_uri = format!("{}{canonical}", pcb_sch::PACKAGE_URI_PREFIX);
-        pcb_sch::resolve_package_uri(&canonical_uri, &self.indexes.package_roots)
-            .map_err(|_| original_error)
+        pcb_sch::resolve_package_uri(uri, &self.indexes.package_roots)
     }
 
     /// Format an absolute path as a stable URI (`package://…`).
@@ -1338,7 +1331,7 @@ mod tests {
 
         impl PackagePathResolver for RecordingResolver {
             fn resolve_package(&self, module_path: &str, version: &str) -> Option<PathBuf> {
-                (module_path == "github.com/diodeinc/registry/modules/CastellatedHoles"
+                (module_path == "code.diode.computer/diode/registry/modules/CastellatedHoles"
                     && version == self.expected_version)
                     .then_some(self.resolved_path.clone())
             }
@@ -1350,7 +1343,7 @@ mod tests {
 
         let workspace_root = PathBuf::from("/workspace");
         let package_root = workspace_root.join("boards/IP0003");
-        let dep_url = "github.com/diodeinc/registry/modules/CastellatedHoles".to_string();
+        let dep_url = "code.diode.computer/diode/registry/modules/CastellatedHoles".to_string();
         let stable_version = Version::parse("0.3.1").unwrap();
         let pseudo_version =
             Version::parse("0.4.3-0.20260318022845-ef7e97a27f6e57783bfbeece051aa2d81a365ace")
@@ -1420,7 +1413,7 @@ mod tests {
 
     #[test]
     fn test_rev_dep_ignores_non_pseudo_prerelease() {
-        let dep = "github.com/diodeinc/registry/modules/CastellatedHoles";
+        let dep = "code.diode.computer/diode/registry/modules/CastellatedHoles";
         let prerelease = Version::parse("1.0.0-alpha-1").unwrap();
         let pseudo =
             Version::parse("1.0.0-0.20260319233030-1cdbd386c7adffd8373fbedf7532122b55092108")

--- a/crates/pcb-zen-core/src/resolution.rs
+++ b/crates/pcb-zen-core/src/resolution.rs
@@ -946,7 +946,11 @@ impl ResolutionResult {
             let canonical = crate::package_url::canonicalize_package_reference(reference);
             if canonical != reference {
                 let canonical_uri = format!("{}{canonical}", pcb_sch::PACKAGE_URI_PREFIX);
-                return pcb_sch::resolve_package_uri(&canonical_uri, &self.indexes.package_roots);
+                if let Ok(path) =
+                    pcb_sch::resolve_package_uri(&canonical_uri, &self.indexes.package_roots)
+                {
+                    return Ok(path);
+                }
             }
         }
 
@@ -1039,40 +1043,54 @@ mod tests {
     }
 
     #[test]
-    fn package_uri_resolves_migrated_registry_alias() {
-        let dep = crate::package_url::CANONICAL_REGISTRY_REPOSITORY.to_string() + "/components/Foo";
-        let dep_root = PathBuf::from("/cache").join(&dep).join("1.2.3");
-        let result = ResolutionResult::frozen(
-            WorkspaceInfo {
-                root: PathBuf::from("/workspace"),
-                cache_dir: PathBuf::new(),
-                config: None,
-                packages: BTreeMap::new(),
-                errors: vec![],
-            },
-            BTreeMap::from([(
-                "github.com/acme/root".into(),
-                FrozenResolutionMap {
-                    selected_remote: BTreeMap::new(),
-                    packages: BTreeMap::from([(
-                        PathBuf::from("/workspace"),
-                        FrozenPackage {
-                            identity: FrozenPackageIdentity::Workspace(
-                                "github.com/acme/root".into(),
-                            ),
-                            deps: BTreeMap::from([(dep, dep_root.clone())]),
-                            parts: Vec::new(),
-                        },
-                    )]),
+    fn package_uri_prefers_migrated_registry_alias_with_legacy_fallback() {
+        fn result_for(dep: String) -> (ResolutionResult, PathBuf) {
+            let dep_root = PathBuf::from("/cache").join(&dep).join("1.2.3");
+            let result = ResolutionResult::frozen(
+                WorkspaceInfo {
+                    root: PathBuf::from("/workspace"),
+                    cache_dir: PathBuf::new(),
+                    config: None,
+                    packages: BTreeMap::new(),
+                    errors: vec![],
                 },
-            )]),
-            HashMap::new(),
-        );
+                BTreeMap::from([(
+                    "github.com/acme/root".into(),
+                    FrozenResolutionMap {
+                        selected_remote: BTreeMap::new(),
+                        packages: BTreeMap::from([(
+                            PathBuf::from("/workspace"),
+                            FrozenPackage {
+                                identity: FrozenPackageIdentity::Workspace(
+                                    "github.com/acme/root".into(),
+                                ),
+                                deps: BTreeMap::from([(dep, dep_root.clone())]),
+                                parts: Vec::new(),
+                            },
+                        )]),
+                    },
+                )]),
+                HashMap::new(),
+            );
+            (result, dep_root)
+        }
 
         let legacy_uri = format!(
             "package://{}/components/Foo@1.2.3/Foo.kicad_mod",
             crate::package_url::LEGACY_REGISTRY_REPOSITORY
         );
+
+        let canonical_dep =
+            crate::package_url::CANONICAL_REGISTRY_REPOSITORY.to_string() + "/components/Foo";
+        let (result, dep_root) = result_for(canonical_dep);
+        assert_eq!(
+            result.resolve_package_uri(&legacy_uri).unwrap(),
+            dep_root.join("Foo.kicad_mod")
+        );
+
+        let legacy_dep =
+            crate::package_url::LEGACY_REGISTRY_REPOSITORY.to_string() + "/components/Foo";
+        let (result, dep_root) = result_for(legacy_dep);
         assert_eq!(
             result.resolve_package_uri(&legacy_uri).unwrap(),
             dep_root.join("Foo.kicad_mod")

--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -439,53 +439,63 @@ mod tests {
         let conn = index.conn();
         conn.execute(
             "INSERT INTO remote_packages VALUES (?1, ?2, ?3)",
-            params!["github.com/diodeinc/registry", "components/LED", "0.1.0"],
+            params![
+                "code.diode.computer/diode/registry",
+                "components/LED",
+                "0.1.0"
+            ],
         )?;
         conn.execute(
             "INSERT INTO remote_packages VALUES (?1, ?2, ?3)",
             params![
-                "github.com/diodeinc/registry",
+                "code.diode.computer/diode/registry",
                 "components/JST/BM04B",
                 "0.2.0"
             ],
         )?;
         conn.execute(
             "INSERT INTO remote_packages VALUES (?1, ?2, ?3)",
-            params!["github.com/diodeinc/registry", "components/JST", "0.3.0"],
+            params![
+                "code.diode.computer/diode/registry",
+                "components/JST",
+                "0.3.0"
+            ],
         )?;
         drop(conn);
 
         let dep = index
-            .find_remote_package("github.com/diodeinc/registry/components/LED/LED.zen")?
+            .find_remote_package("code.diode.computer/diode/registry/components/LED/LED.zen")?
             .unwrap();
         assert_eq!(
             dep.module_path,
-            "github.com/diodeinc/registry/components/LED"
+            "code.diode.computer/diode/registry/components/LED"
         );
         assert_eq!(dep.version, "0.1.0");
 
         let dep = index
-            .find_remote_package("github.com/diodeinc/registry/components/JST/BM04B/x.zen")?
+            .find_remote_package("code.diode.computer/diode/registry/components/JST/BM04B/x.zen")?
             .unwrap();
         assert_eq!(
             dep.module_path,
-            "github.com/diodeinc/registry/components/JST/BM04B"
+            "code.diode.computer/diode/registry/components/JST/BM04B"
         );
         assert_eq!(dep.version, "0.2.0");
 
         let dep = index
-            .find_remote_package("github.com/diodeinc/registry/components/JST/OTHER/x.zen")?
+            .find_remote_package("code.diode.computer/diode/registry/components/JST/OTHER/x.zen")?
             .unwrap();
         assert_eq!(
             dep.module_path,
-            "github.com/diodeinc/registry/components/JST"
+            "code.diode.computer/diode/registry/components/JST"
         );
         assert_eq!(dep.version, "0.3.0");
 
         // Verify cache miss without triggering remote discovery/network.
         assert!(
             index
-                .find_remote_package_cached("github.com/diodeinc/registry/modules/foo/bar.zen")
+                .find_remote_package_cached(
+                    "code.diode.computer/diode/registry/modules/foo/bar.zen",
+                )
                 .is_none()
         );
 

--- a/test-workspaces/bench/bmi270.zen
+++ b/test-workspaces/bench/bmi270.zen
@@ -9,7 +9,7 @@ load(
     "name_contains",
 )
 
-BMI270 = Module("github.com/diodeinc/registry/reference/BMI270x/BMI270x.zen")
+BMI270 = Module("code.diode.computer/diode/registry/reference/BMI270x/BMI270x.zen")
 
 
 def print_info(module: Module, inputs):

--- a/test-workspaces/bench/lm5163q1.zen
+++ b/test-workspaces/bench/lm5163q1.zen
@@ -7,7 +7,7 @@ and power decoupling per Texas Instruments datasheet requirements.
 
 load("matchers.zen", "is_capacitor", "is_resistor")
 
-LM5163Q1 = Module("github.com/diodeinc/registry/reference/LM5163Q1/LM5163Q1.zen")
+LM5163Q1 = Module("code.diode.computer/diode/registry/reference/LM5163Q1/LM5163Q1.zen")
 
 
 # Custom matcher for the SRN6045 inductor (since it doesn't have type="inductor")

--- a/test-workspaces/bench/pcb.toml
+++ b/test-workspaces/bench/pcb.toml
@@ -3,10 +3,10 @@ name = "zener"
 pcb-version = "0.4"
 
 [dependencies]
-"github.com/diodeinc/registry/reference/BMI270x" = "0.6.2"
-"github.com/diodeinc/registry/reference/LM5163Q1" = "0.6.0"
+"code.diode.computer/diode/registry/reference/BMI270x" = "0.6.2"
+"code.diode.computer/diode/registry/reference/LM5163Q1" = "0.6.0"
 
 [dependencies.indirect]
-"github.com/diodeinc/registry/components/BMI270@0.3" = "0.3.2"
-"github.com/diodeinc/registry/components/LM5163QDDARQ1@0.3" = "0.3.2"
-"github.com/diodeinc/registry/components/SRN6045-470M@0.3" = "0.3.2"
+"code.diode.computer/diode/registry/components/BMI270@0.3" = "0.3.2"
+"code.diode.computer/diode/registry/components/LM5163QDDARQ1@0.3" = "0.3.2"
+"code.diode.computer/diode/registry/components/SRN6045-470M@0.3" = "0.3.2"

--- a/test-workspaces/bench/sequential-matchers/pcb.toml
+++ b/test-workspaces/bench/sequential-matchers/pcb.toml
@@ -2,8 +2,8 @@
 workspace = "0.3.87"
 
 [dependencies.indirect]
-"github.com/diodeinc/registry/components/BMI270@0.3" = "0.3.2"
-"github.com/diodeinc/registry/components/LM5163QDDARQ1@0.3" = "0.3.2"
-"github.com/diodeinc/registry/components/SRN6045-470M@0.3" = "0.3.2"
-"github.com/diodeinc/registry/reference/BMI270x@0.6" = "0.6.2"
-"github.com/diodeinc/registry/reference/LM5163Q1@0.6" = "0.6.0"
+"code.diode.computer/diode/registry/components/BMI270@0.3" = "0.3.2"
+"code.diode.computer/diode/registry/components/LM5163QDDARQ1@0.3" = "0.3.2"
+"code.diode.computer/diode/registry/components/SRN6045-470M@0.3" = "0.3.2"
+"code.diode.computer/diode/registry/reference/BMI270x@0.6" = "0.6.2"
+"code.diode.computer/diode/registry/reference/LM5163Q1@0.6" = "0.6.0"


### PR DESCRIPTION
Legacy Registry references could use GitHub-named resolution paths after the Registry moved to DiodeHub. This change normalizes exact legacy references before lookup and updates current fixtures and benchmarks to use the canonical DiodeHub URL; validation passed with `cargo test -p pcb-zen-core`, focused cache-index and sync tests, `cargo fmt --check`, and `git diff --check`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core dependency and package-URI resolution for the public registry; behavior is backward-compatible via legacy fallback but could affect workspaces that still key cache or manifests only on GitHub-named paths.
> 
> **Overview**
> **Registry package resolution now prefers the DiodeHub canonical identity** (`code.diode.computer/diode/registry`) when resolving legacy `github.com/diodeinc/registry` references, while still falling back to the exact legacy string if only that identity is present in the frozen dependency graph.
> 
> `resolve_package_reference` in `package_url.rs` was reordered to canonicalize and resolve first, then retry the original reference. `ResolutionResult::resolve_package_uri` similarly rewrites legacy `package://` URIs to the canonical form before lookup, then uses the literal URI. Tests and bench fixtures were updated to the canonical URLs, and the changelog documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29418ef40d7cd053f933c03924fabca7ba076bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->