### PR TITLE
Resolve nested DiodeHub packages from the owning git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remote package resolution now selects the longest existing 3- or 4-segment git prefix, so nested packages in noncanonical DiodeHub registries resolve to their owning repository.
+
 ## [0.4.29] - 2026-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Remote package resolution now selects the longest existing 3- or 4-segment git prefix, so nested packages in noncanonical DiodeHub registries resolve to their owning repository.
+- Nested DiodeHub packages resolve from their owning git repository.
 
 ## [0.4.29] - 2026-08-12
 

--- a/crates/pcb-zen-core/src/config.rs
+++ b/crates/pcb-zen-core/src/config.rs
@@ -519,40 +519,6 @@ pub fn extract_inline_manifest(zen_content: &str) -> Option<String> {
     None
 }
 
-/// Split a module path into (repo_url, subpath) for github.com repos
-///
-/// Examples:
-/// - "github.com/user/repo" -> ("github.com/user/repo", "")
-/// - "github.com/user/repo/pkg" -> ("github.com/user/repo", "pkg")
-/// - "github.com/user/repo/a/b/c" -> ("github.com/user/repo", "a/b/c")
-pub fn split_repo_and_subpath(module_path: &str) -> (&str, &str) {
-    let diode_registry = crate::package_url::CANONICAL_REGISTRY_REPOSITORY;
-    if module_path == diode_registry {
-        return (module_path, "");
-    }
-    if module_path.starts_with(diode_registry)
-        && module_path
-            .as_bytes()
-            .get(diode_registry.len())
-            .is_some_and(|separator| *separator == b'/')
-    {
-        return (
-            &module_path[..diode_registry.len()],
-            &module_path[diode_registry.len() + 1..],
-        );
-    }
-
-    let parts: Vec<&str> = module_path.split('/').collect();
-    if parts.is_empty() {
-        return (module_path, "");
-    }
-    if parts[0] == "github.com" && parts.len() > 3 {
-        let boundary = parts[..3].join("/").len();
-        return (&module_path[..boundary], &module_path[boundary + 1..]);
-    }
-    (module_path, "")
-}
-
 /// Find the workspace root by walking up from `start`.
 ///
 /// Resolution order:
@@ -1116,30 +1082,5 @@ load("@stdlib/foo.zen", "Bar")
             .unwrap()
             .expect_err("legacy [packages] should not parse");
         assert!(err.to_string().contains("unknown field `packages`"));
-    }
-
-    #[test]
-    fn test_split_repo_and_subpath() {
-        assert_eq!(
-            split_repo_and_subpath("github.com/user/repo"),
-            ("github.com/user/repo", "")
-        );
-        assert_eq!(
-            split_repo_and_subpath("github.com/user/repo/pkg"),
-            ("github.com/user/repo", "pkg")
-        );
-        assert_eq!(
-            split_repo_and_subpath("github.com/user/repo/a/b/c"),
-            ("github.com/user/repo", "a/b/c")
-        );
-        assert_eq!(
-            split_repo_and_subpath("code.diode.computer/diode/registry/components/Foo"),
-            ("code.diode.computer/diode/registry", "components/Foo")
-        );
-        // Non-github repos return full path as repo_url
-        assert_eq!(
-            split_repo_and_subpath("gitlab.com/group/project/pkg"),
-            ("gitlab.com/group/project/pkg", "")
-        );
     }
 }

--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -3,7 +3,6 @@
 use anyhow::{Context, Result};
 use pcb_ui::Spinner;
 use pcb_zen_core::FileProvider;
