### PR TITLE
pcb-component-gen: detect pin name collisions before writing .zen file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Pads with rounded or custom shapes now export as shared Gerber aperture flashes instead of repeated regions, shrinking mask and paste layers.
 - Rounded-rectangle pads export as compact parameterized macro apertures, and hexagon and octagon pads as polygon apertures.
 - Gerber output no longer repeats object attributes on every object.
+- Distinct KiCad signal names that sanitize to the same Starlark identifier are now uniquified (`N_CS`, `N_CS_2`, …) instead of silently merging onto one net.
 
 ## [0.4.25] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - BOM generation no longer panics when truncating UTF-8 component descriptions.
 - Nested modules retain group ownership for copied routing and graphics during layout synchronization.
+- Distinct KiCad signal names that sanitize to the same Starlark identifier are now uniquified instead of silently merging onto one net.
 
 ## [0.4.30] - 2026-08-14
 
@@ -56,7 +57,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Pads with rounded or custom shapes now export as shared Gerber aperture flashes instead of repeated regions, shrinking mask and paste layers.
 - Rounded-rectangle pads export as compact parameterized macro apertures, and hexagon and octagon pads as polygon apertures.
 - Gerber output no longer repeats object attributes on every object.
-- Distinct KiCad signal names that sanitize to the same Starlark identifier are now uniquified (`N_CS`, `N_CS_2`, …) instead of silently merging onto one net.
 
 ## [0.4.25] - 2026-08-07
 

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use deunicode::deunicode;
 use minijinja::{Environment, UndefinedBehavior};
 use pcb_eda::{Pin, Symbol};
@@ -159,6 +159,48 @@ pub fn generated_signal_io_names(symbol: &Symbol) -> BTreeMap<String, String> {
         .collect()
 }
 
