### PR TITLE
Flatten the panel's copper moment within a bounded per-layer trade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - `--layout-target` now takes `board` or `board-array` on every command, and defaults to `board-array`.
+- Copper balancing can shift a layer up to 1% off its target density to counterweight the rest of the stack, paid for by an opposite shift elsewhere.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - `--layout-target` now takes `board` or `board-array` on every command, and defaults to `board-array`.
+- Copper balancing now flattens the copper the panel actually carries about its mid-plane, rather than preserving whatever through-stack imbalance the boards were drawn with.
 - Copper balancing can shift a layer up to 1% off its target density to counterweight the rest of the stack, paid for by an opposite shift elsewhere.
+- The copper-balance summary reports the panel's stack moment before and after balancing.
 
 ### Removed
 

--- a/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
+++ b/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
@@ -125,25 +125,49 @@ For a proposed generated fill, let `rho_li` be the modeled final local density
 and:
 
 ```text
-e_li = rho_li - d_l
-m_i  = sum_l w_l e_li
+M_i = sum_l w_l rho_li
 ```
 
-`m_i` is a first-moment proxy for the stack asymmetry introduced by
-panelization at `x_i`. Equal residual density on mirrored layers cancels;
-thicker copper and copper farther from the mid-plane contribute more. Normalize
-the RMS metric by `W = sum_l abs(w_l)`:
+`M_i` is a first-moment proxy for the copper the panel actually carries about
+its mid-plane at `x_i`. Equal density on mirrored layers cancels; thicker
+copper and copper farther from the mid-plane contribute more. Normalize the RMS
+metric by `W = sum_l abs(w_l)`:
 
 ```text
-E_stack = sqrt(weighted_mean_i(m_i^2)) / W
+E_stack = sqrt(weighted_mean_i(M_i^2)) / W
 ```
 
-The reference is the board's own per-layer density, not zero copper moment.
-The optimizer therefore avoids adding new stack asymmetry without trying to
-repair immutable board content from the rails. Board-array creation prints a
-per-layer balance summary, warns when stackup thickness data is missing (the
-solver then balances each layer independently), and the per-layer report
-retains the signed stack weight.
+Penalizing this field pointwise is what covers both warp modes at once. Bow
+follows the field's mean, twist follows its variation, and squaring `M_i` at
+every site charges for both — so there is one term here rather than separate
+bow and twist machinery.
+
+The reference is zero copper moment, not the board's own per-layer density.
+Reading `rho_li` rather than `rho_li - d_l` is the whole difference: the
+subtracted form is zero exactly when every layer sits on its target, so a
+correctly balanced panel would report no asymmetry left to remove while still
+carrying whatever imbalance the boards were designed with. The optimizer
+therefore does repair immutable board content from the rails, which is
+deliberate — bow answers to the panel-integrated moment, so copper spent
+anywhere on the panel counts against it.
+
+That repair is bounded, because it is spending density the boards did not ask
+for. Two profile settings govern it, with separate jobs:
+
+- `stack_moment_weight` scales this term against the local density match, and
+  says how hard the solver tries. Equal weighting is far too timid to be
+  useful: with `L` layers the local term carries `L` squared errors against
+  this one, so a six-layer stack removes only about a sixth of a uniform
+  moment.
+- `stack_flex_density` caps how far any layer's density may end up from its
+  own target, whatever the weight asks for. It is the guarantee that survives
+  a pathological board: a two-layer panel poured 0.9 against 0.3 wants a 30%
+  correction, and the cap is what refuses it.
+
+Board-array creation prints a per-layer balance summary and the stack moment
+before and after, warns when stackup thickness data is missing (the solver then
+balances each layer independently and neither setting does anything), and the
+per-layer report retains the signed stack weight.
 
 ## One spatial solve
 
@@ -180,29 +204,49 @@ energy:
 
 ```text
 J(x) = sum_l mean_i(e_li^2)
-     + mean_i((m_i / W)^2)
+     + lambda mean_i((M_i / W)^2)
 ```
 
-subject to one box constraint and one equality per perforated layer:
+where `lambda` is `stack_moment_weight`.
+
+Each perforated layer carries a box constraint and a band on its total, and one
+equality couples the bands across the stack:
 
 ```text
-sum_i x_li = X_l
 r_min^2 <= x_li <= r_max^2
+X_l - D_l <= sum_i x_li <= X_l + D_l
+sum_l (sum_i x_li - X_l) / A_l = 0
 ```
 
 `X_l` is computed from the selected total void area after subtracting the
-already-clipped edge-fragment area. The equality therefore redistributes the
-full-void area without changing the layer-density result. Edge fragments keep
-their projected geometry; they are boundary constraints, not optimizer
-variables.
+already-clipped edge-fragment area. Edge fragments keep their projected
+geometry; they are boundary constraints, not optimizer variables.
 
-The objective is a convex quadratic. Its gradient uses the exact transpose
-`-beta P_l^T H^T` of the forward density operator. A fixed-count
-projected-gradient solve applies that gradient, then projects each layer onto
-the intersection of the box and sum constraints with one-dimensional
-bisection. A constant-radius pattern is the result when the measured fields
-and constraints are spatially symmetric; it is not a separate mode or
-fallback.
+`D_l` is `stack_flex_density` converted from density to squared radius through
+the density-domain area `A_l`, so the band is symmetric in copper. Without it
+each `sum_i x_li` is pinned and the layer can only redistribute; the band is
+what lets a layer take on or give back copper to flatten `M_i`.
+
+The joint equality is what keeps that useful. It says the stack's density
+deviations cancel — copper moves between layers rather than being created.
+Freeing each total independently instead frees a direction the stack cannot
+see: a symmetric stackup's weights sum to zero, so every layer drifting the
+same way leaves `M_i` untouched, and the local term will happily spend the
+whole band on exactly that drift, since bare clearance reads as a deficit on
+every layer at once.
+
+The objective is a convex quadratic and the feasible set is convex, so
+projected gradient converges as before. Its gradient uses the exact transpose
+`-beta P_l^T H^T` of the forward density operator. Projection is two-level:
+one linear equality over per-layer convex sets dualizes to a single
+multiplier, so each layer projects its own commonly shifted proposal onto its
+box and band, and the multiplier is found by bisection. A layer pinned at a
+band edge stops responding to the multiplier, so scoring a trial costs one
+clamped sum per layer rather than a nested projection. Setting
+`stack_flex_density` to zero makes every band degenerate and recovers the
+pinned per-layer projection exactly. A constant-radius pattern is the result
+when the measured fields and constraints are spatially symmetric; it is not a
+separate mode or fallback.
 
 ## Fill-to-geometry map
 
@@ -243,6 +287,10 @@ Initial verification should cover:
 - a left-to-right density gradient produces the opposite smooth radius
   gradient without changing generated area;
 - equal mirrored layers cancel in `E_stack`;
+- a stack carrying a copper moment ends with a smaller one, by layers trading
+  density in opposite directions rather than all drifting the same way;
+- no layer's achieved density leaves `stack_flex_density` of its target,
+  however large the moment; and zero flex reproduces the pinned result;
 - conductor thickness and mid-plane distance scale the metric correctly;
 - translation and reflection preserve objective values; and
 - clipped edge voids preserve the existing web and minimum-fragment rules; and

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -894,6 +894,7 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
         },
     )
     .unwrap()
+    .layers
     .pop()
     .unwrap();
     let features = balance_features(&balance).unwrap();

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -159,8 +159,38 @@ pub struct CopperBalanceReport {
 }
 
 impl CopperBalanceReport {
-    /// One short status line per copper layer, plus a warning when the
-    /// stackup could not supply physical stack weights.
+    /// The panel's normalized copper moment about the stack mid-plane, as it
+    /// would stand with every layer on its target and as it actually stands.
+    ///
+    /// The first is what the boards were drawn carrying; the second is what
+    /// the balanced panel carries after layers traded density to flatten it.
+    /// `None` when the stackup supplied no weights, which is also when the
+    /// solver leaves the moment alone.
+    pub fn stack_moments(&self) -> Option<(f64, f64)> {
+        let scale = self
+            .layers
+            .iter()
+            .map(|layer| layer.stack_weight_mm2.abs())
+            .sum::<f64>();
+        if !self.stack_weights_available || scale <= 0.0 {
+            return None;
+        }
+        let moment = |density: fn(&CopperBalanceLayerReport) -> f64| {
+            self.layers
+                .iter()
+                .map(|layer| layer.stack_weight_mm2 * density(layer))
+                .sum::<f64>()
+                / scale
+        };
+        Some((
+            moment(|layer| layer.target_density),
+            moment(|layer| layer.achieved_density),
+        ))
+    }
+
+    /// One short status line per copper layer, the stack moment the trade
+    /// moved, plus a warning when the stackup could not supply physical stack
+    /// weights.
     pub fn summary_lines(&self) -> Vec<String> {
         let mut lines = self
             .layers
@@ -189,6 +219,11 @@ impl CopperBalanceReport {
                 )
             })
             .collect::<Vec<_>>();
