### PR TITLE
Enable strict BOM matching by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Strict (exact MPN) BOM matching is now the default for availability queries; opt out with `[workspace.bom] strict = false`.
+
 ## [0.4.19] - 2026-08-03
 
 ### Changed

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -338,11 +338,21 @@ pub struct WorkspaceConfig {
     pub exclude: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BomConfig {
     /// Require exact MPN matching when fetching availability from the BOM service.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default = "default_true")]
     pub strict: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for BomConfig {
+    fn default() -> Self {
+        Self { strict: true }
+    }
 }
 
 impl BomConfig {
@@ -854,6 +864,35 @@ strict = true
         let workspace = config.workspace.unwrap();
 
         assert!(workspace.bom.strict);
+    }
+
+    #[test]
+    fn test_workspace_bom_strict_defaults_to_true() {
+        let content = r#"
+[workspace]
+pcb-version = "0.4"
+"#;
+
+        let config = PcbToml::parse(content).unwrap();
+        let workspace = config.workspace.unwrap();
+
+        assert!(workspace.bom.strict);
+    }
+
+    #[test]
+    fn test_parse_workspace_bom_strict_disabled() {
+        let content = r#"
+[workspace]
+pcb-version = "0.4"
+
+[workspace.bom]
+strict = false
+"#;
+
+        let config = PcbToml::parse(content).unwrap();
+        let workspace = config.workspace.unwrap();
+
+        assert!(!workspace.bom.strict);
     }
 
     #[test]

--- a/crates/pcbc/tests/snapshots/release__publish_full.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_full.snap
@@ -102,6 +102,9 @@ Designator,Val,Package,Mid X,Mid Y,Rotation,Layer
   },
   "release": {
     "board_name": "TestBoard",
+    "bom": {
+      "strict": true
+    },
     "created_at": "<TIMESTAMP>",
     "git_version": "<GIT_HASH>",
     "layout_path": "boards/build/TestBoard",

--- a/crates/pcbc/tests/snapshots/release__publish_source_only.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_source_only.snap
@@ -29,6 +29,9 @@ expression: sb.snapshot_dir(&staging_dir)
   },
   "release": {
     "board_name": "TestBoard",
+    "bom": {
+      "strict": true
+    },
     "created_at": "<TIMESTAMP>",
     "git_version": "<GIT_HASH>",
     "schema_version": "1",

--- a/crates/pcbc/tests/snapshots/release__publish_with_description.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_with_description.snap
@@ -29,6 +29,9 @@ expression: sb.snapshot_dir(&staging_dir)
   },
   "release": {
     "board_name": "DescBoard",
+    "bom": {
+      "strict": true
+    },
     "created_at": "<TIMESTAMP>",
     "description": "A test board with a description",
     "git_version": "<GIT_HASH>",

--- a/crates/pcbc/tests/snapshots/release__publish_with_file.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_with_file.snap
@@ -19,6 +19,9 @@ expression: sb.snapshot_dir(&staging_dir)
   },
   "release": {
     "board_name": "TB0002",
+    "bom": {
+      "strict": true
+    },
     "created_at": "<TIMESTAMP>",
     "git_version": "<GIT_HASH>",
     "schema_version": "1",

--- a/crates/pcbc/tests/snapshots/release__publish_with_version.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_with_version.snap
@@ -29,6 +29,9 @@ expression: sb.snapshot_dir(staging_dir)
   },
   "release": {
     "board_name": "TB0001",
+    "bom": {
+      "strict": true
+    },
     "created_at": "<TIMESTAMP>",
     "git_version": "v1.3.0",
     "schema_version": "1",

--- a/crates/pcbc/tests/snapshots/tag__publish_board_simple_workspace.snap
+++ b/crates/pcbc/tests/snapshots/tag__publish_board_simple_workspace.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcbc/tests/tag.rs
-assertion_line: 97
 expression: sb.snapshot_dir(&staging_dir)
 ---
 === diagnostics.json
@@ -20,6 +19,9 @@ expression: sb.snapshot_dir(&staging_dir)
   },
   "release": {
     "board_name": "TB0001",
+    "bom": {
+      "strict": true
+    },
     "created_at": "<TIMESTAMP>",
     "git_version": "v0.1.0",
     "layout_path": "boards/Test/build/TB0001",

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -230,16 +230,13 @@ endpoint = "diode.computer"
 
 ## BOM matching (`[workspace.bom]`)
 
-Workspace manifests can enable strict BOM matching for `pcb bom` availability
-queries:
+`pcb bom` availability queries use strict BOM matching by default, requiring
+exact MPN matches. Workspace manifests can opt out to use fuzzy matching:
 
 ```toml
 [workspace.bom]
-strict = true
+strict = false
 ```
-
-When enabled, `pcb bom` requires exact MPN matches. The default is `false`,
-which uses fuzzy matching.
 
 ## Registry search scope
 


### PR DESCRIPTION
default strict bom to true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior change for BOM sourcing/availability may surface different part matches for workspaces that never set `[workspace.bom]`; opt-out is available but easy to miss.
> 
> **Overview**
> **Strict exact-MPN BOM matching is now the default** for `pcb bom` availability queries and for publish release metadata when `[workspace.bom]` is omitted.
> 
> `BomConfig.strict` defaults to **`true`** via serde (`default_true`) and an explicit `Default` impl, replacing the previous implicit **`false`**. Workspaces that want fuzzy matching must set **`[workspace.bom] strict = false`**.
> 
> Docs and **CHANGELOG** describe the new default; config tests cover default-on and explicit opt-out. Publish/tag **snapshot** fixtures now include **`release.bom.strict: true`** to match the resolved workspace config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88b60927d3db9fe919131735fecdbab6b024ca02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->