### PR TITLE
Fix Gerber export naming, polarity, drills, and pad flashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Inner copper Gerbers now use KiCad's layer numbering (`In1_Cu`, `In2_Cu`, ...).
+- Exported Gerbers declare `%TF.FilePolarity,Positive`.
+- Drill tool diameters snap to 1 µm, cleaning up float dust from EDA exports, and the tool table is sorted by diameter.
+- Pads with rounded or custom shapes now export as shared Gerber aperture flashes instead of repeated regions, shrinking mask and paste layers.
+
 ## [0.4.25] - 2026-08-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Exported Gerbers declare `%TF.FilePolarity,Positive`.
 - Drill tool diameters snap to 1 µm, cleaning up float dust from EDA exports, and the tool table is sorted by diameter.
 - Pads with rounded or custom shapes now export as shared Gerber aperture flashes instead of repeated regions, shrinking mask and paste layers.
+- Rounded-rectangle pads export as compact parameterized macro apertures, and hexagon and octagon pads as polygon apertures.
+- Gerber output no longer repeats object attributes on every object.
 
 ## [0.4.25] - 2026-08-07
 

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -593,6 +593,10 @@ impl ApertureTable {
                         "cannot export a Gerber rounded-rectangle aperture with a hole".to_string(),
                     ));
                 }
