### PR TITLE
Add automatic copper balancing to the fab-panel panelizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `fab-panel create` now automatically balances copper in the gutters between placed assembly panels.
+
 ### Fixed
 
 - Pad shapes with padstack offsets now land at the correct position on rotated pads across all IPC-2581 outputs.

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -9,8 +9,8 @@ use std::collections::{BTreeSet, HashMap};
 
 use crate::{
     AttributeValue, Contour, ContourSegment, GerberError, GerberLayer, ObjectKind,
-    Point as GerberPoint, Result, WriterAperture, WriterApertureTemplate, WriterObject,
-    sanitize_attribute_field,
+    Point as GerberPoint, Result, WriterAperture, WriterApertureMacro, WriterApertureTemplate,
+    WriterMacroExpression, WriterMacroPrimitive, WriterObject, sanitize_attribute_field,
 };
 use pcb_ir::dialects::artwork::{Aperture, ApertureShape, Geometry as ArtworkGeometry, PaintStage};
 use pcb_ir::geom::path::{self as geom_path, ContourBuf, PathCmd};
@@ -142,18 +142,150 @@ pub fn lower_artwork_layer(layer: &ArtworkDocument) -> Result<GerberLayer> {
         .map(|layer| layer.meta.clone())
         .unwrap_or_default();
 
+    let flashes = plan_repeated_clear_flashes(layer, &mut apertures)?;
     for (source_index, object) in layer.objects.iter().enumerate() {
-        let objects = lower_artwork_object(layer, object, &mut apertures)?;
+        let objects = if let Some(flash) = flashes.get(&source_index) {
+            vec![WriterObject {
+                kind: ObjectKind::Flash {
+                    at: lower_point(flash.at),
+                    aperture: flash.aperture,
+                },
+                polarity: object.polarity,
+                attributes: lower_object_attributes(&object.meta),
+            }]
+        } else {
+            lower_artwork_object(layer, object, &mut apertures)?
+        };
         plan.push_group(source_index, object.order.stage, objects);
     }
     let objects = plan.into_ordered_objects()?;
 
+    let (aperture_list, aperture_macros) = apertures.into_parts();
     Ok(GerberLayer {
         file_attributes: lower_layer_attributes(&layer_attributes),
-        apertures: apertures.into_apertures(),
+        apertures: aperture_list,
+        aperture_macros,
         objects,
         ..GerberLayer::default()
     })
+}
+
+/// Minimum congruent clear regions before sharing their outline as a macro
+/// aperture pays for the definition.
+const MIN_REPEATED_CLEAR_FLASHES: usize = 16;
+
+/// Congruence quantum for translated-copy detection, in millimeters.
+const CLEAR_FLASH_QUANTUM_MM: f64 = 1e-6;
+
+struct PlannedClearFlash {
+    at: Point,
+    aperture: i32,
+}
+
+/// Plan translation-congruent single-contour clear regions as flashes of one
+/// shared outline-macro aperture.
+///
+/// Each flash replaces its region at the same position in the object order
+/// with identical geometry and polarity, so the painted image is unchanged
+/// and no polarity reasoning is required. Dense generated patterns — copper
+/// balance void lattices above all — collapse from hundreds of bytes per
+/// instance to one flash each.
+fn plan_repeated_clear_flashes(
+    layer: &ArtworkDocument,
+    apertures: &mut ApertureTable,
+) -> Result<HashMap<usize, PlannedClearFlash>> {
+    type Signature = (Vec<String>, Vec<(u8, i64, i64, i64, i64, bool)>);
+    let mut groups: HashMap<Signature, Vec<(usize, Point)>> = HashMap::new();
+    for (index, object) in layer.objects.iter().enumerate() {
+        if object.polarity != Polarity::Clear {
+            continue;
+        }
+        let ArtworkGeometry::Region { path } = object.geometry else {
+            continue;
+        };
+        let contours = layer.arena.path_contours(&layer.arena.paths[path as usize]);
+        let [contour] = contours.as_slice() else {
+            continue;
+        };
+        let Some(anchor) = contour_anchor(contour) else {
+            continue;
+        };
+        if contour.cmds.len() > 256 {
+            continue;
+        }
+        let function = object
+            .meta
+            .aperture_function
+            .clone()
+            .unwrap_or_else(|| vec!["Conductor".to_string()]);
+        groups
+            .entry((function, contour_signature(contour, anchor)))
+            .or_default()
+            .push((index, anchor));
+    }
+
+    let mut plan = HashMap::new();
+    for ((function, _), members) in groups {
+        if members.len() < MIN_REPEATED_CLEAR_FLASHES {
+            continue;
+        }
+        let (template_index, template_anchor) = members[0];
+        let ArtworkGeometry::Region { path } = layer.objects[template_index].geometry else {
+            continue;
+        };
+        let contours = layer.arena.path_contours(&layer.arena.paths[path as usize]);
+        let Some(ring) = region::rings_from_contours(&contours).into_iter().next() else {
+            continue;
+        };
+        let outline = ring
+            .iter()
+            .map(|[x, y]| [x - template_anchor.x, y - template_anchor.y])
+            .collect::<Vec<_>>();
+        let aperture = apertures.outline_macro(&outline, &function)?;
+        for (index, anchor) in members {
+            plan.insert(
+                index,
+                PlannedClearFlash {
+                    at: anchor,
+                    aperture,
+                },
+            );
+        }
+    }
+    Ok(plan)
+}
+
+fn contour_anchor(contour: &ContourBuf) -> Option<Point> {
+    let first = contour.cmds.first()?;
+    matches!(first.op, geom_path::PathOp::MoveTo).then(|| first.p0)
+}
+
+/// Translation-invariant shape identity: command opcodes plus their control
+/// points relative to the contour anchor, quantized to the congruence
+/// quantum.
+fn contour_signature(contour: &ContourBuf, anchor: Point) -> Vec<(u8, i64, i64, i64, i64, bool)> {
+    let quantize = |value: f64| (value / CLEAR_FLASH_QUANTUM_MM).round() as i64;
+    contour
+        .cmds
+        .iter()
+        .map(|cmd| {
+            let (p0, p1, clockwise) = match cmd.op {
+                geom_path::PathOp::ArcTo => (cmd.p0, cmd.p1, cmd.clockwise),
+                geom_path::PathOp::CubicTo => (cmd.p0, cmd.p1, false),
+                geom_path::PathOp::MoveTo | geom_path::PathOp::LineTo => (cmd.p0, anchor, false),
+                // Close carries no control points of its own.
+                geom_path::PathOp::Close => (anchor, anchor, false),
+            };
+            (
+                cmd.op as u8,
+                quantize(p0.x - anchor.x),
+                quantize(p0.y - anchor.y),
+                quantize(p1.x - anchor.x),
+                quantize(p1.y - anchor.y),
+                clockwise,
+            )
+        })
+        .collect()
 }
 
 fn lower_artwork_object(
@@ -435,6 +567,7 @@ struct ApertureTable {
     next_code: i32,
     by_key: HashMap<ApertureKey, i32>,
     apertures: Vec<WriterAperture>,
+    aperture_macros: Vec<WriterApertureMacro>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -571,6 +704,45 @@ impl ApertureTable {
         }
     }
 
+    /// Define a one-off macro aperture filling the given closed outline,
+    /// expressed relative to the flash origin.
+    fn outline_macro(&mut self, outline: &[[f64; 2]], function: &[String]) -> Result<i32> {
+        if outline.len() < 3 {
+            return Err(GerberError::InvalidStructure(
+                "cannot export a Gerber outline macro with fewer than three vertices".to_string(),
+            ));
+        }
+        let name = format!("REPEAT{}", self.aperture_macros.len());
+        let mut parameters = Vec::with_capacity(2 * outline.len() + 5);
+        parameters.push(WriterMacroExpression::Number(1.0));
+        parameters.push(WriterMacroExpression::Number(outline.len() as f64));
+        for [x, y] in outline.iter().chain(std::iter::once(&outline[0])) {
+            parameters.push(WriterMacroExpression::Number(*x));
+            parameters.push(WriterMacroExpression::Number(*y));
+        }
+        parameters.push(WriterMacroExpression::Number(0.0));
+        self.aperture_macros.push(WriterApertureMacro {
+            name: name.clone(),
+            primitives: vec![WriterMacroPrimitive::Shape {
+                code: 4,
+                parameters,
+            }],
+        });
+        let code = self.allocate_code();
+        self.apertures.push(WriterAperture {
+            code,
+            template: WriterApertureTemplate::Macro {
+                name,
+                parameters: Vec::new(),
+            },
+            attributes: vec![AttributeValue::new(
+                ".AperFunction",
+                function.iter().cloned(),
+            )],
+        });
+        Ok(code)
+    }
+
     fn define(
         &mut self,
         template_key: ApertureTemplateKey,
@@ -584,13 +756,7 @@ impl ApertureTable {
         if let Some(code) = self.by_key.get(&key) {
             return Ok(*code);
         }
-        let code = if self.next_code == 0 {
-            self.next_code = 10;
-            10
-        } else {
-            self.next_code += 1;
-            self.next_code
-        };
+        let code = self.allocate_code();
         self.by_key.insert(key, code);
         self.apertures.push(WriterAperture {
             code,
@@ -603,8 +769,17 @@ impl ApertureTable {
         Ok(code)
     }
 
-    fn into_apertures(self) -> Vec<WriterAperture> {
-        self.apertures
+    fn allocate_code(&mut self) -> i32 {
+        if self.next_code == 0 {
+            self.next_code = 10;
+        } else {
+            self.next_code += 1;
+        }
+        self.next_code
+    }
+
+    fn into_parts(self) -> (Vec<WriterAperture>, Vec<WriterApertureMacro>) {
+        (self.apertures, self.aperture_macros)
     }
 }
 

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -5,7 +5,7 @@
 //! can be emitted as a Gerber file, regardless of which source dialect
 //! produced it.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::{
     AttributeValue, Contour, ContourSegment, GerberError, GerberLayer, ObjectKind,
@@ -194,8 +194,9 @@ fn plan_repeated_clear_flashes(
     layer: &ArtworkDocument,
     apertures: &mut ApertureTable,
 ) -> Result<HashMap<usize, PlannedClearFlash>> {
+    // Ordered so macro names and aperture codes are stable across runs.
     type Signature = (Vec<String>, Vec<(u8, i64, i64, i64, i64, bool)>);
-    let mut groups: HashMap<Signature, Vec<(usize, Point)>> = HashMap::new();
+    let mut groups: BTreeMap<Signature, Vec<(usize, Point)>> = BTreeMap::new();
     for (index, object) in layer.objects.iter().enumerate() {
         if object.polarity != Polarity::Clear {
             continue;

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -195,7 +195,7 @@ fn plan_repeated_clear_flashes(
     apertures: &mut ApertureTable,
 ) -> Result<HashMap<usize, PlannedClearFlash>> {
     // Ordered so macro names and aperture codes are stable across runs.
-    type Signature = (Vec<String>, Vec<(u8, i64, i64, i64, i64, bool)>);
+    type Signature = (Vec<String>, Vec<CommandSignature>);
     let mut groups: BTreeMap<Signature, Vec<(usize, Point)>> = BTreeMap::new();
     for (index, object) in layer.objects.iter().enumerate() {
         if object.polarity != Polarity::Clear {
@@ -261,21 +261,25 @@ fn contour_anchor(contour: &ContourBuf) -> Option<Point> {
     matches!(first.op, geom_path::PathOp::MoveTo).then(|| first.p0)
 }
 
-/// Translation-invariant shape identity: command opcodes plus their control
-/// points relative to the contour anchor, quantized to the congruence
+type CommandSignature = (u8, i64, i64, i64, i64, i64, i64, bool);
+
+/// Translation-invariant shape identity: command opcodes plus every control
+/// point relative to the contour anchor, quantized to the congruence
 /// quantum.
-fn contour_signature(contour: &ContourBuf, anchor: Point) -> Vec<(u8, i64, i64, i64, i64, bool)> {
+fn contour_signature(contour: &ContourBuf, anchor: Point) -> Vec<CommandSignature> {
     let quantize = |value: f64| (value / CLEAR_FLASH_QUANTUM_MM).round() as i64;
     contour
         .cmds
         .iter()
         .map(|cmd| {
-            let (p0, p1, clockwise) = match cmd.op {
-                geom_path::PathOp::ArcTo => (cmd.p0, cmd.p1, cmd.clockwise),
-                geom_path::PathOp::CubicTo => (cmd.p0, cmd.p1, false),
-                geom_path::PathOp::MoveTo | geom_path::PathOp::LineTo => (cmd.p0, anchor, false),
+            let (p0, p1, p2, clockwise) = match cmd.op {
+                geom_path::PathOp::ArcTo => (cmd.p0, cmd.p1, anchor, cmd.clockwise),
+                geom_path::PathOp::CubicTo => (cmd.p0, cmd.p1, cmd.p2, false),
+                geom_path::PathOp::MoveTo | geom_path::PathOp::LineTo => {
+                    (cmd.p0, anchor, anchor, false)
+                }
                 // Close carries no control points of its own.
-                geom_path::PathOp::Close => (anchor, anchor, false),
+                geom_path::PathOp::Close => (anchor, anchor, anchor, false),
             };
             (
                 cmd.op as u8,
@@ -283,6 +287,8 @@ fn contour_signature(contour: &ContourBuf, anchor: Point) -> Vec<(u8, i64, i64, 
                 quantize(p0.y - anchor.y),
                 quantize(p1.x - anchor.x),
                 quantize(p1.y - anchor.y),
+                quantize(p2.x - anchor.x),
+                quantize(p2.y - anchor.y),
                 clockwise,
             )
         })

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -22,7 +22,9 @@ Run `pcb ipc2581 <command> --help` for arguments and output options.
 
 The mathematical and geometric strategy for automatically balancing board
 arrays is documented in
-[`docs/board-array-copper-balancing.md`](docs/board-array-copper-balancing.md).
+[`docs/board-array-copper-balancing.md`](docs/board-array-copper-balancing.md);
+the fabrication-panel pass that extends it is documented in
+[`docs/fab-panel-copper-balancing.md`](docs/fab-panel-copper-balancing.md).
 
 `edit bom` modifies the input file when `--output` is omitted. Specify an output
 path when the source document must remain unchanged.

--- a/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
+++ b/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
@@ -1,7 +1,9 @@
 # Board-array copper balancing
 
 This document defines copper balancing for an assembly panel created by
-`board-array create`. Fabrication-panel balancing is a later, independent pass.
+`board-array create`. Fabrication-panel balancing is a later, independent
+pass, documented in
+[fab-panel-copper-balancing.md](fab-panel-copper-balancing.md).
 
 ## Motivation and scope
 
@@ -229,5 +231,7 @@ Initial verification should cover:
 - clipped edge voids preserve the existing web and minimum-fragment rules; and
 - distinct layer-safe regions never contribute sites to the wrong layer.
 
-Fabrication-panel layout and balancing, electroplating simulation, laminate
-material stiffness, and changes inside a board footprint are out of scope.
+Fabrication-panel layout and balancing (see
+[fab-panel-copper-balancing.md](fab-panel-copper-balancing.md)),
+electroplating simulation, laminate material stiffness, and changes inside a
+board footprint are out of scope.

--- a/crates/pcb-ipc2581-tools/docs/fab-panel-copper-balancing.md
+++ b/crates/pcb-ipc2581-tools/docs/fab-panel-copper-balancing.md
@@ -1,0 +1,65 @@
+# Fab-panel copper balancing
+
+This document defines copper balancing for a fabrication panel created by
+`fab-panel create`. It is the fabrication-panel pass that
+[board-array copper balancing](board-array-copper-balancing.md) reserves as
+out of scope; the density model, solver, and generated geometry are shared
+with that pass, so only the differences are described here.
+
+## Balancing region
+
+The placed assembly panels are immutable, and the fabrication-panel step adds
+no per-layer geometry of its own. The balancing region is therefore just the
+gutters: the usable stock region between the reserved process margins, minus
+the placed assembly-panel outlines with the standard clearance, regularized
+and certified by the same construction as the board-array pass. One safe
+region serves every copper layer.
+
+The reserved process margins stay bare. They are excluded from the density
+domain entirely — not merely from the safe region — so the solver never
+chases a deficit it cannot fill at the margin boundary.
+
+As a defensive measure, any copper found outside the placed panel outlines
+joins the shared obstacle set, shrinking the certified safe region instead of
+failing the solve. A correctly generated fabrication panel has no such
+copper.
+
+## Density targets
+
+Each copper layer targets the aggregate copper density measured inside the
+placed assembly-panel outlines. Because the assembly panels were themselves
+balanced during board-array creation, this extends their already-uniform
+density into the gutters. Mixed panel types weight the target by their
+footprint areas, since the denominator is the union of all placements.
+
+With domain `U` (the usable region), footprints `F`, and fixed copper `C_l`,
+the requested generated area reduces to filling the gutters at the panel
+density:
+
+```text
+d_l  = area(C_l ∩ F) / area(F)
+A*_l = d_l area(U) - area(C_l) = d_l area(U \ F)
+```
+
+## Through-stack metric
+
+`fab-panel create` requires every source to carry one identical physical
+stackup, so the signed stack weights come from that shared stackup exactly as
+in the board-array pass. When thickness data is missing, layers balance
+independently and the summary warns, as before.
+
+## Lattice
+
+The void lattice originates at the usable region's minimum corner. It is not
+phase-aligned with the lattices inside the source assembly panels; the
+sources are immutable and the gutters are solver-fresh territory, so no
+alignment is needed and determinism is preserved for identical inputs.
+
+## Flow
+
+Balancing runs unconditionally inside `fab-panel create`: the panel is
+generated provisionally without balance copper, the provisional document
+supplies the composed per-layer copper images and placed-panel outlines, and
+the final document is written with the generated copper as positive
+`LayerFeature` contours in the fabrication-panel step. A per-layer summary is
+printed, matching the board-array report.

--- a/crates/pcb-ipc2581-tools/examples/gerber_copper_svg.rs
+++ b/crates/pcb-ipc2581-tools/examples/gerber_copper_svg.rs
@@ -3,6 +3,11 @@
 //! Development harness for visually inspecting exported copper: the Gerber is
 //! parsed and composed exactly as `pcbc ipc2581 dfm` sees it, so the picture
 //! matches manufacturing output rather than any IPC-2581 view.
+//!
+//! Rings paint back-to-front by containment depth — copper for boundaries,
+//! background for holes — so no path element grows past what common SVG
+//! rasterizers accept, even for planes perforated by tens of thousands of
+//! voids.
 
 use std::fmt::Write as _;
 use std::path::PathBuf;
@@ -10,6 +15,9 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use pcb_ir::geom::region::rings_from_contours;
 use pcb_ir::geom::{ContourSet, FillRule};
+
+const COPPER: &str = "#d87822";
+const BACKGROUND: &str = "#ffffff";
 
 fn main() -> Result<()> {
     let mut args = std::env::args().skip(1);
@@ -30,26 +38,47 @@ fn main() -> Result<()> {
     }
     let region = ContourSet::new(rings, FillRule::NonZero, 1e-4);
 
-    let pad = 1.0;
-    let min_x = region.bbox.min.x - pad;
-    let width = region.bbox.width() + 2.0 * pad;
-    let min_y = -(region.bbox.max.y + pad);
-    let height = region.bbox.height() + 2.0 * pad;
+    // A containing ring always has the larger unsigned area, so painting in
+    // descending area order layers islands over holes over boundaries.
+    let mut rings = region
+        .rings
+        .iter()
+        .map(|ring| (signed_ring_area(ring), ring))
+        .collect::<Vec<_>>();
+    rings.sort_by(|(left, _), (right, _)| right.abs().total_cmp(&left.abs()));
+
+    // Same-color runs split at a fixed size so no attribute outgrows the
+    // 10 MB limit libxml2-based rasterizers enforce.
+    const MAX_PATH_DATA_BYTES: usize = 2_000_000;
+    let mut body = String::new();
+    let mut fill = "";
     let mut path_data = String::new();
-    for ring in &region.rings {
+    for (area, ring) in rings {
+        let ring_fill = if area >= 0.0 { COPPER } else { BACKGROUND };
+        if (ring_fill != fill || path_data.len() > MAX_PATH_DATA_BYTES) && !path_data.is_empty() {
+            writeln!(body, "    <path d='{path_data}' fill='{fill}'/>")?;
+            path_data.clear();
+        }
+        fill = ring_fill;
         for (index, [x, y]) in ring.iter().enumerate() {
             let command = if index == 0 { 'M' } else { 'L' };
             write!(path_data, "{command}{x:.6} {y:.6} ")?;
         }
         path_data.push_str("Z ");
     }
+    if !path_data.is_empty() {
+        writeln!(body, "    <path d='{path_data}' fill='{fill}'/>")?;
+    }
 
+    let pad = 1.0;
+    let min_x = region.bbox.min.x - pad;
+    let width = region.bbox.width() + 2.0 * pad;
+    let min_y = -(region.bbox.max.y + pad);
+    let height = region.bbox.height() + 2.0 * pad;
     let svg = format!(
         "<svg xmlns='http://www.w3.org/2000/svg' viewBox='{min_x:.3} {min_y:.3} {width:.3} {height:.3}'>\n  \
          <title>{}</title>\n  \
-         <g transform='scale(1 -1)'>\n    \
-         <path d='{path_data}' fill='#d87822' fill-opacity='0.9' fill-rule='nonzero'/>\n  \
-         </g>\n</svg>\n",
+         <g transform='scale(1 -1)'>\n{body}  </g>\n</svg>\n",
         input
             .file_name()
             .and_then(|name| name.to_str())
@@ -58,4 +87,12 @@ fn main() -> Result<()> {
     std::fs::write(&output, svg)
         .with_context(|| format!("failed to write {}", output.display()))?;
     Ok(())
+}
+
+fn signed_ring_area(ring: &[[f64; 2]]) -> f64 {
+    ring.iter()
+        .zip(ring.iter().cycle().skip(1))
+        .map(|([x0, y0], [x1, y1])| x0 * y1 - x1 * y0)
+        .sum::<f64>()
+        / 2.0
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -2,198 +2,21 @@
 //!
 //! The planner derives a certified safe region and the composed copper image
 //! of every copper layer from a completed board array, then runs one joint
-//! spatial solve across the stackup.
-
-use std::collections::HashMap;
+//! spatial solve across the stackup via [`crate::copper_balance`].
 
 use anyhow::{Context, Result, bail};
-use ipc2581::types::{
-    LayerFunction,
-    ecad::{FeatureUserPrimitive, SetFeature},
-    primitives::{
-        Contour as IpcContour, Point as IpcPoint, PolyStep, PolyStepCurve, PolyStepSegment,
-        Polygon, UserPrimitive, UserShape, UserShapeType, UserSpecial,
-    },
-};
+use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::ipc::{
     BalancingRegionOptions, BoardArraySupportDocument, BoardArraySupportLayerPolicy, View,
     board_array_balancing_region, collect_board_array_balancing_input,
 };
-use pcb_ir::geom::copper_balance::{
-    DenseCopperBalanceMode, DenseCopperBalanceProfile, DenseCopperBalanceResult,
-    SpatialCopperBalanceLayerRequest, SpatialCopperBalanceRequest,
-    generate_spatial_dense_copper_balance, rounded_hexagonal_void,
-};
-use pcb_ir::geom::path::transform_cmds;
-use pcb_ir::geom::region::simplify_shapes;
-use pcb_ir::geom::{Affine2, ContourBuf, ContourSet, FillRule, PathOp, Point, tol};
-use serde::Serialize;
 
+use crate::copper_balance::{
+    CERTIFICATE_AREA_TOLERANCE_MM2, CopperBalancePlan, PreparedCopperLayer, composed_copper_image,
+    physical_copper_stack_weights, solve_copper_balance,
+};
 use crate::geometry;
 use crate::ipc2581::{Ipc2581, Symbol};
-
-const CERTIFICATE_AREA_TOLERANCE_MM2: f64 = 1e-4;
-
-/// One copper layer's automatic balancing plan and generated IPC features.
-#[derive(Debug, Clone)]
-pub struct AutomaticBoardArrayLayerBalance {
-    pub layer_name: String,
-    /// Copper density measured inside the repeated board footprints.
-    pub board_target_density: f64,
-    /// Signed physical stack weight, or zero when the stackup supplied none.
-    pub stack_weight_mm2: f64,
-    pub existing_copper: ContourSet,
-    pub result: DenseCopperBalanceResult,
-    pub features: Vec<SetFeature>,
-}
-
-/// Inspectable result of planning automatic copper balance for a board array.
-#[derive(Debug, Clone)]
-pub struct AutomaticBoardArrayCopperBalance {
-    pub board_footprints: ContourSet,
-    pub retained_area_mm2: f64,
-    /// Whether the physical stackup supplied signed stack weights. When false,
-    /// every layer balances independently with zero through-stack coupling.
-    pub stack_weights_available: bool,
-    pub layers: Vec<AutomaticBoardArrayLayerBalance>,
-}
-
-/// Compact, serializable accounting for one layer's automatic balance.
-#[derive(Debug, Clone, Serialize)]
-pub struct AutomaticBoardArrayLayerBalanceReport {
-    pub layer_name: String,
-    pub mode: AutomaticBoardArrayCopperBalanceMode,
-    pub void_radius_mm: Option<f64>,
-    pub min_void_radius_mm: Option<f64>,
-    pub max_void_radius_mm: Option<f64>,
-    pub stack_weight_mm2: f64,
-    pub target_density: f64,
-    pub initial_density: f64,
-    pub achieved_density: f64,
-    pub residual_error: f64,
-    pub existing_copper_area_mm2: f64,
-    pub desired_added_area_mm2: f64,
-    pub generated_area_mm2: f64,
-    pub usable_area_mm2: f64,
-    pub fixed_empty_area_mm2: f64,
-    pub void_count: usize,
-}
-
-/// Topology selected for one layer's automatic balance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AutomaticBoardArrayCopperBalanceMode {
-    None,
-    Solid,
-    Perforated,
-}
-
-/// Compact, serializable accounting for a completed automatic balance plan.
-#[derive(Debug, Clone, Serialize)]
-pub struct AutomaticBoardArrayCopperBalanceReport {
-    pub retained_area_mm2: f64,
-    pub board_footprint_area_mm2: f64,
-    pub stack_weights_available: bool,
-    pub layers: Vec<AutomaticBoardArrayLayerBalanceReport>,
-}
-
-impl AutomaticBoardArrayCopperBalanceReport {
-    /// One short status line per copper layer, plus a warning when the
-    /// stackup could not supply physical stack weights.
-    pub fn summary_lines(&self) -> Vec<String> {
-        let mut lines = self
-            .layers
-            .iter()
-            .map(|layer| {
-                let geometry = match (
-                    layer.mode,
-                    layer.min_void_radius_mm,
-                    layer.max_void_radius_mm,
-                ) {
-                    (AutomaticBoardArrayCopperBalanceMode::None, ..) => "no fill".to_string(),
-                    (AutomaticBoardArrayCopperBalanceMode::Solid, ..) => "solid fill".to_string(),
-                    (AutomaticBoardArrayCopperBalanceMode::Perforated, Some(min), Some(max)) => {
-                        format!("{} hex voids r {min:.2}-{max:.2} mm", layer.void_count)
-                    }
-                    (AutomaticBoardArrayCopperBalanceMode::Perforated, ..) => {
-                        format!("{} hex voids", layer.void_count)
-                    }
-                };
-                format!(
-                    "balance {}: {geometry}, density {:.3} -> {:.3} (target {:.3})",
-                    layer.layer_name,
-                    layer.initial_density,
-                    layer.achieved_density,
-                    layer.target_density
-                )
-            })
-            .collect::<Vec<_>>();
-        if !self.layers.is_empty() && !self.stack_weights_available {
-            lines.push(
-                "balance: stackup thickness data unavailable; layers balanced independently"
-                    .to_string(),
-            );
-        }
-        lines
-    }
-}
-
-impl AutomaticBoardArrayCopperBalance {
-    /// Discard heavy geometry while retaining enough data to audit the result.
-    pub fn report(&self) -> AutomaticBoardArrayCopperBalanceReport {
-        AutomaticBoardArrayCopperBalanceReport {
-            retained_area_mm2: self.retained_area_mm2,
-            board_footprint_area_mm2: self.board_footprints.area(),
-            stack_weights_available: self.stack_weights_available,
-            layers: self
-                .layers
-                .iter()
-                .map(|layer| {
-                    let solution = layer.result.solution;
-                    let existing_copper_area_mm2 = layer.existing_copper.area();
-                    let usable_area_mm2 = layer.result.usable.area();
-                    let fixed_empty_area_mm2 =
-                        (self.retained_area_mm2 - existing_copper_area_mm2 - usable_area_mm2)
-                            .max(0.0);
-                    let (mode, void_radius_mm) = match solution.mode {
-                        DenseCopperBalanceMode::None => {
-                            (AutomaticBoardArrayCopperBalanceMode::None, None)
-                        }
-                        DenseCopperBalanceMode::Solid => {
-                            (AutomaticBoardArrayCopperBalanceMode::Solid, None)
-                        }
-                        DenseCopperBalanceMode::Perforated { void_radius_mm } => (
-                            AutomaticBoardArrayCopperBalanceMode::Perforated,
-                            Some(void_radius_mm),
-                        ),
-                    };
-                    let (min_void_radius_mm, max_void_radius_mm) = layer
-                        .result
-                        .full_void_radius_range_mm()
-                        .map_or((None, None), |(min, max)| (Some(min), Some(max)));
-                    AutomaticBoardArrayLayerBalanceReport {
-                        layer_name: layer.layer_name.clone(),
-                        mode,
-                        void_radius_mm,
-                        min_void_radius_mm,
-                        max_void_radius_mm,
-                        stack_weight_mm2: layer.stack_weight_mm2,
-                        target_density: solution.target_density,
-                        initial_density: solution.initial_density,
-                        achieved_density: solution.achieved_density,
-                        residual_error: solution.residual_error,
-                        existing_copper_area_mm2,
-                        desired_added_area_mm2: solution.desired_added_area_mm2,
-                        generated_area_mm2: solution.generated_area_mm2,
-                        usable_area_mm2,
-                        fixed_empty_area_mm2,
-                        void_count: layer.result.void_count(),
-                    }
-                })
-                .collect(),
-        }
-    }
-}
 
 /// Plan best-effort copper balancing for every copper layer in a board array.
 ///
@@ -204,9 +27,7 @@ impl AutomaticBoardArrayCopperBalance {
 /// `ipc` must describe the completed, not-yet-balanced array so that generated
 /// rails, V-scores, tooling holes, and fiducials participate in safe-region
 /// discovery while balance copper itself does not.
-pub fn generate_automatic_board_array_copper_balance(
-    ipc: &Ipc2581,
-) -> Result<AutomaticBoardArrayCopperBalance> {
+pub fn generate_automatic_board_array_copper_balance(ipc: &Ipc2581) -> Result<CopperBalancePlan> {
     let layout = geometry::extract_layout(ipc)
         .context("failed to extract board-array layout for copper balancing")?;
     let score_lines = geometry::board_array_vscore_lines(ipc)
@@ -227,9 +48,7 @@ pub fn generate_automatic_board_array_copper_balance(
     .context("failed to collect board-array balancing obstacles")?;
     let panel_outer = &collection.panel_outer;
     let board_footprints = &collection.board_footprints;
-    let retained_area_mm2 = panel_outer.area();
     let board_area_mm2 = board_footprints.area();
-    let lattice_origin = panel_outer.bbox.min;
     let stack_weights = physical_copper_stack_weights(ipc);
     let stack_weights_available = stack_weights.is_some();
     let mut prepared: Vec<PreparedLayerBalance> = Vec::with_capacity(copper_layers.len());
@@ -253,7 +72,7 @@ pub fn generate_automatic_board_array_copper_balance(
                 candidate.frame_copper_empty
                     && collection.has_same_support_scope(candidate.layer, layer.name)
             }) {
-            representative.safe_region.clone()
+            representative.inner.safe_region.clone()
         } else {
             let mut balancing_input = collection.input_for_layer(layer.name);
             balancing_input.support_features =
@@ -275,62 +94,29 @@ pub fn generate_automatic_board_array_copper_balance(
         };
         prepared.push(PreparedLayerBalance {
             layer: layer.name,
-            board_target_density,
-            stack_weight_mm2,
             frame_copper_empty,
-            existing_copper,
-            safe_region,
+            inner: PreparedCopperLayer {
+                layer_name,
+                target_density: board_target_density,
+                stack_weight_mm2,
+                existing_copper,
+                safe_region,
+            },
         });
     }
-    let spatial_layers = prepared
-        .iter()
-        .map(|layer| SpatialCopperBalanceLayerRequest {
-            safe_region: &layer.safe_region,
-            existing_copper: &layer.existing_copper,
-            target_density: layer.board_target_density,
-            stack_weight_mm2: layer.stack_weight_mm2,
-        })
-        .collect::<Vec<_>>();
-    let results = generate_spatial_dense_copper_balance(
-        DenseCopperBalanceProfile::V1,
-        SpatialCopperBalanceRequest {
-            panel_region: panel_outer,
-            lattice_origin,
-            layers: &spatial_layers,
-        },
-    )
-    .context("failed to generate spatial board-array copper balance")?;
-    let layers = prepared
-        .into_iter()
-        .zip(results)
-        .map(|(layer, result)| {
-            let features = balance_features(&result)?;
-            Ok(AutomaticBoardArrayLayerBalance {
-                layer_name: ipc.resolve(layer.layer).to_string(),
-                board_target_density: layer.board_target_density,
-                stack_weight_mm2: layer.stack_weight_mm2,
-                existing_copper: layer.existing_copper,
-                result,
-                features,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
 
-    Ok(AutomaticBoardArrayCopperBalance {
-        board_footprints: collection.board_footprints,
-        retained_area_mm2,
+    solve_copper_balance(
+        panel_outer,
+        board_footprints.clone(),
         stack_weights_available,
-        layers,
-    })
+        prepared.into_iter().map(|layer| layer.inner).collect(),
+    )
 }
 
 struct PreparedLayerBalance {
     layer: Symbol,
-    board_target_density: f64,
-    stack_weight_mm2: f64,
     frame_copper_empty: bool,
-    existing_copper: ContourSet,
-    safe_region: ContourSet,
+    inner: PreparedCopperLayer,
 }
 
 /// One ECAD layer's `ArraySupport` view plus its physical-obstacle policy.
@@ -373,340 +159,4 @@ pub fn extract_array_support_layers(ipc: &Ipc2581) -> Result<Vec<ArraySupportLay
             })
         })
         .collect()
-}
-
-/// Convert a solved layer to positive IPC features; empty when nothing was
-/// generated.
-pub(crate) fn balance_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeature>> {
-    match result.solution.mode {
-        DenseCopperBalanceMode::None => Ok(Vec::new()),
-        DenseCopperBalanceMode::Solid | DenseCopperBalanceMode::Perforated { .. } => {
-            ipc_contour_features(result)
-        }
-    }
-}
-
-fn composed_copper_image(ipc: &Ipc2581, layer_name: &str) -> Result<ContourSet> {
-    let mut document = geometry::extract_layer_for_view(ipc, layer_name, View::ArrayFlattened)
-        .with_context(|| {
-            format!("failed to extract flattened IPC-2581 copper layer '{layer_name}'")
-        })?;
-    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut document);
-    Ok(ContourSet::from_painted_paths(
-        &document.arena,
-        document
-            .features
-            .iter()
-            .flat_map(|feature| feature.paths.slice(&document.arena.paths)),
-        tol::REGION_MM,
-    ))
-}
-
-fn physical_copper_stack_weights(ipc: &Ipc2581) -> Option<HashMap<String, f64>> {
-    let ecad = ipc.ecad()?;
-    let stackup = ecad.cad_data.stackups.first()?;
-    let mut layers = stackup.layers.iter().collect::<Vec<_>>();
-    if layers.iter().all(|layer| layer.layer_number.is_some()) {
-        layers.sort_by_key(|layer| layer.layer_number);
-    }
-
-    let mut cursor_mm = 0.0;
-    let mut copper = Vec::new();
-    for stack_layer in layers {
-        let thickness_mm = stack_layer.thickness?;
-        if !thickness_mm.is_finite() || thickness_mm < 0.0 {
-            return None;
-        }
-        let center_mm = cursor_mm + thickness_mm / 2.0;
-        let name = ipc.resolve(stack_layer.layer_ref);
-        if ecad.cad_data.layers.iter().any(|layer| {
-            ipc.resolve(layer.name) == name && crate::layers::is_copper(layer.layer_function)
-        }) {
-            if thickness_mm <= 0.0 {
-                return None;
-            }
-            copper.push((name.to_string(), center_mm, thickness_mm));
-        }
-        cursor_mm += thickness_mm;
-    }
-
-    let expected = ecad
-        .cad_data
-        .layers
-        .iter()
-        .filter(|layer| crate::layers::is_copper(layer.layer_function))
-        .count();
-    if copper.len() != expected || cursor_mm <= 0.0 {
-        return None;
-    }
-    let midplane_mm = cursor_mm / 2.0;
-    Some(
-        copper
-            .into_iter()
-            .map(|(name, center_mm, thickness_mm)| (name, (midplane_mm - center_mm) * thickness_mm))
-            .collect(),
-    )
-}
-
-struct IpcCopperComponent {
-    region: ContourSet,
-    outer: ContourBuf,
-    cutouts: Vec<ContourBuf>,
-}
-
-fn ipc_contour_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeature>> {
-    let mut components = simplify_shapes(result.usable.rings.clone(), FillRule::NonZero)
-        .into_iter()
-        .map(|shape| IpcCopperComponent {
-            region: ContourSet::new(shape.clone(), FillRule::NonZero, result.usable.tolerance),
-            outer: pcb_ir::geom::arcfit::ring_to_contour_with_arcs(&shape[0], tol::FLATTEN_MM),
-            cutouts: shape
-                .iter()
-                .skip(1)
-                .map(|ring| pcb_ir::geom::arcfit::ring_to_contour_with_arcs(ring, tol::FLATTEN_MM))
-                .collect(),
-        })
-        .collect::<Vec<_>>();
-
-    if matches!(
-        result.solution.mode,
-        DenseCopperBalanceMode::Perforated { .. }
-    ) {
-        for void in &result.full_voids {
-            let template = rounded_hexagonal_void(void.radius_mm)
-                .context("generated copper balance has an invalid rounded-hex void radius")?;
-            let component = containing_component(&mut components, void.center)
-                .context("generated full copper void lies outside the usable region")?;
-            component.cutouts.push(transform_cmds(
-                template.cmds.iter().copied(),
-                Affine2::translation(void.center),
-            ));
-        }
-    }
-
-    let mut islands = Vec::new();
-    for shape in simplify_shapes(result.partial_voids.rings.clone(), FillRule::NonZero) {
-        let &[x, y] = shape
-            .first()
-            .and_then(|ring| ring.first())
-            .context("generated partial copper void has no outer boundary")?;
-        let component = containing_component(&mut components, Point::new(x, y))
-            .context("generated partial copper void lies outside the usable region")?;
-        component
-            .cutouts
-            .push(pcb_ir::geom::arcfit::ring_to_contour_with_arcs(
-                &shape[0],
-                tol::FLATTEN_MM,
-            ));
-        islands.extend(
-            shape
-                .iter()
-                .skip(1)
-                .map(|ring| pcb_ir::geom::arcfit::ring_to_contour_with_arcs(ring, tol::FLATTEN_MM)),
-        );
-    }
-
-    components
-        .into_iter()
-        .map(|component| ipc_contour_feature(&component.outer, &component.cutouts))
-        .chain(
-            islands
-                .iter()
-                .map(|island| ipc_contour_feature(island, &[])),
-        )
-        .collect()
-}
-
-fn containing_component(
-    components: &mut [IpcCopperComponent],
-    point: Point,
-) -> Option<&mut IpcCopperComponent> {
-    components
-        .iter_mut()
-        .find(|component| component.region.contains_point(point))
-}
-
-fn ipc_contour_feature(outer: &ContourBuf, cutout_contours: &[ContourBuf]) -> Result<SetFeature> {
-    let polygon = ipc_polygon_from_contour(outer)?;
-    let cutouts = cutout_contours
-        .iter()
-        .map(ipc_polygon_from_contour)
-        .collect::<Result<Vec<_>>>()?;
-    Ok(SetFeature::UserPrimitive(FeatureUserPrimitive {
-        primitive: UserPrimitive::UserSpecial(UserSpecial {
-            shapes: vec![UserShape {
-                shape: UserShapeType::Contour(IpcContour { polygon, cutouts }),
-                line_desc: None,
-                line_desc_ref: None,
-                fill_desc: None,
-            }],
-        }),
-        x: 0.0,
-        y: 0.0,
-    }))
-}
-
-fn ipc_polygon_from_contour(contour: &ContourBuf) -> Result<Polygon> {
-    let mut begin = None;
-    let mut steps = Vec::new();
-
-    for command in &contour.cmds {
-        match command.op {
-            PathOp::MoveTo if begin.is_none() => {
-                begin = Some(IpcPoint {
-                    x: command.p0.x,
-                    y: command.p0.y,
-                });
-            }
-            PathOp::LineTo if begin.is_some() => {
-                steps.push(PolyStep::Segment(PolyStepSegment {
-                    point: IpcPoint {
-                        x: command.p0.x,
-                        y: command.p0.y,
-                    },
-                }));
-            }
-            PathOp::ArcTo if begin.is_some() => {
-                steps.push(PolyStep::Curve(PolyStepCurve {
-                    point: IpcPoint {
-                        x: command.p0.x,
-                        y: command.p0.y,
-                    },
-                    center: IpcPoint {
-                        x: command.p1.x,
-                        y: command.p1.y,
-                    },
-                    clockwise: command.clockwise,
-                }));
-            }
-            PathOp::Close if begin.is_some() => {}
-            PathOp::CubicTo => {
-                bail!("generated copper balance polygon contains an unsupported cubic segment")
-            }
-            _ => bail!("generated copper balance polygon contains multiple or missing contours"),
-        }
-    }
-
-    let begin = begin.context("generated copper balance polygon has no starting point")?;
-    if steps.len() < 2 {
-        bail!("generated copper balance polygon has fewer than three vertices");
-    }
-    Ok(Polygon { begin, steps })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use pcb_ir::geom::{BBox, ContourSet, Point, tol};
-
-    #[test]
-    fn converts_perforated_region_to_positive_ipc_contours() {
-        let safe_region = ContourSet::rectangle(
-            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 10.0)),
-            tol::REGION_MM,
-        );
-        let existing = ContourSet::empty(tol::REGION_MM);
-        let layers = [SpatialCopperBalanceLayerRequest {
-            safe_region: &safe_region,
-            existing_copper: &existing,
-            target_density: 0.75,
-            stack_weight_mm2: 0.0,
-        }];
-        let result = generate_spatial_dense_copper_balance(
-            DenseCopperBalanceProfile::V1,
-            SpatialCopperBalanceRequest {
-                panel_region: &safe_region,
-                lattice_origin: Point::new(10.0, 5.0),
-                layers: &layers,
-            },
-        )
-        .unwrap()
-        .pop()
-        .unwrap();
-        let features = balance_features(&result).unwrap();
-
-        assert!(
-            matches!(
-                result.solution.mode,
-                pcb_ir::geom::copper_balance::DenseCopperBalanceMode::Perforated { .. }
-            ),
-            "{:?}",
-            result.solution
-        );
-        assert!(result.solution.generated_area_mm2 > 0.0);
-        assert!(!result.full_voids.is_empty());
-        assert!(!result.partial_voids.is_empty());
-        assert!(
-            features
-                .iter()
-                .all(|feature| matches!(feature, SetFeature::UserPrimitive(_)))
-        );
-        let contours = features
-            .iter()
-            .filter_map(|feature| match feature {
-                SetFeature::UserPrimitive(feature) => {
-                    let UserPrimitive::UserSpecial(user_special) = &feature.primitive;
-                    let UserShapeType::Contour(contour) = &user_special.shapes[0].shape else {
-                        return None;
-                    };
-                    Some(contour)
-                }
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(
-            contours
-                .iter()
-                .map(|contour| contour.cutouts.len())
-                .sum::<usize>(),
-            result.void_count()
-        );
-        assert!(
-            contours
-                .iter()
-                .flat_map(|contour| {
-                    std::iter::once(&contour.polygon).chain(contour.cutouts.iter())
-                })
-                .flat_map(|polygon| &polygon.steps)
-                .any(|step| matches!(step, PolyStep::Curve(_)))
-        );
-    }
-
-    #[test]
-    fn derives_signed_stack_weights_from_physical_layer_centers() {
-        let ipc = Ipc2581::parse(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
-  <Content roleRef="owner">
-    <FunctionMode mode="FABRICATION"/>
-    <StepRef name="board"/>
-    <LayerRef name="F.Cu"/>
-    <LayerRef name="B.Cu"/>
-  </Content>
-  <Ecad>
-    <CadHeader units="MILLIMETER"/>
-    <CadData>
-      <Layer name="F.Cu" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
-      <Layer name="B.Cu" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
-      <Stackup name="Primary" overallThickness="1.6">
-        <StackupGroup name="Primary_Group">
-          <StackupLayer layerOrGroupRef="COATING_TOP" thickness="0" sequence="0"/>
-          <StackupLayer layerOrGroupRef="F.Cu" thickness="0.035" sequence="1"/>
-          <StackupLayer layerOrGroupRef="CORE" thickness="1.53" sequence="2"/>
-          <StackupLayer layerOrGroupRef="B.Cu" thickness="0.035" sequence="3"/>
-          <StackupLayer layerOrGroupRef="COATING_BOTTOM" thickness="0" sequence="4"/>
-        </StackupGroup>
-      </Stackup>
-      <Step name="board" type="BOARD"><Datum x="0" y="0"/></Step>
-    </CadData>
-  </Ecad>
-</IPC-2581>"#,
-        )
-        .unwrap();
-        let weights = physical_copper_stack_weights(&ipc).unwrap();
-
-        assert!((weights["F.Cu"] + weights["B.Cu"]).abs() <= 1e-12);
-        assert!(weights["F.Cu"] > 0.0);
-        assert!(weights["B.Cu"] < 0.0);
-    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -599,14 +599,17 @@ fn write_balanced_board_array_xml(
     let copper_balance = balance.report();
 
     for layer in balance.layers {
-        if layer.features.is_empty() {
-            continue;
-        }
+        spec.generated_geometry.add_layer_feature(
+            GeneratedFeatureScope::Array,
+            layer.layer_name.clone(),
+            Polarity::Positive,
+            layer.features.positive,
+        );
         spec.generated_geometry.add_layer_feature(
             GeneratedFeatureScope::Array,
             layer.layer_name,
-            Polarity::Positive,
-            layer.features,
+            Polarity::Negative,
+            layer.features.negative,
         );
     }
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -6,6 +6,8 @@ use super::board_array_auto::{
     AutoBoardArrayPlan, AutoSheetSize, TargetSizeMm, auto_board_array_plan,
     auto_board_array_plan_for_sheet,
 };
+use crate::copper_balance::CopperBalanceReport;
+use crate::generated::GeneratedLayerFeature;
 use crate::geometry;
 use crate::ipc2581::Ipc2581;
 use crate::utils::file as file_utils;
@@ -55,7 +57,6 @@ const KICAD_VCUT_LABEL_GLYPHS: [&str; 5] = [
     "JZLFXF RR[RF",
 ];
 const TOOLING_HOLE_LAYER_BASE_NAME: &str = "Board_Array_Drill";
-const GENERATED_HOLE_NAME_PREFIX: &str = "array_tooling_hole";
 const FIDUCIAL_COPPER_DIAMETER_MM: f64 = 1.0;
 const FIDUCIAL_MASK_OPENING_DIAMETER_MM: f64 = 2.0;
 const TOOLING_HOLE_DIAMETER_MM: f64 = 2.0;
@@ -186,7 +187,7 @@ pub struct BoardArrayCreateOptions {
 #[derive(Debug, Clone)]
 pub struct BoardArrayCreation {
     pub xml: String,
-    pub copper_balance: balance::AutomaticBoardArrayCopperBalanceReport,
+    pub copper_balance: CopperBalanceReport,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -291,7 +292,7 @@ impl BoardArrayPanelizationMode {
 #[derive(Debug, Clone, Default)]
 struct BoardArrayGeneratedGeometry {
     layers: Vec<GeneratedLayer>,
-    layer_features: Vec<GeneratedLayerFeature>,
+    layer_features: Vec<(GeneratedFeatureScope, GeneratedLayerFeature)>,
 }
 
 impl BoardArrayGeneratedGeometry {
@@ -317,20 +318,22 @@ impl BoardArrayGeneratedGeometry {
         spec_refs: Vec<String>,
         features: Vec<SetFeature>,
     ) {
-        self.layer_features.push(GeneratedLayerFeature {
+        self.layer_features.push((
             scope,
-            layer_name: layer_name.into(),
-            polarity,
-            spec_refs,
-            features,
-        });
+            GeneratedLayerFeature {
+                layer_name: layer_name.into(),
+                polarity,
+                spec_refs,
+                features,
+            },
+        ));
     }
 
     fn referenced_layer_names(&self) -> impl Iterator<Item = &str> {
         self.layers.iter().map(|layer| layer.name.as_str()).chain(
             self.layer_features
                 .iter()
-                .map(|layer_feature| layer_feature.layer_name.as_str()),
+                .map(|(_, layer_feature)| layer_feature.layer_name.as_str()),
         )
     }
 }
@@ -357,15 +360,6 @@ impl GeneratedLayer {
             polarity,
         }
     }
-}
-
-#[derive(Debug, Clone)]
-struct GeneratedLayerFeature {
-    scope: GeneratedFeatureScope,
-    layer_name: String,
-    polarity: Polarity,
-    spec_refs: Vec<String>,
-    features: Vec<SetFeature>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -398,7 +392,7 @@ pub fn execute_auto(input: &Path, output: &Path, sheet: Option<AutoSheetSize>) -
     Ok(())
 }
 
-fn print_copper_balance_summary(report: &balance::AutomaticBoardArrayCopperBalanceReport) {
+fn print_copper_balance_summary(report: &CopperBalanceReport) {
     for line in report.summary_lines() {
         eprintln!("  {line}");
     }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -293,6 +293,7 @@ impl BoardArrayPanelizationMode {
 struct BoardArrayGeneratedGeometry {
     layers: Vec<GeneratedLayer>,
     layer_features: Vec<(GeneratedFeatureScope, GeneratedLayerFeature)>,
+    user_entries: Vec<crate::copper_balance::BalanceVoidTemplate>,
 }
 
 impl BoardArrayGeneratedGeometry {
@@ -325,8 +326,39 @@ impl BoardArrayGeneratedGeometry {
                 polarity,
                 spec_refs,
                 features,
+                instance_refs: Vec::new(),
             },
         ));
+    }
+
+    /// Attach one balanced layer: its positive plane set, its negative
+    /// instance set, and the shared templates the instances reference.
+    fn add_balance_layer(
+        &mut self,
+        scope: GeneratedFeatureScope,
+        layer_name: &str,
+        sets: crate::copper_balance::BalanceFeatureSets,
+    ) {
+        self.add_layer_feature(scope, layer_name, Polarity::Positive, sets.positive);
+        self.layer_features.push((
+            scope,
+            GeneratedLayerFeature {
+                layer_name: layer_name.to_string(),
+                polarity: Polarity::Negative,
+                spec_refs: Vec::new(),
+                features: Vec::new(),
+                instance_refs: sets.instances,
+            },
+        ));
+        for template in sets.templates {
+            if !self
+                .user_entries
+                .iter()
+                .any(|entry| entry.id == template.id)
+            {
+                self.user_entries.push(template);
+            }
+        }
     }
 
     fn referenced_layer_names(&self) -> impl Iterator<Item = &str> {
@@ -599,17 +631,10 @@ fn write_balanced_board_array_xml(
     let copper_balance = balance.report();
 
     for layer in balance.layers {
-        spec.generated_geometry.add_layer_feature(
+        spec.generated_geometry.add_balance_layer(
             GeneratedFeatureScope::Array,
-            layer.layer_name.clone(),
-            Polarity::Positive,
-            layer.features.positive,
-        );
-        spec.generated_geometry.add_layer_feature(
-            GeneratedFeatureScope::Array,
-            layer.layer_name,
-            Polarity::Negative,
-            layer.features.negative,
+            &layer.layer_name,
+            layer.features,
         );
     }
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -263,7 +263,8 @@ fn board_array_creation_automatically_balances_every_copper_layer() {
         );
     }
     let xml = creation.xml;
-    assert!(!xml.contains(r#"<Set polarity="NEGATIVE">"#));
+    // Perforated balance planes carry their voids as a negative instance set.
+    assert!(xml.contains(r#"<Set polarity="NEGATIVE">"#));
     assert!(xml.matches("<Contour>").count() > 0);
 }
 
@@ -844,7 +845,7 @@ fn generated_array_geometry_writes_fiducials_and_nonplated_holes() {
 }
 
 #[test]
-fn explicit_copper_balance_region_round_trips_as_positive_panel_geometry() {
+fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     let input = board_fixture_with_top_line_mm();
     let ipc = Ipc2581::parse(input).unwrap();
     let options = BoardArrayCreateOptions {
@@ -888,35 +889,47 @@ fn explicit_copper_balance_region_round_trips_as_positive_panel_geometry() {
     .pop()
     .unwrap();
     let features = balance_features(&balance).unwrap();
+    let void_count = features.negative.len();
     spec.generated_geometry.add_layer_feature(
         GeneratedFeatureScope::Array,
         "TOP",
         Polarity::Positive,
-        features,
+        features.positive,
+    );
+    spec.generated_geometry.add_layer_feature(
+        GeneratedFeatureScope::Array,
+        "TOP",
+        Polarity::Negative,
+        features.negative,
     );
     assert!(matches!(
         balance.solution.mode,
         DenseCopperBalanceMode::Perforated { .. }
     ));
+    assert!(void_count > 0);
 
     let xml = write_board_array_xml(input, &spec).unwrap();
-    assert!(!xml.contains(r#"<Set polarity="NEGATIVE">"#));
+    assert!(xml.contains(r#"<Set polarity="NEGATIVE">"#));
 
     let parsed = Ipc2581::parse(&xml).unwrap();
     assert!(xml.matches("<Contour>").count() > 0);
 
     let top = geometry::extract_layer_for_view(&parsed, "TOP", View::ArrayFlattened).unwrap();
-    let paths = top
-        .features
-        .iter()
-        .filter(|feature| {
-            feature.source_step_kind == LayoutStepKind::Panel
-                && feature.kind == FeatureKind::Primitive
-        })
-        .flat_map(|feature| feature.paths.slice(&top.arena.paths))
-        .collect::<Vec<_>>();
-    let round_trip =
-        ContourSet::from_painted_paths(&top.arena, paths.iter().copied(), tol::REGION_MM);
+    let balance_paths = |polarity: pcb_ir::geom::Polarity| {
+        let paths = top
+            .features
+            .iter()
+            .filter(|feature| {
+                feature.source_step_kind == LayoutStepKind::Panel
+                    && feature.kind == FeatureKind::Primitive
+                    && feature.polarity == polarity
+            })
+            .flat_map(|feature| feature.paths.slice(&top.arena.paths))
+            .collect::<Vec<_>>();
+        ContourSet::from_painted_paths(&top.arena, paths, tol::REGION_MM)
+    };
+    let round_trip = balance_paths(pcb_ir::geom::Polarity::Dark)
+        .difference(&balance_paths(pcb_ir::geom::Polarity::Clear));
 
     assert!(!round_trip.is_empty());
     assert!(
@@ -935,6 +948,33 @@ fn explicit_copper_balance_region_round_trips_as_positive_panel_geometry() {
         .unwrap();
     assert!(top_gerber.contents.contains("G36*"));
     assert!(top_gerber.contents.contains("G37*"));
+    // The repeated voids share one outline-macro aperture flashed at clear
+    // polarity instead of re-describing each void.
+    assert!(top_gerber.contents.contains("%AMREPEAT0*"));
+    assert!(top_gerber.contents.contains("%LPC*%"));
+    // Groups below the sharing threshold legitimately stay regions.
+    assert!(top_gerber.contents.matches("D03*").count() >= void_count / 2);
+
+    // The composed Gerber image must match the composed IPC image.
+    let ipc_copper = crate::copper_balance::composed_copper_image(&parsed, "TOP").unwrap();
+    let gerber = gerberx2::GerberX2::parse(&top_gerber.contents).unwrap();
+    let mask =
+        pcb_ir::dialects::artwork::compose_to_mask(&gerberx2::geometry::extract_document(&gerber));
+    let mut rings = Vec::new();
+    for layer in &mask.layers {
+        for shape in mask.shapes(layer) {
+            rings.extend(pcb_ir::geom::region::rings_from_contours(
+                &mask.arena.path_contours(shape),
+            ));
+        }
+    }
+    let gerber_copper = ContourSet::new(rings, pcb_ir::geom::FillRule::NonZero, tol::REGION_MM);
+    assert!(
+        (gerber_copper.area() - ipc_copper.area()).abs() <= ipc_copper.area() * 1e-3,
+        "Gerber area {}, IPC area {}",
+        gerber_copper.area(),
+        ipc_copper.area()
+    );
 }
 
 #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -889,19 +889,9 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     .pop()
     .unwrap();
     let features = balance_features(&balance).unwrap();
-    let void_count = features.negative.len();
-    spec.generated_geometry.add_layer_feature(
-        GeneratedFeatureScope::Array,
-        "TOP",
-        Polarity::Positive,
-        features.positive,
-    );
-    spec.generated_geometry.add_layer_feature(
-        GeneratedFeatureScope::Array,
-        "TOP",
-        Polarity::Negative,
-        features.negative,
-    );
+    let void_count = features.instances.len();
+    spec.generated_geometry
+        .add_balance_layer(GeneratedFeatureScope::Array, "TOP", features);
     assert!(matches!(
         balance.solution.mode,
         DenseCopperBalanceMode::Perforated { .. }
@@ -913,6 +903,8 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
 
     let parsed = Ipc2581::parse(&xml).unwrap();
     assert!(xml.matches("<Contour>").count() > 0);
+    assert!(xml.matches("<EntryUser").count() > 0);
+    assert!(xml.matches("<UserPrimitiveRef").count() >= void_count);
 
     let top = geometry::extract_layer_for_view(&parsed, "TOP", View::ArrayFlattened).unwrap();
     let balance_paths = |polarity: pcb_ir::geom::Polarity| {

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -1,6 +1,6 @@
-use super::balance::{
-    balance_features, extract_array_support_layers, generate_automatic_board_array_copper_balance,
-};
+use crate::copper_balance::balance_features;
+
+use super::balance::{extract_array_support_layers, generate_automatic_board_array_copper_balance};
 use super::*;
 use crate::accessors::IpcAccessor;
 use crate::ipc2581::types::LayerFunction;
@@ -227,8 +227,8 @@ fn board_array_creation_automatically_balances_every_copper_layer() {
         .iter()
         .find(|layer| layer.layer_name == "BOTTOM")
         .unwrap();
-    assert!(top.board_target_density > 0.0);
-    assert_eq!(bottom.board_target_density, 0.0);
+    assert!(top.target_density > 0.0);
+    assert_eq!(bottom.target_density, 0.0);
     assert!(!top.features.is_empty());
     assert!(bottom.features.is_empty());
 
@@ -240,14 +240,10 @@ fn board_array_creation_automatically_balances_every_copper_layer() {
                 .intersection(&layer.existing_copper)
                 .is_empty()
         );
-        assert_eq!(
-            layer.result.solution.target_density,
-            layer.board_target_density
-        );
+        assert_eq!(layer.result.solution.target_density, layer.target_density);
         assert!(
             layer.result.solution.residual_error
-                <= (layer.result.solution.initial_density - layer.board_target_density).abs()
-                    + 1e-9
+                <= (layer.result.solution.initial_density - layer.target_density).abs() + 1e-9
         );
     }
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
@@ -84,6 +84,11 @@ pub(super) fn board_array_edits(
     }
 
     edits.push(doc.append_inside(cad_data, array_step_xml));
+    edits.extend(crate::generated::user_dictionary_edit(
+        doc,
+        spec.units,
+        &spec.generated_geometry.user_entries,
+    )?);
 
     Ok(edits)
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
@@ -5,10 +5,9 @@
 //! edits via [`ipc2581::edit`], leaving the rest of the file untouched.
 
 use super::*;
+use crate::generated::{GeneratedNameState, write_generated_layer_feature};
 use ipc2581::XmlWriter;
 use ipc2581::edit::{Doc, Edit};
-use ipc2581::types::ecad::FeatureUserPrimitive;
-use ipc2581::types::primitives::{UserPrimitive, UserShapeType};
 use ipc2581::write;
 use ipc2581::write::{fmt_num, fmt_units};
 
@@ -249,115 +248,14 @@ pub(super) fn write_generated_layer_features(
     scope: GeneratedFeatureScope,
 ) -> Result<()> {
     let mut names = GeneratedNameState::default();
-    for layer_feature in spec
+    for (_, layer_feature) in spec
         .generated_geometry
         .layer_features
         .iter()
-        .filter(|layer_feature| layer_feature.scope == scope)
+        .filter(|(feature_scope, _)| *feature_scope == scope)
     {
         write_generated_layer_feature(writer, spec.units, layer_feature, &mut names)?;
     }
-    Ok(())
-}
-
-pub(super) fn write_generated_layer_feature(
-    writer: &mut XmlWriter,
-    units: Units,
-    layer_feature: &GeneratedLayerFeature,
-    names: &mut GeneratedNameState,
-) -> Result<()> {
-    if layer_feature.features.is_empty() {
-        return Ok(());
-    }
-
-    writer.start_element(
-        "LayerFeature",
-        &[("layerRef", layer_feature.layer_name.as_str())],
-    );
-    writer.start_element(
-        "Set",
-        &[("polarity", write::polarity_attr(layer_feature.polarity))],
-    );
-    for spec_ref in &layer_feature.spec_refs {
-        write::spec_ref(writer, spec_ref);
-    }
-    write_set_features(writer, units, &layer_feature.features, names)?;
-    writer.end_element("Set");
-    writer.end_element("LayerFeature");
-    Ok(())
-}
-
-/// Sequential names for generated holes, unique within one Step.
-#[derive(Debug, Default)]
-pub(super) struct GeneratedNameState {
-    hole_index: usize,
-}
-
-impl GeneratedNameState {
-    fn next_hole_name(&mut self) -> String {
-        let name = format!("{GENERATED_HOLE_NAME_PREFIX}_{}", self.hole_index);
-        self.hole_index += 1;
-        name
-    }
-}
-
-pub(super) fn write_set_features(
-    writer: &mut XmlWriter,
-    units: Units,
-    features: &[SetFeature],
-    names: &mut GeneratedNameState,
-) -> Result<()> {
-    for feature in features {
-        match feature {
-            SetFeature::Line(line) => {
-                writer.start_element("Features", &[]);
-                write::line(writer, units, line)?;
-                writer.end_element("Features");
-            }
-            SetFeature::Polygon(polygon) => {
-                writer.start_element("Features", &[]);
-                writer.start_element("Contour", &[]);
-                write::polygon(writer, units, polygon);
-                writer.end_element("Contour");
-                writer.end_element("Features");
-            }
-            SetFeature::UserPrimitive(feature) => {
-                write_generated_user_primitive(writer, units, feature)?;
-            }
-            SetFeature::Fiducial(fiducial) => {
-                write::fiducial(writer, units, fiducial)?;
-            }
-            SetFeature::Hole(hole) => {
-                write::hole(writer, units, hole, &names.next_hole_name());
-            }
-            _ => bail!("generated board array layer feature has unsupported feature kind"),
-        }
-    }
-    Ok(())
-}
-
-fn write_generated_user_primitive(
-    writer: &mut XmlWriter,
-    units: Units,
-    feature: &FeatureUserPrimitive,
-) -> Result<()> {
-    let UserPrimitive::UserSpecial(user_special) = &feature.primitive;
-    let [shape] = user_special.shapes.as_slice() else {
-        bail!("generated board array user primitive must contain exactly one shape");
-    };
-    let UserShapeType::Contour(contour) = &shape.shape else {
-        bail!("generated board array user primitive must be a contour");
-    };
-    if shape.line_desc.is_some() || shape.line_desc_ref.is_some() || shape.fill_desc.is_some() {
-        bail!("generated board array contour cannot carry explicit style descriptors");
-    }
-
-    writer.start_element("Features", &[]);
-    if feature.x != 0.0 || feature.y != 0.0 {
-        write::location(writer, "Location", feature.x, feature.y, units);
-    }
-    write::contour(writer, units, contour);
-    writer.end_element("Features");
     Ok(())
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
@@ -1,0 +1,99 @@
+//! Automatic fab-panel copper balancing.
+//!
+//! The gutters between the placed assembly panels are the only balancing
+//! region: the reserved process margins stay bare, and every placed panel is
+//! immutable. The fabrication-panel step adds no per-layer geometry of its
+//! own, so one certified safe region serves the whole copper stack.
+
+use anyhow::{Context, Result, bail};
+use pcb_ir::dialects::ipc::{
+    BalancingRegionOptions, board_array_balancing_region, collect_fab_panel_balancing_input,
+};
+use pcb_ir::geom::{BBox, ContourSet, tol};
+
+use crate::copper_balance::{
+    CERTIFICATE_AREA_TOLERANCE_MM2, CopperBalancePlan, PreparedCopperLayer, composed_copper_image,
+    physical_copper_stack_weights, solve_copper_balance,
+};
+use crate::geometry;
+use crate::ipc2581::Ipc2581;
+
+/// Plan best-effort copper balancing for every copper layer of a fabrication
+/// panel.
+///
+/// Each layer targets the aggregate copper density measured inside the placed
+/// assembly panels, extending their already-balanced density into the gutters
+/// between them. `ipc` must describe the completed, not-yet-balanced
+/// fabrication panel, and `usable` the stock region between the reserved
+/// process margins; the margins never enter the density domain and stay bare.
+pub(super) fn generate_automatic_fab_panel_copper_balance(
+    ipc: &Ipc2581,
+    usable: BBox,
+) -> Result<CopperBalancePlan> {
+    let layout = geometry::extract_layout(ipc)
+        .context("failed to extract fabrication-panel layout for copper balancing")?;
+    // V-scores and profile cutouts all lie inside the placed assembly panels,
+    // so the fabrication profile needs no relief geometry here.
+    let fabrication_profile = geometry::board_array_fabrication_profile(ipc, &layout, &[])
+        .context("failed to derive fabrication-panel profile for copper balancing")?;
+    let usable_region = ContourSet::rectangle(usable, tol::REGION_MM);
+    let mut input = collect_fab_panel_balancing_input(usable_region.clone(), &fabrication_profile)
+        .context("failed to collect fabrication-panel balancing obstacles")?;
+    let footprints = input.board_footprints.clone();
+    let footprint_area_mm2 = footprints.area();
+
+    let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
+    let copper_images = crate::layers::copper_layers(ecad)
+        .iter()
+        .map(|layer| {
+            let layer_name = ipc.resolve(layer.name).to_string();
+            let image = composed_copper_image(ipc, &layer_name)?.intersection(&usable_region);
+            Ok((layer_name, image))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    // Copper found outside the placed panels joins the shared obstacle set,
+    // so unexpected overhang shrinks the certified safe region for every
+    // layer instead of failing the solve.
+    for (_, image) in &copper_images {
+        input.support_features = input.support_features.union(&image.difference(&footprints));
+    }
+
+    let balancing_region = board_array_balancing_region(&input, BalancingRegionOptions::default())
+        .context("failed to compute fabrication-panel balancing region")?;
+    if !balancing_region
+        .certificate
+        .passes(CERTIFICATE_AREA_TOLERANCE_MM2)
+    {
+        bail!("computed fabrication-panel balancing region failed clearance certification");
+    }
+    let safe_region = balancing_region.safe_region;
+
+    let stack_weights = physical_copper_stack_weights(ipc);
+    let stack_weights_available = stack_weights.is_some();
+    let prepared = copper_images
+        .into_iter()
+        .map(|(layer_name, existing_copper)| {
+            let target_density = (existing_copper.intersection(&footprints).area()
+                / footprint_area_mm2)
+                .clamp(0.0, 1.0);
+            let stack_weight_mm2 = stack_weights
+                .as_ref()
+                .and_then(|weights| weights.get(&layer_name).copied())
+                .unwrap_or(0.0);
+            PreparedCopperLayer {
+                layer_name,
+                target_density,
+                stack_weight_mm2,
+                existing_copper,
+                safe_region: safe_region.clone(),
+            }
+        })
+        .collect();
+
+    solve_copper_balance(
+        &usable_region,
+        footprints,
+        stack_weights_available,
+        prepared,
+    )
+}

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
@@ -43,14 +43,31 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
     let footprint_area_mm2 = footprints.area();
 
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
-    let copper_images = crate::layers::copper_layers(ecad)
+    let layer_names = crate::layers::copper_layers(ecad)
         .iter()
-        .map(|layer| {
-            let layer_name = ipc.resolve(layer.name).to_string();
-            let image = composed_copper_image(ipc, &layer_name)?.intersection(&usable_region);
-            Ok((layer_name, image))
-        })
-        .collect::<Result<Vec<_>>>()?;
+        .map(|layer| ipc.resolve(layer.name).to_string())
+        .collect::<Vec<_>>();
+    let copper_images = std::thread::scope(|scope| {
+        let extractions = layer_names
+            .iter()
+            .map(|layer_name| {
+                scope.spawn(|| {
+                    composed_copper_image(ipc, layer_name)
+                        .map(|image| image.intersection(&usable_region))
+                })
+            })
+            .collect::<Vec<_>>();
+        layer_names
+            .iter()
+            .zip(extractions)
+            .map(|(layer_name, extraction)| {
+                let image = extraction
+                    .join()
+                    .expect("copper-image extraction panicked")?;
+                Ok((layer_name.clone(), image))
+            })
+            .collect::<Result<Vec<_>>>()
+    })?;
     // Copper found outside the placed panels joins the shared obstacle set,
     // so unexpected overhang shrinks the certified safe region for every
     // layer instead of failing the solve.

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -244,6 +244,31 @@ fn create_fab_panel(
         bail!("at least one assembly panel is required");
     }
 
+    // Reduce every source to manufacturing content once, up front: assembling
+    // already-stripped sources keeps the fabrication panel a pure composition
+    // and avoids stripping the much larger composed document.
+    let source_xml = std::thread::scope(|scope| {
+        let strips = source_xml
+            .iter()
+            .map(|xml| scope.spawn(|| super::fabrication::strip_non_manufacturing(xml)))
+            .collect::<Vec<_>>();
+        strips
+            .into_iter()
+            .enumerate()
+            .map(|(source_index, strip)| {
+                strip
+                    .join()
+                    .expect("assembly panel stripping panicked")
+                    .with_context(|| {
+                        format!(
+                            "failed to reduce assembly panel input {} to manufacturing content",
+                            source_index + 1
+                        )
+                    })
+            })
+            .collect::<Result<Vec<_>>>()
+    })?;
+
     let stackups = source_xml
         .iter()
         .enumerate()
@@ -294,7 +319,9 @@ fn create_fab_panel(
 
     // The provisional panel only feeds copper-balance planning: gutters and
     // placed-panel copper must exist before balance copper can be derived.
-    let provisional = xml::write_fab_panel_xml(
+    // Parsing it below already validates it, so it skips the final document's
+    // reformat and schema-validation passes.
+    let provisional = xml::render_fab_panel_xml(
         &sources,
         occurrences,
         &placements,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -5,14 +5,17 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use ipc2581::Ipc2581;
 use ipc2581::edit::{Doc, Node};
-use ipc2581::types::{Spec, Units};
+use ipc2581::types::{Spec, Units, ecad::Polarity};
 use pcb_ir::dialects::ipc::{LayoutStepKind, root_step};
 use pcb_ir::geom::{BBox, Point};
 
 use super::EdgeInsetsMm;
+use crate::copper_balance::CopperBalanceReport;
+use crate::generated::GeneratedLayerFeature;
 use crate::geometry;
 use crate::utils::file as file_utils;
 
+mod balance;
 mod packing;
 mod xml;
 
@@ -174,6 +177,14 @@ struct SurfaceFinishSignature {
     products: Vec<(String, Option<String>)>,
 }
 
+/// Generated fabrication-panel IPC plus compact per-layer copper-balance
+/// accounting.
+#[derive(Debug, Clone)]
+pub struct FabPanelCreation {
+    pub xml: String,
+    pub copper_balance: CopperBalanceReport,
+}
+
 pub fn execute(inputs: &[PathBuf], output: &Path, spec: FabPanelSpec) -> Result<()> {
     if inputs.is_empty() {
         bail!("at least one assembly panel IPC-2581 file is required");
@@ -202,12 +213,15 @@ pub fn execute(inputs: &[PathBuf], output: &Path, spec: FabPanelSpec) -> Result<
         occurrences.push(source_index);
     }
 
-    let generated = create_fab_panel_xml_with_spec(&source_xml, &occurrences, spec)?;
+    let creation = create_fab_panel(&source_xml, &occurrences, spec)?;
+    for line in creation.copper_balance.summary_lines() {
+        eprintln!("  {line}");
+    }
     if output.as_os_str() == "-" {
-        io::stdout().lock().write_all(generated.as_bytes())?;
+        io::stdout().lock().write_all(creation.xml.as_bytes())?;
         eprintln!("✓ Created IPC-2581 fabrication panel on stdout");
     } else {
-        file_utils::save_ipc_file(output, &generated)?;
+        file_utils::save_ipc_file(output, &creation.xml)?;
         eprintln!(
             "✓ Created IPC-2581 fabrication panel at {}",
             output.display()
@@ -218,14 +232,14 @@ pub fn execute(inputs: &[PathBuf], output: &Path, spec: FabPanelSpec) -> Result<
 
 #[cfg(test)]
 fn create_fab_panel_xml(source_xml: &[String], occurrences: &[usize]) -> Result<String> {
-    create_fab_panel_xml_with_spec(source_xml, occurrences, FabPanelSpec::default())
+    create_fab_panel(source_xml, occurrences, FabPanelSpec::default()).map(|creation| creation.xml)
 }
 
-fn create_fab_panel_xml_with_spec(
+fn create_fab_panel(
     source_xml: &[String],
     occurrences: &[usize],
     spec: FabPanelSpec,
-) -> Result<String> {
+) -> Result<FabPanelCreation> {
     if occurrences.is_empty() {
         bail!("at least one assembly panel is required");
     }
@@ -278,13 +292,44 @@ fn create_fab_panel_xml_with_spec(
         .collect::<Result<Vec<_>>>()?;
     let placements = pack(&items, spec.usable_size()?, spacing_um(spec.panel_gap_mm)?)?;
 
-    xml::write_fab_panel_xml(
+    // The provisional panel only feeds copper-balance planning: gutters and
+    // placed-panel copper must exist before balance copper can be derived.
+    let provisional = xml::write_fab_panel_xml(
         &sources,
         occurrences,
         &placements,
         &shared_stackup_layers,
         spec,
-    )
+        &[],
+    )?;
+    let parsed = Ipc2581::parse(&provisional)
+        .context("Failed to parse provisional IPC-2581 fabrication panel")?;
+    let balance =
+        balance::generate_automatic_fab_panel_copper_balance(&parsed, spec.usable_bbox()?)?;
+    let copper_balance = balance.report();
+    let balance_features = balance
+        .layers
+        .into_iter()
+        .map(|layer| GeneratedLayerFeature {
+            layer_name: layer.layer_name,
+            polarity: Polarity::Positive,
+            spec_refs: Vec::new(),
+            features: layer.features,
+        })
+        .collect::<Vec<_>>();
+
+    let xml = xml::write_fab_panel_xml(
+        &sources,
+        occurrences,
+        &placements,
+        &shared_stackup_layers,
+        spec,
+        &balance_features,
+    )?;
+    Ok(FabPanelCreation {
+        xml,
+        copper_balance,
+    })
 }
 
 fn prepare_source_panel(

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -327,42 +327,51 @@ fn create_fab_panel(
         &placements,
         &shared_stackup_layers,
         spec,
-        &[],
     )?;
     let parsed = Ipc2581::parse(&provisional)
         .context("Failed to parse provisional IPC-2581 fabrication panel")?;
     let balance =
         balance::generate_automatic_fab_panel_copper_balance(&parsed, spec.usable_bbox()?)?;
     let copper_balance = balance.report();
+    let mut templates = Vec::new();
     let balance_features = balance
         .layers
         .into_iter()
         .flat_map(|layer| {
+            for template in layer.features.templates {
+                if !templates
+                    .iter()
+                    .any(|entry: &crate::copper_balance::BalanceVoidTemplate| {
+                        entry.id == template.id
+                    })
+                {
+                    templates.push(template);
+                }
+            }
             [
                 GeneratedLayerFeature {
                     layer_name: layer.layer_name.clone(),
                     polarity: Polarity::Positive,
                     spec_refs: Vec::new(),
                     features: layer.features.positive,
+                    instance_refs: Vec::new(),
                 },
                 GeneratedLayerFeature {
                     layer_name: layer.layer_name,
                     polarity: Polarity::Negative,
                     spec_refs: Vec::new(),
-                    features: layer.features.negative,
+                    features: Vec::new(),
+                    instance_refs: layer.features.instances,
                 },
             ]
         })
         .collect::<Vec<_>>();
 
-    let xml = xml::write_fab_panel_xml(
-        &sources,
-        occurrences,
-        &placements,
-        &shared_stackup_layers,
-        spec,
-        &balance_features,
-    )?;
+    let units = sources
+        .first()
+        .context("at least one assembly panel source is required")?
+        .units;
+    let xml = xml::write_fab_panel_xml(&provisional, units, &balance_features, &templates)?;
     Ok(FabPanelCreation {
         xml,
         copper_balance,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -337,11 +337,21 @@ fn create_fab_panel(
     let balance_features = balance
         .layers
         .into_iter()
-        .map(|layer| GeneratedLayerFeature {
-            layer_name: layer.layer_name,
-            polarity: Polarity::Positive,
-            spec_refs: Vec::new(),
-            features: layer.features,
+        .flat_map(|layer| {
+            [
+                GeneratedLayerFeature {
+                    layer_name: layer.layer_name.clone(),
+                    polarity: Polarity::Positive,
+                    spec_refs: Vec::new(),
+                    features: layer.features.positive,
+                },
+                GeneratedLayerFeature {
+                    layer_name: layer.layer_name,
+                    polarity: Polarity::Negative,
+                    spec_refs: Vec::new(),
+                    features: layer.features.negative,
+                },
+            ]
         })
         .collect::<Vec<_>>();
 

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -750,6 +750,7 @@ fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
         "both sources plus the fab step's positive and negative balance sets should carry TOP copper"
     );
 
+    Ipc2581::validate(&creation.xml).unwrap();
     let parsed = Ipc2581::parse(&creation.xml).unwrap();
     let layout = geometry::extract_layout(&parsed).unwrap();
     // The 200 mm panel exceeds the 120 mm usable width, so packing must

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -1,6 +1,8 @@
 use ipc2581::edit::Doc;
 use pcb_ir::dialects::ipc::{View, root_step};
-use pcb_ir::geom::BBox;
+use pcb_ir::geom::{BBox, ContourSet, tol};
+
+use crate::copper_balance::{CopperBalanceMode, composed_copper_image};
 
 use super::*;
 
@@ -457,7 +459,7 @@ fn creates_supported_standard_fabrication_panel_sizes() {
         (FabPanelSpec::INCHES_18_X_24, 406.4, 508.0),
         (FabPanelSpec::INCHES_21_X_24, 482.6, 508.0),
     ] {
-        let generated = create_fab_panel_xml_with_spec(&sources, &[0], spec).unwrap();
+        let generated = create_fab_panel(&sources, &[0], spec).unwrap().xml;
         Ipc2581::validate(&generated).unwrap();
         let parsed = Ipc2581::parse(&generated).unwrap();
         let layout = geometry::extract_layout(&parsed).unwrap();
@@ -497,8 +499,9 @@ fn applies_asymmetric_process_margin_and_gap_overrides() {
         panel_gap_mm: 7.0,
         ..FabPanelSpec::INCHES_12_X_18
     };
-    let generated =
-        create_fab_panel_xml_with_spec(&[assembly_panel_xml(100.0, 80.0)], &[0], spec).unwrap();
+    let generated = create_fab_panel(&[assembly_panel_xml(100.0, 80.0)], &[0], spec)
+        .unwrap()
+        .xml;
     let parsed = Ipc2581::parse(&generated).unwrap();
     let layout = geometry::extract_layout(&parsed).unwrap();
     let instance = layout
@@ -532,13 +535,13 @@ fn accepts_subtool_spacing_and_rejects_invalid_fabrication_panel_domains() {
         panel_gap_mm: 0.5,
         ..FabPanelSpec::INCHES_18_X_24
     };
-    create_fab_panel_xml_with_spec(&sources, &[0], subtool_spacing).unwrap();
+    create_fab_panel(&sources, &[0], subtool_spacing).unwrap();
 
     let negative_margin = FabPanelSpec {
         edge_margin_mm: EdgeInsetsMm::new(50.8, 25.4, 50.8, -0.5),
         ..FabPanelSpec::INCHES_18_X_24
     };
-    let error = create_fab_panel_xml_with_spec(&sources, &[0], negative_margin).unwrap_err();
+    let error = create_fab_panel(&sources, &[0], negative_margin).unwrap_err();
     assert!(
         error
             .to_string()
@@ -549,7 +552,7 @@ fn accepts_subtool_spacing_and_rejects_invalid_fabrication_panel_domains() {
         panel_gap_mm: -0.5,
         ..FabPanelSpec::INCHES_18_X_24
     };
-    let error = create_fab_panel_xml_with_spec(&sources, &[0], negative_gap).unwrap_err();
+    let error = create_fab_panel(&sources, &[0], negative_gap).unwrap_err();
     assert!(
         error
             .to_string()
@@ -560,7 +563,7 @@ fn accepts_subtool_spacing_and_rejects_invalid_fabrication_panel_domains() {
         edge_margin_mm: EdgeInsetsMm::new(50.8, 250.0, 50.8, 250.0),
         ..FabPanelSpec::INCHES_18_X_24
     };
-    let error = create_fab_panel_xml_with_spec(&sources, &[0], no_usable_width).unwrap_err();
+    let error = create_fab_panel(&sources, &[0], no_usable_width).unwrap_err();
     assert!(
         error
             .to_string()
@@ -678,4 +681,137 @@ fn rejects_a_board_instead_of_an_assembly_panel() {
     );
     let error = create_fab_panel_xml(&[board], &[0]).unwrap_err();
     assert!(error.to_string().contains("expected a board array"));
+}
+
+/// A compact stock so balance tests solve quickly: 120 x 220 mm usable.
+const BALANCE_SPEC: FabPanelSpec = FabPanelSpec {
+    width_mm: 150.0,
+    height_mm: 250.0,
+    edge_margin_mm: EdgeInsetsMm::all(15.0),
+    panel_gap_mm: 5.0,
+};
+
+/// An assembly panel whose left half carries solid copper, inset 1 mm so the
+/// copper stays strictly inside the rounded panel outline.
+fn dense_assembly_panel_xml(width_mm: f64, height_mm: f64) -> String {
+    let copper_max_x = width_mm / 2.0;
+    let copper_max_y = height_mm - 1.0;
+    let sparse = assembly_panel_xml(width_mm, height_mm);
+    let dense = sparse.replace(
+        &format!(
+            r#"<Line startX="0" startY="0" endX="{width_mm}" endY="0">
+                <LineDesc lineWidth="0.1" lineEnd="ROUND"/>
+              </Line>"#
+        ),
+        &format!(
+            r#"<Contour>
+                <Polygon>
+                  <PolyBegin x="1" y="1"/>
+                  <PolyStepSegment x="{copper_max_x}" y="1"/>
+                  <PolyStepSegment x="{copper_max_x}" y="{copper_max_y}"/>
+                  <PolyStepSegment x="1" y="{copper_max_y}"/>
+                  <PolyStepSegment x="1" y="1"/>
+                </Polygon>
+              </Contour>"#
+        ),
+    );
+    assert!(dense.contains("<Contour>"), "copper fixture replace failed");
+    dense
+}
+
+#[test]
+fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
+    let sources = vec![
+        dense_assembly_panel_xml(200.0, 80.0),
+        dense_assembly_panel_xml(30.0, 25.0),
+    ];
+    let creation = create_fab_panel(&sources, &[0, 1], BALANCE_SPEC).unwrap();
+
+    let report = &creation.copper_balance;
+    assert!(report.stack_weights_available);
+    assert_eq!(report.layers.len(), 1);
+    let layer = &report.layers[0];
+    assert_eq!(layer.layer_name, "TOP");
+    assert_eq!(layer.mode, CopperBalanceMode::Perforated);
+    assert!(layer.void_count > 0);
+    assert!((0.4..0.55).contains(&layer.target_density));
+    assert!(
+        layer.residual_error <= 5e-3,
+        "gutter fill should reach the panel density: target {:.4}, achieved {:.4}",
+        layer.target_density,
+        layer.achieved_density
+    );
+    assert_eq!(
+        creation
+            .xml
+            .matches(r#"<LayerFeature layerRef="TOP">"#)
+            .count(),
+        3,
+        "both sources plus the fab step should carry TOP copper"
+    );
+
+    let parsed = Ipc2581::parse(&creation.xml).unwrap();
+    let layout = geometry::extract_layout(&parsed).unwrap();
+    // The 200 mm panel exceeds the 120 mm usable width, so packing must
+    // rotate it; balancing has to respect the rotated footprint.
+    assert!(
+        layout
+            .layout
+            .instances
+            .iter()
+            .filter(|instance| instance.parent_instance.is_none())
+            .any(|instance| (instance.bbox.width() - 80.0).abs() < 1e-6
+                && (instance.bbox.height() - 200.0).abs() < 1e-6)
+    );
+
+    let profile = geometry::board_array_fabrication_profile(&parsed, &layout, &[]).unwrap();
+    let panel_contours = profile
+        .assembly_panel_outlines
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    let footprints = ContourSet::from_filled_contours(&panel_contours, tol::REGION_MM);
+    let usable = ContourSet::rectangle(BALANCE_SPEC.usable_bbox().unwrap(), tol::REGION_MM);
+    let copper = composed_copper_image(&parsed, "TOP").unwrap();
+    let gutter_copper = copper.difference(&footprints);
+
+    assert!(
+        copper.difference(&usable).area() <= 1e-6,
+        "process margins must stay bare"
+    );
+    assert!(
+        gutter_copper.area() > 3_000.0,
+        "expected substantial generated gutter copper, got {:.1} mm²",
+        gutter_copper.area()
+    );
+    assert!(
+        gutter_copper
+            .intersection(&footprints.disk_dilate(0.4))
+            .area()
+            <= 1e-6,
+        "generated copper must keep clearance from the placed panels"
+    );
+    assert!(
+        gutter_copper.difference(&usable.disk_erode(0.4)).area() <= 1e-6,
+        "generated copper must keep clearance from the usable-area boundary"
+    );
+}
+
+#[test]
+fn single_panel_filling_the_usable_area_generates_no_fill() {
+    let sources = vec![dense_assembly_panel_xml(120.0, 220.0)];
+    let creation = create_fab_panel(&sources, &[0], BALANCE_SPEC).unwrap();
+
+    let layer = &creation.copper_balance.layers[0];
+    assert_eq!(layer.mode, CopperBalanceMode::None);
+    assert_eq!(layer.generated_area_mm2, 0.0);
+    assert_eq!(
+        creation
+            .xml
+            .matches(r#"<LayerFeature layerRef="TOP">"#)
+            .count(),
+        1,
+        "a fully covered usable area leaves no room for balance copper"
+    );
 }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -746,8 +746,8 @@ fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
             .xml
             .matches(r#"<LayerFeature layerRef="TOP">"#)
             .count(),
-        3,
-        "both sources plus the fab step should carry TOP copper"
+        4,
+        "both sources plus the fab step's positive and negative balance sets should carry TOP copper"
     );
 
     let parsed = Ipc2581::parse(&creation.xml).unwrap();

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
@@ -254,6 +254,8 @@ pub(super) fn write_fab_panel_xml(
         edit::apply(provisional, edits)?
     };
     let xml = crate::utils::format::reformat_xml(&xml)?;
+    Ipc2581::validate(&xml)
+        .context("Generated IPC-2581 fabrication panel XML failed schema validation")?;
     Ipc2581::parse(&xml).context("Generated IPC-2581 fabrication panel XML did not parse")?;
     Ok(xml)
 }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
@@ -176,7 +176,10 @@ fn should_namespace_attr(
     }
 }
 
-pub(super) fn write_fab_panel_xml(
+/// Render the fabrication-panel document from already-stripped sources. The
+/// provisional balancing pass consumes this directly; only the final document
+/// pays for reformatting via [`write_fab_panel_xml`].
+pub(super) fn render_fab_panel_xml(
     sources: &[SourcePanel],
     occurrences: &[usize],
     placements: &[Placement],
@@ -215,10 +218,26 @@ pub(super) fn write_fab_panel_xml(
     )?;
     writer.end_element("IPC-2581");
 
-    let xml = super::super::fabrication::strip_non_manufacturing(&writer.into_string())?;
+    Ok(writer.into_string())
+}
+
+pub(super) fn write_fab_panel_xml(
+    sources: &[SourcePanel],
+    occurrences: &[usize],
+    placements: &[Placement],
+    shared_stackup_layers: &HashSet<String>,
+    spec: FabPanelSpec,
+    balance_features: &[GeneratedLayerFeature],
+) -> Result<String> {
+    let xml = render_fab_panel_xml(
+        sources,
+        occurrences,
+        placements,
+        shared_stackup_layers,
+        spec,
+        balance_features,
+    )?;
     let xml = crate::utils::format::reformat_xml(&xml)?;
-    Ipc2581::validate(&xml)
-        .context("Generated IPC-2581 fabrication panel XML failed schema validation")?;
     Ipc2581::parse(&xml).context("Generated IPC-2581 fabrication panel XML did not parse")?;
     Ok(xml)
 }
@@ -228,8 +247,15 @@ fn write_content(
     docs: &[Doc<'_>],
     shared_stackup_layers: &HashSet<String>,
 ) -> Result<()> {
+    let section_key = super::super::fabrication::fabrication_section_key_union(docs);
     writer.start_element("Content", &[("roleRef", FAB_ROLE_ID)]);
-    writer.empty_element("FunctionMode", &[("mode", "FABRICATION")]);
+    writer.empty_element(
+        "FunctionMode",
+        &[
+            ("mode", "FABRICATION"),
+            ("sectionKey", section_key.as_str()),
+        ],
+    );
     writer.empty_element("StepRef", &[("name", FAB_PANEL_STEP_NAME)]);
 
     for (doc_index, doc) in docs.iter().enumerate() {

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
@@ -185,7 +185,6 @@ pub(super) fn render_fab_panel_xml(
     placements: &[Placement],
     shared_stackup_layers: &HashSet<String>,
     spec: FabPanelSpec,
-    balance_features: &[GeneratedLayerFeature],
 ) -> Result<String> {
     let docs = sources
         .iter()
@@ -214,29 +213,46 @@ pub(super) fn render_fab_panel_xml(
         placements,
         shared_stackup_layers,
         spec,
-        balance_features,
     )?;
     writer.end_element("IPC-2581");
 
     Ok(writer.into_string())
 }
 
+/// Finalize the provisional document: splice the balance layer features into
+/// the fabrication-panel step, then reformat and re-parse. Splicing avoids a
+/// second full composition of the source documents.
 pub(super) fn write_fab_panel_xml(
-    sources: &[SourcePanel],
-    occurrences: &[usize],
-    placements: &[Placement],
-    shared_stackup_layers: &HashSet<String>,
-    spec: FabPanelSpec,
+    provisional: &str,
+    units: Units,
     balance_features: &[GeneratedLayerFeature],
+    templates: &[crate::copper_balance::BalanceVoidTemplate],
 ) -> Result<String> {
-    let xml = render_fab_panel_xml(
-        sources,
-        occurrences,
-        placements,
-        shared_stackup_layers,
-        spec,
-        balance_features,
-    )?;
+    let mut features_xml = XmlWriter::new();
+    let mut names = GeneratedNameState::default();
+    for layer_feature in balance_features {
+        write_generated_layer_feature(&mut features_xml, units, layer_feature, &mut names)?;
+    }
+    let features_xml = features_xml.into_string();
+
+    let xml = if features_xml.is_empty() && templates.is_empty() {
+        provisional.to_string()
+    } else {
+        let doc = Doc::parse(provisional)?;
+        let mut edits = Vec::new();
+        if !features_xml.is_empty() {
+            let fab_step = doc
+                .find_all("Step")
+                .into_iter()
+                .find(|step| doc.attr(*step, "name") == Some(FAB_PANEL_STEP_NAME))
+                .context("provisional fabrication panel has no fab step")?;
+            edits.push(doc.append_inside(fab_step, features_xml));
+        }
+        edits.extend(crate::generated::user_dictionary_edit(
+            &doc, units, templates,
+        )?);
+        edit::apply(provisional, edits)?
+    };
     let xml = crate::utils::format::reformat_xml(&xml)?;
     Ipc2581::parse(&xml).context("Generated IPC-2581 fabrication panel XML did not parse")?;
     Ok(xml)
@@ -386,7 +402,6 @@ fn write_history_record(writer: &mut XmlWriter) {
     writer.end_element("HistoryRecord");
 }
 
-#[expect(clippy::too_many_arguments)]
 fn write_ecad(
     writer: &mut XmlWriter,
     sources: &[SourcePanel],
@@ -395,7 +410,6 @@ fn write_ecad(
     placements: &[Placement],
     shared_stackup_layers: &HashSet<String>,
     spec: FabPanelSpec,
-    balance_features: &[GeneratedLayerFeature],
 ) -> Result<()> {
     let units = sources
         .first()
@@ -437,15 +451,7 @@ fn write_ecad(
             writer.raw(doc.source(step));
         }
     }
-    write_fab_step(
-        writer,
-        sources,
-        occurrences,
-        placements,
-        units,
-        spec,
-        balance_features,
-    )?;
+    write_fab_step(writer, sources, occurrences, placements, units, spec)?;
     writer.end_element("CadData");
     writer.end_element("Ecad");
     Ok(())
@@ -458,7 +464,6 @@ fn write_fab_step(
     placements: &[Placement],
     units: Units,
     spec: FabPanelSpec,
-    balance_features: &[GeneratedLayerFeature],
 ) -> Result<()> {
     let usable = spec.usable_bbox()?;
     writer.start_element("Step", &[("name", FAB_PANEL_STEP_NAME), ("type", "PALLET")]);
@@ -570,10 +575,6 @@ fn write_fab_step(
                 ("mirror", "false"),
             ],
         );
-    }
-    let mut names = GeneratedNameState::default();
-    for layer_feature in balance_features {
-        write_generated_layer_feature(writer, units, layer_feature, &mut names)?;
     }
     writer.end_element("Step");
     Ok(())

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
@@ -7,6 +7,7 @@ use ipc2581::{Ipc2581, XmlWriter};
 
 use super::{FabPanelSpec, SourcePanel};
 use crate::commands::fab_panel::packing::Placement;
+use crate::generated::{GeneratedLayerFeature, GeneratedNameState, write_generated_layer_feature};
 use crate::steps::FAB_PANEL_STEP_NAME;
 
 const FAB_ROLE_ID: &str = "fab_panel_role";
@@ -181,6 +182,7 @@ pub(super) fn write_fab_panel_xml(
     placements: &[Placement],
     shared_stackup_layers: &HashSet<String>,
     spec: FabPanelSpec,
+    balance_features: &[GeneratedLayerFeature],
 ) -> Result<String> {
     let docs = sources
         .iter()
@@ -209,6 +211,7 @@ pub(super) fn write_fab_panel_xml(
         placements,
         shared_stackup_layers,
         spec,
+        balance_features,
     )?;
     writer.end_element("IPC-2581");
 
@@ -357,6 +360,7 @@ fn write_history_record(writer: &mut XmlWriter) {
     writer.end_element("HistoryRecord");
 }
 
+#[expect(clippy::too_many_arguments)]
 fn write_ecad(
     writer: &mut XmlWriter,
     sources: &[SourcePanel],
@@ -365,6 +369,7 @@ fn write_ecad(
     placements: &[Placement],
     shared_stackup_layers: &HashSet<String>,
     spec: FabPanelSpec,
+    balance_features: &[GeneratedLayerFeature],
 ) -> Result<()> {
     let units = sources
         .first()
@@ -406,7 +411,15 @@ fn write_ecad(
             writer.raw(doc.source(step));
         }
     }
-    write_fab_step(writer, sources, occurrences, placements, units, spec)?;
+    write_fab_step(
+        writer,
+        sources,
+        occurrences,
+        placements,
+        units,
+        spec,
+        balance_features,
+    )?;
     writer.end_element("CadData");
     writer.end_element("Ecad");
     Ok(())
@@ -419,6 +432,7 @@ fn write_fab_step(
     placements: &[Placement],
     units: Units,
     spec: FabPanelSpec,
+    balance_features: &[GeneratedLayerFeature],
 ) -> Result<()> {
     let usable = spec.usable_bbox()?;
     writer.start_element("Step", &[("name", FAB_PANEL_STEP_NAME), ("type", "PALLET")]);
@@ -530,6 +544,10 @@ fn write_fab_step(
                 ("mirror", "false"),
             ],
         );
+    }
+    let mut names = GeneratedNameState::default();
+    for layer_feature in balance_features {
+        write_generated_layer_feature(writer, units, layer_feature, &mut names)?;
     }
     writer.end_element("Step");
     Ok(())

--- a/crates/pcb-ipc2581-tools/src/commands/fabrication.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fabrication.rs
@@ -406,8 +406,26 @@ fn rewrite_function_mode(xml: &str) -> Result<String> {
 }
 
 fn fabrication_section_key(xml: &str) -> Result<String> {
-    let doc = Doc::parse(xml)?;
+    Ok(fabrication_section_key_union(std::slice::from_ref(
+        &Doc::parse(xml)?,
+    )))
+}
+
+/// The IPC-2581 fabrication `sectionKey` implied by the union of the given
+/// documents' physical content. Element presence is monotone under document
+/// composition, so a composed document's key is the union of its sources'.
+pub(crate) fn fabrication_section_key_union(docs: &[Doc<'_>]) -> String {
     let mut keys = HashSet::new();
+    for doc in docs {
+        collect_section_keys(doc, &mut keys);
+    }
+    "KSUMLRDOIEFY"
+        .chars()
+        .filter(|key| keys.contains(key))
+        .collect()
+}
+
+fn collect_section_keys(doc: &Doc<'_>, keys: &mut HashSet<char>) {
     if !doc.find_all("PadStackDef").is_empty() {
         keys.insert('K');
     }
@@ -469,11 +487,6 @@ fn fabrication_section_key(xml: &str) -> Result<String> {
             _ => {}
         }
     }
-
-    Ok("KSUMLRDOIEFY"
-        .chars()
-        .filter(|key| keys.contains(key))
-        .collect())
 }
 
 fn is_manufacturing_layer(function: &str) -> bool {

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -20,9 +20,8 @@ use pcb_ir::geom::copper_balance::{
     SpatialCopperBalanceLayerRequest, SpatialCopperBalanceRequest,
     generate_spatial_dense_copper_balance, rounded_hexagonal_void,
 };
-use pcb_ir::geom::path::transform_cmds;
 use pcb_ir::geom::region::simplify_shapes;
-use pcb_ir::geom::{Affine2, ContourBuf, ContourSet, FillRule, PathOp, Point, tol};
+use pcb_ir::geom::{ContourBuf, ContourSet, FillRule, PathOp, Point, tol};
 use serde::Serialize;
 
 use crate::geometry;
@@ -44,6 +43,25 @@ pub struct PreparedCopperLayer {
     pub safe_region: ContourSet,
 }
 
+/// Generated IPC features for one balanced layer, split by polarity.
+///
+/// The perforated plane is a positive set covering the whole usable region
+/// (partial edge voids stay cut into its contours), while every full interior
+/// void is a translated instance of one rounded-hex template in a negative
+/// set. Keeping the voids as explicit repeated instances lets downstream
+/// lowerings share their geometry instead of re-describing each void.
+#[derive(Debug, Clone, Default)]
+pub struct BalanceFeatureSets {
+    pub positive: Vec<SetFeature>,
+    pub negative: Vec<SetFeature>,
+}
+
+impl BalanceFeatureSets {
+    pub fn is_empty(&self) -> bool {
+        self.positive.is_empty() && self.negative.is_empty()
+    }
+}
+
 /// One copper layer's balancing plan and generated IPC features.
 #[derive(Debug, Clone)]
 pub struct CopperBalanceLayer {
@@ -52,7 +70,7 @@ pub struct CopperBalanceLayer {
     pub stack_weight_mm2: f64,
     pub existing_copper: ContourSet,
     pub result: DenseCopperBalanceResult,
-    pub features: Vec<SetFeature>,
+    pub features: BalanceFeatureSets,
 }
 
 /// Inspectable result of planning automatic copper balance for a panel.
@@ -253,15 +271,48 @@ pub fn solve_copper_balance(
     })
 }
 
-/// Convert a solved layer to positive IPC features; empty when nothing was
-/// generated.
-pub fn balance_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeature>> {
+/// Convert a solved layer to IPC features; empty when nothing was generated.
+pub fn balance_features(result: &DenseCopperBalanceResult) -> Result<BalanceFeatureSets> {
     match result.solution.mode {
-        DenseCopperBalanceMode::None => Ok(Vec::new()),
-        DenseCopperBalanceMode::Solid | DenseCopperBalanceMode::Perforated { .. } => {
-            ipc_contour_features(result)
-        }
+        DenseCopperBalanceMode::None => Ok(BalanceFeatureSets::default()),
+        DenseCopperBalanceMode::Solid => Ok(BalanceFeatureSets {
+            positive: ipc_contour_features(result)?,
+            negative: Vec::new(),
+        }),
+        DenseCopperBalanceMode::Perforated { .. } => Ok(BalanceFeatureSets {
+            positive: ipc_contour_features(result)?,
+            negative: hex_void_features(result)?,
+        }),
     }
+}
+
+/// One negative rounded-hex instance per full interior void, each carrying
+/// the origin-centered template translated to its lattice site.
+fn hex_void_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeature>> {
+    result
+        .full_voids
+        .iter()
+        .map(|void| {
+            let template = rounded_hexagonal_void(void.radius_mm)
+                .context("generated copper balance has an invalid rounded-hex void radius")?;
+            let polygon = ipc_polygon_from_contour(&template)?;
+            Ok(SetFeature::UserPrimitive(FeatureUserPrimitive {
+                primitive: UserPrimitive::UserSpecial(UserSpecial {
+                    shapes: vec![UserShape {
+                        shape: UserShapeType::Contour(IpcContour {
+                            polygon,
+                            cutouts: Vec::new(),
+                        }),
+                        line_desc: None,
+                        line_desc_ref: None,
+                        fill_desc: None,
+                    }],
+                }),
+                x: void.center.x,
+                y: void.center.y,
+            }))
+        })
+        .collect()
 }
 
 /// Extract one layer's flattened, composed copper image.
@@ -336,6 +387,9 @@ struct IpcCopperComponent {
     cutouts: Vec<ContourBuf>,
 }
 
+/// The positive plane: usable-region components with partial edge voids cut
+/// in. Full interior voids are not cut here — they subtract via the negative
+/// instance set.
 fn ipc_contour_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeature>> {
     let mut components = simplify_shapes(result.usable.rings.clone(), FillRule::NonZero)
         .into_iter()
@@ -349,22 +403,6 @@ fn ipc_contour_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeat
                 .collect(),
         })
         .collect::<Vec<_>>();
-
-    if matches!(
-        result.solution.mode,
-        DenseCopperBalanceMode::Perforated { .. }
-    ) {
-        for void in &result.full_voids {
-            let template = rounded_hexagonal_void(void.radius_mm)
-                .context("generated copper balance has an invalid rounded-hex void radius")?;
-            let component = containing_component(&mut components, void.center)
-                .context("generated full copper void lies outside the usable region")?;
-            component.cutouts.push(transform_cmds(
-                template.cmds.iter().copied(),
-                Affine2::translation(void.center),
-            ));
-        }
-    }
 
     let mut islands = Vec::new();
     for shape in simplify_shapes(result.partial_voids.rings.clone(), FillRule::NonZero) {
@@ -518,40 +556,48 @@ mod tests {
         assert!(result.solution.generated_area_mm2 > 0.0);
         assert!(!result.full_voids.is_empty());
         assert!(!result.partial_voids.is_empty());
-        assert!(
-            features
-                .iter()
-                .all(|feature| matches!(feature, SetFeature::UserPrimitive(_)))
-        );
-        let contours = features
+        let contour = |feature: &SetFeature| match feature {
+            SetFeature::UserPrimitive(feature) => {
+                let UserPrimitive::UserSpecial(user_special) = &feature.primitive;
+                let UserShapeType::Contour(contour) = &user_special.shapes[0].shape else {
+                    return None;
+                };
+                Some(contour.clone())
+            }
+            _ => None,
+        };
+
+        // The positive plane carries only the clipped edge voids as cutouts.
+        let positive_contours = features
+            .positive
             .iter()
-            .filter_map(|feature| match feature {
-                SetFeature::UserPrimitive(feature) => {
-                    let UserPrimitive::UserSpecial(user_special) = &feature.primitive;
-                    let UserShapeType::Contour(contour) = &user_special.shapes[0].shape else {
-                        return None;
-                    };
-                    Some(contour)
-                }
-                _ => None,
-            })
+            .map(|feature| contour(feature).expect("positive balance feature is a contour"))
             .collect::<Vec<_>>();
         assert_eq!(
-            contours
+            positive_contours
                 .iter()
                 .map(|contour| contour.cutouts.len())
                 .sum::<usize>(),
-            result.void_count()
+            result.partial_voids.connected_components().len()
         );
-        assert!(
-            contours
-                .iter()
-                .flat_map(|contour| {
-                    std::iter::once(&contour.polygon).chain(contour.cutouts.iter())
-                })
-                .flat_map(|polygon| &polygon.steps)
-                .any(|step| matches!(step, PolyStep::Curve(_)))
-        );
+
+        // Every full void is one translated instance of the hex template.
+        assert_eq!(features.negative.len(), result.full_voids.len());
+        for (feature, void) in features.negative.iter().zip(&result.full_voids) {
+            let SetFeature::UserPrimitive(primitive) = feature else {
+                panic!("negative balance feature is not a user primitive");
+            };
+            assert_eq!((primitive.x, primitive.y), (void.center.x, void.center.y));
+            let template = contour(feature).unwrap();
+            assert!(template.cutouts.is_empty());
+            assert!(
+                template
+                    .polygon
+                    .steps
+                    .iter()
+                    .any(|step| matches!(step, PolyStep::Curve(_)))
+            );
+        }
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -43,22 +43,39 @@ pub struct PreparedCopperLayer {
     pub safe_region: ContourSet,
 }
 
+/// One origin-centered rounded-hex dictionary entry, shared by every void of
+/// its radius.
+#[derive(Debug, Clone)]
+pub struct BalanceVoidTemplate {
+    pub id: String,
+    pub polygon: Polygon,
+}
+
+/// One translated instance of a [`BalanceVoidTemplate`].
+#[derive(Debug, Clone)]
+pub struct BalanceVoidInstance {
+    pub template: String,
+    pub x: f64,
+    pub y: f64,
+}
+
 /// Generated IPC features for one balanced layer, split by polarity.
 ///
 /// The perforated plane is a positive set covering the whole usable region
 /// (partial edge voids stay cut into its contours), while every full interior
-/// void is a translated instance of one rounded-hex template in a negative
-/// set. Keeping the voids as explicit repeated instances lets downstream
-/// lowerings share their geometry instead of re-describing each void.
+/// void is a negative dictionary-instance reference. The solver's radius grid
+/// keeps the template set small, so each void costs one reference instead of
+/// one inline contour.
 #[derive(Debug, Clone, Default)]
 pub struct BalanceFeatureSets {
     pub positive: Vec<SetFeature>,
-    pub negative: Vec<SetFeature>,
+    pub templates: Vec<BalanceVoidTemplate>,
+    pub instances: Vec<BalanceVoidInstance>,
 }
 
 impl BalanceFeatureSets {
     pub fn is_empty(&self) -> bool {
-        self.positive.is_empty() && self.negative.is_empty()
+        self.positive.is_empty() && self.instances.is_empty()
     }
 }
 
@@ -277,42 +294,46 @@ pub fn balance_features(result: &DenseCopperBalanceResult) -> Result<BalanceFeat
         DenseCopperBalanceMode::None => Ok(BalanceFeatureSets::default()),
         DenseCopperBalanceMode::Solid => Ok(BalanceFeatureSets {
             positive: ipc_contour_features(result)?,
-            negative: Vec::new(),
+            ..BalanceFeatureSets::default()
         }),
-        DenseCopperBalanceMode::Perforated { .. } => Ok(BalanceFeatureSets {
-            positive: ipc_contour_features(result)?,
-            negative: hex_void_features(result)?,
-        }),
+        DenseCopperBalanceMode::Perforated { .. } => {
+            let (templates, instances) = hex_void_instances(result)?;
+            Ok(BalanceFeatureSets {
+                positive: ipc_contour_features(result)?,
+                templates,
+                instances,
+            })
+        }
     }
 }
 
-/// One negative rounded-hex instance per full interior void, each carrying
-/// the origin-centered template translated to its lattice site.
-fn hex_void_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeature>> {
-    result
+/// One shared template per distinct void radius plus one translated instance
+/// reference per full interior void.
+fn hex_void_instances(
+    result: &DenseCopperBalanceResult,
+) -> Result<(Vec<BalanceVoidTemplate>, Vec<BalanceVoidInstance>)> {
+    let mut templates: Vec<BalanceVoidTemplate> = Vec::new();
+    let instances = result
         .full_voids
         .iter()
         .map(|void| {
-            let template = rounded_hexagonal_void(void.radius_mm)
-                .context("generated copper balance has an invalid rounded-hex void radius")?;
-            let polygon = ipc_polygon_from_contour(&template)?;
-            Ok(SetFeature::UserPrimitive(FeatureUserPrimitive {
-                primitive: UserPrimitive::UserSpecial(UserSpecial {
-                    shapes: vec![UserShape {
-                        shape: UserShapeType::Contour(IpcContour {
-                            polygon,
-                            cutouts: Vec::new(),
-                        }),
-                        line_desc: None,
-                        line_desc_ref: None,
-                        fill_desc: None,
-                    }],
-                }),
+            let id = format!("balance_hex_{}nm", (void.radius_mm * 1e6).round() as i64);
+            if !templates.iter().any(|template| template.id == id) {
+                let contour = rounded_hexagonal_void(void.radius_mm)
+                    .context("generated copper balance has an invalid rounded-hex void radius")?;
+                templates.push(BalanceVoidTemplate {
+                    id: id.clone(),
+                    polygon: ipc_polygon_from_contour(&contour)?,
+                });
+            }
+            Ok(BalanceVoidInstance {
+                template: id,
                 x: void.center.x,
                 y: void.center.y,
-            }))
+            })
         })
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    Ok((templates, instances))
 }
 
 /// Extract one layer's flattened, composed copper image.
@@ -581,23 +602,25 @@ mod tests {
             result.partial_voids.connected_components().len()
         );
 
-        // Every full void is one translated instance of the hex template.
-        assert_eq!(features.negative.len(), result.full_voids.len());
-        for (feature, void) in features.negative.iter().zip(&result.full_voids) {
-            let SetFeature::UserPrimitive(primitive) = feature else {
-                panic!("negative balance feature is not a user primitive");
-            };
-            assert_eq!((primitive.x, primitive.y), (void.center.x, void.center.y));
-            let template = contour(feature).unwrap();
-            assert!(template.cutouts.is_empty());
+        // Every full void is one translated reference to a shared template.
+        assert_eq!(features.instances.len(), result.full_voids.len());
+        for (instance, void) in features.instances.iter().zip(&result.full_voids) {
+            assert_eq!((instance.x, instance.y), (void.center.x, void.center.y));
             assert!(
-                template
-                    .polygon
-                    .steps
+                features
+                    .templates
                     .iter()
-                    .any(|step| matches!(step, PolyStep::Curve(_)))
+                    .any(|template| template.id == instance.template)
             );
         }
+        assert!(features.templates.len() < features.instances.len());
+        assert!(features.templates.iter().all(|template| {
+            template
+                .polygon
+                .steps
+                .iter()
+                .any(|step| matches!(step, PolyStep::Curve(_)))
+        }));
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -1,0 +1,594 @@
+//! Copper-balance planning shared by the board-array and fab-panel panelizers.
+//!
+//! Each panelizer derives its own certified safe regions and per-layer density
+//! targets; the shared solve distributes the selected copper spatially across
+//! the stackup and lowers the result to positive IPC-2581 features.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, bail};
+use ipc2581::types::{
+    ecad::{FeatureUserPrimitive, SetFeature},
+    primitives::{
+        Contour as IpcContour, Point as IpcPoint, PolyStep, PolyStepCurve, PolyStepSegment,
+        Polygon, UserPrimitive, UserShape, UserShapeType, UserSpecial,
+    },
+};
+use pcb_ir::dialects::ipc::View;
+use pcb_ir::geom::copper_balance::{
+    DenseCopperBalanceMode, DenseCopperBalanceProfile, DenseCopperBalanceResult,
+    SpatialCopperBalanceLayerRequest, SpatialCopperBalanceRequest,
+    generate_spatial_dense_copper_balance, rounded_hexagonal_void,
+};
+use pcb_ir::geom::path::transform_cmds;
+use pcb_ir::geom::region::simplify_shapes;
+use pcb_ir::geom::{Affine2, ContourBuf, ContourSet, FillRule, PathOp, Point, tol};
+use serde::Serialize;
+
+use crate::geometry;
+use crate::ipc2581::Ipc2581;
+
+/// Maximum violation area tolerated when certifying a balancing region.
+pub const CERTIFICATE_AREA_TOLERANCE_MM2: f64 = 1e-4;
+
+/// One copper layer prepared for the joint spatial solve.
+#[derive(Debug, Clone)]
+pub struct PreparedCopperLayer {
+    pub layer_name: String,
+    /// Copper density measured inside the immutable placed footprints.
+    pub target_density: f64,
+    /// Signed physical stack weight, or zero when the stackup supplied none.
+    pub stack_weight_mm2: f64,
+    pub existing_copper: ContourSet,
+    /// Certified, initially empty region available for generated copper.
+    pub safe_region: ContourSet,
+}
+
+/// One copper layer's balancing plan and generated IPC features.
+#[derive(Debug, Clone)]
+pub struct CopperBalanceLayer {
+    pub layer_name: String,
+    pub target_density: f64,
+    pub stack_weight_mm2: f64,
+    pub existing_copper: ContourSet,
+    pub result: DenseCopperBalanceResult,
+    pub features: Vec<SetFeature>,
+}
+
+/// Inspectable result of planning automatic copper balance for a panel.
+#[derive(Debug, Clone)]
+pub struct CopperBalancePlan {
+    /// Immutable placed footprints whose density the generated copper extends.
+    pub footprints: ContourSet,
+    pub retained_area_mm2: f64,
+    /// Whether the physical stackup supplied signed stack weights. When false,
+    /// every layer balances independently with zero through-stack coupling.
+    pub stack_weights_available: bool,
+    pub layers: Vec<CopperBalanceLayer>,
+}
+
+/// Compact, serializable accounting for one layer's automatic balance.
+#[derive(Debug, Clone, Serialize)]
+pub struct CopperBalanceLayerReport {
+    pub layer_name: String,
+    pub mode: CopperBalanceMode,
+    pub void_radius_mm: Option<f64>,
+    pub min_void_radius_mm: Option<f64>,
+    pub max_void_radius_mm: Option<f64>,
+    pub stack_weight_mm2: f64,
+    pub target_density: f64,
+    pub initial_density: f64,
+    pub achieved_density: f64,
+    pub residual_error: f64,
+    pub existing_copper_area_mm2: f64,
+    pub desired_added_area_mm2: f64,
+    pub generated_area_mm2: f64,
+    pub usable_area_mm2: f64,
+    pub fixed_empty_area_mm2: f64,
+    pub void_count: usize,
+}
+
+/// Topology selected for one layer's automatic balance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CopperBalanceMode {
+    None,
+    Solid,
+    Perforated,
+}
+
+/// Compact, serializable accounting for a completed automatic balance plan.
+#[derive(Debug, Clone, Serialize)]
+pub struct CopperBalanceReport {
+    pub retained_area_mm2: f64,
+    pub footprint_area_mm2: f64,
+    pub stack_weights_available: bool,
+    pub layers: Vec<CopperBalanceLayerReport>,
+}
+
+impl CopperBalanceReport {
+    /// One short status line per copper layer, plus a warning when the
+    /// stackup could not supply physical stack weights.
+    pub fn summary_lines(&self) -> Vec<String> {
+        let mut lines = self
+            .layers
+            .iter()
+            .map(|layer| {
+                let geometry = match (
+                    layer.mode,
+                    layer.min_void_radius_mm,
+                    layer.max_void_radius_mm,
+                ) {
+                    (CopperBalanceMode::None, ..) => "no fill".to_string(),
+                    (CopperBalanceMode::Solid, ..) => "solid fill".to_string(),
+                    (CopperBalanceMode::Perforated, Some(min), Some(max)) => {
+                        format!("{} hex voids r {min:.2}-{max:.2} mm", layer.void_count)
+                    }
+                    (CopperBalanceMode::Perforated, ..) => {
+                        format!("{} hex voids", layer.void_count)
+                    }
+                };
+                format!(
+                    "balance {}: {geometry}, density {:.3} -> {:.3} (target {:.3})",
+                    layer.layer_name,
+                    layer.initial_density,
+                    layer.achieved_density,
+                    layer.target_density
+                )
+            })
+            .collect::<Vec<_>>();
+        if !self.layers.is_empty() && !self.stack_weights_available {
+            lines.push(
+                "balance: stackup thickness data unavailable; layers balanced independently"
+                    .to_string(),
+            );
+        }
+        lines
+    }
+}
+
+impl CopperBalancePlan {
+    /// Discard heavy geometry while retaining enough data to audit the result.
+    pub fn report(&self) -> CopperBalanceReport {
+        CopperBalanceReport {
+            retained_area_mm2: self.retained_area_mm2,
+            footprint_area_mm2: self.footprints.area(),
+            stack_weights_available: self.stack_weights_available,
+            layers: self
+                .layers
+                .iter()
+                .map(|layer| {
+                    let solution = layer.result.solution;
+                    let existing_copper_area_mm2 = layer.existing_copper.area();
+                    let usable_area_mm2 = layer.result.usable.area();
+                    let fixed_empty_area_mm2 =
+                        (self.retained_area_mm2 - existing_copper_area_mm2 - usable_area_mm2)
+                            .max(0.0);
+                    let (mode, void_radius_mm) = match solution.mode {
+                        DenseCopperBalanceMode::None => (CopperBalanceMode::None, None),
+                        DenseCopperBalanceMode::Solid => (CopperBalanceMode::Solid, None),
+                        DenseCopperBalanceMode::Perforated { void_radius_mm } => {
+                            (CopperBalanceMode::Perforated, Some(void_radius_mm))
+                        }
+                    };
+                    let (min_void_radius_mm, max_void_radius_mm) = layer
+                        .result
+                        .full_void_radius_range_mm()
+                        .map_or((None, None), |(min, max)| (Some(min), Some(max)));
+                    CopperBalanceLayerReport {
+                        layer_name: layer.layer_name.clone(),
+                        mode,
+                        void_radius_mm,
+                        min_void_radius_mm,
+                        max_void_radius_mm,
+                        stack_weight_mm2: layer.stack_weight_mm2,
+                        target_density: solution.target_density,
+                        initial_density: solution.initial_density,
+                        achieved_density: solution.achieved_density,
+                        residual_error: solution.residual_error,
+                        existing_copper_area_mm2,
+                        desired_added_area_mm2: solution.desired_added_area_mm2,
+                        generated_area_mm2: solution.generated_area_mm2,
+                        usable_area_mm2,
+                        fixed_empty_area_mm2,
+                        void_count: layer.result.void_count(),
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Jointly distribute every prepared layer's copper over the panel region,
+/// then lower each solved layer to positive IPC features.
+///
+/// The lattice origin is the panel region's minimum corner, so identical
+/// inputs always produce identical geometry.
+pub fn solve_copper_balance(
+    panel_region: &ContourSet,
+    footprints: ContourSet,
+    stack_weights_available: bool,
+    prepared: Vec<PreparedCopperLayer>,
+) -> Result<CopperBalancePlan> {
+    let spatial_layers = prepared
+        .iter()
+        .map(|layer| SpatialCopperBalanceLayerRequest {
+            safe_region: &layer.safe_region,
+            existing_copper: &layer.existing_copper,
+            target_density: layer.target_density,
+            stack_weight_mm2: layer.stack_weight_mm2,
+        })
+        .collect::<Vec<_>>();
+    let results = generate_spatial_dense_copper_balance(
+        DenseCopperBalanceProfile::V1,
+        SpatialCopperBalanceRequest {
+            panel_region,
+            lattice_origin: panel_region.bbox.min,
+            layers: &spatial_layers,
+        },
+    )
+    .context("failed to generate spatial copper balance")?;
+
+    let layers = prepared
+        .into_iter()
+        .zip(results)
+        .map(|(layer, result)| {
+            let features = balance_features(&result)?;
+            Ok(CopperBalanceLayer {
+                layer_name: layer.layer_name,
+                target_density: layer.target_density,
+                stack_weight_mm2: layer.stack_weight_mm2,
+                existing_copper: layer.existing_copper,
+                result,
+                features,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(CopperBalancePlan {
+        footprints,
+        retained_area_mm2: panel_region.area(),
+        stack_weights_available,
+        layers,
+    })
+}
+
+/// Convert a solved layer to positive IPC features; empty when nothing was
+/// generated.
+pub fn balance_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeature>> {
+    match result.solution.mode {
+        DenseCopperBalanceMode::None => Ok(Vec::new()),
+        DenseCopperBalanceMode::Solid | DenseCopperBalanceMode::Perforated { .. } => {
+            ipc_contour_features(result)
+        }
+    }
+}
+
+/// Extract one layer's flattened, composed copper image.
+pub fn composed_copper_image(ipc: &Ipc2581, layer_name: &str) -> Result<ContourSet> {
+    let mut document = geometry::extract_layer_for_view(ipc, layer_name, View::ArrayFlattened)
+        .with_context(|| {
+            format!("failed to extract flattened IPC-2581 copper layer '{layer_name}'")
+        })?;
+    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut document);
+    Ok(ContourSet::from_painted_paths(
+        &document.arena,
+        document
+            .features
+            .iter()
+            .flat_map(|feature| feature.paths.slice(&document.arena.paths)),
+        tol::REGION_MM,
+    ))
+}
+
+/// Signed first-moment weight `z * thickness` per copper layer, from the
+/// physical stackup's ordered layer thicknesses. `None` when the stackup
+/// cannot locate every copper layer.
+pub fn physical_copper_stack_weights(ipc: &Ipc2581) -> Option<HashMap<String, f64>> {
+    let ecad = ipc.ecad()?;
+    let stackup = ecad.cad_data.stackups.first()?;
+    let mut layers = stackup.layers.iter().collect::<Vec<_>>();
+    if layers.iter().all(|layer| layer.layer_number.is_some()) {
+        layers.sort_by_key(|layer| layer.layer_number);
+    }
+
+    let mut cursor_mm = 0.0;
+    let mut copper = Vec::new();
+    for stack_layer in layers {
+        let thickness_mm = stack_layer.thickness?;
+        if !thickness_mm.is_finite() || thickness_mm < 0.0 {
+            return None;
+        }
+        let center_mm = cursor_mm + thickness_mm / 2.0;
+        let name = ipc.resolve(stack_layer.layer_ref);
+        if ecad.cad_data.layers.iter().any(|layer| {
+            ipc.resolve(layer.name) == name && crate::layers::is_copper(layer.layer_function)
+        }) {
+            if thickness_mm <= 0.0 {
+                return None;
+            }
+            copper.push((name.to_string(), center_mm, thickness_mm));
+        }
+        cursor_mm += thickness_mm;
+    }
+
+    let expected = ecad
+        .cad_data
+        .layers
+        .iter()
+        .filter(|layer| crate::layers::is_copper(layer.layer_function))
+        .count();
+    if copper.len() != expected || cursor_mm <= 0.0 {
+        return None;
+    }
+    let midplane_mm = cursor_mm / 2.0;
+    Some(
+        copper
+            .into_iter()
+            .map(|(name, center_mm, thickness_mm)| (name, (midplane_mm - center_mm) * thickness_mm))
+            .collect(),
+    )
+}
+
+struct IpcCopperComponent {
+    region: ContourSet,
+    outer: ContourBuf,
+    cutouts: Vec<ContourBuf>,
+}
+
+fn ipc_contour_features(result: &DenseCopperBalanceResult) -> Result<Vec<SetFeature>> {
+    let mut components = simplify_shapes(result.usable.rings.clone(), FillRule::NonZero)
+        .into_iter()
+        .map(|shape| IpcCopperComponent {
+            region: ContourSet::new(shape.clone(), FillRule::NonZero, result.usable.tolerance),
+            outer: pcb_ir::geom::arcfit::ring_to_contour_with_arcs(&shape[0], tol::FLATTEN_MM),
+            cutouts: shape
+                .iter()
+                .skip(1)
+                .map(|ring| pcb_ir::geom::arcfit::ring_to_contour_with_arcs(ring, tol::FLATTEN_MM))
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+
+    if matches!(
+        result.solution.mode,
+        DenseCopperBalanceMode::Perforated { .. }
+    ) {
+        for void in &result.full_voids {
+            let template = rounded_hexagonal_void(void.radius_mm)
+                .context("generated copper balance has an invalid rounded-hex void radius")?;
+            let component = containing_component(&mut components, void.center)
+                .context("generated full copper void lies outside the usable region")?;
+            component.cutouts.push(transform_cmds(
+                template.cmds.iter().copied(),
+                Affine2::translation(void.center),
+            ));
+        }
+    }
+
+    let mut islands = Vec::new();
+    for shape in simplify_shapes(result.partial_voids.rings.clone(), FillRule::NonZero) {
+        let &[x, y] = shape
+            .first()
+            .and_then(|ring| ring.first())
+            .context("generated partial copper void has no outer boundary")?;
+        let component = containing_component(&mut components, Point::new(x, y))
+            .context("generated partial copper void lies outside the usable region")?;
+        component
+            .cutouts
+            .push(pcb_ir::geom::arcfit::ring_to_contour_with_arcs(
+                &shape[0],
+                tol::FLATTEN_MM,
+            ));
+        islands.extend(
+            shape
+                .iter()
+                .skip(1)
+                .map(|ring| pcb_ir::geom::arcfit::ring_to_contour_with_arcs(ring, tol::FLATTEN_MM)),
+        );
+    }
+
+    components
+        .into_iter()
+        .map(|component| ipc_contour_feature(&component.outer, &component.cutouts))
+        .chain(
+            islands
+                .iter()
+                .map(|island| ipc_contour_feature(island, &[])),
+        )
+        .collect()
+}
+
+fn containing_component(
+    components: &mut [IpcCopperComponent],
+    point: Point,
+) -> Option<&mut IpcCopperComponent> {
+    components
+        .iter_mut()
+        .find(|component| component.region.contains_point(point))
+}
+
+fn ipc_contour_feature(outer: &ContourBuf, cutout_contours: &[ContourBuf]) -> Result<SetFeature> {
+    let polygon = ipc_polygon_from_contour(outer)?;
+    let cutouts = cutout_contours
+        .iter()
+        .map(ipc_polygon_from_contour)
+        .collect::<Result<Vec<_>>>()?;
+    Ok(SetFeature::UserPrimitive(FeatureUserPrimitive {
+        primitive: UserPrimitive::UserSpecial(UserSpecial {
+            shapes: vec![UserShape {
+                shape: UserShapeType::Contour(IpcContour { polygon, cutouts }),
+                line_desc: None,
+                line_desc_ref: None,
+                fill_desc: None,
+            }],
+        }),
+        x: 0.0,
+        y: 0.0,
+    }))
+}
+
+fn ipc_polygon_from_contour(contour: &ContourBuf) -> Result<Polygon> {
+    let mut begin = None;
+    let mut steps = Vec::new();
+
+    for command in &contour.cmds {
+        match command.op {
+            PathOp::MoveTo if begin.is_none() => {
+                begin = Some(IpcPoint {
+                    x: command.p0.x,
+                    y: command.p0.y,
+                });
+            }
+            PathOp::LineTo if begin.is_some() => {
+                steps.push(PolyStep::Segment(PolyStepSegment {
+                    point: IpcPoint {
+                        x: command.p0.x,
+                        y: command.p0.y,
+                    },
+                }));
+            }
+            PathOp::ArcTo if begin.is_some() => {
+                steps.push(PolyStep::Curve(PolyStepCurve {
+                    point: IpcPoint {
+                        x: command.p0.x,
+                        y: command.p0.y,
+                    },
+                    center: IpcPoint {
+                        x: command.p1.x,
+                        y: command.p1.y,
+                    },
+                    clockwise: command.clockwise,
+                }));
+            }
+            PathOp::Close if begin.is_some() => {}
+            PathOp::CubicTo => {
+                bail!("generated copper balance polygon contains an unsupported cubic segment")
+            }
+            _ => bail!("generated copper balance polygon contains multiple or missing contours"),
+        }
+    }
+
+    let begin = begin.context("generated copper balance polygon has no starting point")?;
+    if steps.len() < 2 {
+        bail!("generated copper balance polygon has fewer than three vertices");
+    }
+    Ok(Polygon { begin, steps })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pcb_ir::geom::{BBox, ContourSet, Point, tol};
+
+    #[test]
+    fn converts_perforated_region_to_positive_ipc_contours() {
+        let safe_region = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 10.0)),
+            tol::REGION_MM,
+        );
+        let existing = ContourSet::empty(tol::REGION_MM);
+        let layers = [SpatialCopperBalanceLayerRequest {
+            safe_region: &safe_region,
+            existing_copper: &existing,
+            target_density: 0.75,
+            stack_weight_mm2: 0.0,
+        }];
+        let result = generate_spatial_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            SpatialCopperBalanceRequest {
+                panel_region: &safe_region,
+                lattice_origin: Point::new(10.0, 5.0),
+                layers: &layers,
+            },
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+        let features = balance_features(&result).unwrap();
+
+        assert!(
+            matches!(
+                result.solution.mode,
+                DenseCopperBalanceMode::Perforated { .. }
+            ),
+            "{:?}",
+            result.solution
+        );
+        assert!(result.solution.generated_area_mm2 > 0.0);
+        assert!(!result.full_voids.is_empty());
+        assert!(!result.partial_voids.is_empty());
+        assert!(
+            features
+                .iter()
+                .all(|feature| matches!(feature, SetFeature::UserPrimitive(_)))
+        );
+        let contours = features
+            .iter()
+            .filter_map(|feature| match feature {
+                SetFeature::UserPrimitive(feature) => {
+                    let UserPrimitive::UserSpecial(user_special) = &feature.primitive;
+                    let UserShapeType::Contour(contour) = &user_special.shapes[0].shape else {
+                        return None;
+                    };
+                    Some(contour)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            contours
+                .iter()
+                .map(|contour| contour.cutouts.len())
+                .sum::<usize>(),
+            result.void_count()
+        );
+        assert!(
+            contours
+                .iter()
+                .flat_map(|contour| {
+                    std::iter::once(&contour.polygon).chain(contour.cutouts.iter())
+                })
+                .flat_map(|polygon| &polygon.steps)
+                .any(|step| matches!(step, PolyStep::Curve(_)))
+        );
+    }
+
+    #[test]
+    fn derives_signed_stack_weights_from_physical_layer_centers() {
+        let ipc = Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="F.Cu"/>
+    <LayerRef name="B.Cu"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="F.Cu" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Layer name="B.Cu" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+      <Stackup name="Primary" overallThickness="1.6">
+        <StackupGroup name="Primary_Group">
+          <StackupLayer layerOrGroupRef="COATING_TOP" thickness="0" sequence="0"/>
+          <StackupLayer layerOrGroupRef="F.Cu" thickness="0.035" sequence="1"/>
+          <StackupLayer layerOrGroupRef="CORE" thickness="1.53" sequence="2"/>
+          <StackupLayer layerOrGroupRef="B.Cu" thickness="0.035" sequence="3"/>
+          <StackupLayer layerOrGroupRef="COATING_BOTTOM" thickness="0" sequence="4"/>
+        </StackupGroup>
+      </Stackup>
+      <Step name="board" type="BOARD"><Datum x="0" y="0"/></Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let weights = physical_copper_stack_weights(&ipc).unwrap();
+
+        assert!((weights["F.Cu"] + weights["B.Cu"]).abs() <= 1e-12);
+        assert!(weights["F.Cu"] > 0.0);
+        assert!(weights["B.Cu"] < 0.0);
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/generated.rs
+++ b/crates/pcb-ipc2581-tools/src/generated.rs
@@ -1,0 +1,126 @@
+//! Serialization of generated IPC-2581 layer features, shared by the
+//! board-array and fab-panel panelizers.
+
+use anyhow::{Result, bail};
+use ipc2581::XmlWriter;
+use ipc2581::types::{
+    Units,
+    ecad::{FeatureUserPrimitive, Polarity, SetFeature},
+    primitives::{UserPrimitive, UserShapeType},
+};
+use ipc2581::write;
+
+/// Only board-array tooling generates named holes today; the prefix stays
+/// stable so re-panelization produces identical names.
+const GENERATED_HOLE_NAME_PREFIX: &str = "array_tooling_hole";
+
+/// One generated `LayerFeature` element: a single `Set` of features on one
+/// layer.
+#[derive(Debug, Clone)]
+pub(crate) struct GeneratedLayerFeature {
+    pub layer_name: String,
+    pub polarity: Polarity,
+    pub spec_refs: Vec<String>,
+    pub features: Vec<SetFeature>,
+}
+
+/// Sequential names for generated holes, unique within one Step.
+#[derive(Debug, Default)]
+pub(crate) struct GeneratedNameState {
+    hole_index: usize,
+}
+
+impl GeneratedNameState {
+    fn next_hole_name(&mut self) -> String {
+        let name = format!("{GENERATED_HOLE_NAME_PREFIX}_{}", self.hole_index);
+        self.hole_index += 1;
+        name
+    }
+}
+
+pub(crate) fn write_generated_layer_feature(
+    writer: &mut XmlWriter,
+    units: Units,
+    layer_feature: &GeneratedLayerFeature,
+    names: &mut GeneratedNameState,
+) -> Result<()> {
+    if layer_feature.features.is_empty() {
+        return Ok(());
+    }
+
+    writer.start_element(
+        "LayerFeature",
+        &[("layerRef", layer_feature.layer_name.as_str())],
+    );
+    writer.start_element(
+        "Set",
+        &[("polarity", write::polarity_attr(layer_feature.polarity))],
+    );
+    for spec_ref in &layer_feature.spec_refs {
+        write::spec_ref(writer, spec_ref);
+    }
+    write_set_features(writer, units, &layer_feature.features, names)?;
+    writer.end_element("Set");
+    writer.end_element("LayerFeature");
+    Ok(())
+}
+
+fn write_set_features(
+    writer: &mut XmlWriter,
+    units: Units,
+    features: &[SetFeature],
+    names: &mut GeneratedNameState,
+) -> Result<()> {
+    for feature in features {
+        match feature {
+            SetFeature::Line(line) => {
+                writer.start_element("Features", &[]);
+                write::line(writer, units, line)?;
+                writer.end_element("Features");
+            }
+            SetFeature::Polygon(polygon) => {
+                writer.start_element("Features", &[]);
+                writer.start_element("Contour", &[]);
+                write::polygon(writer, units, polygon);
+                writer.end_element("Contour");
+                writer.end_element("Features");
+            }
+            SetFeature::UserPrimitive(feature) => {
+                write_generated_user_primitive(writer, units, feature)?;
+            }
+            SetFeature::Fiducial(fiducial) => {
+                write::fiducial(writer, units, fiducial)?;
+            }
+            SetFeature::Hole(hole) => {
+                write::hole(writer, units, hole, &names.next_hole_name());
+            }
+            _ => bail!("generated layer feature has unsupported feature kind"),
+        }
+    }
+    Ok(())
+}
+
+fn write_generated_user_primitive(
+    writer: &mut XmlWriter,
+    units: Units,
+    feature: &FeatureUserPrimitive,
+) -> Result<()> {
+    let UserPrimitive::UserSpecial(user_special) = &feature.primitive;
+    let [shape] = user_special.shapes.as_slice() else {
+        bail!("generated user primitive must contain exactly one shape");
+    };
+    let UserShapeType::Contour(contour) = &shape.shape else {
+        bail!("generated user primitive must be a contour");
+    };
+    if shape.line_desc.is_some() || shape.line_desc_ref.is_some() || shape.fill_desc.is_some() {
+        bail!("generated contour cannot carry explicit style descriptors");
+    }
+
+    writer.start_element("Features", &[]);
+    if feature.x != 0.0 || feature.y != 0.0 {
+        write::location(writer, "Location", feature.x, feature.y, units);
+    }
+    write::contour(writer, units, contour);
+    writer.end_element("Features");
+    Ok(())
+}

--- a/crates/pcb-ipc2581-tools/src/generated.rs
+++ b/crates/pcb-ipc2581-tools/src/generated.rs
@@ -120,16 +120,26 @@ pub(crate) fn user_dictionary_edit(
     if templates.is_empty() {
         return Ok(None);
     }
-    let mut writer = XmlWriter::new();
-    write_user_dictionary_entries(&mut writer, units, templates);
-    let entries = writer.into_string();
     let root = doc.root()?;
     let content = doc
         .child(root, "Content")
         .ok_or_else(|| anyhow::anyhow!("IPC-2581 document has no Content section"))?;
     if let Some(dictionary) = doc.child(content, "DictionaryUser") {
-        return Ok(Some(doc.append_inside(dictionary, entries)));
+        // An existing dictionary's declared units govern its entries; the
+        // parser defaults an absent attribute to millimeters.
+        let dictionary_units = match doc.attr(dictionary, "units") {
+            Some("INCH") => Units::Inch,
+            Some("MICRON") => Units::Micron,
+            Some("MILS") => Units::Mils,
+            _ => Units::Millimeter,
+        };
+        let mut writer = XmlWriter::new();
+        write_user_dictionary_entries(&mut writer, dictionary_units, templates);
+        return Ok(Some(doc.append_inside(dictionary, writer.into_string())));
     }
+    let mut writer = XmlWriter::new();
+    write_user_dictionary_entries(&mut writer, units, templates);
+    let entries = writer.into_string();
     let mut container = XmlWriter::new();
     container.start_element("DictionaryUser", &[("units", units_attr(units))]);
     container.raw(&entries);

--- a/crates/pcb-ipc2581-tools/src/generated.rs
+++ b/crates/pcb-ipc2581-tools/src/generated.rs
@@ -6,9 +6,11 @@ use ipc2581::XmlWriter;
 use ipc2581::types::{
     Units,
     ecad::{FeatureUserPrimitive, Polarity, SetFeature},
-    primitives::{UserPrimitive, UserShapeType},
+    primitives::{Contour, UserPrimitive, UserShapeType},
 };
 use ipc2581::write;
+
+use crate::copper_balance::{BalanceVoidInstance, BalanceVoidTemplate};
 
 /// Only board-array tooling generates named holes today; the prefix stays
 /// stable so re-panelization produces identical names.
@@ -22,6 +24,8 @@ pub(crate) struct GeneratedLayerFeature {
     pub polarity: Polarity,
     pub spec_refs: Vec<String>,
     pub features: Vec<SetFeature>,
+    /// Flashed dictionary-instance references, emitted after `features`.
+    pub instance_refs: Vec<BalanceVoidInstance>,
 }
 
 /// Sequential names for generated holes, unique within one Step.
@@ -44,7 +48,7 @@ pub(crate) fn write_generated_layer_feature(
     layer_feature: &GeneratedLayerFeature,
     names: &mut GeneratedNameState,
 ) -> Result<()> {
-    if layer_feature.features.is_empty() {
+    if layer_feature.features.is_empty() && layer_feature.instance_refs.is_empty() {
         return Ok(());
     }
 
@@ -60,6 +64,12 @@ pub(crate) fn write_generated_layer_feature(
         write::spec_ref(writer, spec_ref);
     }
     write_set_features(writer, units, &layer_feature.features, names)?;
+    for instance in &layer_feature.instance_refs {
+        writer.start_element("Features", &[]);
+        write::location(writer, "Location", instance.x, instance.y, units);
+        writer.empty_element("UserPrimitiveRef", &[("id", instance.template.as_str())]);
+        writer.end_element("Features");
+    }
     writer.end_element("Set");
     writer.end_element("LayerFeature");
     Ok(())
@@ -98,6 +108,74 @@ fn write_set_features(
         }
     }
     Ok(())
+}
+
+/// Splice shared void templates into the document's `DictionaryUser`,
+/// creating the dictionary in schema position when absent.
+pub(crate) fn user_dictionary_edit(
+    doc: &ipc2581::edit::Doc<'_>,
+    units: Units,
+    templates: &[BalanceVoidTemplate],
+) -> Result<Option<ipc2581::edit::Edit>> {
+    if templates.is_empty() {
+        return Ok(None);
+    }
+    let mut writer = XmlWriter::new();
+    write_user_dictionary_entries(&mut writer, units, templates);
+    let entries = writer.into_string();
+    let root = doc.root()?;
+    let content = doc
+        .child(root, "Content")
+        .ok_or_else(|| anyhow::anyhow!("IPC-2581 document has no Content section"))?;
+    if let Some(dictionary) = doc.child(content, "DictionaryUser") {
+        return Ok(Some(doc.append_inside(dictionary, entries)));
+    }
+    let mut container = XmlWriter::new();
+    container.start_element("DictionaryUser", &[("units", units_attr(units))]);
+    container.raw(&entries);
+    container.end_element("DictionaryUser");
+    let xml = container.into_string();
+    Ok(Some(
+        match doc
+            .children(content)
+            .into_iter()
+            .find(|child| doc.name(*child) == "DictionaryFirmware")
+        {
+            Some(firmware) => doc.insert_before(firmware, xml),
+            None => doc.append_inside(content, xml),
+        },
+    ))
+}
+
+fn units_attr(units: Units) -> &'static str {
+    match units {
+        Units::Millimeter => "MILLIMETER",
+        Units::Inch => "INCH",
+        Units::Micron => "MICRON",
+        Units::Mils => "MILS",
+    }
+}
+
+/// Serialize shared void templates as `DictionaryUser` entries.
+fn write_user_dictionary_entries(
+    writer: &mut XmlWriter,
+    units: Units,
+    templates: &[BalanceVoidTemplate],
+) {
+    for template in templates {
+        writer.start_element("EntryUser", &[("id", template.id.as_str())]);
+        writer.start_element("UserSpecial", &[]);
+        write::contour(
+            writer,
+            units,
+            &Contour {
+                polygon: template.polygon.clone(),
+                cutouts: Vec::new(),
+            },
+        );
+        writer.end_element("UserSpecial");
+        writer.end_element("EntryUser");
+    }
 }
 
 fn write_generated_user_primitive(

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -1180,26 +1180,63 @@ fn nearly_equal(left: f64, right: f64) -> bool {
 fn clear_polarity_needs_resolution(doc: &IpcGeometryDocument) -> bool {
     doc.layers.iter().any(|layer| {
         let features = layer.features.slice(&doc.features);
-        let clear_bounds = features
-            .iter()
-            .filter(|feature| {
-                feature.bucket != FeatureBucket::Cutout
-                    && feature.polarity == Polarity::Clear
-                    && !feature.flags.clears_previous_in_set
-            })
-            .map(|feature| feature.bbox)
-            .collect::<Vec<_>>();
+        let clear_bounds = ClearBoundsGrid::new(features.iter().filter_map(|feature| {
+            (feature.bucket != FeatureBucket::Cutout
+                && feature.polarity == Polarity::Clear
+                && !feature.flags.clears_previous_in_set)
+                .then_some(feature.bbox)
+        }));
         if clear_bounds.is_empty() {
             return false;
         }
         features.iter().any(|feature| {
             feature.polarity == Polarity::Dark
                 && paint_order(feature).stage == PaintStage::Overlay
-                && clear_bounds
-                    .iter()
-                    .any(|bounds| bounds.intersects(feature.bbox))
+                && clear_bounds.intersects(feature.bbox)
         })
     })
+}
+
+/// Uniform spatial hash over clear-feature bounds, sized for the
+/// millimeter-scale voids and pads that dominate them. Both insertion and
+/// queries touch only the handful of cells a bounding box covers, keeping
+/// the clear-versus-overlay reachability check linear in feature count.
+struct ClearBoundsGrid {
+    cells: HashMap<(i64, i64), Vec<pcb_ir::geom::BBox>>,
+}
+
+impl ClearBoundsGrid {
+    const CELL_MM: f64 = 4.0;
+
+    fn new(bounds: impl Iterator<Item = pcb_ir::geom::BBox>) -> Self {
+        let mut cells: HashMap<(i64, i64), Vec<pcb_ir::geom::BBox>> = HashMap::new();
+        for bbox in bounds {
+            for cell in Self::covered_cells(bbox) {
+                cells.entry(cell).or_default().push(bbox);
+            }
+        }
+        Self { cells }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.cells.is_empty()
+    }
+
+    fn intersects(&self, bbox: pcb_ir::geom::BBox) -> bool {
+        Self::covered_cells(bbox).any(|cell| {
+            self.cells
+                .get(&cell)
+                .is_some_and(|bounds| bounds.iter().any(|clear| clear.intersects(bbox)))
+        })
+    }
+
+    fn covered_cells(bbox: pcb_ir::geom::BBox) -> impl Iterator<Item = (i64, i64)> {
+        let min_x = (bbox.min.x / Self::CELL_MM).floor() as i64;
+        let max_x = (bbox.max.x / Self::CELL_MM).floor() as i64;
+        let min_y = (bbox.min.y / Self::CELL_MM).floor() as i64;
+        let max_y = (bbox.max.y / Self::CELL_MM).floor() as i64;
+        (min_x..=max_x).flat_map(move |x| (min_y..=max_y).map(move |y| (x, y)))
+    }
 }
 
 fn paint_order(feature: &Feature<ipc2581::Symbol>) -> PaintOrder {

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -84,6 +84,11 @@ pub fn build_gerber_x2_files_with_options(
         let mut doc = geometry::extract_layer_for_view(ipc, layer_name, view)
             .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
         pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut doc);
+        if clear_polarity_needs_resolution(&doc) {
+            pcb_ir::dialects::ipc::process::resolve_negative_polarity(&mut doc);
+            pcb_ir::dialects::ipc::process::compact(&mut doc);
+            pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
+        }
         if let Err(error) = pcb_ir::dialects::ipc::validate_artwork_ready(&doc) {
             bail!("IPC-2581 layer '{layer_name}' is not artwork-ready: {error}");
         }
@@ -1165,6 +1170,38 @@ fn nearly_equal(left: f64, right: f64) -> bool {
     (left - right).abs() <= GEOMETRY_EPSILON * left.abs().max(right.abs()).max(1.0)
 }
 
+/// Ordered artwork paints clear features in source order within their paint
+/// stage, but overlay-stage dark geometry always lands after the base stage.
+/// When a clear feature can reach overlay geometry that sequential model
+/// diverges from IPC's layer-wide negative semantics, so those documents fall
+/// back to resolving the polarity geometrically. Generated balance planes
+/// keep their clear voids native: the voids are certified clear of all other
+/// copper.
+fn clear_polarity_needs_resolution(doc: &IpcGeometryDocument) -> bool {
+    doc.layers.iter().any(|layer| {
+        let features = layer.features.slice(&doc.features);
+        let clear_bounds = features
+            .iter()
+            .filter(|feature| {
+                feature.bucket != FeatureBucket::Cutout
+                    && feature.polarity == Polarity::Clear
+                    && !feature.flags.clears_previous_in_set
+            })
+            .map(|feature| feature.bbox)
+            .collect::<Vec<_>>();
+        if clear_bounds.is_empty() {
+            return false;
+        }
+        features.iter().any(|feature| {
+            feature.polarity == Polarity::Dark
+                && paint_order(feature).stage == PaintStage::Overlay
+                && clear_bounds
+                    .iter()
+                    .any(|bounds| bounds.intersects(feature.bbox))
+        })
+    })
+}
+
 fn paint_order(feature: &Feature<ipc2581::Symbol>) -> PaintOrder {
     let stage = if feature.intent.role == FeatureRole::Cutout || feature.is_drill_like() {
         PaintStage::FinalCutout
@@ -1343,6 +1380,109 @@ mod tests {
         export_manufacturing_package,
     };
     use std::io::{Cursor, Read};
+
+    #[test]
+    fn negative_set_over_overlay_pad_resolves_geometrically() {
+        // A clear set that reaches overlay-stage dark geometry must fall back
+        // to layer-wide geometric resolution: the stage scheduler would
+        // otherwise paint the pad after the clear and never erase it.
+        let ipc = ipc::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="pad"><Circle diameter="2"/></EntryStandard>
+    </DictionaryStandard>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="10"/>
+            <PolyStepSegment x="0" y="10"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+        </Profile>
+        <PadStackDef name="padstack">
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR">
+            <StandardPrimitiveRef id="pad"/>
+          </PadstackPadDef>
+        </PadStackDef>
+        <LayerFeature layerRef="TOP">
+          <Set net="N1">
+            <Pad padstackDefRef="padstack">
+              <Location x="5" y="5"/>
+              <StandardPrimitiveRef id="pad"/>
+            </Pad>
+          </Set>
+          <Set polarity="NEGATIVE">
+            <Features>
+              <UserSpecial>
+                <Contour>
+                  <Polygon>
+                    <PolyBegin x="4" y="4"/>
+                    <PolyStepSegment x="5" y="4"/>
+                    <PolyStepSegment x="5" y="5"/>
+                    <PolyStepSegment x="4" y="5"/>
+                    <PolyStepSegment x="4" y="4"/>
+                  </Polygon>
+                </Contour>
+              </UserSpecial>
+            </Features>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let copper = files
+            .iter()
+            .find(|file| file.filename == "F_Cu.gtl")
+            .unwrap();
+        let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
+        assert!(
+            parsed
+                .objects()
+                .iter()
+                .all(|object| object.polarity == Polarity::Dark),
+            "clear set reaching an overlay pad should be resolved geometrically"
+        );
+
+        let mask = pcb_ir::dialects::artwork::compose_to_mask(
+            &gerberx2::geometry::extract_document(&parsed),
+        );
+        let mut rings = Vec::new();
+        for layer in &mask.layers {
+            for shape in mask.shapes(layer) {
+                rings.extend(pcb_ir::geom::region::rings_from_contours(
+                    &mask.arena.path_contours(shape),
+                ));
+            }
+        }
+        let copper_area = pcb_ir::geom::ContourSet::new(
+            rings,
+            pcb_ir::geom::FillRule::NonZero,
+            pcb_ir::geom::tol::REGION_MM,
+        )
+        .area();
+        let expected = std::f64::consts::PI * (1.0 - 0.25);
+        assert!(
+            (copper_area - expected).abs() <= expected * 0.02,
+            "expected quarter-cleared pad area {expected:.4}, got {copper_area:.4}"
+        );
+    }
 
     #[test]
     fn drill_and_route_layers_are_not_exported_as_gerber_layers() {

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1178,21 +1178,40 @@ fn nearly_equal(left: f64, right: f64) -> bool {
 /// keep their clear voids native: the voids are certified clear of all other
 /// copper.
 fn clear_polarity_needs_resolution(doc: &IpcGeometryDocument) -> bool {
+    let is_clear = |feature: &Feature<ipc2581::Symbol>| {
+        feature.bucket != FeatureBucket::Cutout
+            && feature.polarity == Polarity::Clear
+            && !feature.flags.clears_previous_in_set
+    };
     doc.layers.iter().any(|layer| {
         let features = layer.features.slice(&doc.features);
-        let clear_bounds = ClearBoundsGrid::new(features.iter().filter_map(|feature| {
-            (feature.bucket != FeatureBucket::Cutout
-                && feature.polarity == Polarity::Clear
-                && !feature.flags.clears_previous_in_set)
-                .then_some(feature.bbox)
-        }));
-        if clear_bounds.is_empty() {
+        let all_clears = ClearBoundsGrid::new(
+            features
+                .iter()
+                .filter_map(|feature| is_clear(feature).then_some(feature.bbox)),
+        );
+        if all_clears.is_empty() {
             return false;
         }
+        // Base-stage darks paint before only the clears that follow them in
+        // source order; every other stage paints after all base-stage
+        // clears. A dark feature that a clear could erase under layer-wide
+        // semantics but that paints after it natively needs resolution.
+        let mut preceding_clears = ClearBoundsGrid::default();
         features.iter().any(|feature| {
-            feature.polarity == Polarity::Dark
-                && paint_order(feature).stage == PaintStage::Overlay
-                && clear_bounds.intersects(feature.bbox)
+            if is_clear(feature) {
+                preceding_clears.insert(feature.bbox);
+                return false;
+            }
+            if feature.polarity != Polarity::Dark {
+                return false;
+            }
+            match paint_order(feature).stage {
+                PaintStage::Base => preceding_clears.intersects(feature.bbox),
+                PaintStage::Overlay | PaintStage::FinalCutout => {
+                    all_clears.intersects(feature.bbox)
+                }
+            }
         })
     })
 }
@@ -1201,6 +1220,7 @@ fn clear_polarity_needs_resolution(doc: &IpcGeometryDocument) -> bool {
 /// millimeter-scale voids and pads that dominate them. Both insertion and
 /// queries touch only the handful of cells a bounding box covers, keeping
 /// the clear-versus-overlay reachability check linear in feature count.
+#[derive(Default)]
 struct ClearBoundsGrid {
     cells: HashMap<(i64, i64), Vec<pcb_ir::geom::BBox>>,
 }
@@ -1209,13 +1229,17 @@ impl ClearBoundsGrid {
     const CELL_MM: f64 = 4.0;
 
     fn new(bounds: impl Iterator<Item = pcb_ir::geom::BBox>) -> Self {
-        let mut cells: HashMap<(i64, i64), Vec<pcb_ir::geom::BBox>> = HashMap::new();
+        let mut grid = Self::default();
         for bbox in bounds {
-            for cell in Self::covered_cells(bbox) {
-                cells.entry(cell).or_default().push(bbox);
-            }
+            grid.insert(bbox);
         }
-        Self { cells }
+        grid
+    }
+
+    fn insert(&mut self, bbox: pcb_ir::geom::BBox) {
+        for cell in Self::covered_cells(bbox) {
+            self.cells.entry(cell).or_default().push(bbox);
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -1417,6 +1441,111 @@ mod tests {
         export_manufacturing_package,
     };
     use std::io::{Cursor, Read};
+
+    #[test]
+    fn negative_set_before_a_later_fill_resolves_geometrically() {
+        // Layer-wide negative semantics erase every dark feature on the
+        // layer, including fills written after the clear; the sequential
+        // paint order would instead paint the later fill over the clear.
+        let ipc = ipc::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="10"/>
+            <PolyStepSegment x="0" y="10"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+        </Profile>
+        <LayerFeature layerRef="TOP">
+          <Set polarity="NEGATIVE">
+            <Features>
+              <UserSpecial>
+                <Contour>
+                  <Polygon>
+                    <PolyBegin x="4" y="4"/>
+                    <PolyStepSegment x="6" y="4"/>
+                    <PolyStepSegment x="6" y="6"/>
+                    <PolyStepSegment x="4" y="6"/>
+                    <PolyStepSegment x="4" y="4"/>
+                  </Polygon>
+                </Contour>
+              </UserSpecial>
+            </Features>
+          </Set>
+          <Set>
+            <Features>
+              <UserSpecial>
+                <Contour>
+                  <Polygon>
+                    <PolyBegin x="2" y="2"/>
+                    <PolyStepSegment x="8" y="2"/>
+                    <PolyStepSegment x="8" y="8"/>
+                    <PolyStepSegment x="2" y="8"/>
+                    <PolyStepSegment x="2" y="2"/>
+                  </Polygon>
+                </Contour>
+              </UserSpecial>
+            </Features>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let copper = files
+            .iter()
+            .find(|file| file.filename == "F_Cu.gtl")
+            .unwrap();
+        let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
+        assert!(
+            parsed
+                .objects()
+                .iter()
+                .all(|object| object.polarity == Polarity::Dark),
+            "clear preceding a later fill should be resolved geometrically"
+        );
+
+        let mask = pcb_ir::dialects::artwork::compose_to_mask(
+            &gerberx2::geometry::extract_document(&parsed),
+        );
+        let mut rings = Vec::new();
+        for layer in &mask.layers {
+            for shape in mask.shapes(layer) {
+                rings.extend(pcb_ir::geom::region::rings_from_contours(
+                    &mask.arena.path_contours(shape),
+                ));
+            }
+        }
+        let copper_area = pcb_ir::geom::ContourSet::new(
+            rings,
+            pcb_ir::geom::FillRule::NonZero,
+            pcb_ir::geom::tol::REGION_MM,
+        )
+        .area();
+        // 6x6 fill minus the 2x2 clear it overlaps.
+        let expected = 36.0 - 4.0;
+        assert!(
+            (copper_area - expected).abs() <= expected * 0.01,
+            "expected cleared fill area {expected:.2}, got {copper_area:.2}"
+        );
+    }
 
     #[test]
     fn negative_set_over_overlay_pad_resolves_geometrically() {

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -4,6 +4,8 @@ use ipc2581::Mode;
 pub mod accessors;
 pub mod board_array;
 pub mod commands;
+pub mod copper_balance;
+mod generated;
 pub mod geometry;
 pub mod gerber;
 pub mod layers;

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -1,4 +1,4 @@
-//! Safe copper-balancing regions for board arrays.
+//! Safe copper-balancing regions for board arrays and fabrication panels.
 //!
 //! This module separates IPC semantic collection from planar set operations:
 //! callers provide the canonical layout document, its fabrication profile, the
@@ -34,8 +34,8 @@ use std::fmt;
 
 use crate::dialects::Side;
 use crate::dialects::ipc::{
-    BoardArrayFabricationProfile, Document, Feature, FeatureSpan, ProfileOccurrenceRole,
-    ProfileSet, profile_occurrences_for, relief::is_vcut_operation_feature,
+    BoardArrayFabricationProfile, Document, Feature, FeatureSpan, LayoutPurpose,
+    ProfileOccurrenceRole, ProfileSet, profile_occurrences_for, relief::is_vcut_operation_feature,
 };
 use crate::geom::{ContourSet, FillRule, Paint, tol};
 
@@ -312,6 +312,8 @@ pub enum BalancingRegionError {
     InvalidNumericalGuard(f64),
     EmptyPanelOutline,
     EmptyBoardFootprints,
+    EmptyAssemblyPanels,
+    NotAFabricationPanel,
     UnpaintedSupportPaths(usize),
     GapRegularization(String),
 }
@@ -340,6 +342,12 @@ impl fmt::Display for BalancingRegionError {
             }
             Self::EmptyBoardFootprints => {
                 write!(f, "board array has no final board-instance profiles")
+            }
+            Self::EmptyAssemblyPanels => {
+                write!(f, "fabrication panel has no placed assembly panels")
+            }
+            Self::NotAFabricationPanel => {
+                write!(f, "layout root is not a fabrication panel")
             }
             Self::UnpaintedSupportPaths(count) => write!(
                 f,
@@ -467,6 +475,45 @@ where
         ));
     }
     Ok(collection)
+}
+
+/// Collect the geometry-only balancing input for a fabrication panel.
+///
+/// The domain is the caller-supplied usable region between the stock's
+/// reserved process margins, so the margins never enter the density
+/// denominator and stay bare. The placed assembly panels are the only
+/// footprint obstacles: every cutout, score, and copper feature of a placed
+/// panel lies inside its nominal outline, and the fabrication-panel step adds
+/// no per-layer geometry of its own, so one input serves every copper layer.
+/// Profile cutouts still ride along as material removal for completeness.
+pub fn collect_fab_panel_balancing_input(
+    usable_region: ContourSet,
+    fabrication_profile: &BoardArrayFabricationProfile,
+) -> Result<BoardArrayBalancingInput, BalancingRegionError> {
+    if fabrication_profile.purpose != LayoutPurpose::FabricationPanel {
+        return Err(BalancingRegionError::NotAFabricationPanel);
+    }
+    let panel_contours = fabrication_profile
+        .assembly_panel_outlines
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    let board_footprints = ContourSet::from_filled_contours(&panel_contours, tol::REGION_MM);
+    if board_footprints.is_empty() {
+        return Err(BalancingRegionError::EmptyAssemblyPanels);
+    }
+
+    Ok(BoardArrayBalancingInput {
+        panel_outer: usable_region,
+        board_footprints,
+        material_removal: ContourSet::from_contours(
+            &fabrication_profile.material_removal,
+            FillRule::NonZero,
+            tol::REGION_MM,
+        ),
+        support_features: ContourSet::empty(tol::REGION_MM),
+    })
 }
 
 /// Collect the same inputs and coverage data as
@@ -1146,6 +1193,62 @@ mod tests {
         assert_eq!(geometry.path_count, 1);
         assert_eq!(geometry.excluded_documentation_path_count, 1);
         assert!(geometry.region_for_layer(100).bbox.max.y < 1.0);
+    }
+
+    #[test]
+    fn fab_panel_collector_uses_assembly_panels_as_the_only_footprints() {
+        let usable_region = ContourSet::rectangle(bbox(10.0, 10.0, 90.0, 60.0), tol::REGION_MM);
+        let profile = BoardArrayFabricationProfile {
+            purpose: LayoutPurpose::FabricationPanel,
+            array_outlines: vec![vec![rectangle_contour(0.0, 0.0, 100.0, 70.0)]],
+            assembly_panel_outlines: vec![
+                vec![rectangle_contour(15.0, 15.0, 45.0, 55.0)],
+                vec![rectangle_contour(50.0, 15.0, 85.0, 55.0)],
+            ],
+            material_removal: vec![rectangle_contour(20.0, 20.0, 22.0, 22.0)],
+        };
+
+        let input = collect_fab_panel_balancing_input(usable_region.clone(), &profile).unwrap();
+
+        assert!((input.panel_outer.area() - usable_region.area()).abs() <= 1e-9);
+        assert!((input.board_footprints.area() - (30.0 * 40.0 + 35.0 * 40.0)).abs() <= 1e-6);
+        assert!((input.material_removal.area() - 4.0).abs() <= 1e-6);
+        assert!(input.support_features.is_empty());
+
+        let result =
+            board_array_balancing_region(&input, BalancingRegionOptions::default()).unwrap();
+        assert!(result.certificate.passes(1e-4));
+        assert!(!result.safe_region.is_empty());
+        assert!(
+            result
+                .safe_region
+                .intersection(&input.board_footprints)
+                .is_empty()
+        );
+        assert!(result.safe_region.difference(&usable_region).is_empty());
+    }
+
+    #[test]
+    fn fab_panel_collector_rejects_wrong_purpose_and_missing_panels() {
+        let usable_region = ContourSet::rectangle(bbox(0.0, 0.0, 50.0, 50.0), tol::REGION_MM);
+        let mut profile = BoardArrayFabricationProfile {
+            purpose: LayoutPurpose::Product,
+            array_outlines: vec![vec![rectangle_contour(0.0, 0.0, 60.0, 60.0)]],
+            assembly_panel_outlines: vec![vec![rectangle_contour(5.0, 5.0, 25.0, 25.0)]],
+            material_removal: Vec::new(),
+        };
+
+        assert_eq!(
+            collect_fab_panel_balancing_input(usable_region.clone(), &profile).unwrap_err(),
+            BalancingRegionError::NotAFabricationPanel
+        );
+
+        profile.purpose = LayoutPurpose::FabricationPanel;
+        profile.assembly_panel_outlines.clear();
+        assert_eq!(
+            collect_fab_panel_balancing_input(usable_region, &profile).unwrap_err(),
+            BalancingRegionError::EmptyAssemblyPanels
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -32,7 +32,7 @@ pub use balancing_region::{
     ClearanceCertificate, DEFAULT_BALANCING_CLEARANCE_MM, DEFAULT_BALANCING_GAP_RADIUS_MM,
     DEFAULT_BALANCING_NUMERICAL_GUARD_MM, DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM,
     board_array_balancing_region, collect_board_array_balancing_input,
-    inspect_board_array_balancing_input,
+    collect_fab_panel_balancing_input, inspect_board_array_balancing_input,
 };
 pub use document::{Document, Layer};
 pub use feature::{

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -37,10 +37,13 @@ where
 
 /// Resolve IPC-specific paint semantics while preserving native artwork shapes.
 ///
-/// IPC feature-set voids, negative polarity, and layer cutouts are semantic
-/// operators on source features, not generic ordered artwork objects. Resolve
-/// those before lowering to source-independent artwork, but do not outline
-/// strokes or flatten unrelated positive features.
+/// IPC feature-set voids and layer cutouts are semantic operators on source
+/// features, not generic ordered artwork objects. Resolve those before
+/// lowering to source-independent artwork, but do not outline strokes or
+/// flatten unrelated positive features. Negative-polarity features stay
+/// native: ordered artwork carries per-object polarity with exactly IPC's
+/// sequential paint semantics, so resolving them here would only flatten
+/// repeated clear instances into unshareable boundary geometry.
 pub fn normalize_for_artwork<S, L>(doc: &mut Document<S, L>)
 where
     S: Copy + Eq + Hash,
@@ -48,7 +51,6 @@ where
 {
     normalize_preserving(doc);
     resolve_set_voids(doc);
-    resolve_negative_polarity(doc);
     subtract_layer_cutouts(doc);
     compact(doc);
     normalize_bounds(doc);
@@ -488,8 +490,9 @@ where
                 if feature.flags.clears_previous_in_set {
                     let cutters = feature_filled_rings(doc, &doc.features[feature_index]);
                     if !cutters.is_empty() {
+                        let bounds = ring_bounds(&cutters);
                         for subject_index in previous.iter().copied() {
-                            subtract_rings_from_feature(doc, subject_index, &cutters);
+                            subtract_rings_from_feature(doc, subject_index, &cutters, &bounds);
                         }
                     }
                     clear_feature_paths(doc, feature_index);
@@ -547,10 +550,11 @@ where
             cutters = region::simplify_rings(cutters, FillRule::NonZero);
         }
 
+        let cutter_bounds = ring_bounds(&cutters);
         for feature_index in layer.features.range() {
             let feature = &doc.features[feature_index];
             if feature.bucket != FeatureBucket::Cutout && feature.polarity == Polarity::Dark {
-                subtract_rings_from_feature(doc, feature_index, &cutters);
+                subtract_rings_from_feature(doc, feature_index, &cutters, &cutter_bounds);
             }
         }
 
@@ -593,7 +597,8 @@ where
                 continue;
             }
 
-            subtract_rings_from_feature(doc, feature_index, &cutters);
+            let bounds = ring_bounds(&cutters);
+            subtract_rings_from_feature(doc, feature_index, &cutters, &bounds);
         }
     }
 }
@@ -697,17 +702,52 @@ fn clear_feature_paths<S, L>(doc: &mut Document<S, L>, feature_index: usize) {
     feature.primitive_ref = None;
 }
 
+fn ring_bounds(rings: &[Ring]) -> Vec<BBox> {
+    rings
+        .iter()
+        .map(|ring| rings_bbox(std::slice::from_ref(ring)))
+        .collect()
+}
+
+fn rings_bbox(rings: &[Ring]) -> BBox {
+    rings
+        .iter()
+        .flat_map(|ring| ring.iter())
+        .fold(BBox::empty(), |bbox, &[x, y]| {
+            bbox.union(BBox::new(
+                crate::geom::Point::new(x, y),
+                crate::geom::Point::new(x, y),
+            ))
+        })
+}
+
 fn subtract_rings_from_feature<S, L>(
     doc: &mut Document<S, L>,
     feature_index: usize,
     cutters: &[Ring],
+    cutter_bounds: &[BBox],
 ) {
     let subject = feature_filled_rings(doc, &doc.features[feature_index]);
     if subject.is_empty() {
         return;
     }
 
-    let contours = region::rings_to_contours(region::difference_rings(subject, cutters.to_vec()));
+    // Only cutters that can reach this feature participate; most features on
+    // a layer are nowhere near any of them, and dense generated cutter sets
+    // (balance void lattices) would otherwise make every subtraction sweep
+    // the whole set.
+    let subject_bounds = rings_bbox(&subject);
+    let near = cutters
+        .iter()
+        .zip(cutter_bounds)
+        .filter(|(_, bounds)| bounds.intersects(subject_bounds))
+        .map(|(ring, _)| ring.clone())
+        .collect::<Vec<_>>();
+    if near.is_empty() {
+        return;
+    }
+
+    let contours = region::rings_to_contours(region::difference_rings(subject, near));
     if contours.is_empty() {
         clear_feature_paths(doc, feature_index);
         return;
@@ -1089,7 +1129,7 @@ mod tests {
     }
 
     #[test]
-    fn artwork_ready_validation_rejects_unresolved_negative_polarity() {
+    fn artwork_ready_validation_accepts_clear_polarity() {
         let mut doc = TestDoc::new();
         doc.push_path(
             Paint::Fill {
@@ -1102,9 +1142,7 @@ mod tests {
             ..Feature::new(FeatureKind::Polygon, Polarity::Clear)
         });
 
-        let error = validate_artwork_ready(&doc).unwrap_err();
-
-        assert!(error.to_string().contains("unresolved negative polarity"));
+        validate_artwork_ready(&doc).unwrap();
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/validate.rs
+++ b/crates/pcb-ir/src/dialects/ipc/validate.rs
@@ -1,13 +1,14 @@
 //! Structural validation for IPC documents headed to artwork export.
 
 use crate::dialects::ipc::Document;
-use crate::dialects::ipc::feature::{Feature, FeatureBucket};
+use crate::dialects::ipc::feature::Feature;
 use crate::geom::path::{PathCmd, PathOp};
-use crate::geom::{Diagnostics, PaintKind, Point, Polarity, Span, tol};
+use crate::geom::{Diagnostics, PaintKind, Point, Span, tol};
 
 /// Check that every feature is exportable as native artwork: no unresolved
-/// set-void or negative-polarity semantics, homogeneous paint per feature,
-/// and circular arcs. All problems are collected.
+/// set-void semantics, homogeneous paint per feature, and circular arcs.
+/// Clear polarity is native — ordered artwork paints it with exactly IPC's
+/// sequential semantics. All problems are collected.
 pub fn validate_artwork_ready<Symbol, LayerFunction>(
     doc: &Document<Symbol, LayerFunction>,
 ) -> Result<(), Diagnostics> {
@@ -20,11 +21,6 @@ pub fn validate_artwork_ready<Symbol, LayerFunction>(
         if feature.flags.clears_previous_in_set {
             diagnostics.error(format!(
                 "feature {feature_index} still has unresolved set-void clear semantics"
-            ));
-        }
-        if feature.bucket != FeatureBucket::Cutout && feature.polarity != Polarity::Dark {
-            diagnostics.error(format!(
-                "feature {feature_index} still has unresolved negative polarity"
             ));
         }
         validate_feature_arcs(doc, feature_index, feature, &mut diagnostics);

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -25,7 +25,12 @@ use spatial::{
 const NUMERIC_EPSILON: f64 = 1e-9;
 const RADIUS_SOLVE_TOLERANCE_MM: f64 = 1e-4;
 const AREA_SOLVE_TOLERANCE_MM2: f64 = 1e-3;
-const SPATIAL_SOLVE_ITERATIONS: usize = 64;
+// Gradient information travels about one kernel support per iteration under
+// the fixed conservative step, so the radius field needs a few hundred
+// iterations to equilibrate across a panel; measured objectives plateau by
+// roughly 500 at both board-array and fabrication-panel scale. Iterations are
+// cheap next to lattice coverage sampling.
+const SPATIAL_SOLVE_ITERATIONS: usize = 512;
 const SQRT_3: f64 = 1.732_050_807_568_877_2;
 
 /// Fixed geometry constraints for a dense perforated copper plane.
@@ -326,36 +331,63 @@ pub fn generate_spatial_dense_copper_balance(
     validate_spatial_request(request)?;
     let retained_area_mm2 = request.panel_region.area();
 
-    let voidable = request
+    // Layers frequently share one safe region — a fab panel's every copper
+    // layer, a board array's layers with equal support scope — so erode and
+    // classify each distinct region once.
+    let mut region_sources: Vec<&ContourSet> = Vec::new();
+    let mut region_voidable: Vec<ContourSet> = Vec::new();
+    let mut region_lattices: Vec<LatticeCandidates> = Vec::new();
+    let layer_regions = request
         .layers
         .iter()
-        .map(|layer| layer.safe_region.disk_erode(profile.boundary_web_mm))
-        .collect::<Vec<_>>();
-    let lattices = voidable
-        .iter()
-        .map(|region| LatticeCandidates::new(region, request.lattice_origin, profile))
-        .collect::<Vec<_>>();
-    let uniform = request
-        .layers
-        .iter()
-        .zip(&voidable)
-        .zip(&lattices)
-        .map(|((layer, voidable), lattice)| {
-            generate_dense_copper_balance_with_lattice(
+        .map(|layer| {
+            if let Some(index) = region_sources
+                .iter()
+                .position(|region| region.rings == layer.safe_region.rings)
+            {
+                return index;
+            }
+            let voidable = layer.safe_region.disk_erode(profile.boundary_web_mm);
+            region_lattices.push(LatticeCandidates::new(
+                &voidable,
+                request.lattice_origin,
                 profile,
-                DenseCopperBalanceRequest {
-                    safe_region: layer.safe_region,
-                    retained_area_mm2,
-                    existing_copper_area_mm2: layer.existing_copper.area(),
-                    target_density: layer.target_density,
-                    lattice_origin: request.lattice_origin,
-                },
-                layer.safe_region.clone(),
-                voidable,
-                lattice,
-            )
+            ));
+            region_voidable.push(voidable);
+            region_sources.push(layer.safe_region);
+            region_sources.len() - 1
         })
         .collect::<Vec<_>>();
+    let uniform = std::thread::scope(|scope| {
+        let solves = request
+            .layers
+            .iter()
+            .zip(&layer_regions)
+            .map(|(layer, region_index)| {
+                let voidable = &region_voidable[*region_index];
+                let lattice = &region_lattices[*region_index];
+                scope.spawn(move || {
+                    generate_dense_copper_balance_with_lattice(
+                        profile,
+                        DenseCopperBalanceRequest {
+                            safe_region: layer.safe_region,
+                            retained_area_mm2,
+                            existing_copper_area_mm2: layer.existing_copper.area(),
+                            target_density: layer.target_density,
+                            lattice_origin: request.lattice_origin,
+                        },
+                        layer.safe_region.clone(),
+                        voidable,
+                        lattice,
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        solves
+            .into_iter()
+            .map(|solve| solve.join().expect("uniform copper-balance solve panicked"))
+            .collect::<Vec<_>>()
+    });
 
     let mut panel_samples =
         hex_aligned_lattice_centers(request.panel_region.bbox, request.lattice_origin, profile)
@@ -375,10 +407,10 @@ pub fn generate_spatial_dense_copper_balance(
     // Full centers lie in eroded safe regions inside the panel; appending any
     // center the tolerance-bound point test missed keeps sample membership
     // structural rather than tolerance-dependent.
-    let active_sites = lattices
+    let active_sites = layer_regions
         .iter()
-        .map(|lattice| {
-            lattice
+        .map(|region_index| {
+            region_lattices[*region_index]
                 .full_centers
                 .iter()
                 .map(|center| {
@@ -407,38 +439,32 @@ pub fn generate_spatial_dense_copper_balance(
         request.lattice_origin,
         profile,
     );
-    let fixed_density = request
-        .layers
-        .iter()
-        .map(|layer| {
-            density_kernel.smooth(&lattice_cell_coverage(
-                &panel_samples,
-                layer.existing_copper,
-                profile,
-            ))
-        })
-        .collect::<Vec<_>>();
-    let available_density = request
-        .layers
-        .iter()
-        .map(|layer| {
-            density_kernel.smooth(&lattice_cell_coverage(
-                &panel_samples,
-                layer.safe_region,
-                profile,
-            ))
-        })
-        .collect::<Vec<_>>();
-    let partial_void_density = uniform
-        .iter()
-        .map(|result| {
-            density_kernel.smooth(&lattice_cell_coverage(
-                &panel_samples,
-                &result.partial_voids,
-                profile,
-            ))
-        })
-        .collect::<Vec<_>>();
+    let smooth_coverage = |region: &ContourSet| {
+        density_kernel.smooth(&lattice_cell_coverage(&panel_samples, region, profile))
+    };
+    let (fixed_density, region_available_density, partial_void_density) =
+        std::thread::scope(|scope| {
+            let fixed = request
+                .layers
+                .iter()
+                .map(|layer| scope.spawn(|| smooth_coverage(layer.existing_copper)))
+                .collect::<Vec<_>>();
+            let available = region_sources
+                .iter()
+                .map(|region| scope.spawn(|| smooth_coverage(region)))
+                .collect::<Vec<_>>();
+            let partial = uniform
+                .iter()
+                .map(|result| scope.spawn(|| smooth_coverage(&result.partial_voids)))
+                .collect::<Vec<_>>();
+            let join_all = |handles: Vec<std::thread::ScopedJoinHandle<'_, Vec<f64>>>| {
+                handles
+                    .into_iter()
+                    .map(|handle| handle.join().expect("coverage sampling panicked"))
+                    .collect::<Vec<_>>()
+            };
+            (join_all(fixed), join_all(available), join_all(partial))
+        });
 
     let lower = active_sites
         .iter()
@@ -504,13 +530,12 @@ pub fn generate_spatial_dense_copper_balance(
                     .iter()
                     .enumerate()
                     .map(|(site_index, fixed)| {
+                        let available = &region_available_density[layer_regions[layer_index]];
                         let generated_density = match uniform[layer_index].solution.mode {
                             DenseCopperBalanceMode::None => 0.0,
-                            DenseCopperBalanceMode::Solid => {
-                                available_density[layer_index][site_index]
-                            }
+                            DenseCopperBalanceMode::Solid => available[site_index],
                             DenseCopperBalanceMode::Perforated { .. } => {
-                                available_density[layer_index][site_index]
+                                available[site_index]
                                     - partial_void_density[layer_index][site_index]
                                     - void_density[site_index]
                             }
@@ -567,7 +592,7 @@ pub fn generate_spatial_dense_copper_balance(
                 return baseline;
             }
             spatial_result_from_squared_radii(
-                &lattices[layer_index].full_centers,
+                &region_lattices[layer_regions[layer_index]].full_centers,
                 &squared_radii[layer_index],
                 baseline,
                 request.layers[layer_index],
@@ -688,10 +713,15 @@ fn project_perforated_geometry(
         return best;
     }
 
+    // Every candidate evaluation clips the boundary voids against the safe
+    // region, so the exit tolerance scales with the region: the absolute
+    // floor governs small solves exactly, while large panels stop once the
+    // area error is negligible relative to their usable area.
+    let area_tolerance_mm2 = AREA_SOLVE_TOLERANCE_MM2.max(1e-6 * usable_area_mm2);
     let mut low_area = low_void_area;
     let mut high_area = high_void_area;
     while high_radius - low_radius > RADIUS_SOLVE_TOLERANCE_MM
-        && best.error_mm2 > AREA_SOLVE_TOLERANCE_MM2
+        && best.error_mm2 > area_tolerance_mm2
     {
         // Interior hex area is linear in r². Interpolate there, with a
         // midpoint fallback that keeps convergence bracketed when clipped

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -42,6 +42,10 @@ pub struct DenseCopperBalanceProfile {
     pub min_copper_web_mm: f64,
     pub boundary_web_mm: f64,
     pub density_sigma_mm: f64,
+    /// Fabrication step the spatially solved void radii snap to. Etching
+    /// cannot hold finer distinctions, and the shared grid keeps the voids a
+    /// small set of repeated templates instead of thousands of unique shapes.
+    pub void_radius_step_mm: f64,
 }
 
 impl DenseCopperBalanceProfile {
@@ -53,6 +57,7 @@ impl DenseCopperBalanceProfile {
         min_copper_web_mm: 0.20,
         boundary_web_mm: 0.20,
         density_sigma_mm: 5.0,
+        void_radius_step_mm: 0.005,
     };
 
     pub fn lattice_column_pitch_mm(self) -> f64 {
@@ -83,6 +88,7 @@ impl DenseCopperBalanceProfile {
             ("minimum copper web", self.min_copper_web_mm),
             ("boundary copper web", self.boundary_web_mm),
             ("density smoothing sigma", self.density_sigma_mm),
+            ("void radius step", self.void_radius_step_mm),
         ] {
             if !value.is_finite() || value <= 0.0 {
                 return Err(DenseCopperBalanceError::InvalidProfile(format!(
@@ -597,6 +603,7 @@ pub fn generate_spatial_dense_copper_balance(
                 baseline,
                 request.layers[layer_index],
                 retained_area_mm2,
+                profile,
             )
         })
         .collect())
@@ -893,6 +900,7 @@ mod tests {
             min_copper_web_mm: 0.05,
             boundary_web_mm: 0.2,
             density_sigma_mm: 5.0,
+            void_radius_step_mm: 0.005,
         };
         profile.validate().unwrap();
         let safe_region = ContourSet::rectangle(
@@ -1262,9 +1270,10 @@ mod tests {
         };
 
         assert!(mean_radius(20.0, 25.0) > mean_radius(35.0, 40.0));
+        let quantization_bound_mm2 = 0.01 * result.full_voids.len() as f64;
         assert!(
             (result.solution.generated_area_mm2 - baseline.solution.generated_area_mm2).abs()
-                <= AREA_SOLVE_TOLERANCE_MM2
+                <= AREA_SOLVE_TOLERANCE_MM2 + quantization_bound_mm2
         );
     }
 
@@ -1328,8 +1337,9 @@ mod tests {
 
         assert!(radius_difference > 0.01);
         assert!(independent.iter().zip(&stack_aware).all(|(left, right)| {
+            let quantization_bound_mm2 = 0.01 * left.full_voids.len() as f64;
             (left.solution.generated_area_mm2 - right.solution.generated_area_mm2).abs()
-                <= AREA_SOLVE_TOLERANCE_MM2
+                <= AREA_SOLVE_TOLERANCE_MM2 + quantization_bound_mm2
         }));
     }
 

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -290,22 +290,39 @@ pub(super) fn spatial_result_from_squared_radii(
     baseline: DenseCopperBalanceResult,
     layer: SpatialCopperBalanceLayerRequest<'_>,
     retained_area_mm2: f64,
+    profile: DenseCopperBalanceProfile,
 ) -> DenseCopperBalanceResult {
+    // Snap the continuous radius field to the fabrication step so the voids
+    // form a small set of repeated templates; round-to-nearest keeps the
+    // aggregate area error stochastic and far below the solve tolerance.
+    let quantize = |radius_squared: f64| {
+        ((radius_squared.sqrt() / profile.void_radius_step_mm).round()
+            * profile.void_radius_step_mm)
+            .clamp(profile.min_void_radius_mm, profile.max_void_radius_mm)
+    };
     let full_voids = centers
         .iter()
         .zip(squared_radii)
         .map(|(center, radius_squared)| DenseCopperVoid {
             center: *center,
-            radius_mm: radius_squared.sqrt(),
+            radius_mm: quantize(*radius_squared),
         })
         .collect::<Vec<_>>();
-    let full_void_area_mm2 = ROUNDED_HEXAGON_AREA_FACTOR * squared_radii.iter().sum::<f64>();
+    let full_void_area_mm2 = ROUNDED_HEXAGON_AREA_FACTOR
+        * full_voids
+            .iter()
+            .map(|void| void.radius_mm * void.radius_mm)
+            .sum::<f64>();
     let partial_voids = baseline.partial_voids;
     let void_area_mm2 = full_void_area_mm2 + partial_voids.area();
     let generated_area_mm2 = (baseline.usable.area() - void_area_mm2).max(0.0);
     let achieved_density = (layer.existing_copper.area() + generated_area_mm2) / retained_area_mm2;
-    let equivalent_radius_mm =
-        (squared_radii.iter().sum::<f64>() / squared_radii.len() as f64).sqrt();
+    let equivalent_radius_mm = (full_voids
+        .iter()
+        .map(|void| void.radius_mm * void.radius_mm)
+        .sum::<f64>()
+        / full_voids.len() as f64)
+        .sqrt();
     let solution = DenseCopperBalanceSolution {
         mode: DenseCopperBalanceMode::Perforated {
             void_radius_mm: equivalent_radius_mm,


### PR DESCRIPTION
\`fab-panel create\` now balances copper automatically, the fabrication-panel pass that the board-array balancing doc reserved as out of scope.

- The balancing region is just the gutters: the usable stock area between the process margins, minus the placed assembly-panel outlines with the standard clearance, built and certified by the existing \`board_array_balancing_region\` construction. One safe region serves every copper layer, since the fab-panel step adds no per-layer geometry of its own.
- Each layer targets the aggregate copper density measured inside the placed panels, extending their already-balanced density into the gutters. The margins are excluded from the density domain entirely and stay bare.
- The joint spatial solve, stack weights, feature lowering, and per-layer summary/report are shared with board-array balancing via new crate-level \`copper_balance\` and \`generated\` modules (extracted from \`board_array\`, no behavior change); \`pcb-ir\` gains a \`collect_fab_panel_balancing_input\` collector.
- Generation is two-pass like board arrays: a provisional panel supplies composed copper and placed outlines, then the final panel is written with the generated copper as positive \`LayerFeature\` contours in the fab step.

Details in \`crates/pcb-ipc2581-tools/docs/fab-panel-copper-balancing.md\`.

Tests: gutters fill to the panel density with a forced-rotation placement, margins/clearances verified bare geometrically, full-coverage panel yields no fill, and sparse existing fixtures resolve to "no fill" so prior behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fabrication-panel geometry, IPC negative sets, and Gerber polarity/export paths; changes are broad but covered by integration tests including Gerber–IPC area checks.
> 
> **Overview**
> **`fab-panel create` now runs automatic copper balancing** in the gutters between placed assembly panels (usable stock minus margins and panel outlines), targeting each layer’s density inside those panels. It uses the same two-pass flow as board arrays: provisional panel → solve → final XML with balance `LayerFeature`s and a per-layer summary on stderr.
> 
> **Board-array and fab-panel balancing share new `copper_balance` and `generated` modules** (logic moved out of `board_array` without intended behavior change). Perforated balance voids are emitted as a **positive plane plus negative `UserPrimitiveRef` instances** backed by `DictionaryUser` hex templates, instead of carving every full void into positive contours.
> 
> **`pcb-ir` adds `collect_fab_panel_balancing_input`**, keeps **clear polarity native** for artwork (no longer resolved in `normalize_for_artwork`), speeds set/cutout subtraction with bbox filtering, and tunes the spatial solver (more iterations, radius quantization step, shared safe-region caching, parallel uniform solves).
> 
> **Gerber export** optionally **resolves clear polarity geometrically** when sequential paint would disagree with layer-wide negatives; **repeated congruent clear regions** (≥16) collapse to shared outline-macro flashes. Fab-panel composition strips sources to manufacturing content up front and unions fabrication `sectionKey` across sources.
> 
> Docs: `fab-panel-copper-balancing.md` and changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48661eca7ea8278489a2d76e58715666c9f872b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->