### PR TITLE
Log two swallowed failures and fix a pre-existing clippy lint

### DIFF
--- a/crates/pcb-ipc2581-tools/src/commands/html_export.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/html_export.rs
@@ -532,6 +532,9 @@ fn surface_finish_to_html(finish: &SurfaceFinishInfo) -> SurfaceFinish {
     }
 }
 
+const HTML_TEMPLATE: &str = include_str!("html_template.html.jinja");
+const CSS_STYLES: &str = include_str!("style.css");
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -801,6 +804,3 @@ mod tests {
 </IPC-2581>"#
     }
 }
-
-const HTML_TEMPLATE: &str = include_str!("html_template.html.jinja");
-const CSS_STYLES: &str = include_str!("style.css");

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -1042,7 +1042,8 @@ def _apply_fragment_routing(
         layout_file = _discover_kicad_pcb_file(layout_dir)
     except ValueError:
         raise
-    except Exception:  # noqa: BLE001 - FIXME: silently swallows fragment-discovery failures
+    except Exception as e:  # noqa: BLE001 - fragment is optional; skip it rather than fail the sync
+        logger.warning(f"Skipping layout fragment for {group_name}: {e}")
         return
     if not layout_file.exists():
         return

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -877,8 +877,8 @@ class FinalizeBoard(Step):
         # Trigger KiCad's connectivity updates and fix orphaned items
         try:
             self.board.GetConnectivity().Build(self.board)
-        except Exception:  # noqa: BLE001, S110 - FIXME: silently swallows connectivity-rebuild failures
-            pass
+        except Exception as e:  # noqa: BLE001 - best-effort; the board is still saved below
+            logger.warning(f"Connectivity rebuild failed: {e}")
 
         # Save board only once at the very end
         save_start = time.time()


### PR DESCRIPTION
Deferred cleanup from the dependency work (#1010, #1011, #1016). I kept all three of these out of those PRs because none belonged in a dependency change; this is the follow-up.

### Two silently swallowed failures in the layout scripts

Both handlers discarded the exception entirely. The broad `except` is deliberate in each case and stays — a missing layout fragment should not fail a sync, and the board is still saved after a connectivity rebuild fails — but the failure is no longer invisible:

| file | before | after |
|---|---|---|
| `lens/kicad_adapter.py` | `except Exception: return` | logs `Skipping layout fragment for {group}: {e}`, then skips |
| `update_layout_file.py` | `except Exception: pass` | logs `Connectivity rebuild failed: {e}` |

Dropping the bare `pass` also makes the `S110` suppression unnecessary, so that came off.

These are the two sites I flagged as FIXME when adopting ruff 0.16's rule set in #1011 — they were the only findings in that sweep that needed a judgement call rather than a mechanical fix.

### Pre-existing clippy lint

`items_after_test_module` in `crates/pcb-ipc2581-tools/src/commands/html_export.rs`: the two `include_str!` consts sat below the test module. Moved above it.

This one never fired in CI — `cargo clippy --workspace` does not build test targets. It only appears under `--all-targets`, which is what I was running locally. Fixing it means the stricter invocation is clean too.

### Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` — both clean
- `cargo nextest run --workspace --profile ci` — 1934 passed, 1 skipped
- `ruff check` / `ruff format --check` / `ty check` — clean; `pytest lens/tests` — 148 passed
- Scripts still byte-compile under KiCad's bundled Python 3.9

### Still outstanding, in other repos

Not touched here because they need commits in the forks first:

- `blake3 = "=1.8.2"` is hard-pinned in the `diodeinc/starlark-rust` workspace, holding blake3 at 1.8.2 (1.8.5 available) and pinning `generic-array`.
- `nalgebra 0.27.1` and `nom 6.1.2` arrive only through foxtrot's `step` crate, and cargo warns both "contain code that will be rejected by a future version of Rust".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only and module-order changes; behavior on failure remains skip-and-continue with no change to success paths.
> 
> **Overview**
> **Observability for best-effort layout paths** — two broad `except` handlers still skip optional work (missing layout fragments during fragment routing; failed KiCad connectivity rebuild before save) but now emit **`logger.warning`** with the group name or a clear message instead of returning or `pass` silently. The `update_layout_file.py` handler no longer needs the **`S110`** noqa.
> 
> **Rust lint** — In `html_export.rs`, `HTML_TEMPLATE` and `CSS_STYLES` `include_str!` constants are moved **above** the `#[cfg(test)]` module so `cargo clippy --all-targets` is clean for `items_after_test_module`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a554c38d797a575ee2064c73abd2de24522ea092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->