+                // An oversized radius images clamped, matching how
+                // `shapes::rounded_rect` flattens the same aperture; past the
+                // limit the macro's rectangle terms would go negative.
+                let radius = radius.min(width / 2.0).min(height / 2.0);
                 if !self.roundrect_macro_defined {
                     self.aperture_macros.push(roundrect_macro());
                     self.roundrect_macro_defined = true;

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -325,6 +325,23 @@ struct GerberObjectGroup {
     objects: Vec<WriterObject>,
 }
 
+/// Emission order for commuting groups: stage first, then object attributes
+/// and aperture so identical writer state runs together. A group's objects
+/// all lower from one artwork object and share attributes.
+fn group_order(group: &GerberObjectGroup) -> (PaintStage, &[AttributeValue], i32) {
+    let first = group.objects.first();
+    (
+        group.stage,
+        first.map_or(&[], |object| object.attributes.as_slice()),
+        first.map_or(i32::MAX, |object| match object.kind {
+            ObjectKind::Draw { aperture, .. }
+            | ObjectKind::Arc { aperture, .. }
+            | ObjectKind::Flash { aperture, .. } => aperture,
+            ObjectKind::Region { .. } => i32::MAX,
+        }),
+    )
+}
+
 impl GerberPlan {
     fn push_group(&mut self, stage: PaintStage, polarity: Polarity, objects: Vec<WriterObject>) {
         if objects.is_empty() {
@@ -340,8 +357,11 @@ impl GerberPlan {
     fn into_ordered_objects(self) -> Vec<WriterObject> {
         // Dark paint commutes with dark paint and clear with clear, but not
         // across a polarity change: stage ordering (fills before pads) may
-        // only permute groups within each maximal same-polarity run. Final
-        // cutouts are terminal by definition and emit after everything.
+        // only permute groups within each maximal same-polarity run. Within
+        // a stage the same commutativity lets groups cluster by object
+        // attributes and aperture, so the writer's attribute and tool state
+        // changes as rarely as possible. Final cutouts are terminal by
+        // definition and emit after everything.
         let (cutouts, mut painted): (Vec<_>, Vec<_>) = self
             .groups
             .into_iter()
@@ -353,7 +373,7 @@ impl GerberPlan {
             while end < painted.len() && painted[end].polarity == polarity {
                 end += 1;
             }
-            painted[start..end].sort_by_key(|group| group.stage);
+            painted[start..end].sort_by(|a, b| group_order(a).cmp(&group_order(b)));
             start = end;
         }
         painted
@@ -370,6 +390,7 @@ struct ApertureTable {
     by_key: HashMap<ApertureKey, i32>,
     apertures: Vec<WriterAperture>,
     aperture_macros: Vec<WriterApertureMacro>,
+    roundrect_macro_defined: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -399,6 +420,11 @@ enum ApertureTemplateKey {
         vertices: u32,
         rotation_microdeg: i64,
         hole_nm: i64,
+    },
+    RoundRect {
+        width_nm: i64,
+        height_nm: i64,
+        radius_nm: i64,
     },
     Contour(Vec<Vec<(i64, i64)>>),
 }
@@ -551,6 +577,39 @@ impl ApertureTable {
                     function,
                 )
             }
+            ApertureShape::RoundRect {
+                width,
+                height,
+                radius,
+            } => {
+                if width <= 0.0 || height <= 0.0 || radius <= 0.0 {
+                    return Err(GerberError::InvalidStructure(format!(
+                        "cannot export non-positive Gerber rounded-rectangle aperture \
+                         {width} x {height} r {radius}"
+                    )));
+                }
+                if hole_diameter.is_some() {
+                    return Err(GerberError::InvalidStructure(
+                        "cannot export a Gerber rounded-rectangle aperture with a hole".to_string(),
+                    ));
+                }
+                if !self.roundrect_macro_defined {
+                    self.aperture_macros.push(roundrect_macro());
+                    self.roundrect_macro_defined = true;
+                }
+                self.define(
+                    ApertureTemplateKey::RoundRect {
+                        width_nm: quantize_mm(width),
+                        height_nm: quantize_mm(height),
+                        radius_nm: quantize_mm(radius),
+                    },
+                    WriterApertureTemplate::Macro {
+                        name: ROUNDRECT_MACRO_NAME.to_string(),
+                        parameters: vec![width, height, radius],
+                    },
+                    function,
+                )
+            }
         }
     }
 
@@ -653,6 +712,74 @@ impl ApertureTable {
 
     fn into_parts(self) -> (Vec<WriterAperture>, Vec<WriterApertureMacro>) {
         (self.apertures, self.aperture_macros)
+    }
+}
+
+const ROUNDRECT_MACRO_NAME: &str = "RoundedRect";
+
+/// The shared parameterized rounded-rectangle macro: two centered rectangles
+/// leaving the corner insets uncovered, plus one circle per corner. Parameters
+/// are `$1` width, `$2` height, `$3` corner radius; at the obround and circle
+/// degeneracies a rectangle collapses to zero area and drops out.
+fn roundrect_macro() -> WriterApertureMacro {
+    use WriterMacroExpression as Expression;
+    let number = |value: f64| Expression::Number(value);
+    let variable = |index: usize| Expression::Variable(index);
+    let subtract =
+        |left: Expression, right: Expression| Expression::Subtract(Box::new(left), Box::new(right));
+    let multiply =
+        |left: Expression, right: Expression| Expression::Multiply(Box::new(left), Box::new(right));
+    let divide =
+        |left: Expression, right: Expression| Expression::Divide(Box::new(left), Box::new(right));
+    // `$n/2-$3` and its negation `$3-$n/2`: the corner-circle center offset.
+    let inset = |axis: usize, positive: bool| {
+        if positive {
+            subtract(divide(variable(axis), number(2.0)), variable(3))
+        } else {
+            subtract(variable(3), divide(variable(axis), number(2.0)))
+        }
+    };
+
+    let mut primitives = vec![
+        WriterMacroPrimitive::Shape {
+            code: 21,
+            parameters: vec![
+                number(1.0),
+                variable(1),
+                subtract(variable(2), multiply(number(2.0), variable(3))),
+                number(0.0),
+                number(0.0),
+                number(0.0),
+            ],
+        },
+        WriterMacroPrimitive::Shape {
+            code: 21,
+            parameters: vec![
+                number(1.0),
+                subtract(variable(1), multiply(number(2.0), variable(3))),
+                variable(2),
+                number(0.0),
+                number(0.0),
+                number(0.0),
+            ],
+        },
+    ];
+    primitives.extend(
+        [(true, true), (false, true), (true, false), (false, false)].map(|(right, top)| {
+            WriterMacroPrimitive::Shape {
+                code: 1,
+                parameters: vec![
+                    number(1.0),
+                    multiply(number(2.0), variable(3)),
+                    inset(1, right),
+                    inset(2, top),
+                ],
+            }
+        }),
+    );
+    WriterApertureMacro {
+        name: ROUNDRECT_MACRO_NAME.to_string(),
+        primitives,
     }
 }
 

--- a/crates/gerberx2/src/write.rs
+++ b/crates/gerberx2/src/write.rs
@@ -6,7 +6,7 @@ use pcb_ir::geom::Polarity;
 ///
 /// Attribute names should include the leading X2 dot, for example
 /// `.FileFunction`, `.AperFunction`, `.N`, `.C`, or `.P`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AttributeValue {
     pub name: String,
     pub fields: Vec<String>,
@@ -253,6 +253,7 @@ struct Writer<'a> {
     current_polarity: Polarity,
     current_plot_mode: Option<PlotMode>,
     current_aperture_transform: WriterApertureTransform,
+    current_object_attributes: Vec<AttributeValue>,
 }
 
 impl<'a> Writer<'a> {
@@ -264,6 +265,7 @@ impl<'a> Writer<'a> {
             current_polarity: Polarity::Dark,
             current_plot_mode: None,
             current_aperture_transform: WriterApertureTransform::default(),
+            current_object_attributes: Vec::new(),
         }
     }
 
@@ -287,7 +289,10 @@ impl<'a> Writer<'a> {
             }
             self.write_aperture(aperture)?;
             if !aperture.attributes.is_empty() {
+                // %TD clears the whole attribute dictionary, including any
+                // object attributes a block aperture's contents left behind.
                 self.output.push_str("%TD*%\n");
+                self.current_object_attributes.clear();
             }
         }
 
@@ -474,9 +479,7 @@ impl<'a> Writer<'a> {
     fn write_object(&mut self, object: &WriterObject) -> Result<()> {
         self.set_aperture_transform(object.aperture_transform)?;
         self.set_polarity(object.polarity);
-        for attr in &object.attributes {
-            self.write_attribute("TO", attr)?;
-        }
+        self.set_object_attributes(&object.attributes)?;
 
         match &object.kind {
             ObjectKind::Draw {
@@ -515,9 +518,32 @@ impl<'a> Writer<'a> {
             }
         }
 
-        if !object.attributes.is_empty() {
-            self.output.push_str("%TD*%\n");
+        Ok(())
+    }
+
+    /// Bring the object attribute dictionary to exactly `attributes`. X2
+    /// attributes are file state, so consecutive objects sharing a value pay
+    /// nothing; a same-name attribute re-emits to override, and a dropped
+    /// name resets the dictionary before the survivors are re-emitted.
+    fn set_object_attributes(&mut self, attributes: &[AttributeValue]) -> Result<()> {
+        if self.current_object_attributes == attributes {
+            return Ok(());
         }
+        let dropped = self.current_object_attributes.iter().any(|current| {
+            !attributes
+                .iter()
+                .any(|attribute| attribute.name == current.name)
+        });
+        if dropped {
+            self.output.push_str("%TD*%\n");
+            self.current_object_attributes.clear();
+        }
+        for attribute in attributes {
+            if !self.current_object_attributes.contains(attribute) {
+                self.write_attribute("TO", attribute)?;
+            }
+        }
+        self.current_object_attributes = attributes.to_vec();
         Ok(())
     }
 
@@ -791,5 +817,43 @@ mod tests {
 
         let err = write_layer(&layer).unwrap_err().to_string();
         assert!(err.contains("field separators"), "{err}");
+    }
+
+    #[test]
+    fn object_attributes_persist_across_objects() {
+        let flash = |x: f64, attributes: Vec<AttributeValue>| WriterObject {
+            kind: ObjectKind::Flash {
+                at: Point { x, y: 0.0 },
+                aperture: 10,
+            },
+            polarity: Polarity::Dark,
+            aperture_transform: WriterApertureTransform::default(),
+            attributes,
+        };
+        let net = |name: &str| AttributeValue::new(".N", [name]);
+        let layer = GerberLayer {
+            apertures: vec![WriterAperture {
+                code: 10,
+                template: WriterApertureTemplate::Circle {
+                    diameter: 1.0,
+                    hole_diameter: None,
+                },
+                attributes: Vec::new(),
+            }],
+            objects: vec![
+                flash(0.0, vec![net("GND")]),
+                flash(1.0, vec![net("GND")]),
+                flash(2.0, vec![net("V3V3")]),
+                flash(3.0, Vec::new()),
+            ],
+            ..GerberLayer::default()
+        };
+
+        let output = write_layer(&layer).unwrap();
+        // The repeated net rides existing state, the changed net overrides in
+        // place, and only dropping attributes resets the dictionary.
+        assert_eq!(output.matches("%TO.N,GND*%").count(), 1);
+        assert_eq!(output.matches("%TO.N,V3V3*%").count(), 1);
+        assert_eq!(output.matches("%TD*%").count(), 1);
     }
 }

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1223,9 +1223,59 @@ fn exact_flash_aperture(primitive: &StandardPrimitive, transform: Affine2) -> Op
                 axis_aligned_size(transform, oval.shape.size.width, oval.shape.size.height)?;
             Aperture::solid(ApertureShape::Obround { width, height })
         }
+        StandardPrimitive::RectRound(rect) => {
+            let corners = [
+                rect.shape.upper_right,
+                rect.shape.upper_left,
+                rect.shape.lower_right,
+                rect.shape.lower_left,
+            ];
+            if corners.iter().any(|rounded| !rounded) {
+                return None;
+            }
+            let (width, height) =
+                axis_aligned_size(transform, rect.shape.size.width, rect.shape.size.height)?;
+            let radius = rect.shape.radius * uniform_scale(transform)?;
+            if radius <= 0.0 {
+                Aperture::solid(ApertureShape::Rectangle { width, height })
+            } else {
+                Aperture::solid(ApertureShape::RoundRect {
+                    width,
+                    height,
+                    radius,
+                })
+            }
+        }
+        StandardPrimitive::Hexagon(hexagon) => {
+            regular_polygon_aperture(6, hexagon.shape.point_to_point, transform)?
+        }
+        StandardPrimitive::Octagon(octagon) => {
+            regular_polygon_aperture(8, octagon.shape.point_to_point, transform)?
+        }
         _ => return None,
     };
     Some(aperture)
+}
+
+/// IPC hexagons and octagons place their first vertex pointing down (-90°);
+/// a rigid rotation folds into the Gerber polygon aperture's own rotation,
+/// while mirrored placements keep the contour fallback.
+fn regular_polygon_aperture(
+    vertices: u32,
+    point_to_point: f64,
+    transform: Affine2,
+) -> Option<Aperture> {
+    let scale = uniform_scale(transform)?;
+    let determinant = transform.m00 * transform.m11 - transform.m01 * transform.m10;
+    if determinant <= 0.0 {
+        return None;
+    }
+    let rotation_degrees = transform.m10.atan2(transform.m00).to_degrees() - 90.0;
+    Some(Aperture::solid(ApertureShape::Polygon {
+        diameter: point_to_point * scale,
+        vertices,
+        rotation_degrees,
+    }))
 }
 
 fn standard_flash_feature_is_eligible(feature: &Feature<ipc2581::Symbol>) -> bool {
@@ -1581,6 +1631,10 @@ mod tests {
         assert!(
             copper.contents.matches("%ADD").count() <= 2,
             "repeated pads share one aperture definition"
+        );
+        assert!(
+            copper.contents.contains("%AMRoundedRect*"),
+            "axis-aligned rounded rectangles use the parameterized macro"
         );
 
         let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -418,7 +418,9 @@ fn layer_attributes(file_function: Vec<String>, part: GerberPart) -> LayerAttrib
     LayerAttributes {
         file_function,
         part: Some(vec![part.as_str().to_string()]),
-        file_polarity: None,
+        // Every exported layer is a positive image; clears stay inside the
+        // file as %LPC state rather than flipping the file polarity.
+        file_polarity: Some("Positive".to_string()),
     }
 }
 
@@ -435,7 +437,8 @@ fn copper_layer_output(
     let filename = match side {
         Some(IpcSide::Top) => "F_Cu.gtl".to_string(),
         Some(IpcSide::Bottom) => "B_Cu.gbl".to_string(),
-        _ => format!("In{}_Cu.gbr", copper_index),
+        // KiCad numbers inner layers from 1, excluding the top layer.
+        _ => format!("In{}_Cu.gbr", copper_index - 1),
     };
     let index = match side {
         Some(IpcSide::Top) => 1,
@@ -649,8 +652,7 @@ impl ArtworkLowering<ipc2581::Symbol, ObjectAttributes> for GerberLowering<'_> {
         &mut self,
         feature: &Feature<ipc2581::Symbol>,
     ) -> Option<(Aperture, Affine2, BBox)> {
-        let (aperture, at, bbox) = standard_flash_aperture(self.ipc, feature)?;
-        Some((aperture, Affine2::translation(at), bbox))
+        standard_flash_aperture(self.ipc, self.doc, feature)
     }
 
     fn stroke_style(&mut self, stroke: StrokeStyle) -> StrokeStyle {
@@ -1177,8 +1179,9 @@ fn ir_side(side: Option<IpcSide>) -> IrSide {
 
 fn standard_flash_aperture(
     ipc: &Ipc2581,
+    doc: &IpcGeometryDocument,
     feature: &Feature<ipc2581::Symbol>,
-) -> Option<(Aperture, Point, BBox)> {
+) -> Option<(Aperture, Affine2, BBox)> {
     if !standard_flash_feature_is_eligible(feature) {
         return None;
     }
@@ -1188,35 +1191,41 @@ fn standard_flash_aperture(
         return None;
     }
 
+    if let Some(aperture) = exact_flash_aperture(primitive, feature.transform) {
+        let at = feature.center;
+        let bbox = flash_bbox(at, &aperture);
+        return Some((aperture, Affine2::translation(at), bbox));
+    }
+
+    // Every other solid catalogue shape flashes through a contour aperture
+    // shared per shape, keeping repeated pads one definition each instead of
+    // re-painting a region at every placement.
+    let shape = pcb_ir::dialects::ipc::contour_flash_aperture(doc, feature)?;
+    Some((Aperture::solid(shape), feature.transform, feature.bbox))
+}
+
+/// The catalogue primitives Gerber expresses as exact standard apertures.
+fn exact_flash_aperture(primitive: &StandardPrimitive, transform: Affine2) -> Option<Aperture> {
     let aperture = match primitive {
         StandardPrimitive::Circle(circle) => {
-            let scale = uniform_scale(feature.transform)?;
+            let scale = uniform_scale(transform)?;
             Aperture::solid(ApertureShape::Circle {
                 diameter: circle.shape.diameter * scale,
             })
         }
         StandardPrimitive::RectCenter(rect) => {
-            let (width, height) = axis_aligned_size(
-                feature.transform,
-                rect.shape.size.width,
-                rect.shape.size.height,
-            )?;
+            let (width, height) =
+                axis_aligned_size(transform, rect.shape.size.width, rect.shape.size.height)?;
             Aperture::solid(ApertureShape::Rectangle { width, height })
         }
         StandardPrimitive::Oval(oval) => {
-            let (width, height) = axis_aligned_size(
-                feature.transform,
-                oval.shape.size.width,
-                oval.shape.size.height,
-            )?;
+            let (width, height) =
+                axis_aligned_size(transform, oval.shape.size.width, oval.shape.size.height)?;
             Aperture::solid(ApertureShape::Obround { width, height })
         }
         _ => return None,
     };
-
-    let at = feature.center;
-    let bbox = flash_bbox(at, &aperture);
-    Some((aperture, at, bbox))
+    Some(aperture)
 }
 
 fn standard_flash_feature_is_eligible(feature: &Feature<ipc2581::Symbol>) -> bool {
@@ -1497,6 +1506,106 @@ mod tests {
         assert!(
             (copper_area - expected).abs() <= expected * 0.01,
             "expected intact fill area {expected:.2}, got {copper_area:.2}"
+        );
+    }
+
+    #[test]
+    fn catalogue_pads_flash_through_shared_apertures() {
+        // Solid catalogue shapes with no exact Gerber aperture (here
+        // RectRound) still flash through a shared contour aperture instead
+        // of re-painting a region at every placement.
+        let ipc = ipc::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="pad"><RectRound width="2" height="1" radius="0.25" upperRight="true" upperLeft="true" lowerRight="true" lowerLeft="true"/></EntryStandard>
+    </DictionaryStandard>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="20" y="0"/>
+            <PolyStepSegment x="20" y="20"/>
+            <PolyStepSegment x="0" y="20"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+        </Profile>
+        <PadStackDef name="padstack">
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR">
+            <StandardPrimitiveRef id="pad"/>
+          </PadstackPadDef>
+        </PadStackDef>
+        <LayerFeature layerRef="TOP">
+          <Set net="N1">
+            <Pad padstackDefRef="padstack">
+              <Location x="5" y="5"/>
+              <StandardPrimitiveRef id="pad"/>
+            </Pad>
+            <Pad padstackDefRef="padstack">
+              <Location x="5" y="15"/>
+              <StandardPrimitiveRef id="pad"/>
+            </Pad>
+            <Pad padstackDefRef="padstack">
+              <Xform rotation="45"/>
+              <Location x="15" y="10"/>
+              <StandardPrimitiveRef id="pad"/>
+            </Pad>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let copper = files
+            .iter()
+            .find(|file| file.filename == "F_Cu.gtl")
+            .unwrap();
+        assert_eq!(copper.contents.matches("D03*").count(), 3);
+        assert!(
+            !copper.contents.contains("G36*"),
+            "catalogue pads must flash, not flatten to regions"
+        );
+        assert!(
+            copper.contents.matches("%ADD").count() <= 2,
+            "repeated pads share one aperture definition"
+        );
+
+        let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
+        let mask = pcb_ir::dialects::artwork::compose_to_mask(
+            &gerberx2::geometry::extract_document(&parsed),
+        );
+        let mut rings = Vec::new();
+        for layer in &mask.layers {
+            for shape in mask.shapes(layer) {
+                rings.extend(pcb_ir::geom::region::rings_from_contours(
+                    &mask.arena.path_contours(shape),
+                ));
+            }
+        }
+        let copper_area = pcb_ir::geom::ContourSet::new(
+            rings,
+            pcb_ir::geom::FillRule::NonZero,
+            pcb_ir::geom::tol::REGION_MM,
+        )
+        .area();
+        let corner_deficit = 0.25 * 0.25 * (4.0 - std::f64::consts::PI);
+        let expected = 3.0 * (2.0 - corner_deficit);
+        assert!(
+            (copper_area - expected).abs() <= expected * 0.02,
+            "expected three roundrect pads with area {expected:.4}, got {copper_area:.4}"
         );
     }
 

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1664,6 +1664,85 @@ mod tests {
     }
 
     #[test]
+    fn oversized_corner_radius_clamps_to_the_obround_image() {
+        let ipc = ipc::Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="pad"><RectRound width="2" height="1" radius="0.75" upperRight="true" upperLeft="true" lowerRight="true" lowerLeft="true"/></EntryStandard>
+    </DictionaryStandard>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="10"/>
+            <PolyStepSegment x="0" y="10"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+        </Profile>
+        <PadStackDef name="padstack">
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR">
+            <StandardPrimitiveRef id="pad"/>
+          </PadstackPadDef>
+        </PadStackDef>
+        <LayerFeature layerRef="TOP">
+          <Set net="N1">
+            <Pad padstackDefRef="padstack">
+              <Location x="5" y="5"/>
+              <StandardPrimitiveRef id="pad"/>
+            </Pad>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let copper = files
+            .iter()
+            .find(|file| file.filename == "F_Cu.gtl")
+            .unwrap();
+        let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
+        let mask = pcb_ir::dialects::artwork::compose_to_mask(
+            &gerberx2::geometry::extract_document(&parsed),
+        );
+        let mut rings = Vec::new();
+        for layer in &mask.layers {
+            for shape in mask.shapes(layer) {
+                rings.extend(pcb_ir::geom::region::rings_from_contours(
+                    &mask.arena.path_contours(shape),
+                ));
+            }
+        }
+        let copper_area = pcb_ir::geom::ContourSet::new(
+            rings,
+            pcb_ir::geom::FillRule::NonZero,
+            pcb_ir::geom::tol::REGION_MM,
+        )
+        .area();
+        // The radius clamps to height / 2, so the pad images as a 2x1 obround.
+        let clamped = 0.5;
+        let expected = 2.0 * 1.0 - clamped * clamped * (4.0 - std::f64::consts::PI);
+        assert!(
+            (copper_area - expected).abs() <= expected * 0.02,
+            "expected clamped obround area {expected:.4}, got {copper_area:.4}"
+        );
+    }
+
+    #[test]
     fn negative_set_after_an_overlay_pad_erases_it_natively() {
         // Sequential set semantics: the clear paints after the pad, erasing
         // the overlap, and exports natively as clear polarity.

--- a/crates/pcb-ipc2581-tools/src/xnc.rs
+++ b/crates/pcb-ipc2581-tools/src/xnc.rs
@@ -39,7 +39,7 @@
 //! - Plating is a file-level attribute, so plated and non-plated holes are
 //!   emitted as separate XNC files rather than mixed in one file.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use anyhow::{Result, bail};
 use gerberx2::sanitize_attribute_field;
@@ -218,15 +218,35 @@ impl XncBuilder {
     }
 
     pub fn finish(self) -> XncDocument {
+        let mut tools = self.tools;
+        let mut objects = self.objects;
+        tools.sort_by(|a, b| a.diameter.total_cmp(&b.diameter));
+        let renumbered: HashMap<u8, u8> = tools
+            .iter()
+            .enumerate()
+            .map(|(index, tool)| (tool.number, index as u8 + 1))
+            .collect();
+        for (index, tool) in tools.iter_mut().enumerate() {
+            tool.number = index as u8 + 1;
+        }
+        for object in &mut objects {
+            let (XncObject::Drill { tool, .. }
+            | XncObject::Slot { tool, .. }
+            | XncObject::Route { tool, .. }) = object;
+            *tool = renumbered[tool];
+        }
         XncDocument {
             unit: self.unit,
             file_attributes: self.file_attributes,
-            tools: self.tools,
-            objects: self.objects,
+            tools,
+            objects,
         }
     }
 
     fn tool(&mut self, diameter: f64, attributes: Vec<XncAttribute>) -> Result<u8> {
+        // Snap to 1 µm: real tools are never finer, and EDA exports carry
+        // nanometer float dust (a 1.0 mm slot arriving as 0.999998 mm).
+        let diameter = (diameter * 1_000.0).round() / 1_000.0;
         validate_positive("tool diameter", diameter)?;
         let key = XncToolKey {
             diameter_nm: quantize_mm(diameter),
@@ -529,6 +549,35 @@ fn format_decimal(value: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tools_snap_to_micrometers_and_sort_by_diameter() {
+        let mut builder = XncBuilder::new(XncUnit::Metric, vec![]);
+        // Float dust from EDA unit conversion snaps to the intended tool,
+        // merging with an exact duplicate, and the table sorts by diameter.
+        builder
+            .add_drill(0.999998, Point::new(1.0, 1.0), vec![], vec![])
+            .unwrap();
+        builder
+            .add_drill(0.3, Point::new(2.0, 2.0), vec![], vec![])
+            .unwrap();
+        builder
+            .add_drill(1.0, Point::new(3.0, 3.0), vec![], vec![])
+            .unwrap();
+
+        let document = builder.finish();
+        assert_eq!(
+            document
+                .tools
+                .iter()
+                .map(|tool| (tool.number, tool.diameter))
+                .collect::<Vec<_>>(),
+            vec![(1, 0.3), (2, 1.0)]
+        );
+        let output = write_xnc(&document).unwrap();
+        assert!(output.contains("T01C0.3\n"));
+        assert!(output.contains("T02C1.0\n"));
+    }
 
     #[test]
     fn emits_decimal_metric_drill_slot_and_route_xnc() {

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -299,6 +299,12 @@ pub enum ApertureShape {
         vertices: u32,
         rotation_degrees: f64,
     },
+    /// Rectangle with all four corners rounded to `radius`.
+    RoundRect {
+        width: f64,
+        height: f64,
+        radius: f64,
+    },
     /// An arbitrary origin-local filled contour, shared by every flash of
     /// this aperture, painted under its source path's fill rule. This is
     /// how repeated dictionary instances stay instances all the way to the
@@ -333,6 +339,11 @@ impl Aperture {
                 vertices,
                 rotation_degrees,
             } => shapes::regular_polygon(*diameter, *vertices, *rotation_degrees),
+            ApertureShape::RoundRect {
+                width,
+                height,
+                radius,
+            } => shapes::rounded_rect(*width, *height, *radius, shapes::ALL_CORNERS, true),
             ApertureShape::Contour { outline, .. } => return vec![outline.clone()],
         };
         let mut contours: Vec<ContourBuf> = outer.into_iter().collect();
@@ -356,7 +367,8 @@ impl Aperture {
                 BBox::from_point(Point::ZERO).expand(diameter / 2.0)
             }
             ApertureShape::Rectangle { width, height }
-            | ApertureShape::Obround { width, height } => BBox::new(
+            | ApertureShape::Obround { width, height }
+            | ApertureShape::RoundRect { width, height, .. } => BBox::new(
                 Point::new(-width / 2.0, -height / 2.0),
                 Point::new(width / 2.0, height / 2.0),
             ),

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -299,7 +299,8 @@ pub enum ApertureShape {
         vertices: u32,
         rotation_degrees: f64,
     },
-    /// Rectangle with all four corners rounded to `radius`.
+    /// Rectangle with all four corners rounded to `radius`. A radius above
+    /// `min(width, height) / 2` images clamped to that limit.
     RoundRect {
         width: f64,
         height: f64,

--- a/crates/pcb-ir/src/dialects/ipc/lower.rs
+++ b/crates/pcb-ir/src/dialects/ipc/lower.rs
@@ -329,17 +329,31 @@ where
     if feature.kind != FeatureKind::Primitive || !is_rigid(feature.transform) {
         return None;
     }
+    if let Some(&aperture) = apertures.get(&primitive) {
+        return Some((aperture, feature.transform));
+    }
+    // Derive the origin-local template from this first instance; every
+    // sibling shares the aperture and differs only by its rigid transform.
+    let shape = contour_flash_aperture(doc, feature)?;
+    let aperture = out.push_aperture(artwork::Aperture::solid(shape));
+    apertures.insert(primitive, aperture);
+    Some((aperture, feature.transform))
+}
+
+/// The feature's whole image as an origin-local contour aperture: its single
+/// filled path pulled back through the inverse of its placement transform.
+/// Flashing the aperture through `feature.transform` reproduces the source
+/// image exactly, so repeated placements of one shape share one definition.
+pub fn contour_flash_aperture<Symbol, LayerFunction>(
+    doc: &Document<Symbol, LayerFunction>,
+    feature: &Feature<Symbol>,
+) -> Option<artwork::ApertureShape> {
     let [path] = feature.paths.slice(&doc.arena.paths) else {
         return None;
     };
     if !path.is_filled() {
         return None;
     }
-    if let Some(&aperture) = apertures.get(&primitive) {
-        return Some((aperture, feature.transform));
-    }
-    // Derive the origin-local template from this first instance; every
-    // sibling shares the aperture and differs only by its rigid transform.
     let inverse = feature.transform.inverse()?;
     let local = doc
         .arena
@@ -347,15 +361,11 @@ where
         .iter()
         .map(|contour| transform_cmds(contour.cmds.iter().copied(), inverse))
         .collect::<Vec<_>>();
-    let [local] = local.as_slice() else {
-        return None;
-    };
-    let aperture = out.push_aperture(artwork::Aperture::solid(artwork::ApertureShape::Contour {
-        outline: local.clone(),
+    let [outline] = local.try_into().ok()?;
+    Some(artwork::ApertureShape::Contour {
+        outline,
         fill_rule: path.fill_rule().unwrap_or(FillRule::NonZero),
-    }));
-    apertures.insert(primitive, aperture);
-    Some((aperture, feature.transform))
+    })
 }
 
 /// A drilled or fiducial feature whose whole image is one filled circle.

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -47,8 +47,9 @@ pub use layout::{
 };
 pub use lower::{
     ArtworkLowering, ArtworkObjectKind, BoardArrayFabricationProfile, BoardArrayReliefFeatures,
-    FabricationProfileOptions, board_array_fabrication_profile, lower_layer_to_artwork,
-    lower_layer_to_artwork_objects_with, lower_layer_to_artwork_with, lower_to_nc,
+    FabricationProfileOptions, board_array_fabrication_profile, contour_flash_aperture,
+    lower_layer_to_artwork, lower_layer_to_artwork_objects_with, lower_layer_to_artwork_with,
+    lower_to_nc,
 };
 pub use spec::{Spec, SpecItem, SpecItemKind, SpecProperty, SpecRef};
 pub use surface_layers::{


### PR DESCRIPTION
Gerber/drill export fixes:

- Inner copper Gerbers now use KiCad's layer numbering (`In1_Cu`, `In2_Cu`, ...) instead of the stackup copper index.
- Exported layers declare `%TF.FilePolarity,Positive`.
- Drill tool diameters snap to 1 µm, cleaning up float dust from EDA exporters (`T07C0.999998` → `T07C1.0`), and the tool table is sorted by diameter. Fixes ENG-703.
- Pads with rounded or custom shapes flash through shared apertures instead of flattening to a region at every placement; rounded rectangles use a compact parameterized `RoundedRect` macro and hexagons/octagons use polygon apertures.
- The writer tracks object attribute state and emits `%TO`/`%TD` only on change, with commuting objects clustered by attributes and aperture.

SO101 board package: 321 KB → 286 KB (KiCad direct plot of the same board: 275 KB). Output verified image-equivalent to the previous region-based export (compose-to-mask area within 1e-4 on copper, mask, and paste layers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Gerber lowering, IPC pad mapping, and drill tool tables used for manufacturing output; behavior is heavily tested but wrong aperture or attribute state could affect CAM compatibility.
> 
> **Overview**
> Improves **IPC→Gerber/XNC manufacturing export** for KiCad-style naming, smaller files, and cleaner X2 output without changing the rendered geometry (verified via compose-to-mask).
> 
> **Metadata and drill files:** Inner copper filenames now use KiCad numbering (`In1_Cu`, …). Every layer gets `%TF.FilePolarity,Positive`. XNC tool diameters snap to 1 µm (merging EDA float dust), tools sort by diameter, and tool numbers are renumbered accordingly.
> 
> **Pad flashing instead of regions:** Catalogue pads (rounded rects, hex/oct, other solids) export as **shared aperture flashes**—including a reusable `RoundedRect` macro and polygon apertures—via new `RoundRect` artwork shape and `contour_flash_aperture` for shapes without an exact standard aperture. Emission order clusters objects by stage, net/component attributes, and aperture so the writer changes state less often.
> 
> **Gerber writer:** Object `%TO` attributes are tracked across objects; repeats skip re-emission, overrides update in place, and `%TD` runs only when an attribute is dropped—shrinking mask/paste/copper files materially on real boards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0abc09231cbdbf6a017e10cfb871dae8f30b52f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->