### PR TITLE
New zener functions to improve mcu modelisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added pin-capability builtins `pin()`, `peripheral()`, `pool()`, `pin_request()` and `pin_solve()` to declare what a multi-function component's pins can do and solve the instance × pin assignment at elaboration; results are stored as `pin_assignment` / `swap_classes` module properties.
+- Added `at(value, pins, soft=)` to constrain the physical pin on the connection itself, e.g. `Mcu(IO0 = at(led_net, "PA8"))`.
+- Added `pin_map()` to turn a solved assignment into a `Component(pins=...)`-ready dict: every solved request's pads plus the mux pads no request claimed, tied to `NotConnected()`.
+- Added `pin_request(if_connected=True)` for optional `io()` capability slots and `pin_request(bind=)` for dict-of-roles demands like `Mcu(gpio = {"LED": at(led_net, "PA8")})`.
+- Added `interface(implies = [...])`: capability matching is nominal and closed over the implication DAG (a `Usart` provider satisfies a `Uart` request, never the reverse).
+- Added `interface(attrs = {...})` to declare the capability-attribute vocabulary peripheral attrs are validated against; the stdlib interfaces now declare `clk_max`/`baud_max`/`bitrate_max`/`vio`, plus `gbw` on `Opamp` and `freq_max` on `OscPair`.
+- Added the stdlib single-signal capability interfaces `AdcIn` and `GpioPin` for ADC inputs and GPIO pools.
+- `pin_solve` now warns when a request's pin-combination enumeration hits the internal cap on wide pin matrices, since the chosen assignment may then be suboptimal.
+
+### Changed
+
+- **Breaking:** `attrs` and `implies` are now reserved keywords of `interface()`. An interface declaring a connection field under either name must rename it.
+
 ### Fixed
 
 - Inner copper Gerbers now use KiCad's layer numbering (`In1_Cu`, `In2_Cu`, ...).

--- a/crates/pcb-sch/src/physical.rs
+++ b/crates/pcb-sch/src/physical.rs
@@ -2032,6 +2032,9 @@ impl PhysicalValueType {
             exported_name: Default::default(),
         }
     }
+    pub fn dims(&self) -> PhysicalUnitDims {
+        self.unit
+    }
 
     fn type_instance_id(&self) -> TypeInstanceId {
         static CACHE: OnceLock<Mutex<HashMap<PhysicalUnitDims, TypeInstanceId>>> = OnceLock::new();

--- a/crates/pcb-zen-core/src/lang/builtin.rs
+++ b/crates/pcb-zen-core/src/lang/builtin.rs
@@ -68,6 +68,14 @@ pub fn builtin_globals(builder: &mut GlobalsBuilder) {
 
 #[starlark_module]
 fn builtin_methods(methods: &mut MethodsBuilder) {
+    /// Pin-capability builtins; see `@stdlib/pinmux.zen`.
+    #[starlark(attribute)]
+    fn pinmux(
+        #[allow(unused_variables)] this: &Builtin,
+    ) -> starlark::Result<crate::lang::pinmux::Pinmux> {
+        Ok(crate::lang::pinmux::Pinmux)
+    }
+
     #[allow(non_snake_case)]
     #[starlark(attribute)]
     fn Mass(#[allow(unused_variables)] this: &Builtin) -> starlark::Result<PhysicalValueType> {
@@ -278,6 +286,12 @@ fn builtin_methods(methods: &mut MethodsBuilder) {
         #[starlark(require = pos)] value: Value<'v>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> starlark::Result<NoneType> {
+        if crate::lang::pinmux::RESULT_PROPERTIES.contains(&name.as_str()) {
+            return Err(starlark::Error::new_other(anyhow::anyhow!(
+                "module property `{name}` is written by pin_solve; record your own data under \
+                 another name"
+            )));
+        }
         crate::lang::module::warn_legacy_module_dnp_add_property(eval, &name);
         eval.add_property(&name, value);
         Ok(NoneType)

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -2009,8 +2009,16 @@ where
                 }
 
                 if v_val.get_type() != "Net" {
+                    // `at()` belongs on a module input, where io()/config()
+                    // hand its constraint to pin_solve; here it is just a
+                    // wrapper the pin cannot read.
+                    let hint = if v_val.get_type() == "PinAt" {
+                        " — at() constrains a module input, not a component pin"
+                    } else {
+                        ""
+                    };
                     return Err(starlark::Error::new_other(anyhow!(format!(
-                        "Pin '{}' must be connected to a Net, got {}",
+                        "Pin '{}' must be connected to a Net, got {}{hint}",
                         signal_name,
                         v_val.get_type()
                     ))));

--- a/crates/pcb-zen-core/src/lang/context.rs
+++ b/crates/pcb-zen-core/src/lang/context.rs
@@ -64,6 +64,14 @@ pub(crate) struct FrozenPendingChild {
     pub(crate) call_stack: CallStack,
 }
 
+/// What one solved `pin_request` took, plus the pad namespace it took it from.
+#[derive(Debug, Clone)]
+pub(crate) struct PinClaim {
+    pub(crate) instance: String,
+    pub(crate) pins: Vec<String>,
+    pub(crate) scope: String,
+}
+
 #[derive(Debug, Trace, ProvidesStaticType, Allocative, Serialize)]
 #[repr(C)]
 pub struct ContextValue<'v> {
@@ -74,12 +82,45 @@ pub struct ContextValue<'v> {
     /// contexts we leave this `false` so that io()/config() placeholders behave
     /// permissively and synthesize defaults instead of failing.
     strict_io_config: bool,
+    /// Names of required io()/config() inputs that were not provided, recorded
+    /// during this module's evaluation; not preserved across freeze.
     missing_inputs: RefCell<Vec<String>>,
     #[allocative(skip)]
     diagnostics: RefCell<Vec<crate::Diagnostic>>,
     #[allocative(skip)]
     #[serde(skip)]
     pending_children: RefCell<Vec<PendingChild<'v>>>,
+    /// Instance and pins each solved request claimed, keyed by request name:
+    /// pin/instance exclusivity spans every pin_solve of the module, and a
+    /// re-solved request releases its own claims.
+    #[allocative(skip)]
+    #[serde(skip)]
+    pin_claims: RefCell<std::collections::HashMap<(String, String), PinClaim>>,
+    /// Requests served by the `if_connected` gate, for the post-eval check.
+    #[allocative(skip)]
+    #[serde(skip)]
+    if_connected_served: RefCell<std::collections::HashSet<String>>,
+    /// Every pad a part exposes, per part scope. Kept whole rather than net
+    /// of the claims: a re-solve releases pads, and what is free is only
+    /// known when `pin_map` asks.
+    #[allocative(skip)]
+    #[serde(skip)]
+    exposed_pads: RefCell<std::collections::HashMap<String, Vec<String>>>,
+    /// Open net each unclaimed pad was tied to, per `(part scope, pin)`, so
+    /// two `pin_map` calls for one part hand back the same net.
+    #[allocative(skip)]
+    #[serde(skip)]
+    tied_off: RefCell<SmallMap<(String, String), Value<'v>>>,
+    /// Truthiness each `unless` axis had for a part, so a design says once
+    /// whether a gated peripheral is there.
+    #[allocative(skip)]
+    #[serde(skip)]
+    config_axes: RefCell<std::collections::HashMap<(String, String), bool>>,
+    /// Net (id, name) each physical pin has been mapped to by `pin_map`,
+    /// keyed by `(part scope, pin)`: two components may share pin names.
+    #[allocative(skip)]
+    #[serde(skip)]
+    mapped_pins: RefCell<std::collections::HashMap<(String, String), (u64, String)>>,
 }
 
 #[derive(Debug, Trace, ProvidesStaticType, Allocative, Serialize)]
@@ -165,6 +206,12 @@ impl<'v> ContextValue<'v> {
             missing_inputs: RefCell::new(Vec::new()),
             diagnostics: RefCell::new(Vec::new()),
             pending_children: RefCell::new(Vec::new()),
+            pin_claims: RefCell::new(std::collections::HashMap::new()),
+            if_connected_served: RefCell::new(std::collections::HashSet::new()),
+            exposed_pads: RefCell::new(std::collections::HashMap::new()),
+            tied_off: RefCell::new(SmallMap::new()),
+            config_axes: RefCell::new(std::collections::HashMap::new()),
+            mapped_pins: RefCell::new(std::collections::HashMap::new()),
         }
     }
 
@@ -191,6 +238,127 @@ impl<'v> ContextValue<'v> {
 
     pub(crate) fn add_missing_input(&self, name: String) {
         self.missing_inputs.borrow_mut().push(name);
+    }
+
+    /// Record what `req` took. A name identifies one request per part, so a
+    /// solve that places it elsewhere among `table`'s parts supersedes the
+    /// earlier placement while another component's like-named request stands.
+    pub(crate) fn record_pin_claim(&self, req: &str, claim: PinClaim, table: &[String]) {
+        let mut claims = self.pin_claims.borrow_mut();
+        claims.retain(|(scope, name), _| name != req || !table.contains(scope));
+        claims.insert((claim.scope.clone(), req.to_owned()), claim);
+    }
+
+    /// Which part's pad namespace a solved request belongs to, when one name
+    /// answers for one part only.
+    pub(crate) fn pin_claim_scope(&self, req: &str) -> Option<String> {
+        let claims = self.pin_claims.borrow();
+        let mut found = claims.iter().filter(|((_, name), _)| name == req);
+        let (_, claim) = found.next()?;
+        found.next().is_none().then(|| claim.scope.clone())
+    }
+
+    /// Claims other than the ones `except` re-solves on `table`'s own parts:
+    /// pin names only mean something inside the part that owns them.
+    pub(crate) fn pin_claims_excluding(
+        &self,
+        except: &std::collections::HashSet<String>,
+        table: &[String],
+    ) -> Vec<PinClaim> {
+        self.pin_claims
+            .borrow()
+            .iter()
+            .filter(|((scope, name), _)| !(except.contains(name) && table.contains(scope)))
+            .map(|(_, c)| c.clone())
+            .collect()
+    }
+
+    /// Net a pad was already mapped to, within one part: a superseded solve's
+    /// assignment must not re-map a pad to a second net.
+    pub(crate) fn pin_map_net(&self, scope: &str, pin: &str) -> Option<(u64, String)> {
+        self.mapped_pins
+            .borrow()
+            .get(&(scope.to_owned(), pin.to_owned()))
+            .cloned()
+    }
+
+    /// Requests `if_connected` served because the caller supplied an input of
+    /// that name, checked against the finished signature once it is complete.
+    pub(crate) fn record_if_connected(&self, name: &str) {
+        self.if_connected_served
+            .borrow_mut()
+            .insert(name.to_owned());
+    }
+
+    pub(crate) fn if_connected_served(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.if_connected_served.borrow().iter().cloned().collect();
+        v.sort();
+        v
+    }
+
+    pub(crate) fn record_exposed_pads(&self, scope: String, pads: Vec<String>) {
+        self.exposed_pads.borrow_mut().insert(scope, pads);
+    }
+
+    /// Every part scope a `pin_solve` has run over in this module, sorted.
+    pub(crate) fn exposed_pad_scopes(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.exposed_pads.borrow().keys().cloned().collect();
+        v.sort();
+        v
+    }
+
+    pub(crate) fn exposed_pads(&self, scope: &str) -> Vec<String> {
+        self.exposed_pads
+            .borrow()
+            .get(scope)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Pads a live claim holds in `scope`. A superseded solve's pads are not
+    /// among them, so they are free to be tied off again.
+    pub(crate) fn claimed_pins(&self, scope: &str) -> std::collections::HashSet<String> {
+        self.pin_claims
+            .borrow()
+            .values()
+            .filter(|c| c.scope == scope)
+            .flat_map(|c| c.pins.iter().cloned())
+            .collect()
+    }
+
+    /// Axes this part has already settled, whatever table named them.
+    pub(crate) fn config_axes_for(&self, scope: &str) -> Vec<String> {
+        self.config_axes
+            .borrow()
+            .keys()
+            .filter(|(s, _)| s == scope)
+            .map(|(_, axis)| axis.clone())
+            .collect()
+    }
+
+    /// Record what `axis` meant for `scope`, returning what it meant before.
+    pub(crate) fn record_config_axis(&self, scope: &str, axis: &str, on: bool) -> Option<bool> {
+        self.config_axes
+            .borrow_mut()
+            .insert((scope.to_owned(), axis.to_owned()), on)
+    }
+
+    /// The open net a pad was already tied to, if this module tied it.
+    pub(crate) fn tied_off_net(&self, scope: &str, pin: &str) -> Option<Value<'v>> {
+        self.tied_off
+            .borrow()
+            .get(&(scope.to_owned(), pin.to_owned()))
+            .copied()
+    }
+
+    pub(crate) fn record_tie_off(&self, scope: &str, pin: &str, net: Value<'v>) {
+        self.tied_off
+            .borrow_mut()
+            .insert((scope.to_owned(), pin.to_owned()), net);
+    }
+
+    pub(crate) fn record_pin_map(&self, scope: String, pin: String, net: (u64, String)) {
+        self.mapped_pins.borrow_mut().insert((scope, pin), net);
     }
 
     pub(crate) fn add_diagnostic<D: Into<crate::Diagnostic>>(&self, diag: D) {

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -4,7 +4,7 @@ use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use anyhow::anyhow;
@@ -475,6 +475,15 @@ pub struct EvalContextConfig {
     /// in the current load chain (ancestors). Thread-local to each evaluation path.
     pub(crate) load_chain: HashSet<PathBuf>,
 
+    /// `at()` pin constraints of the design being elaborated, shared with every
+    /// descendant so a constraint reaches a nested `pin_solve`, and distinct per
+    /// root so concurrent designs never see each other's.
+    pub(crate) pin_constraints: Arc<Mutex<crate::lang::pinmux::PinConstraints>>,
+
+    /// Nominal interface identities for this design: one declaration keeps one
+    /// identity however many times its file is evaluated.
+    pub(crate) interface_ids: Arc<crate::lang::pinmux::InterfaceIds>,
+
     /// The absolute path to the module we are evaluating.
     pub(crate) source_path: Option<PathBuf>,
 
@@ -525,6 +534,8 @@ impl EvalContextConfig {
             builtin_docs,
             file_provider,
             resolution,
+            pin_constraints: Arc::default(),
+            interface_ids: Arc::default(),
             module_path: ModulePath::root(),
             load_chain: HashSet::new(),
             source_path: None,
@@ -597,6 +608,8 @@ impl EvalContextConfig {
             builtin_docs: self.builtin_docs.clone(),
             file_provider: self.file_provider.clone(),
             resolution: self.resolution.clone(),
+            pin_constraints: self.pin_constraints.clone(),
+            interface_ids: self.interface_ids.clone(),
             module_path: child_module_path,
             load_chain: child_load_chain,
             source_path: None,
@@ -625,6 +638,8 @@ impl EvalContextConfig {
             builtin_docs: self.builtin_docs.clone(),
             file_provider: self.file_provider.clone(),
             resolution: self.resolution.clone(),
+            pin_constraints: self.pin_constraints.clone(),
+            interface_ids: self.interface_ids.clone(),
             module_path: child_module_path,
             load_chain: HashSet::new(),
             source_path: None,
@@ -1237,6 +1252,8 @@ impl EvalContext {
             builtin_docs: self.config.builtin_docs.clone(),
             file_provider: self.config.file_provider.clone(),
             resolution: self.config.resolution.clone(),
+            pin_constraints: self.config.pin_constraints.clone(),
+            interface_ids: self.config.interface_ids.clone(),
             module_path,
             load_chain: self.config.load_chain.clone(),
             source_path: None,
@@ -1296,6 +1313,14 @@ impl EvalContext {
     /// Record that `from` references `to` via a `Module()` call.
     pub(crate) fn record_module_dependency(&self, from: &Path, to: &Path) {
         self.session.record_module_dependency(from, to);
+    }
+
+    pub(crate) fn pin_constraints(&self) -> Arc<Mutex<crate::lang::pinmux::PinConstraints>> {
+        self.config.pin_constraints.clone()
+    }
+
+    pub(crate) fn interface_ids(&self) -> Arc<crate::lang::pinmux::InterfaceIds> {
+        self.config.interface_ids.clone()
     }
 
     fn load_cache_scope(&self, path: &Path) -> Option<PackageScopeKey> {
@@ -1511,6 +1536,13 @@ impl EvalContext {
         if self.config.source_path.is_none() {
             return anyhow::anyhow!("source_path not set on Context before eval()").into();
         }
+        // Elaboration state starts empty at a design boundary, whatever config
+        // the caller reused, so one design's `at()` constraints never surface
+        // as another's errors. Loads and children keep theirs.
+        if self.config.module_path.is_root() {
+            self.config.pin_constraints = Arc::default();
+            self.config.interface_ids = Arc::default();
+        }
 
         let ParsedSource { contents, ast } = match self.parsed_source() {
             Ok(source) => source,
@@ -1564,6 +1596,39 @@ impl EvalContext {
 
             match eval_result {
                 Ok(_) => {
+                    // `if_connected` reads the caller's inputs, which include
+                    // config values; one declared after the solve was not yet
+                    // known to be a config. The signature is complete now.
+                    if let Some(ctx) = module
+                        .extra_value()
+                        .and_then(|e| e.downcast_ref::<ContextValue>())
+                    {
+                        let path = self
+                            .config
+                            .source_path
+                            .clone()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .into_owned();
+                        for name in ctx.if_connected_served() {
+                            if ctx
+                                .module()
+                                .signature()
+                                .iter()
+                                .any(|p| p.is_config && p.name == name)
+                            {
+                                diagnostics.push(Diagnostic::categorized(
+                                    &path,
+                                    &format!(
+                                        "pin_request `{name}` was served because the caller passed `{name}`, but that input is a config(), not a connection — declare the config() above the pin_solve, or rename one of them"
+                                    ),
+                                    "pinmux.if_connected_config",
+                                    EvalSeverity::Error,
+                                ));
+                            }
+                        }
+                    }
+
                     let frozen_module = {
                         let _span = info_span!("freeze_module").entered();
                         module
@@ -1626,7 +1691,7 @@ impl EvalContext {
                         .collect();
                     // Process pending children after parent is frozen
                     let module_path = extra.module.path().clone();
-                    let is_root = module_path.segments.is_empty();
+                    let is_root = module_path.is_root();
 
                     if self.config.build_circuit || is_root {
                         self.session
@@ -1672,6 +1737,48 @@ impl EvalContext {
 
                     // Module's own diagnostics (from ContextValue)
                     diagnostics.extend(extra.diagnostics().iter().cloned());
+
+                    // Every solve in the tree has run by now, so a hard
+                    // constraint still unclaimed is one nothing ever wanted,
+                    // and one several solves wanted is reported once, here,
+                    // rather than by whichever of them lost the race.
+                    if is_root {
+                        for (module, input, span, who) in
+                            self.config.pin_constraints.lock().unwrap().contended()
+                        {
+                            diagnostics.push(
+                                Diagnostic::categorized(
+                                    &module,
+                                    &format!(
+                                        "at() pin constraint on input `{input}` is wanted by the solves of `{}`: a pin name answers for one component, so give each its own at()",
+                                        who.join("`, `")
+                                    ),
+                                    "pinmux.contended_at",
+                                    EvalSeverity::Error,
+                                )
+                                .with_span(span),
+                            );
+                        }
+                        for (module, input, span) in self
+                            .config
+                            .pin_constraints
+                            .lock()
+                            .unwrap()
+                            .unconsumed_hard()
+                        {
+                            diagnostics.push(
+                                Diagnostic::categorized(
+                                    &module,
+                                    &format!(
+                                        "at() pin constraint on input `{input}` was never consumed: no pin_request named `{input}` reached a pin_solve"
+                                    ),
+                                    "pinmux.unconsumed_at",
+                                    EvalSeverity::Error,
+                                )
+                                .with_span(span),
+                            );
+                        }
+                    }
 
                     if !diagnostics.iter().any(Diagnostic::is_error) {
                         diagnostics.extend(ast_style_lints(&ast));

--- a/crates/pcb-zen-core/src/lang/interface.rs
+++ b/crates/pcb-zen-core/src/lang/interface.rs
@@ -506,11 +506,15 @@ impl InterfaceCell for FrozenValue {
 #[derive(Clone, Debug, Trace, ProvidesStaticType, NoSerialize, Allocative)]
 pub struct InterfaceFactoryGen<V: InterfaceCell> {
     id: TypeInstanceId,
+    /// Declaring file, paired with the exported name to key nominal identity.
+    declaration_path: String,
     #[allocative(skip)]
     #[trace(unsafe_ignore)]
     interface_type_data: V::InterfaceTypeDataOpt,
     fields: SmallMap<String, V>,
     post_init_fn: Option<V>,
+    implies: Vec<V>,
+    attr_spec: SmallMap<String, V>,
     param_spec: ParametersSpec<FrozenValue>,
 }
 
@@ -526,9 +530,12 @@ impl Freeze for InterfaceFactory<'_> {
     ) -> starlark::values::FreezeResult<Self::Frozen> {
         Ok(FrozenInterfaceFactory {
             id: self.id,
+            declaration_path: self.declaration_path,
             interface_type_data: self.interface_type_data.into_inner(),
             fields: self.fields.freeze(freezer)?,
             post_init_fn: self.post_init_fn.freeze(freezer)?,
+            implies: self.implies.freeze(freezer)?,
+            attr_spec: self.attr_spec.freeze(freezer)?,
             param_spec: self.param_spec,
         })
     }
@@ -767,12 +774,58 @@ pub(crate) fn interface_globals(builder: &mut GlobalsBuilder) {
         let heap = eval.heap();
         let mut fields = SmallMap::new();
         let mut post_init_fn = None;
+        let mut implies: Vec<Value<'v>> = Vec::new();
+        let mut attr_spec: SmallMap<String, Value<'v>> = SmallMap::new();
 
         // Process field specifications and validate reserved names
         for (name, v) in &kwargs {
             if name == "__post_init__" {
                 // Handle __post_init__ as direct function assignment
                 post_init_fn = Some(v.to_value());
+            } else if name == "attrs" {
+                let d =
+                    starlark::values::dict::DictRef::from_value(v.to_value()).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "interface(attrs=...) must be a dict of attribute name -> physical type; \
+                             `attrs` is reserved for capability metadata — rename the field if you \
+                             meant a connection field"
+                        )
+                    })?;
+                for (k, ty) in d.iter() {
+                    let key = k.unpack_str().ok_or_else(|| {
+                        anyhow::anyhow!("interface(attrs=...) keys must be strings")
+                    })?;
+                    if ty
+                        .downcast_ref::<pcb_sch::physical::PhysicalValueType>()
+                        .is_none()
+                    {
+                        return Err(anyhow::anyhow!(
+                            "interface(attrs=...): `{key}` must map to a physical value type (Voltage, Frequency, ...), got `{}`",
+                            ty.get_type()
+                        ));
+                    }
+                    attr_spec.insert(key.to_owned(), ty);
+                }
+            } else if name == "implies" {
+                let list =
+                    starlark::values::list::ListRef::from_value(v.to_value()).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "interface(implies=...) must be a list of interface types; `implies` \
+                             is reserved for capability metadata — rename the field if you meant \
+                             a connection field"
+                        )
+                    })?;
+                for item in list.iter() {
+                    if item.downcast_ref::<InterfaceFactory<'v>>().is_none()
+                        && item.downcast_ref::<FrozenInterfaceFactory>().is_none()
+                    {
+                        return Err(anyhow::anyhow!(
+                            "interface(implies=...) entries must be interface types, got `{}`",
+                            item.get_type()
+                        ));
+                    }
+                    implies.push(item);
+                }
             } else if name == "name" {
                 // Reject "name" as field name to avoid conflict with implicit parameter
                 return Err(anyhow::anyhow!(
@@ -817,9 +870,12 @@ pub(crate) fn interface_globals(builder: &mut GlobalsBuilder) {
 
         let factory = heap.alloc(InterfaceFactory {
             id: TypeInstanceId::r#gen(),
+            declaration_path: eval.source_path().unwrap_or_default(),
             interface_type_data: OnceCell::new(),
             fields,
             post_init_fn,
+            implies,
+            attr_spec,
             param_spec,
         });
 
@@ -873,6 +929,46 @@ pub(crate) fn instantiate_interface<'v>(
         "internal error: unexpected value type in instantiate_interface: {} (expected InterfaceFactory or InterfaceValue)",
         spec.get_type()
     ).into())
+}
+
+impl<'v, V: ValueLike<'v> + InterfaceCell> InterfaceFactoryGen<V> {
+    /// Return the map of field specifications (field name -> type value) that
+    /// define this interface. This is primarily used by the input
+    /// deserialization logic to determine the expected type for nested
+    /// interface fields when reconstructing an instance from a serialised
+    /// `InputValue`.
+    #[inline]
+    pub fn fields(&self) -> &SmallMap<String, V> {
+        &self.fields
+    }
+
+    /// Interface types this one implies (see `interface(implies=...)`).
+    #[inline]
+    pub fn implies(&self) -> &[V] {
+        &self.implies
+    }
+
+    /// Declared capability-attribute vocabulary (see `interface(attrs=...)`).
+    #[inline]
+    pub fn attr_spec(&self) -> &SmallMap<String, V> {
+        &self.attr_spec
+    }
+
+    /// Identity of this very `interface()` evaluation. Capability matching
+    /// keys on the declaration instead — see `nominal_id` in `pinmux.rs`.
+    pub fn evaluation_id(&self) -> TypeInstanceId {
+        self.id
+    }
+
+    /// File that declared this interface.
+    pub fn declaration_path(&self) -> &str {
+        &self.declaration_path
+    }
+
+    /// Best-effort display name: the exported variable name when known.
+    pub fn type_name(&self) -> Option<String> {
+        V::get_ty(&self.interface_type_data).map(|d| d.name.clone())
+    }
 }
 
 #[cfg(test)]

--- a/crates/pcb-zen-core/src/lang/mod.rs
+++ b/crates/pcb-zen-core/src/lang/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod param_decl;
 pub mod part;
 pub(crate) mod path;
 pub(crate) mod pin_erc;
+pub(crate) mod pinmux;
 pub mod spice_model;
 pub mod stackup;
 pub mod symbol;

--- a/crates/pcb-zen-core/src/lang/module.rs
+++ b/crates/pcb-zen-core/src/lang/module.rs
@@ -116,6 +116,9 @@ impl ModulePath {
         ModulePath { segments: vec![] }
     }
 
+    /// A root is a design boundary: elaboration state (pin constraints,
+    /// capability identities) starts empty here and never crosses. Loads and
+    /// children push a segment, so only a genuine root answers true.
     pub fn is_root(&self) -> bool {
         self.segments.is_empty()
     }

--- a/crates/pcb-zen-core/src/lang/net.rs
+++ b/crates/pcb-zen-core/src/lang/net.rs
@@ -600,10 +600,7 @@ pub(crate) fn instantiate_not_connected<'v>(
         }
     }
 
-    let (declaration_path, declaration_span) = eval
-        .call_stack_top_location()
-        .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
-        .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
+    let (declaration_path, declaration_span) = open_net_site(eval);
 
     if ignored_name.is_some() {
         eval.add_diagnostic(
@@ -617,7 +614,30 @@ pub(crate) fn instantiate_not_connected<'v>(
         );
     }
 
-    Ok(eval.heap().alloc(NetValue {
+    Ok(alloc_open_net_at(
+        eval.heap(),
+        declaration_path,
+        declaration_span,
+    ))
+}
+
+/// Where an open net is being created, for its declaration site.
+fn open_net_site<'v>(
+    eval: &Evaluator<'v, '_, '_>,
+) -> (String, Option<starlark::codemap::ResolvedSpan>) {
+    eval.call_stack_top_location()
+        .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
+        .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None))
+}
+
+/// The one place an intentionally open net is built. `NotConnected()` and
+/// `pin_map`'s tie-off both come through here.
+fn alloc_open_net_at<'v>(
+    heap: Heap<'v>,
+    declaration_path: String,
+    declaration_span: Option<starlark::codemap::ResolvedSpan>,
+) -> Value<'v> {
+    heap.alloc(NetValue {
         net_id: generate_net_id(),
         name: String::new(),
         template_name: None,
@@ -630,7 +650,13 @@ pub(crate) fn instantiate_not_connected<'v>(
         type_name: "Net".to_string(),
         connection_intent: ConnectionIntent::Open,
         properties: SmallMap::new(),
-    }))
+    })
+}
+
+/// An intentionally open net, as `NotConnected()` builds one.
+pub(crate) fn alloc_open_net<'v>(eval: &mut Evaluator<'v, '_, '_>) -> Value<'v> {
+    let (path, span) = open_net_site(eval);
+    alloc_open_net_at(eval.heap(), path, span)
 }
 
 /// A callable type constructor for creating typed nets

--- a/crates/pcb-zen-core/src/lang/param_decl.rs
+++ b/crates/pcb-zen-core/src/lang/param_decl.rs
@@ -32,6 +32,7 @@ use super::net::{
     FrozenNetType, FrozenNetValue, NetInstantiateIntent, NetInstantiateOptions, NetType,
     NetTypeGen, NetValue,
 };
+use super::pinmux::unwrap_pin_at;
 
 #[derive(Debug, Clone, Trace, Allocative)]
 struct DeclArgs<'v> {
@@ -404,6 +405,7 @@ fn resolve_config<'v>(
     let is_optional = args.optional.unwrap_or(default_value.is_some());
 
     let value = if let Some(provided) = eval.request_input(name)? {
+        let provided = crate::lang::pinmux::record_pin_at_in_config(name, provided, eval);
         convert_value(eval, provided)?
     } else if is_optional {
         default_value.unwrap_or_else(Value::new_none)
@@ -492,6 +494,7 @@ fn resolve_io<'v>(
     };
 
     let (value, metadata_default) = if let Some(provided) = eval.request_input(name)? {
+        let provided = unwrap_pin_at(name, provided, eval);
         let converted = validate_or_convert(name, provided, normalized.typ, eval)?;
         let converted = register_provided_io_net(name, converted, normalized.typ, eval)?;
         for failure in run_implicit_checks(name, &normalized.implicit_checks, converted) {

--- a/crates/pcb-zen-core/src/lang/pinmux.rs
+++ b/crates/pcb-zen-core/src/lang/pinmux.rs
@@ -1,0 +1,3583 @@
+//! Peripheral capability model: components declare what their pins *can do*,
+//! `pin_solve` performs the joint instance x pin assignment at elaboration,
+//! with exclusivity at both tiers structural (infeasible, not lint). Matching
+//! is nominal over `interface()` identities, closed over `implies=[...]`;
+//! results land in the `pin_assignment` / `swap_classes` module properties.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Mutex;
+
+use allocative::Allocative;
+use pcb_sch::physical::PhysicalValue;
+use starlark::collections::SmallMap;
+use starlark::environment::MethodsBuilder;
+use starlark::eval::Evaluator;
+use starlark::values::dict::{AllocDict, DictRef};
+use starlark::values::list::{ListRef, UnpackList};
+use starlark::values::none::NoneOr;
+use starlark::values::typing::TypeInstanceId;
+use starlark::values::{
+    Coerce, Freeze, Heap, NoSerialize, ProvidesStaticType, StarlarkValue, Trace, Value,
+    ValueLifetimeless, ValueLike, starlark_value,
+};
+use starlark::{starlark_complex_value, starlark_module};
+
+use crate::lang::evaluator_ext::EvaluatorExt;
+use crate::lang::interface::{
+    FrozenInterfaceFactory, FrozenInterfaceValue, InterfaceFactory, InterfaceValue,
+};
+use crate::lang::net::{FrozenNetType, FrozenNetValue, NetType, NetValue};
+
+const REBIND_VALUES: [&str; 3] = ["none", "firmware", "fixed"];
+/// Module properties `pin_solve` writes and merges across solves. User code
+/// records its own data elsewhere, so the merge always reads back what it
+/// wrote.
+/// The assignment first, its swap classes second: both `pin_solve` writing
+/// them and the builtin refusing them to user code read this one list.
+pub(crate) const RESULT_PROPERTIES: [&str; 2] = ["pin_assignment", "swap_classes"];
+const PINMAP_CAP: usize = 512;
+/// In conflict checks, not search nodes: a node scans up to `PINMAP_CAP`
+/// combos per providing instance.
+const SOLVER_BUDGET: usize = 2_000_000;
+const SOLVER_HARD_BUDGET: usize = 50_000_000;
+
+struct IfaceInfo<'v> {
+    id: TypeInstanceId,
+    name: String,
+    /// Net-typed leaves only, nested interfaces flattened (`Usb2.D` -> `D_P`,
+    /// `D_N`). `field()` metadata like `DiffPair.impedance` consumes no pin;
+    /// it reaches the router via `convert.rs` instead.
+    signals: Vec<String>,
+    implies: Vec<Value<'v>>,
+    /// Declared capability-attribute vocabulary: name -> physical type value.
+    attr_specs: Vec<(String, Value<'v>)>,
+}
+
+/// Fields of an interface *type* or *instance*, in declaration order.
+fn iface_fields<'v>(v: Value<'v>) -> Option<Vec<(String, Value<'v>)>> {
+    fn pairs<'v, V: ValueLike<'v>>(m: &SmallMap<String, V>) -> Vec<(String, Value<'v>)> {
+        m.iter().map(|(k, v)| (k.clone(), v.to_value())).collect()
+    }
+    if let Some(f) = v.downcast_ref::<InterfaceFactory<'v>>() {
+        Some(pairs(f.fields()))
+    } else if let Some(f) = v.downcast_ref::<FrozenInterfaceFactory>() {
+        Some(pairs(f.fields()))
+    } else if let Some(i) = v.downcast_ref::<InterfaceValue<'v>>() {
+        Some(pairs(i.fields()))
+    } else {
+        v.downcast_ref::<FrozenInterfaceValue>()
+            .map(|i| pairs(i.fields()))
+    }
+}
+
+/// `at()` constraints for the build, keyed by net: a net keeps its id across
+/// module boundaries, so a solve at any depth can claim one.
+#[derive(Default)]
+pub(crate) struct PinConstraints {
+    /// Set when a claim could not be settled; reported by the solve rather
+    /// than resolved arbitrarily.
+    ambiguous: Option<Ambiguity>,
+    entries: Vec<PinConstraintEntry>,
+    by_net: HashMap<u64, Vec<usize>>,
+    /// Solves that read an `at()` wrapper before its io() bound, keyed by
+    /// `(module, input, net)`: each pairs with exactly one later `record` of
+    /// that module, so parallel siblings cannot spend each other's.
+    preconsumed: HashMap<(Vec<String>, String, u64), usize>,
+}
+
+/// Why a claim could not be settled.
+enum Ambiguity {
+    /// Several inputs' constraints ride the net reaching this input.
+    Entries { input: String, names: String },
+}
+
+/// What claiming a caller constraint for one io() input yielded.
+enum Claimed {
+    /// The pins, and whether the `at()` was declared soft.
+    Yes(PinLock, bool),
+    No,
+    /// Several inputs' constraints ride the net; the solve reports it.
+    Ambiguous,
+    /// Another solve holds it. Recorded on the entry and reported at the
+    /// root, so this solve neither errors nor earns a credit.
+    Contended,
+}
+
+struct PinConstraintEntry {
+    input: String,
+    module: String,
+    /// Where the `at()` was written, so a build error can point at it.
+    span: Option<starlark::codemap::ResolvedSpan>,
+    /// Instance whose io() carried the wrapper. A solve may claim this entry
+    /// only from that instance or below it, so two parts sharing a net each
+    /// get their own constraint.
+    owner: Vec<String>,
+    lock: PinLock,
+    soft: bool,
+    /// Solve that took this constraint, if any. Only that same solve may take
+    /// it again, so re-solving a request keeps its pin while a sibling still
+    /// cannot steal it.
+    claimant: Option<Vec<String>>,
+    /// Solves that wanted it once taken. Children elaborate in parallel, so
+    /// the contention is reported at the root, from the `at()` site, rather
+    /// than by whichever solve happened to lose the race.
+    contested: Vec<Vec<String>>,
+}
+
+impl PinConstraints {
+    #[allow(clippy::too_many_arguments)]
+    fn record(
+        &mut self,
+        input: String,
+        module: String,
+        span: Option<starlark::codemap::ResolvedSpan>,
+        owner: Vec<String>,
+        nets: &[u64],
+        lock: PinLock,
+        soft: bool,
+    ) {
+        let key = |n: &u64| (owner.clone(), input.clone(), *n);
+        let credited = nets
+            .iter()
+            .any(|n| self.preconsumed.get(&key(n)).is_some_and(|c| *c > 0));
+        if credited {
+            for n in nets {
+                if let Some(c) = self.preconsumed.get_mut(&key(n)).filter(|c| **c > 0) {
+                    *c -= 1;
+                }
+            }
+        }
+        // The solve that left the credit is this very module.
+        let claimant = credited.then(|| owner.clone());
+        let idx = self.entries.len();
+        self.entries.push(PinConstraintEntry {
+            input,
+            module,
+            span,
+            owner,
+            lock,
+            soft,
+            claimant,
+            contested: Vec::new(),
+        });
+        for n in nets {
+            self.by_net.entry(*n).or_default().push(idx);
+        }
+    }
+
+    /// Settle `input`'s constraint for a solve that read it off the wrapper:
+    /// claim the entry when its io() already bound, else leave a credit for the
+    /// record still to come. Exactly one of the two, never both.
+    ///
+    /// Only this module's own entry for this input answers here. A constraint
+    /// owned higher up rides the same net but belongs to whoever claims it,
+    /// and what it is doing says nothing about whether ours was recorded.
+    fn settle(&mut self, nets: &[u64], solver: &[String], input: &str) {
+        let mine: Vec<usize> = nets
+            .iter()
+            .filter_map(|n| self.by_net.get(n))
+            .flatten()
+            .copied()
+            .filter(|i| {
+                let e = &self.entries[*i];
+                e.owner == solver
+                    && e.input == input
+                    && e.claimant.as_deref().is_none_or(|c| c == solver)
+            })
+            .collect();
+        if mine.is_empty() {
+            // The credit is keyed on this module, this input and this net, so
+            // only the record of this very declaration can spend it.
+            self.preconsume(solver, input, nets);
+            return;
+        }
+        for i in mine {
+            self.entries[i].claimant = Some(solver.to_vec());
+        }
+    }
+
+    fn preconsume(&mut self, solver: &[String], input: &str, nets: &[u64]) {
+        for n in nets {
+            *self
+                .preconsumed
+                .entry((solver.to_vec(), input.to_owned(), *n))
+                .or_default() += 1;
+        }
+    }
+
+    /// Claim the constraint for `input` of the module at `solver`. An entry
+    /// owned by that very module must name the same io() input — sibling
+    /// inputs often share a net and must not trade constraints. Entries owned
+    /// higher up have no such name to match, so the closest one wins and
+    /// forwarded constraints keep reaching nested solves. A second solve
+    /// wanting one already taken is reported, never served first-come.
+    /// Entries owned higher up that this solve could take, with their index.
+    /// The caller weighs them with the lock released: doing so runs a `where=`
+    /// predicate, and user code must never wait on the design-wide store.
+    fn candidate_locks(&self, nets: &[u64], solver: &[String]) -> Vec<(usize, PinLock)> {
+        nets.iter()
+            .filter_map(|n| self.by_net.get(n))
+            .flatten()
+            .copied()
+            .filter(|i| {
+                let e = &self.entries[*i];
+                e.owner.len() < solver.len()
+                    && solver.starts_with(&e.owner)
+                    && e.claimant.as_deref().is_none_or(|c| c == solver)
+            })
+            .map(|i| (i, self.entries[i].lock.clone()))
+            .collect()
+    }
+
+    /// `usable` names the entries owned higher up this solve can take; `None`
+    /// weighs none of them out.
+    fn claim(
+        &mut self,
+        nets: &[u64],
+        solver: &[String],
+        input: &str,
+        usable: Option<&HashSet<usize>>,
+    ) -> Claimed {
+        let mut eligible: Vec<usize> = Vec::new();
+        let mut held: Vec<usize> = Vec::new();
+        for i in nets
+            .iter()
+            .filter_map(|n| self.by_net.get(n))
+            .flatten()
+            .copied()
+        {
+            let e = &self.entries[i];
+            if !solver.starts_with(&e.owner) {
+                continue;
+            }
+            // Same module: only this very io() input's entry.
+            if e.owner.len() == solver.len() && e.input != input {
+                continue;
+            }
+            // Another solve got here first. Children elaborate in parallel, so
+            // leaving it at that would hand the pin to whichever ran first —
+            // and this must be read before the pin filter below, or a contest
+            // would go unseen whenever the winner claimed it first.
+            if e.claimant.as_deref().is_some_and(|c| c != solver) {
+                held.push(i);
+                continue;
+            }
+            // Owned higher up there is no name to pair with, so the pins do.
+            if e.owner.len() < solver.len() && usable.is_some_and(|set| !set.contains(&i)) {
+                continue;
+            }
+            eligible.push(i);
+        }
+
+        // Closest enclosing owner wins; among equals the matching input name
+        // decides. Entries are appended by parallel child evaluations, so a
+        // remaining tie is genuinely ambiguous rather than order-dependent.
+        let Some(depth) = eligible.iter().map(|i| self.entries[*i].owner.len()).max() else {
+            return self.contend(held, solver);
+        };
+        eligible.retain(|i| self.entries[*i].owner.len() == depth);
+        if eligible.iter().any(|i| self.entries[*i].input == input) {
+            eligible.retain(|i| self.entries[*i].input == input);
+        }
+        // Re-evaluation records the same declaration more than once, so only
+        // distinct input names are a genuine ambiguity.
+        let mut names: Vec<&str> = eligible
+            .iter()
+            .map(|i| self.entries[*i].input.as_str())
+            .collect();
+        names.sort_unstable();
+        names.dedup();
+        if names.len() > 1 {
+            self.ambiguous = Some(Ambiguity::Entries {
+                input: input.to_owned(),
+                names: names.join("`, `"),
+            });
+            return Claimed::Ambiguous;
+        }
+        let Some(&idx) = eligible.first() else {
+            return self.contend(held, solver);
+        };
+        // The group is one declaration recorded several times; claiming all of
+        // it keeps the duplicates from being reported as never consumed.
+        for i in &eligible {
+            self.entries[*i].claimant = Some(solver.to_vec());
+        }
+        let e = &self.entries[idx];
+        Claimed::Yes(e.lock.clone(), e.soft)
+    }
+
+    /// Note that `solver` wanted constraints another solve holds.
+    fn contend(&mut self, held: Vec<usize>, solver: &[String]) -> Claimed {
+        if held.is_empty() {
+            return Claimed::No;
+        }
+        for i in held {
+            let e = &mut self.entries[i];
+            if !e.contested.iter().any(|c| c == solver) {
+                e.contested.push(solver.to_vec());
+            }
+        }
+        Claimed::Contended
+    }
+
+    fn take_ambiguous(&mut self) -> Option<Ambiguity> {
+        self.ambiguous.take()
+    }
+
+    /// Constraints more than one solve wanted, with every contender sorted:
+    /// the winner depends on child-evaluation order, the report must not.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn contended(
+        &self,
+    ) -> Vec<(
+        String,
+        String,
+        Option<starlark::codemap::ResolvedSpan>,
+        Vec<String>,
+    )> {
+        let mut out: Vec<_> = self
+            .entries
+            .iter()
+            .filter(|e| !e.contested.is_empty())
+            .map(|e| {
+                let mut who: Vec<String> = e
+                    .claimant
+                    .iter()
+                    .chain(e.contested.iter())
+                    .map(|p| p.join("."))
+                    .collect();
+                who.sort();
+                who.dedup();
+                (e.module.clone(), e.input.clone(), e.span, who)
+            })
+            .collect();
+        out.sort_by(|a, b| (&a.0, &a.1).cmp(&(&b.0, &b.1)));
+        out
+    }
+
+    /// Hard constraints no solve claimed, as `(module, input, span)`, sorted.
+    pub(crate) fn unconsumed_hard(
+        &self,
+    ) -> Vec<(String, String, Option<starlark::codemap::ResolvedSpan>)> {
+        let mut out: Vec<_> = self
+            .entries
+            .iter()
+            .filter(|e| !e.soft && e.claimant.is_none())
+            .map(|e| (e.module.clone(), e.input.clone(), e.span))
+            .collect();
+        out.sort_by(|a, b| (&a.0, &a.1).cmp(&(&b.0, &b.1)));
+        out
+    }
+}
+
+/// Net ids reachable in `v` (a net, or an interface instance's net leaves).
+fn collect_net_ids<'v>(v: Value<'v>, out: &mut Vec<u64>) {
+    if let Some((id, _)) = net_identity(v) {
+        out.push(id);
+        return;
+    }
+    if let Some(fields) = iface_fields(v) {
+        for (_, val) in fields {
+            collect_net_ids(val, out);
+        }
+    }
+}
+
+/// Net identity (id, display name), if `v` is a net instance.
+fn net_identity<'v>(v: Value<'v>) -> Option<(u64, String)> {
+    if let Some(n) = v.downcast_ref::<NetValue<'v>>() {
+        return Some((n.id(), n.name().to_owned()));
+    }
+    v.downcast_ref::<FrozenNetValue>()
+        .map(|n| (n.id(), n.name().to_owned()))
+}
+
+/// A connection field (net type or net instance) as opposed to metadata.
+fn is_net_field<'v>(v: Value<'v>) -> bool {
+    v.downcast_ref::<NetType<'v>>().is_some()
+        || v.downcast_ref::<FrozenNetType>().is_some()
+        || v.downcast_ref::<NetValue<'v>>().is_some()
+        || v.downcast_ref::<FrozenNetValue>().is_some()
+}
+
+/// Net-typed leaves, nested fields flattened into `_`-joined paths. Runs on a
+/// type and on an instance alike, so declarations and `pin_map()` agree on the
+/// signal names by construction.
+fn net_leaves<'v>(v: Value<'v>) -> Vec<(String, Value<'v>)> {
+    fn walk<'v>(v: Value<'v>, prefix: &str, out: &mut Vec<(String, Value<'v>)>) {
+        let Some(fields) = iface_fields(v) else {
+            return;
+        };
+        for (name, val) in fields {
+            let path = if prefix.is_empty() {
+                name
+            } else {
+                format!("{prefix}_{name}")
+            };
+            if is_net_field(val) {
+                out.push((path, val));
+            } else {
+                // Nested interface; anything else is metadata and yields nothing.
+                walk(val, &path, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(v, "", &mut out);
+    out
+}
+
+/// Flattening can collide (`D: DiffPair` next to `D_P: Net`); one signal must
+/// not silently shadow the other.
+fn check_signal_names(info: &IfaceInfo<'_>) -> anyhow::Result<()> {
+    let mut seen = HashSet::new();
+    for s in &info.signals {
+        if !seen.insert(s.as_str()) {
+            return Err(anyhow::anyhow!(
+                "interface {}: nested fields flatten to two signals named `{s}` — rename one of them",
+                info.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// The build's interface-identity map, or a private one when there is no
+/// evaluation context (identities then matter only within the call).
+fn interface_ids<'v>(eval: &Evaluator<'v, '_, '_>) -> anyhow::Result<std::sync::Arc<InterfaceIds>> {
+    // A private map per call would hand out ids nothing else shares, so two
+    // capabilities from one declaration would quietly stop matching.
+    eval.eval_context()
+        .map(|c| c.interface_ids())
+        .ok_or_else(|| anyhow::anyhow!("pinmux: capability identity needs an evaluation context"))
+}
+
+/// Nominal interface identities for one build, keyed by declaration site.
+/// Session-scoped rather than process-global: sessions run concurrently, and a
+/// shared map would let one build hand another a stale id.
+pub(crate) type InterfaceIds = Mutex<HashMap<(String, String), TypeInstanceId>>;
+
+/// Identity of an interface *declaration* (file + exported name), so a file
+/// evaluated twice — the load cache is per package scope — stays one type.
+/// An interface never bound to a name keeps its per-evaluation identity.
+fn nominal_id(
+    ids: &InterfaceIds,
+    declaration_path: &str,
+    name: Option<String>,
+    evaluation_id: TypeInstanceId,
+) -> TypeInstanceId {
+    let Some(name) = name else {
+        return evaluation_id;
+    };
+    *ids.lock()
+        .unwrap()
+        .entry((declaration_path.to_owned(), name))
+        .or_insert_with(TypeInstanceId::r#gen)
+}
+
+fn iface_info<'v>(v: Value<'v>, ids: &InterfaceIds) -> Option<IfaceInfo<'v>> {
+    let signals = || net_leaves(v).into_iter().map(|(k, _)| k).collect();
+    if let Some(f) = v.downcast_ref::<InterfaceFactory<'v>>() {
+        return Some(IfaceInfo {
+            id: nominal_id(ids, f.declaration_path(), f.type_name(), f.evaluation_id()),
+            name: f.type_name().unwrap_or_else(|| v.to_string()),
+            signals: signals(),
+            implies: f.implies().iter().map(|x| x.to_value()).collect(),
+            attr_specs: f
+                .attr_spec()
+                .iter()
+                .map(|(k, t)| (k.clone(), t.to_value()))
+                .collect(),
+        });
+    }
+    if let Some(f) = v.downcast_ref::<FrozenInterfaceFactory>() {
+        return Some(IfaceInfo {
+            id: nominal_id(ids, f.declaration_path(), f.type_name(), f.evaluation_id()),
+            name: f.type_name().unwrap_or_else(|| v.to_string()),
+            signals: signals(),
+            implies: f.implies().iter().map(|x| x.to_value()).collect(),
+            attr_specs: f
+                .attr_spec()
+                .iter()
+                .map(|(k, t)| (k.clone(), t.to_value()))
+                .collect(),
+        });
+    }
+    None
+}
+
+/// BFS closure of an interface type over `implies`, deduplicated by nominal id.
+fn iface_closure<'v>(root: Value<'v>, ids: &InterfaceIds) -> anyhow::Result<Vec<IfaceInfo<'v>>> {
+    let root_info = iface_info(root, ids)
+        .ok_or_else(|| anyhow::anyhow!("expected an interface type, got `{}`", root.get_type()))?;
+    check_signal_names(&root_info)?;
+    let mut seen: HashSet<TypeInstanceId> = HashSet::new();
+    seen.insert(root_info.id);
+    let mut out = vec![root_info];
+    let mut cursor = 0;
+    while cursor < out.len() {
+        let implied: Vec<Value<'v>> = out[cursor].implies.clone();
+        cursor += 1;
+        for iv in implied {
+            let info = iface_info(iv, ids).ok_or_else(|| {
+                anyhow::anyhow!("interface(implies=...) entry is not an interface type")
+            })?;
+            if seen.insert(info.id) {
+                check_signal_names(&info)?;
+                out.push(info);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn dict_get<'v>(d: &DictRef<'v>, heap: Heap<'v>, key: &str) -> Option<Value<'v>> {
+    d.get(heap.alloc(key)).ok().flatten()
+}
+
+fn dict_get_str<'v>(d: &DictRef<'v>, heap: Heap<'v>, key: &str) -> Option<String> {
+    dict_get(d, heap, key).and_then(|v| v.unpack_str().map(|s| s.to_owned()))
+}
+
+fn is_kind<'v>(v: Value<'v>, heap: Heap<'v>, kind: &str) -> bool {
+    DictRef::from_value(v)
+        .map(|d| dict_get_str(&d, heap, "kind").as_deref() == Some(kind))
+        .unwrap_or(false)
+}
+
+#[derive(Clone, Debug)]
+struct RPin {
+    name: String,
+    /// Opaque realization data (e.g. an STM32 AF index, an ESP32 IOMUX FUNC
+    /// number): whatever downstream tooling needs to realize this candidate.
+    /// Never consulted by the solver; carried verbatim into the assignment.
+    data: Vec<(String, serde_json::Value)>,
+    cost: i64,
+    input_only: bool,
+    strap: bool,
+}
+
+struct RPeriph<'v> {
+    name: String,
+    /// Component this peripheral's pads belong to (`peripheral(part=)`).
+    part: String,
+    /// Index of `part` in the solve's part list.
+    part_idx: usize,
+    provides_ids: HashSet<TypeInstanceId>,
+    /// Display names of everything provided, for diagnostics only.
+    provides_names: HashSet<String>,
+    signals: Vec<(String, Vec<RPin>)>,
+    rebind: String,
+    attrs: Value<'v>,
+    unless: Option<String>,
+    pool: Option<String>,
+}
+
+impl RPeriph<'_> {
+    fn signal(&self, name: &str) -> Option<&Vec<RPin>> {
+        self.signals.iter().find(|(s, _)| s == name).map(|(_, p)| p)
+    }
+
+    /// Provides-set key for cluster swap grouping.
+    fn provides_key(&self) -> ProvidesKey {
+        let mut ids: Vec<String> = self.provides_ids.iter().map(|i| format!("{i:?}")).collect();
+        ids.sort();
+        ProvidesKey(ids.join(","))
+    }
+}
+
+/// Which capabilities a peripheral provides, as one comparable value. Built
+/// from `TypeInstanceId`s, minted per build: it tells clusters apart within a
+/// solve and means nothing outside it, so it is opaque — neither serializable
+/// nor orderable, which keeps it out of emitted data and of sort keys.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct ProvidesKey(String);
+
+#[derive(Clone)]
+struct RReq<'v> {
+    name: String,
+    iface_id: TypeInstanceId,
+    iface_name: String,
+    iface_closure_len: usize,
+    uses: Vec<String>,
+    instance: Option<String>,
+    prefer: PinLock,
+    lock: bool,
+    /// A caller's soft `at()` when the request is locked: it picks among the
+    /// pins the module made mandatory instead of voiding them.
+    soft_prefer: PinLock,
+    where_fn: Option<Value<'v>>,
+    direction: Option<String>,
+    /// Serve this request only when the module input of the same name was
+    /// actually connected by the caller (io() slot pattern).
+    if_connected: bool,
+    /// Value bound on the request itself (dict-of-roles pattern).
+    bind: Option<Value<'v>>,
+}
+
+impl RReq<'_> {
+    /// Pins `signal` may take when the request is locked: its own list, else
+    /// the bare list once it names as many pins as there are signals — with
+    /// pads exclusive, covering them all is the same requirement.
+    fn allowed(&self, signal: &str) -> Option<&[String]> {
+        if !self.lock {
+            return None;
+        }
+        let covering = !self.prefer.any.is_empty() && self.prefer.any.len() == self.uses.len();
+        self.prefer
+            .allowed(signal)
+            .or_else(|| covering.then_some(self.prefer.any.as_slice()))
+    }
+
+    /// Whether the lock holds `pin` where it is: a bare list must be claimed
+    /// in full, so the signal sitting on one of its pins cannot move without
+    /// dropping it.
+    fn pinned_by_lock(&self, pin: &str) -> bool {
+        self.lock && self.prefer.any.iter().any(|p| p == pin)
+    }
+
+    /// How much this request would rather have `pin`: what the request asked
+    /// for, and what a caller wished on top. A wish outranks the request's own
+    /// preference, and the two add up when they name the same pin.
+    fn bias(&self, pin: &str) -> i64 {
+        let mut b = 0;
+        if self.prefer.mentions(pin) {
+            b -= 10;
+        }
+        if self.soft_prefer.mentions(pin) {
+            b -= 25;
+        }
+        b
+    }
+}
+
+#[derive(Clone)]
+struct Combo {
+    periph_idx: usize,
+    pins: Vec<(String, RPin)>,
+    cost: i64,
+    key: String,
+}
+
+struct PrevAssign {
+    instance: String,
+    pins: HashMap<String, String>,
+}
+
+fn parse_rpin<'v>(v: Value<'v>, heap: Heap<'v>, ctx: &str) -> anyhow::Result<RPin> {
+    if let Some(s) = v.unpack_str() {
+        return Ok(RPin {
+            name: s.to_owned(),
+            data: Vec::new(),
+            cost: 0,
+            input_only: false,
+            strap: false,
+        });
+    }
+    let d = DictRef::from_value(v)
+        .ok_or_else(|| anyhow::anyhow!("{ctx}: pin candidate must be pin() or a string"))?;
+    if dict_get_str(&d, heap, "kind").as_deref() != Some("pin") {
+        return Err(anyhow::anyhow!(
+            "{ctx}: pin candidate must be pin() or a string"
+        ));
+    }
+    let mut data = Vec::new();
+    if let Some(dv) = dict_get(&d, heap, "data")
+        && let Some(dd) = DictRef::from_value(dv)
+    {
+        for (k, val) in dd.iter() {
+            let key = k
+                .unpack_str()
+                .ok_or_else(|| anyhow::anyhow!("{ctx}: pin() data keys must be strings"))?;
+            if key == "pin" {
+                return Err(anyhow::anyhow!(
+                    "{ctx}: pin() data key `pin` is reserved (it names the pin itself in the assignment)"
+                ));
+            }
+            let json = val
+                .to_json()
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("{ctx}: pin() data value for `{key}` is not serializable")
+                })?;
+            data.push((key.to_owned(), json));
+        }
+    }
+    Ok(RPin {
+        name: dict_get_str(&d, heap, "name")
+            .ok_or_else(|| anyhow::anyhow!("{ctx}: pin() missing name"))?,
+        data,
+        cost: dict_get(&d, heap, "cost")
+            .and_then(|v| v.unpack_i32())
+            .unwrap_or(0) as i64,
+        input_only: dict_get(&d, heap, "input_only")
+            .map(|v| v.to_bool())
+            .unwrap_or(false),
+        strap: dict_get(&d, heap, "strap")
+            .map(|v| v.to_bool())
+            .unwrap_or(false),
+    })
+}
+
+fn parse_rperiph<'v>(
+    v: Value<'v>,
+    heap: Heap<'v>,
+    ids: &InterfaceIds,
+) -> anyhow::Result<RPeriph<'v>> {
+    let d = DictRef::from_value(v).ok_or_else(|| {
+        anyhow::anyhow!("pin_solve: peripherals must be peripheral()/pool() values")
+    })?;
+    if dict_get_str(&d, heap, "kind").as_deref() != Some("peripheral") {
+        return Err(anyhow::anyhow!(
+            "pin_solve: peripherals must be peripheral()/pool() values"
+        ));
+    }
+    let name = dict_get_str(&d, heap, "name")
+        .ok_or_else(|| anyhow::anyhow!("pin_solve: peripheral missing name"))?;
+    let provides = dict_get(&d, heap, "provides")
+        .ok_or_else(|| anyhow::anyhow!("peripheral `{name}`: missing provides"))?;
+    let provides_list = ListRef::from_value(provides)
+        .ok_or_else(|| anyhow::anyhow!("peripheral `{name}`: provides must be a list"))?;
+    let mut provides_ids = HashSet::new();
+    let mut provides_names = HashSet::new();
+    for p in provides_list.iter() {
+        for info in iface_closure(p, ids)? {
+            provides_ids.insert(info.id);
+            provides_names.insert(info.name.clone());
+        }
+    }
+    let signals_v = dict_get(&d, heap, "signals")
+        .ok_or_else(|| anyhow::anyhow!("peripheral `{name}`: missing signals"))?;
+    let signals_d = DictRef::from_value(signals_v)
+        .ok_or_else(|| anyhow::anyhow!("peripheral `{name}`: signals must be a dict"))?;
+    let mut signals = Vec::new();
+    for (k, cand_list) in signals_d.iter() {
+        let sig = k
+            .unpack_str()
+            .ok_or_else(|| anyhow::anyhow!("peripheral `{name}`: signal names must be strings"))?
+            .to_owned();
+        let cl = ListRef::from_value(cand_list).ok_or_else(|| {
+            anyhow::anyhow!("peripheral `{name}`: signal `{sig}` candidates must be a list")
+        })?;
+        let mut pins = Vec::new();
+        for c in cl.iter() {
+            pins.push(parse_rpin(
+                c,
+                heap,
+                &format!("peripheral `{name}` signal `{sig}`"),
+            )?);
+        }
+        signals.push((sig, pins));
+    }
+    Ok(RPeriph {
+        name,
+        part: dict_get_str(&d, heap, "part").unwrap_or_default(),
+        part_idx: 0,
+        provides_ids,
+        provides_names,
+        signals,
+        rebind: dict_get_str(&d, heap, "rebind").unwrap_or_else(|| "firmware".to_owned()),
+        attrs: dict_get(&d, heap, "attrs").unwrap_or_else(Value::new_none),
+        unless: dict_get_str(&d, heap, "unless"),
+        pool: dict_get_str(&d, heap, "pool"),
+    })
+}
+
+fn parse_rreq<'v>(v: Value<'v>, heap: Heap<'v>, ids: &InterfaceIds) -> anyhow::Result<RReq<'v>> {
+    let d = DictRef::from_value(v)
+        .ok_or_else(|| anyhow::anyhow!("pin_solve: requests must be pin_request() values"))?;
+    if dict_get_str(&d, heap, "kind").as_deref() != Some("request") {
+        return Err(anyhow::anyhow!(
+            "pin_solve: requests must be pin_request() values"
+        ));
+    }
+    let name = dict_get_str(&d, heap, "name")
+        .ok_or_else(|| anyhow::anyhow!("pin_solve: request missing name"))?;
+    let iface = dict_get(&d, heap, "iface")
+        .ok_or_else(|| anyhow::anyhow!("request `{name}`: missing interface"))?;
+    let closure = iface_closure(iface, ids)?;
+    let uses = match dict_get(&d, heap, "uses") {
+        Some(u) if !u.is_none() => ListRef::from_value(u)
+            .ok_or_else(|| anyhow::anyhow!("request `{name}`: uses must be a list"))?
+            .iter()
+            .map(|s| {
+                s.unpack_str().map(|s| s.to_owned()).ok_or_else(|| {
+                    anyhow::anyhow!("request `{name}`: uses entries must be strings")
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?,
+        _ => closure[0].signals.clone(),
+    };
+    if uses.is_empty() {
+        return Err(anyhow::anyhow!(
+            "request `{name}`: uses must name at least one signal"
+        ));
+    }
+    let mut seen_uses = HashSet::new();
+    for s in &uses {
+        if !seen_uses.insert(s.as_str()) {
+            return Err(anyhow::anyhow!(
+                "request `{name}`: duplicate signal `{s}` in uses"
+            ));
+        }
+    }
+    let prefer_by_signal = match dict_get(&d, heap, "prefer_by_signal") {
+        Some(v) if !v.is_none() => {
+            let dd = DictRef::from_value(v).ok_or_else(|| {
+                anyhow::anyhow!("request `{name}`: prefer_by_signal must be a dict")
+            })?;
+            let mut out = Vec::new();
+            for (k, val) in dd.iter() {
+                let sig = k
+                    .unpack_str()
+                    .ok_or_else(|| anyhow::anyhow!("request `{name}`: signal must be a string"))?;
+                let list = ListRef::from_value(val).ok_or_else(|| {
+                    anyhow::anyhow!("request `{name}`: prefer_by_signal values must be lists")
+                })?;
+                let pins: Vec<String> = list
+                    .iter()
+                    .map(|e| {
+                        e.unpack_str().map(|s| s.to_owned()).ok_or_else(|| {
+                            anyhow::anyhow!("request `{name}`: pin names must be strings")
+                        })
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                out.push((sig.to_owned(), pins));
+            }
+            out
+        }
+        _ => Vec::new(),
+    };
+    let prefer_any = match dict_get(&d, heap, "prefer") {
+        Some(p) if !p.is_none() => ListRef::from_value(p)
+            .ok_or_else(|| anyhow::anyhow!("request `{name}`: prefer must be a list"))?
+            .iter()
+            .map(|s| {
+                s.unpack_str().map(|s| s.to_owned()).ok_or_else(|| {
+                    anyhow::anyhow!("request `{name}`: prefer entries must be strings")
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?,
+        _ => Vec::new(),
+    };
+    let prefer = PinLock {
+        any: prefer_any,
+        by_signal: prefer_by_signal,
+    };
+    Ok(RReq {
+        name,
+        iface_id: closure[0].id,
+        iface_name: closure[0].name.clone(),
+        iface_closure_len: closure.len(),
+        uses,
+        instance: dict_get_str(&d, heap, "instance"),
+        prefer,
+        lock: dict_get(&d, heap, "lock")
+            .map(|v| v.to_bool())
+            .unwrap_or(false),
+        soft_prefer: PinLock::default(),
+        where_fn: dict_get(&d, heap, "where").filter(|v| !v.is_none()),
+        direction: dict_get_str(&d, heap, "direction"),
+        if_connected: dict_get(&d, heap, "if_connected")
+            .map(|v| v.to_bool())
+            .unwrap_or(false),
+        bind: dict_get(&d, heap, "bind").filter(|v| !v.is_none()),
+    })
+}
+
+fn parse_previous<'v>(v: Value<'v>, heap: Heap<'v>) -> HashMap<String, PrevAssign> {
+    let mut out = HashMap::new();
+    let Some(d) = DictRef::from_value(v) else {
+        return out;
+    };
+    for (k, entry) in d.iter() {
+        let (Some(req), Some(ed)) = (k.unpack_str(), DictRef::from_value(entry)) else {
+            continue;
+        };
+        let Some(instance) = dict_get_str(&ed, heap, "instance") else {
+            continue;
+        };
+        let mut pins = HashMap::new();
+        if let Some(sigs) = dict_get(&ed, heap, "signals").and_then(DictRef::from_value) {
+            for (s, pv) in sigs.iter() {
+                if let (Some(sig), Some(pd)) = (s.unpack_str(), DictRef::from_value(pv))
+                    && let Some(pin) = dict_get_str(&pd, heap, "pin")
+                {
+                    pins.insert(sig.to_owned(), pin);
+                }
+            }
+        }
+        out.insert(req.to_owned(), PrevAssign { instance, pins });
+    }
+    out
+}
+
+fn config_truthy<'v>(config: &SmallMap<String, Value<'v>>, key: &str) -> bool {
+    config.get(key).map(|v| v.to_bool()).unwrap_or(false)
+}
+
+#[allow(clippy::type_complexity)]
+fn combos_for_request<'v>(
+    req: &RReq<'v>,
+    periphs: &[RPeriph<'v>],
+    config: &SmallMap<String, Value<'v>>,
+    previous: &HashMap<String, PrevAssign>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<(Vec<Combo>, Vec<(String, String)>, Vec<String>)> {
+    let mut out: Vec<Combo> = Vec::new();
+    let mut capped_periphs: Vec<String> = Vec::new();
+    let mut rejects: Vec<(String, String)> = Vec::new();
+    let prev = previous.get(&req.name);
+
+    for (pi, p) in periphs.iter().enumerate() {
+        if let Some(axis) = &p.unless
+            && config_truthy(config, axis)
+        {
+            rejects.push((p.name.clone(), format!("disabled by config axis `{axis}`")));
+            continue;
+        }
+        if !p.provides_ids.contains(&req.iface_id) {
+            // Same display name, different identity: two `interface()` calls,
+            // which are two capabilities however alike they look.
+            let reason = if p.provides_names.contains(&req.iface_name) {
+                format!(
+                    "provides a different {} — capability types are per interface() declaration, so two declarations never match",
+                    req.iface_name
+                )
+            } else {
+                format!("does not provide {}", req.iface_name)
+            };
+            rejects.push((p.name.clone(), reason));
+            continue;
+        }
+        if let Some(inst) = &req.instance
+            && p.name != *inst
+            && p.pool.as_deref() != Some(inst.as_str())
+        {
+            rejects.push((p.name.clone(), format!("instance pinned to `{inst}`")));
+            continue;
+        }
+        if let Some(where_fn) = req.where_fn {
+            // A predicate that trips over an attr this provider does not set
+            // rejects the candidate; it must not sink the whole solve.
+            match eval.eval_function(where_fn, &[p.attrs], &[]) {
+                Ok(v) if v.to_bool() => {}
+                Ok(_) => {
+                    rejects.push((p.name.clone(), "where= predicate rejected".to_owned()));
+                    continue;
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    let first = msg.lines().next().unwrap_or("error").trim().to_owned();
+                    rejects.push((p.name.clone(), format!("where= predicate failed: {first}")));
+                    continue;
+                }
+            }
+        }
+
+        // Candidate pins per used signal (direction-filtered).
+        let mut cand_lists: Vec<(&str, Vec<&RPin>)> = Vec::new();
+        let mut dead: Option<&str> = None;
+        for s in &req.uses {
+            let Some(cands) = p.signal(s) else {
+                dead = Some(s);
+                break;
+            };
+            let usable: Vec<&RPin> = cands
+                .iter()
+                .filter(|c| !(req.direction.as_deref() == Some("output") && c.input_only))
+                .collect();
+            if usable.is_empty() {
+                dead = Some(s);
+                break;
+            }
+            cand_lists.push((s, usable));
+        }
+        if let Some(s) = dead {
+            rejects.push((
+                p.name.clone(),
+                format!("no usable candidate for signal `{s}`"),
+            ));
+            continue;
+        }
+
+        // Narrow the enumeration where the lock allows it: a per-signal entry
+        // restricts that signal exactly, `any` pins only when they must fill
+        // every signal. Otherwise they are merely enumerated first, so a wide
+        // matrix can still truncate away a feasible combination — the `capped`
+        // warning covers that case.
+        let mut starved: Option<(String, Vec<String>)> = None;
+        {
+            for (sig, cands) in cand_lists.iter_mut() {
+                let allowed: Option<&[String]> = req.allowed(sig);
+                if let Some(allowed) = allowed {
+                    *cands = cands
+                        .iter()
+                        .copied()
+                        .filter(|c| allowed.contains(&c.name))
+                        .collect();
+                    if cands.is_empty() && starved.is_none() {
+                        starved = Some(((*sig).to_owned(), allowed.to_vec()));
+                    }
+                }
+            }
+        }
+        if !(req.prefer.is_empty() && req.soft_prefer.is_empty()) {
+            for (_, cands) in cand_lists.iter_mut() {
+                cands.sort_by_key(|c| req.bias(&c.name));
+            }
+        }
+
+        // Enumerate pin maps (product), excluding duplicate pins within the instance.
+        let mut pinmaps: Vec<Vec<(String, RPin)>> = vec![Vec::new()];
+        let mut truncated = false;
+        for (s, cands) in &cand_lists {
+            let mut next = Vec::new();
+            'bases: for base in &pinmaps {
+                let usable = cands
+                    .iter()
+                    .filter(|c| !base.iter().any(|(_, b)| b.name == c.name));
+                for c in usable {
+                    if next.len() >= PINMAP_CAP {
+                        truncated = true;
+                        break 'bases;
+                    }
+                    let mut d = base.clone();
+                    d.push(((*s).to_owned(), (*c).clone()));
+                    next.push(d);
+                }
+            }
+            pinmaps = next;
+        }
+        if truncated {
+            capped_periphs.push(p.name.clone());
+        }
+
+        let surplus = p.provides_ids.len() as i64 - req.iface_closure_len as i64;
+        let had_pinmaps = !pinmaps.is_empty();
+        let combos_before = out.len();
+        for pm in pinmaps {
+            // A bare pin list must be claimed in full, whatever the signal
+            // count; a per-signal entry bounds that signal's choice.
+            if req.lock && !req.prefer.is_empty() {
+                let all_claimed = req
+                    .prefer
+                    .any
+                    .iter()
+                    .all(|p| pm.iter().any(|(_, c)| c.name == *p));
+                let per_signal_ok = req.prefer.by_signal.iter().all(|(sig, allowed)| {
+                    pm.iter()
+                        .find(|(s, _)| s == sig)
+                        .is_none_or(|(_, c)| allowed.contains(&c.name))
+                });
+                if !(all_claimed && per_signal_ok) {
+                    continue;
+                }
+            }
+            let mut cost = 100 * surplus;
+            for (sig, c) in &pm {
+                cost += c.cost;
+                if c.strap {
+                    cost += 50;
+                }
+                cost += req.bias(&c.name);
+                if let Some(prev) = prev
+                    && prev.pins.get(sig) == Some(&c.name)
+                {
+                    cost -= 5;
+                }
+            }
+            if let Some(prev) = prev
+                && prev.instance == p.name
+            {
+                cost -= 20;
+            }
+            let key = pm
+                .iter()
+                .map(|(s, c)| format!("{s}={}", c.name))
+                .collect::<Vec<_>>()
+                .join(",");
+            out.push(Combo {
+                periph_idx: pi,
+                pins: pm,
+                cost,
+                key,
+            });
+        }
+        if out.len() == combos_before {
+            let reason = if let Some((sig, allowed)) = &starved {
+                format!(
+                    "signal `{sig}` has no candidate among the locked pins `{}`",
+                    allowed.join("`, `")
+                )
+            } else if had_pinmaps {
+                format!(
+                    "no pin combination satisfies the locked pins `{}`",
+                    req.prefer.names().join("`, `")
+                )
+            } else {
+                "candidate pins collide within the instance".to_owned()
+            };
+            rejects.push((p.name.clone(), reason));
+        }
+    }
+
+    out.sort_by(|a, b| {
+        (a.cost, &periphs[a.periph_idx].name, &a.key).cmp(&(
+            b.cost,
+            &periphs[b.periph_idx].name,
+            &b.key,
+        ))
+    });
+    Ok((out, rejects, capped_periphs))
+}
+
+enum AssignOutcome {
+    Solved {
+        chosen: Vec<usize>,
+        capped: bool,
+    },
+    Infeasible,
+    /// Hard ceiling hit with no incumbent: feasibility neither proven nor
+    /// refuted — reported as such, never as infeasibility.
+    Unknown,
+}
+
+/// Deterministic branch-and-bound over the joint assignment space (pin
+/// conflicts couple otherwise independent instance choices, so this is
+/// constraint optimization, not plain matching). Candidates are explored in
+/// per-request cost order and pruned with an admissible lower bound, so the
+/// result minimizes total cost. `SOLVER_BUDGET` only bounds the search for a
+/// cheaper solution once one exists (`capped` reports the cut); with no
+/// incumbent the search runs to the first feasible assignment, proven
+/// infeasibility, or the unconditional `SOLVER_HARD_BUDGET` ceiling
+/// (`Unknown`) so pathological instances cannot hang the build.
+fn assign<'v>(reqs: &[RReq<'v>], all_combos: &[Vec<Combo>], part_of: &[usize]) -> AssignOutcome {
+    let n = reqs.len();
+    if n == 0 {
+        return AssignOutcome::Solved {
+            chosen: Vec::new(),
+            capped: false,
+        };
+    }
+    // Evaluation order: locked first, then fewest candidates, then declaration order.
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by_key(|&i| (!reqs[i].lock, all_combos[i].len(), i));
+
+    // Admissible bound: combos are cost-sorted, so index 0 is each request's floor.
+    // suffix_min[k] = total floor of everything not yet placed at position k.
+    let mut suffix_min = vec![0i64; n + 1];
+    for k in (0..n).rev() {
+        suffix_min[k] = suffix_min[k + 1] + all_combos[order[k]][0].cost;
+    }
+
+    // Pads interned once: the conflict scan below runs up to the hard budget,
+    // so it must not allocate. `pads[ri][ci]` holds a combo's pad ids, which
+    // already carry the part a pin name belongs to.
+    let mut ids: HashMap<(usize, &str), usize> = HashMap::new();
+    let pads: Vec<Vec<Vec<usize>>> = all_combos
+        .iter()
+        .map(|combos| {
+            combos
+                .iter()
+                .map(|c| {
+                    let part = part_of[c.periph_idx];
+                    c.pins
+                        .iter()
+                        .map(|(_, p)| {
+                            let next = ids.len();
+                            *ids.entry((part, p.name.as_str())).or_insert(next)
+                        })
+                        .collect()
+                })
+                .collect()
+        })
+        .collect();
+    let mut used_pad = vec![false; ids.len()];
+
+    let mut choice = vec![0usize; n];
+    // chosen combo index per request (by original request index)
+    let mut assigned: Vec<Option<usize>> = vec![None; n];
+    let mut partial_cost = vec![0i64; n + 1];
+    let mut used_inst: HashSet<usize> = HashSet::new();
+    let mut best: Option<(i64, Vec<usize>)> = None;
+    let mut pos: usize = 0;
+    let mut spent = 0usize;
+    let mut capped = false;
+
+    loop {
+        if spent >= SOLVER_BUDGET && best.is_some() {
+            capped = true;
+            break;
+        }
+        if spent >= SOLVER_HARD_BUDGET {
+            return AssignOutcome::Unknown;
+        }
+        spent += 1;
+        if pos == n {
+            let total = partial_cost[n];
+            // Strict improvement keeps the first (deterministic) optimum.
+            if best.as_ref().map(|(b, _)| total < *b).unwrap_or(true) {
+                best = Some((total, assigned.iter().map(|c| c.unwrap()).collect()));
+            }
+            // Keep searching for a cheaper solution: force a backtrack.
+            pos -= 1;
+            let back_ri = order[pos];
+            let back_ci = assigned[back_ri].unwrap();
+            used_inst.remove(&all_combos[back_ri][back_ci].periph_idx);
+            for &pad in &pads[back_ri][back_ci] {
+                used_pad[pad] = false;
+            }
+            assigned[back_ri] = None;
+            choice[pos] += 1;
+            continue;
+        }
+        let ri = order[pos];
+        let combos = &all_combos[ri];
+        let mut placed = false;
+        let mut ci = choice[pos];
+        while ci < combos.len() {
+            let c = &combos[ci];
+            // Cost-sorted candidates: once the bound reaches the incumbent,
+            // every later candidate in this subtree is at least as expensive.
+            if let Some((b, _)) = &best
+                && partial_cost[pos] + c.cost + suffix_min[pos + 1] >= *b
+            {
+                break;
+            }
+            // Charged per check, not per node: this scan is where the time goes.
+            spent += 1;
+            let clash =
+                used_inst.contains(&c.periph_idx) || pads[ri][ci].iter().any(|&pad| used_pad[pad]);
+            if !clash {
+                choice[pos] = ci;
+                assigned[ri] = Some(ci);
+                used_inst.insert(c.periph_idx);
+                for &pad in &pads[ri][ci] {
+                    used_pad[pad] = true;
+                }
+                partial_cost[pos + 1] = partial_cost[pos] + c.cost;
+                placed = true;
+                break;
+            }
+            ci += 1;
+        }
+        if placed {
+            pos += 1;
+            if pos < n {
+                choice[pos] = 0;
+            }
+        } else {
+            choice[pos] = 0;
+            if pos == 0 {
+                break;
+            }
+            pos -= 1;
+            let back_ri = order[pos];
+            let back_ci = assigned[back_ri].unwrap();
+            used_inst.remove(&all_combos[back_ri][back_ci].periph_idx);
+            for &pad in &pads[back_ri][back_ci] {
+                used_pad[pad] = false;
+            }
+            assigned[back_ri] = None;
+            choice[pos] += 1;
+        }
+    }
+    match best {
+        Some((_, chosen)) => AssignOutcome::Solved { chosen, capped },
+        None => AssignOutcome::Infeasible,
+    }
+}
+
+fn json_to_value<'v>(heap: Heap<'v>, v: &serde_json::Value) -> Value<'v> {
+    match v {
+        serde_json::Value::Null => Value::new_none(),
+        serde_json::Value::Bool(b) => Value::new_bool(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                heap.alloc(i)
+            } else if let Some(u) = n.as_u64() {
+                // Vendor data above i64::MAX still round-trips as an integer.
+                heap.alloc(u)
+            } else {
+                heap.alloc(n.as_f64().unwrap_or(0.0))
+            }
+        }
+        serde_json::Value::String(s) => heap.alloc(s.as_str()),
+        serde_json::Value::Array(items) => {
+            let vals: Vec<Value> = items.iter().map(|i| json_to_value(heap, i)).collect();
+            heap.alloc(vals)
+        }
+        serde_json::Value::Object(map) => {
+            let pairs: Vec<(Value, Value)> = map
+                .iter()
+                .map(|(k, val)| (heap.alloc(k.as_str()), json_to_value(heap, val)))
+                .collect();
+            heap.alloc(AllocDict(pairs))
+        }
+    }
+}
+
+fn warn_at_call_site(eval: &mut Evaluator<'_, '_, '_>, msg: String) {
+    if let Some(loc) = eval.call_stack_top_location() {
+        let mut diag =
+            starlark::errors::EvalMessage::from_any_error(Path::new(loc.filename()), &msg);
+        diag.span = Some(loc.resolve_span());
+        diag.severity = starlark::errors::EvalSeverity::Warning;
+        eval.add_diagnostic(diag);
+    }
+}
+
+/// Wrapper produced by `at(value, pins, soft=)`: the caller constrains which
+/// physical pin(s) a capability may land on, on the connection itself
+/// (`Mcu(IO0 = at(led_net, "PA8"))`). `io()` unwraps it at binding time: the
+/// inner value flows as if passed directly, and the constraint is recorded on
+/// the module context for `pin_solve` to consume.
+#[derive(Clone, Debug, Coerce, Trace, ProvidesStaticType, NoSerialize, Allocative, Freeze)]
+#[repr(C)]
+pub struct PinAtGen<V: ValueLifetimeless> {
+    pub inner: V,
+    /// Where `at()` was written, so an unmet constraint points at the caller.
+    pub site: String,
+    #[freeze(identity)]
+    #[trace(unsafe_ignore)]
+    #[allocative(skip)]
+    pub span: Option<starlark::codemap::ResolvedSpan>,
+    pub pins: Vec<String>,
+    pub pins_by_signal: Vec<(String, Vec<String>)>,
+    pub soft: bool,
+}
+
+starlark_complex_value!(pub PinAt);
+
+#[starlark_value(type = "PinAt")]
+impl<'v, V: ValueLike<'v>> StarlarkValue<'v> for PinAtGen<V> where Self: ProvidesStaticType<'v> {}
+
+impl<'v, V: ValueLike<'v>> std::fmt::Display for PinAtGen<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "at({}, {:?})", self.inner, self.pins)
+    }
+}
+
+/// Pins a request is pinned to. `any` names pins that must each be claimed by
+/// some signal; `by_signal` bounds what one named signal may take.
+#[derive(Clone, Debug, Default)]
+struct PinLock {
+    any: Vec<String>,
+    by_signal: Vec<(String, Vec<String>)>,
+}
+
+impl PinLock {
+    fn is_empty(&self) -> bool {
+        self.any.is_empty() && self.by_signal.is_empty()
+    }
+
+    fn allowed(&self, signal: &str) -> Option<&[String]> {
+        self.by_signal
+            .iter()
+            .find(|(s, _)| s == signal)
+            .map(|(_, p)| p.as_slice())
+    }
+
+    /// Does `pin` appear anywhere in the lock? Drives the cost bias.
+    fn mentions(&self, pin: &str) -> bool {
+        self.any.iter().any(|p| p == pin)
+            || self
+                .by_signal
+                .iter()
+                .any(|(_, ps)| ps.iter().any(|p| p == pin))
+    }
+
+    /// Every per-signal entry must name a signal the request actually uses,
+    /// or the requirement would quietly evaporate at combo-check time.
+    fn check_signals(&self, ctx: &str, uses: &[String]) -> anyhow::Result<()> {
+        for (sig, _) in &self.by_signal {
+            if !uses.iter().any(|u| u == sig) {
+                return Err(anyhow::anyhow!(
+                    "{ctx}: pin constraint names signal `{sig}`, which this request does not use (it uses {})",
+                    uses.iter()
+                        .map(|s| format!("`{s}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn names(&self) -> Vec<String> {
+        let mut out = self.any.clone();
+        for (s, ps) in &self.by_signal {
+            for p in ps {
+                out.push(format!("{s}={p}"));
+            }
+        }
+        out
+    }
+}
+
+/// `(pins to claim, per-signal allowed pins)`.
+type PinSpec = (Vec<String>, Vec<(String, Vec<String>)>);
+
+/// A pin spec: a pin name, a list of pin names (each must be claimed), or a
+/// dict of signal -> pin(s) bounding one signal's choice.
+fn parse_pin_spec<'v>(ctx: &str, v: Value<'v>, heap: Heap<'v>) -> anyhow::Result<PinSpec> {
+    fn names(ctx: &str, v: Value<'_>) -> anyhow::Result<Vec<String>> {
+        if let Some(s) = v.unpack_str() {
+            return Ok(vec![s.to_owned()]);
+        }
+        let list = ListRef::from_value(v).ok_or_else(|| {
+            anyhow::anyhow!(
+                "{ctx}: expected a pin name or a list of pin names, got `{}`",
+                v.get_type()
+            )
+        })?;
+        list.iter()
+            .map(|e| {
+                e.unpack_str()
+                    .map(|s| s.to_owned())
+                    .ok_or_else(|| anyhow::anyhow!("{ctx}: pin names must be strings"))
+            })
+            .collect()
+    }
+
+    if let Some(d) = DictRef::from_value(v) {
+        let mut by_signal = Vec::new();
+        for (k, val) in d.iter() {
+            let sig = k
+                .unpack_str()
+                .ok_or_else(|| anyhow::anyhow!("{ctx}: signal names must be strings"))?;
+            let pins = names(ctx, val)?;
+            if pins.is_empty() {
+                return Err(anyhow::anyhow!("{ctx}: signal `{sig}` lists no pin"));
+            }
+            by_signal.push((sig.to_owned(), pins));
+        }
+        if by_signal.is_empty() {
+            return Err(anyhow::anyhow!("{ctx}: pins must not be empty"));
+        }
+        let _ = heap;
+        return Ok((Vec::new(), by_signal));
+    }
+    let any = names(ctx, v)?;
+    if any.is_empty() {
+        return Err(anyhow::anyhow!("{ctx}: pins must not be empty"));
+    }
+    Ok((any, Vec::new()))
+}
+
+/// `(inner, lock, soft, site, span)` of an `at()` wrapper, if `v` is one.
+#[allow(clippy::type_complexity)]
+fn unpack_pin_at_full<'v>(
+    v: Value<'v>,
+) -> Option<(
+    Value<'v>,
+    PinLock,
+    bool,
+    String,
+    Option<starlark::codemap::ResolvedSpan>,
+)> {
+    if let Some(w) = v.downcast_ref::<PinAt<'v>>() {
+        return Some((
+            w.inner.to_value(),
+            PinLock {
+                any: w.pins.clone(),
+                by_signal: w.pins_by_signal.clone(),
+            },
+            w.soft,
+            w.site.clone(),
+            w.span,
+        ));
+    }
+    v.downcast_ref::<FrozenPinAt>().map(|w| {
+        (
+            w.inner.to_value(),
+            PinLock {
+                any: w.pins.clone(),
+                by_signal: w.pins_by_signal.clone(),
+            },
+            w.soft,
+            w.site.clone(),
+            w.span,
+        )
+    })
+}
+
+/// `(inner, lock, soft)` of an `at()` wrapper, dropping its call site.
+fn unpack_pin_at<'v>(v: Value<'v>) -> Option<(Value<'v>, PinLock, bool)> {
+    if let Some(w) = v.downcast_ref::<PinAt<'v>>() {
+        Some((
+            w.inner.to_value(),
+            PinLock {
+                any: w.pins.clone(),
+                by_signal: w.pins_by_signal.clone(),
+            },
+            w.soft,
+        ))
+    } else {
+        v.downcast_ref::<FrozenPinAt>().map(|w| {
+            (
+                w.inner.to_value(),
+                PinLock {
+                    any: w.pins.clone(),
+                    by_signal: w.pins_by_signal.clone(),
+                },
+                w.soft,
+            )
+        })
+    }
+}
+
+/// Record, without unwrapping, every `at()` a caller tucked inside a config
+/// value — the dict-of-roles pattern. `pin_request(bind=)` unwraps it later;
+/// registering it here is what lets the root check notice one nobody used.
+pub(crate) fn record_pin_at_in_config<'v>(
+    name: &str,
+    value: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> Value<'v> {
+    // A role is named by the dict key holding it; a wrapper found anywhere
+    // else keeps the config's own name, so a solve that cannot use it still
+    // reports it rather than dropping it.
+    fn walk<'v>(role: &str, v: Value<'v>, out: &mut Vec<(String, Value<'v>)>) {
+        if unpack_pin_at(v).is_some() {
+            out.push((role.to_owned(), v));
+        } else if let Some(d) = DictRef::from_value(v) {
+            for (k, val) in d.iter() {
+                walk(k.unpack_str().unwrap_or(role), val, out);
+            }
+        } else if let Some(l) = ListRef::from_value(v) {
+            for val in l.iter() {
+                walk(role, val, out);
+            }
+        }
+    }
+    /// The same walk, rebuilding what held a wrapper. `None` when the value
+    /// carries none, so an untouched dict keeps its identity.
+    fn strip<'v>(v: Value<'v>, heap: Heap<'v>) -> Option<Value<'v>> {
+        if let Some((inner, _, _)) = unpack_pin_at(v) {
+            Some(inner)
+        } else if let Some(d) = DictRef::from_value(v) {
+            let entries: Vec<(Value<'v>, Value<'v>, Option<Value<'v>>)> = d
+                .iter()
+                .map(|(k, val)| (k, val, strip(val, heap)))
+                .collect();
+            entries.iter().any(|(_, _, s)| s.is_some()).then(|| {
+                heap.alloc(AllocDict(
+                    entries
+                        .iter()
+                        .map(|(k, val, s)| (*k, s.unwrap_or(*val)))
+                        .collect::<Vec<_>>(),
+                ))
+            })
+        } else if let Some(l) = ListRef::from_value(v) {
+            let items: Vec<(Value<'v>, Option<Value<'v>>)> =
+                l.iter().map(|val| (val, strip(val, heap))).collect();
+            items.iter().any(|(_, s)| s.is_some()).then(|| {
+                heap.alloc(
+                    items
+                        .iter()
+                        .map(|(val, s)| s.unwrap_or(*val))
+                        .collect::<Vec<_>>(),
+                )
+            })
+        } else {
+            None
+        }
+    }
+
+    let mut found: Vec<(String, Value<'v>)> = Vec::new();
+    walk(name, value, &mut found);
+    if found.is_empty() {
+        return value;
+    }
+    for (role, wrapper) in found {
+        record_pin_at(&role, wrapper, eval);
+    }
+    // The constraints are in the store now, so what the module records is the
+    // connection the caller meant — a wrapper here would reach the netlist.
+    let stripped = strip(value, eval.heap()).unwrap_or(value);
+    if let Some(ctx) = eval.context_value() {
+        ctx.module_mut().add_input(name.to_owned(), stripped);
+    }
+    stripped
+}
+
+/// Register an `at()` wrapper's constraint against `name`.
+fn record_pin_at<'v>(name: &str, wrapper: Value<'v>, eval: &mut Evaluator<'v, '_, '_>) {
+    let Some((inner, lock, soft, site, span)) = unpack_pin_at_full(wrapper) else {
+        return;
+    };
+    let mut nets = Vec::new();
+    collect_net_ids(inner, &mut nets);
+    if nets.is_empty() {
+        let path = eval.source_path().unwrap_or_default();
+        eval.add_diagnostic(crate::Diagnostic::categorized(
+            &path,
+            &format!(
+                "at() on input `{name}` carries no net, so its pin constraint can never \
+                 apply — wrap the connection itself"
+            ),
+            "pinmux.at_without_net",
+            starlark::errors::EvalSeverity::Error,
+        ));
+        return;
+    }
+    let Some(store) = eval.eval_context().map(|c| c.pin_constraints()) else {
+        return;
+    };
+    let owner = eval
+        .context_value()
+        .map(|ctx| ctx.module().path().segments.clone())
+        .unwrap_or_default();
+    store
+        .lock()
+        .unwrap()
+        .record(name.to_owned(), site, span, owner, &nets, lock, soft);
+}
+
+/// If `value` is an `at()` wrapper, record its constraint against the io()
+/// input `name` and return the inner value; otherwise return `value` as-is.
+pub(crate) fn unwrap_pin_at<'v>(
+    name: &str,
+    value: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> Value<'v> {
+    match unpack_pin_at_full(value) {
+        Some((inner, lock, soft, site, span)) => {
+            let mut nets = Vec::new();
+            collect_net_ids(inner, &mut nets);
+            if nets.is_empty() {
+                // Nothing to pin: the constraint would vanish and the
+                // "never consumed" net would never catch it.
+                let path = eval.source_path().unwrap_or_default();
+                eval.add_diagnostic(crate::Diagnostic::categorized(
+                    &path,
+                    &format!(
+                        "at() on input `{name}` carries no net, so its pin constraint can never \
+                         apply — wrap the connection itself"
+                    ),
+                    "pinmux.at_without_net",
+                    starlark::errors::EvalSeverity::Error,
+                ));
+            }
+            if !nets.is_empty()
+                && let Some(store) = eval.eval_context().map(|c| c.pin_constraints())
+            {
+                let module = site.clone();
+                let owner = eval
+                    .context_value()
+                    .map(|ctx| ctx.module().path().segments.clone())
+                    .unwrap_or_default();
+                store.lock().unwrap().record(
+                    name.to_owned(),
+                    module,
+                    span,
+                    owner,
+                    &nets,
+                    lock,
+                    soft,
+                );
+            }
+            // The constraint now lives in the store, so the module keeps the
+            // value the caller meant to connect. A solve that runs before this
+            // io() still reads the wrapper off the input, as it must.
+            if let Some(ctx) = eval.context_value() {
+                ctx.module_mut().add_input(name.to_owned(), inner);
+            }
+            inner
+        }
+        None => value,
+    }
+}
+
+/// Shared construction of a peripheral dict (used by `peripheral()` and `pool()`).
+#[allow(clippy::too_many_arguments)]
+fn make_peripheral_dict<'v>(
+    ids: &InterfaceIds,
+    heap: Heap<'v>,
+    name: &str,
+    provides: &[Value<'v>],
+    signals: Vec<(String, Vec<Value<'v>>)>,
+    rebind: &str,
+    attrs: &SmallMap<String, Value<'v>>,
+    unless: Option<&str>,
+    pool: Option<&str>,
+    part: Option<&str>,
+) -> anyhow::Result<Value<'v>> {
+    if !REBIND_VALUES.contains(&rebind) {
+        return Err(anyhow::anyhow!(
+            "peripheral `{name}`: rebind must be one of {REBIND_VALUES:?}, got `{rebind}`"
+        ));
+    }
+    if provides.is_empty() {
+        return Err(anyhow::anyhow!(
+            "peripheral `{name}`: provides must list at least one interface type"
+        ));
+    }
+
+    // A declaration cannot overstate the datasheet: every field of every
+    // provided interface (closure included) needs a non-empty candidate list.
+    for p in provides {
+        for info in iface_closure(*p, ids)? {
+            for sig in &info.signals {
+                let ok = signals
+                    .iter()
+                    .any(|(s, cands)| s == sig && !cands.is_empty());
+                if !ok {
+                    return Err(anyhow::anyhow!(
+                        "peripheral `{name}` claims {} but has no candidate for signal `{sig}` \
+                         (its signals are {})",
+                        info.name,
+                        info.signals
+                            .iter()
+                            .map(|s| format!("`{s}`"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                }
+            }
+        }
+    }
+
+    // Attrs are validated against the vocabulary DECLARED by the provided
+    // interfaces (closure included): an unknown key or a value of the wrong
+    // dimension is a declaration error — every provider of Uart spells
+    // "baud_max" the same way, with a Frequency.
+    let mut declared: Vec<(String, pcb_sch::physical::PhysicalUnitDims, String)> = Vec::new();
+    for p in provides {
+        for info in iface_closure(*p, ids)? {
+            for (aname, ty) in &info.attr_specs {
+                if let Some(t) = ty.downcast_ref::<pcb_sch::physical::PhysicalValueType>() {
+                    match declared.iter().find(|(n, _, _)| n == aname) {
+                        Some((_, dims, owner)) if *dims != t.dims() => {
+                            return Err(anyhow::anyhow!(
+                                "peripheral `{name}`: attr `{aname}` is declared with conflicting dimensions by {owner} and {}",
+                                info.name
+                            ));
+                        }
+                        Some(_) => {}
+                        None => declared.push((aname.clone(), t.dims(), info.name.clone())),
+                    }
+                }
+            }
+        }
+    }
+    let mut attr_pairs: Vec<(Value, Value)> = Vec::new();
+    for (k, v) in attrs.iter() {
+        let Some((_, dims, owner)) = declared.iter().find(|(n, _, _)| n == k) else {
+            let known = if declared.is_empty() {
+                "the provided interfaces declare no attrs".to_owned()
+            } else {
+                format!(
+                    "declared: {}",
+                    declared
+                        .iter()
+                        .map(|(n, _, o)| format!("`{n}` ({o})"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            return Err(anyhow::anyhow!(
+                "peripheral `{name}`: attr `{k}` is not declared by any provided interface — {known}"
+            ));
+        };
+        let parsed: PhysicalValue = match v.unpack_str() {
+            Some(txt) => PhysicalValue::from_str(txt).map_err(|e| {
+                anyhow::anyhow!("peripheral `{name}`: attr `{k}`: cannot parse `{txt}`: {e}")
+            })?,
+            None => PhysicalValue::try_from(*v).map_err(|_| {
+                anyhow::anyhow!(
+                    "peripheral `{name}`: attr `{k}` must be a physical value, got `{}`",
+                    v.get_type()
+                )
+            })?,
+        };
+        if parsed.unit != *dims {
+            return Err(anyhow::anyhow!(
+                "peripheral `{name}`: attr `{k}` (declared on {owner}) expects {}, got {}",
+                dims.quantity(),
+                parsed.unit.quantity()
+            ));
+        }
+        attr_pairs.push((heap.alloc(k.as_str()), heap.alloc(parsed)));
+    }
+
+    let signal_pairs: Vec<(Value, Value)> = signals
+        .into_iter()
+        .map(|(s, cands)| (heap.alloc(s.as_str()), heap.alloc(cands)))
+        .collect();
+
+    let provides_vals: Vec<Value> = provides.to_vec();
+    let pairs: Vec<(Value, Value)> = vec![
+        (heap.alloc("kind"), heap.alloc("peripheral")),
+        (heap.alloc("name"), heap.alloc(name)),
+        (heap.alloc("provides"), heap.alloc(provides_vals)),
+        (heap.alloc("signals"), heap.alloc(AllocDict(signal_pairs))),
+        (heap.alloc("rebind"), heap.alloc(rebind)),
+        (heap.alloc("attrs"), heap.alloc(AllocDict(attr_pairs))),
+        (
+            heap.alloc("unless"),
+            unless
+                .map(|u| heap.alloc(u))
+                .unwrap_or_else(Value::new_none),
+        ),
+        (
+            heap.alloc("pool"),
+            pool.map(|p| heap.alloc(p)).unwrap_or_else(Value::new_none),
+        ),
+        (
+            heap.alloc("part"),
+            part.map(|p| heap.alloc(p)).unwrap_or_else(Value::new_none),
+        ),
+    ];
+    Ok(heap.alloc(AllocDict(pairs)))
+}
+
+/// Normalize a `signals=` entry list into pin dict values (strings auto-wrap).
+fn normalize_candidates<'v>(
+    heap: Heap<'v>,
+    name: &str,
+    sig: &str,
+    cands: Value<'v>,
+) -> anyhow::Result<Vec<Value<'v>>> {
+    let list = ListRef::from_value(cands).ok_or_else(|| {
+        anyhow::anyhow!("peripheral `{name}`: signal `{sig}` candidates must be a list")
+    })?;
+    let mut out = Vec::new();
+    for c in list.iter() {
+        if let Some(s) = c.unpack_str() {
+            out.push(alloc_pin_dict(heap, s, None, 0, false, false));
+        } else if is_kind(c, heap, "pin") {
+            out.push(c);
+        } else {
+            return Err(anyhow::anyhow!(
+                "peripheral `{name}`: signal `{sig}` candidates must be pin() or strings, got `{}`",
+                c.get_type()
+            ));
+        }
+    }
+    Ok(out)
+}
+
+fn alloc_pin_dict<'v>(
+    heap: Heap<'v>,
+    name: &str,
+    data: Option<Value<'v>>,
+    cost: i32,
+    input_only: bool,
+    strap: bool,
+) -> Value<'v> {
+    let pairs: Vec<(Value, Value)> = vec![
+        (heap.alloc("kind"), heap.alloc("pin")),
+        (heap.alloc("name"), heap.alloc(name)),
+        (heap.alloc("data"), data.unwrap_or_else(Value::new_none)),
+        (heap.alloc("cost"), heap.alloc(cost)),
+        (heap.alloc("input_only"), Value::new_bool(input_only)),
+        (heap.alloc("strap"), Value::new_bool(strap)),
+    ];
+    heap.alloc(AllocDict(pairs))
+}
+
+/// The `builtin.pinmux` namespace.
+#[derive(Clone, Copy, Debug, ProvidesStaticType, Freeze, Allocative, NoSerialize)]
+pub struct Pinmux;
+
+impl std::fmt::Display for Pinmux {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "builtin.pinmux")
+    }
+}
+
+starlark::starlark_simple_value!(Pinmux);
+starlark::methods_static!(PINMUX_METHODS = pinmux_methods);
+
+#[starlark_value(type = "pinmux")]
+impl<'v> StarlarkValue<'v> for Pinmux {
+    fn get_methods() -> Option<&'static starlark::environment::Methods> {
+        Some(PINMUX_METHODS.methods())
+    }
+}
+
+#[starlark_module]
+fn pinmux_methods(methods: &mut MethodsBuilder) {
+    /// Constrain which physical pin(s) a connection may use, at the
+    /// connection site: `Mcu(IO0 = at(led_net, "PA8"))`. Hard by default
+    /// (build error if unsatisfiable); `soft = True` makes it a preference
+    /// the solver may fall back from.
+    fn at<'v>(
+        #[allow(unused_variables)] this: &Pinmux,
+        #[starlark(require = pos)] value: Value<'v>,
+        #[starlark(require = pos)] pins: Value<'v>,
+        #[starlark(require = named, default = false)] soft: bool,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let (pin_list, by_signal) = parse_pin_spec("at()", pins, eval.heap())?;
+        let (site, span) = eval
+            .call_stack_top_location()
+            .map(|loc| (loc.file.filename().to_string(), Some(loc.resolve_span())))
+            .unwrap_or_else(|| (eval.source_path().unwrap_or_default(), None));
+        Ok(eval.heap().alloc(PinAt {
+            inner: value,
+            site,
+            span,
+            pins: pin_list,
+            pins_by_signal: by_signal,
+            soft,
+        }))
+    }
+    /// One candidate physical pin for a peripheral signal. `data=` carries
+    /// opaque realization info (e.g. `{"af": 1}` on STM32, `{"iomux_func": 0}`
+    /// on ESP32) verbatim into the solved assignment; the solver ignores it.
+    fn pin<'v>(
+        #[allow(unused_variables)] this: &Pinmux,
+        #[starlark(require = pos)] name: String,
+        #[starlark(require = named, default = SmallMap::default())] data: SmallMap<
+            String,
+            Value<'v>,
+        >,
+        #[starlark(require = named, default = 0)] cost: i32,
+        #[starlark(require = named, default = false)] input_only: bool,
+        #[starlark(require = named, default = false)] strap: bool,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let heap = eval.heap();
+        let data_v = if data.is_empty() {
+            None
+        } else {
+            if data.contains_key("pin") {
+                return Err(anyhow::anyhow!(
+                    "pin `{name}`: data key `pin` is reserved (it names the pin itself in the assignment)"
+                ));
+            }
+            let pairs: Vec<(Value, Value)> = data
+                .iter()
+                .map(|(k, v)| (heap.alloc(k.as_str()), *v))
+                .collect();
+            Some(heap.alloc(AllocDict(pairs)))
+        };
+        Ok(alloc_pin_dict(heap, &name, data_v, cost, input_only, strap))
+    }
+
+    /// A resource cluster: signals -> candidate pins, provided interfaces,
+    /// rebind cost, attributes, optional config-conditional availability.
+    #[allow(clippy::too_many_arguments)]
+    fn peripheral<'v>(
+        #[allow(unused_variables)] this: &Pinmux,
+        #[starlark(require = pos)] name: String,
+        #[starlark(require = named)] provides: UnpackList<Value<'v>>,
+        #[starlark(require = named)] signals: SmallMap<String, Value<'v>>,
+        #[starlark(require = named)] rebind: String,
+        #[starlark(require = named, default = SmallMap::default())] attrs: SmallMap<
+            String,
+            Value<'v>,
+        >,
+        #[starlark(require = named, default = NoneOr::None)] unless: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] part: NoneOr<String>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let heap = eval.heap();
+        let ids = interface_ids(eval)?;
+        for p in &provides.items {
+            if iface_info(*p, &ids).is_none() {
+                return Err(anyhow::anyhow!(
+                    "peripheral `{name}`: provides entries must be interface types, got `{}`",
+                    p.get_type()
+                ));
+            }
+        }
+        let mut normalized = Vec::new();
+        for (sig, cands) in signals.iter() {
+            normalized.push((sig.clone(), normalize_candidates(heap, &name, sig, *cands)?));
+        }
+        make_peripheral_dict(
+            &ids,
+            heap,
+            &name,
+            &provides.items,
+            normalized,
+            &rebind,
+            &attrs,
+            unless.into_option().as_deref(),
+            None,
+            part.into_option().as_deref(),
+        )
+    }
+
+    /// Sugar for N interchangeable single-signal units over a pin set (GPIO pools).
+    fn pool<'v>(
+        #[allow(unused_variables)] this: &Pinmux,
+        #[starlark(require = pos)] name: String,
+        #[starlark(require = named)] provides: UnpackList<Value<'v>>,
+        #[starlark(require = named)] pins: UnpackList<Value<'v>>,
+        #[starlark(require = named, default = "firmware".to_string())] rebind: String,
+        #[starlark(require = named, default = NoneOr::None)] part: NoneOr<String>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let heap = eval.heap();
+        let ids = interface_ids(eval)?;
+        let part = part.into_option();
+        if provides.items.len() != 1 {
+            return Err(anyhow::anyhow!(
+                "pool `{name}`: provides must list exactly one interface type"
+            ));
+        }
+        let info = iface_info(provides.items[0], &ids).ok_or_else(|| {
+            anyhow::anyhow!("pool `{name}`: provides entry must be an interface type")
+        })?;
+        check_signal_names(&info)?;
+        if info.signals.len() != 1 {
+            return Err(anyhow::anyhow!(
+                "pool `{name}`: the provided interface must have exactly one signal, `{}` has {}",
+                info.name,
+                info.signals.len()
+            ));
+        }
+        let field = info.signals[0].clone();
+        let mut units: Vec<Value> = Vec::new();
+        for entry in &pins.items {
+            let pin_dict = if let Some(s) = entry.unpack_str() {
+                alloc_pin_dict(heap, s, None, 0, false, false)
+            } else if is_kind(*entry, heap, "pin") {
+                *entry
+            } else {
+                return Err(anyhow::anyhow!(
+                    "pool `{name}`: pins entries must be pin() or strings, got `{}`",
+                    entry.get_type()
+                ));
+            };
+            let pin_name = DictRef::from_value(pin_dict)
+                .and_then(|d| dict_get_str(&d, heap, "name"))
+                .ok_or_else(|| anyhow::anyhow!("pool `{name}`: invalid pin entry"))?;
+            units.push(make_peripheral_dict(
+                &ids,
+                heap,
+                &format!("{name}.{pin_name}"),
+                &provides.items,
+                vec![(field.clone(), vec![pin_dict])],
+                &rebind,
+                &SmallMap::default(),
+                None,
+                Some(&name),
+                part.as_deref(),
+            )?);
+        }
+        Ok(heap.alloc(units))
+    }
+
+    /// A capability demand: the interface type is the request. Only connected
+    /// signals (`uses=`) consume pins. With `if_connected=True` the request is
+    /// served only when the caller actually connected the module input of the
+    /// same name — the `io(Iface, optional=True)` slot pattern.
+    #[allow(clippy::too_many_arguments)]
+    fn pin_request<'v>(
+        #[allow(unused_variables)] this: &Pinmux,
+        #[starlark(require = pos)] name: String,
+        #[starlark(require = pos)] iface: Value<'v>,
+        #[starlark(require = named, default = NoneOr::None)] uses: NoneOr<UnpackList<String>>,
+        #[starlark(require = named, default = NoneOr::None)] instance: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] prefer: NoneOr<Value<'v>>,
+        #[starlark(require = named, default = false)] lock: bool,
+        #[starlark(require = named, default = NoneOr::None)] r#where: NoneOr<Value<'v>>,
+        #[starlark(require = named, default = NoneOr::None)] direction: NoneOr<String>,
+        #[starlark(require = named, default = false)] if_connected: bool,
+        #[starlark(require = named, default = NoneOr::None)] bind: NoneOr<Value<'v>>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let heap = eval.heap();
+        // bind= carries the connected value on the request itself (the
+        // dict-of-roles pattern). A wrapper rides along untouched — pin_solve
+        // weighs it against what the request asked for — while validation
+        // below looks at the value it wraps.
+        let bound = match bind {
+            NoneOr::Other(v) => Some(v),
+            NoneOr::None => None,
+        };
+        let bind_val = bound.map(|v| unpack_pin_at(v).map(|(inner, _, _)| inner).unwrap_or(v));
+        // Validate the bound value early, with the role name in the message —
+        // otherwise a bad dict entry only surfaces at Component() as
+        // "Pin 'PAx' must be connected to a Net", naming the solved pin
+        // instead of the role.
+        if let Some(v) = bind_val
+            && v.downcast_ref::<NetValue<'v>>().is_none()
+            && v.downcast_ref::<FrozenNetValue>().is_none()
+            && v.downcast_ref::<InterfaceValue<'v>>().is_none()
+            && v.downcast_ref::<FrozenInterfaceValue>().is_none()
+        {
+            return Err(anyhow::anyhow!(
+                "pin_request `{name}`: bind must be a Net or interface instance (optionally wrapped in at()), got `{}`",
+                v.get_type()
+            ));
+        }
+        let ids = interface_ids(eval)?;
+        let info = iface_info(iface, &ids).ok_or_else(|| {
+            anyhow::anyhow!(
+                "pin_request `{name}`: expected an interface type, got `{}`",
+                iface.get_type()
+            )
+        })?;
+        if let NoneOr::Other(dir) = &direction
+            && !["input", "output"].contains(&dir.as_str())
+        {
+            return Err(anyhow::anyhow!(
+                "pin_request `{name}`: direction must be \"input\" or \"output\""
+            ));
+        }
+        check_signal_names(&info)?;
+        let uses_vals: Vec<String> = match uses {
+            NoneOr::Other(u) => {
+                let mut seen = HashSet::new();
+                for s in &u.items {
+                    if !info.signals.contains(s) {
+                        return Err(anyhow::anyhow!(
+                            "pin_request `{name}`: `{s}` is not a signal of {} (its signals are {})",
+                            info.name,
+                            info.signals
+                                .iter()
+                                .map(|s| format!("`{s}`"))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ));
+                    }
+                    if !seen.insert(s.as_str()) {
+                        return Err(anyhow::anyhow!(
+                            "pin_request `{name}`: duplicate signal `{s}` in uses"
+                        ));
+                    }
+                }
+                u.items
+            }
+            NoneOr::None => info.signals.clone(),
+        };
+        if uses_vals.is_empty() {
+            return Err(anyhow::anyhow!(
+                "pin_request `{name}`: uses must name at least one signal"
+            ));
+        }
+        let uses_alloc: Vec<Value> = uses_vals.iter().map(|s| heap.alloc(s.as_str())).collect();
+        // A bound at() rides on the value and is weighed by pin_solve like any
+        // other, so the request keeps what it asked for: one rule decides how
+        // a wish and a lock compose, whichever path delivers the connection.
+        let (pref, lock) = {
+            let (any, by_signal) = match prefer {
+                NoneOr::Other(v) => {
+                    parse_pin_spec(&format!("pin_request `{name}`: prefer"), v, heap)?
+                }
+                NoneOr::None => (Vec::new(), Vec::new()),
+            };
+            (PinLock { any, by_signal }, lock)
+        };
+        pref.check_signals(&format!("pin_request `{name}`"), &uses_vals)?;
+        let prefer_alloc: Vec<Value> = pref.any.iter().map(|s| heap.alloc(s.as_str())).collect();
+        let by_signal_alloc: Vec<(Value, Value)> = pref
+            .by_signal
+            .iter()
+            .map(|(sig, pins)| {
+                let list: Vec<Value> = pins.iter().map(|p| heap.alloc(p.as_str())).collect();
+                (heap.alloc(sig.as_str()), heap.alloc(list))
+            })
+            .collect();
+        let pairs: Vec<(Value, Value)> = vec![
+            (heap.alloc("kind"), heap.alloc("request")),
+            (heap.alloc("name"), heap.alloc(name.as_str())),
+            (heap.alloc("iface"), iface),
+            (heap.alloc("uses"), heap.alloc(uses_alloc)),
+            (
+                heap.alloc("instance"),
+                match instance {
+                    NoneOr::Other(i) => heap.alloc(i),
+                    NoneOr::None => Value::new_none(),
+                },
+            ),
+            (heap.alloc("prefer"), heap.alloc(prefer_alloc)),
+            (
+                heap.alloc("prefer_by_signal"),
+                heap.alloc(AllocDict(by_signal_alloc)),
+            ),
+            (heap.alloc("lock"), Value::new_bool(lock)),
+            (
+                heap.alloc("where"),
+                match r#where {
+                    NoneOr::Other(w) => w,
+                    NoneOr::None => Value::new_none(),
+                },
+            ),
+            (
+                heap.alloc("direction"),
+                match direction {
+                    NoneOr::Other(d) => heap.alloc(d),
+                    NoneOr::None => Value::new_none(),
+                },
+            ),
+            (heap.alloc("if_connected"), Value::new_bool(if_connected)),
+            (heap.alloc("bind"), bound.unwrap_or_else(Value::new_none)),
+        ];
+        Ok(heap.alloc(AllocDict(pairs)))
+    }
+
+    /// Deterministic joint instance x pin assignment. Fails elaboration when
+    /// infeasible; records `pin_assignment` and `swap_classes` module
+    /// properties (JSON) for downstream consumers.
+    fn pin_solve<'v>(
+        #[allow(unused_variables)] this: &Pinmux,
+        #[starlark(require = pos)] peripherals: Value<'v>,
+        #[starlark(require = pos)] requests: Value<'v>,
+        #[starlark(require = named, default = SmallMap::default())] config: SmallMap<
+            String,
+            Value<'v>,
+        >,
+        #[starlark(require = named, default = NoneOr::None)] previous: NoneOr<Value<'v>>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let heap = eval.heap();
+
+        let ids = interface_ids(eval)?;
+        // One level of nesting is flattened: `pool()` yields a list of units,
+        // so `[usart1, gpio_pool]` is one table.
+        let plist = ListRef::from_value(peripherals).ok_or_else(|| {
+            anyhow::anyhow!("pin_solve: peripherals must be a list of peripheral()/pool() values")
+        })?;
+        let mut periphs: Vec<RPeriph> = Vec::new();
+        for entry in plist.iter() {
+            match ListRef::from_value(entry) {
+                Some(nested) => {
+                    for e in nested.iter() {
+                        periphs.push(parse_rperiph(e, heap, &ids)?);
+                    }
+                }
+                None => periphs.push(parse_rperiph(entry, heap, &ids)?),
+            }
+        }
+        // Pads belong to a part: peripherals declaring the same `part=` share a
+        // pin namespace, and those declaring none form a single anonymous part.
+        let mut part_names: Vec<String> = Vec::new();
+        for p in &periphs {
+            if !part_names.contains(&p.part) {
+                part_names.push(p.part.clone());
+            }
+        }
+        for p in periphs.iter_mut() {
+            p.part_idx = part_names.iter().position(|n| *n == p.part).unwrap_or(0);
+        }
+        let mut seen_names = HashSet::new();
+        for p in &periphs {
+            if !seen_names.insert((p.part_idx, p.name.clone())) {
+                return Err(anyhow::anyhow!(
+                    "pin_solve: duplicate peripheral name `{}`",
+                    p.name
+                ));
+            }
+        }
+
+        let rlist = ListRef::from_value(requests)
+            .ok_or_else(|| anyhow::anyhow!("pin_solve: requests must be a list"))?;
+        let mut reqs: Vec<RReq> = Vec::new();
+        for entry in rlist.iter() {
+            reqs.push(parse_rreq(entry, heap, &ids)?);
+        }
+        let mut seen_reqs = HashSet::new();
+        for r in &reqs {
+            if !seen_reqs.insert(r.name.clone()) {
+                return Err(anyhow::anyhow!(
+                    "pin_solve: duplicate request name `{}`",
+                    r.name
+                ));
+            }
+        }
+
+        // `inputs()` holds every caller-supplied argument, config() included;
+        // a request pairs with io() slots only. A config declared after this
+        // solve is not yet known, so pairing with one stays possible.
+        let configs: HashSet<String> = eval
+            .context_value()
+            .map(|ctx| {
+                ctx.module()
+                    .signature()
+                    .iter()
+                    .filter(|p| p.is_config)
+                    .map(|p| p.name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // io() slot pattern: an `if_connected` request is served only when the
+        // caller actually connected the module input of the same name.
+        let connected: HashSet<String> = eval
+            .context_value()
+            .map(|ctx| {
+                ctx.module()
+                    .inputs()
+                    .iter()
+                    .map(|(k, _)| k.clone())
+                    .filter(|k| !configs.contains(k))
+                    .collect()
+            })
+            .unwrap_or_default();
+        reqs.retain(|r| !r.if_connected || connected.contains(&r.name));
+        // A config() declared after this solve is not in `configs` yet, so the
+        // gate may have read one as a connection; the module records what it
+        // served and the check runs once its signature is complete.
+        if let Some(ctx) = eval.context_value() {
+            for r in reqs.iter().filter(|r| r.if_connected) {
+                ctx.record_if_connected(&r.name);
+            }
+        }
+
+        let prev_map = match previous {
+            NoneOr::Other(v) => {
+                let parsed = parse_previous(v, heap);
+                let provided_entries = DictRef::from_value(v)
+                    .map(|d| d.iter().count())
+                    .unwrap_or(1);
+                if parsed.is_empty() && provided_entries > 0 {
+                    warn_at_call_site(
+                        eval,
+                        "pin_solve: previous= contains no usable assignment entry; pass the `assignment` dict of a prior solve".to_owned(),
+                    );
+                }
+                parsed
+            }
+            NoneOr::None => HashMap::new(),
+        };
+
+        // `at()` constraints override request-side prefer/lock. A request
+        // pairs with the io() input of its name; the constraint rides on the
+        // input's nets. Read the inputs first so the claims below, which need
+        // the evaluator to weigh candidates, do not hold the module borrow.
+        let scopes: Vec<String> = part_names.clone();
+        let mut claimed_instances: HashSet<(String, String)> = HashSet::new();
+        let mut claimed_pads: HashSet<(usize, String)> = HashSet::new();
+        if let Some(ctx) = eval.context_value() {
+            // A peripheral is identified by its part and its name: two chips
+            // may legitimately name a resource alike.
+            let ours: HashSet<(&str, &str)> = periphs
+                .iter()
+                .map(|p| (scopes[p.part_idx].as_str(), p.name.as_str()))
+                .collect();
+            let current: HashSet<String> = reqs.iter().map(|r| r.name.clone()).collect();
+            for claim in ctx.pin_claims_excluding(&current, &scopes) {
+                // A pad belongs to the part, not to the peripheral that took
+                // it: another table of the same part still owns it.
+                if let Some(part) = scopes.iter().position(|s| *s == claim.scope) {
+                    claimed_pads.extend(claim.pins.iter().map(|p| (part, p.clone())));
+                }
+                // An instance is only ours to reserve when this table has it.
+                if ours.contains(&(claim.scope.as_str(), claim.instance.as_str())) {
+                    claimed_instances.insert((claim.scope, claim.instance));
+                }
+            }
+        }
+        let store = eval.eval_context().map(|c| c.pin_constraints());
+        let mut solver: Vec<String> = Vec::new();
+        // (request, the nets it rides, its own at() when it carries one)
+        type Ride = (usize, Vec<u64>, Option<(PinLock, bool)>);
+        let mut rides: Vec<Ride> = Vec::new();
+        if let Some(ctx) = eval.context_value() {
+            solver = ctx.module().path().segments.clone();
+            for (i, r) in reqs.iter().enumerate() {
+                // A config() of the request's name is not a connection. A role
+                // carries its own value, so that name cannot mislead it.
+                if r.bind.is_none() && configs.contains(&r.name) {
+                    continue;
+                }
+                // The value bound on the request itself when the caller passed
+                // a dict of roles, else the io() input of this name.
+                let Some(input) = r.bind.or_else(|| {
+                    ctx.module()
+                        .inputs()
+                        .get(r.name.as_str())
+                        .map(|v| v.to_value())
+                }) else {
+                    continue;
+                };
+                // Solving before the io() binds: the wrapper is still here.
+                let (value, raw) = match unpack_pin_at(input) {
+                    Some((inner, pins, soft)) => (inner, Some((pins, soft))),
+                    None => (input, None),
+                };
+                let mut nets = Vec::new();
+                collect_net_ids(value, &mut nets);
+                rides.push((i, nets, raw));
+            }
+        }
+        if let Some(pin_store) = store {
+            for (i, nets, raw) in rides {
+                let mut store = pin_store.lock().unwrap();
+                let constraint = match raw {
+                    Some(c) => {
+                        store.settle(&nets, &solver, &reqs[i].name);
+                        Some(c)
+                    }
+                    None => {
+                        // An ancestor's constraint names an input of its own
+                        // namespace, so only the pins pair it with a request:
+                        // one that has no candidate on them must leave it to
+                        // the request that has. Weighing that runs user code,
+                        // so it happens with the store released.
+                        let candidates = store.candidate_locks(&nets, &solver);
+                        drop(store);
+                        let mut usable: HashSet<usize> = HashSet::new();
+                        for (idx, lock) in candidates {
+                            let mut probe = reqs[i].clone();
+                            probe.prefer = lock;
+                            probe.lock = true;
+                            // Weighed against the same candidates the solve will
+                            // see, earlier solves' claims included, or a pad
+                            // already taken would look like a fit.
+                            let fits =
+                                combos_for_request(&probe, &periphs, &config, &prev_map, eval)
+                                    .map(|(combos, _, _)| {
+                                        combos.iter().any(|c| {
+                                            let p = &periphs[c.periph_idx];
+                                            !claimed_instances.contains(&(
+                                                scopes[p.part_idx].clone(),
+                                                p.name.clone(),
+                                            )) && !c.pins.iter().any(|(_, pin)| {
+                                                claimed_pads
+                                                    .contains(&(p.part_idx, pin.name.clone()))
+                                            })
+                                        })
+                                    })
+                                    .unwrap_or(false);
+                            if fits {
+                                usable.insert(idx);
+                            }
+                        }
+                        store = pin_store.lock().unwrap();
+                        match store.claim(&nets, &solver, &reqs[i].name, Some(&usable)) {
+                            Claimed::Yes(pins, soft) => Some((pins, soft)),
+                            Claimed::No | Claimed::Ambiguous | Claimed::Contended => None,
+                        }
+                    }
+                };
+                if let Some(Ambiguity::Entries { input, names }) = store.take_ambiguous() {
+                    return Err(anyhow::anyhow!(
+                        "pin_solve: at() constraints on `{names}` all ride the net reaching input \
+                         `{input}`; name the io() inputs apart so each constraint has one owner"
+                    ));
+                }
+                if let Some((pins, soft)) = constraint {
+                    let r = &mut reqs[i];
+                    pins.check_signals(&format!("pin_solve: at() on input `{}`", r.name), &r.uses)?;
+                    if soft {
+                        // A wish never replaces what the request asked for: it
+                        // outranks it where both can be had, and leaves it to
+                        // decide where the wish cannot be met.
+                        r.soft_prefer = pins;
+                    } else {
+                        r.prefer = pins;
+                        r.lock = true;
+                    }
+                }
+            }
+        }
+
+        // Candidate combos per request, with reasoned rejections.
+        let mut all_combos: Vec<Vec<Combo>> = Vec::new();
+        let mut truncated_reqs: Vec<String> = Vec::new();
+        for r in &reqs {
+            let (combos, rejects, capped) =
+                combos_for_request(r, &periphs, &config, &prev_map, eval)?;
+            if !capped.is_empty() {
+                truncated_reqs.push(r.name.clone());
+                warn_at_call_site(
+                    eval,
+                    format!(
+                        "pin_solve: request `{}`: pin combinations capped at {PINMAP_CAP} for `{}`; the assignment may be suboptimal",
+                        r.name,
+                        capped.join("`, `")
+                    ),
+                );
+            }
+            if combos.is_empty() {
+                let detail = rejects
+                    .iter()
+                    .map(|(n, why)| format!("  {n}: rejected — {why}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Err(anyhow::anyhow!(
+                    "pin_solve: request `{}` ({}) has no candidate:\n{detail}",
+                    r.name,
+                    r.iface_name
+                ));
+            }
+            all_combos.push(combos);
+        }
+
+        // Pin/instance exclusivity spans every pin_solve of the module:
+        // candidates claimed by another solve's requests are unavailable
+        // (a re-solved request releases its own claims, so `previous=` can
+        // widen an earlier solve). Only claims on a peripheral of *this* table
+        // count: pin names belong to a part, so another part's `7` is not ours.
+        // The claimed sets also seed the reported residual freedom below, so
+        // free/alternate/spare listings match the exclusivity enforced here.
+        let part_of: Vec<usize> = periphs.iter().map(|p| p.part_idx).collect();
+        // A part names its own pad namespace; peripherals declaring no part
+        // share the module's single anonymous one, so pads keep colliding
+        // across solves exactly as they did before parts existed.
+        // Whether a gated peripheral is there belongs to the design, not to
+        // one solve: an axis that said one thing already cannot say another,
+        // or which pads the component exposes would depend on solve order.
+        if let Some(ctx) = eval.context_value() {
+            for (part_idx, part) in scopes.iter().enumerate() {
+                // Axes this table's peripherals name, plus any this part has
+                // already settled and this call speaks about — a later table
+                // may omit the gated peripheral yet still configure it.
+                let mut axes: Vec<String> = periphs
+                    .iter()
+                    .filter(|p| p.part_idx == part_idx)
+                    .filter_map(|p| p.unless.clone())
+                    .collect();
+                axes.extend(
+                    ctx.config_axes_for(part)
+                        .into_iter()
+                        .filter(|axis| config.get(axis.as_str()).is_some()),
+                );
+                axes.sort();
+                axes.dedup();
+                for axis in axes {
+                    let on = config_truthy(&config, &axis);
+                    if let Some(before) = ctx.record_config_axis(part, &axis, on)
+                        && before != on
+                    {
+                        let whose = if part.is_empty() {
+                            "this part".to_owned()
+                        } else {
+                            format!("`{part}`")
+                        };
+                        return Err(anyhow::anyhow!(
+                            "pin_solve: config axis `{axis}` was {before} for {whose} in an \
+                             earlier solve and is {on} here; a part is configured once"
+                        ));
+                    }
+                }
+            }
+        }
+        if !(claimed_instances.is_empty() && claimed_pads.is_empty()) {
+            for (i, combos) in all_combos.iter_mut().enumerate() {
+                combos.retain(|c| {
+                    !claimed_instances.contains(&(
+                        scopes[part_of[c.periph_idx]].clone(),
+                        periphs[c.periph_idx].name.clone(),
+                    )) && !c.pins.iter().any(|(_, p)| {
+                        claimed_pads.contains(&(part_of[c.periph_idx], p.name.clone()))
+                    })
+                });
+                if combos.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "pin_solve: request `{}`: every candidate uses a pin or instance already claimed by an earlier pin_solve in this module",
+                        reqs[i].name
+                    ));
+                }
+            }
+        }
+
+        // Joint assignment. A truncated enumeration may have dropped the very
+        // combinations that would have fit, so failures must say so.
+        let failure_detail = |reqs: &[RReq], all_combos: &[Vec<Combo>]| {
+            let mut detail = reqs
+                .iter()
+                .enumerate()
+                .map(|(i, r)| format!("  {}: {} candidate combo(s)", r.name, all_combos[i].len()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            if !truncated_reqs.is_empty() {
+                detail.push_str(&format!(
+                    "\nnote: pin combinations for `{}` were capped at {PINMAP_CAP}; a feasible \
+                     assignment may have been dropped — constrain those requests \
+                     (instance=/prefer=) to narrow the enumeration",
+                    truncated_reqs.join("`, `")
+                ));
+            }
+            detail
+        };
+        let chosen = match assign(&reqs, &all_combos, &part_of) {
+            AssignOutcome::Solved { chosen, capped } => {
+                if capped {
+                    warn_at_call_site(
+                        eval,
+                        format!(
+                            "pin_solve: solver budget ({SOLVER_BUDGET} conflict checks) exhausted; the assignment is feasible but may be suboptimal"
+                        ),
+                    );
+                }
+                if let Some(ctx) = eval.context_value() {
+                    for (i, r) in reqs.iter().enumerate() {
+                        let combo = &all_combos[i][chosen[i]];
+                        ctx.record_pin_claim(
+                            &r.name,
+                            crate::lang::context::PinClaim {
+                                instance: periphs[combo.periph_idx].name.clone(),
+                                pins: combo.pins.iter().map(|(_, p)| p.name.clone()).collect(),
+                                scope: scopes[periphs[combo.periph_idx].part_idx].clone(),
+                            },
+                            &scopes,
+                        );
+                    }
+                }
+                chosen
+            }
+            AssignOutcome::Infeasible => {
+                // Undeclared peripherals form one part, so identically named
+                // pads of two components collide.
+                let hint = if part_names.len() == 1 && part_names[0].is_empty() {
+                    "\nnote: these peripherals share one pin namespace; if they belong to \
+                     different components, give each `peripheral(part = ...)` so its pads \
+                     stay its own"
+                } else {
+                    ""
+                };
+                return Err(anyhow::anyhow!(
+                    "pin_solve: no feasible assignment (instance/pin exclusivity):\n{}{hint}",
+                    failure_detail(&reqs, &all_combos)
+                ));
+            }
+            AssignOutcome::Unknown => {
+                return Err(anyhow::anyhow!(
+                    "pin_solve: search budget exhausted before feasibility could be proven; \
+                     constrain requests (instance=/prefer=) to narrow the search:\n{}",
+                    failure_detail(&reqs, &all_combos)
+                ));
+            }
+        };
+
+        // Build results (JSON first; the Starlark value mirrors it). Pins
+        // claimed by earlier solves count as used: alternates, spares and the
+        // tie-off list must never offer a pad another request already owns.
+        let mut used_pads: HashSet<(usize, String)> = claimed_pads;
+        for (i, &ci) in chosen.iter().enumerate() {
+            let part = part_of[all_combos[i][ci].periph_idx];
+            for (_, p) in &all_combos[i][ci].pins {
+                used_pads.insert((part, p.name.clone()));
+            }
+        }
+
+        let mut assignment = serde_json::Map::new();
+        for (i, r) in reqs.iter().enumerate() {
+            let combo = &all_combos[i][chosen[i]];
+            let periph = &periphs[combo.periph_idx];
+            let mut signals = serde_json::Map::new();
+            let mut alternates = serde_json::Map::new();
+            for (sig, p) in &combo.pins {
+                let mut entry = serde_json::Map::new();
+                entry.insert("pin".into(), serde_json::Value::String(p.name.clone()));
+                // Realization data is splatted next to "pin" so consumers see
+                // e.g. {"pin": "PA9", "af": 1} without a vendor-specific schema.
+                for (k, val) in &p.data {
+                    entry.insert(k.clone(), val.clone());
+                }
+                signals.insert(sig.clone(), serde_json::Value::Object(entry));
+                if p.strap {
+                    warn_at_call_site(
+                        eval,
+                        format!(
+                            "pin_solve: request `{}` signal `{sig}` uses strapping pin `{}`",
+                            r.name, p.name
+                        ),
+                    );
+                }
+                // Same filters the candidates went through, or the alternates
+                // would offer a pad this request could not have taken.
+                let allowed = r.allowed(sig);
+                let free: Vec<serde_json::Value> = if r.pinned_by_lock(&p.name) {
+                    Vec::new()
+                } else {
+                    periph
+                        .signal(sig)
+                        .map(|cands| {
+                            cands
+                                .iter()
+                                .filter(|c| allowed.is_none_or(|a| a.contains(&c.name)))
+                                .filter(|c| {
+                                    !(r.direction.as_deref() == Some("output") && c.input_only)
+                                })
+                                .filter(|c| !used_pads.contains(&(periph.part_idx, c.name.clone())))
+                                .map(|c| serde_json::Value::String(c.name.clone()))
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                };
+                if !free.is_empty() {
+                    alternates.insert(sig.clone(), serde_json::Value::Array(free));
+                }
+            }
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "instance".into(),
+                serde_json::Value::String(periph.name.clone()),
+            );
+            // Two components may name a resource alike, so the part is what
+            // makes the instance unambiguous.
+            entry.insert(
+                "part".into(),
+                match part_names[periph.part_idx].as_str() {
+                    "" => serde_json::Value::Null,
+                    p => serde_json::Value::String(p.to_owned()),
+                },
+            );
+            entry.insert(
+                "iface".into(),
+                serde_json::Value::String(r.iface_name.clone()),
+            );
+            entry.insert(
+                "pool".into(),
+                periph
+                    .pool
+                    .clone()
+                    .map(serde_json::Value::String)
+                    .unwrap_or(serde_json::Value::Null),
+            );
+            entry.insert(
+                "rebind".into(),
+                serde_json::Value::String(periph.rebind.clone()),
+            );
+            entry.insert("signals".into(), serde_json::Value::Object(signals));
+            entry.insert("alternates".into(), serde_json::Value::Object(alternates));
+            assignment.insert(r.name.clone(), serde_json::Value::Object(entry));
+        }
+
+        // Instances occupied module-wide: this solve's choices plus earlier
+        // solves' claims. Spare-unit listings (and the property merge below)
+        // must never offer an occupied unit.
+        let assigned_instances: HashSet<(String, String)> = chosen
+            .iter()
+            .enumerate()
+            .map(|(i, &ci)| {
+                let p = &periphs[all_combos[i][ci].periph_idx];
+                (scopes[p.part_idx].clone(), p.name.clone())
+            })
+            .chain(claimed_instances.iter().cloned())
+            .collect();
+
+        // Residual freedom: pool classes (pin granularity) + identical-provides
+        // rebind="none" clusters (gate swap). Collected unfiltered: the
+        // emission rule (two members, or one member plus spares) runs on the
+        // returned value now, and again on the merged module property once
+        // prior solves' members are folded in — a class below the threshold
+        // alone can cross it combined with an earlier solve's members.
+        // (part, pool, rebind, members as (request, pin), spare pins)
+        type PoolClass = (String, String, String, Vec<(String, String)>, Vec<String>);
+        // (part, unit names, members as (request, unit), spare units)
+        type ClusterClass = (String, HashSet<String>, Vec<(String, String)>, Vec<String>);
+        // Members grouped by (part, class key).
+        type Grouped<K> = Vec<((String, K), Vec<(String, String)>)>;
+        let mut pool_classes: Vec<PoolClass> = Vec::new();
+        let mut cluster_classes: Vec<ClusterClass> = Vec::new();
+        {
+            // Keyed by part too: two components may hold a pool of one name.
+            let mut by_pool: Grouped<String> = Vec::new();
+            for (i, r) in reqs.iter().enumerate() {
+                // A lock with pins removes the request from the swap freedom;
+                // a bare lock=True constrains nothing and swaps normally.
+                if r.lock && !r.prefer.is_empty() {
+                    continue;
+                }
+                let combo = &all_combos[i][chosen[i]];
+                let periph = &periphs[combo.periph_idx];
+                let Some(pool) = &periph.pool else { continue };
+                let pin = combo.pins[0].1.name.clone();
+                let key = (scopes[periph.part_idx].clone(), pool.clone());
+                match by_pool.iter_mut().find(|(k, _)| *k == key) {
+                    Some((_, members)) => members.push((r.name.clone(), pin)),
+                    None => by_pool.push((key, vec![(r.name.clone(), pin)])),
+                }
+            }
+            by_pool.sort_by(|a, b| a.0.cmp(&b.0));
+            for ((part, pool), mut members) in by_pool {
+                members.sort();
+                let same_pool = |p: &&RPeriph| {
+                    p.pool.as_deref() == Some(pool.as_str()) && scopes[p.part_idx] == part
+                };
+                let mut spares: Vec<String> = periphs
+                    .iter()
+                    .filter(same_pool)
+                    .filter_map(|p| {
+                        p.signals
+                            .first()
+                            .and_then(|(_, c)| c.first())
+                            .map(|c| (p.part_idx, c.name.clone()))
+                    })
+                    .filter(|pad| !used_pads.contains(pad))
+                    .map(|(_, n)| n)
+                    .collect();
+                spares.sort();
+                let rebind = periphs
+                    .iter()
+                    .find(same_pool)
+                    .map(|p| p.rebind.clone())
+                    .unwrap_or_else(|| "firmware".to_owned());
+                pool_classes.push((part, pool, rebind, members, spares));
+            }
+
+            let mut by_cluster: Grouped<ProvidesKey> = Vec::new();
+            for (i, r) in reqs.iter().enumerate() {
+                if r.lock && !r.prefer.is_empty() {
+                    continue;
+                }
+                let combo = &all_combos[i][chosen[i]];
+                let periph = &periphs[combo.periph_idx];
+                if periph.rebind != "none" || periph.pool.is_some() {
+                    continue;
+                }
+                let key = periph.provides_key();
+                let member = (r.name.clone(), periph.name.clone());
+                let key = (scopes[periph.part_idx].clone(), key);
+                match by_cluster.iter_mut().find(|(k, _)| *k == key) {
+                    Some((_, members)) => members.push(member),
+                    None => by_cluster.push((key, vec![member])),
+                }
+            }
+            // Order clusters by their members, not by key: TypeInstanceIds
+            // depend on concurrent module-evaluation order, so the key is
+            // only stable within one build.
+            for (_, members) in by_cluster.iter_mut() {
+                members.sort();
+            }
+            by_cluster.sort_by(|a, b| a.1.cmp(&b.1));
+            for ((part, key), members) in by_cluster {
+                let scoped: Vec<(String, String)> = periphs
+                    .iter()
+                    .filter(|p| {
+                        p.rebind == "none"
+                            && p.pool.is_none()
+                            && p.provides_key() == key
+                            && scopes[p.part_idx] == part
+                    })
+                    .map(|p| (scopes[p.part_idx].clone(), p.name.clone()))
+                    .collect();
+                let units: HashSet<String> = scoped.iter().map(|(_, n)| n.clone()).collect();
+                let mut spares: Vec<String> = scoped
+                    .iter()
+                    .filter(|u| !assigned_instances.contains(u))
+                    .map(|(_, n)| n.clone())
+                    .collect();
+                spares.sort();
+                cluster_classes.push((part, units, members, spares));
+            }
+        }
+        let emits = |members: &[(String, String)], n_spares: usize| {
+            members.len() >= 2 || (!members.is_empty() && n_spares > 0)
+        };
+        let pool_class_json = |(part, pool, rebind, members, spares): &PoolClass| {
+            serde_json::json!({
+                "granularity": "pin",
+                "rebind": rebind,
+                "part": if part.is_empty() { serde_json::Value::Null } else { serde_json::Value::String(part.clone()) },
+                "pool": pool,
+                "members": members
+                    .iter()
+                    .map(|(r, p)| serde_json::json!({"request": r, "pin": p}))
+                    .collect::<Vec<_>>(),
+                "spare_pins": spares,
+            })
+        };
+        let cluster_class_json = |(part, _, members, spares): &ClusterClass| {
+            serde_json::json!({
+                "granularity": "cluster",
+                "rebind": "none",
+                "part": if part.is_empty() { serde_json::Value::Null } else { serde_json::Value::String(part.clone()) },
+                "members": members
+                    .iter()
+                    .map(|(r, u)| serde_json::json!({"request": r, "instance": u}))
+                    .collect::<Vec<_>>(),
+                "spare_units": spares,
+            })
+        };
+        let mut swap_classes: Vec<serde_json::Value> = Vec::new();
+        for c in &pool_classes {
+            if emits(&c.3, c.4.len()) {
+                swap_classes.push(pool_class_json(c));
+            }
+        }
+        for c in &cluster_classes {
+            if emits(&c.2, c.3.len()) {
+                swap_classes.push(cluster_class_json(c));
+            }
+        }
+
+        let assignment_json = serde_json::Value::Object(assignment);
+        let swap_json = serde_json::Value::Array(swap_classes);
+
+        // Persist as module properties so the data reaches the netlist and,
+        // through schematic export, board-side fields. A module may solve
+        // several parts: the properties merge every solve, keyed by request
+        // name — a re-solved request replaces its own entry and drops the
+        // prior swap classes that mention it (their freedom is stale).
+        let mut property_assignment = assignment_json.clone();
+        let mut property_swaps = swap_json.clone();
+        if let Some(ctx) = eval.context_value() {
+            // Pin and unit names belong to a part. A prior entry built on
+            // silicon this solve never touched keeps its freedom verbatim.
+            // Belt and braces with the builtin's own refusal: a value this
+            // solve cannot read would be dropped without a word.
+            let prior = |key: &str, object: bool| -> anyhow::Result<Option<serde_json::Value>> {
+                let module = ctx.module();
+                let Some(v) = module.properties().get(key) else {
+                    return Ok(None);
+                };
+                v.to_value()
+                    .unpack_str()
+                    .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                    .filter(|j| if object { j.is_object() } else { j.is_array() })
+                    .map(Some)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "pin_solve: module property `{key}` is written by pin_solve; \
+                             record your own data under another name"
+                        )
+                    })
+            };
+            if let Some(prev) = prior(RESULT_PROPERTIES[0], true)?
+                && let Some(prev_obj) = prev.as_object()
+            {
+                let cur = property_assignment
+                    .as_object_mut()
+                    .expect("assignment is an object");
+                for (k, v) in prev_obj {
+                    cur.entry(k.clone()).or_insert_with(|| {
+                        // Prior alternates net of pins this solve claimed, but
+                        // only when the entry sits on a part of this table.
+                        let mut v = v.clone();
+                        // Pads belong to the part the entry names — instance
+                        // names repeat across parts. Other silicon is left be.
+                        let named = v.get("part").and_then(|p| p.as_str()).unwrap_or_default();
+                        let Some(part) = part_names.iter().position(|p| p == named) else {
+                            return v;
+                        };
+                        if let Some(alts) = v.get_mut("alternates").and_then(|a| a.as_object_mut())
+                        {
+                            for list in alts.values_mut() {
+                                if let Some(arr) = list.as_array_mut() {
+                                    arr.retain(|p| {
+                                        p.as_str()
+                                            .map(|n| !used_pads.contains(&(part, n.to_owned())))
+                                            .unwrap_or(true)
+                                    });
+                                }
+                            }
+                            alts.retain(|_, l| l.as_array().is_none_or(|a| !a.is_empty()));
+                        }
+                        v
+                    });
+                }
+            }
+            if let Some(prev) = prior(RESULT_PROPERTIES[1], false)?
+                && let Some(prev_arr) = prev.as_array()
+            {
+                // Prior classes stay live, minus what this solve consumed:
+                // re-solved members leave their old class (their freedom is
+                // stale), spares lose newly claimed pins/units, and members
+                // on a pool or cluster this solve touched again fold into the
+                // fresh class — whose spares already account for every claim
+                // in the module — so one class never fragments across solves.
+                let solved: HashSet<&str> = reqs.iter().map(|r| r.name.as_str()).collect();
+                let parse_members =
+                    |class: &serde_json::Value, value_key: &str| -> Vec<(String, String)> {
+                        class
+                            .get("members")
+                            .and_then(|m| m.as_array())
+                            .map(|ms| {
+                                ms.iter()
+                                    .filter_map(|m| {
+                                        let r = m.get("request").and_then(|v| v.as_str())?;
+                                        let v = m.get(value_key).and_then(|v| v.as_str())?;
+                                        (!solved.contains(r)).then(|| (r.to_owned(), v.to_owned()))
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default()
+                    };
+                let class_part = |c: &serde_json::Value| {
+                    c.get("part")
+                        .and_then(|p| p.as_str())
+                        .unwrap_or_default()
+                        .to_owned()
+                };
+                let mut merged_pools = pool_classes.clone();
+                let mut merged_clusters = cluster_classes.clone();
+                let mut merged: Vec<serde_json::Value> = Vec::new();
+                for prior_class in prev_arr {
+                    if prior_class.get("granularity").and_then(|g| g.as_str()) == Some("pin") {
+                        let live = parse_members(prior_class, "pin");
+                        let pool = prior_class
+                            .get("pool")
+                            .and_then(|p| p.as_str())
+                            .unwrap_or_default();
+                        let part = class_part(prior_class);
+                        if let Some(cur) =
+                            merged_pools.iter_mut().find(|c| c.0 == part && c.1 == pool)
+                        {
+                            cur.3.extend(live);
+                            cur.3.sort();
+                            continue;
+                        }
+                        // Pool this solve did not place on: keep it, net of the
+                        // pins this solve claimed only if it is the same part.
+                        let mine = part_names.iter().position(|p| *p == part);
+                        let spares: Vec<String> = prior_class
+                            .get("spare_pins")
+                            .and_then(|s| s.as_array())
+                            .map(|s| {
+                                s.iter()
+                                    .filter_map(|p| p.as_str())
+                                    .filter(|n| {
+                                        mine.is_none_or(|part| {
+                                            !used_pads.contains(&(part, (*n).to_owned()))
+                                        })
+                                    })
+                                    .map(str::to_owned)
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        if emits(&live, spares.len()) {
+                            let rebind = prior_class
+                                .get("rebind")
+                                .and_then(|r| r.as_str())
+                                .unwrap_or("firmware")
+                                .to_owned();
+                            merged.push(pool_class_json(&(
+                                part,
+                                pool.to_owned(),
+                                rebind,
+                                live,
+                                spares,
+                            )));
+                        }
+                    } else {
+                        let live = parse_members(prior_class, "instance");
+                        // A cluster's identity is its unit set (member units
+                        // plus spares); overlap means the same silicon.
+                        let mut prior_units: HashSet<String> = prior_class
+                            .get("members")
+                            .and_then(|m| m.as_array())
+                            .map(|ms| {
+                                ms.iter()
+                                    .filter_map(|m| m.get("instance").and_then(|v| v.as_str()))
+                                    .map(str::to_owned)
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        if let Some(spares) =
+                            prior_class.get("spare_units").and_then(|s| s.as_array())
+                        {
+                            prior_units.extend(
+                                spares.iter().filter_map(|s| s.as_str()).map(str::to_owned),
+                            );
+                        }
+                        let part = class_part(prior_class);
+                        if let Some(cur) = merged_clusters
+                            .iter_mut()
+                            .find(|c| c.0 == part && !c.1.is_disjoint(&prior_units))
+                        {
+                            cur.2.extend(live);
+                            cur.2.sort();
+                            continue;
+                        }
+                        // Cluster this solve did not place on: same rule, the
+                        // units must belong to silicon this table knows.
+                        let mine = part_names.iter().position(|p| *p == part);
+                        let spares: Vec<String> = prior_class
+                            .get("spare_units")
+                            .and_then(|s| s.as_array())
+                            .map(|s| {
+                                s.iter()
+                                    .filter_map(|u| u.as_str())
+                                    .filter(|n| {
+                                        mine.is_none_or(|part| {
+                                            !assigned_instances
+                                                .contains(&(scopes[part].clone(), (*n).to_owned()))
+                                        })
+                                    })
+                                    .map(str::to_owned)
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        if emits(&live, spares.len()) {
+                            merged.push(cluster_class_json(&(part, HashSet::new(), live, spares)));
+                        }
+                    }
+                }
+                for c in &merged_pools {
+                    if emits(&c.3, c.4.len()) {
+                        merged.push(pool_class_json(c));
+                    }
+                }
+                for c in &merged_clusters {
+                    if emits(&c.2, c.3.len()) {
+                        merged.push(cluster_class_json(c));
+                    }
+                }
+                property_swaps = serde_json::Value::Array(merged);
+            }
+        }
+        eval.add_property(
+            RESULT_PROPERTIES[0],
+            heap.alloc(serde_json::to_string_pretty(&property_assignment).unwrap_or_default()),
+        );
+        eval.add_property(
+            RESULT_PROPERTIES[1],
+            heap.alloc(serde_json::to_string_pretty(&property_swaps).unwrap_or_default()),
+        );
+
+        // Every pad this part exposes, per part, for `pin_map` to tie off what
+        // no request holds. Kept cumulative and whole: a module may solve one
+        // part over several tables, and a re-solve hands pads back.
+        if let Some(ctx) = eval.context_value() {
+            for (i, _) in part_names.iter().enumerate() {
+                let exposed = periphs
+                    .iter()
+                    .filter(|p| p.part_idx == i)
+                    // A pad only reachable through a disabled peripheral is not
+                    // this design's to tie off.
+                    .filter(|p| {
+                        p.unless
+                            .as_deref()
+                            .is_none_or(|axis| !config_truthy(&config, axis))
+                    })
+                    .flat_map(|p| p.signals.iter())
+                    .flat_map(|(_, cands)| cands.iter())
+                    .map(|c| c.name.clone());
+                let mut v: Vec<String> = ctx
+                    .exposed_pads(&scopes[i])
+                    .into_iter()
+                    .chain(exposed)
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect();
+                v.sort();
+                ctx.record_exposed_pads(scopes[i].clone(), v);
+            }
+        }
+
+        let pairs: Vec<(Value, Value)> = vec![
+            (
+                heap.alloc("assignment"),
+                json_to_value(heap, &assignment_json),
+            ),
+            (heap.alloc("swap_classes"), json_to_value(heap, &swap_json)),
+        ];
+        Ok(heap.alloc(AllocDict(pairs)))
+    }
+
+    /// Turn a solved assignment into a `Component(pins=...)`-ready dict:
+    /// physical pin name -> the net carried by the matching interface field.
+    /// `ifaces` maps request names to the io()/interface instances holding the
+    /// nets (a bare Net is accepted for single-signal requests). Requests
+    /// absent from the assignment (e.g. dropped by `if_connected`) are
+    /// skipped, so the two dicts can be declared side by side.
+    fn pin_map<'v>(
+        #[allow(unused_variables)] this: &Pinmux,
+        #[starlark(require = pos)] assignment: Value<'v>,
+        #[starlark(require = pos)] ifaces: SmallMap<String, Value<'v>>,
+        #[starlark(require = named, default = NoneOr::None)] part: NoneOr<String>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let heap = eval.heap();
+        let ad = DictRef::from_value(assignment).ok_or_else(|| {
+            anyhow::anyhow!("pin_map: first argument must be the `assignment` dict from pin_solve")
+        })?;
+        let mut out: Vec<(Value, Value)> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        // Which part this call maps: the one named, else the single part the
+        // assignment's requests all belong to.
+        // The entry says which part it was solved on; the claim store only
+        // answers for dicts built by hand.
+        let scope_of = |req: &str| {
+            dict_get(&ad, heap, req)
+                .and_then(|e| DictRef::from_value(e).and_then(|ed| dict_get(&ed, heap, "part")))
+                .map(|p| p.unpack_str().unwrap_or_default().to_owned())
+                .or_else(|| {
+                    eval.context_value()
+                        .and_then(|ctx| ctx.pin_claim_scope(req))
+                })
+        };
+        let mut assigned: Vec<String> = ad
+            .keys()
+            .filter_map(|k| k.unpack_str())
+            .filter_map(scope_of)
+            .collect();
+        assigned.sort();
+        assigned.dedup();
+        // A solve that served no request still has pads to tie off, and the
+        // module may have solved parts this assignment says nothing about.
+        let served_none = assigned.is_empty();
+        let scopes: Vec<String> = if served_none {
+            eval.context_value()
+                .map(|ctx| ctx.exposed_pad_scopes())
+                .unwrap_or_default()
+        } else {
+            assigned
+        };
+        let want_scope: Option<String> = match &part {
+            NoneOr::Other(p) => Some(p.clone()),
+            NoneOr::None => {
+                if scopes.len() > 1 {
+                    return Err(if served_none {
+                        anyhow::anyhow!(
+                            "pin_map: this assignment serves no request and the module solved \
+                             `{}`; pass part= to say which component to tie off",
+                            scopes.join("`, `")
+                        )
+                    } else {
+                        anyhow::anyhow!(
+                            "pin_map: this assignment spans several parts; pass part= to map one \
+                             component at a time"
+                        )
+                    });
+                }
+                scopes.first().cloned()
+            }
+        };
+        let want_part = want_scope.as_deref();
+        for (req_name, raw_val) in ifaces.iter() {
+            // One call feeds one Component, so a multi-part solve maps a part
+            // at a time.
+            if let Some(want) = want_part
+                && scope_of(req_name).is_some_and(|s| s != want)
+            {
+                continue;
+            }
+            // Accept at()-wrapped values: the constraint was consumed at solve
+            // time, only the inner net matters here.
+            let iface_val = &unpack_pin_at(*raw_val)
+                .map(|(inner, _, _)| inner)
+                .unwrap_or(*raw_val);
+            let Some(entry) = dict_get(&ad, heap, req_name) else {
+                continue;
+            };
+            let sigs = DictRef::from_value(entry)
+                .and_then(|ed| dict_get(&ed, heap, "signals"))
+                .and_then(DictRef::from_value)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("pin_map: malformed assignment entry for `{req_name}`")
+                })?;
+            let sig_count = sigs.iter().count();
+            // Declaration-side flattening applied to the instance.
+            let leaves = net_leaves(*iface_val);
+            for (s, pv) in sigs.iter() {
+                let sig = s.unpack_str().unwrap_or_default().to_owned();
+                let pin_name = DictRef::from_value(pv)
+                    .and_then(|pd| dict_get_str(&pd, heap, "pin"))
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "pin_map: malformed assignment entry for `{req_name}`/`{sig}`"
+                        )
+                    })?;
+                let net = match leaves.iter().find(|(n, _)| *n == sig).map(|(_, v)| *v) {
+                    Some(n) => n,
+                    None if sig_count == 1
+                        && (iface_val.downcast_ref::<NetValue>().is_some()
+                            || iface_val.downcast_ref::<FrozenNetValue>().is_some()) =>
+                    {
+                        *iface_val
+                    }
+                    None => {
+                        let carried = if leaves.is_empty() {
+                            "it carries no signal".to_owned()
+                        } else {
+                            format!(
+                                "it carries {}",
+                                leaves
+                                    .iter()
+                                    .map(|(n, _)| format!("`{n}`"))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            )
+                        };
+                        return Err(anyhow::anyhow!(
+                            "pin_map: request `{req_name}`: no signal `{sig}` on the provided \
+                             value — {carried} (pass the io()/interface instance, or a bare Net \
+                             for single-signal requests)"
+                        ));
+                    }
+                };
+                if !seen.insert(pin_name.clone()) {
+                    return Err(anyhow::anyhow!(
+                        "pin_map: physical pin `{pin_name}` mapped by two requests"
+                    ));
+                }
+                // Across calls too: a request re-solved by a later pin_solve
+                // releases its claims, so a superseded assignment can still
+                // hand this pin to a different net.
+                // The entry names the part it was solved on, so the guard holds
+                // even when two components share a request name.
+                if let Some(id) = net_identity(net)
+                    && let Some(scope) = scope_of(req_name).or_else(|| want_part.map(str::to_owned))
+                    && let Some(ctx) = eval.context_value()
+                {
+                    if let Some(prev) = ctx.pin_map_net(&scope, &pin_name)
+                        && prev.0 != id.0
+                    {
+                        return Err(anyhow::anyhow!(
+                            "pin_map: physical pin `{pin_name}` already mapped to net `{}` in \
+                             this module, now `{}` — map the result of the last pin_solve for \
+                             each request",
+                            prev.1,
+                            id.1
+                        ));
+                    }
+                    ctx.record_pin_map(scope, pin_name.clone(), id);
+                }
+                out.push((heap.alloc(pin_name.as_str()), net));
+            }
+        }
+        // The reverse of the skip above. Not an error: mapping an assignment
+        // in several calls is legitimate, and so is mapping a superseded one.
+        let mut unmapped: Vec<String> = ad
+            .keys()
+            .filter_map(|k| k.unpack_str())
+            .filter(|k| !ifaces.contains_key(*k))
+            .filter(|k| want_part.is_none_or(|want| scope_of(k).is_none_or(|s| s == want)))
+            .map(|k| k.to_owned())
+            .collect();
+        if !unmapped.is_empty() {
+            unmapped.sort();
+            warn_at_call_site(
+                eval,
+                format!(
+                    "pin_map: solved request(s) `{}` are absent from the ifaces dict, so their pads are wired nowhere — a claimed pad is not tied off either",
+                    unmapped.join("`, `")
+                ),
+            );
+        }
+        // Pads this part exposes that no request holds are intentionally open,
+        // so one call yields the component's whole pin table.
+        if let Some(scope) = want_part {
+            let free: Vec<String> = eval
+                .context_value()
+                .map(|ctx| {
+                    let held = ctx.claimed_pins(scope);
+                    ctx.exposed_pads(scope)
+                        .into_iter()
+                        .filter(|pad| !held.contains(pad) && seen.insert(pad.clone()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            for pad in free {
+                // The same pad answers with the same net however many calls
+                // map this part, so two dicts merge without contradicting.
+                let open = match eval
+                    .context_value()
+                    .and_then(|ctx| ctx.tied_off_net(scope, &pad))
+                {
+                    Some(net) => net,
+                    None => {
+                        let net = crate::lang::net::alloc_open_net(eval);
+                        if let Some(ctx) = eval.context_value() {
+                            ctx.record_tie_off(scope, &pad, net);
+                        }
+                        net
+                    }
+                };
+                out.push((heap.alloc(pad.as_str()), open));
+            }
+        }
+        Ok(heap.alloc(AllocDict(out)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lock(pin: &str) -> PinLock {
+        PinLock {
+            any: vec![pin.to_owned()],
+            by_signal: Vec::new(),
+        }
+    }
+
+    fn path(segs: &[&str]) -> Vec<String> {
+        segs.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    fn record(
+        c: &mut PinConstraints,
+        input: &str,
+        module: &str,
+        owner: Vec<String>,
+        net: u64,
+        pin: &str,
+    ) {
+        c.record(
+            input.to_owned(),
+            module.to_owned(),
+            None,
+            owner,
+            &[net],
+            lock(pin),
+            false,
+        );
+    }
+
+    /// Inline because the scenario is not reachable from `.zen`: whether a
+    /// second constraint on the same net is recorded before or after the early
+    /// solve depends on child-evaluation order, which a design cannot control.
+    /// A credit is per `(module, input, net)`, so it absolves one entry of its
+    /// own module and nothing of a sibling's.
+    #[test]
+    fn a_preconsume_credit_absolves_one_later_entry_only() {
+        let (a, b) = (path(&["A"]), path(&["B"]));
+        let mut c = PinConstraints::default();
+        c.preconsume(&a, "IO", &[5]);
+        record(&mut c, "IO", "a.zen", a, 5, "PA1");
+        record(&mut c, "IO", "b.zen", b, 5, "PA2");
+
+        let left = c.unconsumed_hard();
+        assert_eq!(left.len(), 1, "only the sibling's remains, got {left:?}");
+        assert_eq!(left[0].0, "b.zen");
+    }
+
+    /// A credit spent on one net must not subtract from a sibling net already
+    /// at zero: `credited` is decided by any net, the decrement is per net.
+    #[test]
+    fn spending_a_credit_never_underflows_a_zero_net() {
+        let a = path(&["A"]);
+        let mut c = PinConstraints::default();
+        c.preconsume(&a, "X", &[1, 2]);
+        c.record(
+            "X".into(),
+            "m".into(),
+            None,
+            a.clone(),
+            &[1, 2],
+            lock("PA1"),
+            false,
+        );
+        c.preconsume(&a, "X", &[1]);
+        c.record("X".into(), "m".into(), None, a, &[1, 2], lock("PA2"), false);
+    }
+
+    /// Settling an entry that already exists must not also leave a credit: the
+    /// stray one would absolve a sibling instance's constraint on the same net.
+    #[test]
+    fn settling_an_existing_entry_leaves_no_stray_credit() {
+        let (a, b) = (path(&["A"]), path(&["B"]));
+        let mut c = PinConstraints::default();
+        record(&mut c, "IO", "a.zen", a.clone(), 9, "P1");
+        c.settle(&[9], &a, "IO");
+        record(&mut c, "IO", "b.zen", b, 9, "P2");
+
+        let left = c.unconsumed_hard();
+        assert_eq!(
+            left.len(),
+            1,
+            "B's constraint must still be reported, got {left:?}"
+        );
+    }
+
+    /// A constraint another solve holds is not this input's, so its own entry
+    /// is still to come and must keep its credit.
+    #[test]
+    fn a_contended_settle_still_credits() {
+        let som = path(&["SOM"]);
+        let leaf = path(&["SOM", "U1"]);
+        let other = path(&["SOM", "U2"]);
+        let mut c = PinConstraints::default();
+        record(&mut c, "RAIL", "som.zen", som, 9, "PA1");
+        assert!(matches!(
+            c.claim(&[9], &other, "RAIL", None),
+            Claimed::Yes(..)
+        ));
+
+        // U1 solves before its own io() records: the ancestor entry is taken,
+        // so nothing here is U1's to claim.
+        c.settle(&[9], &leaf, "IO");
+        record(&mut c, "IO", "u1.zen", leaf, 9, "PA2");
+
+        let left = c.unconsumed_hard();
+        assert!(
+            !left.iter().any(|(_, input, _)| input == "IO"),
+            "U1's own constraint was honoured, got {left:?}"
+        );
+    }
+
+    /// Constraints owned higher up, however tangled among themselves, do not
+    /// cost a module the credit for the wrapper it read off its own input —
+    /// the credit is keyed on that module, that input and that net.
+    #[test]
+    fn an_ancestor_tie_does_not_cost_the_module_its_credit() {
+        let som = path(&["SOM"]);
+        let leaf = path(&["SOM", "U1"]);
+        let mut c = PinConstraints::default();
+        record(&mut c, "A", "som.zen", som.clone(), 9, "PA1");
+        record(&mut c, "B", "som.zen", som, 9, "PA2");
+
+        c.settle(&[9], &leaf, "IO");
+        record(&mut c, "IO", "u1.zen", leaf, 9, "PA3");
+
+        let left = c.unconsumed_hard();
+        assert!(
+            !left.iter().any(|(_, input, _)| input == "IO"),
+            "the solve read it off the wrapper, got {left:?}"
+        );
+        assert_eq!(left.len(), 2, "the ancestors' two remain, got {left:?}");
+    }
+
+    /// Re-evaluation records one declaration twice; the claim takes the whole
+    /// group, so no duplicate is left to be reported as never consumed.
+    #[test]
+    fn a_duplicated_record_is_claimed_with_its_group() {
+        let som = path(&["SOM"]);
+        let leaf = path(&["SOM", "U1"]);
+        let mut c = PinConstraints::default();
+        record(&mut c, "LED", "som.zen", som.clone(), 9, "PA7");
+        record(&mut c, "LED", "som.zen", som, 9, "PA7");
+
+        assert!(matches!(
+            c.claim(&[9], &leaf, "LED", None),
+            Claimed::Yes(..)
+        ));
+        let left = c.unconsumed_hard();
+        assert!(left.is_empty(), "got {left:?}");
+    }
+
+    /// A re-solve of the same request keeps its constraint, while a sibling
+    /// request on the same net still cannot take it.
+    #[test]
+    fn a_claim_is_reserved_for_the_solve_that_took_it() {
+        let som = path(&["SOM"]);
+        let leaf = path(&["SOM", "U1"]);
+        let other = path(&["SOM", "U2"]);
+
+        let mut c = PinConstraints::default();
+        record(&mut c, "LED", "som.zen", som, 9, "PA7");
+        let took = |c: &mut PinConstraints, who: &[String]| {
+            matches!(c.claim(&[9], who, "LED", None), Claimed::Yes(..))
+        };
+        assert!(took(&mut c, &leaf), "first solve takes it");
+        assert!(!took(&mut c, &other), "a sibling may not");
+        assert!(took(&mut c, &leaf), "the same solve may take it again");
+        // Both are named, sorted, whichever of them ran first.
+        let contended = c.contended();
+        assert_eq!(contended.len(), 1, "got {contended:?}");
+        assert_eq!(contended[0].3, ["SOM.U1", "SOM.U2"], "got {contended:?}");
+        assert!(c.unconsumed_hard().is_empty());
+    }
+
+    /// Two ancestor-owned constraints on one net at the same depth cannot be
+    /// told apart by owner, and entry order is not stable under parallel child
+    /// evaluation, so the solve reports rather than picks.
+    #[test]
+    fn two_forwarded_constraints_on_one_net_are_reported_not_guessed() {
+        let som = path(&["SOM"]);
+        let leaf = path(&["SOM", "U1"]);
+
+        let mut c = PinConstraints::default();
+        record(&mut c, "A", "som.zen", som.clone(), 9, "PA1");
+        record(&mut c, "B", "som.zen", som, 9, "PA2");
+
+        assert!(
+            matches!(c.claim(&[9], &leaf, "LED", None), Claimed::Ambiguous),
+            "ambiguous, no guess"
+        );
+        let Some(Ambiguity::Entries { input, names }) = c.take_ambiguous() else {
+            panic!("ambiguity reported");
+        };
+        assert_eq!(input, "LED");
+        assert_eq!(names, "A`, `B");
+    }
+}

--- a/crates/pcb-zen-core/tests/net.rs
+++ b/crates/pcb-zen-core/tests/net.rs
@@ -573,3 +573,58 @@ fn net_constructor_positional_cast_preserves_behavior() {
     let schematic = sch_result.output.expect("expected schematic output");
     assert_eq!(schematic.nets["SIG"].kind, "Net");
 }
+
+#[test]
+fn diffpair_impedance_reaches_net_properties_through_nesting() {
+    // The pin solver ignores `impedance`; the router must still get it.
+    let result = eval_zen(vec![
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/interfaces.zen", "Usb2")
+usb = io("USB", Usb2)
+Component(
+    name = "U1",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod"),
+    pin_defs = {"PA11": "1", "PA12": "2"},
+    pins = {"PA11": usb.D.N, "PA12": usb.D.P},
+    skip_bom = True,
+)
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/interfaces.zen", "Usb2")
+Mcu = Module("./mcu.zen")
+BUS = Usb2("BUS")
+Mcu(name = "U1", USB = BUS)
+"#
+            .to_string(),
+        ),
+    ]);
+
+    assert!(
+        !result.diagnostics.has_errors(),
+        "did not expect errors, got: {:?}",
+        result.diagnostics
+    );
+    let sch_result = result
+        .output
+        .expect("expected eval output")
+        .to_schematic_with_diagnostics();
+    assert!(
+        !sch_result.diagnostics.has_errors(),
+        "schematic conversion failed: {:?}",
+        sch_result.diagnostics
+    );
+    let schematic = sch_result.output.expect("expected schematic output");
+    for net in ["BUS_D_P", "BUS_D_N"] {
+        let value = schematic.nets[net]
+            .properties
+            .get("differential_impedance")
+            .unwrap_or_else(|| panic!("{net} lost its differential_impedance property"));
+        assert_eq!(value.string(), Some("90"), "{net} impedance");
+    }
+}

--- a/crates/pcb-zen-core/tests/pinmux.rs
+++ b/crates/pcb-zen-core/tests/pinmux.rs
@@ -1,0 +1,4146 @@
+//! Integration tests for the peripheral capability model. Behavior assertions
+//! live in the `.zen` fixtures via `check()`; the Rust side asserts overall
+//! success/failure, diagnostics, and emitted module properties. Pin/AF pairs
+//! are illustrative, not datasheet-verified.
+
+mod common;
+
+use common::eval_zen;
+use pcb_zen_core::WithDiagnostics;
+use pcb_zen_core::lang::eval::EvalOutput;
+use pcb_zen_core::lang::eval::{EvalContext, EvalContextConfig, EvalSession};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+const IFACES: &str = r#"
+Frequency = 1 / builtin.Time
+Uart = interface(TX = Net, RX = Net, attrs = {"baud_max": Frequency})
+Usart = interface(TX = Net, RX = Net, CK = Net, implies = [Uart])
+UartFlow = interface(TX = Net, RX = Net, RTS = Net, CTS = Net, implies = [Uart])
+I2c = interface(SDA = Net, SCL = Net, attrs = {"clk_max": Frequency, "vio": Voltage})
+Spi = interface(SCK = Net, MISO = Net, MOSI = Net)
+Gpio = interface(PIN = Net)
+AdcIn = interface(IN = Net)
+Comparator = interface(INP = Net, INN = Net, OUT = Net)
+
+DiffPair = interface(P = Net, N = Net, impedance = field(int, default = 0))
+# Nested as an instance (the stdlib spelling) and as a type.
+Usb2 = interface(D = DiffPair(impedance = 90), VBUS = Net)
+Lvds = interface(CLK = DiffPair, DATA = DiffPair)
+# `D` flattens onto the sibling `D_P`.
+Ambiguous = interface(D = DiffPair, D_P = Net)
+"#;
+
+const STM32: &str = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pool")
+load("./ifaces.zen", "Uart", "Usart", "UartFlow", "I2c", "Spi", "Gpio", "AdcIn")
+
+USART1 = peripheral(
+    "USART1",
+    provides = [Usart, UartFlow],
+    rebind = "firmware",
+    signals = {
+        "TX": [pin("PA9", data = {"af": 1}), pin("PB6", data = {"af": 0})],
+        "RX": [pin("PA10", data = {"af": 1}), pin("PB7", data = {"af": 0})],
+        "CK": [pin("PA8", data = {"af": 1})],
+        "RTS": [pin("PA12", data = {"af": 1})],
+        "CTS": [pin("PA11", data = {"af": 1})],
+    },
+    attrs = {"baud_max": "8MHz"},
+)
+
+USART2 = peripheral(
+    "USART2",
+    provides = [Uart],
+    rebind = "firmware",
+    signals = {
+        "TX": [pin("PA2", data = {"af": 1}), pin("PA14", data = {"af": 1})],
+        "RX": [pin("PA3", data = {"af": 1}), pin("PA15", data = {"af": 1})],
+    },
+    attrs = {"baud_max": "4MHz"},
+)
+
+SPI1 = peripheral(
+    "SPI1",
+    provides = [Spi],
+    rebind = "firmware",
+    signals = {
+        "SCK": [pin("PA5", data = {"af": 0}), pin("PB3", data = {"af": 0})],
+        "MISO": [pin("PA6", data = {"af": 0}), pin("PB4", data = {"af": 0})],
+        "MOSI": [pin("PA7", data = {"af": 0}), pin("PB5", data = {"af": 0})],
+    },
+)
+
+I2C1 = peripheral(
+    "I2C1",
+    provides = [I2c],
+    rebind = "firmware",
+    signals = {
+        "SDA": [pin("PB7", data = {"af": 6})],
+        "SCL": [pin("PB6", data = {"af": 6})],
+    },
+)
+
+ADC1_IN0 = peripheral("ADC1_IN0", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("PA0")]})
+ADC1_IN1 = peripheral("ADC1_IN1", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("PA1")]})
+
+GPIO_POOL = pool(
+    "GPIO",
+    provides = [Gpio],
+    pins = [
+        "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PA8",
+        "PA9", "PA10", "PA11", "PA12", "PA15",
+        "PB0", "PB1", "PB3", "PB4", "PB5", "PB6", "PB7",
+    ],
+)
+
+PERIPHS = [USART1, USART2, SPI1, I2C1, ADC1_IN0, ADC1_IN1, GPIO_POOL]
+"#;
+
+const ESP32C3: &str = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pool")
+load("./ifaces.zen", "Uart", "Gpio", "AdcIn")
+
+_MATRIX = [
+    "GPIO0", "GPIO1", "GPIO2", "GPIO3", "GPIO4", "GPIO5", "GPIO6", "GPIO7",
+    "GPIO8", "GPIO9", "GPIO10", "GPIO18", "GPIO19", "GPIO20", "GPIO21",
+]
+_STRAP = ["GPIO2", "GPIO8", "GPIO9"]
+
+def _matrix(exclude):
+    return [pin(n, cost = 1, strap = n in _STRAP) for n in _MATRIX if n not in exclude]
+
+UART0 = peripheral(
+    "UART0",
+    provides = [Uart],
+    rebind = "firmware",
+    signals = {
+        "TX": [pin("GPIO21", cost = 0, data = {"iomux_func": 0})] + _matrix(["GPIO21"]),
+        "RX": [pin("GPIO20", cost = 0, data = {"iomux_func": 0})] + _matrix(["GPIO20"]),
+    },
+)
+
+UART1 = peripheral(
+    "UART1",
+    provides = [Uart],
+    rebind = "firmware",
+    signals = {"TX": _matrix([]), "RX": _matrix([])},
+)
+
+ADC1_CH0 = peripheral("ADC1_CH0", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("GPIO0")]})
+ADC1_CH1 = peripheral("ADC1_CH1", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("GPIO1")]})
+ADC1_CH2 = peripheral("ADC1_CH2", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("GPIO2")]})
+ADC1_CH3 = peripheral("ADC1_CH3", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("GPIO3")]})
+ADC1_CH4 = peripheral("ADC1_CH4", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("GPIO4")]})
+ADC2_CH0 = peripheral("ADC2_CH0", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("GPIO5")]}, unless = "wifi")
+
+GPIO_POOL = pool(
+    "GPIO",
+    provides = [Gpio],
+    pins = [pin(n, strap = n in _STRAP) for n in _MATRIX],
+)
+
+PERIPHS = [UART0, UART1, ADC1_CH0, ADC1_CH1, ADC1_CH2, ADC1_CH3, ADC1_CH4, ADC2_CH0, GPIO_POOL]
+"#;
+
+const COMPARATOR: &str = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Comparator")
+
+UNIT_A = peripheral("A", provides = [Comparator], rebind = "none",
+    signals = {"INP": [pin("1")], "INN": [pin("2")], "OUT": [pin("3")]})
+UNIT_B = peripheral("B", provides = [Comparator], rebind = "none",
+    signals = {"INP": [pin("5")], "INN": [pin("6")], "OUT": [pin("7")]})
+
+PERIPHS = [UNIT_A, UNIT_B]
+"#;
+
+fn eval_with_fixtures(main: &str) -> WithDiagnostics<EvalOutput> {
+    eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/stm32.zen".to_string(), STM32.to_string()),
+        ("/esp32c3.zen".to_string(), ESP32C3.to_string()),
+        ("/comparator.zen".to_string(), COMPARATOR.to_string()),
+        ("/test.zen".to_string(), main.to_string()),
+    ])
+}
+
+fn assert_ok(result: &WithDiagnostics<EvalOutput>) {
+    if !result.is_success() {
+        panic!(
+            "expected success, got diagnostics: {:#?}",
+            result.diagnostics
+        );
+    }
+}
+
+fn diag_text(result: &WithDiagnostics<EvalOutput>) -> String {
+    format!("{:#?}", result.diagnostics)
+}
+
+fn assert_fails_with(result: &WithDiagnostics<EvalOutput>, needle: &str) {
+    assert!(
+        !result.is_success(),
+        "expected failure containing {needle:?}, but evaluation succeeded"
+    );
+    let text = diag_text(result);
+    assert!(
+        text.contains(needle),
+        "expected diagnostics to contain {needle:?}, got:\n{text}"
+    );
+}
+
+fn json_property(result: &WithDiagnostics<EvalOutput>, key: &str) -> serde_json::Value {
+    let props = result.output.as_ref().unwrap().sch_module.properties();
+    let value = props
+        .get(key)
+        .unwrap_or_else(|| panic!("missing module property {key:?}"));
+    let text = value
+        .to_value()
+        .unpack_str()
+        .unwrap_or_else(|| panic!("module property {key:?} is not a string"));
+    serde_json::from_str(text).unwrap()
+}
+
+#[test]
+fn downgrade_and_poorest_instance() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pin_map")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Usart")
+
+res = pin_solve(PERIPHS, [pin_request("DEBUG", Uart), pin_request("SC", Usart)])
+a = res["assignment"]
+check(a["DEBUG"]["instance"] == "USART2", "DEBUG got " + a["DEBUG"]["instance"])
+check(a["SC"]["instance"] == "USART1", "SC got " + a["SC"]["instance"])
+check(a["SC"]["signals"]["TX"]["pin"] == "PA9", "SC TX pin")
+check(a["SC"]["signals"]["TX"]["af"] == 1, "SC TX af")
+m = pin_map(res["assignment"], {"DEBUG": Uart("D"), "SC": Usart("S")})
+check("PB3" in m, "unclaimed candidate must be tied off")
+"#,
+    );
+    assert_ok(&result);
+    let props = result.output.as_ref().unwrap().sch_module.properties();
+    assert!(
+        props.contains_key("pin_assignment"),
+        "pin_assignment property missing"
+    );
+    assert!(
+        props.contains_key("swap_classes"),
+        "swap_classes property missing"
+    );
+}
+
+#[test]
+fn upgrade_is_impossible() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Usart")
+
+pin_solve(PERIPHS, [pin_request("SC1", Usart), pin_request("SC2", Usart)])
+"#,
+    );
+    assert_fails_with(&result, "no feasible assignment");
+}
+
+#[test]
+fn instance_exclusive_even_on_disjoint_pins() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+
+pin_solve(PERIPHS, [
+    pin_request("U1", Uart),
+    pin_request("U2", Uart),
+    pin_request("U3", Uart),
+])
+"#,
+    );
+    assert_fails_with(&result, "no feasible assignment");
+}
+
+#[test]
+fn intra_instance_pin_mixing() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Gpio")
+
+res = pin_solve(PERIPHS, [
+    pin_request("BTN", Gpio, prefer = ["PA10"], lock = True),
+    pin_request("COM", Uart, instance = "USART1"),
+])
+a = res["assignment"]
+check(a["BTN"]["signals"]["PIN"]["pin"] == "PA10", "BTN pin")
+check(a["COM"]["signals"]["TX"]["pin"] == "PA9", "COM TX " + a["COM"]["signals"]["TX"]["pin"])
+check(a["COM"]["signals"]["RX"]["pin"] == "PB7", "COM RX " + a["COM"]["signals"]["RX"]["pin"])
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn joint_contention_is_infeasible() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "I2c", "Gpio")
+
+pin_solve(PERIPHS, [
+    pin_request("BTN1", Gpio, prefer = ["PA9"], lock = True),
+    pin_request("BTN2", Gpio, prefer = ["PA10"], lock = True),
+    pin_request("BUS", I2c),
+    pin_request("COM", Uart, instance = "USART1"),
+])
+"#,
+    );
+    assert_fails_with(&result, "no feasible assignment");
+}
+
+#[test]
+fn where_predicate_on_unit_attrs() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+
+def fast(a):
+    return a["baud_max"] >= "6MHz"
+
+res = pin_solve(PERIPHS, [pin_request("FAST", Uart, where = fast)])
+check(res["assignment"]["FAST"]["instance"] == "USART1", "FAST got " + res["assignment"]["FAST"]["instance"])
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn where_predicate_starves() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Usart")
+
+def fast(a):
+    return a["baud_max"] >= "6MHz"
+
+pin_solve(PERIPHS, [
+    pin_request("SC", Usart),
+    pin_request("FAST", Uart, where = fast),
+])
+"#,
+    );
+    assert_fails_with(&result, "no feasible assignment");
+}
+
+#[test]
+fn gpio_vs_peripheral_exclusivity() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Spi", "Gpio")
+
+res = pin_solve(PERIPHS, [
+    pin_request("LED", Gpio, prefer = ["PA5"], lock = True),
+    pin_request("FLASH", Spi),
+])
+check(res["assignment"]["FLASH"]["signals"]["SCK"]["pin"] == "PB3", "SCK fallback")
+"#,
+    );
+    assert_ok(&result);
+
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Spi", "Gpio")
+
+pin_solve(PERIPHS, [
+    pin_request("LED", Gpio, prefer = ["PA5"], lock = True),
+    pin_request("LED2", Gpio, prefer = ["PB3"], lock = True),
+    pin_request("FLASH", Spi),
+])
+"#,
+    );
+    assert_fails_with(&result, "no feasible assignment");
+}
+
+#[test]
+fn deterministic_and_stable_across_builds() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Usart", "Gpio", "AdcIn")
+
+reqs = [pin_request("DEBUG", Uart), pin_request("LED", Gpio), pin_request("MES", AdcIn)]
+r1 = pin_solve(PERIPHS, reqs)
+r2 = pin_solve(PERIPHS, reqs)
+check(r1["assignment"] == r2["assignment"], "two identical runs diverged")
+
+r3 = pin_solve(PERIPHS, reqs + [pin_request("SC", Usart)], previous = r1["assignment"])
+check(r3["assignment"]["DEBUG"] == r1["assignment"]["DEBUG"], "DEBUG reshuffled")
+check(r3["assignment"]["LED"]["signals"] == r1["assignment"]["LED"]["signals"], "LED reshuffled")
+check(r3["assignment"]["MES"]["signals"] == r1["assignment"]["MES"]["signals"], "MES reshuffled")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn declaration_cannot_overstate() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "UartFlow")
+
+peripheral("UARTX", provides = [UartFlow], rebind = "firmware",
+    signals = {"TX": [pin("P1")], "RX": [pin("P2")]})
+"#,
+    );
+    assert_fails_with(&result, "no candidate for signal");
+}
+
+#[test]
+fn esp32_iomux_preferred_over_matrix() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./esp32c3.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+
+res = pin_solve(PERIPHS, [pin_request("CONSOLE", Uart), pin_request("GPS", Uart)])
+a = res["assignment"]
+check(a["CONSOLE"]["instance"] == "UART0", "console instance")
+check(a["CONSOLE"]["signals"]["TX"]["pin"] == "GPIO21", "console TX iomux")
+check(a["CONSOLE"]["signals"]["RX"]["pin"] == "GPIO20", "console RX iomux")
+check(a["CONSOLE"]["signals"]["TX"]["iomux_func"] == 0, "iomux realization data")
+check(a["GPS"]["instance"] == "UART1", "gps instance")
+check(not (a["GPS"]["signals"]["TX"]["pin"] in ["GPIO2", "GPIO8", "GPIO9"]), "gps TX strap avoided")
+check(not (a["GPS"]["signals"]["RX"]["pin"] in ["GPIO2", "GPIO8", "GPIO9"]), "gps RX strap avoided")
+check(len(a["GPS"]["alternates"]["TX"]) > 0, "matrix alternates missing")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn esp32_conditional_capability() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./esp32c3.zen", "PERIPHS")
+load("./ifaces.zen", "AdcIn")
+
+pin_solve(
+    PERIPHS,
+    [pin_request("A" + str(i), AdcIn) for i in range(6)],
+    config = {"wifi": True},
+)
+"#,
+    );
+    assert_fails_with(&result, "no feasible assignment");
+
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./esp32c3.zen", "PERIPHS")
+load("./ifaces.zen", "AdcIn")
+
+res = pin_solve(
+    PERIPHS,
+    [pin_request("A" + str(i), AdcIn) for i in range(6)],
+    config = {"wifi": False},
+)
+insts = [res["assignment"]["A" + str(i)]["instance"] for i in range(6)]
+check("ADC2_CH0" in insts, "ADC2 not used: " + str(insts))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn forced_strap_pin_warns() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./esp32c3.zen", "PERIPHS")
+load("./ifaces.zen", "Gpio")
+
+res = pin_solve(PERIPHS, [pin_request("BOOT_BTN", Gpio, prefer = ["GPIO9"], lock = True)])
+check(res["assignment"]["BOOT_BTN"]["signals"]["PIN"]["pin"] == "GPIO9", "locked pin honored")
+"#,
+    );
+    assert_ok(&result);
+    let text = diag_text(&result);
+    assert!(
+        text.contains("strapping pin"),
+        "expected a strapping-pin warning, got:\n{text}"
+    );
+}
+
+#[test]
+fn hard_lock_single_pin_on_multi_signal_role() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+
+res = pin_solve(PERIPHS, [pin_request("DEBUG", Uart, prefer = ["PA2"], lock = True)])
+a = res["assignment"]["DEBUG"]
+check(a["instance"] == "USART2", "expected USART2, got " + a["instance"])
+check(a["signals"]["TX"]["pin"] == "PA2", "TX must land on the locked pin")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn empty_uses_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+
+pin_solve(PERIPHS, [pin_request("X", Uart, uses = [])])
+"#,
+    );
+    assert_fails_with(&result, "at least one signal");
+}
+
+#[test]
+fn infeasible_after_truncation_mentions_the_cap() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+
+WIDE = peripheral(
+    "WIDE",
+    provides = [Uart],
+    rebind = "firmware",
+    signals = {
+        "TX": [pin("P" + str(i)) for i in range(24)],
+        "RX": [pin("P" + str(i)) for i in range(24)],
+    },
+)
+
+pin_solve([WIDE], [pin_request("A", Uart), pin_request("B", Uart)])
+"#,
+    );
+    assert_fails_with(&result, "no feasible assignment");
+    assert_fails_with(&result, "capped at");
+}
+
+#[test]
+fn locked_pin_beyond_the_cap_is_still_found() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+
+P = peripheral(
+    "P",
+    provides = [Gpio],
+    rebind = "firmware",
+    signals = {"PIN": [pin("P" + str(i)) for i in range(600)]},
+)
+
+res = pin_solve([P], [pin_request("R", Gpio, prefer = ["P599"], lock = True)])
+check(res["assignment"]["R"]["signals"]["PIN"]["pin"] == "P599", "locked pin must win over the cap")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn mandatory_pin_beyond_the_cap_is_still_found() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+
+W = peripheral(
+    "W",
+    provides = [Uart],
+    rebind = "firmware",
+    signals = {
+        "TX": [pin("T" + str(i)) for i in range(30)],
+        "RX": [pin("R" + str(i)) for i in range(30)],
+    },
+)
+
+res = pin_solve([W], [pin_request("U", Uart, prefer = ["T29"], lock = True)])
+check(res["assignment"]["U"]["signals"]["TX"]["pin"] == "T29", "mandatory pin must win over the cap")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn failed_lock_names_the_pins_in_the_rejection() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Gpio")
+
+pin_solve(PERIPHS, [pin_request("LED", Gpio, prefer = ["NOPE"], lock = True)])
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "signal `PIN` has no candidate among the locked pins `NOPE`",
+    );
+}
+
+#[test]
+fn at_constraint_survives_solve_before_io() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/stm32.zen".to_string(), STM32.to_string()),
+        (
+            "/mcu_early.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+load("./stm32.zen", "PERIPHS")
+
+res = pin_solve(PERIPHS, [pin_request("IO0", Gpio, if_connected = True)])
+a = res["assignment"]
+builtin.add_property("io0_pin", a["IO0"]["signals"]["PIN"]["pin"] if "IO0" in a else "none")
+
+IO0 = io(Net, optional = True)
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/mcu_early.zen")
+Mcu(name = "M1", IO0 = at(Net("LED"), "PA10"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    assert_eq!(io0_pin(&result), "PA10");
+}
+
+#[test]
+fn duplicate_uses_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+
+pin_solve(PERIPHS, [pin_request("X", Uart, uses = ["TX", "TX"])])
+"#,
+    );
+    assert_fails_with(&result, "duplicate signal");
+}
+
+#[test]
+fn raw_pin_dict_with_reserved_data_key_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+
+forged = {"kind": "pin", "name": "X1", "data": {"pin": "LIE"}, "cost": 0, "input_only": False, "strap": False}
+P = peripheral("P", provides = [Gpio], rebind = "fixed", signals = {"PIN": [forged]})
+pin_solve([P], [pin_request("R", Gpio)])
+"#,
+    );
+    assert_fails_with(&result, "reserved");
+}
+
+#[test]
+fn exclusivity_spans_solves_in_one_module() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+
+P = peripheral("P", provides = [Gpio], rebind = "fixed", signals = {"PIN": [pin("X1")]})
+pin_solve([P], [pin_request("A", Gpio)])
+pin_solve([P], [pin_request("B", Gpio)])
+"#,
+    );
+    assert_fails_with(&result, "already claimed by an earlier pin_solve");
+
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pool")
+load("./ifaces.zen", "Gpio")
+
+POOL = pool("GPIO", provides = [Gpio], pins = ["X1", "X2", "X3"])
+r1 = pin_solve(POOL, [pin_request("A", Gpio)])
+r2 = pin_solve(POOL, [pin_request("B", Gpio)])
+p1 = r1["assignment"]["A"]["signals"]["PIN"]["pin"]
+p2 = r2["assignment"]["B"]["signals"]["PIN"]["pin"]
+check(p1 != p2, "second solve must avoid the claimed pin, got " + p1 + " twice")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn residual_freedom_excludes_prior_solve_claims() {
+    // Tied-off pads and pool spare_pins must not list a pin an earlier solve owns.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pool", "pin_map")
+load("./ifaces.zen", "Gpio")
+
+POOL = pool("GPIO", provides = [Gpio], pins = ["X1", "X2", "X3"])
+r1 = pin_solve(POOL, [pin_request("A", Gpio)])
+r2 = pin_solve(POOL, [pin_request("B", Gpio)])
+p1 = r1["assignment"]["A"]["signals"]["PIN"]["pin"]
+m2 = pin_map(r2["assignment"], {"B": Net("NB")})
+check(not (p1 in m2), "the pin claimed by the first solve must not be tied off here")
+pools = [c for c in r2["swap_classes"] if c["granularity"] == "pin"]
+check(len(pools) == 1, "expected one pool class")
+check(p1 not in pools[0]["spare_pins"], "spare_pins must exclude the pin claimed by the first solve")
+"#,
+    );
+    assert_ok(&result);
+
+    // Per-signal alternates must not offer a pin an earlier solve owns.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+
+P1 = peripheral("P1", provides = [Gpio], rebind = "firmware",
+    signals = {"PIN": [pin("X1"), pin("X2")]})
+P2 = peripheral("P2", provides = [Gpio], rebind = "firmware",
+    signals = {"PIN": [pin("X1"), pin("X2")]})
+r1 = pin_solve([P1, P2], [pin_request("A", Gpio)])
+r2 = pin_solve([P1, P2], [pin_request("B", Gpio)])
+p1 = r1["assignment"]["A"]["signals"]["PIN"]["pin"]
+alts = r2["assignment"]["B"]["alternates"]
+check(p1 not in alts.get("PIN", []), "alternates must exclude the pin claimed by the first solve")
+"#,
+    );
+    assert_ok(&result);
+
+    // Cluster spare_units must not offer a unit an earlier solve owns: with
+    // both comparator units taken across two solves, no swap class remains.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./comparator.zen", "PERIPHS")
+load("./ifaces.zen", "Comparator")
+
+pin_solve(PERIPHS, [pin_request("CMP1", Comparator)])
+r2 = pin_solve(PERIPHS, [pin_request("CMP2", Comparator)])
+clusters = [c for c in r2["swap_classes"] if c["granularity"] == "cluster"]
+check(len(clusters) == 0, "no residual cluster freedom once both units are claimed, got " + str(clusters))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn misused_previous_warns() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+
+r1 = pin_solve(PERIPHS, [pin_request("DEBUG", Uart)])
+pin_solve(PERIPHS, [pin_request("DEBUG", Uart)], previous = r1)
+"#,
+    );
+    assert_ok(&result);
+    let text = diag_text(&result);
+    assert!(
+        text.contains("no usable assignment entry"),
+        "expected a previous= misuse warning, got:\n{text}"
+    );
+}
+
+#[test]
+fn conflicting_attr_dims_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Frequency")
+
+A = interface(X = Net, attrs = {"m": Frequency})
+B = interface(Y = Net, attrs = {"m": builtin.Time})
+
+peripheral("P", provides = [A, B], rebind = "fixed",
+    signals = {"X": [pin("P1")], "Y": [pin("P2")]})
+"#,
+    );
+    assert_fails_with(&result, "conflicting dimensions");
+}
+
+#[test]
+fn two_solves_merge_into_the_module_properties() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Gpio")
+
+pin_solve(PERIPHS, [pin_request("DEBUG", Uart)])
+pin_solve(PERIPHS, [pin_request("LED", Gpio)])
+"#,
+    );
+    assert_ok(&result);
+    let props = result.output.as_ref().unwrap().sch_module.properties();
+    let assignment = format!("{:?}", props.get("pin_assignment"));
+    assert!(
+        assignment.contains("DEBUG") && assignment.contains("LED"),
+        "both solves must reach the property, got:\n{assignment}"
+    );
+}
+
+#[test]
+fn swap_classes_property_merges_pool_solves() {
+    // Two solves on one pool merge into a single property class whose spares
+    // reflect every claim in the module, not just the last solve's.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pool")
+load("./ifaces.zen", "Gpio")
+
+POOL = pool("GPIO", provides = [Gpio], pins = ["X1", "X2", "X3", "X4"])
+pin_solve(POOL, [pin_request("A", Gpio)])
+pin_solve(POOL, [pin_request("B", Gpio)])
+"#,
+    );
+    assert_ok(&result);
+    let swaps = json_property(&result, "swap_classes");
+    let classes = swaps.as_array().unwrap();
+    assert_eq!(classes.len(), 1, "one merged pool class, got {swaps}");
+    let members = classes[0]["members"].as_array().unwrap();
+    let requests: Vec<&str> = members
+        .iter()
+        .map(|m| m["request"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        requests,
+        ["A", "B"],
+        "members from both solves, got {swaps}"
+    );
+    let member_pins: Vec<&str> = members.iter().map(|m| m["pin"].as_str().unwrap()).collect();
+    let spares: Vec<&str> = classes[0]["spare_pins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap())
+        .collect();
+    assert_eq!(spares.len(), 2, "two of four pool pins left, got {swaps}");
+    assert!(
+        spares.iter().all(|s| !member_pins.contains(s)),
+        "spares must exclude claimed pins, got {swaps}"
+    );
+}
+
+#[test]
+fn resolving_one_member_keeps_its_siblings_in_the_property() {
+    // Re-solving A must not drop B's membership from the shared class.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pool")
+load("./ifaces.zen", "Gpio")
+
+POOL = pool("GPIO", provides = [Gpio], pins = ["X1", "X2"])
+pin_solve(POOL, [pin_request("A", Gpio), pin_request("B", Gpio)])
+pin_solve(POOL, [pin_request("A", Gpio)])
+"#,
+    );
+    assert_ok(&result);
+    let swaps = json_property(&result, "swap_classes");
+    let classes = swaps.as_array().unwrap();
+    assert_eq!(classes.len(), 1, "one merged pool class, got {swaps}");
+    let requests: Vec<&str> = classes[0]["members"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["request"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        requests,
+        ["A", "B"],
+        "the sibling survives the re-solve, got {swaps}"
+    );
+}
+
+#[test]
+fn cluster_property_merges_and_refreshes_spares_across_solves() {
+    // Cluster classes from separate solves over the same silicon merge, and
+    // spare units drop out as later solves occupy them.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Comparator")
+
+UNIT_A = peripheral("A", provides = [Comparator], rebind = "none",
+    signals = {"INP": [pin("1")], "INN": [pin("2")], "OUT": [pin("3")]})
+UNIT_B = peripheral("B", provides = [Comparator], rebind = "none",
+    signals = {"INP": [pin("5")], "INN": [pin("6")], "OUT": [pin("7")]})
+UNIT_C = peripheral("C", provides = [Comparator], rebind = "none",
+    signals = {"INP": [pin("8")], "INN": [pin("9")], "OUT": [pin("10")]})
+PERIPHS = [UNIT_A, UNIT_B, UNIT_C]
+
+pin_solve(PERIPHS, [pin_request("CMP1", Comparator)])
+pin_solve(PERIPHS, [pin_request("CMP2", Comparator)])
+"#,
+    );
+    assert_ok(&result);
+    let swaps = json_property(&result, "swap_classes");
+    let classes = swaps.as_array().unwrap();
+    assert_eq!(classes.len(), 1, "one merged cluster class, got {swaps}");
+    let members = classes[0]["members"].as_array().unwrap();
+    let requests: Vec<&str> = members
+        .iter()
+        .map(|m| m["request"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        requests,
+        ["CMP1", "CMP2"],
+        "members from both solves, got {swaps}"
+    );
+    let member_units: Vec<&str> = members
+        .iter()
+        .map(|m| m["instance"].as_str().unwrap())
+        .collect();
+    let spares: Vec<&str> = classes[0]["spare_units"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap())
+        .collect();
+    assert_eq!(spares.len(), 1, "one unit left, got {swaps}");
+    assert!(
+        spares.iter().all(|s| !member_units.contains(s)),
+        "spare units must exclude occupied units, got {swaps}"
+    );
+}
+
+#[test]
+fn reserved_interface_kwargs_misuse_mentions_reservation() {
+    let result = eval_with_fixtures("A = interface(X = Net, attrs = Net)\n");
+    assert_fails_with(&result, "reserved for capability metadata");
+
+    let result = eval_with_fixtures("B = interface(X = Net, implies = Net)\n");
+    assert_fails_with(&result, "reserved for capability metadata");
+
+    // A field slipped into the container form is caught by its own contents.
+    let result = eval_with_fixtures("C = interface(X = Net, attrs = {\"a\": Net})\n");
+    assert_fails_with(&result, "must map to a physical value type");
+
+    let result = eval_with_fixtures("D = interface(X = Net, implies = [Net])\n");
+    assert_fails_with(&result, "entries must be interface types");
+}
+
+#[test]
+fn unconsumed_at_failure_keeps_module_warnings() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/esp32c3.zen".to_string(), ESP32C3.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./esp32c3.zen", "PERIPHS")
+load("./ifaces.zen", "Gpio")
+
+IO0 = io(Net, optional = True)
+pin_solve(PERIPHS, [pin_request("BOOT_BTN", Gpio, prefer = ["GPIO9"], lock = True)])
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/mcu.zen")
+Mcu(name = "M1", IO0 = at(Net("LED"), "GPIO4"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(&result, "never consumed");
+    let text = diag_text(&result);
+    assert!(
+        text.contains("strapping pin"),
+        "module warnings must survive the failure, got:\n{text}"
+    );
+}
+
+#[test]
+fn unconsumed_hard_at_fails_the_build() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/plain.zen".to_string(),
+            "IO0 = io(Net, optional = True)\n".to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/plain.zen")
+Mcu(name = "M1", IO0 = at(Net("LED"), "PA10"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(&result, "never consumed");
+}
+
+#[test]
+fn an_at_inside_a_list_config_is_not_dropped() {
+    // Only the dict-of-roles shape reaches a request, so a wrapper handed in a
+    // list is reported rather than silently forgotten.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/plain.zen".to_string(),
+            "GPIO = config(\"gpio\", list, optional = True)\n".to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/plain.zen")
+Mcu(name = "M1", gpio = [at(Net("LED"), "PA10")])
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(&result, "never consumed");
+}
+
+#[test]
+fn unconsumed_soft_at_is_tolerated() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/plain.zen".to_string(),
+            "IO0 = io(Net, optional = True)\n".to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/plain.zen")
+Mcu(name = "M1", IO0 = at(Net("LED"), "PA10", soft = True))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+}
+
+#[test]
+fn a_factory_built_capability_is_fresh_per_binding() {
+    // An interface() minted inside a helper is keyed to the module that binds
+    // it, so two callers hold two capabilities. The solve says so instead of
+    // quietly failing to match.
+    let result = eval_zen(vec![
+        (
+            "/mk.zen".to_string(),
+            "def mk():\n    return interface(PIN = Net)\n".to_string(),
+        ),
+        (
+            "/chip.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pool")
+load("./mk.zen", "mk")
+Cap = mk()
+PERIPHS = [pool("GPIO", provides = [Cap], pins = ["PA0", "PA1"])]
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./mk.zen", "mk")
+load("./chip.zen", "PERIPHS")
+Cap = mk()
+r = pin_solve(PERIPHS, [pin_request("A", Cap)])
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(
+        &result,
+        "provides a different Cap — capability types are per interface() declaration",
+    );
+}
+
+#[test]
+fn an_unnamed_factory_capability_stands_on_its_own() {
+    // No top-level binding to key on, so each interface() call is its own
+    // capability — two widths from one helper never pass for each other.
+    let result = eval_zen(vec![
+        (
+            "/mk.zen".to_string(),
+            "def mk(n):\n    return interface(PIN = Net, width = field(int, default = n))\n"
+                .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./mk.zen", "mk")
+CAPS = [mk(8), mk(16)]
+P = [pool("GPIO", provides = [CAPS[0]], pins = ["PA0", "PA1"])]
+r = pin_solve(P, [pin_request("A", CAPS[1])])
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(&result, "capability types are per interface() declaration");
+}
+
+/// The module makes a pin mandatory; the caller only wishes for another.
+fn soft_over_lock(arg: &str, module: &str) -> WithDiagnostics<EvalOutput> {
+    eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/mcu.zen".to_string(), module.to_string()),
+        (
+            "/test.zen".to_string(),
+            format!(
+                r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio", "Uart")
+Mcu = Module("/mcu.zen")
+Mcu(name = "U1", {arg})
+"#
+            ),
+        ),
+    ])
+}
+
+fn solved_pin(result: &WithDiagnostics<EvalOutput>) -> String {
+    assert_ok(result);
+    result
+        .output
+        .as_ref()
+        .and_then(|o| {
+            o.module_tree()
+                .values()
+                .filter_map(|m| m.properties().get("led"))
+                .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+                .next()
+        })
+        .unwrap_or_default()
+}
+
+const LOCKED_GPIO: &str = r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA5", "PA6"])
+LED = io(Gpio)
+res = pin_solve([P], [pin_request("LED", Gpio, prefer = ["PA6"], lock = True)])
+builtin.add_property("led", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#;
+
+#[test]
+fn a_soft_at_cannot_void_a_lock_the_module_set() {
+    // A wish must not achieve what a hard at() could not: PA6 is mandatory,
+    // so wishing elsewhere drops the wish, never the requirement.
+    let none = soft_over_lock("LED = Gpio(\"L\")", LOCKED_GPIO);
+    assert_eq!(solved_pin(&none), "PA6", "the module's own pin");
+
+    let absent = soft_over_lock("LED = at(Gpio(\"L\"), \"PA9\", soft = True)", LOCKED_GPIO);
+    assert_eq!(
+        solved_pin(&absent),
+        "PA6",
+        "a wish for a pad the part lacks"
+    );
+
+    let elsewhere = soft_over_lock("LED = at(Gpio(\"L\"), \"PA5\", soft = True)", LOCKED_GPIO);
+    assert_eq!(
+        solved_pin(&elsewhere),
+        "PA6",
+        "a wish for another of its pads"
+    );
+
+    // A hard at() still overrides, as documented.
+    let hard = soft_over_lock("LED = at(Gpio(\"L\"), \"PA5\")", LOCKED_GPIO);
+    assert_eq!(solved_pin(&hard), "PA5", "a hard caller at() wins");
+}
+
+const UNLOCKED_GPIO: &str = r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA4", "PA5", "PA6"])
+LED = io(Gpio)
+res = pin_solve([P], [pin_request("LED", Gpio, prefer = ["PA6"])])
+builtin.add_property("led", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#;
+
+#[test]
+fn a_soft_at_falls_back_to_what_the_request_asked_for() {
+    // Nothing is mandatory here, so the wish outranks the request's own
+    // preference — but only where it can be met.
+    let none = soft_over_lock("LED = Gpio(\"L\")", UNLOCKED_GPIO);
+    assert_eq!(solved_pin(&none), "PA6", "the request's own preference");
+
+    let absent = soft_over_lock("LED = at(Gpio(\"L\"), \"PA9\", soft = True)", UNLOCKED_GPIO);
+    assert_eq!(
+        solved_pin(&absent),
+        "PA6",
+        "an unmeetable wish leaves it standing"
+    );
+
+    let real = soft_over_lock("LED = at(Gpio(\"L\"), \"PA5\", soft = True)", UNLOCKED_GPIO);
+    assert_eq!(solved_pin(&real), "PA5", "a wish that can be met wins");
+}
+
+const LOCKED_UART: &str = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("PA5"), pin("PA6")], "RX": [pin("PA7")]})
+LED = io(Uart)
+res = pin_solve([U], [pin_request("LED", Uart, prefer = {"TX": ["PA5", "PA6"]}, lock = True)])
+builtin.add_property("led", res["assignment"]["LED"]["signals"]["TX"]["pin"])
+"#;
+
+#[test]
+fn a_soft_at_still_chooses_within_the_locked_pins() {
+    // Both pads are mandatory-set members, so the wish is what decides.
+    let none = soft_over_lock("LED = Uart(\"L\")", LOCKED_UART);
+    assert_eq!(solved_pin(&none), "PA5");
+
+    let wish = soft_over_lock(
+        "LED = at(Uart(\"L\"), {\"TX\": [\"PA6\"]}, soft = True)",
+        LOCKED_UART,
+    );
+    assert_eq!(solved_pin(&wish), "PA6", "the wish picks among them");
+}
+
+#[test]
+fn an_io_that_consumed_an_at_records_the_bare_value() {
+    // Once io() has handed the constraint to the store, the module keeps what
+    // the caller meant to connect — a PinAt left here would reach anything
+    // that reads module inputs.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0", "PA1"])
+LED = io(Gpio)
+builtin.add_property("kind", str(type(LED)))
+res = pin_solve([P], [pin_request("LED", Gpio)])
+builtin.add_property("led", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Mcu = Module("/mcu.zen")
+Mcu(name = "U1", LED = at(Gpio("L"), "PA1"))
+"#
+            .to_string(),
+        ),
+    ]);
+    let inputs: Vec<String> = result
+        .output
+        .as_ref()
+        .map(|o| {
+            o.module_tree()
+                .values()
+                .flat_map(|m| {
+                    m.inputs()
+                        .iter()
+                        .map(|(k, v)| format!("{k}:{}", v.to_value().get_type()))
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_ok(&result);
+    assert_eq!(inputs, ["LED:InterfaceValue"], "got {inputs:?}");
+}
+
+#[test]
+fn a_part_cannot_be_configured_two_ways() {
+    // The tie-off list carries pads across solves, so an axis that flipped
+    // would make the component's pin table depend on which solve ran last.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+A = peripheral("A", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0")]}, unless = "wifi")
+B = peripheral("B", provides = [Gpio], rebind = "fixed", signals = {"PIN": [pin("PA1")]})
+r1 = pin_solve([A, B], [pin_request("X", Gpio, instance = "B")], config = {"wifi": False})
+r2 = pin_solve([A, B], [], config = {"wifi": True})
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "config axis `wifi` was false for this part in an earlier solve",
+    );
+
+    // …even when the later table leaves the gated peripheral out but still
+    // speaks about its axis.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+A = peripheral("A", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0")]}, unless = "wifi")
+B = peripheral("B", provides = [Gpio], rebind = "fixed", signals = {"PIN": [pin("PA1")]})
+pin_solve([A, B], [pin_request("X", Gpio, instance = "B")], config = {"wifi": False})
+pin_solve([B], [], config = {"wifi": True})
+"#,
+    );
+    assert_fails_with(&result, "config axis `wifi` was false for this part");
+
+    // Said the same way twice, the gated pad stays out of the tie-off.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+A = peripheral("A", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0")]}, unless = "wifi")
+B = peripheral("B", provides = [Gpio], rebind = "fixed", signals = {"PIN": [pin("PA1")]})
+r1 = pin_solve([A, B], [pin_request("X", Gpio, instance = "B")], config = {"wifi": True})
+r2 = pin_solve([A, B], [], config = {"wifi": True})
+m = pin_map(r1["assignment"], {"X": Net("N")})
+check(sorted(m.keys()) == ["PA1"], "the wifi pad stays out, got " + str(sorted(m.keys())))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn a_role_dict_records_the_net_not_the_wrapper() {
+    // The constraint goes to the store; what the module records is the
+    // connection, or the netlist would carry a placeholder for that role.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0", "PA1"])
+GPIO = config("gpio", dict, optional = True)
+res = pin_solve([P], [pin_request(k, Gpio, bind = v) for k, v in (GPIO or {}).items()])
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Mcu = Module("/mcu.zen")
+Mcu(name = "U1", gpio = {"LED": at(Gpio("L"), "PA1")})
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+
+    let recorded: Vec<String> = result
+        .output
+        .as_ref()
+        .map(|o| {
+            o.module_tree()
+                .values()
+                .flat_map(|m| {
+                    m.signature()
+                        .iter()
+                        .filter(|p| p.name == "gpio")
+                        .filter_map(|p| p.actual_value.as_ref())
+                        .map(|v| v.to_value().to_string())
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        recorded.iter().all(|v| !v.contains("at(")),
+        "the role holds its net, got {recorded:?}"
+    );
+    assert!(
+        recorded.iter().any(|v| v.contains("LED")),
+        "and the net is still there, got {recorded:?}"
+    );
+}
+
+#[test]
+fn two_ats_on_one_net_read_the_same_either_side_of_io() {
+    // Each input carries its own constraint, so which side of the solve the
+    // io() calls sit on must not change the answer.
+    for (label, body) in [
+        (
+            "solve after io()",
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["P1", "P2", "P3"])
+A = io(Gpio)
+B = io(Gpio)
+res = pin_solve([P], [pin_request("A", Gpio), pin_request("B", Gpio)])
+builtin.add_property("a", res["assignment"]["A"]["signals"]["PIN"]["pin"])
+builtin.add_property("b", res["assignment"]["B"]["signals"]["PIN"]["pin"])
+"#,
+        ),
+        (
+            "solve before io()",
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["P1", "P2", "P3"])
+res = pin_solve([P], [pin_request("A", Gpio), pin_request("B", Gpio)])
+A = io(Gpio)
+B = io(Gpio)
+builtin.add_property("a", res["assignment"]["A"]["signals"]["PIN"]["pin"])
+builtin.add_property("b", res["assignment"]["B"]["signals"]["PIN"]["pin"])
+"#,
+        ),
+    ] {
+        let result = eval_zen(vec![
+            ("/ifaces.zen".to_string(), IFACES.to_string()),
+            ("/mcu.zen".to_string(), body.to_string()),
+            (
+                "/test.zen".to_string(),
+                r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+N = Gpio("SHARED")
+Mcu = Module("/mcu.zen")
+Mcu(name = "U1", A = at(N, "P2"), B = at(N, "P3"))
+"#
+                .to_string(),
+            ),
+        ]);
+        assert_ok(&result);
+        let pins: Vec<String> = result
+            .output
+            .as_ref()
+            .map(|o| {
+                o.module_tree()
+                    .values()
+                    .flat_map(|m| {
+                        ["a", "b"].iter().filter_map(move |k| {
+                            m.properties()
+                                .get(*k)
+                                .and_then(|v| v.to_value().unpack_str().map(|s| format!("{k}={s}")))
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert_eq!(pins, ["a=P2", "b=P3"], "{label}, got {pins:?}");
+    }
+}
+
+#[test]
+fn alternates_leave_out_pads_the_request_could_not_take() {
+    // An output request never lands on an input-only pad, so its reported
+    // freedom must not offer one either.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = peripheral("P", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0"), pin("PA1", input_only = True), pin("PA2")]})
+res = pin_solve([P], [pin_request("A", Gpio, direction = "output")])
+alts = res["assignment"]["A"]["alternates"]["PIN"]
+check(alts == ["PA2"], "input-only pads are not alternates, got " + str(alts))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn an_assignment_serving_nobody_says_so() {
+    // Nothing was served, so the map has no part to infer; the message must
+    // point at that rather than claim the assignment spans components.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+A = pool("GPIO", part = "U1", provides = [Gpio], pins = ["PA0"])
+B = pool("GPIO", part = "U2", provides = [Gpio], pins = ["PB0"])
+pin_solve([A], [pin_request("X", Gpio)])
+r = pin_solve([B], [])
+m = pin_map(r["assignment"], {})
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "serves no request and the module solved `U1`, `U2`",
+    );
+}
+
+#[test]
+fn mapping_a_part_twice_yields_the_same_table() {
+    // Mapping in several calls is legitimate, so a second call must repeat the
+    // first: same pads, and the tie-offs reuse the nets the first call minted.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0", "PA1", "PA2"])
+r = pin_solve([P], [pin_request("A", Gpio)])
+BUS = Gpio("N")
+m1 = pin_map(r["assignment"], {"A": BUS})
+m2 = pin_map(r["assignment"], {"A": BUS})
+check(sorted(m1.keys()) == sorted(m2.keys()), "both calls yield the same table")
+check(sorted(m1.keys()) == ["PA0", "PA1", "PA2"], "and it is the whole table")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn a_locked_list_as_long_as_the_signals_is_claimed_in_full() {
+    // As many pins as signals, so "every pin ends up on some signal" and "each
+    // signal takes one of these" are the same requirement: pads are exclusive.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("PA9"), pin("PB6")], "RX": [pin("PA10")]})
+res = pin_solve([U], [pin_request("A", Uart, prefer = ["PA9", "PB6"], lock = True)])
+"#,
+    );
+    // RX reaches neither pin, so the second one could never be used at all.
+    assert_fails_with(
+        &result,
+        "signal `RX` has no candidate among the locked pins `PA9`, `PB6`",
+    );
+
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("PA9"), pin("PB6")], "RX": [pin("PA10"), pin("PB6")]})
+res = pin_solve([U], [pin_request("A", Uart, prefer = ["PA9", "PB6"], lock = True)])
+sig = res["assignment"]["A"]["signals"]
+check(sorted([sig["TX"]["pin"], sig["RX"]["pin"]]) == ["PA9", "PB6"],
+      "both locked pins are used, got " + str(sig))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn a_list_borne_at_is_not_claimed_by_a_like_named_request() {
+    // The list shape reaches no request, and the request named like the config
+    // cannot pair with it either — so it is reported, never quietly applied.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0", "PA1"])
+led_list = config("led", list, optional = True)
+LED = io(Gpio)
+res = pin_solve([P], [pin_request("led", Gpio)])
+builtin.add_property("led_pin", res["assignment"]["led"]["signals"]["PIN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Mcu = Module("/mcu.zen")
+Mcu(name = "U1", led = [at(Gpio("L"), "PA1")], LED = Gpio("M"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(
+        &result,
+        "at() pin constraint on input `led` was never consumed",
+    );
+    let pin: Vec<String> = result
+        .output
+        .as_ref()
+        .map(|o| {
+            o.module_tree()
+                .values()
+                .filter_map(|m| m.properties().get("led_pin"))
+                .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        pin,
+        ["PA0"],
+        "the request solved unconstrained, got {pin:?}"
+    );
+}
+
+#[test]
+fn three_solves_keep_one_class_per_pool() {
+    // The third solve places elsewhere, so the pool's class rides along
+    // whole rather than splitting off a second one.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio", "AdcIn")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0", "PA1", "PA2", "PA3"])
+Q = pool("ADC", provides = [AdcIn], pins = ["PB0", "PB1"])
+a = pin_solve([P, Q], [pin_request("A", Gpio)])
+b = pin_solve([P, Q], [pin_request("B", Gpio)])
+c = pin_solve([P, Q], [pin_request("C", AdcIn)])
+"#,
+    );
+    assert_ok(&result);
+
+    let swaps = json_property(&result, "swap_classes");
+    let classes = swaps.as_array().unwrap();
+    let mut pools: Vec<&str> = classes
+        .iter()
+        .map(|c| c["pool"].as_str().unwrap())
+        .collect();
+    pools.sort();
+    assert_eq!(pools, ["ADC", "GPIO"], "one class per pool, got {swaps}");
+    let gpio = classes.iter().find(|c| c["pool"] == "GPIO").unwrap();
+    assert_eq!(
+        gpio["members"].as_array().unwrap().len(),
+        2,
+        "both requests in it, got {swaps}"
+    );
+}
+
+#[test]
+fn a_bound_soft_at_cannot_void_the_requests_own_lock() {
+    // Whichever path delivers the connection, a wish chooses among the pins
+    // the request made mandatory rather than replacing them.
+    let solve = |bind: &str| {
+        eval_with_fixtures(&format!(
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve", "at")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA5", "PA6"])
+res = pin_solve([P], [pin_request("LED", Gpio, prefer = ["PA6"], lock = True, bind = {bind})])
+builtin.add_property("led", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#
+        ))
+    };
+    let pin = |r: &WithDiagnostics<EvalOutput>| {
+        assert_ok(r);
+        r.output
+            .as_ref()
+            .and_then(|o| {
+                o.module_tree()
+                    .values()
+                    .filter_map(|m| m.properties().get("led"))
+                    .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+                    .next()
+            })
+            .unwrap_or_default()
+    };
+
+    let soft = solve("at(Gpio(\"D\"), \"PA5\", soft = True)");
+    assert_eq!(pin(&soft), "PA6", "the lock stands against a wish");
+    let hard = solve("at(Gpio(\"D\"), \"PA5\")");
+    assert_eq!(pin(&hard), "PA5", "a hard bound at() still overrides");
+}
+
+#[test]
+fn a_forwarded_at_on_a_taken_pad_is_reported_not_forced() {
+    // An earlier solve holds PA7, so no request here can honour the pinned
+    // pad. Judging one "usable" would lock it into an infeasible solve and
+    // blame the request; the constraint is what could not be met.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio", "AdcIn")
+G = pool("GPIO", provides = [Gpio], pins = ["PA5", "PA7"])
+A = peripheral("A", provides = [AdcIn], rebind = "fixed",
+    signals = {"IN": [pin("PA1"), pin("PA2")]})
+first = pin_solve([G, A], [pin_request("PRE", Gpio, prefer = ["PA7"], lock = True)])
+ADC = io(AdcIn)
+LED = io(Gpio)
+res = pin_solve([G, A], [pin_request("ADC", AdcIn), pin_request("LED", Gpio)])
+builtin.add_property("led", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/som.zen".to_string(),
+            r#"
+load("./ifaces.zen", "Gpio", "AdcIn")
+RAIL = io(Gpio)
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", LED = RAIL, ADC = AdcIn(IN = RAIL.PIN))
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Som = Module("./som.zen")
+Som(name = "SOM", RAIL = at(Gpio("RAIL_NET"), "PA7"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(&result, "was never consumed");
+}
+
+#[test]
+fn an_at_on_a_component_pin_says_where_it_belongs() {
+    // The wrapper only means something on a module input; a pin sees a value
+    // it cannot read, and the message says so rather than naming a type.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "at")
+Component(
+    name = "R1",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod"),
+    pin_defs = {"P1": "1", "P2": "2"},
+    pins = {"P1": at(Net("LED"), "PA10"), "P2": Net("GND")},
+    skip_bom = True,
+)
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "at() constrains a module input, not a component pin",
+    );
+}
+
+#[test]
+fn alternates_leave_out_pads_the_lock_forbids() {
+    // TX is nailed to PA9, so it has nowhere to move; RX is free and says so.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("PA9"), pin("PB6")], "RX": [pin("PA10"), pin("PB7")]})
+res = pin_solve([U], [pin_request("A", Uart, prefer = {"TX": ["PA9"]}, lock = True)])
+alts = res["assignment"]["A"]["alternates"]
+check("TX" not in alts, "a locked signal has no alternate, got " + str(alts))
+check(alts["RX"] == ["PB7"], "the free one keeps its own, got " + str(alts))
+"#,
+    );
+    assert_ok(&result);
+
+    // A bare list shorter than the signal count restricts nothing per signal,
+    // but must be claimed in full — so TX cannot leave PA9 either.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("PA9"), pin("PB6")], "RX": [pin("PA10"), pin("PB7")]})
+res = pin_solve([U], [pin_request("A", Uart, prefer = ["PA9"], lock = True)])
+check(res["assignment"]["A"]["signals"]["TX"]["pin"] == "PA9", "TX holds the locked pin")
+alts = res["assignment"]["A"]["alternates"]
+check("TX" not in alts, "leaving PA9 would drop it, got " + str(alts))
+check(alts["RX"] == ["PB7"], "RX is free, got " + str(alts))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn a_role_named_like_a_config_still_gets_its_at() {
+    // Role names come from caller data and may collide with a config() name;
+    // the role carries its own value, so the collision must not disarm it.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/stm32.zen".to_string(), STM32.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Gpio")
+
+LED = config("LED", str, optional = True)
+GPIO = config("gpio", dict, optional = True)
+res = pin_solve(PERIPHS, [pin_request(k, Gpio, bind = v) for k, v in (GPIO or {}).items()])
+if "LED" in res["assignment"]:
+    check(res["assignment"]["LED"]["signals"]["PIN"]["pin"] == "PA10",
+          "the role\'s at() must apply, got " + res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/mcu.zen")
+Mcu(name = "M1", gpio = {"LED": at(Net("L"), "PA10")})
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+}
+
+#[test]
+fn bind_at_overrides_request_prefer() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "at", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Gpio")
+
+res = pin_solve(PERIPHS, [
+    pin_request("LED", Gpio, prefer = ["PB0"], bind = at(Net("LED"), "PA10")),
+])
+check(res["assignment"]["LED"]["signals"]["PIN"]["pin"] == "PA10", "caller at() must win over request prefer")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn symmetric_parameter_is_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral")
+load("./ifaces.zen", "Gpio")
+
+peripheral("P", provides = [Gpio], rebind = "none", signals = {"PIN": ["X1"]}, symmetric = [["A"]])
+"#,
+    );
+    assert_fails_with(&result, "symmetric");
+}
+
+#[test]
+fn pin_data_above_i64_roundtrips_as_an_integer() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+BIG = 18446744073709551615
+P = peripheral("P", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("X1", data = {"big": BIG})]})
+res = pin_solve([P], [pin_request("R", Gpio)])
+got = res["assignment"]["R"]["signals"]["PIN"]["big"]
+check(got == BIG, "must round-trip, got " + str(got))
+check(type(got) == "int", "and stay an int, got " + type(got))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn pin_data_large_int_roundtrip() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+
+P = peripheral(
+    "P",
+    provides = [Gpio],
+    rebind = "fixed",
+    signals = {"PIN": [pin("X1", data = {"big": 5000000000})]},
+)
+
+res = pin_solve([P], [pin_request("R", Gpio)])
+check(res["assignment"]["R"]["signals"]["PIN"]["big"] == 5000000000, "large data value must round-trip")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn pinmap_cap_truncation_warns() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+
+WIDE = peripheral(
+    "WIDE",
+    provides = [Uart],
+    rebind = "firmware",
+    signals = {
+        "TX": [pin("P" + str(i)) for i in range(24)],
+        "RX": [pin("P" + str(i)) for i in range(24)],
+    },
+)
+
+res = pin_solve([WIDE], [pin_request("LINK", Uart)])
+check(res["assignment"]["LINK"]["instance"] == "WIDE", "assigned despite cap")
+"#,
+    );
+    assert_ok(&result);
+    let text = diag_text(&result);
+    assert!(
+        text.contains("capped at"),
+        "expected a pin-combination cap warning, got:\n{text}"
+    );
+}
+
+#[test]
+fn gpio_pool_swap_class() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./esp32c3.zen", "PERIPHS")
+load("./ifaces.zen", "Gpio")
+
+res = pin_solve(PERIPHS, [
+    pin_request("LED1", Gpio),
+    pin_request("LED2", Gpio),
+    pin_request("BTN", Gpio),
+])
+pools = [c for c in res["swap_classes"] if c["granularity"] == "pin"]
+check(len(pools) == 1, "expected one pool class, got " + str(len(pools)))
+check(len(pools[0]["members"]) == 3, "members")
+check(len(pools[0]["spare_pins"]) > 0, "spares")
+check(pools[0]["rebind"] == "firmware", "rebind")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn gate_swap_cluster_class() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./comparator.zen", "PERIPHS")
+load("./ifaces.zen", "Comparator")
+
+res = pin_solve(PERIPHS, [pin_request("CMP1", Comparator), pin_request("CMP2", Comparator)])
+clusters = [c for c in res["swap_classes"] if c["granularity"] == "cluster"]
+check(len(clusters) == 1, "expected one cluster class")
+check(len(clusters[0]["members"]) == 2, "cluster members")
+check(clusters[0]["rebind"] == "none", "cluster rebind")
+"#,
+    );
+    assert_ok(&result);
+
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./comparator.zen", "PERIPHS")
+load("./ifaces.zen", "Comparator")
+
+pin_solve(PERIPHS, [pin_request("C" + str(i), Comparator) for i in range(3)])
+"#,
+    );
+    assert_fails_with(&result, "no feasible assignment");
+}
+
+#[test]
+fn unconnected_signals_leave_pins_free() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Gpio")
+
+res = pin_solve(PERIPHS, [
+    pin_request("DBG", Uart, instance = "USART1", uses = ["TX"]),
+    pin_request("BTN", Gpio, prefer = ["PA10"], lock = True),
+])
+a = res["assignment"]
+check(a["DBG"]["signals"]["TX"]["pin"] == "PA9", "DBG TX")
+check(not ("RX" in a["DBG"]["signals"]), "RX should not be assigned")
+check(a["BTN"]["signals"]["PIN"]["pin"] == "PA10", "BTN on freed pin")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn optimal_not_merely_greedy() {
+    // Greedy first-feasible would let A grab (P1, X, cost 0) and force B onto
+    // (P2, Z, cost 10) — total 10. Branch-and-bound must return the global
+    // optimum (total 1): A on P2/X, B on P1/Y.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+
+P1 = peripheral("P1", provides = [Gpio], rebind = "firmware",
+    signals = {"PIN": [pin("X"), pin("Y", cost = 1)]})
+P2 = peripheral("P2", provides = [Gpio], rebind = "firmware",
+    signals = {"PIN": [pin("X"), pin("Z", cost = 10)]})
+
+res = pin_solve([P1, P2], [pin_request("A", Gpio), pin_request("B", Gpio)])
+a = res["assignment"]
+pins = [a["A"]["signals"]["PIN"]["pin"], a["B"]["signals"]["PIN"]["pin"]]
+check(not ("Z" in pins), "suboptimal: Z (cost 10) used while X+Y (cost 1) was feasible: " + str(pins))
+"#,
+    );
+    assert_ok(&result);
+}
+
+const MCU_SLOTS: &str = r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart", "Usart")
+load("./stm32.zen", "PERIPHS")
+
+DEBUG = io(Uart, optional = True)
+SC = io(Usart, optional = True)
+
+res = pin_solve(PERIPHS, [
+    pin_request("DEBUG", Uart, if_connected = True),
+    pin_request("SC", Usart, if_connected = True),
+])
+builtin.add_property("dbg_served", str("DEBUG" in res["assignment"]))
+builtin.add_property("sc_served", str("SC" in res["assignment"]))
+"#;
+
+#[test]
+fn if_connected_serves_only_connected_slots() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/stm32.zen".to_string(), STM32.to_string()),
+        ("/mcu.zen".to_string(), MCU_SLOTS.to_string()),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("./ifaces.zen", "Uart")
+Mcu = Module("/mcu.zen")
+Mcu(name = "MCU1", DEBUG = Uart("DBG"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let tree = result.output.as_ref().unwrap().module_tree();
+    let child = tree
+        .values()
+        .find(|m| m.properties().contains_key("dbg_served"))
+        .expect("child MCU module with pinmux properties not found");
+    let get = |key: &str| {
+        child
+            .properties()
+            .get(key)
+            .and_then(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+            .unwrap_or_default()
+    };
+    assert_eq!(get("dbg_served"), "True", "connected slot must be served");
+    assert_eq!(
+        get("sc_served"),
+        "False",
+        "unconnected slot must be dropped"
+    );
+}
+
+#[test]
+fn pin_map_builds_component_pins() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_map", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Gpio")
+
+DBG = Uart("DBG")
+LED = Net("LED")
+
+res = pin_solve(PERIPHS, [
+    pin_request("COM", Uart, instance = "USART1"),
+    pin_request("LED", Gpio, prefer = ["PB0"], lock = True),
+])
+m = pin_map(res["assignment"], {"COM": DBG, "LED": LED})
+check(m["PA9"] == DBG.TX and m["PA10"] == DBG.RX, "mapped pins present")
+check(m["PA9"] == DBG.TX, "PA9 must carry DBG.TX")
+check(m["PA10"] == DBG.RX, "PA10 must carry DBG.RX")
+check(m["PB0"] == LED, "PB0 must carry the LED net")
+"#,
+    );
+    assert_ok(&result);
+}
+
+const MCU_AT: &str = r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+load("./stm32.zen", "PERIPHS")
+
+IO0 = io(Net, optional = True)
+
+res = pin_solve(PERIPHS, [pin_request("IO0", Gpio, if_connected = True)])
+a = res["assignment"]
+builtin.add_property("io0_pin", a["IO0"]["signals"]["PIN"]["pin"] if "IO0" in a else "none")
+"#;
+
+fn eval_mcu_at(parent: &str) -> WithDiagnostics<EvalOutput> {
+    eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/stm32.zen".to_string(), STM32.to_string()),
+        ("/mcu_at.zen".to_string(), MCU_AT.to_string()),
+        ("/test.zen".to_string(), parent.to_string()),
+    ])
+}
+
+fn io0_pin(result: &WithDiagnostics<EvalOutput>) -> String {
+    let tree = result.output.as_ref().unwrap().module_tree();
+    tree.values()
+        .filter_map(|m| m.properties().get("io0_pin").cloned())
+        .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+        .find(|s| s != "none")
+        .unwrap_or_default()
+}
+
+#[test]
+fn at_constrains_pin_on_the_connection() {
+    let result = eval_mcu_at(
+        r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/mcu_at.zen")
+Mcu(name = "M1", IO0 = at(Net("LED"), "PA10"))
+"#,
+    );
+    assert_ok(&result);
+    assert_eq!(io0_pin(&result), "PA10");
+}
+
+#[test]
+fn at_hard_constraint_fails_loudly() {
+    // PA13 is deliberately absent from the fixture's GPIO pool.
+    let result = eval_mcu_at(
+        r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/mcu_at.zen")
+Mcu(name = "M1", IO0 = at(Net("LED"), "PA13"))
+"#,
+    );
+    assert_fails_with(&result, "has no candidate");
+}
+
+#[test]
+fn at_soft_constraint_falls_back() {
+    let result = eval_mcu_at(
+        r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/mcu_at.zen")
+Mcu(name = "M1", IO0 = at(Net("LED"), "PA13", soft = True))
+"#,
+    );
+    assert_ok(&result);
+    let pin = io0_pin(&result);
+    assert!(
+        !pin.is_empty() && pin != "PA13",
+        "soft must fall back, got {pin:?}"
+    );
+}
+
+const MCU_ROLES: &str = r#"
+load("@stdlib/pinmux.zen", "pin_map", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio", "AdcIn")
+load("./stm32.zen", "PERIPHS")
+
+gpio = config(dict, default = {})
+adc = config(dict, default = {})
+
+res = pin_solve(
+    PERIPHS,
+    [pin_request(n, Gpio, bind = gpio[n]) for n in gpio]
+    + [pin_request(n, AdcIn, bind = adc[n]) for n in adc],
+)
+named = {}
+named.update(gpio)
+named.update(adc)
+a = res["assignment"]
+m = pin_map(res["assignment"], named)
+
+builtin.add_property("led_pin", a["LED"]["signals"]["PIN"]["pin"] if "LED" in a else "none")
+builtin.add_property("vbat_pin", a["VBAT"]["signals"]["IN"]["pin"] if "VBAT" in a else "none")
+_led = a["LED"]["signals"]["PIN"]["pin"] if "LED" in a else "?"
+_vbat = a["VBAT"]["signals"]["IN"]["pin"] if "VBAT" in a else "?"
+builtin.add_property("map_roles", str(int(_led in m) + int(_vbat in m)))
+"#;
+
+#[test]
+fn dict_of_roles_demands() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/stm32.zen".to_string(), STM32.to_string()),
+        ("/mcu_roles.zen".to_string(), MCU_ROLES.to_string()),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+Mcu = Module("/mcu_roles.zen")
+Mcu(name = "M1", gpio = {"LED": at(Net("LED"), "PA10")}, adc = {"VBAT": Net("VBAT")})
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let tree = result.output.as_ref().unwrap().module_tree();
+    let child = tree
+        .values()
+        .find(|m| m.properties().contains_key("led_pin"))
+        .expect("child module with role properties not found");
+    let get = |key: &str| {
+        child
+            .properties()
+            .get(key)
+            .and_then(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+            .unwrap_or_default()
+    };
+    assert_eq!(get("led_pin"), "PA10", "at() constraint through the dict");
+    assert_eq!(get("vbat_pin"), "PA0", "ADC role served");
+    assert_eq!(get("map_roles"), "2", "pin_map must cover both roles");
+}
+
+#[test]
+fn attr_vocabulary_is_enforced() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Uart")
+
+peripheral("U9", provides = [Uart], rebind = "firmware",
+    signals = {"TX": [pin("P1")], "RX": [pin("P2")]},
+    attrs = {"baudMax": "8MHz"})
+"#,
+    );
+    assert_fails_with(&result, "not declared by any provided interface");
+
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Uart")
+
+peripheral("U9", provides = [Uart], rebind = "firmware",
+    signals = {"TX": [pin("P1")], "RX": [pin("P2")]},
+    attrs = {"baud_max": "3.3V"})
+"#,
+    );
+    assert_fails_with(&result, "expects");
+
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Spi")
+
+peripheral("S9", provides = [Spi], rebind = "firmware",
+    signals = {"SCK": [pin("P1")], "MISO": [pin("P2")], "MOSI": [pin("P3")]},
+    attrs = {"clk_max": "10MHz"})
+"#,
+    );
+    assert_fails_with(&result, "declare no attrs");
+}
+
+#[test]
+fn vio_attr_selects_fixed_level_provider() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "I2c")
+
+B3V3 = peripheral("B3V3", provides = [I2c], rebind = "fixed",
+    signals = {"SDA": [pin("P1")], "SCL": [pin("P2")]},
+    attrs = {"vio": "3.3V"})
+B5V = peripheral("B5V", provides = [I2c], rebind = "fixed",
+    signals = {"SDA": [pin("P3")], "SCL": [pin("P4")]},
+    attrs = {"vio": "5V"})
+
+def lv(a):
+    return a["vio"] <= "3.3V"
+
+res = pin_solve([B3V3, B5V], [pin_request("BUS", I2c, where = lv)])
+check(res["assignment"]["BUS"]["instance"] == "B3V3", "3V3 provider expected")
+"#,
+    );
+    assert_ok(&result);
+
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "I2c")
+
+peripheral("B9", provides = [I2c], rebind = "fixed",
+    signals = {"SDA": [pin("P1")], "SCL": [pin("P2")]},
+    attrs = {"vio": "400kHz"})
+"#,
+    );
+    assert_fails_with(&result, "expects");
+}
+
+// --- Signals are the net-typed leaves, not every interface field -------------
+
+#[test]
+fn metadata_field_is_not_a_signal() {
+    // Neither demanded of the declaration nor consuming a pin in the solve.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "DiffPair")
+
+LVDS0 = peripheral("LVDS0", provides = [DiffPair], rebind = "fixed",
+    signals = {"P": [pin("A1")], "N": [pin("A2")]})
+
+res = pin_solve([LVDS0], [pin_request("D", DiffPair)])
+sigs = res["assignment"]["D"]["signals"]
+check(len(sigs) == 2, "impedance must not consume a pin, got " + str(len(sigs)))
+check(sigs["P"]["pin"] == "A1", "P -> A1")
+check(sigs["N"]["pin"] == "A2", "N -> A2")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn metadata_field_cannot_be_named_in_uses() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request")
+load("./ifaces.zen", "DiffPair")
+pin_request("D", DiffPair, uses = ["impedance"])
+"#,
+    );
+    assert_fails_with(&result, "`impedance` is not a signal of DiffPair");
+}
+
+#[test]
+fn nested_interface_flattens_into_signals() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_map", "pin_request", "pin_solve")
+load("./ifaces.zen", "Usb2")
+
+USB0 = peripheral("USB0", provides = [Usb2], rebind = "fixed",
+    signals = {"D_P": [pin("PA12")], "D_N": [pin("PA11")], "VBUS": [pin("PA9")]})
+
+BUS = Usb2("BUS")
+res = pin_solve([USB0], [pin_request("U", Usb2)])
+sigs = res["assignment"]["U"]["signals"]
+check(len(sigs) == 3, "expected 3 signals, got " + str(len(sigs)))
+
+m = pin_map(res["assignment"], {"U": BUS})
+check(m["PA12"] == BUS.D.P, "PA12 must carry the nested D.P net")
+check(m["PA11"] == BUS.D.N, "PA11 must carry the nested D.N net")
+check(m["PA9"] == BUS.VBUS, "PA9 must carry VBUS")
+check(type(m["PA12"]) == "Net", "a mapped pin must be a Net, got " + type(m["PA12"]))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn nested_interface_type_field_flattens_too() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_map", "pin_request", "pin_solve")
+load("./ifaces.zen", "Lvds")
+
+LV = peripheral("LV", provides = [Lvds], rebind = "fixed",
+    signals = {
+        "CLK_P": [pin("B1")], "CLK_N": [pin("B2")],
+        "DATA_P": [pin("B3")], "DATA_N": [pin("B4")],
+    })
+
+LINK = Lvds("LINK")
+res = pin_solve([LV], [pin_request("L", Lvds)])
+m = pin_map(res["assignment"], {"L": LINK})
+check(m["B1"] == LINK.CLK.P, "B1 must carry CLK.P")
+check(m["B4"] == LINK.DATA.N, "B4 must carry DATA.N")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn nested_interface_declared_as_one_signal_names_the_flattened_signal() {
+    // The pre-fix spelling: `D` as if the whole pair were one pin.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Usb2")
+peripheral("USB0", provides = [Usb2], rebind = "fixed",
+    signals = {"D": [pin("PA12")], "VBUS": [pin("PA9")]})
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "peripheral `USB0` claims Usb2 but has no candidate for signal `D_P`",
+    );
+}
+
+#[test]
+fn uses_can_select_a_flattened_signal() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Usb2")
+
+USB0 = peripheral("USB0", provides = [Usb2], rebind = "fixed",
+    signals = {"D_P": [pin("PA12")], "D_N": [pin("PA11")], "VBUS": [pin("PA9")]})
+
+res = pin_solve([USB0], [pin_request("U", Usb2, uses = ["D_P", "D_N"])])
+sigs = res["assignment"]["U"]["signals"]
+check(len(sigs) == 2, "VBUS must stay free, got " + str(len(sigs)))
+check("VBUS" not in sigs, "VBUS must not be assigned")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn flattened_signal_name_collision_is_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request")
+load("./ifaces.zen", "Ambiguous")
+pin_request("X", Ambiguous)
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "nested fields flatten to two signals named `D_P` — rename one of them",
+    );
+}
+
+#[test]
+fn pin_map_error_lists_the_available_signals() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_map", "pin_request", "pin_solve")
+load("./ifaces.zen", "Usb2", "DiffPair")
+
+USB0 = peripheral("USB0", provides = [Usb2], rebind = "fixed",
+    signals = {"D_P": [pin("PA12")], "D_N": [pin("PA11")], "VBUS": [pin("PA9")]})
+
+res = pin_solve([USB0], [pin_request("U", Usb2)])
+pin_map(res["assignment"], {"U": DiffPair("WRONG")})
+"#,
+    );
+    assert_fails_with(&result, "it carries `P`, `N`");
+}
+
+#[test]
+fn stdlib_differential_interface_backs_a_capability_table() {
+    // Real stdlib shapes: `impedance` is a nullable physical, not the int above.
+    let result = eval_zen(vec![(
+        "/test.zen".to_string(),
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_map", "pin_request", "pin_solve")
+load("@stdlib/interfaces.zen", "Usb2")
+
+USB_OTG = peripheral("USB_OTG", provides = [Usb2], rebind = "fixed",
+    signals = {"D_P": [pin("PA12")], "D_N": [pin("PA11")]})
+
+BUS = Usb2("BUS")
+res = pin_solve([USB_OTG], [pin_request("U", Usb2)])
+m = pin_map(res["assignment"], {"U": BUS})
+check(len(m) == 2, "expected 2 mapped pins, got " + str(len(m)))
+check(m["PA12"] == BUS.D.P, "PA12 must carry D.P")
+
+Component(
+    name = "U1",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0402_1005Metric.kicad_mod"),
+    pin_defs = {"PA11": "1", "PA12": "2"},
+    pins = m,
+    skip_bom = True,
+)
+"#
+        .to_string(),
+    )]);
+    assert_ok(&result);
+}
+
+// --- Capability identity is per declaration, not per evaluation --------------
+
+const ONE_IFACE: &str = r#"
+Uart = interface(TX = Net, RX = Net)
+"#;
+
+const ONE_PERIPH: &str = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Uart")
+PERIPHS = [peripheral("U0", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("A1")], "RX": [pin("A2")]})]
+"#;
+
+#[test]
+fn capability_identity_crosses_file_boundaries() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), ONE_IFACE.to_string()),
+        ("/lib.zen".to_string(), ONE_PERIPH.to_string()),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./lib.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+res = pin_solve(PERIPHS, [pin_request("C", Uart)])
+check(res["assignment"]["C"]["instance"] == "U0", "must match across files")
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+}
+
+#[test]
+fn separately_declared_interfaces_stay_distinct() {
+    // Matching is nominal: identical text in two files is two capabilities.
+    // Also pins down that identity keys on the declaring file, not on nothing.
+    let result = eval_zen(vec![
+        ("/a.zen".to_string(), ONE_IFACE.to_string()),
+        ("/b.zen".to_string(), ONE_IFACE.to_string()),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./a.zen", "Uart")
+load("./b.zen", Uart2 = "Uart")
+P = [peripheral("U0", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("A1")], "RX": [pin("A2")]})]
+pin_solve(P, [pin_request("C", Uart2)])
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(&result, "U0: rejected — provides a different Uart");
+}
+
+#[test]
+fn a_shared_request_name_keeps_the_remap_guard() {
+    // Same shape as the guard above, but a second component also has a request
+    // named `COM`. The name no longer answers for one part — the entry does.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_map", "pin_request", "pin_solve", "pool")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Gpio")
+
+OTHER = pool("GPIO", part = "U2", provides = [Gpio], pins = ["PB0", "PB1"])
+BUS = Uart("BUS")
+LED = Net("LED")
+
+r1 = pin_solve(PERIPHS, [pin_request("COM", Uart, instance = "USART1")])
+r2 = pin_solve(PERIPHS, [pin_request("COM", Uart, instance = "USART2")])
+r3 = pin_solve(PERIPHS, [pin_request("LED", Gpio, prefer = ["PA9"], lock = True)])
+r4 = pin_solve([OTHER], [pin_request("COM", Gpio)])
+
+pin_map(r3["assignment"], {"LED": LED})
+pin_map(r1["assignment"], {"COM": BUS})
+"#,
+    );
+    assert_fails_with(&result, "already mapped to net `LED` in this module");
+}
+
+#[test]
+fn superseded_assignment_cannot_remap_a_pin() {
+    // Re-solving `COM` releases its claims, so a later solve may take PA9 —
+    // mapping the stale result would put two nets on it.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_map", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Gpio")
+
+BUS = Uart("BUS")
+LED = Net("LED")
+
+r1 = pin_solve(PERIPHS, [pin_request("COM", Uart, instance = "USART1")])
+r2 = pin_solve(PERIPHS, [pin_request("COM", Uart, instance = "USART2")])
+r3 = pin_solve(PERIPHS, [pin_request("LED", Gpio, prefer = ["PA9"], lock = True)])
+
+pin_map(r3["assignment"], {"LED": LED})
+pin_map(r1["assignment"], {"COM": BUS})
+"#,
+    );
+    assert_fails_with(&result, "already mapped to net `LED` in this module");
+}
+
+#[test]
+fn same_request_mapped_to_two_nets_across_solves_is_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_map", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+
+r1 = pin_solve(PERIPHS, [pin_request("COM", Uart, instance = "USART1")])
+r2 = pin_solve(PERIPHS, [pin_request("COM", Uart, instance = "USART1")])
+pin_map(r1["assignment"], {"COM": Uart("A")})
+pin_map(r2["assignment"], {"COM": Uart("B")})
+"#,
+    );
+    assert_fails_with(&result, "already mapped to net");
+}
+
+#[test]
+fn remapping_the_same_net_stays_allowed() {
+    // The `previous=` widening pattern: the stable requests land on the same
+    // pins and the same nets, so mapping either result is harmless.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_map", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Usart")
+
+BUS = Uart("BUS")
+reqs = [pin_request("DEBUG", Uart)]
+r1 = pin_solve(PERIPHS, reqs)
+r2 = pin_solve(PERIPHS, reqs + [pin_request("SC", Usart)], previous = r1["assignment"])
+pin_map(r1["assignment"], {"DEBUG": BUS})
+pin_map(r2["assignment"], {"DEBUG": BUS})
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn unconsumed_at_names_the_requests_that_were_solved() {
+    // The at() pairing is nominal: io("debug_uart") is not served by
+    // pin_request("DEBUG"), and the message must show that mismatch.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/stm32.zen".to_string(), STM32.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_map", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart")
+debug_uart = io("debug_uart", Uart)
+res = pin_solve(PERIPHS, [pin_request("DEBUG", Uart)])
+pin_map(res["assignment"], {"DEBUG": debug_uart})
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Uart")
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", debug_uart = at(Uart("BUS"), ["PA9", "PA10"]))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(
+        &result,
+        "constraint on input `debug_uart` was never consumed: no pin_request named `debug_uart` reached a pin_solve",
+    );
+}
+
+#[test]
+fn a_forwarded_at_goes_to_the_request_that_can_take_it() {
+    // The pinned rail reaches both requests, but only the GPIO one has PA7.
+    // Claiming by declaration order would lock the ADC to a pad it has no
+    // candidate for and fail a design that has an answer.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio", "AdcIn")
+G = pool("GPIO", provides = [Gpio], pins = ["PA5", "PA7"])
+A = peripheral("A", provides = [AdcIn], rebind = "fixed", signals = {"IN": [pin("PA1")]})
+ADC = io(AdcIn)
+LED = io(Gpio)
+res = pin_solve([G, A], [pin_request("ADC", AdcIn), pin_request("LED", Gpio)])
+builtin.add_property("led", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+builtin.add_property("adc", res["assignment"]["ADC"]["signals"]["IN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/som.zen".to_string(),
+            r#"
+load("./ifaces.zen", "Gpio", "AdcIn")
+RAIL = io(Gpio)
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", LED = RAIL, ADC = AdcIn(IN = RAIL.PIN))
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Som = Module("./som.zen")
+Som(name = "SOM", RAIL = at(Gpio("RAIL_NET"), "PA7"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let props: Vec<String> = result
+        .output
+        .as_ref()
+        .map(|o| {
+            o.module_tree()
+                .values()
+                .flat_map(|m| {
+                    ["led", "adc"].iter().filter_map(move |p| {
+                        m.properties()
+                            .get(*p)
+                            .and_then(|v| v.to_value().unpack_str().map(|s| format!("{p}={s}")))
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(props, ["led=PA7", "adc=PA1"], "got {props:?}");
+}
+
+#[test]
+fn a_forwarded_at_wanted_by_two_children_is_reported() {
+    // Both children solve on the pinned net. Children elaborate in parallel,
+    // so first-come-wins would hand the pin to a different one each build.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pool")
+load("./ifaces.zen", "Gpio")
+POOL = pool("GPIO", provides = [Gpio], pins = ["PA5", "PA6", "PA7"])
+LED = io("LED", Gpio)
+res = pin_solve([POOL], [pin_request("LED", Gpio)])
+builtin.add_property("led_pin", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/som.zen".to_string(),
+            r#"
+load("./ifaces.zen", "Gpio")
+LED = io("LED", Gpio)
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", LED = LED)
+Mcu(name = "U2", LED = LED)
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Som = Module("./som.zen")
+Som(name = "SOM", LED = at(Gpio("LED_NET"), "PA7"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(
+        &result,
+        "is wanted by the solves of `SOM.U1`, `SOM.U2`: a pin name answers for one component",
+    );
+    // The report hangs off the at() itself, not off whichever solve lost.
+    let t = diag_text(&result);
+    assert!(t.contains("pinmux.contended_at"), "got {t}");
+}
+
+#[test]
+fn at_reaches_a_solve_through_a_forwarding_module() {
+    // The intermediate owns no solve and just forwards the value; the
+    // constraint rides the net down to the leaf that does solve.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pool")
+load("./ifaces.zen", "Gpio")
+POOL = pool("GPIO", provides = [Gpio], pins = ["PA5", "PA6", "PA7"])
+LED = io("LED", Gpio)
+res = pin_solve([POOL], [pin_request("LED", Gpio)])
+builtin.add_property("led_pin", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/som.zen".to_string(),
+            r#"
+load("./ifaces.zen", "Gpio")
+LED = io("LED", Gpio)
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", LED = LED)
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Som = Module("./som.zen")
+Som(name = "SOM", LED = at(Gpio("LED_NET"), "PA7"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let tree = result.output.as_ref().unwrap().module_tree();
+    let pin = tree
+        .values()
+        .filter_map(|m| m.properties().get("led_pin").cloned())
+        .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+        .next()
+        .unwrap_or_default();
+    assert_eq!(pin, "PA7", "at() must reach the leaf solve two levels down");
+}
+
+#[test]
+fn soft_at_reaches_a_solve_through_a_forwarding_module() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pool")
+load("./ifaces.zen", "Gpio")
+POOL = pool("GPIO", provides = [Gpio], pins = ["PA5", "PA6", "PA7"])
+LED = io("LED", Gpio)
+res = pin_solve([POOL], [pin_request("LED", Gpio)])
+builtin.add_property("led_pin", res["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/som.zen".to_string(),
+            r#"
+load("./ifaces.zen", "Gpio")
+LED = io("LED", Gpio)
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", LED = LED)
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Som = Module("./som.zen")
+Som(name = "SOM", LED = at(Gpio("LED_NET"), "PA6", soft = True))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let tree = result.output.as_ref().unwrap().module_tree();
+    let pin = tree
+        .values()
+        .filter_map(|m| m.properties().get("led_pin").cloned())
+        .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+        .next()
+        .unwrap_or_default();
+    assert_eq!(
+        pin, "PA6",
+        "a soft at() must bias the leaf solve, not vanish"
+    );
+}
+
+#[test]
+fn if_connected_ignores_a_config_of_the_same_name() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/stm32.zen".to_string(), STM32.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Gpio")
+gpio = config("gpio", str)
+res = pin_solve(PERIPHS, [pin_request("gpio", Gpio, if_connected = True)])
+builtin.add_property("served", "yes" if "gpio" in res["assignment"] else "no")
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", gpio = "not a connection")
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let served = result
+        .output
+        .as_ref()
+        .unwrap()
+        .module_tree()
+        .values()
+        .filter_map(|m| m.properties().get("served").cloned())
+        .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+        .next()
+        .unwrap_or_default();
+    assert_eq!(served, "no", "a config() must not count as a connection");
+}
+
+#[test]
+fn pin_map_warns_about_a_solved_request_it_was_not_given() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pin_map", "pin_request", "pin_solve")
+load("./stm32.zen", "PERIPHS")
+load("./ifaces.zen", "Uart", "Gpio")
+
+res = pin_solve(PERIPHS, [pin_request("COM", Uart), pin_request("LED", Gpio)])
+pin_map(res["assignment"], {"COM": Uart("BUS")})
+"#,
+    );
+    assert_ok(&result);
+    assert!(
+        diag_text(&result).contains("solved request(s) `LED` are absent from the ifaces dict"),
+        "expected a warning naming LED, got:\n{}",
+        diag_text(&result)
+    );
+}
+
+// --- Locked pins: a list must be claimed in full, a dict bounds one signal ---
+
+#[test]
+fn locked_list_that_starves_a_signal_names_it() {
+    // Both pins are TX-only candidates, so RX is left with nothing.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+
+U = peripheral("U0", provides = [Uart], rebind = "firmware",
+    signals = {"TX": [pin("PA9"), pin("PB6")], "RX": [pin("PA10")]})
+pin_solve([U], [pin_request("COM", Uart, prefer = ["PA9", "PB6"], lock = True)])
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "signal `RX` has no candidate among the locked pins `PA9`, `PB6`",
+    );
+}
+
+#[test]
+fn locked_dict_picks_one_of_several_pins_for_one_signal() {
+    // The intent a bare list could not express: either pin for TX, RX free.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+
+U = peripheral("U0", provides = [Uart], rebind = "firmware",
+    signals = {"TX": [pin("PA9"), pin("PB6")], "RX": [pin("PA10")]})
+res = pin_solve([U], [pin_request("COM", Uart, prefer = {"TX": ["PA9", "PB6"]}, lock = True)])
+sigs = res["assignment"]["COM"]["signals"]
+check(sigs["TX"]["pin"] in ["PA9", "PB6"], "TX must take one of the named pins")
+check(sigs["RX"]["pin"] == "PA10", "RX stays free, got " + sigs["RX"]["pin"])
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn locked_dict_rejects_a_pin_outside_the_named_set() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+
+U = peripheral("U0", provides = [Uart], rebind = "firmware",
+    signals = {"TX": [pin("PA9")], "RX": [pin("PA10")]})
+pin_solve([U], [pin_request("COM", Uart, prefer = {"TX": ["PB6"]}, lock = True)])
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "signal `TX` has no candidate among the locked pins `PB6`",
+    );
+}
+
+#[test]
+fn at_accepts_a_per_signal_dict() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U0", provides = [Uart], rebind = "firmware",
+    signals = {"TX": [pin("PA9"), pin("PB6")], "RX": [pin("PA10")]})
+COM = io("COM", Uart)
+res = pin_solve([U], [pin_request("COM", Uart)])
+builtin.add_property("tx", res["assignment"]["COM"]["signals"]["TX"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Uart")
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", COM = at(Uart("BUS"), {"TX": "PB6"}))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let tx = result
+        .output
+        .as_ref()
+        .unwrap()
+        .module_tree()
+        .values()
+        .filter_map(|m| m.properties().get("tx").cloned())
+        .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+        .next()
+        .unwrap_or_default();
+    assert_eq!(tx, "PB6", "at() dict must pin the named signal");
+}
+
+#[test]
+fn two_parts_pinning_one_shared_net_each_get_their_own() {
+    let part = |p: &str| {
+        format!(
+            r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = peripheral("P0", provides = [Gpio], rebind = "fixed",
+    signals = {{"PIN": [pin("{p}"), pin("OTHER")]}})
+BUS = io("BUS", Gpio)
+res = pin_solve([P], [pin_request("BUS", Gpio)])
+builtin.add_property("chosen", res["assignment"]["BUS"]["signals"]["PIN"]["pin"])
+"#
+        )
+    };
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/a.zen".to_string(), part("PB7")),
+        ("/b.zen".to_string(), part("P3")),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+A = Module("./a.zen")
+B = Module("./b.zen")
+bus = Gpio("SHARED")
+A(name = "A", BUS = at(bus, "PB7"))
+B(name = "B", BUS = at(bus, "P3"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let chosen: Vec<(String, String)> = result
+        .output
+        .as_ref()
+        .unwrap()
+        .module_tree()
+        .iter()
+        .filter_map(|(path, m)| {
+            let v = m.properties().get("chosen")?;
+            Some((
+                path.segments.join("."),
+                v.to_value().unpack_str()?.to_owned(),
+            ))
+        })
+        .collect();
+    assert_eq!(
+        chosen,
+        [
+            ("A".to_string(), "PB7".to_string()),
+            ("B".to_string(), "P3".to_string())
+        ],
+        "each part must get the pin named at its own call site"
+    );
+}
+
+#[test]
+fn where_predicate_failure_rejects_only_that_candidate() {
+    // B9 declares no `baud_max`, so the predicate raises on it; the solve must
+    // fall through to the provider that does instead of aborting.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+
+NOATTR = peripheral("NOATTR", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("P1")], "RX": [pin("P2")]})
+WITHATTR = peripheral("WITHATTR", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("P3")], "RX": [pin("P4")]},
+    attrs = {"baud_max": "8MHz"})
+
+def fast(a):
+    return a["baud_max"] >= "1MHz"
+
+res = pin_solve([NOATTR, WITHATTR], [pin_request("COM", Uart, where = fast)])
+check(res["assignment"]["COM"]["instance"] == "WITHATTR", "must skip the attr-less provider")
+"#,
+    );
+    assert_ok(&result);
+}
+
+/// A hard `at()` left unconsumed by the first design must not fail the second.
+/// No `prepare_for_root_eval` here on purpose: each root owns its constraint
+/// store, so the isolation holds by construction rather than by a reset.
+#[test]
+fn a_failed_design_does_not_poison_the_next_one() {
+    let mut files = common::stdlib_test_files();
+    files.insert(
+        "/leaf.zen".to_string(),
+        "IO0 = io(\"IO0\", Net, optional = True)\n".to_string(),
+    );
+    files.insert(
+        "/a.zen".to_string(),
+        r#"
+load("@stdlib/pinmux.zen", "at")
+Leaf = Module("./leaf.zen")
+Leaf(name = "L", IO0 = at(Net("LED"), "PA9"))
+"#
+        .to_string(),
+    );
+    files.insert("/b.zen".to_string(), "N = Net(\"B\")\n".to_string());
+
+    let file_provider: Arc<dyn pcb_zen_core::FileProvider> =
+        Arc::new(common::InMemoryFileProvider::new(files));
+    let resolution = Arc::new(common::test_resolution());
+    let session = EvalSession::default();
+
+    let eval_root = |path: &str| {
+        EvalContext::from_session_and_config(
+            session.clone(),
+            EvalContextConfig::new(file_provider.clone(), resolution.clone()),
+        )
+        .set_source_path(PathBuf::from(path))
+        .eval()
+    };
+
+    let a = eval_root("/a.zen");
+    assert!(
+        !a.is_success(),
+        "a.zen must fail on its own unconsumed at()"
+    );
+    let b = eval_root("/b.zen");
+    assert!(
+        b.is_success(),
+        "b.zen must build clean, got: {:#?}",
+        b.diagnostics
+    );
+}
+
+const TWO_CHIPS: &str = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Comparator")
+
+# Same part number twice, so both chips carry the same pin numbering.
+def quad(ref):
+    return [
+        peripheral(ref + ".A", part = ref, provides = [Comparator], rebind = "none",
+            signals = {"INP": [pin("7")], "INN": [pin("6")], "OUT": [pin("1")]}),
+        peripheral(ref + ".B", part = ref, provides = [Comparator], rebind = "none",
+            signals = {"INP": [pin("5")], "INN": [pin("4")], "OUT": [pin("2")]}),
+    ]
+"#;
+
+fn eval_two_chips(main: &str) -> WithDiagnostics<EvalOutput> {
+    eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/chip.zen".to_string(), TWO_CHIPS.to_string()),
+        ("/test.zen".to_string(), main.to_string()),
+    ])
+}
+
+#[test]
+fn a_second_part_is_not_blocked_by_the_first_parts_pin_names() {
+    let result = eval_two_chips(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./chip.zen", "quad")
+load("./ifaces.zen", "Comparator")
+
+r1 = pin_solve(quad("U1"), [pin_request("OV", Comparator)])
+r2 = pin_solve(quad("U2"), [pin_request("UV", Comparator)])
+check(r1["assignment"]["OV"]["instance"] == "U1.A", "U1 must take its first unit")
+check(r2["assignment"]["UV"]["instance"] == "U2.A", "U2 must take its own first unit")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn a_fully_used_part_does_not_exhaust_a_second_one() {
+    let result = eval_two_chips(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./chip.zen", "quad")
+load("./ifaces.zen", "Comparator")
+
+pin_solve(quad("U1"), [pin_request("OV", Comparator), pin_request("UV", Comparator)])
+r2 = pin_solve(quad("U2"), [pin_request("TEMP", Comparator)])
+check(r2["assignment"]["TEMP"]["instance"] == "U2.A", "U2 must still be free")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn exclusivity_still_holds_within_one_part() {
+    let result = eval_two_chips(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./chip.zen", "quad")
+load("./ifaces.zen", "Comparator")
+
+U = quad("U1")
+r1 = pin_solve(U, [pin_request("OV", Comparator)])
+r2 = pin_solve(U, [pin_request("UV", Comparator)])
+check(r1["assignment"]["OV"]["instance"] == "U1.A", "first solve takes unit A")
+check(r2["assignment"]["UV"]["instance"] == "U1.B", "second must move to unit B")
+"#,
+    );
+    assert_ok(&result);
+}
+
+const TWO_SLOTS: &str = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+PA = peripheral("PA", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("P1"), pin("P2")]})
+PB = peripheral("PB", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("P1"), pin("P2")]})
+A = io("A", Gpio)
+B = io("B", Gpio)
+res = pin_solve([PA, PB], [pin_request("B", Gpio), pin_request("A", Gpio)])
+builtin.add_property("A", res["assignment"]["A"]["signals"]["PIN"]["pin"])
+builtin.add_property("B", res["assignment"]["B"]["signals"]["PIN"]["pin"])
+"#;
+
+#[test]
+fn an_unconstrained_io_does_not_steal_a_siblings_at() {
+    // Both inputs carry the same net; only `A` is pinned.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/mcu.zen".to_string(), TWO_SLOTS.to_string()),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Mcu = Module("./mcu.zen")
+n = Gpio("SHARED")
+Mcu(name = "U1", A = at(n, "P2"), B = n)
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let pin = |k: &str| {
+        result
+            .output
+            .as_ref()
+            .unwrap()
+            .module_tree()
+            .values()
+            .filter_map(|m| m.properties().get(k).cloned())
+            .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+            .next()
+            .unwrap_or_default()
+    };
+    assert_eq!(pin("A"), "P2", "A keeps the pin the caller named");
+    assert_eq!(pin("B"), "P1", "B was never constrained");
+}
+
+#[test]
+fn a_lock_naming_an_unknown_signal_is_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U0", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("PA9")], "RX": [pin("PA10")]})
+pin_solve([U], [pin_request("COM", Uart, prefer = {"TXX": "PA9"}, lock = True)])
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "pin constraint names signal `TXX`, which this request does not use (it uses `TX`, `RX`)",
+    );
+}
+
+#[test]
+fn a_lock_naming_a_signal_outside_uses_is_rejected() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U0", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("PA9")], "RX": [pin("PA10")]})
+pin_solve([U], [pin_request("COM", Uart, uses = ["TX"], prefer = {"RX": "PA10"})])
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "names signal `RX`, which this request does not use",
+    );
+}
+
+#[test]
+fn an_at_naming_an_unknown_signal_is_rejected() {
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart")
+U = peripheral("U0", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("PA9")], "RX": [pin("PA10")]})
+COM = io("COM", Uart)
+pin_solve([U], [pin_request("COM", Uart)])
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Uart")
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", COM = at(Uart("BUS"), {"TXX": "PA9"}))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(
+        &result,
+        "at() on input `COM`: pin constraint names signal `TXX`",
+    );
+}
+
+#[test]
+fn a_second_parts_pins_do_not_eat_the_firsts_spares() {
+    // Two chips, overlapping pin numbering. U2 taking its `B` must not strike
+    // `B` off U1's spare list in the merged property.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P1 = pool("U1.GPIO", part = "U1", provides = [Gpio], pins = ["A", "B", "C"])
+P2 = pool("U2.GPIO", part = "U2", provides = [Gpio], pins = ["B", "D"])
+pin_solve([P1], [pin_request("L1", Gpio)])
+pin_solve([P2], [pin_request("L2", Gpio)])
+"#,
+    );
+    assert_ok(&result);
+    let swaps = json_property(&result, "swap_classes");
+    let u1 = swaps
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["pool"] == "U1.GPIO")
+        .expect("U1 class present");
+    let spares: Vec<&str> = u1["spare_pins"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap())
+        .collect();
+    assert_eq!(spares, ["B", "C"], "U1 keeps both of its own spares");
+}
+
+#[test]
+fn undeclared_silicon_shares_one_pad_namespace() {
+    // Without `part=` there is one namespace, which is why the solver refuses
+    // `A` to L2 — so `B` is gone from L1's alternates too. `part=` is how a
+    // table says the pads sit on different components.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+U1 = peripheral("U1.P", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("A"), pin("B")]})
+U2 = peripheral("U2.P", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("A"), pin("B")]})
+pin_solve([U1], [pin_request("L1", Gpio)])
+pin_solve([U2], [pin_request("L2", Gpio)])
+"#,
+    );
+    assert_ok(&result);
+
+    let a = json_property(&result, "pin_assignment");
+    assert_eq!(a["L2"]["signals"]["PIN"]["pin"], "B", "got {a}");
+    assert!(
+        a["L1"]["alternates"].as_object().unwrap().is_empty(),
+        "got {a}"
+    );
+}
+
+#[test]
+fn a_second_parts_pins_do_not_eat_the_firsts_alternates() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+U1 = peripheral("U1.P", part = "U1", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("A"), pin("B")]})
+U2 = peripheral("U2.P", part = "U2", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("B")]})
+pin_solve([U1], [pin_request("L1", Gpio)])
+pin_solve([U2], [pin_request("L2", Gpio)])
+"#,
+    );
+    assert_ok(&result);
+    let a = json_property(&result, "pin_assignment");
+    let alts = &a["L1"]["alternates"]["PIN"];
+    assert_eq!(
+        alts.as_array().map(|v| v.len()),
+        Some(1),
+        "U1 keeps its own alternate, got {a}"
+    );
+}
+
+#[test]
+fn pin_map_allows_two_declared_parts_to_share_a_pin_name() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+U1 = peripheral("U1.P", part = "U1", provides = [Gpio], rebind = "fixed", signals = {"PIN": [pin("7")]})
+U2 = peripheral("U2.P", part = "U2", provides = [Gpio], rebind = "fixed", signals = {"PIN": [pin("7")]})
+r1 = pin_solve([U1], [pin_request("A", Gpio)])
+r2 = pin_solve([U2], [pin_request("B", Gpio)])
+m1 = pin_map(r1["assignment"], {"A": Net("NA")})
+m2 = pin_map(r2["assignment"], {"B": Net("NB")})
+check(m1["7"] != m2["7"], "each part keeps its own pad 7")
+"#,
+    );
+    assert_ok(&result);
+}
+
+const QUAD: &str = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin")
+load("./ifaces.zen", "Comparator")
+def quad(ref):
+    return [
+        peripheral(ref + ".A", part = ref, provides = [Comparator], rebind = "none",
+            signals = {"INP": [pin("7")], "INN": [pin("6")], "OUT": [pin("1")]}),
+        peripheral(ref + ".B", part = ref, provides = [Comparator], rebind = "none",
+            signals = {"INP": [pin("5")], "INN": [pin("4")], "OUT": [pin("2")]}),
+    ]
+"#;
+
+fn eval_quad(main: &str) -> WithDiagnostics<EvalOutput> {
+    eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        ("/chip.zen".to_string(), QUAD.to_string()),
+        ("/test.zen".to_string(), main.to_string()),
+    ])
+}
+
+#[test]
+fn declared_parts_spread_requests_over_both_components() {
+    let result = eval_quad(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pin_map")
+load("./chip.zen", "quad")
+load("./ifaces.zen", "Comparator")
+
+roles = ["R1", "R2", "R3", "R4"]
+res = pin_solve(quad("U1") + quad("U2"), [pin_request(k, Comparator) for k in roles])
+check(res["assignment"]["R1"]["instance"] == "U1.A", "R1 on U1.A")
+check(res["assignment"]["R3"]["instance"] == "U2.A", "R3 must reach the second chip")
+
+ifaces = {k: Comparator(k) for k in roles}
+m1 = pin_map(res["assignment"], ifaces, part = "U1")
+m2 = pin_map(res["assignment"], ifaces, part = "U2")
+check(sorted(m1.keys()) == sorted(m2.keys()), "both chips carry the same pad names")
+check(m1["7"] != m2["7"], "but they are different pads")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn mapping_a_multi_part_assignment_needs_a_part() {
+    let result = eval_quad(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pin_map")
+load("./chip.zen", "quad")
+load("./ifaces.zen", "Comparator")
+roles = ["R1", "R2", "R3", "R4"]
+res = pin_solve(quad("U1") + quad("U2"), [pin_request(k, Comparator) for k in roles])
+pin_map(res["assignment"], {k: Comparator(k) for k in roles})
+"#,
+    );
+    assert_fails_with(
+        &result,
+        "spans several parts; pass part= to map one component at a time",
+    );
+}
+
+#[test]
+fn a_pool_inside_a_flat_list_is_still_one_part() {
+    // `pool()` yields a list, so nesting is how pools compose: it must not be
+    // read as a part boundary.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Uart", "Gpio")
+U = peripheral("U0", provides = [Uart], rebind = "fixed",
+    signals = {"TX": [pin("P1")], "RX": [pin("P2")]})
+G = pool("GPIO", provides = [Gpio], pins = ["P1", "P3"])
+res = pin_solve([U, G], [pin_request("COM", Uart), pin_request("LED", Gpio)])
+check(res["assignment"]["LED"]["signals"]["PIN"]["pin"] == "P3", "P1 is taken by TX")
+"#,
+    );
+    assert_ok(&result);
+}
+
+/// `pin_map` ties unclaimed pads off; a design may still override them, which
+/// is how the LM339 example straps its unused comparator units.
+#[test]
+fn unclaimed_pads_are_tied_off_and_can_be_overridden() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Comparator")
+
+def unit(n, p, m, o):
+    return peripheral(n, provides = [Comparator], rebind = "none",
+        signals = {"INP": [pin(p)], "INN": [pin(m)], "OUT": [pin(o)]})
+UNITS = [unit("A", "IN1P", "IN1N", "OUT1"), unit("B", "IN2P", "IN2N", "OUT2")]
+VCC = Net("VCC")
+GND = Net("GND")
+role = Comparator("OV")
+
+res = pin_solve(UNITS, [pin_request("OV", Comparator, bind = role)])
+pins = pin_map(res["assignment"], {"OV": role})
+
+# The served unit carries its role...
+check(pins["IN1P"] == role.INP, "IN1P carries the role")
+check(pins["OUT1"] == role.OUT, "OUT1 carries the role")
+# ...the spare unit's pads come back open, and a design may strap them.
+check(pins["OUT2"].name == "", "an unclaimed pad is open")
+pins["IN2P"] = VCC
+pins["IN2N"] = GND
+check(pins["IN2P"] == VCC, "an open pad can be overridden")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn an_ancestors_constraint_survives_a_second_solve() {
+    // The at() came from the board and was forwarded down, so the leaf can
+    // only read it from the constraint store — re-solving must not lose it.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA5", "PA6", "PA7"])
+LED = io("LED", Gpio)
+reqs = [pin_request("LED", Gpio)]
+r1 = pin_solve([P], reqs)
+r2 = pin_solve([P], reqs)
+builtin.add_property("first", r1["assignment"]["LED"]["signals"]["PIN"]["pin"])
+builtin.add_property("second", r2["assignment"]["LED"]["signals"]["PIN"]["pin"])
+"#
+            .to_string(),
+        ),
+        (
+            "/som.zen".to_string(),
+            r#"
+load("./ifaces.zen", "Gpio")
+LED = io("LED", Gpio)
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", LED = LED)
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Som = Module("./som.zen")
+Som(name = "SOM", LED = at(Gpio("LED_NET"), "PA7"))
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_ok(&result);
+    let pin = |k: &str| {
+        result
+            .output
+            .as_ref()
+            .unwrap()
+            .module_tree()
+            .values()
+            .filter_map(|m| m.properties().get(k).cloned())
+            .filter_map(|v| v.to_value().unpack_str().map(|s| s.to_owned()))
+            .next()
+            .unwrap_or_default()
+    };
+    assert_eq!(pin("first"), "PA7", "the forwarded at() applies");
+    assert_eq!(pin("second"), "PA7", "and still applies on a re-solve");
+}
+
+#[test]
+fn an_idle_part_keeps_its_pads_when_another_part_uses_the_same_names() {
+    // Both requests land on U1; U2 exposes the very same pad names and must
+    // still come back tied off, or Component() rejects it as unconnected.
+    let result = eval_quad(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve", "pin_map")
+load("./chip.zen", "quad")
+load("./ifaces.zen", "Comparator")
+
+res = pin_solve(quad("U1") + quad("U2"),
+                [pin_request("R1", Comparator), pin_request("R2", Comparator)])
+check(res["assignment"]["R1"]["instance"] == "U1.A", "R1 on U1.A")
+check(res["assignment"]["R2"]["instance"] == "U1.B", "R2 on U1.B")
+
+ifaces = {"R1": Comparator("a"), "R2": Comparator("b")}
+u2 = pin_map(res["assignment"], ifaces, part = "U2")
+check(sorted(u2.keys()) == ["1", "2", "4", "5", "6", "7"], "U2 ties off all six pads, got " + str(sorted(u2.keys())))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn an_earlier_solve_on_one_part_leaves_the_other_free() {
+    // Same table solved twice: U1's claimed pads must not block U2's, which
+    // carry identical names.
+    let result = eval_quad(
+        r#"
+load("@stdlib/pinmux.zen", "pin_request", "pin_solve")
+load("./chip.zen", "quad")
+load("./ifaces.zen", "Comparator")
+
+ALL = quad("U1") + quad("U2")
+pin_solve(ALL, [pin_request("R1", Comparator), pin_request("R2", Comparator)])
+r = pin_solve(ALL, [pin_request("R3", Comparator)])
+check(r["assignment"]["R3"]["instance"] == "U2.A", "R3 must reach the idle chip")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn the_unsolvable_hint_points_at_advice_that_works() {
+    let undeclared = r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Comparator")
+def u(ref):
+    return peripheral(ref, provides = [Comparator], rebind = "none",
+        signals = {"INP": [pin("7")], "INN": [pin("6")], "OUT": [pin("1")]})
+pin_solve([u("U1"), u("U2")], [pin_request("R1", Comparator), pin_request("R2", Comparator)])
+"#;
+    let result = eval_with_fixtures(undeclared);
+    assert_fails_with(
+        &result,
+        "give each `peripheral(part = ...)` so its pads stay its own",
+    );
+
+    // And taking the advice actually solves it.
+    let declared = undeclared.replace(
+        "provides = [Comparator]",
+        "part = ref, provides = [Comparator]",
+    );
+    let result = eval_with_fixtures(&format!(
+        r#"{declared}
+"#
+    ));
+    assert_ok(&result);
+}
+
+#[test]
+fn two_parts_may_name_a_resource_alike() {
+    // `part=` separates pad namespaces; resource names may then repeat, so
+    // instance exclusivity has to be per part too — and the assignment says
+    // which part each one is on.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+U1 = pool("GPIO", part = "U1", provides = [Gpio], pins = ["PA0"])
+U2 = pool("GPIO", part = "U2", provides = [Gpio], pins = ["PA0"])
+
+a = pin_solve([U1, U2], [pin_request("A", Gpio)])
+b = pin_solve([U1, U2], [pin_request("B", Gpio)])
+check(a["assignment"]["A"]["instance"] == "GPIO.PA0", "A on the shared name")
+check(b["assignment"]["B"]["instance"] == "GPIO.PA0", "B too")
+check(a["assignment"]["A"]["part"] != b["assignment"]["B"]["part"],
+      "but on different parts, got " + str(a["assignment"]["A"]["part"]))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn an_inherited_entry_keeps_the_alternates_of_its_own_part() {
+    // X sits on U2, whose P2 stays free; the pad U1 took in the second solve
+    // has the same name and must not shrink X's freedom.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio", "AdcIn")
+U1A = peripheral("A", part = "U1", provides = [Gpio], rebind = "none",
+    signals = {"PIN": [pin("P2")]})
+U2A = peripheral("A", part = "U2", provides = [AdcIn], rebind = "none",
+    signals = {"IN": [pin("P1"), pin("P2")]})
+
+x = pin_solve([U1A, U2A], [pin_request("X", AdcIn)])
+y = pin_solve([U1A, U2A], [pin_request("Y", Gpio)])
+"#,
+    );
+    assert_ok(&result);
+
+    let assign = json_property(&result, "pin_assignment");
+    assert_eq!(
+        assign["X"]["alternates"]["IN"].as_array().unwrap(),
+        &["P2"],
+        "got {assign}"
+    );
+}
+
+#[test]
+fn a_pool_class_merged_across_solves_keeps_its_part() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio", "AdcIn")
+U1 = pool("GPIO", part = "U1", provides = [Gpio], pins = ["PA0", "PA1"])
+U2 = pool("GPIO", part = "U2", provides = [AdcIn], pins = ["PB0", "PB1"])
+
+a = pin_solve([U1, U2], [pin_request("A", Gpio)])
+b = pin_solve([U1, U2], [pin_request("B", AdcIn)])
+"#,
+    );
+    assert_ok(&result);
+
+    let swaps = json_property(&result, "swap_classes");
+    let classes = swaps.as_array().unwrap();
+    assert_eq!(classes.len(), 2, "one class per component, got {swaps}");
+    for c in classes {
+        let part = c["part"].as_str().unwrap_or("?");
+        let spare = c["spare_pins"][0].as_str().unwrap_or("?");
+        let expect = if part == "U1" { "PA1" } else { "PB1" };
+        assert_eq!(spare, expect, "spares stay on their component, got {swaps}");
+    }
+}
+
+#[test]
+fn a_class_merged_across_solves_keeps_its_part() {
+    // The module property folds every solve together; a prior class must not
+    // land on the class of the same-named units of another component.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Comparator")
+def unit(name, part, pads):
+    return peripheral(name, part = part, provides = [Comparator], rebind = "none",
+        signals = {"INP": [pin(pads[0])], "INN": [pin(pads[1])], "OUT": [pin(pads[2])]})
+
+P = [unit("A", "U1", ["1", "2", "3"]), unit("B", "U1", ["5", "6", "7"]),
+     unit("A", "U2", ["1", "2", "3"]), unit("B", "U2", ["5", "6", "7"])]
+
+x = pin_solve(P, [pin_request("X", Comparator)])
+y = pin_solve(P, [pin_request("Y", Comparator)])
+"#,
+    );
+    assert_ok(&result);
+
+    let swaps = json_property(&result, "swap_classes");
+    let classes = swaps.as_array().unwrap();
+    assert_eq!(classes.len(), 2, "one class per component, got {swaps}");
+    let mut parts: Vec<&str> = classes
+        .iter()
+        .map(|c| c["part"].as_str().unwrap_or("?"))
+        .collect();
+    parts.sort();
+    assert_eq!(
+        parts,
+        ["U1", "U2"],
+        "each class names its component, got {swaps}"
+    );
+}
+
+#[test]
+fn a_gate_swap_class_never_spans_two_parts() {
+    // Same story for gate swap: X may move to U1's spare comparator, never to
+    // the identically named one on U2.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve")
+load("./ifaces.zen", "Comparator")
+def unit(name, part, pads):
+    return peripheral(name, part = part, provides = [Comparator], rebind = "none",
+        signals = {"INP": [pin(pads[0])], "INN": [pin(pads[1])], "OUT": [pin(pads[2])]})
+
+U1A = unit("A", "U1", ["1", "2", "3"])
+U1B = unit("B", "U1", ["5", "6", "7"])
+U2A = unit("A", "U2", ["1", "2", "3"])
+U2B = unit("B", "U2", ["5", "6", "7"])
+
+r = pin_solve([U1A, U1B, U2A, U2B], [pin_request("X", Comparator), pin_request("Y", Comparator)])
+"#,
+    );
+    assert_ok(&result);
+
+    let swaps = json_property(&result, "swap_classes");
+    let classes = swaps.as_array().unwrap();
+    assert_eq!(classes.len(), 2, "one class per component, got {swaps}");
+    for c in classes {
+        assert_eq!(c["members"].as_array().unwrap().len(), 1, "got {swaps}");
+        assert_eq!(c["spare_units"].as_array().unwrap(), &["B"], "got {swaps}");
+    }
+    let parts: Vec<&str> = classes
+        .iter()
+        .map(|c| c["part"].as_str().unwrap_or("?"))
+        .collect();
+    assert!(
+        parts.contains(&"U1") && parts.contains(&"U2"),
+        "each class names its component, got {swaps}"
+    );
+}
+
+#[test]
+fn a_clobbered_result_property_is_reported() {
+    // pin_solve owns these names; overwriting one would otherwise cost the
+    // earlier solves their data with no word said.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0", "PA1"])
+builtin.add_property("pin_assignment", "mine")
+r = pin_solve([P], [pin_request("A", Gpio)])
+"#,
+    );
+    assert_fails_with(&result, "written by pin_solve");
+
+    // ...and after it, where the merge would have kept no trace at all.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0", "PA1"])
+r = pin_solve([P], [pin_request("A", Gpio)])
+builtin.add_property("swap_classes", "mine")
+"#,
+    );
+    assert_fails_with(&result, "written by pin_solve");
+}
+
+#[test]
+fn one_request_name_may_serve_two_parts() {
+    // A name identifies a request per component, not per module: solving `LED`
+    // on U2 must not release what `LED` took on U1.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+U1 = pool("GPIO", part = "U1", provides = [Gpio], pins = ["PA0", "PA1"])
+U2 = pool("GPIO", part = "U2", provides = [Gpio], pins = ["PA0", "PA1"])
+
+a = pin_solve([U1], [pin_request("LED", Gpio)])
+b = pin_solve([U2], [pin_request("LED", Gpio)])
+c = pin_solve([U1], [pin_request("BTN", Gpio)])
+
+led = a["assignment"]["LED"]["signals"]["PIN"]["pin"]
+check(c["assignment"]["BTN"]["signals"]["PIN"]["pin"] != led,
+      "BTN took the pad LED holds on U1")
+m = pin_map(a["assignment"], {"LED": Gpio("L")}, part = "U1")
+check(led in m, "U1 still maps the pad its own LED took, got " + str(sorted(m.keys())))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn a_swap_class_never_spans_two_parts() {
+    // Two components whose pools carry the same name: the residual freedom of
+    // a request on one is not freedom to move onto the other's pads.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio", "AdcIn")
+U1 = pool("GPIO", part = "U1", provides = [Gpio], pins = ["PA0", "PA1"])
+U2 = pool("GPIO", part = "U2", provides = [AdcIn], pins = ["PA0", "PA1"])
+
+r = pin_solve([U1, U2], [pin_request("A", Gpio), pin_request("B", AdcIn)])
+"#,
+    );
+    assert_ok(&result);
+
+    let swaps = json_property(&result, "swap_classes");
+    let classes = swaps.as_array().unwrap();
+    assert_eq!(classes.len(), 2, "one class per component, got {swaps}");
+    for c in classes {
+        assert_eq!(c["members"].as_array().unwrap().len(), 1, "got {swaps}");
+        assert_eq!(c["spare_pins"].as_array().unwrap().len(), 1, "got {swaps}");
+    }
+    let parts: Vec<&str> = classes
+        .iter()
+        .map(|c| c["part"].as_str().unwrap_or("?"))
+        .collect();
+    assert!(
+        parts.contains(&"U1") && parts.contains(&"U2"),
+        "each class names its component, got {swaps}"
+    );
+}
+
+/// Re-analysing files on one `EvalContext` — the editor path — must not carry
+/// one design's unmet `at()` into the next one's diagnostics.
+#[test]
+fn repeated_analysis_keeps_designs_apart() {
+    let mut files = common::stdlib_test_files();
+    files.insert(
+        "/leaf.zen".to_string(),
+        "IO0 = io(\"IO0\", Net, optional = True)\n".to_string(),
+    );
+    files.insert(
+        "/bad.zen".to_string(),
+        r#"
+load("@stdlib/pinmux.zen", "at")
+Leaf = Module("./leaf.zen")
+Leaf(name = "L", IO0 = at(Net("LED"), "PA9"))
+"#
+        .to_string(),
+    );
+    files.insert("/good.zen".to_string(), "N = Net(\"OK\")\n".to_string());
+
+    let file_provider: Arc<dyn pcb_zen_core::FileProvider> =
+        Arc::new(common::InMemoryFileProvider::new(files.clone()));
+    let ctx = EvalContext::from_session_and_config(
+        EvalSession::default(),
+        EvalContextConfig::new(file_provider, Arc::new(common::test_resolution())),
+    );
+
+    let analyze = |name: &str| ctx.parse_and_analyze_file(PathBuf::from(name), files[name].clone());
+    assert!(!analyze("/bad.zen").is_success(), "bad.zen owns its error");
+    for _ in 0..2 {
+        let r = analyze("/good.zen");
+        assert!(
+            r.is_success(),
+            "good.zen must stay clean, got: {:#?}",
+            r.diagnostics
+        );
+    }
+}
+
+#[test]
+fn an_at_in_a_role_dict_nobody_reads_is_reported() {
+    // The module wires only the roles it knows, so a mistyped key would
+    // otherwise drop its pin constraint without a word.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0", "PA1", "PA8"])
+gpio = config("gpio", dict, default = {})
+reqs = [pin_request("LED", Gpio, bind = gpio["LED"])] if "LED" in gpio else []
+pin_solve([P], reqs)
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "at")
+load("./ifaces.zen", "Gpio")
+Mcu = Module("./mcu.zen")
+Mcu(name = "U1", gpio = {"LED": at(Gpio("L"), "PA8"), "TYPO": at(Gpio("T"), "PA1")})
+"#
+            .to_string(),
+        ),
+    ]);
+    assert_fails_with(
+        &result,
+        "at() pin constraint on input `TYPO` was never consumed",
+    );
+}
+
+#[test]
+fn free_pads_accumulate_across_solves_of_one_part() {
+    // Two tables, one anonymous part: the second solve must not erase the
+    // first table's unclaimed pads, or they end up wired nowhere.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+P1 = peripheral("P1", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0"), pin("PA1")]})
+P2 = peripheral("P2", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PB0"), pin("PB1")]})
+r1 = pin_solve([P1], [pin_request("A", Gpio)])
+pin_solve([P2], [pin_request("B", Gpio)])
+
+m = pin_map(r1["assignment"], {"A": Net("NA")})
+check("PA1" in m, "P1's own unclaimed pad survives the second solve")
+check(not ("PB0" in m), "a pad the second solve claimed is not tied off")
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn declared_parts_keep_their_free_pads_apart() {
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+P1 = peripheral("P1", part = "U1", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0"), pin("PA1")]})
+P2 = peripheral("P2", part = "U2", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PB0"), pin("PB1")]})
+r1 = pin_solve([P1], [pin_request("A", Gpio)])
+pin_solve([P2], [pin_request("B", Gpio)])
+
+m = pin_map(r1["assignment"], {"A": Net("NA")})
+check(sorted(m.keys()) == ["PA0", "PA1"], "U1 keeps only its own, got " + str(sorted(m.keys())))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn a_pad_a_resolve_gave_back_is_tied_off_again() {
+    // R moves from P1's table to P2's. Nobody holds PA0 any more, and the
+    // component still has to wire it, though the later table never named it.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+P1 = peripheral("P1", part = "U1", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0"), pin("PA1")]})
+P2 = peripheral("P2", part = "U1", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA2"), pin("PA3")]})
+r1 = pin_solve([P1], [pin_request("R", Gpio)])
+r2 = pin_solve([P2], [pin_request("R", Gpio)])
+
+m = pin_map(r2["assignment"], {"R": Net("NA")}, part = "U1")
+check(sorted(m.keys()) == ["PA0", "PA1", "PA2", "PA3"],
+      "the whole pin table of U1, got " + str(sorted(m.keys())))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn a_named_part_solved_over_two_subsets_keeps_every_pad() {
+    // One component, two tables: pads reachable only through the table absent
+    // from the later solve must still reach the component's pin dict.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+P1 = peripheral("P1", part = "U1", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0"), pin("PA1")]})
+P2 = peripheral("P2", part = "U1", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA2"), pin("PA3")]})
+r1 = pin_solve([P1], [pin_request("A", Gpio)])
+pin_solve([P2], [pin_request("B", Gpio)])
+
+m = pin_map(r1["assignment"], {"A": Net("NA")})
+check(sorted(m.keys()) == ["PA0", "PA1", "PA3"],
+      "every unclaimed pad of U1 is tied off, got " + str(sorted(m.keys())))
+"#,
+    );
+    assert_ok(&result);
+}
+
+#[test]
+fn if_connected_rejects_a_config_declared_after_the_solve() {
+    // `configs` only knows declarations seen so far, so the gate can read a
+    // later config as a connection — caught once the signature is complete.
+    let result = eval_zen(vec![
+        ("/ifaces.zen".to_string(), IFACES.to_string()),
+        (
+            "/mcu.zen".to_string(),
+            r#"
+load("@stdlib/pinmux.zen", "pool", "pin_request", "pin_solve")
+load("./ifaces.zen", "Gpio")
+P = pool("GPIO", provides = [Gpio], pins = ["PA0"])
+pin_solve([P], [pin_request("gpio", Gpio, if_connected = True)])
+gpio = config("gpio", str)
+"#
+            .to_string(),
+        ),
+        (
+            "/test.zen".to_string(),
+            "Mcu = Module(\"./mcu.zen\")\nMcu(name = \"U1\", gpio = \"hello\")\n".to_string(),
+        ),
+    ]);
+    assert_fails_with(
+        &result,
+        "was served because the caller passed `gpio`, but that input is a config()",
+    );
+}
+
+#[test]
+fn a_pad_shared_by_two_tables_of_one_part_is_claimed_once() {
+    // P1 and P2 belong to the same (anonymous) part and both expose PA0.
+    // Solved separately, the second must not be handed the pad the first took.
+    let result = eval_with_fixtures(
+        r#"
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+load("./ifaces.zen", "Gpio")
+P1 = peripheral("P1", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0")]})
+P2 = peripheral("P2", provides = [Gpio], rebind = "fixed",
+    signals = {"PIN": [pin("PA0"), pin("PA1")]})
+a = pin_solve([P1], [pin_request("A", Gpio)])
+b = pin_solve([P2], [pin_request("B", Gpio)])
+check(a["assignment"]["A"]["signals"]["PIN"]["pin"] == "PA0", "A takes PA0")
+check(b["assignment"]["B"]["signals"]["PIN"]["pin"] == "PA1",
+      "B must avoid PA0, got " + b["assignment"]["B"]["signals"]["PIN"]["pin"])
+m = pin_map(b["assignment"], {"B": Net("NB")})
+check(not ("PA0" in m), "and PA0 must not be tied off as free")
+"#,
+    );
+    assert_ok(&result);
+}

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -257,7 +257,7 @@ bus = MyBus("BUS1", enable=False)
 debug_bus = MyBus()
 ```
 
-Interface fields can be net instances, interface instances (for hierarchical composition), or `field()` specs. When instantiated, the first positional argument is an optional name; named arguments override defaults.
+Interface fields can be net instances, interface instances (for hierarchical composition), or `field()` specs. The names `implies`, `attrs`, and `__post_init__` are reserved for interface metadata and cannot be fields. When instantiated, the first positional argument is an optional name; named arguments override defaults.
 
 If an interface instance omits its explicit name, the assigned variable name becomes the root used for generated child nets:
 
@@ -280,6 +280,176 @@ power = PowerIf(vcc = ext)
 ```
 
 The standard library provides common interfaces (`Spi`, `I2c`, `Uart`, `Usb2`, `DiffPair`, `Pcie`, `Jtag`, `Swd`, etc.) in `@stdlib/interfaces.zen`. Helper functions `UartPair(a, b)` and `UsartPair(a, b)` create cross-connected pairs for point-to-point links.
+
+### Interface implication (`implies=`)
+
+An interface type may declare that it implies other interface types. This is a
+capability statement consumed by the pin-capability model (below): a resource
+providing the richer interface automatically satisfies requests for any implied
+one — never the reverse.
+
+```python
+Uart  = interface(TX = Net, RX = Net)
+Usart = interface(TX = Net, RX = Net, CK = Net, implies = [Uart])
+# same signals, distinct capability — a "marker" interface:
+LpUart = interface(TX = Net, RX = Net, implies = [Uart])
+```
+
+An interface may imply several others; matching is nominal — two structurally
+identical interfaces remain distinct capabilities.
+
+An interface may also declare the **attribute vocabulary** its capability
+providers use, as attribute name → physical value type:
+
+```python
+Uart = interface(TX = Net, RX = Net, attrs = {"baud_max": Frequency})
+```
+
+## Pin capabilities and assignment
+
+Multi-function components (MCUs, multi-unit analog/logic parts) can declare
+what each pin *can do* and let elaboration solve the assignment. This covers
+GPIO matrices and classic gate/pin swap.
+
+Matching is nominal: a capability is the `interface()` **declaration**, not its
+shape. Two files declaring identical fields are two capabilities, and an
+interface built by a factory function is a fresh one per binding. Declare a
+capability interface once, at a file's top level, and `load()` it wherever it
+is provided or requested.
+
+These builtins are not in the prelude — load the ones you use:
+
+```python
+load("@stdlib/pinmux.zen", "peripheral", "pool", "pin", "pin_request", "pin_solve", "pin_map", "at")
+
+UartFlow = interface(TX = Net, RX = Net, RTS = Net, CTS = Net, implies = [Uart])
+
+USART1 = peripheral(
+    "USART1",
+    provides = [Usart, UartFlow],       # interface types, closed over implies=
+    rebind   = "firmware",              # "none" | "firmware" | "fixed"
+    signals  = {
+        "TX": [pin("PA9", data = {"af": 1}), pin("PB6", data = {"af": 0})],
+        "RX": [pin("PA10", data = {"af": 1}), pin("PB7", data = {"af": 0})],
+        "CK": [pin("PA8", data = {"af": 1})],
+        "RTS": [pin("PA12", data = {"af": 1})],
+        "CTS": [pin("PA11", data = {"af": 1})],
+    },
+    attrs = {"baud_max": "8MHz"},       # unit strings parse to physical values
+)
+GPIOS = pool("GPIO", provides = [GpioPin], pins = ["PB4", "PB5", "PD6"])
+
+result = pin_solve(
+    [USART1, GPIOS],
+    [
+        pin_request("DEBUG", Uart),                       # any provider of Uart
+        pin_request("LED", GpioPin, prefer = ["PB4"]),
+        pin_request("SC", Usart),                         # needs CK: USART-class only
+    ],
+)
+```
+
+**`pin(name, data={}, cost=0, input_only=False, strap=False)`** — one
+candidate physical pin for a signal.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `name` | yes | Physical pin name (`"PA9"`) |
+| `data` | no | Realization info (an STM32 AF index, an ESP32 IOMUX FUNC number), passed through unchanged into the solved assignment |
+| `cost` | no | The solver prefers lower-cost candidates |
+| `input_only` | no | Pin has no output driver: excluded from `direction = "output"` requests |
+| `strap` | no | Boot-strapping pin: penalized against any alternative, warns when chosen |
+
+**`peripheral(name, provides, signals, rebind, attrs={}, unless=None)`** — a
+resource cluster (an MCU USART, one comparator of a dual package).
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `name` | yes | Instance name (`"USART1"`) |
+| `provides` | yes | Interface types this cluster can serve, including implied ones |
+| `signals` | yes | Signal name → list of `pin()` candidates (bare strings allowed); every signal of every provided interface needs at least one candidate |
+| `rebind` | yes | What a later swap costs: `"none"` (gate swap), `"firmware"` (a constant to regenerate), `"fixed"` (never movable) |
+| `attrs` | no | Capability attributes, validated against the interfaces' vocabulary |
+| `unless` | no | The peripheral is unavailable when this key is truthy in `pin_solve(config=...)`; its exclusive pads are then left out of the tie-off `pin_map` produces. A part is configured once: an axis that flips between two solves of the same part is an error |
+| `part` | no | Component these pads belong to; peripherals sharing a `part` share a pin namespace |
+
+**`pool(name, provides, pins, rebind="firmware")`** — sugar for N
+interchangeable single-signal units (GPIO pools): one unit per pin, all
+providing the same single-signal interface.
+
+**`pin_request(name, Iface, uses=None, instance=None, prefer=[], lock=False, where=None, direction=None, if_connected=False, bind=None)`** — a capability
+demand: the interface type *is* the request.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `name` | yes | Request name; keys the result and pairs with the `io()` input of the same name (`if_connected`, caller `at()`) |
+| `Iface` | yes | Requested interface type; any provider, direct or through `implies`, can serve it |
+| `uses` | no | Signals that consume pins (default: all of the interface's signals) |
+| `where` | no | Predicate over the provider's attrs: `lambda a: a["baud_max"] >= "1MHz"`. The solver may weigh a candidate more than once, so keep it pure |
+| `instance` | no | Restrict to a named peripheral or pool |
+| `prefer` | no | Pins the solver favors: a name/list of names, or a `{signal: name-or-list}` dict |
+| `lock` | no | Make `prefer` mandatory instead of preferred |
+| `direction` | no | `"input"` or `"output"`; `"output"` excludes `input_only` pins |
+| `if_connected` | no | Serve the request only when the caller connected the module input of the same name; pair with `io(Iface, optional = True)`. A `config()` of that name does not count as a connection; declare it above the `pin_solve` or the build reports the collision |
+| `bind` | no | The connected value, carried on the request itself (dict-of-roles pattern) |
+
+**`pin_solve(peripherals, requests, config={}, previous=None)`** — solve the
+joint instance × pin assignment across every peripheral given. Pin names are a
+part's pads: peripherals declaring the same `part=` share a pin namespace,
+those declaring none form one anonymous part, and a module holding two
+components solves both in one call. A pin carries at most one function and an
+instance serves at most one request (even on disjoint pin sets); when no
+assignment satisfies every request, the build fails with per-candidate
+rejection reasons. The result is deterministic and globally optimized: the
+solver prefers the least-capable sufficient instance, avoids strapping pins,
+honors per-pin `cost` and `prefer=`, and biases toward `previous=` (a prior
+assignment passed as a stability seed) so adding a request tends to keep a
+routed design in place.
+
+**`at(value, pins, soft=False)`** — constrain the physical pin(s) on the
+connection itself: `Mcu(IO0 = at(led_net, "PA8"))`. The wrapper is
+transparent: the inner value flows as if passed directly and the constraint
+reaches the `pin_request` of the same name as the `io()` input it annotates.
+Hard by default (unsatisfiable → build error); `soft = True` is a preference
+the solver may fall back from — it falls back to what the `pin_request` itself
+asked for, so a wish never voids a `lock = True` the module set, it only
+chooses among the pins that lock allows. A pin name answers for one component,
+so a constrained net that reaches two solves is an error rather than a race:
+give each side its own `at()`.
+
+A name or list of names must be claimed *in full* — every pin listed ends up
+on some signal of the request, whatever the signal count, so
+`at(uart, "PA2")` pins one signal of a multi-signal role and leaves the rest
+free. To bound a single signal instead, pass a dict:
+`at(uart, {"TX": ["PA9", "PB6"]})` means "TX takes one of these, RX is
+free".
+
+**`pin_map(assignment, ifaces, part=None)`** — the whole pin table of one
+component: every solved request's pads mapped to the net of the matching
+interface field (a bare `Net` works for single-signal requests), plus every
+candidate pad no request claimed, tied to `NotConnected()`. Override any of
+them afterwards. Requests absent from the assignment (e.g. dropped by
+`if_connected`) are skipped. `part=` selects the component when the assignment
+spans several; it is required then.
+
+`pin_solve` returns a dict:
+
+| Key | Content |
+|-----|---------|
+| `assignment` | Per request: the chosen instance, its `part`, and the pin per signal (with each pin's realization `data`), plus free alternates |
+| `swap_classes` | Residual swap freedom of *this* solve: pool classes with spare pins, gate-swap clusters. Each class names its `part` and never spans two of them. The module property of the same name merges every solve, so the two differ once a module solves more than once |
+
+Several `pin_solve` calls may share a module: every result stays live, so a
+later call never re-uses a pin or an instance an earlier one took. A request
+name identifies its claim on the parts of the table that solves it, so solving
+the same name again over the same component replaces its earlier claim — which
+is how `previous=` widens a solve — while a like-named request on another
+component keeps its own. Requests a call does not mention keep theirs.
+
+`assignment` and `swap_classes` are also stored as module properties (JSON) —
+several solves in one module merge, keyed by request name — and flow through
+the netlist into schematic fields, so the assignment and the
+remaining swap freedom reach layout tools with no side files.
 
 ## Components and symbols
 

--- a/examples/McuPinCapability/DevBoard.zen
+++ b/examples/McuPinCapability/DevBoard.zen
@@ -1,0 +1,51 @@
+"""
+Type: Board (pin-capability model demo)
+Description: Small dev board around the STM32G030 example module. The board
+asks for capabilities (a debug UART, a SPI bus, one LED, one button, one
+analog input) and never names a pin: `pin_solve` inside the MCU module
+assigns instances and pins, and the solved `pin_assignment` / `swap_classes`
+land on the MCU instance as properties.
+"""
+
+load("@stdlib/pinmux.zen", "at")
+load("@stdlib/interfaces.zen", "Uart", "Spi", "Swd")
+
+Mcu = Module("./STM32G030.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
+Capacitor = Module("@stdlib/generics/Capacitor.zen")
+Led = Module("@stdlib/generics/Led.zen")
+
+VDD = Power("VDD_3V3", voltage = "3.3V")
+GND = Ground("GND")
+
+# Declaring the logic level on the bus nets is what arms the MCU's
+# logic-level check: a 5V UART here fails the build against VDD=3.3V.
+DEBUG = Uart("DEBUG", TX = Net("DEBUG_TX", voltage = "3.3V"), RX = Net("DEBUG_RX", voltage = "3.3V"))
+FLASH = Spi("FLASH")
+SWD = Swd("SWD")
+LED_CTRL = Net("LED_CTRL")
+LED_K = Net("LED_K")
+VBAT_SENSE = Net("VBAT_SENSE")
+
+Mcu(
+    name = "MCU1",
+    VDD = VDD,
+    VSS = GND,
+    SWD = SWD,
+    # Every capability is a dict of DESIGN roles: "DEBUG", "FLASH", "LED" are
+    # labels this board chooses, in whatever number it needs — the module only
+    # knows Uart/Spi/GpioPin/AdcIn. at() pins a role to a physical pad (hard:
+    # build error if missing or taken; the pad also leaves the swap classes) —
+    # on this package pads are shared, so the constraint names the pad, not a
+    # port. Drop at() to let the solver choose.
+    uart = {"DEBUG": DEBUG},
+    spi = {"FLASH": FLASH},
+    gpio = {"LED": at(LED_CTRL, "PB0/PB1/PB2/PA8")},
+    adc = {"VBAT": VBAT_SENSE},
+)
+
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = VDD, P2 = GND)
+Resistor(name = "R1", value = "1kohm", package = "0402", P1 = LED_CTRL, P2 = LED_K)
+Led(name = "D1", package = "0402", color = "green", A = LED_K, K = GND)
+
+Board(name = "McuPinCapability", layers = 2, layout_path = "layout/McuPinCapability")

--- a/examples/McuPinCapability/STM32G030.kicad_sym
+++ b/examples/McuPinCapability/STM32G030.kicad_sym
@@ -1,0 +1,421 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "STM32G030"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at -25.4 15.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "STM32G030F6P6"
+			(at -25.4 -15.875 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SO:TSSOP-20_4.4x6.5mm_P0.65mm"
+			(at 0 -18.415 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.st.com/resource/en/datasheet/stm32g030f6.pdf"
+			(at 0 -20.955 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "STM32G030_0_1"
+			(rectangle
+				(start -25.4 13.97)
+				(end 25.4 -13.97)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "STM32G030_1_1"
+			(pin bidirectional line
+				(at -30.479999999999997 11.43 0)
+				(length 5.08)
+				(name "PB7/PB8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -30.479999999999997 8.89 0)
+				(length 5.08)
+				(name "PB9/PC14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -30.479999999999997 6.35 0)
+				(length 5.08)
+				(name "PC15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -30.479999999999997 3.81 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -30.479999999999997 1.27 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -30.479999999999997 -1.27 0)
+				(length 5.08)
+				(name "NRST"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -30.479999999999997 -3.81 0)
+				(length 5.08)
+				(name "PA0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -30.479999999999997 -6.35 0)
+				(length 5.08)
+				(name "PA1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -30.479999999999997 -8.89 0)
+				(length 5.08)
+				(name "PA2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -30.479999999999997 -11.43 0)
+				(length 5.08)
+				(name "PA3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 11.43 180)
+				(length 5.08)
+				(name "PB3/PB4/PB5/PB6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 8.89 180)
+				(length 5.08)
+				(name "PA14/PA15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 6.35 180)
+				(length 5.08)
+				(name "PA13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 3.81 180)
+				(length 5.08)
+				(name "PA12/PA10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 1.27 180)
+				(length 5.08)
+				(name "PA11/PA9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 -1.27 180)
+				(length 5.08)
+				(name "PB0/PB1/PB2/PA8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 -3.81 180)
+				(length 5.08)
+				(name "PA7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 -6.35 180)
+				(length 5.08)
+				(name "PA6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 -8.89 180)
+				(length 5.08)
+				(name "PA5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 30.479999999999997 -11.43 180)
+				(length 5.08)
+				(name "PA4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+)

--- a/examples/McuPinCapability/STM32G030.zen
+++ b/examples/McuPinCapability/STM32G030.zen
@@ -1,0 +1,198 @@
+"""
+Type: Microcontroller (pin-capability model demo)
+Description: STM32G030F6P6 (TSSOP-20) showing the peripheral capability model
+end to end: `peripheral()`/`pool()` tables, dict-of-roles capability demands,
+`pin_solve()` at elaboration and `pin_map()` feeding `Component(pins=...)`.
+
+The caller connects only the capabilities it uses; the solver assigns
+peripheral instances and pins (AF matrix included), enforces exclusivity, and
+records `pin_assignment` / `swap_classes` as module properties.
+
+Pin data per ST DS12991 (STM32G030x6/x8), figure 5 and tables 12-14. On
+TSSOP-20 several ports share one physical pad (pin 1 = PB7/PB8, pin 15 =
+PB0/PB1/PB2/PA8, pin 19 = PA14/PA15 where PA14 is also BOOT0, pin 20 =
+PB3/PB4/PB5/PB6), and PA9/PA10 exist only as SYSCFG remaps of the PA11/PA12
+pads. Candidate pins are therefore named after the PADS so the solver's pin
+exclusivity is the package's, not the port matrix's; `data` records which
+port and AF realize each candidate (`remap` flags SYSCFG_CFGR1).
+"""
+
+load("@stdlib/pinmux.zen", "at", "peripheral", "pin", "pin_map", "pin_request", "pin_solve", "pool")
+load("@stdlib/interfaces.zen", "Uart", "Usart", "Spi", "I2c", "Swd", "AdcIn", "GpioPin")
+load("@stdlib/checks.zen", "voltage_within")
+load("@stdlib/units.zen", "Voltage")
+
+# --- Capability tables (datasheet facts) --------------------------------------
+
+USART1 = peripheral(
+    "USART1",
+    provides = [Usart],  # implies Uart (stdlib): serves plain-UART requests too
+    rebind = "firmware",
+    signals = {
+        "TX": [pin("PA11/PA9", data = {"port": "PA9", "af": 1, "remap": True}),
+               pin("PB3/PB4/PB5/PB6", data = {"port": "PB6", "af": 0})],
+        "RX": [pin("PA12/PA10", data = {"port": "PA10", "af": 1, "remap": True}),
+               pin("PB7/PB8", data = {"port": "PB7", "af": 0})],
+        "CK": [pin("PB0/PB1/PB2/PA8", data = {"port": "PA8", "af": 1}),
+               pin("PB3/PB4/PB5/PB6", data = {"port": "PB3", "af": 4})],
+        "RTS": [pin("PA12/PA10", data = {"port": "PA12", "af": 1}),
+                pin("PB3/PB4/PB5/PB6", data = {"port": "PB3", "af": 4})],
+        "CTS": [pin("PA11/PA9", data = {"port": "PA11", "af": 1}),
+                pin("PB3/PB4/PB5/PB6", data = {"port": "PB4", "af": 4})],
+    },
+    attrs = {"baud_max": "8MHz"},
+)
+
+USART2 = peripheral(
+    "USART2",
+    provides = [Usart],
+    rebind = "firmware",
+    signals = {
+        # PA14 carries the BOOT0 strap; PA1 is RTS_DE_CK: CK and RTS are the
+        # same pin, so a request using both is structurally infeasible — as on
+        # the silicon.
+        "TX": [pin("PA2", data = {"af": 1}),
+               pin("PA14/PA15", data = {"port": "PA14", "af": 1}, strap = True)],
+        "RX": [pin("PA3", data = {"af": 1}),
+               pin("PA14/PA15", data = {"port": "PA15", "af": 1}, strap = True)],
+        "CK": [pin("PA1", data = {"af": 1})],
+        "RTS": [pin("PA1", data = {"af": 1})],
+        "CTS": [pin("PA0", data = {"af": 1})],
+    },
+    attrs = {"baud_max": "8MHz"},
+)
+
+SPI1 = peripheral(
+    "SPI1",
+    provides = [Spi],
+    rebind = "firmware",
+    signals = {
+        "CS": [pin("PA4", data = {"af": 0}),
+               pin("PA14/PA15", data = {"port": "PA15", "af": 0}, strap = True),
+               pin("PB0/PB1/PB2/PA8", data = {"port": "PB0", "af": 0})],
+        "CLK": [pin("PA5", data = {"af": 0}),
+                pin("PA1", data = {"af": 0}),
+                pin("PB3/PB4/PB5/PB6", data = {"port": "PB3", "af": 0})],
+        "MISO": [pin("PA6", data = {"af": 0}),
+                 pin("PA11/PA9", data = {"port": "PA11", "af": 0}),
+                 pin("PB3/PB4/PB5/PB6", data = {"port": "PB4", "af": 0})],
+        "MOSI": [pin("PA7", data = {"af": 0}),
+                 pin("PA2", data = {"af": 0}),
+                 pin("PA12/PA10", data = {"port": "PA12", "af": 0}),
+                 pin("PB3/PB4/PB5/PB6", data = {"port": "PB5", "af": 0})],
+    },
+    attrs = {"clk_max": "32MHz"},
+)
+
+I2C1 = peripheral(
+    "I2C1",
+    provides = [I2c],
+    rebind = "firmware",
+    signals = {
+        "SCL": [pin("PB3/PB4/PB5/PB6", data = {"port": "PB6", "af": 6}),
+                pin("PB7/PB8", data = {"port": "PB8", "af": 6}),
+                pin("PA11/PA9", data = {"port": "PA9", "af": 6, "remap": True})],
+        "SDA": [pin("PB7/PB8", data = {"port": "PB7", "af": 6}),
+                pin("PB9/PC14", data = {"port": "PB9", "af": 6}),
+                pin("PA12/PA10", data = {"port": "PA10", "af": 6, "remap": True})],
+    },
+    attrs = {"clk_max": "1MHz"},
+)
+
+SWD_PORT = peripheral(
+    "SWD",
+    provides = [Swd],
+    rebind = "fixed",
+    signals = {
+        "SWDIO": [pin("PA13", data = {"af": 0})],
+        "SWCLK": [pin("PA14/PA15", data = {"port": "PA14", "af": 0})],
+    },
+)
+
+ADC_CH = [
+    peripheral("ADC1_IN%d" % i, provides = [AdcIn], rebind = "fixed",
+               signals = {"IN": [pin("PA%d" % i, data = {"ch": i})]})
+    for i in range(8)
+]
+
+# PA13 and the PA14/PA15 pad stay out of the pool: this module keeps the
+# debug port alive.
+GPIO_POOL = pool(
+    "GPIO",
+    provides = [GpioPin],
+    pins = [
+        pin("PB7/PB8", data = {"port": "PB7"}),
+        pin("PB9/PC14", data = {"port": "PB9"}),
+        "PC15",
+        "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7",
+        pin("PB0/PB1/PB2/PA8", data = {"port": "PA8"}),
+        pin("PA11/PA9", data = {"port": "PA11"}),
+        pin("PA12/PA10", data = {"port": "PA12"}),
+        pin("PB3/PB4/PB5/PB6", data = {"port": "PB6"}),
+    ],
+)
+
+PERIPHS = [USART1, USART2, SPI1, I2C1, SWD_PORT] + ADC_CH + GPIO_POOL
+
+# --- What the design asks for --------------------------------------------------
+# Every countable capability is demanded through a dict: the DESIGN names
+# each role ("DEBUG", "FLASH", "LED", "VBAT"...) and there are as many
+# entries as it needs — the module never bakes in application roles. Pin
+# constraints ride the value: Mcu(uart = {"DEBUG": at(dbg, "PA2")}).
+# Only singular hardware ports keep a named io() slot (SWD).
+
+VDD = io(Power)   # pad 4 also bonds VDDA
+VSS = io(Ground)  # pad 5 also bonds VSSA
+NRST = io(Net, optional = True)
+
+SWD = io(Swd)
+uart = config(dict, default = {})  # role name -> Uart instance (or at(...))
+spi = config(dict, default = {})   # role name -> Spi instance (or at(...))
+i2c = config(dict, default = {})   # role name -> I2c instance (or at(...))
+gpio = config(dict, default = {})  # role name -> Net (or at(net, pad))
+adc = config(dict, default = {})   # role name -> Net
+
+res = pin_solve(PERIPHS, [pin_request("SWD", Swd, instance = "SWD")]
+  + [pin_request(n, Uart, bind = uart[n]) for n in uart]
+  + [pin_request(n, Spi, bind = spi[n]) for n in spi]
+  + [pin_request(n, I2c, bind = i2c[n]) for n in i2c]
+  + [pin_request(n, GpioPin, bind = gpio[n]) for n in gpio]
+  + [pin_request(n, AdcIn, bind = adc[n]) for n in adc])
+
+named = {"SWD": SWD}
+for roles in [uart, spi, i2c, gpio, adc]:
+    named.update(roles)
+m = pin_map(res["assignment"], named)
+
+# Logic-level contract: every signal this MCU drives or reads lives between
+# 0V and VDD — computed from the caller's ACTUAL rail, never hardcoded (the
+# same die is a 1.8V part on a 1.8V rail). Nets with no declared voltage are
+# skipped (stdlib guard): declaring levels is how a design opts into the
+# check, and how a 5V net gets rejected at build time.
+def _enforce_logic_levels():
+    v = VDD.voltage
+    if v == None:
+        return
+    lvl = voltage_within(Voltage(min = 0.0, max = v.max), name = "logic_level")
+    for net in m.values():
+        lvl(net)
+
+_enforce_logic_levels()
+
+# Every candidate pad no request claimed is intentionally open — the solver
+# knows the full mux-pin set from the capability tables, no separate list.
+pins = m
+pins.update({"VDD": VDD, "VSS": VSS, "NRST": NRST})
+
+Component(
+    name = "MCU",
+    symbol = Symbol(library = "./STM32G030.kicad_sym"),
+    footprint = "Package_SO:TSSOP-20_4.4x6.5mm_P0.65mm",
+    prefix = "U",
+    part = Part(
+        mpn = "STM32G030F6P6",
+        manufacturer = "STMicroelectronics",
+        datasheet = "https://www.st.com/resource/en/datasheet/stm32g030f6.pdf",
+    ),
+    pins = pins,
+)

--- a/examples/QuadComparator/LM339.kicad_sym
+++ b/examples/QuadComparator/LM339.kicad_sym
@@ -1,0 +1,313 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "LM339"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at -10.16 13.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LM339"
+			(at -10.16 -14.605 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SO:SOIC-14_3.9x8.7mm_P1.27mm"
+			(at 0 -17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.ti.com/lit/ds/symlink/lm339.pdf"
+			(at 0 -20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "LM339_0_1"
+			(rectangle
+				(start -10.16 12.7)
+				(end 10.16 -12.7)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "LM339_1_1"
+			(pin input line
+				(at -15.24 10.16 0)
+				(length 5.08)
+				(name "IN1P"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 7.62 0)
+				(length 5.08)
+				(name "IN1N"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 5.08 0)
+				(length 5.08)
+				(name "IN2P"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 2.54 0)
+				(length 5.08)
+				(name "IN2N"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 -2.54 0)
+				(length 5.08)
+				(name "IN3P"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 -5.08 0)
+				(length 5.08)
+				(name "IN3N"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 -7.62 0)
+				(length 5.08)
+				(name "IN4P"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 -10.16 0)
+				(length 5.08)
+				(name "IN4N"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 15.24 7.62 180)
+				(length 5.08)
+				(name "OUT1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 15.24 2.54 180)
+				(length 5.08)
+				(name "OUT2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 15.24 -2.54 180)
+				(length 5.08)
+				(name "OUT3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 15.24 -7.62 180)
+				(length 5.08)
+				(name "OUT4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 17.78 270)
+				(length 5.08)
+				(name "VCC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -17.78 90)
+				(length 5.08)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+)

--- a/examples/QuadComparator/LM339.zen
+++ b/examples/QuadComparator/LM339.zen
@@ -1,0 +1,71 @@
+"""
+Type: Quad comparator (pin-capability model demo)
+Description: LM339-style quad comparator showing pure gate swap: four
+identical units declared as `peripheral(rebind = "none")`, demanded through a
+dict of design roles. The solver assigns units, publishes the residual
+freedom as a cluster-granularity swap class (`spare_units` included), and
+unused units are tied off per the datasheet (INP to VCC, INN to GND, output
+transistor off) unless the caller opts out with `tie_unused = False`.
+
+Pinout per TI SLCS006 (D/N/PW 14-pin packages): OUT1=1, OUT2=2, VCC=3,
+IN2N=4, IN2P=5, IN1N=6, IN1P=7, IN3N=8, IN3P=9, IN4N=10, IN4P=11, GND=12,
+OUT4=13, OUT3=14. Channels 1 and 2 cross on the die: unit 1 is IN1+/- (7/6)
+to OUT1 (1), unit 2 is IN2+/- (5/4) to OUT2 (2).
+"""
+
+load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_map", "pin_request", "pin_solve")
+
+Comparator = interface(INP = Net(), INN = Net(), OUT = Net())
+
+def _unit(name, inp, inn, out):
+    return peripheral(
+        name,
+        provides = [Comparator],
+        rebind = "none",
+        signals = {"INP": [pin(inp)], "INN": [pin(inn)], "OUT": [pin(out)]},
+    )
+
+UNITS = [
+    _unit("A", "IN1P", "IN1N", "OUT1"),
+    _unit("B", "IN2P", "IN2N", "OUT2"),
+    _unit("C", "IN3P", "IN3N", "OUT3"),
+    _unit("D", "IN4P", "IN4N", "OUT4"),
+]
+
+VCC = io(Power)
+GND = io(Ground)
+comp = config(dict, default = {})  # role name -> Comparator
+tie_unused = config(bool, default = True)
+
+res = pin_solve(UNITS, [pin_request(n, Comparator, bind = comp[n]) for n in comp])
+
+m = pin_map(res["assignment"], comp)
+
+pins = m
+pins.update({"VCC": VCC, "GND": GND})
+
+# A floating comparator input oscillates: strap unused units to a defined
+# state (INP > INN keeps the open-collector output off, OUT stays NC).
+def _tie_unused_units():
+    if not tie_unused:
+        return
+    used = [res["assignment"][r]["instance"] for r in res["assignment"]]
+    for u in UNITS:
+        if not (u["name"] in used):
+            pins[u["signals"]["INP"][0]["name"]] = VCC
+            pins[u["signals"]["INN"][0]["name"]] = GND
+
+_tie_unused_units()
+
+Component(
+    name = "CMP",
+    symbol = Symbol(library = "./LM339.kicad_sym"),
+    footprint = "Package_SO:SOIC-14_3.9x8.7mm_P1.27mm",
+    prefix = "U",
+    part = Part(
+        mpn = "LM339DR",
+        manufacturer = "Texas Instruments",
+        datasheet = "https://www.ti.com/lit/ds/symlink/lm339.pdf",
+    ),
+    pins = pins,
+)

--- a/examples/QuadComparator/WindowMonitor.zen
+++ b/examples/QuadComparator/WindowMonitor.zen
@@ -1,0 +1,56 @@
+"""
+Type: Board (pin-capability model demo)
+Description: Battery window monitor around the LM339 example module. The
+board names three comparator roles (undervoltage, overvoltage,
+overtemperature) and never picks a gate: the solver assigns three of the
+four units, the fourth gets its inputs tied to VCC/GND by the module (no
+floating comparator) and appears as a `spare_units` entry of a
+`rebind = "none"` swap class — a pure copper swap, no firmware involved.
+"""
+
+load("./LM339.zen", "Comparator")
+
+Cmp = Module("./LM339.zen")
+Resistor = Module("@stdlib/generics/Resistor.zen")
+Capacitor = Module("@stdlib/generics/Capacitor.zen")
+
+VCC = Power("VCC_5V", voltage = "5V")
+GND = Ground("GND")
+
+VBAT = Net("VBAT")
+VBAT_SENSE = Net("VBAT_SENSE")
+NTC_SENSE = Net("NTC_SENSE")
+VREF_HI = Net("VREF_HI")
+VREF_LO = Net("VREF_LO")
+UV_ALERT = Net("UV_ALERT")
+OV_ALERT = Net("OV_ALERT")
+OT_ALERT = Net("OT_ALERT")
+
+Cmp(
+    name = "CMP1",
+    VCC = VCC,
+    GND = GND,
+    comp = {
+        "UV": Comparator("UV", INP = VBAT_SENSE, INN = VREF_LO, OUT = UV_ALERT),
+        "OV": Comparator("OV", INP = VREF_HI, INN = VBAT_SENSE, OUT = OV_ALERT),
+        "OT": Comparator("OT", INP = NTC_SENSE, INN = VREF_LO, OUT = OT_ALERT),
+    },
+)
+
+# Threshold ladder and battery divider.
+Resistor(name = "R1", value = "10kohm", package = "0402", P1 = VCC, P2 = VREF_HI)
+Resistor(name = "R2", value = "10kohm", package = "0402", P1 = VREF_HI, P2 = VREF_LO)
+Resistor(name = "R3", value = "10kohm", package = "0402", P1 = VREF_LO, P2 = GND)
+Resistor(name = "R4", value = "100kohm", package = "0402", P1 = VBAT, P2 = VBAT_SENSE)
+Resistor(name = "R5", value = "33kohm", package = "0402", P1 = VBAT_SENSE, P2 = GND)
+
+# NTC leg and open-collector pull-ups.
+Resistor(name = "R6", value = "10kohm", package = "0402", P1 = VCC, P2 = NTC_SENSE)
+Resistor(name = "RT1", value = "10kohm", package = "0603", P1 = NTC_SENSE, P2 = GND)
+Resistor(name = "R7", value = "100kohm", package = "0402", P1 = VCC, P2 = UV_ALERT)
+Resistor(name = "R8", value = "100kohm", package = "0402", P1 = VCC, P2 = OV_ALERT)
+Resistor(name = "R9", value = "100kohm", package = "0402", P1 = VCC, P2 = OT_ALERT)
+
+Capacitor(name = "C1", value = "100nF", package = "0402", P1 = VCC, P2 = GND)
+
+Board(name = "QuadComparator", layers = 2, layout_path = "layout/QuadComparator")

--- a/lib/std/interfaces.zen
+++ b/lib/std/interfaces.zen
@@ -1,4 +1,4 @@
-load("units.zen", "Voltage", "Impedance")
+load("units.zen", "Voltage", "Impedance", "Frequency")
 
 Net = builtin.net_type(
     "Net",
@@ -31,14 +31,20 @@ DiffPair = interface(
     impedance=field(Impedance | None, default=None),
 )
 
+AdcIn = interface(
+    IN=Net(),
+)
+
 Can = interface(
     CAN_H=Net(),
     CAN_L=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 CanTtl = interface(
     TX=Net(),
     RX=Net(),
+    attrs={"bitrate_max": Frequency, "vio": Voltage},
 )
 
 Csi = interface(
@@ -47,6 +53,7 @@ Csi = interface(
     D1=DiffPair(impedance=Impedance(100)),
     D2=DiffPair(impedance=Impedance(100)),
     D3=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Dvp8 = interface(
@@ -62,6 +69,7 @@ Dvp8 = interface(
     D5=Net(),
     D6=Net(),
     D7=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Dvp10 = interface(
@@ -79,6 +87,7 @@ Dvp10 = interface(
     D7=Net(),
     D8=Net(),
     D9=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Dvp12 = interface(
@@ -98,6 +107,7 @@ Dvp12 = interface(
     D9=Net(),
     D10=Net(),
     D11=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Dvp16 = interface(
@@ -121,6 +131,7 @@ Dvp16 = interface(
     D13=Net(),
     D14=Net(),
     D15=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 
@@ -131,6 +142,7 @@ DisplayPort = interface(
     ML2=DiffPair(impedance=Impedance(100)),
     ML3=DiffPair(impedance=Impedance(100)),
     HPD=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 Dsi = interface(
@@ -139,6 +151,7 @@ Dsi = interface(
     D1=DiffPair(impedance=Impedance(100)),
     D2=DiffPair(impedance=Impedance(100)),
     D3=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Edp = interface(
@@ -147,6 +160,7 @@ Edp = interface(
     TX1=DiffPair(impedance=Impedance(100)),
     TX2=DiffPair(impedance=Impedance(100)),
     TX3=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Emmc = interface(
@@ -162,11 +176,13 @@ Emmc = interface(
     DAT7=Net(impedance=Impedance(50)),
     DS=Net(impedance=Impedance(50)),
     RST_N=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Ethernet = interface(
     TX=DiffPair(impedance=Impedance(100)),
     RX=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Ethernet_Phy = interface(
@@ -183,6 +199,11 @@ Ethernet_1000BaseT = interface(
     BI_DD=DiffPair(impedance=Impedance(100)),
 )
 
+GpioPin = interface(
+    PIN=Net(),
+    attrs={"vio": Voltage},
+)
+
 Hdmi = interface(
     CLK=DiffPair(impedance=Impedance(100)),
     D0=DiffPair(impedance=Impedance(100)),
@@ -192,11 +213,13 @@ Hdmi = interface(
     SCL=Net(),
     SDA=Net(),
     HPD=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 I2c = interface(
     SDA=Net(),
     SCL=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 I2s = interface(
@@ -204,6 +227,7 @@ I2s = interface(
     LRCLK=Net(),
     SDATA=Net(),
     MCLK=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 I2sBidirectional = interface(
@@ -212,11 +236,13 @@ I2sBidirectional = interface(
     SDATA_IN=Net(),
     SDATA_OUT=Net(),
     MCLK=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 I3c = interface(
     SDA=Net(),
     SCL=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Jtag = interface(
@@ -225,6 +251,7 @@ Jtag = interface(
     TCK=Net(),
     TMS=Net(),
     TRST=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Lcd = interface(
@@ -256,6 +283,7 @@ Lcd = interface(
     B5=Net(),
     B6=Net(),
     B7=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Lvds = interface(
@@ -263,11 +291,13 @@ Lvds = interface(
     DATA0=DiffPair(impedance=Impedance(100)),
     DATA1=DiffPair(impedance=Impedance(100)),
     DATA2=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Mdio = interface(
     MDC=Net(),
     MDIO=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Mdi = interface(
@@ -275,6 +305,7 @@ Mdi = interface(
     B=DiffPair(impedance=Impedance(100)),
     C=DiffPair(impedance=Impedance(100)),
     D=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Mii = interface(
@@ -293,6 +324,7 @@ Mii = interface(
     RX_ER=Net(),
     COL=Net(),
     CRS=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 Mipi = interface(
@@ -301,21 +333,25 @@ Mipi = interface(
     DATA1=DiffPair(impedance=Impedance(100)),
     DATA2=DiffPair(impedance=Impedance(100)),
     DATA3=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 OneWire = interface(
     DQ=Net(),
+    attrs={"bitrate_max": Frequency, "vio": Voltage},
 )
 
 Opamp = interface(
     IN_P=Net(),
     IN_N=Net(),
     OUT=Net(),
+    attrs={"gbw": Frequency},
 )
 
 OscPair = interface(
     XIN=Net(),
     XOUT=Net(),
+    attrs={"freq_max": Frequency},
 )
 
 Pcie = interface(
@@ -324,6 +360,7 @@ Pcie = interface(
     REFCLK=DiffPair(impedance=Impedance(85)),
     PERST=Net(),
     WAKE=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 PcieGen3x1Lane = interface(
@@ -333,6 +370,7 @@ PcieGen3x1Lane = interface(
     RESET_N=Net(),
     WAKE_N=Net(),
     CLK_REQ_N=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 PcieGen3x2Lane = interface(
@@ -344,6 +382,7 @@ PcieGen3x2Lane = interface(
     RESET_N=Net(),
     WAKE_N=Net(),
     CLK_REQ_N=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 PcieGen4x1Lane = interface(
@@ -353,6 +392,7 @@ PcieGen4x1Lane = interface(
     RESET_N=Net(),
     WAKE_N=Net(),
     CLK_REQ_N=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 PcieGen4x2Lane = interface(
@@ -364,6 +404,7 @@ PcieGen4x2Lane = interface(
     RESET_N=Net(),
     WAKE_N=Net(),
     CLK_REQ_N=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 PcieGen4x4Lane = interface(
@@ -379,6 +420,7 @@ PcieGen4x4Lane = interface(
     RESET_N=Net(),
     WAKE_N=Net(),
     CLK_REQ_N=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 PcieGen4x8Lane = interface(
@@ -402,6 +444,7 @@ PcieGen4x8Lane = interface(
     RESET_N=Net(),
     WAKE_N=Net(),
     CLK_REQ_N=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 PcieGen4x16Lane = interface(
@@ -441,6 +484,7 @@ PcieGen4x16Lane = interface(
     RESET_N=Net(),
     WAKE_N=Net(),
     CLK_REQ_N=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 QLink = interface(
@@ -450,6 +494,7 @@ QLink = interface(
     L2=DiffPair(impedance=Impedance(100)),
     L3=DiffPair(impedance=Impedance(100)),
     L4=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Qspi = interface(
@@ -459,6 +504,7 @@ Qspi = interface(
     IO1=Net(impedance=Impedance(50)),
     IO2=Net(impedance=Impedance(50)),
     IO3=Net(impedance=Impedance(50)),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Rgmii = interface(
@@ -474,6 +520,7 @@ Rgmii = interface(
     RXD3=Net(impedance=Impedance(50)),
     RX_CTL=Net(impedance=Impedance(50)),
     RXC=Net(impedance=Impedance(50)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Rmii = interface(
@@ -485,6 +532,7 @@ Rmii = interface(
     CRS_DV=Net(),
     RX_ER=Net(),
     REF_CLK=Net(),
+    attrs={"bitrate_max": Frequency},
 )
 
 Rs232 = interface(
@@ -496,6 +544,7 @@ Rs232 = interface(
     DSR=Net("DSR"),
     DCD=Net("DCD"),
     RI=Net("RI"),
+    attrs={"baud_max": Frequency},
 )
 
 Rs422 = interface(
@@ -503,6 +552,7 @@ Rs422 = interface(
     RX=DiffPair(impedance=Impedance(100)),
     RTS=DiffPair(impedance=Impedance(100)),
     CTS=DiffPair(impedance=Impedance(100)),
+    attrs={"baud_max": Frequency},
 )
 
 Rs485 = Rs422
@@ -510,6 +560,7 @@ Rs485 = Rs422
 Sata = interface(
     TX=DiffPair(impedance=Impedance(100)),
     RX=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Sdio = interface(
@@ -519,6 +570,7 @@ Sdio = interface(
     DAT1=Net(impedance=Impedance(50)),
     DAT2=Net(impedance=Impedance(50)),
     DAT3=Net(impedance=Impedance(50)),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Sdmmc = interface(
@@ -532,6 +584,7 @@ Sdmmc = interface(
     DAT5=Net(impedance=Impedance(50)),
     DAT6=Net(impedance=Impedance(50)),
     DAT7=Net(impedance=Impedance(50)),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Lpddr4Channel = interface(
@@ -565,6 +618,7 @@ Lpddr4Channel = interface(
     DQS0=DiffPair(impedance=Impedance(80)),
     DQS1=DiffPair(impedance=Impedance(80)),
     ODT_CA=Net(impedance=Impedance(40)),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Sdram16 = interface(
@@ -607,6 +661,7 @@ Sdram16 = interface(
     WE_N=Net(),
     DQM0=Net(),
     DQM1=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Sdram32 = interface(
@@ -667,6 +722,7 @@ Sdram32 = interface(
     DQM1=Net(),
     DQM2=Net(),
     DQM3=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 SmBus = I2c
@@ -676,21 +732,25 @@ Spi = interface(
     MISO=Net(),
     MOSI=Net(),
     CLK=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Spmi = interface(
     CLK=Net(impedance=Impedance(50)),
     DATA=Net(impedance=Impedance(50)),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Swd = interface(
     SWDIO=Net(),
     SWCLK=Net(),
+    attrs={"clk_max": Frequency, "vio": Voltage},
 )
 
 Uart = interface(
     TX=Net(),
     RX=Net(),
+    attrs={"baud_max": Frequency, "vio": Voltage},
 )
 
 Usart = interface(
@@ -699,6 +759,7 @@ Usart = interface(
     CK=Net(),
     RTS=Net(),
     CTS=Net(),
+    implies=[Uart],
 )
 
 
@@ -728,16 +789,19 @@ Ufs = interface(
     L0_TX=DiffPair(impedance=Impedance(100)),
     L1_RX=DiffPair(impedance=Impedance(100)),
     L1_TX=DiffPair(impedance=Impedance(100)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Usb2 = interface(
     D=DiffPair(impedance=Impedance(90)),
+    attrs={"bitrate_max": Frequency},
 )
 
 Usb3 = interface(
     D=DiffPair(impedance=Impedance(90)),
     SSTX=DiffPair(impedance=Impedance(90)),
     SSRX=DiffPair(impedance=Impedance(90)),
+    attrs={"bitrate_max": Frequency},
 )
 
 UsbTypeC = interface(

--- a/lib/std/pinmux.zen
+++ b/lib/std/pinmux.zen
@@ -1,0 +1,15 @@
+"""Pin-capability model: declare what a multi-function component's pins can do
+and solve the instance x pin assignment at elaboration.
+
+Not in the prelude — load what you use:
+
+    load("@stdlib/pinmux.zen", "peripheral", "pin", "pin_request", "pin_solve", "pin_map")
+"""
+
+at = builtin.pinmux.at
+pin = builtin.pinmux.pin
+peripheral = builtin.pinmux.peripheral
+pool = builtin.pinmux.pool
+pin_request = builtin.pinmux.pin_request
+pin_solve = builtin.pinmux.pin_solve
+pin_map = builtin.pinmux.pin_map


### PR DESCRIPTION
When trying to make zener model for a STM32 a did not find a good way to ensure the user use the right port for a given peripheral.

So, I have extended zener language for supporting this natively. The idea is to add a solver to automatically select the best pins for a selected peripheral (specified with zener stdlib interface). You do not select manually, you request an interface (uart, i2c). You are still free to force the use of a specific pin.

 It also add basic first support for swapiness declaration.

The idea is to let zener choose best ports to ensure all peripheral constraints are met and this also allow zener to throw an error if the mcu you choose do not have enough peripheral for you need.

I tried to make it as generic as possible, and added an example for a non mcu part like a quad comparator. This even allow the quad comparator module to automatically wire unused inputs to prevent oscillation.

Disclaimer: I used claude, especially for the pinmux constraint solver
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new elaboration solver (~3.5k LOC) on the critical eval/io/module path, plus a breaking `interface()` keyword change that can fail existing designs at elaboration time.
> 
> **Overview**
> Adds a **pinmux** elaboration layer so multi-function parts declare peripheral capabilities and **interface requests**, then **`pin_solve`** picks a joint instance × pin assignment (with pin/instance exclusivity across repeated solves in a module). Results land in module properties **`pin_assignment`** and **`swap_classes`**; **`pin_map`** turns a solve into `Component(pins=…)`, tying unclaimed pads to open nets.
> 
> Designers constrain placement with **`at(value, pins, soft=)`** on module connections (recorded through `io()` / `config()` and enforced at the root for contended or unused hard constraints). **`pin_request`** supports optional slots (`if_connected`), dict-of-roles (`bind=`), locks, and `where=` predicates; **`peripheral` / `pool` / `pin`** describe what each block can provide.
> 
> **`interface()`** gains **`implies`** (nominal capability matching over a DAG) and **`attrs`** (typed peripheral metadata); **`attrs` and `implies` are now reserved**—connection fields with those names must be renamed. Stdlib interfaces pick up attr vocabularies and new **`AdcIn` / `GpioPin`** types.
> 
> Smaller wiring: **`builtin.pinmux`**, module-context claim/tie-off state, clearer errors when `at()` is used on component pins, and a test that **DiffPair impedance** still reaches net properties through nested interfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3e8695ac55d3a6648b8d0d6550e875235107796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->