### PR TITLE
Refresh same-name embedded models during footprint sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `pcb layout --sync-footprints` refreshes changed embedded 3D models even when their filenames stay the same.
 - `pcb bom` again colors planner-selected parts by green, yellow, and red sourceability tiers.
 - Copper balancing no longer emits sliver voids where boundary voids graze the fill boundary.
 

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -255,7 +255,7 @@ fn render_patches(source: &str, patches: &pcb_sexpr::PatchSet) -> anyhow::Result
 struct EmbeddedFileRecord {
     name: String,
     file_type: String,
-    checksum: String,
+    checksum: Option<String>,
     span: pcb_sexpr::Span,
     has_data: bool,
 }
@@ -291,9 +291,7 @@ fn embedded_file_records(items: &[pcb_sexpr::Sexpr]) -> anyhow::Result<Vec<Embed
             let file_type = child_atom(file, "type")
                 .with_context(|| format!("Embedded file `{name}` is missing its type"))?
                 .to_string();
-            let checksum = child_atom(file, "checksum")
-                .with_context(|| format!("Embedded file `{name}` is missing its checksum"))?
-                .to_ascii_uppercase();
+            let checksum = child_atom(file, "checksum").map(str::to_ascii_uppercase);
 
             Ok(EmbeddedFileRecord {
                 name,
@@ -371,7 +369,13 @@ fn source_embedded_models(
                 })?
                 .to_string();
             let candidate = SourceEmbeddedModel {
-                checksum: file.checksum,
+                checksum: file.checksum.clone().with_context(|| {
+                    format!(
+                        "Embedded model `{}` with data is missing its checksum in {}",
+                        file.name,
+                        source_path.display()
+                    )
+                })?,
                 file_text,
                 source_path: source_path.clone(),
             };
@@ -471,18 +475,23 @@ fn refresh_board_embedded_models(pcb_path: &Path, schematic: &Schematic) -> anyh
             .collect();
 
         for (name, source_model) in &source_models {
-            if let Some(nested) = nested_by_name.get(name.as_str()) {
-                if nested.checksum != source_model.checksum {
-                    anyhow::bail!(
-                        "Cannot update embedded model `{name}` to checksum {} because unmanaged footprint `{reference}` still uses checksum {}",
-                        source_model.checksum,
-                        nested.checksum
-                    );
-                }
-            } else if unmanaged_footprint_reference(footprint, name)
+            if let Some(nested) = nested_by_name.get(name.as_str())
+                && let Some(nested_checksum) = &nested.checksum
+                && nested_checksum != &source_model.checksum
+            {
+                anyhow::bail!(
+                    "Cannot update embedded model `{name}` to checksum {} because unmanaged footprint `{reference}` still uses checksum {}",
+                    source_model.checksum,
+                    nested_checksum
+                );
+            }
+
+            if unmanaged_footprint_reference(footprint, name)
                 && board_files_by_name
                     .get(name.as_str())
-                    .is_some_and(|board_file| board_file.checksum != source_model.checksum)
+                    .is_some_and(|board_file| {
+                        board_file.checksum.as_deref() != Some(source_model.checksum.as_str())
+                    })
             {
                 anyhow::bail!(
                     "Cannot update embedded model `{name}` because unmanaged footprint `{reference}` still uses the board payload"
@@ -502,10 +511,11 @@ fn refresh_board_embedded_models(pcb_path: &Path, schematic: &Schematic) -> anyh
                 board_file.file_type
             );
         }
-        if board_file.checksum != source_model.checksum {
+        if board_file.checksum.as_deref() != Some(source_model.checksum.as_str()) {
             info!(
                 "Refreshing embedded model {name}: {} -> {}",
-                board_file.checksum, source_model.checksum
+                board_file.checksum.as_deref().unwrap_or("<missing>"),
+                source_model.checksum
             );
             patches.replace_raw(board_file.span, source_model.file_text);
         }

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -252,12 +252,11 @@ fn render_patches(source: &str, patches: &pcb_sexpr::PatchSet) -> anyhow::Result
 }
 
 #[derive(Debug, Clone)]
-struct EmbeddedFileRecord {
+struct EmbeddedFilePayload {
     name: String,
     file_type: String,
-    checksum: Option<String>,
+    checksum: String,
     span: pcb_sexpr::Span,
-    has_data: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -271,7 +270,7 @@ fn child_atom<'a>(items: &'a [pcb_sexpr::Sexpr], name: &str) -> Option<&'a str> 
     pcb_sexpr::find_child_list(items, name)?.get(1)?.as_atom()
 }
 
-fn embedded_file_records(items: &[pcb_sexpr::Sexpr]) -> anyhow::Result<Vec<EmbeddedFileRecord>> {
+fn embedded_file_payloads(items: &[pcb_sexpr::Sexpr]) -> anyhow::Result<Vec<EmbeddedFilePayload>> {
     let Some(embedded_files) = pcb_sexpr::find_child_list(items, "embedded_files") else {
         return Ok(Vec::new());
     };
@@ -284,6 +283,9 @@ fn embedded_file_records(items: &[pcb_sexpr::Sexpr]) -> anyhow::Result<Vec<Embed
             (file.first().and_then(pcb_sexpr::Sexpr::as_sym) == Some("file"))
                 .then_some((node, file))
         })
+        .filter(|(_, file)| {
+            pcb_sexpr::find_child_list(file, "data").is_some_and(|data| data.len() > 1)
+        })
         .map(|(node, file)| {
             let name = child_atom(file, "name")
                 .with_context(|| "Embedded file is missing its name")?
@@ -291,15 +293,17 @@ fn embedded_file_records(items: &[pcb_sexpr::Sexpr]) -> anyhow::Result<Vec<Embed
             let file_type = child_atom(file, "type")
                 .with_context(|| format!("Embedded file `{name}` is missing its type"))?
                 .to_string();
-            let checksum = child_atom(file, "checksum").map(str::to_ascii_uppercase);
+            let checksum = child_atom(file, "checksum")
+                .with_context(|| {
+                    format!("Embedded file `{name}` with data is missing its checksum")
+                })?
+                .to_ascii_uppercase();
 
-            Ok(EmbeddedFileRecord {
+            Ok(EmbeddedFilePayload {
                 name,
                 file_type,
                 checksum,
                 span: node.span,
-                has_data: pcb_sexpr::find_child_list(file, "data")
-                    .is_some_and(|data| data.len() > 1),
             })
         })
         .collect()
@@ -318,20 +322,14 @@ fn source_footprint_path(
 
 fn source_embedded_models(
     schematic: &Schematic,
-) -> anyhow::Result<(BTreeMap<String, SourceEmbeddedModel>, HashSet<String>)> {
+) -> anyhow::Result<BTreeMap<String, SourceEmbeddedModel>> {
     let mut models: BTreeMap<String, SourceEmbeddedModel> = BTreeMap::new();
-    let mut managed_kiid_paths = HashSet::new();
     let mut visited_sources = HashSet::new();
 
-    for (instance_ref, instance) in &schematic.instances {
+    for instance in schematic.instances.values() {
         if instance.kind != InstanceKind::Component {
             continue;
         }
-
-        let component_path = instance_ref.instance_path.join(".");
-        managed_kiid_paths.insert(pcb_sch::kicad_identity::footprint_kiid_path(
-            &component_path,
-        ));
 
         let Some(AttributeValue::String(footprint)) = instance.attributes.get("footprint") else {
             continue;
@@ -353,8 +351,8 @@ fn source_embedded_models(
             .as_list()
             .with_context(|| format!("Source footprint {} is not a list", source_path.display()))?;
 
-        for file in embedded_file_records(root_items)? {
-            if file.file_type != "model" || !file.has_data {
+        for file in embedded_file_payloads(root_items)? {
+            if file.file_type != "model" {
                 continue;
             }
 
@@ -369,13 +367,7 @@ fn source_embedded_models(
                 })?
                 .to_string();
             let candidate = SourceEmbeddedModel {
-                checksum: file.checksum.clone().with_context(|| {
-                    format!(
-                        "Embedded model `{}` with data is missing its checksum in {}",
-                        file.name,
-                        source_path.display()
-                    )
-                })?,
+                checksum: file.checksum,
                 file_text,
                 source_path: source_path.clone(),
             };
@@ -397,38 +389,15 @@ fn source_embedded_models(
         }
     }
 
-    Ok((models, managed_kiid_paths))
-}
-
-fn board_footprint_is_managed(
-    footprint: &[pcb_sexpr::Sexpr],
-    managed_kiid_paths: &HashSet<String>,
-) -> bool {
-    let properties = pcb_sexpr::kicad::schematic_properties(footprint);
-    if properties.get("Path").is_some_and(|path| !path.is_empty()) {
-        return true;
-    }
-
-    child_atom(footprint, "path").is_some_and(|path| managed_kiid_paths.contains(path))
-}
-
-fn unmanaged_footprint_reference(footprint: &[pcb_sexpr::Sexpr], name: &str) -> bool {
-    let link = format!("kicad-embed://{name}");
-    footprint.iter().skip(1).any(|node| {
-        let Some(model) = node.as_list() else {
-            return false;
-        };
-        model.first().and_then(pcb_sexpr::Sexpr::as_sym) == Some("model")
-            && model.get(1).and_then(pcb_sexpr::Sexpr::as_atom) == Some(link.as_str())
-    })
+    Ok(models)
 }
 
 /// Replace stale board-level model payloads before KiCad loads the board.
 ///
 /// KiCad consolidates footprint payloads by filename and otherwise keeps the existing board entry,
-/// so a freshly loaded footprint cannot replace same-named bytes during serialization.
+/// so `--sync-footprints` makes each source model authoritative for its filename.
 fn refresh_board_embedded_models(pcb_path: &Path, schematic: &Schematic) -> anyhow::Result<()> {
-    let (source_models, managed_kiid_paths) = source_embedded_models(schematic)?;
+    let source_models = source_embedded_models(schematic)?;
     if source_models.is_empty() {
         return Ok(());
     }
@@ -440,87 +409,18 @@ fn refresh_board_embedded_models(pcb_path: &Path, schematic: &Schematic) -> anyh
     let board_items = board
         .as_list()
         .with_context(|| format!("PCB file {} is not a list", pcb_path.display()))?;
-    let board_files = embedded_file_records(board_items)?;
-    let mut board_files_by_name: BTreeMap<&str, &EmbeddedFileRecord> = BTreeMap::new();
-
-    for file in &board_files {
-        if let Some(existing) = board_files_by_name.insert(&file.name, file)
-            && (existing.checksum != file.checksum || existing.file_type != file.file_type)
-        {
-            anyhow::bail!(
-                "Board contains conflicting embedded files named `{}`",
-                file.name
-            );
-        }
-    }
-
-    for node in board_items.iter().skip(1) {
-        let Some(footprint) = node.as_list() else {
-            continue;
-        };
-        if footprint.first().and_then(pcb_sexpr::Sexpr::as_sym) != Some("footprint")
-            || board_footprint_is_managed(footprint, &managed_kiid_paths)
-        {
-            continue;
-        }
-
-        let reference = pcb_sexpr::kicad::schematic_properties(footprint)
-            .get("Reference")
-            .cloned()
-            .unwrap_or_else(|| "<unmanaged footprint>".to_string());
-        let nested_files = embedded_file_records(footprint)?;
-        let nested_by_name: BTreeMap<&str, &EmbeddedFileRecord> = nested_files
-            .iter()
-            .map(|file| (file.name.as_str(), file))
-            .collect();
-
-        for (name, source_model) in &source_models {
-            let nested_checksum = nested_by_name
-                .get(name.as_str())
-                .and_then(|nested| nested.checksum.as_deref());
-            if let Some(nested_checksum) = nested_checksum
-                && nested_checksum != source_model.checksum
-            {
-                anyhow::bail!(
-                    "Cannot update embedded model `{name}` to checksum {} because unmanaged footprint `{reference}` still uses checksum {}",
-                    source_model.checksum,
-                    nested_checksum
-                );
-            }
-
-            if nested_checksum.is_none()
-                && unmanaged_footprint_reference(footprint, name)
-                && board_files_by_name
-                    .get(name.as_str())
-                    .is_some_and(|board_file| {
-                        board_file.checksum.as_deref() != Some(source_model.checksum.as_str())
-                    })
-            {
-                anyhow::bail!(
-                    "Cannot update embedded model `{name}` because unmanaged footprint `{reference}` still uses the board payload"
-                );
-            }
-        }
-    }
 
     let mut patches = pcb_sexpr::PatchSet::new();
-    for (name, source_model) in source_models {
-        let Some(board_file) = board_files_by_name.get(name.as_str()) else {
+    for board_file in embedded_file_payloads(board_items)? {
+        let Some(source_model) = source_models.get(&board_file.name) else {
             continue;
         };
-        if board_file.file_type != "model" {
-            anyhow::bail!(
-                "Cannot update embedded model `{name}` because the board contains a same-named embedded {}",
-                board_file.file_type
-            );
-        }
-        if board_file.checksum.as_deref() != Some(source_model.checksum.as_str()) {
+        if board_file.checksum != source_model.checksum {
             info!(
-                "Refreshing embedded model {name}: {} -> {}",
-                board_file.checksum.as_deref().unwrap_or("<missing>"),
-                source_model.checksum
+                "Refreshing embedded model {}: {} -> {}",
+                board_file.name, board_file.checksum, source_model.checksum
             );
-            patches.replace_raw(board_file.span, source_model.file_text);
+            patches.replace_raw(board_file.span, source_model.file_text.clone());
         }
     }
 

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -251,6 +251,273 @@ fn render_patches(source: &str, patches: &pcb_sexpr::PatchSet) -> anyhow::Result
     String::from_utf8(out).context("Patched PCB is not valid UTF-8")
 }
 
+#[derive(Debug, Clone)]
+struct EmbeddedFileRecord {
+    name: String,
+    file_type: String,
+    checksum: String,
+    span: pcb_sexpr::Span,
+    has_data: bool,
+}
+
+#[derive(Debug, Clone)]
+struct SourceEmbeddedModel {
+    checksum: String,
+    file_text: String,
+    source_path: PathBuf,
+}
+
+fn child_atom<'a>(items: &'a [pcb_sexpr::Sexpr], name: &str) -> Option<&'a str> {
+    pcb_sexpr::find_child_list(items, name)?.get(1)?.as_atom()
+}
+
+fn embedded_file_records(items: &[pcb_sexpr::Sexpr]) -> anyhow::Result<Vec<EmbeddedFileRecord>> {
+    let Some(embedded_files) = pcb_sexpr::find_child_list(items, "embedded_files") else {
+        return Ok(Vec::new());
+    };
+
+    embedded_files
+        .iter()
+        .skip(1)
+        .filter_map(|node| {
+            let file = node.as_list()?;
+            (file.first().and_then(pcb_sexpr::Sexpr::as_sym) == Some("file"))
+                .then_some((node, file))
+        })
+        .map(|(node, file)| {
+            let name = child_atom(file, "name")
+                .with_context(|| "Embedded file is missing its name")?
+                .to_string();
+            let file_type = child_atom(file, "type")
+                .with_context(|| format!("Embedded file `{name}` is missing its type"))?
+                .to_string();
+            let checksum = child_atom(file, "checksum")
+                .with_context(|| format!("Embedded file `{name}` is missing its checksum"))?
+                .to_ascii_uppercase();
+
+            Ok(EmbeddedFileRecord {
+                name,
+                file_type,
+                checksum,
+                span: node.span,
+                has_data: pcb_sexpr::find_child_list(file, "data")
+                    .is_some_and(|data| data.len() > 1),
+            })
+        })
+        .collect()
+}
+
+fn source_footprint_path(
+    footprint: &str,
+    package_roots: &BTreeMap<String, PathBuf>,
+) -> anyhow::Result<PathBuf> {
+    if footprint.starts_with(pcb_sch::PACKAGE_URI_PREFIX) {
+        pcb_sch::resolve_package_uri(footprint, package_roots)
+    } else {
+        Ok(PathBuf::from(footprint))
+    }
+}
+
+fn source_embedded_models(
+    schematic: &Schematic,
+) -> anyhow::Result<(BTreeMap<String, SourceEmbeddedModel>, HashSet<String>)> {
+    let mut models: BTreeMap<String, SourceEmbeddedModel> = BTreeMap::new();
+    let mut managed_kiid_paths = HashSet::new();
+    let mut visited_sources = HashSet::new();
+
+    for (instance_ref, instance) in &schematic.instances {
+        if instance.kind != InstanceKind::Component {
+            continue;
+        }
+
+        let component_path = instance_ref.instance_path.join(".");
+        managed_kiid_paths.insert(pcb_sch::kicad_identity::footprint_kiid_path(
+            &component_path,
+        ));
+
+        let Some(AttributeValue::String(footprint)) = instance.attributes.get("footprint") else {
+            continue;
+        };
+        let source_path = source_footprint_path(footprint, &schematic.package_roots)
+            .with_context(|| format!("Failed to resolve footprint path `{footprint}`"))?;
+        if !visited_sources.insert(source_path.clone()) {
+            continue;
+        }
+        let source = fs::read_to_string(&source_path).with_context(|| {
+            format!("Failed to read source footprint {}", source_path.display())
+        })?;
+        pcb_sexpr::kicad::footprint::validate_footprint_source(&source)
+            .with_context(|| format!("Invalid source footprint {}", source_path.display()))?;
+        let root = pcb_sexpr::parse(&source).with_context(|| {
+            format!("Failed to parse source footprint {}", source_path.display())
+        })?;
+        let root_items = root
+            .as_list()
+            .with_context(|| format!("Source footprint {} is not a list", source_path.display()))?;
+
+        for file in embedded_file_records(root_items)? {
+            if file.file_type != "model" || !file.has_data {
+                continue;
+            }
+
+            let file_text = source
+                .get(file.span.start..file.span.end)
+                .with_context(|| {
+                    format!(
+                        "Embedded model `{}` has an invalid source span in {}",
+                        file.name,
+                        source_path.display()
+                    )
+                })?
+                .to_string();
+            let candidate = SourceEmbeddedModel {
+                checksum: file.checksum,
+                file_text,
+                source_path: source_path.clone(),
+            };
+
+            if let Some(existing) = models.get(&file.name)
+                && existing.checksum != candidate.checksum
+            {
+                anyhow::bail!(
+                    "Cannot synchronize embedded model `{}`: source footprints {} and {} contain different payloads ({} and {})",
+                    file.name,
+                    existing.source_path.display(),
+                    candidate.source_path.display(),
+                    existing.checksum,
+                    candidate.checksum
+                );
+            }
+
+            models.entry(file.name).or_insert(candidate);
+        }
+    }
+
+    Ok((models, managed_kiid_paths))
+}
+
+fn board_footprint_is_managed(
+    footprint: &[pcb_sexpr::Sexpr],
+    managed_kiid_paths: &HashSet<String>,
+) -> bool {
+    let properties = pcb_sexpr::kicad::schematic_properties(footprint);
+    if properties.get("Path").is_some_and(|path| !path.is_empty()) {
+        return true;
+    }
+
+    child_atom(footprint, "path").is_some_and(|path| managed_kiid_paths.contains(path))
+}
+
+fn unmanaged_footprint_reference(footprint: &[pcb_sexpr::Sexpr], name: &str) -> bool {
+    let link = format!("kicad-embed://{name}");
+    footprint.iter().skip(1).any(|node| {
+        let Some(model) = node.as_list() else {
+            return false;
+        };
+        model.first().and_then(pcb_sexpr::Sexpr::as_sym) == Some("model")
+            && model.get(1).and_then(pcb_sexpr::Sexpr::as_atom) == Some(link.as_str())
+    })
+}
+
+/// Replace stale board-level model payloads before KiCad loads the board.
+///
+/// KiCad consolidates footprint payloads by filename and otherwise keeps the existing board entry,
+/// so a freshly loaded footprint cannot replace same-named bytes during serialization.
+fn refresh_board_embedded_models(pcb_path: &Path, schematic: &Schematic) -> anyhow::Result<()> {
+    let (source_models, managed_kiid_paths) = source_embedded_models(schematic)?;
+    if source_models.is_empty() {
+        return Ok(());
+    }
+
+    let board_source = fs::read_to_string(pcb_path)
+        .with_context(|| format!("Failed to read PCB file: {}", pcb_path.display()))?;
+    let board = pcb_sexpr::parse(&board_source)
+        .with_context(|| format!("Failed to parse PCB file: {}", pcb_path.display()))?;
+    let board_items = board
+        .as_list()
+        .with_context(|| format!("PCB file {} is not a list", pcb_path.display()))?;
+    let board_files = embedded_file_records(board_items)?;
+    let mut board_files_by_name: BTreeMap<&str, &EmbeddedFileRecord> = BTreeMap::new();
+
+    for file in &board_files {
+        if let Some(existing) = board_files_by_name.insert(&file.name, file)
+            && (existing.checksum != file.checksum || existing.file_type != file.file_type)
+        {
+            anyhow::bail!(
+                "Board contains conflicting embedded files named `{}`",
+                file.name
+            );
+        }
+    }
+
+    for node in board_items.iter().skip(1) {
+        let Some(footprint) = node.as_list() else {
+            continue;
+        };
+        if footprint.first().and_then(pcb_sexpr::Sexpr::as_sym) != Some("footprint")
+            || board_footprint_is_managed(footprint, &managed_kiid_paths)
+        {
+            continue;
+        }
+
+        let reference = pcb_sexpr::kicad::schematic_properties(footprint)
+            .get("Reference")
+            .cloned()
+            .unwrap_or_else(|| "<unmanaged footprint>".to_string());
+        let nested_files = embedded_file_records(footprint)?;
+        let nested_by_name: BTreeMap<&str, &EmbeddedFileRecord> = nested_files
+            .iter()
+            .map(|file| (file.name.as_str(), file))
+            .collect();
+
+        for (name, source_model) in &source_models {
+            if let Some(nested) = nested_by_name.get(name.as_str()) {
+                if nested.checksum != source_model.checksum {
+                    anyhow::bail!(
+                        "Cannot update embedded model `{name}` to checksum {} because unmanaged footprint `{reference}` still uses checksum {}",
+                        source_model.checksum,
+                        nested.checksum
+                    );
+                }
+            } else if unmanaged_footprint_reference(footprint, name)
+                && board_files_by_name
+                    .get(name.as_str())
+                    .is_some_and(|board_file| board_file.checksum != source_model.checksum)
+            {
+                anyhow::bail!(
+                    "Cannot update embedded model `{name}` because unmanaged footprint `{reference}` still uses the board payload"
+                );
+            }
+        }
+    }
+
+    let mut patches = pcb_sexpr::PatchSet::new();
+    for (name, source_model) in source_models {
+        let Some(board_file) = board_files_by_name.get(name.as_str()) else {
+            continue;
+        };
+        if board_file.file_type != "model" {
+            anyhow::bail!(
+                "Cannot update embedded model `{name}` because the board contains a same-named embedded {}",
+                board_file.file_type
+            );
+        }
+        if board_file.checksum != source_model.checksum {
+            info!(
+                "Refreshing embedded model {name}: {} -> {}",
+                board_file.checksum, source_model.checksum
+            );
+            patches.replace_raw(board_file.span, source_model.file_text);
+        }
+    }
+
+    if !patches.is_empty() {
+        apply_source_preserving_patches_to_file(pcb_path, &board_source, &patches)?;
+    }
+
+    Ok(())
+}
+
 /// Apply moved() path renames to a PCB file
 fn apply_moved_paths(
     pcb_path: &Path,
@@ -552,6 +819,10 @@ pub fn process_layout(
     );
 
     ensure_board_compatible_with_installed_kicad(&paths.pcb)?;
+
+    if pcb_exists && options.sync_footprints {
+        refresh_board_embedded_models(&paths.pcb, schematic)?;
+    }
 
     // Check for moved() paths that can't be applied to submodule layouts (always warn)
     for warning in check_submodule_moved_paths(schematic) {

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -475,9 +475,11 @@ fn refresh_board_embedded_models(pcb_path: &Path, schematic: &Schematic) -> anyh
             .collect();
 
         for (name, source_model) in &source_models {
-            if let Some(nested) = nested_by_name.get(name.as_str())
-                && let Some(nested_checksum) = &nested.checksum
-                && nested_checksum != &source_model.checksum
+            let nested_checksum = nested_by_name
+                .get(name.as_str())
+                .and_then(|nested| nested.checksum.as_deref());
+            if let Some(nested_checksum) = nested_checksum
+                && nested_checksum != source_model.checksum
             {
                 anyhow::bail!(
                     "Cannot update embedded model `{name}` to checksum {} because unmanaged footprint `{reference}` still uses checksum {}",
@@ -486,7 +488,8 @@ fn refresh_board_embedded_models(pcb_path: &Path, schematic: &Schematic) -> anyh
                 );
             }
 
-            if unmanaged_footprint_reference(footprint, name)
+            if nested_checksum.is_none()
+                && unmanaged_footprint_reference(footprint, name)
                 && board_files_by_name
                     .get(name.as_str())
                     .is_some_and(|board_file| {

--- a/crates/pcb-layout/tests/sync_footprints.rs
+++ b/crates/pcb-layout/tests/sync_footprints.rs
@@ -88,11 +88,6 @@ fn sync_footprints_reloads_same_fpid_models_and_preserves_board_state() -> Resul
 
     let source = std::fs::read_to_string(&footprint_file)?;
     let source = embed_step_in_footprint(source, old_step.to_vec(), "BMI270.step")?;
-    let source = source.replacen(
-        "(embedded_files",
-        "(embedded_files\n\t\t(file (name \"unused.step\") (type model))",
-        1,
-    );
     std::fs::write(&footprint_file, source)?;
 
     let schematic = evaluate_board(&zen_file, resolution.clone())?;

--- a/crates/pcb-layout/tests/sync_footprints.rs
+++ b/crates/pcb-layout/tests/sync_footprints.rs
@@ -88,6 +88,11 @@ fn sync_footprints_reloads_same_fpid_models_and_preserves_board_state() -> Resul
 
     let source = std::fs::read_to_string(&footprint_file)?;
     let source = embed_step_in_footprint(source, old_step.to_vec(), "BMI270.step")?;
+    let source = source.replacen(
+        "(embedded_files",
+        "(embedded_files\n\t\t(file (name \"unused.step\") (type model))",
+        1,
+    );
     std::fs::write(&footprint_file, source)?;
 
     let schematic = evaluate_board(&zen_file, resolution.clone())?;

--- a/crates/pcb-layout/tests/sync_footprints.rs
+++ b/crates/pcb-layout/tests/sync_footprints.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
+use pcb_kicad::footprint::embed_step_in_footprint;
 use pcb_layout::{LayoutOptions, process_layout};
+use pcb_sexpr::kicad::footprint::embedded_file_checksum;
 use pcb_zen_core::{DefaultFileProvider, Diagnostics};
 
 use crate::helpers::*;
@@ -79,6 +81,14 @@ fn sync_footprints_reloads_same_fpid_models_and_preserves_board_state() -> Resul
     let (temp, resolution) = prepare_simple_workspace()?;
     let zen_file = temp.path().join("MyBoard.zen");
     let footprint_file = temp.path().join("eda/BMI270.kicad_mod");
+    let old_step = b"ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION(('old model'),'2;1');\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n";
+    let new_step = b"ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION(('new model'),'2;1');\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n";
+    let old_checksum = embedded_file_checksum(old_step);
+    let new_checksum = embedded_file_checksum(new_step);
+
+    let source = std::fs::read_to_string(&footprint_file)?;
+    let source = embed_step_in_footprint(source, old_step.to_vec(), "BMI270.step")?;
+    std::fs::write(&footprint_file, source)?;
 
     let schematic = evaluate_board(&zen_file, resolution.clone())?;
     let mut diagnostics = Diagnostics::default();
@@ -90,6 +100,7 @@ fn sync_footprints_reloads_same_fpid_models_and_preserves_board_state() -> Resul
     let initial_placement = placement_state(initial_ic1);
     let initial_board = std::fs::read_to_string(&initial.pcb_file)?;
     assert!(initial_board.contains("(xyz -90 0 0)"));
+    assert!(initial_board.contains(&old_checksum));
     add_test_track(&initial.pcb_file)?;
 
     let source = std::fs::read_to_string(&footprint_file)?;
@@ -98,6 +109,7 @@ fn sync_footprints_reloads_same_fpid_models_and_preserves_board_state() -> Resul
         source, updated_source,
         "test fixture model transform was not found"
     );
+    let updated_source = embed_step_in_footprint(updated_source, new_step.to_vec(), "BMI270.step")?;
     std::fs::write(&footprint_file, updated_source)?;
 
     let schematic = evaluate_board(&zen_file, resolution.clone())?;
@@ -107,12 +119,14 @@ fn sync_footprints_reloads_same_fpid_models_and_preserves_board_state() -> Resul
     let unchanged_board = std::fs::read_to_string(&unchanged.pcb_file)?;
     assert!(unchanged_board.contains("(xyz -90 0 0)"));
     assert!(!unchanged_board.contains("(xyz -45 0 0)"));
+    assert!(unchanged_board.contains(&old_checksum));
+    assert!(!unchanged_board.contains(&new_checksum));
     let unchanged_snapshot: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&unchanged.snapshot_file)?)?;
     let unchanged_tracks = unchanged_snapshot["tracks"].clone();
     assert_eq!(unchanged_tracks.as_array().map(Vec::len), Some(1));
 
-    let schematic = evaluate_board(&zen_file, resolution)?;
+    let schematic = evaluate_board(&zen_file, resolution.clone())?;
     let mut diagnostics = Diagnostics::default();
     let synced = process_layout(
         &schematic,
@@ -127,12 +141,22 @@ fn sync_footprints_reloads_same_fpid_models_and_preserves_board_state() -> Resul
     let synced_board = std::fs::read_to_string(&synced.pcb_file)?;
     assert!(synced_board.contains("(xyz -45 0 0)"));
     assert!(!synced_board.contains("(xyz -90 0 0)"));
+    assert!(synced_board.contains(&new_checksum));
+    assert!(!synced_board.contains(&old_checksum));
     let synced_snapshot: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&synced.snapshot_file)?)?;
     let synced_ic1 = footprint_snapshot(&synced_snapshot, "IC1")?;
     assert_eq!(placement_state(synced_ic1), initial_placement);
     assert_eq!(synced_ic1["pads"], initial_ic1["pads"]);
     assert_eq!(synced_snapshot["tracks"], unchanged_tracks);
+
+    let schematic = evaluate_board(&zen_file, resolution)?;
+    let mut diagnostics = Diagnostics::default();
+    let reloaded = process_layout(&schematic, LayoutOptions::default(), &mut diagnostics)?
+        .context("reloaded layout was not generated")?;
+    let reloaded_board = std::fs::read_to_string(&reloaded.pcb_file)?;
+    assert!(reloaded_board.contains(&new_checksum));
+    assert!(!reloaded_board.contains(&old_checksum));
 
     Ok(())
 }


### PR DESCRIPTION
`pcb layout --sync-footprints` could keep an old board-embedded STEP payload when the source model changed but its filename did not. This change makes each source embedded model authoritative for its filename before KiCad loads the board, keeps only the unavoidable same-name source conflict, and verifies replacement without losing placement or routing.