### PR TITLE
Use API BOM offer order (ENG-739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- BOM sourcing now uses the API's deterministic offer order for five-board builds.
+
 ## [0.4.28] - 2026-08-11
 
 ### Changed

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -3,14 +3,9 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::{collections::HashMap, time::Duration};
 
-use pcb_sch::bom::availability::{
-    HardToSourceReason, NUM_BOARDS, is_small_generic_passive, tier_for_stock,
-};
-use pcb_sch::bom::{Availability, AvailabilitySummary, Offer};
+use pcb_sch::bom::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer};
 
 use crate::WorkspaceContext;
-
-const PRICING_BATCH_CHUNK_SIZE: usize = 10;
 
 /// Price break structure
 #[derive(Debug, Clone, Deserialize)]
@@ -48,7 +43,6 @@ struct ComponentOffer {
     distributor_part_id: Option<String>,
     mpn: Option<String>,
     manufacturer: Option<String>,
-    moq: Option<i32>,
     #[serde(rename = "priceBreaks")]
     price_breaks: Option<Vec<PriceBreak>>,
     #[serde(rename = "stockAvailable")]
@@ -79,22 +73,6 @@ impl ComponentOffer {
             part_id: self.distributor_part_id.clone(),
         }
     }
-}
-
-fn offer_passes_moq_affordability(offer: &ComponentOffer, target_qty: i32) -> bool {
-    let moq = offer.moq.unwrap_or(1);
-    moq <= target_qty || offer.unit_price_at_qty(moq).unwrap_or(f64::MAX) * moq as f64 <= 100.0
-}
-
-fn hard_to_source_reason_for_offers(
-    offers: &[&ComponentOffer],
-    target_qty: i32,
-) -> Option<HardToSourceReason> {
-    let _ = offers.first()?;
-    offers
-        .iter()
-        .all(|offer| !offer_passes_moq_affordability(offer, target_qty))
-        .then_some(HardToSourceReason::UnaffordableMoq)
 }
 
 /// Design BOM entry structure from the API
@@ -139,45 +117,6 @@ struct MatchBomResponse {
     offers: HashMap<String, ComponentOffer>,
 }
 