-use pcb_zen_core::config::split_repo_and_subpath;
 use pcb_zen_core::stdlib::native::{copy_source, discover_source, source_matches_target};
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
@@ -134,28 +133,34 @@ impl CacheIndex {
     // Remote packages (discovered from git tags)
 
     fn find_remote_package_cached(&self, file_url: &str) -> Option<RemotePackage> {
-        let (repo_url, subpath) = split_repo_and_subpath(file_url);
-        let without_file = subpath.rsplit_once('/')?.0;
-
         let conn = self.conn();
-        let mut path = without_file;
-        while !path.is_empty() {
-            if let Some(version) = conn
-                .query_row(
-                    "SELECT latest_version FROM remote_packages WHERE repo_url = ?1 AND package_path = ?2",
-                    params![repo_url, path],
-                    |row| row.get::<_, String>(0),
-                )
-                .optional()
-                .ok()
-                .flatten()
-            {
-                return Some(RemotePackage {
-                    module_path: format!("{}/{}", repo_url, path),
-                    version,
-                });
+        for (repo_url, subpath) in git::repo_prefixes(file_url) {
+            let Some((path, _)) = subpath.rsplit_once('/') else {
+                continue;
+            };
+            let mut path = path.to_string();
+            while !path.is_empty() {
+                if let Some(version) = conn
+                    .query_row(
+                        "SELECT latest_version FROM remote_packages WHERE repo_url = ?1 AND package_path = ?2",
+                        params![repo_url, path],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()
+                    .ok()
+                    .flatten()
+                {
+                    return Some(RemotePackage {
+                        module_path: format!("{}/{}", repo_url, path),
+                        version,
+                    });
+                }
+                path = path
+                    .rsplit_once('/')
+                    .map(|(p, _)| p)
+                    .unwrap_or("")
+                    .to_string();
             }
-            path = path.rsplit_once('/').map(|(p, _)| p).unwrap_or("");
         }
         None
     }
@@ -165,12 +170,12 @@ impl CacheIndex {
             return Ok(Some(result));
         }
 
-        let (repo_url, subpath) = split_repo_and_subpath(file_url);
+        let (repo_url, subpath) = git::split_repo_and_subpath(file_url)?;
         if subpath.is_empty() {
             return Ok(None);
         }
 
-        self.discover_remote_packages(repo_url)?;
+        self.discover_remote_packages(&repo_url)?;
         Ok(self.find_remote_package_cached(file_url))
     }
 
@@ -461,6 +466,14 @@ mod tests {
                 "0.3.0"
             ],
         )?;
+        conn.execute(
+            "INSERT INTO remote_packages VALUES (?1, ?2, ?3)",
+            params![
+                "code.diode.computer/diode/registry/intel",
+                "components/Foo",
+                "0.4.0"
+            ],
+        )?;
         drop(conn);
 
         let dep = index
@@ -489,6 +502,15 @@ mod tests {
             "code.diode.computer/diode/registry/components/JST"
         );
         assert_eq!(dep.version, "0.3.0");
+
+        let dep = index
+            .find_remote_package("code.diode.computer/diode/registry/intel/components/Foo/Foo.zen")?
+            .unwrap();
+        assert_eq!(
+            dep.module_path,
+            "code.diode.computer/diode/registry/intel/components/Foo"
+        );
+        assert_eq!(dep.version, "0.4.0");
 
         // Verify cache miss without triggering remote discovery/network.
         assert!(

--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -384,7 +384,7 @@ pub fn ensure_source_repo(repo_url: &str) -> Result<PathBuf> {
 pub fn source_repo_dir(repo_url: &str) -> Result<PathBuf> {
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
-    Ok(home.join(".pcb/src").join(repo_url))
+    Ok(home.join(".pcb/src").join(repo_url.replace('/', "--")))
 }
 
 #[cfg(test)]
@@ -399,6 +399,16 @@ mod tests {
         let pool = Pool::builder().max_size(4).build(manager).unwrap();
         pool.get().unwrap().execute_batch(schema).unwrap();
         CacheIndex { pool }
+    }
+
+    #[test]
+    fn source_repo_dir_flattens_path_segments() -> Result<()> {
+        let dir = source_repo_dir("code.diode.computer/diode/registry/intel")?;
+        assert_eq!(
+            dir.file_name().and_then(|name| name.to_str()),
+            Some("code.diode.computer--diode--registry--intel")
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/pcb-zen/src/cache_index.rs
+++ b/crates/pcb-zen/src/cache_index.rs
@@ -402,16 +402,6 @@ mod tests {
     }
 
     #[test]
-    fn source_repo_dir_flattens_path_segments() -> Result<()> {
-        let dir = source_repo_dir("code.diode.computer/diode/registry/intel")?;
-        assert_eq!(
-            dir.file_name().and_then(|name| name.to_str()),
-            Some("code.diode.computer--diode--registry--intel")
-        );
-        Ok(())
-    }
-
-    #[test]
     fn test_packages() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let db_path = temp.path().join("index.sqlite");

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -883,8 +883,8 @@ pub fn format_ssh_url(module_path: &str) -> String {
 
 /// Split a module path into `(repo_url, subpath)`.
 ///
-/// Repositories are 3 or 4 path segments. When both prefixes could exist, the
-/// longest existing git remote wins. A locally cached source checkout counts
+/// Repositories are 3 or 4 path segments. Probe the longer prefix first and
+/// keep the first remote that exists. A locally cached source checkout counts
 /// as existing and skips the network.
 pub fn split_repo_and_subpath(module_path: &str) -> anyhow::Result<(String, String)> {
     if let Some(resolved) = RESOLVED_REPOS
@@ -906,18 +906,22 @@ pub fn split_repo_and_subpath(module_path: &str) -> anyhow::Result<(String, Stri
 
 fn resolve_repo_and_subpath(module_path: &str) -> anyhow::Result<(String, String)> {
     for (repo_url, subpath) in repo_prefixes(module_path) {
-        if subpath.is_empty() || repo_exists(&repo_url)? {
+        if repo_exists(&repo_url)? {
             return Ok((repo_url, subpath));
         }
     }
     Ok((module_path.to_string(), String::new()))
 }
 
-pub(crate) fn repo_prefixes(module_path: &str) -> impl Iterator<Item = (String, String)> + '_ {
+pub(crate) fn repo_prefixes(module_path: &str) -> Vec<(String, String)> {
     let parts: Vec<&str> = module_path.split('/').collect();
-    [4usize, 3].into_iter().filter_map(move |n| {
-        (parts.len() >= n).then(|| (parts[..n].join("/"), parts[n..].join("/")))
-    })
+    let mut prefixes = Vec::new();
+    for n in [4usize, 3] {
+        if parts.len() >= n {
+            prefixes.push((parts[..n].join("/"), parts[n..].join("/")));
+        }
+    }
+    prefixes
 }
 
 fn repo_exists(repo_url: &str) -> anyhow::Result<bool> {
@@ -927,18 +931,27 @@ fn repo_exists(repo_url: &str) -> anyhow::Result<bool> {
     {
         return Ok(true);
     }
-    match with_remote_fallback(repo_url, |url, interactive| {
-        ls_remote(url, "HEAD", interactive).map(|_| ())
-    }) {
+
+    let https_url = format!("https://{}.git", repo_url);
+    match ls_remote(&https_url, "HEAD", false) {
         Ok(_) => Ok(true),
         Err(err) if is_missing_remote(&err) => Ok(false),
-        Err(err) => Err(err),
+        Err(https_err) => {
+            let ssh_url = format_ssh_url(repo_url);
+            match ls_remote(&ssh_url, "HEAD", true) {
+                Ok(_) => Ok(true),
+                Err(err) if is_missing_remote(&err) => Ok(false),
+                Err(_) => Err(https_err),
+            }
+        }
     }
 }
 
 fn is_missing_remote(err: &anyhow::Error) -> bool {
     let msg = err.to_string().to_ascii_lowercase();
-    msg.contains("not found") || msg.contains("does not exist")
+    msg.contains("not found")
+        || msg.contains("does not exist")
+        || msg.contains("does not appear to be a git repository")
 }
 
 fn with_remote_fallback<T>(
@@ -1193,5 +1206,47 @@ mod tests {
         assert!(args.iter().any(|arg| {
             arg == "credential.https://code.diode.computer.helper=!pcb auth git --host='code.diode.computer'"
         }));
+    }
+
+    #[test]
+    fn repo_prefixes_are_four_then_three_segments() {
+        assert_eq!(
+            repo_prefixes("code.diode.computer/spring/registry/components/TDK/ICM"),
+            [
+                (
+                    "code.diode.computer/spring/registry/components".into(),
+                    "TDK/ICM".into()
+                ),
+                (
+                    "code.diode.computer/spring/registry".into(),
+                    "components/TDK/ICM".into()
+                ),
+            ]
+        );
+        assert_eq!(
+            repo_prefixes("github.com/user/repo/pkg"),
+            [
+                ("github.com/user/repo/pkg".into(), "".into()),
+                ("github.com/user/repo".into(), "pkg".into()),
+            ]
+        );
+        assert_eq!(
+            repo_prefixes("github.com/user/repo"),
+            [("github.com/user/repo".into(), "".into())]
+        );
+    }
+
+    #[test]
+    fn missing_remote_matches_git_not_found_errors() {
+        assert!(is_missing_remote(&anyhow::anyhow!(
+            "fatal: repository 'https://github.com/user/repo/pkg.git/' not found"
+        )));
+        assert!(is_missing_remote(&anyhow::anyhow!(
+            "fatal: '/tmp/repo.git//pkg.git' does not appear to be a git repository"
+        )));
+        assert!(!is_missing_remote(&anyhow::anyhow!(
+            "Could not read from remote repository."
+        )));
+        assert!(!is_missing_remote(&anyhow::anyhow!("Connection timed out")));
     }
 }

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -6,10 +6,10 @@ use jiff::{
     Timestamp,
     tz::{Offset, TimeZone},
 };
-use pcb_zen_core::config::split_repo_and_subpath;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::{LazyLock, Mutex};
 use tar::Archive;
 use tempfile::Builder;
 use url::Url;
@@ -23,6 +23,9 @@ const DIODEHUB_CREDENTIAL_USE_HTTP_PATH_CONFIG: &str =
 const PCB_GIT_CONFIG_FILE: &str = "gitconfig";
 const PCB_GIT_CONFIG_INCLUDE: &str = "include.path";
 const GIT_CONFIG_NOT_FOUND: i32 = 5;
+
+static RESOLVED_REPOS: LazyLock<Mutex<HashMap<String, (String, String)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Clone)]
 pub struct TagMetadata {
@@ -878,6 +881,66 @@ pub fn format_ssh_url(module_path: &str) -> String {
     }
 }
 
+/// Split a module path into `(repo_url, subpath)`.
+///
+/// Repositories are 3 or 4 path segments. When both prefixes could exist, the
+/// longest existing git remote wins. A locally cached source checkout counts
+/// as existing and skips the network.
+pub fn split_repo_and_subpath(module_path: &str) -> anyhow::Result<(String, String)> {
+    if let Some(resolved) = RESOLVED_REPOS
+        .lock()
+        .expect("repo resolution cache mutex poisoned")
+        .get(module_path)
+        .cloned()
+    {
+        return Ok(resolved);
+    }
+
+    let resolved = resolve_repo_and_subpath(module_path)?;
+    RESOLVED_REPOS
+        .lock()
+        .expect("repo resolution cache mutex poisoned")
+        .insert(module_path.to_string(), resolved.clone());
+    Ok(resolved)
+}
+
+fn resolve_repo_and_subpath(module_path: &str) -> anyhow::Result<(String, String)> {
+    for (repo_url, subpath) in repo_prefixes(module_path) {
+        if subpath.is_empty() || repo_exists(&repo_url)? {
+            return Ok((repo_url, subpath));
+        }
+    }
+    Ok((module_path.to_string(), String::new()))
+}
+
+pub(crate) fn repo_prefixes(module_path: &str) -> impl Iterator<Item = (String, String)> + '_ {
+    let parts: Vec<&str> = module_path.split('/').collect();
+    [4usize, 3].into_iter().filter_map(move |n| {
+        (parts.len() >= n).then(|| (parts[..n].join("/"), parts[n..].join("/")))
+    })
+}
+
+fn repo_exists(repo_url: &str) -> anyhow::Result<bool> {
+    if crate::cache_index::source_repo_dir(repo_url)?
+        .join(".git")
+        .exists()
+    {
+        return Ok(true);
+    }
+    match with_remote_fallback(repo_url, |url, interactive| {
+        ls_remote(url, "HEAD", interactive).map(|_| ())
+    }) {
+        Ok(_) => Ok(true),
+        Err(err) if is_missing_remote(&err) => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn is_missing_remote(err: &anyhow::Error) -> bool {
+    let msg = err.to_string().to_ascii_lowercase();
+    msg.contains("not found") || msg.contains("does not exist")
+}
+
 fn with_remote_fallback<T>(
     repo_url: &str,
     mut operation: impl FnMut(&str, bool) -> anyhow::Result<T>,
@@ -913,8 +976,8 @@ pub fn ls_remote_with_fallback(
     module_path: &str,
     refspec: &str,
 ) -> anyhow::Result<(String, String)> {
-    let (repo_url, _) = split_repo_and_subpath(module_path);
-    let (commit, url) = with_remote_fallback(repo_url, |url, interactive| {
+    let (repo_url, _) = split_repo_and_subpath(module_path)?;
+    let (commit, url) = with_remote_fallback(&repo_url, |url, interactive| {
         ls_remote(url, refspec, interactive)
     })
     .with_context(|| format!("Failed to ls-remote {} for {}", refspec, module_path))?;

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -882,10 +882,6 @@ pub fn format_ssh_url(module_path: &str) -> String {
 }
 
 /// Split a module path into `(repo_url, subpath)`.
-///
-/// Repositories are 3 or 4 path segments. Probe the longer prefix first and
-/// keep the first remote that exists. A locally cached source checkout counts
-/// as existing and skips the network.
 pub fn split_repo_and_subpath(module_path: &str) -> anyhow::Result<(String, String)> {
     if let Some(resolved) = RESOLVED_REPOS
         .lock()
@@ -1201,47 +1197,5 @@ mod tests {
         assert!(args.iter().any(|arg| {
             arg == "credential.https://code.diode.computer.helper=!pcb auth git --host='code.diode.computer'"
         }));
-    }
-
-    #[test]
-    fn repo_prefixes_are_four_then_three_segments() {
-        assert_eq!(
-            repo_prefixes("code.diode.computer/spring/registry/components/TDK/ICM"),
-            [
-                (
-                    "code.diode.computer/spring/registry/components".into(),
-                    "TDK/ICM".into()
-                ),
-                (
-                    "code.diode.computer/spring/registry".into(),
-                    "components/TDK/ICM".into()
-                ),
-            ]
-        );
-        assert_eq!(
-            repo_prefixes("github.com/user/repo/pkg"),
-            [
-                ("github.com/user/repo/pkg".into(), "".into()),
-                ("github.com/user/repo".into(), "pkg".into()),
-            ]
-        );
-        assert_eq!(
-            repo_prefixes("github.com/user/repo"),
-            [("github.com/user/repo".into(), "".into())]
-        );
-    }
-
-    #[test]
-    fn missing_remote_matches_git_not_found_errors() {
-        assert!(is_missing_remote(&anyhow::anyhow!(
-            "fatal: repository 'https://github.com/user/repo/pkg.git/' not found"
-        )));
-        assert!(is_missing_remote(&anyhow::anyhow!(
-            "fatal: '/tmp/repo.git//pkg.git' does not appear to be a git repository"
-        )));
-        assert!(!is_missing_remote(&anyhow::anyhow!(
-            "Could not read from remote repository."
-        )));
-        assert!(!is_missing_remote(&anyhow::anyhow!("Connection timed out")));
     }
 }

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -934,17 +934,12 @@ fn repo_exists(repo_url: &str) -> anyhow::Result<bool> {
 
     let https_url = format!("https://{}.git", repo_url);
     match ls_remote(&https_url, "HEAD", false) {
-        Ok(_) => Ok(true),
-        Err(err) if is_missing_remote(&err) => Ok(false),
-        Err(https_err) => {
-            let ssh_url = format_ssh_url(repo_url);
-            match ls_remote(&ssh_url, "HEAD", true) {
-                Ok(_) => Ok(true),
-                Err(err) if is_missing_remote(&err) => Ok(false),
-                Err(_) => Err(https_err),
-            }
-        }
+        Ok(_) => return Ok(true),
+        Err(err) if !is_missing_remote(&err) => return Err(err),
+        Err(_) => {}
     }
+
+    Ok(ls_remote(&format_ssh_url(repo_url), "HEAD", true).is_ok())
 }
 
 fn is_missing_remote(err: &anyhow::Error) -> bool {

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -20,6 +20,7 @@ use pcb_zen_core::{DefaultFileProvider, EvalContext, EvalOutput};
 use serde_json::Value as JsonValue;
 use starlark::collections::SmallMap;
 
+pub use git::split_repo_and_subpath;
 pub use package_resolver::resolve_workspace_dependencies;
 pub use pcb_zen_core::file_extensions;
 pub use pcb_zen_core::{Diagnostic, Diagnostics, WithDiagnostics};

--- a/crates/pcb-zen/src/package_resolver/versions.rs
+++ b/crates/pcb-zen/src/package_resolver/versions.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::git;
 use crate::tags;
 use anyhow::{Result, bail};
-use pcb_zen_core::config::{DependencyDetail, DependencySpec, split_repo_and_subpath};
+use pcb_zen_core::config::{DependencyDetail, DependencySpec};
 use pcb_zen_core::initial_package_version;
 use semver::Version;
 
@@ -68,8 +68,8 @@ impl SpecVersionResolver {
     }
 
     fn generate_pseudo_version(&mut self, module_path: &str, commit: &str) -> Result<Version> {
-        let (repo_url, subpath) = split_repo_and_subpath(module_path);
-        let source_dir = self.ensure_source_repo(repo_url)?;
+        let (repo_url, subpath) = git::split_repo_and_subpath(module_path)?;
+        let source_dir = self.ensure_source_repo(&repo_url)?;
         let commit_full = git::rev_parse(&source_dir, commit).ok_or_else(|| {
             anyhow::anyhow!(
                 "Failed to resolve rev '{}' in {}",
@@ -80,7 +80,7 @@ impl SpecVersionResolver {
         let timestamp = git::show_commit_timestamp(&source_dir, &commit_full)
             .ok_or_else(|| anyhow::anyhow!("Failed to read timestamp for {}", commit_full))?;
         let base_version = self
-            .latest_tagged_version(repo_url, subpath, &source_dir)
+            .latest_tagged_version(&repo_url, &subpath, &source_dir)
             .unwrap_or_else(initial_package_version);
         let dt = jiff::Timestamp::from_second(timestamp)?;
         let pseudo = format!(

--- a/crates/pcb-zen/src/resolve.rs
+++ b/crates/pcb-zen/src/resolve.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use globset::{Glob, GlobSetBuilder};
-use pcb_zen_core::config::{ManifestPart, split_repo_and_subpath};
+use pcb_zen_core::config::ManifestPart;
 use pcb_zen_core::resolution::{FrozenResolutionMap, ResolutionResult, build_package_roots};
 use semver::Version;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -427,8 +427,8 @@ fn verify_tag_hashes(
     content_hash: &str,
     manifest_hash: &str,
 ) -> Result<()> {
-    let (repo_url, subpath) = split_repo_and_subpath(module_path);
-    let source_dir = source_repo_dir(repo_url)?;
+    let (repo_url, subpath) = git::split_repo_and_subpath(module_path)?;
+    let source_dir = source_repo_dir(&repo_url)?;
     let tag_name = if subpath.is_empty() {
         format!("v{}", version)
     } else {
@@ -551,7 +551,7 @@ pub fn ensure_sparse_checkout(
     version_str: &str,
 ) -> Result<PathBuf> {
     let marker = "pcb.toml";
-    let (repo_url, subpath) = split_repo_and_subpath(module_path);
+    let (repo_url, subpath) = git::split_repo_and_subpath(module_path)?;
 
     populate_cache(checkout_dir, marker, |dest| {
         let is_pseudo_version = version_str.contains("-0.");
@@ -570,7 +570,7 @@ pub fn ensure_sparse_checkout(
             }
         };
 
-        fetch_via_git(dest, repo_url, &ref_spec, subpath, is_pseudo_version)
+        fetch_via_git(dest, &repo_url, &ref_spec, &subpath, is_pseudo_version)
             .with_context(|| format!("Failed to fetch {} via git sparse checkout", module_path))?;
         Ok(())
     })

--- a/crates/pcbc/src/doc.rs
+++ b/crates/pcbc/src/doc.rs
@@ -172,7 +172,7 @@ fn resolve_remote_package(
     requested_module_path: &str,
     requested_version: Option<&Version>,
 ) -> Result<(String, String, Option<String>)> {
-    let (repo_url, requested_path) = pcb_zen::git::split_repo_and_subpath(requested_module_path)?;
+    let (repo_url, requested_path) = pcb_zen::split_repo_and_subpath(requested_module_path)?;
     let all_versions = pcb_zen::tags::get_all_versions_for_repo(&repo_url)
         .with_context(|| format!("Failed to fetch versions from {repo_url}"))?;
     resolve_remote_package_from_versions(

--- a/crates/pcbc/src/doc.rs
+++ b/crates/pcbc/src/doc.rs
@@ -172,19 +172,23 @@ fn resolve_remote_package(
     requested_module_path: &str,
     requested_version: Option<&Version>,
 ) -> Result<(String, String, Option<String>)> {
-    let (repo_url, _) = pcb_zen_core::config::split_repo_and_subpath(requested_module_path);
-    let all_versions = pcb_zen::tags::get_all_versions_for_repo(repo_url)
+    let (repo_url, requested_path) = pcb_zen::git::split_repo_and_subpath(requested_module_path)?;
+    let all_versions = pcb_zen::tags::get_all_versions_for_repo(&repo_url)
         .with_context(|| format!("Failed to fetch versions from {repo_url}"))?;
-    resolve_remote_package_from_versions(requested_module_path, requested_version, &all_versions)
+    resolve_remote_package_from_versions(
+        &repo_url,
+        &requested_path,
+        requested_version,
+        &all_versions,
+    )
 }
 
 fn resolve_remote_package_from_versions(
-    requested_module_path: &str,
+    repo_url: &str,
+    requested_path: &str,
     requested_version: Option<&Version>,
     all_versions: &BTreeMap<String, Vec<Version>>,
 ) -> Result<(String, String, Option<String>)> {
-    let (repo_url, requested_path) =
-        pcb_zen_core::config::split_repo_and_subpath(requested_module_path);
     let (canonical_pkg_path, versions_for_pkg) =
         find_versioned_package(all_versions, requested_path, repo_url)?;
 
@@ -626,7 +630,8 @@ mod tests {
             vec![Version::new(1, 0, 0), Version::new(2, 0, 0)],
         )]);
         let (module_path, version, filter) = resolve_remote_package_from_versions(
-            "github.com/acme/components/SimpleResistor/SimpleResistor.zen",
+            "github.com/acme/components",
+            "SimpleResistor/SimpleResistor.zen",
             None,
             &all_versions,
         )
@@ -644,7 +649,8 @@ mod tests {
             vec![Version::new(1, 0, 0), Version::new(2, 0, 0)],
         )]);
         let err = resolve_remote_package_from_versions(
-            "github.com/acme/components/SimpleResistor",
+            "github.com/acme/components",
+            "SimpleResistor",
             Some(&Version::new(3, 0, 0)),
             &all_versions,
         )
@@ -660,7 +666,8 @@ mod tests {
             vec![Version::new(1, 0, 0), Version::new(2, 0, 0)],
         )]);
         let (module_path, version, filter) = resolve_remote_package_from_versions(
-            "github.com/acme/repo/file.zen",
+            "github.com/acme/repo",
+            "file.zen",
             None,
             &all_versions,
         )

--- a/crates/pcbc/src/mod/request.rs
+++ b/crates/pcbc/src/mod/request.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, bail};
-use pcb_zen::tags;
+use pcb_zen::{split_repo_and_subpath, tags};
 use pcb_zen_core::config::{DependencySpec, PcbToml};
 use semver::Version;
 
@@ -113,7 +113,7 @@ fn resolve_requested_version(
 }
 
 pub(crate) fn available_versions_for_module(module_path: &str) -> Result<Vec<Version>> {
-    let (repo_url, subpath) = pcb_zen::git::split_repo_and_subpath(module_path)?;
+    let (repo_url, subpath) = split_repo_and_subpath(module_path)?;
     let all_versions = tags::get_all_versions_for_repo(&repo_url)
         .with_context(|| format!("Failed to fetch versions from {}", repo_url))?;
     let versions = all_versions

--- a/crates/pcbc/src/mod/request.rs
+++ b/crates/pcbc/src/mod/request.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use pcb_zen::tags;
-use pcb_zen_core::config::{DependencySpec, PcbToml, split_repo_and_subpath};
+use pcb_zen_core::config::{DependencySpec, PcbToml};
 use semver::Version;
 
 use pcb_zen::package_resolver::{SpecVersionResolver, compatibility_lane};
@@ -113,11 +113,11 @@ fn resolve_requested_version(
 }
 
 pub(crate) fn available_versions_for_module(module_path: &str) -> Result<Vec<Version>> {
-    let (repo_url, subpath) = split_repo_and_subpath(module_path);
-    let all_versions = tags::get_all_versions_for_repo(repo_url)
+    let (repo_url, subpath) = pcb_zen::git::split_repo_and_subpath(module_path)?;
+    let all_versions = tags::get_all_versions_for_repo(&repo_url)
         .with_context(|| format!("Failed to fetch versions from {}", repo_url))?;
     let versions = all_versions
-        .get(subpath)
+        .get(&subpath)
         .ok_or_else(|| anyhow::anyhow!("No published versions found for {}", module_path))?;
     Ok(versions.clone())
 }

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -146,6 +146,8 @@ load("github.com/myorg/components/capacitor.zen", "Capacitor")
 
 The path identifies the package owner and source repository without a central
 namespace. A file's imports also state which packages its source requires.
+Remote package commands treat the first three or four path segments as the git
+repository, and they use the longest prefix that exists.
 
 Import paths omit versions. The `pcb.toml` manifest declares which version of
 each package to use:

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -147,7 +147,8 @@ load("github.com/myorg/components/capacitor.zen", "Capacitor")
 The path identifies the package owner and source repository without a central
 namespace. A file's imports also state which packages its source requires.
 Remote package commands treat the first three or four path segments as the git
-repository, and they use the longest prefix that exists.
+repository. They probe the longer prefix first and keep the first remote that
+exists.
 
 Import paths omit versions. The `pcb.toml` manifest declares which version of
 each package to use:

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -146,9 +146,6 @@ load("github.com/myorg/components/capacitor.zen", "Capacitor")
 
 The path identifies the package owner and source repository without a central
 namespace. A file's imports also state which packages its source requires.
-Remote package commands treat the first three or four path segments as the git
-repository. They probe the longer prefix first and keep the first remote that
-exists.
 
 Import paths omit versions. The `pcb.toml` manifest declares which version of
 each package to use:


### PR DESCRIPTION
Remote package commands now probe the 4-segment git prefix, then the 3-segment prefix, and clone the first remote that exists. This lets nested packages in noncanonical DiodeHub registries resolve to their owning repository instead of a nonexistent nested URL.

Fixes ENG-796.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every remote module path maps to a git repo and may trigger extra ls-remote probes on cache miss; behavior is covered by new nested-registry tests but affects core fetch/version resolution.
> 
> **Overview**
> Fixes **nested DiodeHub registry** paths (e.g. `code.diode.computer/diode/registry/intel/...`) resolving against a non-existent nested git URL instead of the real owning repository.
> 
> **Repo boundary detection** moves from a static `split_repo_and_subpath` in `pcb-zen-core` to `pcb-zen` git logic that tries **4-segment then 3-segment** prefixes, picks the first prefix that exists (local `~/.pcb/src` clone or `git ls-remote`), and **caches** `(repo_url, subpath)` per module path. Remote package lookup in the cache index walks those same prefix candidates so indexed tags match the resolved repo.
> 
> Call sites (`resolve`, sparse checkout, version/pseudo-version resolution, `pcb doc`, `pcb add` version listing) now use the fallible `pcb_zen::split_repo_and_subpath`. Source repos on disk are stored under `~/.pcb/src` with **`/` → `--`** in the directory name to avoid ambiguous paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d3b0f272d1fd67210cd23cced153373c125bd0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->