### PR TITLE
Restore API-driven BOM sourceability colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `pcb bom` again colors planner-selected parts by green, yellow, and red sourceability tiers.
+
 ## [0.4.31] - 2026-08-18
 
 ### Added

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -3,7 +3,7 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::{collections::HashMap, time::Duration};
 
-use pcb_sch::bom::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer};
+use pcb_sch::bom::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer, SourcingStockClass};
 
 use crate::WorkspaceContext;
 
@@ -102,6 +102,8 @@ struct BomLine {
     design_entry: DesignBomEntry,
     #[serde(rename = "offerIds")]
     offer_ids: Vec<String>,
+    #[serde(rename = "offerStockClasses")]
+    offer_stock_classes: HashMap<String, SourcingStockClass>,
     #[serde(rename = "match", default)]
     match_status: Option<BomMatchStatus>,
 }
@@ -167,6 +169,7 @@ fn build_availability_summary(
     };
 
     AvailabilitySummary {
+        stock_class: SourcingStockClass::Unknown,
         price: offer.unit_price_at_qty(target_qty),
         stock: offer.stock_available.unwrap_or_default(),
         alt_stock,
@@ -281,9 +284,24 @@ pub fn fetch_and_populate_availability_with_context(
 
         let target_qty = qty * BOARD_QUANTITY;
 
-        let (us_offers, us) = summarize_region(&resolved_offers, Geography::Us, target_qty, qty);
-        let (global_offers, global) =
+        let (us_offers, mut us) =
+            summarize_region(&resolved_offers, Geography::Us, target_qty, qty);
+        let (global_offers, mut global) =
             summarize_region(&resolved_offers, Geography::Global, target_qty, qty);
+        for (summary, offers) in [(&mut us, &us_offers), (&mut global, &global_offers)] {
+            if let (Some(summary), Some(offer)) = (summary, offers.first()) {
+                summary.stock_class = bom_line
+                    .offer_stock_classes
+                    .get(&offer.id)
+                    .copied()
+                    .with_context(|| {
+                        format!(
+                            "BOM match response omitted the stock class for offer {}",
+                            offer.id
+                        )
+                    })?;
+            }
+        }
 
         // Build offers for JSON output
         let all_offers: Vec<_> = us_offers
@@ -516,6 +534,7 @@ mod tests {
                 path: Some("root.U1".to_string()),
             },
             offer_ids,
+            offer_stock_classes: HashMap::new(),
             match_status,
         }
     }
@@ -586,7 +605,7 @@ mod tests {
     }
 
     #[test]
