### PR TITLE
Exclude unfillable area from the copper-balance density denominator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Copper balancing no longer over-fills narrow panel frames and gutters, which made board-array frames pour solid instead of matching the board's copper density.
+
 ## [0.4.23] - 2026-08-05
 
 ### Added

--- a/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
+++ b/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
@@ -25,17 +25,34 @@ area.
 
 For copper layer `l`, let:
 
-- `P` be the retained assembly-panel region with area `A_P`;
+- `P` be the retained assembly-panel region;
 - `B` be the union of repeated board footprints with area `A_B`;
 - `C_l` be the fixed copper region;
 - `S_l` be the initially empty safe region; and
 - `d_l = area(C_l intersect B) / A_B` be the board-density target.
 
+The density domain `D_l` is the part of `P` that holds copper or could hold
+copper, and `A_Dl` is its area:
+
+```text
+D_l = B union S_l union C_l
+```
+
 The requested generated area is:
 
 ```text
-A*_l = d_l A_P - area(C_l)
+A*_l = d_l A_Dl - area(C_l)
 ```
+
+Panel material that is permanently bare — board clearance, rails, V-score
+relief, tooling holes, gaps too narrow to hold a void — is excluded from `D_l`
+and so from both sides of the ratio. Charging the request against all of `P`
+instead would ask for `d_l` times that bare area on top of the real request,
+and the solver could only spend it by over-filling the region it can reach:
+a thin frame saturates to a solid pour whose local density far exceeds the
+board density it exists to match. Excluding it makes `A*_l` reduce to
+`d_l area(S_l)` whenever `C_l` lies inside `B` — fill the fillable at the
+board's own density.
 
 `S_l` is certified independently from board geometry, through-stack
 operations, and panel features whose existing IR span reaches layer `l`.

--- a/crates/pcb-ipc2581-tools/docs/fab-panel-copper-balancing.md
+++ b/crates/pcb-ipc2581-tools/docs/fab-panel-copper-balancing.md
@@ -17,12 +17,15 @@ region serves every copper layer.
 
 The reserved process margins stay bare. They are excluded from the density
 domain entirely — not merely from the safe region — so the solver never
-chases a deficit it cannot fill at the margin boundary.
+chases a deficit it cannot fill at the margin boundary. Every other
+permanently bare area inside the usable region is excluded on the same
+grounds; see [Density targets](#density-targets).
 
 As a defensive measure, any copper found outside the placed panel outlines
 joins the shared obstacle set, shrinking the certified safe region instead of
-failing the solve. A correctly generated fabrication panel has no such
-copper.
+failing the solve. It stays in that layer's density domain, since it is real
+copper even where no generated copper may go. A correctly generated
+fabrication panel has no such copper.
 
 ## Density targets
 
@@ -32,14 +35,20 @@ balanced during board-array creation, this extends their already-uniform
 density into the gutters. Mixed panel types weight the target by their
 footprint areas, since the denominator is the union of all placements.
 
-With domain `U` (the usable region), footprints `F`, and fixed copper `C_l`,
-the requested generated area reduces to filling the gutters at the panel
-density:
+With footprints `F`, safe region `S`, and fixed copper `C_l`, the density
+domain is `D_l = F ∪ S ∪ C_l` and the requested generated area reduces to
+filling the gutters at the panel density:
 
 ```text
 d_l  = area(C_l ∩ F) / area(F)
-A*_l = d_l area(U) - area(C_l) = d_l area(U \ F)
+A*_l = d_l area(D_l) - area(C_l) = d_l area(S)
 ```
+
+The usable region is the solve's spatial extent, not its density denominator.
+Everything inside it that no generated copper could occupy — the clearance
+around each placed panel, material removal, gaps too narrow for a void — is
+excluded from `D_l` exactly as the process margins are, so the request never
+includes copper the gutters have nowhere to put.
 
 ## Through-stack metric
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -92,6 +92,12 @@ pub fn generate_automatic_board_array_copper_balance(ipc: &Ipc2581) -> Result<Co
             }
             balancing_region.safe_region
         };
