### PR TITLE
Render IPC layers through instance-preserving artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `--layout-target` now takes `board` or `board-array` on every command, and defaults to `board-array`.
+- `ipc2581 render` no longer takes `--flat`; use `ipc2581 outline --nested-outlines` for nested panel boundaries.
+- Rendered SVGs are several times smaller and open in `rsvg-convert`, ImageMagick, and other SVG tools.
+
 ### Fixed
 
 - Copper balancing no longer over-fills narrow panel frames and gutters, which made board-array frames pour solid instead of matching the board's copper density.
+- `ipc2581 render` now draws the copper inside repeated boards on a board array or fabrication panel.
 
 ## [0.4.23] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `--layout-target` now takes `board` or `board-array` on every command, and defaults to `board-array`.
 
+### Removed
+
+- `ipc2581 render --flat`, which produced the same output as a plain render.
+
 ### Fixed
 
 - Copper balancing no longer over-fills narrow panel frames and gutters, which made board-array frames pour solid instead of matching the board's copper density.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - `--layout-target` now takes `board` or `board-array` on every command, and defaults to `board-array`.
-- `ipc2581 render` no longer takes `--flat`; use `ipc2581 outline --nested-outlines` for nested panel boundaries.
-- Rendered SVGs are several times smaller and open in `rsvg-convert`, ImageMagick, and other SVG tools.
 
 ### Fixed
 

--- a/crates/pcb-ipc2581-tools/src/accessors/drills.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/drills.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use ipc2581::types::LayerFunction;
-use pcb_ir::dialects::ipc::{FeatureKind, PlatingKind, View};
+use pcb_ir::dialects::ipc::{ArtworkScope, FeatureKind, PlatingKind};
 use serde::{Deserialize, Serialize};
 
 use super::IpcAccessor;
