### PR TITLE
Adopt ruff 0.16's default lint rule set for the layout scripts

### DIFF
--- a/crates/pcb-layout/src/scripts/lens/__init__.py
+++ b/crates/pcb-layout/src/scripts/lens/__init__.py
@@ -1,5 +1,7 @@
 """Lens-based layout synchronization module."""
 
-from .lens import run_lens_sync, SyncResult
+from __future__ import annotations
 
-__all__ = ["run_lens_sync", "SyncResult"]
+from .lens import SyncResult, run_lens_sync
+
+__all__ = ["SyncResult", "run_lens_sync"]

--- a/crates/pcb-layout/src/scripts/lens/changeset.py
+++ b/crates/pcb-layout/src/scripts/lens/changeset.py
@@ -10,22 +10,23 @@ Note: Renames (moved() paths) are handled in Rust preprocessing before
 the Python sync runs. This module no longer tracks renames.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Set
+from typing import Any, Literal
 
 from .types import (
+    BoardComplement,
+    BoardView,
     EntityId,
     EntityPath,
-    Position,
-    BoardView,
-    BoardComplement,
-    FootprintView,
     FootprintComplement,
-    GroupView,
+    FootprintView,
     GroupComplement,
+    GroupView,
+    Position,
     default_footprint_complement,
 )
-
 
 # =============================================================================
 # Serialization Utilities
@@ -101,7 +102,7 @@ def parse_value(s: str) -> Any:
         return s
 
 
-def _split_list(s: str) -> List[str]:
+def _split_list(s: str) -> list[str]:
     """Split a comma-separated list, respecting quotes and brackets."""
     items = []
     current = ""
@@ -136,7 +137,7 @@ def _split_list(s: str) -> List[str]:
     return items
 
 
-def _tokenize(line: str) -> List[str]:
+def _tokenize(line: str) -> list[str]:
     """Tokenize a line into command and key=value pairs."""
     tokens = []
     current = ""
@@ -172,7 +173,7 @@ def _tokenize(line: str) -> List[str]:
     return tokens
 
 
-def format_line(kind: str, fields: Dict[str, Any]) -> str:
+def format_line(kind: str, fields: dict[str, Any]) -> str:
     """Format a single line: KIND key=value key=value ..."""
     parts = [kind]
     for key, value in fields.items():
@@ -191,7 +192,7 @@ def parse_line(line: str) -> tuple:
         raise ValueError(f"No tokens in line: {line!r}")
 
     kind = tokens[0]
-    fields: Dict[str, Any] = {}
+    fields: dict[str, Any] = {}
 
     for token in tokens[1:]:
         if "=" not in token:
@@ -218,7 +219,7 @@ def _normalize_layout_path(path: str) -> str:
 
 def _serialize_footprint_view(fp: FootprintView) -> str:
     """Serialize a FootprintView to a single line."""
