### PR TITLE
Support deployment-specific DiodeHub Git hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- `pcb auth git configure` now accepts a DiodeHub repository URL and scopes Git credentials to its exact HTTPS origin.
 - Panasonic house resistor matches now use the current Panasonic Industry manufacturer name.
 - The TDK MPZ house ferrite bead now uses the current TDK manufacturer name.
 

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -132,7 +132,10 @@ fn provide_credential(
     }
 
     let path = std::str::from_utf8(path).context("Git credential path is not UTF-8")?;
-    let credential = exchange_credential(ctx, configured_host, path)?;
+    let api_host = configured_host
+        .split_once(':')
+        .map_or(configured_host, |(host, _)| host);
+    let credential = exchange_credential(ctx, api_host, path)?;
 
     writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
     writeln!(output, "authtype=Bearer")?;

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -132,10 +132,7 @@ fn provide_credential(
     }
 
     let path = std::str::from_utf8(path).context("Git credential path is not UTF-8")?;
-    let api_host = configured_host
-        .split_once(':')
-        .map_or(configured_host, |(host, _)| host);
-    let credential = exchange_credential(ctx, api_host, path)?;
+    let credential = exchange_credential(ctx, host_without_port(configured_host), path)?;
 
     writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
     writeln!(output, "authtype=Bearer")?;
