### PR TITLE
Update the default 1 oz via size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- The default 1 oz board netclass now uses a 0.45 mm via diameter with a 0.20 mm drill.
 - `--layout-target` now takes `board` or `board-array` on every command, and defaults to `board-array`.
 - Copper balancing now flattens the copper the panel actually carries about its mid-plane, rather than preserving whatever through-stack imbalance the boards were drawn with.
 - Copper balancing can shift a layer up to 1% off its target density to counterweight the rest of the stack, paid for by an opposite shift elsewhere.

--- a/lib/std/board_config.zen
+++ b/lib/std/board_config.zen
@@ -485,8 +485,8 @@ DEFAULT_NETCLASS = NetClass(
     name="Default",
     clearance=0.16,
     track_width=0.16,  # Matches 2oz netclass
-    via_diameter=0.5,  # Standard via size (5.3:1 aspect ratio on 1.6mm board)
-    via_drill=0.3,  # Standard drill size
+    via_diameter=0.45,
+    via_drill=0.2,
     diff_pair_width=0.2,  # Reasonable diff pair width
     diff_pair_gap=0.2,  # Reasonable diff pair gap
 )


### PR DESCRIPTION
The default 1 oz netclass used a larger 0.30 mm drill than needed for the selected JLCPCB profile. This change sets the via to a 0.45 mm diameter with a 0.20 mm drill and records the user-visible change; `cargo run -p pcbc -- test lib/std/test/test_BoardConfig.zen` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manufacturing-default tweak in stdlib board config only; may change KiCad netclass defaults for boards that rely on implicit 1 oz defaults without custom overrides.
> 
> **Overview**
> Updates the **default 1 oz** `DEFAULT_NETCLASS` via geometry from **0.5 mm / 0.3 mm** to **0.45 mm / 0.2 mm**, aligning default routing rules with the JLCPCB-oriented profile (smaller drill than before).
> 
> The **Unreleased** changelog notes the user-visible default netclass change. **2 oz** defaults and predefined via lists are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59557644127913e0f49743cde423993a0d0d8c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->