### PR TITLE
Cache `pcb bom` offers + selection data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - `pcb bom` caches API matches for ten minutes and reuses an exact stale match offline or when an online refresh fails.
-- `pcb bom` writes an API-selected compatible MPN into output without replacing explicit or modifier-assigned parts.
+- `pcb bom` writes the API-selected compatible MPN and manufacturer into output.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb ipc dfm check` validates IPC-2581 files against fabrication PDKs.
 
+### Changed
+
+- `pcb bom` caches API matches for ten minutes and reuses exact stale matches offline or after transient failures while retaining its local-BOM fallback on cache misses.
+- `pcb bom` writes an API-selected compatible MPN into output without replacing explicit or modifier-assigned parts.
+
 ### Fixed
 
 - LSP navigation now resolves loaded symbols in the same package scope as evaluation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- `pcb bom` caches API matches for ten minutes and reuses exact stale matches offline or after transient failures while retaining its local-BOM fallback on cache misses.
+- `pcb bom` caches API matches for ten minutes and reuses an exact stale match offline or when an online refresh fails.
 - `pcb bom` writes an API-selected compatible MPN into output without replacing explicit or modifier-assigned parts.
 
 ### Fixed

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -1,10 +1,8 @@
 use anyhow::{Context, Result};
-use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::{
     collections::{HashMap, HashSet},
-    fmt,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -12,24 +10,15 @@ use pcb_sch::bom::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer, Sou
 
 use crate::{
     WorkspaceContext,
-    bom_cache::{BomMatchCache, CachedResponse, cache_identity},
+    bom_cache::{BomMatchCache, cache_key},
 };
 
 const BOM_MATCH_TIMEOUT_SECS: u64 = 120;
-const BOM_MATCH_CACHE_TTL_SECS: u64 = 10 * 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BomMatchMode {
     Online,
     Offline,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BomMatchSource {
-    Network,
-    FreshCache { age_seconds: u64 },
-    StaleCache { age_seconds: Option<u64> },
-    OfflineCacheMiss,
 }
 
 /// Price break structure
@@ -155,24 +144,6 @@ impl MatchBomResponse {
 }
 
 #[derive(Debug)]
-struct MatchRequestError {
-    transient: bool,
-    error: anyhow::Error,
-}
-
-impl fmt::Display for MatchRequestError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.error.fmt(formatter)
-    }
-}
-
-impl std::error::Error for MatchRequestError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.error.source()
-    }
-}
-
-#[derive(Debug)]
 struct PreparedBomMatch {
     availability: HashMap<String, Availability>,
     selected_parts: HashMap<String, (String, String)>,
@@ -288,40 +259,26 @@ fn send_bom_match_request(
     request_body: &serde_json::Value,
     timeout_secs: u64,
     strict: bool,
-) -> std::result::Result<String, MatchRequestError> {
+) -> Result<String> {
     let url = bom_match_url(ctx.api_base_url(), strict);
 
     let client = Client::builder()
         .timeout(Duration::from_secs(timeout_secs))
-        .build()
-        .map_err(|error| MatchRequestError {
-            transient: false,
-            error: error.into(),
-        })?;
+        .build()?;
 
     let response = crate::auth::apply_bearer_auth(client.post(&url), auth_token)
         .json(request_body)
         .send()
-        .map_err(|error| MatchRequestError {
-            transient: true,
-            error: anyhow::Error::new(error).context("Failed to send BOM match request"),
-        })?;
+        .context("Failed to send BOM match request")?;
 
     let status = response.status();
-    let response_text = response.text().map_err(|error| MatchRequestError {
-        transient: true,
-        error: anyhow::Error::new(error).context("Failed to read BOM match response"),
-    })?;
-
-    if !status.is_success() {
-        let transient = status == StatusCode::REQUEST_TIMEOUT
-            || status == StatusCode::TOO_MANY_REQUESTS
-            || status.is_server_error();
-        return Err(MatchRequestError {
-            transient,
-            error: anyhow::anyhow!("BOM match request failed ({}): {}", status, response_text),
-        });
-    }
+    let response_text = response
+        .text()
+        .context("Failed to read BOM match response")?;
+    anyhow::ensure!(
+        status.is_success(),
+        "BOM match request failed ({status}): {response_text}"
+    );
 
     Ok(response_text)
 }
@@ -336,8 +293,7 @@ fn call_bom_match_api(
 ) -> Result<MatchBomResponse> {
     let request_body = bom_match_request(bom_entries);
     let response_text =
-        send_bom_match_request(ctx, auth_token, &request_body, timeout_secs, strict)
-            .map_err(anyhow::Error::new)?;
+        send_bom_match_request(ctx, auth_token, &request_body, timeout_secs, strict)?;
     serde_json::from_str(&response_text).context("Failed to parse BOM match response")
 }
 
@@ -353,6 +309,10 @@ fn prepare_bom_match(
     bom: &pcb_sch::bom::Bom,
     match_response: &MatchBomResponse,
 ) -> Result<PreparedBomMatch> {
+    anyhow::ensure!(
+        !match_response.needs_retry(),
+        "BOM matching could not complete"
+    );
     let expected_paths = bom.entries.keys().cloned().collect::<HashSet<_>>();
     anyhow::ensure!(
         match_response.results.len() == expected_paths.len(),
@@ -381,13 +341,8 @@ fn prepare_bom_match(
         );
 
         let entry = &bom.entries[path];
-        let mut seen_offer_ids = HashSet::new();
         let mut resolved_offers = Vec::with_capacity(bom_line.offer_ids.len());
         for offer_id in &bom_line.offer_ids {
-            anyhow::ensure!(
-                seen_offer_ids.insert(offer_id),
-                "BOM match response repeated offer {offer_id} for {path}"
-            );
             let offer = match_response.offers.get(offer_id).with_context(|| {
                 format!("BOM match response omitted referenced offer {offer_id} for {path}")
             })?;
@@ -411,7 +366,7 @@ fn prepare_bom_match(
             let selected_offer = match_response
                 .offers
                 .get(selected_offer_id)
-                .expect("selected offer was validated as a ranked offer");
+                .with_context(|| format!("BOM match response omitted offer {selected_offer_id}"))?;
 
             if bom_line.match_status == BomMatchStatus::Compatible
                 && entry.mpn.is_none()
@@ -450,7 +405,10 @@ fn prepare_bom_match(
             summarize_region(&resolved_offers, Geography::Global, target_qty, qty);
         for (summary, offers) in [(&mut us, &us_offers), (&mut global, &global_offers)] {
             if let (Some(summary), Some(offer)) = (summary, offers.first()) {
-                summary.stock_class = bom_line.offer_stock_classes[&offer.id];
+                summary.stock_class = *bom_line
+                    .offer_stock_classes
+                    .get(&offer.id)
+                    .expect("validated offer stock class");
             }
         }
 
@@ -470,55 +428,38 @@ fn prepare_bom_match(
         );
     }
 
-    anyhow::ensure!(
-        seen_paths == expected_paths,
-        "BOM match response did not cover every requested path"
-    );
-
     Ok(PreparedBomMatch {
         availability,
         selected_parts,
     })
 }
 
-#[derive(Debug)]
-struct PreparedCachedMatch {
-    prepared: PreparedBomMatch,
-    age_seconds: Option<u64>,
-    fresh: bool,
+fn prepare_response(bom: &pcb_sch::bom::Bom, response_json: &str) -> Result<PreparedBomMatch> {
+    let response =
+        serde_json::from_str(response_json).context("Failed to parse BOM match response")?;
+    prepare_bom_match(bom, &response)
 }
 
-fn prepare_cached_match(
-    cached: CachedResponse,
+fn load_cached_match(
+    cache: Option<&BomMatchCache>,
+    key: &str,
     bom: &pcb_sch::bom::Bom,
     now: i64,
-) -> Result<PreparedCachedMatch> {
-    let response: MatchBomResponse = serde_json::from_str(&cached.response_json)
-        .context("Failed to parse cached BOM match response")?;
-    anyhow::ensure!(
-        !response.needs_retry(),
-        "Cached BOM match response contains a retryable result"
-    );
-    let prepared = prepare_bom_match(bom, &response)?;
-    let age_seconds = now
-        .checked_sub(cached.fetched_at)
-        .and_then(|age| u64::try_from(age).ok());
-    let fresh = age_seconds.is_some_and(|age| age < BOM_MATCH_CACHE_TTL_SECS);
-    Ok(PreparedCachedMatch {
-        prepared,
-        age_seconds,
-        fresh,
-    })
-}
-
-fn cache_source(cached: &PreparedCachedMatch) -> BomMatchSource {
-    if cached.fresh {
-        BomMatchSource::FreshCache {
-            age_seconds: cached.age_seconds.expect("fresh cache has a valid age"),
+) -> Option<(PreparedBomMatch, bool)> {
+    let cached = match cache?.load(key) {
+        Ok(Some(cached)) => cached,
+        Ok(None) => return None,
+        Err(error) => {
+            log::warn!("Ignoring unreadable BOM cache entry: {error:#}");
+            return None;
         }
-    } else {
-        BomMatchSource::StaleCache {
-            age_seconds: cached.age_seconds,
+    };
+    let fresh = cached.is_fresh(now);
+    match prepare_response(bom, &cached.response_json) {
+        Ok(prepared) => Some((prepared, fresh)),
+        Err(error) => {
+            log::warn!("Ignoring invalid BOM cache entry: {error:#}");
+            None
         }
     }
 }
@@ -551,8 +492,7 @@ pub fn fetch_and_populate_availability_with_context(
     bom: &mut pcb_sch::bom::Bom,
     strict: bool,
 ) -> Result<()> {
-    match_bom_with_context(ctx, auth_token, bom, strict, BomMatchMode::Online)?;
-    Ok(())
+    match_bom_with_context(ctx, auth_token, bom, strict, BomMatchMode::Online)
 }
 
 pub fn match_bom_with_context(
@@ -561,7 +501,7 @@ pub fn match_bom_with_context(
     bom: &mut pcb_sch::bom::Bom,
     strict: bool,
     mode: BomMatchMode,
-) -> Result<BomMatchSource> {
+) -> Result<()> {
     let cache = match BomMatchCache::open() {
         Ok(cache) => Some(cache),
         Err(error) => {
@@ -569,7 +509,7 @@ pub fn match_bom_with_context(
             None
         }
     };
-    fetch_and_populate_availability_with_cache(
+    match_bom_with_cache(
         ctx,
         auth_token,
         bom,
@@ -580,7 +520,7 @@ pub fn match_bom_with_context(
     )
 }
 
-fn fetch_and_populate_availability_with_cache(
+fn match_bom_with_cache(
     ctx: &WorkspaceContext,
     auth_token: Option<&str>,
     bom: &mut pcb_sch::bom::Bom,
@@ -588,81 +528,60 @@ fn fetch_and_populate_availability_with_cache(
     mode: BomMatchMode,
     cache: Option<&BomMatchCache>,
     now: i64,
-) -> Result<BomMatchSource> {
+) -> Result<()> {
     let bom_entries = bom_request_entries(bom)?;
-
     let request_body = bom_match_request(&bom_entries);
     let url = bom_match_url(ctx.api_base_url(), strict);
-    let identity = cache_identity(&url, &request_body)?;
-    let mut cached = cache.and_then(|cache| match cache.load(&identity) {
-        Ok(Some(cached)) => match prepare_cached_match(cached, bom, now) {
-            Ok(prepared) => Some(prepared),
-            Err(error) => {
-                log::warn!("Ignoring invalid cached BOM response: {error:#}");
-                None
-            }
-        },
-        Ok(None) => None,
-        Err(error) => {
-            log::warn!("Ignoring unreadable cached BOM response: {error:#}");
-            None
-        }
-    });
+    let key = cache_key(&url, &request_body)?;
+    let mut cached = load_cached_match(cache, &key, bom, now);
 
     if mode == BomMatchMode::Offline {
-        let Some(cached) = cached else {
-            return Ok(BomMatchSource::OfflineCacheMiss);
-        };
-        let source = cache_source(&cached);
-        cached.prepared.apply(bom);
-        return Ok(source);
+        if let Some((prepared, _)) = cached {
+            prepared.apply(bom);
+        }
+        return Ok(());
     }
 
-    if cached.as_ref().is_some_and(|cached| cached.fresh) {
-        let cached = cached.take().expect("checked fresh cached response");
-        let source = cache_source(&cached);
-        cached.prepared.apply(bom);
-        return Ok(source);
+    if cached.as_ref().is_some_and(|(_, fresh)| *fresh) {
+        cached
+            .take()
+            .expect("checked fresh cache entry")
+            .0
+            .apply(bom);
+        return Ok(());
     }
 
-    let response_json = match send_bom_match_request(
+    let live = send_bom_match_request(
         ctx,
         auth_token,
         &request_body,
         BOM_MATCH_TIMEOUT_SECS,
         strict,
-    ) {
-        Ok(response_json) => response_json,
-        Err(error) if error.transient && cached.is_some() => {
-            let cached = cached.take().expect("checked stale cached response");
-            let source = cache_source(&cached);
-            cached.prepared.apply(bom);
-            return Ok(source);
+    )
+    .and_then(|response_json| {
+        let prepared = prepare_response(bom, &response_json)?;
+        Ok((response_json, prepared))
+    });
+
+    match live {
+        Ok((response_json, prepared)) => {
+            if let Some(cache) = cache
+                && let Err(error) = cache.store(&key, &response_json, now)
+            {
+                log::warn!("Failed to update local BOM cache: {error:#}");
+            }
+            prepared.apply(bom);
+            Ok(())
         }
-        Err(error) => return Err(anyhow::Error::new(error)),
-    };
-
-    let match_response: MatchBomResponse =
-        serde_json::from_str(&response_json).context("Failed to parse BOM match response")?;
-    let prepared = prepare_bom_match(bom, &match_response)?;
-
-    if match_response.needs_retry() {
-        if let Some(cached) = cached {
-            let source = cache_source(&cached);
-            cached.prepared.apply(bom);
-            return Ok(source);
+        Err(error) => {
+            let Some((prepared, _)) = cached else {
+                return Err(error);
+            };
+            log::warn!("BOM matching failed; using stale cache: {error:#}");
+            prepared.apply(bom);
+            Ok(())
         }
-        anyhow::bail!("BOM matching could not complete and no cached response is available");
     }
-
-    if let Some(cache) = cache
-        && let Err(error) = cache.store(&identity, &response_json, now)
-    {
-        log::warn!("Failed to update local BOM cache: {error:#}");
-    }
-
-    prepared.apply(bom);
-    Ok(BomMatchSource::Network)
 }
 
 /// Component key for pricing requests
@@ -998,21 +917,6 @@ mod tests {
     }
 
     #[test]
-    fn missing_match_status_is_rejected() {
-        let response = serde_json::json!({
-            "results": [{
-                "designEntry": {"path": "root.U1"},
-                "offerIds": [],
-                "offerStockClasses": {},
-                "selectedOfferId": null
-            }],
-            "offers": {}
-        });
-
-        assert!(serde_json::from_value::<MatchBomResponse>(response).is_err());
-    }
-
-    #[test]
     fn first_ranked_regional_offer_wins() {
         let response: MatchBomResponse =
             serde_json::from_str(include_str!("../tests/fixtures/bom_match_api_order.json"))
@@ -1092,91 +996,91 @@ mod tests {
             "offers": {}
         }))
         .unwrap();
-        let mut response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
-        response.offers.get_mut("selected-offer").unwrap().id = "mismatched-offer".to_string();
         let bom = test_bom(None);
 
         assert!(prepare_bom_match(&bom, &incomplete).is_err());
-        assert!(prepare_bom_match(&bom, &response).is_err());
         assert!(bom.availability.is_empty());
         assert!(bom.entries["root.U1"].mpn.is_none());
     }
 
     #[test]
-    fn request_entries_exclude_previous_availability() {
-        let without_availability = test_bom(None);
-        let mut with_availability = without_availability.clone();
-        with_availability
-            .availability
-            .insert("root.U1".to_string(), Availability::default());
-
-        assert_eq!(
-            bom_request_entries(&without_availability).unwrap(),
-            bom_request_entries(&with_availability).unwrap()
-        );
-    }
-
-    #[test]
-    fn cache_expires_at_ten_minutes() {
-        let response_json = compatible_response().to_string();
-        let bom = test_bom(None);
-
-        for (now, expected_fresh) in [(1_599, true), (1_600, false)] {
-            let cached = CachedResponse {
-                response_json: response_json.clone(),
-                fetched_at: 1_000,
-            };
-            assert_eq!(
-                prepare_cached_match(cached, &bom, now).unwrap().fresh,
-                expected_fresh
-            );
-        }
-    }
-
-    #[test]
-    fn fresh_network_response_is_cached_for_online_and_offline_use() {
+    fn cache_policy_is_fresh_then_live_with_one_stale_fallback() {
         let server = MockServer::start();
-        let response = compatible_response();
-        let network = server.mock(|when, then| {
+        let mut success = server.mock(|when, then| {
             when.method(POST)
                 .path("/api/boms/match")
                 .query_param("strict", "true");
-            then.status(200).json_body(response);
+            then.status(200).json_body(compatible_response());
         });
         let tempdir = tempfile::tempdir().unwrap();
         let cache = cache_for(&tempdir);
         let context = WorkspaceContext::from_api_base_url(server.base_url());
 
-        let mut first = test_bom(None);
-        let source = fetch_and_populate_availability_with_cache(
+        let mut offline_miss = test_bom(None);
+        match_bom_with_cache(
             &context,
             None,
-            &mut first,
+            &mut offline_miss,
+            true,
+            BomMatchMode::Offline,
+            Some(&cache),
+            1_000,
+        )
+        .unwrap();
+        assert!(offline_miss.entries["root.U1"].mpn.is_none());
+        success.assert_calls(0);
+
+        let mut network = test_bom(None);
+        match_bom_with_cache(
+            &context,
+            None,
+            &mut network,
             true,
             BomMatchMode::Online,
             Some(&cache),
             1_000,
         )
         .unwrap();
-        assert_eq!(source, BomMatchSource::Network);
-        network.assert_calls(1);
+        assert_eq!(network.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
+        success.assert_calls(1);
 
-        let mut online = test_bom(None);
-        let source = fetch_and_populate_availability_with_cache(
+        let mut fresh = test_bom(None);
+        match_bom_with_cache(
             &context,
             None,
-            &mut online,
+            &mut fresh,
             true,
             BomMatchMode::Online,
             Some(&cache),
             1_100,
         )
         .unwrap();
-        assert_eq!(source, BomMatchSource::FreshCache { age_seconds: 100 });
-        network.assert_calls(1);
+        assert_eq!(fresh.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
+        success.assert_calls(1);
+        success.delete();
+
+        let failure = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/boms/match")
+                .query_param("strict", "true");
+            then.status(503).body("deploying");
+        });
+        let mut stale = test_bom(None);
+        match_bom_with_cache(
+            &context,
+            None,
+            &mut stale,
+            true,
+            BomMatchMode::Online,
+            Some(&cache),
+            2_000,
+        )
+        .unwrap();
+        assert_eq!(stale.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
+        failure.assert_calls(1);
 
         let mut offline = test_bom(None);
-        let source = fetch_and_populate_availability_with_cache(
+        match_bom_with_cache(
             &context,
             None,
             &mut offline,
@@ -1186,132 +1090,23 @@ mod tests {
             2_000,
         )
         .unwrap();
-        assert_eq!(
-            source,
-            BomMatchSource::StaleCache {
-                age_seconds: Some(1_000)
-            }
-        );
-        network.assert_calls(1);
         assert_eq!(offline.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
-    }
+        failure.assert_calls(1);
 
-    #[test]
-    fn stale_cache_only_falls_back_for_transient_online_failures() {
-        let server = MockServer::start();
-        let response = compatible_response();
-        let mut success = server.mock(|when, then| {
-            when.method(POST).path("/api/boms/match");
-            then.status(200).json_body(response);
-        });
-        let tempdir = tempfile::tempdir().unwrap();
-        let cache = cache_for(&tempdir);
-        let context = WorkspaceContext::from_api_base_url(server.base_url());
-
-        fetch_and_populate_availability_with_cache(
-            &context,
-            None,
-            &mut test_bom(None),
-            false,
-            BomMatchMode::Online,
-            Some(&cache),
-            1_000,
-        )
-        .unwrap();
-        success.delete();
-
-        let mut unavailable = server.mock(|when, then| {
-            when.method(POST).path("/api/boms/match");
-            then.status(503).body("deploying");
-        });
-        let mut transient = test_bom(None);
-        let source = fetch_and_populate_availability_with_cache(
-            &context,
-            None,
-            &mut transient,
-            false,
-            BomMatchMode::Online,
-            Some(&cache),
-            2_000,
-        )
-        .unwrap();
-        assert!(matches!(source, BomMatchSource::StaleCache { .. }));
-        assert_eq!(transient.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
-        unavailable.assert_calls(1);
-        unavailable.delete();
-
-        let retry_response = serde_json::json!({
-            "results": [{
-                "designEntry": {"path": "root.U1"},
-                "offerIds": [],
-                "offerStockClasses": {},
-                "match": "MATCH_NEEDS_RETRY",
-                "selectedOfferId": null
-            }],
-            "offers": {}
-        });
-        let mut retry = server.mock(|when, then| {
-            when.method(POST).path("/api/boms/match");
-            then.status(200).json_body(retry_response);
-        });
-        let mut retryable = test_bom(None);
-        let source = fetch_and_populate_availability_with_cache(
-            &context,
-            None,
-            &mut retryable,
-            false,
-            BomMatchMode::Online,
-            Some(&cache),
-            2_000,
-        )
-        .unwrap();
-        assert!(matches!(source, BomMatchSource::StaleCache { .. }));
-        assert_eq!(retryable.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
-        retry.assert_calls(1);
-        retry.delete();
-
-        let bad_request = server.mock(|when, then| {
-            when.method(POST).path("/api/boms/match");
-            then.status(400).body("invalid request");
-        });
-        let mut permanent = test_bom(None);
+        let mut no_cache = test_bom(None);
         assert!(
-            fetch_and_populate_availability_with_cache(
+            match_bom_with_cache(
                 &context,
                 None,
-                &mut permanent,
-                false,
+                &mut no_cache,
+                true,
                 BomMatchMode::Online,
-                Some(&cache),
+                None,
                 2_000,
             )
             .is_err()
         );
-        assert!(permanent.entries["root.U1"].mpn.is_none());
-        assert!(permanent.availability.is_empty());
-        bad_request.assert_calls(1);
-    }
-
-    #[test]
-    fn offline_cache_miss_does_not_mutate_the_bom() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let cache = cache_for(&tempdir);
-        let context = WorkspaceContext::from_api_base_url("http://127.0.0.1:1");
-        let mut bom = test_bom(None);
-
-        let source = fetch_and_populate_availability_with_cache(
-            &context,
-            None,
-            &mut bom,
-            true,
-            BomMatchMode::Offline,
-            Some(&cache),
-            1_000,
-        )
-        .unwrap();
-
-        assert_eq!(source, BomMatchSource::OfflineCacheMiss);
-        assert!(bom.entries["root.U1"].mpn.is_none());
-        assert!(bom.availability.is_empty());
+        assert!(no_cache.entries["root.U1"].mpn.is_none());
+        failure.assert_calls(2);
     }
 }

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -340,7 +340,6 @@ fn prepare_bom_match(
             "BOM match response returned duplicate path: {path}"
         );
 
-        let entry = &bom.entries[path];
         let mut resolved_offers = Vec::with_capacity(bom_line.offer_ids.len());
         for offer_id in &bom_line.offer_ids {
             let offer = match_response.offers.get(offer_id).with_context(|| {
@@ -368,11 +367,7 @@ fn prepare_bom_match(
                 .get(selected_offer_id)
                 .with_context(|| format!("BOM match response omitted offer {selected_offer_id}"))?;
 
-            if bom_line.match_status == BomMatchStatus::Compatible
-                && entry.mpn.is_none()
-                && entry.alternatives.is_empty()
-                && entry.generic_data.is_some()
-            {
+            if bom_line.match_status == BomMatchStatus::Compatible {
                 let mpn = selected_offer
                     .mpn
                     .as_deref()
@@ -809,11 +804,11 @@ mod tests {
         }
     }
 
-    fn test_bom(mpn: Option<&str>) -> Bom {
+    fn test_bom() -> Bom {
         let entry = BomEntry {
-            mpn: mpn.map(str::to_string),
+            mpn: None,
             alternatives: Vec::new(),
-            manufacturer: mpn.map(|_| "Original Manufacturer".to_string()),
+            manufacturer: None,
             package: Some("0603".to_string()),
             value: Some("10kOhm".to_string()),
             description: None,
@@ -959,33 +954,15 @@ mod tests {
     }
 
     #[test]
-    fn selected_compatible_offer_populates_only_unassigned_generic_parts() {
+    fn selected_compatible_offer_populates_part_identity() {
         let response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
 
-        let mut generic_bom = test_bom(None);
-        prepare_bom_match(&generic_bom, &response)
-            .unwrap()
-            .apply(&mut generic_bom);
+        let mut bom = test_bom();
+        prepare_bom_match(&bom, &response).unwrap().apply(&mut bom);
+        assert_eq!(bom.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
         assert_eq!(
-            generic_bom.entries["root.U1"].mpn.as_deref(),
-            Some("API-MPN")
-        );
-        assert_eq!(
-            generic_bom.entries["root.U1"].manufacturer.as_deref(),
+            bom.entries["root.U1"].manufacturer.as_deref(),
             Some("API Manufacturer")
-        );
-
-        let mut explicit_bom = test_bom(Some("EXPLICIT-MPN"));
-        prepare_bom_match(&explicit_bom, &response)
-            .unwrap()
-            .apply(&mut explicit_bom);
-        assert_eq!(
-            explicit_bom.entries["root.U1"].mpn.as_deref(),
-            Some("EXPLICIT-MPN")
-        );
-        assert_eq!(
-            explicit_bom.entries["root.U1"].manufacturer.as_deref(),
-            Some("Original Manufacturer")
         );
     }
 
@@ -996,7 +973,7 @@ mod tests {
             "offers": {}
         }))
         .unwrap();
-        let bom = test_bom(None);
+        let bom = test_bom();
 
         assert!(prepare_bom_match(&bom, &incomplete).is_err());
         assert!(bom.availability.is_empty());
@@ -1016,7 +993,7 @@ mod tests {
         let cache = cache_for(&tempdir);
         let context = WorkspaceContext::from_api_base_url(server.base_url());
 
-        let mut offline_miss = test_bom(None);
+        let mut offline_miss = test_bom();
         match_bom_with_cache(
             &context,
             None,
@@ -1030,7 +1007,7 @@ mod tests {
         assert!(offline_miss.entries["root.U1"].mpn.is_none());
         success.assert_calls(0);
 
-        let mut network = test_bom(None);
+        let mut network = test_bom();
         match_bom_with_cache(
             &context,
             None,
@@ -1044,7 +1021,7 @@ mod tests {
         assert_eq!(network.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
         success.assert_calls(1);
 
-        let mut fresh = test_bom(None);
+        let mut fresh = test_bom();
         match_bom_with_cache(
             &context,
             None,
@@ -1065,7 +1042,7 @@ mod tests {
                 .query_param("strict", "true");
             then.status(503).body("deploying");
         });
-        let mut stale = test_bom(None);
+        let mut stale = test_bom();
         match_bom_with_cache(
             &context,
             None,
@@ -1079,7 +1056,7 @@ mod tests {
         assert_eq!(stale.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
         failure.assert_calls(1);
 
-        let mut offline = test_bom(None);
+        let mut offline = test_bom();
         match_bom_with_cache(
             &context,
             None,
@@ -1093,7 +1070,7 @@ mod tests {
         assert_eq!(offline.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
         failure.assert_calls(1);
 
-        let mut no_cache = test_bom(None);
+        let mut no_cache = test_bom();
         assert!(
             match_bom_with_cache(
                 &context,

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -560,8 +560,9 @@ fn match_bom_with_cache(
 
     match live {
         Ok((response_json, prepared)) => {
+            let fetched_at = unix_now().unwrap_or(now);
             if let Some(cache) = cache
-                && let Err(error) = cache.store(&key, &response_json, now)
+                && let Err(error) = cache.store(&key, &response_json, fetched_at)
             {
                 log::warn!("Failed to update local BOM cache: {error:#}");
             }
@@ -992,6 +993,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let cache = cache_for(&tempdir);
         let context = WorkspaceContext::from_api_base_url(server.base_url());
+        let now = unix_now().unwrap();
 
         let mut offline_miss = test_bom();
         match_bom_with_cache(
@@ -1001,7 +1003,7 @@ mod tests {
             true,
             BomMatchMode::Offline,
             Some(&cache),
-            1_000,
+            now,
         )
         .unwrap();
         assert!(offline_miss.entries["root.U1"].mpn.is_none());
@@ -1015,7 +1017,7 @@ mod tests {
             true,
             BomMatchMode::Online,
             Some(&cache),
-            1_000,
+            now,
         )
         .unwrap();
         assert_eq!(network.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
@@ -1029,7 +1031,7 @@ mod tests {
             true,
             BomMatchMode::Online,
             Some(&cache),
-            1_100,
+            now + 100,
         )
         .unwrap();
         assert_eq!(fresh.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
@@ -1050,7 +1052,7 @@ mod tests {
             true,
             BomMatchMode::Online,
             Some(&cache),
-            2_000,
+            now + 1_000,
         )
         .unwrap();
         assert_eq!(stale.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
@@ -1064,7 +1066,7 @@ mod tests {
             true,
             BomMatchMode::Offline,
             Some(&cache),
-            2_000,
+            now + 1_000,
         )
         .unwrap();
         assert_eq!(offline.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
@@ -1079,7 +1081,7 @@ mod tests {
                 true,
                 BomMatchMode::Online,
                 None,
-                2_000,
+                now + 1_000,
             )
             .is_err()
         );

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -1,11 +1,36 @@
 use anyhow::{Context, Result};
+use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use serde::Deserialize;
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use pcb_sch::bom::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer, SourcingStockClass};
 
-use crate::WorkspaceContext;
+use crate::{
+    WorkspaceContext,
+    bom_cache::{BomMatchCache, CachedResponse, cache_identity},
+};
+
+const BOM_MATCH_TIMEOUT_SECS: u64 = 120;
+const BOM_MATCH_CACHE_TTL_SECS: u64 = 10 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BomMatchMode {
+    Online,
+    Offline,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BomMatchSource {
+    Network,
+    FreshCache { age_seconds: u64 },
+    StaleCache { age_seconds: Option<u64> },
+    OfflineCacheMiss,
+}
 
 /// Price break structure
 #[derive(Debug, Clone, Deserialize)]
@@ -104,12 +129,14 @@ struct BomLine {
     offer_ids: Vec<String>,
     #[serde(rename = "offerStockClasses")]
     offer_stock_classes: HashMap<String, SourcingStockClass>,
-    #[serde(rename = "match", default)]
-    match_status: Option<BomMatchStatus>,
+    #[serde(rename = "match")]
+    match_status: BomMatchStatus,
+    #[serde(rename = "selectedOfferId")]
+    selected_offer_id: Option<String>,
 }
 
 fn bom_line_no_match(bom_line: &BomLine) -> bool {
-    matches!(bom_line.match_status, Some(BomMatchStatus::Failed))
+    bom_line.match_status == BomMatchStatus::Failed
 }
 
 /// Response from /api/boms/match endpoint
@@ -117,6 +144,52 @@ fn bom_line_no_match(bom_line: &BomLine) -> bool {
 struct MatchBomResponse {
     results: Vec<BomLine>,
     offers: HashMap<String, ComponentOffer>,
+}
+
+impl MatchBomResponse {
+    fn needs_retry(&self) -> bool {
+        self.results
+            .iter()
+            .any(|line| line.match_status == BomMatchStatus::NeedsRetry)
+    }
+}
+
+#[derive(Debug)]
+struct MatchRequestError {
+    transient: bool,
+    error: anyhow::Error,
+}
+
+impl fmt::Display for MatchRequestError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(formatter)
+    }
+}
+
+impl std::error::Error for MatchRequestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.error.source()
+    }
+}
+
+#[derive(Debug)]
+struct PreparedBomMatch {
+    availability: HashMap<String, Availability>,
+    selected_parts: HashMap<String, (String, String)>,
+}
+
+impl PreparedBomMatch {
+    fn apply(self, bom: &mut pcb_sch::bom::Bom) {
+        for (path, (mpn, manufacturer)) in self.selected_parts {
+            let entry = bom
+                .entries
+                .get_mut(&path)
+                .expect("validated BOM selection path");
+            entry.mpn = Some(mpn);
+            entry.manufacturer = Some(manufacturer);
+        }
+        bom.availability = self.availability;
+    }
 }
 
 /// Calculate alt stock from offers, deduplicating by (distributor, mpn).
@@ -200,7 +273,60 @@ fn summarize_region<'a>(
     (regional, summary)
 }
 
-/// Call the BOM match API and return parsed response
+fn bom_match_request(bom_entries: &[serde_json::Value]) -> serde_json::Value {
+    serde_json::json!({
+        "designBom": bom_entries,
+        "format": "normalized",
+        "boardQuantity": BOARD_QUANTITY,
+        "regions": ["US", "GLOBAL"],
+    })
+}
+
+fn send_bom_match_request(
+    ctx: &WorkspaceContext,
+    auth_token: Option<&str>,
+    request_body: &serde_json::Value,
+    timeout_secs: u64,
+    strict: bool,
+) -> std::result::Result<String, MatchRequestError> {
+    let url = bom_match_url(ctx.api_base_url(), strict);
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|error| MatchRequestError {
+            transient: false,
+            error: error.into(),
+        })?;
+
+    let response = crate::auth::apply_bearer_auth(client.post(&url), auth_token)
+        .json(request_body)
+        .send()
+        .map_err(|error| MatchRequestError {
+            transient: true,
+            error: anyhow::Error::new(error).context("Failed to send BOM match request"),
+        })?;
+
+    let status = response.status();
+    let response_text = response.text().map_err(|error| MatchRequestError {
+        transient: true,
+        error: anyhow::Error::new(error).context("Failed to read BOM match response"),
+    })?;
+
+    if !status.is_success() {
+        let transient = status == StatusCode::REQUEST_TIMEOUT
+            || status == StatusCode::TOO_MANY_REQUESTS
+            || status.is_server_error();
+        return Err(MatchRequestError {
+            transient,
+            error: anyhow::anyhow!("BOM match request failed ({}): {}", status, response_text),
+        });
+    }
+
+    Ok(response_text)
+}
+
+/// Call the BOM match API and return a parsed response without using the CLI cache.
 fn call_bom_match_api(
     ctx: &WorkspaceContext,
     auth_token: Option<&str>,
@@ -208,37 +334,206 @@ fn call_bom_match_api(
     timeout_secs: u64,
     strict: bool,
 ) -> Result<MatchBomResponse> {
-    let url = bom_match_url(ctx.api_base_url(), strict);
-
-    let client = Client::builder()
-        .timeout(Duration::from_secs(timeout_secs))
-        .build()?;
-    let request_body = serde_json::json!({
-        "designBom": bom_entries,
-        "format": "normalized",
-        "boardQuantity": BOARD_QUANTITY,
-        "regions": ["US", "GLOBAL"],
-    });
-
-    let response = crate::auth::apply_bearer_auth(client.post(&url), auth_token)
-        .json(&request_body)
-        .send()
-        .context("Failed to send BOM match request")?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let error_text = response.text().unwrap_or_default();
-        anyhow::bail!("BOM match request failed ({}): {}", status, error_text);
-    }
-
-    response
-        .json()
-        .context("Failed to parse BOM match response")
+    let request_body = bom_match_request(bom_entries);
+    let response_text =
+        send_bom_match_request(ctx, auth_token, &request_body, timeout_secs, strict)
+            .map_err(anyhow::Error::new)?;
+    serde_json::from_str(&response_text).context("Failed to parse BOM match response")
 }
 
 fn bom_match_url(api_base_url: &str, strict: bool) -> String {
     let suffix = if strict { "?strict=true" } else { "" };
-    format!("{api_base_url}/api/boms/match{suffix}")
+    format!(
+        "{}/api/boms/match{suffix}",
+        api_base_url.trim_end_matches('/')
+    )
+}
+
+fn prepare_bom_match(
+    bom: &pcb_sch::bom::Bom,
+    match_response: &MatchBomResponse,
+) -> Result<PreparedBomMatch> {
+    let expected_paths = bom.entries.keys().cloned().collect::<HashSet<_>>();
+    anyhow::ensure!(
+        match_response.results.len() == expected_paths.len(),
+        "BOM match response returned {} results for {} requested paths",
+        match_response.results.len(),
+        expected_paths.len()
+    );
+
+    let mut seen_paths = HashSet::with_capacity(expected_paths.len());
+    let mut availability = HashMap::with_capacity(expected_paths.len());
+    let mut selected_parts = HashMap::new();
+
+    for bom_line in &match_response.results {
+        let path = bom_line
+            .design_entry
+            .path
+            .as_deref()
+            .context("BOM match response omitted a design entry path")?;
+        anyhow::ensure!(
+            expected_paths.contains(path),
+            "BOM match response returned an unknown path: {path}"
+        );
+        anyhow::ensure!(
+            seen_paths.insert(path.to_string()),
+            "BOM match response returned duplicate path: {path}"
+        );
+
+        let entry = &bom.entries[path];
+        let mut seen_offer_ids = HashSet::new();
+        let mut resolved_offers = Vec::with_capacity(bom_line.offer_ids.len());
+        for offer_id in &bom_line.offer_ids {
+            anyhow::ensure!(
+                seen_offer_ids.insert(offer_id),
+                "BOM match response repeated offer {offer_id} for {path}"
+            );
+            let offer = match_response.offers.get(offer_id).with_context(|| {
+                format!("BOM match response omitted referenced offer {offer_id} for {path}")
+            })?;
+            anyhow::ensure!(
+                offer.id == *offer_id,
+                "BOM match response keyed offer {offer_id} with mismatched ID {}",
+                offer.id
+            );
+            anyhow::ensure!(
+                bom_line.offer_stock_classes.contains_key(offer_id),
+                "BOM match response omitted the stock class for offer {offer_id}"
+            );
+            resolved_offers.push(offer);
+        }
+
+        if let Some(selected_offer_id) = &bom_line.selected_offer_id {
+            anyhow::ensure!(
+                bom_line.offer_ids.contains(selected_offer_id),
+                "BOM match response selected offer {selected_offer_id} outside the ranked offers for {path}"
+            );
+            let selected_offer = match_response
+                .offers
+                .get(selected_offer_id)
+                .expect("selected offer was validated as a ranked offer");
+
+            if bom_line.match_status == BomMatchStatus::Compatible
+                && entry.mpn.is_none()
+                && entry.alternatives.is_empty()
+                && entry.generic_data.is_some()
+            {
+                let mpn = selected_offer
+                    .mpn
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .context("Selected compatible offer omitted its MPN")?;
+                let manufacturer = selected_offer
+                    .manufacturer
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .context("Selected compatible offer omitted its manufacturer")?;
+                selected_parts.insert(
+                    path.to_string(),
+                    (mpn.to_string(), manufacturer.to_string()),
+                );
+            }
+        }
+
+        let qty = bom
+            .designators
+            .iter()
+            .filter(|(candidate_path, _)| candidate_path.as_str() == path)
+            .count() as i32;
+        let target_qty = qty * BOARD_QUANTITY;
+
+        let (us_offers, mut us) =
+            summarize_region(&resolved_offers, Geography::Us, target_qty, qty);
+        let (global_offers, mut global) =
+            summarize_region(&resolved_offers, Geography::Global, target_qty, qty);
+        for (summary, offers) in [(&mut us, &us_offers), (&mut global, &global_offers)] {
+            if let (Some(summary), Some(offer)) = (summary, offers.first()) {
+                summary.stock_class = bom_line.offer_stock_classes[&offer.id];
+            }
+        }
+
+        let all_offers = us_offers
+            .iter()
+            .chain(global_offers.iter())
+            .map(|offer| offer.to_offer(target_qty))
+            .collect();
+        availability.insert(
+            path.to_string(),
+            Availability {
+                us,
+                global,
+                no_match: bom_line_no_match(bom_line),
+                offers: all_offers,
+            },
+        );
+    }
+
+    anyhow::ensure!(
+        seen_paths == expected_paths,
+        "BOM match response did not cover every requested path"
+    );
+
+    Ok(PreparedBomMatch {
+        availability,
+        selected_parts,
+    })
+}
+
+#[derive(Debug)]
+struct PreparedCachedMatch {
+    prepared: PreparedBomMatch,
+    age_seconds: Option<u64>,
+    fresh: bool,
+}
+
+fn prepare_cached_match(
+    cached: CachedResponse,
+    bom: &pcb_sch::bom::Bom,
+    now: i64,
+) -> Result<PreparedCachedMatch> {
+    let response: MatchBomResponse = serde_json::from_str(&cached.response_json)
+        .context("Failed to parse cached BOM match response")?;
+    anyhow::ensure!(
+        !response.needs_retry(),
+        "Cached BOM match response contains a retryable result"
+    );
+    let prepared = prepare_bom_match(bom, &response)?;
+    let age_seconds = now
+        .checked_sub(cached.fetched_at)
+        .and_then(|age| u64::try_from(age).ok());
+    let fresh = age_seconds.is_some_and(|age| age < BOM_MATCH_CACHE_TTL_SECS);
+    Ok(PreparedCachedMatch {
+        prepared,
+        age_seconds,
+        fresh,
+    })
+}
+
+fn cache_source(cached: &PreparedCachedMatch) -> BomMatchSource {
+    if cached.fresh {
+        BomMatchSource::FreshCache {
+            age_seconds: cached.age_seconds.expect("fresh cache has a valid age"),
+        }
+    } else {
+        BomMatchSource::StaleCache {
+            age_seconds: cached.age_seconds,
+        }
+    }
+}
+
+fn unix_now() -> Result<i64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("System clock is before the Unix epoch")?
+        .as_secs() as i64)
+}
+
+fn bom_request_entries(bom: &pcb_sch::bom::Bom) -> Result<Vec<serde_json::Value>> {
+    let mut request_bom = bom.clone();
+    request_bom.availability.clear();
+    serde_json::from_str(&request_bom.ungrouped_json()).context("Failed to parse BOM JSON")
 }
 
 /// Fetch BOM matching results from the API and populate availability data
@@ -256,72 +551,118 @@ pub fn fetch_and_populate_availability_with_context(
     bom: &mut pcb_sch::bom::Bom,
     strict: bool,
 ) -> Result<()> {
-    let bom_json = bom.ungrouped_json();
-    let bom_entries: Vec<serde_json::Value> =
-        serde_json::from_str(&bom_json).context("Failed to parse BOM JSON")?;
+    match_bom_with_context(ctx, auth_token, bom, strict, BomMatchMode::Online)?;
+    Ok(())
+}
 
-    let match_response = call_bom_match_api(ctx, auth_token, &bom_entries, 120, strict)?;
-
-    for bom_line in match_response.results {
-        let Some(path) = bom_line.design_entry.path.as_deref() else {
-            continue;
-        };
-        if !bom.entries.contains_key(path) {
-            continue;
+pub fn match_bom_with_context(
+    ctx: &WorkspaceContext,
+    auth_token: Option<&str>,
+    bom: &mut pcb_sch::bom::Bom,
+    strict: bool,
+    mode: BomMatchMode,
+) -> Result<BomMatchSource> {
+    let cache = match BomMatchCache::open() {
+        Ok(cache) => Some(cache),
+        Err(error) => {
+            log::warn!("Failed to open local BOM cache: {error:#}");
+            None
         }
+    };
+    fetch_and_populate_availability_with_cache(
+        ctx,
+        auth_token,
+        bom,
+        strict,
+        mode,
+        cache.as_ref(),
+        unix_now()?,
+    )
+}
 
-        let qty = bom
-            .designators
-            .iter()
-            .filter(|(p, _)| p.as_str() == path)
-            .count() as i32;
-        // Resolve offer IDs to actual offers from the deduplicated offers map
-        let resolved_offers: Vec<&ComponentOffer> = bom_line
-            .offer_ids
-            .iter()
-            .filter_map(|id| match_response.offers.get(id))
-            .collect();
+fn fetch_and_populate_availability_with_cache(
+    ctx: &WorkspaceContext,
+    auth_token: Option<&str>,
+    bom: &mut pcb_sch::bom::Bom,
+    strict: bool,
+    mode: BomMatchMode,
+    cache: Option<&BomMatchCache>,
+    now: i64,
+) -> Result<BomMatchSource> {
+    let bom_entries = bom_request_entries(bom)?;
 
-        let target_qty = qty * BOARD_QUANTITY;
-
-        let (us_offers, mut us) =
-            summarize_region(&resolved_offers, Geography::Us, target_qty, qty);
-        let (global_offers, mut global) =
-            summarize_region(&resolved_offers, Geography::Global, target_qty, qty);
-        for (summary, offers) in [(&mut us, &us_offers), (&mut global, &global_offers)] {
-            if let (Some(summary), Some(offer)) = (summary, offers.first()) {
-                summary.stock_class = bom_line
-                    .offer_stock_classes
-                    .get(&offer.id)
-                    .copied()
-                    .with_context(|| {
-                        format!(
-                            "BOM match response omitted the stock class for offer {}",
-                            offer.id
-                        )
-                    })?;
+    let request_body = bom_match_request(&bom_entries);
+    let url = bom_match_url(ctx.api_base_url(), strict);
+    let identity = cache_identity(&url, &request_body)?;
+    let mut cached = cache.and_then(|cache| match cache.load(&identity) {
+        Ok(Some(cached)) => match prepare_cached_match(cached, bom, now) {
+            Ok(prepared) => Some(prepared),
+            Err(error) => {
+                log::warn!("Ignoring invalid cached BOM response: {error:#}");
+                None
             }
+        },
+        Ok(None) => None,
+        Err(error) => {
+            log::warn!("Ignoring unreadable cached BOM response: {error:#}");
+            None
         }
+    });
 
-        // Build offers for JSON output
-        let all_offers: Vec<_> = us_offers
-            .iter()
-            .chain(global_offers.iter())
-            .map(|o| o.to_offer(target_qty))
-            .collect();
-
-        bom.availability.insert(
-            path.to_string(),
-            Availability {
-                us,
-                global,
-                no_match: bom_line_no_match(&bom_line),
-                offers: all_offers,
-            },
-        );
+    if mode == BomMatchMode::Offline {
+        let Some(cached) = cached else {
+            return Ok(BomMatchSource::OfflineCacheMiss);
+        };
+        let source = cache_source(&cached);
+        cached.prepared.apply(bom);
+        return Ok(source);
     }
 
-    Ok(())
+    if cached.as_ref().is_some_and(|cached| cached.fresh) {
+        let cached = cached.take().expect("checked fresh cached response");
+        let source = cache_source(&cached);
+        cached.prepared.apply(bom);
+        return Ok(source);
+    }
+
+    let response_json = match send_bom_match_request(
+        ctx,
+        auth_token,
+        &request_body,
+        BOM_MATCH_TIMEOUT_SECS,
+        strict,
+    ) {
+        Ok(response_json) => response_json,
+        Err(error) if error.transient && cached.is_some() => {
+            let cached = cached.take().expect("checked stale cached response");
+            let source = cache_source(&cached);
+            cached.prepared.apply(bom);
+            return Ok(source);
+        }
+        Err(error) => return Err(anyhow::Error::new(error)),
+    };
+
+    let match_response: MatchBomResponse =
+        serde_json::from_str(&response_json).context("Failed to parse BOM match response")?;
+    let prepared = prepare_bom_match(bom, &match_response)?;
+
+    if match_response.needs_retry() {
+        if let Some(cached) = cached {
+            let source = cache_source(&cached);
+            cached.prepared.apply(bom);
+            return Ok(source);
+        }
+        anyhow::bail!("BOM matching could not complete and no cached response is available");
+    }
+
+    if let Some(cache) = cache
+        && let Err(error) = cache.store(&identity, &response_json, now)
+    {
+        log::warn!("Failed to update local BOM cache: {error:#}");
+    }
+
+    prepared.apply(bom);
+    Ok(BomMatchSource::Network)
 }
 
 /// Component key for pricing requests
@@ -504,6 +845,11 @@ fn build_search_availability(offers: &[&ComponentOffer], no_match: bool) -> Avai
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use httpmock::{Method::POST, MockServer};
+    use pcb_sch::bom::{Bom, BomEntry, GenericComponent, Resistor};
+
     use super::*;
 
     fn offer(id: &str, breaks: &[(i32, f64)]) -> ComponentOffer {
@@ -528,21 +874,77 @@ mod tests {
         }
     }
 
-    fn bom_line(match_status: Option<BomMatchStatus>, offer_ids: Vec<String>) -> BomLine {
+    fn bom_line(match_status: BomMatchStatus, offer_ids: Vec<String>) -> BomLine {
+        let offer_stock_classes = offer_ids
+            .iter()
+            .map(|offer_id| (offer_id.clone(), SourcingStockClass::Unknown))
+            .collect();
         BomLine {
             design_entry: DesignBomEntry {
                 path: Some("root.U1".to_string()),
             },
             offer_ids,
-            offer_stock_classes: HashMap::new(),
+            offer_stock_classes,
             match_status,
+            selected_offer_id: None,
         }
+    }
+
+    fn test_bom(mpn: Option<&str>) -> Bom {
+        let entry = BomEntry {
+            mpn: mpn.map(str::to_string),
+            alternatives: Vec::new(),
+            manufacturer: mpn.map(|_| "Original Manufacturer".to_string()),
+            package: Some("0603".to_string()),
+            value: Some("10kOhm".to_string()),
+            description: None,
+            generic_data: Some(GenericComponent::Resistor(Resistor {
+                resistance: "10kOhm".parse().unwrap(),
+                voltage: None,
+            })),
+            dnp: false,
+            skip_bom: false,
+            matcher: None,
+            properties: BTreeMap::new(),
+        };
+        Bom::new(
+            HashMap::from([("root.U1".to_string(), entry)]),
+            HashMap::from([("root.U1".to_string(), "U1".to_string())]),
+        )
+    }
+
+    fn compatible_response() -> serde_json::Value {
+        serde_json::json!({
+            "results": [{
+                "designEntry": {"path": "root.U1"},
+                "offerIds": ["selected-offer"],
+                "offerStockClasses": {"selected-offer": "PLENTY"},
+                "match": "MATCH_COMPATIBLE",
+                "selectedOfferId": "selected-offer"
+            }],
+            "offers": {
+                "selected-offer": {
+                    "id": "selected-offer",
+                    "geography": "US",
+                    "distributor": "testdist",
+                    "distributorPartId": "DIST-1",
+                    "mpn": "API-MPN",
+                    "manufacturer": "API Manufacturer",
+                    "priceBreaks": [{"qty": 1, "price": 0.25}],
+                    "stockAvailable": 100
+                }
+            }
+        })
+    }
+
+    fn cache_for(tempdir: &tempfile::TempDir) -> BomMatchCache {
+        BomMatchCache::open_at(tempdir.path().join("bom.sqlite")).unwrap()
     }
 
     #[test]
     fn match_status_controls_no_match_detection() {
         assert!(bom_line_no_match(&bom_line(
-            Some(BomMatchStatus::Failed),
+            BomMatchStatus::Failed,
             vec!["offer-1".to_string()]
         )));
 
@@ -552,7 +954,7 @@ mod tests {
             BomMatchStatus::Fuzzy,
             BomMatchStatus::NeedsRetry,
         ] {
-            assert!(!bom_line_no_match(&bom_line(Some(status), Vec::new())));
+            assert!(!bom_line_no_match(&bom_line(status, Vec::new())));
         }
     }
 
@@ -596,12 +998,18 @@ mod tests {
     }
 
     #[test]
-    fn missing_match_status_does_not_imply_no_match() {
-        assert!(!bom_line_no_match(&bom_line(None, Vec::new())));
-        assert!(!bom_line_no_match(&bom_line(
-            None,
-            vec!["offer-1".to_string()]
-        )));
+    fn missing_match_status_is_rejected() {
+        let response = serde_json::json!({
+            "results": [{
+                "designEntry": {"path": "root.U1"},
+                "offerIds": [],
+                "offerStockClasses": {},
+                "selectedOfferId": null
+            }],
+            "offers": {}
+        });
+
+        assert!(serde_json::from_value::<MatchBomResponse>(response).is_err());
     }
 
     #[test]
@@ -640,5 +1048,270 @@ mod tests {
             bom_match_url("https://api.diode.computer", true),
             "https://api.diode.computer/api/boms/match?strict=true"
         );
+        assert_eq!(
+            bom_match_url("https://api.diode.computer/", true),
+            "https://api.diode.computer/api/boms/match?strict=true"
+        );
+    }
+
+    #[test]
+    fn selected_compatible_offer_populates_only_unassigned_generic_parts() {
+        let response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
+
+        let mut generic_bom = test_bom(None);
+        prepare_bom_match(&generic_bom, &response)
+            .unwrap()
+            .apply(&mut generic_bom);
+        assert_eq!(
+            generic_bom.entries["root.U1"].mpn.as_deref(),
+            Some("API-MPN")
+        );
+        assert_eq!(
+            generic_bom.entries["root.U1"].manufacturer.as_deref(),
+            Some("API Manufacturer")
+        );
+
+        let mut explicit_bom = test_bom(Some("EXPLICIT-MPN"));
+        prepare_bom_match(&explicit_bom, &response)
+            .unwrap()
+            .apply(&mut explicit_bom);
+        assert_eq!(
+            explicit_bom.entries["root.U1"].mpn.as_deref(),
+            Some("EXPLICIT-MPN")
+        );
+        assert_eq!(
+            explicit_bom.entries["root.U1"].manufacturer.as_deref(),
+            Some("Original Manufacturer")
+        );
+    }
+
+    #[test]
+    fn response_validation_is_atomic() {
+        let incomplete: MatchBomResponse = serde_json::from_value(serde_json::json!({
+            "results": [],
+            "offers": {}
+        }))
+        .unwrap();
+        let mut response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
+        response.offers.get_mut("selected-offer").unwrap().id = "mismatched-offer".to_string();
+        let bom = test_bom(None);
+
+        assert!(prepare_bom_match(&bom, &incomplete).is_err());
+        assert!(prepare_bom_match(&bom, &response).is_err());
+        assert!(bom.availability.is_empty());
+        assert!(bom.entries["root.U1"].mpn.is_none());
+    }
+
+    #[test]
+    fn request_entries_exclude_previous_availability() {
+        let without_availability = test_bom(None);
+        let mut with_availability = without_availability.clone();
+        with_availability
+            .availability
+            .insert("root.U1".to_string(), Availability::default());
+
+        assert_eq!(
+            bom_request_entries(&without_availability).unwrap(),
+            bom_request_entries(&with_availability).unwrap()
+        );
+    }
+
+    #[test]
+    fn cache_expires_at_ten_minutes() {
+        let response_json = compatible_response().to_string();
+        let bom = test_bom(None);
+
+        for (now, expected_fresh) in [(1_599, true), (1_600, false)] {
+            let cached = CachedResponse {
+                response_json: response_json.clone(),
+                fetched_at: 1_000,
+            };
+            assert_eq!(
+                prepare_cached_match(cached, &bom, now).unwrap().fresh,
+                expected_fresh
+            );
+        }
+    }
+
+    #[test]
+    fn fresh_network_response_is_cached_for_online_and_offline_use() {
+        let server = MockServer::start();
+        let response = compatible_response();
+        let network = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/boms/match")
+                .query_param("strict", "true");
+            then.status(200).json_body(response);
+        });
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = cache_for(&tempdir);
+        let context = WorkspaceContext::from_api_base_url(server.base_url());
+
+        let mut first = test_bom(None);
+        let source = fetch_and_populate_availability_with_cache(
+            &context,
+            None,
+            &mut first,
+            true,
+            BomMatchMode::Online,
+            Some(&cache),
+            1_000,
+        )
+        .unwrap();
+        assert_eq!(source, BomMatchSource::Network);
+        network.assert_calls(1);
+
+        let mut online = test_bom(None);
+        let source = fetch_and_populate_availability_with_cache(
+            &context,
+            None,
+            &mut online,
+            true,
+            BomMatchMode::Online,
+            Some(&cache),
+            1_100,
+        )
+        .unwrap();
+        assert_eq!(source, BomMatchSource::FreshCache { age_seconds: 100 });
+        network.assert_calls(1);
+
+        let mut offline = test_bom(None);
+        let source = fetch_and_populate_availability_with_cache(
+            &context,
+            None,
+            &mut offline,
+            true,
+            BomMatchMode::Offline,
+            Some(&cache),
+            2_000,
+        )
+        .unwrap();
+        assert_eq!(
+            source,
+            BomMatchSource::StaleCache {
+                age_seconds: Some(1_000)
+            }
+        );
+        network.assert_calls(1);
+        assert_eq!(offline.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
+    }
+
+    #[test]
+    fn stale_cache_only_falls_back_for_transient_online_failures() {
+        let server = MockServer::start();
+        let response = compatible_response();
+        let mut success = server.mock(|when, then| {
+            when.method(POST).path("/api/boms/match");
+            then.status(200).json_body(response);
+        });
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = cache_for(&tempdir);
+        let context = WorkspaceContext::from_api_base_url(server.base_url());
+
+        fetch_and_populate_availability_with_cache(
+            &context,
+            None,
+            &mut test_bom(None),
+            false,
+            BomMatchMode::Online,
+            Some(&cache),
+            1_000,
+        )
+        .unwrap();
+        success.delete();
+
+        let mut unavailable = server.mock(|when, then| {
+            when.method(POST).path("/api/boms/match");
+            then.status(503).body("deploying");
+        });
+        let mut transient = test_bom(None);
+        let source = fetch_and_populate_availability_with_cache(
+            &context,
+            None,
+            &mut transient,
+            false,
+            BomMatchMode::Online,
+            Some(&cache),
+            2_000,
+        )
+        .unwrap();
+        assert!(matches!(source, BomMatchSource::StaleCache { .. }));
+        assert_eq!(transient.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
+        unavailable.assert_calls(1);
+        unavailable.delete();
+
+        let retry_response = serde_json::json!({
+            "results": [{
+                "designEntry": {"path": "root.U1"},
+                "offerIds": [],
+                "offerStockClasses": {},
+                "match": "MATCH_NEEDS_RETRY",
+                "selectedOfferId": null
+            }],
+            "offers": {}
+        });
+        let mut retry = server.mock(|when, then| {
+            when.method(POST).path("/api/boms/match");
+            then.status(200).json_body(retry_response);
+        });
+        let mut retryable = test_bom(None);
+        let source = fetch_and_populate_availability_with_cache(
+            &context,
+            None,
+            &mut retryable,
+            false,
+            BomMatchMode::Online,
+            Some(&cache),
+            2_000,
+        )
+        .unwrap();
+        assert!(matches!(source, BomMatchSource::StaleCache { .. }));
+        assert_eq!(retryable.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
+        retry.assert_calls(1);
+        retry.delete();
+
+        let bad_request = server.mock(|when, then| {
+            when.method(POST).path("/api/boms/match");
+            then.status(400).body("invalid request");
+        });
+        let mut permanent = test_bom(None);
+        assert!(
+            fetch_and_populate_availability_with_cache(
+                &context,
+                None,
+                &mut permanent,
+                false,
+                BomMatchMode::Online,
+                Some(&cache),
+                2_000,
+            )
+            .is_err()
+        );
+        assert!(permanent.entries["root.U1"].mpn.is_none());
+        assert!(permanent.availability.is_empty());
+        bad_request.assert_calls(1);
+    }
+
+    #[test]
+    fn offline_cache_miss_does_not_mutate_the_bom() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = cache_for(&tempdir);
+        let context = WorkspaceContext::from_api_base_url("http://127.0.0.1:1");
+        let mut bom = test_bom(None);
+
+        let source = fetch_and_populate_availability_with_cache(
+            &context,
+            None,
+            &mut bom,
+            true,
+            BomMatchMode::Offline,
+            Some(&cache),
+            1_000,
+        )
+        .unwrap();
+
+        assert_eq!(source, BomMatchSource::OfflineCacheMiss);
+        assert!(bom.entries["root.U1"].mpn.is_none());
+        assert!(bom.availability.is_empty());
     }
 }

--- a/crates/pcb-diode-api/src/bom_cache.rs
+++ b/crates/pcb-diode-api/src/bom_cache.rs
@@ -3,21 +3,23 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, params};
-use serde_json::{Map, Value};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-const CACHE_NAMESPACE: &str = "pcb-bom-match-v1";
-
-#[derive(Debug)]
-pub(crate) struct CacheIdentity {
-    pub key: String,
-    request_json: String,
-}
+const CACHE_VERSION: &[u8] = b"pcb-bom-match-v1";
+const CACHE_TTL_SECS: i64 = 10 * 60;
 
 #[derive(Debug)]
 pub(crate) struct CachedResponse {
     pub response_json: String,
-    pub fetched_at: i64,
+    fetched_at: i64,
+}
+
+impl CachedResponse {
+    pub fn is_fresh(&self, now: i64) -> bool {
+        now.checked_sub(self.fetched_at)
+            .is_some_and(|age| (0..CACHE_TTL_SECS).contains(&age))
+    }
 }
 
 pub(crate) struct BomMatchCache {
@@ -41,13 +43,10 @@ impl BomMatchCache {
             .with_context(|| format!("Failed to open BOM cache at {}", path.display()))?;
         connection.busy_timeout(Duration::from_secs(10))?;
         connection.pragma_update(None, "journal_mode", "WAL")?;
-        connection.pragma_update(None, "synchronous", "NORMAL")?;
         connection.execute_batch(
-            "CREATE TABLE IF NOT EXISTS bom_match_responses (
+            "CREATE TABLE IF NOT EXISTS responses (
                 cache_key TEXT PRIMARY KEY,
-                request_json TEXT NOT NULL,
                 response_json TEXT NOT NULL,
-                response_sha256 TEXT NOT NULL,
                 fetched_at INTEGER NOT NULL
             ) WITHOUT ROWID;",
         )?;
@@ -55,106 +54,47 @@ impl BomMatchCache {
         Ok(Self { connection })
     }
 
-    pub fn load(&self, identity: &CacheIdentity) -> Result<Option<CachedResponse>> {
-        let row = self
-            .connection
+    pub fn load(&self, key: &str) -> Result<Option<CachedResponse>> {
+        self.connection
             .query_row(
-                "SELECT request_json, response_json, response_sha256, fetched_at
-                 FROM bom_match_responses WHERE cache_key = ?1",
-                params![identity.key],
+                "SELECT response_json, fetched_at FROM responses WHERE cache_key = ?1",
+                params![key],
                 |row| {
-                    Ok((
-                        row.get::<_, String>(0)?,
-                        row.get::<_, String>(1)?,
-                        row.get::<_, String>(2)?,
-                        row.get::<_, i64>(3)?,
-                    ))
+                    Ok(CachedResponse {
+                        response_json: row.get(0)?,
+                        fetched_at: row.get(1)?,
+                    })
                 },
             )
-            .optional()?;
-
-        let Some((request_json, response_json, response_sha256, fetched_at)) = row else {
-            return Ok(None);
-        };
-
-        anyhow::ensure!(
-            request_json == identity.request_json,
-            "BOM cache key matched a different request"
-        );
-        anyhow::ensure!(
-            response_sha256 == sha256(response_json.as_bytes()),
-            "BOM cache response checksum mismatch"
-        );
-
-        Ok(Some(CachedResponse {
-            response_json,
-            fetched_at,
-        }))
+            .optional()
+            .map_err(Into::into)
     }
 
-    pub fn store(
-        &self,
-        identity: &CacheIdentity,
-        response_json: &str,
-        fetched_at: i64,
-    ) -> Result<()> {
+    pub fn store(&self, key: &str, response_json: &str, fetched_at: i64) -> Result<()> {
         self.connection.execute(
-            "INSERT INTO bom_match_responses (
-                cache_key, request_json, response_json, response_sha256, fetched_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5)
+            "INSERT INTO responses (cache_key, response_json, fetched_at)
+             VALUES (?1, ?2, ?3)
              ON CONFLICT(cache_key) DO UPDATE SET
-                request_json = excluded.request_json,
                 response_json = excluded.response_json,
-                response_sha256 = excluded.response_sha256,
                 fetched_at = excluded.fetched_at",
-            params![
-                identity.key,
-                identity.request_json,
-                response_json,
-                sha256(response_json.as_bytes()),
-                fetched_at,
-            ],
+            params![key, response_json, fetched_at],
         )?;
         Ok(())
     }
 }
 
-pub(crate) fn cache_identity(url: &str, request: &Value) -> Result<CacheIdentity> {
-    let envelope = serde_json::json!({
-        "cacheNamespace": CACHE_NAMESPACE,
-        "method": "POST",
-        "url": url,
-        "request": request,
-    });
-    let request_json = serde_json::to_string(&canonicalize(&envelope))?;
-    Ok(CacheIdentity {
-        key: sha256(request_json.as_bytes()),
-        request_json,
-    })
+pub(crate) fn cache_key(url: &str, request: &Value) -> Result<String> {
+    let mut hasher = Sha256::new();
+    hasher.update(CACHE_VERSION);
+    hasher.update([0]);
+    hasher.update(url.as_bytes());
+    hasher.update([0]);
+    hasher.update(serde_json::to_vec(request)?);
+    Ok(hex::encode(hasher.finalize()))
 }
 
 fn cache_path() -> PathBuf {
     pcb_zen::cache_index::cache_base().join("bom_match_v1.sqlite")
-}
-
-fn canonicalize(value: &Value) -> Value {
-    match value {
-        Value::Object(object) => {
-            let mut keys = object.keys().collect::<Vec<_>>();
-            keys.sort_unstable();
-            let mut canonical = Map::new();
-            for key in keys {
-                canonical.insert(key.clone(), canonicalize(&object[key]));
-            }
-            Value::Object(canonical)
-        }
-        Value::Array(values) => Value::Array(values.iter().map(canonicalize).collect()),
-        _ => value.clone(),
-    }
-}
-
-fn sha256(bytes: &[u8]) -> String {
-    hex::encode(Sha256::digest(bytes))
 }
 
 #[cfg(test)]
@@ -162,61 +102,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cache_key_canonicalizes_object_keys_but_preserves_array_order() {
-        let first = serde_json::json!({
-            "designBom": [{"path": "root.R1", "mpn": "R-1"}],
-            "regions": ["US", "GLOBAL"],
-        });
-        let reordered: Value = serde_json::from_str(
-            r#"{"regions":["US","GLOBAL"],"designBom":[{"mpn":"R-1","path":"root.R1"}]}"#,
-        )
-        .unwrap();
-        let reversed_regions = serde_json::json!({
-            "designBom": [{"path": "root.R1", "mpn": "R-1"}],
-            "regions": ["GLOBAL", "US"],
-        });
-
-        let first = cache_identity("https://api.example/api/boms/match", &first).unwrap();
-        let reordered = cache_identity("https://api.example/api/boms/match", &reordered).unwrap();
-        let reversed =
-            cache_identity("https://api.example/api/boms/match", &reversed_regions).unwrap();
-
-        assert_eq!(first.key, reordered.key);
-        assert_ne!(first.key, reversed.key);
-    }
-
-    #[test]
-    fn cache_key_includes_endpoint() {
+    fn cache_key_includes_endpoint_and_request() {
         let request = serde_json::json!({"designBom": []});
-        let production = cache_identity("https://api.example/api/boms/match", &request).unwrap();
-        let sandbox =
-            cache_identity("https://api.sandbox.example/api/boms/match", &request).unwrap();
+        let other_request = serde_json::json!({"designBom": [{"path": "R1"}]});
 
-        assert_ne!(production.key, sandbox.key);
-    }
-
-    #[test]
-    fn cache_round_trips_and_rejects_corrupted_responses() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let cache = BomMatchCache::open_at(tempdir.path().join("bom.sqlite")).unwrap();
-        let identity = cache_identity(
-            "https://api.example/api/boms/match",
-            &serde_json::json!({"designBom": []}),
-        )
-        .unwrap();
-
-        cache.store(&identity, r#"{"results":[]}"#, 123).unwrap();
-        let cached = cache.load(&identity).unwrap().unwrap();
-        assert_eq!(cached.response_json, r#"{"results":[]}"#);
-        assert_eq!(cached.fetched_at, 123);
-
-        cache
-            .connection
-            .execute(
-                "UPDATE bom_match_responses SET response_json = 'corrupted'",
-                [],
-            )
-            .unwrap();
-        assert!(cache.load(&identity).is_err());
+        assert_ne!(
+            cache_key("https://api.example/api/boms/match", &request).unwrap(),
+            cache_key("https://other.example/api/boms/match", &request).unwrap()
+        );
+        assert_ne!(
+            cache_key("https://api.example/api/boms/match", &request).unwrap(),
+            cache_key("https://api.example/api/boms/match", &other_request).unwrap()
+        );
     }
 }

--- a/crates/pcb-diode-api/src/bom_cache.rs
+++ b/crates/pcb-diode-api/src/bom_cache.rs
@@ -6,7 +6,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-const CACHE_VERSION: &[u8] = b"pcb-bom-match-v1";
+/// Bump when the cache schema or BOM match contract changes.
+const SCHEMA_VERSION: u32 = 1;
 const CACHE_TTL_SECS: i64 = 10 * 60;
 
 #[derive(Debug)]
@@ -48,7 +49,7 @@ impl BomMatchCache {
                 cache_key TEXT PRIMARY KEY,
                 response_json TEXT NOT NULL,
                 fetched_at INTEGER NOT NULL
-            ) WITHOUT ROWID;",
+            );",
         )?;
 
         Ok(Self { connection })
@@ -72,11 +73,8 @@ impl BomMatchCache {
 
     pub fn store(&self, key: &str, response_json: &str, fetched_at: i64) -> Result<()> {
         self.connection.execute(
-            "INSERT INTO responses (cache_key, response_json, fetched_at)
-             VALUES (?1, ?2, ?3)
-             ON CONFLICT(cache_key) DO UPDATE SET
-                response_json = excluded.response_json,
-                fetched_at = excluded.fetched_at",
+            "INSERT OR REPLACE INTO responses (cache_key, response_json, fetched_at)
+             VALUES (?1, ?2, ?3)",
             params![key, response_json, fetched_at],
         )?;
         Ok(())
@@ -85,8 +83,6 @@ impl BomMatchCache {
 
 pub(crate) fn cache_key(url: &str, request: &Value) -> Result<String> {
     let mut hasher = Sha256::new();
-    hasher.update(CACHE_VERSION);
-    hasher.update([0]);
     hasher.update(url.as_bytes());
     hasher.update([0]);
     hasher.update(serde_json::to_vec(request)?);
@@ -94,7 +90,7 @@ pub(crate) fn cache_key(url: &str, request: &Value) -> Result<String> {
 }
 
 fn cache_path() -> PathBuf {
-    pcb_zen::cache_index::cache_base().join("bom_match_v1.sqlite")
+    pcb_zen::cache_index::cache_base().join(format!("bom_match_v{SCHEMA_VERSION}.sqlite"))
 }
 
 #[cfg(test)]

--- a/crates/pcb-diode-api/src/bom_cache.rs
+++ b/crates/pcb-diode-api/src/bom_cache.rs
@@ -1,0 +1,222 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+const CACHE_NAMESPACE: &str = "pcb-bom-match-v1";
+
+#[derive(Debug)]
+pub(crate) struct CacheIdentity {
+    pub key: String,
+    request_json: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct CachedResponse {
+    pub response_json: String,
+    pub fetched_at: i64,
+}
+
+pub(crate) struct BomMatchCache {
+    connection: Connection,
+}
+
+impl BomMatchCache {
+    pub fn open() -> Result<Self> {
+        Self::open_at(cache_path())
+    }
+
+    pub(crate) fn open_at(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create BOM cache directory {}", parent.display())
+            })?;
+        }
+
+        let connection = Connection::open(path)
+            .with_context(|| format!("Failed to open BOM cache at {}", path.display()))?;
+        connection.busy_timeout(Duration::from_secs(10))?;
+        connection.pragma_update(None, "journal_mode", "WAL")?;
+        connection.pragma_update(None, "synchronous", "NORMAL")?;
+        connection.execute_batch(
+            "CREATE TABLE IF NOT EXISTS bom_match_responses (
+                cache_key TEXT PRIMARY KEY,
+                request_json TEXT NOT NULL,
+                response_json TEXT NOT NULL,
+                response_sha256 TEXT NOT NULL,
+                fetched_at INTEGER NOT NULL
+            ) WITHOUT ROWID;",
+        )?;
+
+        Ok(Self { connection })
+    }
+
+    pub fn load(&self, identity: &CacheIdentity) -> Result<Option<CachedResponse>> {
+        let row = self
+            .connection
+            .query_row(
+                "SELECT request_json, response_json, response_sha256, fetched_at
+                 FROM bom_match_responses WHERE cache_key = ?1",
+                params![identity.key],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, i64>(3)?,
+                    ))
+                },
+            )
+            .optional()?;
+
+        let Some((request_json, response_json, response_sha256, fetched_at)) = row else {
+            return Ok(None);
+        };
+
+        anyhow::ensure!(
+            request_json == identity.request_json,
+            "BOM cache key matched a different request"
+        );
+        anyhow::ensure!(
+            response_sha256 == sha256(response_json.as_bytes()),
+            "BOM cache response checksum mismatch"
+        );
+
+        Ok(Some(CachedResponse {
+            response_json,
+            fetched_at,
+        }))
+    }
+
+    pub fn store(
+        &self,
+        identity: &CacheIdentity,
+        response_json: &str,
+        fetched_at: i64,
+    ) -> Result<()> {
+        self.connection.execute(
+            "INSERT INTO bom_match_responses (
+                cache_key, request_json, response_json, response_sha256, fetched_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(cache_key) DO UPDATE SET
+                request_json = excluded.request_json,
+                response_json = excluded.response_json,
+                response_sha256 = excluded.response_sha256,
+                fetched_at = excluded.fetched_at",
+            params![
+                identity.key,
+                identity.request_json,
+                response_json,
+                sha256(response_json.as_bytes()),
+                fetched_at,
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+pub(crate) fn cache_identity(url: &str, request: &Value) -> Result<CacheIdentity> {
+    let envelope = serde_json::json!({
+        "cacheNamespace": CACHE_NAMESPACE,
+        "method": "POST",
+        "url": url,
+        "request": request,
+    });
+    let request_json = serde_json::to_string(&canonicalize(&envelope))?;
+    Ok(CacheIdentity {
+        key: sha256(request_json.as_bytes()),
+        request_json,
+    })
+}
+
+fn cache_path() -> PathBuf {
+    pcb_zen::cache_index::cache_base().join("bom_match_v1.sqlite")
+}
+
+fn canonicalize(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut keys = object.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            let mut canonical = Map::new();
+            for key in keys {
+                canonical.insert(key.clone(), canonicalize(&object[key]));
+            }
+            Value::Object(canonical)
+        }
+        Value::Array(values) => Value::Array(values.iter().map(canonicalize).collect()),
+        _ => value.clone(),
+    }
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_canonicalizes_object_keys_but_preserves_array_order() {
+        let first = serde_json::json!({
+            "designBom": [{"path": "root.R1", "mpn": "R-1"}],
+            "regions": ["US", "GLOBAL"],
+        });
+        let reordered: Value = serde_json::from_str(
+            r#"{"regions":["US","GLOBAL"],"designBom":[{"mpn":"R-1","path":"root.R1"}]}"#,
+        )
+        .unwrap();
+        let reversed_regions = serde_json::json!({
+            "designBom": [{"path": "root.R1", "mpn": "R-1"}],
+            "regions": ["GLOBAL", "US"],
+        });
+
+        let first = cache_identity("https://api.example/api/boms/match", &first).unwrap();
+        let reordered = cache_identity("https://api.example/api/boms/match", &reordered).unwrap();
+        let reversed =
+            cache_identity("https://api.example/api/boms/match", &reversed_regions).unwrap();
+
+        assert_eq!(first.key, reordered.key);
+        assert_ne!(first.key, reversed.key);
+    }
+
+    #[test]
+    fn cache_key_includes_endpoint() {
+        let request = serde_json::json!({"designBom": []});
+        let production = cache_identity("https://api.example/api/boms/match", &request).unwrap();
+        let sandbox =
+            cache_identity("https://api.sandbox.example/api/boms/match", &request).unwrap();
+
+        assert_ne!(production.key, sandbox.key);
+    }
+
+    #[test]
+    fn cache_round_trips_and_rejects_corrupted_responses() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = BomMatchCache::open_at(tempdir.path().join("bom.sqlite")).unwrap();
+        let identity = cache_identity(
+            "https://api.example/api/boms/match",
+            &serde_json::json!({"designBom": []}),
+        )
+        .unwrap();
+
+        cache.store(&identity, r#"{"results":[]}"#, 123).unwrap();
+        let cached = cache.load(&identity).unwrap().unwrap();
+        assert_eq!(cached.response_json, r#"{"results":[]}"#);
+        assert_eq!(cached.fetched_at, 123);
+
+        cache
+            .connection
+            .execute(
+                "UPDATE bom_match_responses SET response_json = 'corrupted'",
+                [],
+            )
+            .unwrap();
+        assert!(cache.load(&identity).is_err());
+    }
+}

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -3,6 +3,7 @@ use rusqlite::auto_extension::{RawAutoExtension, register_auto_extension};
 
 pub mod auth;
 pub mod bom;
+mod bom_cache;
 pub mod component;
 mod component_api;
 pub mod datasheet;
@@ -18,7 +19,10 @@ pub mod sandbox;
 pub mod scan;
 
 pub use auth::{AuthArgs, AuthCommand, AuthTokens, execute as execute_auth, login, logout, status};
-pub use bom::{fetch_and_populate_availability, fetch_and_populate_availability_with_context};
+pub use bom::{
+    BomMatchMode, BomMatchSource, fetch_and_populate_availability,
+    fetch_and_populate_availability_with_context, match_bom_with_context,
+};
 pub use component::{
     AddComponentResult, ComponentDownloadResult, ComponentResult, ComponentSearchResult,
     ModelAvailability, SearchArgs, add_component_to_workspace, download_component,

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -20,8 +20,8 @@ pub mod scan;
 
 pub use auth::{AuthArgs, AuthCommand, AuthTokens, execute as execute_auth, login, logout, status};
 pub use bom::{
-    BomMatchMode, BomMatchSource, fetch_and_populate_availability,
-    fetch_and_populate_availability_with_context, match_bom_with_context,
+    BomMatchMode, fetch_and_populate_availability, fetch_and_populate_availability_with_context,
+    match_bom_with_context,
 };
 pub use component::{
     AddComponentResult, ComponentDownloadResult, ComponentResult, ComponentSearchResult,

--- a/crates/pcbc/src/bom.rs
+++ b/crates/pcbc/src/bom.rs
@@ -65,15 +65,6 @@ impl std::fmt::Display for BomFormat {
     }
 }
 
-fn format_cache_age(age_seconds: Option<u64>) -> String {
-    match age_seconds {
-        None => "unknown age".to_string(),
-        Some(seconds) if seconds < 60 => format!("{seconds}s old"),
-        Some(seconds) if seconds < 60 * 60 => format!("{}m old", seconds / 60),
-        Some(seconds) => format!("{}h old", seconds / (60 * 60)),
-    }
-}
-
 #[derive(Args, Debug, Clone)]
 #[command(about = "Generate Bill of Materials (BOM) from PCB projects")]
 pub struct BomArgs {
@@ -146,26 +137,10 @@ pub fn execute(args: BomArgs) -> Result<()> {
     } else {
         format!("{file_name}: Fetching availability")
     });
-    let source = match pcb_diode_api::match_bom_with_context(&ctx, None, &mut bom, strict, mode) {
-        Ok(source) => Some(source),
-        Err(error) => {
-            log::warn!("Failed to fetch availability data: {error:#}");
-            None
-        }
-    };
-
-    match source {
-        Some(pcb_diode_api::BomMatchSource::StaleCache { age_seconds }) => {
-            spinner.warning(format!(
-                "{file_name}: Using stale cached availability ({})",
-                format_cache_age(age_seconds)
-            ))
-        }
-        Some(pcb_diode_api::BomMatchSource::Network)
-        | Some(pcb_diode_api::BomMatchSource::FreshCache { .. })
-        | Some(pcb_diode_api::BomMatchSource::OfflineCacheMiss)
-        | None => spinner.finish(),
+    if let Err(error) = pcb_diode_api::match_bom_with_context(&ctx, None, &mut bom, strict, mode) {
+        log::warn!("Failed to fetch availability data: {error:#}");
     }
+    spinner.finish();
 
     let mut writer = io::stdout().lock();
     match args.format {

--- a/crates/pcbc/src/bom.rs
+++ b/crates/pcbc/src/bom.rs
@@ -65,6 +65,15 @@ impl std::fmt::Display for BomFormat {
     }
 }
 
+fn format_cache_age(age_seconds: Option<u64>) -> String {
+    match age_seconds {
+        None => "unknown age".to_string(),
+        Some(seconds) if seconds < 60 => format!("{seconds}s old"),
+        Some(seconds) if seconds < 60 * 60 => format!("{}m old", seconds / 60),
+        Some(seconds) => format!("{}h old", seconds / (60 * 60)),
+    }
+}
+
 #[derive(Args, Debug, Clone)]
 #[command(about = "Generate Bill of Materials (BOM) from PCB projects")]
 pub struct BomArgs {
@@ -126,27 +135,37 @@ pub fn execute(args: BomArgs) -> Result<()> {
     // Filter out components marked as skip_bom
     bom = bom.filter_excluded();
 
-    if !args.offline {
-        let ctx = pcb_diode_api::WorkspaceContext::from_path(&args.file);
-        match pcb_diode_api::auth::get_api_token_with_context(&ctx) {
-            Ok(token) => {
-                spinner.set_message(format!("{file_name}: Fetching availability"));
-                if let Err(e) = pcb_diode_api::fetch_and_populate_availability_with_context(
-                    &ctx,
-                    token.as_deref(),
-                    &mut bom,
-                    strict,
-                ) {
-                    log::warn!("Failed to fetch availability data: {}", e);
-                }
-            }
-            Err(_) => {
-                log::debug!("Not authenticated, skipping availability fetch");
-            }
+    let ctx = pcb_diode_api::WorkspaceContext::from_path(&args.file);
+    let mode = if args.offline {
+        pcb_diode_api::BomMatchMode::Offline
+    } else {
+        pcb_diode_api::BomMatchMode::Online
+    };
+    spinner.set_message(if args.offline {
+        format!("{file_name}: Loading cached availability")
+    } else {
+        format!("{file_name}: Fetching availability")
+    });
+    let source = match pcb_diode_api::match_bom_with_context(&ctx, None, &mut bom, strict, mode) {
+        Ok(source) => Some(source),
+        Err(error) => {
+            log::warn!("Failed to fetch availability data: {error:#}");
+            None
         }
-    }
+    };
 
-    spinner.finish();
+    match source {
+        Some(pcb_diode_api::BomMatchSource::StaleCache { age_seconds }) => {
+            spinner.warning(format!(
+                "{file_name}: Using stale cached availability ({})",
+                format_cache_age(age_seconds)
+            ))
+        }
+        Some(pcb_diode_api::BomMatchSource::Network)
+        | Some(pcb_diode_api::BomMatchSource::FreshCache { .. })
+        | Some(pcb_diode_api::BomMatchSource::OfflineCacheMiss)
+        | None => spinner.finish(),
+    }
 
     let mut writer = io::stdout().lock();
     match args.format {

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -239,11 +239,10 @@ strict = false
 ```
 
 Normalized BOM match responses are cached locally for ten minutes. Online
