### PR TITLE
Carry the source fill rule on contour apertures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Pad shapes with padstack offsets now land at the correct position on rotated pads across all IPC-2581 outputs.
-- Copper-balance density targets no longer count cleared areas as copper.
-- Repeated dictionary shapes with self-overlapping outlines keep their carved holes in Gerber exports.
 
 ## [0.4.22] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Pad shapes with padstack offsets now land at the correct position on rotated pads across all IPC-2581 outputs.
 - Copper-balance density targets no longer count cleared areas as copper.
+- Repeated dictionary shapes with self-overlapping outlines keep their carved holes in Gerber exports.
 
 ## [0.4.22] - 2026-08-04
 

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -231,7 +231,7 @@ fn lower_artwork_object(
             if !transform_is_translation(transform) {
                 // Contour apertures absorb a rotated basis by rotating their
                 // outline; the aperture table dedups per rotated shape.
-                let ApertureShape::Contour(contour) = &artwork_aperture.shape else {
+                let ApertureShape::Contour { outline, fill_rule } = &artwork_aperture.shape else {
                     return Err(GerberError::InvalidStructure(
                         "cannot lower transformed artwork flash to Gerber".to_string(),
                     ));
@@ -241,9 +241,10 @@ fn lower_artwork_object(
                     m12: 0.0,
                     ..transform
                 };
-                artwork_aperture = Aperture::solid(ApertureShape::Contour(
-                    geom_path::transform_cmds(contour.cmds.iter().copied(), basis),
-                ));
+                artwork_aperture = Aperture::solid(ApertureShape::Contour {
+                    outline: geom_path::transform_cmds(outline.cmds.iter().copied(), basis),
+                    fill_rule: *fill_rule,
+                });
             }
             let default_function = vec!["Conductor".to_string()];
             let aperture_function = object
@@ -407,15 +408,14 @@ impl ApertureTable {
 
     fn artwork_aperture(&mut self, aperture: Aperture, function: &[String]) -> Result<i32> {
         let hole_diameter = (aperture.hole_diameter > 0.0).then_some(aperture.hole_diameter);
-        let fill_rule = aperture.fill_rule();
         match aperture.shape {
-            ApertureShape::Contour(contour) => {
+            ApertureShape::Contour { outline, fill_rule } => {
                 // Resolve the buffer's raw loops under the aperture's fill
                 // rule so winding is canonical: each shape is an outer ring
                 // followed by its holes, wound opposite. Larger shapes paint
                 // first so an island inside a hole survives the hole's erase.
                 let mut shapes = region::simplify_shapes(
-                    region::rings_from_contours(std::slice::from_ref(&contour)),
+                    region::rings_from_contours(std::slice::from_ref(&outline)),
                     fill_rule,
                 );
                 shapes.sort_by(|a, b| {
@@ -978,7 +978,10 @@ mod tests {
         }
         let contour = ContourBuf::from_parts(bbox, cmds);
 
-        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour(contour)));
+        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour {
+            outline: contour,
+            fill_rule: FillRule::NonZero,
+        }));
         artwork.push_object(
             layer_id,
             ArtworkObject {
@@ -1006,6 +1009,63 @@ mod tests {
         assert!(
             (summary.area_mm2 - 64.0).abs() < 0.01,
             "the hole ring must survive as an exposure-off outline: {}",
+            summary.area_mm2
+        );
+    }
+
+    #[test]
+    fn contour_apertures_honor_even_odd_fill() {
+        // Two same-winding nested loops: NonZero fills solid, EvenOdd carves
+        // the inner loop out. The aperture's fill rule must decide.
+        let mut artwork = ArtworkDocument::new();
+        let layer_id = artwork.push_layer(IrArtworkDocument {
+            name: "F.Cu".to_string(),
+            role: LayerRole::Copper,
+            side: Side::Top,
+            objects: Span::EMPTY,
+            bbox: BBox::empty(),
+            meta: LayerAttributes::default(),
+        });
+
+        let outer = rect_payload(0.0, 0.0, 10.0, 10.0);
+        let inner = rect_payload(2.0, 2.0, 8.0, 8.0);
+        let mut bbox = outer.bbox;
+        bbox.include_point(inner.bbox.min);
+        bbox.include_point(inner.bbox.max);
+        let mut cmds = outer.cmds.clone();
+        cmds.extend(inner.cmds.iter().copied());
+        let contour = ContourBuf::from_parts(bbox, cmds);
+
+        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour {
+            outline: contour,
+            fill_rule: FillRule::EvenOdd,
+        }));
+        artwork.push_object(
+            layer_id,
+            ArtworkObject {
+                polarity: Polarity::Dark,
+                order: Default::default(),
+                geometry: ArtworkGeometry::Flash {
+                    aperture,
+                    transform: pcb_ir::geom::Affine2::translation(Point::new(20.0, 5.0)),
+                },
+                bbox: BBox {
+                    min: Point::new(20.0, 5.0),
+                    max: Point::new(30.0, 15.0),
+                },
+                meta: ObjectAttributes::default(),
+            },
+        );
+
+        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let contents = crate::write_layer(&gerber).expect("write Gerber");
+        assert_external_parser_accepts(&contents);
+        let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
+        let geometry = crate::geometry::extract_document(&parsed);
+        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        assert!(
+            (summary.area_mm2 - 64.0).abs() < 0.01,
+            "even-odd fill must carve the nested loop out: {}",
             summary.area_mm2
         );
     }
@@ -1043,7 +1103,10 @@ mod tests {
         cmds.push(PathCmd::close());
         let contour = ContourBuf::from_parts(bbox, cmds);
 
-        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour(contour)));
+        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour {
+            outline: contour,
+            fill_rule: FillRule::NonZero,
+        }));
         artwork.push_object(
             layer_id,
             ArtworkObject {
@@ -1108,7 +1171,10 @@ mod tests {
         cmds.push(PathCmd::close());
         let contour = ContourBuf::from_parts(bbox, cmds);
 
-        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour(contour)));
+        let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour {
+            outline: contour,
+            fill_rule: FillRule::NonZero,
+        }));
         artwork.push_object(
             layer_id,
             ArtworkObject {

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -24,7 +24,8 @@ use pcb_ir::dialects::ipc::{
 use pcb_ir::dialects::{LayerRole, Side as IrSide};
 use pcb_ir::geom::path::{ContourBuf, PathCmd, PathOp};
 use pcb_ir::geom::{
-    Affine2, Arc, BBox, LineCap, LineJoin, LinePattern, Paint, Point, Polarity, Span, StrokeStyle,
+    Affine2, Arc, BBox, FillRule, LineCap, LineJoin, LinePattern, Paint, Point, Polarity, Span,
+    StrokeStyle,
 };
 
 type IpcGeometryDocument = pcb_ir::dialects::ipc::Document<ipc2581::Symbol, LayerFunction>;
@@ -1027,7 +1028,10 @@ fn instance_flash(
         return None;
     };
     let aperture = artwork.push_aperture(Aperture::solid(
-        pcb_ir::dialects::artwork::ApertureShape::Contour(local.clone()),
+        pcb_ir::dialects::artwork::ApertureShape::Contour {
+            outline: local.clone(),
+            fill_rule: path.fill_rule().unwrap_or(FillRule::NonZero),
+        },
     ));
     apertures.by_primitive.insert(primitive, aperture);
     Some((aperture, feature.transform))

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -238,9 +238,13 @@ pub enum ApertureShape {
         rotation_degrees: f64,
     },
     /// An arbitrary origin-local filled contour, shared by every flash of
-    /// this aperture. This is how repeated dictionary instances stay
-    /// instances all the way to the output.
-    Contour(ContourBuf),
+    /// this aperture, painted under its source path's fill rule. This is
+    /// how repeated dictionary instances stay instances all the way to the
+    /// output.
+    Contour {
+        outline: ContourBuf,
+        fill_rule: FillRule,
+    },
 }
 
 impl Aperture {
@@ -267,7 +271,7 @@ impl Aperture {
                 vertices,
                 rotation_degrees,
             } => shapes::regular_polygon(*diameter, *vertices, *rotation_degrees),
-            ApertureShape::Contour(contour) => return vec![contour.clone()],
+            ApertureShape::Contour { outline, .. } => return vec![outline.clone()],
         };
         let mut contours: Vec<ContourBuf> = outer.into_iter().collect();
         if !contours.is_empty() && self.hole_diameter > 0.0 {
@@ -277,10 +281,10 @@ impl Aperture {
     }
 
     pub fn fill_rule(&self) -> FillRule {
-        if self.hole_diameter > 0.0 {
-            FillRule::EvenOdd
-        } else {
-            FillRule::NonZero
+        match &self.shape {
+            ApertureShape::Contour { fill_rule, .. } => *fill_rule,
+            _ if self.hole_diameter > 0.0 => FillRule::EvenOdd,
+            _ => FillRule::NonZero,
         }
     }
 
@@ -297,7 +301,7 @@ impl Aperture {
             ApertureShape::Polygon { diameter, .. } => {
                 BBox::from_point(Point::ZERO).expand(diameter / 2.0)
             }
-            ApertureShape::Contour(contour) => contour.bbox,
+            ApertureShape::Contour { outline, .. } => outline.bbox,
         }
     }
 }


### PR DESCRIPTION
Instance flashing dropped the shared template path's fill rule: `Aperture::solid(ApertureShape::Contour(...))` always composed and exported under NonZero, so an even-odd dictionary shape whose outline folds back on itself stamped completely solid, in both Gerbers and previews.

`ApertureShape::Contour` now carries its fill rule, taken from the source path at template derivation and preserved through rotated-basis baking. Every consumer — mask composition, flash expansion, and the Gerber macro lowering's winding resolve — already reads `Aperture::fill_rule()`, so the rule flows end to end with no added branching, and flashed vs. region-lowered instances of the same entry render identically by construction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fill semantics for flashed dictionary shapes in Gerber and IPC export paths; wrong rules would alter copper/mask geometry but the change is narrow and covered by a new regression test.
> 
> **Overview**
> **Contour apertures now store the source path’s fill rule** instead of always compositing and exporting under **NonZero**. `ApertureShape::Contour` is a struct with `outline` and `fill_rule`; `Aperture::fill_rule()` returns that rule for contour shapes (holes on other shapes still imply **EvenOdd**).
> 
> IPC-2581 → Gerber template derivation copies `path.fill_rule()` onto new contour apertures. Gerber lowering resolves winding with the aperture’s rule and keeps `fill_rule` when baking a rotated contour basis into the outline. A Gerber test asserts **EvenOdd** nested loops carve correctly when flashed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88349023c83233557328b71e2e731500ee2de836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->