### PR TITLE
Take both copper-moment readings from one field

### DIFF
--- a/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
+++ b/crates/pcb-ipc2581-tools/docs/board-array-copper-balancing.md
@@ -142,6 +142,13 @@ follows the field's mean, twist follows its variation, and squaring `M_i` at
 every site charges for both — so there is one term here rather than separate
 bow and twist machinery.
 
+Both readings are taken from that one field over the same sites, which is what
+makes them comparable: `E_stack` never falls below the mean's magnitude, so a
+mean that drops while `E_stack` holds has moved bow into twist rather than
+removing anything. Measuring the two separately — say a mean over per-layer
+average densities against an RMS over the field — would weight the panel
+differently in each and quietly break that reading.
+
 The reference is zero copper moment, not the board's own per-layer density.
 Reading `rho_li` rather than `rho_li - d_l` is the whole difference: the
 subtracted form is zero exactly when every layer sits on its target, so a

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -158,14 +158,18 @@ pub enum CopperBalanceMode {
 /// serializable and `pcb-ir` carries no serde dependency.
 #[derive(Debug, Clone, Copy, Serialize)]
 pub struct StackMomentFieldReport {
+    pub initial_mean: f64,
     pub initial_rms: f64,
+    pub achieved_mean: f64,
     pub achieved_rms: f64,
 }
 
 impl From<StackMomentField> for StackMomentFieldReport {
     fn from(field: StackMomentField) -> Self {
         Self {
+            initial_mean: field.initial_mean,
             initial_rms: field.initial_rms,
+            achieved_mean: field.achieved_mean,
             achieved_rms: field.achieved_rms,
         }
     }
@@ -185,38 +189,9 @@ pub struct CopperBalanceReport {
 }
 
 impl CopperBalanceReport {
-    /// The panel's normalized copper moment about the stack mid-plane, as it
-    /// would stand with every layer on its target and as it actually stands.
-    ///
-    /// The first is what the boards were drawn carrying; the second is what
-    /// the balanced panel carries after layers traded density to flatten it.
-    /// `None` when the stackup supplied no weights, which is also when the
-    /// solver leaves the moment alone.
-    pub fn stack_moments(&self) -> Option<(f64, f64)> {
-        // The solver already decided whether the moment was modelled at all;
-        // deciding it a second time here is how the two drift apart.
-        self.moment_field?;
-        let scale = self
-            .layers
-            .iter()
-            .map(|layer| layer.stack_weight_mm2.abs())
-            .sum::<f64>();
-        let moment = |density: fn(&CopperBalanceLayerReport) -> f64| {
-            self.layers
-                .iter()
-                .map(|layer| layer.stack_weight_mm2 * density(layer))
-                .sum::<f64>()
-                / scale
-        };
-        Some((
-            moment(|layer| layer.target_density),
-            moment(|layer| layer.achieved_density),
-        ))
-    }
-
-    /// One short status line per copper layer, the stack moment the trade
-    /// moved, plus a warning when the stackup could not supply physical stack
-    /// weights.
+    /// One short status line per copper layer, what the trade did to the
+    /// panel's copper moment, plus a warning when the stackup could not supply
+    /// physical stack weights.
     pub fn summary_lines(&self) -> Vec<String> {
         let mut lines = self
             .layers
@@ -245,12 +220,10 @@ impl CopperBalanceReport {
                 )
             })
             .collect::<Vec<_>>();
-        if let (Some((untouched, achieved)), Some(field)) =
-            (self.stack_moments(), self.moment_field)
-        {
+        if let Some(field) = self.moment_field {
             lines.push(format!(
-                "balance: stack moment {untouched:.4} -> {achieved:.4} (field rms {:.4} -> {:.4})",
-                field.initial_rms, field.achieved_rms
+                "balance: stack moment {:.4} -> {:.4} (field rms {:.4} -> {:.4})",
+                field.initial_mean, field.achieved_mean, field.initial_rms, field.achieved_rms
             ));
         }
         if !self.layers.is_empty() && !self.stack_weights_available {

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -251,13 +251,33 @@ pub struct DenseCopperVoid {
 ///
 /// The field's mean is the panel's bow and its variation is twist, so an RMS
 /// carries both: a falling RMS means the field flattened, not merely that a
-/// positive lobe found a negative one to cancel against. Comparing it against
-/// the mean alone separates the two — a mean that drops while the RMS holds
-/// has moved bow into twist.
+/// positive lobe found a negative one to cancel against. Both readings come
+/// from the same field over the same sites, so the pair can be compared — a
+/// mean that drops while the RMS holds has moved bow into twist, and that
+/// reading is only trustworthy because neither number was measured its own way.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StackMomentField {
+    pub initial_mean: f64,
     pub initial_rms: f64,
+    pub achieved_mean: f64,
     pub achieved_rms: f64,
+}
+
+/// One reading of the copper-moment field.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct MomentReading {
+    mean: f64,
+    rms: f64,
+}
+
+impl MomentReading {
+    fn of(field: &[f64]) -> Self {
+        let count = field.len() as f64;
+        Self {
+            mean: field.iter().sum::<f64>() / count,
+            rms: (field.iter().map(|moment| moment * moment).sum::<f64>() / count).sqrt(),
+        }
+    }
 }
 
 /// Every layer's solved geometry, plus what the solve did to the stack.
@@ -654,8 +674,11 @@ pub fn generate_spatial_dense_copper_balance(
     // reduction. The first reading is the field the uniform selection left
     // behind; the last trails the emitted radii by one gradient step, which at
     // convergence is smaller than the radius quantization.
-    let mut initial_rms: Option<f64> = None;
-    let mut achieved_rms = 0.0;
+    let mut initial_reading: Option<MomentReading> = None;
+    let mut achieved_reading = MomentReading {
+        mean: 0.0,
+        rms: 0.0,
+    };
     for _ in 0..SPATIAL_SOLVE_ITERATIONS {
         // The modeled final copper fraction of each layer, not its distance
         // from target: the moment below is the copper the panel carries, and
@@ -730,13 +753,8 @@ pub fn generate_spatial_dense_copper_balance(
             })
             .collect::<Vec<_>>();
         if moment_gain > 0.0 {
-            achieved_rms = (stack_moment
-                .iter()
-                .map(|moment| moment * moment)
-                .sum::<f64>()
-                / stack_moment.len() as f64)
-                .sqrt();
-            initial_rms.get_or_insert(achieved_rms);
+            achieved_reading = MomentReading::of(&stack_moment);
+            initial_reading.get_or_insert(achieved_reading);
         }
 
         let proposals = std::thread::scope(|scope| {
@@ -833,9 +851,11 @@ pub fn generate_spatial_dense_copper_balance(
                 )
             })
             .collect(),
-        moment_field: initial_rms.map(|initial_rms| StackMomentField {
-            initial_rms,
-            achieved_rms,
+        moment_field: initial_reading.map(|initial| StackMomentField {
+            initial_mean: initial.mean,
+            initial_rms: initial.rms,
+            achieved_mean: achieved_reading.mean,
+            achieved_rms: achieved_reading.rms,
         }),
     })
 }
@@ -1822,6 +1842,17 @@ mod tests {
         };
 
         let weighed = solve(1.0).moment_field.expect("weights were supplied");
+        // Both readings come from one field over one set of sites, so the RMS
+        // bounds the mean's magnitude. Measuring them apart would let this
+        // slip without anything noticing.
+        assert!(
+            weighed.initial_rms >= weighed.initial_mean.abs(),
+            "{weighed:?}"
+        );
+        assert!(
+            weighed.achieved_rms >= weighed.achieved_mean.abs(),
+            "{weighed:?}"
+        );
         // These layers are asked for markedly different densities, so the
         // field starts well away from zero and the solve flattens it.
         assert!(weighed.initial_rms > 0.0, "{weighed:?}");


### PR DESCRIPTION
The balance summary prints two readings of the panel's copper moment — a mean and an RMS — and they described the same quantity while being measured apart. The RMS came from the moment field inside the solver; the mean was reconstructed a crate up from per-layer *average* densities, carrying its own copy of the normalize-by-sum-of-weights rule.

Those two weight the panel differently, so the pair could drift with nothing to notice. And the pair is the whole point: a mean that drops while the RMS holds has moved bow into twist rather than removing anything. That reading is only sound when one field over one set of sites produces both — which also makes `rms >= |mean|` structural rather than coincidental.

The solver now reports both, the consumer only formats them, and `stack_moments()` is deleted along with the duplicated normalization.

## Effect

The printed mean moves with its baseline. On a 6-layer A6 array `0.0018 -> 0.0012` becomes `0.0012 -> 0.0008` — the same third removed, now measured where the RMS is measured rather than over each layer's own density domain. The five-up panel reads `0.0010 -> 0.0005`. Balanced geometry is unchanged.

Net -7 lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting and metric plumbing only; balancing geometry and solve behavior are unchanged aside from summary numbers shifting to a consistent baseline.
> 
> **Overview**
> Balance summaries used to show **stack moment mean** rebuilt in `pcb-ipc2581-tools` from per-layer average densities, while **field RMS** came from the spatial solver’s copper-moment field—so the two metrics could disagree even though they were meant to be read together (bow vs twist).
> 
> The solver now records **initial/achieved mean and RMS** on `StackMomentField` via a shared `MomentReading` over the same evaluation sites; IPC reports only format those values. **`CopperBalanceReport::stack_moments()`** and its duplicate weight normalization are removed. Docs note that both readings must share one field, and tests assert **`rms >= |mean|`** so split measurement cannot slip back in.
> 
> Printed mean values shift to the field baseline (geometry unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96782b3b47f3f997201d754d7607376beba1f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->