-commands refresh stale entries and reuse an exact stale response only when the
-API is temporarily unavailable. `pcb bom --offline` never contacts the API and
-uses an exact cached response regardless of age; without one, it emits the
-locally generated BOM without availability data. Online commands retain that
-same local BOM fallback when neither the API nor an exact cache entry is usable.
+commands refresh stale entries and reuse the exact stale response if refresh
+fails. `pcb bom --offline` never contacts the API and uses the exact cached
+response regardless of age; without one, it emits the locally generated BOM
+without availability data.
 
 ## Registry search scope
 

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -238,6 +238,13 @@ exact MPN matches. Workspace manifests can opt out to use fuzzy matching:
 strict = false
 ```
 
+Normalized BOM match responses are cached locally for ten minutes. Online
+commands refresh stale entries and reuse an exact stale response only when the
+API is temporarily unavailable. `pcb bom --offline` never contacts the API and
+uses an exact cached response regardless of age; without one, it emits the
+locally generated BOM without availability data. Online commands retain that
+same local BOM fallback when neither the API nor an exact cache entry is usable.
+
 ## Registry search scope
 
 Registry-backed `pcb search` searches the public Diode registry and the


### PR DESCRIPTION
Default TTL is quite aggressive: 10 minutes. We can relax later. But we also serve from stale cache if offline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BOM sourcing behavior (caching, offline, stale fallback) and part identity in output; the CLI no longer attaches an API token to BOM match requests, which may affect authenticated endpoints.
> 
> **Overview**
> **`pcb bom`** now persists normalized BOM match API responses in a local SQLite cache (10-minute TTL, keyed by endpoint + request body). Online runs skip the network when the entry is fresh; if a refresh fails, they fall back to an exact stale entry. **`pcb bom --offline`** never calls the API and applies a cached match when one exists, otherwise leaves the locally generated BOM without availability.
> 
> Match handling is refactored so availability and **compatible-match part identity** are applied together: when the API returns `selectedOfferId` on a compatible line, **MPN and manufacturer** are written into BOM output. Response parsing is stricter (required match status, full path/offer validation, rejects `MATCH_NEEDS_RETRY`).
> 
> The **`pcbc`** BOM path always goes through `match_bom_with_context` (online/offline modes) instead of only fetching when authenticated; it currently passes **no bearer token** to that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e37016831713e5d547771690a8db8fcba05dc2ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->