### PR TITLE
Fix UTF-8 BOM description truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- BOM generation no longer panics when truncating UTF-8 component descriptions.
+
 ## [0.4.30] - 2026-08-14
 
 ### Fixed

--- a/crates/pcb-ipc2581-tools/src/commands/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/bom.rs
@@ -4,25 +4,13 @@ use std::path::Path;
 
 use anyhow::Context;
 use anyhow::Result;
-use pcb_sch::bom::{Bom, BomEntry, Capacitor, GenericComponent, Resistor};
+use pcb_sch::bom::{
+    Alternative, Bom, BomEntry, Capacitor, GenericComponent, Resistor, trim_description,
+};
 
 use crate::OutputFormat;
 use crate::accessors::{CharacteristicsData, IpcAccessor};
 use crate::utils::file as file_utils;
-use pcb_sch::bom::Alternative;
-
-/// Trim and truncate description to 100 chars max
-fn trim_description(s: Option<String>) -> Option<String> {
-    s.map(|s| {
-        let trimmed = s.trim();
-        if trimmed.len() > 100 {
-            format!("{} ...", &trimmed[..96])
-        } else {
-            trimmed.to_string()
-        }
-    })
-    .filter(|s| !s.is_empty())
-}
 
 /// Build GenericComponent from extracted characteristics
 /// Reuses the same logic as detect_generic_component in pcb-sch

--- a/crates/pcb-sch/src/bom/core.rs
+++ b/crates/pcb-sch/src/bom/core.rs
@@ -14,12 +14,12 @@ pub struct Bom {
     pub availability: HashMap<String, super::availability::Availability>, // path -> availability data
 }
 
-/// Trim and truncate description to 100 chars max
-fn trim_description(s: Option<String>) -> Option<String> {
+/// Trim surrounding whitespace and truncate descriptions to 100 characters.
+pub fn trim_description(s: Option<String>) -> Option<String> {
     s.map(|s| {
         let trimmed = s.trim();
-        if trimmed.len() > 100 {
-            format!("{} ...", &trimmed[..96])
+        if trimmed.chars().count() > 100 {
+            format!("{} ...", trimmed.chars().take(96).collect::<String>())
         } else {
             trimmed.to_string()
         }
@@ -794,6 +794,29 @@ mod tests {
             internal_connectivity: Default::default(),
             symbol_positions: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn trim_description_preserves_utf8_at_the_truncation_boundary() {
+        let description = format!("{}Ω{}", "a".repeat(95), "b".repeat(10));
+
+        assert_eq!(
+            trim_description(Some(description)),
+            Some(format!("{}Ω ...", "a".repeat(95)))
+        );
+    }
+
+    #[test]
+    fn trim_description_limits_unicode_characters() {
+        let exactly_100 = "Ω".repeat(100);
+        assert_eq!(
+            trim_description(Some(exactly_100.clone())),
+            Some(exactly_100)
+        );
+
+        let truncated = trim_description(Some("Ω".repeat(101))).unwrap();
+        assert_eq!(truncated, format!("{} ...", "Ω".repeat(96)));
+        assert_eq!(truncated.chars().count(), 100);
     }
 
     #[test]


### PR DESCRIPTION
`pcb bom` sliced UTF-8 descriptions by byte offset, so valid multibyte text could panic during BOM generation. This change truncates by Unicode character, shares one normalizer across schematic and IPC BOM paths, and adds regression tests; 375 crate tests and all doctests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to description normalization with added tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **BOM generation panics** when component descriptions contain multibyte UTF-8 and need to be shortened to 100 characters. Truncation now uses **Unicode character counts** (`chars().count()` / `chars().take(96)`) instead of slicing by byte index, which could split a code point and panic.
> 
> **`trim_description`** is now a shared, public helper in `pcb_sch::bom`; the duplicate copy in the IPC-2581 BOM command was removed in favor of that import so schematic and IPC BOM paths behave the same.
> 
> Regression tests cover truncation at a multibyte boundary and the 100-character limit for non-ASCII text; the unreleased changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5531f832e87a33b3114805f057039d9e81bdef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->