### PR TITLE
Prevent pcb import from silently changing connectivity and stackups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `pcb import` keeps physical pins separate when punctuation in their displayed names would otherwise produce the same Zener identifier.
+- `pcb import` rejects unsupported copper layer counts instead of silently generating a four-layer board.
+- `pcb import` preserves KiCad's numeric suffixes on otherwise identical `unconnected-*` net names.
 - Copper balancing no longer over-fills narrow panel frames and gutters, which made board-array frames pour solid instead of matching the board's copper density.
 
 ## [0.4.23] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `pcb import` keeps physical pins separate when punctuation in their displayed names would otherwise produce the same Zener identifier.
-- `pcb import` rejects unsupported copper layer counts instead of silently generating a four-layer board.
+- `pcb import` preserves explicit KiCad stackups with up to 32 copper layers instead of silently generating a four-layer board.
 - `pcb import` preserves KiCad's numeric suffixes on otherwise identical `unconnected-*` net names.
 - Copper balancing no longer over-fills narrow panel frames and gutters, which made board-array frames pour solid instead of matching the board's copper density.
 

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -57,7 +57,9 @@ pub fn sanitize_mpn_for_path(mpn: &str) -> String {
 /// - `~` or `!` at start: becomes `N_` prefix (e.g., `~CS` → `N_CS`)
 /// - `+` at end: becomes `_POS` suffix (e.g., `V+` → `V_POS`)
 /// - `-` at end: becomes `_NEG` suffix (e.g., `V-` → `V_NEG`)
-/// - `+` or `-` elsewhere: becomes `_` (e.g., `A+B` → `A_B`)
+/// - `+` elsewhere: becomes `_POS_` (e.g., `A+B` → `A_POS_B`)
+/// - `-` elsewhere: becomes `_NEG_` (e.g., `A-B` → `A_NEG_B`)
+/// - `'` or `′`: becomes `_PRIME` (e.g., `QH'` → `QH_PRIME`)
 /// - `#`: becomes `H` (e.g., `CS#` → `CSH`)
 /// - All alphanumeric chars: uppercased
 pub fn sanitize_pin_name(name: &str) -> String {
@@ -71,7 +73,9 @@ pub fn sanitize_pin_name(name: &str) -> String {
         match c {
             '+' if is_last => result.push_str("_POS"),
             '-' if is_last => result.push_str("_NEG"),
-            '+' | '-' => result.push('_'),
+            '+' => result.push_str("_POS_"),
+            '-' => result.push_str("_NEG_"),
+            '\'' | '′' => result.push_str("_PRIME"),
             '~' | '!' => result.push_str("N_"), // NOT prefix
             '#' => result.push('H'),
             c if c.is_alphanumeric() => result.push(c.to_ascii_uppercase()),
@@ -148,13 +152,25 @@ pub fn generated_signal_io_names(symbol: &Symbol) -> BTreeMap<String, String> {
             .push(pin);
     }
 
+    let mut used_io_names = BTreeSet::new();
     signals
         .into_iter()
         .filter_map(|(signal_name, pins)| {
-            (!pins_are_only_no_connect(pins)).then(|| {
-                let sanitized_name = sanitize_pin_name(&signal_name);
-                (signal_name, sanitized_name)
-            })
+            if pins_are_only_no_connect(pins) {
+                return None;
+            }
+
+            let mut base = sanitize_pin_name(&signal_name);
+            if base.is_empty() {
+                base = "PIN".to_string();
+            }
+            let mut io_name = base.clone();
+            let mut suffix = 2;
+            while !used_io_names.insert(io_name.clone()) {
+                io_name = format!("{base}_{suffix}");
+                suffix += 1;
+            }
+            Some((signal_name, io_name))
         })
         .collect()
 }
@@ -261,9 +277,35 @@ mod tests {
         assert_eq!(sanitize_pin_name("~CS"), "N_CS");
         assert_eq!(sanitize_pin_name("V+"), "V_POS");
         assert_eq!(sanitize_pin_name("V-"), "V_NEG");
-        assert_eq!(sanitize_pin_name("A+B"), "A_B");
+        assert_eq!(sanitize_pin_name("A+B"), "A_POS_B");
+        assert_eq!(sanitize_pin_name("A-B"), "A_NEG_B");
+        assert_eq!(sanitize_pin_name("QH'"), "QH_PRIME");
+        assert_eq!(sanitize_pin_name("QH′"), "QH_PRIME");
         assert_eq!(sanitize_pin_name("CS#"), "CSH");
         assert_eq!(sanitize_pin_name("1V8"), "P1V8");
+    }
+
+    #[test]
+    fn generated_signal_io_names_disambiguates_remaining_sanitizer_collisions() {
+        let symbol = Symbol {
+            pins: vec![
+                Pin {
+                    name: "A/B".to_string(),
+                    number: "1".to_string(),
+                    ..Default::default()
+                },
+                Pin {
+                    name: "A.B".to_string(),
+                    number: "2".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let names = generated_signal_io_names(&symbol);
+        assert_eq!(names["A.B"], "A_B");
+        assert_eq!(names["A/B"], "A_B_2");
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -2317,10 +2317,10 @@ mod tests {
 
     #[test]
     fn test_sanitize_pin_name_plus_minus_in_middle() {
-        // + and - in middle become underscores
-        assert_eq!(pcb_component_gen::sanitize_pin_name("A+B"), "A_B");
-        assert_eq!(pcb_component_gen::sanitize_pin_name("IN-OUT"), "IN_OUT");
-        assert_eq!(pcb_component_gen::sanitize_pin_name("V+REF"), "V_REF");
+        // Preserve the polarity of + and - in the middle of a name.
+        assert_eq!(pcb_component_gen::sanitize_pin_name("A+B"), "A_POS_B");
+        assert_eq!(pcb_component_gen::sanitize_pin_name("IN-OUT"), "IN_NEG_OUT");
+        assert_eq!(pcb_component_gen::sanitize_pin_name("V+REF"), "V_POS_REF");
     }
 
     #[test]

--- a/crates/pcbc/src/import/extract.rs
+++ b/crates/pcbc/src/import/extract.rs
@@ -51,6 +51,7 @@ pub(super) fn extract_ir(
             &validation.summary.selected,
             &mut netlist.components,
         )?;
+        restore_unconnected_net_suffixes_from_layout(&mut netlist.nets, &netlist.components)?;
     } else {
         resolve_standalone_footprints(selection, staged_root, &mut netlist.components)?;
     }
@@ -591,6 +592,82 @@ fn extract_kicad_layout_data(
     }
 
     Ok(())
+}
+
+fn restore_unconnected_net_suffixes_from_layout(
+    nets: &mut BTreeMap<KiCadNetName, ImportNetData>,
+    components: &BTreeMap<KiCadUuidPathKey, ImportComponentData>,
+) -> Result<()> {
+    let collapsed_names = nets
+        .iter()
+        .filter(|(name, net)| name.as_str().starts_with("unconnected-(") && net.ports.len() > 1)
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+
+    for collapsed_name in collapsed_names {
+        let Some(collapsed_net) = nets.remove(&collapsed_name) else {
+            continue;
+        };
+        let mut ports_by_layout_name: BTreeMap<KiCadNetName, BTreeSet<ImportNetPort>> =
+            BTreeMap::new();
+
+        for port in collapsed_net.ports {
+            let matching_layout_names = components
+                .get(&port.component)
+                .and_then(|component| component.layout.as_ref())
+                .and_then(|layout| layout.pads.get(&port.pin))
+                .into_iter()
+                .flat_map(|pad| pad.net_names.iter())
+                .filter(|name| {
+                    is_disambiguated_unconnected_name(collapsed_name.as_str(), name.as_str())
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+
+            if matching_layout_names.len() > 1 {
+                anyhow::bail!(
+                    "KiCad layout pad {}:{} has multiple names matching collapsed net {}: {}",
+                    port.component.pcb_path(),
+                    port.pin,
+                    collapsed_name,
+                    matching_layout_names
+                        .iter()
+                        .map(KiCadNetName::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+            let layout_name = matching_layout_names
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| collapsed_name.clone());
+            ports_by_layout_name
+                .entry(layout_name)
+                .or_default()
+                .insert(port);
+        }
+
+        for (name, ports) in ports_by_layout_name {
+            nets.entry(name)
+                .or_insert_with(|| ImportNetData {
+                    ports: BTreeSet::new(),
+                })
+                .ports
+                .extend(ports);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_disambiguated_unconnected_name(collapsed: &str, candidate: &str) -> bool {
+    if candidate == collapsed {
+        return true;
+    }
+    candidate
+        .strip_prefix(collapsed)
+        .and_then(|suffix| suffix.strip_prefix('_'))
+        .is_some_and(|suffix| !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()))
 }
 
 fn resolve_standalone_footprints(
@@ -1142,6 +1219,75 @@ fn key_from_schematic_instance_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn restores_layout_suffixes_for_collapsed_unconnected_nets() {
+        let anchor = KiCadUuidPathKey {
+            sheetpath_tstamps: "/".to_string(),
+            symbol_uuid: "u33".to_string(),
+        };
+        let pad = |name: &str| ImportLayoutPad {
+            net_names: BTreeSet::from([KiCadNetName::from(name.to_string())]),
+            uuids: BTreeSet::new(),
+        };
+        let components = BTreeMap::from([(
+            anchor.clone(),
+            ImportComponentData {
+                netlist: ImportNetlistComponent {
+                    refdes: KiCadRefDes::from("U33".to_string()),
+                    value: None,
+                    footprint: None,
+                    sheetpath_names: None,
+                    unit_pcb_paths: Vec::new(),
+                },
+                schematic: None,
+                layout: Some(ImportLayoutComponent {
+                    fpid: None,
+                    unresolved_footprint: None,
+                    uuid: None,
+                    layer: None,
+                    at: None,
+                    sheetname: None,
+                    sheetfile: None,
+                    attrs: Vec::new(),
+                    properties: BTreeMap::new(),
+                    pads: BTreeMap::from([
+                        (
+                            KiCadPinNumber::from("5".to_string()),
+                            pad("unconnected-(U33-Pad5)_1"),
+                        ),
+                        (
+                            KiCadPinNumber::from("6".to_string()),
+                            pad("unconnected-(U33-Pad5)"),
+                        ),
+                    ]),
+                    footprint_geometry: ImportFootprintGeometry::BoardInstance(String::new()),
+                }),
+            },
+        )]);
+        let port = |pin: &str| ImportNetPort {
+            component: anchor.clone(),
+            pin: KiCadPinNumber::from(pin.to_string()),
+        };
+        let mut nets = BTreeMap::from([(
+            KiCadNetName::from("unconnected-(U33-Pad5)".to_string()),
+            ImportNetData {
+                ports: BTreeSet::from([port("5"), port("6")]),
+            },
+        )]);
+
+        restore_unconnected_net_suffixes_from_layout(&mut nets, &components).unwrap();
+
+        assert_eq!(nets.len(), 2);
+        assert_eq!(
+            nets[&KiCadNetName::from("unconnected-(U33-Pad5)_1".to_string())].ports,
+            BTreeSet::from([port("5")])
+        );
+        assert_eq!(
+            nets[&KiCadNetName::from("unconnected-(U33-Pad5)".to_string())].ports,
+            BTreeSet::from([port("6")])
+        );
+    }
 
     #[test]
     fn parses_kicad_sexpr_netlist_and_builds_uuid_path_keys() -> Result<()> {

--- a/crates/pcbc/src/import/generate.rs
+++ b/crates/pcbc/src/import/generate.rs
@@ -505,36 +505,60 @@ fn try_extract_stackup(
     layout_kicad_pcb: &Path,
 ) -> Result<(usize, Option<zen_stackup::Stackup>)> {
     let fallback_layers = infer_copper_layers_from_layers_section(pcb_text)?;
+    let has_default_stackup = matches!(fallback_layers, 2 | 4 | 6 | 8 | 10);
 
     let stackup = match zen_stackup::Stackup::from_kicad_pcb(pcb_text) {
-        Ok(Some(s)) => s,
+        Ok(Some(stackup)) => stackup,
+        Ok(None) if has_default_stackup => return Ok((fallback_layers, None)),
         Ok(None) => {
-            return Ok((fallback_layers, None));
+            anyhow::bail!(
+                "{} has {fallback_layers} copper layers but no explicit KiCad stackup; imports above 10 layers require a complete stackup",
+                layout_kicad_pcb.display()
+            );
         }
-        Err(e) => {
+        Err(error) if has_default_stackup => {
             debug!(
                 "Skipping stackup extraction (failed to parse stackup from {}): {}",
                 layout_kicad_pcb.display(),
-                e
+                error
             );
             return Ok((fallback_layers, None));
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "Failed to parse the required {fallback_layers}-layer stackup from {}",
+                    layout_kicad_pcb.display()
+                )
+            });
         }
     };
 
     let Some(layers) = stackup.layers.as_deref() else {
-        return Ok((fallback_layers, None));
+        if has_default_stackup {
+            return Ok((fallback_layers, None));
+        }
+        anyhow::bail!(
+            "{} has {fallback_layers} copper layers but its KiCad stackup has no layers",
+            layout_kicad_pcb.display()
+        );
     };
     if layers.is_empty() {
-        return Ok((fallback_layers, None));
+        if has_default_stackup {
+            return Ok((fallback_layers, None));
+        }
+        anyhow::bail!(
+            "{} has {fallback_layers} copper layers but its KiCad stackup is empty",
+            layout_kicad_pcb.display()
+        );
     }
 
     let copper_layers = stackup.copper_layer_count();
-    if !matches!(copper_layers, 2 | 4 | 6 | 8 | 10) {
-        debug!(
-            "Skipping stackup extraction (unexpected copper layer count {copper_layers} in {}); using layer count inferred from (layers ...) section ({fallback_layers}).",
+    if copper_layers != fallback_layers {
+        anyhow::bail!(
+            "KiCad stackup in {} has {copper_layers} copper layers, but its (layers ...) section has {fallback_layers}",
             layout_kicad_pcb.display()
         );
-        return Ok((fallback_layers, None));
     }
 
     Ok((copper_layers, Some(stackup)))
@@ -562,9 +586,9 @@ fn infer_copper_layers_from_layers_section(pcb_text: &str) -> Result<usize> {
     }
 
     let count = copper_layer_names.len();
-    if !matches!(count, 2 | 4 | 6 | 8 | 10) {
+    if !(2..=32).contains(&count) || !count.is_multiple_of(2) {
         anyhow::bail!(
-            "Unsupported copper layer count inferred from KiCad (layers ...) section: {count}"
+            "Unsupported copper layer count inferred from KiCad (layers ...) section: {count}; expected an even count from 2 through 32"
         );
     }
     Ok(count)
@@ -604,17 +628,75 @@ mod stackup_fallback_tests {
     }
 
     #[test]
-    fn unsupported_layer_count_is_an_error() {
-        let mut layers = vec!["(0 \"F.Cu\" signal)".to_string()];
-        layers.extend((1..=10).map(|index| format!("({index} \"In{index}.Cu\" signal)")));
-        layers.push("(31 \"B.Cu\" signal)".to_string());
-        let pcb_text = format!("(kicad_pcb (layers {}))", layers.join(" "));
+    fn preserves_twelve_layer_stackup() {
+        let pcb_text = twelve_layer_pcb(true);
+        let (layers, stackup) =
+            try_extract_stackup(&pcb_text, Path::new("twelve-layer.kicad_pcb")).unwrap();
 
+        assert_eq!(layers, 12);
+        let stackup = stackup.unwrap();
+        assert_eq!(stackup.copper_layer_count(), 12);
+
+        let rendered = crate::codegen::board::render_imported_board(
+            crate::codegen::board::RenderImportedBoardArgs {
+                board_name: "TwelveLayer",
+                copper_layers: layers,
+                design_rules: None,
+                stackup: Some(&stackup),
+                net_decls: &[],
+                module_decls: &[],
+                instance_calls: &[],
+            },
+        );
+        assert!(rendered.contains("    layers = 12,"));
+        assert_eq!(rendered.matches("CopperLayer(").count(), 12);
+    }
+
+    #[test]
+    fn twelve_layers_require_an_explicit_stackup() {
+        let pcb_text = twelve_layer_pcb(false);
         let error = try_extract_stackup(&pcb_text, Path::new("twelve-layer.kicad_pcb"))
-            .expect_err("a 12-layer board must not fall back to four layers")
+            .expect_err("a 12-layer board without a stackup must not use a default")
             .to_string();
-        assert!(error.contains("Unsupported copper layer count"));
-        assert!(error.contains("12"));
+
+        assert!(error.contains("required 12-layer stackup"), "{error}");
+    }
+
+    fn twelve_layer_pcb(include_stackup: bool) -> String {
+        let mut copper_names = vec!["F.Cu".to_string()];
+        copper_names.extend((1..=10).map(|index| format!("In{index}.Cu")));
+        copper_names.push("B.Cu".to_string());
+
+        let layer_table = copper_names
+            .iter()
+            .enumerate()
+            .map(|(index, name)| format!("({index} \"{name}\" signal)"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let setup = if include_stackup {
+            let stackup_layers = copper_names
+                .iter()
+                .enumerate()
+                .flat_map(|(index, name)| {
+                    let mut layers = vec![format!(
+                        "(layer \"{name}\" (type \"copper\") (thickness 0.035))"
+                    )];
+                    if index + 1 < copper_names.len() {
+                        layers.push(format!(
+                            "(layer \"dielectric {}\" (type \"core\") (thickness 0.1) (material \"FR4\"))",
+                            index + 1
+                        ));
+                    }
+                    layers
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            format!("(setup (stackup {stackup_layers}))")
+        } else {
+            String::new()
+        };
+
+        format!("(kicad_pcb (layers {layer_table}) {setup})")
     }
 }
 

--- a/crates/pcbc/src/import/generate.rs
+++ b/crates/pcbc/src/import/generate.rs
@@ -169,13 +169,15 @@ fn write_imported_board_zen(args: ImportedBoardZenArgs<'_>) -> Result<()> {
                 layout_kicad_pcb.display()
             )
         })?;
-        match try_extract_stackup(&pcb_text, layout_kicad_pcb) {
-            Ok((layers, extracted_stackup)) => {
-                copper_layers = layers;
-                stackup = extracted_stackup;
-            }
-            Err(e) => debug!("{e:#}"),
-        }
+        let (layers, extracted_stackup) = try_extract_stackup(&pcb_text, layout_kicad_pcb)
+            .with_context(|| {
+                format!(
+                    "Failed to determine the copper layer count from {}",
+                    layout_kicad_pcb.display()
+                )
+            })?;
+        copper_layers = layers;
+        stackup = extracted_stackup;
         if let Some(layout_kicad_pro) = args.layout_kicad_pro {
             design_rules = pcb_layout::extract_design_rules_from_kicad_pro(layout_kicad_pro)
                 .ok()
@@ -599,6 +601,20 @@ mod stackup_fallback_tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("missing (layers"));
+    }
+
+    #[test]
+    fn unsupported_layer_count_is_an_error() {
+        let mut layers = vec!["(0 \"F.Cu\" signal)".to_string()];
+        layers.extend((1..=10).map(|index| format!("({index} \"In{index}.Cu\" signal)")));
+        layers.push("(31 \"B.Cu\" signal)".to_string());
+        let pcb_text = format!("(kicad_pcb (layers {}))", layers.join(" "));
+
+        let error = try_extract_stackup(&pcb_text, Path::new("twelve-layer.kicad_pcb"))
+            .expect_err("a 12-layer board must not fall back to four layers")
+            .to_string();
+        assert!(error.contains("Unsupported copper layer count"));
+        assert!(error.contains("12"));
     }
 }
 
@@ -2937,13 +2953,66 @@ mod tests {
         assert_eq!(by_pad["3"].io_name.as_deref(), Some("D_POS_3_2"));
         assert_eq!(by_pad["4"].io_name.as_deref(), Some("D_POS_4"));
         assert_eq!(by_pad["5"].io_name.as_deref(), Some("D_POS_3"));
-        assert_eq!(by_pad["6"].io_name.as_deref(), Some("A_B"));
-        assert_eq!(by_pad["7"].io_name.as_deref(), Some("A_B_2"));
+        assert_eq!(by_pad["6"].io_name.as_deref(), Some("A_POS_B"));
+        assert_eq!(by_pad["7"].io_name.as_deref(), Some("A_NEG_B"));
         assert_eq!(by_pad["10"].logical_name, "NC__10");
         assert_eq!(by_pad["11"].logical_name, "NC__11");
         assert_eq!(by_pad["10"].io_name, None);
         assert_eq!(by_pad["11"].io_name, None);
     }
+
+    fn assert_physical_pin_io_names(pins: &[(&str, &str, &str)]) {
+        let symbol = pcb_eda::Symbol {
+            pins: pins
+                .iter()
+                .map(|(name, number, _)| make_pin(name, number, Some("bidirectional")))
+                .collect(),
+            ..Default::default()
+        };
+        let plan = build_physical_pin_plan(
+            &symbol,
+            &[],
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        let by_pad = plan
+            .bindings
+            .iter()
+            .map(|binding| (binding.pad_number.as_str(), binding))
+            .collect::<BTreeMap<_, _>>();
+
+        for (_, pad, expected_io) in pins {
+            assert_eq!(by_pad[pad].io_name.as_deref(), Some(*expected_io));
+        }
+        assert_eq!(plan.io_pins.len(), pins.len());
+    }
+
+    #[test]
+    fn physical_pin_plan_preserves_prime_names() {
+        assert_physical_pin_io_names(&[("QH", "7", "QH"), ("QH'", "9", "QH_PRIME")]);
+    }
+
+    #[test]
+    fn physical_pin_plan_preserves_interior_signs() {
+        assert_physical_pin_io_names(&[("D0+A", "38", "D0_POS_A"), ("D0-A", "37", "D0_NEG_A")]);
+    }
+
+    #[test]
+    fn physical_pin_plan_preserves_interior_signs_next_to_other_separators() {
+        assert_physical_pin_io_names(&[
+            ("SDA/AUX-", "4", "SDA_AUX_NEG"),
+            ("SDA/AUX-_B", "39", "SDA_AUX_NEG_B"),
+        ]);
+    }
+
+    #[test]
+    fn physical_pin_plan_preserves_bar_notation() {
+        assert_physical_pin_io_names(&[("Q", "1", "Q"), ("~{Q}", "2", "N_Q")]);
+    }
+
     #[test]
     fn connected_electrical_no_connect_pin_is_exposed() {
         let anchor = make_anchor("u1");

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -596,7 +596,8 @@ Board(name="MainBoard", layers=4, layout_path="layout/MainBoard")
 Board(name="my_board", layers=4, layout_path="layout/my_board")
 ```
 
-Key parameters: `name`, `layout_path`, `layers` (2/4/6/8/10), `config` (explicit `BoardConfig`), `outer_copper_weight` (`"1oz"` or `"2oz"`), `copper_finish` (default `"ENIG"`).
+Key parameters: `name`, `layout_path`, `layers`, `config` (explicit `BoardConfig`), `outer_copper_weight` (`"1oz"` or `"2oz"`), and `copper_finish` (default `"ENIG"`).
+Default configurations are available for 2, 4, 6, 8, and 10 copper layers; other layer counts require an explicit configuration.
 
 When `layers` is provided, `Board()` selects an appropriate default stackup, netclasses, and design rules. An explicit `config` is merged on top. See `@stdlib/board_config.zen` for `BoardConfig`, `Stackup`, `DesignRules`, `NetClass`, and preset stackups.
 

--- a/lib/std/board_config.zen
+++ b/lib/std/board_config.zen
@@ -358,7 +358,7 @@ def DefaultBoardConfig(
     }.get(outer_copper_weight)
 
     if stackup == None:
-        print("Unsupported default stackup for layers: " + str(layers))
+        # Board() accepts layer counts without a default when the caller supplies an explicit config.
         return None
     if netclasses == None:
         print("Unsupported default netclasses for layers: " + str(layers))
@@ -411,7 +411,7 @@ def Board(
         layout_path: Path to the board layout file (e.g., PCB file)
         config: Optional BoardConfig overrides to merge with a layers-derived default.
                 If layers is not provided, this is used directly.
-        layers: Number of PCB layers (2, 4, 6, 8, or 10). Optional helper for deriving a default BoardConfig.
+        layers: Number of PCB layers. Counts 2, 4, 6, 8, and 10 have default configurations; other counts require an explicit config.
         outer_copper_weight: Outer copper weight ("1oz" or "2oz"). Default is "1oz".
                             Currently only 4-layer boards support 2oz outer copper.
         track_widths: Additional track widths (in mm) to append to the base configuration.


### PR DESCRIPTION
## Summary

- preserve prime marks and interior polarity signs when generating Zener pin identifiers, and disambiguate any remaining sanitizer collisions
- add regression coverage for `QH`/`QH'`, interior `+`/`-`, separator-adjacent signs, and KiCad bar notation
- reconstruct KiCad's numeric `unconnected-*` suffixes from layout pad metadata before generating connectivity
- preserve complete KiCad stackups for even copper-layer counts from 2 through 32 instead of silently falling back to four layers

The generated-board physical-pin partition validation remains blocking, so an imported board cannot pass when generated connectivity differs from the source partition.

No board corpus data, generated KiCad files, extraction reports, or other external artifacts are included in this PR.

## Verification

- `cargo test -p pcb-component-gen`
- `cargo test -p pcbc --bin pcbc` (156 passed)
- `cargo test -p pcbc --test import` (8 passed)
- `cargo test -p pcb-diode-api test_sanitize_pin_name --lib` (8 passed)
- standalone reimports of the RDIMM DDR5 tester and Jetson Orin baseboard passed generated physical-pin partition validation
- duplicate-IO corpus scan over both generated outputs found zero collisions
- project-mode RDIMM import preserved its complete 12-layer stackup, emitted `layers = 12`, and passed generated physical-pin partition validation
- generating a fresh KiCad layout from the imported stackup produced `F.Cu`, ten inner copper layers, and `B.Cu`

Fixes #1023

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the import connectivity and board-config path; behavior is stricter (more errors, different io names) but replaces prior silent mis-imports.
> 
> **Overview**
> **`pcb import`** no longer silently merges distinct physical pins or downgrades multi-layer boards when KiCad metadata is richer than the old heuristics allowed.
> 
> **Pin → Zener `io()` names:** `sanitize_pin_name` now encodes interior `+`/`-` as `_POS_`/`_NEG_`, prime marks as `_PRIME`, and `generated_signal_io_names` assigns numeric suffixes when punctuation still collides (e.g. `A/B` vs `A.B`). Import’s physical-pin plan picks up the same rules so generated connectivity matches KiCad partitions.
> 
> **Nets:** After layout extraction, collapsed `unconnected-*` nets are split again using pad net names from the PCB so KiCad’s `_1`, `_2`, … suffixes are restored before codegen.
> 
> **Stackup:** Copper layer count is accepted for even counts **2–32**; boards above 10 layers (or with stackup/layer mismatches) must parse a complete KiCad stackup instead of falling back to a default four-layer board. Stackup read failures for non-standard layer counts are now hard errors.
> 
> Docs and `Board()`/`board_config` text note that only 2/4/6/8/10 have default configs; other counts need an explicit `config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 471408ff77a021cf94bb7813a8ac0a0e2b623f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->