### PR TITLE
Preserve nested routing group ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - BOM generation no longer panics when truncating UTF-8 component descriptions.
+- Nested modules retain group ownership for copied routing and graphics during layout synchronization.
 
 ## [0.4.30] - 2026-08-14
 

--- a/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/kicad_adapter.py
@@ -38,13 +38,8 @@ from .types import (
     EntityId,
     FootprintComplement,
     FootprintView,
-    GraphicComplement,
-    GroupComplement,
     GroupView,
     Position,
-    TrackComplement,
-    ViaComplement,
-    ZoneComplement,
     default_footprint_complement,
 )
 
@@ -1008,8 +1003,26 @@ def apply_changeset(
     return oplog
 
 
+def _fragment_target_group(
+    source_item: Any,
+    root_group_name: str,
+    root_group: Any,
+    groups_by_name: dict[str, Any],
+) -> Any:
+    """Map a fragment item's relative group to its instantiated board group."""
+    source_group = source_item.GetParentGroup()
+    relative_group_name = source_group.GetName() if source_group else ""
+    target_group_name = (
+        f"{root_group_name}.{relative_group_name}"
+        if relative_group_name
+        else root_group_name
+    )
+    return groups_by_name.get(target_group_name, root_group)
+
+
 def _apply_fragment_routing(
     group: Any,
+    groups_by_name: dict[str, Any],
     group_view: GroupView,
     entity_id: EntityId,
     fragment_data: FragmentDataType,
@@ -1029,10 +1042,6 @@ def _apply_fragment_routing(
         move_delta: (dx, dy) offset to apply to duplicated items (from group move)
     """
     if not group_view.layout_path:
-        return
-
-    group_complement = fragment_data.group_complement
-    if group_complement.is_empty:
         return
 
     group_name = str(entity_id.path)
@@ -1067,31 +1076,6 @@ def _apply_fragment_routing(
 
     valid_nets = set(board_view.nets.keys()) | {""}
 
-    # Build UUID lookup tables from the fragment board
-    fragment_tracks: dict[str, Any] = {}
-    fragment_vias: dict[str, Any] = {}
-    for track in fragment_board.GetTracks():
-        item_uuid = str(track.m_Uuid.AsString())
-        if "VIA" in track.GetClass().upper():
-            fragment_vias[item_uuid] = track
-        else:
-            fragment_tracks[item_uuid] = track
-
-    fragment_zones: dict[str, Any] = {}
-    for zone in fragment_board.Zones():
-        fragment_zones[str(zone.m_Uuid.AsString())] = zone
-
-    fragment_graphics: dict[str, Any] = {}
-    for drawing in fragment_board.GetDrawings():
-        parent = drawing.GetParent()
-        if (
-            parent
-            and hasattr(pcbnew, "FOOTPRINT")
-            and isinstance(parent, pcbnew.FOOTPRINT)
-        ):
-            continue
-        fragment_graphics[str(drawing.m_Uuid.AsString())] = drawing
-
     def _set_net(item: Any, fragment_net_name: str) -> None:
         """Set net on item, remapping from fragment net to board net."""
         if not fragment_net_name:
@@ -1112,79 +1096,85 @@ def _apply_fragment_routing(
     offset = pcbnew.VECTOR2I(move_delta[0], move_delta[1])
 
     def _dup_and_add(src: Any, net_name: str = "") -> Any:
-        """Duplicate item, offset it, set net, and add to board+group."""
+        """Duplicate item, offset it, set net, and restore its relative group."""
         item = pcbnew.BOARD_ITEM.Duplicate(src)
         if net_name:
             _set_net(item, net_name)
         kicad_board.Add(item)
         item.Move(offset)
-        group.AddItem(item)
+        _fragment_target_group(src, group_name, group, groups_by_name).AddItem(item)
         return item
 
-    # Duplicate tracks
+    def _dup_connected(src: Any) -> tuple[Any, str]:
+        source_net = src.GetNet()
+        source_net_name = source_net.GetNetname() if source_net else ""
+        return (
+            _dup_and_add(src, source_net_name),
+            net_remap.get(source_net_name, source_net_name),
+        )
+
+    source_routing = list(fragment_board.GetTracks())
+
     tracks_created = 0
-    for track_comp in group_complement.tracks:
-        src = fragment_tracks.get(track_comp.uuid)
-        if src:
-            track = _dup_and_add(src, track_comp.net_name)
-            start = track.GetStart()
-            end = track.GetEnd()
-            width = track.GetWidth() if hasattr(track, "GetWidth") else 0
-            remapped_net = net_remap.get(track_comp.net_name, track_comp.net_name)
-            oplog.frag_track(
-                group_name,
-                remapped_net or "(no-net)",
-                fragment_board.GetLayerName(track.GetLayer()),
-                start.x,
-                start.y,
-                end.x,
-                end.y,
-                width=width,
-            )
-            tracks_created += 1
+    for source_track in (
+        item for item in source_routing if "VIA" not in item.GetClass().upper()
+    ):
+        track, remapped_net = _dup_connected(source_track)
+        start = track.GetStart()
+        end = track.GetEnd()
+        width = track.GetWidth() if hasattr(track, "GetWidth") else 0
+        oplog.frag_track(
+            group_name,
+            remapped_net or "(no-net)",
+            fragment_board.GetLayerName(track.GetLayer()),
+            start.x,
+            start.y,
+            end.x,
+            end.y,
+            width=width,
+        )
+        tracks_created += 1
 
-    # Duplicate vias
     vias_created = 0
-    for via_comp in group_complement.vias:
-        src = fragment_vias.get(via_comp.uuid)
-        if src:
-            via = _dup_and_add(src, via_comp.net_name)
-            pos = via.GetPosition()
-            drill = via.GetDrill() if hasattr(via, "GetDrill") else 0
-            remapped_net = net_remap.get(via_comp.net_name, via_comp.net_name)
-            oplog.frag_via(
-                group_name, remapped_net or "(no-net)", pos.x, pos.y, drill=drill
-            )
-            vias_created += 1
+    for source_via in (
+        item for item in source_routing if "VIA" in item.GetClass().upper()
+    ):
+        via, remapped_net = _dup_connected(source_via)
+        pos = via.GetPosition()
+        drill = via.GetDrill() if hasattr(via, "GetDrill") else 0
+        oplog.frag_via(
+            group_name, remapped_net or "(no-net)", pos.x, pos.y, drill=drill
+        )
+        vias_created += 1
 
-    # Duplicate zones
     zones_created = 0
-    for zone_comp in group_complement.zones:
-        src = fragment_zones.get(zone_comp.uuid)
-        if src:
-            zone = _dup_and_add(src, zone_comp.net_name)
-            zone.SetAssignedPriority(zone_comp.priority + FRAGMENT_ZONE_PRIORITY_BIAS)
-            remapped_net = net_remap.get(zone_comp.net_name, zone_comp.net_name)
-            oplog.frag_zone(
-                group_name,
-                remapped_net or "(no-net)",
-                fragment_board.GetLayerName(zone.GetLayer()),
-                zone.GetZoneName() or "",
-            )
-            zones_created += 1
+    for source_zone in fragment_board.Zones():
+        source_net = source_zone.GetNet()
+        source_net_name = source_net.GetNetname() if source_net else ""
+        zone = _dup_and_add(source_zone, source_net_name)
+        zone.SetAssignedPriority(
+            source_zone.GetAssignedPriority() + FRAGMENT_ZONE_PRIORITY_BIAS
+        )
+        remapped_net = net_remap.get(source_net_name, source_net_name)
+        oplog.frag_zone(
+            group_name,
+            remapped_net or "(no-net)",
+            fragment_board.GetLayerName(zone.GetLayer()),
+            zone.GetZoneName() or "",
+        )
+        zones_created += 1
 
-    # Duplicate graphics
     graphics_created = 0
-    for gr_comp in group_complement.graphics:
-        src = fragment_graphics.get(gr_comp.uuid)
-        if src:
-            graphic = _dup_and_add(src)
-            oplog.frag_graphic(
-                group_name,
-                graphic.GetClass(),
-                fragment_board.GetLayerName(graphic.GetLayer()),
-            )
-            graphics_created += 1
+    for source_graphic in fragment_board.GetDrawings():
+        if isinstance(source_graphic.GetParent(), pcbnew.FOOTPRINT):
+            continue
+        graphic = _dup_and_add(source_graphic)
+        oplog.frag_graphic(
+            group_name,
+            graphic.GetClass(),
+            fragment_board.GetLayerName(graphic.GetLayer()),
+        )
+        graphics_created += 1
 
     if tracks_created or vias_created or zones_created or graphics_created:
         logger.info(
@@ -1484,6 +1474,7 @@ def _run_hierarchical_placement(
         if gv and group:
             _apply_fragment_routing(
                 group,
+                groups_by_name,
                 gv,
                 gid,
                 fragment_data,
@@ -1711,100 +1702,7 @@ def load_layout_fragment_with_footprints(
                 fp_key = path_str if path_str else reference
                 pad_net_map[(fp_key, pad_name)] = net.GetNetname()
 
-    tracks: list[TrackComplement] = []
-    vias: list[ViaComplement] = []
-
-    for track in layout_board.GetTracks():
-        item_class = track.GetClass().upper()
-        net = track.GetNet()
-        net_name = net.GetNetname() if net else ""
-        item_uuid = str(track.m_Uuid.AsString())
-
-        if "VIA" in item_class:
-            pos = track.GetPosition()
-            vias.append(
-                ViaComplement(
-                    uuid=item_uuid,
-                    position=Position(x=pos.x, y=pos.y),
-                    diameter=track.GetWidth(pcbnew.F_Cu),
-                    drill=track.GetDrill(),
-                    via_type="through",
-                    net_name=net_name,
-                )
-            )
-        else:
-            start = track.GetStart()
-            end = track.GetEnd()
-            tracks.append(
-                TrackComplement(
-                    uuid=item_uuid,
-                    start=Position(x=start.x, y=start.y),
-                    end=Position(x=end.x, y=end.y),
-                    width=track.GetWidth(),
-                    layer=layout_board.GetLayerName(track.GetLayer()),
-                    net_name=net_name,
-                )
-            )
-
-    zones: list[ZoneComplement] = []
-    for zone in layout_board.Zones():
-        item_uuid = str(zone.m_Uuid.AsString())
-        net = zone.GetNet()
-        net_name = net.GetNetname() if net else ""
-
-        positions = extract_zone_outline_positions(zone)
-
-        zones.append(
-            ZoneComplement(
-                uuid=item_uuid,
-                name=zone.GetZoneName() or "",
-                outline=tuple(positions),
-                layer=layout_board.GetLayerName(zone.GetLayer()),
-                priority=zone.GetAssignedPriority(),
-                net_name=net_name,
-            )
-        )
-
-    graphics: list[GraphicComplement] = []
-    for drawing in layout_board.GetDrawings():
-        parent = drawing.GetParent()
-        if (
-            parent
-            and hasattr(pcbnew, "FOOTPRINT")
-            and isinstance(parent, pcbnew.FOOTPRINT)
-        ):
-            continue
-
-        item_uuid = str(drawing.m_Uuid.AsString())
-        graphic_type = drawing.GetClass()
-        layer = layout_board.GetLayerName(drawing.GetLayer())
-
-        geometry: dict[str, Any] = {}
-        if hasattr(drawing, "GetStart"):
-            start = drawing.GetStart()
-            geometry["start"] = {"x": start.x, "y": start.y}
-        if hasattr(drawing, "GetEnd"):
-            end = drawing.GetEnd()
-            geometry["end"] = {"x": end.x, "y": end.y}
-
-        graphics.append(
-            GraphicComplement(
-                uuid=item_uuid,
-                graphic_type=graphic_type,
-                layer=layer,
-                geometry=geometry,
-            )
-        )
-
-    group_complement = GroupComplement(
-        tracks=tuple(tracks),
-        vias=tuple(vias),
-        zones=tuple(zones),
-        graphics=tuple(graphics),
-    )
-
     return FragmentData(
-        group_complement=group_complement,
         footprint_complements=footprint_complements,
         pad_net_map=pad_net_map,
     )

--- a/crates/pcb-layout/src/scripts/lens/lens.py
+++ b/crates/pcb-layout/src/scripts/lens/lens.py
@@ -66,12 +66,10 @@ class FragmentData:
     The apply phase loads the fragment board fresh to duplicate items.
 
     Fields:
-    - group_complement: Routing/graphics with fragment-local net names
     - footprint_complements: Positions keyed by reference and path
     - pad_net_map: Maps (fp_path, pad_name) -> fragment_net_name for net remapping
     """
 
-    group_complement: GroupComplement
     footprint_complements: dict[str, FootprintComplement]
     pad_net_map: dict[tuple[str, str], str] = field(default_factory=dict)
 

--- a/crates/pcb-layout/src/scripts/lens/tests/test_adapter.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_adapter.py
@@ -7,6 +7,9 @@ without requiring actual KiCad objects.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 from .. import kicad_adapter
 from ..lens import (
     FragmentData,
@@ -14,10 +17,12 @@ from ..lens import (
     build_fragment_net_remap,
 )
 from ..types import (
+    BoardView,
     EntityId,
     EntityPath,
     FootprintComplement,
     GroupComplement,
+    GroupView,
     Position,
     TrackComplement,
     ViaComplement,
@@ -80,6 +85,111 @@ class TestApplyPadAssignment:
         assert pads[1].net is net_info
         assert pads[0].pin_type is None
         assert pads[1].pin_type is None
+
+
+class _MockGroup:
+    def __init__(self, name: str):
+        self._name = name
+
+    def GetName(self) -> str:
+        return self._name
+
+
+class _MockGroupedItem:
+    def __init__(self, group: _MockGroup | None):
+        self._group = group
+
+    def GetParentGroup(self) -> _MockGroup | None:
+        return self._group
+
+
+class TestFragmentTargetGroup:
+    def test_restores_relative_nested_group(self):
+        root = _MockGroup("PORT0")
+        nested = _MockGroup("PORT0.U_RCB")
+
+        result = kicad_adapter._fragment_target_group(
+            _MockGroupedItem(_MockGroup("U_RCB")),
+            "PORT0",
+            root,
+            {"PORT0": root, "PORT0.U_RCB": nested},
+        )
+
+        assert result is nested
+
+    def test_keeps_ungrouped_items_in_root_group(self):
+        root = _MockGroup("PORT0")
+
+        result = kicad_adapter._fragment_target_group(
+            _MockGroupedItem(None), "PORT0", root, {"PORT0": root}
+        )
+
+        assert result is root
+
+    def test_missing_nested_group_falls_back_to_root(self):
+        root = _MockGroup("PORT0")
+
+        result = kicad_adapter._fragment_target_group(
+            _MockGroupedItem(_MockGroup("MANUAL")),
+            "PORT0",
+            root,
+            {"PORT0": root},
+        )
+
+        assert result is root
+
+    def test_fragment_copy_adds_track_to_its_nested_group(self, monkeypatch, tmp_path):
+        layout_file = tmp_path / "layout.kicad_pcb"
+        layout_file.touch()
+        monkeypatch.setattr(
+            kicad_adapter, "_discover_kicad_pcb_file", lambda _layout_dir: layout_file
+        )
+
+        source_group = Mock()
+        source_group.GetName.return_value = "U_RCB"
+        source_track = Mock()
+        source_track.GetParentGroup.return_value = source_group
+        source_track.GetClass.return_value = "PCB_TRACK"
+        source_track.GetNet.return_value = None
+
+        copied_track = Mock()
+        copied_track.GetStart.return_value = SimpleNamespace(x=1, y=2)
+        copied_track.GetEnd.return_value = SimpleNamespace(x=3, y=4)
+        copied_track.GetWidth.return_value = 5
+        copied_track.GetLayer.return_value = 0
+
+        fragment_board = Mock()
+        fragment_board.GetTracks.return_value = [source_track]
+        fragment_board.Zones.return_value = []
+        fragment_board.GetDrawings.return_value = []
+        fragment_board.GetLayerName.return_value = "F.Cu"
+
+        pcbnew = Mock()
+        pcbnew.LoadBoard.return_value = fragment_board
+        pcbnew.BOARD_ITEM.Duplicate.return_value = copied_track
+        pcbnew.FOOTPRINT = type("MockFootprint", (), {})
+
+        root = Mock()
+        nested = Mock()
+        target_board = Mock()
+        entity_id = EntityId.from_string("PORT0")
+
+        kicad_adapter._apply_fragment_routing(
+            root,
+            {"PORT0": root, "PORT0.U_RCB": nested},
+            GroupView(entity_id=entity_id, member_ids=(), layout_path="package://test"),
+            entity_id,
+            FragmentData(footprint_complements={}),
+            BoardView(),
+            target_board,
+            pcbnew,
+            kicad_adapter.OpLog(),
+            {"test": str(tmp_path)},
+        )
+
+        target_board.Add.assert_called_once_with(copied_track)
+        nested.AddItem.assert_called_once_with(copied_track)
+        root.AddItem.assert_not_called()
 
 
 class TestBuildFragmentNetRemap:
@@ -240,56 +350,20 @@ class TestFragmentData:
     def test_has_required_fields(self):
         """FragmentData should have all required fields."""
         cache = FragmentData(
-            group_complement=GroupComplement(),
             footprint_complements={"R1": default_footprint_complement()},
             pad_net_map={("R1", "1"): "VCC"},
         )
 
-        assert cache.group_complement is not None
         assert "R1" in cache.footprint_complements
         assert ("R1", "1") in cache.pad_net_map
 
     def test_default_pad_net_map(self):
         """pad_net_map should default to empty dict."""
         cache = FragmentData(
-            group_complement=GroupComplement(),
             footprint_complements={},
         )
 
         assert cache.pad_net_map == {}
-
-    def test_stores_routing_in_group_complement(self):
-        """Routing data should be stored in GroupComplement dataclasses."""
-        gc = GroupComplement(
-            tracks=(
-                TrackComplement(
-                    uuid="t1",
-                    start=Position(0, 0),
-                    end=Position(1000, 0),
-                    width=200,
-                    layer="F.Cu",
-                    net_name="VCC",
-                ),
-            ),
-            vias=(
-                ViaComplement(
-                    uuid="v1",
-                    position=Position(500, 0),
-                    diameter=800,
-                    drill=400,
-                    net_name="VCC",
-                ),
-            ),
-        )
-
-        cache = FragmentData(
-            group_complement=gc,
-            footprint_complements={},
-        )
-
-        assert len(cache.group_complement.tracks) == 1
-        assert len(cache.group_complement.vias) == 1
-        assert cache.group_complement.tracks[0].net_name == "VCC"
 
 
 class TestGroupComplementRouting:

--- a/crates/pcb-layout/src/scripts/lens/tests/test_layout_fragment.py
+++ b/crates/pcb-layout/src/scripts/lens/tests/test_layout_fragment.py
@@ -18,7 +18,6 @@ from ..types import (
     EntityId,
     FootprintComplement,
     FootprintView,
-    GroupComplement,
     GroupView,
     Position,
 )
@@ -183,28 +182,11 @@ class TestLayoutFragmentInAdaptComplement:
 class TestFragmentDataDataClass:
     """Tests for FragmentData dataclass."""
 
-    def test_cache_stores_group_complement(self):
-        """Cache stores the group complement for tracks/vias/zones."""
-        group_comp = GroupComplement(
-            tracks=(),
-            vias=(),
-            zones=(),
-            graphics=(),
-        )
-
-        cache = FragmentData(
-            group_complement=group_comp,
-            footprint_complements={},
-        )
-
-        assert cache.group_complement == group_comp
-
     def test_cache_stores_footprint_complements(self):
         """Cache stores footprint complements by reference/path."""
         fp_comp = make_footprint_complement(x=1000, y=2000)
 
         cache = FragmentData(
-            group_complement=GroupComplement(),
             footprint_complements={"R1": fp_comp, "Path.C1": fp_comp},
         )
 


### PR DESCRIPTION
Nested layout fragments lost routing and graphic ownership when the layout was copied into a parent design, so moving a subgroup could leave its copper behind. This change uses the fragment board as the single source for copied items and restores each item to the matching nested group, with a root-group fallback when no match exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes layout synchronization and group membership for copied copper; wrong mapping could mis-attach routing, but scope is fragment apply with tests and root fallback.
> 
> **Overview**
> Fixes nested layout sync so **copied tracks, vias, zones, and board graphics stay in the same subgroup** as in the fragment, so moving a nested module moves its copper with it instead of leaving routing on the parent group.
> 
> Fragment routing copy no longer relies on pre-serialized `GroupComplement` UUID lists on `FragmentData`. It **reloads the fragment `.kicad_pcb` and duplicates all board routing/graphics** (still remapping nets from pad connectivity). New `_fragment_target_group` maps each source item’s `GetParentGroup()` to the matching instantiated group name (`{root}.{relative}`), with **fallback to the root fragment group** when a nested group is missing.
> 
> `FragmentData` is trimmed to footprint positions and `pad_net_map` only; tests cover nested vs root group assignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729375b9605c10ee8bb5893f368106fb72f97127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->