-    fields: Dict[str, Any] = {
+    fields: dict[str, Any] = {
         "path": str(fp.path),
         "ref": fp.reference,
         "value": fp.value,
@@ -245,7 +246,7 @@ def _serialize_footprint_complement(
     entity_id: EntityId, fc: FootprintComplement
 ) -> str:
     """Serialize a FootprintComplement to a single line."""
-    fields: Dict[str, Any] = {
+    fields: dict[str, Any] = {
         "path": str(entity_id.path),
         "x": fc.position.x,
         "y": fc.position.y,
@@ -270,7 +271,7 @@ def _serialize_footprint_complement(
 def _serialize_group_view(gv: GroupView) -> str:
     """Serialize a GroupView to a single line."""
     members = sorted(str(m.path) for m in gv.member_ids)
-    fields: Dict[str, Any] = {
+    fields: dict[str, Any] = {
         "path": str(gv.path),
         "members": members,
     }
@@ -279,13 +280,13 @@ def _serialize_group_view(gv: GroupView) -> str:
     return format_line("GRV", fields)
 
 
-def _serialize_group_complement(entity_id: EntityId, gc: GroupComplement) -> List[str]:
+def _serialize_group_complement(entity_id: EntityId, gc: GroupComplement) -> list[str]:
     """Serialize a GroupComplement to multiple lines (one per routing item)."""
-    lines: List[str] = []
+    lines: list[str] = []
     path = str(entity_id.path)
 
     for track in sorted(gc.tracks, key=lambda t: (t.layer, t.net_name, t.uuid)):
-        fields: Dict[str, Any] = {
+        fields: dict[str, Any] = {
             "group": path,
             "net": track.net_name or "",
             "layer": track.layer,
@@ -319,9 +320,9 @@ def _serialize_group_complement(entity_id: EntityId, gc: GroupComplement) -> Lis
     return lines
 
 
-def serialize_view(view: BoardView) -> List[str]:
+def serialize_view(view: BoardView) -> list[str]:
     """Serialize a BoardView to lines (footprints and groups only, not nets)."""
-    lines: List[str] = []
+    lines: list[str] = []
 
     for entity_id in sorted(view.footprints.keys(), key=lambda e: str(e.path)):
         lines.append(_serialize_footprint_view(view.footprints[entity_id]))
@@ -332,9 +333,9 @@ def serialize_view(view: BoardView) -> List[str]:
     return lines
 
 
-def serialize_complement(complement: BoardComplement) -> List[str]:
+def serialize_complement(complement: BoardComplement) -> list[str]:
     """Serialize a BoardComplement to lines."""
-    lines: List[str] = []
+    lines: list[str] = []
 
     for entity_id in sorted(complement.footprints.keys(), key=lambda e: str(e.path)):
         lines.append(
@@ -380,13 +381,13 @@ class SyncChangeset:
     view: BoardView
     complement: BoardComplement
 
-    added_footprints: Set[EntityId] = field(default_factory=set)
-    removed_footprints: Dict[EntityId, FootprintComplement] = field(
+    added_footprints: set[EntityId] = field(default_factory=set)
+    removed_footprints: dict[EntityId, FootprintComplement] = field(
         default_factory=dict
     )
 
-    added_groups: Set[EntityId] = field(default_factory=set)
-    removed_groups: Set[EntityId] = field(default_factory=set)
+    added_groups: set[EntityId] = field(default_factory=set)
+    removed_groups: set[EntityId] = field(default_factory=set)
 
     @property
     def is_empty(self) -> bool:
@@ -398,8 +399,8 @@ class SyncChangeset:
         )
 
     @property
-    def footprint_changes(self) -> List[FootprintChange]:
-        changes: List[FootprintChange] = []
+    def footprint_changes(self) -> list[FootprintChange]:
+        changes: list[FootprintChange] = []
         for eid in sorted(self.added_footprints, key=lambda e: str(e.path)):
             changes.append(FootprintChange(kind="add", entity_id=eid))
         for eid in sorted(self.removed_footprints.keys(), key=lambda e: str(e.path)):
@@ -407,8 +408,8 @@ class SyncChangeset:
         return changes
 
     @property
-    def group_changes(self) -> List[GroupChange]:
-        changes: List[GroupChange] = []
+    def group_changes(self) -> list[GroupChange]:
+        changes: list[GroupChange] = []
         for eid in sorted(self.added_groups, key=lambda e: str(e.path)):
             changes.append(GroupChange(kind="add", entity_id=eid))
         for eid in sorted(self.removed_groups, key=lambda e: str(e.path)):
@@ -417,7 +418,7 @@ class SyncChangeset:
 
     def to_plaintext(self) -> str:
         """Serialize to plaintext - one line per change, parseable."""
-        lines: List[str] = []
+        lines: list[str] = []
 
         for change in self.footprint_changes:
             if change.kind == "add":
@@ -471,12 +472,12 @@ class SyncChangeset:
     @classmethod
     def from_plaintext(
         cls, text: str, view: BoardView, complement: BoardComplement
-    ) -> "SyncChangeset":
+    ) -> SyncChangeset:
         """Parse plaintext back to SyncChangeset."""
-        added_footprints: Set[EntityId] = set()
-        removed_footprints: Dict[EntityId, FootprintComplement] = {}
-        added_groups: Set[EntityId] = set()
-        removed_groups: Set[EntityId] = set()
+        added_footprints: set[EntityId] = set()
+        removed_footprints: dict[EntityId, FootprintComplement] = {}
+        added_groups: set[EntityId] = set()
+        removed_groups: set[EntityId] = set()
 
         for line in text.strip().split("\n"):
             line = line.strip()
@@ -522,7 +523,7 @@ class SyncChangeset:
 def build_sync_changeset(
     new_view: BoardView,
     new_complement: BoardComplement,
-    old_complement: Optional[BoardComplement] = None,
+    old_complement: BoardComplement | None = None,
 ) -> SyncChangeset:
     """Build a SyncChangeset by diffing new and old complements.
 
@@ -573,7 +574,7 @@ def log_lens_state(
         logger.info(f"{prefix} {line}")
 
 
-def log_changeset(changeset: "SyncChangeset", logger: Any) -> None:
+def log_changeset(changeset: SyncChangeset, logger: Any) -> None:
     """Log changeset as INFO-level messages."""
     text = changeset.to_plaintext()
     if text.strip():

--- a/crates/pcb-layout/src/scripts/lens/hierplace.py
+++ b/crates/pcb-layout/src/scripts/lens/hierplace.py
@@ -8,13 +8,14 @@ Algorithm:
 4. Optionally normalize so cluster top-left is at (0, 0)
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
 
 from .types import EntityId
 
 # Bounding box: (left, top, width, height)
-Rect = Tuple[int, int, int, int]
+Rect = tuple[int, int, int, int]
 
 # A4 sheet dimensions in nanometers
 DEFAULT_SHEET_WIDTH = 297_000_000
@@ -40,7 +41,7 @@ class PlacementRect:
     x: int = 0
     y: int = 0
 
-    def move_to(self, x: int, y: int) -> "PlacementRect":
+    def move_to(self, x: int, y: int) -> PlacementRect:
         """Return a new PlacementRect at (x, y)."""
         return PlacementRect(self.entity_id, self.width, self.height, x, y)
 
@@ -64,7 +65,7 @@ def merge_rects(a: Rect, b: Rect) -> Rect:
     return (min_x, min_y, max_x - min_x, max_y - min_y)
 
 
-def compute_cluster_bbox(rects: List[PlacementRect]) -> Optional[Rect]:
+def compute_cluster_bbox(rects: list[PlacementRect]) -> Rect | None:
     """Compute the bounding box of all placed rectangles."""
     if not rects:
         return None
@@ -75,13 +76,13 @@ def compute_cluster_bbox(rects: List[PlacementRect]) -> Optional[Rect]:
 
 
 def pack(
-    rects: List[PlacementRect],
+    rects: list[PlacementRect],
     gap: int = 0,
-    anchor: Optional[Rect] = None,
+    anchor: Rect | None = None,
     sheet_width: int = DEFAULT_SHEET_WIDTH,
     sheet_height: int = DEFAULT_SHEET_HEIGHT,
     normalize: bool = False,
-) -> Dict[EntityId, Tuple[int, int]]:
+) -> dict[EntityId, tuple[int, int]]:
     """Pack rectangles using corner-based greedy placement.
 
     Args:
@@ -100,9 +101,9 @@ def pack(
     valid = sorted(valid, key=lambda r: (-r.width * r.height, str(r.entity_id.path)))
 
     half_gap = gap // 2
-    placed: List[Rect] = []  # (x, y, w, h) tuples
-    pts: List[Tuple[int, int]] = []  # candidate bottom-left points
-    result: Dict[EntityId, Tuple[int, int]] = {}
+    placed: list[Rect] = []  # (x, y, w, h) tuples
+    pts: list[tuple[int, int]] = []  # candidate bottom-left points
+    result: dict[EntityId, tuple[int, int]] = {}
 
     # Initialize placement points and pre-placed rects
     if anchor:
@@ -122,7 +123,7 @@ def pack(
         pts.append((start_x, start_y + first.height))
 
     for rect in valid:
-        best_pos: Optional[Tuple[int, int]] = None
+        best_pos: tuple[int, int] | None = None
         best_size = float("inf")
 
         for pt_x, pt_y in pts:

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -16,36 +16,37 @@ the Python sync runs. FPID changes are now handled as delete + add operations
 since EntityId includes fpid.
 """
 
-from typing import Any, Dict, List, Optional, Set, Tuple
+from __future__ import annotations
+
 import logging
 import os
 import uuid as uuid_module
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-from .types import (
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
-    GroupView,
-    GroupComplement,
-    BoardView,
-    TrackComplement,
-    ViaComplement,
-    ZoneComplement,
-    GraphicComplement,
-    default_footprint_complement,
-)
 from .hierplace import (
     PlacementRect,
     Rect,
+    compute_cluster_bbox,
     pack,
     pad_for_depth,
-    compute_cluster_bbox,
 )
 from .oplog import OpLog
-from typing import TYPE_CHECKING
-from dataclasses import dataclass
+from .types import (
+    BoardView,
+    EntityId,
+    FootprintComplement,
+    FootprintView,
+    GraphicComplement,
+    GroupComplement,
+    GroupView,
+    Position,
+    TrackComplement,
+    ViaComplement,
+    ZoneComplement,
+    default_footprint_complement,
+)
 
 if TYPE_CHECKING:
     from .changeset import SyncChangeset
@@ -63,7 +64,7 @@ FRAGMENT_ZONE_PRIORITY_BIAS = 1
 _UNCASTABLE_GROUP_ITEM_CLASSES = {"PCB_GENERATOR"}
 
 
-def resolve_package_uri(uri: str, package_roots: Dict[str, str]) -> Path:
+def resolve_package_uri(uri: str, package_roots: dict[str, str]) -> Path:
     """Resolve a package:// URI to an absolute filesystem path.
 
     Uses longest-prefix matching against the package_roots map.
@@ -74,10 +75,13 @@ def resolve_package_uri(uri: str, package_roots: Dict[str, str]) -> Path:
     best_root = None
 
     for url, root in package_roots.items():
-        if rest.startswith(url) and (len(rest) == len(url) or rest[len(url)] == "/"):
-            if best_url is None or len(url) > len(best_url):
-                best_url = url
-                best_root = root
+        if (
+            rest.startswith(url)
+            and (len(rest) == len(url) or rest[len(url)] == "/")
+            and (best_url is None or len(url) > len(best_url))
+        ):
+            best_url = url
+            best_root = root
 
     if best_url is None or best_root is None:
         raise ValueError(f"Unknown package in URI: {uri}")
@@ -88,7 +92,7 @@ def resolve_package_uri(uri: str, package_roots: Dict[str, str]) -> Path:
     return Path(best_root)
 
 
-def get_footprint_field(fp: Any, name: str) -> Optional[Any]:
+def get_footprint_field(fp: Any, name: str) -> Any | None:
     """Look up a footprint field by name across KiCad 9 and 10."""
     if hasattr(fp, "GetFieldByName"):
         return fp.GetFieldByName(name)
@@ -97,12 +101,12 @@ def get_footprint_field(fp: Any, name: str) -> Optional[Any]:
     return None
 
 
-def get_group_items(group: Any) -> List[Any]:
+def get_group_items(group: Any) -> list[Any]:
     """Return group items, skipping KiCad item classes the Python wrapper cannot cast."""
     if not hasattr(group, "GetItemsDeque"):
         return list(group.GetItems())
 
-    items: List[Any] = []
+    items: list[Any] = []
     for item in group.GetItemsDeque():
         item_class = str(item.GetClass()).upper() if hasattr(item, "GetClass") else ""
         if item_class in _UNCASTABLE_GROUP_ITEM_CLASSES:
@@ -111,7 +115,7 @@ def get_group_items(group: Any) -> List[Any]:
     return items
 
 
-def get_group_items_for_detach(group: Any) -> List[Any]:
+def get_group_items_for_detach(group: Any) -> list[Any]:
     """Return every raw group item that can be passed to PCB_GROUP.RemoveItem."""
     if not hasattr(group, "GetItemsDeque"):
         return list(group.GetItems())
@@ -128,7 +132,7 @@ def _discover_kicad_pcb_file(layout_dir: Path) -> Path:
     if not layout_dir.is_dir():
         raise FileNotFoundError(f"Layout fragment not found: {layout_dir}")
 
-    pro_files: List[Path] = [
+    pro_files: list[Path] = [
         entry
         for entry in layout_dir.iterdir()
         if entry.is_file() and entry.suffix == ".kicad_pro"
@@ -150,11 +154,11 @@ class FragmentPlan:
     which entities they cover, and which footprints belong to each fragment.
     """
 
-    loaded: Dict[EntityId, "FragmentDataType"]  # authoritative fragments only
-    owner: Dict[EntityId, EntityId]  # entity -> owning authoritative fragment
+    loaded: dict[EntityId, FragmentDataType]  # authoritative fragments only
+    owner: dict[EntityId, EntityId]  # entity -> owning authoritative fragment
     descendant_ids: frozenset  # all entities covered by any fragment
-    descendant_footprints: Dict[
-        EntityId, List[EntityId]
+    descendant_footprints: dict[
+        EntityId, list[EntityId]
     ]  # fragment -> covered footprints
 
     def is_covered(self, eid: EntityId) -> bool:
@@ -166,12 +170,12 @@ class FragmentPlan:
         return eid in self.loaded
 
 
-def extract_zone_outline_positions(zone: Any) -> List[Position]:
+def extract_zone_outline_positions(zone: Any) -> list[Position]:
     """Extract the zone's main outline as a list of Positions.
 
     Uses the correct KiCad API: SHAPE_POLY_SET.COutline(0).CPoints()
     """
-    positions: List[Position] = []
+    positions: list[Position] = []
     outline = zone.Outline()
     if not outline or outline.OutlineCount() <= 0:
         return positions
@@ -180,7 +184,7 @@ def extract_zone_outline_positions(zone: Any) -> List[Position]:
     return positions
 
 
-def _get_entity_id_from_footprint(fp: Any) -> Optional[EntityId]:
+def _get_entity_id_from_footprint(fp: Any) -> EntityId | None:
     """Extract EntityId from a KiCad footprint.
 
     The canonical EntityId includes both path and fpid.
@@ -218,7 +222,7 @@ def _get_item_bbox(item: Any, pcbnew: Any) -> Any:
 # =============================================================================
 
 
-def _compute_items_bbox(items: List[Any], pcbnew: Any) -> Optional[Rect]:
+def _compute_items_bbox(items: list[Any], pcbnew: Any) -> Rect | None:
     """Compute bounding box of a list of KiCad items.
 
     This is the single source of truth for bbox computation from KiCad objects.
@@ -243,7 +247,7 @@ def _compute_items_bbox(items: List[Any], pcbnew: Any) -> Optional[Rect]:
 
 def _move_footprint_to(
     fp: Any, target_x: int, target_y: int, pcbnew: Any
-) -> Optional[Tuple[int, int]]:
+) -> tuple[int, int] | None:
     """Move footprint so its bbox top-left is at (target_x, target_y).
 
     Returns (width, height) of the footprint, or None if move failed.
@@ -262,7 +266,7 @@ def _move_footprint_to(
 
 def _move_group_to(
     group: Any, target_x: int, target_y: int, pcbnew: Any
-) -> Optional[Tuple[int, int]]:
+) -> tuple[int, int] | None:
     """Move all items in a group so the group's bbox top-left is at (target_x, target_y).
 
     Returns (dx, dy) applied to all items, or None if move failed.
@@ -283,10 +287,10 @@ def _move_group_to(
 
 
 def _build_rects_from_footprints(
-    entity_ids: List[EntityId],
-    fps_by_entity_id: Dict[EntityId, Any],
+    entity_ids: list[EntityId],
+    fps_by_entity_id: dict[EntityId, Any],
     pcbnew: Any,
-) -> List[PlacementRect]:
+) -> list[PlacementRect]:
     """Build PlacementRects from KiCad footprints by reading their bboxes.
 
     This is the single source of truth for building rects from live KiCad objects.
@@ -308,13 +312,13 @@ def _build_rects_from_footprints(
     return rects
 
 
-def _build_groups_index(kicad_board: Any) -> Dict[str, Any]:
+def _build_groups_index(kicad_board: Any) -> dict[str, Any]:
     """Build fresh index of groups by name.
 
     Must be called after any structural change (deletions/additions) to avoid
     stale SWIG pointers. KiCad's SWIG bindings become invalid after board mutations.
     """
-    idx: Dict[str, Any] = {}
+    idx: dict[str, Any] = {}
     for g in kicad_board.Groups():
         name = g.GetName()
         if not name:
@@ -325,13 +329,13 @@ def _build_groups_index(kicad_board: Any) -> Dict[str, Any]:
     return idx
 
 
-def _build_footprints_index(kicad_board: Any) -> Dict[EntityId, Any]:
+def _build_footprints_index(kicad_board: Any) -> dict[EntityId, Any]:
     """Build fresh index of footprints by entity ID.
 
     Must be called after any structural change (deletions/additions) to avoid
     stale SWIG pointers. KiCad's SWIG bindings become invalid after board mutations.
     """
-    idx: Dict[EntityId, Any] = {}
+    idx: dict[EntityId, Any] = {}
     for fp in kicad_board.GetFootprints():
         entity_id = _get_entity_id_from_footprint(fp)
         if entity_id:
@@ -343,7 +347,7 @@ def _build_pad_net_map(
     entity_id: EntityId,
     view: BoardView,
     kicad_board: Any,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build a mapping from pad/pin name to KiCad NETINFO for a footprint.
 
     Looks up net assignments from SOURCE (BoardView.nets) rather than copying
@@ -357,7 +361,7 @@ def _build_pad_net_map(
     Returns:
         Dict mapping pin_name -> NETINFO object (or None if net not found)
     """
-    pad_net_map: Dict[str, Any] = {}
+    pad_net_map: dict[str, Any] = {}
 
     for net_view in view.nets.values():
         for conn_entity_id, pin_name in net_view.connections:
@@ -373,7 +377,7 @@ def _apply_pad_assignment(
     fp: Any,
     pad_name: str,
     net_info: Any,
-    pin_type: Optional[str] = None,
+    pin_type: str | None = None,
 ) -> int:
     """Apply a net assignment to all physical pads with the given pad name."""
     applied = 0
@@ -393,12 +397,12 @@ def _apply_pad_assignment(
 
 
 def _build_fragment_plan(
-    changeset: "SyncChangeset",
+    changeset: SyncChangeset,
     board_view: BoardView,
     pcbnew: Any,
     oplog: OpLog,
-    placeable_footprints: Set[EntityId],
-    package_roots: Dict[str, str],
+    placeable_footprints: set[EntityId],
+    package_roots: dict[str, str],
 ) -> FragmentPlan:
     """Build a FragmentPlan implementing Rule A (Top-Most Fragment Wins).
 
@@ -438,8 +442,8 @@ def _build_fragment_plan(
     ]
     groups_with_layout.sort(key=lambda x: (x[0].path.depth, str(x[0].path)))
 
-    loaded: Dict[EntityId, FragmentData] = {}
-    authoritative: Set[EntityId] = set()
+    loaded: dict[EntityId, FragmentData] = {}
+    authoritative: set[EntityId] = set()
 
     # Phase 1: Determine authoritative fragments (Rule A)
     for gid, gv in groups_with_layout:
@@ -464,12 +468,12 @@ def _build_fragment_plan(
             authoritative.add(gid)
         except ValueError:
             raise
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - any fragment load failure falls back to HierPlace
             logger.warning(f"Fragment {gv.layout_path} not found, using HierPlace: {e}")
 
     # Phase 2: Compute coverage maps in one pass
-    owner: Dict[EntityId, EntityId] = {}
-    descendant_footprints: Dict[EntityId, List[EntityId]] = {
+    owner: dict[EntityId, EntityId] = {}
+    descendant_footprints: dict[EntityId, list[EntityId]] = {
         gid: [] for gid in authoritative
     }
 
@@ -487,8 +491,8 @@ def _build_fragment_plan(
             descendant_footprints[auth].append(fid)
 
     # Sort for determinism
-    for gid in descendant_footprints:
-        descendant_footprints[gid].sort(key=lambda e: str(e.path))
+    for fids in descendant_footprints.values():
+        fids.sort(key=lambda e: str(e.path))
 
     # Log authoritative fragments for debugging
     if authoritative:
@@ -504,8 +508,8 @@ def _build_fragment_plan(
 
 
 def _find_authoritative_ancestor(
-    eid: EntityId, authoritative: Set[EntityId]
-) -> Optional[EntityId]:
+    eid: EntityId, authoritative: set[EntityId]
+) -> EntityId | None:
     """Walk up parent chain to find authoritative fragment ancestor."""
     p = eid.path.parent()
     while p:
@@ -517,19 +521,19 @@ def _find_authoritative_ancestor(
 
 
 def _collect_item_sizes(
-    changeset: "SyncChangeset",
-    fps_by_entity_id: Dict[EntityId, Any],
-    groups_by_name: Dict[str, Any],
+    changeset: SyncChangeset,
+    fps_by_entity_id: dict[EntityId, Any],
+    groups_by_name: dict[str, Any],
     pcbnew: Any,
     plan: FragmentPlan,
-    exclude_footprints: Optional[Set[EntityId]] = None,
-) -> Dict[EntityId, Tuple[int, int]]:
+    exclude_footprints: set[EntityId] | None = None,
+) -> dict[EntityId, tuple[int, int]]:
     """Collect width/height for all newly-added items from KiCad bboxes.
 
     This is the ONLY place we read geometry from KiCad for layout.
     Uses FragmentPlan to determine which items to skip (covered by fragments).
     """
-    sizes: Dict[EntityId, Tuple[int, int]] = {}
+    sizes: dict[EntityId, tuple[int, int]] = {}
     exclude = exclude_footprints or set()
 
     # Footprints (excluding inherited ones and fragment-covered ones)
@@ -550,7 +554,7 @@ def _collect_item_sizes(
     return sizes
 
 
-def _get_group_bbox_size(group: Any, pcbnew: Any) -> Tuple[int, int]:
+def _get_group_bbox_size(group: Any, pcbnew: Any) -> tuple[int, int]:
     """Get the bounding box size of a KiCad group."""
     if not group:
         return (0, 0)
@@ -559,9 +563,9 @@ def _get_group_bbox_size(group: Any, pcbnew: Any) -> Tuple[int, int]:
 
 
 def _build_rects(
-    entity_ids: List[EntityId],
-    sizes: Dict[EntityId, Tuple[int, int]],
-) -> List[PlacementRect]:
+    entity_ids: list[EntityId],
+    sizes: dict[EntityId, tuple[int, int]],
+) -> list[PlacementRect]:
     """Build PlacementRects for entities with non-zero sizes."""
     rects = []
     for eid in entity_ids:
@@ -572,9 +576,9 @@ def _build_rects(
 
 
 def _compute_depths(
-    tree: Dict[Optional[EntityId], List[EntityId]],
-    group_ids: Set[EntityId],
-) -> Dict[EntityId, int]:
+    tree: dict[EntityId | None, list[EntityId]],
+    group_ids: set[EntityId],
+) -> dict[EntityId, int]:
     """Compute hierarchy depth for each entity (bottom-up).
 
     Depth determines padding: depth 0 = tight, higher = more spacing.
@@ -582,7 +586,7 @@ def _compute_depths(
     - Group with only footprints: depth 1
     - Group with child groups: 1 + max(child depths)
     """
-    depths: Dict[EntityId, int] = {}
+    depths: dict[EntityId, int] = {}
 
     def get_depth(eid: EntityId) -> int:
         if eid in depths:
@@ -609,18 +613,18 @@ def _compute_depths(
 
 
 def _compute_hierarchical_layout(
-    tree: Dict[Optional[EntityId], List[EntityId]],
-    sizes: Dict[EntityId, Tuple[int, int]],
-    group_ids: Set[EntityId],
-    fragment_group_ids: Set[EntityId],
-    existing_bbox: Optional[Rect],
-) -> Dict[EntityId, Tuple[int, int]]:
+    tree: dict[EntityId | None, list[EntityId]],
+    sizes: dict[EntityId, tuple[int, int]],
+    group_ids: set[EntityId],
+    fragment_group_ids: set[EntityId],
+    existing_bbox: Rect | None,
+) -> dict[EntityId, tuple[int, int]]:
     """Pure hierarchical layout: bottom-up packing, then top-down position propagation.
 
     Uses pack() for local group packing and root placement.
     Padding scales with hierarchy depth for visual separation.
     """
-    child_local_pos: Dict[EntityId, Dict[EntityId, Tuple[int, int]]] = {}
+    child_local_pos: dict[EntityId, dict[EntityId, tuple[int, int]]] = {}
     sizes = dict(sizes)  # Make mutable copy
 
     # Compute depths for depth-based padding
@@ -675,16 +679,16 @@ def _compute_hierarchical_layout(
 
 
 def _apply_hierarchical_layout(
-    layout: Dict[EntityId, Tuple[int, int]],
-    changeset: "SyncChangeset",
-    fps_by_entity_id: Dict[EntityId, Any],
-    groups_by_name: Dict[str, Any],
+    layout: dict[EntityId, tuple[int, int]],
+    changeset: SyncChangeset,
+    fps_by_entity_id: dict[EntityId, Any],
+    groups_by_name: dict[str, Any],
     pcbnew: Any,
-    fragment_group_ids: Set[EntityId],
+    fragment_group_ids: set[EntityId],
     board_view: BoardView,
     oplog: OpLog,
-    exclude_footprints: Optional[Set[EntityId]] = None,
-    group_move_deltas: Optional[Dict[EntityId, Tuple[int, int]]] = None,
+    exclude_footprints: set[EntityId] | None = None,
+    group_move_deltas: dict[EntityId, tuple[int, int]] | None = None,
 ) -> int:
     """Apply computed layout to KiCad objects using unified move helpers."""
     placed_count = 0
@@ -693,7 +697,7 @@ def _apply_hierarchical_layout(
         group_move_deltas = {}
 
     # Pre-compute footprints that belong to fragment groups (moved with their group)
-    fragment_footprints: Set[EntityId] = set()
+    fragment_footprints: set[EntityId] = set()
     for gid in fragment_group_ids:
         gv = board_view.groups.get(gid)
         if gv:
@@ -732,12 +736,12 @@ def _apply_hierarchical_layout(
 
 
 def apply_changeset(
-    changeset: "SyncChangeset",
+    changeset: SyncChangeset,
     kicad_board: Any,
     pcbnew: Any,
-    footprint_lib_map: Dict[str, str],
-    package_roots: Dict[str, str],
-    board_path: Optional[Path] = None,
+    footprint_lib_map: dict[str, str],
+    package_roots: dict[str, str],
+    board_path: Path | None = None,
 ) -> OpLog:
     """Apply a SyncChangeset to a KiCad board.
 
@@ -772,7 +776,7 @@ def apply_changeset(
     groups_by_name = _build_groups_index(kicad_board)
 
     # Build KIID->footprint index for old boards without Path field (O(N) once, not O(N²))
-    fps_by_kiid: Dict[str, Any] = {}
+    fps_by_kiid: dict[str, Any] = {}
     for fp in kicad_board.GetFootprints():
         kiid_path = fp.GetPath().AsString()
         if kiid_path:
@@ -780,7 +784,7 @@ def apply_changeset(
             if parts:
                 fps_by_kiid[parts[-1]] = fp
 
-    def _lookup_fp(entity_id: EntityId) -> Optional[Any]:
+    def _lookup_fp(entity_id: EntityId) -> Any | None:
         """Look up footprint by EntityId, falling back to KIID index for old boards."""
         fp = fps_by_entity_id.get(entity_id)
         if fp:
@@ -864,7 +868,7 @@ def apply_changeset(
                     pad_count=pad_count,
                 )
                 logger.info(f"Added footprint: {entity_id}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - one bad footprint must not abort the whole sync
             logger.error(f"Failed to add footprint {entity_id}: {e}")
 
     # 2b. GR-ADD - create groups (routing applied in Phase 6 after membership rebuild)
@@ -1008,13 +1012,13 @@ def _apply_fragment_routing(
     group: Any,
     group_view: GroupView,
     entity_id: EntityId,
-    fragment_data: "FragmentDataType",
+    fragment_data: FragmentDataType,
     board_view: BoardView,
     kicad_board: Any,
     pcbnew: Any,
     oplog: OpLog,
-    package_roots: Dict[str, str],
-    move_delta: Tuple[int, int] = (0, 0),
+    package_roots: dict[str, str],
+    move_delta: tuple[int, int] = (0, 0),
 ) -> None:
     """Apply routing from a layout fragment to a new group.
 
@@ -1038,7 +1042,7 @@ def _apply_fragment_routing(
         layout_file = _discover_kicad_pcb_file(layout_dir)
     except ValueError:
         raise
-    except Exception:
+    except Exception:  # noqa: BLE001 - FIXME: silently swallows fragment-discovery failures
         return
     if not layout_file.exists():
         return
@@ -1048,7 +1052,7 @@ def _apply_fragment_routing(
     # Build net remapping from fragment nets to board nets
     from .lens import build_fragment_net_remap
 
-    board_pad_net_map: Dict[Tuple[EntityId, str], str] = {}
+    board_pad_net_map: dict[tuple[EntityId, str], str] = {}
     for net_name, net_view in board_view.nets.items():
         for conn_entity_id, pad_name in net_view.connections:
             board_pad_net_map[(conn_entity_id, pad_name)] = net_name
@@ -1063,8 +1067,8 @@ def _apply_fragment_routing(
     valid_nets = set(board_view.nets.keys()) | {""}
 
     # Build UUID lookup tables from the fragment board
-    fragment_tracks: Dict[str, Any] = {}
-    fragment_vias: Dict[str, Any] = {}
+    fragment_tracks: dict[str, Any] = {}
+    fragment_vias: dict[str, Any] = {}
     for track in fragment_board.GetTracks():
         item_uuid = str(track.m_Uuid.AsString())
         if "VIA" in track.GetClass().upper():
@@ -1072,11 +1076,11 @@ def _apply_fragment_routing(
         else:
             fragment_tracks[item_uuid] = track
 
-    fragment_zones: Dict[str, Any] = {}
+    fragment_zones: dict[str, Any] = {}
     for zone in fragment_board.Zones():
         fragment_zones[str(zone.m_Uuid.AsString())] = zone
 
-    fragment_graphics: Dict[str, Any] = {}
+    fragment_graphics: dict[str, Any] = {}
     for drawing in fragment_board.GetDrawings():
         parent = drawing.GetParent()
         if (
@@ -1190,10 +1194,10 @@ def _apply_fragment_routing(
 
 
 def _build_group_tree(
-    changeset: "SyncChangeset",
+    changeset: SyncChangeset,
     plan: FragmentPlan,
-    exclude_footprints: Optional[Set[EntityId]] = None,
-) -> Dict[Optional[EntityId], List[EntityId]]:
+    exclude_footprints: set[EntityId] | None = None,
+) -> dict[EntityId | None, list[EntityId]]:
     """Build a tree of groups and footprints by parent EntityId.
 
     Returns a dict mapping parent_entity_id -> list of child EntityIds.
@@ -1204,11 +1208,11 @@ def _build_group_tree(
     """
     from collections import defaultdict
 
-    tree: Dict[Optional[EntityId], List[EntityId]] = defaultdict(list)
-    added_group_ids: Set[EntityId] = set(changeset.added_groups)
+    tree: dict[EntityId | None, list[EntityId]] = defaultdict(list)
+    added_group_ids: set[EntityId] = set(changeset.added_groups)
     exclude = exclude_footprints or set()
 
-    def parent_for(entity_id: EntityId) -> Optional[EntityId]:
+    def parent_for(entity_id: EntityId) -> EntityId | None:
         """Walk up ancestry to find nearest added group parent."""
         p = entity_id.path.parent()
         while p:
@@ -1242,11 +1246,11 @@ def _build_group_tree(
 
 
 def _apply_position_inheritance(
-    changeset: "SyncChangeset",
-    fps_by_entity_id: Dict[EntityId, Any],
+    changeset: SyncChangeset,
+    fps_by_entity_id: dict[EntityId, Any],
     pcbnew: Any,
     oplog: OpLog,
-) -> Tuple[int, Set[EntityId]]:
+) -> tuple[int, set[EntityId]]:
     """Apply position inheritance for FPID changes.
 
     When a footprint's FPID changes, it appears as removed (old fpid) + added (new fpid)
@@ -1255,7 +1259,7 @@ def _apply_position_inheritance(
     Returns (placed_count, inherited_footprint_ids).
     """
     placed_count = 0
-    inherited: Set[EntityId] = set()
+    inherited: set[EntityId] = set()
 
     # Map path -> (old EntityId, old complement)
     removed_by_path = {
@@ -1287,11 +1291,11 @@ def _apply_position_inheritance(
 
 def _apply_fragment_positions(
     plan: FragmentPlan,
-    inherited: Set[EntityId],
-    fps_by_entity_id: Dict[EntityId, Any],
+    inherited: set[EntityId],
+    fps_by_entity_id: dict[EntityId, Any],
     pcbnew: Any,
     oplog: OpLog,
-) -> Tuple[int, Set[EntityId]]:
+) -> tuple[int, set[EntityId]]:
     """Apply positions from fragments to ALL descendant footprints (Rule B).
 
     For each authoritative fragment:
@@ -1302,7 +1306,7 @@ def _apply_fragment_positions(
     Returns (count, positioned_ids).
     """
     placed = 0
-    positioned: Set[EntityId] = set()
+    positioned: set[EntityId] = set()
 
     for gid in sorted(plan.loaded.keys(), key=lambda e: str(e.path)):
         fragment_data = plan.loaded[gid]
@@ -1311,8 +1315,8 @@ def _apply_fragment_positions(
         ]
 
         # Separate into in-fragment (have positions) and orphans (don't)
-        in_fragment: List[Tuple[EntityId, FootprintComplement]] = []
-        orphans: List[EntityId] = []
+        in_fragment: list[tuple[EntityId, FootprintComplement]] = []
+        orphans: list[EntityId] = []
 
         for fid in descendant_fps:
             fp = fps_by_entity_id.get(fid)
@@ -1347,8 +1351,8 @@ def _apply_fragment_positions(
 
 
 def _lookup_fragment_complement(
-    fid: EntityId, gid: EntityId, fragment_data: "FragmentDataType"
-) -> Optional[FootprintComplement]:
+    fid: EntityId, gid: EntityId, fragment_data: FragmentDataType
+) -> FootprintComplement | None:
     """Look up footprint complement from fragment by relative path or name."""
     rel = fid.path.relative_to(gid.path)
     comp = fragment_data.footprint_complements.get(str(rel)) if rel else None
@@ -1356,13 +1360,13 @@ def _lookup_fragment_complement(
 
 
 def _pack_orphans(
-    orphans: List[EntityId],
-    in_fragment: List[Tuple[EntityId, FootprintComplement]],
+    orphans: list[EntityId],
+    in_fragment: list[tuple[EntityId, FootprintComplement]],
     gid: EntityId,
-    fps_by_entity_id: Dict[EntityId, Any],
+    fps_by_entity_id: dict[EntityId, Any],
     pcbnew: Any,
     oplog: OpLog,
-) -> Tuple[int, Set[EntityId]]:
+) -> tuple[int, set[EntityId]]:
     """Pack orphan footprints to the right of the fragment bbox.
 
     Uses unified helpers: _build_rects_from_footprints, pack, _move_footprint_to.
@@ -1381,7 +1385,7 @@ def _pack_orphans(
     orphan_layout = pack(orphan_rects, anchor=fragment_bbox, gap=pad_for_depth(0))
 
     placed = 0
-    positioned: Set[EntityId] = set()
+    positioned: set[EntityId] = set()
     for fid, (target_x, target_y) in orphan_layout.items():
         fp = fps_by_entity_id.get(fid)
         if fp and _move_footprint_to(fp, target_x, target_y, pcbnew):
@@ -1393,14 +1397,14 @@ def _pack_orphans(
 
 
 def _run_hierarchical_placement(
-    changeset: "SyncChangeset",
+    changeset: SyncChangeset,
     board_view: BoardView,
-    fps_by_entity_id: Dict[EntityId, Any],
-    groups_by_name: Dict[str, Any],
+    fps_by_entity_id: dict[EntityId, Any],
+    groups_by_name: dict[str, Any],
     kicad_board: Any,
     pcbnew: Any,
     oplog: OpLog,
-    package_roots: Dict[str, str],
+    package_roots: dict[str, str],
 ) -> int:
     """Position new items using HierPlace rules.
 
@@ -1457,7 +1461,7 @@ def _run_hierarchical_placement(
     if not layout:
         return placed
 
-    group_move_deltas: Dict[EntityId, Tuple[int, int]] = {}
+    group_move_deltas: dict[EntityId, tuple[int, int]] = {}
     placed += _apply_hierarchical_layout(
         layout,
         changeset,
@@ -1495,9 +1499,9 @@ def _run_hierarchical_placement(
 
 def _compute_existing_bbox(
     kicad_board: Any,
-    exclude_entity_ids: Set[EntityId],
+    exclude_entity_ids: set[EntityId],
     pcbnew: Any,
-) -> Optional[Rect]:
+) -> Rect | None:
     """Compute bbox of board edge + existing footprints for placement anchor."""
     min_x = min_y = float("inf")
     max_x = max_y = float("-inf")
@@ -1540,9 +1544,7 @@ def apply_footprint_placement(
     target_on_back = complement.layer == "B.Cu"
     current_on_back = fp.IsFlipped()
 
-    if target_on_back and not current_on_back:
-        fp.Flip(fp.GetPosition(), True)
-    elif not target_on_back and current_on_back:
+    if target_on_back and not current_on_back or not target_on_back and current_on_back:
         fp.Flip(fp.GetPosition(), True)
 
     fp.SetOrientation(pcbnew.EDA_ANGLE(complement.orientation, pcbnew.DEGREES_T))
@@ -1550,7 +1552,7 @@ def apply_footprint_placement(
 
 
 def _resolve_field_value(
-    value: str, package_roots: Dict[str, str], layout_dir: Optional[Path]
+    value: str, package_roots: dict[str, str], layout_dir: Path | None
 ) -> str:
     """Resolve package:// URIs in field values to layout-relative paths."""
     if not value.startswith(PACKAGE_URI_PREFIX) or not layout_dir:
@@ -1565,8 +1567,8 @@ def _resolve_field_value(
 def _apply_view_to_footprint(
     fp: Any,
     view: FootprintView,
-    package_roots: Dict[str, str],
-    layout_dir: Optional[Path],
+    package_roots: dict[str, str],
+    layout_dir: Path | None,
 ) -> None:
     """Apply view properties to a footprint. Hides newly-created custom fields."""
     fp.SetReference(view.reference)
@@ -1590,9 +1592,9 @@ def _create_footprint(
     complement: FootprintComplement,
     board: Any,
     pcbnew: Any,
-    footprint_lib_map: Dict[str, str],
-    package_roots: Dict[str, str],
-    layout_dir: Optional[Path],
+    footprint_lib_map: dict[str, str],
+    package_roots: dict[str, str],
+    layout_dir: Path | None,
 ) -> Any:
     """Create a new KiCad footprint from view and complement."""
     if ":" not in view.fpid:
@@ -1632,8 +1634,8 @@ def _update_footprint_view(
     fp: Any,
     view: FootprintView,
     pcbnew: Any,
-    package_roots: Dict[str, str],
-    layout_dir: Optional[Path],
+    package_roots: dict[str, str],
+    layout_dir: Path | None,
 ) -> None:
     """Update footprint view properties from SOURCE."""
     _apply_view_to_footprint(fp, view, package_roots, layout_dir)
@@ -1642,8 +1644,8 @@ def _update_footprint_view(
 def load_layout_fragment_with_footprints(
     layout_path: str,
     pcbnew: Any,
-    package_roots: Dict[str, str],
-) -> "FragmentDataType":
+    package_roots: dict[str, str],
+) -> FragmentDataType:
     """Load a layout fragment including footprint positions.
 
     Returns a FragmentData with pure Python dataclasses only (no KiCad C++ objects).
@@ -1660,8 +1662,8 @@ def load_layout_fragment_with_footprints(
 
     layout_board = pcbnew.LoadBoard(str(layout_file))
 
-    footprint_complements: Dict[str, FootprintComplement] = {}
-    pad_net_map: Dict[Tuple[str, str], str] = {}
+    footprint_complements: dict[str, FootprintComplement] = {}
+    pad_net_map: dict[tuple[str, str], str] = {}
 
     for fp in layout_board.GetFootprints():
         reference = fp.GetReference()
@@ -1708,8 +1710,8 @@ def load_layout_fragment_with_footprints(
                 fp_key = path_str if path_str else reference
                 pad_net_map[(fp_key, pad_name)] = net.GetNetname()
 
-    tracks: List[TrackComplement] = []
-    vias: List[ViaComplement] = []
+    tracks: list[TrackComplement] = []
+    vias: list[ViaComplement] = []
 
     for track in layout_board.GetTracks():
         item_class = track.GetClass().upper()
@@ -1743,7 +1745,7 @@ def load_layout_fragment_with_footprints(
                 )
             )
 
-    zones: List[ZoneComplement] = []
+    zones: list[ZoneComplement] = []
     for zone in layout_board.Zones():
         item_uuid = str(zone.m_Uuid.AsString())
         net = zone.GetNet()
@@ -1762,7 +1764,7 @@ def load_layout_fragment_with_footprints(
             )
         )
 
-    graphics: List[GraphicComplement] = []
+    graphics: list[GraphicComplement] = []
     for drawing in layout_board.GetDrawings():
         parent = drawing.GetParent()
         if (
@@ -1776,7 +1778,7 @@ def load_layout_fragment_with_footprints(
         graphic_type = drawing.GetClass()
         layer = layout_board.GetLayerName(drawing.GetLayer())
 
-        geometry: Dict[str, Any] = {}
+        geometry: dict[str, Any] = {}
         if hasattr(drawing, "GetStart"):
             start = drawing.GetStart()
             geometry["start"] = {"x": start.x, "y": start.y}

--- a/crates/pcb-layout/src/scripts/lens/lens.py
+++ b/crates/pcb-layout/src/scripts/lens/lens.py
@@ -20,37 +20,39 @@ Note: Renames (moved() paths) are now handled in Rust preprocessing before
 the Python sync runs. Paths are already in their final form.
 """
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from __future__ import annotations
+
 import logging
 import uuid as uuid_module
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .changeset import SyncChangeset
     from .oplog import OpLog
 
+from .kicad_adapter import (
+    extract_zone_outline_positions,
+    get_footprint_field,
+    get_group_items,
+)
 from .types import (
-    EntityPath,
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
-    GroupView,
-    GroupComplement,
-    NetView,
-    BoardView,
     BoardComplement,
+    BoardView,
+    EntityId,
+    EntityPath,
+    FootprintComplement,
+    FootprintView,
+    GroupComplement,
+    GroupView,
+    NetView,
+    Position,
     TrackComplement,
     ViaComplement,
     ZoneComplement,
     default_footprint_complement,
     default_group_complement,
-)
-from .kicad_adapter import (
-    extract_zone_outline_positions,
-    get_footprint_field,
-    get_group_items,
 )
 
 logger = logging.getLogger("pcb.lens")
@@ -70,8 +72,8 @@ class FragmentData:
     """
 
     group_complement: GroupComplement
-    footprint_complements: Dict[str, FootprintComplement]
-    pad_net_map: Dict[Tuple[str, str], str] = field(default_factory=dict)
+    footprint_complements: dict[str, FootprintComplement]
+    pad_net_map: dict[tuple[str, str], str] = field(default_factory=dict)
 
 
 def get(netlist: Any) -> BoardView:
@@ -81,9 +83,9 @@ def get(netlist: Any) -> BoardView:
     This is a pure function that extracts all SOURCE-authoritative data
     and structures it for the lens.
     """
-    footprints: Dict[EntityId, FootprintView] = {}
-    groups: Dict[EntityId, GroupView] = {}
-    nets: Dict[str, NetView] = {}
+    footprints: dict[EntityId, FootprintView] = {}
+    groups: dict[EntityId, GroupView] = {}
+    nets: dict[str, NetView] = {}
 
     for part in netlist.parts:
         path_str = part.sheetpath.names.split(":")[-1] if part.sheetpath.names else ""
@@ -91,7 +93,7 @@ def get(netlist: Any) -> BoardView:
         # Include fpid in entity identity - FPID change = delete + create
         entity_id = EntityId(path=entity_path, fpid=part.footprint)
 
-        fields: Dict[str, str] = {
+        fields: dict[str, str] = {
             "Datasheet": "",
             "Description": "",
             "Path": path_str,
@@ -134,7 +136,7 @@ def get(netlist: Any) -> BoardView:
             fields=fields,
         )
 
-    fp_id_by_ref: Dict[str, EntityId] = {
+    fp_id_by_ref: dict[str, EntityId] = {
         fp_view.reference: fp_id for fp_id, fp_view in footprints.items()
     }
 
@@ -150,9 +152,7 @@ def get(netlist: Any) -> BoardView:
 
             # Count direct children: footprints + submodules
             direct_footprints = [
-                fp_id
-                for fp_id in footprints.keys()
-                if fp_id.path.parent() == entity_path
+                fp_id for fp_id in footprints if fp_id.path.parent() == entity_path
             ]
             direct_submodules = [
                 sub_path
@@ -170,10 +170,8 @@ def get(netlist: Any) -> BoardView:
 
             # Build member list - include all descendant footprints
             # (not just direct children, since nested component wrappers are skipped)
-            member_ids: List[EntityId] = [
-                fp_id
-                for fp_id in footprints.keys()
-                if entity_path.is_ancestor_of(fp_id.path)
+            member_ids: list[EntityId] = [
+                fp_id for fp_id in footprints if entity_path.is_ancestor_of(fp_id.path)
             ]
 
             groups[entity_id] = GroupView(
@@ -186,7 +184,7 @@ def get(netlist: Any) -> BoardView:
         net_kind = getattr(net, "kind", "Net")
 
         # Normalize nodes to strings. Each node is (refdes, pad_num, pin_name).
-        nodes: List[Tuple[str, str, str]] = [
+        nodes: list[tuple[str, str, str]] = [
             (str(ref), str(pad_num), str(pin_name))
             for ref, pad_num, pin_name in net.nodes
         ]
@@ -194,7 +192,7 @@ def get(netlist: Any) -> BoardView:
         # Compute logical ports (component refdes + pin/port name), independent of pad fanout.
         # The third element in the node tuple is a logical pin/port name.
         logical_ports_set: set[tuple[str, str]] = set()
-        pad_nums_by_logical_port: Dict[Tuple[str, str], set[str]] = {}
+        pad_nums_by_logical_port: dict[tuple[str, str], set[str]] = {}
         for ref, pad_num, pin_name in nodes:
             port = (ref, pin_name)
             logical_ports_set.add(port)
@@ -225,8 +223,8 @@ def get(netlist: Any) -> BoardView:
                     )
                 continue
 
-        connections_list: List[Tuple[EntityId, str]] = []
-        seen_connections: set[Tuple[EntityId, str]] = set()
+        connections_list: list[tuple[EntityId, str]] = []
+        seen_connections: set[tuple[EntityId, str]] = set()
         for ref, pad_num, _pin_name in nodes:
             fp_id = fp_id_by_ref.get(ref)
             if not fp_id:
@@ -266,7 +264,7 @@ def _unconnected_net_name(path: EntityPath, ref: str, pad_num: str) -> str:
     return f"unconnected-({path_str}:{pad_num})"
 
 
-def _unique_net_name(base: str, existing: Dict[str, Any]) -> str:
+def _unique_net_name(base: str, existing: dict[str, Any]) -> str:
     """Return a name that's not already in `existing` (dict keyed by net name)."""
     if base not in existing:
         return base
@@ -289,9 +287,9 @@ def _pad_sort_key(pad_num: str) -> tuple[int, object]:
 def extract(
     board: Any,
     pcbnew: Any,
-    kiid_to_path: Optional[Dict[str, str]] = None,
-    diagnostics: Optional[List[Dict[str, Any]]] = None,
-) -> Tuple[BoardView, BoardComplement]:
+    kiid_to_path: dict[str, str] | None = None,
+    diagnostics: list[dict[str, Any]] | None = None,
+) -> tuple[BoardView, BoardComplement]:
     """
     Extract both View (π_V) and Complement (π_C) from a KiCad board in a single pass.
 
@@ -309,15 +307,15 @@ def extract(
         - complement: BoardComplement with placement data (position, orientation, routing)
     """
     # Footprint data
-    footprint_views: Dict[EntityId, FootprintView] = {}
-    footprint_complements: Dict[EntityId, FootprintComplement] = {}
+    footprint_views: dict[EntityId, FootprintView] = {}
+    footprint_complements: dict[EntityId, FootprintComplement] = {}
 
     # Group data
-    group_views: Dict[EntityId, GroupView] = {}
-    group_complements: Dict[EntityId, GroupComplement] = {}
+    group_views: dict[EntityId, GroupView] = {}
+    group_complements: dict[EntityId, GroupComplement] = {}
 
     # Net data (view only)
-    net_connections: Dict[str, List[Tuple[EntityId, str]]] = {}
+    net_connections: dict[str, list[tuple[EntityId, str]]] = {}
 
     if kiid_to_path is None:
         kiid_to_path = {}
@@ -360,7 +358,7 @@ def extract(
         # ─────────────────────────────────────────────────────────────────────
         # Extract View (SOURCE-authoritative metadata)
         # ─────────────────────────────────────────────────────────────────────
-        fields: Dict[str, str] = {}
+        fields: dict[str, str] = {}
         for field_obj in fp.GetFields():
             field_name = field_obj.GetName()
             if field_name not in {"Reference", "Value", "Footprint"}:
@@ -430,8 +428,8 @@ def extract(
         entity_id = EntityId(path=entity_path)
 
         # Find members (footprints whose path is a descendant)
-        member_ids: List[EntityId] = []
-        for fp_id in footprint_views.keys():
+        member_ids: list[EntityId] = []
+        for fp_id in footprint_views:
             if entity_path.is_ancestor_of(fp_id.path):
                 member_ids.append(fp_id)
 
@@ -442,9 +440,9 @@ def extract(
         )
 
         # Extract group complement (routing within the group)
-        tracks: List[TrackComplement] = []
-        vias: List[ViaComplement] = []
-        zones: List[ZoneComplement] = []
+        tracks: list[TrackComplement] = []
+        vias: list[ViaComplement] = []
+        zones: list[ZoneComplement] = []
 
         for item in get_group_items(group):
             item_class = item.GetClass().upper()
@@ -501,7 +499,7 @@ def extract(
         )
 
     # Build net views
-    net_views: Dict[str, NetView] = {}
+    net_views: dict[str, NetView] = {}
     for net_name, connections in net_connections.items():
         net_views[net_name] = NetView(
             name=net_name,
@@ -524,10 +522,10 @@ def extract(
 
 def build_fragment_net_remap(
     group_path: EntityPath,
-    member_paths: List[EntityPath],
-    fragment_pad_net_map: Dict[Tuple[str, str], str],
-    board_pad_net_map: Dict[Tuple[EntityId, str], str],
-) -> Tuple[Dict[str, str], List[str]]:
+    member_paths: list[EntityPath],
+    fragment_pad_net_map: dict[tuple[str, str], str],
+    board_pad_net_map: dict[tuple[EntityId, str], str],
+) -> tuple[dict[str, str], list[str]]:
     """Build a net remapping from fragment-local nets to board nets.
 
     For each footprint in the group, find what net each pad connects to in the board,
@@ -535,8 +533,8 @@ def build_fragment_net_remap(
 
     Returns (net_remap, warnings) tuple.
     """
-    net_remap: Dict[str, str] = {}
-    warnings: List[str] = []
+    net_remap: dict[str, str] = {}
+    warnings: list[str] = []
     group_path_str = str(group_path)
 
     for member_path in member_paths:
@@ -572,7 +570,7 @@ def build_fragment_net_remap(
 
 def _remap_routing_nets(
     items: tuple,
-    net_remap: Dict[str, str],
+    net_remap: dict[str, str],
     valid_nets: set,
     context: str,
 ) -> tuple:
@@ -580,7 +578,7 @@ def _remap_routing_nets(
     from dataclasses import replace
 
     result = []
-    orphan_nets: List[str] = []
+    orphan_nets: list[str] = []
 
     for item in items:
         net = item.net_name
@@ -628,14 +626,14 @@ def adapt_complement(
 
     Returns the adapted BoardComplement.
     """
-    new_footprints: Dict[EntityId, FootprintComplement] = {}
-    new_groups: Dict[EntityId, GroupComplement] = {}
+    new_footprints: dict[EntityId, FootprintComplement] = {}
+    new_groups: dict[EntityId, GroupComplement] = {}
 
     # ═══════════════════════════════════════════════════════════════════════════
     # Adapt footprint complements
     # EntityId includes fpid, so exact match means same path AND same fpid
     # ═══════════════════════════════════════════════════════════════════════════
-    for entity_id, fp_view in new_view.footprints.items():
+    for entity_id in new_view.footprints:
         existing = old_complement.footprints.get(entity_id)
 
         if existing:
@@ -649,7 +647,7 @@ def adapt_complement(
     # ═══════════════════════════════════════════════════════════════════════════
     # Adapt group complements
     # ═══════════════════════════════════════════════════════════════════════════
-    for entity_id, group_view in new_view.groups.items():
+    for entity_id in new_view.groups:
         existing = old_complement.groups.get(entity_id)
 
         if existing:
@@ -672,7 +670,7 @@ def adapt_complement(
 def check_lens_invariants(
     view: BoardView,
     complement: BoardComplement,
-    diagnostics: Optional[List[Dict[str, Any]]] = None,
+    diagnostics: list[dict[str, Any]] | None = None,
 ) -> None:
     """
     Verify the four lens laws hold for a view/complement pair.
@@ -720,8 +718,8 @@ def check_lens_invariants(
                 f"Extra groups in complement: {extra}",
             )
 
-    fp_paths = {fp_id.path for fp_id in view.footprints.keys()}
-    for group_id in view.groups.keys():
+    fp_paths = {fp_id.path for fp_id in view.footprints}
+    for group_id in view.groups:
         if group_id.path in fp_paths:
             _add_diagnostic(
                 "layout.sync.no_leaf_groups",
@@ -782,10 +780,10 @@ def check_lens_invariants(
 class SyncResult:
     """Result of a sync operation."""
 
-    changeset: "SyncChangeset"
-    diagnostics: List[Dict[str, Any]] = field(default_factory=list)
+    changeset: SyncChangeset
+    diagnostics: list[dict[str, Any]] = field(default_factory=list)
     applied: bool = False
-    oplog: Optional["OpLog"] = None
+    oplog: OpLog | None = None
 
 
 def run_lens_sync(
@@ -793,32 +791,33 @@ def run_lens_sync(
     kicad_board: Any,
     pcbnew: Any,
     board_path: Path,
-    footprint_lib_map: Dict[str, str],
-    package_roots: Dict[str, str],
+    footprint_lib_map: dict[str, str],
+    package_roots: dict[str, str],
 ) -> SyncResult:
     """Run the lens-based sync pipeline.
 
     This is the main entry point called by ImportNetlist in update_layout_file.py.
     """
     import time
-    from .kicad_adapter import apply_changeset
+
     from .changeset import (
         build_sync_changeset,
-        log_lens_state,
         log_changeset,
+        log_lens_state,
     )
+    from .kicad_adapter import apply_changeset
 
     start_time = time.time()
     logger.info("Starting lens-based layout sync")
 
-    diagnostics: List[Dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
 
     new_view = get(netlist)
 
     # Build KIID->path map for old boards without Path field
     # This allows extract() to identify footprints by their KIID_PATH UUID
-    kiid_to_path: Dict[str, str] = {}
-    for entity_id in new_view.footprints.keys():
+    kiid_to_path: dict[str, str] = {}
+    for entity_id in new_view.footprints:
         kiid_to_path[entity_id.kiid_uuid] = str(entity_id.path)
 
     dest_view, old_complement = extract(kicad_board, pcbnew, kiid_to_path, diagnostics)

--- a/crates/pcb-layout/src/scripts/lens/oplog.py
+++ b/crates/pcb-layout/src/scripts/lens/oplog.py
@@ -8,11 +8,12 @@ Note: Renames (moved() paths) are handled in Rust preprocessing before
 the Python sync runs. This module does not log rename operations.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal
+from typing import Any, Literal
 
 from .changeset import format_line, parse_line
-
 
 OpKind = Literal[
     "NET_ADD",
@@ -38,14 +39,14 @@ class OpEvent:
     """A single structured operation event."""
 
     kind: OpKind
-    fields: Dict[str, Any] = field(default_factory=dict)
+    fields: dict[str, Any] = field(default_factory=dict)
 
     def to_line(self) -> str:
         """Serialize to a single human-readable line."""
         return format_line(self.kind, self.fields)
 
     @classmethod
-    def from_line(cls, line: str) -> "OpEvent":
+    def from_line(cls, line: str) -> OpEvent:
         """Parse a single line back to OpEvent."""
         kind, fields = parse_line(line)
         return cls(kind=kind, fields=fields)
@@ -55,7 +56,7 @@ class OpEvent:
 class OpLog:
     """Accumulates layout operations for debugging and testing."""
 
-    events: List[OpEvent] = field(default_factory=list)
+    events: list[OpEvent] = field(default_factory=list)
 
     def emit(self, event: OpEvent) -> None:
         """Append an event to the log."""
@@ -98,7 +99,7 @@ class OpLog:
         layer: str = "",
         pad_count: int = 0,
     ) -> None:
-        fields: Dict[str, Any] = {
+        fields: dict[str, Any] = {
             "path": path,
             "ref": reference,
             "fpid": fpid,
@@ -135,7 +136,7 @@ class OpLog:
         dx = end_x - start_x
         dy = end_y - start_y
         length = int(math.sqrt(dx * dx + dy * dy))
-        fields: Dict[str, Any] = {
+        fields: dict[str, Any] = {
             "group": group_path,
             "net": net_name,
             "layer": layer,
@@ -157,7 +158,7 @@ class OpLog:
         y: int,
         drill: int = 0,
     ) -> None:
-        fields: Dict[str, Any] = {
+        fields: dict[str, Any] = {
             "group": group_path,
             "net": net_name,
             "x": x,
@@ -168,7 +169,7 @@ class OpLog:
         self.emit(OpEvent(kind="FRAG_VIA", fields=fields))
 
     def frag_zone(self, group_path: str, net_name: str, layer: str, name: str) -> None:
-        fields: Dict[str, Any] = {
+        fields: dict[str, Any] = {
             "group": group_path,
             "net": net_name,
             "layer": layer,
@@ -190,14 +191,14 @@ class OpLog:
     # =========================================================================
 
     def place_fp(self, path: str, x: int, y: int, w: int = 0, h: int = 0) -> None:
-        fields: Dict[str, Any] = {"path": path, "x": x, "y": y}
+        fields: dict[str, Any] = {"path": path, "x": x, "y": y}
         if w and h:
             fields["w"] = w
             fields["h"] = h
         self.emit(OpEvent(kind="PLACE_FP", fields=fields))
 
     def place_gr(self, path: str, x: int, y: int, w: int = 0, h: int = 0) -> None:
-        fields: Dict[str, Any] = {"path": path, "x": x, "y": y}
+        fields: dict[str, Any] = {"path": path, "x": x, "y": y}
         if w and h:
             fields["w"] = w
             fields["h"] = h
@@ -298,9 +299,9 @@ class OpLog:
             logger.info(f"OPLOG {event.to_line()}")
 
     @classmethod
-    def from_plaintext(cls, text: str) -> "OpLog":
+    def from_plaintext(cls, text: str) -> OpLog:
         """Parse plaintext back to OpLog."""
-        events: List[OpEvent] = []
+        events: list[OpEvent] = []
         for line in text.strip().split("\n"):
             line = line.strip()
             if not line or line.startswith("#"):

--- a/crates/pcb-layout/src/scripts/lens/tests/strategies.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/strategies.py
@@ -8,21 +8,22 @@ Note: Renames (moved() paths) are now handled in Rust preprocessing.
 Paths are already in their final form when the Python sync runs.
 """
 
+from __future__ import annotations
+
 from hypothesis import strategies as st
 from hypothesis.strategies import composite
 
 from ..types import (
-    EntityPath,
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
-    GroupView,
-    GroupComplement,
-    BoardView,
     BoardComplement,
+    BoardView,
+    EntityId,
+    EntityPath,
+    FootprintComplement,
+    FootprintView,
+    GroupComplement,
+    GroupView,
+    Position,
 )
-
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Primitive Strategies
@@ -262,9 +263,9 @@ def board_view_strategy(draw, min_footprints: int = 0, max_footprints: int = 6):
     # Derive groups from footprint paths
     # Skip groups whose path equals a footprint path (NoLeafGroups invariant)
     groups = {}
-    fp_paths = {fp_id.path for fp_id in footprints.keys()}
+    fp_paths = {fp_id.path for fp_id in footprints}
 
-    for fp_id in footprints.keys():
+    for fp_id in footprints:
         parent = fp_id.path.parent()
         while parent and parent.segments:
             # Skip if this path is also a footprint path
@@ -277,7 +278,7 @@ def board_view_strategy(draw, min_footprints: int = 0, max_footprints: int = 6):
                 # Find all descendant footprints
                 member_ids = [
                     other_id
-                    for other_id in footprints.keys()
+                    for other_id in footprints
                     if parent.is_ancestor_of(other_id.path)
                 ]
 
@@ -314,11 +315,11 @@ def board_complement_strategy(draw, view: BoardView = None):
 
     if view is not None:
         # Create complements for entities in view
-        for entity_id in view.footprints.keys():
+        for entity_id in view.footprints:
             if draw(st.booleans()):  # Maybe we have a complement
                 footprints[entity_id] = draw(footprint_complement_strategy())
 
-        for entity_id in view.groups.keys():
+        for entity_id in view.groups:
             if draw(st.booleans()):
                 groups[entity_id] = draw(group_complement_strategy())
 

--- a/crates/pcb-layout/src/scripts/lens/tests/test_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_adapter.py
@@ -5,24 +5,24 @@ These tests verify the pure computation logic in the adapter layer
 without requiring actual KiCad objects.
 """
 
-from typing import Dict, Tuple
+from __future__ import annotations
 
 from .. import kicad_adapter
+from ..lens import (
+    FragmentData,
+    _remap_routing_nets,
+    build_fragment_net_remap,
+)
 from ..types import (
-    EntityPath,
     EntityId,
-    Position,
+    EntityPath,
     FootprintComplement,
     GroupComplement,
+    Position,
     TrackComplement,
     ViaComplement,
     ZoneComplement,
     default_footprint_complement,
-)
-from ..lens import (
-    build_fragment_net_remap,
-    FragmentData,
-    _remap_routing_nets,
 )
 
 
@@ -91,12 +91,12 @@ class TestBuildFragmentNetRemap:
         member_paths = [EntityPath.from_string("Power.R1")]
 
         # Fragment: R1.1 is connected to "LOCAL_VCC"
-        fragment_pad_net_map: Dict[Tuple[str, str], str] = {
+        fragment_pad_net_map: dict[tuple[str, str], str] = {
             ("R1", "1"): "LOCAL_VCC",
         }
 
         # Board: Power.R1.1 is connected to "VCC_3V3"
-        board_pad_net_map: Dict[Tuple[EntityId, str], str] = {
+        board_pad_net_map: dict[tuple[EntityId, str], str] = {
             (EntityId.from_string("Power.R1"), "1"): "VCC_3V3",
         }
 
@@ -115,12 +115,12 @@ class TestBuildFragmentNetRemap:
             EntityPath.from_string("Power.R2"),
         ]
 
-        fragment_pad_net_map: Dict[Tuple[str, str], str] = {
+        fragment_pad_net_map: dict[tuple[str, str], str] = {
             ("R1", "1"): "LOCAL_GND",
             ("R2", "2"): "LOCAL_GND",
         }
 
-        board_pad_net_map: Dict[Tuple[EntityId, str], str] = {
+        board_pad_net_map: dict[tuple[EntityId, str], str] = {
             (EntityId.from_string("Power.R1"), "1"): "GND",
             (EntityId.from_string("Power.R2"), "2"): "GND",
         }
@@ -137,12 +137,12 @@ class TestBuildFragmentNetRemap:
         group_path = EntityPath.from_string("Power")
         member_paths = [EntityPath.from_string("Power.R1")]
 
-        fragment_pad_net_map: Dict[Tuple[str, str], str] = {
+        fragment_pad_net_map: dict[tuple[str, str], str] = {
             ("R1", "1"): "LOCAL_VCC",
             ("R1", "2"): "LOCAL_GND",
         }
 
-        board_pad_net_map: Dict[Tuple[EntityId, str], str] = {
+        board_pad_net_map: dict[tuple[EntityId, str], str] = {
             (EntityId.from_string("Power.R1"), "1"): "VCC_3V3",
             (EntityId.from_string("Power.R1"), "2"): "GND",
         }
@@ -163,12 +163,12 @@ class TestBuildFragmentNetRemap:
         ]
 
         # Both pads have same fragment net but different board nets
-        fragment_pad_net_map: Dict[Tuple[str, str], str] = {
+        fragment_pad_net_map: dict[tuple[str, str], str] = {
             ("R1", "1"): "LOCAL_VCC",
             ("R2", "1"): "LOCAL_VCC",
         }
 
-        board_pad_net_map: Dict[Tuple[EntityId, str], str] = {
+        board_pad_net_map: dict[tuple[EntityId, str], str] = {
             (EntityId.from_string("Power.R1"), "1"): "VCC_3V3",
             (EntityId.from_string("Power.R2"), "1"): "VCC_5V",  # Different!
         }
@@ -188,11 +188,11 @@ class TestBuildFragmentNetRemap:
         group_path = EntityPath.from_string("Power")
         member_paths = [EntityPath.from_string("Power.R1")]
 
-        fragment_pad_net_map: Dict[Tuple[str, str], str] = {
+        fragment_pad_net_map: dict[tuple[str, str], str] = {
             # R1.1 is NOT in fragment map
         }
 
-        board_pad_net_map: Dict[Tuple[EntityId, str], str] = {
+        board_pad_net_map: dict[tuple[EntityId, str], str] = {
             (EntityId.from_string("Power.R1"), "1"): "VCC_3V3",
         }
 
@@ -209,11 +209,11 @@ class TestBuildFragmentNetRemap:
         member_paths = [EntityPath.from_string("TopModule.Power.R1")]
 
         # Fragment uses relative path "R1"
-        fragment_pad_net_map: Dict[Tuple[str, str], str] = {
+        fragment_pad_net_map: dict[tuple[str, str], str] = {
             ("R1", "1"): "LOCAL_VCC",
         }
 
-        board_pad_net_map: Dict[Tuple[EntityId, str], str] = {
+        board_pad_net_map: dict[tuple[EntityId, str], str] = {
             (EntityId.from_string("TopModule.Power.R1"), "1"): "VCC_3V3",
         }
 
@@ -564,8 +564,9 @@ class TestFieldVisibility:
     def test_create_footprint_hides_value_and_custom_fields(self):
         """New footprints should have Value and custom fields hidden."""
         from unittest.mock import Mock
+
         from ..kicad_adapter import _create_footprint
-        from ..types import FootprintView, FootprintComplement, Position, EntityId
+        from ..types import EntityId, FootprintComplement, FootprintView, Position
 
         # Create view with custom fields
         entity_id = EntityId.from_string("Power.R1", fpid="Resistor_SMD:R_0603")
@@ -627,8 +628,9 @@ class TestFieldVisibility:
     def test_update_footprint_preserves_field_visibility(self):
         """Updating footprints should not change field visibility."""
         from unittest.mock import Mock
+
         from ..kicad_adapter import _update_footprint_view
-        from ..types import FootprintView, EntityId
+        from ..types import EntityId, FootprintView
 
         entity_id = EntityId.from_string("Power.R1", fpid="Resistor_SMD:R_0603")
         view = FootprintView(

--- a/crates/pcb-layout/src/scripts/lens/tests/test_changeset.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_changeset.py
@@ -5,18 +5,20 @@ and effectful application.
 Note: Renames (moved() paths) are now handled in Rust preprocessing.
 """
 
-from ..types import (
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
-    BoardView,
-    BoardComplement,
-    default_footprint_complement,
-)
+from __future__ import annotations
+
 from ..changeset import (
     SyncChangeset,
     build_sync_changeset,
+)
+from ..types import (
+    BoardComplement,
+    BoardView,
+    EntityId,
+    FootprintComplement,
+    FootprintView,
+    Position,
+    default_footprint_complement,
 )
 
 

--- a/crates/pcb-layout/src/scripts/lens/tests/test_hierplace.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_hierplace.py
@@ -14,18 +14,20 @@ Invariants tested:
 Run with: pytest -v test_hierplace.py
 """
 
-from hypothesis import given, settings, assume
+from __future__ import annotations
+
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
-from ..types import EntityPath, EntityId
 from ..hierplace import (
     PlacementRect,
     Rect,
-    rects_intersect,
     merge_rects,
     pack,
     pad_for_depth,
+    rects_intersect,
 )
+from ..types import EntityId, EntityPath
 
 # A4 sheet dimensions
 SHEET_CENTER_X = 297_000_000 // 2

--- a/crates/pcb-layout/src/scripts/lens/tests/test_layout_fragment.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_layout_fragment.py
@@ -5,21 +5,23 @@ These tests verify that when a parent module has a layout_path,
 new footprints can inherit their positions from the layout fragment.
 """
 
-from ..types import (
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
-    GroupView,
-    GroupComplement,
-    BoardView,
-    BoardComplement,
-)
-from ..lens import (
-    adapt_complement,
-    FragmentData,
-)
+from __future__ import annotations
+
 from ..changeset import build_sync_changeset
+from ..lens import (
+    FragmentData,
+    adapt_complement,
+)
+from ..types import (
+    BoardComplement,
+    BoardView,
+    EntityId,
+    FootprintComplement,
+    FootprintView,
+    GroupComplement,
+    GroupView,
+    Position,
+)
 
 
 def make_footprint_view(

--- a/crates/pcb-layout/src/scripts/lens/tests/test_lens.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_lens.py
@@ -1,17 +1,19 @@
 """Tests for lens operations."""
 
-from ..types import (
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
-    GroupView,
-    GroupComplement,
-    BoardView,
-    BoardComplement,
-)
-from ..lens import adapt_complement
+from __future__ import annotations
+
 from ..changeset import build_sync_changeset
+from ..lens import adapt_complement
+from ..types import (
+    BoardComplement,
+    BoardView,
+    EntityId,
+    FootprintComplement,
+    FootprintView,
+    GroupComplement,
+    GroupView,
+    Position,
+)
 
 
 class TestAdaptComplement:

--- a/crates/pcb-layout/src/scripts/lens/tests/test_not_connected.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_not_connected.py
@@ -5,6 +5,8 @@ NotConnected nets are treated as regular nets for connectivity.
 Any "no connect" behavior is expressed via pad pin type in the adapter.
 """
 
+from __future__ import annotations
+
 from ..lens import get
 
 
@@ -46,7 +48,7 @@ class MockProperty:
 class MockNetlist:
     """Mock netlist object for testing get()."""
 
-    def __init__(self, parts: list = None, nets: list = None):
+    def __init__(self, parts: list | None = None, nets: list | None = None):
         self.parts = parts or []
         self.nets = nets or []
 

--- a/crates/pcb-layout/src/scripts/lens/tests/test_pad_net_map.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_pad_net_map.py
@@ -6,15 +6,17 @@ BoardView.nets (SOURCE) rather than copying from existing pads (DEST).
 This ensures the netlist is always the source of truth for connectivity.
 """
 
+from __future__ import annotations
+
 from unittest.mock import Mock
 
+from ..kicad_adapter import _build_pad_net_map
 from ..types import (
+    BoardView,
     EntityId,
     FootprintView,
-    BoardView,
     NetView,
 )
-from ..kicad_adapter import _build_pad_net_map
 
 
 class MockNetInfo:

--- a/crates/pcb-layout/src/scripts/lens/tests/test_properties.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_properties.py
@@ -22,25 +22,26 @@ Run with: pytest -v test_properties.py
 Requires: hypothesis>=6.0
 """
 
-from hypothesis import given, settings, assume
+from __future__ import annotations
 
-from ..types import (
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
-    BoardView,
-    BoardComplement,
-    NetView,
-)
-from ..lens import adapt_complement, check_lens_invariants
+from hypothesis import assume, given, settings
+
 from ..changeset import build_sync_changeset
+from ..lens import adapt_complement, check_lens_invariants
+from ..types import (
+    BoardComplement,
+    BoardView,
+    EntityId,
+    FootprintComplement,
+    FootprintView,
+    NetView,
+    Position,
+)
 from .strategies import (
-    board_view_strategy,
     board_complement_strategy,
+    board_view_strategy,
     footprint_complement_strategy,
 )
-
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Law 1: View Consistency
@@ -185,11 +186,11 @@ class TestStructuralFidelity:
         new_complement = adapt_complement(view, complement)
 
         # Every complement should have a view
-        for entity_id in new_complement.footprints.keys():
+        for entity_id in new_complement.footprints:
             assert entity_id in view.footprints, f"Stale complement for {entity_id}"
 
         # Every view should have a complement
-        for entity_id in view.footprints.keys():
+        for entity_id in view.footprints:
             assert entity_id in new_complement.footprints, (
                 f"Missing complement for {entity_id}"
             )

--- a/crates/pcb-layout/src/scripts/lens/tests/test_regressions.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_regressions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from .. import kicad_adapter

--- a/crates/pcb-layout/src/scripts/lens/tests/test_scenarios.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_scenarios.py
@@ -8,21 +8,23 @@ Note: Renames (moved() paths) are now handled in Rust preprocessing before
 the Python sync runs. Rename-related tests have been moved to Rust integration tests.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
-from ..types import (
-    EntityPath,
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
-    GroupView,
-    GroupComplement,
-    BoardView,
-    BoardComplement,
-)
-from ..lens import adapt_complement
 from ..changeset import build_sync_changeset
+from ..lens import adapt_complement
+from ..types import (
+    BoardComplement,
+    BoardView,
+    EntityId,
+    EntityPath,
+    FootprintComplement,
+    FootprintView,
+    GroupComplement,
+    GroupView,
+    Position,
+)
 
 
 def make_footprint_view(
@@ -499,6 +501,7 @@ class TestUnmanagedFootprints:
         """Footprint with matching KIID_PATH should be extracted normally."""
         import uuid as uuid_module
         from unittest.mock import Mock
+
         from ..lens import extract
 
         path_str = "Power.R1"
@@ -538,7 +541,7 @@ class TestUnmanagedFootprints:
         pcbnew.B_Cu = 31
 
         diagnostics: list[dict[str, Any]] = []
-        view, complement = extract(board, pcbnew, None, diagnostics)
+        view, _complement = extract(board, pcbnew, None, diagnostics)
 
         # Should be extracted as managed footprint
         assert len(view.footprints) == 1
@@ -548,6 +551,7 @@ class TestUnmanagedFootprints:
         """Old boards without Path field should use kiid_to_path map to identify footprints."""
         import uuid as uuid_module
         from unittest.mock import Mock
+
         from ..lens import extract
 
         path_str = "Power.R1"
@@ -590,19 +594,20 @@ class TestUnmanagedFootprints:
         kiid_to_path = {expected_uuid: path_str}
 
         diagnostics: list[dict[str, Any]] = []
-        view, complement = extract(board, pcbnew, kiid_to_path, diagnostics)
+        view, _complement = extract(board, pcbnew, kiid_to_path, diagnostics)
 
         # Should be extracted successfully using KIID fallback
         assert len(view.footprints) == 1
         assert len(diagnostics) == 0
 
         # Verify the path was correctly resolved
-        entity_id = list(view.footprints.keys())[0]
+        entity_id = next(iter(view.footprints.keys()))
         assert str(entity_id.path) == path_str
 
     def test_footprint_with_wrong_kiid_path_is_not_extracted(self):
         """Footprint with mismatched KIID_PATH should not be extracted as managed."""
         from unittest.mock import Mock
+
         from ..lens import extract
 
         path_str = "Power.R1"
@@ -626,7 +631,7 @@ class TestUnmanagedFootprints:
         pcbnew = Mock()
 
         diagnostics: list[dict[str, Any]] = []
-        view, complement = extract(board, pcbnew, None, diagnostics)
+        view, _complement = extract(board, pcbnew, None, diagnostics)
 
         # Should NOT be extracted
         assert len(view.footprints) == 0
@@ -637,6 +642,7 @@ class TestUnmanagedFootprints:
     def test_apply_prunes_footprint_with_wrong_kiid_path(self):
         """Normal sync should delete footprints with a Path but wrong KIID_PATH."""
         from unittest.mock import Mock
+
         from ..changeset import SyncChangeset
         from ..kicad_adapter import apply_changeset
 

--- a/crates/pcb-layout/src/scripts/lens/tests/test_stateful.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_stateful.py
@@ -16,34 +16,37 @@ Run with: pytest -v test_stateful.py
 Requires: hypothesis>=6.0
 """
 
-from hypothesis import settings, note
+from __future__ import annotations
+
+from typing import ClassVar
+
+from hypothesis import note, settings
 from hypothesis import strategies as st
 from hypothesis.stateful import (
-    RuleBasedStateMachine,
-    rule,
-    invariant,
-    initialize,
     Bundle,
+    RuleBasedStateMachine,
+    initialize,
+    invariant,
+    rule,
 )
 
+from ..changeset import build_sync_changeset
+from ..lens import adapt_complement
 from ..types import (
+    BoardComplement,
+    BoardView,
     EntityId,
-    Position,
-    FootprintView,
     FootprintComplement,
+    FootprintView,
     GroupView,
     NetView,
-    BoardView,
-    BoardComplement,
+    Position,
 )
-from ..lens import adapt_complement
-from ..changeset import build_sync_changeset
 from .strategies import (
-    entity_path_strategy,
     FPID_POOL,
     VALUE_POOL,
+    entity_path_strategy,
 )
-
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Common Helpers
@@ -58,9 +61,9 @@ def derive_groups_from_footprints(footprints: dict) -> dict:
     not just direct children.
     """
     groups = {}
-    fp_paths = {fp_id.path for fp_id in footprints.keys()}
+    fp_paths = {fp_id.path for fp_id in footprints}
 
-    for fp_id in footprints.keys():
+    for fp_id in footprints:
         parent = fp_id.path.parent()
         while parent and parent.segments:
             # Skip if this parent path equals a footprint path (NoLeafGroups)
@@ -73,7 +76,7 @@ def derive_groups_from_footprints(footprints: dict) -> dict:
                 # Members are all descendant footprints (not just direct children)
                 member_ids = [
                     other_id
-                    for other_id in footprints.keys()
+                    for other_id in footprints
                     if parent.is_ancestor_of(other_id.path)
                 ]
                 # Only create group if it has at least 2 members (skip wrappers)
@@ -369,7 +372,7 @@ class PadNetSourceMachine(RuleBasedStateMachine):
     - Adding new connections is reflected in view
     """
 
-    NET_POOL = ["VCC", "GND", "SDA", "SCL", "NET1", "NET2"]
+    NET_POOL: ClassVar[list] = ["VCC", "GND", "SDA", "SCL", "NET1", "NET2"]
 
     def __init__(self):
         super().__init__()
@@ -468,7 +471,7 @@ class PadNetSourceMachine(RuleBasedStateMachine):
         )
 
         # Verify all footprints have complements
-        for entity_id in new_view.footprints.keys():
+        for entity_id in new_view.footprints:
             assert entity_id in new_complement.footprints
 
         self.complements = dict(new_complement.footprints)

--- a/crates/pcb-layout/src/scripts/lens/tests/test_swig_stability.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_swig_stability.py
@@ -11,36 +11,32 @@ Bug 2 (Group Deletion): Deleting a group was also deleting all its contents,
 causing footprints to be unintentionally removed.
 """
 
-from typing import Any, Dict, List
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import Mock
 
+from ..changeset import SyncChangeset
 from ..types import (
-    EntityPath,
-    EntityId,
-    FootprintView,
-    BoardView,
     BoardComplement,
+    BoardView,
+    EntityId,
+    EntityPath,
+    FootprintView,
     default_footprint_complement,
 )
-from ..changeset import SyncChangeset
 
 
 class StaleObjectError(Exception):
     """Raised when accessing an invalidated SWIG-like object."""
 
-    pass
-
 
 class _FakeFOOTPRINT:
     """Base class for fake footprints (defined early for inheritance)."""
 
-    pass
-
 
 class _FakePCB_GROUP:
     """Base class for fake groups (defined early for inheritance)."""
-
-    pass
 
 
 class InvalidatableFootprint(_FakeFOOTPRINT):
@@ -139,7 +135,7 @@ class InvalidatableGroup(_FakePCB_GROUP):
     def __init__(self, name: str):
         self._valid = True
         self._name = name
-        self._items: List[Any] = []
+        self._items: list[Any] = []
 
     def _check_valid(self):
         if not self._valid:
@@ -158,7 +154,7 @@ class InvalidatableGroup(_FakePCB_GROUP):
         self._check_valid()
         self._name = name
 
-    def GetItems(self) -> List[Any]:
+    def GetItems(self) -> list[Any]:
         self._check_valid()
         return list(self._items)
 
@@ -177,11 +173,11 @@ class InvalidatableBoard:
     """Fake KiCad board that invalidates cached objects on mutations."""
 
     def __init__(self):
-        self._footprints: List[InvalidatableFootprint] = []
-        self._groups: List[InvalidatableGroup] = []
-        self._nets: Dict[str, Any] = {}
-        self._deleted_footprints: List[InvalidatableFootprint] = []
-        self._deleted_groups: List[InvalidatableGroup] = []
+        self._footprints: list[InvalidatableFootprint] = []
+        self._groups: list[InvalidatableGroup] = []
+        self._nets: dict[str, Any] = {}
+        self._deleted_footprints: list[InvalidatableFootprint] = []
+        self._deleted_groups: list[InvalidatableGroup] = []
 
     def _invalidate_all_cached(self):
         """Simulate SWIG pointer invalidation after structural change."""
@@ -210,11 +206,11 @@ class InvalidatableBoard:
             new_groups.append(new_g)
         self._groups = new_groups
 
-    def GetFootprints(self) -> List[InvalidatableFootprint]:
+    def GetFootprints(self) -> list[InvalidatableFootprint]:
         # Return fresh wrappers each time (simulates real KiCad behavior)
         return list(self._footprints)
 
-    def Groups(self) -> List[InvalidatableGroup]:
+    def Groups(self) -> list[InvalidatableGroup]:
         # Return fresh wrappers each time
         return list(self._groups)
 

--- a/crates/pcb-layout/src/scripts/lens/tests/test_types.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_types.py
@@ -1,12 +1,14 @@
 """Tests for lens core types."""
 
+from __future__ import annotations
+
 from ..types import (
-    EntityPath,
-    EntityId,
-    Position,
-    FootprintView,
-    FootprintComplement,
     BoardView,
+    EntityId,
+    EntityPath,
+    FootprintComplement,
+    FootprintView,
+    Position,
     default_footprint_complement,
     default_group_complement,
 )

--- a/crates/pcb-layout/src/scripts/lens/types.py
+++ b/crates/pcb-layout/src/scripts/lens/types.py
@@ -2,19 +2,21 @@
 Core data types for the lens-based layout synchronization system.
 """
 
-from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple
+from __future__ import annotations
+
 import uuid as uuid_module
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass(frozen=True)
 class EntityPath:
     """Hierarchical path identifying an entity. Immutable and hashable."""
 
-    segments: Tuple[str, ...]
+    segments: tuple[str, ...]
 
     @classmethod
-    def from_string(cls, path: str) -> "EntityPath":
+    def from_string(cls, path: str) -> EntityPath:
         if not path:
             return cls(segments=())
         return cls(segments=tuple(path.split(".")))
@@ -25,18 +27,18 @@ class EntityPath:
     def __bool__(self) -> bool:
         return len(self.segments) > 0
 
-    def parent(self) -> Optional["EntityPath"]:
+    def parent(self) -> EntityPath | None:
         if len(self.segments) <= 1:
             return None
         return EntityPath(segments=self.segments[:-1])
 
-    def is_ancestor_of(self, other: "EntityPath") -> bool:
+    def is_ancestor_of(self, other: EntityPath) -> bool:
         return (
             len(other.segments) > len(self.segments)
             and other.segments[: len(self.segments)] == self.segments
         )
 
-    def relative_to(self, ancestor: "EntityPath") -> Optional["EntityPath"]:
+    def relative_to(self, ancestor: EntityPath) -> EntityPath | None:
         if not ancestor.is_ancestor_of(self) and ancestor != self:
             return None
         suffix = self.segments[len(ancestor.segments) :]
@@ -87,7 +89,7 @@ class EntityId:
         return self.path == other.path and self.fpid == other.fpid
 
     @classmethod
-    def from_string(cls, path: str, fpid: str = "") -> "EntityId":
+    def from_string(cls, path: str, fpid: str = "") -> EntityId:
         return cls(path=EntityPath.from_string(path), fpid=fpid)
 
     @property
@@ -111,7 +113,7 @@ class FootprintView:
     dnp: bool = False
     exclude_from_bom: bool = False
     exclude_from_pos: bool = False
-    fields: Dict[str, str] = field(default_factory=dict)
+    fields: dict[str, str] = field(default_factory=dict)
 
     @property
     def path(self) -> EntityPath:
@@ -123,8 +125,8 @@ class GroupView:
     """View portion of a group - derived from SOURCE netlist."""
 
     entity_id: EntityId
-    member_ids: Tuple[EntityId, ...]
-    layout_path: Optional[str] = None
+    member_ids: tuple[EntityId, ...]
+    layout_path: str | None = None
 
     @property
     def path(self) -> EntityPath:
@@ -136,12 +138,12 @@ class NetView:
     """View portion of a net - derived from SOURCE netlist."""
 
     name: str
-    connections: Tuple[Tuple[EntityId, str], ...]
+    connections: tuple[tuple[EntityId, str], ...]
     kind: str = "Net"  # Net type kind (e.g., "Net", "Power", "Ground", "NotConnected")
     # Unique logical ports touched by this net, as (refdes, pin_name) pairs.
     # This is SOURCE-derived metadata used for diagnostics and adapter behavior
     # (e.g. when it's valid to mark pads as no_connect).
-    logical_ports: Tuple[Tuple[str, str], ...] = ()
+    logical_ports: tuple[tuple[str, str], ...] = ()
 
     def has_connection_to(self, entity_id: EntityId) -> bool:
         return any(fp_id == entity_id for fp_id, _ in self.connections)
@@ -151,9 +153,9 @@ class NetView:
 class BoardView:
     """Complete View derived from SOURCE netlist."""
 
-    footprints: Dict[EntityId, FootprintView] = field(default_factory=dict)
-    groups: Dict[EntityId, GroupView] = field(default_factory=dict)
-    nets: Dict[str, NetView] = field(default_factory=dict)
+    footprints: dict[EntityId, FootprintView] = field(default_factory=dict)
+    groups: dict[EntityId, GroupView] = field(default_factory=dict)
+    nets: dict[str, NetView] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -163,13 +165,13 @@ class Position:
     x: int
     y: int
 
-    def offset_by(self, dx: int, dy: int) -> "Position":
+    def offset_by(self, dx: int, dy: int) -> Position:
         return Position(x=self.x + dx, y=self.y + dy)
 
-    def __add__(self, other: "Position") -> "Position":
+    def __add__(self, other: Position) -> Position:
         return Position(x=self.x + other.x, y=self.y + other.y)
 
-    def __sub__(self, other: "Position") -> "Position":
+    def __sub__(self, other: Position) -> Position:
         return Position(x=self.x - other.x, y=self.y - other.y)
 
 
@@ -181,12 +183,12 @@ class FootprintComplement:
     orientation: float
     layer: str
     locked: bool = False
-    reference_position: Optional[Position] = None
+    reference_position: Position | None = None
     reference_visible: bool = True
-    value_position: Optional[Position] = None
+    value_position: Position | None = None
     value_visible: bool = False
 
-    def with_position(self, position: Position) -> "FootprintComplement":
+    def with_position(self, position: Position) -> FootprintComplement:
         return FootprintComplement(
             position=position,
             orientation=self.orientation,
@@ -198,7 +200,7 @@ class FootprintComplement:
             value_visible=self.value_visible,
         )
 
-    def with_locked(self, locked: bool) -> "FootprintComplement":
+    def with_locked(self, locked: bool) -> FootprintComplement:
         return FootprintComplement(
             position=self.position,
             orientation=self.orientation,
@@ -241,11 +243,11 @@ class ZoneComplement:
 
     uuid: str
     name: str
-    outline: Tuple[Position, ...]
+    outline: tuple[Position, ...]
     layer: str
     priority: int = 0
     net_name: str = ""
-    fill_settings: Dict[str, Any] = field(default_factory=dict)
+    fill_settings: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -255,17 +257,17 @@ class GraphicComplement:
     uuid: str
     graphic_type: str
     layer: str
-    geometry: Dict[str, Any] = field(default_factory=dict)
+    geometry: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class GroupComplement:
     """Complement for a group - routing and graphics within the group."""
 
-    tracks: Tuple[TrackComplement, ...] = ()
-    vias: Tuple[ViaComplement, ...] = ()
-    zones: Tuple[ZoneComplement, ...] = ()
-    graphics: Tuple[GraphicComplement, ...] = ()
+    tracks: tuple[TrackComplement, ...] = ()
+    vias: tuple[ViaComplement, ...] = ()
+    zones: tuple[ZoneComplement, ...] = ()
+    graphics: tuple[GraphicComplement, ...] = ()
 
     @property
     def is_empty(self) -> bool:
@@ -281,15 +283,15 @@ class GroupComplement:
 class BoardComplement:
     """Complete Complement - all user-authored data from DEST."""
 
-    footprints: Dict[EntityId, FootprintComplement] = field(default_factory=dict)
-    groups: Dict[EntityId, GroupComplement] = field(default_factory=dict)
+    footprints: dict[EntityId, FootprintComplement] = field(default_factory=dict)
+    groups: dict[EntityId, GroupComplement] = field(default_factory=dict)
 
     def get_footprint_complement(
         self, entity_id: EntityId
-    ) -> Optional[FootprintComplement]:
+    ) -> FootprintComplement | None:
         return self.footprints.get(entity_id)
 
-    def get_group_complement(self, entity_id: EntityId) -> Optional[GroupComplement]:
+    def get_group_complement(self, entity_id: EntityId) -> GroupComplement | None:
         return self.groups.get(entity_id)
 
 

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -20,19 +20,19 @@ Pipeline Overview
    • Save the updated *.kicad_pcb*.
 """
 
+from __future__ import annotations
+
 import argparse
+import json
 import logging
 import os
 import os.path
 import re
-import time
-from abc import ABC, abstractmethod
-from typing import Optional
-from pathlib import Path
-import json
 import sys
+import time
 import uuid
-from typing import List, Dict
+from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 # Global logger.
@@ -45,7 +45,7 @@ def footprint_field_is_true(fp: Any, name: str) -> bool:
     return field is not None and field.GetText() == "true"
 
 
-def export_diagnostics(diagnostics: List[Dict[str, Any]], path: Path) -> None:
+def export_diagnostics(diagnostics: list[dict[str, Any]], path: Path) -> None:
     """Export diagnostics to JSON file."""
     output = {"diagnostics": diagnostics}
     with open(path, "w", encoding="utf-8") as f:
@@ -119,7 +119,7 @@ if python_path:
             logger.info(f"Added {path} to Python search path")
 
 # Available in KiCad's Python environment.
-import pcbnew  # noqa: E402
+import pcbnew
 
 # Suppress wxWidgets debug messages (e.g., "Adding duplicate image handler")
 # These are noisy and non-deterministic, interfering with test snapshots.
@@ -127,7 +127,7 @@ try:
     import wx
 
     wx.Log.EnableLogging(False)
-except Exception:
+except Exception:  # noqa: BLE001, S110 - wx is optional; its absence is expected
     pass  # wx may not be available in all environments
 
 
@@ -290,45 +290,46 @@ class JsonNetlistParser:
 
             # Add properties from attributes
             for attr_name, attr_value in instance["attributes"].items():
-                if attr_name not in ["footprint", "value", "Value"]:
-                    if isinstance(attr_value, dict):
-                        if "String" in attr_value:
-                            prop = JsonNetlistParser.Property(
-                                attr_name, attr_value["String"]
-                            )
-                            part.properties.append(prop)
-                        elif "Boolean" in attr_value:
-                            # Convert boolean to string for consistency
-                            prop = JsonNetlistParser.Property(
-                                attr_name, "true" if attr_value["Boolean"] else "false"
-                            )
-                            part.properties.append(prop)
-                        elif "Number" in attr_value:
-                            prop = JsonNetlistParser.Property(
-                                attr_name, str(attr_value["Number"])
-                            )
-                            part.properties.append(prop)
-                        elif "Array" in attr_value:
-                            # Arrays are formatted as CSV strings
-                            # Convert array elements to CSV format
-                            array_items = []
-                            for item in attr_value["Array"]:
-                                if isinstance(item, dict):
-                                    if "String" in item:
-                                        array_items.append(item["String"])
-                                    elif "Number" in item:
-                                        array_items.append(str(item["Number"]))
-                                    elif "Boolean" in item:
-                                        array_items.append(
-                                            "true" if item["Boolean"] else "false"
-                                        )
-                                    else:
-                                        # For other types, use string representation
-                                        array_items.append(str(item))
-                            prop = JsonNetlistParser.Property(
-                                attr_name, ",".join(array_items)
-                            )
-                            part.properties.append(prop)
+                if attr_name not in ["footprint", "value", "Value"] and isinstance(
+                    attr_value, dict
+                ):
+                    if "String" in attr_value:
+                        prop = JsonNetlistParser.Property(
+                            attr_name, attr_value["String"]
+                        )
+                        part.properties.append(prop)
+                    elif "Boolean" in attr_value:
+                        # Convert boolean to string for consistency
+                        prop = JsonNetlistParser.Property(
+                            attr_name, "true" if attr_value["Boolean"] else "false"
+                        )
+                        part.properties.append(prop)
+                    elif "Number" in attr_value:
+                        prop = JsonNetlistParser.Property(
+                            attr_name, str(attr_value["Number"])
+                        )
+                        part.properties.append(prop)
+                    elif "Array" in attr_value:
+                        # Arrays are formatted as CSV strings
+                        # Convert array elements to CSV format
+                        array_items = []
+                        for item in attr_value["Array"]:
+                            if isinstance(item, dict):
+                                if "String" in item:
+                                    array_items.append(item["String"])
+                                elif "Number" in item:
+                                    array_items.append(str(item["Number"]))
+                                elif "Boolean" in item:
+                                    array_items.append(
+                                        "true" if item["Boolean"] else "false"
+                                    )
+                                else:
+                                    # For other types, use string representation
+                                    array_items.append(str(item))
+                        prop = JsonNetlistParser.Property(
+                            attr_name, ",".join(array_items)
+                        )
+                        part.properties.append(prop)
 
             parser.parts.append(part)
 
@@ -388,7 +389,7 @@ class JsonNetlistParser:
 
     def get_component_module(
         self, component_path: str
-    ) -> Optional["JsonNetlistParser.Module"]:
+    ) -> JsonNetlistParser.Module | None:
         """Find which module a component belongs to based on its hierarchical path.
 
         For example, if component_path is "Power.Regulator.C1", this will check:
@@ -475,7 +476,7 @@ class SyncState:
 
     def __init__(self):
         # Diagnostics collected during sync (e.g., FPID mismatches)
-        self.layout_diagnostics: List[Dict[str, Any]] = []
+        self.layout_diagnostics: list[dict[str, Any]] = []
 
 
 ####################################################################################################
@@ -486,8 +487,8 @@ class SyncState:
 ####################################################################################################
 
 # Import the lens module (extracted to temp dir by Rust and added to PYTHONPATH)
-from lens import run_lens_sync  # noqa: E402
-from lens.kicad_adapter import get_footprint_field  # noqa: E402
+from lens import run_lens_sync
+from lens.kicad_adapter import get_footprint_field
 
 
 class ImportNetlist(Step):
@@ -511,11 +512,11 @@ class ImportNetlist(Step):
         self.board_path = Path(board_path)
         self.netlist = netlist
         self.package_roots = netlist.package_roots
-        self.footprint_lib_map: Dict[str, str] = {}
+        self.footprint_lib_map: dict[str, str] = {}
 
     def _setup_env(self):
         """Set up project-local variables for footprint resolution."""
-        if "KIPRJMOD" not in os.environ.keys():
+        if "KIPRJMOD" not in os.environ:
             os.environ["KIPRJMOD"] = str(self.board_path.parent)
 
     def _load_footprint_lib_map(self):
@@ -527,7 +528,7 @@ class ImportNetlist(Step):
             try:
                 with open(path) as fp:
                     tbl = fp.read()
-            except IOError:
+            except OSError:
                 return
 
             # Get individual "(lib ...)" entries from the string.
@@ -629,8 +630,8 @@ class FinalizeBoard(Step):
         self,
         state: SyncState,
         board: pcbnew.BOARD,
-        snapshot_path: Optional[Path],
-        diagnostics_path: Optional[Path] = None,
+        snapshot_path: Path | None,
+        diagnostics_path: Path | None = None,
     ):
         self.state = state
         self.board = board
@@ -876,7 +877,7 @@ class FinalizeBoard(Step):
         # Trigger KiCad's connectivity updates and fix orphaned items
         try:
             self.board.GetConnectivity().Build(self.board)
-        except Exception:
+        except Exception:  # noqa: BLE001, S110 - FIXME: silently swallows connectivity-rebuild failures
             pass
 
         # Save board only once at the very end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dev = ["pytest>=7.0", "hypothesis>=6.0", "ruff>=0.4", "ty>=0.0.65"]
 # pytest and ty both run on 3.12 and do not catch it.
 target-version = "py39"
 
+[tool.ruff.lint]
+# `required-imports` below is only enforced by I002, which is NOT part of ruff's
+# default selection (that only includes I001), so it must be selected explicitly
+# or the setting is silently inert.
+extend-select = ["I002"]
+
 [tool.ruff.lint.isort]
 # Paired with target-version above: `from __future__ import annotations` makes
 # every annotation a lazy string, so modern `list[str]` / `X | None` spellings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,21 @@ dependencies = ["click>=8.0"]
 [dependency-groups]
 dev = ["pytest>=7.0", "hypothesis>=6.0", "ruff>=0.4", "ty>=0.0.65"]
 
-[tool.ruff.lint]
-# ruff 0.16 widened its default rule selection well beyond the pre-0.16 default
-# of E4/E7/E9/F. Pinning it here keeps the ruff 0.15 -> 0.16 bump
-# behaviour-preserving. Adopting 0.16's defaults is a separate decision: it
-# reports 420 findings on this tree (369 auto-fixable), mostly UP006
-# non-pep585-annotation, UP045, and I001 unsorted-imports.
-select = ["E4", "E7", "E9", "F"]
+[tool.ruff]
+# These scripts execute inside KiCad's bundled interpreter, which is Python
+# 3.9.13 as of KiCad 10 -- NOT the >=3.10 above, which only describes the uv
+# dev/test environment. Without this, ruff infers py310 from requires-python and
+# rewrites `Optional[X]` to PEP 604 `X | None`, which raises
+# `TypeError: unsupported operand type(s) for |` at import time under KiCad.
+# pytest and ty both run on 3.12 and do not catch it.
+target-version = "py39"
+
+[tool.ruff.lint.isort]
+# Paired with target-version above: `from __future__ import annotations` makes
+# every annotation a lazy string, so modern `list[str]` / `X | None` spellings
+# are safe to write even though KiCad's interpreter is 3.9. Without it those
+# spellings would be evaluated at import time and raise.
+required-imports = ["from __future__ import annotations"]
 
 [tool.ty.src]
 exclude = ["**/tests/"]


### PR DESCRIPTION
Follow-up to the dependency sweep (#1010), which bumped ruff 0.15.20 -> 0.16.1 and pinned the old default rule selection to keep that bump behaviour-preserving. This removes the pin and adopts ruff 0.16's full default selection.

`ruff check` is now clean — all 420 findings resolved.

## What changed

Mostly mechanical: PEP 585/604 annotations, import sorting, redundant `.keys()`, collapsed nested `if`s, `ClassVar` on a mutable class default, explicit `Optional` on implicit-optional parameters.

Five error-handling sites got `# noqa` with a stated reason instead of a rewrite — changing error handling in the KiCad sync path is not a lint change. **Two are marked FIXME** because they genuinely swallow failures with no logging and deserve a real fix:

- `lens/kicad_adapter.py` — fragment discovery failures silently `return`
- `update_layout_file.py` — connectivity-rebuild failures silently `pass`

## The constraint worth knowing about

**These scripts run inside KiCad's bundled interpreter, which is Python 3.9.13 as of KiCad 10** — not the `requires-python = ">=3.10"` in `pyproject.toml`, which only describes the uv dev/test environment.

ruff derives its target from `requires-python`, so the first attempt rewrote `Optional[X]` to PEP 604 `X | None` in 40 places across modules KiCad imports. That raises at import time on 3.9:

```
layout_path: str | None = None
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

I caught this before committing, but it is worth stating plainly that **neither `pytest` nor `ty check` catches it** — both run on Python 3.12.

The fix is two settings, both commented in `pyproject.toml` so they do not get "helpfully" deleted later:

- `target-version = "py39"` — pins ruff to the real runtime floor
- `required-imports = ["from __future__ import annotations"]` — makes every annotation a lazy string, so modern spellings stay safe on 3.9

## Verification

- `ruff check` and `ruff format --check` clean; `ty check` clean; `pytest lens/tests` 148 passed
- Every lens module imports under KiCad's actual `python3.9.13` binary; the whole tree byte-compiles under it
- `cargo nextest run --workspace --profile ci --locked` — 1937 passed, 1 skipped
- **Proved the guard is real:** temporarily removing the future import from `lens/types.py` makes `cargo nextest run -p pcb-layout` fail with the Python import error. So the Rust suite genuinely drives these scripts through KiCad rather than passing vacuously — it is the only layer that would catch a 3.9 incompatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and annotation/import hygiene only; sync logic is unchanged aside from documented noqa on existing silent exception paths.
> 
> **Overview**
> Adopts **ruff 0.16’s default lint set** for the KiCad layout Python tree (lens modules, tests, `update_layout_file.py`) after removing the prior pin to the older E/F-only selection. The diff is largely **mechanical cleanup**: PEP 585/604-style annotations, sorted imports, dropping redundant `.keys()` iteration, small refactors (e.g. collapsed `if`s, `ClassVar` on a mutable class default), and import reordering in `__init__.py`.
> 
> **KiCad runtime safety** is the substantive config change in `pyproject.toml`: **`target-version = "py39"`** so ruff does not assume 3.10+, plus **`extend-select = ["I002"]`** and **`required-imports = ["from __future__ import annotations"]`** so modern `list[str]` / `X | None` annotations stay valid under KiCad’s bundled **Python 3.9** (with comments explaining why dev-only pytest/ty on 3.12 won’t catch `|` at import time).
> 
> A handful of **broad `except` handlers** keep behavior but gain **`# noqa: BLE001`** (and FIXME notes where failures are silently swallowed in fragment discovery and connectivity rebuild).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9ace0c2fc7b034014d6a525c19bbdba0383cd5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->