### PR TITLE
Use TDK manufacturer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Panasonic house resistor matches now use the current Panasonic Industry manufacturer name.
+- The TDK MPZ house ferrite bead now uses the current TDK manufacturer name.
 
 ## [0.4.20] - 2026-08-03
 

--- a/lib/std/bom/match_generics.zen
+++ b/lib/std/bom/match_generics.zen
@@ -378,7 +378,7 @@ HOUSE_FB_BY_PKG = {
     ],
     "0805": [
         ferrite_bead("220Ohm 25%", "100MHz", "2A", "45mOhm", "BLM21PG221SN1D", "Murata Electronics"),
-        ferrite_bead("220Ohm 25%", "100MHz", "3A", "40mOhm", "MPZ2012S221AT000", "TDK Corporation"),
+        ferrite_bead("220Ohm 25%", "100MHz", "3A", "40mOhm", "MPZ2012S221AT000", "TDK"),
     ],
 }
 


### PR DESCRIPTION
The strict BOM service recognizes the MPZ2012S221AT000 manufacturer as `TDK`. This change updates the house ferrite-bead entry from `TDK Corporation` to `TDK`, adds a changelog note, and passes the focused ferrite-bead test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single catalog metadata string in stdlib generic BOM matching; no logic or API behavior changes beyond manufacturer identity alignment.
> 
> **Overview**
> Updates the **0805** house ferrite bead entry for `MPZ2012S221AT000` so the manufacturer string is **`TDK`** instead of **`TDK Corporation`**, matching what strict BOM / availability matching expects for that MPN.
> 
> Documents the change under **Unreleased → Changed** in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61c237c93e6bef1aba3aa30fdeeee8b1d9b8e92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->