-/// Compare offers within the same tier: prefer lower price, then higher stock
-#[inline]
-fn within_tier_cmp(a: &ComponentOffer, b: &ComponentOffer, qty: i32) -> std::cmp::Ordering {
-    use std::cmp::Ordering::*;
-
-    let price_a = a.unit_price_at_qty(qty * NUM_BOARDS);
-    let price_b = b.unit_price_at_qty(qty * NUM_BOARDS);
-
-    match (price_a, price_b) {
-        (Some(pa), Some(pb)) => pa
-            .partial_cmp(&pb)
-            .unwrap_or(Equal)
-            .then_with(|| b.stock_available.cmp(&a.stock_available)),
-        (None, None) => b.stock_available.cmp(&a.stock_available),
-        (Some(_), None) => Less,
-        (None, Some(_)) => Greater,
-    }
-}
-
-/// Select the best offer: Plenty > Limited > None tier, then lowest price within tier.
-/// Single-pass, allocation-free selection using iterator comparator.
-fn select_best_offer<'a>(
-    offers: impl Iterator<Item = &'a ComponentOffer>,
-    qty: i32,
-    is_small_passive: bool,
-) -> Option<&'a ComponentOffer> {
-    offers.min_by(|a, b| {
-        let stock_a = a.stock_available.unwrap_or(0);
-        let stock_b = b.stock_available.unwrap_or(0);
-        let tier_a = tier_for_stock(stock_a, qty, is_small_passive);
-        let tier_b = tier_for_stock(stock_b, qty, is_small_passive);
-
-        tier_a
-            .rank()
-            .cmp(&tier_b.rank())
-            .then_with(|| within_tier_cmp(a, b, qty))
-    })
-}
-
 /// Calculate alt stock from offers, deduplicating by (distributor, mpn).
 fn calculate_alt_stock(
     offers: &[&ComponentOffer],
@@ -210,19 +149,7 @@ fn build_availability_summary(
     offer: &ComponentOffer,
     alt_stock: i32,
     target_qty: i32,
-    include_internal_fields: bool,
-    hard_to_source_reason: Option<HardToSourceReason>,
 ) -> AvailabilitySummary {
-    if !include_internal_fields {
-        return AvailabilitySummary {
-            price: offer.unit_price_at_qty(target_qty),
-            stock: offer.stock_available.unwrap_or_default(),
-            alt_stock,
-            hard_to_source_reason,
-            ..Default::default()
-        };
-    }
-
     let lcsc_part_ids = match (offer.distributor.as_deref(), &offer.distributor_part_id) {
         (Some("lcsc"), Some(id)) => {
             let id = if id.starts_with('C') {
@@ -243,7 +170,6 @@ fn build_availability_summary(
         price: offer.unit_price_at_qty(target_qty),
         stock: offer.stock_available.unwrap_or_default(),
         alt_stock,
-        hard_to_source_reason,
         price_breaks: offer
             .price_breaks
             .as_ref()
@@ -252,6 +178,23 @@ fn build_availability_summary(
         mpn: offer.mpn.clone().filter(|s| !s.is_empty()),
         manufacturer: offer.manufacturer.clone().filter(|s| !s.is_empty()),
     }
+}
+
+fn summarize_region<'a>(
+    offers: &[&'a ComponentOffer],
+    geography: Geography,
+    target_qty: i32,
+    alt_stock_price_qty: i32,
+) -> (Vec<&'a ComponentOffer>, Option<AvailabilitySummary>) {
+    let regional: Vec<_> = offers
+        .iter()
+        .copied()
+        .filter(|offer| offer.geography == geography)
+        .collect();
+    let selected = regional.first().copied();
+    let alt_stock = calculate_alt_stock(&regional, selected, alt_stock_price_qty);
+    let summary = selected.map(|offer| build_availability_summary(offer, alt_stock, target_qty));
+    (regional, summary)
 }
 
 /// Call the BOM match API and return parsed response
@@ -267,7 +210,12 @@ fn call_bom_match_api(
     let client = Client::builder()
         .timeout(Duration::from_secs(timeout_secs))
         .build()?;
-    let request_body = bom_match_request_body(bom_entries);
+    let request_body = serde_json::json!({
+        "designBom": bom_entries,
+        "format": "normalized",
+        "boardQuantity": BOARD_QUANTITY,
+        "regions": ["US", "GLOBAL"],
+    });
 
     let response = crate::auth::apply_bearer_auth(client.post(&url), auth_token)
         .json(&request_body)
@@ -288,13 +236,6 @@ fn call_bom_match_api(
 fn bom_match_url(api_base_url: &str, strict: bool) -> String {
     let suffix = if strict { "?strict=true" } else { "" };
     format!("{api_base_url}/api/boms/match{suffix}")
-}
-
-fn bom_match_request_body(bom_entries: &[serde_json::Value]) -> serde_json::Value {
-    serde_json::json!({
-        "designBom": bom_entries,
-        "format": "normalized",
-    })
 }
 
 /// Fetch BOM matching results from the API and populate availability data
@@ -322,20 +263,15 @@ pub fn fetch_and_populate_availability_with_context(
         let Some(path) = bom_line.design_entry.path.as_deref() else {
             continue;
         };
-        let Some(bom_entry) = bom.entries.get(path) else {
+        if !bom.entries.contains_key(path) {
             continue;
-        };
+        }
 
         let qty = bom
             .designators
             .iter()
             .filter(|(p, _)| p.as_str() == path)
             .count() as i32;
-        let is_small_passive = is_small_generic_passive(
-            bom_entry.generic_data.as_ref(),
-            bom_entry.package.as_deref(),
-        );
-
         // Resolve offer IDs to actual offers from the deduplicated offers map
         let resolved_offers: Vec<&ComponentOffer> = bom_line
             .offer_ids
@@ -343,24 +279,11 @@ pub fn fetch_and_populate_availability_with_context(
             .filter_map(|id| match_response.offers.get(id))
             .collect();
 
-        let target_qty = qty * NUM_BOARDS;
+        let target_qty = qty * BOARD_QUANTITY;
 
-        // Process each geography
-        let process_geo = |geo: Geography| {
-            let offers: Vec<_> = resolved_offers
-                .iter()
-                .copied()
-                .filter(|o| o.geography == geo)
-                .collect();
-            let best = select_best_offer(offers.iter().copied(), qty, is_small_passive);
-            let alt = calculate_alt_stock(&offers, best, qty);
-            let hard_to_source_reason = hard_to_source_reason_for_offers(&offers, target_qty);
-            (offers, best, alt, hard_to_source_reason)
-        };
-
-        let (us_offers, best_us, us_alt, us_hard_to_source_reason) = process_geo(Geography::Us);
-        let (global_offers, best_global, global_alt, global_hard_to_source_reason) =
-            process_geo(Geography::Global);
+        let (us_offers, us) = summarize_region(&resolved_offers, Geography::Us, target_qty, qty);
+        let (global_offers, global) =
+            summarize_region(&resolved_offers, Geography::Global, target_qty, qty);
 
         // Build offers for JSON output
         let all_offers: Vec<_> = us_offers
@@ -372,24 +295,8 @@ pub fn fetch_and_populate_availability_with_context(
         bom.availability.insert(
             path.to_string(),
             Availability {
-                us: best_us.map(|o| {
-                    build_availability_summary(
-                        o,
-                        us_alt,
-                        target_qty,
-                        true,
-                        us_hard_to_source_reason,
-                    )
-                }),
-                global: best_global.map(|o| {
-                    build_availability_summary(
-                        o,
-                        global_alt,
-                        target_qty,
-                        true,
-                        global_hard_to_source_reason,
-                    )
-                }),
+                us,
+                global,
                 no_match: bom_line_no_match(&bom_line),
                 offers: all_offers,
             },
@@ -404,6 +311,32 @@ pub fn fetch_and_populate_availability_with_context(
 pub struct ComponentKey {
     pub mpn: String,
     pub manufacturer: Option<String>,
+}
+
+fn component_part_json(component: &ComponentKey) -> serde_json::Value {
+    let mut part = serde_json::json!({ "mpn": component.mpn });
+    if let Some(manufacturer) = &component.manufacturer {
+        part["manufacturer"] = serde_json::json!(manufacturer);
+    }
+    part
+}
+
+fn component_bom_entry(index: usize, component: &ComponentKey) -> serde_json::Value {
+    let mut entry = component_part_json(component);
+    entry["path"] = serde_json::json!(format!("component_{index}"));
+    entry["designator"] = serde_json::json!(format!("X{index}"));
+    entry
+}
+
+fn grouped_component_bom_entry(
+    index: usize,
+    components: &[ComponentKey],
+) -> Option<serde_json::Value> {
+    let (primary, alternatives) = components.split_first()?;
+    let mut entry = component_bom_entry(index, primary);
+    entry["alternatives"] =
+        serde_json::Value::Array(alternatives.iter().map(component_part_json).collect());
+    Some(entry)
 }
 
 /// Format a price value for display (always 2 decimal places)
@@ -431,55 +364,15 @@ pub fn fetch_pricing_batch(
     auth_token: Option<&str>,
     components: &[ComponentKey],
 ) -> Result<Vec<Availability>> {
-    fetch_pricing_in_chunks(components, |chunk| {
-        fetch_pricing_batch_once(auth_token, chunk)
-    })
+    fetch_pricing_batch_once(auth_token, components)
 }
 
-/// Fetch pricing for grouped alternate components, combining all offers per group.
+/// Fetch pricing for grouped alternate components as one planned BOM line per group.
 pub fn fetch_pricing_grouped_batch(
     auth_token: Option<&str>,
     groups: &[Vec<ComponentKey>],
 ) -> Result<Vec<Availability>> {
-    fetch_pricing_in_chunks(groups, |chunk| {
-        fetch_pricing_grouped_batch_once(auth_token, chunk)
-    })
-}
-
-fn fetch_pricing_in_chunks<T: Clone>(
-    items: &[T],
-    fetch_chunk: impl Fn(&[T]) -> Result<Vec<Availability>>,
-) -> Result<Vec<Availability>> {
-    if items.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut results = vec![Availability::default(); items.len()];
-    for (offset, chunk) in items.chunks(PRICING_BATCH_CHUNK_SIZE).enumerate() {
-        let start = offset * PRICING_BATCH_CHUNK_SIZE;
-        let chunk_results = match fetch_chunk(chunk) {
-            Ok(chunk_results) => chunk_results,
-            Err(_) if chunk.len() > 1 => chunk
-                .iter()
-                .map(|item| {
-                    fetch_chunk(std::slice::from_ref(item))
-                        .unwrap_or_else(|_| vec![Availability::default()])
-                        .into_iter()
-                        .next()
-                        .unwrap_or_default()
-                })
-                .collect(),
-            Err(err) => return Err(err),
-        };
-
-        for (idx, availability) in chunk_results.into_iter().enumerate() {
-            if let Some(slot) = results.get_mut(start + idx) {
-                *slot = availability;
-            }
-        }
-    }
-
-    Ok(results)
+    fetch_pricing_grouped_batch_once(auth_token, groups)
 }
 
 fn fetch_pricing_grouped_batch_once(
@@ -490,71 +383,43 @@ fn fetch_pricing_grouped_batch_once(
         return Ok(Vec::new());
     }
 
-    let mut flat_components = Vec::new();
-    let mut component_to_group = Vec::new();
-    for (group_idx, group) in groups.iter().enumerate() {
-        for component in group {
-            flat_components.push(component.clone());
-            component_to_group.push(group_idx);
-        }
-    }
+    let bom_entries: Vec<_> = groups
+        .iter()
+        .enumerate()
+        .filter_map(|(index, group)| grouped_component_bom_entry(index, group))
+        .collect();
 
-    if flat_components.is_empty() {
+    if bom_entries.is_empty() {
         return Ok(vec![Availability::default(); groups.len()]);
     }
 
-    let bom_entries: Vec<_> = flat_components
-        .iter()
-        .enumerate()
-        .map(|(i, c)| {
-            let mut entry = serde_json::json!({
-                "path": format!("component_{}", i),
-                "designator": format!("X{}", i),
-                "mpn": c.mpn,
-            });
-            if let Some(ref mfr) = c.manufacturer {
-                entry["manufacturer"] = serde_json::json!(mfr);
-            }
-            entry
-        })
-        .collect();
-
     let ctx = WorkspaceContext::from_cwd().unwrap_or_default();
     let match_response = call_bom_match_api(&ctx, auth_token, &bom_entries, 30, false)?;
-    let mut grouped_offers: Vec<Vec<&ComponentOffer>> = vec![Vec::new(); groups.len()];
-    let mut grouped_no_match = vec![false; groups.len()];
+    let mut results = vec![Availability::default(); groups.len()];
 
     for bom_line in &match_response.results {
         let Some(path) = bom_line.design_entry.path.as_deref() else {
             continue;
         };
-        let Some(component_idx) = path
+        let Some(group_idx) = path
             .strip_prefix("component_")
             .and_then(|s| s.parse::<usize>().ok())
         else {
             continue;
         };
-        let Some(&group_idx) = component_to_group.get(component_idx) else {
+        let Some(slot) = results.get_mut(group_idx) else {
             continue;
         };
 
-        let resolved_offers: Vec<_> = bom_line
+        let offers: Vec<_> = bom_line
             .offer_ids
             .iter()
             .filter_map(|id| match_response.offers.get(id))
             .collect();
-        grouped_no_match[group_idx] |= bom_line_no_match(bom_line);
-        grouped_offers[group_idx].extend(resolved_offers);
+        *slot = build_search_availability(&offers, bom_line_no_match(bom_line));
     }
 
-    Ok(grouped_offers
-        .into_iter()
-        .enumerate()
-        .map(|(idx, offers)| {
-            let no_match = grouped_no_match[idx] && offers.is_empty();
-            build_search_availability(&offers, no_match)
-        })
-        .collect())
+    Ok(results)
 }
 
 fn fetch_pricing_batch_once(
@@ -569,17 +434,7 @@ fn fetch_pricing_batch_once(
     let bom_entries: Vec<_> = components
         .iter()
         .enumerate()
-        .map(|(i, c)| {
-            let mut entry = serde_json::json!({
-                "path": format!("component_{}", i),
-                "designator": format!("X{}", i),
-                "mpn": c.mpn,
-            });
-            if let Some(ref mfr) = c.manufacturer {
-                entry["manufacturer"] = serde_json::json!(mfr);
-            }
-            entry
-        })
+        .map(|(index, component)| component_bom_entry(index, component))
         .collect();
 
     let ctx = WorkspaceContext::from_cwd().unwrap_or_default();
@@ -614,20 +469,12 @@ fn fetch_pricing_batch_once(
 }
 
 fn build_search_availability(offers: &[&ComponentOffer], no_match: bool) -> Availability {
-    let summary_for = |geo: Geography| {
-        let filtered: Vec<_> = offers
-            .iter()
-            .copied()
-            .filter(|offer| offer.geography == geo)
-            .collect();
-        let best = select_best_offer(filtered.iter().copied(), 1, false);
-        let alt = calculate_alt_stock(&filtered, best, 1);
-        best.map(|offer| build_availability_summary(offer, alt, 1, false, None))
-    };
+    let (_, us) = summarize_region(offers, Geography::Us, 1, 1);
+    let (_, global) = summarize_region(offers, Geography::Global, 1, 1);
 
     Availability {
-        us: summary_for(Geography::Us),
-        global: summary_for(Geography::Global),
+        us,
+        global,
         no_match,
         offers: offers
             .iter()
@@ -641,7 +488,7 @@ fn build_search_availability(offers: &[&ComponentOffer], no_match: bool) -> Avai
 mod tests {
     use super::*;
 
-    fn offer(id: &str, moq: Option<i32>, breaks: &[(i32, f64)]) -> ComponentOffer {
+    fn offer(id: &str, breaks: &[(i32, f64)]) -> ComponentOffer {
         ComponentOffer {
             id: id.to_string(),
             geography: Geography::Us,
@@ -649,7 +496,6 @@ mod tests {
             distributor_part_id: Some(id.to_string()),
             mpn: Some("TEST-MPN".to_string()),
             manufacturer: Some("Test Manufacturer".to_string()),
-            moq,
             price_breaks: Some(
                 breaks
                     .iter()
@@ -720,7 +566,7 @@ mod tests {
 
     #[test]
     fn uk_offers_are_ignored() {
-        let mut uk_offer = offer("uk-offer", Some(1), &[(1, 1.0)]);
+        let mut uk_offer = offer("uk-offer", &[(1, 1.0)]);
         uk_offer.geography = Geography::Uk;
 
         let availability = build_search_availability(&[&uk_offer], false);
@@ -740,53 +586,22 @@ mod tests {
     }
 
     #[test]
-    fn affordable_moq_passes() {
-        let offer = offer("affordable", Some(1000), &[(1000, 0.05)]);
-        assert!(offer_passes_moq_affordability(&offer, 20));
-    }
+    fn first_api_ranked_regional_offer_wins() {
+        let response: MatchBomResponse =
+            serde_json::from_str(include_str!("../tests/fixtures/bom_match_api_order.json"))
+                .unwrap();
+        let line = &response.results[0];
+        let offers: Vec<_> = line
+            .offer_ids
+            .iter()
+            .filter_map(|id| response.offers.get(id))
+            .collect();
 
-    #[test]
-    fn expensive_moq_fails() {
-        let offer = offer("expensive", Some(1000), &[(1000, 0.124)]);
-        assert!(!offer_passes_moq_affordability(&offer, 20));
-    }
+        let availability = build_search_availability(&offers, false);
 
-    #[test]
-    fn mixed_offers_do_not_flag_hard_to_source() {
-        let expensive_best = offer("expensive", Some(1000), &[(1000, 0.124)]);
-        let affordable_alt = offer("affordable", Some(1000), &[(1000, 0.09)]);
-
-        let offers = vec![&expensive_best, &affordable_alt];
-
-        assert_eq!(hard_to_source_reason_for_offers(&offers, 20), None);
-    }
-
-    #[test]
-    fn all_unaffordable_offers_flag_hard_to_source() {
-        let expensive_a = offer("expensive-a", Some(1000), &[(1000, 0.124)]);
-        let expensive_b = offer("expensive-b", Some(1000), &[(1000, 0.132)]);
-
-        let offers = vec![&expensive_a, &expensive_b];
-
-        assert_eq!(
-            hard_to_source_reason_for_offers(&offers, 20),
-            Some(HardToSourceReason::UnaffordableMoq)
-        );
-    }
-
-    #[test]
-    fn bom_match_request_body_omits_strict_by_default() {
-        let entries = vec![serde_json::json!({
-            "path": "root.U1",
-            "designator": "U1",
-            "mpn": "ABC123",
-        })];
-
-        let body = bom_match_request_body(&entries);
-
-        assert_eq!(body["format"], "normalized");
-        assert_eq!(body["designBom"], serde_json::Value::Array(entries));
-        assert!(body.get("strict").is_none());
+        assert_eq!(availability.us.as_ref().unwrap().stock, 5);
+        assert_eq!(availability.us.as_ref().unwrap().price, Some(10.0));
+        assert_eq!(availability.offers[0].part_id.as_deref(), Some("API-FIRST"));
     }
 
     #[test]

--- a/crates/pcb-diode-api/tests/fixtures/bom_match_api_order.json
+++ b/crates/pcb-diode-api/tests/fixtures/bom_match_api_order.json
@@ -1,0 +1,46 @@
+{
+  "results": [
+    {
+      "designEntry": {
+        "path": "root.U1"
+      },
+      "offerIds": [
+        "api-first",
+        "old-rust-policy-first"
+      ],
+      "match": "MATCH_EXACT"
+    }
+  ],
+  "offers": {
+    "api-first": {
+      "id": "api-first",
+      "geography": "US",
+      "distributor": "Planner Choice",
+      "distributorPartId": "API-FIRST",
+      "mpn": "TEST-MPN",
+      "manufacturer": "Test Manufacturer",
+      "priceBreaks": [
+        {
+          "qty": 1,
+          "price": 10.0
+        }
+      ],
+      "stockAvailable": 5
+    },
+    "old-rust-policy-first": {
+      "id": "old-rust-policy-first",
+      "geography": "US",
+      "distributor": "Local Policy Choice",
+      "distributorPartId": "OLD-RUST-FIRST",
+      "mpn": "TEST-MPN",
+      "manufacturer": "Test Manufacturer",
+      "priceBreaks": [
+        {
+          "qty": 1,
+          "price": 0.1
+        }
+      ],
+      "stockAvailable": 500
+    }
+  }
+}

--- a/crates/pcb-sch/src/bom/availability.rs
+++ b/crates/pcb-sch/src/bom/availability.rs
@@ -1,76 +1,9 @@
-//! BOM availability types and domain logic.
-//!
-//! Contains both the JSON-facing availability types and domain logic for tier
-//! classification and offer selection.
+//! BOM availability types.
 
 use serde::{Deserialize, Serialize};
 
-use super::GenericComponent;
-
-/// Number of boards to use for availability and pricing calculations
-pub const NUM_BOARDS: i32 = 20;
-
-/// Availability tier for sourcing status
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum Tier {
-    #[default]
-    Insufficient = 0,
-    Limited = 1,
-    Plenty = 2,
-}
-
-impl Tier {
-    /// Rank for comparisons (lower is better)
-    #[inline]
-    pub fn rank(self) -> u8 {
-        match self {
-            Tier::Plenty => 0,
-            Tier::Limited => 1,
-            Tier::Insufficient => 2,
-        }
-    }
-}
-
-/// Internal reason why an otherwise-stocked offer is still hard to source.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HardToSourceReason {
-    UnaffordableMoq,
-}
-
-/// Check if component is a small generic passive requiring higher stock threshold
-pub fn is_small_generic_passive(
-    generic_data: Option<&GenericComponent>,
-    package: Option<&str>,
-) -> bool {
-    let is_generic_passive = matches!(
-        generic_data,
-        Some(GenericComponent::Resistor(_) | GenericComponent::Capacitor(_))
-    );
-    let is_small_package = matches!(package, Some("0201" | "0402" | "0603"));
-
-    is_generic_passive && is_small_package
-}
-
-/// Determine availability tier based on stock and quantity
-pub fn tier_for_stock(stock: i32, qty: i32, is_small_passive: bool) -> Tier {
-    // Red tier: not enough for even 1 board
-    if stock < qty {
-        return Tier::Insufficient;
-    }
-
-    // Green tier: enough for NUM_BOARDS or 100 for small passives
-    let required_stock = if is_small_passive {
-        100
-    } else {
-        qty * NUM_BOARDS
-    };
-
-    if stock >= required_stock {
-        Tier::Plenty
-    } else {
-        Tier::Limited
-    }
-}
+/// Board quantity sent to the sourcing planner and used for price presentation.
+pub const BOARD_QUANTITY: i32 = 5;
 
 /// Pricing and availability data for a component
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -98,9 +31,6 @@ pub struct AvailabilitySummary {
     pub stock: i32,
     /// Combined stock from alternative offers
     pub alt_stock: i32,
-    /// Internal reason code for hard-to-source classification
-    #[serde(skip, default)]
-    pub hard_to_source_reason: Option<HardToSourceReason>,
     /// Price breaks for computing prices at different quantities (internal only)
     #[serde(skip, default)]
     pub price_breaks: Option<Vec<(i32, f64)>>,

--- a/crates/pcb-sch/src/bom/mod.rs
+++ b/crates/pcb-sch/src/bom/mod.rs
@@ -4,8 +4,5 @@ mod core;
 // Re-export core BOM types
 pub use core::*;
 
-// Re-export availability types and helpers
-pub use availability::{
-    Availability, AvailabilitySummary, NUM_BOARDS, Offer, Tier, is_small_generic_passive,
-    tier_for_stock,
-};
+// Re-export availability types and sourcing quantity
+pub use availability::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer};

--- a/crates/pcb-sch/src/bom_table.rs
+++ b/crates/pcb-sch/src/bom_table.rs
@@ -6,10 +6,8 @@ use terminal_hyperlink::Hyperlink as _;
 use urlencoding::encode as urlencode;
 
 use crate::bom::AvailabilitySummary;
-use crate::bom::availability::{
-    HardToSourceReason, NUM_BOARDS, Tier, is_small_generic_passive, tier_for_stock,
-};
-use crate::bom::{Bom, GenericComponent};
+use crate::bom::Bom;
+use crate::bom::availability::BOARD_QUANTITY;
 
 const NO_MATCH_LABEL: &str = "No match (unknown part)";
 
@@ -101,45 +99,34 @@ fn summary_row(
     ]
 }
 
-/// Map availability tier to table cell color
-fn color_for_tier(tier: Tier) -> Color {
-    match tier {
-        Tier::Insufficient => Color::Red,
-        Tier::Limited => Color::Yellow,
-        Tier::Plenty => Color::Green,
-    }
-}
-
 /// Apply styling to a cell based on component flags
-fn styled_cell(content: impl ToString, is_dnp: bool, is_house: bool, tier: Option<Tier>) -> Cell {
+fn styled_cell(content: impl ToString, is_dnp: bool, is_house: bool) -> Cell {
     let cell = Cell::new(content);
-    match (is_dnp, is_house, tier) {
-        (true, _, _) => cell.fg(Color::DarkGrey),
-        (false, true, _) => cell.fg(Color::Blue),
-        (false, false, Some(t)) => cell.fg(color_for_tier(t)),
-        (false, false, None) => cell,
+    match (is_dnp, is_house) {
+        (true, _) => cell.fg(Color::DarkGrey),
+        (false, true) => cell.fg(Color::Blue),
+        (false, false) => cell,
     }
 }
 
-/// Map a sourcing status to its display color, including states outside stock tiers.
-fn color_for_status(is_dnp: bool, no_match: bool, tier: Tier) -> Color {
+/// Map response states to display colors without recreating sourcing policy.
+fn color_for_status(is_dnp: bool, no_match: bool) -> Option<Color> {
     if is_dnp {
-        Color::DarkGrey
+        Some(Color::DarkGrey)
     } else if no_match {
-        Color::Magenta
+        Some(Color::Magenta)
     } else {
-        color_for_tier(tier)
+        None
     }
 }
 
-/// Apply styling to a sourcing-status cell, including states outside stock tiers.
-fn styled_status_cell(content: impl ToString, is_dnp: bool, no_match: bool, tier: Tier) -> Cell {
-    Cell::new(content).fg(color_for_status(is_dnp, no_match, tier))
-}
-
-/// Check if MPN and manufacturer are both present
-fn has_complete_part_info(mpn: &str, manufacturer: &str) -> bool {
-    !mpn.is_empty() && !manufacturer.is_empty()
+/// Apply styling to response-state cells.
+fn styled_status_cell(content: impl ToString, is_dnp: bool, no_match: bool) -> Cell {
+    let cell = Cell::new(content);
+    match color_for_status(is_dnp, no_match) {
+        Some(color) => cell.fg(color),
+        None => cell,
+    }
 }
 
 /// Calculate unit price at a given quantity using price breaks
@@ -177,35 +164,24 @@ struct RegionDisplayData {
     alt_stock: i32,
     price_single: Option<f64>,
     price_boards: Option<f64>,
-    tier: Tier,
-    hard_to_source_reason: Option<HardToSourceReason>,
     lcsc_ids: Vec<(String, String)>,
     mpn: Option<String>,
     manufacturer: Option<String>,
 }
 
 impl RegionDisplayData {
-    fn from_region_avail(
-        avail: Option<&AvailabilitySummary>,
-        qty: usize,
-        is_small_passive: bool,
-    ) -> Self {
+    fn from_region_avail(avail: Option<&AvailabilitySummary>, qty: usize) -> Self {
         let Some(a) = avail else {
             return Self::default();
         };
 
-        let tier = if a.hard_to_source_reason.is_some() {
-            Tier::Insufficient
-        } else {
-            tier_for_stock(a.stock, qty as i32, is_small_passive)
-        };
         let (price_single, price_boards) = match &a.price_breaks {
             Some(breaks) => {
                 let unit_single = unit_price_from_breaks(breaks, qty as i32);
-                let unit_boards = unit_price_from_breaks(breaks, (qty as i32) * NUM_BOARDS);
+                let unit_boards = unit_price_from_breaks(breaks, (qty as i32) * BOARD_QUANTITY);
                 (
                     unit_single.map(|p| p * qty as f64),
-                    unit_boards.map(|p| p * (qty as i32 * NUM_BOARDS) as f64),
+                    unit_boards.map(|p| p * (qty as i32 * BOARD_QUANTITY) as f64),
                 )
             }
             None => (None, None),
@@ -216,8 +192,6 @@ impl RegionDisplayData {
             alt_stock: a.alt_stock,
             price_single,
             price_boards,
-            tier,
-            hard_to_source_reason: a.hard_to_source_reason,
             lcsc_ids: a.lcsc_part_ids.clone(),
             mpn: a.mpn.clone(),
             manufacturer: a.manufacturer.clone(),
@@ -276,29 +250,34 @@ impl Bom {
         legend_table.load_preset(comfy_table::presets::NOTHING);
         legend_table.set_content_arrangement(comfy_table::ContentArrangement::Disabled);
 
-        legend_table.add_row(vec![
-            Cell::new("■").fg(Color::Green),
-            Cell::new("Plenty available / easy to source"),
-            Cell::new("  "),
-            Cell::new("■").fg(Color::Blue),
-            Cell::new("House component"),
-        ]);
-        legend_table.add_row(vec![
-            Cell::new("■").fg(Color::Yellow),
-            Cell::new("Limited inventory / harder to source"),
-            Cell::new("  "),
-            Cell::new("■").fg(Color::DarkGrey),
-            Cell::new("DNP (Do Not Populate)"),
-        ]);
         if has_availability {
             legend_table.add_row(vec![
-                Cell::new("■").fg(Color::Red),
-                Cell::new("Insufficient stock / hard to source"),
+                Cell::new("■").fg(Color::Blue),
+                Cell::new("House component"),
                 Cell::new("  "),
+                Cell::new("■").fg(Color::DarkGrey),
+                Cell::new("DNP (Do Not Populate)"),
+            ]);
+            legend_table.add_row(vec![
                 Cell::new("■").fg(Color::Magenta),
                 Cell::new(NO_MATCH_LABEL),
             ]);
         } else {
+            // Keep the established offline legend, where no live sourcing data is rendered.
+            legend_table.add_row(vec![
+                Cell::new("■").fg(Color::Green),
+                Cell::new("Plenty available / easy to source"),
+                Cell::new("  "),
+                Cell::new("■").fg(Color::Blue),
+                Cell::new("House component"),
+            ]);
+            legend_table.add_row(vec![
+                Cell::new("■").fg(Color::Yellow),
+                Cell::new("Limited inventory / harder to source"),
+                Cell::new("  "),
+                Cell::new("■").fg(Color::DarkGrey),
+                Cell::new("DNP (Do Not Populate)"),
+            ]);
             legend_table.add_row(vec![
                 Cell::new("■").fg(Color::Red),
                 Cell::new("Insufficient stock / hard to source"),
@@ -308,12 +287,8 @@ impl Bom {
         writeln!(writer, "{legend_table}")?;
 
         // Track summary stats (only used when has_availability)
-        let mut plenty_count = 0;
-        let mut plenty_qty = 0;
-        let mut limited_count = 0;
-        let mut limited_qty = 0;
-        let mut hard_count = 0;
-        let mut hard_qty = 0;
+        let mut matched_count = 0;
+        let mut matched_qty = 0;
         let mut no_match_count = 0;
         let mut no_match_qty = 0;
         let mut dnp_count = 0;
@@ -419,28 +394,14 @@ impl Bom {
                 .map(|(p, _)| p)
                 .collect();
 
-            // Get generic_data and package for sourcing status
-            let generic_data = entry
-                .get("generic_data")
-                .and_then(|gd| serde_json::from_value::<GenericComponent>(gd.clone()).ok());
-
-            let package = entry.get("package").and_then(|p| p.as_str());
-            let is_small_passive = is_small_generic_passive(generic_data.as_ref(), package);
-
             // Get per-region availability from first matching path
             let avail = paths.iter().find_map(|path| self.availability.get(*path));
             let no_match = avail.is_some_and(|a| a.no_match);
 
-            let us_data = RegionDisplayData::from_region_avail(
-                avail.and_then(|a| a.us.as_ref()),
-                qty,
-                is_small_passive,
-            );
-            let global_data = RegionDisplayData::from_region_avail(
-                avail.and_then(|a| a.global.as_ref()),
-                qty,
-                is_small_passive,
-            );
+            let us_data =
+                RegionDisplayData::from_region_avail(avail.and_then(|a| a.us.as_ref()), qty);
+            let global_data =
+                RegionDisplayData::from_region_avail(avail.and_then(|a| a.global.as_ref()), qty);
 
             // Use US offer data for MPN/Manufacturer autofill
             let avail_mpn = us_data.mpn.clone();
@@ -451,27 +412,6 @@ impl Bom {
             let (manufacturer, is_manufacturer_autofilled) =
                 autofill_from_availability(original_manufacturer, &avail_manufacturer);
 
-            // Designator tier:
-            // - Red: any region is explicitly hard to source due to MOQ affordability
-            // - Green: both regions Plenty AND has MPN/manufacturer
-            // - Red: both regions Insufficient
-            // - Yellow: everything else
-            let hard_to_source = us_data.hard_to_source_reason.is_some()
-                || global_data.hard_to_source_reason.is_some();
-
-            let designator_tier = if hard_to_source
-                || (us_data.tier == Tier::Insufficient && global_data.tier == Tier::Insufficient)
-            {
-                Tier::Insufficient
-            } else if us_data.tier == Tier::Plenty
-                && global_data.tier == Tier::Plenty
-                && has_complete_part_info(original_mpn, original_manufacturer)
-            {
-                Tier::Plenty
-            } else {
-                Tier::Limited
-            };
-
             // Track summary stats
             if has_availability {
                 if is_dnp {
@@ -481,20 +421,8 @@ impl Bom {
                     no_match_count += 1;
                     no_match_qty += qty;
                 } else {
-                    match designator_tier {
-                        Tier::Plenty => {
-                            plenty_count += 1;
-                            plenty_qty += qty;
-                        }
-                        Tier::Limited => {
-                            limited_count += 1;
-                            limited_qty += qty;
-                        }
-                        Tier::Insufficient => {
-                            hard_count += 1;
-                            hard_qty += qty;
-                        }
-                    }
+                    matched_count += 1;
+                    matched_qty += qty;
 
                     // Track house vs non-house (excluding DNP)
                     if is_house_part {
@@ -508,11 +436,11 @@ impl Bom {
             }
 
             // Create qty and designators cells
-            let qty_cell = styled_cell(format!("{:>4}", qty), is_dnp, false, None);
+            let qty_cell = styled_cell(format!("{:>4}", qty), is_dnp, false);
             let designators_cell = (if has_availability {
-                styled_status_cell(designators.as_str(), is_dnp, no_match, designator_tier)
+                styled_status_cell(designators.as_str(), is_dnp, no_match)
             } else {
-                styled_cell(designators.as_str(), is_dnp, false, None)
+                styled_cell(designators.as_str(), is_dnp, false)
             })
             .set_delimiter(',');
 
@@ -529,39 +457,28 @@ impl Bom {
                 );
                 style_if_autofilled(&link, is_mpn_autofilled)
             };
-            let mpn_cell = styled_cell(mpn_display, is_dnp, is_house_part, None);
+            let mpn_cell = styled_cell(mpn_display, is_dnp, is_house_part);
 
             // Manufacturer: style if auto-filled
             let manufacturer_cell = styled_cell(
                 style_if_autofilled(manufacturer, is_manufacturer_autofilled),
                 is_dnp,
                 false,
-                None,
             );
-            let package_cell = styled_cell(
-                entry["package"].as_str().unwrap_or_default(),
-                is_dnp,
-                false,
-                None,
-            );
-            let description_cell = styled_cell(description, is_dnp, false, None);
+            let package_cell =
+                styled_cell(entry["package"].as_str().unwrap_or_default(), is_dnp, false);
+            let description_cell = styled_cell(description, is_dnp, false);
 
             // Build row
             let mut row = vec![qty_cell];
 
             // Add stock columns (US and Global)
             if has_availability {
-                row.push(styled_status_cell(
-                    us_data.format_stock(),
-                    is_dnp,
-                    no_match,
-                    us_data.tier,
-                ));
+                row.push(styled_status_cell(us_data.format_stock(), is_dnp, no_match));
                 row.push(styled_status_cell(
                     global_data.format_stock(),
                     is_dnp,
                     no_match,
-                    global_data.tier,
                 ));
             }
 
@@ -591,8 +508,8 @@ impl Bom {
 
             // Add price columns (US and Global)
             if has_availability {
-                row.push(styled_cell(us_data.format_price(), is_dnp, false, None));
-                row.push(styled_cell(global_data.format_price(), is_dnp, false, None));
+                row.push(styled_cell(us_data.format_price(), is_dnp, false));
+                row.push(styled_cell(global_data.format_price(), is_dnp, false));
             }
 
             row.push(description_cell);
@@ -613,8 +530,8 @@ impl Bom {
             headers.push("LCSC");
         }
 
-        let price_us_header = format!("Price US ({}x)", NUM_BOARDS);
-        let price_global_header = format!("Price Global ({}x)", NUM_BOARDS);
+        let price_us_header = format!("Price US ({}x)", BOARD_QUANTITY);
+        let price_global_header = format!("Price Global ({}x)", BOARD_QUANTITY);
         if has_availability {
             headers.push(&price_us_header);
             headers.push(&price_global_header);
@@ -678,32 +595,15 @@ impl Bom {
             let mut summary_table = Table::new();
             configure_summary_table(&mut summary_table);
 
-            let total_count =
-                plenty_count + limited_count + hard_count + no_match_count + dnp_count;
-            let total_with_dnp = plenty_qty + limited_qty + hard_qty + no_match_qty + dnp_qty;
+            let total_count = matched_count + no_match_count + dnp_count;
+            let total_with_dnp = matched_qty + no_match_qty + dnp_qty;
 
             summary_table.add_row(summary_row(
-                Color::Green,
-                "Plenty available / easy to source",
-                plenty_count,
+                Color::White,
+                "Matched / planner-ranked",
+                matched_count,
                 total_count,
-                plenty_qty,
-                total_with_dnp,
-            ));
-            summary_table.add_row(summary_row(
-                Color::Yellow,
-                "Limited inventory / harder to source",
-                limited_count,
-                total_count,
-                limited_qty,
-                total_with_dnp,
-            ));
-            summary_table.add_row(summary_row(
-                Color::Red,
-                "Insufficient stock / hard to source",
-                hard_count,
-                total_count,
-                hard_qty,
+                matched_qty,
                 total_with_dnp,
             ));
             summary_table.add_row(summary_row(
@@ -767,31 +667,8 @@ mod tests {
     use crate::bom::{Availability, BomEntry};
 
     #[test]
-    fn hard_to_source_availability_forces_red_tier() {
-        let avail = AvailabilitySummary {
-            stock: 78_000,
-            hard_to_source_reason: Some(HardToSourceReason::UnaffordableMoq),
-            price_breaks: Some(vec![(1000, 0.124)]),
-            ..Default::default()
-        };
-
-        let region = RegionDisplayData::from_region_avail(Some(&avail), 1, false);
-
-        assert_eq!(region.tier, Tier::Insufficient);
-        assert_eq!(
-            region.hard_to_source_reason,
-            Some(HardToSourceReason::UnaffordableMoq)
-        );
-        assert_eq!(region.stock, 78_000);
-        assert_eq!(region.price_single, Some(0.124));
-    }
-
-    #[test]
-    fn no_match_status_color_overrides_insufficient_tier() {
-        assert_eq!(
-            color_for_status(false, true, Tier::Insufficient),
-            Color::Magenta
-        );
+    fn no_match_status_is_magenta() {
+        assert_eq!(color_for_status(false, true), Some(Color::Magenta));
     }
 
     #[test]


### PR DESCRIPTION
Depends on https://github.com/diodeinc/diode/pull/2120


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sourcing results and displayed prices can change materially (5 vs 20 boards, different “best” offers) because ranking moved to the API; grouped search pricing request shape also changed.
> 
> **Overview**
> BOM availability and search pricing now **trust the Diode BOM match API** for which offer wins in each region, instead of re-ranking offers in Rust by stock tier, price, MOQ affordability, or small-passive rules.
> 
> **API client (`pcb-diode-api`)** sends `boardQuantity` (**5**, renamed from `NUM_BOARDS` **20**), `regions` `["US", "GLOBAL"]`, and picks the **first regional offer** in each line’s `offerIds` order via `summarize_region`. Local `select_best_offer`, MOQ/`hard_to_source` handling, and `moq` deserialization are removed. Batch pricing no longer chunks requests; grouped alternate pricing sends **one planned BOM line per group** with `alternatives` instead of flattening parts.
> 
> **Shared types (`pcb-sch`)** drop tier/MOQ domain helpers and `hard_to_source_reason` on summaries; `BOARD_QUANTITY` is the single build multiplier for API and table price columns.
> 
> **`pcb bom` table** with live data drops green/yellow/red stock-tier coloring and the plenty/limited/hard summary buckets; it highlights **no match**, DNP, and house parts, with a **“Matched / planner-ranked”** summary. Offline tables keep the old tier legend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e086a92e263c735a7abc008a63bf77dc4051524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->