### PR TITLE
Fall back to the other rail pair for board array tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - BOM sourcing now uses the API's deterministic offer order for five-board builds.
+- Board arrays place rail fiducials and tooling holes on the other rail pair when the preferred pair does not fit.
+- Auto board arrays error out when rail fiducials and tooling holes cannot fit.
 
 ## [0.4.28] - 2026-08-11
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -786,24 +786,32 @@ fn build_board_array_spec(
         array_width,
         array_height,
     );
+    let tooling_spec = BoardArrayToolingSpec {
+        columns,
+        rows,
+        board_width_mm: board_width,
+        board_height_mm: board_height,
+        margin_x_mm: margin_x,
+        margin_y_mm: margin_y,
+        pitch_x_mm: pitch_x,
+        pitch_y_mm: pitch_y,
+        array_width_mm: array_width,
+        array_height_mm: array_height,
+    };
+    if validation_mode != BoardArrayValidationMode::Manual
+        && board_array_tooling_orientation(&tooling_spec).is_none()
+    {
+        bail!(
+            "auto board array cannot fit rail fiducials and tooling holes on either rail pair; \
+             panelize manually to skip rail tooling"
+        );
+    }
     add_board_array_tooling(
         &mut generated_geometry,
         ipc,
         ecad,
         &mut used_layer_names,
-        BoardArrayToolingSpec {
-            orientation: board_array_tooling_orientation(array_width, array_height),
-            columns,
-            rows,
-            board_width_mm: board_width,
-            board_height_mm: board_height,
-            margin_x_mm: margin_x,
-            margin_y_mm: margin_y,
-            pitch_x_mm: pitch_x,
-            pitch_y_mm: pitch_y,
-            array_width_mm: array_width,
-            array_height_mm: array_height,
-        },
+        tooling_spec,
     )?;
     add_board_cell_fiducials(
         &mut generated_geometry,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -143,13 +143,13 @@ fn creates_rounded_panel_step_from_board_bbox() {
 
 #[test]
 fn generated_board_array_has_a_certified_safe_balancing_region() {
-    let input = board_fixture_mm();
-    let source = Ipc2581::parse(input).unwrap();
+    let input = board_fixture_with_mask_bbox_mm(12.0, 10.0);
+    let source = Ipc2581::parse(&input).unwrap();
     let (options, validation_mode, panelization) = auto_board_array_options(&source, None).unwrap();
     let spec = build_board_array_spec(&source, &options, validation_mode, panelization).unwrap();
     // Safe-region discovery runs on the completed but not-yet-balanced array;
     // otherwise the generated balance copper becomes its own obstacle.
-    let xml = write_board_array_xml(input, &spec).unwrap();
+    let xml = write_board_array_xml(&input, &spec).unwrap();
     let ipc = Ipc2581::parse(&xml).unwrap();
     let layout = geometry::extract_layout(&ipc).unwrap();
     let score_lines = geometry::board_array_vscore_lines(&ipc).unwrap();
@@ -192,18 +192,7 @@ fn generated_board_array_has_a_certified_safe_balancing_region() {
 /// A two-copper-layer board with copper only on TOP, on the smallest sheet:
 /// balancing costs the panel's area, and nothing here asks how many boards fit.
 fn two_layer_board_xml() -> String {
-    board_fixture_with_top_line_mm()
-        .replace(
-            r#"<LayerRef name="TOP"/>"#,
-            r#"<LayerRef name="TOP"/>
-<LayerRef name="BOTTOM"/>"#,
-        )
-        .replace(
-            r#"<Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>"#,
-            r#"<Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
-  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>"#,
-        )
-        .replace(r#"lineWidth="0.2""#, r#"lineWidth="4""#)
+    board_fixture_with_top_line_mm().replace(r#"lineWidth="0.2""#, r#"lineWidth="4""#)
 }
 
 #[test]
@@ -293,7 +282,17 @@ fn board_array_creation_accepts_no_source_copper_layers() {
         r#"<Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>"#,
         r#"<Layer name="TOP" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>"#,
     );
-    let creation = create_auto_board_array(&input, None, true).unwrap();
+    let creation = create_board_array(
+        &input,
+        &BoardArrayCreateOptions {
+            columns: 2,
+            rows: 2,
+            board_margin_mm: board_margin(10.0, 10.0),
+            edge_rail_mm: BoardMarginMm::all(20.0),
+        },
+        true,
+    )
+    .unwrap();
 
     assert!(creation.copper_balance.unwrap().layers.is_empty());
 }
@@ -402,10 +401,10 @@ fn generated_board_array_xml_validates_with_existing_history_and_callouts() {
 
 #[test]
 fn auto_create_projects_board_to_a7_array() {
-    let xml = create_auto_board_array_xml(board_fixture_mm()).unwrap();
+    let xml = create_auto_board_array_xml(&board_fixture_with_mask_bbox_mm(12.0, 10.0)).unwrap();
 
     assert!(xml.contains(
-        r#"<StepRepeat stepRef="board_cell" x="12.5" y="7" nx="4" ny="3" dx="20" dy="20" angle="0.00" mirror="false"/>"#
+        r#"<StepRepeat stepRef="board_cell" x="8.5" y="7" nx="4" ny="3" dx="22" dy="20" angle="0.00" mirror="false"/>"#
     ));
     assert!(xml.contains(
         r#"<NonstandardAttribute name="diode.panelize.mode" type="STRING" value="auto"/>"#
@@ -420,7 +419,7 @@ fn auto_create_projects_board_to_a7_array() {
         r#"<NonstandardAttribute name="diode.panelize.sheet_height_mm" type="DOUBLE" value="74"/>"#
     ));
     assert!(xml.contains(
-        r#"<NonstandardAttribute name="diode.panelize.edge_rail_left_mm" type="DOUBLE" value="12.5"/>"#
+        r#"<NonstandardAttribute name="diode.panelize.edge_rail_left_mm" type="DOUBLE" value="8.5"/>"#
     ));
     assert!(xml.contains(
         r#"<NonstandardAttribute name="diode.panelize.edge_rail_top_mm" type="DOUBLE" value="7"/>"#
@@ -436,11 +435,14 @@ fn auto_create_projects_board_to_a7_array() {
 
 #[test]
 fn auto_create_projects_board_to_requested_a5_array() {
-    let xml = create_auto_board_array_xml_with_sheet(board_fixture_mm(), Some(AutoSheetSize::A5))
-        .unwrap();
+    let xml = create_auto_board_array_xml_with_sheet(
+        &board_fixture_with_mask_bbox_mm(12.0, 10.0),
+        Some(AutoSheetSize::A5),
+    )
+    .unwrap();
 
     assert!(xml.contains(
-        r#"<StepRepeat stepRef="board_cell" x="5" y="14" nx="10" ny="6" dx="20" dy="20" angle="0.00" mirror="false"/>"#
+        r#"<StepRepeat stepRef="board_cell" x="8" y="5" nx="6" ny="10" dx="22" dy="20" angle="0.00" mirror="false"/>"#
     ));
     assert!(xml.contains(
         r#"<NonstandardAttribute name="diode.panelize.mode" type="STRING" value="auto_sheet"/>"#
@@ -449,17 +451,17 @@ fn auto_create_projects_board_to_requested_a5_array() {
         r#"<NonstandardAttribute name="diode.panelize.sheet" type="STRING" value="A5"/>"#
     ));
     assert!(xml.contains(
-        r#"<NonstandardAttribute name="diode.panelize.sheet_width_mm" type="DOUBLE" value="210"/>"#
+        r#"<NonstandardAttribute name="diode.panelize.sheet_width_mm" type="DOUBLE" value="148"/>"#
     ));
     assert!(xml.contains(
-        r#"<NonstandardAttribute name="diode.panelize.sheet_height_mm" type="DOUBLE" value="148"/>"#
+        r#"<NonstandardAttribute name="diode.panelize.sheet_height_mm" type="DOUBLE" value="210"/>"#
     ));
 
     let ipc = Ipc2581::parse(&xml).unwrap();
     let layout = geometry::extract_layout(&ipc).unwrap();
     let (_, panel_step) = pcb_ir::dialects::ipc::root_panel_step(&layout).unwrap();
     assert_point_close(panel_step.bbox.min, Point::new(0.0, 0.0));
-    assert_point_close(panel_step.bbox.max, Point::new(210.0, 148.0));
+    assert_point_close(panel_step.bbox.max, Point::new(148.0, 210.0));
     assert_eq!(pcb_ir::dialects::ipc::board_instance_count(&layout), 60);
 }
 
@@ -474,7 +476,7 @@ fn auto_create_derives_board_margin_from_courtyard_overhang() {
         margin,
         BoardMarginMm {
             top: 7.0,
-            right: 8.0,
+            right: 6.0,
             bottom: 6.0,
             left: 7.0,
         }
@@ -500,7 +502,7 @@ fn auto_create_allows_large_computed_board_margins() {
         margin,
         BoardMarginMm {
             top: 5.0,
-            right: 26.0,
+            right: 24.0,
             bottom: 5.0,
             left: 5.0,
         }
@@ -977,7 +979,8 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     assert!(
         top.features
             .iter()
-            .filter(|feature| feature.source_step_kind == LayoutStepKind::Panel)
+            .filter(|feature| feature.source_step_kind == LayoutStepKind::Panel
+                && !feature.is_fiducial())
             .all(|feature| feature.flags.copper_balance.is_some())
     );
     let balance_paths = |kind: pcb_ir::dialects::ipc::CopperBalanceKind| {
@@ -1222,7 +1225,7 @@ fn board_array_creation_places_array_tooling_on_left_right_for_landscape_arrays(
 }
 
 #[test]
-fn board_array_creation_skips_default_tooling_when_board_width_is_too_small() {
+fn board_array_tooling_falls_back_to_the_other_rail_pair() {
     let input = board_fixture_with_mask_bbox_mm(11.99, 40.0);
     let xml = create_board_array_xml(
         &input,
@@ -1236,37 +1239,62 @@ fn board_array_creation_skips_default_tooling_when_board_width_is_too_small() {
     .unwrap();
 
     let ipc = Ipc2581::parse(&xml).unwrap();
-    let ecad = ipc.ecad().unwrap();
-    assert!(
-        ecad.cad_data
-            .layers
-            .iter()
-            .any(|layer| ipc.resolve(layer.name) == TOOLING_HOLE_LAYER_BASE_NAME)
-    );
-
     let step = array_step(&ipc);
+    let top_fiducials = fiducials_on_layer(&ipc, step, "TOP");
     let tooling_holes = holes_on_layer(&ipc, step, TOOLING_HOLE_LAYER_BASE_NAME);
+    let rail_holes = holes_with_diameter(&tooling_holes, TOOLING_HOLE_DIAMETER_MM);
+
+    assert_points_close(
+        fiducial_points(&top_fiducials),
+        vec![(3.85, 52.0), (3.85, 28.0), (67.13, 48.0), (67.13, 32.0)],
+    );
+    assert_points_close(
+        hole_points(&rail_holes),
+        vec![(2.5, 57.5), (2.5, 22.5), (68.48, 53.5), (68.48, 26.5)],
+    );
+}
+
+#[test]
+fn auto_create_errors_when_rail_tooling_cannot_fit() {
+    let input = board_fixture_with_mask_bbox_mm(10.0, 10.0);
+    let error = create_auto_board_array_xml(&input).unwrap_err();
+    assert!(
+        format!("{error:#}").contains("cannot fit rail fiducials and tooling holes"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn board_array_tooling_skips_when_no_rail_pair_fits() {
+    let input = board_fixture_with_mask_bbox_mm(11.99, 27.99);
+    let xml = create_board_array_xml(
+        &input,
+        &BoardArrayCreateOptions {
+            columns: 2,
+            rows: 1,
+            board_margin_mm: board_margin(5.0, 0.0),
+            edge_rail_mm: edge_rail(18.5, 21.5),
+        },
+    )
+    .unwrap();
+
+    let ipc = Ipc2581::parse(&xml).unwrap();
+    let step = array_step(&ipc);
     let fiducial_count = step
         .layer_features
         .iter()
         .flat_map(|layer_feature| &layer_feature.sets)
         .flat_map(|set| set.fiducials())
         .count();
-    let hole_count = step
-        .layer_features
-        .iter()
-        .flat_map(|layer_feature| &layer_feature.sets)
-        .flat_map(|set| set.holes())
-        .count();
+    let tooling_holes = holes_on_layer(&ipc, step, TOOLING_HOLE_LAYER_BASE_NAME);
 
     assert_eq!(fiducial_count, 0);
-    assert_eq!(hole_count, 4);
     assert!(
         tooling_holes
             .iter()
             .all(|hole| close(hole.diameter, CORNER_TOOLING_HOLE_DIAMETER_MM))
     );
-    assert_corner_holes(&tooling_holes, 70.98, 80.0);
+    assert_corner_holes(&tooling_holes, 70.98, 70.99);
 }
 
 #[test]
@@ -1996,14 +2024,17 @@ fn board_fixture_with_courtyard_overhang_mm() -> &'static str {
 <CadHeader units="MILLIMETER"/>
 <CadData>
   <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+  <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+  <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
   <Layer name="F.Courtyard" layerFunction="COURTYARD" side="TOP" polarity="POSITIVE"/>
   <Step name="board" type="BOARD">
     <Datum x="0" y="0"/>
     <Profile>
       <Polygon>
         <PolyBegin x="0" y="0"/>
-        <PolyStepSegment x="10" y="0"/>
-        <PolyStepSegment x="10" y="10"/>
+        <PolyStepSegment x="12" y="0"/>
+        <PolyStepSegment x="12" y="10"/>
         <PolyStepSegment x="0" y="10"/>
         <PolyStepSegment x="0" y="0"/>
       </Polygon>
@@ -2040,14 +2071,17 @@ fn board_fixture_with_large_courtyard_overhang_mm() -> &'static str {
 <CadHeader units="MILLIMETER"/>
 <CadData>
   <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+  <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+  <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
   <Layer name="F.Courtyard" layerFunction="COURTYARD" side="TOP" polarity="POSITIVE"/>
   <Step name="board" type="BOARD">
     <Datum x="0" y="0"/>
     <Profile>
       <Polygon>
         <PolyBegin x="0" y="0"/>
-        <PolyStepSegment x="10" y="0"/>
-        <PolyStepSegment x="10" y="10"/>
+        <PolyStepSegment x="12" y="0"/>
+        <PolyStepSegment x="12" y="10"/>
         <PolyStepSegment x="0" y="10"/>
         <PolyStepSegment x="0" y="0"/>
       </Polygon>
@@ -2113,13 +2147,16 @@ fn board_fixture_with_top_line_mm() -> &'static str {
 <CadHeader units="MILLIMETER"/>
 <CadData>
   <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+  <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+  <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+  <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
   <Step name="board" type="BOARD">
     <Datum x="0" y="0"/>
     <Profile>
       <Polygon>
         <PolyBegin x="-2" y="-3"/>
-        <PolyStepSegment x="8" y="-3"/>
-        <PolyStepSegment x="8" y="7"/>
+        <PolyStepSegment x="10" y="-3"/>
+        <PolyStepSegment x="10" y="7"/>
         <PolyStepSegment x="-2" y="7"/>
         <PolyStepSegment x="-2" y="-3"/>
       </Polygon>

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tooling.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tooling.rs
@@ -3,7 +3,6 @@
 use super::*;
 
 pub(super) struct BoardArrayToolingSpec {
-    pub(super) orientation: BoardArrayToolingOrientation,
     pub(super) columns: u32,
     pub(super) rows: u32,
     pub(super) board_width_mm: f64,
@@ -22,15 +21,47 @@ pub(super) enum BoardArrayToolingOrientation {
     LeftRight,
 }
 
+/// Pick the rail pair for board array tooling.
+///
+/// Eligibility is checked per orientation: the board span along the rail
+/// direction must satisfy the single- or multi-board minimum. Prefer the
+/// shorter pair of rails (left/right for landscape arrays), then fall back
+/// to the other eligible pair.
 pub(super) fn board_array_tooling_orientation(
-    array_width_mm: f64,
-    array_height_mm: f64,
-) -> BoardArrayToolingOrientation {
-    if array_width_mm > array_height_mm {
-        BoardArrayToolingOrientation::LeftRight
+    spec: &BoardArrayToolingSpec,
+) -> Option<BoardArrayToolingOrientation> {
+    let top_bottom =
+        board_array_tooling_span_eligible(spec, BoardArrayToolingOrientation::TopBottom);
+    let left_right =
+        board_array_tooling_span_eligible(spec, BoardArrayToolingOrientation::LeftRight);
+
+    if spec.array_width_mm > spec.array_height_mm {
+        if left_right {
+            Some(BoardArrayToolingOrientation::LeftRight)
+        } else {
+            top_bottom.then_some(BoardArrayToolingOrientation::TopBottom)
+        }
+    } else if top_bottom {
+        Some(BoardArrayToolingOrientation::TopBottom)
     } else {
-        BoardArrayToolingOrientation::TopBottom
+        left_right.then_some(BoardArrayToolingOrientation::LeftRight)
     }
+}
+
+fn board_array_tooling_span_eligible(
+    spec: &BoardArrayToolingSpec,
+    orientation: BoardArrayToolingOrientation,
+) -> bool {
+    let (span_count, board_span) = match orientation {
+        BoardArrayToolingOrientation::TopBottom => (spec.columns, spec.board_width_mm),
+        BoardArrayToolingOrientation::LeftRight => (spec.rows, spec.board_height_mm),
+    };
+    let min_span = if span_count == 1 {
+        SINGLE_BOARD_TOOLING_MIN_SPAN_MM
+    } else {
+        MULTI_BOARD_TOOLING_MIN_SPAN_MM
+    };
+    board_span + EPSILON >= min_span
 }
 
 pub(super) fn add_board_array_tooling(
@@ -40,23 +71,14 @@ pub(super) fn add_board_array_tooling(
     used_layer_names: &mut HashSet<String>,
     spec: BoardArrayToolingSpec,
 ) -> Result<()> {
-    let (span_count, board_span) = match spec.orientation {
-        BoardArrayToolingOrientation::TopBottom => (spec.columns, spec.board_width_mm),
-        BoardArrayToolingOrientation::LeftRight => (spec.rows, spec.board_height_mm),
-    };
-    let min_span = if span_count == 1 {
-        SINGLE_BOARD_TOOLING_MIN_SPAN_MM
-    } else {
-        MULTI_BOARD_TOOLING_MIN_SPAN_MM
-    };
-    if board_span + EPSILON < min_span {
+    let Some(orientation) = board_array_tooling_orientation(&spec) else {
         return Ok(());
-    }
+    };
 
     let tooling_hole_layer_name =
         ensure_tooling_hole_layer_name(generated_geometry, used_layer_names);
 
-    let fiducials = board_array_tooling_fiducials(&spec);
+    let fiducials = board_array_tooling_fiducials(&spec, orientation);
     add_two_sided_fiducials(
         generated_geometry,
         ipc,
@@ -70,7 +92,10 @@ pub(super) fn add_board_array_tooling(
         GeneratedFeatureScope::Array,
         tooling_hole_layer_name,
         Polarity::Positive,
-        round_nonplated_hole_features(board_array_tooling_holes(&spec), TOOLING_HOLE_DIAMETER_MM),
+        round_nonplated_hole_features(
+            board_array_tooling_holes(&spec, orientation),
+            TOOLING_HOLE_DIAMETER_MM,
+        ),
     );
     Ok(())
 }
@@ -146,7 +171,8 @@ fn add_two_sided_fiducials(
     Ok(())
 }
 
-/// Place board array tooling on the shorter pair of array rails.
+/// Place board array tooling on the rail pair chosen by
+/// [`board_array_tooling_orientation`].
 ///
 /// The generated board array uses a rectangular profile with the lower-left
 /// array corner at (0, 0). Fiducials and tooling holes live in the outer 5 mm
@@ -166,18 +192,26 @@ fn add_two_sided_fiducials(
 /// Rail-depth rules:
 /// - tooling hole centers are 2.5 mm from the array edge;
 /// - fiducial centers are 3.85 mm from the array edge.
-pub(super) fn board_array_tooling_fiducials(spec: &BoardArrayToolingSpec) -> [(f64, f64); 4] {
+pub(super) fn board_array_tooling_fiducials(
+    spec: &BoardArrayToolingSpec,
+    orientation: BoardArrayToolingOrientation,
+) -> [(f64, f64); 4] {
     board_array_tooling_points(
         spec,
+        orientation,
         FIDUCIAL_EDGE_OFFSET_MM,
         PRIMARY_FIDUCIAL_SPAN_INSET_MM,
         SECONDARY_FIDUCIAL_SPAN_INSET_MM,
     )
 }
 
-pub(super) fn board_array_tooling_holes(spec: &BoardArrayToolingSpec) -> [(f64, f64); 4] {
+pub(super) fn board_array_tooling_holes(
+    spec: &BoardArrayToolingSpec,
+    orientation: BoardArrayToolingOrientation,
+) -> [(f64, f64); 4] {
     board_array_tooling_points(
         spec,
+        orientation,
         TOOLING_HOLE_EDGE_OFFSET_MM,
         PRIMARY_TOOLING_HOLE_SPAN_INSET_MM,
         SECONDARY_TOOLING_HOLE_SPAN_INSET_MM,
@@ -186,11 +220,12 @@ pub(super) fn board_array_tooling_holes(spec: &BoardArrayToolingSpec) -> [(f64, 
 
 pub(super) fn board_array_tooling_points(
     spec: &BoardArrayToolingSpec,
+    orientation: BoardArrayToolingOrientation,
     rail_depth_mm: f64,
     primary_span_inset_mm: f64,
     secondary_span_inset_mm: f64,
 ) -> [(f64, f64); 4] {
-    match spec.orientation {
+    match orientation {
         BoardArrayToolingOrientation::TopBottom => {
             let left_edge = spec.margin_x_mm;
             let right_edge = spec.margin_x_mm


### PR DESCRIPTION
Array-level rail fiducials and tooling holes committed to the rail pair chosen by aspect ratio and silently skipped when the board span along that pair was too small (e.g. a 63×10 mm board in a 1×3 landscape array got no panel fiducials).

Rail tooling now uses the same eligibility-plus-fallback selection as board-cell fiducials: prefer the shorter rail pair, fall back to the other eligible pair. Auto panelization errors out when neither rail pair can host the tooling; manual creation keeps the silent skip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes manufacturing panel geometry (rail fiducials and tooling holes) and makes auto panelization fail in cases that previously succeeded without rail tooling.
> 
> **Overview**
> **Rail tooling** no longer commits solely to the aspect-ratio-preferred rail pair and silently drops fiducials/holes when that span is too small.
> 
> `board_array_tooling_orientation` now checks eligibility per orientation, prefers the shorter rail pair, and **falls back to the other eligible pair**. **Auto** panelization errors when neither pair can host rail tooling; **manual** creation still skips rail tooling in that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51feeef9cdae9334a5c7e475141019153f05d2ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->