### PR TITLE
Add Cloud Agent development environment (Debian 12 + KiCad 10)

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,62 @@
+# Cloud Agent base image for the pcb / Zener toolchain.
+#
+# Debian 12 (bookworm) is required because the Diode KiCad 10 package that the
+# workspace tests and `pcb layout` depend on is built for Debian 12 (it depends
+# on libpython3.11, libocct-*-7.6, libwxbase3.2, etc. that only resolve there).
+# This mirrors CI, which runs the workspace inside a Debian-based KiCad image.
+#
+# Repository-dependent work (pinned Rust toolchain, cargo fetch/build, uv sync)
+# lives in the `install` script from .cursor/environment.json, not here.
+FROM debian:12-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:/usr/local/bin:/usr/bin:/bin
+
+# --- Base system packages ----------------------------------------------------
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        xz-utils \
+        build-essential \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Diode KiCad 10 (native Debian package + Python bindings) ----------------
+# Installed via apt so the KiCad dependency graph is resolved automatically.
+RUN set -eux; \
+    metadata="$(curl -fsSL https://kicad-mirror.api.diode.computer/packages/kicad/diode/10.0/latest.json)"; \
+    deb_url="$(jq -er .deb_url <<<"$metadata")"; \
+    sha256="$(jq -er .sha256 <<<"$metadata")"; \
+    tmp="$(mktemp -d)"; \
+    curl -fsSL "$deb_url" -o "$tmp/kicad.deb"; \
+    printf '%s  %s\n' "$sha256" "$tmp/kicad.deb" | sha256sum --check --strict; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends "$tmp/kicad.deb"; \
+    rm -rf "$tmp" /var/lib/apt/lists/*; \
+    kicad-cli --version; \
+    /usr/bin/python3 -c 'import pcbnew'
+
+# --- Rust toolchain (rustup; pinned channel resolved from rust-toolchain.toml
+#     by the install script after checkout) -----------------------------------
+RUN set -eux; \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --profile minimal --default-toolchain stable --component clippy rustfmt; \
+    chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"; \
+    rustup --version; \
+    cargo --version
+
+# --- cargo-nextest (official prebuilt binary; stay on the 0.9 series) --------
+RUN set -eux; \
+    curl -LsSf https://get.nexte.st/0.9/linux | tar zxf - -C /usr/local/cargo/bin; \
+    cargo nextest --version
+
+# --- uv (standalone installer) ----------------------------------------------
+RUN set -eux; \
+    curl -LsSf https://astral.sh/uv/install.sh \
+        | env UV_INSTALL_DIR=/usr/local/bin UV_UNMANAGED_INSTALL=/usr/local/bin sh; \
+    uv --version

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,9 @@
+{
+  "name": "pcb",
+  "user": "root",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Repository bootstrap for the pcb Cloud Agent environment.
+#
+# Runs after the repository is checked out. It is idempotent and only prepares
+# source-derived state: the pinned Rust toolchain/components, Python dev deps,
+# and a warm Cargo build cache. Heavy, repo-independent tooling (KiCad, rustup,
+# cargo-nextest, uv) is installed in .cursor/Dockerfile.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Materialize the Rust toolchain pinned by rust-toolchain.toml and ensure the
+# lint/format components exist for it.
+rustup show active-toolchain || rustup show
+rustup component add clippy rustfmt
+
+# Python dev/test environment for the layout-lens scripts.
+uv sync --locked
+
+# Warm the Cargo caches so agents (and CI-style checks) start fast.
+cargo fetch --locked
+cargo build -p pcb -p pcbc --locked


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cursor Cloud Agent environment so the `pcb` / Zener toolchain is fully usable out of the box, matching how CI builds and tests the workspace.

The environment is repository-managed via `.cursor/`:

- `.cursor/Dockerfile` — Debian 12 (bookworm) base. Debian 12 is required because the Diode KiCad 10 package that the workspace tests and `pcb layout` depend on is built for Debian 12 (`libpython3.11`, `libocct-*-7.6`, `libwxbase3.2`, …), the same way CI runs the workspace inside a Debian-based KiCad image. Installs system build deps, the Diode KiCad 10 package (+ `pcbnew` Python bindings), the Rust `rustup` toolchain, `cargo-nextest`, and `uv`.
- `.cursor/install.sh` — idempotent repository bootstrap: materializes the pinned Rust toolchain from `rust-toolchain.toml`, adds `clippy`/`rustfmt`, runs `uv sync --locked`, and warms the Cargo caches (`cargo fetch` + `cargo build -p pcb -p pcbc`).
- `.cursor/environment.json` — wires the Dockerfile + install script together.

The KiCad install mirrors the existing canonical `.agents/setup` orb script, which already installs the same Diode Debian 12 package.

## Validation

Non-KiCad flows validated locally; KiCad flows validated in a fresh Cloud Agent booted from the built image (see PR checks / agent summary).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f965a114-58e1-4019-b956-69dc6b4677e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f965a114-58e1-4019-b956-69dc6b4677e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