@@ -56,21 +56,21 @@ pub struct DrillSize {
 impl<'a> IpcAccessor<'a> {
     /// Get board-local drill hole statistics with per-type distribution.
     pub fn board_drill_stats(&self) -> Option<DrillStats> {
-        self.drill_stats_for_view(View::Board)
+        self.drill_stats_for_view(ArtworkScope::Board)
     }
 
     /// Get array-local drill hole statistics, excluding repeated board drills.
     pub fn board_array_drill_stats(&self) -> Option<DrillStats> {
-        self.drill_stats_for_view(View::ArrayLocal)
+        self.drill_stats_for_view(ArtworkScope::ArrayLocal)
     }
 
     /// Get flattened board-array drill statistics, including repeated board drills
     /// and array-local drill features.
     pub fn board_array_flattened_drill_stats(&self) -> Option<DrillStats> {
-        self.drill_stats_for_view(View::ArrayFlattened)
+        self.drill_stats_for_view(ArtworkScope::ArrayFlattened)
     }
 
-    fn drill_stats_for_view(&self, view: View) -> Option<DrillStats> {
+    fn drill_stats_for_view(&self, view: ArtworkScope) -> Option<DrillStats> {
         let ecad = self.ecad()?;
         let mut collector = DrillStatsCollector::default();
         let mut has_drill_layer = false;

--- a/crates/pcb-ipc2581-tools/src/board_array.rs
+++ b/crates/pcb-ipc2581-tools/src/board_array.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use anyhow::{Context, Result};
 use ipc2581::Ipc2581;
 use ipc2581::types::LayerFunction;
-use pcb_ir::dialects::ipc::{LayoutStep, LayoutStepKind, View};
+use pcb_ir::dialects::ipc::{ArtworkScope, LayoutStep, LayoutStepKind};
 use pcb_ir::geom::path::{PathCmd, PathOp};
 use pcb_ir::geom::{Affine2, Arc, BBox, ContourBuf, Point};
 
@@ -176,7 +176,7 @@ fn board_array_layer_overlays(
             let Ok(doc) = crate::geometry::extract_layer_for_view(
                 accessor.ipc(),
                 layer_name,
-                View::ArraySupport,
+                ArtworkScope::ArraySupport,
             ) else {
                 return None;
             };

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result, bail};
 use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::ipc::{
-    BalancingRegionOptions, BoardArraySupportDocument, BoardArraySupportLayerPolicy, View,
+    ArtworkScope, BalancingRegionOptions, BoardArraySupportDocument, BoardArraySupportLayerPolicy,
     board_array_balancing_region, collect_board_array_balancing_input,
 };
 
@@ -149,7 +149,7 @@ pub fn extract_array_support_layers(ipc: &Ipc2581) -> Result<Vec<ArraySupportLay
         .iter()
         .map(|layer| {
             let name = ipc.resolve(layer.name).to_string();
-            let document = geometry::extract_layer_for_view(ipc, &name, View::ArraySupport)
+            let document = geometry::extract_layer_for_view(ipc, &name, ArtworkScope::ArraySupport)
                 .with_context(|| {
                     format!("failed to extract IPC-2581 array-support layer '{name}'")
                 })?;

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -571,11 +571,12 @@ fn board_courtyard_bbox(ipc: &Ipc2581) -> Result<BBox> {
         .filter(|layer| layer.layer_function == LayerFunction::Courtyard)
     {
         let layer_name = ipc.resolve(layer.name);
-        let doc =
-            geometry::extract_layer_for_view(ipc, layer_name, pcb_ir::dialects::ipc::View::Board)
-                .with_context(|| {
-                format!("failed to extract IPC-2581 courtyard layer '{layer_name}'")
-            })?;
+        let doc = geometry::extract_layer_for_view(
+            ipc,
+            layer_name,
+            pcb_ir::dialects::ipc::ArtworkScope::Board,
+        )
+        .with_context(|| format!("failed to extract IPC-2581 courtyard layer '{layer_name}'"))?;
         for feature in doc
             .features
             .iter()

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -6,9 +6,9 @@ use crate::accessors::IpcAccessor;
 use crate::ipc2581::types::LayerFunction;
 use crate::manufacturing::{ManufacturingPackage, build_manufacturing_package};
 use pcb_ir::dialects::ipc::{
-    BalancingRegionOptions, BoardArraySupportDocument, FeatureBucket, FeatureDomain, FeatureIntent,
-    FeatureKind, FeatureOperation, FeatureRole, FeatureSpan, FiducialKind, LayoutStepKind,
-    PlatingKind, View, board_array_balancing_region, collect_board_array_balancing_input,
+    ArtworkScope, BalancingRegionOptions, BoardArraySupportDocument, FeatureBucket, FeatureDomain,
+    FeatureIntent, FeatureKind, FeatureOperation, FeatureRole, FeatureSpan, FiducialKind,
+    LayoutStepKind, PlatingKind, board_array_balancing_region, collect_board_array_balancing_input,
 };
 use pcb_ir::geom::copper_balance::{
     DenseCopperBalanceMode, DenseCopperBalanceProfile, SpatialCopperBalanceLayerRequest,
@@ -130,7 +130,8 @@ fn creates_rounded_panel_step_from_board_bbox() {
     assert_point_close(first_instance.bbox.min, Point::new(7.5, 7.5));
     assert_point_close(first_instance.bbox.max, Point::new(17.5, 17.5));
 
-    let vcut = geometry::extract_layer_for_view(&ipc, "V-Score", View::ArrayFlattened).unwrap();
+    let vcut =
+        geometry::extract_layer_for_view(&ipc, "V-Score", ArtworkScope::ArrayFlattened).unwrap();
     assert!(vcut.features.len() > 24);
     assert!(
         vcut.features
@@ -573,7 +574,7 @@ fn created_board_array_vcuts_flow_to_svg_and_gerber() {
     assert!(viewbox.1 + viewbox.3 > 100.0);
     assert_eq!(geometry::board_array_vscore_lines(&ipc).unwrap().len(), 24);
 
-    let package = build_manufacturing_package(&ipc, View::ArrayFlattened).unwrap();
+    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
     let vcut = package
         .files
@@ -586,7 +587,7 @@ fn created_board_array_vcuts_flow_to_svg_and_gerber() {
     assert!(!vcut.contents.contains("G36*"));
     assert!(vcut.contents.matches("D01*").count() > 24);
 
-    let board_package = build_manufacturing_package(&ipc, View::Board).unwrap();
+    let board_package = build_manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
     assert!(
         board_package
             .files
@@ -624,7 +625,7 @@ fn created_board_array_profile_gerber_derives_vscore_reliefs() {
     );
     assert!(fabrication_profile.assembly_panel_outlines.is_empty());
 
-    let package = build_manufacturing_package(&ipc, View::ArrayFlattened).unwrap();
+    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
     let vcut = package
         .files
         .iter()
@@ -675,7 +676,7 @@ fn board_array_creation_drops_source_board_outline_layer_features() {
     assert!(!xml.contains(r#"<LayerFeature layerRef="Edge.Cuts">"#));
 
     let ipc = Ipc2581::parse(&xml).unwrap();
-    let package = build_manufacturing_package(&ipc, View::ArrayFlattened).unwrap();
+    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
     assert!(
         package
             .files
@@ -694,7 +695,7 @@ fn board_array_creation_drops_source_board_outline_layer_features() {
 fn board_array_creation_preserves_board_target_geometry() {
     let input = board_fixture_with_top_line_mm();
     let before_ipc = Ipc2581::parse(input).unwrap();
-    let before = geometry::extract_layer_for_view(&before_ipc, "TOP", View::Board).unwrap();
+    let before = geometry::extract_layer_for_view(&before_ipc, "TOP", ArtworkScope::Board).unwrap();
 
     let xml = create_board_array_xml(
         input,
@@ -707,7 +708,7 @@ fn board_array_creation_preserves_board_target_geometry() {
     )
     .unwrap();
     let after_ipc = Ipc2581::parse(&xml).unwrap();
-    let after = geometry::extract_layer_for_view(&after_ipc, "TOP", View::Board).unwrap();
+    let after = geometry::extract_layer_for_view(&after_ipc, "TOP", ArtworkScope::Board).unwrap();
 
     assert_eq!(before.features.len(), after.features.len());
     assert_eq!(before.arena.paths.len(), after.arena.paths.len());
@@ -796,14 +797,16 @@ fn generated_array_geometry_writes_fiducials_and_nonplated_holes() {
     assert!(xml.contains(r#"x="20" y="20""#));
 
     let parsed = Ipc2581::parse(&xml).unwrap();
-    let top = geometry::extract_layer_for_view(&parsed, "TOP", View::ArrayFlattened).unwrap();
+    let top =
+        geometry::extract_layer_for_view(&parsed, "TOP", ArtworkScope::ArrayFlattened).unwrap();
     assert!(top.features.iter().any(|feature| {
         feature.intent.role == FeatureRole::Fiducial
             && feature.fiducial_kind == FiducialKind::Global
     }));
 
     let drill =
-        geometry::extract_layer_for_view(&parsed, "Array_Drill", View::ArrayFlattened).unwrap();
+        geometry::extract_layer_for_view(&parsed, "Array_Drill", ArtworkScope::ArrayFlattened)
+            .unwrap();
     assert_eq!(drill.features.len(), 1);
     assert_eq!(drill.features[0].kind, FeatureKind::Hole);
     assert_eq!(drill.features[0].bucket, FeatureBucket::Cutout);
@@ -812,7 +815,7 @@ fn generated_array_geometry_writes_fiducials_and_nonplated_holes() {
     assert_eq!(drill.features[0].intent.operation, FeatureOperation::Drill);
     assert_eq!(drill.features[0].intent.plating, PlatingKind::NonPlated);
 
-    let package = build_manufacturing_package(&parsed, View::ArrayFlattened).unwrap();
+    let package = build_manufacturing_package(&parsed, ArtworkScope::ArrayFlattened).unwrap();
     let top = package
         .files
         .iter()
@@ -911,7 +914,8 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     assert!(xml.matches("<EntryUser").count() > 0);
     assert!(xml.matches("<UserPrimitiveRef").count() >= void_count);
 
-    let top = geometry::extract_layer_for_view(&parsed, "TOP", View::ArrayFlattened).unwrap();
+    let top =
+        geometry::extract_layer_for_view(&parsed, "TOP", ArtworkScope::ArrayFlattened).unwrap();
     let balance_paths = |polarity: pcb_ir::geom::Polarity| {
         let paths = top
             .features
@@ -937,7 +941,7 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
         balance.solution.generated_area_mm2
     );
 
-    let package = build_manufacturing_package(&parsed, View::ArrayFlattened).unwrap();
+    let package = build_manufacturing_package(&parsed, ArtworkScope::ArrayFlattened).unwrap();
     let top_gerber = package
         .files
         .iter()
@@ -1013,7 +1017,7 @@ fn board_array_creation_adds_default_tooling_at_single_column_min_width() {
         vec![(23.5, 67.5), (46.5, 67.5), (27.5, 2.5), (42.5, 2.5)],
     );
 
-    let package = build_manufacturing_package(&ipc, View::ArrayFlattened).unwrap();
+    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
     assert_fiducial_gerbers(&package, "Global");
 }
 
@@ -1220,7 +1224,7 @@ fn board_array_creation_adds_board_cell_fiducials_on_top_bottom_margins() {
         &[(3.0, 38.0), (37.0, 38.0), (7.0, 2.0), (33.0, 2.0)],
     );
 
-    let top = geometry::extract_layer_for_view(&ipc, "TOP", View::ArrayFlattened).unwrap();
+    let top = geometry::extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened).unwrap();
     assert_eq!(
         top.features
             .iter()
@@ -1229,7 +1233,7 @@ fn board_array_creation_adds_board_cell_fiducials_on_top_bottom_margins() {
         8
     );
 
-    let package = build_manufacturing_package(&ipc, View::ArrayFlattened).unwrap();
+    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
     assert_fiducial_gerbers(&package, "Local");
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -7,14 +7,14 @@
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
-use pcb_ir::dialects::ipc::View;
+use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::geom::region::rings_from_contours;
 use pcb_ir::geom::{ContourSet, FillRule, dfm};
 
 use crate::ipc2581::Ipc2581;
 use crate::utils::file as file_utils;
 
-pub fn execute(file: &Path, view: View, min_width_mm: f64) -> Result<()> {
+pub fn execute(file: &Path, view: ArtworkScope, min_width_mm: f64) -> Result<()> {
     if !(min_width_mm.is_finite() && min_width_mm > 0.0) {
         bail!("minimum width must be positive; got {min_width_mm}");
     }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -1,5 +1,5 @@
 use ipc2581::edit::Doc;
-use pcb_ir::dialects::ipc::{View, root_step};
+use pcb_ir::dialects::ipc::{ArtworkScope, root_step};
 use pcb_ir::geom::{BBox, ContourSet, tol};
 
 use crate::copper_balance::{CopperBalanceMode, composed_copper_image};
@@ -284,7 +284,8 @@ fn exports_separate_nominal_panel_outlines_and_board_cutouts() {
     let expected_cutout_bbox =
         contour_bbox(profile.material_removal.iter()).expand(profile_stroke_radius);
     let package =
-        crate::manufacturing::build_manufacturing_package(&parsed, View::ArrayFlattened).unwrap();
+        crate::manufacturing::build_manufacturing_package(&parsed, ArtworkScope::ArrayFlattened)
+            .unwrap();
     for (filename, expected_bbox) in [
         ("Fab_Panel_Outline.gm1", expected_fab_bbox),
         ("Assembly_Panel_Outlines.gm1", expected_assembly_bbox),
@@ -601,8 +602,9 @@ fn strips_non_manufacturing_data_and_preserves_manufacturing_exports() {
 
     Ipc2581::validate(&generated).expect("fabrication panel should validate against IPC-2581C");
     let parsed = Ipc2581::parse(&generated).expect("fabrication panel should parse");
-    let package = crate::manufacturing::build_manufacturing_package(&parsed, View::ArrayFlattened)
-        .expect("fabrication panel should export manufacturing files");
+    let package =
+        crate::manufacturing::build_manufacturing_package(&parsed, ArtworkScope::ArrayFlattened)
+            .expect("fabrication panel should export manufacturing files");
     assert!(package.files.iter().any(|file| file.filename == "F_Cu.gtl"));
     assert!(package.files.iter().any(|file| file.filename == "PTH.drl"));
     assert!(

--- a/crates/pcb-ipc2581-tools/src/commands/html_export.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/html_export.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use ipc2581::types::ecad::Layer;
 use minijinja::{Environment, context};
-use pcb_ir::dialects::ipc::{ProfileSet, View};
+use pcb_ir::dialects::ipc::{ArtworkScope, ProfileSet};
 use serde::Serialize;
 
 use crate::UnitFormat;
@@ -389,8 +389,10 @@ fn rendered_source_layer(
         has_native_content: false,
     };
 
-    match geometry::extract_layer_for_view(ipc, &name, View::Board) {
-        Ok(geometry) => render_extracted_layer(&mut rendered, geometry, View::Board.profile_set()),
+    match geometry::extract_layer_for_view(ipc, &name, ArtworkScope::Board) {
+        Ok(geometry) => {
+            render_extracted_layer(&mut rendered, geometry, ArtworkScope::Board.profile_set())
+        }
         Err(error) => {
             rendered.warning = Some(format!("Render unavailable: {error}"));
         }
@@ -405,7 +407,7 @@ fn render_extracted_layer(
     profile_set: ProfileSet,
 ) {
     rendered.has_native_content = geometry::render::layer_has_native_content(&geometry);
-    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut geometry);
+    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry);
     rendered.svg = Some(geometry::render::render_layer_svg(
         &geometry,
         true,

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use pcb_ir::dialects::ipc::profile_occurrences_for;
+use pcb_ir::dialects::ipc::{ProfileSet, profile_occurrences_for};
 
 use crate::LayoutTarget;
 use crate::geometry;
@@ -13,6 +13,9 @@ use crate::utils::file as file_utils;
 pub struct OutlineOptions {
     pub output: PathBuf,
     pub layout_target: LayoutTarget,
+    /// Draw every placed boundary in the layout graph, including nested
+    /// assembly-panel boundaries, instead of the fabrication outlines alone.
+    pub nested_outlines: bool,
 }
 
 /// Export Step/Profile outlines as a DXF file.
@@ -20,7 +23,11 @@ pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = Ipc2581::parse(&content)?;
     let layout = geometry::extract_layout(&ipc)?;
-    let profile_set = options.layout_target.geometry_view().profile_set();
+    let profile_set = if options.nested_outlines {
+        ProfileSet::LayoutBoundaries
+    } else {
+        options.layout_target.artwork_scope().profile_set()
+    };
     if profile_occurrences_for(&layout, profile_set).is_empty() {
         bail!("IPC-2581 primary step and repeated child steps have no board Profile outline");
     }
@@ -79,7 +86,7 @@ mod tests {
         assert_eq!(
             profile_occurrences_for(
                 &layout,
-                LayoutTarget::BoardArray.geometry_view().profile_set()
+                LayoutTarget::BoardArray.artwork_scope().profile_set()
             )
             .len(),
             1

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -14,27 +14,25 @@ pub struct RenderOptions {
     pub output: Option<PathBuf>,
     pub format: RenderFormat,
     pub layout_target: LayoutTarget,
-    pub flat: bool,
 }
 
 /// Render processed geometry for one IPC-2581 layer.
+///
+/// The layer runs through the same normalization Gerber export uses, so a
+/// render and a fabrication file describe the same image.
 pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
     let target = resolve_target(options)?;
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
-    let view = options.layout_target.geometry_view();
+    let view = options.layout_target.artwork_scope();
     let mut geometry = geometry::extract_layer_for_view(&ipc, &options.layer, view)?;
-    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut geometry);
-    if options.flat {
-        pcb_ir::dialects::ipc::process::flatten_layers_to_masks(&mut geometry);
-    }
+    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry);
 
     match target {
         RenderTarget::Svg => render_svg(&geometry, options, view)?,
         RenderTarget::Png => render_png(&geometry, options, view)?,
         RenderTarget::Terminal => {
-            let mask = geometry::render::layer_mask(&geometry, true, view.profile_set());
-            pcb_ir::render::to_terminal(&mask, &pcb_ir::render::RenderOptions::default())
+            geometry::render::render_layer_terminal(&geometry, true, view.profile_set())
                 .map_err(anyhow::Error::msg)?;
         }
     }
@@ -89,7 +87,7 @@ fn infer_format_from_output(output: &Path) -> Result<RenderTarget> {
 fn render_svg(
     geometry: &pcb_ir::dialects::ipc::Document<ipc2581::Symbol, ipc2581::types::LayerFunction>,
     options: &RenderOptions,
-    view: pcb_ir::dialects::ipc::View,
+    view: pcb_ir::dialects::ipc::ArtworkScope,
 ) -> Result<()> {
     let svg = geometry::render::render_layer_svg(geometry, true, view.profile_set());
 
@@ -111,10 +109,9 @@ fn render_svg(
 fn render_png(
     geometry: &pcb_ir::dialects::ipc::Document<ipc2581::Symbol, ipc2581::types::LayerFunction>,
     options: &RenderOptions,
-    view: pcb_ir::dialects::ipc::View,
+    view: pcb_ir::dialects::ipc::ArtworkScope,
 ) -> Result<()> {
-    let mask = geometry::render::layer_mask(geometry, true, view.profile_set());
-    let png = pcb_ir::render::png(&mask, &pcb_ir::render::RenderOptions::default())
+    let png = geometry::render::render_layer_png(geometry, true, view.profile_set())
         .map_err(anyhow::Error::msg)?;
 
     if let Some(output) = &options.output {

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -14,7 +14,7 @@ use ipc2581::types::{
         Polygon, UserPrimitive, UserShape, UserShapeType, UserSpecial,
     },
 };
-use pcb_ir::dialects::ipc::View;
+use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::geom::copper_balance::{
     DenseCopperBalanceMode, DenseCopperBalanceProfile, DenseCopperBalanceResult,
     SpatialCopperBalanceLayerRequest, SpatialCopperBalanceRequest,
@@ -362,10 +362,11 @@ fn hex_void_instances(
 /// Composition goes through the artwork mask fold so clear-polarity
 /// features subtract in paint order instead of being unioned as copper.
 pub fn composed_copper_image(ipc: &Ipc2581, layer_name: &str) -> Result<ContourSet> {
-    let mut document = geometry::extract_layer_for_view(ipc, layer_name, View::ArrayFlattened)
-        .with_context(|| {
-            format!("failed to extract flattened IPC-2581 copper layer '{layer_name}'")
-        })?;
+    let mut document =
+        geometry::extract_layer_for_view(ipc, layer_name, ArtworkScope::ArrayFlattened)
+            .with_context(|| {
+                format!("failed to extract flattened IPC-2581 copper layer '{layer_name}'")
+            })?;
     pcb_ir::dialects::ipc::process::compose_for_rendering(&mut document);
     let artwork = pcb_ir::dialects::ipc::lower_layer_to_artwork(
         &document,

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -411,13 +411,13 @@ fn plating_kind(status: PlatingStatus) -> PlatingKind {
 }
 
 pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument> {
-    extract_layer_for_view(ipc, layer_name, View::ArrayFlattened)
+    extract_layer_for_view(ipc, layer_name, ArtworkScope::ArrayFlattened)
 }
 
 pub fn extract_layer_for_view(
     ipc: &Ipc2581,
     layer_name: &str,
-    view: View,
+    view: ArtworkScope,
 ) -> Result<GeometryDocument> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let layer = ecad
@@ -430,42 +430,36 @@ pub fn extract_layer_for_view(
         .context("IPC-2581 ECAD section has no Step")?;
 
     let step = match view {
-        View::Board => canonical_board_step(ipc, &ecad.cad_data.steps, primary_step)?,
-        View::ArrayLocal | View::ArraySupport | View::ArrayFlattened | View::LayoutSymbolic => {
+        ArtworkScope::Board => canonical_board_step(ipc, &ecad.cad_data.steps, primary_step)?,
+        ArtworkScope::ArrayLocal | ArtworkScope::ArraySupport | ArtworkScope::ArrayFlattened => {
             primary_step
         }
     };
 
-    let mut doc = match view {
-        View::Board => extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)?,
-        View::ArraySupport if is_panel_step(step) => extract_panel_layer(
+    let panel_mode = match view {
+        ArtworkScope::ArraySupport => Some(PanelLayerMode::SupportOnly),
+        ArtworkScope::ArrayFlattened => Some(PanelLayerMode::Flattened),
+        ArtworkScope::Board | ArtworkScope::ArrayLocal => None,
+    };
+
+    let mut doc = match panel_mode.filter(|_| is_panel_step(step)) {
+        Some(mode) => extract_panel_layer(
             ipc,
             &ecad.cad_data.steps,
             &ecad.cad_data.layers,
             step,
             layer,
             layer_name,
-            PanelLayerMode::SupportOnly,
+            mode,
         )?,
-        View::ArrayFlattened if is_panel_step(step) => extract_panel_layer(
-            ipc,
-            &ecad.cad_data.steps,
-            &ecad.cad_data.layers,
-            step,
-            layer,
-            layer_name,
-            PanelLayerMode::Flattened,
-        )?,
-        View::ArrayLocal | View::ArraySupport | View::ArrayFlattened | View::LayoutSymbolic => {
-            extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)?
-        }
+        None => extract_step_layer(ipc, step, &ecad.cad_data.layers, layer, layer_name)?,
     };
 
     match view {
-        View::Board | View::ArrayLocal | View::ArraySupport => {
+        ArtworkScope::Board | ArtworkScope::ArrayLocal | ArtworkScope::ArraySupport => {
             append_step_only_layout_geometry(&mut doc, step)
         }
-        View::ArrayFlattened | View::LayoutSymbolic => {
+        ArtworkScope::ArrayFlattened => {
             append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?
         }
     }
@@ -3374,7 +3368,7 @@ mod tests {
         )
         .unwrap();
 
-        let layer = extract_layer_for_view(&ipc, "TOP", View::Board).unwrap();
+        let layer = extract_layer_for_view(&ipc, "TOP", ArtworkScope::Board).unwrap();
         let path = &layer.arena.paths[layer.features[0].paths.start as usize];
 
         assert_eq!(path.stroke().unwrap().pattern, LinePattern::Phantom);
@@ -3434,7 +3428,7 @@ mod tests {
         )
         .unwrap();
 
-        let top = extract_layer_for_view(&ipc, "TOP", View::ArrayFlattened).unwrap();
+        let top = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened).unwrap();
         assert_eq!(top.specs.len(), 1);
         assert_eq!(top.layers[0].spec_refs.count, 1);
         assert_eq!(top.feature_sets.len(), 1);
@@ -3453,7 +3447,7 @@ mod tests {
         assert_eq!(top.features[0].pin_refs.count, 1);
         assert_eq!(ipc.resolve(top.pin_refs[0].pin), "1");
 
-        let vcut = extract_layer_for_view(&ipc, "VCUT", View::ArrayFlattened).unwrap();
+        let vcut = extract_layer_for_view(&ipc, "VCUT", ArtworkScope::ArrayFlattened).unwrap();
         assert_eq!(vcut.layers[0].spec_refs.count, 1);
         assert_eq!(vcut.feature_sets[0].spec_refs.count, 1);
         assert_eq!(vcut.features[0].intent.domain, FeatureDomain::VCut);
@@ -4029,8 +4023,8 @@ mod tests {
         let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
             .expect("synthetic panel fixture should parse");
 
-        let board =
-            extract_layer_for_view(&ipc, "TOP", View::Board).expect("board layer should extract");
+        let board = extract_layer_for_view(&ipc, "TOP", ArtworkScope::Board)
+            .expect("board layer should extract");
         let board_layer = &board.layers[0];
         let board_features = board_layer.features.slice(&board.features);
 
@@ -4045,7 +4039,7 @@ mod tests {
             1
         );
 
-        let panel = extract_layer_for_view(&ipc, "TOP", View::ArrayFlattened)
+        let panel = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened)
             .expect("panel layer should extract");
         let panel_layer = &panel.layers[0];
         let panel_features = panel_layer.features.slice(&panel.features);
@@ -4063,27 +4057,10 @@ mod tests {
     }
 
     #[test]
-    fn symbolic_panel_extraction_carries_repeats_without_child_features() {
-        let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
-            .expect("synthetic panel fixture should parse");
-        let doc = extract_layer_for_view(&ipc, "TOP", View::LayoutSymbolic)
-            .expect("panel layer should extract");
-        let layer = &doc.layers[0];
-        let features = layer.features.slice(&doc.features);
-
-        assert_eq!(features.len(), 1);
-        assert_eq!(features[0].center, Point::new(40.0, 5.0));
-        assert_eq!(doc.layout.steps.len(), 2);
-        assert_eq!(doc.layout.repeats.len(), 1);
-        assert_eq!(doc.layout.instances.len(), 2);
-        assert_eq!(board_instance_count(&doc), 2);
-    }
-
-    #[test]
     fn step_only_panel_extraction_omits_repeat_graph_expansion() {
         let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
             .expect("synthetic panel fixture should parse");
-        let doc = extract_layer_for_view(&ipc, "TOP", View::ArrayLocal)
+        let doc = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayLocal)
             .expect("panel layer should extract");
         let layer = &doc.layers[0];
         let features = layer.features.slice(&doc.features);
@@ -4170,7 +4147,7 @@ mod tests {
     fn nested_panel_layer_extraction_materializes_descendant_board_features() {
         let ipc = ipc2581::Ipc2581::parse(nested_panel_fixture())
             .expect("synthetic nested panel fixture should parse");
-        let doc = extract_layer_for_view(&ipc, "TOP", View::ArrayFlattened)
+        let doc = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened)
             .expect("nested panel layer should extract");
         let layer = &doc.layers[0];
         let features = layer.features.slice(&doc.features);
@@ -4189,6 +4166,27 @@ mod tests {
             ]
         );
         assert_eq!(board_instance_count(&doc), 4);
+    }
+
+    /// The reported fabrication-panel bug: a render of a nested panel has to
+    /// carry every descendant board's copper, not just the root step's own
+    /// support geometry.
+    #[test]
+    fn nested_panel_render_draws_every_descendant_board_instance() {
+        let ipc = ipc2581::Ipc2581::parse(nested_panel_fixture())
+            .expect("synthetic nested panel fixture should parse");
+        let mut doc = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened)
+            .expect("nested panel layer should extract");
+        pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut doc);
+
+        let svg = crate::geometry::render::render_layer_svg(
+            &doc,
+            false,
+            ArtworkScope::ArrayFlattened.profile_set(),
+        );
+
+        // One drawn pad per board across both nested repeat levels.
+        assert_eq!(svg.matches("<path d=").count(), 4, "{svg}");
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -5,8 +5,8 @@ pub mod render;
 use anyhow::{Context, Result, bail};
 use ipc2581::{Ipc2581, Symbol, types::LayerFunction};
 use pcb_ir::dialects::ipc::{
-    BoardArrayFabricationProfile, BoardArrayReliefFeatures, Feature, FeatureBucket, FeatureDomain,
-    FeatureKind, PlatingKind, View,
+    ArtworkScope, BoardArrayFabricationProfile, BoardArrayReliefFeatures, Feature, FeatureBucket,
+    FeatureDomain, FeatureKind, PlatingKind,
     relief::{
         DEFAULT_RELIEF_TOLERANCE_MM, DEFAULT_SCORE_ALIGNMENT_TOLERANCE_MM, VScoreLine,
         vscore_lines_for,
@@ -29,7 +29,7 @@ pub fn board_array_vscore_lines(ipc: &Ipc2581) -> Result<Vec<VScoreLine>> {
         .filter(|layer| layer.layer_function == LayerFunction::VCut)
     {
         let layer_name = ipc.resolve(source_layer.name);
-        let doc = extract_layer_for_view(ipc, layer_name, View::ArrayFlattened)
+        let doc = extract_layer_for_view(ipc, layer_name, ArtworkScope::ArrayFlattened)
             .with_context(|| format!("failed to extract IPC-2581 V-cut layer '{layer_name}'"))?;
         lines.extend(vscore_lines_for(&doc));
     }
@@ -120,7 +120,7 @@ fn collect_relief_feature_candidates(
         .filter(|layer| relief_feature_layer(layer.layer_function))
     {
         let layer_name = ipc.resolve(layer.name);
-        let doc = extract_layer_for_view(ipc, layer_name, View::ArrayFlattened)
+        let doc = extract_layer_for_view(ipc, layer_name, ArtworkScope::ArrayFlattened)
             .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
         for feature in &doc.features {
             if is_through_cutout(feature) {

--- a/crates/pcb-ipc2581-tools/src/geometry/render.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/render.rs
@@ -17,8 +17,26 @@ pub fn render_layer_svg(
     include_profiles: bool,
     profile_set: ProfileSet,
 ) -> String {
-    let mask = layer_mask(geometry, include_profiles, profile_set);
-    pcb_ir::render::svg(&mask, &pcb_ir::render::RenderOptions::default())
+    let artwork = layer_artwork(geometry, include_profiles, profile_set);
+    pcb_ir::render::artwork_svg(&artwork, &pcb_ir::render::RenderOptions::default())
+}
+
+pub fn render_layer_png(
+    geometry: &GeometryDocument,
+    include_profiles: bool,
+    profile_set: ProfileSet,
+) -> Result<Vec<u8>, String> {
+    let artwork = layer_artwork(geometry, include_profiles, profile_set);
+    pcb_ir::render::artwork_png(&artwork, &pcb_ir::render::RenderOptions::default())
+}
+
+pub fn render_layer_terminal(
+    geometry: &GeometryDocument,
+    include_profiles: bool,
+    profile_set: ProfileSet,
+) -> Result<(), String> {
+    let artwork = layer_artwork(geometry, include_profiles, profile_set);
+    pcb_ir::render::artwork_to_terminal(&artwork, &pcb_ir::render::RenderOptions::default())
 }
 
 fn layer_has_content(geometry: &GeometryDocument) -> bool {
@@ -60,11 +78,13 @@ pub fn native_layer_document(geometry: &GeometryDocument) -> Option<GeometryDocu
     Some(native)
 }
 
-pub fn layer_mask(
+/// Lower a single-layer geometry document to artwork, with the display
+/// profile outlines a viewer expects overlaid.
+pub fn layer_artwork(
     geometry: &GeometryDocument,
     include_profiles: bool,
     profile_set: ProfileSet,
-) -> mask::Document<LayerFunction> {
+) -> ArtworkDocument {
     let layer = &geometry.layers[0];
     let mut artwork = pcb_ir::dialects::ipc::lower_layer_to_artwork(
         geometry,
@@ -75,7 +95,19 @@ pub fn layer_mask(
     if include_profiles {
         append_display_profiles(&mut artwork, geometry, profile_set, layer.layer_function);
     }
-    pcb_ir::dialects::artwork::compose_to_mask(&artwork)
+    artwork
+}
+
+pub fn layer_mask(
+    geometry: &GeometryDocument,
+    include_profiles: bool,
+    profile_set: ProfileSet,
+) -> mask::Document<LayerFunction> {
+    pcb_ir::dialects::artwork::compose_to_mask(&layer_artwork(
+        geometry,
+        include_profiles,
+        profile_set,
+    ))
 }
 
 fn append_display_profiles(

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -18,14 +18,14 @@ use pcb_ir::dialects::artwork::{
     PaintStage,
 };
 use pcb_ir::dialects::ipc::{
-    Feature, FeatureBucket, FeatureDomain, FeatureOperation, FeatureRole, FiducialKind,
-    LayoutPurpose, PlatingKind, PrimitiveRef, ProfileSet, View, profile_occurrences_for, relief,
+    ArtworkLowering, ArtworkObjectKind, ArtworkScope, Feature, FeatureBucket, FeatureDomain,
+    FeatureOperation, FeatureRole, FiducialKind, LayoutPurpose, PlatingKind, PrimitiveRef,
+    ProfileSet, lower_layer_to_artwork_with, profile_occurrences_for, relief,
 };
 use pcb_ir::dialects::{LayerRole, Side as IrSide};
 use pcb_ir::geom::path::{ContourBuf, PathCmd, PathOp};
 use pcb_ir::geom::{
-    Affine2, Arc, BBox, FillRule, LineCap, LineJoin, LinePattern, Paint, Point, Polarity, Span,
-    StrokeStyle,
+    Affine2, Arc, BBox, LineCap, LineJoin, LinePattern, Paint, Point, Polarity, Span, StrokeStyle,
 };
 
 type IpcGeometryDocument = pcb_ir::dialects::ipc::Document<ipc2581::Symbol, LayerFunction>;
@@ -59,19 +59,15 @@ impl Default for ProfileGerberStyle {
     }
 }
 
-pub fn build_gerber_x2_files(ipc: &Ipc2581, view: View) -> Result<Vec<GerberX2File>> {
+pub fn build_gerber_x2_files(ipc: &Ipc2581, view: ArtworkScope) -> Result<Vec<GerberX2File>> {
     build_gerber_x2_files_with_options(ipc, view, &GerberExportOptions::default())
 }
 
 pub fn build_gerber_x2_files_with_options(
     ipc: &Ipc2581,
-    view: View,
+    view: ArtworkScope,
     options: &GerberExportOptions,
 ) -> Result<Vec<GerberX2File>> {
-    if view == View::LayoutSymbolic {
-        bail!("Gerber export does not support symbolic layout view; use board or board-array");
-    }
-
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let mut files = Vec::new();
     let plans = export_layer_plans(ipc, &ecad.cad_data.layers);
@@ -116,7 +112,7 @@ pub fn build_gerber_x2_files_with_options(
             contents,
         });
     }
-    if view == View::ArrayFlattened {
+    if view == ArtworkScope::ArrayFlattened {
         files.extend(board_array_profile_gerber_files(
             ipc,
             options.relief_debug_dir.as_deref(),
@@ -452,34 +448,24 @@ fn artwork_from_ipc_layer(
     spec: GerberArtworkSpec,
 ) -> Result<GerberArtwork> {
     let layer = &doc.layers[layer_index];
-    let mut artwork = GerberArtwork::new();
-    let artwork_layer = artwork.push_layer(pcb_ir::dialects::artwork::Layer {
+    let header = pcb_ir::dialects::artwork::Layer {
         name: layer.name.clone(),
         role: spec.role.ir_role(),
         side: spec.side,
         objects: Span::EMPTY,
         bbox: layer.bbox,
         meta: spec.meta,
-    });
-    let mut instance_apertures = InstanceApertures::default();
-    for feature in layer.features.slice(&doc.features) {
-        push_artwork_feature(
-            &mut artwork,
-            artwork_layer,
-            ipc,
-            doc,
-            feature,
-            &layer.name,
-            &mut instance_apertures,
-        )?;
-    }
+    };
+    let mut lowering = GerberLowering { ipc, doc };
+    let mut artwork = lower_layer_to_artwork_with(doc, layer_index, header, &mut lowering);
+
     if spec.role == GerberLayerRole::Profile
-        && spec.view != View::ArrayFlattened
-        && artwork.layers[artwork_layer as usize].objects.is_empty()
+        && spec.view != ArtworkScope::ArrayFlattened
+        && artwork.layers[0].objects.is_empty()
     {
         append_profile_occurrences(
             &mut artwork,
-            artwork_layer,
+            0,
             doc,
             spec.view.profile_set(),
             ProfileGerberStyle::default(),
@@ -488,14 +474,68 @@ fn artwork_from_ipc_layer(
     Ok(artwork)
 }
 
+/// Gerber's source-specific half of IPC artwork lowering: standard-dictionary
+/// primitives flash through standard apertures, traces are round-joined, and
+/// every object carries X2 attributes.
+struct GerberLowering<'a> {
+    ipc: &'a Ipc2581,
+    doc: &'a IpcGeometryDocument,
+}
+
+impl ArtworkLowering<ipc2581::Symbol, ObjectAttributes> for GerberLowering<'_> {
+    fn source_aperture(
+        &mut self,
+        feature: &Feature<ipc2581::Symbol>,
+    ) -> Option<(Aperture, Affine2, BBox)> {
+        let (aperture, at, bbox) = standard_flash_aperture(self.ipc, feature)?;
+        Some((aperture, Affine2::translation(at), bbox))
+    }
+
+    fn stroke_style(&mut self, stroke: StrokeStyle) -> StrokeStyle {
+        StrokeStyle {
+            join: LineJoin::Round,
+            ..stroke
+        }
+    }
+
+    /// Gerber orders removals rather than imaging them as clears, so every
+    /// drilled or routed feature stages last regardless of its bucket.
+    fn paint_order(&mut self, feature: &Feature<ipc2581::Symbol>) -> PaintOrder {
+        let stage = if feature.intent.role == FeatureRole::Cutout || feature.is_drill_like() {
+            PaintStage::FinalCutout
+        } else if feature.polarity == Polarity::Clear
+            || feature.flags.clears_previous_in_set
+            || feature.bucket == FeatureBucket::Fill
+        {
+            PaintStage::Base
+        } else {
+            PaintStage::Overlay
+        };
+        PaintOrder { stage }
+    }
+
+    fn object_meta(
+        &mut self,
+        feature: &Feature<ipc2581::Symbol>,
+        kind: ArtworkObjectKind,
+    ) -> ObjectAttributes {
+        let aperture_function =
+            (kind != ArtworkObjectKind::Region).then(|| aperture_function(feature));
+        object_attributes(self.ipc, self.doc, feature, aperture_function)
+    }
+}
+
 struct GerberArtworkSpec {
     role: GerberLayerRole,
     side: IrSide,
     meta: LayerAttributes,
-    view: View,
+    view: ArtworkScope,
 }
 
-fn synthetic_profile_gerber_file(ipc: &Ipc2581, view: View) -> Result<Option<GerberX2File>> {
+fn synthetic_profile_gerber_file(
+    ipc: &Ipc2581,
+    view: ArtworkScope,
+) -> Result<Option<GerberX2File>> {
     let doc = geometry::extract_layout(ipc)?;
     let mut artwork = GerberArtwork::new();
     let artwork_layer = artwork.push_layer(pcb_ir::dialects::artwork::Layer {
@@ -876,8 +916,8 @@ fn debug_num(value: f64) -> String {
     if text == "-0" { "0".to_string() } else { text }
 }
 
-fn gerber_part_for_view(doc: &IpcGeometryDocument, view: View) -> GerberPart {
-    if view == View::Board {
+fn gerber_part_for_view(doc: &IpcGeometryDocument, view: ArtworkScope) -> GerberPart {
+    if view == ArtworkScope::Board {
         GerberPart::Single
     } else {
         gerber_part_for_doc(doc)
@@ -979,148 +1019,6 @@ fn ir_side(side: Option<IpcSide>) -> IrSide {
         Some(IpcSide::Bottom) => IrSide::Bottom,
         _ => IrSide::None,
     }
-}
-
-/// Shared contour apertures for repeated primitive instances, one per
-/// referenced dictionary entry.
-#[derive(Default)]
-struct InstanceApertures {
-    by_primitive: HashMap<ipc2581::Symbol, u32>,
-}
-
-/// A user-dictionary instance feature: a placed reference whose local shape
-/// is shared by every sibling instance. The shape flashes through one
-/// contour aperture per dictionary entry, keeping repeated geometry
-/// repeated in the output. Standard-dictionary references stay out: those
-/// are exact catalogue primitives and flash through standard apertures.
-fn instance_flash(
-    artwork: &mut GerberArtwork,
-    doc: &IpcGeometryDocument,
-    feature: &Feature<ipc2581::Symbol>,
-    apertures: &mut InstanceApertures,
-) -> Option<(u32, Affine2)> {
-    let Some(PrimitiveRef::User(primitive)) = feature.primitive_ref else {
-        return None;
-    };
-    if feature.kind != pcb_ir::dialects::ipc::FeatureKind::Primitive || !is_rigid(feature.transform)
-    {
-        return None;
-    }
-    let [path] = feature.paths.slice(&doc.arena.paths) else {
-        return None;
-    };
-    if !path.is_filled() {
-        return None;
-    }
-    if let Some(&aperture) = apertures.by_primitive.get(&primitive) {
-        return Some((aperture, feature.transform));
-    }
-    // Derive the origin-local template from this first instance; every
-    // sibling shares the aperture and differs only by its rigid transform.
-    let inverse = feature.transform.inverse()?;
-    let local = doc
-        .arena
-        .path_contours(path)
-        .iter()
-        .map(|contour| pcb_ir::geom::path::transform_cmds(contour.cmds.iter().copied(), inverse))
-        .collect::<Vec<_>>();
-    let [local] = local.as_slice() else {
-        return None;
-    };
-    let aperture = artwork.push_aperture(Aperture::solid(
-        pcb_ir::dialects::artwork::ApertureShape::Contour {
-            outline: local.clone(),
-            fill_rule: path.fill_rule().unwrap_or(FillRule::NonZero),
-        },
-    ));
-    apertures.by_primitive.insert(primitive, aperture);
-    Some((aperture, feature.transform))
-}
-
-/// Rotation plus translation, without mirroring or scaling.
-fn is_rigid(transform: Affine2) -> bool {
-    let determinant = transform.m00 * transform.m11 - transform.m01 * transform.m10;
-    (determinant - 1.0).abs() <= GEOMETRY_EPSILON
-        && (transform.m00 * transform.m00 + transform.m10 * transform.m10 - 1.0).abs()
-            <= GEOMETRY_EPSILON
-}
-
-fn push_artwork_feature(
-    artwork: &mut GerberArtwork,
-    artwork_layer: u32,
-    ipc: &Ipc2581,
-    doc: &IpcGeometryDocument,
-    feature: &Feature<ipc2581::Symbol>,
-    layer_name: &str,
-    instance_apertures: &mut InstanceApertures,
-) -> Result<()> {
-    if let Some((aperture, transform)) = instance_flash(artwork, doc, feature, instance_apertures) {
-        artwork.push_object(
-            artwork_layer,
-            ArtworkObject {
-                polarity: feature.polarity,
-                order: paint_order(feature),
-                geometry: ArtworkGeometry::Flash {
-                    aperture,
-                    transform,
-                },
-                bbox: feature.bbox,
-                meta: object_attributes(ipc, doc, feature, Some(aperture_function(feature))),
-            },
-        );
-        return Ok(());
-    }
-
-    if let Some((aperture, at, bbox)) = standard_flash_aperture(ipc, feature) {
-        let aperture = artwork.push_aperture(aperture);
-        artwork.push_object(
-            artwork_layer,
-            ArtworkObject {
-                polarity: feature.polarity,
-                order: paint_order(feature),
-                geometry: ArtworkGeometry::Flash {
-                    aperture,
-                    transform: Affine2::translation(at),
-                },
-                bbox,
-                meta: object_attributes(ipc, doc, feature, Some(aperture_function(feature))),
-            },
-        );
-        return Ok(());
-    }
-
-    if let Some((at, diameter)) = circle_flash(doc, feature) {
-        let aperture = artwork.push_aperture(Aperture::circle(diameter));
-        artwork.push_object(
-            artwork_layer,
-            ArtworkObject {
-                polarity: feature.polarity,
-                order: paint_order(feature),
-                geometry: ArtworkGeometry::Flash {
-                    aperture,
-                    transform: Affine2::translation(at),
-                },
-                bbox: BBox::from_point(at).expand(diameter / 2.0),
-                meta: object_attributes(ipc, doc, feature, Some(aperture_function(feature))),
-            },
-        );
-        return Ok(());
-    }
-
-    for path in feature.paths.slice(&doc.arena.paths) {
-        let aperture_function = path.is_stroked().then(|| aperture_function(feature));
-        push_artwork_object(
-            artwork,
-            artwork_layer,
-            doc,
-            feature,
-            path,
-            object_attributes(ipc, doc, feature, aperture_function),
-            layer_name,
-        )?;
-    }
-
-    Ok(())
 }
 
 fn standard_flash_aperture(
@@ -1259,43 +1157,6 @@ fn nearly_equal(left: f64, right: f64) -> bool {
     (left - right).abs() <= GEOMETRY_EPSILON * left.abs().max(right.abs()).max(1.0)
 }
 
-fn paint_order(feature: &Feature<ipc2581::Symbol>) -> PaintOrder {
-    let stage = if feature.intent.role == FeatureRole::Cutout || feature.is_drill_like() {
-        PaintStage::FinalCutout
-    } else if feature.polarity == Polarity::Clear
-        || feature.flags.clears_previous_in_set
-        || feature.bucket == FeatureBucket::Fill
-    {
-        PaintStage::Base
-    } else {
-        PaintStage::Overlay
-    };
-    PaintOrder { stage }
-}
-
-fn circle_flash(
-    doc: &IpcGeometryDocument,
-    feature: &Feature<ipc2581::Symbol>,
-) -> Option<(Point, f64)> {
-    if feature.outer_diameter <= 0.0 || feature.paths.len() != 1 {
-        return None;
-    }
-
-    let path = &feature.paths.slice(&doc.arena.paths)[0];
-    if !path.is_filled() {
-        return None;
-    }
-
-    if feature.is_fiducial()
-        || feature.intent.role == FeatureRole::Hole
-        || feature.intent.operation == FeatureOperation::Drill
-    {
-        Some((feature.center, feature.outer_diameter))
-    } else {
-        None
-    }
-}
-
 fn object_attributes(
     ipc: &Ipc2581,
     doc: &IpcGeometryDocument,
@@ -1378,56 +1239,6 @@ fn fiducial_aperture_function(feature: &Feature<ipc2581::Symbol>) -> Vec<String>
     vec!["FiducialPad".to_string(), kind.to_string()]
 }
 
-fn push_artwork_path(
-    artwork: &mut GerberArtwork,
-    paint: Paint,
-    doc: &IpcGeometryDocument,
-    path: &pcb_ir::geom::Path,
-) -> u32 {
-    artwork.push_path(paint, doc.arena.path_contours(path))
-}
-
-fn push_artwork_object(
-    artwork: &mut GerberArtwork,
-    artwork_layer: u32,
-    doc: &IpcGeometryDocument,
-    feature: &Feature<ipc2581::Symbol>,
-    path: &pcb_ir::geom::Path,
-    meta: ObjectAttributes,
-    layer_name: &str,
-) -> Result<()> {
-    let (geometry, path_id) = match path.paint {
-        Paint::Fill { rule } => {
-            let path = push_artwork_path(artwork, Paint::Fill { rule }, doc, path);
-            (ArtworkGeometry::Region { path }, path)
-        }
-        Paint::Stroke(stroke) => {
-            let paint = Paint::Stroke(StrokeStyle {
-                join: LineJoin::Round,
-                ..stroke
-            });
-            let path = push_artwork_path(artwork, paint, doc, path);
-            (ArtworkGeometry::Stroke { path }, path)
-        }
-        Paint::None => {
-            bail!(
-                "processed IPC geometry path is neither filled nor stroked on layer '{layer_name}'"
-            );
-        }
-    };
-    artwork.push_object(
-        artwork_layer,
-        ArtworkObject {
-            polarity: feature.polarity,
-            order: paint_order(feature),
-            geometry,
-            bbox: artwork.path_bbox(path_id),
-            meta,
-        },
-    );
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1503,7 +1314,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
         let copper = files
             .iter()
             .find(|file| file.filename == "F_Cu.gtl")
@@ -1599,7 +1410,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
         let copper = files
             .iter()
             .find(|file| file.filename == "F_Cu.gtl")
@@ -1686,7 +1497,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
         let copper = files
             .iter()
             .find(|file| file.filename == "F_Cu.gtl")
@@ -1810,7 +1621,7 @@ mod tests {
         )
         .unwrap();
 
-        let board_files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let board_files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
         let board_fab = board_files
             .iter()
             .find(|file| file.filename == "F_Fab.gbr")
@@ -1839,7 +1650,7 @@ mod tests {
             2
         );
 
-        let array_files = build_gerber_x2_files(&ipc, View::ArrayFlattened).unwrap();
+        let array_files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
         let array_fab = array_files
             .iter()
             .find(|file| file.filename == "F_Fab.gbr")
@@ -1915,7 +1726,7 @@ mod tests {
         )
         .unwrap();
 
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
         let edge_cuts = files
             .iter()
             .find(|file| file.filename == "Edge_Cuts.gm1")
@@ -1973,7 +1784,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
 
         assert!(files.iter().any(|file| file.filename == "F_Cu.gtl"));
         for file in &files {
@@ -1997,7 +1808,7 @@ mod tests {
                 .any(|object| matches!(object.kind, gerberx2::ObjectKind::Flash { .. }))
         );
 
-        let panel_target_files = build_gerber_x2_files(&ipc, View::ArrayFlattened).unwrap();
+        let panel_target_files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
         let panel_target_copper = panel_target_files
             .iter()
@@ -2066,7 +1877,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
 
         let copper = files
             .iter()
@@ -2163,7 +1974,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
 
         let copper = files
             .iter()
@@ -2241,7 +2052,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let package = build_manufacturing_package(&ipc, View::Board).unwrap();
+        let package = build_manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
 
         assert!(
             !package
@@ -2339,7 +2150,7 @@ mod tests {
             &ipc,
             &ManufacturingExportOptions {
                 output: output_zip.clone(),
-                view: View::Board,
+                view: ArtworkScope::Board,
                 relief_debug_dir: None,
             },
         )
@@ -2363,26 +2174,6 @@ mod tests {
             .unwrap();
         assert!(top_copper.contains("%TF.FileFunction,Copper,L1,Top*%"));
         let _ = std::fs::remove_file(output_zip);
-    }
-
-    #[test]
-    fn gerber_export_rejects_symbolic_layout_view() {
-        let ipc = ipc::Ipc2581::parse(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
-  <Content roleRef="owner">
-    <FunctionMode mode="FABRICATION"/>
-  </Content>
-</IPC-2581>"#,
-        )
-        .unwrap();
-        let error = build_manufacturing_package(&ipc, View::LayoutSymbolic).unwrap_err();
-
-        assert!(
-            error
-                .to_string()
-                .contains("manufacturing export does not support symbolic layout view")
-        );
     }
 
     #[test]
@@ -2432,7 +2223,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
 
         let silk = files
             .iter()
@@ -2505,7 +2296,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::ArrayFlattened).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
         let top = files
             .iter()
@@ -2560,7 +2351,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::ArrayFlattened).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
         assert!(files.iter().all(|file| file.filename != "V_Cut.gbr"));
         let profile = files
@@ -2641,7 +2432,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, View::ArrayFlattened).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
         let top = files
             .iter()
@@ -2682,7 +2473,7 @@ mod tests {
         let compressed = include_bytes!("../../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
         let content = zstd::decode_all(Cursor::new(compressed)).unwrap();
         let ipc = ipc::Ipc2581::parse(std::str::from_utf8(&content).unwrap()).unwrap();
-        let files = build_gerber_x2_files(&ipc, View::Board).unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
 
         assert!(files.len() >= 10);
         assert!(files.iter().any(|file| file.filename == "F_Cu.gtl"));

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -38,20 +38,25 @@ pub enum UnitFormat {
     Inch,
 }
 
+/// What a command materializes from an IPC-2581 file.
+///
+/// One vocabulary, one default, for every command that produces artwork or
+/// outlines. `board-array` is the root step of the file with every repeat
+/// materialized, and is identical to `board` for a plain board file.
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LayoutTarget {
+    /// The canonical source board, as if it were fabricated alone.
     Board,
+    /// The file's root step with every nested repeat materialized.
     #[value(name = "board-array", alias = "panel")]
     BoardArray,
-    Layout,
 }
 
 impl LayoutTarget {
-    pub fn geometry_view(self) -> pcb_ir::dialects::ipc::View {
+    pub fn artwork_scope(self) -> pcb_ir::dialects::ipc::ArtworkScope {
         match self {
-            Self::Board => pcb_ir::dialects::ipc::View::Board,
-            Self::BoardArray => pcb_ir::dialects::ipc::View::ArrayFlattened,
-            Self::Layout => pcb_ir::dialects::ipc::View::LayoutSymbolic,
+            Self::Board => pcb_ir::dialects::ipc::ArtworkScope::Board,
+            Self::BoardArray => pcb_ir::dialects::ipc::ArtworkScope::ArrayFlattened,
         }
     }
 }

--- a/crates/pcb-ipc2581-tools/src/manufacturing/drill.rs
+++ b/crates/pcb-ipc2581-tools/src/manufacturing/drill.rs
@@ -1,14 +1,14 @@
 use anyhow::{Context, Result};
 use ipc2581::Ipc2581;
 use ipc2581::types::LayerFunction;
-use pcb_ir::dialects::ipc::View;
+use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::dialects::nc;
 
 use crate::geometry;
 use crate::manufacturing::{ManufacturingFile, ManufacturingFileKind};
 use crate::xnc::{XncAttribute, XncBuilder, XncUnit, write_xnc};
 
-pub fn build_xnc_drill_files(ipc: &Ipc2581, view: View) -> Result<Vec<ManufacturingFile>> {
+pub fn build_xnc_drill_files(ipc: &Ipc2581, view: ArtworkScope) -> Result<Vec<ManufacturingFile>> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let copper_layers = copper_layer_refs(&ecad.cad_data.layers);
     let mut nc = nc::Document::new();

--- a/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
+++ b/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
@@ -2,10 +2,10 @@ use std::fs;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use gerberx2::GerberLayer;
 use ipc2581::Ipc2581;
-use pcb_ir::dialects::ipc::View;
+use pcb_ir::dialects::ipc::ArtworkScope;
 use zip::{ZipWriter, write::FileOptions};
 
 use crate::{gerber, ipc2581 as ipc};
@@ -13,7 +13,7 @@ use crate::{gerber, ipc2581 as ipc};
 #[derive(Debug, Clone)]
 pub struct ManufacturingExportOptions {
     pub output: PathBuf,
-    pub view: View,
+    pub view: ArtworkScope,
     pub relief_debug_dir: Option<PathBuf>,
 }
 
@@ -44,7 +44,10 @@ pub fn export_manufacturing_package(
     Ok(package)
 }
 
-pub fn build_manufacturing_package(ipc: &Ipc2581, view: View) -> Result<ManufacturingPackage> {
+pub fn build_manufacturing_package(
+    ipc: &Ipc2581,
+    view: ArtworkScope,
+) -> Result<ManufacturingPackage> {
     build_manufacturing_package_inner(ipc, view, None)
 }
 
@@ -57,15 +60,9 @@ pub fn build_manufacturing_package_with_options(
 
 fn build_manufacturing_package_inner(
     ipc: &Ipc2581,
-    view: View,
+    view: ArtworkScope,
     relief_debug_dir: Option<&Path>,
 ) -> Result<ManufacturingPackage> {
-    if view == View::LayoutSymbolic {
-        bail!(
-            "manufacturing export does not support symbolic layout view; use board or board-array"
-        );
-    }
-
     let mut files = gerber::build_gerber_x2_files_with_options(
         ipc,
         view,

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -345,7 +345,7 @@ pub fn expand_native_geometry_to_regions<LayerMeta, ObjectMeta>(
 /// a polarity change, so stage ordering may only permute objects within each
 /// maximal same-polarity run. Final cutouts are terminal by definition and
 /// paint after everything.
-fn paint_ordered<ObjectMeta>(objects: &[Object<ObjectMeta>]) -> Vec<&Object<ObjectMeta>> {
+pub fn paint_ordered<ObjectMeta>(objects: &[Object<ObjectMeta>]) -> Vec<&Object<ObjectMeta>> {
     let (cutouts, mut painted): (Vec<_>, Vec<_>) = objects
         .iter()
         .partition(|object| object.order.stage == PaintStage::FinalCutout);

--- a/crates/pcb-ir/src/dialects/ipc/analysis.rs
+++ b/crates/pcb-ir/src/dialects/ipc/analysis.rs
@@ -11,8 +11,14 @@ use crate::dialects::ipc::layout::{
 use crate::geom::{Affine2, BBox};
 
 /// Which geometry a layer extraction materializes.
+///
+/// Every scope materializes a well-defined image: there is no scope that
+/// silently leaves nested `StepRepeat` content out of a layer it claims to
+/// describe. The symbolic layout graph is not a scope — it carries no layer
+/// artwork at all, and is reached through [`ProfileSet::LayoutBoundaries`]
+/// over an extracted layout document instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum View {
+pub enum ArtworkScope {
     /// Canonical board-step geometry only.
     Board,
     /// Root array-step geometry only, with no repeated child board materialization.
@@ -21,18 +27,15 @@ pub enum View {
     ArraySupport,
     /// Root array-step geometry plus repeated child board/sub-array geometry in array coordinates.
     ArrayFlattened,
-    /// Root-step geometry plus the symbolic layout graph, without repeated feature materialization.
-    LayoutSymbolic,
 }
 
-impl View {
+impl ArtworkScope {
     pub fn profile_set(self) -> ProfileSet {
         match self {
             Self::Board => ProfileSet::BoardOutlines,
             Self::ArrayLocal => ProfileSet::RootOnly,
             Self::ArraySupport => ProfileSet::RootOnly,
             Self::ArrayFlattened => ProfileSet::FabricationOutlines,
-            Self::LayoutSymbolic => ProfileSet::LayoutBoundaries,
         }
     }
 }

--- a/crates/pcb-ir/src/dialects/ipc/lower.rs
+++ b/crates/pcb-ir/src/dialects/ipc/lower.rs
@@ -1,56 +1,212 @@
 //! Lowerings out of the IPC dialect: per-layer artwork, NC drill/rout
 //! documents, and fabrication profiles.
 
+use std::collections::HashMap;
+use std::hash::Hash;
+
 use crate::dialects::ipc::analysis::{
     ProfileOccurrenceRole, ProfileSet, profile_occurrences_for, root_panel_step,
 };
 use crate::dialects::ipc::feature::{
-    Feature, FeatureBucket, FeatureKind, FeatureOperation, FeatureSpan, PlatingKind,
+    Feature, FeatureBucket, FeatureKind, FeatureOperation, FeatureRole, FeatureSpan, PlatingKind,
+    PrimitiveRef,
 };
 use crate::dialects::ipc::layout::{LayoutPurpose, LayoutStepKind, StepProfile};
 use crate::dialects::ipc::{Document, relief};
 use crate::dialects::{LayerRole, Side};
 use crate::dialects::{artwork, nc};
-use crate::geom::path::ContourBuf;
-use crate::geom::{Affine2, BBox, ContourSet, PaintKind, Point, Polarity, Span};
+use crate::geom::path::{ContourBuf, transform_cmds};
+use crate::geom::{
+    Affine2, BBox, ContourSet, Diagnostic, FillRule, Paint, PaintKind, Point, Polarity, Span,
+    StrokeStyle, tol,
+};
+
+/// How one artwork object was expressed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtworkObjectKind {
+    /// A shared aperture stamped under a placement transform.
+    Flash,
+    /// A filled region path.
+    Region,
+    /// A stroked centerline path.
+    Stroke,
+}
+
+/// Source-specific hooks for artwork lowering.
+///
+/// Everything a lowering can decide from the IR alone — dictionary-instance
+/// apertures, circular flashes, per-path regions and strokes, paint staging —
+/// lives in [`lower_layer_to_artwork_with`]. A source dialect implements this
+/// trait only for what it alone knows: apertures declared by its own shape
+/// catalogue, the stroke styles its target can express, and the per-object
+/// metadata that target carries.
+pub trait ArtworkLowering<Symbol, ObjectMeta> {
+    /// An aperture the source document declares for this feature, with its
+    /// placement and bounds. Returning `None` falls through to the generic
+    /// instance, circle, and per-path tiers.
+    fn source_aperture(
+        &mut self,
+        _feature: &Feature<Symbol>,
+    ) -> Option<(artwork::Aperture, Affine2, BBox)> {
+        None
+    }
+
+    /// Rewrite a stroke into what the target can express. Gerber traces, for
+    /// example, are round-joined by construction.
+    fn stroke_style(&mut self, stroke: StrokeStyle) -> StrokeStyle {
+        stroke
+    }
+
+    /// Which paint stage a feature belongs to. Override where the target
+    /// stages material removal differently from [`paint_order`].
+    fn paint_order(&mut self, feature: &Feature<Symbol>) -> artwork::PaintOrder {
+        paint_order(feature)
+    }
+
+    fn object_meta(&mut self, feature: &Feature<Symbol>, kind: ArtworkObjectKind) -> ObjectMeta;
+}
+
+/// The default lowering: no source catalogue, native strokes, net metadata.
+struct NetMetaLowering;
+
+impl<Symbol: Clone> ArtworkLowering<Symbol, Option<Symbol>> for NetMetaLowering {
+    fn object_meta(
+        &mut self,
+        feature: &Feature<Symbol>,
+        _kind: ArtworkObjectKind,
+    ) -> Option<Symbol> {
+        feature.net.clone()
+    }
+}
 
 /// Lower one layer's features into a single-layer artwork document.
 ///
 /// Run [`process::normalize_for_artwork`](crate::dialects::ipc::process::normalize_for_artwork)
 /// first so set voids, negative polarity, and cutouts are resolved.
-pub fn lower_layer_to_artwork<Symbol: Clone, LayerFunction: Clone>(
+pub fn lower_layer_to_artwork<Symbol, LayerFunction>(
     doc: &Document<Symbol, LayerFunction>,
     layer_index: usize,
     role: LayerRole,
     side: Side,
-) -> artwork::Document<LayerFunction, Option<Symbol>> {
+) -> artwork::Document<LayerFunction, Option<Symbol>>
+where
+    Symbol: Copy + Eq + Hash,
+    LayerFunction: Clone,
+{
+    let layer = &doc.layers[layer_index];
+    lower_layer_to_artwork_with(
+        doc,
+        layer_index,
+        artwork::Layer {
+            name: layer.name.clone(),
+            role,
+            side,
+            objects: Span::EMPTY,
+            bbox: BBox::empty(),
+            meta: layer.layer_function.clone(),
+        },
+        &mut NetMetaLowering,
+    )
+}
+
+/// Lower one layer's features into artwork, resolving repeated geometry to
+/// shared apertures.
+///
+/// Repeated dictionary instances stay instances: every sibling placement of
+/// one dictionary entry flashes through a single aperture instead of carrying
+/// its own copy of the shape. Targets that can express instancing — Gerber
+/// apertures, SVG `<use>` — inherit that directly, and targets that cannot
+/// expand it in [`artwork::compose_to_mask`].
+pub fn lower_layer_to_artwork_with<Symbol, LayerFunction, LayerMeta, ObjectMeta>(
+    doc: &Document<Symbol, LayerFunction>,
+    layer_index: usize,
+    header: artwork::Layer<LayerMeta>,
+    lowering: &mut impl ArtworkLowering<Symbol, ObjectMeta>,
+) -> artwork::Document<LayerMeta, ObjectMeta>
+where
+    Symbol: Copy + Eq + Hash,
+{
     let mut out = artwork::Document::new();
     let layer = &doc.layers[layer_index];
-    let artwork_layer = out.push_layer(artwork::Layer {
-        name: layer.name.clone(),
-        role,
-        side,
-        objects: Span::EMPTY,
-        bbox: BBox::empty(),
-        meta: layer.layer_function.clone(),
-    });
+    let layer_name = layer.name.clone();
+    let artwork_layer = out.push_layer(header);
+    let mut instance_apertures = HashMap::<Symbol, u32>::new();
 
     for feature in layer.features.slice(&doc.features) {
+        if let Some((aperture, transform, bbox)) = lowering.source_aperture(feature) {
+            let aperture = out.push_aperture(aperture);
+            push_flash(
+                &mut out,
+                artwork_layer,
+                lowering,
+                feature,
+                aperture,
+                transform,
+                bbox,
+            );
+            continue;
+        }
+
+        if let Some((aperture, transform)) =
+            instance_aperture(&mut out, doc, feature, &mut instance_apertures)
+        {
+            push_flash(
+                &mut out,
+                artwork_layer,
+                lowering,
+                feature,
+                aperture,
+                transform,
+                feature.bbox,
+            );
+            continue;
+        }
+
+        if let Some((at, diameter)) = circle_flash(doc, feature) {
+            let aperture = out.push_aperture(artwork::Aperture::circle(diameter));
+            push_flash(
+                &mut out,
+                artwork_layer,
+                lowering,
+                feature,
+                aperture,
+                Affine2::translation(at),
+                BBox::from_point(at).expand(diameter / 2.0),
+            );
+            continue;
+        }
+
         for path in feature.paths.slice(&doc.arena.paths) {
-            let make_geometry: fn(u32) -> artwork::Geometry = match path.paint.kind() {
-                PaintKind::Fill => |path| artwork::Geometry::Region { path },
-                PaintKind::Stroke => |path| artwork::Geometry::Stroke { path },
-                PaintKind::None => continue,
-            };
-            let path_id = out.push_path(path.paint, doc.arena.path_contours(path));
+            let (paint, kind, make_geometry): (_, _, fn(u32) -> artwork::Geometry) =
+                match path.paint {
+                    Paint::Stroke(stroke) => (
+                        Paint::Stroke(lowering.stroke_style(stroke)),
+                        ArtworkObjectKind::Stroke,
+                        |path| artwork::Geometry::Stroke { path },
+                    ),
+                    paint if paint.kind() == PaintKind::Fill => {
+                        (paint, ArtworkObjectKind::Region, |path| {
+                            artwork::Geometry::Region { path }
+                        })
+                    }
+                    _ => {
+                        out.diagnostics.push(Diagnostic::warning(format!(
+                            "dropped unpainted path on layer '{layer_name}'"
+                        )));
+                        continue;
+                    }
+                };
+            let path_id = out.push_path(paint, doc.arena.path_contours(path));
+            let bbox = out.path_bbox(path_id);
+            let meta = lowering.object_meta(feature, kind);
             out.push_object(
                 artwork_layer,
                 artwork::Object {
                     polarity: feature.polarity,
-                    order: paint_order(feature),
+                    order: lowering.paint_order(feature),
                     geometry: make_geometry(path_id),
-                    bbox: path.bbox,
-                    meta: feature.net.clone(),
+                    bbox,
+                    meta,
                 },
             );
         }
@@ -61,6 +217,113 @@ pub fn lower_layer_to_artwork<Symbol: Clone, LayerFunction: Clone>(
     out
 }
 
+fn push_flash<Symbol, LayerFunction, ObjectMeta>(
+    out: &mut artwork::Document<LayerFunction, ObjectMeta>,
+    artwork_layer: u32,
+    lowering: &mut impl ArtworkLowering<Symbol, ObjectMeta>,
+    feature: &Feature<Symbol>,
+    aperture: u32,
+    transform: Affine2,
+    bbox: BBox,
+) {
+    let meta = lowering.object_meta(feature, ArtworkObjectKind::Flash);
+    let order = lowering.paint_order(feature);
+    out.push_object(
+        artwork_layer,
+        artwork::Object {
+            polarity: feature.polarity,
+            order,
+            geometry: artwork::Geometry::Flash {
+                aperture,
+                transform,
+            },
+            bbox,
+            meta,
+        },
+    );
+}
+
+/// A user-dictionary instance feature: a placed reference whose local shape
+/// is shared by every sibling instance. The shape flashes through one contour
+/// aperture per dictionary entry, keeping repeated geometry repeated all the
+/// way to the output. Standard-dictionary references stay out: those are
+/// exact catalogue primitives that a source lowering flashes through standard
+/// apertures instead.
+fn instance_aperture<Symbol, LayerFunction, LayerMeta, ObjectMeta>(
+    out: &mut artwork::Document<LayerMeta, ObjectMeta>,
+    doc: &Document<Symbol, LayerFunction>,
+    feature: &Feature<Symbol>,
+    apertures: &mut HashMap<Symbol, u32>,
+) -> Option<(u32, Affine2)>
+where
+    Symbol: Copy + Eq + Hash,
+{
+    let Some(PrimitiveRef::User(primitive)) = feature.primitive_ref else {
+        return None;
+    };
+    if feature.kind != FeatureKind::Primitive || !is_rigid(feature.transform) {
+        return None;
+    }
+    let [path] = feature.paths.slice(&doc.arena.paths) else {
+        return None;
+    };
+    if !path.is_filled() {
+        return None;
+    }
+    if let Some(&aperture) = apertures.get(&primitive) {
+        return Some((aperture, feature.transform));
+    }
+    // Derive the origin-local template from this first instance; every
+    // sibling shares the aperture and differs only by its rigid transform.
+    let inverse = feature.transform.inverse()?;
+    let local = doc
+        .arena
+        .path_contours(path)
+        .iter()
+        .map(|contour| transform_cmds(contour.cmds.iter().copied(), inverse))
+        .collect::<Vec<_>>();
+    let [local] = local.as_slice() else {
+        return None;
+    };
+    let aperture = out.push_aperture(artwork::Aperture::solid(artwork::ApertureShape::Contour {
+        outline: local.clone(),
+        fill_rule: path.fill_rule().unwrap_or(FillRule::NonZero),
+    }));
+    apertures.insert(primitive, aperture);
+    Some((aperture, feature.transform))
+}
+
+/// A drilled or fiducial feature whose whole image is one filled circle.
+fn circle_flash<Symbol, LayerFunction>(
+    doc: &Document<Symbol, LayerFunction>,
+    feature: &Feature<Symbol>,
+) -> Option<(Point, f64)> {
+    if feature.outer_diameter <= 0.0 || feature.paths.len() != 1 {
+        return None;
+    }
+    if !feature.paths.slice(&doc.arena.paths)[0].is_filled() {
+        return None;
+    }
+    (feature.is_fiducial()
+        || feature.intent.role == FeatureRole::Hole
+        || feature.intent.operation == FeatureOperation::Drill)
+        .then_some((feature.center, feature.outer_diameter))
+}
+
+/// Rotation plus translation, without mirroring or scaling.
+fn is_rigid(transform: Affine2) -> bool {
+    let determinant = transform.m00 * transform.m11 - transform.m01 * transform.m10;
+    (determinant - 1.0).abs() <= tol::EPSILON_MM
+        && (transform.m00 * transform.m00 + transform.m10 * transform.m10 - 1.0).abs()
+            <= tol::EPSILON_MM
+}
+
+/// Which paint stage a feature belongs to.
+///
+/// Targets that image a removal as a clear (mask composition, SVG) and
+/// targets that only order it (Gerber) disagree on how wide `FinalCutout`
+/// should reach, so a source lowering may override this through
+/// [`ArtworkLowering::paint_order`].
 pub fn paint_order<Symbol>(feature: &Feature<Symbol>) -> artwork::PaintOrder {
     let stage = if feature.bucket == FeatureBucket::Cutout {
         artwork::PaintStage::FinalCutout

--- a/crates/pcb-ir/src/dialects/ipc/lower.rs
+++ b/crates/pcb-ir/src/dialects/ipc/lower.rs
@@ -131,45 +131,23 @@ where
     let mut instance_apertures = HashMap::<Symbol, u32>::new();
 
     for feature in layer.features.slice(&doc.features) {
-        if let Some((aperture, transform, bbox)) = lowering.source_aperture(feature) {
-            let aperture = out.push_aperture(aperture);
-            push_flash(
-                &mut out,
-                artwork_layer,
-                lowering,
-                feature,
-                aperture,
-                transform,
-                bbox,
-            );
-            continue;
-        }
-
-        if let Some((aperture, transform)) =
-            instance_aperture(&mut out, doc, feature, &mut instance_apertures)
+        if let Some((aperture, transform, bbox)) =
+            flash_for(&mut out, doc, feature, lowering, &mut instance_apertures)
         {
-            push_flash(
-                &mut out,
+            let meta = lowering.object_meta(feature, ArtworkObjectKind::Flash);
+            let order = lowering.paint_order(feature);
+            out.push_object(
                 artwork_layer,
-                lowering,
-                feature,
-                aperture,
-                transform,
-                feature.bbox,
-            );
-            continue;
-        }
-
-        if let Some((at, diameter)) = circle_flash(doc, feature) {
-            let aperture = out.push_aperture(artwork::Aperture::circle(diameter));
-            push_flash(
-                &mut out,
-                artwork_layer,
-                lowering,
-                feature,
-                aperture,
-                Affine2::translation(at),
-                BBox::from_point(at).expand(diameter / 2.0),
+                artwork::Object {
+                    polarity: feature.polarity,
+                    order,
+                    geometry: artwork::Geometry::Flash {
+                        aperture,
+                        transform,
+                    },
+                    bbox,
+                    meta,
+                },
             );
             continue;
         }
@@ -209,30 +187,31 @@ where
     out
 }
 
-fn push_flash<Symbol, LayerFunction, ObjectMeta>(
-    out: &mut artwork::Document<LayerFunction, ObjectMeta>,
-    artwork_layer: u32,
-    lowering: &mut impl ArtworkLowering<Symbol, ObjectMeta>,
+/// The shared aperture a feature flashes through, if any: one the source
+/// declares, one derived from a repeated dictionary instance, or a plain
+/// circle for a drilled or fiducial feature.
+fn flash_for<Symbol, LayerFunction, LayerMeta, ObjectMeta>(
+    out: &mut artwork::Document<LayerMeta, ObjectMeta>,
+    doc: &Document<Symbol, LayerFunction>,
     feature: &Feature<Symbol>,
-    aperture: u32,
-    transform: Affine2,
-    bbox: BBox,
-) {
-    let meta = lowering.object_meta(feature, ArtworkObjectKind::Flash);
-    let order = lowering.paint_order(feature);
-    out.push_object(
-        artwork_layer,
-        artwork::Object {
-            polarity: feature.polarity,
-            order,
-            geometry: artwork::Geometry::Flash {
-                aperture,
-                transform,
-            },
-            bbox,
-            meta,
-        },
-    );
+    lowering: &mut impl ArtworkLowering<Symbol, ObjectMeta>,
+    apertures: &mut HashMap<Symbol, u32>,
+) -> Option<(u32, Affine2, BBox)>
+where
+    Symbol: Copy + Eq + Hash,
+{
+    if let Some((aperture, transform, bbox)) = lowering.source_aperture(feature) {
+        return Some((out.push_aperture(aperture), transform, bbox));
+    }
+    if let Some((aperture, transform)) = instance_aperture(out, doc, feature, apertures) {
+        return Some((aperture, transform, feature.bbox));
+    }
+    let (at, diameter) = circle_flash(doc, feature)?;
+    Some((
+        out.push_aperture(artwork::Aperture::circle(diameter)),
+        Affine2::translation(at),
+        BBox::from_point(at).expand(diameter / 2.0),
+    ))
 }
 
 /// A user-dictionary instance feature: a placed reference whose local shape

--- a/crates/pcb-ir/src/dialects/ipc/lower.rs
+++ b/crates/pcb-ir/src/dialects/ipc/lower.rs
@@ -17,8 +17,7 @@ use crate::dialects::{LayerRole, Side};
 use crate::dialects::{artwork, nc};
 use crate::geom::path::{ContourBuf, transform_cmds};
 use crate::geom::{
-    Affine2, BBox, ContourSet, Diagnostic, FillRule, Paint, PaintKind, Point, Polarity, Span,
-    StrokeStyle, tol,
+    Affine2, BBox, ContourSet, FillRule, Paint, Point, Polarity, Span, StrokeStyle, tol,
 };
 
 /// How one artwork object was expressed.
@@ -128,7 +127,6 @@ where
 {
     let mut out = artwork::Document::new();
     let layer = &doc.layers[layer_index];
-    let layer_name = layer.name.clone();
     let artwork_layer = out.push_layer(header);
     let mut instance_apertures = HashMap::<Symbol, u32>::new();
 
@@ -177,25 +175,19 @@ where
         }
 
         for path in feature.paths.slice(&doc.arena.paths) {
-            let (paint, kind, make_geometry): (_, _, fn(u32) -> artwork::Geometry) =
-                match path.paint {
-                    Paint::Stroke(stroke) => (
-                        Paint::Stroke(lowering.stroke_style(stroke)),
-                        ArtworkObjectKind::Stroke,
-                        |path| artwork::Geometry::Stroke { path },
-                    ),
-                    paint if paint.kind() == PaintKind::Fill => {
-                        (paint, ArtworkObjectKind::Region, |path| {
-                            artwork::Geometry::Region { path }
-                        })
-                    }
-                    _ => {
-                        out.diagnostics.push(Diagnostic::warning(format!(
-                            "dropped unpainted path on layer '{layer_name}'"
-                        )));
-                        continue;
-                    }
-                };
+            let (paint, kind, make_geometry): (_, _, fn(u32) -> artwork::Geometry) = match path
+                .paint
+            {
+                Paint::Fill { rule } => (Paint::Fill { rule }, ArtworkObjectKind::Region, |path| {
+                    artwork::Geometry::Region { path }
+                }),
+                Paint::Stroke(stroke) => (
+                    Paint::Stroke(lowering.stroke_style(stroke)),
+                    ArtworkObjectKind::Stroke,
+                    |path| artwork::Geometry::Stroke { path },
+                ),
+                Paint::None => continue,
+            };
             let path_id = out.push_path(paint, doc.arena.path_contours(path));
             let bbox = out.path_bbox(path_id);
             let meta = lowering.object_meta(feature, kind);

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -19,10 +19,11 @@ pub mod surface_layers;
 pub mod validate;
 
 pub use analysis::{
-    ProfileOccurrence, ProfileOccurrenceRole, ProfileSet, SimpleBoardArrayLayout, View, board_bbox,
-    board_instance_count, board_step_count, layout_child_repeats, layout_instances_by_kind,
-    layout_repeat_instances, layout_steps_by_kind, panel_bbox, panel_step_count,
-    profile_occurrences_for, root_panel_step, root_step, simple_board_array_layout,
+    ArtworkScope, ProfileOccurrence, ProfileOccurrenceRole, ProfileSet, SimpleBoardArrayLayout,
+    board_bbox, board_instance_count, board_step_count, layout_child_repeats,
+    layout_instances_by_kind, layout_repeat_instances, layout_steps_by_kind, panel_bbox,
+    panel_step_count, profile_occurrences_for, root_panel_step, root_step,
+    simple_board_array_layout,
 };
 pub use balancing_region::{
     BalancingRegionError, BalancingRegionOptions, BoardArrayBalancingCollection,
@@ -45,8 +46,9 @@ pub use layout::{
     LayoutStepKind, StepProfile, StepProfileCutout,
 };
 pub use lower::{
-    BoardArrayFabricationProfile, BoardArrayReliefFeatures, FabricationProfileOptions,
-    board_array_fabrication_profile, lower_layer_to_artwork, lower_to_nc,
+    ArtworkLowering, ArtworkObjectKind, BoardArrayFabricationProfile, BoardArrayReliefFeatures,
+    FabricationProfileOptions, board_array_fabrication_profile, lower_layer_to_artwork,
+    lower_layer_to_artwork_with, lower_to_nc,
 };
 pub use spec::{Spec, SpecItem, SpecItemKind, SpecProperty, SpecRef};
 pub use surface_layers::{

--- a/crates/pcb-ir/src/geom/style.rs
+++ b/crates/pcb-ir/src/geom/style.rs
@@ -57,6 +57,12 @@ impl StrokeStyle {
     pub fn round(width: f64) -> Self {
         Self::new(width, LineCap::Round)
     }
+
+    /// Whether this stroke images as one unbroken run, so a target that only
+    /// understands solid strokes can draw it natively.
+    pub fn is_solid(&self) -> bool {
+        matches!(self.pattern, LinePattern::Solid | LinePattern::Erase)
+    }
 }
 
 /// How a path's contours are painted.

--- a/crates/pcb-ir/src/render/mod.rs
+++ b/crates/pcb-ir/src/render/mod.rs
@@ -1,18 +1,18 @@
-//! Render backends for composed mask documents.
+//! Render backends for artwork and composed mask documents.
 //!
-//! All entry points take a [`mask::Document`](crate::dialects::mask::Document)
-//! and a [`RenderOptions`]. To render artwork or IPC geometry, lower it first
-//! (`artwork::compose_to_mask`, `ipc::lower_layer_to_artwork`).
+//! Artwork renders keep the source's structure: apertures stay shared, so
+//! repeated geometry stays repeated and polarity runs paint sequentially.
+//! Mask renders take an already-composed image. Both take a [`RenderOptions`].
 
 mod png;
 mod svg;
 mod term;
 
-pub use png::png;
-pub use svg::svg;
-pub use term::{can_render_to_terminal, to_terminal, write_kitty_png};
+pub use png::{artwork_png, png};
+pub use svg::{artwork_svg, svg};
+pub use term::{artwork_to_terminal, can_render_to_terminal, to_terminal, write_kitty_png};
 
-use crate::dialects::mask;
+use crate::dialects::{artwork, mask};
 use crate::geom::{BBox, Point};
 
 pub(crate) const VIEWBOX_PADDING_MM: f64 = 1.0;
@@ -63,11 +63,26 @@ pub enum SizeConstraint {
 /// The bbox a render of these layers covers (padded; falls back to a default
 /// viewport for empty documents).
 pub fn bbox<LayerMeta>(doc: &mask::Document<LayerMeta>, layers: Option<&[usize]>) -> BBox {
-    let bbox = layer_indices(doc, layers)
-        .into_iter()
-        .fold(BBox::empty(), |bbox, index| {
-            bbox.union(doc.layers[index].bbox)
-        });
+    padded_bbox(
+        layer_indices(doc.layers.len(), layers)
+            .into_iter()
+            .map(|index| doc.layers[index].bbox),
+    )
+}
+
+pub(crate) fn artwork_bbox<LayerMeta, ObjectMeta>(
+    doc: &artwork::Document<LayerMeta, ObjectMeta>,
+    layers: Option<&[usize]>,
+) -> BBox {
+    padded_bbox(
+        layer_indices(doc.layers.len(), layers)
+            .into_iter()
+            .map(|index| doc.layers[index].bbox),
+    )
+}
+
+pub(crate) fn padded_bbox(bboxes: impl IntoIterator<Item = BBox>) -> BBox {
+    let bbox = bboxes.into_iter().fold(BBox::empty(), BBox::union);
     if bbox.is_empty() {
         BBox::new(Point::new(0.0, 0.0), Point::new(100.0, 100.0))
     } else {
@@ -75,23 +90,15 @@ pub fn bbox<LayerMeta>(doc: &mask::Document<LayerMeta>, layers: Option<&[usize]>
     }
 }
 
-pub(crate) fn layer_indices<LayerMeta>(
-    doc: &mask::Document<LayerMeta>,
-    layers: Option<&[usize]>,
-) -> Vec<usize> {
+pub(crate) fn layer_indices(layer_count: usize, layers: Option<&[usize]>) -> Vec<usize> {
     match layers {
         Some(layers) => layers.to_vec(),
-        None => (0..doc.layers.len()).collect(),
+        None => (0..layer_count).collect(),
     }
 }
 
-/// Pixel dimensions for a raster render under the given constraint.
-pub(crate) fn pixel_size<LayerMeta>(
-    doc: &mask::Document<LayerMeta>,
-    layers: Option<&[usize]>,
-    max_dimension_px: u32,
-) -> (u32, u32) {
-    let bbox = bbox(doc, layers);
+/// Pixel dimensions for a raster render of this bbox under the given constraint.
+pub(crate) fn pixel_size(bbox: BBox, max_dimension_px: u32) -> (u32, u32) {
     if bbox.is_empty() || bbox.width() <= 0.0 || bbox.height() <= 0.0 {
         return (max_dimension_px, max_dimension_px);
     }

--- a/crates/pcb-ir/src/render/png.rs
+++ b/crates/pcb-ir/src/render/png.rs
@@ -1,6 +1,7 @@
 use resvg::{tiny_skia, usvg};
 
-use crate::dialects::mask;
+use crate::dialects::{artwork, mask};
+use crate::geom::BBox;
 use crate::render::{RenderOptions, SizeConstraint};
 
 /// Rasterize mask layers to a PNG. `Auto` renders at the default maximum
@@ -9,31 +10,42 @@ pub fn png<LayerMeta>(
     doc: &mask::Document<LayerMeta>,
     options: &RenderOptions,
 ) -> Result<Vec<u8>, String> {
+    let bbox = crate::render::bbox(doc, options.layers.as_deref());
+    svg_to_png(&crate::render::svg(doc, &raster_options(options, bbox)))
+}
+
+/// Rasterize artwork layers to a PNG, through the same SVG the SVG backend
+/// writes.
+pub fn artwork_png<LayerMeta, ObjectMeta>(
+    doc: &artwork::Document<LayerMeta, ObjectMeta>,
+    options: &RenderOptions,
+) -> Result<Vec<u8>, String> {
+    let bbox = crate::render::artwork_bbox(doc, options.layers.as_deref());
+    svg_to_png(&crate::render::artwork_svg(
+        doc,
+        &raster_options(options, bbox),
+    ))
+}
+
+/// Resolve a size constraint into the fixed pixel size a raster needs.
+fn raster_options(options: &RenderOptions, bbox: BBox) -> RenderOptions {
     let (width_px, height_px) = match options.size {
-        SizeConstraint::Auto => crate::render::pixel_size(
-            doc,
-            options.layers.as_deref(),
-            crate::render::DEFAULT_MAX_DIMENSION_PX,
-        ),
-        SizeConstraint::MaxDimension(max) => {
-            crate::render::pixel_size(doc, options.layers.as_deref(), max)
+        SizeConstraint::Auto => {
+            crate::render::pixel_size(bbox, crate::render::DEFAULT_MAX_DIMENSION_PX)
         }
+        SizeConstraint::MaxDimension(max) => crate::render::pixel_size(bbox, max),
         SizeConstraint::Fixed {
             width_px,
             height_px,
         } => (width_px, height_px),
     };
-    let svg = crate::render::svg(
-        doc,
-        &RenderOptions {
-            layers: options.layers.clone(),
-            size: SizeConstraint::Fixed {
-                width_px,
-                height_px,
-            },
+    RenderOptions {
+        layers: options.layers.clone(),
+        size: SizeConstraint::Fixed {
+            width_px,
+            height_px,
         },
-    );
-    svg_to_png(&svg)
+    }
 }
 
 fn svg_to_png(svg: &str) -> Result<Vec<u8>, String> {

--- a/crates/pcb-ir/src/render/svg.rs
+++ b/crates/pcb-ir/src/render/svg.rs
@@ -1,9 +1,11 @@
 use std::fmt::Write;
 
 use crate::dialects::LayerRole;
+use crate::dialects::artwork::{self, Geometry, PaintStage};
 use crate::dialects::mask;
 use crate::geom::path::{PathCmd, PathOp};
-use crate::geom::{Arc, FillRule, Path, Point};
+
+use crate::geom::{Affine2, Arc, BBox, FillRule, Paint, Path, PathArena, Point, Polarity};
 use crate::render::{RenderOptions, SizeConstraint};
 
 const POINT_EPSILON_MM: f64 = 1e-9;
@@ -11,76 +13,286 @@ const POINT_EPSILON_MM: f64 = 1e-9;
 /// Render mask layers to an SVG document (millimeter units, y-up source
 /// coordinates flipped for screen display).
 pub fn svg<LayerMeta>(doc: &mask::Document<LayerMeta>, options: &RenderOptions) -> String {
-    let layers = crate::render::layer_indices(doc, options.layers.as_deref());
-    let pixel_size = match options.size {
+    let layers = crate::render::layer_indices(doc.layers.len(), options.layers.as_deref());
+    let bbox = crate::render::bbox(doc, Some(&layers));
+    let mut svg = open_svg(
+        &bbox,
+        pixel_size(options, bbox),
+        layers
+            .first()
+            .and_then(|&index| doc.layers.get(index))
+            .map(|layer| layer.name.as_str())
+            .unwrap_or("mask"),
+    );
+
+    for &layer_index in &layers {
+        let layer = &doc.layers[layer_index];
+        for shape in doc.shapes(layer) {
+            write_shape(&mut svg, &doc.arena, layer.role, shape);
+        }
+    }
+
+    close_svg(svg)
+}
+
+/// Render artwork layers to an SVG document.
+///
+/// Apertures become `<defs>` shapes that flashes reference with `<use>`, so
+/// repeated geometry stays repeated instead of being copied per placement.
+/// Polarity runs paint sequentially: a clear run masks everything painted
+/// before it, which is exactly how the same artwork images in Gerber.
+pub fn artwork_svg<LayerMeta, ObjectMeta>(
+    doc: &artwork::Document<LayerMeta, ObjectMeta>,
+    options: &RenderOptions,
+) -> String {
+    let layers = crate::render::layer_indices(doc.layers.len(), options.layers.as_deref());
+    let bbox = crate::render::artwork_bbox(doc, Some(&layers));
+    let mut defs = String::new();
+    let mut body = String::new();
+
+    for (aperture_index, aperture) in doc.apertures.iter().enumerate() {
+        let d = contours_data(&aperture.contours());
+        if d.is_empty() {
+            continue;
+        }
+        // Colour is inherited from the referencing group so one aperture can
+        // serve both a dark run and a clear run's mask; `stroke` is not, or
+        // every filled shape would gain the default one-unit outline.
+        writeln!(
+            defs,
+            "    <path id='a{aperture_index}' d='{d}' fill-rule='{}' stroke='none'/>",
+            fill_rule_name(aperture.fill_rule())
+        )
+        .unwrap();
+    }
+
+    for &layer_index in &layers {
+        let layer = &doc.layers[layer_index];
+        write_artwork_layer(&mut body, &mut defs, doc, layer);
+    }
+
+    let mut svg = open_svg(
+        &bbox,
+        pixel_size(options, bbox),
+        layers
+            .first()
+            .and_then(|&index| doc.layers.get(index))
+            .map(|layer| layer.name.as_str())
+            .unwrap_or("artwork"),
+    );
+    if !defs.is_empty() {
+        writeln!(svg, "  <defs>\n{defs}  </defs>").unwrap();
+    }
+    svg.push_str(&body);
+    close_svg(svg)
+}
+
+fn write_artwork_layer<LayerMeta, ObjectMeta>(
+    body: &mut String,
+    defs: &mut String,
+    doc: &artwork::Document<LayerMeta, ObjectMeta>,
+    layer: &artwork::Layer<LayerMeta>,
+) {
+    let objects = artwork::paint_ordered(layer.objects.slice(&doc.objects));
+    let has_material = objects
+        .iter()
+        .any(|object| object.order.stage != PaintStage::FinalCutout);
+
+    // Sequential polarity: paint dark runs in order, and fold every clear run
+    // into a mask over everything painted before it.
+    let mut painted = String::new();
+    let mut run = String::new();
+    let mut run_polarity = None;
+    for object in objects {
+        let polarity = if object.order.stage == PaintStage::FinalCutout && has_material {
+            Polarity::Clear
+        } else {
+            object.polarity
+        };
+        if run_polarity != Some(polarity) {
+            flush_run(&mut painted, defs, &mut run, run_polarity, layer);
+            run_polarity = Some(polarity);
+        }
+        write_artwork_object(&mut run, doc, layer.role, object);
+    }
+    flush_run(&mut painted, defs, &mut run, run_polarity, layer);
+    if painted.is_empty() {
+        return;
+    }
+
+    // One group opacity rather than per-object alpha, so overlapping objects
+    // composite once instead of darkening where they touch.
+    let (color, opacity) = layer_style(layer.role);
+    writeln!(
+        body,
+        "    <g fill='{color}' stroke='{color}' opacity='{}'>\n{painted}    </g>",
+        fmt_num(opacity)
+    )
+    .unwrap();
+}
+
+fn flush_run<LayerMeta>(
+    painted: &mut String,
+    defs: &mut String,
+    run: &mut String,
+    polarity: Option<Polarity>,
+    layer: &artwork::Layer<LayerMeta>,
+) {
+    let run = std::mem::take(run);
+    if run.is_empty() {
+        return;
+    }
+    match polarity {
+        Some(Polarity::Clear) if !painted.is_empty() => {
+            let mask_id = format!("m{}", defs.matches("<mask ").count());
+            let bounds = layer.bbox.expand(1.0);
+            writeln!(
+                defs,
+                "    <mask id='{mask_id}' maskUnits='userSpaceOnUse' x='{}' y='{}' width='{}' height='{}'>\n      <rect x='{}' y='{}' width='{}' height='{}' fill='#ffffff'/>\n      <g fill='#000000' stroke='#000000'>\n{run}      </g>\n    </mask>",
+                fmt_num(bounds.min.x),
+                fmt_num(bounds.min.y),
+                fmt_num(bounds.width()),
+                fmt_num(bounds.height()),
+                fmt_num(bounds.min.x),
+                fmt_num(bounds.min.y),
+                fmt_num(bounds.width()),
+                fmt_num(bounds.height()),
+            )
+            .unwrap();
+            *painted = format!("      <g mask='url(#{mask_id})'>\n{painted}      </g>\n");
+        }
+        // A clear run with nothing under it removes nothing.
+        Some(Polarity::Clear) | None => {}
+        Some(Polarity::Dark) => painted.push_str(&run),
+    }
+}
+
+fn write_artwork_object<LayerMeta, ObjectMeta>(
+    out: &mut String,
+    doc: &artwork::Document<LayerMeta, ObjectMeta>,
+    role: LayerRole,
+    object: &artwork::Object<ObjectMeta>,
+) {
+    match object.geometry {
+        Geometry::Flash {
+            aperture,
+            transform,
+        } => {
+            writeln!(
+                out,
+                "      <use href='#a{aperture}'{}/>",
+                svg_transform(transform)
+            )
+            .unwrap();
+        }
+        Geometry::Region { path } => {
+            let path = doc.arena.path(path);
+            let d = path_data(&doc.arena, path);
+            if d.is_empty() {
+                return;
+            }
+            writeln!(
+                out,
+                "      <path d='{d}' fill-rule='{}' stroke='none'/>",
+                fill_rule_name(path.fill_rule().unwrap_or(FillRule::NonZero))
+            )
+            .unwrap();
+        }
+        Geometry::Stroke { path } => {
+            let path = doc.arena.path(path);
+            let d = path_data(&doc.arena, path);
+            if d.is_empty() {
+                return;
+            }
+            let Paint::Stroke(stroke) = path.paint else {
+                return;
+            };
+            let outline = (role == LayerRole::Profile)
+                .then_some(" data-board-outline='true'")
+                .unwrap_or_default();
+            writeln!(
+                out,
+                "      <path d='{d}' fill='none' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='{}'{outline}/>",
+                fmt_num(stroke.width),
+                match stroke.cap {
+                    crate::geom::LineCap::Round => "round",
+                    crate::geom::LineCap::Square => "square",
+                    crate::geom::LineCap::Butt => "butt",
+                },
+                match stroke.join {
+                    crate::geom::LineJoin::Round => "round",
+                    crate::geom::LineJoin::Bevel => "bevel",
+                    crate::geom::LineJoin::Miter => "miter",
+                },
+            )
+            .unwrap();
+        }
+    }
+}
+
+fn svg_transform(transform: Affine2) -> String {
+    if transform.is_identity() {
+        return String::new();
+    }
+    format!(
+        " transform='matrix({} {} {} {} {} {})'",
+        fmt_num(transform.m00),
+        fmt_num(transform.m10),
+        fmt_num(transform.m01),
+        fmt_num(transform.m11),
+        fmt_num(transform.m02),
+        fmt_num(transform.m12),
+    )
+}
+
+fn pixel_size(options: &RenderOptions, bbox: BBox) -> Option<(u32, u32)> {
+    match options.size {
         SizeConstraint::Auto => None,
         SizeConstraint::Fixed {
             width_px,
             height_px,
         } => Some((width_px, height_px)),
-        SizeConstraint::MaxDimension(max) => Some(crate::render::pixel_size(
-            doc,
-            options.layers.as_deref(),
-            max,
-        )),
-    };
-    render_layers(doc, &layers, pixel_size)
+        SizeConstraint::MaxDimension(max) => Some(crate::render::pixel_size(bbox, max)),
+    }
 }
 
-fn render_layers<LayerMeta>(
-    doc: &mask::Document<LayerMeta>,
-    layer_indices: &[usize],
-    pixel_size: Option<(u32, u32)>,
-) -> String {
-    let bbox = crate::render::bbox(doc, Some(layer_indices));
-    let viewbox_y = -bbox.max.y;
+fn open_svg(bbox: &BBox, pixel_size: Option<(u32, u32)>, title: &str) -> String {
     let mut svg = String::new();
     let size = pixel_size
         .map(|(width, height)| format!(" width='{width}' height='{height}'"))
         .unwrap_or_default();
     writeln!(
         svg,
-        "<svg xmlns='http://www.w3.org/2000/svg'{size} viewBox='{} {} {} {}'>",
+        "<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'{size} viewBox='{} {} {} {}'>",
         fmt_num(bbox.min.x),
-        fmt_num(viewbox_y),
+        fmt_num(-bbox.max.y),
         fmt_num(bbox.width()),
         fmt_num(bbox.height())
     )
     .unwrap();
-    let title = layer_indices
-        .first()
-        .and_then(|&index| doc.layers.get(index))
-        .map(|layer| layer.name.as_str())
-        .unwrap_or("mask");
     writeln!(svg, "  <title>{}</title>", escape_xml(title)).unwrap();
     writeln!(svg, "  <g transform='scale(1 -1)'>").unwrap();
+    svg
+}
 
-    for &layer_index in layer_indices {
-        let layer = &doc.layers[layer_index];
-        for shape in doc.shapes(layer) {
-            write_shape(&mut svg, doc, layer.role, shape);
-        }
-    }
-
+fn close_svg(mut svg: String) -> String {
     writeln!(svg, "  </g>").unwrap();
     writeln!(svg, "</svg>").unwrap();
     svg
 }
 
-fn write_shape<LayerMeta>(
-    svg: &mut String,
-    doc: &mask::Document<LayerMeta>,
-    role: LayerRole,
-    shape: &Path,
-) {
-    let d = path_data(doc, shape);
+fn fill_rule_name(rule: FillRule) -> &'static str {
+    match rule {
+        FillRule::NonZero => "nonzero",
+        FillRule::EvenOdd => "evenodd",
+    }
+}
+
+fn write_shape(svg: &mut String, arena: &PathArena, role: LayerRole, shape: &Path) {
+    let d = path_data(arena, shape);
     if d.is_empty() {
         return;
     }
-    let fill_rule = match shape.fill_rule().unwrap_or(FillRule::NonZero) {
-        FillRule::NonZero => "nonzero",
-        FillRule::EvenOdd => "evenodd",
-    };
     let (color, opacity) = layer_style(role);
     if role == LayerRole::Profile {
         writeln!(
@@ -91,53 +303,66 @@ fn write_shape<LayerMeta>(
     } else {
         writeln!(
             svg,
-            "    <path d='{d}' fill='{color}' fill-opacity='{}' fill-rule='{fill_rule}'/>",
-            fmt_num(opacity)
+            "    <path d='{d}' fill='{color}' fill-opacity='{}' fill-rule='{}'/>",
+            fmt_num(opacity),
+            fill_rule_name(shape.fill_rule().unwrap_or(FillRule::NonZero))
         )
         .unwrap();
     }
 }
 
-fn path_data<LayerMeta>(doc: &mask::Document<LayerMeta>, shape: &Path) -> String {
+fn contours_data(contours: &[crate::geom::path::ContourBuf]) -> String {
     let mut data = String::new();
-    for contour in doc.arena.contours(shape.contours) {
-        let mut current = Point::default();
-        for cmd in doc.arena.cmds(*contour) {
-            match cmd.op {
-                PathOp::MoveTo => {
-                    current = cmd.p0;
-                    if !data.is_empty() {
-                        data.push(' ');
-                    }
-                    write!(data, "M{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap();
-                }
-                PathOp::LineTo => {
-                    current = cmd.p0;
-                    write!(data, " L{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap();
-                }
-                PathOp::ArcTo => {
-                    write_arc(&mut data, current, *cmd);
-                    current = cmd.p0;
-                }
-                PathOp::CubicTo => {
-                    current = cmd.p2;
-                    write!(
-                        data,
-                        " C{} {},{} {},{} {}",
-                        fmt_num(cmd.p0.x),
-                        fmt_num(cmd.p0.y),
-                        fmt_num(cmd.p1.x),
-                        fmt_num(cmd.p1.y),
-                        fmt_num(cmd.p2.x),
-                        fmt_num(cmd.p2.y)
-                    )
-                    .unwrap();
-                }
-                PathOp::Close => data.push_str(" Z"),
-            }
-        }
+    for contour in contours {
+        write_contour(&mut data, contour.cmds.iter().copied());
     }
     data
+}
+
+fn path_data(arena: &PathArena, shape: &Path) -> String {
+    let mut data = String::new();
+    for contour in arena.contours(shape.contours) {
+        write_contour(&mut data, arena.cmds(*contour).iter().copied());
+    }
+    data
+}
+
+fn write_contour(data: &mut String, cmds: impl IntoIterator<Item = PathCmd>) {
+    let mut current = Point::default();
+    for cmd in cmds {
+        match cmd.op {
+            PathOp::MoveTo => {
+                current = cmd.p0;
+                if !data.is_empty() {
+                    data.push(' ');
+                }
+                write!(data, "M{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap();
+            }
+            PathOp::LineTo => {
+                current = cmd.p0;
+                write!(data, " L{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap();
+            }
+            PathOp::ArcTo => {
+                write_arc(data, current, cmd);
+                current = cmd.p0;
+            }
+            PathOp::CubicTo => {
+                current = cmd.p2;
+                write!(
+                    data,
+                    " C{} {},{} {},{} {}",
+                    fmt_num(cmd.p0.x),
+                    fmt_num(cmd.p0.y),
+                    fmt_num(cmd.p1.x),
+                    fmt_num(cmd.p1.y),
+                    fmt_num(cmd.p2.x),
+                    fmt_num(cmd.p2.y)
+                )
+                .unwrap();
+            }
+            PathOp::Close => data.push_str(" Z"),
+        }
+    }
 }
 
 fn write_arc(data: &mut String, start: Point, cmd: PathCmd) {
@@ -210,6 +435,107 @@ mod tests {
     use crate::dialects::{Side, mask::Layer};
     use crate::geom::BBox;
     use crate::geom::path::ContourBuf;
+
+    fn square(size: f64) -> ContourBuf {
+        ContourBuf::new(vec![
+            PathCmd::move_to(Point::new(0.0, 0.0)),
+            PathCmd::line_to(Point::new(size, 0.0)),
+            PathCmd::line_to(Point::new(size, size)),
+            PathCmd::line_to(Point::new(0.0, size)),
+            PathCmd::close(),
+        ])
+    }
+
+    fn copper_artwork() -> artwork::Document<(), ()> {
+        let mut doc = artwork::Document::new();
+        doc.push_layer(artwork::Layer {
+            name: "F.Cu".to_string(),
+            role: LayerRole::Copper,
+            side: Side::Top,
+            objects: crate::geom::Span::EMPTY,
+            bbox: BBox::empty(),
+            meta: (),
+        });
+        doc
+    }
+
+    #[test]
+    fn artwork_svg_shares_one_defs_shape_across_repeated_flashes() {
+        let mut doc = copper_artwork();
+        let aperture = doc.push_aperture(artwork::Aperture::circle(1.0));
+        for index in 0..4 {
+            doc.push_object(
+                0,
+                artwork::Object::new(
+                    Polarity::Dark,
+                    Geometry::Flash {
+                        aperture,
+                        transform: Affine2::translation(Point::new(f64::from(index) * 2.0, 0.0)),
+                    },
+                ),
+            );
+        }
+        artwork::normalize_bounds(&mut doc);
+
+        let svg = artwork_svg(&doc, &RenderOptions::default());
+
+        assert_eq!(svg.matches("<path id='a0'").count(), 1);
+        assert_eq!(svg.matches("<use href='#a0'").count(), 4);
+    }
+
+    #[test]
+    fn artwork_svg_keeps_filled_regions_unstroked() {
+        // A layer group carries the colour for both fills and strokes, so a
+        // region that does not opt out would gain the default one-unit
+        // outline and swallow neighbouring clearances.
+        let mut doc = copper_artwork();
+        let path = doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            vec![square(10.0)],
+        );
+        doc.push_object(
+            0,
+            artwork::Object::new(Polarity::Dark, Geometry::Region { path }),
+        );
+        artwork::normalize_bounds(&mut doc);
+
+        let svg = artwork_svg(&doc, &RenderOptions::default());
+
+        assert!(svg.contains("stroke='none'"), "{svg}");
+    }
+
+    #[test]
+    fn artwork_svg_masks_a_clear_run_over_earlier_paint() {
+        let mut doc = copper_artwork();
+        let pour = doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            vec![square(10.0)],
+        );
+        let void = doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            vec![square(2.0)],
+        );
+        doc.push_object(
+            0,
+            artwork::Object::new(Polarity::Dark, Geometry::Region { path: pour }),
+        );
+        doc.push_object(
+            0,
+            artwork::Object::new(Polarity::Clear, Geometry::Region { path: void }),
+        );
+        artwork::normalize_bounds(&mut doc);
+
+        let svg = artwork_svg(&doc, &RenderOptions::default());
+
+        assert_eq!(svg.matches("<mask id='m0'").count(), 1);
+        assert_eq!(svg.matches("<g mask='url(#m0)'>").count(), 1);
+    }
 
     #[test]
     fn renders_full_circle_arc_as_two_svg_arcs() {

--- a/crates/pcb-ir/src/render/svg.rs
+++ b/crates/pcb-ir/src/render/svg.rs
@@ -5,7 +5,9 @@ use crate::dialects::artwork::{self, Geometry, PaintStage};
 use crate::dialects::mask;
 use crate::geom::path::{PathCmd, PathOp};
 
-use crate::geom::{Affine2, Arc, BBox, FillRule, Paint, Path, PathArena, Point, Polarity};
+use crate::geom::{
+    Affine2, Arc, BBox, FillRule, LineCap, LineJoin, Path, PathArena, Point, Polarity,
+};
 use crate::render::{RenderOptions, SizeConstraint};
 
 const POINT_EPSILON_MM: f64 = 1e-9;
@@ -51,16 +53,13 @@ pub fn artwork_svg<LayerMeta, ObjectMeta>(
     let mut body = String::new();
 
     for (aperture_index, aperture) in doc.apertures.iter().enumerate() {
-        let d = contours_data(&aperture.contours());
-        if d.is_empty() {
-            continue;
-        }
         // Colour is inherited from the referencing group so one aperture can
         // serve both a dark run and a clear run's mask; `stroke` is not, or
         // every filled shape would gain the default one-unit outline.
         writeln!(
             defs,
-            "    <path id='a{aperture_index}' d='{d}' fill-rule='{}' stroke='none'/>",
+            "    <path id='a{aperture_index}' d='{}' fill-rule='{}' stroke='none'/>",
+            contours_data(&aperture.contours()),
             fill_rule_name(aperture.fill_rule())
         )
         .unwrap();
@@ -80,9 +79,7 @@ pub fn artwork_svg<LayerMeta, ObjectMeta>(
             .map(|layer| layer.name.as_str())
             .unwrap_or("artwork"),
     );
-    if !defs.is_empty() {
-        writeln!(svg, "  <defs>\n{defs}  </defs>").unwrap();
-    }
+    writeln!(svg, "  <defs>\n{defs}  </defs>").unwrap();
     svg.push_str(&body);
     close_svg(svg)
 }
@@ -102,16 +99,16 @@ fn write_artwork_layer<LayerMeta, ObjectMeta>(
     // into a mask over everything painted before it.
     let mut painted = String::new();
     let mut run = String::new();
-    let mut run_polarity = None;
+    let mut run_polarity = Polarity::Dark;
     for object in objects {
         let polarity = if object.order.stage == PaintStage::FinalCutout && has_material {
             Polarity::Clear
         } else {
             object.polarity
         };
-        if run_polarity != Some(polarity) {
+        if polarity != run_polarity {
             flush_run(&mut painted, defs, &mut run, run_polarity, layer);
-            run_polarity = Some(polarity);
+            run_polarity = polarity;
         }
         write_artwork_object(&mut run, doc, layer.role, object);
     }
@@ -135,35 +132,27 @@ fn flush_run<LayerMeta>(
     painted: &mut String,
     defs: &mut String,
     run: &mut String,
-    polarity: Option<Polarity>,
+    polarity: Polarity,
     layer: &artwork::Layer<LayerMeta>,
 ) {
     let run = std::mem::take(run);
-    if run.is_empty() {
-        return;
-    }
     match polarity {
-        Some(Polarity::Clear) if !painted.is_empty() => {
+        Polarity::Dark => painted.push_str(&run),
+        // A clear run removes from what is already painted, so with nothing
+        // under it there is nothing to remove.
+        Polarity::Clear if painted.is_empty() || run.is_empty() => {}
+        Polarity::Clear => {
             let mask_id = format!("m{}", defs.matches("<mask ").count());
             let bounds = layer.bbox.expand(1.0);
+            let (x, y) = (fmt_num(bounds.min.x), fmt_num(bounds.min.y));
+            let (width, height) = (fmt_num(bounds.width()), fmt_num(bounds.height()));
             writeln!(
                 defs,
-                "    <mask id='{mask_id}' maskUnits='userSpaceOnUse' x='{}' y='{}' width='{}' height='{}'>\n      <rect x='{}' y='{}' width='{}' height='{}' fill='#ffffff'/>\n      <g fill='#000000' stroke='#000000'>\n{run}      </g>\n    </mask>",
-                fmt_num(bounds.min.x),
-                fmt_num(bounds.min.y),
-                fmt_num(bounds.width()),
-                fmt_num(bounds.height()),
-                fmt_num(bounds.min.x),
-                fmt_num(bounds.min.y),
-                fmt_num(bounds.width()),
-                fmt_num(bounds.height()),
+                "    <mask id='{mask_id}' maskUnits='userSpaceOnUse' x='{x}' y='{y}' width='{width}' height='{height}'>\n      <rect x='{x}' y='{y}' width='{width}' height='{height}' fill='#ffffff'/>\n      <g fill='#000000' stroke='#000000'>\n{run}      </g>\n    </mask>",
             )
             .unwrap();
             *painted = format!("      <g mask='url(#{mask_id})'>\n{painted}      </g>\n");
         }
-        // A clear run with nothing under it removes nothing.
-        Some(Polarity::Clear) | None => {}
-        Some(Polarity::Dark) => painted.push_str(&run),
     }
 }
 
@@ -187,46 +176,50 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
         }
         Geometry::Region { path } => {
             let path = doc.arena.path(path);
-            let d = path_data(&doc.arena, path);
-            if d.is_empty() {
-                return;
-            }
             writeln!(
                 out,
-                "      <path d='{d}' fill-rule='{}' stroke='none'/>",
+                "      <path d='{}' fill-rule='{}' stroke='none'/>",
+                path_data(&doc.arena, path),
                 fill_rule_name(path.fill_rule().unwrap_or(FillRule::NonZero))
             )
             .unwrap();
         }
         Geometry::Stroke { path } => {
             let path = doc.arena.path(path);
-            let d = path_data(&doc.arena, path);
-            if d.is_empty() {
-                return;
-            }
-            let Paint::Stroke(stroke) = path.paint else {
-                return;
+            let stroke = path
+                .stroke()
+                .expect("stroke geometry carries a stroke paint");
+            let outline = if role == LayerRole::Profile {
+                " data-board-outline='true'"
+            } else {
+                ""
             };
-            let outline = (role == LayerRole::Profile)
-                .then_some(" data-board-outline='true'")
-                .unwrap_or_default();
             writeln!(
                 out,
-                "      <path d='{d}' fill='none' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='{}'{outline}/>",
+                "      <path d='{}' fill='none' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='{}'{outline}/>",
+                path_data(&doc.arena, path),
                 fmt_num(stroke.width),
-                match stroke.cap {
-                    crate::geom::LineCap::Round => "round",
-                    crate::geom::LineCap::Square => "square",
-                    crate::geom::LineCap::Butt => "butt",
-                },
-                match stroke.join {
-                    crate::geom::LineJoin::Round => "round",
-                    crate::geom::LineJoin::Bevel => "bevel",
-                    crate::geom::LineJoin::Miter => "miter",
-                },
+                line_cap_name(stroke.cap),
+                line_join_name(stroke.join),
             )
             .unwrap();
         }
+    }
+}
+
+fn line_cap_name(cap: LineCap) -> &'static str {
+    match cap {
+        LineCap::Round => "round",
+        LineCap::Square => "square",
+        LineCap::Butt => "butt",
+    }
+}
+
+fn line_join_name(join: LineJoin) -> &'static str {
+    match join {
+        LineJoin::Round => "round",
+        LineJoin::Bevel => "bevel",
+        LineJoin::Miter => "miter",
     }
 }
 
@@ -433,8 +426,8 @@ pub(crate) fn fmt_num(value: f64) -> String {
 mod tests {
     use super::*;
     use crate::dialects::{Side, mask::Layer};
-    use crate::geom::BBox;
     use crate::geom::path::ContourBuf;
+    use crate::geom::{BBox, Paint};
 
     fn square(size: f64) -> ContourBuf {
         ContourBuf::new(vec![

--- a/crates/pcb-ir/src/render/svg.rs
+++ b/crates/pcb-ir/src/render/svg.rs
@@ -6,7 +6,7 @@ use crate::dialects::mask;
 use crate::geom::path::{PathCmd, PathOp};
 
 use crate::geom::{
-    Affine2, Arc, BBox, FillRule, LineCap, LineJoin, Path, PathArena, Point, Polarity,
+    Affine2, Arc, BBox, FillRule, LineCap, LineJoin, Path, PathArena, Point, Polarity, StrokeStyle,
 };
 use crate::render::{RenderOptions, SizeConstraint};
 
@@ -17,15 +17,11 @@ const POINT_EPSILON_MM: f64 = 1e-9;
 pub fn svg<LayerMeta>(doc: &mask::Document<LayerMeta>, options: &RenderOptions) -> String {
     let layers = crate::render::layer_indices(doc.layers.len(), options.layers.as_deref());
     let bbox = crate::render::bbox(doc, Some(&layers));
-    let mut svg = open_svg(
-        &bbox,
-        pixel_size(options, bbox),
-        layers
-            .first()
-            .and_then(|&index| doc.layers.get(index))
-            .map(|layer| layer.name.as_str())
-            .unwrap_or("mask"),
-    );
+    let title = layers
+        .first()
+        .and_then(|&index| doc.layers.get(index))
+        .map(|layer| layer.name.as_str());
+    let mut svg = open_svg(&bbox, pixel_size(options, bbox), title);
 
     for &layer_index in &layers {
         let layer = &doc.layers[layer_index];
@@ -70,15 +66,11 @@ pub fn artwork_svg<LayerMeta, ObjectMeta>(
         write_artwork_layer(&mut body, &mut defs, doc, layer);
     }
 
-    let mut svg = open_svg(
-        &bbox,
-        pixel_size(options, bbox),
-        layers
-            .first()
-            .and_then(|&index| doc.layers.get(index))
-            .map(|layer| layer.name.as_str())
-            .unwrap_or("artwork"),
-    );
+    let title = layers
+        .first()
+        .and_then(|&index| doc.layers.get(index))
+        .map(|layer| layer.name.as_str());
+    let mut svg = open_svg(&bbox, pixel_size(options, bbox), title);
     writeln!(svg, "  <defs>\n{defs}  </defs>").unwrap();
     svg.push_str(&body);
     close_svg(svg)
@@ -113,9 +105,6 @@ fn write_artwork_layer<LayerMeta, ObjectMeta>(
         write_artwork_object(&mut run, doc, layer.role, object);
     }
     flush_run(&mut painted, defs, &mut run, run_polarity, layer);
-    if painted.is_empty() {
-        return;
-    }
 
     // One group opacity rather than per-object alpha, so overlapping objects
     // composite once instead of darkening where they touch.
@@ -140,7 +129,7 @@ fn flush_run<LayerMeta>(
         Polarity::Dark => painted.push_str(&run),
         // A clear run removes from what is already painted, so with nothing
         // under it there is nothing to remove.
-        Polarity::Clear if painted.is_empty() || run.is_empty() => {}
+        Polarity::Clear if painted.is_empty() => {}
         Polarity::Clear => {
             let mask_id = format!("m{}", defs.matches("<mask ").count());
             let bounds = layer.bbox.expand(1.0);
@@ -180,15 +169,30 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
                 out,
                 "      <path d='{}' fill-rule='{}' stroke='none'/>",
                 path_data(&doc.arena, path),
-                fill_rule_name(path.fill_rule().unwrap_or(FillRule::NonZero))
+                fill_rule_name(
+                    path.fill_rule()
+                        .expect("region geometry carries a fill paint")
+                )
+            )
+            .unwrap();
+        }
+        // SVG has no notion of IPC line patterns, so a patterned stroke
+        // images through the same expansion the mask compositor uses.
+        Geometry::Stroke { path } if !stroke_of(doc, path).is_solid() => {
+            let contours = crate::geom::path::stroke_to_fill(
+                &doc.arena.path_contours(doc.arena.path(path)),
+                stroke_of(doc, path).into(),
+            )
+            .unwrap_or_default();
+            writeln!(
+                out,
+                "      <path d='{}' fill-rule='nonzero' stroke='none'/>",
+                contours_data(&contours)
             )
             .unwrap();
         }
         Geometry::Stroke { path } => {
-            let path = doc.arena.path(path);
-            let stroke = path
-                .stroke()
-                .expect("stroke geometry carries a stroke paint");
+            let stroke = stroke_of(doc, path);
             let outline = if role == LayerRole::Profile {
                 " data-board-outline='true'"
             } else {
@@ -197,7 +201,7 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
             writeln!(
                 out,
                 "      <path d='{}' fill='none' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='{}'{outline}/>",
-                path_data(&doc.arena, path),
+                path_data(&doc.arena, doc.arena.path(path)),
                 fmt_num(stroke.width),
                 line_cap_name(stroke.cap),
                 line_join_name(stroke.join),
@@ -205,6 +209,16 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
             .unwrap();
         }
     }
+}
+
+fn stroke_of<LayerMeta, ObjectMeta>(
+    doc: &artwork::Document<LayerMeta, ObjectMeta>,
+    path: u32,
+) -> StrokeStyle {
+    doc.arena
+        .path(path)
+        .stroke()
+        .expect("stroke geometry carries a stroke paint")
 }
 
 fn line_cap_name(cap: LineCap) -> &'static str {
@@ -224,9 +238,6 @@ fn line_join_name(join: LineJoin) -> &'static str {
 }
 
 fn svg_transform(transform: Affine2) -> String {
-    if transform.is_identity() {
-        return String::new();
-    }
     format!(
         " transform='matrix({} {} {} {} {} {})'",
         fmt_num(transform.m00),
@@ -249,7 +260,8 @@ fn pixel_size(options: &RenderOptions, bbox: BBox) -> Option<(u32, u32)> {
     }
 }
 
-fn open_svg(bbox: &BBox, pixel_size: Option<(u32, u32)>, title: &str) -> String {
+fn open_svg(bbox: &BBox, pixel_size: Option<(u32, u32)>, title: Option<&str>) -> String {
+    let title = title.unwrap_or("layer");
     let mut svg = String::new();
     let size = pixel_size
         .map(|(width, height)| format!(" width='{width}' height='{height}'"))
@@ -298,7 +310,7 @@ fn write_shape(svg: &mut String, arena: &PathArena, role: LayerRole, shape: &Pat
             svg,
             "    <path d='{d}' fill='{color}' fill-opacity='{}' fill-rule='{}'/>",
             fmt_num(opacity),
-            fill_rule_name(shape.fill_rule().unwrap_or(FillRule::NonZero))
+            fill_rule_name(shape.fill_rule().expect("mask shapes are filled"))
         )
         .unwrap();
     }
@@ -500,6 +512,32 @@ mod tests {
     }
 
     #[test]
+    fn artwork_svg_images_patterned_strokes_as_dashes() {
+        let mut doc = copper_artwork();
+        let path = doc.push_path(
+            Paint::Stroke(StrokeStyle {
+                pattern: crate::geom::LinePattern::Dashed,
+                ..StrokeStyle::round(0.2)
+            }),
+            vec![ContourBuf::new(vec![
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(20.0, 0.0)),
+            ])],
+        );
+        doc.push_object(
+            0,
+            artwork::Object::new(Polarity::Dark, Geometry::Stroke { path }),
+        );
+        artwork::normalize_bounds(&mut doc);
+
+        let svg = artwork_svg(&doc, &RenderOptions::default());
+
+        // Expanded into separate filled dashes rather than one native stroke.
+        assert!(!svg.contains("stroke-width"), "{svg}");
+        assert!(svg.matches('M').count() > 1, "{svg}");
+    }
+
+    #[test]
     fn artwork_svg_masks_a_clear_run_over_earlier_paint() {
         let mut doc = copper_artwork();
         let pour = doc.push_path(
@@ -528,6 +566,14 @@ mod tests {
 
         assert_eq!(svg.matches("<mask id='m0'").count(), 1);
         assert_eq!(svg.matches("<g mask='url(#m0)'>").count(), 1);
+        // The mask's covering rect shares the user space of the geometry it
+        // masks, so it spans the layer bounds in source coordinates. Flipping
+        // it would leave the masked content outside the rect and drop the
+        // whole layer.
+        assert!(
+            svg.contains("<rect x='-1' y='-1' width='12' height='12'"),
+            "{svg}"
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/render/term.rs
+++ b/crates/pcb-ir/src/render/term.rs
@@ -20,13 +20,25 @@ pub fn to_terminal<LayerMeta>(
     doc: &mask::Document<LayerMeta>,
     options: &RenderOptions,
 ) -> Result<(), String> {
-    let png = crate::render::png(
-        doc,
-        &RenderOptions {
-            layers: options.layers.clone(),
-            size: SizeConstraint::MaxDimension(terminal_max_dimension_px()),
-        },
-    )?;
+    write_terminal_png(crate::render::png(doc, &terminal_options(options))?)
+}
+
+/// Render artwork layers as an inline terminal image.
+pub fn artwork_to_terminal<LayerMeta, ObjectMeta>(
+    doc: &crate::dialects::artwork::Document<LayerMeta, ObjectMeta>,
+    options: &RenderOptions,
+) -> Result<(), String> {
+    write_terminal_png(crate::render::artwork_png(doc, &terminal_options(options))?)
+}
+
+fn terminal_options(options: &RenderOptions) -> RenderOptions {
+    RenderOptions {
+        layers: options.layers.clone(),
+        size: SizeConstraint::MaxDimension(terminal_max_dimension_px()),
+    }
+}
+
+fn write_terminal_png(png: Vec<u8>) -> Result<(), String> {
     if !io::stdout().is_terminal() {
         return Err(
             "stdout is not an interactive terminal; pass an SVG or PNG output path".to_string(),

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -92,9 +92,12 @@ enum Commands {
         /// IPC-2581 XML file to export from
         #[arg(value_hint = clap::ValueHint::FilePath)]
         file: PathBuf,
-        /// Layout target to export
-        #[arg(long, default_value = "board")]
+        /// What to export: the canonical board, or the file's root step with every repeat materialized.
+        #[arg(long, default_value = "board-array")]
         layout_target: LayoutTarget,
+        /// Also draw nested assembly-panel boundaries, not just the fabrication outlines.
+        #[arg(long)]
+        nested_outlines: bool,
         /// Output DXF file path
         #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
         output: PathBuf,
@@ -113,21 +116,18 @@ enum Commands {
         /// Render format. Auto infers SVG/PNG from the output extension or uses terminal graphics.
         #[arg(short, long, default_value = "auto")]
         format: RenderFormat,
-        /// Layout target to render
-        #[arg(long, default_value = "layout")]
+        /// What to render: the canonical board, or the file's root step with every repeat materialized.
+        #[arg(long, default_value = "board-array")]
         layout_target: LayoutTarget,
-        /// Flatten the layer into a single Gerber-style mask before rendering.
-        #[arg(long)]
-        flat: bool,
     },
     /// Check exported Gerber geometry for manufacturability slivers
     Dfm {
         /// IPC-2581 XML file to check
         #[arg(value_hint = clap::ValueHint::FilePath)]
         file: PathBuf,
-        /// Layout target to check. Supports board or board-array.
-        #[arg(long, default_value = "board")]
-        layout_target: GerberLayoutTarget,
+        /// What to check: the canonical board, or the file's root step with every repeat materialized.
+        #[arg(long, default_value = "board-array")]
+        layout_target: LayoutTarget,
         /// Minimum feature and gap width in millimeters
         #[arg(long, default_value_t = 0.09)]
         min_width_mm: f64,
@@ -137,9 +137,9 @@ enum Commands {
         /// IPC-2581 XML file to export from
         #[arg(value_hint = clap::ValueHint::FilePath)]
         file: PathBuf,
-        /// Layout target to export. Manufacturing export supports board or board-array.
-        #[arg(long, default_value = "board")]
-        layout_target: GerberLayoutTarget,
+        /// What to export: the canonical board, or the file's root step with every repeat materialized.
+        #[arg(long, default_value = "board-array")]
+        layout_target: LayoutTarget,
         /// Output directory, or a .zip file for an archived manufacturing package
         #[arg(short, long, value_hint = clap::ValueHint::AnyPath)]
         output: PathBuf,
@@ -265,22 +265,6 @@ impl FabPanelSize {
             Self::Inches16x18 => commands::fab_panel::FabPanelSpec::INCHES_16_X_18,
             Self::Inches18x24 => commands::fab_panel::FabPanelSpec::INCHES_18_X_24,
             Self::Inches21x24 => commands::fab_panel::FabPanelSpec::INCHES_21_X_24,
-        }
-    }
-}
-
-#[derive(ValueEnum, Debug, Clone, Copy)]
-enum GerberLayoutTarget {
-    Board,
-    #[value(name = "board-array", alias = "panel")]
-    BoardArray,
-}
-
-impl From<GerberLayoutTarget> for pcb_ir::dialects::ipc::View {
-    fn from(target: GerberLayoutTarget) -> Self {
-        match target {
-            GerberLayoutTarget::Board => Self::Board,
-            GerberLayoutTarget::BoardArray => Self::ArrayFlattened,
         }
     }
 }
@@ -418,12 +402,14 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
         Commands::Outline {
             file,
             layout_target,
+            nested_outlines,
             output,
         } => commands::outline::execute(
             &file,
             &commands::outline::OutlineOptions {
                 output,
                 layout_target,
+                nested_outlines,
             },
         ),
         Commands::Render {
@@ -432,7 +418,6 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             output,
             format,
             layout_target,
-            flat,
         } => commands::render::execute(
             &file,
             &commands::render::RenderOptions {
@@ -440,14 +425,13 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 output,
                 format,
                 layout_target,
-                flat,
             },
         ),
         Commands::Dfm {
             file,
             layout_target,
             min_width_mm,
-        } => commands::dfm::execute(&file, layout_target.into(), min_width_mm),
+        } => commands::dfm::execute(&file, layout_target.artwork_scope(), min_width_mm),
         Commands::Gerber {
             file,
             layout_target,
@@ -458,7 +442,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 &file,
                 &manufacturing::ManufacturingExportOptions {
                     output: output.clone(),
-                    view: layout_target.into(),
+                    view: layout_target.artwork_scope(),
                     relief_debug_dir: debug_reliefs,
                 },
             )?;


### PR DESCRIPTION
`ipc2581 render` defaulted to `--layout-target layout`, which maps to a view that materializes no nested `StepRepeat` content. On a board array or fabrication panel it drew the root step's support copper and none of the repeated boards' artwork — a panel review could conclude the board copper was missing. Gerber export was never affected.

## Predictable targets

`View` conflated artwork scope with profile-display scope. `LayoutSymbolic` was only meaningful as the latter, but layer extraction accepted it in a catch-all arm. Two consumers guarded against it at runtime and a second CLI enum existed to keep it out of manufacturing; `render` had neither guard and defaulted to it.

- `View` becomes `ArtworkScope` with no variant that can drop nested repeats. The symbolic layout graph is reached through `ProfileSet::LayoutBoundaries` instead, which is all `outline` ever used it for.
- `--layout-target` is `board` or `board-array` everywhere, defaulting to `board-array` (the file's root step with every repeat materialized; identical to `board` for a plain board file). This changes the default target for `gerber` and `dfm`.
- `outline` gains `--nested-outlines` for nested assembly-panel boundaries.
- Drops `GerberLayoutTarget`, both `does not support symbolic layout view` guards, and `render --flat` (verified byte-identical output).

## One artwork lowering

There were two: pcb-ir's, which expands every path individually, and a private one in the Gerber exporter that preserves dictionary instances as apertures. Rendering got the first.

`lower_layer_to_artwork_with` in pcb-ir now covers instance flashes, circle flashes and per-path regions/strokes, with an `ArtworkLowering` hook for what only the source knows — apertures from the IPC standard dictionary, target stroke joins, paint staging, and object metadata. The Gerber exporter is a ~30-line impl of that trait.

## Artwork-native SVG

`compose_to_mask` collapses a layer to one shape, so the writer emitted the whole image as one `<path d>`. On a 5-array panel that was 36.3 MB in a single XML attribute, past libxml2's 10 MB cap — `rsvg-convert` and ImageMagick both refused it, including the gerber-derived SVG suggested as a workaround.

`artwork_svg` consumes the artwork document: apertures become `<defs>` shapes referenced by `<use>`, and each clear run masks what came before it. PNG and terminal rasterize the same SVG. `compose_to_mask` keeps its analysis consumers.

## Verification

On a five-array A6 fabrication panel:

| | before | after |
|---|---|---|
| F.Cu SVG | 36.3 MB, 1 path | 11.5 MB, 78k `<use>` + 9k paths |
| largest attribute | 36.3 MB | 868 KB |
| `rsvg-convert` | parse error | renders |

All 16 manufacturing files are byte-identical before and after. Renders were compared against `compose_to_mask` output and against the Gerber render for the same layer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches IPC extraction, rendering, Gerber lowering, and CLI defaults (`board-array` for render/gerber/dfm), but manufacturing output is intended to stay byte-identical and behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **`ipc2581 render`** on board arrays and fab panels so repeated boards’ copper actually appears, and makes previews match Gerber export instead of collapsing layers into one giant mask path.
> 
> **Layout targets:** Renames `View` to **`ArtworkScope`** and drops **`LayoutSymbolic`** from layer extraction (nested repeats are always materialized for real artwork scopes). **`--layout-target`** is only **`board`** or **`board-array`** everywhere, defaulting to **`board-array`**; removes **`render --flat`**, duplicate Gerber layout enums, and symbolic-view export guards. **`outline`** adds **`--nested-outlines`** via `ProfileSet::LayoutBoundaries`.
> 
> **Shared pipeline:** Centralizes IPC→artwork in **`lower_layer_to_artwork_with`** and **`ArtworkLowering`** (instance flashes, circle flashes, paint order); Gerber export becomes a thin impl instead of a second lowering. Render/HTML use **`normalize_for_artwork`** and artwork-native **`artwork_svg`** / PNG/terminal (aperture `<use>`, sequential clear masks) so large panels stay parseable and instance geometry stays shared.
> 
> **Extraction:** Panel layer extraction is refactored so **`ArrayFlattened`** reliably includes descendant board features (with a regression test for nested panel renders).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9291192b56320f006226ddfd6650d3a31b59b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->