### PR TITLE
Bump foxtrot to e74e944

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
 dependencies = [
- "nom 7.1.3",
+ "nom",
  "vte",
 ]
 
@@ -211,12 +211,6 @@ name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -476,26 +470,14 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
-dependencies = [
- "funty 1.1.0",
- "radium 0.5.3",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
- "funty 2.0.0",
- "radium 0.7.0",
+ "funty",
+ "radium",
  "tap",
- "wyz 0.5.1",
+ "wyz",
 ]
 
 [[package]]
@@ -505,7 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.8",
+ "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -703,11 +685,11 @@ dependencies = [
 [[package]]
 name = "cdt"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/foxtrot.git?rev=a1e6d588743ef474454497ba07e3662502e792f7#a1e6d588743ef474454497ba07e3662502e792f7"
+source = "git+https://github.com/diodeinc/foxtrot.git?rev=e74e9446dc8acf78d3f09ef2b59dfd90a493fac8#e74e9446dc8acf78d3f09ef2b59dfd90a493fac8"
 dependencies = [
  "geometry-predicates",
  "log",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1943,12 +1925,6 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
@@ -2196,6 +2172,24 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 
 [[package]]
 name = "glam"
@@ -3173,7 +3167,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec",
  "euclid",
  "polycool",
  "smallvec",
@@ -3213,19 +3207,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags 1.3.2",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -3607,11 +3588,15 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.27.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462fffe4002f4f2e1f6a9dcf12cc1a6fc0e15989014efc02a941d3e0f5dc2120"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
 dependencies = [
  "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.3",
  "matrixmultiply",
  "num-complex",
  "num-rational",
@@ -3622,9 +3607,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-glm"
-version = "0.13.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170915b0416369385f0b7951de22326f6c58c2ea4e321092812632fe8f6ae9bd"
+checksum = "13b96517d106ac058c7af5187951de92ea45847e5039be7294ec8db62901ff38"
 dependencies = [
  "approx",
  "nalgebra",
@@ -3697,19 +3682,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.2",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
-dependencies = [
- "bitvec 0.19.6",
- "funty 1.1.0",
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -3837,12 +3809,12 @@ dependencies = [
 [[package]]
 name = "nurbs"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/foxtrot.git?rev=a1e6d588743ef474454497ba07e3662502e792f7#a1e6d588743ef474454497ba07e3662502e792f7"
+source = "git+https://github.com/diodeinc/foxtrot.git?rev=e74e9446dc8acf78d3f09ef2b59dfd90a493fac8#e74e9446dc8acf78d3f09ef2b59dfd90a493fac8"
 dependencies = [
  "log",
  "nalgebra-glm",
  "num-integer",
- "ordered-float 2.10.1",
+ "ordered-float 5.3.0",
  "smallvec",
 ]
 
@@ -3952,15 +3924,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ordered-float"
@@ -4594,7 +4557,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "gerberx2",
- "glam",
+ "glam 0.33.3",
  "httpmock",
  "ignore",
  "inquire",
@@ -4793,7 +4756,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec",
 ]
 
 [[package]]
@@ -4946,7 +4909,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
 dependencies = [
- "bitvec 1.1.1",
+ "bitvec",
  "bytemuck",
  "image",
  "libm",
@@ -4957,7 +4920,7 @@ dependencies = [
  "rand_xoshiro",
  "rayon",
  "ref-cast",
- "wide",
+ "wide 0.8.3",
 ]
 
 [[package]]
@@ -5098,12 +5061,6 @@ dependencies = [
  "rusqlite",
  "uuid",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radium"
@@ -5378,7 +5335,7 @@ dependencies = [
  "base64 0.23.0",
  "clap",
  "env_logger",
- "glam",
+ "glam 0.33.3",
  "indicatif",
  "ndarray",
  "num-complex",
@@ -5558,7 +5515,7 @@ version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
- "bitvec 1.1.1",
+ "bitvec",
  "bytecheck",
  "bytes",
  "hashbrown 0.12.3",
@@ -5736,7 +5693,7 @@ version = "0.0.7"
 source = "git+https://github.com/astral-sh/ruff?tag=0.16.1#80790b348b5188e7fc253665540f442c6ec7dd05"
 dependencies = [
  "aho-corasick",
- "arrayvec 0.7.8",
+ "arrayvec",
  "bitflags 2.13.1",
  "char_str",
  "compact_str 0.10.0",
@@ -5856,7 +5813,7 @@ version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
@@ -6063,6 +6020,15 @@ name = "safe_arch"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "safe_arch"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
 dependencies = [
  "bytemuck",
 ]
@@ -6482,14 +6448,14 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.5.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e82063457853d00243beda9952e910b82593e4b07ae9f721b9278a99a0d3d5c"
+checksum = "834a9952211d4a60ff10ac1d20cc01640a75bdc0a0c688d62f359ea7d17459f3"
 dependencies = [
  "approx",
  "num-complex",
  "num-traits",
- "paste",
+ "wide 1.6.0",
 ]
 
 [[package]]
@@ -6747,13 +6713,13 @@ dependencies = [
 [[package]]
 name = "step"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/foxtrot.git?rev=a1e6d588743ef474454497ba07e3662502e792f7#a1e6d588743ef474454497ba07e3662502e792f7"
+source = "git+https://github.com/diodeinc/foxtrot.git?rev=e74e9446dc8acf78d3f09ef2b59dfd90a493fac8#e74e9446dc8acf78d3f09ef2b59dfd90a493fac8"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec",
  "fast-float",
  "log",
  "memchr",
- "nom 6.1.2",
+ "nom",
 ]
 
 [[package]]
@@ -7065,7 +7031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom 7.1.3",
+ "nom",
  "phf",
  "phf_codegen",
 ]
@@ -7239,7 +7205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.8",
+ "arrayvec",
  "bytemuck",
  "cfg-if",
  "log",
@@ -7517,14 +7483,14 @@ dependencies = [
 [[package]]
 name = "triangulate"
 version = "0.1.0"
-source = "git+https://github.com/diodeinc/foxtrot.git?rev=a1e6d588743ef474454497ba07e3662502e792f7#a1e6d588743ef474454497ba07e3662502e792f7"
+source = "git+https://github.com/diodeinc/foxtrot.git?rev=e74e9446dc8acf78d3f09ef2b59dfd90a493fac8#e74e9446dc8acf78d3f09ef2b59dfd90a493fac8"
 dependencies = [
  "cdt",
  "log",
  "nalgebra-glm",
  "nurbs",
  "step",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7846,7 +7812,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec",
  "memchr",
 ]
 
@@ -8081,7 +8047,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
 dependencies = [
  "bytemuck",
- "safe_arch",
+ "safe_arch 0.9.3",
+]
+
+[[package]]
+name = "wide"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+dependencies = [
+ "bytemuck",
+ "safe_arch 1.1.0",
 ]
 
 [[package]]
@@ -8500,12 +8476,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-chrome = "0.7"
 
 # rectify: STEP tessellation (foxtrot), raster grids, and FFT numerics
-triangulate = { git = "https://github.com/diodeinc/foxtrot.git", rev = "a1e6d588743ef474454497ba07e3662502e792f7" }
+triangulate = { git = "https://github.com/diodeinc/foxtrot.git", rev = "e74e9446dc8acf78d3f09ef2b59dfd90a493fac8" }
 ndarray = "0.17"
 rustfft = "6.4"
 num-complex = "0.4"


### PR DESCRIPTION
Picks up nalgebra-glm 0.13 → 0.21 and nom 6 → 7 from diodeinc/foxtrot#13.

Clears the `nalgebra 0.27.1` and `nom 6.1.2` future-incompatibility warnings.

Tessellation output unchanged: same sorted vertex set (80,670 vertices, 26,890 triangles) on the repo's STEP fixture before and after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps core geometry/tessellation numerics (nalgebra stack and foxtrot STEP pipeline) without application code changes; validated on one fixture but still a moderate risk for edge-case STEP meshes.
> 
> **Overview**
> Updates the workspace **`triangulate`** git dependency on **foxtrot** from `a1e6d588` to **`e74e944`**, which is the only intentional source change; **`Cargo.lock`** follows with a refreshed transitive graph.
> 
> That foxtrot revision brings **`nalgebra-glm` 0.13 → 0.21**, **`nalgebra` 0.27 → 0.35**, **`nom` 6 → 7**, **`thiserror` 1 → 2** on foxtrot crates, and **`ordered-float` 5** for **`nurbs`**, and drops several older duplicate crate versions (e.g. legacy **`nom` 6**, **`bitvec` 0.19**, **`ordered-float` 2.x**) from the lockfile.
> 
> Per the PR description, STEP tessellation behavior on the repo fixture is unchanged (same vertex/triangle counts), so this is primarily a dependency hygiene / future-incompatibility cleanup for rectify’s STEP mesh path in **`crates/rectify`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec088d457d200938cbd13737ac96f45cd609227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->