### PR TITLE
chore: install native Diode KiCad package in orb

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -55,9 +55,8 @@ log 'Verifying Diode KiCad package checksum'
 printf '%s  %s\n' "$sha256" "$tmp/kicad.deb" | sha256sum --check --strict
 
 log 'Installing Diode KiCad package'
-export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update -qq
-sudo apt-get install -y -qq "$tmp/kicad.deb"
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$tmp/kicad.deb"
 
 # Fail setup immediately if the command-line tools or Python bindings are not
 # usable; otherwise the problem surfaces much later as pcb-layout test failures.

--- a/.agents/setup
+++ b/.agents/setup
@@ -9,82 +9,29 @@ log() {
   printf '[orb setup %s +%ss] %s\n' "$(date -Is)" "$SECONDS" "$*" >&2
 }
 
-# --- Rust toolchain (pinned to stable by rust-toolchain.toml) ----------------
-if ! command -v rustup >/dev/null 2>&1; then
-  log 'Installing Rust toolchain'
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain stable --profile minimal
-  # shellcheck disable=SC1091
-  source "$HOME/.cargo/env"
-  log 'Installed Rust toolchain'
-fi
-log 'Installing Rust components'
-rustup component add clippy rustfmt
-log 'Installed Rust components'
+KICAD_METADATA_URL=https://kicad-mirror.api.diode.computer/packages/kicad/diode/10.0/latest.json
 
-# --- cargo-nextest (official prebuilt binary; stay on the 0.9 series) --------
-if ! cargo nextest --version >/dev/null 2>&1; then
-  log 'Installing cargo-nextest'
-  mkdir -p "${CARGO_HOME:-$HOME/.cargo}/bin"
-  curl -LsSf https://get.nexte.st/0.9/linux \
-    | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
-  log 'Installed cargo-nextest'
-fi
+log 'Downloading Diode KiCad package metadata'
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL "$KICAD_METADATA_URL" -o "$tmp/latest.json"
+KICAD_DEB_URL=$(/usr/bin/python3 -c \
+  'import json, sys; print(json.load(open(sys.argv[1]))["deb_url"])' \
+  "$tmp/latest.json")
+KICAD_SHA256=$(/usr/bin/python3 -c \
+  'import json, sys; print(json.load(open(sys.argv[1]))["sha256"])' \
+  "$tmp/latest.json")
 
-# --- uv (standalone installer; installs to ~/.local/bin) ---------------------
-if ! command -v uv >/dev/null 2>&1; then
-  log 'Installing uv'
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  log 'Installed uv'
-fi
+log 'Downloading Diode KiCad package'
+curl -fsSL "$KICAD_DEB_URL" -o "$tmp/kicad.deb"
 
-# --- KiCad 10 (official lite AppImage, installed as a host tool) -------------
-KICAD_VERSION=10.0.4
-KICAD_DIR="/opt/kicad/$KICAD_VERSION"
+log 'Verifying Diode KiCad package checksum'
+printf '%s  %s\n' "$KICAD_SHA256" "$tmp/kicad.deb" | sha256sum --check --strict
 
-if [[ ! -x "$KICAD_DIR/bin/kicad-cli" ]]; then
-  (
-    log "Installing KiCad $KICAD_VERSION"
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    archive="kicad-$KICAD_VERSION-x86_64-lite.AppImage.tar"
-
-    log "Downloading $archive"
-    curl -fL "https://kicad-downloads.s3.cern.ch/appimage/stable/$archive" \
-      -o "$tmp/$archive"
-    log "Extracting $archive"
-    tar -xf "$tmp/$archive" -C "$tmp"
-    chmod +x "$tmp/${archive%.tar}"
-    cd "$tmp"
-    log 'Extracting KiCad AppImage filesystem'
-    "./${archive%.tar}" --appimage-extract >/dev/null
-
-    log "Installing KiCad to $KICAD_DIR"
-    sudo install -d -m 0755 /opt/kicad
-    # KiCad's AppImage extractor creates AppDir plus a relative
-    # `squashfs-root -> ./AppDir` symlink. Install the directory itself so it
-    # remains valid after the temporary extraction directory is removed.
-    sudo mv AppDir "$KICAD_DIR"
-    sudo chown -R root:root "$KICAD_DIR"
-    log "Installed KiCad $KICAD_VERSION"
-  )
-fi
-
-log 'Linking KiCad executables'
-sudo ln -sfn "$KICAD_VERSION" /opt/kicad/current
-for command in kicad kicad-cli pcbnew eeschema gerbview bitmap2component \
-  pcb_calculator pl_editor; do
-  sudo ln -sfn "/opt/kicad/current/bin/$command" "/usr/local/bin/$command"
-done
-
-log 'Configuring KiCad libraries and Python bindings'
-printf '%s\n' \
-  /opt/kicad/current/shared/lib \
-  /opt/kicad/current/shared/lib/tmp/AppDir/usr/lib/x86_64-linux-gnu \
-  | sudo tee /etc/ld.so.conf.d/kicad.conf >/dev/null
-printf '%s\n' /opt/kicad/current/shared/lib/python3.11/dist-packages \
-  | sudo tee /usr/lib/python3/dist-packages/kicad.pth >/dev/null
-sudo ldconfig
+log 'Installing Diode KiCad package'
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -qq
+sudo apt-get install -y -qq "$tmp/kicad.deb"
 
 # Fail setup immediately if the command-line tools or Python bindings are not
 # usable; otherwise the problem surfaces much later as pcb-layout test failures.

