### PR TITLE
Use Panasonic Industry for house resistors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Added AEC-Q200-qualified Vishay D/CRCW e3 parts as 0402 generic resistor matches through 10 MΩ.
 
+### Changed
+
+- Panasonic house resistor matches now use the current Panasonic Industry manufacturer name.
+
 ## [0.4.20] - 2026-08-03
 
 ### Changed

--- a/lib/std/bom/helpers.zen
+++ b/lib/std/bom/helpers.zen
@@ -213,7 +213,7 @@ def resistor_series(
     """Helper to create resistor series entry.
 
     Args:
-        manufacturer: Manufacturer name (e.g., "Panasonic Electronic Components")
+        manufacturer: Manufacturer name (e.g., "Panasonic Industry")
         series: Series prefix (e.g., "ERJ-2RKF")
         resistance_range: Resistance range (e.g., "10Ohm – 1MOhm")
         max_v: Max voltage (e.g., "50V")
@@ -258,7 +258,7 @@ def panasonic_erj(series, resistance_range, voltage, power, tolerance, e_series,
     """
     datasheet = panasonic_datasheet(datasheet_path) if datasheet_path else None
     return resistor_series(
-        "Panasonic Electronic Components",
+        "Panasonic Industry",
         series,
         resistance_range,
         voltage,

--- a/lib/std/bom/match_generics.zen
+++ b/lib/std/bom/match_generics.zen
@@ -83,7 +83,7 @@ SERIES_BY_PKG = {
     "0201": [
         # 0 ohm jumpers (checked first for exact 0 ohm match)
         discrete_resistor_series(
-            "Panasonic Electronic Components",
+            "Panasonic Industry",
             "ERJ-1GJ",
             "25V",
             "0.05W",
@@ -126,7 +126,7 @@ SERIES_BY_PKG = {
     "0402": [
         # 0 ohm jumpers (checked first for exact 0 ohm match)
         discrete_resistor_series(
-            "Panasonic Electronic Components",
+            "Panasonic Industry",
             "ERJ-2G",
             "50V",
             "0.1W",
@@ -189,7 +189,7 @@ SERIES_BY_PKG = {
     "0603": [
         # 0 ohm jumpers (checked first for exact 0 ohm match)
         discrete_resistor_series(
-            "Panasonic Electronic Components",
+            "Panasonic Industry",
             "ERJ-3G",
             "75V",
             "0.333W",


### PR DESCRIPTION
Panasonic’s current device-business name is Panasonic Industry, but the standard-library resistor catalog used an obsolete name. This change updates all Panasonic house resistor matches and the changelog; the focused resistor test, Zener format checks, Rust formatting, and diff checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only manufacturer string updates with no changes to MPNs, matching rules, or runtime behavior; strict BOM or distributor lookups keyed on the old name could behave differently until data sources align.
> 
> **Overview**
> Updates **Panasonic house resistor** generic BOM matching to use the current manufacturer name **Panasonic Industry** instead of the obsolete **Panasonic Electronic Components** string.
> 
> The `panasonic_erj` helper and **0201/0402/0603** discrete jumper entries in `match_generics.zen` now emit the new name on matched parts; MPNs and matching logic are unchanged. **[Unreleased]** changelog adds a **Changed** entry for this rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50893326a96269897fa9aa08fa2f3637e345e8ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->