### PR TITLE
Use ambient API auth for pcb auth git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `pcb layout` now keeps generated KiCad board files canonically formatted after updating board settings.
+- `pcb auth git` now uses ambient Diode API authentication in managed sandboxes.
 - Git dependency resolution now falls back to SSH when DiodeHub HTTPS authentication is unavailable.
 
 ## [0.4.18] - 2026-08-03

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -135,9 +135,6 @@ fn exchange_credential(
     host: &str,
     path: &str,
 ) -> Result<MintedGitCredential> {
-    let api_token = ctx
-        .token()
-        .context("Failed to get a valid Diode API token")?;
     let url = format!("{}/api/git/credentials", ctx.api_base_url());
     let client = Client::builder()
         .user_agent(format!("diode-pcb/{}", env!("CARGO_PKG_VERSION")))
@@ -145,10 +142,11 @@ fn exchange_credential(
         .build()
         .context("Failed to create Git credential HTTP client")?;
 
-    let response = client
+    let request = client
         .post(url)
-        .bearer_auth(api_token)
-        .json(&GitCredentialExchangeRequest { host, path })
+        .json(&GitCredentialExchangeRequest { host, path });
+
+    let response = crate::auth::apply_api_auth_with_context(ctx, request)?
         .send()
         .context("Failed to exchange Diode authentication for a Git credential")?;
 

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -139,6 +139,7 @@ impl TestContext {
             .env("NO_PROXY", "127.0.0.1,localhost")
             .env("no_proxy", "127.0.0.1,localhost")
             .env("PATH", &self.path)
+            .env_remove("DIODE_API_AUTH")
             .env_remove("RUST_LOG");
     }
 }
@@ -208,15 +209,20 @@ fn assert_clean_success(output: &Output) {
     assert!(output.stderr.is_empty());
 }
 
-fn mock_exchange<'a>(server: &'a MockServer, status: u16) -> Mock<'a> {
+fn mock_exchange<'a>(server: &'a MockServer, status: u16, authorization: Option<&str>) -> Mock<'a> {
     server.mock(move |when, then| {
-        when.method(POST)
+        let when = when
+            .method(POST)
             .path("/api/git/credentials")
-            .header("authorization", format!("Bearer {USER_ACCESS_TOKEN}"))
             .json_body(json!({
                 "host": GIT_HOST,
                 "path": REPOSITORY_PATH,
             }));
+        if let Some(authorization) = authorization {
+            when.header("authorization", authorization);
+        } else {
+            when.header_missing("authorization");
+        }
         if status == 200 {
             then.status(200).json_body(json!({
                 "provider": "diodehub",
@@ -344,7 +350,7 @@ fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
 #[test]
 fn modern_git_fill_caches_the_bearer_credential_until_rejected() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 200);
+    let exchange = mock_exchange(&server, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 
@@ -390,9 +396,38 @@ fn modern_git_fill_caches_the_bearer_credential_until_rejected() {
 }
 
 #[test]
+fn ambient_api_auth_without_auth_file_returns_bearer_credential_to_git() {
+    let server = MockServer::start();
+    let exchange = mock_exchange(&server, 200, None);
+    let context = TestContext::new(server.base_url());
+    fs::remove_dir_all(context.config_dir.join("auth")).expect("remove PCB auth directory");
+    assert!(!context.config_dir.join("auth").exists());
+    assert_clean_success(&context.run_config_command("configure"));
+
+    let fill = run_with_input(
+        {
+            let mut command = context.git_credential("fill");
+            command.env("DIODE_API_AUTH", "none");
+            command
+        },
+        &credential_request(),
+    );
+    assert_success(&fill);
+    assert!(fill.stderr.is_empty());
+
+    let credential = String::from_utf8(fill.stdout).unwrap();
+    assert!(credential.contains("authtype=Bearer"));
+    assert!(credential.contains(&format!("credential={REPOSITORY_TOKEN}")));
+    assert!(credential.contains(&format!(
+        "password_expiry_utc={REPOSITORY_TOKEN_EXPIRES_AT}"
+    )));
+    exchange.assert_calls(1);
+}
+
+#[test]
 fn modern_git_ignores_an_expired_cached_bearer_credential() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 200);
+    let exchange = mock_exchange(&server, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
     let expired_credential = format!(
@@ -422,7 +457,7 @@ fn modern_git_ignores_an_expired_cached_bearer_credential() {
 #[test]
 fn auth_logout_stops_the_git_credential_cache() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 200);
+    let exchange = mock_exchange(&server, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 
@@ -447,7 +482,7 @@ fn auth_logout_stops_the_git_credential_cache() {
 #[test]
 fn modern_git_honors_quit_when_the_exchange_fails() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 403);
+    let exchange = mock_exchange(&server, 403, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 


### PR DESCRIPTION
`pcb auth git` read a local user token directly, so it failed in managed sandboxes that use proxy-injected API authentication. This change applies the shared API authentication helper and adds an integration test for credential exchange without a local auth file or client `Authorization` header; `cargo test -p pcbc --test auth_git` and `cargo test -p pcb-diode-api` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Git credential HTTP auth wiring with integration test coverage; no new user-facing surface beyond fixing sandbox behavior.
> 
> **Overview**
> **`pcb auth git`** no longer requires a local Diode API token for the `/api/git/credentials` exchange. It now goes through the shared **`apply_api_auth_with_context`** helper, matching other API clients and allowing **proxy-injected authentication** in managed sandboxes (e.g. **`DIODE_API_AUTH=none`** with no **`Authorization`** header).
> 
> Integration tests were updated so mocks can expect either a Bearer token or a missing **`authorization`** header, and a new test covers credential exchange with no PCB auth directory and ambient auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e13c696f739be7309c84b6fa99ab8c7a1c8ea0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->