--- a/.agents/setup
+++ b/.agents/setup
@@ -12,21 +12,17 @@ log() {
 KICAD_METADATA_URL=https://kicad-mirror.api.diode.computer/packages/kicad/diode/10.0/latest.json
 
 log 'Downloading Diode KiCad package metadata'
-tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
-curl -fsSL "$KICAD_METADATA_URL" -o "$tmp/latest.json"
-KICAD_DEB_URL=$(/usr/bin/python3 -c \
-  'import json, sys; print(json.load(open(sys.argv[1]))["deb_url"])' \
-  "$tmp/latest.json")
-KICAD_SHA256=$(/usr/bin/python3 -c \
-  'import json, sys; print(json.load(open(sys.argv[1]))["sha256"])' \
-  "$tmp/latest.json")
+metadata=$(curl -fsSL "$KICAD_METADATA_URL")
+deb_url=$(jq -er .deb_url <<<"$metadata")
+sha256=$(jq -er .sha256 <<<"$metadata")
 
 log 'Downloading Diode KiCad package'
-curl -fsSL "$KICAD_DEB_URL" -o "$tmp/kicad.deb"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL "$deb_url" -o "$tmp/kicad.deb"
 
 log 'Verifying Diode KiCad package checksum'
-printf '%s  %s\n' "$KICAD_SHA256" "$tmp/kicad.deb" | sha256sum --check --strict
+printf '%s  %s\n' "$sha256" "$tmp/kicad.deb" | sha256sum --check --strict
 
 log 'Installing Diode KiCad package'
 export DEBIAN_FRONTEND=noninteractive

--- a/.agents/setup
+++ b/.agents/setup
@@ -9,6 +9,36 @@ log() {
   printf '[orb setup %s +%ss] %s\n' "$(date -Is)" "$SECONDS" "$*" >&2
 }
 
+# --- Rust toolchain (pinned to stable by rust-toolchain.toml) ----------------
+if ! command -v rustup >/dev/null 2>&1; then
+  log 'Installing Rust toolchain'
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --profile minimal
+  # shellcheck disable=SC1091
+  source "$HOME/.cargo/env"
+  log 'Installed Rust toolchain'
+fi
+log 'Installing Rust components'
+rustup component add clippy rustfmt
+log 'Installed Rust components'
+
+# --- cargo-nextest (official prebuilt binary; stay on the 0.9 series) --------
+if ! cargo nextest --version >/dev/null 2>&1; then
+  log 'Installing cargo-nextest'
+  mkdir -p "${CARGO_HOME:-$HOME/.cargo}/bin"
+  curl -LsSf https://get.nexte.st/0.9/linux \
+    | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+  log 'Installed cargo-nextest'
+fi
+
+# --- uv (standalone installer; installs to ~/.local/bin) ---------------------
+if ! command -v uv >/dev/null 2>&1; then
+  log 'Installing uv'
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  log 'Installed uv'
+fi
+
+# --- Diode KiCad 10 (native Debian package) ----------------------------------
 KICAD_METADATA_URL=https://kicad-mirror.api.diode.computer/packages/kicad/diode/10.0/latest.json
 
 log 'Downloading Diode KiCad package metadata'


### PR DESCRIPTION
Replace the custom KiCad AppImage setup with the published native Diode KiCad Debian package while preserving the existing Rust, nextest, and uv setup. Read the current package URL and SHA-256 from latest metadata, verify the download, and let apt install native dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-environment-only change to `.agents/setup`; no application runtime or auth/data paths affected.
> 
> **Overview**
> **Orb setup** now installs KiCad 10 from Diode’s published Debian package instead of extracting and wiring up the official lite AppImage under `/opt/kicad`.
> 
> The script fetches `latest.json` from `kicad-mirror.api.diode.computer`, downloads the `.deb` from the metadata `deb_url`, verifies `sha256`, and runs `apt-get install` on the local package. The previous AppImage download/extract, `/opt/kicad/current` symlinks, `/usr/local/bin` command links, and custom `ld.so.conf` / `kicad.pth` / `ldconfig` steps are removed. **Rust, nextest, uv, and post-install checks** (`kicad-cli --version`, `import pcbnew`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c269b601e7bfc2f7cafa25bf3d31b5bb7bc1e30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->