### PR TITLE
Increase default hole-to-hole clearance to 0.3 mm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb layout --sync-footprints` reloads footprint definitions from source.
 
+### Changed
+
+- Default hole-to-hole clearance is now 0.3 mm.
+
 ### Fixed
 
 - Board-array rail fiducials now distinguish top and bottom surfaces.

--- a/lib/std/board_config.zen
+++ b/lib/std/board_config.zen
@@ -929,7 +929,7 @@ BASE_CONSTRAINTS = Constraints(
     ),
     holes=Holes(
         minimum_through_hole=0.15,  # Min via hole size
-        hole_to_hole_clearance=0.2,  # Via hole-to-hole spacing
+        hole_to_hole_clearance=0.3,  # Via hole-to-hole spacing
     ),
     uvias=Uvias(
         minimum_uvia_diameter=0.15,  # Micro via diameter (if supported)
@@ -960,7 +960,7 @@ BASE_CONSTRAINTS_2OZ = Constraints(
     ),
     holes=Holes(
         minimum_through_hole=0.15,  # Same hole size
-        hole_to_hole_clearance=0.2,  # Same hole spacing
+        hole_to_hole_clearance=0.3,  # Same hole spacing
     ),
     uvias=Uvias(
         minimum_uvia_diameter=0.15,


### PR DESCRIPTION
Increase the default hole-to-hole clearance from 0.2 mm to 0.3 mm for both 1 oz and 2 oz board configurations. This gives drilled holes more manufacturing margin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightening default DRC can surface new hole-to-hole violations on existing layouts that used the old 0.2 mm default without an explicit override.
> 
> **Overview**
> Raises the **default hole-to-hole clearance** from **0.2 mm** to **0.3 mm** in stdlib board design rules for both **1 oz** (`BASE_CONSTRAINTS`) and **2 oz** (`BASE_CONSTRAINTS_2OZ`) defaults.
> 
> Boards that rely on these defaults (via `DefaultBoardConfig` / `Board(..., layers=...)`) will sync a stricter **KiCad `min_hole_to_hole`** on the next layout sync, giving drilled holes more manufacturing margin. The unreleased **CHANGELOG** notes the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 112f3e3273f5b4bdee86521e2c6b134cc86b2d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->