+        // The panel material the solver may fill, plus the boards whose
+        // density set the target and any frame copper already present.
+        // Everything else inside the array — board clearance, rails, V-score
+        // relief, tooling holes — can never hold generated copper and so
+        // stays out of the density denominator.
+        let density_domain = board_footprints.union(&frame_copper).union(&safe_region);
         prepared.push(PreparedLayerBalance {
             layer: layer.name,
             frame_copper_empty,
@@ -101,6 +107,7 @@ pub fn generate_automatic_board_array_copper_balance(ipc: &Ipc2581) -> Result<Co
                 stack_weight_mm2,
                 existing_copper,
                 safe_region,
+                density_domain,
             },
         });
     }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -209,7 +209,7 @@ fn board_array_creation_automatically_balances_every_copper_layer() {
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
     let balance = generate_automatic_board_array_copper_balance(&provisional).unwrap();
 
-    assert!(balance.retained_area_mm2 > 0.0);
+    assert!(balance.panel_area_mm2 > 0.0);
     assert_eq!(balance.layers.len(), 2);
     assert!(
         balance
@@ -250,14 +250,18 @@ fn board_array_creation_automatically_balances_every_copper_layer() {
     let creation = create_auto_board_array(&input, None).unwrap();
     assert_eq!(creation.copper_balance.layers.len(), 2);
     for report in &creation.copper_balance.layers {
+        // Fixed copper, fillable region, and permanently bare area partition
+        // that layer's density domain exactly.
         assert!(
             (report.existing_copper_area_mm2
                 + report.usable_area_mm2
                 + report.fixed_empty_area_mm2
-                - creation.copper_balance.retained_area_mm2)
+                - report.density_domain_area_mm2)
                 .abs()
                 <= 1e-6
         );
+        // Unfillable panel material stays out of the denominator entirely.
+        assert!(report.density_domain_area_mm2 <= creation.copper_balance.panel_area_mm2 + 1e-6);
         assert!(
             report.residual_error <= (report.initial_density - report.target_density).abs() + 1e-9
         );
@@ -874,6 +878,7 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     let layers = [SpatialCopperBalanceLayerRequest {
         safe_region: &safe_region,
         existing_copper: &existing,
+        density_domain: &safe_region,
         target_density: 0.70,
         stack_weight_mm2: 0.0,
     }];

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
@@ -70,9 +70,15 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
     })?;
     // Copper found outside the placed panels joins the shared obstacle set,
     // so unexpected overhang shrinks the certified safe region for every
-    // layer instead of failing the solve.
-    for (_, image) in &copper_images {
-        input.support_features = input.support_features.union(&image.difference(&footprints));
+    // layer instead of failing the solve. Each layer keeps its own overhang:
+    // it is real copper and belongs in that layer's density domain even
+    // though no generated copper may be placed there.
+    let stray_copper = copper_images
+        .iter()
+        .map(|(_, image)| image.difference(&footprints))
+        .collect::<Vec<_>>();
+    for stray in &stray_copper {
+        input.support_features = input.support_features.union(stray);
     }
 
     let balancing_region = board_array_balancing_region(&input, BalancingRegionOptions::default())
@@ -85,11 +91,18 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
     }
     let safe_region = balancing_region.safe_region;
 
+    // The gutters the solver may fill, plus the panels whose density set the
+    // target. Everything else inside the usable region — clearance around each
+    // placed panel, material removal, gaps too narrow for a void — can never
+    // hold generated copper and so stays out of the density denominator.
+    let panel_domain = footprints.union(&safe_region);
+
     let stack_weights = physical_copper_stack_weights(ipc);
     let stack_weights_available = stack_weights.is_some();
     let prepared = copper_images
         .into_iter()
-        .map(|(layer_name, existing_copper)| {
+        .zip(stray_copper)
+        .map(|((layer_name, existing_copper), stray)| {
             let target_density = (existing_copper.intersection(&footprints).area()
                 / footprint_area_mm2)
                 .clamp(0.0, 1.0);
@@ -103,6 +116,7 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
                 stack_weight_mm2,
                 existing_copper,
                 safe_region: safe_region.clone(),
+                density_domain: panel_domain.union(&stray),
             }
         })
         .collect();

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -41,6 +41,12 @@ pub struct PreparedCopperLayer {
     pub existing_copper: ContourSet,
     /// Certified, initially empty region available for generated copper.
     pub safe_region: ContourSet,
+    /// Region the target density is measured and applied over: the immutable
+    /// footprints, this layer's safe region, and any copper outside both.
+    /// Permanently bare area is excluded, so the solve never budgets copper it
+    /// has nowhere to put. See
+    /// [`SpatialCopperBalanceLayerRequest::density_domain`].
+    pub density_domain: ContourSet,
 }
 
 /// One origin-centered rounded-hex dictionary entry, shared by every void of
@@ -86,6 +92,9 @@ pub struct CopperBalanceLayer {
     pub target_density: f64,
     pub stack_weight_mm2: f64,
     pub existing_copper: ContourSet,
+    /// Area of this layer's density domain, the denominator behind every
+    /// density in [`CopperBalanceLayer::result`].
+    pub density_domain_area_mm2: f64,
     pub result: DenseCopperBalanceResult,
     pub features: BalanceFeatureSets,
 }
@@ -95,7 +104,9 @@ pub struct CopperBalanceLayer {
 pub struct CopperBalancePlan {
     /// Immutable placed footprints whose density the generated copper extends.
     pub footprints: ContourSet,
-    pub retained_area_mm2: f64,
+    /// Area of the whole panel region the solve ran over. Context only — each
+    /// layer's densities are relative to its own density domain.
+    pub panel_area_mm2: f64,
     /// Whether the physical stackup supplied signed stack weights. When false,
     /// every layer balances independently with zero through-stack coupling.
     pub stack_weights_available: bool,
@@ -119,6 +130,12 @@ pub struct CopperBalanceLayerReport {
     pub desired_added_area_mm2: f64,
     pub generated_area_mm2: f64,
     pub usable_area_mm2: f64,
+    /// Denominator behind every density on this layer.
+    pub density_domain_area_mm2: f64,
+    /// Domain area that holds no copper and can take none: the footprints'
+    /// own empty space. Permanently bare area outside the domain — process
+    /// margins, clearance rings, material removal — is not counted here
+    /// because it never enters the density calculation.
     pub fixed_empty_area_mm2: f64,
     pub void_count: usize,
 }
@@ -135,7 +152,7 @@ pub enum CopperBalanceMode {
 /// Compact, serializable accounting for a completed automatic balance plan.
 #[derive(Debug, Clone, Serialize)]
 pub struct CopperBalanceReport {
-    pub retained_area_mm2: f64,
+    pub panel_area_mm2: f64,
     pub footprint_area_mm2: f64,
     pub stack_weights_available: bool,
     pub layers: Vec<CopperBalanceLayerReport>,
@@ -186,7 +203,7 @@ impl CopperBalancePlan {
     /// Discard heavy geometry while retaining enough data to audit the result.
     pub fn report(&self) -> CopperBalanceReport {
         CopperBalanceReport {
-            retained_area_mm2: self.retained_area_mm2,
+            panel_area_mm2: self.panel_area_mm2,
             footprint_area_mm2: self.footprints.area(),
             stack_weights_available: self.stack_weights_available,
             layers: self
@@ -196,9 +213,10 @@ impl CopperBalancePlan {
                     let solution = layer.result.solution;
                     let existing_copper_area_mm2 = layer.existing_copper.area();
                     let usable_area_mm2 = layer.result.usable.area();
-                    let fixed_empty_area_mm2 =
-                        (self.retained_area_mm2 - existing_copper_area_mm2 - usable_area_mm2)
-                            .max(0.0);
+                    let fixed_empty_area_mm2 = (layer.density_domain_area_mm2
+                        - existing_copper_area_mm2
+                        - usable_area_mm2)
+                        .max(0.0);
                     let (mode, void_radius_mm) = match solution.mode {
                         DenseCopperBalanceMode::None => (CopperBalanceMode::None, None),
                         DenseCopperBalanceMode::Solid => (CopperBalanceMode::Solid, None),
@@ -225,6 +243,7 @@ impl CopperBalancePlan {
                         desired_added_area_mm2: solution.desired_added_area_mm2,
                         generated_area_mm2: solution.generated_area_mm2,
                         usable_area_mm2,
+                        density_domain_area_mm2: layer.density_domain_area_mm2,
                         fixed_empty_area_mm2,
                         void_count: layer.result.void_count(),
                     }
@@ -250,6 +269,7 @@ pub fn solve_copper_balance(
         .map(|layer| SpatialCopperBalanceLayerRequest {
             safe_region: &layer.safe_region,
             existing_copper: &layer.existing_copper,
+            density_domain: &layer.density_domain,
             target_density: layer.target_density,
             stack_weight_mm2: layer.stack_weight_mm2,
         })
@@ -274,6 +294,7 @@ pub fn solve_copper_balance(
                 target_density: layer.target_density,
                 stack_weight_mm2: layer.stack_weight_mm2,
                 existing_copper: layer.existing_copper,
+                density_domain_area_mm2: layer.density_domain.area(),
                 result,
                 features,
             })
@@ -282,7 +303,7 @@ pub fn solve_copper_balance(
 
     Ok(CopperBalancePlan {
         footprints,
-        retained_area_mm2: panel_region.area(),
+        panel_area_mm2: panel_region.area(),
         stack_weights_available,
         layers,
     })
@@ -561,6 +582,7 @@ mod tests {
         let layers = [SpatialCopperBalanceLayerRequest {
             safe_region: &safe_region,
             existing_copper: &existing,
+            density_domain: &safe_region,
             target_density: 0.75,
             stack_weight_mm2: 0.0,
         }];

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -844,9 +844,15 @@ fn validate_request(request: DenseCopperBalanceRequest<'_>) -> Result<(), DenseC
             "density domain area must be finite and greater than zero".to_string(),
         ));
     }
+    // These three bounds are the scalar shadow of the geometric containments
+    // `C subset D`, `S subset D`, and `C disjoint S`, so they tolerate the same
+    // sliver area those predicates do. Holding them to NUMERIC_EPSILON would
+    // reject a request whose geometry passed containment, and the slack only
+    // vanishes when the footprints are fully poured.
     if !request.existing_copper_area_mm2.is_finite()
         || request.existing_copper_area_mm2 < 0.0
-        || request.existing_copper_area_mm2 > request.density_domain_area_mm2 + NUMERIC_EPSILON
+        || request.existing_copper_area_mm2
+            > request.density_domain_area_mm2 + CONTAINMENT_AREA_TOLERANCE_MM2
     {
         return Err(DenseCopperBalanceError::InvalidInput(
             "existing copper area must be between zero and the density domain area".to_string(),
@@ -860,14 +866,14 @@ fn validate_request(request: DenseCopperBalanceRequest<'_>) -> Result<(), DenseC
     let usable_area_mm2 = request.safe_region.area();
     if !usable_area_mm2.is_finite()
         || usable_area_mm2 < 0.0
-        || usable_area_mm2 > request.density_domain_area_mm2 + NUMERIC_EPSILON
+        || usable_area_mm2 > request.density_domain_area_mm2 + CONTAINMENT_AREA_TOLERANCE_MM2
     {
         return Err(DenseCopperBalanceError::InvalidInput(
             "usable area must be between zero and the density domain area".to_string(),
         ));
     }
     if request.existing_copper_area_mm2 + usable_area_mm2
-        > request.density_domain_area_mm2 + NUMERIC_EPSILON
+        > request.density_domain_area_mm2 + CONTAINMENT_AREA_TOLERANCE_MM2
     {
         return Err(DenseCopperBalanceError::InvalidInput(
             "existing copper and usable areas together exceed the density domain area".to_string(),
@@ -1486,6 +1492,36 @@ mod tests {
             (left.solution.generated_area_mm2 - right.solution.generated_area_mm2).abs()
                 <= AREA_SOLVE_TOLERANCE_MM2 + quantization_bound_mm2
         }));
+    }
+
+    /// The scalar area bounds must tolerate what `contains` tolerates.
+    ///
+    /// Fixed copper, fillable region, and permanently bare area partition the
+    /// density domain, so a domain whose measured area is short by a boolean
+    /// sliver breaks the sum bound. There is no slack to absorb it once the
+    /// footprints are fully poured, and rejecting then would fail a request
+    /// whose geometry passed every containment check.
+    #[test]
+    fn area_bounds_tolerate_the_same_slivers_as_containment() {
+        let safe_region = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 10.0)),
+            tol::REGION_MM,
+        );
+        let existing_copper_area_mm2 = 100.0;
+        let exact_domain_area_mm2 = existing_copper_area_mm2 + safe_region.area();
+        let result = generate_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            DenseCopperBalanceRequest {
+                safe_region: &safe_region,
+                density_domain_area_mm2: exact_domain_area_mm2
+                    - CONTAINMENT_AREA_TOLERANCE_MM2 / 2.0,
+                existing_copper_area_mm2,
+                target_density: 0.9,
+                lattice_origin: Point::ZERO,
+            },
+        );
+
+        assert!(result.is_ok(), "{:?}", result.err());
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -25,6 +25,11 @@ use spatial::{
 const NUMERIC_EPSILON: f64 = 1e-9;
 const RADIUS_SOLVE_TOLERANCE_MM: f64 = 1e-4;
 const AREA_SOLVE_TOLERANCE_MM2: f64 = 1e-3;
+/// Leftover area tolerated when certifying that one region contains another.
+/// Roughly a 30 um square: three orders of magnitude below the smallest void
+/// the profile can place, and above the slivers a regularized difference
+/// leaves where its operands share an edge.
+const CONTAINMENT_AREA_TOLERANCE_MM2: f64 = 1e-3;
 // Gradient information travels about one kernel support per iteration under
 // the fixed conservative step, so the radius field needs a few hundred
 // iterations to equilibrate across a panel; measured objectives plateau by
@@ -141,11 +146,11 @@ pub struct DenseCopperBalanceSolution {
 /// Geometry inputs for the internal single-layer baseline solve.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DenseCopperBalanceRequest<'a> {
-    /// Safe, initially empty subset of the retained board-array area.
+    /// Safe, initially empty subset of the density domain.
     pub safe_region: &'a ContourSet,
-    /// Entire retained board-array area used as the density denominator.
-    pub retained_area_mm2: f64,
-    /// Fixed copper anywhere in that retained area on this layer.
+    /// Area of the density domain, used as the density denominator.
+    pub density_domain_area_mm2: f64,
+    /// Fixed copper anywhere in that density domain on this layer.
     pub existing_copper_area_mm2: f64,
     pub target_density: f64,
     pub lattice_origin: Point,
@@ -158,6 +163,20 @@ pub struct SpatialCopperBalanceLayerRequest<'a> {
     pub safe_region: &'a ContourSet,
     /// Fixed copper within `SpatialCopperBalanceRequest::panel_region`.
     pub existing_copper: &'a ContourSet,
+    /// Region over which `target_density` is both measured and applied.
+    ///
+    /// This is the area that holds copper or could hold copper: the immutable
+    /// footprints whose measured density set the target, this layer's safe
+    /// region, and any fixed copper outside both. Permanently bare area —
+    /// process margins, clearance rings, material removal, gaps narrower than
+    /// the minimum web — must be excluded, so the solver never budgets copper
+    /// for area no generated feature could occupy. Including it would inflate
+    /// the request by `target_density` times that area, which the solver can
+    /// only spend by over-filling the region it can reach.
+    ///
+    /// Must contain `safe_region` and `existing_copper`, and be contained by
+    /// `SpatialCopperBalanceRequest::panel_region`.
+    pub density_domain: &'a ContourSet,
     pub target_density: f64,
     /// Signed first-moment weight `z * thickness` from the physical stackup.
     pub stack_weight_mm2: f64,
@@ -166,7 +185,9 @@ pub struct SpatialCopperBalanceLayerRequest<'a> {
 /// Geometry shared by all layers in a joint spatial copper-balance solve.
 #[derive(Debug, Clone, Copy)]
 pub struct SpatialCopperBalanceRequest<'a> {
-    /// Canonical retained panel geometry and density denominator.
+    /// Canonical panel geometry: the lattice extent and the domain over which
+    /// local density error is evaluated. Each layer's density denominator is
+    /// its own [`SpatialCopperBalanceLayerRequest::density_domain`].
     pub panel_region: &'a ContourSet,
     pub lattice_origin: Point,
     pub layers: &'a [SpatialCopperBalanceLayerRequest<'a>],
@@ -259,8 +280,8 @@ fn generate_dense_copper_balance_with_lattice(
 ) -> DenseCopperBalanceResult {
     let usable_area_mm2 = usable.area();
     let desired_added_area_mm2 =
-        request.target_density * request.retained_area_mm2 - request.existing_copper_area_mm2;
-    let initial_density = request.existing_copper_area_mm2 / request.retained_area_mm2;
+        request.target_density * request.density_domain_area_mm2 - request.existing_copper_area_mm2;
+    let initial_density = request.existing_copper_area_mm2 / request.density_domain_area_mm2;
     let mut best = ProjectedArea::new(DenseCopperBalanceMode::None, 0.0, desired_added_area_mm2);
     best.consider(ProjectedArea::new(
         DenseCopperBalanceMode::Solid,
@@ -295,7 +316,7 @@ fn generate_dense_copper_balance_with_lattice(
         }
     };
     let achieved_density =
-        (request.existing_copper_area_mm2 + best.area_mm2) / request.retained_area_mm2;
+        (request.existing_copper_area_mm2 + best.area_mm2) / request.density_domain_area_mm2;
     let solution = DenseCopperBalanceSolution {
         mode: best.mode,
         desired_added_area_mm2,
@@ -335,7 +356,11 @@ pub fn generate_spatial_dense_copper_balance(
 ) -> Result<Vec<DenseCopperBalanceResult>, DenseCopperBalanceError> {
     profile.validate()?;
     validate_spatial_request(request)?;
-    let retained_area_mm2 = request.panel_region.area();
+    let density_domain_areas = request
+        .layers
+        .iter()
+        .map(|layer| layer.density_domain.area())
+        .collect::<Vec<_>>();
 
     // Layers frequently share one safe region — a fab panel's every copper
     // layer, a board array's layers with equal support scope — so erode and
@@ -369,7 +394,8 @@ pub fn generate_spatial_dense_copper_balance(
             .layers
             .iter()
             .zip(&layer_regions)
-            .map(|(layer, region_index)| {
+            .zip(&density_domain_areas)
+            .map(|((layer, region_index), density_domain_area_mm2)| {
                 let voidable = &region_voidable[*region_index];
                 let lattice = &region_lattices[*region_index];
                 scope.spawn(move || {
@@ -377,7 +403,7 @@ pub fn generate_spatial_dense_copper_balance(
                         profile,
                         DenseCopperBalanceRequest {
                             safe_region: layer.safe_region,
-                            retained_area_mm2,
+                            density_domain_area_mm2: *density_domain_area_mm2,
                             existing_copper_area_mm2: layer.existing_copper.area(),
                             target_density: layer.target_density,
                             lattice_origin: request.lattice_origin,
@@ -602,11 +628,23 @@ pub fn generate_spatial_dense_copper_balance(
                 &squared_radii[layer_index],
                 baseline,
                 request.layers[layer_index],
-                retained_area_mm2,
+                density_domain_areas[layer_index],
                 profile,
             )
         })
         .collect())
+}
+
+/// Whether `outer` contains `inner`, ignoring boolean sliver artifacts.
+///
+/// A regularized difference between operands that share an edge leaves
+/// sub-micron slivers along it, so exact emptiness is not a usable containment
+/// test here. A genuine containment error — a domain that omits real copper or
+/// real fillable material — is orders of magnitude above this bound, which is
+/// itself far below the smallest void the profile can place.
+fn contains(outer: &ContourSet, inner: &ContourSet) -> bool {
+    let leftover = inner.difference(outer);
+    leftover.is_empty() || leftover.area() <= CONTAINMENT_AREA_TOLERANCE_MM2
 }
 
 fn validate_spatial_request(
@@ -617,31 +655,45 @@ fn validate_spatial_request(
             "panel region must be non-empty and have valid bounds".to_string(),
         ));
     }
-    let retained_area_mm2 = request.panel_region.area();
+    // A fab panel gives every copper layer the same domain and safe region,
+    // and a board array shares them across layers of equal support scope, so
+    // certify each distinct pair once rather than repeating identical boolean
+    // work per layer.
+    let mut certified: Vec<(&ContourSet, &ContourSet)> = Vec::new();
     for layer in request.layers {
         if !layer.stack_weight_mm2.is_finite() {
             return Err(DenseCopperBalanceError::InvalidInput(
                 "stack weights must be finite".to_string(),
             ));
         }
-        if !layer
-            .safe_region
-            .difference(request.panel_region)
-            .is_empty()
-        {
+        // The density domain is assembled from the very regions checked
+        // against it, so every containment predicate here compares operands
+        // that share long stretches of boundary. Containment through the
+        // density domain also implies containment by the panel region, so the
+        // safe region and fixed copper need no separate panel-region check.
+        if !certified.iter().any(|(domain, safe_region)| {
+            domain.rings == layer.density_domain.rings
+                && safe_region.rings == layer.safe_region.rings
+        }) {
+            if !contains(request.panel_region, layer.density_domain) {
+                return Err(DenseCopperBalanceError::InvalidInput(
+                    "density domain must be contained by the panel region".to_string(),
+                ));
+            }
+            if !contains(layer.density_domain, layer.safe_region) {
+                return Err(DenseCopperBalanceError::InvalidInput(
+                    "safe region must be contained by the density domain".to_string(),
+                ));
+            }
+            certified.push((layer.density_domain, layer.safe_region));
+        }
+        if !contains(layer.density_domain, layer.existing_copper) {
             return Err(DenseCopperBalanceError::InvalidInput(
-                "safe region must be contained by the panel region".to_string(),
+                "existing copper must be contained by the density domain".to_string(),
             ));
         }
-        if !layer
-            .existing_copper
-            .difference(request.panel_region)
-            .is_empty()
-        {
-            return Err(DenseCopperBalanceError::InvalidInput(
-                "existing copper must be contained by the panel region".to_string(),
-            ));
-        }
+        // Fixed copper and the safe region are separated by a clearance rule
+        // rather than by a shared edge, so their overlap needs no tolerance.
         if !layer
             .safe_region
             .intersection(layer.existing_copper)
@@ -653,7 +705,7 @@ fn validate_spatial_request(
         }
         validate_request(DenseCopperBalanceRequest {
             safe_region: layer.safe_region,
-            retained_area_mm2,
+            density_domain_area_mm2: layer.density_domain.area(),
             existing_copper_area_mm2: layer.existing_copper.area(),
             target_density: layer.target_density,
             lattice_origin: request.lattice_origin,
@@ -787,17 +839,17 @@ fn validate_request(request: DenseCopperBalanceRequest<'_>) -> Result<(), DenseC
             "safe region has invalid bounds".to_string(),
         ));
     }
-    if !request.retained_area_mm2.is_finite() || request.retained_area_mm2 <= 0.0 {
+    if !request.density_domain_area_mm2.is_finite() || request.density_domain_area_mm2 <= 0.0 {
         return Err(DenseCopperBalanceError::InvalidInput(
-            "retained area must be finite and greater than zero".to_string(),
+            "density domain area must be finite and greater than zero".to_string(),
         ));
     }
     if !request.existing_copper_area_mm2.is_finite()
         || request.existing_copper_area_mm2 < 0.0
-        || request.existing_copper_area_mm2 > request.retained_area_mm2 + NUMERIC_EPSILON
+        || request.existing_copper_area_mm2 > request.density_domain_area_mm2 + NUMERIC_EPSILON
     {
         return Err(DenseCopperBalanceError::InvalidInput(
-            "existing copper area must be between zero and retained area".to_string(),
+            "existing copper area must be between zero and the density domain area".to_string(),
         ));
     }
     if !request.target_density.is_finite() || !(0.0..=1.0).contains(&request.target_density) {
@@ -808,17 +860,17 @@ fn validate_request(request: DenseCopperBalanceRequest<'_>) -> Result<(), DenseC
     let usable_area_mm2 = request.safe_region.area();
     if !usable_area_mm2.is_finite()
         || usable_area_mm2 < 0.0
-        || usable_area_mm2 > request.retained_area_mm2 + NUMERIC_EPSILON
+        || usable_area_mm2 > request.density_domain_area_mm2 + NUMERIC_EPSILON
     {
         return Err(DenseCopperBalanceError::InvalidInput(
-            "usable area must be between zero and retained area".to_string(),
+            "usable area must be between zero and the density domain area".to_string(),
         ));
     }
     if request.existing_copper_area_mm2 + usable_area_mm2
-        > request.retained_area_mm2 + NUMERIC_EPSILON
+        > request.density_domain_area_mm2 + NUMERIC_EPSILON
     {
         return Err(DenseCopperBalanceError::InvalidInput(
-            "existing copper and usable areas together exceed the retained area".to_string(),
+            "existing copper and usable areas together exceed the density domain area".to_string(),
         ));
     }
     Ok(())
@@ -855,7 +907,7 @@ mod tests {
             DenseCopperBalanceProfile::V1,
             DenseCopperBalanceRequest {
                 safe_region: &safe_region,
-                retained_area_mm2: 200.0,
+                density_domain_area_mm2: 200.0,
                 existing_copper_area_mm2: 0.0,
                 target_density: 0.75,
                 lattice_origin: Point::new(10.0, 5.0),
@@ -911,7 +963,7 @@ mod tests {
             profile,
             DenseCopperBalanceRequest {
                 safe_region: &safe_region,
-                retained_area_mm2: 96.0,
+                density_domain_area_mm2: 96.0,
                 existing_copper_area_mm2: 0.0,
                 target_density: 0.15,
                 lattice_origin: Point::new(0.0, 0.0),
@@ -938,7 +990,7 @@ mod tests {
             DenseCopperBalanceProfile::V1,
             DenseCopperBalanceRequest {
                 safe_region: &safe_region,
-                retained_area_mm2: 16.0,
+                density_domain_area_mm2: 16.0,
                 existing_copper_area_mm2: 0.0,
                 target_density: 0.45,
                 lattice_origin: Point::new(0.0, 0.0),
@@ -1005,6 +1057,7 @@ mod tests {
         let layers = [SpatialCopperBalanceLayerRequest {
             safe_region: &safe,
             existing_copper: &existing,
+            density_domain: &panel,
             target_density: 0.5,
             stack_weight_mm2: 0.0,
         }];
@@ -1028,7 +1081,7 @@ mod tests {
     }
 
     #[test]
-    fn spatial_solver_rejects_geometry_outside_the_panel() {
+    fn spatial_solver_rejects_geometry_outside_its_containing_region() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 12.0)),
             tol::REGION_MM,
@@ -1042,10 +1095,11 @@ mod tests {
             tol::REGION_MM,
         );
         let empty = ContourSet::empty(tol::REGION_MM);
-        let solve = |safe_region, existing_copper| {
+        let solve = |safe_region, existing_copper, density_domain| {
             let layers = [SpatialCopperBalanceLayerRequest {
                 safe_region,
                 existing_copper,
+                density_domain,
                 target_density: 0.5,
                 stack_weight_mm2: 0.0,
             }];
@@ -1060,15 +1114,21 @@ mod tests {
         };
 
         assert_eq!(
-            solve(&outside, &empty).unwrap_err(),
+            solve(&inside, &empty, &outside).unwrap_err(),
             DenseCopperBalanceError::InvalidInput(
-                "safe region must be contained by the panel region".to_string()
+                "density domain must be contained by the panel region".to_string()
             )
         );
         assert_eq!(
-            solve(&inside, &outside).unwrap_err(),
+            solve(&outside, &empty, &inside).unwrap_err(),
             DenseCopperBalanceError::InvalidInput(
-                "existing copper must be contained by the panel region".to_string()
+                "safe region must be contained by the density domain".to_string()
+            )
+        );
+        assert_eq!(
+            solve(&inside, &outside, &inside).unwrap_err(),
+            DenseCopperBalanceError::InvalidInput(
+                "existing copper must be contained by the density domain".to_string()
             )
         );
     }
@@ -1089,6 +1149,7 @@ mod tests {
         let layer = SpatialCopperBalanceLayerRequest {
             safe_region: &panel,
             existing_copper: &existing,
+            density_domain: &panel,
             target_density,
             stack_weight_mm2: 0.0,
         };
@@ -1096,7 +1157,7 @@ mod tests {
             profile,
             DenseCopperBalanceRequest {
                 safe_region: &panel,
-                retained_area_mm2: panel.area(),
+                density_domain_area_mm2: panel.area(),
                 existing_copper_area_mm2: 0.0,
                 target_density,
                 lattice_origin: Point::ZERO,
@@ -1137,6 +1198,7 @@ mod tests {
         let layers = [SpatialCopperBalanceLayerRequest {
             safe_region: &panel,
             existing_copper: &existing,
+            density_domain: &panel,
             target_density: 0.5,
             stack_weight_mm2: 0.0,
         }];
@@ -1158,6 +1220,75 @@ mod tests {
         assert!((result.solution.achieved_density - 0.5).abs() <= 5e-3);
     }
 
+    /// Unfillable panel material must not inflate the copper request.
+    ///
+    /// A denominator that spans the whole panel charges the layer for filling
+    /// clearance it may never touch, and the solver can only spend that budget
+    /// by over-filling the gutter it can reach — saturating to a solid pour
+    /// whose local density far exceeds the footprint it is supposed to match.
+    #[test]
+    fn unfillable_clearance_stays_out_of_the_density_denominator() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        // An immutable footprint poured to 80%, a gutter beside it, and a wide
+        // clearance ring in between that no generated copper may enter.
+        let footprint = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let existing = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 16.0)),
+            tol::REGION_MM,
+        );
+        let safe = ContourSet::rectangle(
+            BBox::new(Point::new(25.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let target_density = existing.area() / footprint.area();
+        let density_domain = footprint.union(&safe);
+        let layers = [SpatialCopperBalanceLayerRequest {
+            safe_region: &safe,
+            existing_copper: &existing,
+            density_domain: &density_domain,
+            target_density,
+            stack_weight_mm2: 0.0,
+        }];
+
+        let result = generate_spatial_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            SpatialCopperBalanceRequest {
+                panel_region: &panel,
+                lattice_origin: Point::ZERO,
+                layers: &layers,
+            },
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+
+        // The gutter is perforated to the footprint's own density, not poured
+        // solid to chase copper the clearance can never hold.
+        assert!(
+            matches!(
+                result.solution.mode,
+                DenseCopperBalanceMode::Perforated { .. }
+            ),
+            "{:?}",
+            result.solution
+        );
+        assert!((result.solution.achieved_density - target_density).abs() <= 5e-3);
+        let gutter_fill = result.solution.generated_area_mm2 / safe.area();
+        assert!(
+            (gutter_fill - target_density).abs() <= 5e-3,
+            "gutter filled to {gutter_fill}, footprint sits at {target_density}"
+        );
+        // Charging the request against the whole panel would have demanded
+        // more copper than the gutter can hold.
+        assert!(target_density * panel.area() - existing.area() > safe.area());
+    }
+
     #[test]
     fn spatial_solver_preserves_each_layers_safe_region() {
         let panel = ContourSet::rectangle(
@@ -1173,16 +1304,20 @@ mod tests {
             tol::REGION_MM,
         );
         let existing = ContourSet::empty(tol::REGION_MM);
+        // Nothing outside each layer's own half can hold copper, so each
+        // layer's density domain is exactly its safe region.
         let layers = [
             SpatialCopperBalanceLayerRequest {
                 safe_region: &left,
                 existing_copper: &existing,
+                density_domain: &left,
                 target_density: 0.25,
                 stack_weight_mm2: 1.0,
             },
             SpatialCopperBalanceLayerRequest {
                 safe_region: &right,
                 existing_copper: &existing,
+                density_domain: &right,
                 target_density: 0.25,
                 stack_weight_mm2: -1.0,
             },
@@ -1231,9 +1366,12 @@ mod tests {
             BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
             tol::REGION_MM,
         );
+        // Fixed copper fills the left half and the right half is fillable, so
+        // the density domain is the whole panel.
         let layer = SpatialCopperBalanceLayerRequest {
             safe_region: &safe,
             existing_copper: &existing,
+            density_domain: &panel,
             target_density: 0.75,
             stack_weight_mm2: 0.0,
         };
@@ -1241,7 +1379,7 @@ mod tests {
             DenseCopperBalanceProfile::V1,
             DenseCopperBalanceRequest {
                 safe_region: &safe,
-                retained_area_mm2: panel.area(),
+                density_domain_area_mm2: panel.area(),
                 existing_copper_area_mm2: existing.area(),
                 target_density: layer.target_density,
                 lattice_origin: Point::ZERO,
@@ -1295,6 +1433,11 @@ mod tests {
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 10.0)),
             tol::REGION_MM,
         );
+        // The layers hold different fixed copper, so their density domains
+        // differ: the bottom layer's upper-left quadrant is bare and
+        // unfillable, and stays out of its denominator.
+        let top_domain = top_copper.union(&safe);
+        let bottom_domain = bottom_copper.union(&safe);
         let solve = |stack_weight_mm2: f64| {
             generate_spatial_dense_copper_balance(
                 DenseCopperBalanceProfile::V1,
@@ -1305,12 +1448,14 @@ mod tests {
                         SpatialCopperBalanceLayerRequest {
                             safe_region: &safe,
                             existing_copper: &top_copper,
+                            density_domain: &top_domain,
                             target_density: 0.75,
                             stack_weight_mm2,
                         },
                         SpatialCopperBalanceLayerRequest {
                             safe_region: &safe,
                             existing_copper: &bottom_copper,
+                            density_domain: &bottom_domain,
                             target_density: 0.50,
                             stack_weight_mm2: -stack_weight_mm2,
                         },
@@ -1355,7 +1500,7 @@ mod tests {
                 DenseCopperBalanceProfile::V1,
                 DenseCopperBalanceRequest {
                     safe_region: &safe_region,
-                    retained_area_mm2: 100.0,
+                    density_domain_area_mm2: 100.0,
                     existing_copper_area_mm2: 20.0,
                     target_density,
                     lattice_origin: Point::new(0.0, 0.0),

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -289,7 +289,7 @@ pub(super) fn spatial_result_from_squared_radii(
     squared_radii: &[f64],
     baseline: DenseCopperBalanceResult,
     layer: SpatialCopperBalanceLayerRequest<'_>,
-    retained_area_mm2: f64,
+    density_domain_area_mm2: f64,
     profile: DenseCopperBalanceProfile,
 ) -> DenseCopperBalanceResult {
     // Snap the continuous radius field to the fabrication step so the voids
@@ -316,7 +316,8 @@ pub(super) fn spatial_result_from_squared_radii(
     let partial_voids = baseline.partial_voids;
     let void_area_mm2 = full_void_area_mm2 + partial_voids.area();
     let generated_area_mm2 = (baseline.usable.area() - void_area_mm2).max(0.0);
-    let achieved_density = (layer.existing_copper.area() + generated_area_mm2) / retained_area_mm2;
+    let achieved_density =
+        (layer.existing_copper.area() + generated_area_mm2) / density_domain_area_mm2;
     let equivalent_radius_mm = (full_voids
         .iter()
         .map(|void| void.radius_mm * void.radius_mm)


### PR DESCRIPTION
The requested generated area was charged against the whole panel region, including area no generated copper may ever occupy: board clearance, rails, V-score relief, tooling holes, process margins, material removal, and gaps narrower than the minimum web. That inflated the request by the target density times that bare area, and the solver could only spend the surplus by over-filling the region it could reach.

Each copper layer now carries a density domain — the footprints whose measured density set the target, its safe region, and any copper outside both — and the target is measured and applied over that. Bare area leaves both sides of the ratio, so the request reduces to filling the fillable at the source density. `panel_region` keeps its other roles: lattice extent and the domain for local density error.

Containment is certified by leftover area rather than exact emptiness, since the domain is assembled from the regions checked against it and a regularized difference leaves sub-micron slivers along the shared edges. The scalar area bounds that mirror those containments carry the same tolerance: fixed copper, fillable region, and bare area partition the domain, so there is no slack to absorb a sliver once the footprints are fully poured. Domain and safe-region pairs recur across layers and are certified once, so validation does less boolean work than before.

## Effect

On a 6-layer A6 array the frame poured solid at 100% copper against a 78% board, and the inner layers missed their target by up to 7.7 points because even a solid frame could not make up the difference:

| Layer | Before | After |
|---|---|---|
| F.Cu | solid fill, →0.790 (target 0.784) | 5018 hex voids, →0.784 |
| In1.Cu | solid fill, →0.846 (target 0.923) | 5053 hex voids, →0.923 |
| In2.Cu | solid fill, →0.832 (target 0.885) | 5053 hex voids, →0.885 |
| In3.Cu | solid fill, →0.829 (target 0.877) | 5053 hex voids, →0.877 |
| In4.Cu | solid fill, →0.846 (target 0.923) | 5053 hex voids, →0.923 |
| B.Cu | solid fill, →0.788 (target 0.779) | 5018 hex voids, →0.779 |

Every layer now hits its target exactly. The fab panel inherits the arrays' densities and hits those exactly too; they are lower than before because the arrays now genuinely average less copper over their full outline. Confirmed on a rendered 5-up 18x24 panel: frames and gutters perforate, margins stay bare.

Fab-panel generation on the same input uses less CPU than before (71s vs 91s user). End-to-end it is slower only because a correctly balanced array is a richer document.

`CopperBalanceLayerReport` gains `density_domain_area_mm2`, and the plan's `retained_area_mm2` becomes `panel_area_mm2`.