### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -18,13 +18,14 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
 
@@ -251,7 +252,7 @@ jobs:
 
       - name: Find existing comment
         id: find_comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
@@ -259,7 +260,7 @@ jobs:
 
       - name: Create or update comment
         if: steps.perf_comment.outputs.has_changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
@@ -268,11 +269,13 @@ jobs:
 
       - name: Delete stale comment
         if: steps.perf_comment.outputs.has_changes == 'false' && steps.find_comment.outputs.comment-id != '' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENT_ID: ${{ steps.find_comment.outputs.comment-id }}
         with:
           script: |
             await github.rest.issues.deleteComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: ${{ steps.find_comment.outputs.comment-id }}
+              comment_id: Number(process.env.COMMENT_ID)
             })

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Cache APT packages (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/apt-cache/archives
           key: apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-ca-certificates-curl-build-essential-pkg-config
@@ -53,12 +53,14 @@ jobs:
           apt-get -o Dir::Cache::archives="$apt_cache_dir/" update
           apt-get -o Dir::Cache::archives="$apt_cache_dir/" install -y --no-install-recommends ca-certificates curl build-essential pkg-config
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Cache KiCad (macOS)
         if: matrix.config.name == 'macOS'
         id: cache-kicad-mac
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /Applications/KiCad
           key: ${{ runner.os }}-kicad-${{ env.KICAD_VERSION }}
@@ -72,7 +74,7 @@ jobs:
           brew install --cask kicad
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
 
@@ -107,11 +109,12 @@ jobs:
 
       - name: Checkout kicad-test-fixtures
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: diodeinc/kicad-test-fixtures
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           path: kicad-test-fixtures
+          persist-credentials: false
 
       - name: Test pcb import (E2E)
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,15 +16,20 @@ jobs:
   build:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           target: wasm32-unknown-unknown
           cache-bin: false
-      - uses: taiki-e/install-action@wasm-pack
+          cache: false
+      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        with:
+          tool: wasm-pack
       - name: Build WASM bundle
         run: ./bin/build-wasm-bundle.sh
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-package
           path: target/wasm-bundle
@@ -36,14 +41,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-package
           path: target/wasm-bundle
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
       - name: Publish to npm
         env:
           REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/pcb-release.yml
+++ b/.github/workflows/pcb-release.yml
@@ -18,7 +18,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   prepare:
@@ -28,21 +27,24 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
           cache: false
 
       - id: release
         shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          tag="${{ inputs.tag || github.ref_name }}"
+          tag="$RELEASE_TAG"
           case "$tag" in
             pcb/v*) version="${tag#pcb/v}" ;;
             *) echo "Unsupported pcb shim release tag: $tag" >&2; exit 1 ;;
@@ -89,14 +91,16 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
+          cache: false
           rustflags: ""
           target: ${{ matrix.target }}
 
