### PR TITLE
Centralize CI Rust toolchain

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache-bin: false
 
       - name: Checkout benchmark workspace

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache-bin: false
 
       - name: Install local pcb toolchain

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache-bin: false
           cache: false
 
@@ -99,7 +98,6 @@ jobs:
         with:
           cache-bin: false
           rustflags: ""
-          toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 
       - name: Install Linux musl build dependencies

--- a/.github/workflows/pcb-version-bump.yml
+++ b/.github/workflows/pcb-version-bump.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache-bin: false
 
       - name: Update pcb shim version

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -114,7 +114,6 @@ jobs:
         with:
           cache-bin: false
           rustflags: ""
-          toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 
       - name: Install Linux musl build dependencies

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache-bin: false
           cache: false
 
@@ -116,7 +115,6 @@ jobs:
         with:
           cache-bin: false
           rustflags: ""
-          toolchain: ${{ runner.os == 'Windows' && 'stable-x86_64-pc-windows-msvc' || 'stable' }}
           target: ${{ matrix.target }}
 
       - name: Install Linux musl build dependencies

--- a/.github/workflows/pcbc-version-bump.yml
+++ b/.github/workflows/pcbc-version-bump.yml
@@ -43,7 +43,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache-bin: false
 
       - name: Update changelog

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           components: rustfmt, clippy
           cache-bin: false
 
@@ -127,14 +126,12 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ""
-          toolchain: stable-x86_64-pc-windows-msvc
           cache-bin: false
 
       - name: Install Rust
         if: runner.os != 'Windows'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           cache-bin: false
 
       - name: Install nextest

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           target: wasm32-unknown-unknown
           cache-bin: false
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.97.1"


### PR DESCRIPTION
Release npm CI reused Rust 1.92.0 because the unpinned `stable` channel could resolve to a stale runner installation. This change pins Rust 1.97.1 in `rust-toolchain.toml`, removes all workflow toolchain overrides, and passes workflow lint with existing warnings excluded, `cargo fmt`, and the WASM bundle build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and toolchain configuration only; no application logic, auth, or release artifact semantics change beyond using a consistent Rust version.
> 
> **Overview**
> **Pins the repo Rust version to `1.97.1`** in `rust-toolchain.toml` (replacing the floating `stable` channel) so local dev and CI agree on the compiler instead of picking up whatever `stable` happens to be on a runner—e.g. release/npm WASM builds sticking on an older toolchain.
> 
> **Removes per-job `toolchain:` settings** from GitHub Actions workflows (`test`, `e2e`, `wasm`, build-perf, pcb/pcbc release, nightly, and version-bump jobs). Those steps now rely on `actions-rust-lang/setup-rust-toolchain` reading `rust-toolchain.toml`, including Windows matrix builds that previously forced `stable-x86_64-pc-windows-msvc`. Workflow-specific options like `target`, `components`, and `rustflags` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2840b4131557696de55003af79b2858df13ef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->