@@ -145,6 +142,12 @@ fn provide_credential(
     output.flush()?;
 
     Ok(())
+}
+
+fn host_without_port(host: &str) -> &str {
+    host.rsplit_once(':')
+        .filter(|(hostname, _)| !hostname.ends_with(':'))
+        .map_or(host, |(hostname, _)| hostname)
 }
 
 fn exchange_credential(
@@ -290,5 +293,15 @@ mod tests {
                 .to_string()
                 .contains("Git credential request line exceeds 65535 bytes")
         );
+    }
+
+    #[test]
+    fn strips_ports_without_mangling_ipv6_hosts() {
+        assert_eq!(
+            host_without_port("code.example.com:8443"),
+            "code.example.com"
+        );
+        assert_eq!(host_without_port("[::1]:8443"), "[::1]");
+        assert_eq!(host_without_port("[::1]"), "[::1]");
     }
 }

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -13,6 +13,10 @@ const MAX_CREDENTIAL_LINE_BYTES: usize = 65_535;
 #[derive(Args, Debug)]
 #[command(about = "Configure or provide Git credentials using PCB authentication")]
 pub struct GitAuthArgs {
+    /// DiodeHub host assigned to this credential helper
+    #[arg(long, hide = true)]
+    host: Option<String>,
+
     /// Git credential helper operation, `configure`, or `unconfigure`
     operation: String,
 
@@ -83,8 +87,9 @@ pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
             writeln!(stdout, "capability {AUTHTYPE_CAPABILITY}")?;
         }
         "get" => {
+            let host = args.host.as_deref().unwrap_or_default();
             let result = read_credential_request(stdin.lock())
-                .and_then(|request| provide_credential(ctx, request, &mut stdout));
+                .and_then(|request| provide_credential(ctx, host, request, &mut stdout));
             if let Err(error) = result {
                 writeln!(stdout, "quit=true")?;
                 writeln!(stdout)?;
@@ -103,16 +108,16 @@ pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
 
 fn provide_credential(
     ctx: &WorkspaceContext,
+    configured_host: &str,
     request: CredentialRequest,
     output: &mut impl Write,
 ) -> Result<()> {
-    if request.protocol.as_deref() != Some(b"https") {
+    if request.protocol.as_deref() != Some(b"https")
+        || request.host.as_deref() != Some(configured_host.as_bytes())
+    {
         return Ok(());
     }
 
-    let Some(host) = request.host.as_deref().filter(|host| !host.is_empty()) else {
-        return Ok(());
-    };
     let Some(path) = request.path.as_deref().filter(|path| !path.is_empty()) else {
         return Ok(());
     };
@@ -125,9 +130,8 @@ fn provide_credential(
         bail!("Git did not advertise the `authtype` credential capability");
     }
 
-    let host = std::str::from_utf8(host).context("Git credential host is not UTF-8")?;
     let path = std::str::from_utf8(path).context("Git credential path is not UTF-8")?;
-    let credential = exchange_credential(ctx, host, path)?;
+    let credential = exchange_credential(ctx, configured_host, path)?;
 
     writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
     writeln!(output, "authtype=Bearer")?;

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -8,7 +8,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::WorkspaceContext;
 
 const AUTHTYPE_CAPABILITY: &str = "authtype";
-const DIODEHUB_HOST: &str = "code.diode.computer";
 const MAX_CREDENTIAL_LINE_BYTES: usize = 65_535;
 
 #[derive(Args, Debug)]
@@ -16,6 +15,9 @@ const MAX_CREDENTIAL_LINE_BYTES: usize = 65_535;
 pub struct GitAuthArgs {
     /// Git credential helper operation, `configure`, or `unconfigure`
     operation: String,
+
+    /// DiodeHub HTTPS repository URL to configure
+    repository_url: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -69,7 +71,12 @@ pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
     let mut stdout = io::stdout().lock();
 
     match args.operation.as_str() {
-        "configure" => pcb_zen::git::configure_diodehub_credentials_globally()?,
+        "configure" => {
+            let repository_url = args.repository_url.as_deref().context(
+                "Missing DiodeHub repository URL; use `pcb auth git configure <repository-url>`",
+            )?;
+            pcb_zen::git::configure_diodehub_credentials_globally(repository_url)?;
+        }
         "unconfigure" => pcb_zen::git::unconfigure_diodehub_credentials_globally()?,
         "capability" => {
             writeln!(stdout, "version 0")?;
@@ -99,12 +106,13 @@ fn provide_credential(
     request: CredentialRequest,
     output: &mut impl Write,
 ) -> Result<()> {
-    if request.protocol.as_deref() != Some(b"https")
-        || request.host.as_deref() != Some(DIODEHUB_HOST.as_bytes())
-    {
+    if request.protocol.as_deref() != Some(b"https") {
         return Ok(());
     }
 
+    let Some(host) = request.host.as_deref().filter(|host| !host.is_empty()) else {
+        return Ok(());
+    };
     let Some(path) = request.path.as_deref().filter(|path| !path.is_empty()) else {
         return Ok(());
     };
@@ -117,8 +125,9 @@ fn provide_credential(
         bail!("Git did not advertise the `authtype` credential capability");
     }
 
+    let host = std::str::from_utf8(host).context("Git credential host is not UTF-8")?;
     let path = std::str::from_utf8(path).context("Git credential path is not UTF-8")?;
-    let credential = exchange_credential(ctx, DIODEHUB_HOST, path)?;
+    let credential = exchange_credential(ctx, host, path)?;
 
     writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
     writeln!(output, "authtype=Bearer")?;

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::WorkspaceContext;
 
 const AUTHTYPE_CAPABILITY: &str = "authtype";
+const DEFAULT_DIODEHUB_HOST: &str = "code.diode.computer";
 const MAX_CREDENTIAL_LINE_BYTES: usize = 65_535;
 
 #[derive(Args, Debug)]
@@ -87,7 +88,7 @@ pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
             writeln!(stdout, "capability {AUTHTYPE_CAPABILITY}")?;
         }
         "get" => {
-            let host = args.host.as_deref().unwrap_or_default();
+            let host = args.host.as_deref().unwrap_or(DEFAULT_DIODEHUB_HOST);
             let result = read_credential_request(stdin.lock())
                 .and_then(|request| provide_credential(ctx, host, request, &mut stdout));
             if let Err(error) = result {

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -4,6 +4,7 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use url::Url;
 
 use crate::WorkspaceContext;
 
@@ -113,9 +114,13 @@ fn provide_credential(
     request: CredentialRequest,
     output: &mut impl Write,
 ) -> Result<()> {
-    if request.protocol.as_deref() != Some(b"https")
-        || request.host.as_deref() != Some(configured_host.as_bytes())
-    {
+    if request.protocol.as_deref() != Some(b"https") {
+        return Ok(());
+    }
+    let Some(request_host) = request.host.as_deref() else {
+        return Ok(());
+    };
+    if credential_hostname(request_host)? != configured_host {
         return Ok(());
     }
 
@@ -132,7 +137,7 @@ fn provide_credential(
     }
 
     let path = std::str::from_utf8(path).context("Git credential path is not UTF-8")?;
-    let credential = exchange_credential(ctx, host_without_port(configured_host), path)?;
+    let credential = exchange_credential(ctx, configured_host, path)?;
 
     writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
     writeln!(output, "authtype=Bearer")?;
@@ -144,10 +149,14 @@ fn provide_credential(
     Ok(())
 }
 
-fn host_without_port(host: &str) -> &str {
-    host.rsplit_once(':')
-        .filter(|(hostname, _)| !hostname.ends_with(':'))
-        .map_or(host, |(hostname, _)| hostname)
+fn credential_hostname(authority: &[u8]) -> Result<String> {
+    let authority = std::str::from_utf8(authority).context("Git credential host is not UTF-8")?;
+    let url =
+        Url::parse(&format!("https://{authority}")).context("Git credential host is invalid")?;
+    Ok(url
+        .host_str()
+        .context("Git credential host is invalid")?
+        .to_owned())
 }
 
 fn exchange_credential(
@@ -296,12 +305,14 @@ mod tests {
     }
 
     #[test]
-    fn strips_ports_without_mangling_ipv6_hosts() {
-        assert_eq!(
-            host_without_port("code.example.com:8443"),
-            "code.example.com"
-        );
-        assert_eq!(host_without_port("[::1]:8443"), "[::1]");
-        assert_eq!(host_without_port("[::1]"), "[::1]");
+    fn normalizes_credential_hostnames() {
+        for (authority, hostname) in [
+            ("code.example.com:443", "code.example.com"),
+            ("code.example.com:8443", "code.example.com"),
+            ("[2001:db8::1:2]", "[2001:db8::1:2]"),
+            ("[2001:db8::1:2]:8443", "[2001:db8::1:2]"),
+        ] {
+            assert_eq!(credential_hostname(authority.as_bytes()).unwrap(), hostname);
+        }
     }
 }

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -15,7 +15,6 @@ use tempfile::Builder;
 use url::{Position, Url};
 
 const DIODEHUB_CREDENTIAL_CACHE_TIMEOUT_SECONDS: u64 = 55 * 60;
-const DIODEHUB_HOST: &str = "code.diode.computer";
 const LEGACY_DIODEHUB_CREDENTIAL_HELPER: &str = "!pcb auth git";
 const DIODEHUB_CREDENTIAL_HELPER_CONFIG: &str = "credential.https://code.diode.computer.helper";
 const DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG: &str =
@@ -44,25 +43,19 @@ fn make_noninteractive(cmd: &mut Command) {
     cmd.env("GCM_INTERACTIVE", "never");
 }
 
-fn git_network(repo_root: &Path) -> anyhow::Result<Command> {
-    let mut cmd = git_global_network()?;
+fn git_network(repo_root: &Path) -> Command {
+    let mut cmd = git_global();
     make_noninteractive(&mut cmd);
     cmd.arg("-C").arg(repo_root);
-    Ok(cmd)
+    cmd
 }
 
-fn git_global_network() -> anyhow::Result<Command> {
+fn git_global_network_with_prompt(interactive: bool) -> Command {
     let mut cmd = git_global();
-    add_diodehub_https_auth_config(&mut cmd, &credential_cache_socket()?)?;
-    Ok(cmd)
-}
-
-fn git_global_network_with_prompt(interactive: bool) -> anyhow::Result<Command> {
-    let mut cmd = git_global_network()?;
     if !interactive {
         make_noninteractive(&mut cmd);
     }
-    Ok(cmd)
+    cmd
 }
 
 fn pcb_config_dir() -> anyhow::Result<PathBuf> {
@@ -109,20 +102,6 @@ fn diodehub_credential_helper(host: &str) -> String {
 
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
-}
-
-fn add_git_config(cmd: &mut Command, key: &str, value: &str) {
-    cmd.arg("-c").arg(format!("{key}={value}"));
-}
-
-fn add_diodehub_https_auth_config(cmd: &mut Command, cache_socket: &Path) -> anyhow::Result<()> {
-    let cache_helper = credential_cache_helper(cache_socket)?;
-    let credential_helper = diodehub_credential_helper(DIODEHUB_HOST);
-    add_git_config(cmd, DIODEHUB_CREDENTIAL_HELPER_CONFIG, "");
-    add_git_config(cmd, DIODEHUB_CREDENTIAL_HELPER_CONFIG, &cache_helper);
-    add_git_config(cmd, DIODEHUB_CREDENTIAL_HELPER_CONFIG, &credential_helper);
-    add_git_config(cmd, DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG, "true");
-    Ok(())
 }
 
 fn run_silent(mut cmd: Command) -> anyhow::Result<()> {
@@ -175,7 +154,7 @@ pub fn run_in(repo_root: &Path, args: &[&str]) -> anyhow::Result<()> {
 }
 
 fn run_network_in(repo_root: &Path, args: &[&str]) -> anyhow::Result<()> {
-    let mut cmd = git_network(repo_root)?;
+    let mut cmd = git_network(repo_root);
     cmd.args(args);
     run_silent(cmd)
 }
@@ -291,23 +270,7 @@ fn ensure_git_config_include(config_path: &Path) -> anyhow::Result<()> {
     let config_path = config_path
         .to_str()
         .context("PCB config directory is not valid UTF-8")?;
-    let output = git_global()
-        .args(["config", "--global", "--get-all", PCB_GIT_CONFIG_INCLUDE])
-        .output()
-        .context("Failed to read global Git configuration")?;
-    if output.status.success()
-        && String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .any(|value| value == config_path)
-    {
-        return Ok(());
-    }
-    if !output.status.success() && output.status.code() != Some(1) {
-        bail!(
-            "`git config --global --get-all include.path` failed with {}",
-            output.status
-        );
-    }
+    unset_git_config_value(PCB_GIT_CONFIG_INCLUDE, config_path)?;
     run_git_config(&["--add", PCB_GIT_CONFIG_INCLUDE, config_path])
 }
 
@@ -666,7 +629,7 @@ fn parse_git_timezone_offset(offset: &str) -> Option<i32> {
 }
 
 fn clone(remote_url: &str, dest_dir: &Path, prompt: bool) -> anyhow::Result<()> {
-    let mut cmd = git_global_network_with_prompt(prompt)?;
+    let mut cmd = git_global_network_with_prompt(prompt);
     cmd.arg("clone");
     cmd.args(["--quiet", "--no-checkout", remote_url])
         .arg(dest_dir);
@@ -947,7 +910,7 @@ pub fn ls_remote_with_fallback(
 }
 
 fn ls_remote(url: &str, refspec: &str, interactive: bool) -> anyhow::Result<Option<String>> {
-    let mut cmd = git_global_network_with_prompt(interactive)?;
+    let mut cmd = git_global_network_with_prompt(interactive);
     cmd.args(["ls-remote", url, refspec]);
     let out = run_stdout(cmd)?;
     Ok(out
@@ -1004,56 +967,6 @@ pub fn lock_dir(dir: &Path) -> anyhow::Result<fslock::LockFile> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use std::io::Write;
-    use std::process::Output;
-
-    struct CredentialCacheGuard(PathBuf);
-
-    impl Drop for CredentialCacheGuard {
-        fn drop(&mut self) {
-            let mut socket_argument = OsString::from("--socket=");
-            socket_argument.push(&self.0);
-            let _ = git_global()
-                .arg("credential-cache")
-                .arg(socket_argument)
-                .arg("exit")
-                .output();
-        }
-    }
-
-    fn run_with_input(mut command: Command, input: &str) -> Output {
-        let mut child = command
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
-        child
-            .stdin
-            .take()
-            .unwrap()
-            .write_all(input.as_bytes())
-            .unwrap();
-        child.wait_with_output().unwrap()
-    }
-
-    fn isolate_git_config(command: &mut Command, config: &Path) {
-        command
-            .env("GIT_CONFIG_GLOBAL", config)
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env("GIT_TERMINAL_PROMPT", "0");
-    }
-
-    fn assert_success(output: &Output) {
-        assert!(
-            output.status.success(),
-            "command failed with {}\nstdout:\n{}\nstderr:\n{}",
-            output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
 
     #[test]
     fn test_lock_path_appends_suffix() {
@@ -1193,7 +1106,7 @@ mod tests {
 
     #[test]
     fn repository_network_commands_are_noninteractive() {
-        let command = git_network(Path::new(".")).unwrap();
+        let command = git_network(Path::new("."));
         let env = |key| {
             command
                 .get_envs()
@@ -1209,99 +1122,5 @@ mod tests {
             env(std::ffi::OsStr::new("GCM_INTERACTIVE")),
             Some(std::ffi::OsStr::new("never"))
         );
-    }
-
-    #[test]
-    fn process_local_auth_uses_the_pcb_cache_without_mutating_global_config() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let git_config = tempdir.path().join("gitconfig");
-        let original_config = b"[user]\n\temail = dev@example.com\n";
-        fs::write(&git_config, original_config).unwrap();
-        let cache_socket = tempdir.path().join("git-credential-cache/socket");
-        let _cache_guard = CredentialCacheGuard(cache_socket.clone());
-        let cached_credential = "capability[]=authtype\n\
-                                 protocol=https\n\
-                                 host=code.diode.computer\n\
-                                 path=diode/registry.git\n\
-                                 authtype=Bearer\n\
-                                 credential=repository-token\n\
-                                 password_expiry_utc=4102444800\n\
-                                 \n";
-
-        let mut socket_argument = OsString::from("--socket=");
-        socket_argument.push(&cache_socket);
-        let mut store = git_global();
-        store
-            .arg("credential-cache")
-            .arg(socket_argument)
-            .arg("--timeout=3300")
-            .arg("store");
-        isolate_git_config(&mut store, &git_config);
-        assert_success(&run_with_input(store, cached_credential));
-
-        let mut fill = git_global();
-        add_diodehub_https_auth_config(&mut fill, &cache_socket).unwrap();
-        fill.args(["credential", "fill"]);
-        isolate_git_config(&mut fill, &git_config);
-        let output = run_with_input(
-            fill,
-            "capability[]=authtype\n\
-             protocol=https\n\
-             host=code.diode.computer\n\
-             path=diode/registry.git\n\
-             \n",
-        );
-        assert_success(&output);
-
-        let credential = String::from_utf8(output.stdout).unwrap();
-        assert!(credential.contains("authtype=Bearer"));
-        assert!(credential.contains("credential=repository-token"));
-        assert!(credential.contains("path=diode/registry.git"));
-        assert_eq!(fs::read(&git_config).unwrap(), original_config);
-    }
-
-    #[test]
-    fn process_local_https_auth_preserves_remote_transport() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let repo = tempdir.path().join("repo");
-        fs::create_dir(&repo).unwrap();
-        init(&repo).unwrap();
-        let git_config = tempdir.path().join("gitconfig");
-        fs::write(&git_config, "").unwrap();
-        for (remote, stored_url) in [
-            ("bare", "code.diode.computer:diode/registry.git"),
-            ("scp", "git@code.diode.computer:diode/registry.git"),
-            (
-                "ssh-default-port",
-                "ssh://git@code.diode.computer/diode/registry.git",
-            ),
-            (
-                "ssh",
-                "ssh://git@code.diode.computer:23231/diode/registry.git",
-            ),
-            ("https", "https://code.diode.computer/diode/registry.git"),
-        ] {
-            run_in(&repo, &["remote", "add", remote, stored_url]).unwrap();
-
-            let mut command = git_global();
-            add_diodehub_https_auth_config(
-                &mut command,
-                &tempdir.path().join("git-credential-cache/socket"),
-            )
-            .unwrap();
-            command
-                .arg("-C")
-                .arg(&repo)
-                .args(["remote", "get-url", remote]);
-            isolate_git_config(&mut command, &git_config);
-            let output = command.output().unwrap();
-            assert_success(&output);
-
-            assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), stored_url);
-            assert_eq!(
-                run_output(&repo, &["config", "--get", &format!("remote.{remote}.url")]).unwrap(),
-                stored_url
-            );
-        }
     }
 }

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -11,12 +11,16 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tar::Archive;
+use tempfile::Builder;
+use url::Url;
 
 const DIODEHUB_CREDENTIAL_CACHE_TIMEOUT_SECONDS: u64 = 55 * 60;
 const DIODEHUB_CREDENTIAL_HELPER: &str = "!pcb auth git";
 const DIODEHUB_CREDENTIAL_HELPER_CONFIG: &str = "credential.https://code.diode.computer.helper";
 const DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG: &str =
     "credential.https://code.diode.computer.useHttpPath";
+const PCB_GIT_CONFIG_FILE: &str = "gitconfig";
+const PCB_GIT_CONFIG_INCLUDE: &str = "include.path";
 const GIT_CONFIG_NOT_FOUND: i32 = 5;
 
 #[derive(Debug, Clone)]
@@ -60,7 +64,7 @@ fn git_global_network_with_prompt(interactive: bool) -> anyhow::Result<Command> 
     Ok(cmd)
 }
 
-fn credential_cache_socket() -> anyhow::Result<PathBuf> {
+fn pcb_config_dir() -> anyhow::Result<PathBuf> {
     let config_dir = if let Ok(config_dir) = std::env::var("PCB_CONFIG_DIR") {
         PathBuf::from(config_dir)
     } else {
@@ -75,7 +79,17 @@ fn credential_cache_socket() -> anyhow::Result<PathBuf> {
             .context("Failed to resolve PCB config directory")?
             .join(config_dir)
     };
-    Ok(config_dir.join("git-credential-cache").join("socket"))
+    Ok(config_dir)
+}
+
+fn credential_cache_socket() -> anyhow::Result<PathBuf> {
+    Ok(pcb_config_dir()?
+        .join("git-credential-cache")
+        .join("socket"))
+}
+
+fn pcb_git_config_path() -> anyhow::Result<PathBuf> {
+    Ok(pcb_config_dir()?.join(PCB_GIT_CONFIG_FILE))
 }
 
 fn credential_cache_helper(socket: &Path) -> anyhow::Result<String> {
@@ -193,24 +207,103 @@ pub fn init(repo_root: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn configure_diodehub_credentials_globally() -> anyhow::Result<()> {
+pub fn configure_diodehub_credentials_globally(repository_url: &str) -> anyhow::Result<()> {
+    let credential_origin = credential_origin(repository_url)?;
+    let config_path = pcb_git_config_path()?;
     let cache_helper = credential_cache_helper(&credential_cache_socket()?)?;
-    run_git_config(&["--replace-all", DIODEHUB_CREDENTIAL_HELPER_CONFIG, ""])?;
-    run_git_config(&["--add", DIODEHUB_CREDENTIAL_HELPER_CONFIG, &cache_helper])?;
-    run_git_config(&[
-        "--add",
-        DIODEHUB_CREDENTIAL_HELPER_CONFIG,
-        DIODEHUB_CREDENTIAL_HELPER,
-    ])?;
-    run_git_config(&[
-        "--replace-all",
-        DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG,
-        "true",
-    ])
+    write_pcb_git_config(&config_path, &credential_origin, &cache_helper)?;
+    ensure_git_config_include(&config_path)?;
+    remove_legacy_diodehub_config()
 }
 
 pub fn unconfigure_diodehub_credentials_globally() -> anyhow::Result<()> {
     clear_diodehub_credential_cache();
+    let config_path = pcb_git_config_path()?;
+    let config_path = config_path
+        .to_str()
+        .context("PCB config directory is not valid UTF-8")?;
+    unset_git_config_value(PCB_GIT_CONFIG_INCLUDE, config_path)?;
+    match std::fs::remove_file(config_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error).context("Failed to remove PCB Git configuration"),
+    }
+    remove_legacy_diodehub_config()
+}
+
+fn credential_origin(repository_url: &str) -> anyhow::Result<String> {
+    let url = Url::parse(repository_url).context("Invalid DiodeHub repository URL")?;
+    if url.scheme() != "https" {
+        bail!("DiodeHub repository URL must use HTTPS");
+    }
+    if url.host_str().is_none() {
+        bail!("DiodeHub repository URL must include a host");
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        bail!("DiodeHub repository URL must not include credentials");
+    }
+    Ok(url.origin().ascii_serialization())
+}
+
+fn write_pcb_git_config(
+    config_path: &Path,
+    credential_origin: &str,
+    cache_helper: &str,
+) -> anyhow::Result<()> {
+    let config_dir = config_path
+        .parent()
+        .context("PCB Git configuration must have a parent directory")?;
+    std::fs::create_dir_all(config_dir).context("Failed to create PCB config directory")?;
+    let temp = Builder::new()
+        .prefix(".gitconfig.")
+        .tempfile_in(config_dir)
+        .context("Failed to create temporary PCB Git configuration")?;
+    let temp_path = temp.into_temp_path();
+    let helper_config = format!("credential.{credential_origin}.helper");
+    let use_http_path_config = format!("credential.{credential_origin}.useHttpPath");
+
+    run_git_config_file(&temp_path, &["--replace-all", &helper_config, ""])?;
+    run_git_config_file(&temp_path, &["--add", &helper_config, cache_helper])?;
+    run_git_config_file(
+        &temp_path,
+        &["--add", &helper_config, DIODEHUB_CREDENTIAL_HELPER],
+    )?;
+    run_git_config_file(
+        &temp_path,
+        &["--replace-all", &use_http_path_config, "true"],
+    )?;
+    temp_path
+        .persist(config_path)
+        .map_err(|error| anyhow::anyhow!(error))
+        .context("Failed to persist PCB Git configuration")?;
+    Ok(())
+}
+
+fn ensure_git_config_include(config_path: &Path) -> anyhow::Result<()> {
+    let config_path = config_path
+        .to_str()
+        .context("PCB config directory is not valid UTF-8")?;
+    let output = git_global()
+        .args(["config", "--global", "--get-all", PCB_GIT_CONFIG_INCLUDE])
+        .output()
+        .context("Failed to read global Git configuration")?;
+    if output.status.success()
+        && String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .any(|value| value == config_path)
+    {
+        return Ok(());
+    }
+    if !output.status.success() && output.status.code() != Some(1) {
+        bail!(
+            "`git config --global --get-all include.path` failed with {}",
+            output.status
+        );
+    }
+    run_git_config(&["--add", PCB_GIT_CONFIG_INCLUDE, config_path])
+}
+
+fn remove_legacy_diodehub_config() -> anyhow::Result<()> {
     unset_git_config(DIODEHUB_CREDENTIAL_HELPER_CONFIG)?;
     unset_git_config(DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG)
 }
@@ -249,9 +342,44 @@ fn run_git_config(args: &[&str]) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn run_git_config_file(path: &Path, args: &[&str]) -> anyhow::Result<()> {
+    let status = git_global()
+        .args(["config", "--file"])
+        .arg(path)
+        .args(args)
+        .status()
+        .context("Failed to run `git config`")?;
+    if !status.success() {
+        bail!(
+            "`git config --file {} {}` failed with {status}",
+            path.display(),
+            args.join(" ")
+        );
+    }
+    Ok(())
+}
+
 fn unset_git_config(key: &str) -> anyhow::Result<()> {
     let status = git_global()
         .args(["config", "--global", "--unset-all", key])
+        .status()
+        .context("Failed to run `git config`")?;
+    if !status.success() && status.code() != Some(GIT_CONFIG_NOT_FOUND) {
+        bail!("`git config --global --unset-all {key}` failed with {status}");
+    }
+    Ok(())
+}
+
+fn unset_git_config_value(key: &str, value: &str) -> anyhow::Result<()> {
+    let status = git_global()
+        .args([
+            "config",
+            "--global",
+            "--fixed-value",
+            "--unset-all",
+            key,
+            value,
+        ])
         .status()
         .context("Failed to run `git config`")?;
     if !status.success() && status.code() != Some(GIT_CONFIG_NOT_FOUND) {
@@ -1042,6 +1170,19 @@ mod tests {
             shell_quote("/tmp/PCB's cache/socket"),
             "'/tmp/PCB'\\''s cache/socket'"
         );
+    }
+
+    #[test]
+    fn derives_the_exact_https_credential_origin() {
+        assert_eq!(
+            credential_origin("https://code.gov.diode.computer/acme/widget.git").unwrap(),
+            "https://code.gov.diode.computer"
+        );
+        assert_eq!(
+            credential_origin("https://git.preview.diode.localhost:8443/acme/widget.git").unwrap(),
+            "https://git.preview.diode.localhost:8443"
+        );
+        assert!(credential_origin("http://code.diode.computer/acme/widget.git").is_err());
     }
 
     #[test]

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -12,10 +12,11 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tar::Archive;
 use tempfile::Builder;
-use url::Url;
+use url::{Position, Url};
 
 const DIODEHUB_CREDENTIAL_CACHE_TIMEOUT_SECONDS: u64 = 55 * 60;
-const DIODEHUB_CREDENTIAL_HELPER: &str = "!pcb auth git";
+const DIODEHUB_HOST: &str = "code.diode.computer";
+const LEGACY_DIODEHUB_CREDENTIAL_HELPER: &str = "!pcb auth git";
 const DIODEHUB_CREDENTIAL_HELPER_CONFIG: &str = "credential.https://code.diode.computer.helper";
 const DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG: &str =
     "credential.https://code.diode.computer.useHttpPath";
@@ -102,6 +103,10 @@ fn credential_cache_helper(socket: &Path) -> anyhow::Result<String> {
     ))
 }
 
+fn diodehub_credential_helper(host: &str) -> String {
+    format!("!pcb auth git --host={host}")
+}
+
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
@@ -112,13 +117,10 @@ fn add_git_config(cmd: &mut Command, key: &str, value: &str) {
 
 fn add_diodehub_https_auth_config(cmd: &mut Command, cache_socket: &Path) -> anyhow::Result<()> {
     let cache_helper = credential_cache_helper(cache_socket)?;
+    let credential_helper = diodehub_credential_helper(DIODEHUB_HOST);
     add_git_config(cmd, DIODEHUB_CREDENTIAL_HELPER_CONFIG, "");
     add_git_config(cmd, DIODEHUB_CREDENTIAL_HELPER_CONFIG, &cache_helper);
-    add_git_config(
-        cmd,
-        DIODEHUB_CREDENTIAL_HELPER_CONFIG,
-        DIODEHUB_CREDENTIAL_HELPER,
-    );
+    add_git_config(cmd, DIODEHUB_CREDENTIAL_HELPER_CONFIG, &credential_helper);
     add_git_config(cmd, DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG, "true");
     Ok(())
 }
@@ -208,10 +210,17 @@ pub fn init(repo_root: &Path) -> anyhow::Result<()> {
 }
 
 pub fn configure_diodehub_credentials_globally(repository_url: &str) -> anyhow::Result<()> {
-    let credential_origin = credential_origin(repository_url)?;
+    let url = credential_url(repository_url)?;
+    let credential_origin = url.origin().ascii_serialization();
+    let credential_host = &url[Position::BeforeHost..Position::AfterPort];
     let config_path = pcb_git_config_path()?;
     let cache_helper = credential_cache_helper(&credential_cache_socket()?)?;
-    write_pcb_git_config(&config_path, &credential_origin, &cache_helper)?;
+    write_pcb_git_config(
+        &config_path,
+        &credential_origin,
+        credential_host,
+        &cache_helper,
+    )?;
     ensure_git_config_include(&config_path)?;
     remove_legacy_diodehub_config()
 }
@@ -231,7 +240,7 @@ pub fn unconfigure_diodehub_credentials_globally() -> anyhow::Result<()> {
     remove_legacy_diodehub_config()
 }
 
-fn credential_origin(repository_url: &str) -> anyhow::Result<String> {
+fn credential_url(repository_url: &str) -> anyhow::Result<Url> {
     let url = Url::parse(repository_url).context("Invalid DiodeHub repository URL")?;
     if url.scheme() != "https" {
         bail!("DiodeHub repository URL must use HTTPS");
@@ -242,12 +251,13 @@ fn credential_origin(repository_url: &str) -> anyhow::Result<String> {
     if !url.username().is_empty() || url.password().is_some() {
         bail!("DiodeHub repository URL must not include credentials");
     }
-    Ok(url.origin().ascii_serialization())
+    Ok(url)
 }
 
 fn write_pcb_git_config(
     config_path: &Path,
     credential_origin: &str,
+    credential_host: &str,
     cache_helper: &str,
 ) -> anyhow::Result<()> {
     let config_dir = config_path
@@ -261,13 +271,11 @@ fn write_pcb_git_config(
     let temp_path = temp.into_temp_path();
     let helper_config = format!("credential.{credential_origin}.helper");
     let use_http_path_config = format!("credential.{credential_origin}.useHttpPath");
+    let credential_helper = diodehub_credential_helper(credential_host);
 
     run_git_config_file(&temp_path, &["--replace-all", &helper_config, ""])?;
     run_git_config_file(&temp_path, &["--add", &helper_config, cache_helper])?;
-    run_git_config_file(
-        &temp_path,
-        &["--add", &helper_config, DIODEHUB_CREDENTIAL_HELPER],
-    )?;
+    run_git_config_file(&temp_path, &["--add", &helper_config, &credential_helper])?;
     run_git_config_file(
         &temp_path,
         &["--replace-all", &use_http_path_config, "true"],
@@ -304,8 +312,11 @@ fn ensure_git_config_include(config_path: &Path) -> anyhow::Result<()> {
 }
 
 fn remove_legacy_diodehub_config() -> anyhow::Result<()> {
-    unset_git_config(DIODEHUB_CREDENTIAL_HELPER_CONFIG)?;
-    unset_git_config(DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG)
+    let cache_helper = credential_cache_helper(&credential_cache_socket()?)?;
+    for value in ["", cache_helper.as_str(), LEGACY_DIODEHUB_CREDENTIAL_HELPER] {
+        unset_git_config_value(DIODEHUB_CREDENTIAL_HELPER_CONFIG, value)?;
+    }
+    unset_git_config_value(DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG, "true")
 }
 
 pub fn clear_diodehub_credential_cache() {
@@ -355,17 +366,6 @@ fn run_git_config_file(path: &Path, args: &[&str]) -> anyhow::Result<()> {
             path.display(),
             args.join(" ")
         );
-    }
-    Ok(())
-}
-
-fn unset_git_config(key: &str) -> anyhow::Result<()> {
-    let status = git_global()
-        .args(["config", "--global", "--unset-all", key])
-        .status()
-        .context("Failed to run `git config`")?;
-    if !status.success() && status.code() != Some(GIT_CONFIG_NOT_FOUND) {
-        bail!("`git config --global --unset-all {key}` failed with {status}");
     }
     Ok(())
 }
@@ -1175,14 +1175,20 @@ mod tests {
     #[test]
     fn derives_the_exact_https_credential_origin() {
         assert_eq!(
-            credential_origin("https://code.gov.diode.computer/acme/widget.git").unwrap(),
+            credential_url("https://code.gov.diode.computer/acme/widget.git")
+                .unwrap()
+                .origin()
+                .ascii_serialization(),
             "https://code.gov.diode.computer"
         );
         assert_eq!(
-            credential_origin("https://git.preview.diode.localhost:8443/acme/widget.git").unwrap(),
+            credential_url("https://git.preview.diode.localhost:8443/acme/widget.git")
+                .unwrap()
+                .origin()
+                .ascii_serialization(),
             "https://git.preview.diode.localhost:8443"
         );
-        assert!(credential_origin("http://code.diode.computer/acme/widget.git").is_err());
+        assert!(credential_url("http://code.diode.computer/acme/widget.git").is_err());
     }
 
     #[test]

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tar::Archive;
 use tempfile::Builder;
-use url::{Position, Url};
+use url::Url;
 
 const DIODEHUB_CREDENTIAL_CACHE_TIMEOUT_SECONDS: u64 = 55 * 60;
 const DEFAULT_DIODEHUB_HOST: &str = "code.diode.computer";
@@ -104,7 +104,7 @@ fn credential_cache_helper(socket: &Path) -> anyhow::Result<String> {
 }
 
 fn diodehub_credential_helper(host: &str) -> String {
-    format!("!pcb auth git --host={host}")
+    format!("!pcb auth git --host={}", shell_quote(host))
 }
 
 fn shell_quote(value: &str) -> String {
@@ -223,7 +223,7 @@ pub fn init(repo_root: &Path) -> anyhow::Result<()> {
 pub fn configure_diodehub_credentials_globally(repository_url: &str) -> anyhow::Result<()> {
     let url = credential_url(repository_url)?;
     let credential_origin = url.origin().ascii_serialization();
-    let credential_host = &url[Position::BeforeHost..Position::AfterPort];
+    let credential_host = url.host_str().expect("credential URL has a host");
     let config_path = pcb_git_config_path()?;
     let cache_helper = credential_cache_helper(&credential_cache_socket()?)?;
     write_pcb_git_config(
@@ -284,13 +284,14 @@ fn write_pcb_git_config(
     let use_http_path_config = format!("credential.{credential_origin}.useHttpPath");
     let credential_helper = diodehub_credential_helper(credential_host);
 
-    run_git_config_file(&temp_path, &["--replace-all", &helper_config, ""])?;
-    run_git_config_file(&temp_path, &["--add", &helper_config, cache_helper])?;
-    run_git_config_file(&temp_path, &["--add", &helper_config, &credential_helper])?;
-    run_git_config_file(
-        &temp_path,
-        &["--replace-all", &use_http_path_config, "true"],
-    )?;
+    for (key, value) in [
+        (helper_config.as_str(), ""),
+        (helper_config.as_str(), cache_helper),
+        (helper_config.as_str(), credential_helper.as_str()),
+        (use_http_path_config.as_str(), "true"),
+    ] {
+        run_git_config_file(&temp_path, &["--add", key, value])?;
+    }
     temp_path
         .persist(config_path)
         .map_err(|error| anyhow::anyhow!(error))
@@ -334,35 +335,15 @@ fn stop_credential_cache() -> anyhow::Result<()> {
 }
 
 fn run_git_config(args: &[&str]) -> anyhow::Result<()> {
-    let status = git_global()
-        .args(["config", "--global"])
-        .args(args)
-        .status()
-        .context("Failed to run `git config`")?;
-    if !status.success() {
-        bail!(
-            "`git config --global {}` failed with {status}",
-            args.join(" ")
-        );
-    }
-    Ok(())
+    let mut cmd = git_global();
+    cmd.args(["config", "--global"]).args(args);
+    run_silent(cmd)
 }
 
 fn run_git_config_file(path: &Path, args: &[&str]) -> anyhow::Result<()> {
-    let status = git_global()
-        .args(["config", "--file"])
-        .arg(path)
-        .args(args)
-        .status()
-        .context("Failed to run `git config`")?;
-    if !status.success() {
-        bail!(
-            "`git config --file {} {}` failed with {status}",
-            path.display(),
-            args.join(" ")
-        );
-    }
-    Ok(())
+    let mut cmd = git_global();
+    cmd.args(["config", "--file"]).arg(path).args(args);
+    run_silent(cmd)
 }
 
 fn unset_git_config_value(key: &str, value: &str) -> anyhow::Result<()> {
@@ -1118,25 +1099,6 @@ mod tests {
     }
 
     #[test]
-    fn derives_the_exact_https_credential_origin() {
-        assert_eq!(
-            credential_url("https://code.gov.diode.computer/acme/widget.git")
-                .unwrap()
-                .origin()
-                .ascii_serialization(),
-            "https://code.gov.diode.computer"
-        );
-        assert_eq!(
-            credential_url("https://git.preview.diode.localhost:8443/acme/widget.git")
-                .unwrap()
-                .origin()
-                .ascii_serialization(),
-            "https://git.preview.diode.localhost:8443"
-        );
-        assert!(credential_url("http://code.diode.computer/acme/widget.git").is_err());
-    }
-
-    #[test]
     fn repository_network_commands_are_noninteractive() {
         let command = git_network(Path::new(".")).unwrap();
         let env = |key| {
@@ -1166,7 +1128,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(args.iter().any(|arg| {
-            arg == "credential.https://code.diode.computer.helper=!pcb auth git --host=code.diode.computer"
+            arg == "credential.https://code.diode.computer.helper=!pcb auth git --host='code.diode.computer'"
         }));
     }
 }

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -15,6 +15,7 @@ use tempfile::Builder;
 use url::{Position, Url};
 
 const DIODEHUB_CREDENTIAL_CACHE_TIMEOUT_SECONDS: u64 = 55 * 60;
+const DEFAULT_DIODEHUB_HOST: &str = "code.diode.computer";
 const LEGACY_DIODEHUB_CREDENTIAL_HELPER: &str = "!pcb auth git";
 const DIODEHUB_CREDENTIAL_HELPER_CONFIG: &str = "credential.https://code.diode.computer.helper";
 const DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG: &str =
@@ -43,19 +44,25 @@ fn make_noninteractive(cmd: &mut Command) {
     cmd.env("GCM_INTERACTIVE", "never");
 }
 
-fn git_network(repo_root: &Path) -> Command {
-    let mut cmd = git_global();
+fn git_network(repo_root: &Path) -> anyhow::Result<Command> {
+    let mut cmd = git_global_network()?;
     make_noninteractive(&mut cmd);
     cmd.arg("-C").arg(repo_root);
-    cmd
+    Ok(cmd)
 }
 
-fn git_global_network_with_prompt(interactive: bool) -> Command {
+fn git_global_network() -> anyhow::Result<Command> {
     let mut cmd = git_global();
+    add_default_diodehub_https_auth_config(&mut cmd, &credential_cache_socket()?)?;
+    Ok(cmd)
+}
+
+fn git_global_network_with_prompt(interactive: bool) -> anyhow::Result<Command> {
+    let mut cmd = git_global_network()?;
     if !interactive {
         make_noninteractive(&mut cmd);
     }
-    cmd
+    Ok(cmd)
 }
 
 fn pcb_config_dir() -> anyhow::Result<PathBuf> {
@@ -102,6 +109,31 @@ fn diodehub_credential_helper(host: &str) -> String {
 
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn add_git_config(cmd: &mut Command, key: &str, value: &str) {
+    cmd.arg("-c").arg(format!("{key}={value}"));
+}
+
+// Preserve automatic authentication for existing Commercial users. Other
+// deployments use the managed Git configuration installed by `configure`.
+fn add_default_diodehub_https_auth_config(
+    cmd: &mut Command,
+    cache_socket: &Path,
+) -> anyhow::Result<()> {
+    add_git_config(cmd, DIODEHUB_CREDENTIAL_HELPER_CONFIG, "");
+    add_git_config(
+        cmd,
+        DIODEHUB_CREDENTIAL_HELPER_CONFIG,
+        &credential_cache_helper(cache_socket)?,
+    );
+    add_git_config(
+        cmd,
+        DIODEHUB_CREDENTIAL_HELPER_CONFIG,
+        &diodehub_credential_helper(DEFAULT_DIODEHUB_HOST),
+    );
+    add_git_config(cmd, DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG, "true");
+    Ok(())
 }
 
 fn run_silent(mut cmd: Command) -> anyhow::Result<()> {
@@ -154,7 +186,7 @@ pub fn run_in(repo_root: &Path, args: &[&str]) -> anyhow::Result<()> {
 }
 
 fn run_network_in(repo_root: &Path, args: &[&str]) -> anyhow::Result<()> {
-    let mut cmd = git_network(repo_root);
+    let mut cmd = git_network(repo_root)?;
     cmd.args(args);
     run_silent(cmd)
 }
@@ -629,7 +661,7 @@ fn parse_git_timezone_offset(offset: &str) -> Option<i32> {
 }
 
 fn clone(remote_url: &str, dest_dir: &Path, prompt: bool) -> anyhow::Result<()> {
-    let mut cmd = git_global_network_with_prompt(prompt);
+    let mut cmd = git_global_network_with_prompt(prompt)?;
     cmd.arg("clone");
     cmd.args(["--quiet", "--no-checkout", remote_url])
         .arg(dest_dir);
@@ -910,7 +942,7 @@ pub fn ls_remote_with_fallback(
 }
 
 fn ls_remote(url: &str, refspec: &str, interactive: bool) -> anyhow::Result<Option<String>> {
-    let mut cmd = git_global_network_with_prompt(interactive);
+    let mut cmd = git_global_network_with_prompt(interactive)?;
     cmd.args(["ls-remote", url, refspec]);
     let out = run_stdout(cmd)?;
     Ok(out
@@ -1106,7 +1138,7 @@ mod tests {
 
     #[test]
     fn repository_network_commands_are_noninteractive() {
-        let command = git_network(Path::new("."));
+        let command = git_network(Path::new(".")).unwrap();
         let env = |key| {
             command
                 .get_envs()
@@ -1122,5 +1154,19 @@ mod tests {
             env(std::ffi::OsStr::new("GCM_INTERACTIVE")),
             Some(std::ffi::OsStr::new("never"))
         );
+    }
+
+    #[test]
+    fn process_local_auth_preserves_the_commercial_default() {
+        let mut command = git_global();
+        add_default_diodehub_https_auth_config(&mut command, Path::new("/tmp/pcb-cache")).unwrap();
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(args.iter().any(|arg| {
+            arg == "credential.https://code.diode.computer.helper=!pcb auth git --host=code.diode.computer"
+        }));
     }
 }

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -9,9 +9,13 @@ use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 use std::sync::{Mutex, MutexGuard};
 
-const GIT_HELPER_CONFIG: &str = "credential.https://code.diode.computer.helper";
-const GIT_HOST: &str = "code.diode.computer";
-const GIT_USE_HTTP_PATH_CONFIG: &str = "credential.https://code.diode.computer.useHttpPath";
+const GIT_ORIGIN: &str = "https://git.preview.diode.localhost:8443";
+const GIT_HELPER_CONFIG: &str = "credential.https://git.preview.diode.localhost:8443.helper";
+const GIT_HOST: &str = "git.preview.diode.localhost:8443";
+const GIT_USE_HTTP_PATH_CONFIG: &str =
+    "credential.https://git.preview.diode.localhost:8443.useHttpPath";
+const LEGACY_GIT_HELPER_CONFIG: &str = "credential.https://code.diode.computer.helper";
+const LEGACY_GIT_USE_HTTP_PATH_CONFIG: &str = "credential.https://code.diode.computer.useHttpPath";
 const REPOSITORY_PATH: &str = "acme/boards/widget.git";
 const USER_ACCESS_TOKEN: &str = "user-access-token";
 const REPOSITORY_TOKEN: &str = "repository-token";
@@ -100,6 +104,10 @@ impl TestContext {
         self.config_dir.join("git-credential-cache/socket")
     }
 
+    fn managed_git_config(&self) -> PathBuf {
+        self.config_dir.join("gitconfig")
+    }
+
     fn run_git_config(&self, args: &[&str]) -> Output {
         self.git()
             .args(["config", "--global"])
@@ -121,9 +129,39 @@ impl TestContext {
             .collect()
     }
 
+    fn managed_git_config_values(&self, key: &str) -> Vec<String> {
+        let output = self
+            .git()
+            .args(["config", "--file"])
+            .arg(self.managed_git_config())
+            .args(["--get-all", key])
+            .output()
+            .expect("read PCB-managed Git config");
+        if output.status.code() == Some(1) {
+            return Vec::new();
+        }
+        assert_success(&output);
+        String::from_utf8(output.stdout)
+            .expect("PCB-managed Git config output is UTF-8")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
     fn run_config_command(&self, operation: &str) -> Output {
+        let mut command = self.pcbc();
+        command.args(["auth", "git", operation]);
+        if operation == "configure" {
+            command.arg(format!("{GIT_ORIGIN}/{REPOSITORY_PATH}"));
+        }
+        command
+            .output()
+            .expect("run pcb auth git configuration command")
+    }
+
+    fn run_config_command_with_url(&self, repository_url: &str) -> Output {
         self.pcbc()
-            .args(["auth", "git", operation])
+            .args(["auth", "git", "configure", repository_url])
             .output()
             .expect("run pcb auth git configuration command")
     }
@@ -267,39 +305,124 @@ fn advertises_authtype_and_ignores_unknown_operations() {
 #[test]
 fn configure_is_idempotent_and_preserves_unrelated_global_config() {
     let context = TestContext::new("http://127.0.0.1:1".to_string());
+    let unrelated_include = context._tempdir.path().join("unrelated.gitconfig");
+    fs::write(&unrelated_include, "[alias]\n\tco = checkout\n").unwrap();
     assert_clean_success(&context.run_git_config(&["--add", "user.email", "dev@example.com"]));
     assert_clean_success(&context.run_git_config(&["--add", "credential.helper", "store"]));
     assert_clean_success(&context.run_git_config(&[
         "--add",
-        "credential.https://code.diode.computer.username",
+        "include.path",
+        unrelated_include.to_str().unwrap(),
+    ]));
+    assert_clean_success(&context.run_git_config(&[
+        "--add",
+        "credential.https://git.preview.diode.localhost:8443.username",
         "developer",
     ]));
-    assert_clean_success(&context.run_git_config(&["--add", GIT_HELPER_CONFIG, "!old-helper"]));
-    assert_clean_success(&context.run_git_config(&["--add", GIT_USE_HTTP_PATH_CONFIG, "false"]));
+    assert_clean_success(&context.run_git_config(&[
+        "--add",
+        LEGACY_GIT_HELPER_CONFIG,
+        "!pcb auth git",
+    ]));
+    assert_clean_success(&context.run_git_config(&[
+        "--add",
+        LEGACY_GIT_USE_HTTP_PATH_CONFIG,
+        "true",
+    ]));
 
     assert_clean_success(&context.run_config_command("configure"));
     assert_clean_success(&context.run_config_command("configure"));
 
-    let helpers = context.git_config_values(GIT_HELPER_CONFIG);
+    let helpers = context.managed_git_config_values(GIT_HELPER_CONFIG);
     assert_eq!(helpers.len(), 3);
     assert_eq!(helpers[0], "");
     assert!(helpers[1].starts_with("cache --timeout=3300 --socket="));
     assert_eq!(helpers[2], "!pcb auth git");
     assert_eq!(
-        context.git_config_values(GIT_USE_HTTP_PATH_CONFIG),
+        context.managed_git_config_values(GIT_USE_HTTP_PATH_CONFIG),
         ["true"]
+    );
+    let includes = context.git_config_values("include.path");
+    assert_eq!(
+        includes
+            .iter()
+            .filter(|value| *value == context.managed_git_config().to_str().unwrap())
+            .count(),
+        1
+    );
+    assert!(includes.contains(&unrelated_include.to_string_lossy().into_owned()));
+    assert!(
+        context
+            .git_config_values(LEGACY_GIT_HELPER_CONFIG)
+            .is_empty()
+    );
+    assert!(
+        context
+            .git_config_values(LEGACY_GIT_USE_HTTP_PATH_CONFIG)
+            .is_empty()
     );
     assert_eq!(context.git_config_values("user.email"), ["dev@example.com"]);
     assert_eq!(context.git_config_values("credential.helper"), ["store"]);
     assert_eq!(
-        context.git_config_values("credential.https://code.diode.computer.username"),
+        context.git_config_values("credential.https://git.preview.diode.localhost:8443.username"),
         ["developer"]
     );
 }
 
 #[test]
+fn configure_replaces_the_managed_credential_origin() {
+    let context = TestContext::new("http://127.0.0.1:1".to_string());
+    assert_clean_success(&context.run_config_command("configure"));
+
+    let other_origin = "https://code.gov.diode.computer";
+    assert_clean_success(
+        &context.run_config_command_with_url(&format!("{other_origin}/acme/boards/widget.git")),
+    );
+
+    assert!(
+        context
+            .managed_git_config_values(GIT_HELPER_CONFIG)
+            .is_empty()
+    );
+    let helpers = context.managed_git_config_values(&format!("credential.{other_origin}.helper"));
+    assert_eq!(helpers.len(), 3);
+    assert_eq!(helpers[0], "");
+    assert!(helpers[1].starts_with("cache --timeout=3300 --socket="));
+    assert_eq!(helpers[2], "!pcb auth git");
+}
+
+#[test]
+fn configure_requires_an_https_repository_url() {
+    let context = TestContext::new("http://127.0.0.1:1".to_string());
+
+    let missing = context
+        .pcbc()
+        .args(["auth", "git", "configure"])
+        .output()
+        .expect("run configure without a repository URL");
+    assert!(!missing.status.success());
+    assert!(String::from_utf8_lossy(&missing.stderr).contains(
+        "Missing DiodeHub repository URL; use `pcb auth git configure <repository-url>`"
+    ));
+
+    let http = context.run_config_command_with_url("http://code.example.com/acme/widget.git");
+    assert!(!http.status.success());
+    assert!(
+        String::from_utf8_lossy(&http.stderr).contains("DiodeHub repository URL must use HTTPS")
+    );
+    assert!(!context.managed_git_config().exists());
+}
+
+#[test]
 fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
     let context = TestContext::new("http://127.0.0.1:1".to_string());
+    let unrelated_include = context._tempdir.path().join("unrelated.gitconfig");
+    fs::write(&unrelated_include, "[alias]\n\tco = checkout\n").unwrap();
+    assert_clean_success(&context.run_git_config(&[
+        "--add",
+        "include.path",
+        unrelated_include.to_str().unwrap(),
+    ]));
     assert_clean_success(&context.run_git_config(&[
         "--add",
         "credential.https://github.com.helper",
@@ -307,7 +430,7 @@ fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
     ]));
     assert_clean_success(&context.run_git_config(&[
         "--add",
-        "credential.https://code.diode.computer.username",
+        "credential.https://git.preview.diode.localhost:8443.username",
         "developer",
     ]));
     assert_clean_success(&context.run_config_command("configure"));
@@ -331,6 +454,7 @@ fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
     assert_clean_success(&context.run_config_command("unconfigure"));
 
     assert!(!context.cache_socket().exists());
+    assert!(!context.managed_git_config().exists());
     assert!(context.git_config_values(GIT_HELPER_CONFIG).is_empty());
     assert!(
         context
@@ -338,11 +462,15 @@ fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
             .is_empty()
     );
     assert_eq!(
+        context.git_config_values("include.path"),
+        [unrelated_include.to_string_lossy().into_owned()]
+    );
+    assert_eq!(
         context.git_config_values("credential.https://github.com.helper"),
         ["!github-helper"]
     );
     assert_eq!(
-        context.git_config_values("credential.https://code.diode.computer.username"),
+        context.git_config_values("credential.https://git.preview.diode.localhost:8443.username"),
         ["developer"]
     );
 }

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -247,13 +247,18 @@ fn assert_clean_success(output: &Output) {
     assert!(output.stderr.is_empty());
 }
 
-fn mock_exchange<'a>(server: &'a MockServer, status: u16, authorization: Option<&str>) -> Mock<'a> {
+fn mock_exchange<'a>(
+    server: &'a MockServer,
+    host: &'a str,
+    status: u16,
+    authorization: Option<&str>,
+) -> Mock<'a> {
     server.mock(move |when, then| {
         let when = when
             .method(POST)
             .path("/api/git/credentials")
             .json_body(json!({
-                "host": GIT_HOST,
+                "host": host,
                 "path": REPOSITORY_PATH,
             }));
         if let Some(authorization) = authorization {
@@ -486,7 +491,7 @@ fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
 #[test]
 fn modern_git_fill_caches_the_bearer_credential_until_rejected() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 200, Some("Bearer user-access-token"));
+    let exchange = mock_exchange(&server, GIT_HOST, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 
@@ -534,7 +539,7 @@ fn modern_git_fill_caches_the_bearer_credential_until_rejected() {
 #[test]
 fn ambient_api_auth_without_auth_file_returns_bearer_credential_to_git() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 200, None);
+    let exchange = mock_exchange(&server, GIT_HOST, 200, None);
     let context = TestContext::new(server.base_url());
     fs::remove_dir_all(context.config_dir.join("auth")).expect("remove PCB auth directory");
     assert!(!context.config_dir.join("auth").exists());
@@ -563,7 +568,7 @@ fn ambient_api_auth_without_auth_file_returns_bearer_credential_to_git() {
 #[test]
 fn modern_git_ignores_an_expired_cached_bearer_credential() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 200, Some("Bearer user-access-token"));
+    let exchange = mock_exchange(&server, GIT_HOST, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
     let expired_credential = format!(
@@ -593,7 +598,7 @@ fn modern_git_ignores_an_expired_cached_bearer_credential() {
 #[test]
 fn auth_logout_stops_the_git_credential_cache() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 200, Some("Bearer user-access-token"));
+    let exchange = mock_exchange(&server, GIT_HOST, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 
@@ -618,7 +623,7 @@ fn auth_logout_stops_the_git_credential_cache() {
 #[test]
 fn modern_git_honors_quit_when_the_exchange_fails() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, 403, Some("Bearer user-access-token"));
+    let exchange = mock_exchange(&server, GIT_HOST, 403, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 
@@ -675,6 +680,37 @@ fn credential_helpers_ignore_unrelated_hosts() {
     let credential = String::from_utf8(fill.stdout).unwrap();
     assert!(credential.contains("username=fallback-user"));
     assert!(credential.contains("password=fallback-password"));
+}
+
+#[test]
+fn legacy_helper_defaults_to_the_commercial_diodehub_host() {
+    let server = MockServer::start();
+    let host = "code.diode.computer";
+    let exchange = mock_exchange(&server, host, 200, Some("Bearer user-access-token"));
+    let context = TestContext::new(server.base_url());
+    let output = run_with_input(
+        {
+            let mut command = context.pcbc();
+            command.args(["auth", "git", "get"]);
+            command
+        },
+        &format!(
+            "capability[]=authtype\n\
+             protocol=https\n\
+             host={host}\n\
+             path={REPOSITORY_PATH}\n\
+             \n"
+        ),
+    );
+
+    assert_success(&output);
+    assert!(output.stderr.is_empty());
+    assert!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .contains(&format!("credential={REPOSITORY_TOKEN}"))
+    );
+    exchange.assert_calls(1);
 }
 
 #[test]

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -12,6 +12,7 @@ use std::sync::{Mutex, MutexGuard};
 const GIT_ORIGIN: &str = "https://git.preview.diode.localhost:8443";
 const GIT_HELPER_CONFIG: &str = "credential.https://git.preview.diode.localhost:8443.helper";
 const GIT_HOST: &str = "git.preview.diode.localhost:8443";
+const GIT_API_HOST: &str = "git.preview.diode.localhost";
 const GIT_USE_HTTP_PATH_CONFIG: &str =
     "credential.https://git.preview.diode.localhost:8443.useHttpPath";
 const LEGACY_GIT_HELPER_CONFIG: &str = "credential.https://code.diode.computer.helper";
@@ -383,6 +384,18 @@ fn configure_is_idempotent_and_preserves_unrelated_global_config() {
 }
 
 #[test]
+fn configure_keeps_the_managed_include_last() {
+    let context = TestContext::new("http://127.0.0.1:1".to_string());
+    assert_clean_success(&context.run_config_command("configure"));
+    assert_clean_success(&context.run_git_config(&["--add", "credential.helper", "!later-helper"]));
+
+    assert_clean_success(&context.run_config_command("configure"));
+
+    let config = fs::read_to_string(&context.git_config).unwrap();
+    assert!(config.rfind("[include]").unwrap() > config.rfind("[credential]").unwrap());
+}
+
+#[test]
 fn configure_replaces_the_managed_credential_origin() {
     let context = TestContext::new("http://127.0.0.1:1".to_string());
     assert_clean_success(&context.run_config_command("configure"));
@@ -491,7 +504,7 @@ fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
 #[test]
 fn modern_git_fill_caches_the_bearer_credential_until_rejected() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, GIT_HOST, 200, Some("Bearer user-access-token"));
+    let exchange = mock_exchange(&server, GIT_API_HOST, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 
@@ -539,7 +552,7 @@ fn modern_git_fill_caches_the_bearer_credential_until_rejected() {
 #[test]
 fn ambient_api_auth_without_auth_file_returns_bearer_credential_to_git() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, GIT_HOST, 200, None);
+    let exchange = mock_exchange(&server, GIT_API_HOST, 200, None);
     let context = TestContext::new(server.base_url());
     fs::remove_dir_all(context.config_dir.join("auth")).expect("remove PCB auth directory");
     assert!(!context.config_dir.join("auth").exists());
@@ -568,7 +581,7 @@ fn ambient_api_auth_without_auth_file_returns_bearer_credential_to_git() {
 #[test]
 fn modern_git_ignores_an_expired_cached_bearer_credential() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, GIT_HOST, 200, Some("Bearer user-access-token"));
+    let exchange = mock_exchange(&server, GIT_API_HOST, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
     let expired_credential = format!(
@@ -598,7 +611,7 @@ fn modern_git_ignores_an_expired_cached_bearer_credential() {
 #[test]
 fn auth_logout_stops_the_git_credential_cache() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, GIT_HOST, 200, Some("Bearer user-access-token"));
+    let exchange = mock_exchange(&server, GIT_API_HOST, 200, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 
@@ -623,7 +636,7 @@ fn auth_logout_stops_the_git_credential_cache() {
 #[test]
 fn modern_git_honors_quit_when_the_exchange_fails() {
     let server = MockServer::start();
-    let exchange = mock_exchange(&server, GIT_HOST, 403, Some("Bearer user-access-token"));
+    let exchange = mock_exchange(&server, GIT_API_HOST, 403, Some("Bearer user-access-token"));
     let context = TestContext::new(server.base_url());
     assert_clean_success(&context.run_config_command("configure"));
 

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -322,7 +322,17 @@ fn configure_is_idempotent_and_preserves_unrelated_global_config() {
     assert_clean_success(&context.run_git_config(&[
         "--add",
         LEGACY_GIT_HELPER_CONFIG,
+        "!developer-helper",
+    ]));
+    assert_clean_success(&context.run_git_config(&[
+        "--add",
+        LEGACY_GIT_HELPER_CONFIG,
         "!pcb auth git",
+    ]));
+    assert_clean_success(&context.run_git_config(&[
+        "--add",
+        LEGACY_GIT_USE_HTTP_PATH_CONFIG,
+        "false",
     ]));
     assert_clean_success(&context.run_git_config(&[
         "--add",
@@ -337,7 +347,7 @@ fn configure_is_idempotent_and_preserves_unrelated_global_config() {
     assert_eq!(helpers.len(), 3);
     assert_eq!(helpers[0], "");
     assert!(helpers[1].starts_with("cache --timeout=3300 --socket="));
-    assert_eq!(helpers[2], "!pcb auth git");
+    assert_eq!(helpers[2], format!("!pcb auth git --host={GIT_HOST}"));
     assert_eq!(
         context.managed_git_config_values(GIT_USE_HTTP_PATH_CONFIG),
         ["true"]
@@ -351,15 +361,13 @@ fn configure_is_idempotent_and_preserves_unrelated_global_config() {
         1
     );
     assert!(includes.contains(&unrelated_include.to_string_lossy().into_owned()));
-    assert!(
-        context
-            .git_config_values(LEGACY_GIT_HELPER_CONFIG)
-            .is_empty()
+    assert_eq!(
+        context.git_config_values(LEGACY_GIT_HELPER_CONFIG),
+        ["!developer-helper"]
     );
-    assert!(
-        context
-            .git_config_values(LEGACY_GIT_USE_HTTP_PATH_CONFIG)
-            .is_empty()
+    assert_eq!(
+        context.git_config_values(LEGACY_GIT_USE_HTTP_PATH_CONFIG),
+        ["false"]
     );
     assert_eq!(context.git_config_values("user.email"), ["dev@example.com"]);
     assert_eq!(context.git_config_values("credential.helper"), ["store"]);
@@ -388,7 +396,7 @@ fn configure_replaces_the_managed_credential_origin() {
     assert_eq!(helpers.len(), 3);
     assert_eq!(helpers[0], "");
     assert!(helpers[1].starts_with("cache --timeout=3300 --socket="));
-    assert_eq!(helpers[2], "!pcb auth git");
+    assert_eq!(helpers[2], "!pcb auth git --host=code.gov.diode.computer");
 }
 
 #[test]
@@ -626,14 +634,30 @@ fn modern_git_honors_quit_when_the_exchange_fails() {
 }
 
 #[test]
-fn global_helper_ignores_unrelated_hosts() {
+fn credential_helpers_ignore_unrelated_hosts() {
     let context = TestContext::new("http://127.0.0.1:1".to_string());
+    let github_request = "capability[]=authtype\n\
+                          protocol=https\n\
+                          host=github.com\n\
+                          path=acme/widget.git\n\
+                          \n";
+    let scoped_helper = run_with_input(
+        {
+            let mut command = context.pcbc();
+            command.args(["auth", "git", "--host", GIT_HOST, "get"]);
+            command
+        },
+        github_request,
+    );
+    assert_clean_success(&scoped_helper);
+
     let credential_file = context._tempdir.path().join("credentials");
     fs::write(
         &credential_file,
         "https://fallback-user:fallback-password@github.com/acme/widget.git\n",
     )
     .expect("write fallback credentials");
+    assert_clean_success(&context.run_git_config(&["--add", "credential.helper", "!pcb auth git"]));
     assert_clean_success(&context.run_git_config(&[
         "--add",
         "credential.helper",
@@ -644,14 +668,7 @@ fn global_helper_ignores_unrelated_hosts() {
     ]));
     assert_clean_success(&context.run_config_command("configure"));
 
-    let fill = run_with_input(
-        context.git_credential("fill"),
-        "capability[]=authtype\n\
-         protocol=https\n\
-         host=github.com\n\
-         path=acme/widget.git\n\
-         \n",
-    );
+    let fill = run_with_input(context.git_credential("fill"), github_request);
     assert_success(&fill);
     assert!(fill.stderr.is_empty());
 

--- a/crates/pcbc/tests/auth_git.rs
+++ b/crates/pcbc/tests/auth_git.rs
@@ -117,33 +117,20 @@ impl TestContext {
             .expect("run git config")
     }
 
-    fn git_config_values(&self, key: &str) -> Vec<String> {
-        let output = self.run_git_config(&["--get-all", key]);
-        if output.status.code() == Some(1) {
-            return Vec::new();
-        }
-        assert_success(&output);
-        String::from_utf8(output.stdout)
-            .expect("git config output is UTF-8")
-            .lines()
-            .map(str::to_string)
-            .collect()
-    }
-
-    fn managed_git_config_values(&self, key: &str) -> Vec<String> {
+    fn git_config_values(&self, config: &std::path::Path, key: &str) -> Vec<String> {
         let output = self
             .git()
             .args(["config", "--file"])
-            .arg(self.managed_git_config())
+            .arg(config)
             .args(["--get-all", key])
             .output()
-            .expect("read PCB-managed Git config");
+            .expect("read Git config");
         if output.status.code() == Some(1) {
             return Vec::new();
         }
         assert_success(&output);
         String::from_utf8(output.stdout)
-            .expect("PCB-managed Git config output is UTF-8")
+            .expect("Git config output is UTF-8")
             .lines()
             .map(str::to_string)
             .collect()
@@ -309,21 +296,14 @@ fn advertises_authtype_and_ignores_unknown_operations() {
 }
 
 #[test]
-fn configure_is_idempotent_and_preserves_unrelated_global_config() {
+fn configure_and_unconfigure_manage_only_pcb_git_config() {
     let context = TestContext::new("http://127.0.0.1:1".to_string());
     let unrelated_include = context._tempdir.path().join("unrelated.gitconfig");
     fs::write(&unrelated_include, "[alias]\n\tco = checkout\n").unwrap();
-    assert_clean_success(&context.run_git_config(&["--add", "user.email", "dev@example.com"]));
-    assert_clean_success(&context.run_git_config(&["--add", "credential.helper", "store"]));
     assert_clean_success(&context.run_git_config(&[
         "--add",
         "include.path",
         unrelated_include.to_str().unwrap(),
-    ]));
-    assert_clean_success(&context.run_git_config(&[
-        "--add",
-        "credential.https://git.preview.diode.localhost:8443.username",
-        "developer",
     ]));
     assert_clean_success(&context.run_git_config(&[
         "--add",
@@ -347,74 +327,83 @@ fn configure_is_idempotent_and_preserves_unrelated_global_config() {
     ]));
 
     assert_clean_success(&context.run_config_command("configure"));
+    assert_clean_success(&context.run_git_config(&["--add", "credential.helper", "!later-helper"]));
     assert_clean_success(&context.run_config_command("configure"));
 
-    let helpers = context.managed_git_config_values(GIT_HELPER_CONFIG);
+    let managed_config = context.managed_git_config();
+    let helpers = context.git_config_values(&managed_config, GIT_HELPER_CONFIG);
     assert_eq!(helpers.len(), 3);
     assert_eq!(helpers[0], "");
     assert!(helpers[1].starts_with("cache --timeout=3300 --socket="));
-    assert_eq!(helpers[2], format!("!pcb auth git --host={GIT_HOST}"));
+    assert_eq!(helpers[2], format!("!pcb auth git --host='{GIT_API_HOST}'"));
     assert_eq!(
-        context.managed_git_config_values(GIT_USE_HTTP_PATH_CONFIG),
+        context.git_config_values(&managed_config, GIT_USE_HTTP_PATH_CONFIG),
         ["true"]
     );
-    let includes = context.git_config_values("include.path");
+    let includes = context.git_config_values(&context.git_config, "include.path");
     assert_eq!(
-        includes
-            .iter()
-            .filter(|value| *value == context.managed_git_config().to_str().unwrap())
-            .count(),
-        1
+        includes,
+        [
+            unrelated_include.to_string_lossy().into_owned(),
+            managed_config.to_string_lossy().into_owned(),
+        ]
     );
-    assert!(includes.contains(&unrelated_include.to_string_lossy().into_owned()));
     assert_eq!(
-        context.git_config_values(LEGACY_GIT_HELPER_CONFIG),
+        context.git_config_values(&context.git_config, LEGACY_GIT_HELPER_CONFIG),
         ["!developer-helper"]
     );
     assert_eq!(
-        context.git_config_values(LEGACY_GIT_USE_HTTP_PATH_CONFIG),
+        context.git_config_values(&context.git_config, LEGACY_GIT_USE_HTTP_PATH_CONFIG),
         ["false"]
     );
-    assert_eq!(context.git_config_values("user.email"), ["dev@example.com"]);
-    assert_eq!(context.git_config_values("credential.helper"), ["store"]);
-    assert_eq!(
-        context.git_config_values("credential.https://git.preview.diode.localhost:8443.username"),
-        ["developer"]
-    );
-}
-
-#[test]
-fn configure_keeps_the_managed_include_last() {
-    let context = TestContext::new("http://127.0.0.1:1".to_string());
-    assert_clean_success(&context.run_config_command("configure"));
-    assert_clean_success(&context.run_git_config(&["--add", "credential.helper", "!later-helper"]));
-
-    assert_clean_success(&context.run_config_command("configure"));
-
-    let config = fs::read_to_string(&context.git_config).unwrap();
-    assert!(config.rfind("[include]").unwrap() > config.rfind("[credential]").unwrap());
-}
-
-#[test]
-fn configure_replaces_the_managed_credential_origin() {
-    let context = TestContext::new("http://127.0.0.1:1".to_string());
-    assert_clean_success(&context.run_config_command("configure"));
 
     let other_origin = "https://code.gov.diode.computer";
     assert_clean_success(
-        &context.run_config_command_with_url(&format!("{other_origin}/acme/boards/widget.git")),
+        &context.run_config_command_with_url(
+            "https://code.gov.diode.computer:443/acme/boards/widget.git",
+        ),
     );
-
     assert!(
         context
-            .managed_git_config_values(GIT_HELPER_CONFIG)
+            .git_config_values(&managed_config, GIT_HELPER_CONFIG)
             .is_empty()
     );
-    let helpers = context.managed_git_config_values(&format!("credential.{other_origin}.helper"));
+    let helpers = context.git_config_values(
+        &managed_config,
+        &format!("credential.{other_origin}.helper"),
+    );
     assert_eq!(helpers.len(), 3);
-    assert_eq!(helpers[0], "");
-    assert!(helpers[1].starts_with("cache --timeout=3300 --socket="));
-    assert_eq!(helpers[2], "!pcb auth git --host=code.gov.diode.computer");
+    assert_eq!(helpers[2], "!pcb auth git --host='code.gov.diode.computer'");
+
+    let cached_credential = format!(
+        "capability[]=authtype\n\
+         protocol=https\n\
+         host={GIT_HOST}\n\
+         path={REPOSITORY_PATH}\n\
+         authtype=Bearer\n\
+         credential={REPOSITORY_TOKEN}\n\
+         password_expiry_utc={REPOSITORY_TOKEN_EXPIRES_AT}\n\
+         \n"
+    );
+    assert_clean_success(&run_with_input(
+        context.git_credential_cache("store"),
+        &cached_credential,
+    ));
+    assert!(context.cache_socket().exists());
+
+    assert_clean_success(&context.run_config_command("unconfigure"));
+    assert_clean_success(&context.run_config_command("unconfigure"));
+
+    assert!(!context.cache_socket().exists());
+    assert!(!managed_config.exists());
+    assert_eq!(
+        context.git_config_values(&context.git_config, "include.path"),
+        [unrelated_include.to_string_lossy().into_owned()]
+    );
+    assert_eq!(
+        context.git_config_values(&context.git_config, "credential.helper"),
+        ["!later-helper"]
+    );
 }
 
 #[test]
@@ -437,68 +426,6 @@ fn configure_requires_an_https_repository_url() {
         String::from_utf8_lossy(&http.stderr).contains("DiodeHub repository URL must use HTTPS")
     );
     assert!(!context.managed_git_config().exists());
-}
-
-#[test]
-fn unconfigure_is_idempotent_and_preserves_unrelated_global_config() {
-    let context = TestContext::new("http://127.0.0.1:1".to_string());
-    let unrelated_include = context._tempdir.path().join("unrelated.gitconfig");
-    fs::write(&unrelated_include, "[alias]\n\tco = checkout\n").unwrap();
-    assert_clean_success(&context.run_git_config(&[
-        "--add",
-        "include.path",
-        unrelated_include.to_str().unwrap(),
-    ]));
-    assert_clean_success(&context.run_git_config(&[
-        "--add",
-        "credential.https://github.com.helper",
-        "!github-helper",
-    ]));
-    assert_clean_success(&context.run_git_config(&[
-        "--add",
-        "credential.https://git.preview.diode.localhost:8443.username",
-        "developer",
-    ]));
-    assert_clean_success(&context.run_config_command("configure"));
-    let cached_credential = format!(
-        "capability[]=authtype\n\
-         protocol=https\n\
-         host={GIT_HOST}\n\
-         path={REPOSITORY_PATH}\n\
-         authtype=Bearer\n\
-         credential={REPOSITORY_TOKEN}\n\
-         password_expiry_utc={REPOSITORY_TOKEN_EXPIRES_AT}\n\
-         \n"
-    );
-    assert_clean_success(&run_with_input(
-        context.git_credential_cache("store"),
-        &cached_credential,
-    ));
-    assert!(context.cache_socket().exists());
-
-    assert_clean_success(&context.run_config_command("unconfigure"));
-    assert_clean_success(&context.run_config_command("unconfigure"));
-
-    assert!(!context.cache_socket().exists());
-    assert!(!context.managed_git_config().exists());
-    assert!(context.git_config_values(GIT_HELPER_CONFIG).is_empty());
-    assert!(
-        context
-            .git_config_values(GIT_USE_HTTP_PATH_CONFIG)
-            .is_empty()
-    );
-    assert_eq!(
-        context.git_config_values("include.path"),
-        [unrelated_include.to_string_lossy().into_owned()]
-    );
-    assert_eq!(
-        context.git_config_values("credential.https://github.com.helper"),
-        ["!github-helper"]
-    );
-    assert_eq!(
-        context.git_config_values("credential.https://git.preview.diode.localhost:8443.username"),
-        ["developer"]
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Accept a DiodeHub repository URL in `pcb auth git configure`.
- Scope PCB-managed Git credentials to that exact HTTPS origin.
- Forward Git's requested host and path to the existing API exchange.
- Preserve unrelated user Git settings.

## Why

DiodeHub hostnames differ across Commercial, Gov, preview, and local deployments. The previous PCB configuration and credential helper accepted only `code.diode.computer`.

## Validation

- `cargo test -p pcbc --test auth_git` (12 passed)
- `cargo test -p pcb-zen git::tests` (12 passed)
- `cargo test -p pcb-diode-api git_auth::tests` (4 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: ENG-609

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Git credentials are installed globally and which host the helper serves, which can affect clone/fetch auth across deployments; behavior is heavily tested but misconfiguration could block Git access until reconfigured.
> 
> **Overview**
> **DiodeHub Git auth now keys off the repository URL you configure**, so Commercial, Gov, preview, and local hosts each get their own credential scope instead of everything being hardwired to `code.diode.computer`.
> 
> `pcb auth git configure` **requires** an HTTPS DiodeHub repo URL. It validates the URL, derives the exact HTTPS origin, and writes PCB-managed Git settings under `~/.pcb/gitconfig` (cache + `!pcb auth git --host=…`), then **includes** that file from the user’s global Git config. Re-running configure for another origin replaces the managed file for that deployment. **Unconfigure** drops the include, removes the managed file, stops the credential cache, and strips legacy global `code.diode.computer` helper entries.
> 
> The credential helper’s `get` path takes a hidden `--host` and only mints tokens when Git’s request host (with port/IPv6 normalization) matches that host. Invoking `pcb auth git get` without `--host` still defaults to the commercial host for backward compatibility. PCB’s own Git network commands keep injecting the commercial default so existing users aren’t broken before they run configure.
> 
> Integration tests cover origin-scoped config, HTTPS validation, unrelated hosts, and the legacy helper default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30516b6b9a3d0a5e6646549308f01956b72875e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->