### PR TITLE
Skip build performance comments for fork PRs

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -258,7 +258,7 @@ jobs:
           body-includes: "<!-- pcb-build-perf -->"
 
       - name: Create or update comment
-        if: steps.perf_comment.outputs.has_changes == 'true'
+        if: steps.perf_comment.outputs.has_changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -267,7 +267,7 @@ jobs:
           edit-mode: replace
 
       - name: Delete stale comment
-        if: steps.perf_comment.outputs.has_changes == 'false' && steps.find_comment.outputs.comment-id != ''
+        if: steps.perf_comment.outputs.has_changes == 'false' && steps.find_comment.outputs.comment-id != '' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
Fork pull request workflows receive a read-only GitHub token, so the build performance job fails when it tries to write a pull request comment. This change skips comment updates for fork pull requests while the benchmark and job summary still run; `actionlint` validates the workflow after known repository warnings are excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only guard on PR comment steps; benchmarks and summaries still run, with no application or auth logic touched.
> 
> **Overview**
> **Fork PRs no longer trigger build-performance comment writes**, which avoids failures when Actions only has a read-only token on external contributions.
> 
> The **Create or update comment** and **Delete stale comment** steps in `build-perf.yml` now also require `github.event.pull_request.head.repo.full_name == github.repository`, so comment create/update/delete runs only for same-repo PRs. Benchmark execution and the job summary (from the earlier step) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16071b91f41e4555bec61869b0db604759bd44f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->