### PR TITLE
Sequential polarity runs and native dictionary instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `fab-panel create` now automatically balances copper in the gutters between placed assembly panels.
 
+### Changed
+
+- Gerber exports for copper-balanced panels are much smaller.
+
 ### Fixed
 
 - Pad shapes with padstack offsets now land at the correct position on rotated pads across all IPC-2581 outputs.
+- Copper-balance density targets no longer count cleared areas as copper.
 
 ## [0.4.22] - 2026-08-04
 

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -407,21 +407,31 @@ impl ApertureTable {
 
     fn artwork_aperture(&mut self, aperture: Aperture, function: &[String]) -> Result<i32> {
         let hole_diameter = (aperture.hole_diameter > 0.0).then_some(aperture.hole_diameter);
+        let fill_rule = aperture.fill_rule();
         match aperture.shape {
             ApertureShape::Contour(contour) => {
-                let mut rings = region::rings_from_contours(std::slice::from_ref(&contour));
+                // Resolve the buffer's raw loops under the aperture's fill
+                // rule so winding is canonical: each shape is an outer ring
+                // followed by its holes, wound opposite. Larger shapes paint
+                // first so an island inside a hole survives the hole's erase.
+                let mut shapes = region::simplify_shapes(
+                    region::rings_from_contours(std::slice::from_ref(&contour)),
+                    fill_rule,
+                );
+                shapes.sort_by(|a, b| {
+                    let area = |shape: &region::Shape| {
+                        shape
+                            .first()
+                            .map_or(0.0, |ring| region::ring_signed_area(ring).abs())
+                    };
+                    area(b).total_cmp(&area(a))
+                });
+                let rings = shapes.into_iter().flatten().collect::<Vec<_>>();
                 if rings.is_empty() {
                     return Err(GerberError::InvalidStructure(
                         "cannot export an empty contour aperture".to_string(),
                     ));
                 }
-                // Paint larger loops before the loops they contain, so a
-                // hole's exposure-off outline erases the material under it.
-                rings.sort_by(|a, b| {
-                    region::ring_signed_area(b)
-                        .abs()
-                        .total_cmp(&region::ring_signed_area(a).abs())
-                });
                 let key = rings
                     .iter()
                     .map(|ring| {
@@ -996,6 +1006,70 @@ mod tests {
         assert!(
             (summary.area_mm2 - 64.0).abs() < 0.01,
             "the hole ring must survive as an exposure-off outline: {}",
+            summary.area_mm2
+        );
+    }
+
+    #[test]
+    fn contour_apertures_normalize_material_winding() {
+        // A clockwise-wound solitary loop is still material under NonZero;
+        // winding normalization must not turn it into an exposure-off ring.
+        let mut artwork = ArtworkDocument::new();
+        let layer_id = artwork.push_layer(IrArtworkDocument {
+            name: "F.Cu".to_string(),
+            role: LayerRole::Copper,
+            side: Side::Top,
+            objects: Span::EMPTY,
+            bbox: BBox::empty(),
+            meta: LayerAttributes::default(),
+        });
+
+        let clockwise = [
+            Point::new(0.0, 0.0),
+            Point::new(0.0, 10.0),
+            Point::new(10.0, 10.0),
+            Point::new(10.0, 0.0),
+        ];
+        let mut bbox = BBox::empty();
+        let mut cmds = Vec::new();
+        for (index, point) in clockwise.into_iter().enumerate() {
+            bbox.include_point(point);
+            cmds.push(if index == 0 {
+                PathCmd::move_to(point)
+            } else {
+                PathCmd::line_to(point)
+            });
+        }
+        cmds.push(PathCmd::close());
+        let contour = ContourBuf::from_parts(bbox, cmds);
+
+        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour(contour)));
+        artwork.push_object(
+            layer_id,
+            ArtworkObject {
+                polarity: Polarity::Dark,
+                order: Default::default(),
+                geometry: ArtworkGeometry::Flash {
+                    aperture,
+                    transform: pcb_ir::geom::Affine2::translation(Point::new(20.0, 5.0)),
+                },
+                bbox: BBox {
+                    min: Point::new(20.0, 5.0),
+                    max: Point::new(30.0, 15.0),
+                },
+                meta: ObjectAttributes::default(),
+            },
+        );
+
+        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let contents = crate::write_layer(&gerber).expect("write Gerber");
+        assert_external_parser_accepts(&contents);
+        let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
+        let geometry = crate::geometry::extract_document(&parsed);
+        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        assert!(
+            (summary.area_mm2 - 100.0).abs() < 0.01,
+            "a clockwise material loop must keep its full area: {}",
             summary.area_mm2
         );
     }

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -5,7 +5,7 @@
 //! can be emitted as a Gerber file, regardless of which source dialect
 //! produced it.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use crate::{
     AttributeValue, Contour, ContourSegment, GerberError, GerberLayer, ObjectKind,
@@ -142,20 +142,8 @@ pub fn lower_artwork_layer(layer: &ArtworkDocument) -> Result<GerberLayer> {
         .map(|layer| layer.meta.clone())
         .unwrap_or_default();
 
-    let flashes = plan_repeated_clear_flashes(layer, &mut apertures)?;
-    for (source_index, object) in layer.objects.iter().enumerate() {
-        let objects = if let Some(flash) = flashes.get(&source_index) {
-            vec![WriterObject {
-                kind: ObjectKind::Flash {
-                    at: lower_point(flash.at),
-                    aperture: flash.aperture,
-                },
-                polarity: object.polarity,
-                attributes: lower_object_attributes(&object.meta),
-            }]
-        } else {
-            lower_artwork_object(layer, object, &mut apertures)?
-        };
+    for object in layer.objects.iter() {
+        let objects = lower_artwork_object(layer, object, &mut apertures)?;
         plan.push_group(object.order.stage, object.polarity, objects);
     }
     let objects = plan.into_ordered_objects();
@@ -168,131 +156,6 @@ pub fn lower_artwork_layer(layer: &ArtworkDocument) -> Result<GerberLayer> {
         objects,
         ..GerberLayer::default()
     })
-}
-
-/// Minimum congruent clear regions before sharing their outline as a macro
-/// aperture pays for the definition.
-const MIN_REPEATED_CLEAR_FLASHES: usize = 16;
-
-/// Congruence quantum for translated-copy detection, in millimeters.
-const CLEAR_FLASH_QUANTUM_MM: f64 = 1e-6;
-
-struct PlannedClearFlash {
-    at: Point,
-    aperture: i32,
-}
-
-/// Plan translation-congruent single-contour clear regions as flashes of one
-/// shared outline-macro aperture.
-///
-/// Each flash replaces its region at the same position in the object order
-/// with identical geometry and polarity, so the painted image is unchanged
-/// and no polarity reasoning is required. Dense generated patterns — copper
-/// balance void lattices above all — collapse from hundreds of bytes per
-/// instance to one flash each.
-fn plan_repeated_clear_flashes(
-    layer: &ArtworkDocument,
-    apertures: &mut ApertureTable,
-) -> Result<HashMap<usize, PlannedClearFlash>> {
-    // Ordered so macro names and aperture codes are stable across runs.
-    type Signature = (Vec<String>, Vec<CommandSignature>);
-    let mut groups: BTreeMap<Signature, Vec<(usize, Point)>> = BTreeMap::new();
-    for (index, object) in layer.objects.iter().enumerate() {
-        if object.polarity != Polarity::Clear {
-            continue;
-        }
-        let ArtworkGeometry::Region { path } = object.geometry else {
-            continue;
-        };
-        let contours = layer.arena.path_contours(&layer.arena.paths[path as usize]);
-        let [contour] = contours.as_slice() else {
-            continue;
-        };
-        let Some(anchor) = contour_anchor(contour) else {
-            continue;
-        };
-        if contour.cmds.len() > 256 {
-            continue;
-        }
-        let function = object
-            .meta
-            .aperture_function
-            .clone()
-            .unwrap_or_else(|| vec!["Conductor".to_string()]);
-        groups
-            .entry((function, contour_signature(contour, anchor)))
-            .or_default()
-            .push((index, anchor));
-    }
-
-    let mut plan = HashMap::new();
-    for ((function, _), members) in groups {
-        if members.len() < MIN_REPEATED_CLEAR_FLASHES {
-            continue;
-        }
-        let (template_index, template_anchor) = members[0];
-        let ArtworkGeometry::Region { path } = layer.objects[template_index].geometry else {
-            continue;
-        };
-        let contours = layer.arena.path_contours(&layer.arena.paths[path as usize]);
-        let Some(ring) = region::rings_from_contours(&contours).into_iter().next() else {
-            continue;
-        };
-        let outline = ring
-            .iter()
-            .map(|[x, y]| [x - template_anchor.x, y - template_anchor.y])
-            .collect::<Vec<_>>();
-        let aperture = apertures.outline_macro(&outline, &function)?;
-        for (index, anchor) in members {
-            plan.insert(
-                index,
-                PlannedClearFlash {
-                    at: anchor,
-                    aperture,
-                },
-            );
-        }
-    }
-    Ok(plan)
-}
-
-fn contour_anchor(contour: &ContourBuf) -> Option<Point> {
-    let first = contour.cmds.first()?;
-    matches!(first.op, geom_path::PathOp::MoveTo).then(|| first.p0)
-}
-
-type CommandSignature = (u8, i64, i64, i64, i64, i64, i64, bool);
-
-/// Translation-invariant shape identity: command opcodes plus every control
-/// point relative to the contour anchor, quantized to the congruence
-/// quantum.
-fn contour_signature(contour: &ContourBuf, anchor: Point) -> Vec<CommandSignature> {
-    let quantize = |value: f64| (value / CLEAR_FLASH_QUANTUM_MM).round() as i64;
-    contour
-        .cmds
-        .iter()
-        .map(|cmd| {
-            let (p0, p1, p2, clockwise) = match cmd.op {
-                geom_path::PathOp::ArcTo => (cmd.p0, cmd.p1, anchor, cmd.clockwise),
-                geom_path::PathOp::CubicTo => (cmd.p0, cmd.p1, cmd.p2, false),
-                geom_path::PathOp::MoveTo | geom_path::PathOp::LineTo => {
-                    (cmd.p0, anchor, anchor, false)
-                }
-                // Close carries no control points of its own.
-                geom_path::PathOp::Close => (anchor, anchor, anchor, false),
-            };
-            (
-                cmd.op as u8,
-                quantize(p0.x - anchor.x),
-                quantize(p0.y - anchor.y),
-                quantize(p1.x - anchor.x),
-                quantize(p1.y - anchor.y),
-                quantize(p2.x - anchor.x),
-                quantize(p2.y - anchor.y),
-                clockwise,
-            )
-        })
-        .collect()
 }
 
 fn lower_artwork_object(
@@ -360,11 +223,16 @@ fn lower_artwork_object(
                     "cannot lower transformed artwork flash to Gerber".to_string(),
                 ));
             }
-            let artwork_aperture = *layer.apertures.get(aperture as usize).ok_or_else(|| {
-                GerberError::InvalidStructure(format!(
-                    "artwork flash references missing aperture {aperture}"
-                ))
-            })?;
+            let artwork_aperture =
+                layer
+                    .apertures
+                    .get(aperture as usize)
+                    .cloned()
+                    .ok_or_else(|| {
+                        GerberError::InvalidStructure(format!(
+                            "artwork flash references missing aperture {aperture}"
+                        ))
+                    })?;
             let default_function = vec!["Conductor".to_string()];
             let aperture_function = object
                 .meta
@@ -493,6 +361,7 @@ enum ApertureTemplateKey {
         rotation_microdeg: i64,
         hole_nm: i64,
     },
+    Contour(Vec<(i64, i64)>),
 }
 
 impl ApertureTable {
@@ -527,6 +396,35 @@ impl ApertureTable {
     fn artwork_aperture(&mut self, aperture: Aperture, function: &[String]) -> Result<i32> {
         let hole_diameter = (aperture.hole_diameter > 0.0).then_some(aperture.hole_diameter);
         match aperture.shape {
+            ApertureShape::Contour(contour) => {
+                let Some(ring) = region::rings_from_contours(std::slice::from_ref(&contour))
+                    .into_iter()
+                    .next()
+                else {
+                    return Err(GerberError::InvalidStructure(
+                        "cannot export an empty contour aperture".to_string(),
+                    ));
+                };
+                let key = ring
+                    .iter()
+                    .map(|[x, y]| (quantize_mm(*x), quantize_mm(*y)))
+                    .collect::<Vec<_>>();
+                if let Some(code) = self.by_key.get(&ApertureKey {
+                    template: ApertureTemplateKey::Contour(key.clone()),
+                    function: function.to_vec(),
+                }) {
+                    return Ok(*code);
+                }
+                let code = self.outline_macro(&ring, function)?;
+                self.by_key.insert(
+                    ApertureKey {
+                        template: ApertureTemplateKey::Contour(key),
+                        function: function.to_vec(),
+                    },
+                    code,
+                );
+                Ok(code)
+            }
             ApertureShape::Circle { diameter } => {
                 self.circle_with_hole(diameter, hole_diameter, function)
             }

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -1075,6 +1075,78 @@ mod tests {
     }
 
     #[test]
+    fn contour_apertures_survive_mirrored_bases() {
+        // A mirrored basis reverses ring winding when it is baked into the
+        // aperture outline; normalization happens after baking, so the
+        // material must survive with its full area.
+        let mut artwork = ArtworkDocument::new();
+        let layer_id = artwork.push_layer(IrArtworkDocument {
+            name: "F.Cu".to_string(),
+            role: LayerRole::Copper,
+            side: Side::Top,
+            objects: Span::EMPTY,
+            bbox: BBox::empty(),
+            meta: LayerAttributes::default(),
+        });
+
+        let counter_clockwise = [
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Point::new(10.0, 10.0),
+            Point::new(0.0, 10.0),
+        ];
+        let mut bbox = BBox::empty();
+        let mut cmds = Vec::new();
+        for (index, point) in counter_clockwise.into_iter().enumerate() {
+            bbox.include_point(point);
+            cmds.push(if index == 0 {
+                PathCmd::move_to(point)
+            } else {
+                PathCmd::line_to(point)
+            });
+        }
+        cmds.push(PathCmd::close());
+        let contour = ContourBuf::from_parts(bbox, cmds);
+
+        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour(contour)));
+        artwork.push_object(
+            layer_id,
+            ArtworkObject {
+                polarity: Polarity::Dark,
+                order: Default::default(),
+                geometry: ArtworkGeometry::Flash {
+                    aperture,
+                    transform: pcb_ir::geom::Affine2 {
+                        m00: -1.0,
+                        m01: 0.0,
+                        m02: 30.0,
+                        m10: 0.0,
+                        m11: 1.0,
+                        m12: 5.0,
+                    },
+                },
+                bbox: BBox {
+                    min: Point::new(20.0, 5.0),
+                    max: Point::new(30.0, 15.0),
+                },
+                meta: ObjectAttributes::default(),
+            },
+        );
+
+        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let contents = crate::write_layer(&gerber).expect("write Gerber");
+        assert_external_parser_accepts(&contents);
+        let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
+        let geometry = crate::geometry::extract_document(&parsed);
+        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        assert!(
+            (summary.area_mm2 - 100.0).abs() < 0.01,
+            "a mirrored basis must not invert the loop into a hole: {}",
+            summary.area_mm2
+        );
+    }
+
+    #[test]
     fn lowers_single_self_cut_even_odd_region_before_emitting_gerber() {
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -5,7 +5,7 @@
 //! can be emitted as a Gerber file, regardless of which source dialect
 //! produced it.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     AttributeValue, Contour, ContourSegment, GerberError, GerberLayer, ObjectKind,
@@ -156,9 +156,9 @@ pub fn lower_artwork_layer(layer: &ArtworkDocument) -> Result<GerberLayer> {
         } else {
             lower_artwork_object(layer, object, &mut apertures)?
         };
-        plan.push_group(source_index, object.order.stage, objects);
+        plan.push_group(object.order.stage, object.polarity, objects);
     }
-    let objects = plan.into_ordered_objects()?;
+    let objects = plan.into_ordered_objects();
 
     let (aperture_list, aperture_macros) = apertures.into_parts();
     Ok(GerberLayer {
@@ -413,159 +413,47 @@ struct GerberPlan {
 
 #[derive(Debug)]
 struct GerberObjectGroup {
-    source_index: usize,
     stage: PaintStage,
+    polarity: Polarity,
     objects: Vec<WriterObject>,
 }
 
 impl GerberPlan {
-    fn push_group(&mut self, source_index: usize, stage: PaintStage, objects: Vec<WriterObject>) {
+    fn push_group(&mut self, stage: PaintStage, polarity: Polarity, objects: Vec<WriterObject>) {
         if objects.is_empty() {
             return;
         }
         self.groups.push(GerberObjectGroup {
-            source_index,
             stage,
+            polarity,
             objects,
         });
     }
 
-    fn into_ordered_objects(self) -> Result<Vec<WriterObject>> {
-        let order = self.topological_order()?;
-        let mut groups = self.groups.into_iter().map(Some).collect::<Vec<_>>();
-        let mut objects = Vec::new();
-        for group_index in order {
-            let Some(group) = groups[group_index].take() else {
-                continue;
-            };
-            objects.extend(group.objects);
-        }
-        Ok(objects)
-    }
-
-    fn topological_order(&self) -> Result<Vec<usize>> {
-        let group_count = self.groups.len();
-        let base_barrier = group_count;
-        let overlay_barrier = group_count + 1;
-        let node_count = group_count + 2;
-        let mut graph = ScheduleGraph::new(node_count);
-
-        let mut by_stage = [
-            Vec::<usize>::new(),
-            Vec::<usize>::new(),
-            Vec::<usize>::new(),
-        ];
-        for (index, group) in self.groups.iter().enumerate() {
-            by_stage[group.stage as usize].push(index);
-        }
-
-        for stage_groups in &by_stage {
-            for pair in stage_groups.windows(2) {
-                graph.add_edge(pair[0], pair[1]);
-            }
-        }
-        for &group in &by_stage[PaintStage::Base as usize] {
-            graph.add_edge(group, base_barrier);
-        }
-        graph.add_edge(base_barrier, overlay_barrier);
-        for &group in &by_stage[PaintStage::Overlay as usize] {
-            graph.add_edge(base_barrier, group);
-            graph.add_edge(group, overlay_barrier);
-        }
-        for &group in &by_stage[PaintStage::FinalCutout as usize] {
-            graph.add_edge(overlay_barrier, group);
-        }
-
-        let priorities = (0..node_count)
-            .map(|node| self.schedule_priority(node, base_barrier, overlay_barrier))
-            .collect::<Vec<_>>();
-        let order = graph.topological_order(&priorities)?;
-        Ok(order
+    fn into_ordered_objects(self) -> Vec<WriterObject> {
+        // Dark paint commutes with dark paint and clear with clear, but not
+        // across a polarity change: stage ordering (fills before pads) may
+        // only permute groups within each maximal same-polarity run. Final
+        // cutouts are terminal by definition and emit after everything.
+        let (cutouts, mut painted): (Vec<_>, Vec<_>) = self
+            .groups
             .into_iter()
-            .filter(|&node| node < group_count)
-            .collect())
-    }
-
-    fn schedule_priority(
-        &self,
-        node: usize,
-        base_barrier: usize,
-        overlay_barrier: usize,
-    ) -> SchedulePriority {
-        if node == base_barrier {
-            return SchedulePriority {
-                stage: PaintStage::Base,
-                source_index: usize::MAX,
-                barrier: 0,
-            };
-        }
-        if node == overlay_barrier {
-            return SchedulePriority {
-                stage: PaintStage::Overlay,
-                source_index: usize::MAX,
-                barrier: 0,
-            };
-        }
-        let group = &self.groups[node];
-        SchedulePriority {
-            stage: group.stage,
-            source_index: group.source_index,
-            barrier: 1,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct SchedulePriority {
-    stage: PaintStage,
-    source_index: usize,
-    barrier: usize,
-}
-
-struct ScheduleGraph {
-    outgoing: Vec<Vec<usize>>,
-    indegree: Vec<usize>,
-}
-
-impl ScheduleGraph {
-    fn new(node_count: usize) -> Self {
-        Self {
-            outgoing: vec![Vec::new(); node_count],
-            indegree: vec![0; node_count],
-        }
-    }
-
-    fn add_edge(&mut self, from: usize, to: usize) {
-        self.outgoing[from].push(to);
-        self.indegree[to] += 1;
-    }
-
-    fn topological_order(&self, priorities: &[SchedulePriority]) -> Result<Vec<usize>> {
-        let mut indegree = self.indegree.clone();
-        let mut ready = BTreeSet::new();
-        for (node, &degree) in indegree.iter().enumerate() {
-            if degree == 0 {
-                ready.insert((priorities[node], node));
+            .partition(|group| group.stage == PaintStage::FinalCutout);
+        let mut start = 0;
+        while start < painted.len() {
+            let polarity = painted[start].polarity;
+            let mut end = start + 1;
+            while end < painted.len() && painted[end].polarity == polarity {
+                end += 1;
             }
+            painted[start..end].sort_by_key(|group| group.stage);
+            start = end;
         }
-
-        let mut order = Vec::with_capacity(indegree.len());
-        while let Some((_, node)) = ready.pop_first() {
-            order.push(node);
-            for &next in &self.outgoing[node] {
-                indegree[next] -= 1;
-                if indegree[next] == 0 {
-                    ready.insert((priorities[next], next));
-                }
-            }
-        }
-
-        if order.len() != indegree.len() {
-            return Err(GerberError::InvalidStructure(
-                "Gerber emission schedule contains a cycle".to_string(),
-            ));
-        }
-        Ok(order)
+        painted
+            .into_iter()
+            .chain(cutouts)
+            .flat_map(|group| group.objects)
+            .collect()
     }
 }
 

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -373,7 +373,7 @@ enum ApertureTemplateKey {
         rotation_microdeg: i64,
         hole_nm: i64,
     },
-    Contour(Vec<(i64, i64)>),
+    Contour(Vec<Vec<(i64, i64)>>),
 }
 
 impl ApertureTable {
@@ -409,17 +409,26 @@ impl ApertureTable {
         let hole_diameter = (aperture.hole_diameter > 0.0).then_some(aperture.hole_diameter);
         match aperture.shape {
             ApertureShape::Contour(contour) => {
-                let Some(ring) = region::rings_from_contours(std::slice::from_ref(&contour))
-                    .into_iter()
-                    .next()
-                else {
+                let mut rings = region::rings_from_contours(std::slice::from_ref(&contour));
+                if rings.is_empty() {
                     return Err(GerberError::InvalidStructure(
                         "cannot export an empty contour aperture".to_string(),
                     ));
-                };
-                let key = ring
+                }
+                // Paint larger loops before the loops they contain, so a
+                // hole's exposure-off outline erases the material under it.
+                rings.sort_by(|a, b| {
+                    region::ring_signed_area(b)
+                        .abs()
+                        .total_cmp(&region::ring_signed_area(a).abs())
+                });
+                let key = rings
                     .iter()
-                    .map(|[x, y]| (quantize_mm(*x), quantize_mm(*y)))
+                    .map(|ring| {
+                        ring.iter()
+                            .map(|[x, y]| (quantize_mm(*x), quantize_mm(*y)))
+                            .collect::<Vec<_>>()
+                    })
                     .collect::<Vec<_>>();
                 if let Some(code) = self.by_key.get(&ApertureKey {
                     template: ApertureTemplateKey::Contour(key.clone()),
@@ -427,7 +436,7 @@ impl ApertureTable {
                 }) {
                     return Ok(*code);
                 }
-                let code = self.outline_macro(&ring, function)?;
+                let code = self.outline_macro(&rings, function)?;
                 self.by_key.insert(
                     ApertureKey {
                         template: ApertureTemplateKey::Contour(key),
@@ -511,27 +520,39 @@ impl ApertureTable {
 
     /// Define a one-off macro aperture filling the given closed outline,
     /// expressed relative to the flash origin.
-    fn outline_macro(&mut self, outline: &[[f64; 2]], function: &[String]) -> Result<i32> {
-        if outline.len() < 3 {
-            return Err(GerberError::InvalidStructure(
-                "cannot export a Gerber outline macro with fewer than three vertices".to_string(),
-            ));
-        }
+    /// One code-4 outline primitive per ring: material rings expose, hole
+    /// rings (negative winding) erase what earlier primitives painted.
+    fn outline_macro(&mut self, rings: &[Ring], function: &[String]) -> Result<i32> {
         let name = format!("REPEAT{}", self.aperture_macros.len());
-        let mut parameters = Vec::with_capacity(2 * outline.len() + 5);
-        parameters.push(WriterMacroExpression::Number(1.0));
-        parameters.push(WriterMacroExpression::Number(outline.len() as f64));
-        for [x, y] in outline.iter().chain(std::iter::once(&outline[0])) {
-            parameters.push(WriterMacroExpression::Number(*x));
-            parameters.push(WriterMacroExpression::Number(*y));
-        }
-        parameters.push(WriterMacroExpression::Number(0.0));
-        self.aperture_macros.push(WriterApertureMacro {
-            name: name.clone(),
-            primitives: vec![WriterMacroPrimitive::Shape {
+        let mut primitives = Vec::with_capacity(rings.len());
+        for outline in rings {
+            if outline.len() < 3 {
+                return Err(GerberError::InvalidStructure(
+                    "cannot export a Gerber outline macro with fewer than three vertices"
+                        .to_string(),
+                ));
+            }
+            let exposure = if region::ring_signed_area(outline) < 0.0 {
+                0.0
+            } else {
+                1.0
+            };
+            let mut parameters = Vec::with_capacity(2 * outline.len() + 5);
+            parameters.push(WriterMacroExpression::Number(exposure));
+            parameters.push(WriterMacroExpression::Number(outline.len() as f64));
+            for [x, y] in outline.iter().chain(std::iter::once(&outline[0])) {
+                parameters.push(WriterMacroExpression::Number(*x));
+                parameters.push(WriterMacroExpression::Number(*y));
+            }
+            parameters.push(WriterMacroExpression::Number(0.0));
+            primitives.push(WriterMacroPrimitive::Shape {
                 code: 4,
                 parameters,
-            }],
+            });
+        }
+        self.aperture_macros.push(WriterApertureMacro {
+            name: name.clone(),
+            primitives,
         });
         let code = self.allocate_code();
         self.apertures.push(WriterAperture {
@@ -903,6 +924,78 @@ mod tests {
         assert!(
             (summary.area_mm2 - 56.0).abs() < 0.001,
             "deep even-odd topology exported wrong area: {}",
+            summary.area_mm2
+        );
+    }
+
+    #[test]
+    fn contour_apertures_keep_hole_rings_as_exposure_off_outlines() {
+        let mut artwork = ArtworkDocument::new();
+        let layer_id = artwork.push_layer(IrArtworkDocument {
+            name: "F.Cu".to_string(),
+            role: LayerRole::Copper,
+            side: Side::Top,
+            objects: Span::EMPTY,
+            bbox: BBox::empty(),
+            meta: LayerAttributes::default(),
+        });
+
+        // One contour buffer with a material loop and a reverse-wound hole.
+        let outer = [
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Point::new(10.0, 10.0),
+            Point::new(0.0, 10.0),
+        ];
+        let hole = [
+            Point::new(2.0, 2.0),
+            Point::new(2.0, 8.0),
+            Point::new(8.0, 8.0),
+            Point::new(8.0, 2.0),
+        ];
+        let mut bbox = BBox::empty();
+        let mut cmds = Vec::new();
+        for ring in [outer, hole] {
+            for (index, point) in ring.into_iter().enumerate() {
+                bbox.include_point(point);
+                cmds.push(if index == 0 {
+                    PathCmd::move_to(point)
+                } else {
+                    PathCmd::line_to(point)
+                });
+            }
+            cmds.push(PathCmd::close());
+        }
+        let contour = ContourBuf::from_parts(bbox, cmds);
+
+        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour(contour)));
+        artwork.push_object(
+            layer_id,
+            ArtworkObject {
+                polarity: Polarity::Dark,
+                order: Default::default(),
+                geometry: ArtworkGeometry::Flash {
+                    aperture,
+                    transform: pcb_ir::geom::Affine2::translation(Point::new(20.0, 5.0)),
+                },
+                bbox: BBox {
+                    min: Point::new(20.0, 5.0),
+                    max: Point::new(30.0, 15.0),
+                },
+                meta: ObjectAttributes::default(),
+            },
+        );
+
+        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let contents = crate::write_layer(&gerber).expect("write Gerber");
+        assert_external_parser_accepts(&contents);
+        assert_eq!(contents.matches("%AM").count(), 1);
+        let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
+        let geometry = crate::geometry::extract_document(&parsed);
+        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        assert!(
+            (summary.area_mm2 - 64.0).abs() < 0.01,
+            "the hole ring must survive as an exposure-off outline: {}",
             summary.area_mm2
         );
     }

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -218,12 +218,7 @@ fn lower_artwork_object(
             aperture,
             transform,
         } => {
-            if !transform_is_translation(transform) {
-                return Err(GerberError::InvalidStructure(
-                    "cannot lower transformed artwork flash to Gerber".to_string(),
-                ));
-            }
-            let artwork_aperture =
+            let mut artwork_aperture =
                 layer
                     .apertures
                     .get(aperture as usize)
@@ -233,6 +228,23 @@ fn lower_artwork_object(
                             "artwork flash references missing aperture {aperture}"
                         ))
                     })?;
+            if !transform_is_translation(transform) {
+                // Contour apertures absorb a rotated basis by rotating their
+                // outline; the aperture table dedups per rotated shape.
+                let ApertureShape::Contour(contour) = &artwork_aperture.shape else {
+                    return Err(GerberError::InvalidStructure(
+                        "cannot lower transformed artwork flash to Gerber".to_string(),
+                    ));
+                };
+                let basis = pcb_ir::geom::Affine2 {
+                    m02: 0.0,
+                    m12: 0.0,
+                    ..transform
+                };
+                artwork_aperture = Aperture::solid(ApertureShape::Contour(
+                    geom_path::transform_cmds(contour.cmds.iter().copied(), basis),
+                ));
+            }
             let default_function = vec!["Conductor".to_string()];
             let aperture_function = object
                 .meta

--- a/crates/pcb-ipc2581-tools/src/board_array.rs
+++ b/crates/pcb-ipc2581-tools/src/board_array.rs
@@ -173,18 +173,16 @@ fn board_array_layer_overlays(
         .iter()
         .filter_map(|layer| {
             let layer_name = accessor.ipc().resolve(layer.name);
-            let Ok(mut doc) = crate::geometry::extract_layer_for_view(
+            let Ok(doc) = crate::geometry::extract_layer_for_view(
                 accessor.ipc(),
                 layer_name,
                 View::ArraySupport,
             ) else {
                 return None;
             };
-            if !crate::geometry::render::layer_has_native_content(&doc) {
-                return None;
-            }
-            pcb_ir::dialects::ipc::process::compose_for_rendering(&mut doc);
-            let paths = layer_paths(&doc, array_height);
+            let mut native = crate::geometry::render::native_layer_document(&doc)?;
+            pcb_ir::dialects::ipc::process::compose_for_rendering(&mut native);
+            let paths = layer_paths(&native, array_height);
             (!paths.is_empty()).then_some(BoardArrayLayerOverlay {
                 function: layer.layer_function,
                 paths,
@@ -228,12 +226,64 @@ fn layer_paths(doc: &GeometryDocument, panel_height: f64) -> Vec<BoardArrayLayer
     };
     let transform = y_flip_transform(panel_height);
 
-    layer
-        .features
-        .slice(&doc.features)
+    // V-score features draw as stroked guides; everything else composes
+    // through the shared layer image fold, which resolves paint polarity.
+    let features = layer.features.slice(&doc.features);
+    let mut paths = features
         .iter()
-        .filter(|feature| feature.source_layer_ref == Some(layer.source_layer_ref))
+        .filter(|feature| feature.is_vscore())
         .flat_map(|feature| feature_paths(doc, feature, transform))
+        .collect::<Vec<_>>();
+
+    let image_features = features
+        .iter()
+        .filter(|feature| !feature.is_vscore())
+        .cloned()
+        .collect::<Vec<_>>();
+    if !image_features.is_empty() {
+        let mut image = doc.clone();
+        image.layers[0].features =
+            pcb_ir::geom::Span::new(0, image_features.len() as u32);
+        image.features = image_features;
+        let mask = crate::geometry::render::layer_mask(
+            &image,
+            false,
+            pcb_ir::dialects::ipc::ProfileSet::RootOnly,
+        );
+        paths.extend(mask_paths(&mask, transform));
+    }
+
+    paths
+}
+
+fn mask_paths(
+    mask: &pcb_ir::dialects::mask::Document<LayerFunction>,
+    transform: Affine2,
+) -> Vec<BoardArrayLayerPath> {
+    let Some(layer) = mask.layers.first() else {
+        return Vec::new();
+    };
+
+    mask.shapes(layer)
+        .iter()
+        .filter_map(|shape| {
+            let mut data = String::new();
+            for contour in mask.arena.contours(shape.contours) {
+                let transformed = pcb_ir::geom::path::transform_cmds(
+                    mask.arena.cmds(*contour).iter().copied(),
+                    transform,
+                );
+                append_path_cmds(&mut data, &transformed.cmds);
+            }
+            (!data.is_empty()).then_some(BoardArrayLayerPath {
+                data,
+                bbox: transform_bbox(shape.bbox, transform),
+                stroke_width: 0.0,
+                filled: true,
+                stroked: false,
+                vscore: false,
+            })
+        })
         .collect()
 }
 
@@ -991,5 +1041,97 @@ mod tests {
 
         assert_eq!(svg.matches("array-layer-copper").count(), 1);
         assert!(!svg.contains("M7 5.5 L15 5.5"));
+    }
+
+    #[test]
+    fn renders_clear_features_as_holes_in_the_layer_overlay() {
+        let ipc = ipc2581::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="panel"/>
+    <LayerRef name="TOP"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="5"/>
+            <PolyStepSegment x="0" y="5"/>
+          </Polygon>
+        </Profile>
+      </Step>
+      <Step name="panel" type="PALLET">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="0" y="24"/>
+            <PolyStepSegment x="44" y="24"/>
+            <PolyStepSegment x="44" y="0"/>
+          </Polygon>
+        </Profile>
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <Features>
+              <UserSpecial>
+                <Contour>
+                  <Polygon>
+                    <PolyBegin x="1" y="19"/>
+                    <PolyStepSegment x="9" y="19"/>
+                    <PolyStepSegment x="9" y="23"/>
+                    <PolyStepSegment x="1" y="23"/>
+                    <PolyStepSegment x="1" y="19"/>
+                  </Polygon>
+                </Contour>
+              </UserSpecial>
+            </Features>
+          </Set>
+          <Set polarity="NEGATIVE">
+            <Features>
+              <UserSpecial>
+                <Contour>
+                  <Polygon>
+                    <PolyBegin x="4" y="20"/>
+                    <PolyStepSegment x="6" y="20"/>
+                    <PolyStepSegment x="6" y="22"/>
+                    <PolyStepSegment x="4" y="22"/>
+                    <PolyStepSegment x="4" y="20"/>
+                  </Polygon>
+                </Contour>
+              </UserSpecial>
+            </Features>
+          </Set>
+        </LayerFeature>
+        <StepRepeat stepRef="board" x="5" y="5.5" nx="3" ny="2" dx="12" dy="8"/>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let accessor = IpcAccessor::new(&ipc);
+
+        let svg = render_board_array_overview_svg(&accessor).unwrap().unwrap();
+
+        assert_eq!(
+            svg.matches("array-layer-copper").count(),
+            1,
+            "the layer composes to one image path"
+        );
+        let copper = svg
+            .lines()
+            .find(|line| line.contains("array-layer-copper"))
+            .unwrap();
+        assert_eq!(
+            copper.matches('M').count(),
+            2,
+            "the clear feature survives as a hole subpath, not a copper fill"
+        );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/board_array.rs
+++ b/crates/pcb-ipc2581-tools/src/board_array.rs
@@ -242,8 +242,7 @@ fn layer_paths(doc: &GeometryDocument, panel_height: f64) -> Vec<BoardArrayLayer
         .collect::<Vec<_>>();
     if !image_features.is_empty() {
         let mut image = doc.clone();
-        image.layers[0].features =
-            pcb_ir::geom::Span::new(0, image_features.len() as u32);
+        image.layers[0].features = pcb_ir::geom::Span::new(0, image_features.len() as u32);
         image.features = image_features;
         let mask = crate::geometry::render::layer_mask(
             &image,

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -337,20 +337,31 @@ fn hex_void_instances(
 }
 
 /// Extract one layer's flattened, composed copper image.
+///
+/// Composition goes through the artwork mask fold so clear-polarity
+/// features subtract in paint order instead of being unioned as copper.
 pub fn composed_copper_image(ipc: &Ipc2581, layer_name: &str) -> Result<ContourSet> {
     let mut document = geometry::extract_layer_for_view(ipc, layer_name, View::ArrayFlattened)
         .with_context(|| {
             format!("failed to extract flattened IPC-2581 copper layer '{layer_name}'")
         })?;
     pcb_ir::dialects::ipc::process::compose_for_rendering(&mut document);
-    Ok(ContourSet::from_painted_paths(
-        &document.arena,
-        document
-            .features
-            .iter()
-            .flat_map(|feature| feature.paths.slice(&document.arena.paths)),
-        tol::REGION_MM,
-    ))
+    let artwork = pcb_ir::dialects::ipc::lower_layer_to_artwork(
+        &document,
+        0,
+        pcb_ir::dialects::LayerRole::Copper,
+        pcb_ir::dialects::Side::None,
+    );
+    let mask = pcb_ir::dialects::artwork::compose_to_mask(&artwork);
+    let mut rings = Vec::new();
+    for layer in &mask.layers {
+        for shape in mask.shapes(layer) {
+            rings.extend(pcb_ir::geom::region::rings_from_contours(
+                &mask.arena.path_contours(shape),
+            ));
+        }
+    }
+    Ok(ContourSet::new(rings, FillRule::NonZero, tol::REGION_MM))
 }
 
 /// Signed first-moment weight `z * thickness` per copper layer, from the

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -131,12 +131,6 @@ fn apply_ipc_placement(feature: &mut GeometryFeature, placement: IpcPlacement) {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum PadPrimitiveRef {
-    Standard(Symbol),
-    User(Symbol),
-}
-
-#[derive(Debug, Clone, Copy)]
 struct StrokedFeatureStyle {
     net: Option<Symbol>,
     polarity: GeometryPolarity,
@@ -1379,7 +1373,7 @@ fn extract_pad(
 
     let path_start = doc.arena.paths.len() as u32;
     let paint = match primitive_ref {
-        PadPrimitiveRef::Standard(primitive_ref) => {
+        PrimitiveRef::Standard(primitive_ref) => {
             let Some(primitive) = context.standard_primitives.get(&primitive_ref).copied() else {
                 doc.warn(format!(
                     "Skipping padstack '{}' because primitive '{}' is missing",
@@ -1390,7 +1384,7 @@ fn extract_pad(
             };
             lower_standard_primitive(context, doc, primitive, placement.transform)?
         }
-        PadPrimitiveRef::User(primitive_ref) => {
+        PrimitiveRef::User(primitive_ref) => {
             let Some(primitive) = context.user_primitives.get(&primitive_ref).copied() else {
                 doc.warn(format!(
                     "Skipping padstack '{}' because user primitive '{}' is missing",
@@ -1424,11 +1418,7 @@ fn extract_pad(
     feature.intent.role = role;
     apply_ipc_placement(&mut feature, placement);
     feature.padstack_ref = Some(padstack_ref);
-    feature.primitive_ref = match primitive_ref {
-        PadPrimitiveRef::Standard(primitive_ref) | PadPrimitiveRef::User(primitive_ref) => {
-            Some(primitive_ref)
-        }
-    };
+    feature.primitive_ref = Some(primitive_ref);
     feature.intent.plating = padstack
         .hole_def
         .as_ref()
@@ -1455,7 +1445,7 @@ fn extract_pad(
 /// The layer's `PadstackPadDef` is the sole authority for the offset, even
 /// when the pad-level inline primitive reference wins the primitive choice.
 struct PadShape {
-    primitive: PadPrimitiveRef,
+    primitive: PrimitiveRef<Symbol>,
     offset: Point,
 }
 
@@ -1475,14 +1465,14 @@ fn pad_shape(
         });
     let primitive = pad
         .standard_primitive_ref
-        .map(PadPrimitiveRef::Standard)
-        .or_else(|| pad.user_primitive_ref.map(PadPrimitiveRef::User))
+        .map(PrimitiveRef::Standard)
+        .or_else(|| pad.user_primitive_ref.map(PrimitiveRef::User))
         .or_else(|| {
             pad_def.and_then(|pad_def| {
                 pad_def
                     .standard_primitive_ref
-                    .map(PadPrimitiveRef::Standard)
-                    .or_else(|| pad_def.user_primitive_ref.map(PadPrimitiveRef::User))
+                    .map(PrimitiveRef::Standard)
+                    .or_else(|| pad_def.user_primitive_ref.map(PrimitiveRef::User))
             })
         })?;
     let offset = pad_def.map_or(Point::default(), |pad_def| Point::new(pad_def.x, pad_def.y));
@@ -1511,7 +1501,7 @@ fn extract_feature_primitive(
         1.0,
     );
     let path_start = doc.arena.paths.len() as u32;
-    let paint = match primitive_kind {
+    let (paint, primitive_ref) = match primitive_kind {
         FeaturePrimitiveKind::Standard => {
             let Some(primitive) = context.standard_primitives.get(&primitive_ref.id).copied()
             else {
@@ -1521,7 +1511,10 @@ fn extract_feature_primitive(
                 ));
                 return Ok(Vec::new());
             };
-            lower_standard_primitive(context, doc, primitive, transform)?
+            (
+                lower_standard_primitive(context, doc, primitive, transform)?,
+                PrimitiveRef::Standard(primitive_ref.id),
+            )
         }
         FeaturePrimitiveKind::User => {
             let Some(primitive) = context.user_primitives.get(&primitive_ref.id).copied() else {
@@ -1531,7 +1524,10 @@ fn extract_feature_primitive(
                 ));
                 return Ok(Vec::new());
             };
-            lower_user_primitive(context, doc, primitive, transform)
+            (
+                lower_user_primitive(context, doc, primitive, transform),
+                PrimitiveRef::User(primitive_ref.id),
+            )
         }
     };
 
@@ -1544,7 +1540,7 @@ fn extract_feature_primitive(
             transform,
             path_start,
             paint,
-            Some(primitive_ref.id),
+            Some(primitive_ref),
         ),
     )
 }
@@ -1574,7 +1570,7 @@ fn primitive_path_feature(
     transform: Affine2,
     path_start: u32,
     paint: PrimitivePaint,
-    primitive_ref: Option<Symbol>,
+    primitive_ref: Option<PrimitiveRef<Symbol>>,
 ) -> GeometryFeature {
     let mut feature = GeometryFeature::new(
         FeatureKind::Primitive,
@@ -1636,7 +1632,7 @@ fn extract_fiducial(
             };
             (
                 lower_standard_primitive(context, doc, primitive, placement.transform)?,
-                Some(*primitive_ref),
+                Some(PrimitiveRef::Standard(*primitive_ref)),
                 standard_primitive_outer_diameter(primitive),
             )
         }

--- a/crates/pcb-ipc2581-tools/src/geometry/render.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/render.rs
@@ -30,9 +30,17 @@ fn layer_has_content(geometry: &GeometryDocument) -> bool {
 }
 
 pub fn layer_has_native_content(geometry: &GeometryDocument) -> bool {
-    let Some(layer) = geometry.layers.first() else {
+    let Some(mut native) = native_layer_document(geometry) else {
         return false;
     };
+    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut native);
+    layer_has_content(&native)
+}
+
+/// Restrict a single-layer document to the features native to its source
+/// layer, dropping borrowed features. Returns `None` when nothing is native.
+pub fn native_layer_document(geometry: &GeometryDocument) -> Option<GeometryDocument> {
+    let layer = geometry.layers.first()?;
 
     let source_layer_ref = layer.source_layer_ref;
     let features = layer
@@ -43,14 +51,13 @@ pub fn layer_has_native_content(geometry: &GeometryDocument) -> bool {
         .cloned()
         .collect::<Vec<_>>();
     if features.is_empty() {
-        return false;
+        return None;
     }
 
     let mut native = geometry.clone();
     native.layers[0].features = Span::new(0, features.len() as u32);
     native.features = features;
-    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut native);
-    layer_has_content(&native)
+    Some(native)
 }
 
 pub fn layer_mask(

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -84,11 +84,6 @@ pub fn build_gerber_x2_files_with_options(
         let mut doc = geometry::extract_layer_for_view(ipc, layer_name, view)
             .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
         pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut doc);
-        if clear_polarity_needs_resolution(&doc) {
-            pcb_ir::dialects::ipc::process::resolve_negative_polarity(&mut doc);
-            pcb_ir::dialects::ipc::process::compact(&mut doc);
-            pcb_ir::dialects::ipc::process::normalize_bounds(&mut doc);
-        }
         if let Err(error) = pcb_ir::dialects::ipc::validate_artwork_ready(&doc) {
             bail!("IPC-2581 layer '{layer_name}' is not artwork-ready: {error}");
         }
@@ -1170,99 +1165,6 @@ fn nearly_equal(left: f64, right: f64) -> bool {
     (left - right).abs() <= GEOMETRY_EPSILON * left.abs().max(right.abs()).max(1.0)
 }
 
-/// Ordered artwork paints clear features in source order within their paint
-/// stage, but overlay-stage dark geometry always lands after the base stage.
-/// When a clear feature can reach overlay geometry that sequential model
-/// diverges from IPC's layer-wide negative semantics, so those documents fall
-/// back to resolving the polarity geometrically. Generated balance planes
-/// keep their clear voids native: the voids are certified clear of all other
-/// copper.
-fn clear_polarity_needs_resolution(doc: &IpcGeometryDocument) -> bool {
-    let is_clear = |feature: &Feature<ipc2581::Symbol>| {
-        feature.bucket != FeatureBucket::Cutout
-            && feature.polarity == Polarity::Clear
-            && !feature.flags.clears_previous_in_set
-    };
-    doc.layers.iter().any(|layer| {
-        let features = layer.features.slice(&doc.features);
-        let all_clears = ClearBoundsGrid::new(
-            features
-                .iter()
-                .filter_map(|feature| is_clear(feature).then_some(feature.bbox)),
-        );
-        if all_clears.is_empty() {
-            return false;
-        }
-        // Base-stage darks paint before only the clears that follow them in
-        // source order; every other stage paints after all base-stage
-        // clears. A dark feature that a clear could erase under layer-wide
-        // semantics but that paints after it natively needs resolution.
-        let mut preceding_clears = ClearBoundsGrid::default();
-        features.iter().any(|feature| {
-            if is_clear(feature) {
-                preceding_clears.insert(feature.bbox);
-                return false;
-            }
-            if feature.polarity != Polarity::Dark {
-                return false;
-            }
-            match paint_order(feature).stage {
-                PaintStage::Base => preceding_clears.intersects(feature.bbox),
-                PaintStage::Overlay | PaintStage::FinalCutout => {
-                    all_clears.intersects(feature.bbox)
-                }
-            }
-        })
-    })
-}
-
-/// Uniform spatial hash over clear-feature bounds, sized for the
-/// millimeter-scale voids and pads that dominate them. Both insertion and
-/// queries touch only the handful of cells a bounding box covers, keeping
-/// the clear-versus-overlay reachability check linear in feature count.
-#[derive(Default)]
-struct ClearBoundsGrid {
-    cells: HashMap<(i64, i64), Vec<pcb_ir::geom::BBox>>,
-}
-
-impl ClearBoundsGrid {
-    const CELL_MM: f64 = 4.0;
-
-    fn new(bounds: impl Iterator<Item = pcb_ir::geom::BBox>) -> Self {
-        let mut grid = Self::default();
-        for bbox in bounds {
-            grid.insert(bbox);
-        }
-        grid
-    }
-
-    fn insert(&mut self, bbox: pcb_ir::geom::BBox) {
-        for cell in Self::covered_cells(bbox) {
-            self.cells.entry(cell).or_default().push(bbox);
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.cells.is_empty()
-    }
-
-    fn intersects(&self, bbox: pcb_ir::geom::BBox) -> bool {
-        Self::covered_cells(bbox).any(|cell| {
-            self.cells
-                .get(&cell)
-                .is_some_and(|bounds| bounds.iter().any(|clear| clear.intersects(bbox)))
-        })
-    }
-
-    fn covered_cells(bbox: pcb_ir::geom::BBox) -> impl Iterator<Item = (i64, i64)> {
-        let min_x = (bbox.min.x / Self::CELL_MM).floor() as i64;
-        let max_x = (bbox.max.x / Self::CELL_MM).floor() as i64;
-        let min_y = (bbox.min.y / Self::CELL_MM).floor() as i64;
-        let max_y = (bbox.max.y / Self::CELL_MM).floor() as i64;
-        (min_x..=max_x).flat_map(move |x| (min_y..=max_y).map(move |y| (x, y)))
-    }
-}
-
 fn paint_order(feature: &Feature<ipc2581::Symbol>) -> PaintOrder {
     let stage = if feature.intent.role == FeatureRole::Cutout || feature.is_drill_like() {
         PaintStage::FinalCutout
@@ -1443,10 +1345,9 @@ mod tests {
     use std::io::{Cursor, Read};
 
     #[test]
-    fn negative_set_before_a_later_fill_resolves_geometrically() {
-        // Layer-wide negative semantics erase every dark feature on the
-        // layer, including fills written after the clear; the sequential
-        // paint order would instead paint the later fill over the clear.
+    fn negative_set_before_a_later_fill_is_repainted_by_it() {
+        // Sequential set semantics: a fill written after the clear repaints
+        // the cleared area, so the fill survives intact.
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -1514,13 +1415,6 @@ mod tests {
             .find(|file| file.filename == "F_Cu.gtl")
             .unwrap();
         let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
-        assert!(
-            parsed
-                .objects()
-                .iter()
-                .all(|object| object.polarity == Polarity::Dark),
-            "clear preceding a later fill should be resolved geometrically"
-        );
 
         let mask = pcb_ir::dialects::artwork::compose_to_mask(
             &gerberx2::geometry::extract_document(&parsed),
@@ -1539,19 +1433,18 @@ mod tests {
             pcb_ir::geom::tol::REGION_MM,
         )
         .area();
-        // 6x6 fill minus the 2x2 clear it overlaps.
-        let expected = 36.0 - 4.0;
+        // The 6x6 fill paints after the clear and survives whole.
+        let expected = 36.0;
         assert!(
             (copper_area - expected).abs() <= expected * 0.01,
-            "expected cleared fill area {expected:.2}, got {copper_area:.2}"
+            "expected intact fill area {expected:.2}, got {copper_area:.2}"
         );
     }
 
     #[test]
-    fn negative_set_over_overlay_pad_resolves_geometrically() {
-        // A clear set that reaches overlay-stage dark geometry must fall back
-        // to layer-wide geometric resolution: the stage scheduler would
-        // otherwise paint the pad after the clear and never erase it.
+    fn negative_set_after_an_overlay_pad_erases_it_natively() {
+        // Sequential set semantics: the clear paints after the pad, erasing
+        // the overlap, and exports natively as clear polarity.
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -1622,8 +1515,8 @@ mod tests {
             parsed
                 .objects()
                 .iter()
-                .all(|object| object.polarity == Polarity::Dark),
-            "clear set reaching an overlay pad should be resolved geometrically"
+                .any(|object| object.polarity == Polarity::Clear),
+            "the clear set should export natively as clear polarity"
         );
 
         let mask = pcb_ir::dialects::artwork::compose_to_mask(

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -19,7 +19,7 @@ use pcb_ir::dialects::artwork::{
 };
 use pcb_ir::dialects::ipc::{
     Feature, FeatureBucket, FeatureDomain, FeatureOperation, FeatureRole, FiducialKind,
-    LayoutPurpose, PlatingKind, ProfileSet, View, profile_occurrences_for, relief,
+    LayoutPurpose, PlatingKind, PrimitiveRef, ProfileSet, View, profile_occurrences_for, relief,
 };
 use pcb_ir::dialects::{LayerRole, Side as IrSide};
 use pcb_ir::geom::path::{ContourBuf, PathCmd, PathOp};
@@ -987,17 +987,20 @@ struct InstanceApertures {
     by_primitive: HashMap<ipc2581::Symbol, u32>,
 }
 
-/// A dictionary-instance feature: a translated reference whose local shape
+/// A user-dictionary instance feature: a placed reference whose local shape
 /// is shared by every sibling instance. The shape flashes through one
 /// contour aperture per dictionary entry, keeping repeated geometry
-/// repeated in the output.
+/// repeated in the output. Standard-dictionary references stay out: those
+/// are exact catalogue primitives and flash through standard apertures.
 fn instance_flash(
     artwork: &mut GerberArtwork,
     doc: &IpcGeometryDocument,
     feature: &Feature<ipc2581::Symbol>,
     apertures: &mut InstanceApertures,
 ) -> Option<(u32, Affine2)> {
-    let primitive = feature.primitive_ref?;
+    let Some(PrimitiveRef::User(primitive)) = feature.primitive_ref else {
+        return None;
+    };
     if feature.kind != pcb_ir::dialects::ipc::FeatureKind::Primitive || !is_rigid(feature.transform)
     {
         return None;
@@ -1173,7 +1176,9 @@ fn standard_primitive_for_feature<'a>(
     ipc: &'a Ipc2581,
     feature: &Feature<ipc2581::Symbol>,
 ) -> Option<&'a StandardPrimitive> {
-    let primitive_ref = feature.primitive_ref?;
+    let Some(PrimitiveRef::Standard(primitive_ref)) = feature.primitive_ref else {
+        return None;
+    };
     ipc.content()
         .dictionary_standard
         .entries
@@ -1625,6 +1630,70 @@ mod tests {
         assert!(
             (copper_area - expected).abs() <= expected * 0.02,
             "expected quarter-cleared pad area {expected:.4}, got {copper_area:.4}"
+        );
+    }
+
+    #[test]
+    fn standard_dictionary_fiducials_keep_exact_circle_apertures() {
+        // Repeated references to a standard catalogue entry are exact
+        // primitives, not user-dictionary instances: they must flash as
+        // circle apertures rather than flatten into outline macros.
+        let ipc = ipc::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="fid"><Circle diameter="1"/></EntryStandard>
+    </DictionaryStandard>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="10"/>
+            <PolyStepSegment x="0" y="10"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+        </Profile>
+        <LayerFeature layerRef="TOP">
+          <Set>
+            <LocalFiducial>
+              <Location x="3" y="3"/>
+              <StandardPrimitiveRef id="fid"/>
+            </LocalFiducial>
+            <LocalFiducial>
+              <Location x="7" y="7"/>
+              <StandardPrimitiveRef id="fid"/>
+            </LocalFiducial>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let copper = files
+            .iter()
+            .find(|file| file.filename == "F_Cu.gtl")
+            .unwrap();
+        assert!(
+            !copper.contents.contains("%AM"),
+            "catalogue circles must not lower to outline macros"
+        );
+        assert!(
+            copper.contents.contains("C,1"),
+            "fiducials should flash through a shared circle aperture"
         );
     }
 

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -460,8 +460,17 @@ fn artwork_from_ipc_layer(
         bbox: layer.bbox,
         meta: spec.meta,
     });
+    let mut instance_apertures = InstanceApertures::default();
     for feature in layer.features.slice(&doc.features) {
-        push_artwork_feature(&mut artwork, artwork_layer, ipc, doc, feature, &layer.name)?;
+        push_artwork_feature(
+            &mut artwork,
+            artwork_layer,
+            ipc,
+            doc,
+            feature,
+            &layer.name,
+            &mut instance_apertures,
+        )?;
     }
     if spec.role == GerberLayerRole::Profile
         && spec.view != View::ArrayFlattened
@@ -971,6 +980,68 @@ fn ir_side(side: Option<IpcSide>) -> IrSide {
     }
 }
 
+/// Shared contour apertures for repeated primitive instances, one per
+/// referenced dictionary entry.
+#[derive(Default)]
+struct InstanceApertures {
+    by_primitive: HashMap<ipc2581::Symbol, u32>,
+}
+
+/// A dictionary-instance feature: a translated reference whose local shape
+/// is shared by every sibling instance. The shape flashes through one
+/// contour aperture per dictionary entry, keeping repeated geometry
+/// repeated in the output.
+fn instance_flash(
+    artwork: &mut GerberArtwork,
+    doc: &IpcGeometryDocument,
+    feature: &Feature<ipc2581::Symbol>,
+    apertures: &mut InstanceApertures,
+) -> Option<(u32, Point)> {
+    let primitive = feature.primitive_ref?;
+    if feature.kind != pcb_ir::dialects::ipc::FeatureKind::Primitive
+        || !is_translation(feature.transform)
+    {
+        return None;
+    }
+    let [path] = feature.paths.slice(&doc.arena.paths) else {
+        return None;
+    };
+    if !path.is_filled() {
+        return None;
+    }
+    let at = Point::new(feature.transform.m02, feature.transform.m12);
+    if let Some(&aperture) = apertures.by_primitive.get(&primitive) {
+        return Some((aperture, at));
+    }
+    // Derive the origin-local template from this first instance.
+    let local = doc
+        .arena
+        .path_contours(path)
+        .iter()
+        .map(|contour| {
+            pcb_ir::geom::path::transform_cmds(
+                contour.cmds.iter().copied(),
+                Affine2::translation(Point::new(-at.x, -at.y)),
+            )
+        })
+        .collect::<Vec<_>>();
+    let [local] = local.as_slice() else {
+        return None;
+    };
+    let aperture = artwork.push_aperture(Aperture::solid(
+        pcb_ir::dialects::artwork::ApertureShape::Contour(local.clone()),
+    ));
+    apertures.by_primitive.insert(primitive, aperture);
+    Some((aperture, at))
+}
+
+fn is_translation(transform: Affine2) -> bool {
+    (transform.m00 - 1.0).abs() <= GEOMETRY_EPSILON
+        && transform.m01.abs() <= GEOMETRY_EPSILON
+        && transform.m10.abs() <= GEOMETRY_EPSILON
+        && (transform.m11 - 1.0).abs() <= GEOMETRY_EPSILON
+}
+
 fn push_artwork_feature(
     artwork: &mut GerberArtwork,
     artwork_layer: u32,
@@ -978,7 +1049,25 @@ fn push_artwork_feature(
     doc: &IpcGeometryDocument,
     feature: &Feature<ipc2581::Symbol>,
     layer_name: &str,
+    instance_apertures: &mut InstanceApertures,
 ) -> Result<()> {
+    if let Some((aperture, at)) = instance_flash(artwork, doc, feature, instance_apertures) {
+        artwork.push_object(
+            artwork_layer,
+            ArtworkObject {
+                polarity: feature.polarity,
+                order: paint_order(feature),
+                geometry: ArtworkGeometry::Flash {
+                    aperture,
+                    transform: Affine2::translation(at),
+                },
+                bbox: feature.bbox,
+                meta: object_attributes(ipc, doc, feature, Some(aperture_function(feature))),
+            },
+        );
+        return Ok(());
+    }
+
     if let Some((aperture, at, bbox)) = standard_flash_aperture(ipc, feature) {
         let aperture = artwork.push_aperture(aperture);
         artwork.push_object(
@@ -1071,7 +1160,7 @@ fn standard_flash_aperture(
     };
 
     let at = feature.center;
-    let bbox = flash_bbox(at, aperture);
+    let bbox = flash_bbox(at, &aperture);
     Some((aperture, at, bbox))
 }
 
@@ -1154,7 +1243,7 @@ fn axis_aligned_size(transform: Affine2, width: f64, height: f64) -> Option<(f64
     None
 }
 
-fn flash_bbox(at: Point, aperture: Aperture) -> BBox {
+fn flash_bbox(at: Point, aperture: &Aperture) -> BBox {
     let local = aperture.bbox();
     BBox::new(at + local.min, at + local.max)
 }

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -996,10 +996,9 @@ fn instance_flash(
     doc: &IpcGeometryDocument,
     feature: &Feature<ipc2581::Symbol>,
     apertures: &mut InstanceApertures,
-) -> Option<(u32, Point)> {
+) -> Option<(u32, Affine2)> {
     let primitive = feature.primitive_ref?;
-    if feature.kind != pcb_ir::dialects::ipc::FeatureKind::Primitive
-        || !is_translation(feature.transform)
+    if feature.kind != pcb_ir::dialects::ipc::FeatureKind::Primitive || !is_rigid(feature.transform)
     {
         return None;
     }
@@ -1009,21 +1008,17 @@ fn instance_flash(
     if !path.is_filled() {
         return None;
     }
-    let at = Point::new(feature.transform.m02, feature.transform.m12);
     if let Some(&aperture) = apertures.by_primitive.get(&primitive) {
-        return Some((aperture, at));
+        return Some((aperture, feature.transform));
     }
-    // Derive the origin-local template from this first instance.
+    // Derive the origin-local template from this first instance; every
+    // sibling shares the aperture and differs only by its rigid transform.
+    let inverse = feature.transform.inverse()?;
     let local = doc
         .arena
         .path_contours(path)
         .iter()
-        .map(|contour| {
-            pcb_ir::geom::path::transform_cmds(
-                contour.cmds.iter().copied(),
-                Affine2::translation(Point::new(-at.x, -at.y)),
-            )
-        })
+        .map(|contour| pcb_ir::geom::path::transform_cmds(contour.cmds.iter().copied(), inverse))
         .collect::<Vec<_>>();
     let [local] = local.as_slice() else {
         return None;
@@ -1032,14 +1027,15 @@ fn instance_flash(
         pcb_ir::dialects::artwork::ApertureShape::Contour(local.clone()),
     ));
     apertures.by_primitive.insert(primitive, aperture);
-    Some((aperture, at))
+    Some((aperture, feature.transform))
 }
 
-fn is_translation(transform: Affine2) -> bool {
-    (transform.m00 - 1.0).abs() <= GEOMETRY_EPSILON
-        && transform.m01.abs() <= GEOMETRY_EPSILON
-        && transform.m10.abs() <= GEOMETRY_EPSILON
-        && (transform.m11 - 1.0).abs() <= GEOMETRY_EPSILON
+/// Rotation plus translation, without mirroring or scaling.
+fn is_rigid(transform: Affine2) -> bool {
+    let determinant = transform.m00 * transform.m11 - transform.m01 * transform.m10;
+    (determinant - 1.0).abs() <= GEOMETRY_EPSILON
+        && (transform.m00 * transform.m00 + transform.m10 * transform.m10 - 1.0).abs()
+            <= GEOMETRY_EPSILON
 }
 
 fn push_artwork_feature(
@@ -1051,7 +1047,7 @@ fn push_artwork_feature(
     layer_name: &str,
     instance_apertures: &mut InstanceApertures,
 ) -> Result<()> {
-    if let Some((aperture, at)) = instance_flash(artwork, doc, feature, instance_apertures) {
+    if let Some((aperture, transform)) = instance_flash(artwork, doc, feature, instance_apertures) {
         artwork.push_object(
             artwork_layer,
             ArtworkObject {
@@ -1059,7 +1055,7 @@ fn push_artwork_feature(
                 order: paint_order(feature),
                 geometry: ArtworkGeometry::Flash {
                     aperture,
-                    transform: Affine2::translation(at),
+                    transform,
                 },
                 bbox: feature.bbox,
                 meta: object_attributes(ipc, doc, feature, Some(aperture_function(feature))),

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -329,6 +329,30 @@ pub fn expand_native_geometry_to_regions<LayerMeta, ObjectMeta>(
 /// clears and final cutouts remove painted material. A layer containing only
 /// final-cutout objects, such as a drill or rout document, images the
 /// removals themselves.
+/// Order a layer's objects for painting.
+///
+/// Dark paint commutes with dark paint and clear with clear, but not across
+/// a polarity change, so stage ordering may only permute objects within each
+/// maximal same-polarity run. Final cutouts are terminal by definition and
+/// paint after everything.
+fn paint_ordered<ObjectMeta>(objects: &[Object<ObjectMeta>]) -> Vec<&Object<ObjectMeta>> {
+    let (cutouts, mut painted): (Vec<_>, Vec<_>) = objects
+        .iter()
+        .partition(|object| object.order.stage == PaintStage::FinalCutout);
+    let mut start = 0;
+    while start < painted.len() {
+        let polarity = painted[start].polarity;
+        let mut end = start + 1;
+        while end < painted.len() && painted[end].polarity == polarity {
+            end += 1;
+        }
+        painted[start..end].sort_by_key(|object| object.order.stage);
+        start = end;
+    }
+    painted.extend(cutouts);
+    painted
+}
+
 pub fn compose_to_mask<LayerMeta: Clone, ObjectMeta: Clone>(
     doc: &Document<LayerMeta, ObjectMeta>,
 ) -> mask::Document<LayerMeta> {
@@ -347,8 +371,7 @@ pub fn compose_to_mask<LayerMeta: Clone, ObjectMeta: Clone>(
     }
 
     for (layer_index, layer) in doc.layers.iter().enumerate() {
-        let mut objects = layer.objects.slice(&doc.objects).iter().collect::<Vec<_>>();
-        objects.sort_by_key(|object| object.order.stage);
+        let objects = paint_ordered(layer.objects.slice(&doc.objects));
         let has_material = objects
             .iter()
             .any(|object| object.order.stage != PaintStage::FinalCutout);
@@ -567,19 +590,21 @@ mod tests {
             object
         };
 
-        // Painted out of stage order: overlay trace first, then the base pour
-        // with a clear, then a dark-drawn final cutout.
-        let overlay = rect(&mut doc, 4.0, 4.0, 6.0, 6.0);
-        doc.push_object(
-            layer,
-            stage_object(Polarity::Dark, overlay, PaintStage::Overlay),
-        );
+        // The thermal-relief pattern in its paint order: pour, clearance,
+        // then the overlay trace over the cleared area, then a dark-drawn
+        // final cutout. Stage ordering may only permute within polarity
+        // runs, so the trace survives because it follows the clear.
         let base = rect(&mut doc, 0.0, 0.0, 10.0, 10.0);
         doc.push_object(layer, stage_object(Polarity::Dark, base, PaintStage::Base));
         let base_clear = rect(&mut doc, 3.0, 3.0, 7.0, 7.0);
         doc.push_object(
             layer,
             stage_object(Polarity::Clear, base_clear, PaintStage::Base),
+        );
+        let overlay = rect(&mut doc, 4.0, 4.0, 6.0, 6.0);
+        doc.push_object(
+            layer,
+            stage_object(Polarity::Dark, overlay, PaintStage::Overlay),
         );
         let cutout = rect(&mut doc, 0.0, 0.0, 1.0, 1.0);
         doc.push_object(
@@ -595,7 +620,7 @@ mod tests {
             crate::geom::tol::REGION_MM,
         );
 
-        // Overlay survives the base-stage clear painted after it.
+        // The overlay trace follows the clear in paint order and survives.
         assert!(image.contains_point(Point::new(5.0, 5.0)));
         // The base clear still removes material around the overlay.
         assert!(!image.contains_point(Point::new(3.5, 5.0)));

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -210,14 +210,14 @@ impl Geometry {
 }
 
 /// A standard aperture: a primitive shape with an optional round hole.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Aperture {
     pub shape: ApertureShape,
     /// Diameter of the round hole through the aperture; `0.0` means solid.
     pub hole_diameter: f64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ApertureShape {
     Circle {
         diameter: f64,
@@ -237,6 +237,10 @@ pub enum ApertureShape {
         vertices: u32,
         rotation_degrees: f64,
     },
+    /// An arbitrary origin-local filled contour, shared by every flash of
+    /// this aperture. This is how repeated dictionary instances stay
+    /// instances all the way to the output.
+    Contour(ContourBuf),
 }
 
 impl Aperture {
@@ -254,15 +258,16 @@ impl Aperture {
     /// Flatten to local-space contours. With a hole, the result is the outer
     /// shape plus the hole contour and must be filled with `EvenOdd`.
     pub fn contours(&self) -> Vec<ContourBuf> {
-        let outer = match self.shape {
-            ApertureShape::Circle { diameter } => shapes::circle(diameter),
-            ApertureShape::Rectangle { width, height } => shapes::rect(width, height),
-            ApertureShape::Obround { width, height } => shapes::obround(width, height, true),
+        let outer = match &self.shape {
+            ApertureShape::Circle { diameter } => shapes::circle(*diameter),
+            ApertureShape::Rectangle { width, height } => shapes::rect(*width, *height),
+            ApertureShape::Obround { width, height } => shapes::obround(*width, *height, true),
             ApertureShape::Polygon {
                 diameter,
                 vertices,
                 rotation_degrees,
-            } => shapes::regular_polygon(diameter, vertices, rotation_degrees),
+            } => shapes::regular_polygon(*diameter, *vertices, *rotation_degrees),
+            ApertureShape::Contour(contour) => return vec![contour.clone()],
         };
         let mut contours: Vec<ContourBuf> = outer.into_iter().collect();
         if !contours.is_empty() && self.hole_diameter > 0.0 {
@@ -280,7 +285,7 @@ impl Aperture {
     }
 
     pub fn bbox(&self) -> BBox {
-        match self.shape {
+        match &self.shape {
             ApertureShape::Circle { diameter } => {
                 BBox::from_point(Point::ZERO).expand(diameter / 2.0)
             }
@@ -292,6 +297,7 @@ impl Aperture {
             ApertureShape::Polygon { diameter, .. } => {
                 BBox::from_point(Point::ZERO).expand(diameter / 2.0)
             }
+            ApertureShape::Contour(contour) => contour.bbox,
         }
     }
 }
@@ -437,7 +443,7 @@ fn expand_flashes_to_regions<LayerMeta, ObjectMeta>(doc: &mut Document<LayerMeta
         else {
             continue;
         };
-        let Some(aperture) = doc.apertures.get(aperture as usize).copied() else {
+        let Some(aperture) = doc.apertures.get(aperture as usize).cloned() else {
             doc.warn("Skipping artwork flash with invalid aperture reference");
             continue;
         };

--- a/crates/pcb-ir/src/dialects/ipc/feature.rs
+++ b/crates/pcb-ir/src/dialects/ipc/feature.rs
@@ -48,10 +48,27 @@ pub struct Feature<Symbol> {
     pub line_cap: LineCap,
     pub fill_rule: FillRule,
     pub padstack_ref: Option<Symbol>,
-    pub primitive_ref: Option<Symbol>,
+    pub primitive_ref: Option<PrimitiveRef<Symbol>>,
     /// Spans `doc.pin_refs`.
     pub pin_refs: Span,
     pub flags: FeatureFlags,
+}
+
+/// A reference into one of the source document's two shape dictionaries.
+/// The dictionary matters: standard entries are exact catalogue primitives
+/// (circles, rectangles, ovals), user entries are arbitrary contour shapes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrimitiveRef<Symbol> {
+    Standard(Symbol),
+    User(Symbol),
+}
+
+impl<Symbol: Copy> PrimitiveRef<Symbol> {
+    pub fn id(self) -> Symbol {
+        match self {
+            Self::Standard(id) | Self::User(id) => id,
+        }
+    }
 }
 
 impl<Symbol> Feature<Symbol> {

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -38,7 +38,7 @@ pub use document::{Document, Layer};
 pub use feature::{
     Feature, FeatureBucket, FeatureDomain, FeatureFlags, FeatureIntent, FeatureKind,
     FeatureMaterial, FeatureOperation, FeatureRole, FeatureSet, FeatureSpan, FiducialKind, PinRef,
-    PlatingKind, SourceRef,
+    PlatingKind, PrimitiveRef, SourceRef,
 };
 pub use layout::{
     LayoutGraph, LayoutInstance, LayoutMargins, LayoutPurpose, LayoutRepeat, LayoutStep,

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -60,7 +60,9 @@ where
 ///
 /// This is intentionally destructive: it outlines strokes, applies boolean
 /// union/difference, resolves voids, and may convert arcs into polygon
-/// contours. Use it only when a target needs a final painted image.
+/// contours. Negative polarity stays native — mask composition paints
+/// polarity runs sequentially. Use it only when a target needs a final
+/// painted image.
 pub fn compose_for_rendering<S, L>(doc: &mut Document<S, L>)
 where
     S: Copy + Eq + Hash,
@@ -71,7 +73,6 @@ where
     union_feature_filled_paths(doc);
     coalesce_related_trace_features(doc);
     resolve_set_voids(doc);
-    resolve_negative_polarity(doc);
     subtract_layer_cutouts(doc);
     compact(doc);
     normalize_bounds(doc);
@@ -521,49 +522,6 @@ fn layer_features_by_set<S, L>(
     features_by_set
 }
 
-/// Resolve negative (clear) polarity as a layer-wide subtraction.
-pub fn resolve_negative_polarity<S, L>(doc: &mut Document<S, L>)
-where
-    S: Clone,
-    L: Clone,
-{
-    for layer_index in 0..doc.layers.len() {
-        let layer = doc.layers[layer_index].clone();
-        let negative_features = layer
-            .features
-            .range()
-            .filter(|&feature_index| {
-                let feature = &doc.features[feature_index];
-                feature.bucket != FeatureBucket::Cutout
-                    && !feature.flags.clears_previous_in_set
-                    && feature.polarity == Polarity::Clear
-            })
-            .collect::<Vec<_>>();
-        let mut cutters = negative_features
-            .iter()
-            .flat_map(|&feature_index| feature_filled_rings(doc, &doc.features[feature_index]))
-            .collect::<Vec<_>>();
-        if cutters.is_empty() {
-            continue;
-        }
-        if cutters.len() > 1 {
-            cutters = region::simplify_rings(cutters, FillRule::NonZero);
-        }
-
-        let cutter_bounds = ring_bounds(&cutters);
-        for feature_index in layer.features.range() {
-            let feature = &doc.features[feature_index];
-            if feature.bucket != FeatureBucket::Cutout && feature.polarity == Polarity::Dark {
-                subtract_rings_from_feature(doc, feature_index, &cutters, &cutter_bounds);
-            }
-        }
-
-        for feature_index in negative_features {
-            clear_feature_paths(doc, feature_index);
-        }
-    }
-}
-
 /// Subtract cutout features from every other feature on their layer.
 pub fn subtract_layer_cutouts<S, L>(doc: &mut Document<S, L>)
 where
@@ -1001,7 +959,7 @@ mod tests {
     }
 
     #[test]
-    fn resolves_negative_polarity_as_layer_subtraction() {
+    fn compose_keeps_clear_polarity_native() {
         let mut doc = TestDoc::new();
         doc.push_path(
             Paint::Fill {
@@ -1027,14 +985,28 @@ mod tests {
 
         compose_for_rendering(&mut doc);
 
-        let feature = &doc.features[0];
-        let path = &doc.arena.paths[feature.paths.start as usize];
-        assert_eq!(feature.paths.len(), 1);
-        assert!(path.contours.len() > 1);
-        assert_eq!(path.bbox.min, Point::new(0.0, 0.0));
-        assert_eq!(path.bbox.max, Point::new(4.0, 4.0));
-        assert_eq!(doc.features[1].paths.len(), 0);
-        assert!(doc.features[1].bbox.is_empty());
+        // Both features keep their native geometry and polarity; the
+        // sequential paint fold applies the subtraction at composition.
+        assert_eq!(doc.features[0].paths.len(), 1);
+        assert_eq!(doc.features[0].polarity, Polarity::Dark);
+        assert_eq!(doc.features[1].paths.len(), 1);
+        assert_eq!(doc.features[1].polarity, Polarity::Clear);
+
+        let artwork = crate::dialects::ipc::lower_layer_to_artwork(
+            &doc,
+            0,
+            crate::dialects::LayerRole::Copper,
+            crate::dialects::Side::Top,
+        );
+        let mask = crate::dialects::artwork::compose_to_mask(&artwork);
+        let shape = mask.layers[0].shapes.slice(&mask.arena.paths)[0];
+        let image = crate::geom::region::ContourSet::from_contours(
+            &mask.arena.path_contours(&shape),
+            FillRule::NonZero,
+            crate::geom::tol::REGION_MM,
+        );
+        assert!((image.area() - 12.0).abs() < 1e-6);
+        assert!(!image.contains_point(Point::new(2.0, 2.0)));
     }
 
     #[test]
@@ -1323,13 +1295,17 @@ mod tests {
         );
         doc.features.push(Feature {
             paths: Span::new(1, 1),
+            flags: crate::dialects::ipc::FeatureFlags {
+                clears_previous_in_set: true,
+                ..Default::default()
+            },
             ..Feature::new(FeatureKind::Polygon, Polarity::Clear)
         });
         doc.layers.push(test_layer(Span::new(0, 2)));
 
         compose_for_rendering(&mut doc);
 
-        // The negative feature and the pre-subtraction positive path are gone.
+        // The set void and the pre-subtraction positive path are gone.
         assert_eq!(doc.arena.paths.len(), 1);
         assert_eq!(doc.features[0].paths, Span::new(0, 1));
         doc.arena.validate("compacted").unwrap();

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -603,6 +603,14 @@ pub fn split_primitive_feature_path_runs<S: Clone, L>(
         );
     }
 
+    // A fragment of a dictionary entry is not the entry: only a feature
+    // carrying the entry's entire geometry keeps its primitive identity.
+    if features.len() != 1 || features[0].paths != feature.paths {
+        for fragment in &mut features {
+            fragment.primitive_ref = None;
+        }
+    }
+
     Ok(features)
 }
 
@@ -803,7 +811,7 @@ fn feature_set_bbox<S, L>(doc: &Document<S, L>, set_index: usize) -> BBox {
 mod tests {
     use super::*;
     use crate::dialects::ipc::feature::{
-        FeatureDomain, FeatureMaterial, FeatureOperation, FeatureRole, SourceRef,
+        FeatureDomain, FeatureMaterial, FeatureOperation, FeatureRole, PrimitiveRef, SourceRef,
     };
     use crate::dialects::ipc::validate::validate_artwork_ready;
     use crate::geom::path::PathCmd;
@@ -1340,5 +1348,41 @@ mod tests {
             PathCmd::line_to(Point::new(x0, y1)),
             PathCmd::close(),
         ])
+    }
+
+    #[test]
+    fn split_path_runs_keep_primitive_identity_only_for_whole_entries() {
+        let mut doc = TestDoc::new();
+        doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            [rect_contour(0.0, 0.0, 1.0, 1.0)],
+        );
+        doc.push_path(
+            Paint::Stroke(StrokeStyle::new(0.2, LineCap::Round)),
+            [ContourBuf::new(vec![
+                PathCmd::move_to(Point::new(0.0, 2.0)),
+                PathCmd::line_to(Point::new(1.0, 2.0)),
+            ])],
+        );
+
+        let mut feature = Feature::new(FeatureKind::Primitive, Polarity::Dark);
+        feature.primitive_ref = Some(PrimitiveRef::User(7));
+        feature.paths = Span::new(0, 2);
+
+        let fragments = split_primitive_feature_path_runs(&doc, feature.clone()).unwrap();
+        assert_eq!(fragments.len(), 2);
+        assert!(
+            fragments
+                .iter()
+                .all(|fragment| fragment.primitive_ref.is_none()),
+            "fragments must not claim the dictionary entry's identity"
+        );
+
+        feature.paths = Span::new(0, 1);
+        let whole = split_primitive_feature_path_runs(&doc, feature).unwrap();
+        assert_eq!(whole.len(), 1);
+        assert_eq!(whole[0].primitive_ref, Some(PrimitiveRef::User(7)));
     }
 }

--- a/crates/pcb-ir/src/geom/path.rs
+++ b/crates/pcb-ir/src/geom/path.rs
@@ -89,7 +89,7 @@ impl PathCmd {
 ///
 /// This is the detached form of an arena [`crate::geom::Contour`] record, used
 /// to move contours between documents and geometry passes.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct ContourBuf {
     pub bbox: BBox,
     pub cmds: Vec<PathCmd>,


### PR DESCRIPTION
Two structural refactors that replace the polarity guards, fallbacks, and congruence heuristics with one algebra and one structure-preserving pipeline. Net −206 lines.

**Sequential polarity runs are the single paint semantics.** A layer's image is a fold over maximal same-polarity runs: dark commutes with dark, clear with clear, never across. Mask composition and the Gerber plan now permute stage order (fills before pads) only within runs — the exact set of image-invariant permutations — with final cutouts terminal. Clear features flow natively everywhere with identical meaning, so the layer-wide \`resolve_negative_polarity\` pass, the export-side reachability guard with its spatial grids, and the schedule graph all delete. Composed copper images (density measurement included) go through the mask fold; this also fixes them counting hole/clear geometry as copper, which shifts balance targets by ~0.003 density on the reference mix.

**Dictionary instances stay instances to the output.** The artwork dialect gains a \`Contour\` aperture shape; the Gerber export flashes rigid-transform dictionary-instance features through one shared aperture per referenced entry (rotated placements absorb their basis into a per-rotation outline macro); the writer lowers contour apertures to \`%AM\` outline macros. The congruence-recovery planner — quantized signatures, group thresholds, ordering concerns — deletes; sharing and determinism follow from document structure.

Verified: full suites green including the IPC↔Gerber composed-geometry equivalence gates, sequential-semantics regression tests for clears before and after overlapping copper, and an end-to-end regeneration of the 18×24 reference mix (Gerber zip 8.6 → 8.2 MB, export ~4.8 s; copper renders identical apart from the corrected density measurement).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core IPC→artwork→Gerber composition and copper-balance density; behavior changes for negative polarity and large balanced-panel exports, though covered by updated regression tests and reference mix regeneration.
> 
> **Overview**
> **Paint semantics** are unified on **sequential same-polarity runs**: dark/clear only commute within a run; stage ordering (base vs overlay) is permuted inside each run, with final cutouts last. That replaces layer-wide `resolve_negative_polarity`, Gerber export reachability guards, and the old schedule graph—clears export natively and compose the same way in mask folding, board-array SVGs, and copper-balance density (cleared areas no longer count as copper).
> 
> **Gerber output** shrinks by keeping **user-dictionary instances as instances**: artwork gains a `Contour` aperture, IPC export flashes rigid transforms through one shared aperture per entry, and the writer emits `%AM` outline macros (including holes via exposure-off rings). The congruence-based repeated-clear flash planner is removed.
> 
> `PrimitiveRef` distinguishes standard vs user dictionary refs so catalogue circles stay circle flashes. Export tests now expect sequential set semantics (later fills repaint clears; clears after pads erase natively).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50df740e604a8e89c1b137470c1c7b3eb0b73fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->