### PR TITLE
Desliver copper-balance boundary voids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `pcb bom` again colors planner-selected parts by green, yellow, and red sourceability tiers.
+- Copper balancing no longer emits sliver voids where boundary voids graze the fill boundary.
 
 ## [0.4.31] - 2026-08-18
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -957,7 +957,7 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
 
     let xml = write_board_array_xml(input, &spec).unwrap();
     assert!(xml.contains(r#"<Set polarity="NEGATIVE">"#));
-    for kind in ["plane", "full_void", "boundary_web"] {
+    for kind in ["plane", "full_void", "edge_void", "boundary_web"] {
         assert!(xml.contains(&format!(
             r#"<NonstandardAttribute name="diode.copper_balance" type="STRING" value="{kind}"/>"#
         )));
@@ -999,6 +999,9 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     let round_trip = balance_paths(pcb_ir::dialects::ipc::CopperBalanceKind::Plane)
         .difference(&balance_paths(
             pcb_ir::dialects::ipc::CopperBalanceKind::FullVoid,
+        ))
+        .difference(&balance_paths(
+            pcb_ir::dialects::ipc::CopperBalanceKind::EdgeVoid,
         ))
         .union(&balance_paths(
             pcb_ir::dialects::ipc::CopperBalanceKind::BoundaryWeb,

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -17,9 +17,10 @@ use ipc2581::types::{
 use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::geom::copper_balance::{
     DenseCopperBalanceMode, DenseCopperBalanceProfile, DenseCopperBalanceResult,
-    DenseCopperLattice, DenseCopperLatticeSite, ROUNDED_HEXAGON_CORNER_RADIUS_RATIO,
-    SpatialCopperBalanceLayerRequest, SpatialCopperBalanceRequest, StackMomentField,
-    generate_spatial_dense_copper_balance, rounded_hexagonal_void,
+    DenseCopperLattice, DenseCopperLatticeSite, DenseCopperVoid,
+    ROUNDED_HEXAGON_CORNER_RADIUS_RATIO, SpatialCopperBalanceLayerRequest,
+    SpatialCopperBalanceRequest, StackMomentField, generate_spatial_dense_copper_balance,
+    rounded_hexagonal_void,
 };
 use pcb_ir::geom::path::ContourBuf;
 use pcb_ir::geom::region::{rings_to_contours, simplify_shapes};
@@ -48,6 +49,7 @@ pub(crate) fn copper_balance_attribute_value(kind: CopperBalanceKind) -> &'stati
     match kind {
         CopperBalanceKind::Plane => "plane",
         CopperBalanceKind::FullVoid => "full_void",
+        CopperBalanceKind::EdgeVoid => "edge_void",
         CopperBalanceKind::BoundaryWeb => "boundary_web",
     }
 }
@@ -56,6 +58,7 @@ pub(crate) fn parse_copper_balance_attribute(value: &str) -> Result<CopperBalanc
     match value {
         "plane" => Ok(CopperBalanceKind::Plane),
         "full_void" => Ok(CopperBalanceKind::FullVoid),
+        "edge_void" => Ok(CopperBalanceKind::EdgeVoid),
         "boundary_web" => Ok(CopperBalanceKind::BoundaryWeb),
         _ => bail!("unknown diode.copper_balance value '{value}'"),
     }
@@ -101,23 +104,25 @@ pub struct BalanceVoidSet {
     pub sites: Vec<DenseCopperLatticeSite>,
 }
 
-/// Generated IPC features for one balanced layer, split by polarity.
-///
-/// The perforated plane covers the whole usable region, every void is a full
-/// negative dictionary-instance reference, and the boundary web restores the
-/// portion edge voids must not remove. Repeated shapes share templates, so
-/// each occurrence costs only a location.
+/// Generated IPC features for one balanced layer, split by polarity: the
+/// plane over the whole usable region, voids as shared-template lattice
+/// instances, crossing edge voids as pre-clipped contours, and the boundary
+/// web as the labeled copper band along the usable boundary.
 #[derive(Debug, Clone, Default)]
 pub struct BalanceFeatureSets {
     pub plane: Vec<SetFeature>,
     pub boundary_web: Vec<SetFeature>,
     pub templates: Vec<BalanceVoidTemplate>,
     pub void_sets: Vec<BalanceVoidSet>,
+    pub edge_voids: Vec<SetFeature>,
 }
 
 impl BalanceFeatureSets {
     pub fn is_empty(&self) -> bool {
-        self.plane.is_empty() && self.boundary_web.is_empty() && self.void_sets.is_empty()
+        self.plane.is_empty()
+            && self.boundary_web.is_empty()
+            && self.void_sets.is_empty()
+            && self.edge_voids.is_empty()
     }
 
     /// Lower one balanced layer to its ordered generated feature sets — the
@@ -139,6 +144,7 @@ impl BalanceFeatureSets {
             boundary_web,
             templates,
             void_sets,
+            edge_voids,
         } = self;
         let balance_features = |polarity, kind, features, void_set| GeneratedLayerFeature {
             layer_name: layer_name.to_string(),
@@ -148,26 +154,36 @@ impl BalanceFeatureSets {
             features,
             void_set,
         };
-        let mut features = vec![balance_features(
+        let has_edge_voids = !edge_voids.is_empty();
+        let features = std::iter::once(balance_features(
             Polarity::Positive,
             CopperBalanceKind::Plane,
             plane,
             None,
-        )];
-        features.extend(void_sets.into_iter().map(|void_set| {
+        ))
+        .chain(void_sets.into_iter().map(|void_set| {
             balance_features(
                 Polarity::Negative,
                 CopperBalanceKind::FullVoid,
                 Vec::new(),
                 Some(void_set),
             )
-        }));
-        features.push(balance_features(
+        }))
+        .chain(has_edge_voids.then(|| {
+            balance_features(
+                Polarity::Negative,
+                CopperBalanceKind::EdgeVoid,
+                edge_voids,
+                None,
+            )
+        }))
+        .chain(std::iter::once(balance_features(
             Polarity::Positive,
             CopperBalanceKind::BoundaryWeb,
             boundary_web,
             None,
-        ));
+        )))
+        .collect();
         (templates, features)
     }
 }
@@ -444,53 +460,61 @@ pub fn balance_features(result: &DenseCopperBalanceResult) -> Result<BalanceFeat
             ..BalanceFeatureSets::default()
         }),
         DenseCopperBalanceMode::Perforated { .. } => {
-            let (templates, void_sets) = void_sets(result)?;
+            let emission = &result.edge_void_emission;
+            let (templates, void_sets) = void_sets(result, &emission.instanced)?;
             Ok(BalanceFeatureSets {
                 plane: ipc_region_features(&result.usable)?,
-                boundary_web: ipc_region_features(&result.boundary_web())?,
+                // The plane covers the web exactly, so its decimation is free.
+                boundary_web: ipc_region_features(
+                    &result.boundary_web().decimate_inward(tol::FLATTEN_MM),
+                )?,
                 templates,
                 void_sets,
+                edge_voids: ipc_region_features(&emission.clipped)?,
             })
         }
     }
 }
 
-/// One dictionary template and one declared-lattice site set per exact radius.
+/// One dictionary template and one declared-lattice site set per exact
+/// radius, covering the interior voids and the instanced edge voids.
 fn void_sets(
     result: &DenseCopperBalanceResult,
+    instanced_edge_voids: &[DenseCopperVoid],
 ) -> Result<(Vec<BalanceVoidTemplate>, Vec<BalanceVoidSet>)> {
     let mut sites_by_radius = std::collections::BTreeMap::<i64, Vec<DenseCopperLatticeSite>>::new();
-    for void in result.full_voids.iter().chain(&result.edge_voids) {
+    for void in result.full_voids.iter().chain(instanced_edge_voids) {
         sites_by_radius
             .entry((void.radius_mm * 1e6).round() as i64)
             .or_default()
             .push(void.site);
     }
-
-    let mut templates = Vec::with_capacity(sites_by_radius.len());
-    let mut sets = Vec::with_capacity(sites_by_radius.len());
-    for (radius_nm, mut sites) in sites_by_radius {
-        sites.sort_by_key(|site| (site.column, site.row));
-        let radius_mm = radius_nm as f64 / 1e6;
-        let id = format!("balance_hex_{radius_nm}nm");
-        let contour = rounded_hexagonal_void(radius_mm)
-            .context("generated copper balance has an invalid rounded-hex void radius")?;
-        templates.push(BalanceVoidTemplate {
-            id: id.clone(),
-            contour: IpcContour {
-                polygon: ipc_polygon_from_contour(&contour)?,
-                cutouts: Vec::new(),
-            },
-        });
-        sets.push(BalanceVoidSet {
-            template: id,
-            radius_mm,
-            corner_radius_mm: radius_mm * ROUNDED_HEXAGON_CORNER_RADIUS_RATIO,
-            lattice: result.lattice,
-            sites,
-        });
-    }
-    Ok((templates, sets))
+    sites_by_radius
+        .into_iter()
+        .map(|(radius_nm, mut sites)| {
+            sites.sort_by_key(|site| (site.column, site.row));
+            let radius_mm = radius_nm as f64 / 1e6;
+            let id = format!("balance_hex_{radius_nm}nm");
+            let contour = rounded_hexagonal_void(radius_mm)
+                .context("generated copper balance has an invalid rounded-hex void radius")?;
+            let template = BalanceVoidTemplate {
+                id: id.clone(),
+                contour: IpcContour {
+                    polygon: ipc_polygon_from_contour(&contour)?,
+                    cutouts: Vec::new(),
+                },
+            };
+            let set = BalanceVoidSet {
+                template: id,
+                radius_mm,
+                corner_radius_mm: radius_mm * ROUNDED_HEXAGON_CORNER_RADIUS_RATIO,
+                lattice: result.lattice,
+                sites,
+            };
+            Ok((template, set))
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|pairs| pairs.into_iter().unzip())
 }
 
 /// Extract one layer's flattened, composed copper image.
@@ -702,14 +726,19 @@ mod tests {
         );
 
         assert!(!features.boundary_web.is_empty());
+        // Dictionary instances cover interior and contained edge voids;
+        // crossing voids become clipped contours inside the voidable region.
+        let emission = &result.edge_void_emission;
         assert_eq!(
             features
                 .void_sets
                 .iter()
                 .map(|set| set.sites.len())
                 .sum::<usize>(),
-            result.void_count()
+            result.full_voids.len() + emission.instanced.len()
         );
+        assert_eq!(features.edge_voids.is_empty(), emission.clipped.is_empty());
+        assert!(emission.clipped.difference(&result.voidable).area() < 1e-6);
         assert!(features.void_sets.iter().all(|set| {
             features
                 .templates

--- a/crates/pcb-ir/src/dialects/ipc/feature.rs
+++ b/crates/pcb-ir/src/dialects/ipc/feature.rs
@@ -349,6 +349,9 @@ pub enum FiducialKind {
 pub enum CopperBalanceKind {
     Plane,
     FullVoid,
+    /// A boundary void emitted as an explicit clipped contour rather than a
+    /// lattice hex instance.
+    EdgeVoid,
     BoundaryWeb,
 }
 

--- a/crates/pcb-ir/src/geom/copper_balance/lattice.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/lattice.rs
@@ -102,11 +102,9 @@ impl LatticeCandidates {
         profile: DenseCopperBalanceProfile,
     ) -> ContourSet {
         let candidates = self
-            .edge_voids(radius, profile)
-            .into_iter()
-            .map(|void| (self.lattice.center(void.site), void.radius_mm))
-            .collect::<Vec<_>>();
-        clipped_voids_containing_minimum_disk(voidable, &candidates, profile)
+            .lattice
+            .void_candidates(&self.edge_voids(radius, profile));
+        clipped_partial_voids(voidable, &candidates, profile)
     }
 
     pub(super) fn void_area(
@@ -243,7 +241,9 @@ fn accepted_candidate_mask(
     candidate_point_mask(candidates, &core_points, profile)
 }
 
-fn clipped_voids_containing_minimum_disk(
+/// The clipped partial-void geometry the solver accounts with: components of
+/// `hex ∩ voidable` that contain the minimum partial-void disk.
+pub(super) fn clipped_partial_voids(
     voidable: &ContourSet,
     candidates: &[(Point, f64)],
     profile: DenseCopperBalanceProfile,
@@ -258,6 +258,19 @@ fn clipped_voids_containing_minimum_disk(
         .flat_map(|component| component.rings)
         .collect();
     ContourSet::new(rings, FillRule::NonZero, voidable.tolerance)
+}
+
+/// The emitted form of the clipped partial voids: opened at the profile's
+/// regularization radius to shed near-tangent clip tails, then decimated
+/// inward to the arc-flattening tolerance.
+pub(super) fn emission_partial_voids(
+    voidable: &ContourSet,
+    candidates: &[(Point, f64)],
+    profile: DenseCopperBalanceProfile,
+) -> ContourSet {
+    clipped_partial_voids(voidable, candidates, profile)
+        .disk_open(profile.void_regularization_radius_mm())
+        .decimate_inward(tol::FLATTEN_MM)
 }
 
 fn minimum_disk_core_points(

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -381,10 +381,11 @@ pub struct DenseCopperBalanceResult {
     pub edge_void_emission: EdgeVoidEmission,
 }
 
-/// Edge voids resolved to their emitted form: hexes that fit inside the
-/// voidable region at their solved radius keep the compact lattice template
-/// form, and only genuinely crossing voids become one clipped, regularized
-/// region.
+/// Edge voids resolved to their emitted form: voids whose circumscribed
+/// disk fits inside the voidable region keep the compact lattice template
+/// form, and the rest become one clipped, regularized region. The disk is a
+/// conservative containment proxy — a fitting hex it misclassifies still
+/// emits its exact clip through the contour path, at a small size cost.
 #[derive(Debug, Clone)]
 pub struct EdgeVoidEmission {
     /// Edge voids emitted as ordinary lattice template instances.

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -129,6 +129,13 @@ impl DenseCopperBalanceProfile {
         self.min_void_radius_mm / 2.0
     }
 
+    /// Rolling-disk radius applied to emitted partial-void geometry: half
+    /// the partial-void inradius floor, so conforming components survive an
+    /// opening intact while sub-floor clip tails are removed.
+    pub fn void_regularization_radius_mm(self) -> f64 {
+        self.minimum_partial_void_inradius_mm() / 2.0
+    }
+
     /// Minimum flat-to-flat web between nearest-neighbor hexagonal voids.
     ///
     /// The center lattice is rotated 30° from the hexagon vertices, putting
@@ -295,6 +302,14 @@ impl DenseCopperLattice {
         let site = DenseCopperLatticeSite { column, row };
         (site, self.center(site))
     }
+
+    /// The `(center, radius)` candidate tuples geometry helpers consume.
+    pub fn void_candidates(&self, voids: &[DenseCopperVoid]) -> Vec<(Point, f64)> {
+        voids
+            .iter()
+            .map(|void| (self.center(void.site), void.radius_mm))
+            .collect()
+    }
 }
 
 /// One full, unclipped rounded-hex void.
@@ -354,15 +369,55 @@ pub struct DenseCopperBalanceResult {
     pub lattice: DenseCopperLattice,
     /// Safe, initially empty region available for generated copper.
     pub usable: ContourSet,
-    /// Eroded subset in which voids may remove the generated plane. Keeping
-    /// this domain plus full edge sites is the canonical boundary geometry;
-    /// clipped fragments are derived only for analysis and composition.
+    /// Eroded subset in which voids may remove the generated plane.
     pub voidable: ContourSet,
     /// Interior voids that retain the exact rounded-hex template.
     pub full_voids: Vec<DenseCopperVoid>,
-    /// Boundary sites retained as complete rounded-hex templates. Output
-    /// clears these full shapes, then restores `usable - voidable`.
+    /// Boundary sites at their solved radii; emitted as
+    /// [`Self::edge_void_emission`].
     pub edge_voids: Vec<DenseCopperVoid>,
+    /// The one emitted form of the edge voids, computed once at solve time
+    /// so density accounting and emission read the same geometry.
+    pub edge_void_emission: EdgeVoidEmission,
+}
+
+/// Edge voids resolved to their emitted form: hexes that fit inside the
+/// voidable region at their solved radius keep the compact lattice template
+/// form, and only genuinely crossing voids become one clipped, regularized
+/// region.
+#[derive(Debug, Clone)]
+pub struct EdgeVoidEmission {
+    /// Edge voids emitted as ordinary lattice template instances.
+    pub instanced: Vec<DenseCopperVoid>,
+    /// Crossing voids, clipped to the voidable region and regularized.
+    pub clipped: ContourSet,
+    /// Union of both parts, for density fields and area accounting.
+    pub region: ContourSet,
+}
+
+impl EdgeVoidEmission {
+    fn new(
+        lattice: DenseCopperLattice,
+        voidable: &ContourSet,
+        edge_voids: &[DenseCopperVoid],
+        profile: DenseCopperBalanceProfile,
+    ) -> Self {
+        let (instanced, crossing): (Vec<DenseCopperVoid>, Vec<DenseCopperVoid>) = edge_voids
+            .iter()
+            .partition(|void| voidable.contains_disk(lattice.center(void.site), void.radius_mm));
+        let clipped =
+            lattice::emission_partial_voids(voidable, &lattice.void_candidates(&crossing), profile);
+        let region = lattice::void_set(&instanced, lattice, voidable.tolerance).union(&clipped);
+        Self {
+            instanced,
+            clipped,
+            region,
+        }
+    }
+
+    pub fn area_mm2(&self) -> f64 {
+        self.region.area()
+    }
 }
 
 impl DenseCopperBalanceResult {
@@ -382,11 +437,6 @@ impl DenseCopperBalanceResult {
             .map(|void| void.radius_mm)
             .max_by(f64::total_cmp)?;
         Some((min, max))
-    }
-
-    pub fn clipped_edge_voids(&self) -> ContourSet {
-        lattice::void_set(&self.edge_voids, self.lattice, self.voidable.tolerance)
-            .intersection(&self.voidable)
     }
 
     pub fn boundary_web(&self) -> ContourSet {
@@ -475,21 +525,32 @@ fn generate_dense_copper_balance_with_lattice(
         ),
         DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => (Vec::new(), Vec::new()),
     };
+    // Account generated copper from the emitted geometry, not the solve's
+    // projection, so achieved density is truthful to the output.
+    let edge_void_emission = EdgeVoidEmission::new(lattice.lattice, voidable, &edge_voids, profile);
+    let generated_area_mm2 = match best.mode {
+        DenseCopperBalanceMode::None => 0.0,
+        DenseCopperBalanceMode::Solid => usable_area_mm2,
+        DenseCopperBalanceMode::Perforated { .. } => {
+            let full_void_area_mm2 = ROUNDED_HEXAGON_AREA_FACTOR
+                * full_voids
+                    .iter()
+                    .map(|void| void.radius_mm * void.radius_mm)
+                    .sum::<f64>();
+            (usable_area_mm2 - full_void_area_mm2 - edge_void_emission.area_mm2()).max(0.0)
+        }
+    };
     let achieved_density =
-        (request.existing_copper_area_mm2 + best.area_mm2) / request.density_domain_area_mm2;
+        (request.existing_copper_area_mm2 + generated_area_mm2) / request.density_domain_area_mm2;
     let solution = DenseCopperBalanceSolution {
         mode: best.mode,
         desired_added_area_mm2,
-        generated_area_mm2: best.area_mm2,
+        generated_area_mm2,
         initial_density,
         achieved_density,
         target_density: request.target_density,
         residual_error: (achieved_density - request.target_density).abs(),
     };
-    debug_assert!(
-        solution.residual_error
-            <= (solution.initial_density - request.target_density).abs() + NUMERIC_EPSILON
-    );
     DenseCopperBalanceResult {
         solution,
         lattice: lattice.lattice,
@@ -497,6 +558,7 @@ fn generate_dense_copper_balance_with_lattice(
         voidable: voidable.clone(),
         full_voids,
         edge_voids,
+        edge_void_emission,
     }
 }
 
@@ -640,10 +702,7 @@ pub fn generate_spatial_dense_copper_balance(
     let smooth_coverage = |region: &ContourSet| {
         density_kernel.smooth(&lattice_cell_coverage(&panel_samples, region, profile))
     };
-    let clipped_edge_voids = uniform
-        .iter()
-        .map(DenseCopperBalanceResult::clipped_edge_voids)
-        .collect::<Vec<_>>();
+
     let (fixed_density, region_available_density, partial_void_density) =
         std::thread::scope(|scope| {
             let fixed = request
@@ -655,9 +714,9 @@ pub fn generate_spatial_dense_copper_balance(
                 .iter()
                 .map(|region| scope.spawn(|| smooth_coverage(region)))
                 .collect::<Vec<_>>();
-            let partial = clipped_edge_voids
+            let partial = uniform
                 .iter()
-                .map(|region| scope.spawn(|| smooth_coverage(region)))
+                .map(|result| scope.spawn(|| smooth_coverage(&result.edge_void_emission.region)))
                 .collect::<Vec<_>>();
             let join_all = |handles: Vec<std::thread::ScopedJoinHandle<'_, Vec<f64>>>| {
                 handles
@@ -1195,7 +1254,11 @@ mod tests {
             .map(|void| (result.lattice.center(void.site), void.radius_mm))
             .collect::<Vec<_>>();
         let mut rings = hexagon_set_with_radii(&candidates, result.usable.tolerance).rings;
-        rings.extend(result.clipped_edge_voids().rings);
+        rings.extend(
+            lattice::void_set(&result.edge_voids, result.lattice, result.usable.tolerance)
+                .intersection(&result.voidable)
+                .rings,
+        );
         ContourSet::new(rings, FillRule::NonZero, result.usable.tolerance)
     }
 

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -262,7 +262,7 @@ pub(super) fn spatial_result_from_squared_radii(
             .iter()
             .map(|void| void.radius_mm * void.radius_mm)
             .sum::<f64>();
-    let clipped_edge_void_area_mm2 = baseline.clipped_edge_voids().area();
+    let clipped_edge_void_area_mm2 = baseline.edge_void_emission.area_mm2();
     let void_area_mm2 = full_void_area_mm2 + clipped_edge_void_area_mm2;
     let generated_area_mm2 = (baseline.usable.area() - void_area_mm2).max(0.0);
     let achieved_density =
@@ -291,6 +291,7 @@ pub(super) fn spatial_result_from_squared_radii(
         voidable: baseline.voidable,
         full_voids,
         edge_voids: baseline.edge_voids,
+        edge_void_emission: baseline.edge_void_emission,
     }
 }
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -139,6 +139,72 @@ pub fn rings_bbox(rings: &[Ring]) -> BBox {
         })
 }
 
+/// Decimate rings so the region only shrinks: the result covers no point the
+/// source did not, and no source vertex ends farther than `deviation_mm`
+/// from the decimated boundary.
+pub fn decimate_rings_inward(rings: &[Ring], deviation_mm: f64) -> Vec<Ring> {
+    rings
+        .iter()
+        .map(|ring| decimate_ring_inward(ring, deviation_mm))
+        .collect()
+}
+
+fn decimate_ring_inward(ring: &Ring, deviation_mm: f64) -> Ring {
+    if ring.len() < 4 {
+        return ring.clone();
+    }
+    let point = |index: usize| {
+        let [x, y] = ring[index % ring.len()];
+        Point::new(x, y)
+    };
+    // Rings keep material on the left of travel, so a chord absorbs the
+    // vertices between its ends exactly when every one lies on the chord's
+    // right — the removed bulge is material — and within the deviation.
+    // Every chord re-checks its whole chain, so error cannot accumulate.
+    let chord_absorbs = |anchor: usize, end: usize| {
+        let start = point(anchor);
+        let chord = point(end) - start;
+        let length = chord.length();
+        if length <= f64::EPSILON {
+            return false;
+        }
+        (anchor + 1..end).all(|index| {
+            let offset = point(index) - start;
+            let cross = chord.x * offset.y - chord.y * offset.x;
+            cross <= 0.0 && -cross / length <= deviation_mm
+        })
+    };
+
+    let mut kept = vec![ring[0]];
+    let mut anchor = 0;
+    while anchor + 1 < ring.len() {
+        // Grow the chord greedily; `end == ring.len()` is the closing chord
+        // back to the first vertex, which absorbs the remaining tail.
+        let mut end = anchor + 1;
+        while end < ring.len() && chord_absorbs(anchor, end + 1) {
+            end += 1;
+        }
+        if end == ring.len() {
+            break;
+        }
+        kept.push(ring[end]);
+        anchor = end;
+    }
+    if kept.len() < 3 {
+        return ring.clone();
+    }
+    kept
+}
+
+/// The closed edge cycle of one ring, as start/end point pairs.
+pub fn ring_edges(ring: &Ring) -> impl Iterator<Item = (Point, Point)> + '_ {
+    ring.iter()
+        .copied()
+        .zip(ring.iter().copied().cycle().skip(1))
+        .take(ring.len())
+        .map(|([x0, y0], [x1, y1])| (Point::new(x0, y0), Point::new(x1, y1)))
+}
+
 /// Signed area of one ring (positive when counter-clockwise).
 pub fn ring_signed_area(ring: &Ring) -> f64 {
     if ring.len() < 3 {
@@ -456,6 +522,16 @@ impl ContourSet {
             first = last;
         }
         result
+    }
+
+    /// Decimate the region's boundary so it only shrinks; see
+    /// [`decimate_rings_inward`].
+    pub fn decimate_inward(&self, deviation_mm: f64) -> Self {
+        Self::new(
+            decimate_rings_inward(&self.rings, deviation_mm),
+            FillRule::NonZero,
+            self.tolerance,
+        )
     }
 
     /// What fraction of each cell of a regular grid over `bounds` the region
@@ -1488,6 +1564,50 @@ fn segment_bbox(start: Point, end: Point) -> BBox {
 mod tests {
     use super::*;
     use crate::geom::shapes;
+
+    #[test]
+    fn inward_decimation_only_shrinks_and_respects_deviation() {
+        let ring = ContourSet::from_contours(
+            &[shapes::circle(10.0).unwrap(), shapes::circle(6.0).unwrap()],
+            FillRule::EvenOdd,
+            tol::REGION_MM,
+        );
+        let deviation = 0.05;
+        let decimated = ring.decimate_inward(deviation);
+
+        // The outer boundary decimates; the convex hole cannot lose a vertex
+        // without growing the region, so it stays exact.
+        let ring_len = |set: &ContourSet, hole: bool| {
+            set.rings
+                .iter()
+                .find(|ring| (ring_signed_area(ring) < 0.0) == hole)
+                .expect("annulus ring")
+                .len()
+        };
+        assert_eq!(
+            ring_len(&decimated, true),
+            ring_len(&ring, true),
+            "hole ring must stay exact"
+        );
+        assert!(
+            ring_len(&decimated, false) * 2 < ring_len(&ring, false),
+            "outer ring kept {} of {} vertices",
+            ring_len(&decimated, false),
+            ring_len(&ring, false)
+        );
+
+        // The region only shrinks: nothing outside the source survives.
+        assert!(decimated.difference(&ring).area() < 1e-9);
+
+        // Area loss is bounded by the deviation times the boundary length.
+        let perimeter: f64 = ring
+            .rings
+            .iter()
+            .flat_map(ring_edges)
+            .map(|(start, end)| start.distance_to(end))
+            .sum();
+        assert!(ring.area() - decimated.area() <= deviation * perimeter);
+    }
 
     #[test]
     fn fixed_grid_regularization_removes_sub_grid_geometry() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes fabrication geometry (IPC copper balance voids and area/density accounting) and boolean region ops; mistakes could affect panel copper density or CAM output, though scope is confined to copper-balance generation.
> 
> **Overview**
> **Copper balancing** no longer leaves thin sliver voids where boundary hexes graze the fill edge. Boundary voids are split at solve time into **instanced** lattice templates (when the circumscribed disk fits in the voidable region) versus **clipped, regularized** geometry for crossing cases; that unified `EdgeVoidEmission` drives density accounting, spatial smoothing, and IPC output so reported achieved density matches what is actually emitted.
> 
> **IPC export** adds a negative **`edge_void`** feature class (`CopperBalanceKind::EdgeVoid`) for pre-clipped contours, while full interior voids stay dictionary instances; the boundary web is **inward-decimated** for cheaper geometry without growing copper. **`decimate_inward`** on `ContourSet` shrinks boundaries only within a deviation bound.
> 
> Partial-void clipping is renamed/refined (`clipped_partial_voids`, `emission_partial_voids` with disk opening + decimation). Tests and the changelog are updated for the new emission path and round-trip area checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af68d5d3357c9401bc7c587a6bca010c5a04b195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->