+/// Check that no two distinct signal names sanitize to the same Starlark identifier.
+///
+/// When two pin names collide (e.g. `~CS` and `!CS` both become `N_CS`) the generated
+/// `.zen` file would declare the same `io()` variable twice, which is a Starlark error.
+/// Catching this here gives a clear, actionable message at generation time instead of a
+/// cryptic build failure after the file has already been written to disk.
+fn check_pin_name_collisions(signal_io_names: &BTreeMap<String, String>) -> Result<()> {
+    // Invert the map: sanitized name → list of original signal names that produced it.
+    let mut by_sanitized: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for (original, sanitized) in signal_io_names {
+        by_sanitized
+            .entry(sanitized.as_str())
+            .or_default()
+            .push(original.as_str());
+    }
+
+    let collisions: Vec<_> = by_sanitized
+        .into_iter()
+        .filter(|(_, originals)| originals.len() > 1)
+        .collect();
+
+    if collisions.is_empty() {
+        return Ok(());
+    }
+
+    let details = collisions
+        .iter()
+        .map(|(sanitized, originals)| {
+            let mut sorted = originals.to_vec();
+            sorted.sort();
+            format!("  '{}' ← {}", sanitized, sorted.join(", "))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    bail!(
+        "pin name collision: multiple pins sanitize to the same Starlark identifier:\n{}\n\
+        Rename the conflicting pins in the KiCad symbol to make them distinct.",
+        details
+    );
+}
+
 pub fn generate_component_zen(args: GenerateComponentZenArgs<'_>) -> Result<String> {
     generate_component_zen_inner(args, None, None)
 }
@@ -178,6 +220,12 @@ fn generate_component_zen_inner(
 ) -> Result<String> {
     let component_name = sanitize_mpn_for_path(args.component_name);
     let signal_io_names = generated_signal_io_names(args.symbol);
+
+    // Detect collisions before rendering so the user gets a clear error rather than
+    // a broken .zen file that fails later during `pcb build`.
+    if explicit_pins.is_none() {
+        check_pin_name_collisions(&signal_io_names)?;
+    }
 
     let pin_groups_vec: Vec<_> = match explicit_pins {
         Some(pins) => pins
@@ -631,5 +679,147 @@ mod tests {
         assert!(zen.contains("\"VCC\": VCC"));
         assert!(!zen.contains("NC = io(Net)"));
         assert!(!zen.contains("\"NC\": NC"));
+    }
+
+    #[test]
+    fn collision_tilde_and_bang_prefix_errors() {
+        // ~CS and !CS both sanitize to N_CS — should be caught before any file is written.
+        let symbol = pcb_eda::Symbol {
+            name: "X".to_string(),
+            pins: vec![
+                pcb_eda::Pin {
+                    name: "~CS".to_string(),
+                    number: "1".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "!CS".to_string(),
+                    number: "2".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "VCC".to_string(),
+                    number: "3".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let err = generate_component_zen(GenerateComponentZenArgs {
+            component_name: "MPN1",
+            symbol: &symbol,
+            symbol_filename: "MPN1.kicad_sym",
+            generated_by: "pcb import",
+            include_skip_bom: false,
+            include_skip_pos: false,
+            skip_bom_default: false,
+            skip_pos_default: false,
+        })
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pin name collision"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains("N_CS"),
+            "expected colliding identifier in error: {msg}"
+        );
+        assert!(
+            msg.contains("~CS"),
+            "expected original pin name in error: {msg}"
+        );
+        assert!(
+            msg.contains("!CS"),
+            "expected original pin name in error: {msg}"
+        );
+        assert!(msg.contains("Rename"), "expected fix hint in error: {msg}");
+    }
+
+    #[test]
+    fn collision_distinct_signals_same_sanitized_name_errors() {
+        // ENABLE and enable both sanitize to ENABLE — case collision.
+        let symbol = pcb_eda::Symbol {
+            name: "X".to_string(),
+            pins: vec![
+                pcb_eda::Pin {
+                    name: "ENABLE".to_string(),
+                    number: "1".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "enable".to_string(),
+                    number: "2".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let err = generate_component_zen(GenerateComponentZenArgs {
+            component_name: "MPN1",
+            symbol: &symbol,
+            symbol_filename: "MPN1.kicad_sym",
+            generated_by: "pcb import",
+            include_skip_bom: false,
+            include_skip_pos: false,
+            skip_bom_default: false,
+            skip_pos_default: false,
+        })
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pin name collision"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains("ENABLE"),
+            "expected colliding identifier in error: {msg}"
+        );
+    }
+
+    #[test]
+    fn no_collision_passes_through() {
+        // Sanity check: a normal symbol with distinct sanitized names should still work fine.
+        let symbol = pcb_eda::Symbol {
+            name: "X".to_string(),
+            pins: vec![
+                pcb_eda::Pin {
+                    name: "~CS".to_string(),
+                    number: "1".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "VCC".to_string(),
+                    number: "2".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "GND".to_string(),
+                    number: "3".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let zen = generate_component_zen(GenerateComponentZenArgs {
+            component_name: "MPN1",
+            symbol: &symbol,
+            symbol_filename: "MPN1.kicad_sym",
+            generated_by: "pcb import",
+            include_skip_bom: false,
+            include_skip_pos: false,
+            skip_bom_default: false,
+            skip_pos_default: false,
+        })
+        .unwrap();
+
+        assert!(zen.contains("N_CS = io(Net)"));
+        assert!(zen.contains("VCC = io(Net)"));
+        assert!(zen.contains("GND = io(Net)"));
     }
 }

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use deunicode::deunicode;
 use minijinja::{Environment, UndefinedBehavior};
 use pcb_eda::{Pin, Symbol};
@@ -148,7 +148,7 @@ pub fn generated_signal_io_names(symbol: &Symbol) -> BTreeMap<String, String> {
             .push(pin);
     }
 
-    signals
+    let base_names: Vec<(String, String)> = signals
         .into_iter()
         .filter_map(|(signal_name, pins)| {
             (!pins_are_only_no_connect(pins)).then(|| {
@@ -156,49 +156,34 @@ pub fn generated_signal_io_names(symbol: &Symbol) -> BTreeMap<String, String> {
                 (signal_name, sanitized_name)
             })
         })
-        .collect()
-}
-
-/// Check that no two distinct signal names sanitize to the same Starlark identifier.
-///
-/// When two pin names collide (e.g. `~CS` and `!CS` both become `N_CS`) the generated
-/// `.zen` file would declare the same `io()` variable twice, which is a Starlark error.
-/// Catching this here gives a clear, actionable message at generation time instead of a
-/// cryptic build failure after the file has already been written to disk.
-fn check_pin_name_collisions(signal_io_names: &BTreeMap<String, String>) -> Result<()> {
-    // Invert the map: sanitized name → list of original signal names that produced it.
-    let mut by_sanitized: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
-    for (original, sanitized) in signal_io_names {
-        by_sanitized
-            .entry(sanitized.as_str())
-            .or_default()
-            .push(original.as_str());
-    }
-
-    let collisions: Vec<_> = by_sanitized
-        .into_iter()
-        .filter(|(_, originals)| originals.len() > 1)
         .collect();
 
-    if collisions.is_empty() {
-        return Ok(());
+    uniquify_sanitized_names(base_names)
+}
+
+/// Ensure every sanitized Starlark identifier is unique.
+///
+/// When two distinct signal names sanitize to the same identifier (e.g. `~CS` and `!CS`
+/// both becoming `N_CS`), giving them the same `io()` variable would silently map two
+/// different physical pins onto one net. Instead of failing, later collisions get a
+/// numeric suffix (`N_CS`, `N_CS_2`, `N_CS_3`, ...), assigned in deterministic
+/// (signal name) order.
+fn uniquify_sanitized_names(base_names: Vec<(String, String)>) -> BTreeMap<String, String> {
+    let mut seen_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut result = BTreeMap::new();
+
+    for (signal_name, sanitized_name) in base_names {
+        let count = seen_counts.entry(sanitized_name.clone()).or_insert(0);
+        *count += 1;
+        let final_name = if *count == 1 {
+            sanitized_name
+        } else {
+            format!("{sanitized_name}_{count}")
+        };
+        result.insert(signal_name, final_name);
     }
 
-    let details = collisions
-        .iter()
-        .map(|(sanitized, originals)| {
-            let mut sorted = originals.to_vec();
-            sorted.sort();
-            format!("  '{}' ← {}", sanitized, sorted.join(", "))
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    bail!(
-        "pin name collision: multiple pins sanitize to the same Starlark identifier:\n{}\n\
-        Rename the conflicting pins in the KiCad symbol to make them distinct.",
-        details
-    );
+    result
 }
 
 pub fn generate_component_zen(args: GenerateComponentZenArgs<'_>) -> Result<String> {
@@ -220,12 +205,6 @@ fn generate_component_zen_inner(
 ) -> Result<String> {
     let component_name = sanitize_mpn_for_path(args.component_name);
     let signal_io_names = generated_signal_io_names(args.symbol);
-
-    // Detect collisions before rendering so the user gets a clear error rather than
-    // a broken .zen file that fails later during `pcb build`.
-    if explicit_pins.is_none() {
-        check_pin_name_collisions(&signal_io_names)?;
-    }
 
     let pin_groups_vec: Vec<_> = match explicit_pins {
         Some(pins) => pins
@@ -637,6 +616,51 @@ mod tests {
     }
 
     #[test]
+    fn colliding_pin_names_get_uniquified() {
+        // ~CS and !CS both sanitize to N_CS — should not collapse onto one net.
+        let symbol = pcb_eda::Symbol {
+            name: "X".to_string(),
+            pins: vec![
+                pcb_eda::Pin {
+                    name: "~CS".to_string(),
+                    number: "1".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "!CS".to_string(),
+                    number: "2".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "VCC".to_string(),
+                    number: "3".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let zen = generate_component_zen(GenerateComponentZenArgs {
+            component_name: "MPN1",
+            symbol: &symbol,
+            symbol_filename: "MPN1.kicad_sym",
+            generated_by: "pcb import",
+            include_skip_bom: false,
+            include_skip_pos: false,
+            skip_bom_default: false,
+            skip_pos_default: false,
+        })
+        .unwrap();
+
+        // "!CS" sorts before "~CS" in a BTreeMap, so it claims the base name first.
+        assert!(zen.contains("N_CS = io(Net)"));
+        assert!(zen.contains("N_CS_2 = io(Net)"));
+        assert!(zen.contains("\"!CS\": N_CS"));
+        assert!(zen.contains("\"~CS\": N_CS_2"));
+        assert!(zen.contains("VCC = io(Net)"));
+    }
+
+    #[test]
     fn skips_no_connect_pins_entirely() {
         let symbol = pcb_eda::Symbol {
             name: "X".to_string(),
@@ -679,147 +703,5 @@ mod tests {
         assert!(zen.contains("\"VCC\": VCC"));
         assert!(!zen.contains("NC = io(Net)"));
         assert!(!zen.contains("\"NC\": NC"));
-    }
-
-    #[test]
-    fn collision_tilde_and_bang_prefix_errors() {
-        // ~CS and !CS both sanitize to N_CS — should be caught before any file is written.
-        let symbol = pcb_eda::Symbol {
-            name: "X".to_string(),
-            pins: vec![
-                pcb_eda::Pin {
-                    name: "~CS".to_string(),
-                    number: "1".to_string(),
-                    ..Default::default()
-                },
-                pcb_eda::Pin {
-                    name: "!CS".to_string(),
-                    number: "2".to_string(),
-                    ..Default::default()
-                },
-                pcb_eda::Pin {
-                    name: "VCC".to_string(),
-                    number: "3".to_string(),
-                    ..Default::default()
-                },
-            ],
-            ..Default::default()
-        };
-
-        let err = generate_component_zen(GenerateComponentZenArgs {
-            component_name: "MPN1",
-            symbol: &symbol,
-            symbol_filename: "MPN1.kicad_sym",
-            generated_by: "pcb import",
-            include_skip_bom: false,
-            include_skip_pos: false,
-            skip_bom_default: false,
-            skip_pos_default: false,
-        })
-        .unwrap_err();
-
-        let msg = err.to_string();
-        assert!(
-            msg.contains("pin name collision"),
-            "unexpected error: {msg}"
-        );
-        assert!(
-            msg.contains("N_CS"),
-            "expected colliding identifier in error: {msg}"
-        );
-        assert!(
-            msg.contains("~CS"),
-            "expected original pin name in error: {msg}"
-        );
-        assert!(
-            msg.contains("!CS"),
-            "expected original pin name in error: {msg}"
-        );
-        assert!(msg.contains("Rename"), "expected fix hint in error: {msg}");
-    }
-
-    #[test]
-    fn collision_distinct_signals_same_sanitized_name_errors() {
-        // ENABLE and enable both sanitize to ENABLE — case collision.
-        let symbol = pcb_eda::Symbol {
-            name: "X".to_string(),
-            pins: vec![
-                pcb_eda::Pin {
-                    name: "ENABLE".to_string(),
-                    number: "1".to_string(),
-                    ..Default::default()
-                },
-                pcb_eda::Pin {
-                    name: "enable".to_string(),
-                    number: "2".to_string(),
-                    ..Default::default()
-                },
-            ],
-            ..Default::default()
-        };
-
-        let err = generate_component_zen(GenerateComponentZenArgs {
-            component_name: "MPN1",
-            symbol: &symbol,
-            symbol_filename: "MPN1.kicad_sym",
-            generated_by: "pcb import",
-            include_skip_bom: false,
-            include_skip_pos: false,
-            skip_bom_default: false,
-            skip_pos_default: false,
-        })
-        .unwrap_err();
-
-        let msg = err.to_string();
-        assert!(
-            msg.contains("pin name collision"),
-            "unexpected error: {msg}"
-        );
-        assert!(
-            msg.contains("ENABLE"),
-            "expected colliding identifier in error: {msg}"
-        );
-    }
-
-    #[test]
-    fn no_collision_passes_through() {
-        // Sanity check: a normal symbol with distinct sanitized names should still work fine.
-        let symbol = pcb_eda::Symbol {
-            name: "X".to_string(),
-            pins: vec![
-                pcb_eda::Pin {
-                    name: "~CS".to_string(),
-                    number: "1".to_string(),
-                    ..Default::default()
-                },
-                pcb_eda::Pin {
-                    name: "VCC".to_string(),
-                    number: "2".to_string(),
-                    ..Default::default()
-                },
-                pcb_eda::Pin {
-                    name: "GND".to_string(),
-                    number: "3".to_string(),
-                    ..Default::default()
-                },
-            ],
-            ..Default::default()
-        };
-
-        let zen = generate_component_zen(GenerateComponentZenArgs {
-            component_name: "MPN1",
-            symbol: &symbol,
-            symbol_filename: "MPN1.kicad_sym",
-            generated_by: "pcb import",
-            include_skip_bom: false,
-            include_skip_pos: false,
-            skip_bom_default: false,
-            skip_pos_default: false,
-        })
-        .unwrap();
-
-        assert!(zen.contains("N_CS = io(Net)"));
-        assert!(zen.contains("VCC = io(Net)"));
-        assert!(zen.contains("GND = io(Net)"));
     }
 }

--- a/crates/pcb-component-gen/src/lib.rs
+++ b/crates/pcb-component-gen/src/lib.rs
@@ -148,42 +148,25 @@ pub fn generated_signal_io_names(symbol: &Symbol) -> BTreeMap<String, String> {
             .push(pin);
     }
 
-    let base_names: Vec<(String, String)> = signals
+    // Distinct signal names can sanitize to the same identifier (e.g. `~CS` and `!CS`
+    // both become `N_CS`). Track assigned names so a suffix like `N_CS_2` cannot collide
+    // with another signal's natural sanitized name.
+    let mut used = BTreeSet::new();
+    signals
         .into_iter()
         .filter_map(|(signal_name, pins)| {
             (!pins_are_only_no_connect(pins)).then(|| {
-                let sanitized_name = sanitize_pin_name(&signal_name);
-                (signal_name, sanitized_name)
+                let base = sanitize_pin_name(&signal_name);
+                let mut name = base.clone();
+                let mut n = 2;
+                while !used.insert(name.clone()) {
+                    name = format!("{base}_{n}");
+                    n += 1;
+                }
+                (signal_name, name)
             })
         })
-        .collect();
-
-    uniquify_sanitized_names(base_names)
-}
-
-/// Ensure every sanitized Starlark identifier is unique.
-///
-/// When two distinct signal names sanitize to the same identifier (e.g. `~CS` and `!CS`
-/// both becoming `N_CS`), giving them the same `io()` variable would silently map two
-/// different physical pins onto one net. Instead of failing, later collisions get a
-/// numeric suffix (`N_CS`, `N_CS_2`, `N_CS_3`, ...), assigned in deterministic
-/// (signal name) order.
-fn uniquify_sanitized_names(base_names: Vec<(String, String)>) -> BTreeMap<String, String> {
-    let mut seen_counts: BTreeMap<String, usize> = BTreeMap::new();
-    let mut result = BTreeMap::new();
-
-    for (signal_name, sanitized_name) in base_names {
-        let count = seen_counts.entry(sanitized_name.clone()).or_insert(0);
-        *count += 1;
-        let final_name = if *count == 1 {
-            sanitized_name
-        } else {
-            format!("{sanitized_name}_{count}")
-        };
-        result.insert(signal_name, final_name);
-    }
-
-    result
+        .collect()
 }
 
 pub fn generate_component_zen(args: GenerateComponentZenArgs<'_>) -> Result<String> {
@@ -658,6 +641,40 @@ mod tests {
         assert!(zen.contains("\"!CS\": N_CS"));
         assert!(zen.contains("\"~CS\": N_CS_2"));
         assert!(zen.contains("VCC = io(Net)"));
+    }
+
+    #[test]
+    fn uniquify_skips_suffixes_that_already_exist() {
+        // `!CS`/`~CS` both sanitize to `N_CS`. The naive `_2` suffix would collide
+        // with a pin that already sanitizes to `N_CS_2`.
+        let symbol = pcb_eda::Symbol {
+            name: "X".to_string(),
+            pins: vec![
+                pcb_eda::Pin {
+                    name: "~CS".to_string(),
+                    number: "1".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "!CS".to_string(),
+                    number: "2".to_string(),
+                    ..Default::default()
+                },
+                pcb_eda::Pin {
+                    name: "N_CS_2".to_string(),
+                    number: "3".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let names = generated_signal_io_names(&symbol);
+        let unique: BTreeSet<_> = names.values().collect();
+        assert_eq!(unique.len(), names.len());
+        assert_eq!(names.get("!CS").map(String::as_str), Some("N_CS"));
+        assert_eq!(names.get("N_CS_2").map(String::as_str), Some("N_CS_2"));
+        assert_eq!(names.get("~CS").map(String::as_str), Some("N_CS_3"));
     }
 
     #[test]


### PR DESCRIPTION
## What

When two distinct pin names in a KiCad symbol sanitize to the same
Starlark identifier (e.g. `~CS` and `!CS` both become `N_CS`), the
generated `.zen` file declares the same `io()` variable twice. This is
a Starlark error that previously only surfaced during `pcb build`
after the broken file had already been written to disk.

## Why

Silent failures here are especially bad in the registry/AI component
generation pipeline — a user runs `pcb search`, downloads a component,
and only finds out it's broken when they try to use it in a board.

## How

Added `check_pin_name_collisions()` in `pcb-component-gen` that inverts
the sanitized name map, detects any collisions, and returns a clear
error with the offending pin names and a fix hint — before any rendering
or file I/O happens.

Only applies to the symbol-backed path. The `explicit_pins` path is
caller-controlled so collision responsibility stays with the caller.

## Testing

- 3 new unit tests covering: `~`/`!` prefix collision, case collision,
  and a clean symbol that should pass through unchanged
- All 14 tests pass
- `cargo fmt` produced no changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to symbol-backed component `.zen` generation with deterministic suffixing and a focused unit test; explicit-pin generation is unchanged.
> 
> **Overview**
> **Component `.zen` generation** no longer maps distinct KiCad signal names that sanitize to the same Starlark identifier onto a single `io()` net (e.g. `~CS` and `!CS` both becoming `N_CS`).
> 
> `generated_signal_io_names` now runs sanitized names through **`uniquify_sanitized_names`**, which keeps the first signal on the base name and assigns **`_2`, `_3`, …** suffixes to later collisions in deterministic signal-name order. A unit test covers the `~CS` / `!CS` case.
> 
> **CHANGELOG** records this under Unreleased → Fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b23c54e321d295bc09ae7f9e586b872cc619dffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->