@@ -162,7 +166,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pcb-${{ matrix.target }}
           path: artifacts/*
@@ -172,13 +176,20 @@ jobs:
       - prepare
       - build
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    env:
+      RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
+          persist-credentials: false
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pcb-*
           path: artifacts
@@ -186,7 +197,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
           aws-region: us-east-1
@@ -194,17 +205,18 @@ jobs:
       - name: Upload artifacts to S3
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
         run: |
-          aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/${{ needs.prepare.outputs.tag }}/" \
+          aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/$RELEASE_TAG/" \
             --cache-control "public, max-age=31536000, immutable"
 
       - name: Publish latest shim metadata
         if: ${{ needs.prepare.outputs.prerelease == 'false' && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true) }}
         run: |
+          base_url="https://pcb.api.diode.computer/pcb/$RELEASE_TAG"
           jq -n \
-            --arg version "${{ needs.prepare.outputs.version }}" \
-            --arg tag "${{ needs.prepare.outputs.tag }}" \
+            --arg version "$RELEASE_VERSION" \
+            --arg tag "$RELEASE_TAG" \
             --arg published_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --arg base_url "https://pcb.api.diode.computer/pcb/${{ needs.prepare.outputs.tag }}" \
+            --arg base_url "$base_url" \
             '{ version: $version, tag: $tag, published_at: $published_at, base_url: $base_url }' > pcb-latest.json
           aws s3 cp pcb-latest.json "s3://diode-pcb-releases/pcb/pcb-latest.json" \
             --cache-control "public, max-age=60" \

--- a/.github/workflows/pcb-version-bump.yml
+++ b/.github/workflows/pcb-version-bump.yml
@@ -9,26 +9,29 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   bump:
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate version format
         run: |
-          if ! echo "${{ inputs.version }}" | grep -qE '^pcb/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
+          if ! printf '%s\n' "$VERSION" | grep -qE '^pcb/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
             echo "Invalid pcb shim version format. Use pcb/v0.1.1"
             exit 1
           fi
 
-          if git rev-parse "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "Tag ${{ inputs.version }} already exists"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists"
             exit 1
           fi
 
@@ -38,13 +41,12 @@ jobs:
           git config user.email "info@diode.run"
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
 
       - name: Update pcb shim version
         run: |
-          VERSION="${{ inputs.version }}"
           CARGO_VERSION="${VERSION#pcb/v}"
           sed -i "0,/^version = /{s/^version = \".*\"/version = \"${CARGO_VERSION}\"/}" crates/pcb/Cargo.toml
 
@@ -56,17 +58,17 @@ jobs:
       - name: Update Cargo.lock
         run: cargo check
 
-      - name: Commit and push
+      - name: Commit, push, and tag
+        env:
+          GH_TOKEN: ${{ secrets.DIODE_ROBOT_TOKEN }}
         run: |
+          gh auth setup-git
           git add crates/pcb/Cargo.toml Cargo.lock
           if git diff --cached --quiet; then
             echo "No changes to commit (version already set)"
           else
-            git commit -m "Release ${{ inputs.version }}"
+            git commit -m "Release $VERSION"
             git push origin main
           fi
-
-      - name: Create and push tag
-        run: |
-          git tag ${{ inputs.version }}
-          git push origin ${{ inputs.version }}
+          git tag "$VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/pcbc-nightly.yml
+++ b/.github/workflows/pcbc-nightly.yml
@@ -13,11 +13,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   prepare:
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       should_build: ${{ steps.nightly.outputs.should_build }}
       sha: ${{ steps.nightly.outputs.sha }}
@@ -25,13 +27,14 @@ jobs:
       tag: ${{ steps.nightly.outputs.tag }}
       base_url: ${{ steps.nightly.outputs.base_url }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
+          persist-credentials: false
 
       - name: Configure AWS credentials
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
           aws-region: us-east-1
@@ -74,7 +77,7 @@ jobs:
 
       - name: Upload stdlib source archive
         if: steps.nightly.outputs.should_build == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pcbc-nightly-stdlib
           path: artifacts/stdlib.tar.zst*
@@ -105,12 +108,13 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.sha }}
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
           rustflags: ""
@@ -160,7 +164,7 @@ jobs:
           done
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pcbc-nightly-${{ matrix.target }}
           path: artifacts/*
@@ -171,9 +175,17 @@ jobs:
       - build
     if: needs.prepare.outputs.should_build == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    env:
+      NIGHTLY_BASE_URL: ${{ needs.prepare.outputs.base_url }}
+      NIGHTLY_DATE: ${{ needs.prepare.outputs.date }}
+      NIGHTLY_SHA: ${{ needs.prepare.outputs.sha }}
+      NIGHTLY_TAG: ${{ needs.prepare.outputs.tag }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pcbc-nightly-*
           path: artifacts
@@ -181,7 +193,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
           aws-region: us-east-1
@@ -189,7 +201,7 @@ jobs:
       - name: Upload nightly artifacts to S3
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
         run: |
-          aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/${{ needs.prepare.outputs.tag }}/" \
+          aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/$NIGHTLY_TAG/" \
             --cache-control "public, max-age=31536000, immutable"
 
       - name: Publish nightly pointer
@@ -197,10 +209,10 @@ jobs:
         run: |
           jq -n \
             --arg channel "nightly" \
-            --arg date "${{ needs.prepare.outputs.date }}" \
-            --arg sha "${{ needs.prepare.outputs.sha }}" \
-            --arg tag "${{ needs.prepare.outputs.tag }}" \
-            --arg base_url "${{ needs.prepare.outputs.base_url }}" \
+            --arg date "$NIGHTLY_DATE" \
+            --arg sha "$NIGHTLY_SHA" \
+            --arg tag "$NIGHTLY_TAG" \
+            --arg base_url "$NIGHTLY_BASE_URL" \
             --arg published_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             '{ channel: $channel, date: $date, sha: $sha, tag: $tag, base_url: $base_url, published_at: $published_at }' > latest.json
           aws s3 cp latest.json "s3://diode-pcb-releases/pcb/nightly/latest.json" \

--- a/.github/workflows/pcbc-release.yml
+++ b/.github/workflows/pcbc-release.yml
@@ -17,8 +17,7 @@ on:
         default: false
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   prepare:
@@ -28,21 +27,24 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || inputs.tag || github.ref_name }}
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
           cache: false
 
       - id: release
         shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          tag="${{ inputs.tag || github.ref_name }}"
+          tag="$RELEASE_TAG"
           case "$tag" in
             v*) version="${tag#v}" ;;
             *) echo "Unsupported pcbc release tag: $tag" >&2; exit 1 ;;
@@ -76,7 +78,7 @@ jobs:
           sha256sum artifacts/stdlib.tar.zst > artifacts/stdlib.tar.zst.sha256
 
       - name: Upload stdlib source archive
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pcbc-stdlib
           path: artifacts/stdlib.tar.zst*
@@ -106,14 +108,16 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.dry_run && github.ref_name || needs.prepare.outputs.tag }}
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
+          cache: false
           rustflags: ""
           target: ${{ matrix.target }}
 
@@ -182,7 +186,7 @@ jobs:
           done
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pcbc-${{ matrix.target }}
           path: artifacts/*
@@ -192,9 +196,16 @@ jobs:
       - prepare
       - build
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    env:
+      PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
+      RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pcbc-*
           path: artifacts
@@ -202,7 +213,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ vars.AWS_PCB_RELEASE_S3_ROLE_ARN }}
           aws-region: us-east-1
@@ -214,7 +225,7 @@ jobs:
           # shim only resolves versions that have a completion marker under
           # pcb/index/ (written by the next step), so a partially-synced release
           # is invisible.
-          aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/${{ needs.prepare.outputs.tag }}/" \
+          aws s3 sync artifacts/ "s3://diode-pcb-releases/pcb/$RELEASE_TAG/" \
             --cache-control "public, max-age=31536000, immutable"
 
       - name: Publish release completion marker
@@ -224,11 +235,11 @@ jobs:
           # the shim never resolves a half-uploaded version. The shim only keys
           # off the marker's presence; the body is informational.
           jq -n \
-            --arg version "${{ needs.prepare.outputs.version }}" \
-            --arg tag "${{ needs.prepare.outputs.tag }}" \
+            --arg version "$RELEASE_VERSION" \
+            --arg tag "$RELEASE_TAG" \
             --arg published_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             '{ version: $version, tag: $tag, published_at: $published_at }' > release.json
-          aws s3 cp release.json "s3://diode-pcb-releases/pcb/index/${{ needs.prepare.outputs.tag }}" \
+          aws s3 cp release.json "s3://diode-pcb-releases/pcb/index/$RELEASE_TAG" \
             --cache-control "public, max-age=31536000, immutable" \
             --content-type "application/json"
 
@@ -239,12 +250,12 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           prerelease_flag=""
-          if [ "${{ needs.prepare.outputs.prerelease }}" = "true" ]; then
+          if [ "$PRERELEASE" = "true" ]; then
             prerelease_flag="--prerelease"
           fi
-          gh release create "${{ needs.prepare.outputs.tag }}" \
+          gh release create "$RELEASE_TAG" \
             --verify-tag \
             $prerelease_flag \
-            --title "${{ needs.prepare.outputs.version }} - $(date -u +%Y-%m-%d)" \
-            --notes "Release ${{ needs.prepare.outputs.tag }}" \
+            --title "$RELEASE_VERSION - $(date -u +%Y-%m-%d)" \
+            --notes "Release $RELEASE_TAG" \
             artifacts/*

--- a/.github/workflows/pcbc-version-bump.yml
+++ b/.github/workflows/pcbc-version-bump.yml
@@ -9,26 +9,29 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   bump:
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.DIODE_ROBOT_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate version format
         run: |
-          if ! echo "${{ inputs.version }}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
+          if ! printf '%s\n' "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
             echo "Invalid pcbc version format. Use v0.3.84"
             exit 1
           fi
 
-          if git rev-parse "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "Tag ${{ inputs.version }} already exists"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists"
             exit 1
           fi
 
@@ -38,19 +41,18 @@ jobs:
           git config user.email "info@diode.run"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
 
       - name: Update changelog
-        run: ./bin/changelog.py release ${{ inputs.version }}
+        run: ./bin/changelog.py release "$VERSION"
 
       - name: Update workspace version
         run: |
-          VERSION="${{ inputs.version }}"
           CARGO_VERSION="${VERSION#v}"
           sed -i "0,/^version = /{s/^version = \".*\"/version = \"${CARGO_VERSION}\"/}" Cargo.toml
 
@@ -62,17 +64,17 @@ jobs:
       - name: Update Cargo.lock
         run: cargo check
 
-      - name: Commit and push
+      - name: Commit, push, and tag
+        env:
+          GH_TOKEN: ${{ secrets.DIODE_ROBOT_TOKEN }}
         run: |
+          gh auth setup-git
           git add Cargo.toml Cargo.lock CHANGELOG.md
           if git diff --cached --quiet; then
             echo "No changes to commit (version already set)"
           else
-            git commit -m "Release ${{ inputs.version }}"
+            git commit -m "Release $VERSION"
             git push origin main
           fi
-
-      - name: Create and push tag
-        run: |
-          git tag ${{ inputs.version }}
-          git push origin ${{ inputs.version }}
+          git tag "$VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,12 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: rustfmt, clippy
           cache-bin: false
@@ -64,7 +66,7 @@ jobs:
     steps:
       - name: Cache APT packages (Ubuntu)
         if: matrix.config.name == 'Ubuntu'
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/apt-cache/archives
           key: apt-${{ runner.os }}-${{ runner.arch }}-debian-trixie-${{ env.KICAD_VERSION }}-ca-certificates-curl-build-essential-pkg-config
@@ -79,12 +81,14 @@ jobs:
           apt-get -o Dir::Cache::archives="$apt_cache_dir/" update
           apt-get -o Dir::Cache::archives="$apt_cache_dir/" install -y --no-install-recommends ca-certificates curl build-essential pkg-config
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Cache KiCad (macOS)
         if: contains(matrix.config.name, 'macOS')
         id: cache-kicad-mac
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /Applications/KiCad
           key: ${{ runner.os }}-kicad-${{ env.KICAD_VERSION }}
@@ -100,7 +104,7 @@ jobs:
       - name: Cache KiCad (Windows)
         if: matrix.config.name == 'Windows'
         id: cache-kicad-windows
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\Program Files\KiCad\10.0
           key: ${{ runner.os }}-kicad-${{ env.KICAD_VERSION }}
@@ -134,19 +138,21 @@ jobs:
 
       - name: Install Rust (Windows)
         if: runner.os == 'Windows'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           rustflags: ""
           cache-bin: false
 
       - name: Install Rust
         if: runner.os != 'Windows'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-bin: false
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        with:
+          tool: nextest
 
       - name: Test All (Workspace)
         env:
@@ -168,8 +174,10 @@ jobs:
       run:
         working-directory: crates/pcb-layout/src/scripts
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - run: uv sync --locked
         working-directory: .
       - run: uv run --locked ty check
@@ -182,7 +190,9 @@ jobs:
     name: Check README Sync
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Check README sync
         run: bin/embed-readme --check README.md

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -32,17 +32,21 @@ jobs:
           apt-get update
           apt-get install -y ca-certificates curl build-essential pkg-config libssl-dev jq git openssh-client zstd
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           target: wasm32-unknown-unknown
           cache-bin: false
 
-      - uses: taiki-e/install-action@wasm-pack
+      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        with:
+          tool: wasm-pack
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: GitHub Actions Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          annotations: true
+          version: 1.29.0


### PR DESCRIPTION
GitHub Actions currently use mutable action references and unsafe expression expansion. This change pins current action releases, reduces credential and permission scope, disables publish caches, and adds zizmor and Dependabot checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release, nightly, and version-bump automation (git push, S3, npm, GitHub Releases); mistakes could block releases, though changes are mostly security hardening with equivalent behavior.
> 
> **Overview**
> **Pins third-party actions** to immutable commit SHAs (with version comments) across build, test, release, and publish workflows, and adds **Dependabot** for weekly grouped `github-actions` updates with a 7-day cooldown.
> 
> **Tightens supply-chain and token exposure:** `actions/checkout` now sets `persist-credentials: false` everywhere; workflow default `permissions` are reduced to `contents: read` (and `packages: read` where needed), with **`id-token: write`** and **`contents: write`** only on jobs that publish to AWS, npm, or GitHub Releases. Release/version-bump jobs pass tags and versions through **`env`** instead of expanding `${{ }}` inside shell scripts; the build-perf stale-comment delete step passes **`comment_id` via `env`** into `github-script`.
> 
> **Release automation:** pcb/pcbc version-bump workflows use **`gh auth setup-git`** with the robot token for push/tag in one step. **npm-publish** disables Rust and Node package-manager caches; **taiki-e/install-action** steps use explicit `tool:` inputs.
> 
> Adds a **`zizmor`** workflow on push/PR to scan workflow definitions for common Actions security issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d32a95e3561ceccfefd9a7111dc5abbec905135b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->