### PR TITLE
ENG-672 Remove pcb layout --temp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Removed
 
+- `pcb layout --temp`; layouts are now always generated in their configured directory.
 - `ipc2581 render --flat`, which produced the same output as a plain render.
 
 ### Fixed

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -468,7 +468,6 @@ pub fn check_layout_sync(
 /// - Runs the pure semantic layout sync check without mutating layout files
 pub fn process_layout(
     schematic: &Schematic,
-    use_temp_dir: bool,
     check_mode: bool,
     diagnostics: &mut pcb_zen_core::Diagnostics,
 ) -> Result<Option<LayoutResult>, LayoutError> {
@@ -477,18 +476,9 @@ pub fn process_layout(
     }
 
     // Resolve layout directory
-    let resolved_layout_dir = if use_temp_dir {
-        // Create a temporary directory and keep it (prevent cleanup on drop)
-        tempfile::Builder::new()
-            .prefix("pcb-layout-")
-            .tempdir()
-            .expect("Failed to create temporary directory")
-            .keep()
-    } else {
-        match utils::resolve_layout_dir(schematic)? {
-            Some(path) => path,
-            None => return Ok(None),
-        }
+    let resolved_layout_dir = match utils::resolve_layout_dir(schematic)? {
+        Some(path) => path,
+        None => return Ok(None),
     };
 
     let source_path = schematic

--- a/crates/pcb-layout/tests/fpid_change.rs
+++ b/crates/pcb-layout/tests/fpid_change.rs
@@ -47,7 +47,7 @@ fn test_fpid_change_replaces_footprint_geometry() -> Result<()> {
     let schematic = output.expect("Zen evaluation should produce a schematic");
 
     let mut layout_diagnostics = Diagnostics::default();
-    let result = process_layout(&schematic, false, false, &mut layout_diagnostics)?.unwrap();
+    let result = process_layout(&schematic, false, &mut layout_diagnostics)?.unwrap();
     assert!(
         result.pcb_file.exists(),
         "PCB file should exist after initial sync"
@@ -99,7 +99,7 @@ fn test_fpid_change_replaces_footprint_geometry() -> Result<()> {
     let schematic2 = output2.expect("Second Zen evaluation should produce a schematic");
 
     let mut layout_diagnostics2 = Diagnostics::default();
-    let result2 = process_layout(&schematic2, false, false, &mut layout_diagnostics2)?.unwrap();
+    let result2 = process_layout(&schematic2, false, &mut layout_diagnostics2)?.unwrap();
     assert!(
         result2.pcb_file.exists(),
         "PCB file should exist after FPID change sync"
@@ -174,7 +174,7 @@ fn test_fpid_change_preserves_position() -> Result<()> {
     let (output, _) = pcb_zen::run(&zen_file, res.clone(), Default::default()).unpack();
     let schematic = output.expect("Zen evaluation should produce a schematic");
     let mut layout_diagnostics = Diagnostics::default();
-    let result = process_layout(&schematic, false, false, &mut layout_diagnostics)?.unwrap();
+    let result = process_layout(&schematic, false, &mut layout_diagnostics)?.unwrap();
 
     let initial_snapshot: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&result.snapshot_file)?)?;
@@ -198,7 +198,7 @@ fn test_fpid_change_preserves_position() -> Result<()> {
     let (output2, _) = pcb_zen::run(&zen_file, res, Default::default()).unpack();
     let schematic2 = output2.expect("Second Zen evaluation should produce a schematic");
     let mut layout_diagnostics2 = Diagnostics::default();
-    let result2 = process_layout(&schematic2, false, false, &mut layout_diagnostics2)?.unwrap();
+    let result2 = process_layout(&schematic2, false, &mut layout_diagnostics2)?.unwrap();
 
     let updated_snapshot: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&result2.snapshot_file)?)?;

--- a/crates/pcb-layout/tests/layout_generation.rs
+++ b/crates/pcb-layout/tests/layout_generation.rs
@@ -46,7 +46,7 @@ macro_rules! layout_test {
 
                 // Process the layout
                 let mut diagnostics = Diagnostics::default();
-                let result = process_layout(&schematic, false, false, &mut diagnostics)?.unwrap();
+                let result = process_layout(&schematic, false, &mut diagnostics)?.unwrap();
 
                 // Verify the layout was created
                 assert!(result.pcb_file.exists(), "PCB file should exist");

--- a/crates/pcb-layout/tests/moved.rs
+++ b/crates/pcb-layout/tests/moved.rs
@@ -40,7 +40,7 @@ fn test_moved_renames_path_and_preserves_position() -> Result<()> {
     let schematic = output.expect("Zen evaluation should produce a schematic");
 
     let mut layout_diagnostics = Diagnostics::default();
-    let result = process_layout(&schematic, false, false, &mut layout_diagnostics)?.unwrap();
+    let result = process_layout(&schematic, false, &mut layout_diagnostics)?.unwrap();
     assert!(
         result.pcb_file.exists(),
         "PCB file should exist after initial sync"
@@ -85,7 +85,7 @@ fn test_moved_renames_path_and_preserves_position() -> Result<()> {
     );
 
     let mut layout_diagnostics2 = Diagnostics::default();
-    let result2 = process_layout(&schematic2, false, false, &mut layout_diagnostics2)?.unwrap();
+    let result2 = process_layout(&schematic2, false, &mut layout_diagnostics2)?.unwrap();
     assert!(
         result2.pcb_file.exists(),
         "PCB file should exist after rename sync"

--- a/crates/pcbc/src/layout.rs
+++ b/crates/pcbc/src/layout.rs
@@ -246,20 +246,3 @@ fn print_layout_result(
     }
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use clap::Parser;
-
-    #[derive(Parser)]
-    struct TestCli {
-        #[command(flatten)]
-        args: LayoutArgs,
-    }
-
-    #[test]
-    fn temp_flag_is_rejected() {
-        assert!(TestCli::try_parse_from(["pcb", "--temp", "board.zen"]).is_err());
-    }
-}

--- a/crates/pcbc/src/layout.rs
+++ b/crates/pcbc/src/layout.rs
@@ -28,10 +28,6 @@ pub struct LayoutArgs {
     #[arg(long = "offline")]
     pub offline: bool,
 
-    /// Generate layout in a temporary directory (fresh layout, opens KiCad)
-    #[arg(long = "temp")]
-    pub temp: bool,
-
     /// Run KiCad DRC checks after layout generation
     #[arg(long = "check")]
     pub check: bool,
@@ -43,7 +39,7 @@ pub struct LayoutArgs {
     pub suppress: Vec<String>,
 
     /// Resolve existing layout files without updating them
-    #[arg(long = "no-sync", conflicts_with_all = ["temp", "check"])]
+    #[arg(long = "no-sync", conflicts_with = "check")]
     pub no_sync: bool,
 
     /// Output format
@@ -137,7 +133,7 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
     };
     let spinner = Spinner::builder(spinner_msg).hidden(hide_progress).start();
     let mut diagnostics = pcb_zen_core::Diagnostics::default();
-    let result = process_layout(&schematic, args.temp, args.check, &mut diagnostics)?;
+    let result = process_layout(&schematic, args.check, &mut diagnostics)?;
     spinner.finish();
 
     let Some(layout_result) = result else {
@@ -191,8 +187,8 @@ pub fn execute(mut args: LayoutArgs) -> Result<()> {
         anyhow::bail!("DRC failed");
     }
 
-    // Open the layout if not disabled (or if using temp)
-    if !args.no_open || args.temp {
+    // Open the layout if not disabled
+    if !args.no_open {
         pcb_kicad::open_pcbnew(&pcb_file)?;
     }
 
@@ -249,4 +245,21 @@ fn print_layout_result(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: LayoutArgs,
+    }
+
+    #[test]
+    fn temp_flag_is_rejected() {
+        assert!(TestCli::try_parse_from(["pcb", "--temp", "board.zen"]).is_err());
+    }
 }

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -1322,7 +1322,7 @@ fn run_kicad_drc(info: &ReleaseInfo, spinner: &Spinner) -> Result<()> {
 
     // Collect diagnostics from layout sync check (run on staged sources/layout).
     let Some(layout_result) =
-        pcb_layout::process_layout(&staged_schematic, false, true, &mut diagnostics)?
+        pcb_layout::process_layout(&staged_schematic, true, &mut diagnostics)?
     else {
         anyhow::bail!("No layout directory for DRC checks");
     };

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -39,9 +39,6 @@ struct RemoteLayoutResult {
 }
 
 pub fn execute_layout(uri: SandboxFileUri, args: LayoutArgs) -> Result<()> {
-    if args.temp {
-        bail!("Remote sandbox layout does not support --temp");
-    }
     let should_open = !args.no_open && !args.check;
 
     let client = sandbox_client(&uri)?;
@@ -83,7 +80,6 @@ pub fn execute_open(uri: SandboxFileUri, args: OpenArgs) -> Result<()> {
             config: Vec::new(),
             no_open: true,
             offline: args.offline,
-            temp: false,
             check: false,
             suppress: Vec::new(),
             no_sync: true,


### PR DESCRIPTION
Remove the unused `pcb layout --temp` option and delete the temporary layout generation path. Layout generation now always uses the configured layout directory; `cargo test -p pcbc` and `cargo test -p pcb-layout` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes an alternate code path and narrows the CLI; behavior change is limited to users who relied on `--temp`, with no auth or data-handling impact.
> 
> **Overview**
> **Removes the `pcb layout --temp` flag** and the temporary-directory layout path. `process_layout` no longer takes a `use_temp_dir` argument; generation always uses `resolve_layout_dir` from the schematic.
> 
> The **CLI** drops the `--temp` field, simplifies `--no-sync` conflicts (no longer tied to `--temp`), and only opens KiCad when `--no-open` is not set (previously `--temp` could force open). **Remote sandbox** layout no longer errors on `--temp` or special-cases opening for temp runs.
> 
> **Call sites** (`pcbc` layout/release, layout integration tests) are updated to the new `process_layout(schematic, check_mode, diagnostics)` signature. **CHANGELOG** records the removal under 0.4.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67cd7033d6b4a7bcfda9551529c2c7864a5d1373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->