### PR TITLE
Cache Ubuntu APT packages in Blacksmith CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /tmp/apt-cache/archives
-          key: apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-build-essential-pkg-config
+          key: apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-ca-certificates-curl-build-essential-pkg-config
           restore-keys: |
             apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-
 
@@ -51,7 +51,7 @@ jobs:
           apt_cache_dir=/tmp/apt-cache/archives
           mkdir -p "$apt_cache_dir/partial"
           apt-get -o Dir::Cache::archives="$apt_cache_dir/" update
-          apt-get -o Dir::Cache::archives="$apt_cache_dir/" install -y --no-install-recommends build-essential pkg-config
+          apt-get -o Dir::Cache::archives="$apt_cache_dir/" install -y --no-install-recommends ca-certificates curl build-essential pkg-config
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,11 +36,22 @@ jobs:
               image: ghcr.io/diodeinc/kicad:10.0.5
               options: --user root
     steps:
+      - name: Cache APT packages (Ubuntu)
+        if: matrix.config.name == 'Ubuntu'
+        uses: actions/cache@v6
+        with:
+          path: /tmp/apt-cache/archives
+          key: apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-build-essential-pkg-config
+          restore-keys: |
+            apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-
+
       - name: Install Dependencies (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
         run: |
-          apt-get update
-          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
+          apt_cache_dir=/tmp/apt-cache/archives
+          mkdir -p "$apt_cache_dir/partial"
+          apt-get -o Dir::Cache::archives="$apt_cache_dir/" update
+          apt-get -o Dir::Cache::archives="$apt_cache_dir/" install -y --no-install-recommends build-essential pkg-config
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /tmp/apt-cache/archives
-          key: apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-build-essential-pkg-config
+          key: apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-ca-certificates-curl-build-essential-pkg-config
           restore-keys: |
             apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-
 
@@ -77,7 +77,7 @@ jobs:
           apt_cache_dir=/tmp/apt-cache/archives
           mkdir -p "$apt_cache_dir/partial"
           apt-get -o Dir::Cache::archives="$apt_cache_dir/" update
-          apt-get -o Dir::Cache::archives="$apt_cache_dir/" install -y --no-install-recommends build-essential pkg-config
+          apt-get -o Dir::Cache::archives="$apt_cache_dir/" install -y --no-install-recommends ca-certificates curl build-essential pkg-config
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,11 +62,22 @@ jobs:
               image: ghcr.io/diodeinc/kicad:10.0.5
               options: --user root
     steps:
+      - name: Cache APT packages (Ubuntu)
+        if: matrix.config.name == 'Ubuntu'
+        uses: actions/cache@v6
+        with:
+          path: /tmp/apt-cache/archives
+          key: apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-build-essential-pkg-config
+          restore-keys: |
+            apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-
+
       - name: Install Dependencies (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
         run: |
-          apt-get update
-          apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev
+          apt_cache_dir=/tmp/apt-cache/archives
+          mkdir -p "$apt_cache_dir/partial"
+          apt-get -o Dir::Cache::archives="$apt_cache_dir/" update
+          apt-get -o Dir::Cache::archives="$apt_cache_dir/" install -y --no-install-recommends build-essential pkg-config
 
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Cache Debian package archives in Blacksmith's Actions cache for the Ubuntu CI jobs.

Keep apt indexes fresh, install only the required build packages, and use a separate cache directory because the KiCad image clears its default apt cache.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; risk is limited to Ubuntu matrix jobs failing if cached or installed packages are insufficient for Rust builds.
> 
> **Overview**
> Ubuntu jobs in **Build and Test** and **E2E CLI Tests** now cache Debian package archives under `/tmp/apt-cache/archives` via `actions/cache@v6`, with keys tied to OS, arch, Debian trixie, `KICAD_VERSION`, and the fixed package set.
> 
> **Install Dependencies (Ubuntu)** still runs `apt-get update`, but directs apt’s archive cache to that directory (with `partial` created first) so installs reuse cached `.deb` files instead of the KiCad image’s cleared default cache. Installs use `--no-install-recommends` and drop **`libssl-dev`** from the package list, leaving `ca-certificates`, `curl`, `build-essential`, and `pkg-config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04ab1b88da238677b4254c20716a1bbd5fbb977a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->