+        if let Some((untouched, achieved)) = self.stack_moments() {
+            lines.push(format!(
+                "balance: stack moment {untouched:.4} -> {achieved:.4}"
+            ));
+        }
         if !self.layers.is_empty() && !self.stack_weights_available {
             lines.push(
                 "balance: stackup thickness data unavailable; layers balanced independently"

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -17,7 +17,7 @@ use ipc2581::types::{
 use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::geom::copper_balance::{
     DenseCopperBalanceMode, DenseCopperBalanceProfile, DenseCopperBalanceResult,
-    SpatialCopperBalanceLayerRequest, SpatialCopperBalanceRequest,
+    SpatialCopperBalanceLayerRequest, SpatialCopperBalanceRequest, StackMomentField,
     generate_spatial_dense_copper_balance, rounded_hexagonal_void,
 };
 use pcb_ir::geom::region::simplify_shapes;
@@ -110,6 +110,9 @@ pub struct CopperBalancePlan {
     /// Whether the physical stackup supplied signed stack weights. When false,
     /// every layer balances independently with zero through-stack coupling.
     pub stack_weights_available: bool,
+    /// What the solve did to the panel's copper-moment field, when the stackup
+    /// supplied the weights to measure it.
+    pub moment_field: Option<StackMomentField>,
     pub layers: Vec<CopperBalanceLayer>,
 }
 
@@ -155,6 +158,10 @@ pub struct CopperBalanceReport {
     pub panel_area_mm2: f64,
     pub footprint_area_mm2: f64,
     pub stack_weights_available: bool,
+    /// RMS of the copper-moment field before and after the spatial solve.
+    /// Carries bow and twist together, where
+    /// [`CopperBalanceReport::stack_moments`] carries bow alone.
+    pub moment_field_rms: Option<(f64, f64)>,
     pub layers: Vec<CopperBalanceLayerReport>,
 }
 
@@ -220,8 +227,13 @@ impl CopperBalanceReport {
             })
             .collect::<Vec<_>>();
         if let Some((untouched, achieved)) = self.stack_moments() {
+            let field = self
+                .moment_field_rms
+                .map_or(String::new(), |(before, after)| {
+                    format!(" (field rms {before:.4} -> {after:.4})")
+                });
             lines.push(format!(
-                "balance: stack moment {untouched:.4} -> {achieved:.4}"
+                "balance: stack moment {untouched:.4} -> {achieved:.4}{field}"
             ));
         }
         if !self.layers.is_empty() && !self.stack_weights_available {
@@ -241,6 +253,9 @@ impl CopperBalancePlan {
             panel_area_mm2: self.panel_area_mm2,
             footprint_area_mm2: self.footprints.area(),
             stack_weights_available: self.stack_weights_available,
+            moment_field_rms: self
+                .moment_field
+                .map(|field| (field.initial_rms, field.achieved_rms)),
             layers: self
                 .layers
                 .iter()
@@ -309,7 +324,7 @@ pub fn solve_copper_balance(
             stack_weight_mm2: layer.stack_weight_mm2,
         })
         .collect::<Vec<_>>();
-    let results = generate_spatial_dense_copper_balance(
+    let balance = generate_spatial_dense_copper_balance(
         DenseCopperBalanceProfile::V1,
         SpatialCopperBalanceRequest {
             panel_region,
@@ -321,7 +336,7 @@ pub fn solve_copper_balance(
 
     let layers = prepared
         .into_iter()
-        .zip(results)
+        .zip(balance.layers)
         .map(|(layer, result)| {
             let features = balance_features(&result)?;
             Ok(CopperBalanceLayer {
@@ -340,6 +355,7 @@ pub fn solve_copper_balance(
         footprints,
         panel_area_mm2: panel_region.area(),
         stack_weights_available,
+        moment_field: balance.moment_field,
         layers,
     })
 }
@@ -631,6 +647,7 @@ mod tests {
             },
         )
         .unwrap()
+        .layers
         .pop()
         .unwrap();
         let features = balance_features(&result).unwrap();

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -152,6 +152,25 @@ pub enum CopperBalanceMode {
     Perforated,
 }
 
+/// RMS of the panel's copper-moment field before and after the spatial solve.
+///
+/// Named separately from [`StackMomentField`] only because the report is
+/// serializable and `pcb-ir` carries no serde dependency.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct StackMomentFieldReport {
+    pub initial_rms: f64,
+    pub achieved_rms: f64,
+}
+
+impl From<StackMomentField> for StackMomentFieldReport {
+    fn from(field: StackMomentField) -> Self {
+        Self {
+            initial_rms: field.initial_rms,
+            achieved_rms: field.achieved_rms,
+        }
+    }
+}
+
 /// Compact, serializable accounting for a completed automatic balance plan.
 #[derive(Debug, Clone, Serialize)]
 pub struct CopperBalanceReport {
@@ -161,7 +180,7 @@ pub struct CopperBalanceReport {
     /// RMS of the copper-moment field before and after the spatial solve.
     /// Carries bow and twist together, where
     /// [`CopperBalanceReport::stack_moments`] carries bow alone.
-    pub moment_field_rms: Option<(f64, f64)>,
+    pub moment_field: Option<StackMomentFieldReport>,
     pub layers: Vec<CopperBalanceLayerReport>,
 }
 
@@ -174,14 +193,14 @@ impl CopperBalanceReport {
     /// `None` when the stackup supplied no weights, which is also when the
     /// solver leaves the moment alone.
     pub fn stack_moments(&self) -> Option<(f64, f64)> {
+        // The solver already decided whether the moment was modelled at all;
+        // deciding it a second time here is how the two drift apart.
+        self.moment_field?;
         let scale = self
             .layers
             .iter()
             .map(|layer| layer.stack_weight_mm2.abs())
             .sum::<f64>();
-        if !self.stack_weights_available || scale <= 0.0 {
-            return None;
-        }
         let moment = |density: fn(&CopperBalanceLayerReport) -> f64| {
             self.layers
                 .iter()
@@ -226,14 +245,12 @@ impl CopperBalanceReport {
                 )
             })
             .collect::<Vec<_>>();
-        if let Some((untouched, achieved)) = self.stack_moments() {
-            let field = self
-                .moment_field_rms
-                .map_or(String::new(), |(before, after)| {
-                    format!(" (field rms {before:.4} -> {after:.4})")
-                });
+        if let (Some((untouched, achieved)), Some(field)) =
+            (self.stack_moments(), self.moment_field)
+        {
             lines.push(format!(
-                "balance: stack moment {untouched:.4} -> {achieved:.4}{field}"
+                "balance: stack moment {untouched:.4} -> {achieved:.4} (field rms {:.4} -> {:.4})",
+                field.initial_rms, field.achieved_rms
             ));
         }
         if !self.layers.is_empty() && !self.stack_weights_available {
@@ -253,9 +270,7 @@ impl CopperBalancePlan {
             panel_area_mm2: self.panel_area_mm2,
             footprint_area_mm2: self.footprints.area(),
             stack_weights_available: self.stack_weights_available,
-            moment_field_rms: self
-                .moment_field
-                .map(|field| (field.initial_rms, field.achieved_rms)),
+            moment_field: self.moment_field.map(StackMomentFieldReport::from),
             layers: self
                 .layers
                 .iter()

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -1684,9 +1684,16 @@ mod tests {
         // unfillable, and stays out of its denominator.
         let top_domain = top_copper.union(&safe);
         let bottom_domain = bottom_copper.union(&safe);
+        // This is the redistribution the stack weights drive at a fixed copper
+        // area, so the band stays shut: with it open the two solves are free
+        // to trade area as well, and the area assertion below would be
+        // asserting the opposite of what the band exists to allow.
         let solve = |stack_weight_mm2: f64| {
             generate_spatial_dense_copper_balance(
-                DenseCopperBalanceProfile::V1,
+                DenseCopperBalanceProfile {
+                    stack_flex_density: 0.0,
+                    ..DenseCopperBalanceProfile::V1
+                },
                 SpatialCopperBalanceRequest {
                     panel_region: &panel,
                     lattice_origin: Point::ZERO,

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -566,7 +566,10 @@ pub fn generate_spatial_dense_copper_balance(
         .map(|(layer_index, sum)| {
             let slack = profile.stack_flex_density * density_domain_areas[layer_index]
                 / ROUNDED_HEXAGON_AREA_FACTOR;
-            let site_count = active_sites[layer_index].len() as f64;
+            // A layer that took no lattice has no radii to trade with, and its
+            // sites are not its own to spend: sizing the box range from them
+            // would put the band above a sum that is fixed at zero.
+            let site_count = squared_radii[layer_index].len() as f64;
             (
                 (sum - slack).max(site_count * profile.min_void_radius_mm.powi(2)),
                 (sum + slack).min(site_count * profile.max_void_radius_mm.powi(2)),
@@ -1535,6 +1538,61 @@ mod tests {
         assert!(
             (result.solution.generated_area_mm2 - baseline.solution.generated_area_mm2).abs()
                 <= AREA_SOLVE_TOLERANCE_MM2 + quantization_bound_mm2
+        );
+    }
+
+    /// A layer that takes no lattice still sits in the joint solve, and its
+    /// band has to describe a sum that cannot move. Sizing that band from the
+    /// sites it declined would place it above zero and invert it.
+    #[test]
+    fn a_layer_without_a_lattice_keeps_a_degenerate_band() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(30.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let empty = ContourSet::empty(tol::REGION_MM);
+        // A target its whole safe region cannot reach saturates this layer to
+        // a solid pour, leaving it no radii while its sites still exist.
+        let results = generate_spatial_dense_copper_balance(
+            DenseCopperBalanceProfile {
+                stack_flex_density: 0.01,
+                ..DenseCopperBalanceProfile::V1
+            },
+            SpatialCopperBalanceRequest {
+                panel_region: &panel,
+                lattice_origin: Point::ZERO,
+                layers: &[
+                    SpatialCopperBalanceLayerRequest {
+                        safe_region: &panel,
+                        existing_copper: &empty,
+                        density_domain: &panel,
+                        target_density: 1.0,
+                        stack_weight_mm2: 1.0,
+                    },
+                    SpatialCopperBalanceLayerRequest {
+                        safe_region: &panel,
+                        existing_copper: &empty,
+                        density_domain: &panel,
+                        target_density: 0.5,
+                        stack_weight_mm2: -1.0,
+                    },
+                ],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(results[0].solution.mode, DenseCopperBalanceMode::Solid);
+        assert!(matches!(
+            results[1].solution.mode,
+            DenseCopperBalanceMode::Perforated { .. }
+        ));
+        // The saturated layer cannot trade, so the free layer has no partner
+        // and stays on its own target.
+        assert!(
+            (results[1].solution.achieved_density - results[1].solution.target_density).abs()
+                <= 5e-3,
+            "{:?}",
+            results[1].solution
         );
     }
 

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -79,7 +79,7 @@ impl DenseCopperBalanceProfile {
         boundary_web_mm: 0.20,
         density_sigma_mm: 5.0,
         void_radius_step_mm: 0.005,
-        stack_flex_density: 0.0,
+        stack_flex_density: 0.01,
     };
 
     pub fn lattice_column_pitch_mm(self) -> f64 {

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -592,25 +592,38 @@ pub fn generate_spatial_dense_copper_balance(
     // symmetric band on the squared-radius sum. Clamping to the range the box
     // itself can reach keeps the feasible set nonempty, and since each uniform
     // sum is already inside that range the band always contains its own center.
+    let normalized_stack_weights = normalized_stack_weights(request.layers);
+    // A stackup that located no conductors leaves every weight zero, so there
+    // is no moment to flatten and nothing to spend the bands on. Holding them
+    // shut is what keeps "balanced independently" true: an open band would
+    // still let the local density error trade layers off their targets.
+    let weights_measured = normalized_stack_weights.iter().any(|weight| *weight != 0.0);
     let squared_radius_bands = squared_radius_sums
         .iter()
         .enumerate()
         .map(|(layer_index, sum)| {
-            let slack = profile.stack_flex_density * density_domain_areas[layer_index]
-                / ROUNDED_HEXAGON_AREA_FACTOR;
+            let slack = if weights_measured {
+                profile.stack_flex_density * density_domain_areas[layer_index]
+                    / ROUNDED_HEXAGON_AREA_FACTOR
+            } else {
+                0.0
+            };
             // A layer that took no lattice has no radii to trade with, and its
             // sites are not its own to spend: sizing the box range from them
             // would put the band above a sum that is fixed at zero.
             let site_count = squared_radii[layer_index].len() as f64;
+            // The band always contains the sum it surrounds. Reaching that
+            // through the clamps alone would rest on an accumulated sum
+            // comparing exactly against a multiplied bound, and a layer whose
+            // radii all sit on one bound can round across it.
             (
-                (sum - slack).max(site_count * lower),
-                (sum + slack).min(site_count * upper),
+                (sum - slack).max(site_count * lower).min(*sum),
+                (sum + slack).min(site_count * upper).max(*sum),
             )
         })
         .collect::<Vec<_>>();
     let cell_area_mm2 = SQRT_3 * profile.pitch_mm.powi(2) / 2.0;
     let void_fraction_per_radius_squared = ROUNDED_HEXAGON_AREA_FACTOR / cell_area_mm2;
-    let normalized_stack_weights = normalized_stack_weights(request.layers);
     let target_densities = request
         .layers
         .iter()
@@ -795,9 +808,6 @@ pub fn generate_spatial_dense_copper_balance(
         }
     }
 
-    // A stackup that supplied no weights leaves the field identically zero,
-    // which is an absence of measurement rather than a flat panel.
-    let weights_measured = normalized_stack_weights.iter().any(|weight| *weight != 0.0);
     Ok(SpatialCopperBalance {
         layers: uniform
             .into_iter()
@@ -1672,6 +1682,101 @@ mod tests {
             "{:?}",
             results[1].solution
         );
+    }
+
+    /// A layer whose radii all sit on one bound is where the band is most
+    /// fragile: its accumulated sum is compared against a multiplied bound, so
+    /// rounding can carry it across, and with the band shut there is no slack
+    /// to absorb that. The band has to hold the sum it surrounds regardless.
+    #[test]
+    fn a_saturated_radius_field_still_yields_a_usable_band() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(30.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let empty = ContourSet::empty(tol::REGION_MM);
+        // Just under the sparsest fill the lattice can reach, so a perforated
+        // plane is still the nearest projection but every radius pins to the
+        // maximum; zero weights hold the band shut around that sum.
+        let results = generate_spatial_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            SpatialCopperBalanceRequest {
+                panel_region: &panel,
+                lattice_origin: Point::ZERO,
+                layers: &[SpatialCopperBalanceLayerRequest {
+                    safe_region: &panel,
+                    existing_copper: &empty,
+                    density_domain: &panel,
+                    target_density: 0.30,
+                    stack_weight_mm2: 0.0,
+                }],
+            },
+        )
+        .unwrap();
+
+        let (min, max) = results.layers[0]
+            .full_void_radius_range_mm()
+            .expect("a perforated layer has voids");
+        assert!(
+            (max - DenseCopperBalanceProfile::V1.max_void_radius_mm).abs() <= 1e-9,
+            "expected saturated radii, got {min}..{max}"
+        );
+    }
+
+    /// Without stack weights there is no moment to flatten, so the bands buy
+    /// nothing and must stay shut. An open band would still let the local
+    /// density error trade layers off their targets, which is exactly what a
+    /// panel told its layers were balanced independently must not do.
+    #[test]
+    fn layers_hold_their_targets_when_the_stackup_weighs_nothing() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        // Fixed copper on one layer only, so the two layers see different
+        // local fields and would trade if anything let them.
+        let left_copper = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let safe = ContourSet::rectangle(
+            BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let empty = ContourSet::empty(tol::REGION_MM);
+        let results = generate_spatial_dense_copper_balance(
+            DenseCopperBalanceProfile::V1,
+            SpatialCopperBalanceRequest {
+                panel_region: &panel,
+                lattice_origin: Point::ZERO,
+                layers: &[
+                    SpatialCopperBalanceLayerRequest {
+                        safe_region: &safe,
+                        existing_copper: &left_copper,
+                        density_domain: &panel,
+                        target_density: 0.75,
+                        stack_weight_mm2: 0.0,
+                    },
+                    SpatialCopperBalanceLayerRequest {
+                        safe_region: &safe,
+                        existing_copper: &empty,
+                        density_domain: &safe,
+                        target_density: 0.5,
+                        stack_weight_mm2: 0.0,
+                    },
+                ],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(results.moment_field, None);
+        for result in &results.layers {
+            assert!(
+                (result.solution.achieved_density - result.solution.target_density).abs() <= 5e-3,
+                "{:?}",
+                result.solution
+            );
+        }
     }
 
     /// The field metric reports what the solve did to the moment, and reports

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -245,6 +245,29 @@ pub struct DenseCopperVoid {
     pub radius_mm: f64,
 }
 
+/// What the panel's copper-moment field measured before the spatial solve
+/// redistributed anything, and after it settled.
+///
+/// The field's mean is the panel's bow and its variation is twist, so an RMS
+/// carries both: a falling RMS means the field flattened, not merely that a
+/// positive lobe found a negative one to cancel against. Comparing it against
+/// the mean alone separates the two — a mean that drops while the RMS holds
+/// has moved bow into twist.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StackMomentField {
+    pub initial_rms: f64,
+    pub achieved_rms: f64,
+}
+
+/// Every layer's solved geometry, plus what the solve did to the stack.
+#[derive(Debug, Clone)]
+pub struct SpatialCopperBalance {
+    pub layers: Vec<DenseCopperBalanceResult>,
+    /// `None` when the stackup supplied no weights, and so nothing was
+    /// measured, or when no layer took a lattice and no solve ran.
+    pub moment_field: Option<StackMomentField>,
+}
+
 /// Selected density solution plus its canonical copper geometry.
 #[derive(Debug, Clone)]
 pub struct DenseCopperBalanceResult {
@@ -398,7 +421,7 @@ fn generate_dense_copper_balance_with_lattice(
 pub fn generate_spatial_dense_copper_balance(
     profile: DenseCopperBalanceProfile,
     request: SpatialCopperBalanceRequest<'_>,
-) -> Result<Vec<DenseCopperBalanceResult>, DenseCopperBalanceError> {
+) -> Result<SpatialCopperBalance, DenseCopperBalanceError> {
     profile.validate()?;
     validate_spatial_request(request)?;
     let density_domain_areas = request
@@ -502,7 +525,10 @@ pub fn generate_spatial_dense_copper_balance(
         })
         .collect::<Vec<_>>();
     if active_sites.iter().all(Vec::is_empty) {
-        return Ok(uniform);
+        return Ok(SpatialCopperBalance {
+            layers: uniform,
+            moment_field: None,
+        });
     }
 
     // The objective lives on one coarse subset of the panel lattice. Every
@@ -604,6 +630,11 @@ pub fn generate_spatial_dense_copper_balance(
         .map(|_| vec![0.0; panel_samples.len()])
         .collect::<Vec<_>>();
     let mut influence_scratch = void_scratch.clone();
+    // The moment field is already built every iteration, so its RMS costs a
+    // reduction. The first reading is the field the uniform selection left
+    // behind; the last trails the emitted radii by one gradient step, which at
+    // convergence is smaller than the radius quantization.
+    let mut moment_rms: Option<(f64, f64)> = None;
     for _ in 0..SPATIAL_SOLVE_ITERATIONS {
         // The modeled final copper fraction of each layer, not its distance
         // from target: the moment below is the copper the panel carries, and
@@ -677,6 +708,14 @@ pub fn generate_spatial_dense_copper_balance(
                     .sum::<f64>()
             })
             .collect::<Vec<_>>();
+        let rms = (stack_moment
+            .iter()
+            .map(|moment| moment * moment)
+            .sum::<f64>()
+            / stack_moment.len() as f64)
+            .sqrt();
+        let initial_rms = moment_rms.map_or(rms, |(initial, _)| initial);
+        moment_rms = Some((initial_rms, rms));
 
         let proposals = std::thread::scope(|scope| {
             let active_sites = &active_sites;
@@ -756,23 +795,34 @@ pub fn generate_spatial_dense_copper_balance(
         }
     }
 
-    Ok(uniform
-        .into_iter()
-        .enumerate()
-        .map(|(layer_index, baseline)| {
-            if squared_radii[layer_index].is_empty() {
-                return baseline;
-            }
-            spatial_result_from_squared_radii(
-                &region_lattices[layer_regions[layer_index]].full_centers,
-                &squared_radii[layer_index],
-                baseline,
-                request.layers[layer_index],
-                density_domain_areas[layer_index],
-                profile,
-            )
-        })
-        .collect())
+    // A stackup that supplied no weights leaves the field identically zero,
+    // which is an absence of measurement rather than a flat panel.
+    let weights_measured = normalized_stack_weights.iter().any(|weight| *weight != 0.0);
+    Ok(SpatialCopperBalance {
+        layers: uniform
+            .into_iter()
+            .enumerate()
+            .map(|(layer_index, baseline)| {
+                if squared_radii[layer_index].is_empty() {
+                    return baseline;
+                }
+                spatial_result_from_squared_radii(
+                    &region_lattices[layer_regions[layer_index]].full_centers,
+                    &squared_radii[layer_index],
+                    baseline,
+                    request.layers[layer_index],
+                    density_domain_areas[layer_index],
+                    profile,
+                )
+            })
+            .collect(),
+        moment_field: moment_rms
+            .filter(|_| weights_measured)
+            .map(|(initial_rms, achieved_rms)| StackMomentField {
+                initial_rms,
+                achieved_rms,
+            }),
+    })
 }
 
 /// Whether `outer` contains `inner`, ignoring boolean sliver artifacts.
@@ -1185,7 +1235,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(result.is_empty());
+        assert!(result.layers.is_empty());
     }
 
     #[test]
@@ -1321,6 +1371,7 @@ mod tests {
             },
         )
         .unwrap()
+        .layers
         .pop()
         .unwrap();
 
@@ -1359,6 +1410,7 @@ mod tests {
             },
         )
         .unwrap()
+        .layers
         .pop()
         .unwrap();
 
@@ -1413,6 +1465,7 @@ mod tests {
             },
         )
         .unwrap()
+        .layers
         .pop()
         .unwrap();
 
@@ -1479,7 +1532,8 @@ mod tests {
                 layers: &layers,
             },
         )
-        .unwrap();
+        .unwrap()
+        .layers;
 
         assert_eq!(results.len(), 2);
         assert!(results[0].usable.difference(&left).is_empty());
@@ -1543,6 +1597,7 @@ mod tests {
             },
         )
         .unwrap()
+        .layers
         .pop()
         .unwrap();
         let mean_radius = |minimum_x: f64, maximum_x: f64| {
@@ -1601,7 +1656,8 @@ mod tests {
                 ],
             },
         )
-        .unwrap();
+        .unwrap()
+        .layers;
 
         assert_eq!(results[0].solution.mode, DenseCopperBalanceMode::Solid);
         assert!(matches!(
@@ -1616,6 +1672,52 @@ mod tests {
             "{:?}",
             results[1].solution
         );
+    }
+
+    /// The field metric reports what the solve did to the moment, and reports
+    /// nothing at all when the stackup gave it no weights to measure with —
+    /// an absence of measurement rather than a flat panel.
+    #[test]
+    fn moment_field_is_measured_only_when_the_stackup_weighs_the_layers() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let empty = ContourSet::empty(tol::REGION_MM);
+        let solve = |stack_weight_mm2: f64| {
+            generate_spatial_dense_copper_balance(
+                DenseCopperBalanceProfile::V1,
+                SpatialCopperBalanceRequest {
+                    panel_region: &panel,
+                    lattice_origin: Point::ZERO,
+                    layers: &[
+                        SpatialCopperBalanceLayerRequest {
+                            safe_region: &panel,
+                            existing_copper: &empty,
+                            density_domain: &panel,
+                            target_density: 0.70,
+                            stack_weight_mm2,
+                        },
+                        SpatialCopperBalanceLayerRequest {
+                            safe_region: &panel,
+                            existing_copper: &empty,
+                            density_domain: &panel,
+                            target_density: 0.40,
+                            stack_weight_mm2: -stack_weight_mm2,
+                        },
+                    ],
+                },
+            )
+            .unwrap()
+        };
+
+        assert_eq!(solve(0.0).moment_field, None);
+
+        let weighed = solve(1.0).moment_field.expect("weights were supplied");
+        // These layers are asked for markedly different densities, so the
+        // field starts well away from zero and the solve flattens it.
+        assert!(weighed.initial_rms > 0.0, "{weighed:?}");
+        assert!(weighed.achieved_rms < weighed.initial_rms, "{weighed:?}");
     }
 
     /// Two layers that both sit exactly on their targets can still carry a
@@ -1661,6 +1763,7 @@ mod tests {
                 },
             )
             .unwrap()
+            .layers
         };
         // Mirrored weights normalize to +/- 0.5, so this is the moment.
         let moment = |results: &[DenseCopperBalanceResult]| {
@@ -1753,6 +1856,7 @@ mod tests {
                 },
             )
             .unwrap()
+            .layers
         };
         // Radius quantization alone moves the achieved density this far.
         let quantization = 5e-3;
@@ -1844,6 +1948,7 @@ mod tests {
                 },
             )
             .unwrap()
+            .layers
         };
         let independent = solve(0.0);
         let stack_aware = solve(1.0);

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -51,21 +51,36 @@ pub struct DenseCopperBalanceProfile {
     /// cannot hold finer distinctions, and the shared grid keeps the voids a
     /// small set of repeated templates instead of thousands of unique shapes.
     pub void_radius_step_mm: f64,
-    /// How far a layer's density may drift from its target to counterweight
-    /// the stack, as a fraction of its density domain.
+    /// How far a layer's density may end up from its target to flatten the
+    /// stack's copper moment, as a fraction of its density domain.
     ///
     /// The spatial solve otherwise conserves each layer's selected copper area
     /// exactly, which lets it redistribute copper but never trade a little of
-    /// one layer's density match for a flatter through-stack moment. This band
-    /// frees that trade and bounds it: no layer's achieved density leaves this
-    /// distance from its target. Zero pins every layer to its uniform
-    /// selection, the behavior before the band existed.
+    /// one layer's density match for a flatter moment. This band frees that
+    /// trade and is the bound on it: no layer's achieved density leaves this
+    /// distance from its target, whatever [`Self::stack_moment_weight`] asks
+    /// for. Zero pins every layer to its uniform selection, the behavior
+    /// before the band existed, and nothing below can move it.
     ///
-    /// The trade needs no weight of its own. Both terms already sit in the
-    /// objective, so a layer spends the band only while `w_l |m|` exceeds its
-    /// own growing density error, and never spends it at all when the stackup
-    /// supplies no weights.
+    /// The cap earns its keep on boards the weight alone would maul. A
+    /// two-layer panel poured 0.9 against 0.3 carries a moment worth a 30%
+    /// correction; this is what refuses to spend it.
     pub stack_flex_density: f64,
+    /// How hard the through-stack moment competes with each layer's own
+    /// density match.
+    ///
+    /// The objective already holds both terms, so this only sets their
+    /// exchange rate — but leaving it at one is far too timid to be useful.
+    /// The local term contributes one squared error per layer against this
+    /// term's one, so the moment that survives is `M_0 / (1 + w * sum_l w_l^2)`
+    /// and a six-layer stack sheds only about a sixth of it. Raising the
+    /// weight moves that toward zero; [`Self::stack_flex_density`] is what
+    /// keeps the correction bounded while it does.
+    ///
+    /// Zero drops the moment from the objective, leaving each layer to match
+    /// its own density alone. A stackup that supplies no weights reaches the
+    /// same place on its own, whatever this is set to.
+    pub stack_moment_weight: f64,
 }
 
 impl DenseCopperBalanceProfile {
@@ -79,6 +94,7 @@ impl DenseCopperBalanceProfile {
         density_sigma_mm: 5.0,
         void_radius_step_mm: 0.005,
         stack_flex_density: 0.01,
+        stack_moment_weight: 10.0,
     };
 
     pub fn lattice_column_pitch_mm(self) -> f64 {
@@ -123,6 +139,11 @@ impl DenseCopperBalanceProfile {
         if !self.stack_flex_density.is_finite() || !(0.0..=1.0).contains(&self.stack_flex_density) {
             return Err(DenseCopperBalanceError::InvalidProfile(
                 "stack flex density must be between zero and one".to_string(),
+            ));
+        }
+        if !self.stack_moment_weight.is_finite() || self.stack_moment_weight < 0.0 {
+            return Err(DenseCopperBalanceError::InvalidProfile(
+                "stack moment weight must be finite and non-negative".to_string(),
             ));
         }
         if self.min_void_radius_mm > self.max_void_radius_mm {
@@ -564,6 +585,11 @@ pub fn generate_spatial_dense_copper_balance(
     let cell_area_mm2 = SQRT_3 * profile.pitch_mm.powi(2) / 2.0;
     let void_fraction_per_radius_squared = ROUNDED_HEXAGON_AREA_FACTOR / cell_area_mm2;
     let normalized_stack_weights = normalized_stack_weights(request.layers);
+    let target_densities = request
+        .layers
+        .iter()
+        .map(|layer| layer.target_density)
+        .collect::<Vec<_>>();
     let step = 0.25 / void_fraction_per_radius_squared.powi(2);
 
     // Updates below this leave every radius well inside half a quantization
@@ -579,7 +605,11 @@ pub fn generate_spatial_dense_copper_balance(
         .collect::<Vec<_>>();
     let mut influence_scratch = void_scratch.clone();
     for _ in 0..SPATIAL_SOLVE_ITERATIONS {
-        let error = std::thread::scope(|scope| {
+        // The modeled final copper fraction of each layer, not its distance
+        // from target: the moment below is the copper the panel carries, and
+        // subtracting the targets would leave it blind to whatever imbalance
+        // the boards were designed with.
+        let density = std::thread::scope(|scope| {
             let uniform = &uniform;
             let active_sites = &active_sites;
             let fixed_density = &fixed_density;
@@ -588,12 +618,10 @@ pub fn generate_spatial_dense_copper_balance(
             let partial_void_density = &partial_void_density;
             let density_kernel = &density_kernel;
             let evaluation_points = &evaluation_points;
-            let handles = request
-                .layers
-                .iter()
-                .zip(void_scratch.iter_mut())
+            let handles = void_scratch
+                .iter_mut()
                 .enumerate()
-                .map(|(layer_index, (layer, void_fraction))| {
+                .map(|(layer_index, void_fraction)| {
                     let squared_radii = &squared_radii;
                     scope.spawn(move || {
                         let void_density = match uniform[layer_index].solution.mode {
@@ -626,7 +654,7 @@ pub fn generate_spatial_dense_copper_balance(
                                             - void_density[site_index]
                                     }
                                 };
-                                fixed + generated_density - layer.target_density
+                                fixed + generated_density
                             })
                             .collect::<Vec<_>>()
                     })
@@ -634,15 +662,18 @@ pub fn generate_spatial_dense_copper_balance(
                 .collect::<Vec<_>>();
             handles
                 .into_iter()
-                .map(|handle| handle.join().expect("spatial error pass panicked"))
+                .map(|handle| handle.join().expect("spatial density pass panicked"))
                 .collect::<Vec<_>>()
         });
-        let stack_error = (0..evaluation_points.len())
+        // The panel's copper moment about its mid-plane. Squaring this field
+        // pointwise charges for both warp modes at once: bow is its mean,
+        // twist is its variation.
+        let stack_moment = (0..evaluation_points.len())
             .map(|site_index| {
                 normalized_stack_weights
                     .iter()
                     .enumerate()
-                    .map(|(layer_index, weight)| weight * error[layer_index][site_index])
+                    .map(|(layer_index, weight)| weight * density[layer_index][site_index])
                     .sum::<f64>()
             })
             .collect::<Vec<_>>();
@@ -656,17 +687,24 @@ pub fn generate_spatial_dense_copper_balance(
                 .zip(influence_scratch.iter_mut())
                 .enumerate()
                 .map(|(layer_index, (radii, influence))| {
-                    let error = &error;
-                    let stack_error = &stack_error;
+                    let density = &density;
+                    let stack_moment = &stack_moment;
+                    let target_densities = &target_densities;
                     scope.spawn(move || {
                         if radii.is_empty() {
                             return Vec::new();
                         }
-                        let residual = error[layer_index]
+                        // Its own density error, plus its share of the moment
+                        // it helps carry, weighted by how hard the moment is
+                        // allowed to argue.
+                        let residual = density[layer_index]
                             .iter()
-                            .zip(stack_error)
-                            .map(|(local, stack)| {
-                                local + normalized_stack_weights[layer_index] * stack
+                            .zip(stack_moment)
+                            .map(|(density, moment)| {
+                                (density - target_densities[layer_index])
+                                    + profile.stack_moment_weight
+                                        * normalized_stack_weights[layer_index]
+                                        * moment
                             })
                             .collect::<Vec<_>>();
                         density_kernel.smooth_adjoint_into(&residual, influence);
@@ -1062,6 +1100,7 @@ mod tests {
             density_sigma_mm: 5.0,
             void_radius_step_mm: 0.005,
             stack_flex_density: 0.0,
+            stack_moment_weight: 0.0,
         };
         profile.validate().unwrap();
         let safe_region = ContourSet::rectangle(
@@ -1579,10 +1618,98 @@ mod tests {
         );
     }
 
+    /// Two layers that both sit exactly on their targets can still carry a
+    /// copper moment, because their targets differ and the boards were drawn
+    /// that way. Balancing against the deviation from target cannot see it —
+    /// the deviations are zero. Balancing against the copper itself does, and
+    /// spends the band pulling the heavy layer down and the light one up.
+    #[test]
+    fn stack_moment_shrinks_when_the_boards_themselves_are_asymmetric() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let empty = ContourSet::empty(tol::REGION_MM);
+        // Mirrored layers, no fixed copper, but one is asked for markedly more
+        // copper than the other: the imbalance is in the targets themselves.
+        let (heavy, light) = (0.70, 0.40);
+        let solve = |stack_moment_weight: f64| {
+            generate_spatial_dense_copper_balance(
+                DenseCopperBalanceProfile {
+                    stack_moment_weight,
+                    ..DenseCopperBalanceProfile::V1
+                },
+                SpatialCopperBalanceRequest {
+                    panel_region: &panel,
+                    lattice_origin: Point::ZERO,
+                    layers: &[
+                        SpatialCopperBalanceLayerRequest {
+                            safe_region: &panel,
+                            existing_copper: &empty,
+                            density_domain: &panel,
+                            target_density: heavy,
+                            stack_weight_mm2: 1.0,
+                        },
+                        SpatialCopperBalanceLayerRequest {
+                            safe_region: &panel,
+                            existing_copper: &empty,
+                            density_domain: &panel,
+                            target_density: light,
+                            stack_weight_mm2: -1.0,
+                        },
+                    ],
+                },
+            )
+            .unwrap()
+        };
+        // Mirrored weights normalize to +/- 0.5, so this is the moment.
+        let moment = |results: &[DenseCopperBalanceResult]| {
+            0.5 * results[0].solution.achieved_density - 0.5 * results[1].solution.achieved_density
+        };
+
+        let ignored = solve(0.0);
+        let weighted = solve(DenseCopperBalanceProfile::V1.stack_moment_weight);
+
+        // Ignored, the boards' own imbalance survives: the layers stay within
+        // their bands of their targets, and nothing pulls them together.
+        let untouched = 0.5 * (heavy - light);
+        let band_reach = DenseCopperBalanceProfile::V1.stack_flex_density + 5e-3;
+        assert!(
+            (moment(&ignored) - untouched).abs() <= band_reach,
+            "{} vs {untouched}",
+            moment(&ignored)
+        );
+        // Weighted, the same panel carries measurably less.
+        assert!(
+            moment(&weighted) < moment(&ignored) - 5e-3,
+            "{} vs {}",
+            moment(&weighted),
+            moment(&ignored)
+        );
+        // And it is paid for by a trade, not by removing copper from the panel.
+        let deviations = weighted
+            .iter()
+            .map(|result| result.solution.achieved_density - result.solution.target_density)
+            .collect::<Vec<_>>();
+        assert!(deviations[0] < 0.0 && deviations[1] > 0.0, "{deviations:?}");
+        assert!(
+            deviations.iter().sum::<f64>().abs() <= 1e-2,
+            "{deviations:?}"
+        );
+        for deviation in &deviations {
+            assert!(
+                deviation.abs() <= DenseCopperBalanceProfile::V1.stack_flex_density + 5e-3,
+                "{deviations:?}"
+            );
+        }
+    }
+
     /// Fixed copper on one side of one layer tilts the stack in a way no
-    /// redistribution can answer. The band lets that layer take copper on and
-    /// its mirror give the same density back, bounded on both sides, and the
-    /// trade nets to zero so the stack gains no copper overall.
+    /// redistribution can answer: it is real copper sitting off the mid-plane,
+    /// and only the layer opposite it can counterweight. The band lets the
+    /// tilted layer shed density and its mirror take the same amount on,
+    /// bounded on both sides, and the trade nets to zero so the stack gains no
+    /// copper overall.
     #[test]
     fn stack_flex_trades_density_between_mirrored_layers() {
         let panel = ContourSet::rectangle(
@@ -1648,9 +1775,10 @@ mod tests {
             .iter()
             .map(|result| result.solution.achieved_density - result.solution.target_density)
             .collect::<Vec<_>>();
-        // One layer takes density on, the other gives it back.
-        assert!(deviations[0] > quantization, "{deviations:?}");
-        assert!(deviations[1] < -quantization, "{deviations:?}");
+        // The layer holding the fixed copper is the one tilting the stack, so
+        // it sheds density and its mirror takes the same amount on.
+        assert!(deviations[0] < -quantization, "{deviations:?}");
+        assert!(deviations[1] > quantization, "{deviations:?}");
         // Neither leaves its band, and the stack gains nothing overall.
         for deviation in &deviations {
             assert!(deviation.abs() <= flex + quantization, "{deviations:?}");

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -18,8 +18,8 @@ use lattice::{
     LatticeCandidates, ROUNDED_HEXAGON_AREA_FACTOR, hex_aligned_lattice_centers, lattice_index,
 };
 use spatial::{
-    LatticeDensityKernel, density_evaluation_points, lattice_cell_coverage,
-    normalized_stack_weights, project_box_interval, project_box_sum,
+    CoupledBand, LatticeDensityKernel, density_evaluation_points, lattice_cell_coverage,
+    normalized_stack_weights, project_box_sum, project_coupled_bands,
     spatial_result_from_squared_radii,
 };
 
@@ -659,15 +659,12 @@ pub fn generate_spatial_dense_copper_balance(
             })
             .collect::<Vec<_>>();
 
-        let update = std::thread::scope(|scope| {
+        let proposals = std::thread::scope(|scope| {
             let active_sites = &active_sites;
             let density_kernel = &density_kernel;
-            let lower = &lower;
-            let upper = &upper;
-            let squared_radius_bands = &squared_radius_bands;
             let normalized_stack_weights = &normalized_stack_weights;
             let handles = squared_radii
-                .iter_mut()
+                .iter()
                 .zip(influence_scratch.iter_mut())
                 .enumerate()
                 .map(|(layer_index, (radii, influence))| {
@@ -675,7 +672,7 @@ pub fn generate_spatial_dense_copper_balance(
                     let stack_error = &stack_error;
                     scope.spawn(move || {
                         if radii.is_empty() {
-                            return 0.0_f64;
+                            return Vec::new();
                         }
                         let residual = error[layer_index]
                             .iter()
@@ -685,7 +682,7 @@ pub fn generate_spatial_dense_copper_balance(
                             })
                             .collect::<Vec<_>>();
                         density_kernel.smooth_adjoint_into(&residual, influence);
-                        let proposed = radii
+                        radii
                             .iter()
                             .enumerate()
                             .map(|(local_index, radius_squared)| {
@@ -694,30 +691,42 @@ pub fn generate_spatial_dense_copper_balance(
                                         * void_fraction_per_radius_squared
                                         * influence[active_sites[layer_index][local_index]]
                             })
-                            .collect::<Vec<_>>();
-                        let (sum_min, sum_max) = squared_radius_bands[layer_index];
-                        let projected = project_box_interval(
-                            &proposed,
-                            &lower[layer_index],
-                            &upper[layer_index],
-                            sum_min,
-                            sum_max,
-                        );
-                        let update = radii
-                            .iter()
-                            .zip(&projected)
-                            .map(|(before, after)| (before - after).abs())
-                            .fold(0.0_f64, f64::max);
-                        *radii = projected;
-                        update
+                            .collect::<Vec<_>>()
                     })
                 })
                 .collect::<Vec<_>>();
             handles
                 .into_iter()
                 .map(|handle| handle.join().expect("spatial update pass panicked"))
-                .fold(0.0_f64, f64::max)
+                .collect::<Vec<_>>()
         });
+        // The layers meet here: their bands are only useful against each other,
+        // so the trade between them is settled before any radius is committed.
+        let bands = proposals
+            .iter()
+            .enumerate()
+            .map(|(layer_index, proposal)| CoupledBand {
+                proposal,
+                lower: &lower[layer_index],
+                upper: &upper[layer_index],
+                sum_bounds: squared_radius_bands[layer_index],
+                center: squared_radius_sums[layer_index],
+                domain_area_mm2: density_domain_areas[layer_index],
+            })
+            .collect::<Vec<_>>();
+        let update = squared_radii
+            .iter_mut()
+            .zip(project_coupled_bands(&bands))
+            .map(|(radii, projected)| {
+                let update = radii
+                    .iter()
+                    .zip(&projected)
+                    .map(|(before, after)| (before - after).abs())
+                    .fold(0.0_f64, f64::max);
+                *radii = projected;
+                update
+            })
+            .fold(0.0_f64, f64::max);
         if update < convergence_mm2 {
             break;
         }
@@ -1529,22 +1538,24 @@ mod tests {
         );
     }
 
-    /// A layer with nowhere to generate leaves a moment that redistribution
-    /// cannot touch. Its mirror sits exactly on its own target, so the only
-    /// force acting on it is the stack term, and the only way it can answer is
-    /// to leave that target. The band both permits and bounds that move.
+    /// Fixed copper on one side of one layer tilts the stack in a way no
+    /// redistribution can answer. The band lets that layer take copper on and
+    /// its mirror give the same density back, bounded on both sides, and the
+    /// trade nets to zero so the stack gains no copper overall.
     #[test]
-    fn stack_flex_moves_a_layer_off_target_to_counterweight_its_mirror() {
+    fn stack_flex_trades_density_between_mirrored_layers() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
             tol::REGION_MM,
         );
-        // The immutable layer is poured solid and has no safe region, so its
-        // surplus is uniform across the panel. A uniform moment is exactly
-        // what redistribution cannot answer: every site sees the same
-        // residual, leaving the layer's total as the only remaining lever.
-        let solid = panel.clone();
-        let safe = panel.clone();
+        let left_copper = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
+            tol::REGION_MM,
+        );
+        let safe = ContourSet::rectangle(
+            BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
         let empty = ContourSet::empty(tol::REGION_MM);
         let solve = |stack_flex_density: f64| {
             generate_spatial_dense_copper_balance(
@@ -1557,10 +1568,10 @@ mod tests {
                     lattice_origin: Point::ZERO,
                     layers: &[
                         SpatialCopperBalanceLayerRequest {
-                            safe_region: &empty,
-                            existing_copper: &solid,
-                            density_domain: &solid,
-                            target_density: 0.5,
+                            safe_region: &safe,
+                            existing_copper: &left_copper,
+                            density_domain: &panel,
+                            target_density: 0.75,
                             stack_weight_mm2: 1.0,
                         },
                         SpatialCopperBalanceLayerRequest {
@@ -1582,24 +1593,31 @@ mod tests {
         let pinned = solve(0.0);
         let flexed = solve(flex);
 
-        // The immutable layer generates nothing either way.
-        for results in [&pinned, &flexed] {
-            assert_eq!(results[0].solution.mode, DenseCopperBalanceMode::None);
-            assert_eq!(results[0].solution.generated_area_mm2, 0.0);
+        // Pinned, both layers are held on their own targets.
+        for result in &pinned {
+            assert!(
+                (result.solution.achieved_density - result.solution.target_density).abs()
+                    <= quantization,
+                "{:?}",
+                result.solution
+            );
         }
-        // Pinned, the free layer is held on its target and the moment stands.
+
+        let deviations = flexed
+            .iter()
+            .map(|result| result.solution.achieved_density - result.solution.target_density)
+            .collect::<Vec<_>>();
+        // One layer takes density on, the other gives it back.
+        assert!(deviations[0] > quantization, "{deviations:?}");
+        assert!(deviations[1] < -quantization, "{deviations:?}");
+        // Neither leaves its band, and the stack gains nothing overall.
+        for deviation in &deviations {
+            assert!(deviation.abs() <= flex + quantization, "{deviations:?}");
+        }
         assert!(
-            (pinned[1].solution.achieved_density - pinned[1].solution.target_density).abs()
-                <= quantization,
-            "{:?}",
-            pinned[1].solution
+            deviations.iter().sum::<f64>().abs() <= 2.0 * quantization,
+            "{deviations:?}"
         );
-        // Flexed, it takes on copper to answer the surplus opposite it, and
-        // stops at the edge of its band rather than chasing the moment all the
-        // way down.
-        let deviation = flexed[1].solution.achieved_density - pinned[1].solution.target_density;
-        assert!(deviation > quantization, "{:?}", flexed[1].solution);
-        assert!(deviation <= flex + quantization, "{:?}", flexed[1].solution);
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -70,16 +70,17 @@ pub struct DenseCopperBalanceProfile {
     /// density match.
     ///
     /// The objective already holds both terms, so this only sets their
-    /// exchange rate — but leaving it at one is far too timid to be useful.
-    /// The local term contributes one squared error per layer against this
-    /// term's one, so the moment that survives is `M_0 / (1 + w * sum_l w_l^2)`
-    /// and a six-layer stack sheds only about a sixth of it. Raising the
-    /// weight moves that toward zero; [`Self::stack_flex_density`] is what
-    /// keeps the correction bounded while it does.
+    /// exchange rate. It is normalized against the stack's own weights, which
+    /// makes it scale-free: the moment that survives is `M_0 / (1 + weight)`
+    /// whatever the stack's depth, so two sheds two thirds of it on a
+    /// two-layer board and on a twelve-layer one alike.
+    /// [`Self::stack_flex_density`] is what keeps the correction bounded while
+    /// it does.
     ///
     /// Zero drops the moment from the objective, leaving each layer to match
-    /// its own density alone. A stackup that supplies no weights reaches the
-    /// same place on its own, whatever this is set to.
+    /// its own density alone — and with nothing to spend them on, holds the
+    /// bands shut. A stackup that supplies no weights reaches the same place
+    /// on its own, whatever this is set to.
     pub stack_moment_weight: f64,
 }
 
@@ -94,7 +95,7 @@ impl DenseCopperBalanceProfile {
         density_sigma_mm: 5.0,
         void_radius_step_mm: 0.005,
         stack_flex_density: 0.01,
-        stack_moment_weight: 10.0,
+        stack_moment_weight: 2.0,
     };
 
     pub fn lattice_column_pitch_mm(self) -> f64 {
@@ -593,42 +594,48 @@ pub fn generate_spatial_dense_copper_balance(
     // itself can reach keeps the feasible set nonempty, and since each uniform
     // sum is already inside that range the band always contains its own center.
     let normalized_stack_weights = normalized_stack_weights(request.layers);
-    // A stackup that located no conductors leaves every weight zero, so there
-    // is no moment to flatten and nothing to spend the bands on. Holding them
-    // shut is what keeps "balanced independently" true: an open band would
-    // still let the local density error trade layers off their targets.
-    let weights_measured = normalized_stack_weights.iter().any(|weight| *weight != 0.0);
+    // Whether there is a moment to flatten at all: a stackup that located no
+    // conductors leaves every weight zero, and a zero weight drops the term
+    // from the objective. Either way the bands buy nothing, and leaving them
+    // open would let the local density error trade layers off their targets
+    // for it -- on the very panels reported as balanced independently.
+    let moment_scale = normalized_stack_weights
+        .iter()
+        .map(|weight| weight * weight)
+        .sum::<f64>();
+    // Dividing by `sum_l w_l^2` is what makes the weight scale-free: the
+    // moment that survives is `M_0 / (1 + weight)` whatever the stack's depth,
+    // rather than shrinking with layer count because the local term brings one
+    // squared error per layer against this term's one.
+    let moment_gain = if moment_scale > 0.0 {
+        profile.stack_moment_weight / moment_scale
+    } else {
+        0.0
+    };
     let squared_radius_bands = squared_radius_sums
         .iter()
         .enumerate()
         .map(|(layer_index, sum)| {
-            let slack = if weights_measured {
+            let slack = if moment_gain > 0.0 {
                 profile.stack_flex_density * density_domain_areas[layer_index]
                     / ROUNDED_HEXAGON_AREA_FACTOR
             } else {
                 0.0
             };
-            // A layer that took no lattice has no radii to trade with, and its
-            // sites are not its own to spend: sizing the box range from them
-            // would put the band above a sum that is fixed at zero.
+            // Clamping the slack rather than the endpoints keeps "the band
+            // contains the sum it surrounds" structural. Clamping the
+            // endpoints would rest on an accumulated sum comparing against a
+            // multiplied bound, which a layer whose radii all sit on one bound
+            // rounds across, and it would need its own case for the layer that
+            // took no lattice and has nothing to trade.
             let site_count = squared_radii[layer_index].len() as f64;
-            // The band always contains the sum it surrounds. Reaching that
-            // through the clamps alone would rest on an accumulated sum
-            // comparing exactly against a multiplied bound, and a layer whose
-            // radii all sit on one bound can round across it.
-            (
-                (sum - slack).max(site_count * lower).min(*sum),
-                (sum + slack).min(site_count * upper).max(*sum),
-            )
+            let room_below = (sum - site_count * lower).max(0.0);
+            let room_above = (site_count * upper - sum).max(0.0);
+            (sum - slack.min(room_below), sum + slack.min(room_above))
         })
         .collect::<Vec<_>>();
     let cell_area_mm2 = SQRT_3 * profile.pitch_mm.powi(2) / 2.0;
     let void_fraction_per_radius_squared = ROUNDED_HEXAGON_AREA_FACTOR / cell_area_mm2;
-    let target_densities = request
-        .layers
-        .iter()
-        .map(|layer| layer.target_density)
-        .collect::<Vec<_>>();
     let step = 0.25 / void_fraction_per_radius_squared.powi(2);
 
     // Updates below this leave every radius well inside half a quantization
@@ -647,7 +654,8 @@ pub fn generate_spatial_dense_copper_balance(
     // reduction. The first reading is the field the uniform selection left
     // behind; the last trails the emitted radii by one gradient step, which at
     // convergence is smaller than the radius quantization.
-    let mut moment_rms: Option<(f64, f64)> = None;
+    let mut initial_rms: Option<f64> = None;
+    let mut achieved_rms = 0.0;
     for _ in 0..SPATIAL_SOLVE_ITERATIONS {
         // The modeled final copper fraction of each layer, not its distance
         // from target: the moment below is the copper the panel carries, and
@@ -721,14 +729,15 @@ pub fn generate_spatial_dense_copper_balance(
                     .sum::<f64>()
             })
             .collect::<Vec<_>>();
-        let rms = (stack_moment
-            .iter()
-            .map(|moment| moment * moment)
-            .sum::<f64>()
-            / stack_moment.len() as f64)
-            .sqrt();
-        let initial_rms = moment_rms.map_or(rms, |(initial, _)| initial);
-        moment_rms = Some((initial_rms, rms));
+        if moment_gain > 0.0 {
+            achieved_rms = (stack_moment
+                .iter()
+                .map(|moment| moment * moment)
+                .sum::<f64>()
+                / stack_moment.len() as f64)
+                .sqrt();
+            initial_rms.get_or_insert(achieved_rms);
+        }
 
         let proposals = std::thread::scope(|scope| {
             let active_sites = &active_sites;
@@ -741,7 +750,7 @@ pub fn generate_spatial_dense_copper_balance(
                 .map(|(layer_index, (radii, influence))| {
                     let density = &density;
                     let stack_moment = &stack_moment;
-                    let target_densities = &target_densities;
+                    let layers = request.layers;
                     scope.spawn(move || {
                         if radii.is_empty() {
                             return Vec::new();
@@ -753,10 +762,8 @@ pub fn generate_spatial_dense_copper_balance(
                             .iter()
                             .zip(stack_moment)
                             .map(|(density, moment)| {
-                                (density - target_densities[layer_index])
-                                    + profile.stack_moment_weight
-                                        * normalized_stack_weights[layer_index]
-                                        * moment
+                                (density - layers[layer_index].target_density)
+                                    + moment_gain * normalized_stack_weights[layer_index] * moment
                             })
                             .collect::<Vec<_>>();
                         density_kernel.smooth_adjoint_into(&residual, influence);
@@ -826,12 +833,10 @@ pub fn generate_spatial_dense_copper_balance(
                 )
             })
             .collect(),
-        moment_field: moment_rms
-            .filter(|_| weights_measured)
-            .map(|(initial_rms, achieved_rms)| StackMomentField {
-                initial_rms,
-                achieved_rms,
-            }),
+        moment_field: initial_rms.map(|initial_rms| StackMomentField {
+            initial_rms,
+            achieved_rms,
+        }),
     })
 }
 
@@ -1779,11 +1784,11 @@ mod tests {
         }
     }
 
-    /// The field metric reports what the solve did to the moment, and reports
-    /// nothing at all when the stackup gave it no weights to measure with —
-    /// an absence of measurement rather than a flat panel.
+    /// The field metric records what the solve did to the moment. Its silence
+    /// when nothing weighs the layers is covered by
+    /// [`layers_hold_their_targets_when_the_stackup_weighs_nothing`].
     #[test]
-    fn moment_field_is_measured_only_when_the_stackup_weighs_the_layers() {
+    fn moment_field_records_the_flattening_it_achieved() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
             tol::REGION_MM,
@@ -1815,8 +1820,6 @@ mod tests {
             )
             .unwrap()
         };
-
-        assert_eq!(solve(0.0).moment_field, None);
 
         let weighed = solve(1.0).moment_field.expect("weights were supplied");
         // These layers are asked for markedly different densities, so the
@@ -1878,12 +1881,12 @@ mod tests {
         let ignored = solve(0.0);
         let weighted = solve(DenseCopperBalanceProfile::V1.stack_moment_weight);
 
-        // Ignored, the boards' own imbalance survives: the layers stay within
-        // their bands of their targets, and nothing pulls them together.
+        // Ignored, the boards' own imbalance survives untouched: with no
+        // moment in the objective the bands stay shut and each layer holds its
+        // own target.
         let untouched = 0.5 * (heavy - light);
-        let band_reach = DenseCopperBalanceProfile::V1.stack_flex_density + 5e-3;
         assert!(
-            (moment(&ignored) - untouched).abs() <= band_reach,
+            (moment(&ignored) - untouched).abs() <= 5e-3,
             "{} vs {untouched}",
             moment(&ignored)
         );

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -19,8 +19,7 @@ use lattice::{
 };
 use spatial::{
     CoupledBand, LatticeDensityKernel, density_evaluation_points, lattice_cell_coverage,
-    normalized_stack_weights, project_box_sum, project_coupled_bands,
-    spatial_result_from_squared_radii,
+    normalized_stack_weights, project_coupled_bands, spatial_result_from_squared_radii,
 };
 
 const NUMERIC_EPSILON: f64 = 1e-9;
@@ -523,39 +522,25 @@ pub fn generate_spatial_dense_copper_balance(
             (join_all(fixed), join_all(available), join_all(partial))
         });
 
-    let lower = active_sites
-        .iter()
-        .map(|active| vec![profile.min_void_radius_mm.powi(2); active.len()])
-        .collect::<Vec<_>>();
-    let upper = active_sites
-        .iter()
-        .map(|active| vec![profile.max_void_radius_mm.powi(2); active.len()])
-        .collect::<Vec<_>>();
-    // The uniform solve already selected each layer's full-void area; its
-    // radius is within the profile bounds, so the sum is directly feasible.
-    let squared_radius_sums = uniform
-        .iter()
-        .enumerate()
-        .map(|(layer_index, result)| match result.solution.mode {
-            DenseCopperBalanceMode::Perforated { void_radius_mm } => {
-                active_sites[layer_index].len() as f64 * void_radius_mm.powi(2)
-            }
-            DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => 0.0,
-        })
-        .collect::<Vec<_>>();
+    let lower = profile.min_void_radius_mm.powi(2);
+    let upper = profile.max_void_radius_mm.powi(2);
+    // The uniform solve already selected each layer's full-void area at one
+    // radius within the profile bounds, so the equal-radius field it implies
+    // is already feasible and needs no projection.
     let mut squared_radii = uniform
         .iter()
         .enumerate()
         .map(|(layer_index, result)| match result.solution.mode {
-            DenseCopperBalanceMode::Perforated { void_radius_mm } => project_box_sum(
-                &vec![void_radius_mm.powi(2); active_sites[layer_index].len()],
-                &lower[layer_index],
-                &upper[layer_index],
-                squared_radius_sums[layer_index],
-            ),
+            DenseCopperBalanceMode::Perforated { void_radius_mm } => {
+                vec![void_radius_mm.powi(2); active_sites[layer_index].len()]
+            }
             DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => Vec::new(),
         })
         .collect::<Vec<Vec<f64>>>();
+    let squared_radius_sums = squared_radii
+        .iter()
+        .map(|radii| radii.iter().sum::<f64>())
+        .collect::<Vec<_>>();
     // Void area moves opposite to copper area, so a symmetric copper band is a
     // symmetric band on the squared-radius sum. Clamping to the range the box
     // itself can reach keeps the feasible set nonempty, and since each uniform
@@ -571,8 +556,8 @@ pub fn generate_spatial_dense_copper_balance(
             // would put the band above a sum that is fixed at zero.
             let site_count = squared_radii[layer_index].len() as f64;
             (
-                (sum - slack).max(site_count * profile.min_void_radius_mm.powi(2)),
-                (sum + slack).min(site_count * profile.max_void_radius_mm.powi(2)),
+                (sum - slack).max(site_count * lower),
+                (sum + slack).min(site_count * upper),
             )
         })
         .collect::<Vec<_>>();
@@ -710,8 +695,6 @@ pub fn generate_spatial_dense_copper_balance(
             .enumerate()
             .map(|(layer_index, proposal)| CoupledBand {
                 proposal,
-                lower: &lower[layer_index],
-                upper: &upper[layer_index],
                 sum_bounds: squared_radius_bands[layer_index],
                 center: squared_radius_sums[layer_index],
                 domain_area_mm2: density_domain_areas[layer_index],
@@ -719,7 +702,7 @@ pub fn generate_spatial_dense_copper_balance(
             .collect::<Vec<_>>();
         let update = squared_radii
             .iter_mut()
-            .zip(project_coupled_bands(&bands))
+            .zip(project_coupled_bands(&bands, lower, upper))
             .map(|(radii, projected)| {
                 let update = radii
                     .iter()

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -19,7 +19,8 @@ use lattice::{
 };
 use spatial::{
     LatticeDensityKernel, density_evaluation_points, lattice_cell_coverage,
-    normalized_stack_weights, project_box_sum, spatial_result_from_squared_radii,
+    normalized_stack_weights, project_box_interval, project_box_sum,
+    spatial_result_from_squared_radii,
 };
 
 const NUMERIC_EPSILON: f64 = 1e-9;
@@ -51,6 +52,21 @@ pub struct DenseCopperBalanceProfile {
     /// cannot hold finer distinctions, and the shared grid keeps the voids a
     /// small set of repeated templates instead of thousands of unique shapes.
     pub void_radius_step_mm: f64,
+    /// How far a layer's density may drift from its target to counterweight
+    /// the stack, as a fraction of its density domain.
+    ///
+    /// The spatial solve otherwise conserves each layer's selected copper area
+    /// exactly, which lets it redistribute copper but never trade a little of
+    /// one layer's density match for a flatter through-stack moment. This band
+    /// frees that trade and bounds it: no layer's achieved density leaves this
+    /// distance from its target. Zero pins every layer to its uniform
+    /// selection, the behavior before the band existed.
+    ///
+    /// The trade needs no weight of its own. Both terms already sit in the
+    /// objective, so a layer spends the band only while `w_l |m|` exceeds its
+    /// own growing density error, and never spends it at all when the stackup
+    /// supplies no weights.
+    pub stack_flex_density: f64,
 }
 
 impl DenseCopperBalanceProfile {
@@ -63,6 +79,7 @@ impl DenseCopperBalanceProfile {
         boundary_web_mm: 0.20,
         density_sigma_mm: 5.0,
         void_radius_step_mm: 0.005,
+        stack_flex_density: 0.0,
     };
 
     pub fn lattice_column_pitch_mm(self) -> f64 {
@@ -100,6 +117,14 @@ impl DenseCopperBalanceProfile {
                     "{name} must be finite and greater than zero"
                 )));
             }
+        }
+        // Zero is meaningful here — it pins every layer to its uniform
+        // selection — so this bound is separate from the strictly positive
+        // geometry above.
+        if !self.stack_flex_density.is_finite() || !(0.0..=1.0).contains(&self.stack_flex_density) {
+            return Err(DenseCopperBalanceError::InvalidProfile(
+                "stack flex density must be between zero and one".to_string(),
+            ));
         }
         if self.min_void_radius_mm > self.max_void_radius_mm {
             return Err(DenseCopperBalanceError::InvalidProfile(
@@ -531,6 +556,23 @@ pub fn generate_spatial_dense_copper_balance(
             DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => Vec::new(),
         })
         .collect::<Vec<Vec<f64>>>();
+    // Void area moves opposite to copper area, so a symmetric copper band is a
+    // symmetric band on the squared-radius sum. Clamping to the range the box
+    // itself can reach keeps the feasible set nonempty, and since each uniform
+    // sum is already inside that range the band always contains its own center.
+    let squared_radius_bands = squared_radius_sums
+        .iter()
+        .enumerate()
+        .map(|(layer_index, sum)| {
+            let slack = profile.stack_flex_density * density_domain_areas[layer_index]
+                / ROUNDED_HEXAGON_AREA_FACTOR;
+            let site_count = active_sites[layer_index].len() as f64;
+            (
+                (sum - slack).max(site_count * profile.min_void_radius_mm.powi(2)),
+                (sum + slack).min(site_count * profile.max_void_radius_mm.powi(2)),
+            )
+        })
+        .collect::<Vec<_>>();
     let cell_area_mm2 = SQRT_3 * profile.pitch_mm.powi(2) / 2.0;
     let void_fraction_per_radius_squared = ROUNDED_HEXAGON_AREA_FACTOR / cell_area_mm2;
     let normalized_stack_weights = normalized_stack_weights(request.layers);
@@ -622,7 +664,7 @@ pub fn generate_spatial_dense_copper_balance(
             let density_kernel = &density_kernel;
             let lower = &lower;
             let upper = &upper;
-            let squared_radius_sums = &squared_radius_sums;
+            let squared_radius_bands = &squared_radius_bands;
             let normalized_stack_weights = &normalized_stack_weights;
             let handles = squared_radii
                 .iter_mut()
@@ -653,11 +695,13 @@ pub fn generate_spatial_dense_copper_balance(
                                         * influence[active_sites[layer_index][local_index]]
                             })
                             .collect::<Vec<_>>();
-                        let projected = project_box_sum(
+                        let (sum_min, sum_max) = squared_radius_bands[layer_index];
+                        let projected = project_box_interval(
                             &proposed,
                             &lower[layer_index],
                             &upper[layer_index],
-                            squared_radius_sums[layer_index],
+                            sum_min,
+                            sum_max,
                         );
                         let update = radii
                             .iter()
@@ -1022,6 +1066,7 @@ mod tests {
             boundary_web_mm: 0.2,
             density_sigma_mm: 5.0,
             void_radius_step_mm: 0.005,
+            stack_flex_density: 0.0,
         };
         profile.validate().unwrap();
         let safe_region = ContourSet::rectangle(
@@ -1482,6 +1527,79 @@ mod tests {
             (result.solution.generated_area_mm2 - baseline.solution.generated_area_mm2).abs()
                 <= AREA_SOLVE_TOLERANCE_MM2 + quantization_bound_mm2
         );
+    }
+
+    /// A layer with nowhere to generate leaves a moment that redistribution
+    /// cannot touch. Its mirror sits exactly on its own target, so the only
+    /// force acting on it is the stack term, and the only way it can answer is
+    /// to leave that target. The band both permits and bounds that move.
+    #[test]
+    fn stack_flex_moves_a_layer_off_target_to_counterweight_its_mirror() {
+        let panel = ContourSet::rectangle(
+            BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
+            tol::REGION_MM,
+        );
+        // The immutable layer is poured solid and has no safe region, so its
+        // surplus is uniform across the panel. A uniform moment is exactly
+        // what redistribution cannot answer: every site sees the same
+        // residual, leaving the layer's total as the only remaining lever.
+        let solid = panel.clone();
+        let safe = panel.clone();
+        let empty = ContourSet::empty(tol::REGION_MM);
+        let solve = |stack_flex_density: f64| {
+            generate_spatial_dense_copper_balance(
+                DenseCopperBalanceProfile {
+                    stack_flex_density,
+                    ..DenseCopperBalanceProfile::V1
+                },
+                SpatialCopperBalanceRequest {
+                    panel_region: &panel,
+                    lattice_origin: Point::ZERO,
+                    layers: &[
+                        SpatialCopperBalanceLayerRequest {
+                            safe_region: &empty,
+                            existing_copper: &solid,
+                            density_domain: &solid,
+                            target_density: 0.5,
+                            stack_weight_mm2: 1.0,
+                        },
+                        SpatialCopperBalanceLayerRequest {
+                            safe_region: &safe,
+                            existing_copper: &empty,
+                            density_domain: &safe,
+                            target_density: 0.5,
+                            stack_weight_mm2: -1.0,
+                        },
+                    ],
+                },
+            )
+            .unwrap()
+        };
+        // Radius quantization alone moves the achieved density this far.
+        let quantization = 5e-3;
+        let flex = 0.02;
+
+        let pinned = solve(0.0);
+        let flexed = solve(flex);
+
+        // The immutable layer generates nothing either way.
+        for results in [&pinned, &flexed] {
+            assert_eq!(results[0].solution.mode, DenseCopperBalanceMode::None);
+            assert_eq!(results[0].solution.generated_area_mm2, 0.0);
+        }
+        // Pinned, the free layer is held on its target and the moment stands.
+        assert!(
+            (pinned[1].solution.achieved_density - pinned[1].solution.target_density).abs()
+                <= quantization,
+            "{:?}",
+            pinned[1].solution
+        );
+        // Flexed, it takes on copper to answer the surplus opposite it, and
+        // stops at the edge of its band rather than chasing the moment all the
+        // way down.
+        let deviation = flexed[1].solution.achieved_density - pinned[1].solution.target_density;
+        assert!(deviation > quantization, "{:?}", flexed[1].solution);
+        assert!(deviation <= flex + quantization, "{:?}", flexed[1].solution);
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -275,8 +275,6 @@ fn scanline_indicator(points: &[Point], region: &ContourSet) -> Vec<f64> {
 pub(super) struct CoupledBand<'a> {
     /// Gradient proposal, one squared radius per active site.
     pub proposal: &'a [f64],
-    pub lower: &'a [f64],
-    pub upper: &'a [f64],
     /// Bounds on this layer's squared-radius sum.
     pub sum_bounds: (f64, f64),
     /// Sum those bounds surround: the layer's selected copper area.
@@ -300,7 +298,11 @@ pub(super) struct CoupledBand<'a> {
 /// commonly shifted proposal and the multiplier follows by bisection. Shifting
 /// harder only lowers each sum, and a layer whose band binds stops responding
 /// altogether, so the deviation falls monotonically and brackets cleanly.
-pub(super) fn project_coupled_bands(layers: &[CoupledBand<'_>]) -> Vec<Vec<f64>> {
+pub(super) fn project_coupled_bands(
+    layers: &[CoupledBand<'_>],
+    lower: f64,
+    upper: f64,
+) -> Vec<Vec<f64>> {
     // A layer pinned at a band edge takes the same value for every multiplier
     // past that point, so scoring a trial needs one clamped sum per layer
     // rather than a nested projection.
@@ -312,9 +314,7 @@ pub(super) fn project_coupled_bands(layers: &[CoupledBand<'_>]) -> Vec<Vec<f64>>
                 let sum = layer
                     .proposal
                     .iter()
-                    .zip(layer.lower)
-                    .zip(layer.upper)
-                    .map(|((value, lower), upper)| (value - shift).clamp(*lower, *upper))
+                    .map(|value| (value - shift).clamp(lower, upper))
                     .sum::<f64>()
                     .clamp(layer.sum_bounds.0, layer.sum_bounds.1);
                 (sum - layer.center) / layer.domain_area_mm2
@@ -325,14 +325,8 @@ pub(super) fn project_coupled_bands(layers: &[CoupledBand<'_>]) -> Vec<Vec<f64>>
     // Past this shift every site clamps, so both ends saturate their bands.
     let span = layers
         .iter()
-        .flat_map(|layer| {
-            layer
-                .proposal
-                .iter()
-                .zip(layer.lower)
-                .zip(layer.upper)
-                .map(|((value, lower), upper)| (value - lower).abs().max((upper - value).abs()))
-        })
+        .flat_map(|layer| layer.proposal.iter())
+        .map(|value| (value - lower).abs().max((upper - value).abs()))
         .fold(0.0_f64, f64::max);
     let widest_domain = layers
         .iter()
@@ -361,8 +355,8 @@ pub(super) fn project_coupled_bands(layers: &[CoupledBand<'_>]) -> Vec<Vec<f64>>
                 .collect::<Vec<_>>();
             project_box_interval(
                 &shifted,
-                layer.lower,
-                layer.upper,
+                lower,
+                upper,
                 layer.sum_bounds.0,
                 layer.sum_bounds.1,
             )
@@ -378,17 +372,15 @@ pub(super) fn project_coupled_bands(layers: &[CoupledBand<'_>]) -> Vec<Vec<f64>>
 /// `sum_min == sum_max` recovers that fixed-sum projection unchanged.
 pub(super) fn project_box_interval(
     values: &[f64],
-    lower: &[f64],
-    upper: &[f64],
+    lower: f64,
+    upper: f64,
     sum_min: f64,
     sum_max: f64,
 ) -> Vec<f64> {
     debug_assert!(sum_min <= sum_max);
     let clamped = values
         .iter()
-        .zip(lower)
-        .zip(upper)
-        .map(|((value, lower), upper)| value.clamp(*lower, *upper))
+        .map(|value| value.clamp(lower, upper))
         .collect::<Vec<_>>();
     let total = clamped.iter().sum::<f64>();
     if total < sum_min {
@@ -400,33 +392,22 @@ pub(super) fn project_box_interval(
     }
 }
 
-pub(super) fn project_box_sum(
-    values: &[f64],
-    lower: &[f64],
-    upper: &[f64],
-    target: f64,
-) -> Vec<f64> {
-    debug_assert_eq!(values.len(), lower.len());
-    debug_assert_eq!(values.len(), upper.len());
+fn project_box_sum(values: &[f64], lower: f64, upper: f64, target: f64) -> Vec<f64> {
     let mut low_shift = values
         .iter()
-        .zip(upper)
-        .map(|(value, bound)| value - bound)
+        .map(|value| value - upper)
         .min_by(f64::total_cmp)
         .unwrap_or(0.0);
     let mut high_shift = values
         .iter()
-        .zip(lower)
-        .map(|(value, bound)| value - bound)
+        .map(|value| value - lower)
         .max_by(f64::total_cmp)
         .unwrap_or(0.0);
     for _ in 0..44 {
         let shift = (low_shift + high_shift) / 2.0;
         let sum = values
             .iter()
-            .zip(lower)
-            .zip(upper)
-            .map(|((value, lower), upper)| (value - shift).clamp(*lower, *upper))
+            .map(|value| (value - shift).clamp(lower, upper))
             .sum::<f64>();
         if sum > target {
             low_shift = shift;
@@ -437,9 +418,7 @@ pub(super) fn project_box_sum(
     let shift = (low_shift + high_shift) / 2.0;
     values
         .iter()
-        .zip(lower)
-        .zip(upper)
-        .map(|((value, lower), upper)| (value - shift).clamp(*lower, *upper))
+        .map(|value| (value - shift).clamp(lower, upper))
         .collect()
 }
 
@@ -513,34 +492,26 @@ mod tests {
     #[test]
     fn box_interval_projection_binds_only_at_its_edges() {
         let values: [f64; 5] = [0.10, 0.42, -0.30, 0.25, 0.61];
-        let lower = [0.04_f64; 5];
-        let upper = [0.42_f64; 5];
+        let (lower, upper) = (0.04_f64, 0.42_f64);
         let clamped = values
             .iter()
-            .zip(&lower)
-            .zip(&upper)
-            .map(|((value, lower), upper)| value.clamp(*lower, *upper))
+            .map(|value| value.clamp(lower, upper))
             .collect::<Vec<_>>();
         let clamped_sum = clamped.iter().sum::<f64>();
 
         // Band straddling the clamped sum: the clamp already satisfies it.
-        let inside = project_box_interval(
-            &values,
-            &lower,
-            &upper,
-            clamped_sum - 0.2,
-            clamped_sum + 0.2,
-        );
+        let inside =
+            project_box_interval(&values, lower, upper, clamped_sum - 0.2, clamped_sum + 0.2);
         assert_eq!(inside, clamped);
 
         // Band entirely below or above it: the near edge holds with equality.
         for target in [clamped_sum - 0.3, clamped_sum + 0.15] {
             let band = if target < clamped_sum {
-                project_box_interval(&values, &lower, &upper, target - 0.5, target)
+                project_box_interval(&values, lower, upper, target - 0.5, target)
             } else {
-                project_box_interval(&values, &lower, &upper, target, target + 0.5)
+                project_box_interval(&values, lower, upper, target, target + 0.5)
             };
-            let fixed = project_box_sum(&values, &lower, &upper, target);
+            let fixed = project_box_sum(&values, lower, upper, target);
             assert!(
                 band.iter().zip(&fixed).all(|(l, r)| (l - r).abs() <= 1e-12),
                 "{band:?} != {fixed:?}"
@@ -549,8 +520,8 @@ mod tests {
         }
 
         // A degenerate band is the fixed-sum projection exactly.
-        let pinned = project_box_interval(&values, &lower, &upper, 1.0, 1.0);
-        let fixed = project_box_sum(&values, &lower, &upper, 1.0);
+        let pinned = project_box_interval(&values, lower, upper, 1.0, 1.0);
+        let fixed = project_box_sum(&values, lower, upper, 1.0);
         assert!(
             pinned
                 .iter()

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -334,34 +334,50 @@ pub(super) fn project_coupled_bands(
         .fold(0.0_f64, f64::max);
     let bound = span * widest_domain + 1.0;
     let (mut low, mut high) = (-bound, bound);
+    let mut multiplier = 0.0;
     for _ in 0..64 {
-        let multiplier = (low + high) / 2.0;
-        if deviation(multiplier) > 0.0 {
+        multiplier = (low + high) / 2.0;
+        let deviation = deviation(multiplier);
+        // Every trial rescans every site, so stop as soon as the constraint
+        // holds to a density the radius quantization could not express anyway.
+        // A stack whose bands all saturate never gets here and runs the full
+        // bracket down.
+        if deviation.abs() <= NUMERIC_EPSILON {
+            break;
+        }
+        if deviation > 0.0 {
             low = multiplier;
         } else {
             high = multiplier;
         }
     }
-    let multiplier = (low + high) / 2.0;
 
-    layers
-        .iter()
-        .map(|layer| {
-            let shift = multiplier / layer.domain_area_mm2;
-            let shifted = layer
-                .proposal
-                .iter()
-                .map(|value| value - shift)
-                .collect::<Vec<_>>();
-            project_box_interval(
-                &shifted,
-                lower,
-                upper,
-                layer.sum_bounds.0,
-                layer.sum_bounds.1,
-            )
-        })
-        .collect()
+    std::thread::scope(|scope| {
+        let handles = layers
+            .iter()
+            .map(|layer| {
+                scope.spawn(move || {
+                    let shift = multiplier / layer.domain_area_mm2;
+                    let shifted = layer
+                        .proposal
+                        .iter()
+                        .map(|value| value - shift)
+                        .collect::<Vec<_>>();
+                    project_box_interval(
+                        &shifted,
+                        lower,
+                        upper,
+                        layer.sum_bounds.0,
+                        layer.sum_bounds.1,
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("coupled band projection panicked"))
+            .collect()
+    })
 }
 
 /// Euclidean projection onto `{x : lower <= x <= upper, sum_min <= sum(x) <= sum_max}`.

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -271,6 +271,36 @@ fn scanline_indicator(points: &[Point], region: &ContourSet) -> Vec<f64> {
     result
 }
 
+/// Euclidean projection onto `{x : lower <= x <= upper, sum_min <= sum(x) <= sum_max}`.
+///
+/// The band is two halfspaces and at most one can bind, so clamping to the box
+/// is already the projection whenever its sum lands inside the band; otherwise
+/// the binding halfspace holds with equality and [`project_box_sum`] is exact.
+/// `sum_min == sum_max` recovers that fixed-sum projection unchanged.
+pub(super) fn project_box_interval(
+    values: &[f64],
+    lower: &[f64],
+    upper: &[f64],
+    sum_min: f64,
+    sum_max: f64,
+) -> Vec<f64> {
+    debug_assert!(sum_min <= sum_max);
+    let clamped = values
+        .iter()
+        .zip(lower)
+        .zip(upper)
+        .map(|((value, lower), upper)| value.clamp(*lower, *upper))
+        .collect::<Vec<_>>();
+    let total = clamped.iter().sum::<f64>();
+    if total < sum_min {
+        project_box_sum(values, lower, upper, sum_min)
+    } else if total > sum_max {
+        project_box_sum(values, lower, upper, sum_max)
+    } else {
+        clamped
+    }
+}
+
 pub(super) fn project_box_sum(
     values: &[f64],
     lower: &[f64],
@@ -378,6 +408,57 @@ mod tests {
     use super::super::lattice::hex_aligned_lattice_centers;
     use super::*;
     use crate::geom::{BBox, ContourSet, Point, tol};
+
+    /// The band projection agrees with the fixed-sum projection wherever the
+    /// band binds, and is a plain box clamp wherever it does not.
+    #[test]
+    fn box_interval_projection_binds_only_at_its_edges() {
+        let values: [f64; 5] = [0.10, 0.42, -0.30, 0.25, 0.61];
+        let lower = [0.04_f64; 5];
+        let upper = [0.42_f64; 5];
+        let clamped = values
+            .iter()
+            .zip(&lower)
+            .zip(&upper)
+            .map(|((value, lower), upper)| value.clamp(*lower, *upper))
+            .collect::<Vec<_>>();
+        let clamped_sum = clamped.iter().sum::<f64>();
+
+        // Band straddling the clamped sum: the clamp already satisfies it.
+        let inside = project_box_interval(
+            &values,
+            &lower,
+            &upper,
+            clamped_sum - 0.2,
+            clamped_sum + 0.2,
+        );
+        assert_eq!(inside, clamped);
+
+        // Band entirely below or above it: the near edge holds with equality.
+        for target in [clamped_sum - 0.3, clamped_sum + 0.15] {
+            let band = if target < clamped_sum {
+                project_box_interval(&values, &lower, &upper, target - 0.5, target)
+            } else {
+                project_box_interval(&values, &lower, &upper, target, target + 0.5)
+            };
+            let fixed = project_box_sum(&values, &lower, &upper, target);
+            assert!(
+                band.iter().zip(&fixed).all(|(l, r)| (l - r).abs() <= 1e-12),
+                "{band:?} != {fixed:?}"
+            );
+            assert!((band.iter().sum::<f64>() - target).abs() <= 1e-9);
+        }
+
+        // A degenerate band is the fixed-sum projection exactly.
+        let pinned = project_box_interval(&values, &lower, &upper, 1.0, 1.0);
+        let fixed = project_box_sum(&values, &lower, &upper, 1.0);
+        assert!(
+            pinned
+                .iter()
+                .zip(&fixed)
+                .all(|(l, r)| (l - r).abs() <= 1e-12)
+        );
+    }
 
     #[test]
     fn density_kernel_adjoint_matches_the_forward_operator() {

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -310,14 +310,16 @@ pub(super) fn project_coupled_bands(
         layers
             .iter()
             .map(|layer| {
-                let shift = multiplier / layer.domain_area_mm2;
-                let sum = layer
-                    .proposal
-                    .iter()
-                    .map(|value| (value - shift).clamp(lower, upper))
-                    .sum::<f64>()
-                    .clamp(layer.sum_bounds.0, layer.sum_bounds.1);
-                (sum - layer.center) / layer.domain_area_mm2
+                let sum = clamped_sum(
+                    layer.proposal,
+                    multiplier / layer.domain_area_mm2,
+                    lower,
+                    upper,
+                )
+                .clamp(layer.sum_bounds.0, layer.sum_bounds.1);
+                // Carrying the void-area factor keeps this a density, which is
+                // the unit the exit tolerance below is stated in.
+                ROUNDED_HEXAGON_AREA_FACTOR * (sum - layer.center) / layer.domain_area_mm2
             })
             .sum::<f64>()
     };
@@ -357,14 +359,9 @@ pub(super) fn project_coupled_bands(
             .iter()
             .map(|layer| {
                 scope.spawn(move || {
-                    let shift = multiplier / layer.domain_area_mm2;
-                    let shifted = layer
-                        .proposal
-                        .iter()
-                        .map(|value| value - shift)
-                        .collect::<Vec<_>>();
                     project_box_interval(
-                        &shifted,
+                        layer.proposal,
+                        multiplier / layer.domain_area_mm2,
                         lower,
                         upper,
                         layer.sum_bounds.0,
@@ -388,53 +385,59 @@ pub(super) fn project_coupled_bands(
 /// `sum_min == sum_max` recovers that fixed-sum projection unchanged.
 pub(super) fn project_box_interval(
     values: &[f64],
+    shift: f64,
     lower: f64,
     upper: f64,
     sum_min: f64,
     sum_max: f64,
 ) -> Vec<f64> {
     debug_assert!(sum_min <= sum_max);
-    let clamped = values
-        .iter()
-        .map(|value| value.clamp(lower, upper))
-        .collect::<Vec<_>>();
-    let total = clamped.iter().sum::<f64>();
-    if total < sum_min {
-        project_box_sum(values, lower, upper, sum_min)
+    let total = clamped_sum(values, shift, lower, upper);
+    let target = if total < sum_min {
+        sum_min
     } else if total > sum_max {
-        project_box_sum(values, lower, upper, sum_max)
+        sum_max
     } else {
-        clamped
-    }
+        return values
+            .iter()
+            .map(|value| (value - shift).clamp(lower, upper))
+            .collect();
+    };
+    project_box_sum(values, shift, lower, upper, target)
 }
 
-fn project_box_sum(values: &[f64], lower: f64, upper: f64, target: f64) -> Vec<f64> {
+/// `sum_i clamp(values_i - shift, lower, upper)`, the quantity both sum
+/// projections bisect on.
+fn clamped_sum(values: &[f64], shift: f64, lower: f64, upper: f64) -> f64 {
+    values
+        .iter()
+        .map(|value| (value - shift).clamp(lower, upper))
+        .sum()
+}
+
+fn project_box_sum(values: &[f64], shift: f64, lower: f64, upper: f64, target: f64) -> Vec<f64> {
     let mut low_shift = values
         .iter()
-        .map(|value| value - upper)
+        .map(|value| value - shift - upper)
         .min_by(f64::total_cmp)
         .unwrap_or(0.0);
     let mut high_shift = values
         .iter()
-        .map(|value| value - lower)
+        .map(|value| value - shift - lower)
         .max_by(f64::total_cmp)
         .unwrap_or(0.0);
     for _ in 0..44 {
-        let shift = (low_shift + high_shift) / 2.0;
-        let sum = values
-            .iter()
-            .map(|value| (value - shift).clamp(lower, upper))
-            .sum::<f64>();
-        if sum > target {
-            low_shift = shift;
+        let trial = (low_shift + high_shift) / 2.0;
+        if clamped_sum(values, shift + trial, lower, upper) > target {
+            low_shift = trial;
         } else {
-            high_shift = shift;
+            high_shift = trial;
         }
     }
-    let shift = (low_shift + high_shift) / 2.0;
+    let trial = (low_shift + high_shift) / 2.0;
     values
         .iter()
-        .map(|value| (value - shift).clamp(lower, upper))
+        .map(|value| (value - shift - trial).clamp(lower, upper))
         .collect()
 }
 
@@ -516,18 +519,24 @@ mod tests {
         let clamped_sum = clamped.iter().sum::<f64>();
 
         // Band straddling the clamped sum: the clamp already satisfies it.
-        let inside =
-            project_box_interval(&values, lower, upper, clamped_sum - 0.2, clamped_sum + 0.2);
+        let inside = project_box_interval(
+            &values,
+            0.0,
+            lower,
+            upper,
+            clamped_sum - 0.2,
+            clamped_sum + 0.2,
+        );
         assert_eq!(inside, clamped);
 
         // Band entirely below or above it: the near edge holds with equality.
         for target in [clamped_sum - 0.3, clamped_sum + 0.15] {
             let band = if target < clamped_sum {
-                project_box_interval(&values, lower, upper, target - 0.5, target)
+                project_box_interval(&values, 0.0, lower, upper, target - 0.5, target)
             } else {
-                project_box_interval(&values, lower, upper, target, target + 0.5)
+                project_box_interval(&values, 0.0, lower, upper, target, target + 0.5)
             };
-            let fixed = project_box_sum(&values, lower, upper, target);
+            let fixed = project_box_sum(&values, 0.0, lower, upper, target);
             assert!(
                 band.iter().zip(&fixed).all(|(l, r)| (l - r).abs() <= 1e-12),
                 "{band:?} != {fixed:?}"
@@ -536,8 +545,8 @@ mod tests {
         }
 
         // A degenerate band is the fixed-sum projection exactly.
-        let pinned = project_box_interval(&values, lower, upper, 1.0, 1.0);
-        let fixed = project_box_sum(&values, lower, upper, 1.0);
+        let pinned = project_box_interval(&values, 0.0, lower, upper, 1.0, 1.0);
+        let fixed = project_box_sum(&values, 0.0, lower, upper, 1.0);
         assert!(
             pinned
                 .iter()

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -271,6 +271,105 @@ fn scanline_indicator(points: &[Point], region: &ContourSet) -> Vec<f64> {
     result
 }
 
+/// One layer's share of a coupled band projection.
+pub(super) struct CoupledBand<'a> {
+    /// Gradient proposal, one squared radius per active site.
+    pub proposal: &'a [f64],
+    pub lower: &'a [f64],
+    pub upper: &'a [f64],
+    /// Bounds on this layer's squared-radius sum.
+    pub sum_bounds: (f64, f64),
+    /// Sum those bounds surround: the layer's selected copper area.
+    pub center: f64,
+    /// Density denominator, turning a squared-radius change into the density
+    /// change the stack conserves.
+    pub domain_area_mm2: f64,
+}
+
+/// Project every layer onto its box and band, jointly constrained so the
+/// stack's density deviations cancel: `sum_l (sum(x_l) - center_l) / area_l == 0`.
+///
+/// The joint constraint says copper moves between layers rather than being
+/// created. Without it the bands free a direction the stack cannot see — every
+/// layer drifting the same way leaves the moment untouched, because a
+/// symmetric stackup's weights sum to zero — and that common drift is what the
+/// local density error spends them on.
+///
+/// One linear equality over separable convex sets dualizes to a single
+/// multiplier, so the solution is each layer's own band projection of a
+/// commonly shifted proposal and the multiplier follows by bisection. Shifting
+/// harder only lowers each sum, and a layer whose band binds stops responding
+/// altogether, so the deviation falls monotonically and brackets cleanly.
+pub(super) fn project_coupled_bands(layers: &[CoupledBand<'_>]) -> Vec<Vec<f64>> {
+    // A layer pinned at a band edge takes the same value for every multiplier
+    // past that point, so scoring a trial needs one clamped sum per layer
+    // rather than a nested projection.
+    let deviation = |multiplier: f64| {
+        layers
+            .iter()
+            .map(|layer| {
+                let shift = multiplier / layer.domain_area_mm2;
+                let sum = layer
+                    .proposal
+                    .iter()
+                    .zip(layer.lower)
+                    .zip(layer.upper)
+                    .map(|((value, lower), upper)| (value - shift).clamp(*lower, *upper))
+                    .sum::<f64>()
+                    .clamp(layer.sum_bounds.0, layer.sum_bounds.1);
+                (sum - layer.center) / layer.domain_area_mm2
+            })
+            .sum::<f64>()
+    };
+
+    // Past this shift every site clamps, so both ends saturate their bands.
+    let span = layers
+        .iter()
+        .flat_map(|layer| {
+            layer
+                .proposal
+                .iter()
+                .zip(layer.lower)
+                .zip(layer.upper)
+                .map(|((value, lower), upper)| (value - lower).abs().max((upper - value).abs()))
+        })
+        .fold(0.0_f64, f64::max);
+    let widest_domain = layers
+        .iter()
+        .map(|layer| layer.domain_area_mm2)
+        .fold(0.0_f64, f64::max);
+    let bound = span * widest_domain + 1.0;
+    let (mut low, mut high) = (-bound, bound);
+    for _ in 0..64 {
+        let multiplier = (low + high) / 2.0;
+        if deviation(multiplier) > 0.0 {
+            low = multiplier;
+        } else {
+            high = multiplier;
+        }
+    }
+    let multiplier = (low + high) / 2.0;
+
+    layers
+        .iter()
+        .map(|layer| {
+            let shift = multiplier / layer.domain_area_mm2;
+            let shifted = layer
+                .proposal
+                .iter()
+                .map(|value| value - shift)
+                .collect::<Vec<_>>();
+            project_box_interval(
+                &shifted,
+                layer.lower,
+                layer.upper,
+                layer.sum_bounds.0,
+                layer.sum_bounds.1,
+            )
+        })
+        .collect()
+}
+
 /// Euclidean projection onto `{x : lower <= x <= upper, sum_min <= sum(x) <= sum_max}`.
 ///
 /// The band is two halfspaces and at most one can bind, so clamping to the box


### PR DESCRIPTION
Copper balancing preserved whatever through-stack imbalance the boards were drawn with. It measured the moment of each layer's *deviation from its target*, which is zero exactly when every layer lands on target — the normal case since #1024 — so a correctly balanced panel reported nothing left to flatten while still carrying real asymmetry.

This reads the density itself, so the moment is of the copper actually present, and gives each layer a bounded budget to answer it with.

## The metric

```
M_i = sum_l w_l rho_li          (was: sum_l w_l (rho_li - d_l))
```

Penalizing this field pointwise covers both warp modes with one term rather than separate machinery: **bow is the field's mean, twist is its variation**, and squaring it at every site charges for both.

## The budget

The spatial solve used to conserve each layer's copper area exactly, so it could redistribute within a layer but never trade one layer's density match for a flatter moment. Each layer now has a band around its selected area, and the bands are settled jointly so the stack's density deviations cancel — a layer may only take on what another gives back.

Two settings, separate jobs:

- `stack_moment_weight` (10) scales the moment against the local density match. Equal weighting is far too timid: the local term brings one squared error per layer against this one's single term, so a six-layer stack sheds only about a sixth of a uniform moment.
- `stack_flex_density` (1%) caps where any layer can end up, whatever the weight asks for. It is what refuses a two-layer panel poured 0.9 against 0.3 the 30% correction it wants.

Zero flex reproduces the pinned result exactly; a stackup with no weights is unaffected by either.

## Why the bands are coupled

Freeing each layer's total independently frees a direction the stack cannot see. A symmetric stackup's weights sum to zero, so every layer drifting the same way leaves the moment untouched — and the local term will spend the whole band on exactly that drift, since bare clearance reads as a deficit on every layer at once.

Measured with independent bands: all six layers rose by the full 1%, no mirror gap moved, and the two densest layers were pushed into the corner of the radius box, flattening their voids to a single radius. Coupling removes that failure mode.

One linear equality over separable convex sets dualizes to a single multiplier, so each layer projects its own commonly shifted proposal onto its box and band, with the multiplier found by bisection. A layer pinned at a band edge stops responding to it, so a trial costs one clamped sum per layer rather than a nested projection.

## Effect

6-layer A6 array, normalized stack moment **0.0018 -> 0.0012**:

| Layer | Target | Before | After | Δ |
|---|---|---|---|---|
| F.Cu | 0.784 | 0.784 | 0.788 | +0.004 |
| In1.Cu | 0.923 | 0.923 | 0.916 | −0.007 |
| In2.Cu | 0.885 | 0.885 | 0.886 | +0.001 |
| In3.Cu | 0.877 | 0.877 | 0.879 | +0.002 |
| In4.Cu | 0.923 | 0.923 | 0.916 | −0.007 |
| B.Cu | 0.779 | 0.779 | 0.785 | +0.006 |

F.Cu and B.Cu close from 0.005 apart to 0.003, no layer ends more than 0.007 off its target, and the trade nets to −0.001. The five-up 18x24 panel built from those arrays falls **0.0011 -> 0.0005** — the improvement compounds, since the panel inherits already-flattened arrays. Both numbers are printed in the balance summary, so the trade is never silent.

Panel generation goes 24.4s -> 31.0s wall at unchanged total CPU; the coupled projection is one serial scalar solve per iteration, with the per-layer projections fanned back out.

`docs/board-array-copper-balancing.md` is rewritten where it required the opposite behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core panelization geometry and numerical optimization defaults; bounded by profile knobs and extensive tests, but affects fabrication copper fill on all balanced panels.
> 
> **Overview**
> Copper balancing now targets the **panel’s actual through-stack copper moment** (weighted density about the mid-plane), not per-layer deviation from target—so asymmetric boards that already hit their targets can still be flattened.
> 
> The spatial solver adds **`stack_moment_weight`** and **`stack_flex_density`** (defaults 2.0 and 1%): layers may shift density within a band so copper trades between layers under a **joint equality** that keeps stack deviations net-zero. Projection moves from pinned per-layer sums to **`project_coupled_bands`** (bisection on a shared multiplier plus per-layer box/band projection). **`stack_flex_density: 0`** restores the old pinned behavior; missing stack weights keep bands closed.
> 
> **`generate_spatial_dense_copper_balance`** now returns **`SpatialCopperBalance`** (layer results plus optional **`StackMomentField`** RMS before/after). IPC tooling reports stack moment and field RMS in **`CopperBalanceReport::summary_lines`**. Docs and changelog describe the new metric and settings; tests cover moment shrinkage, flex caps, coupled bands, and edge cases (no lattice, no weights).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573d68f5657470727a03ae48ae5bb5a437339576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->