-    fn first_api_ranked_regional_offer_wins() {
+    fn first_ranked_regional_offer_wins() {
         let response: MatchBomResponse =
             serde_json::from_str(include_str!("../tests/fixtures/bom_match_api_order.json"))
                 .unwrap();
@@ -601,7 +620,14 @@ mod tests {
 
         assert_eq!(availability.us.as_ref().unwrap().stock, 5);
         assert_eq!(availability.us.as_ref().unwrap().price, Some(10.0));
-        assert_eq!(availability.offers[0].part_id.as_deref(), Some("API-FIRST"));
+        assert_eq!(
+            availability.offers[0].part_id.as_deref(),
+            Some("SELECTED-OFFER")
+        );
+        assert_eq!(
+            line.offer_stock_classes["selected-offer"],
+            SourcingStockClass::Limited
+        );
     }
 
     #[test]

--- a/crates/pcb-diode-api/tests/fixtures/bom_match_api_order.json
+++ b/crates/pcb-diode-api/tests/fixtures/bom_match_api_order.json
@@ -5,18 +5,22 @@
         "path": "root.U1"
       },
       "offerIds": [
-        "api-first",
-        "old-rust-policy-first"
+        "selected-offer",
+        "alternate-offer"
       ],
+      "offerStockClasses": {
+        "selected-offer": "LIMITED",
+        "alternate-offer": "PLENTY"
+      },
       "match": "MATCH_EXACT"
     }
   ],
   "offers": {
-    "api-first": {
-      "id": "api-first",
+    "selected-offer": {
+      "id": "selected-offer",
       "geography": "US",
-      "distributor": "Planner Choice",
-      "distributorPartId": "API-FIRST",
+      "distributor": "Selected Distributor",
+      "distributorPartId": "SELECTED-OFFER",
       "mpn": "TEST-MPN",
       "manufacturer": "Test Manufacturer",
       "priceBreaks": [
@@ -27,11 +31,11 @@
       ],
       "stockAvailable": 5
     },
-    "old-rust-policy-first": {
-      "id": "old-rust-policy-first",
+    "alternate-offer": {
+      "id": "alternate-offer",
       "geography": "US",
-      "distributor": "Local Policy Choice",
-      "distributorPartId": "OLD-RUST-FIRST",
+      "distributor": "Alternate Distributor",
+      "distributorPartId": "ALTERNATE-OFFER",
       "mpn": "TEST-MPN",
       "manufacturer": "Test Manufacturer",
       "priceBreaks": [

--- a/crates/pcb-sch/src/bom/availability.rs
+++ b/crates/pcb-sch/src/bom/availability.rs
@@ -5,6 +5,17 @@ use serde::{Deserialize, Serialize};
 /// Board quantity sent to the sourcing planner and used for price presentation.
 pub const BOARD_QUANTITY: i32 = 5;
 
+/// Stock classification computed by the API sourcing planner.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SourcingStockClass {
+    Plenty,
+    Limited,
+    Insufficient,
+    #[default]
+    Unknown,
+}
+
 /// Pricing and availability data for a component
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Availability {
@@ -25,6 +36,9 @@ pub struct Availability {
 /// Compact availability summary for a region
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct AvailabilitySummary {
+    /// API planner classification for the selected offer (internal only)
+    #[serde(skip, default)]
+    pub stock_class: SourcingStockClass,
     /// Unit price at target quantity
     pub price: Option<f64>,
     /// Stock available (best offer)

--- a/crates/pcb-sch/src/bom/mod.rs
+++ b/crates/pcb-sch/src/bom/mod.rs
@@ -5,4 +5,6 @@ mod core;
 pub use core::*;
 
 // Re-export availability types and sourcing quantity
-pub use availability::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer};
+pub use availability::{
+    Availability, AvailabilitySummary, BOARD_QUANTITY, Offer, SourcingStockClass,
+};

--- a/crates/pcb-sch/src/bom_table.rs
+++ b/crates/pcb-sch/src/bom_table.rs
@@ -5,9 +5,8 @@ use comfy_table::{Cell, Color, Table};
 use terminal_hyperlink::Hyperlink as _;
 use urlencoding::encode as urlencode;
 
-use crate::bom::AvailabilitySummary;
-use crate::bom::Bom;
 use crate::bom::availability::BOARD_QUANTITY;
+use crate::bom::{AvailabilitySummary, Bom, SourcingStockClass};
 
 const NO_MATCH_LABEL: &str = "No match (unknown part)";
 
@@ -109,23 +108,52 @@ fn styled_cell(content: impl ToString, is_dnp: bool, is_house: bool) -> Cell {
     }
 }
 
-/// Map response states to display colors without recreating sourcing policy.
-fn color_for_status(is_dnp: bool, no_match: bool) -> Option<Color> {
+/// Map the selected planner result to its presentation color.
+fn color_for_status(
+    is_dnp: bool,
+    no_match: bool,
+    sourceability: Option<SourcingStockClass>,
+) -> Option<Color> {
     if is_dnp {
         Some(Color::DarkGrey)
     } else if no_match {
         Some(Color::Magenta)
     } else {
-        None
+        sourceability.map(|sourceability| match sourceability {
+            SourcingStockClass::Plenty => Color::Green,
+            SourcingStockClass::Limited | SourcingStockClass::Unknown => Color::Yellow,
+            SourcingStockClass::Insufficient => Color::Red,
+        })
     }
 }
 
 /// Apply styling to response-state cells.
-fn styled_status_cell(content: impl ToString, is_dnp: bool, no_match: bool) -> Cell {
+fn styled_status_cell(
+    content: impl ToString,
+    is_dnp: bool,
+    no_match: bool,
+    sourceability: Option<SourcingStockClass>,
+) -> Cell {
     let cell = Cell::new(content);
-    match color_for_status(is_dnp, no_match) {
+    match color_for_status(is_dnp, no_match, sourceability) {
         Some(color) => cell.fg(color),
         None => cell,
+    }
+}
+
+fn line_sourceability(
+    us: Option<SourcingStockClass>,
+    global: Option<SourcingStockClass>,
+) -> Option<SourcingStockClass> {
+    match (us, global) {
+        (None, class) | (class, None) => class,
+        (Some(SourcingStockClass::Insufficient), Some(SourcingStockClass::Insufficient)) => {
+            Some(SourcingStockClass::Insufficient)
+        }
+        (Some(SourcingStockClass::Plenty), Some(SourcingStockClass::Plenty)) => {
+            Some(SourcingStockClass::Plenty)
+        }
+        _ => Some(SourcingStockClass::Limited),
     }
 }
 
@@ -164,6 +192,7 @@ struct RegionDisplayData {
     alt_stock: i32,
     price_single: Option<f64>,
     price_boards: Option<f64>,
+    sourceability: Option<SourcingStockClass>,
     lcsc_ids: Vec<(String, String)>,
     mpn: Option<String>,
     manufacturer: Option<String>,
@@ -192,6 +221,7 @@ impl RegionDisplayData {
             alt_stock: a.alt_stock,
             price_single,
             price_boards,
+            sourceability: Some(a.stock_class),
             lcsc_ids: a.lcsc_part_ids.clone(),
             mpn: a.mpn.clone(),
             manufacturer: a.manufacturer.clone(),
@@ -252,13 +282,23 @@ impl Bom {
 
         if has_availability {
             legend_table.add_row(vec![
+                Cell::new("■").fg(Color::Green),
+                Cell::new("Plenty available / easy to source"),
+                Cell::new("  "),
                 Cell::new("■").fg(Color::Blue),
                 Cell::new("House component"),
+            ]);
+            legend_table.add_row(vec![
+                Cell::new("■").fg(Color::Yellow),
+                Cell::new("Limited inventory / harder to source"),
                 Cell::new("  "),
                 Cell::new("■").fg(Color::DarkGrey),
                 Cell::new("DNP (Do Not Populate)"),
             ]);
             legend_table.add_row(vec![
+                Cell::new("■").fg(Color::Red),
+                Cell::new("Insufficient stock / hard to source"),
+                Cell::new("  "),
                 Cell::new("■").fg(Color::Magenta),
                 Cell::new(NO_MATCH_LABEL),
             ]);
@@ -412,6 +452,9 @@ impl Bom {
             let (manufacturer, is_manufacturer_autofilled) =
                 autofill_from_availability(original_manufacturer, &avail_manufacturer);
 
+            let line_sourceability =
+                line_sourceability(us_data.sourceability, global_data.sourceability);
+
             // Track summary stats
             if has_availability {
                 if is_dnp {
@@ -438,7 +481,7 @@ impl Bom {
             // Create qty and designators cells
             let qty_cell = styled_cell(format!("{:>4}", qty), is_dnp, false);
             let designators_cell = (if has_availability {
-                styled_status_cell(designators.as_str(), is_dnp, no_match)
+                styled_status_cell(designators.as_str(), is_dnp, no_match, line_sourceability)
             } else {
                 styled_cell(designators.as_str(), is_dnp, false)
             })
@@ -474,11 +517,17 @@ impl Bom {
 
             // Add stock columns (US and Global)
             if has_availability {
-                row.push(styled_status_cell(us_data.format_stock(), is_dnp, no_match));
+                row.push(styled_status_cell(
+                    us_data.format_stock(),
+                    is_dnp,
+                    no_match,
+                    us_data.sourceability,
+                ));
                 row.push(styled_status_cell(
                     global_data.format_stock(),
                     is_dnp,
                     no_match,
+                    global_data.sourceability,
                 ));
             }
 
@@ -668,7 +717,43 @@ mod tests {
 
     #[test]
     fn no_match_status_is_magenta() {
-        assert_eq!(color_for_status(false, true), Some(Color::Magenta));
+        assert_eq!(
+            color_for_status(false, true, Some(SourcingStockClass::Plenty)),
+            Some(Color::Magenta)
+        );
+    }
+
+    #[test]
+    fn api_stock_classes_map_to_sourceability_colors() {
+        assert_eq!(
+            color_for_status(false, false, Some(SourcingStockClass::Plenty)),
+            Some(Color::Green)
+        );
+        assert_eq!(
+            color_for_status(false, false, Some(SourcingStockClass::Limited)),
+            Some(Color::Yellow)
+        );
+        assert_eq!(
+            color_for_status(false, false, Some(SourcingStockClass::Insufficient)),
+            Some(Color::Red)
+        );
+        assert_eq!(
+            color_for_status(false, false, Some(SourcingStockClass::Unknown)),
+            Some(Color::Yellow)
+        );
+    }
+
+    #[test]
+    fn missing_region_is_uncolored_and_existing_region_drives_line() {
+        assert_eq!(color_for_status(false, false, None), None);
+        assert_eq!(
+            line_sourceability(Some(SourcingStockClass::Plenty), None),
+            Some(SourcingStockClass::Plenty)
+        );
+        assert_eq!(
+            line_sourceability(None, Some(SourcingStockClass::Insufficient)),
+            Some(SourcingStockClass::Insufficient)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Restore BOM sourceability colors by consuming planner-provided offer stock classes from the API. Show PLENTY in green, LIMITED and UNKNOWN in yellow, and INSUFFICIENT in red without rebuilding sourcing policy in the CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and BOM API deserialization only; errors if the API omits a stock class for a selected offer, which surfaces contract mismatches early.
> 
> **Overview**
> **Restores green/yellow/red sourceability coloring in `pcb bom` when live availability is loaded**, using planner stock classes from the BOM match API instead of inferring sourcing policy in the CLI.
> 
> The match response now carries per-offer `offerStockClasses`; US and Global summaries attach the class for the **first ranked regional offer**, and missing classes fail parsing rather than silently defaulting. A new internal `SourcingStockClass` drives table styling: **PLENTY** → green, **LIMITED** / **UNKNOWN** → yellow, **INSUFFICIENT** → red (DNP and no-match colors unchanged). The availability legend documents the tiers when sourcing data is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fafe850c7454ddb4a4fe3c0c3dc27b64a7b6f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->