### PR TITLE
Serialize additional generic BOM parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - `pcb bom` caches API matches for ten minutes and reuses an exact stale match offline or when an online refresh fails.
+- `pcb bom` sends structured parameters for inductors, ferrite beads, rectifiers, Zener diodes, and TVS diodes to the API matcher.
 - `pcb bom` writes the API-selected compatible MPN and manufacturer into output.
 
 ### Fixed

--- a/crates/pcb-sch/src/bom/core.rs
+++ b/crates/pcb-sch/src/bom/core.rs
@@ -173,7 +173,12 @@ pub struct UngroupedBomEntry {
 #[serde(tag = "component_type")]
 pub enum GenericComponent {
     Capacitor(Capacitor),
+    FerriteBead(FerriteBead),
+    Inductor(Inductor),
+    Rectifier(Rectifier),
     Resistor(Resistor),
+    Tvs(Tvs),
+    Zener(Zener),
 }
 
 impl GenericComponent {
@@ -253,6 +258,54 @@ impl Resistor {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FerriteBead {
+    pub impedance: PhysicalValue,
+    pub frequency: PhysicalValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current: Option<PhysicalValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dcr: Option<PhysicalValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Inductor {
+    pub inductance: PhysicalValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current: Option<PhysicalValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dcr: Option<PhysicalValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Rectifier {
+    pub technology: String,
+    pub reverse_voltage: PhysicalValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forward_current: Option<PhysicalValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forward_voltage: Option<PhysicalValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Tvs {
+    pub direction: String,
+    pub reverse_standoff_voltage: PhysicalValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reverse_clamping_voltage: Option<PhysicalValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peak_pulse_power: Option<PhysicalValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capacitance: Option<PhysicalValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Zener {
+    pub zener_voltage: PhysicalValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub power: Option<PhysicalValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Dielectric {
     C0G,
     NP0,
@@ -283,6 +336,10 @@ impl FromStr for Dielectric {
 }
 
 // BOM Matching API
+// Matching keys are short-lived BOM data. Keeping every generic component
+// inline preserves one consistent public representation and avoids arbitrary
+// heap allocation for only the larger component families.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BomMatchingKey {
     Mpn(String),
@@ -763,6 +820,63 @@ fn detect_generic_component(instance: &crate::Instance) -> Option<GenericCompone
                     dielectric,
                     esr,
                     voltage,
+                }));
+            }
+        }
+        "ferrite_bead" => {
+            if let (Some(impedance), Some(frequency)) = (
+                instance.physical_attr(&["impedance"]),
+                instance.physical_attr(&["frequency"]),
+            ) {
+                return Some(GenericComponent::FerriteBead(FerriteBead {
+                    impedance,
+                    frequency,
+                    current: instance.physical_attr(&["current"]),
+                    dcr: instance.physical_attr(&["dcr"]),
+                }));
+            }
+        }
+        "inductor" => {
+            if let Some(inductance) = instance.physical_attr(&["inductance"]) {
+                return Some(GenericComponent::Inductor(Inductor {
+                    inductance,
+                    current: instance.physical_attr(&["current"]),
+                    dcr: instance.physical_attr(&["dcr"]),
+                }));
+            }
+        }
+        "rectifier" => {
+            if let (Some(technology), Some(reverse_voltage)) = (
+                instance.string_attr(&["technology"]),
+                instance.physical_attr(&["reverse_voltage"]),
+            ) {
+                return Some(GenericComponent::Rectifier(Rectifier {
+                    technology,
+                    reverse_voltage,
+                    forward_current: instance.physical_attr(&["forward_current"]),
+                    forward_voltage: instance.physical_attr(&["forward_voltage"]),
+                }));
+            }
+        }
+        "tvs" => {
+            if let (Some(direction), Some(reverse_standoff_voltage)) = (
+                instance.string_attr(&["direction"]),
+                instance.physical_attr(&["reverse_standoff_voltage"]),
+            ) {
+                return Some(GenericComponent::Tvs(Tvs {
+                    direction,
+                    reverse_standoff_voltage,
+                    reverse_clamping_voltage: instance.physical_attr(&["reverse_clamping_voltage"]),
+                    peak_pulse_power: instance.physical_attr(&["peak_pulse_power"]),
+                    capacitance: instance.physical_attr(&["capacitance"]),
+                }));
+            }
+        }
+        "zener" => {
+            if let Some(zener_voltage) = instance.physical_attr(&["zener_voltage"]) {
+                return Some(GenericComponent::Zener(Zener {
+                    zener_voltage,
+                    power: instance.physical_attr(&["power"]),
                 }));
             }
         }

--- a/crates/pcbc/tests/bom.rs
+++ b/crates/pcbc/tests/bom.rs
@@ -52,6 +52,29 @@ Capacitor(name = "C4", value = "22pF", package = "0402", P1 = osc_xo, P2 = gnd)
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 "#;
 
+const PARAMETRIC_GENERICS_BOARD_ZEN: &str = r#"
+# ```pcb
+# [workspace]
+# pcb-version = "0.4"
+# ```
+
+FerriteBead = Module("@stdlib/generics/FerriteBead.zen")
+Inductor = Module("@stdlib/generics/Inductor.zen")
+Rectifier = Module("@stdlib/generics/Rectifier.zen")
+Tvs = Module("@stdlib/generics/Tvs.zen")
+Zener = Module("@stdlib/generics/Zener.zen")
+
+vcc = Power("VCC")
+gnd = Ground("GND")
+signal = Net("SIGNAL")
+
+Inductor(name = "L1", value = "4.7uH", package = "0603", current = "1A", dcr = "120mOhm", P1 = vcc, P2 = signal)
+FerriteBead(name = "FB1", value = "600Ohm", package = "0603", frequency = "100MHz", current = "500mA", dcr = "200mOhm", P1 = vcc, P2 = signal)
+Rectifier(name = "D1", package = "SOD-123", technology = "Schottky", reverse_voltage = "40V", forward_current = "1A", forward_voltage = "500mV", A = signal, K = gnd)
+Zener(name = "Z1", package = "SOD-123", zener_voltage = "5.1V", power = "500mW", A = signal, K = gnd)
+Tvs(name = "TVS1", package = "DO-219AB", direction = "Unidirectional", reverse_standoff_voltage = "5V", reverse_clamping_voltage = "9V", peak_pulse_power = "400W", capacitance = "30pF", A = gnd, K = signal)
+"#;
+
 const SIMPLE_RESISTOR_BOARD_ZEN: &str = r#"
 # ```pcb
 # [workspace]
@@ -217,6 +240,28 @@ fn test_bom_json_format() {
         .sync()
         .snapshot_run("pcbc", ["bom", "boards/TestBoard.zen", "-f", "json"]);
     assert_snapshot!("bom_json", output);
+}
+
+#[test]
+fn test_parametric_generics_json_format() {
+    let output = Sandbox::new()
+        .write("pcb.toml", WORKSPACE_TOML)
+        .write(
+            "boards/ParametricGenerics.zen",
+            PARAMETRIC_GENERICS_BOARD_ZEN,
+        )
+        .sync()
+        .snapshot_run(
+            "pcbc",
+            [
+                "bom",
+                "boards/ParametricGenerics.zen",
+                "--offline",
+                "-f",
+                "json",
+            ],
+        );
+    assert_snapshot!("bom_parametric_generics_json", output);
 }
 
 #[test]

--- a/crates/pcbc/tests/snapshots/bom__bom_parametric_generics_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_parametric_generics_json.snap
@@ -1,0 +1,150 @@
+---
+source: crates/pcbc/tests/bom.rs
+assertion_line: 264
+expression: output
+---
+Command: pcbc bom boards/ParametricGenerics.zen --offline -f json
+Exit Code: 0
+
+--- STDOUT ---
+[
+  {
+    "path": "D1.D",
+    "designator": "D1",
+    "package": "SOD-123",
+    "value": "1A 40V Schottky Rectifier",
+    "description": "1A 40V Schottky Rectifier",
+    "component_type": "Rectifier",
+    "technology": "Schottky",
+    "reverse_voltage": {
+      "nominal": "40",
+      "min": "40",
+      "max": "40",
+      "unit": "Volts"
+    },
+    "forward_current": {
+      "nominal": "1",
+      "min": "1",
+      "max": "1",
+      "unit": "Amperes"
+    },
+    "forward_voltage": {
+      "nominal": "0.500",
+      "min": "0.500",
+      "max": "0.500",
+      "unit": "Volts"
+    }
+  },
+  {
+    "path": "TVS1.D",
+    "designator": "D2",
+    "package": "DO-219AB",
+    "value": "5V TVS Diode 400W",
+    "description": "5V TVS Diode 400W",
+    "component_type": "Tvs",
+    "direction": "Unidirectional",
+    "reverse_standoff_voltage": {
+      "nominal": "5",
+      "min": "5",
+      "max": "5",
+      "unit": "Volts"
+    },
+    "reverse_clamping_voltage": {
+      "nominal": "9",
+      "min": "9",
+      "max": "9",
+      "unit": "Volts"
+    },
+    "peak_pulse_power": {
+      "nominal": "400",
+      "min": "400",
+      "max": "400",
+      "unit": "Watts"
+    },
+    "capacitance": {
+      "nominal": "0.000000000030",
+      "min": "0.000000000030",
+      "max": "0.000000000030",
+      "unit": "Farads"
+    }
+  },
+  {
+    "path": "Z1.D",
+    "designator": "D3",
+    "package": "SOD-123",
+    "value": "5.1V Zener 500mW",
+    "description": "5.1V Zener 500mW",
+    "component_type": "Zener",
+    "zener_voltage": {
+      "nominal": "5.1",
+      "min": "5.1",
+      "max": "5.1",
+      "unit": "Volts"
+    },
+    "power": {
+      "nominal": "0.500",
+      "min": "0.500",
+      "max": "0.500",
+      "unit": "Watts"
+    }
+  },
+  {
+    "path": "FB1.FB",
+    "designator": "FB1",
+    "package": "0603",
+    "value": "600 500mA 100MHz",
+    "description": "600 500mA 100MHz",
+    "component_type": "FerriteBead",
+    "impedance": {
+      "nominal": "600",
+      "min": "600",
+      "max": "600",
+      "unit": "Ohms"
+    },
+    "frequency": {
+      "nominal": "100000000",
+      "min": "100000000",
+      "max": "100000000",
+      "unit": "Hertz"
+    },
+    "current": {
+      "nominal": "0.500",
+      "min": "0.500",
+      "max": "0.500",
+      "unit": "Amperes"
+    },
+    "dcr": {
+      "nominal": "0.200",
+      "min": "0.200",
+      "max": "0.200",
+      "unit": "Ohms"
+    }
+  },
+  {
+    "path": "L1.L",
+    "designator": "L1",
+    "package": "0603",
+    "value": "4.7uH 1A",
+    "description": "4.7uH 1A",
+    "component_type": "Inductor",
+    "inductance": {
+      "nominal": "0.0000047",
+      "min": "0.0000047",
+      "max": "0.0000047",
+      "unit": "Henries"
+    },
+    "current": {
+      "nominal": "1",
+      "min": "1",
+      "max": "1",
+      "unit": "Amperes"
+    },
+    "dcr": {
+      "nominal": "0.120",
+      "min": "0.120",
+      "max": "0.120",
+      "unit": "Ohms"
+    }
+  }
+]
+--- STDERR ---


### PR DESCRIPTION
PCB BOM requests only describe generic resistors and capacitors, so the API cannot perform parametric matching for other standard generic parts. This change serializes existing electrical properties for inductors, ferrite beads, rectifiers, Zener diodes, and TVS diodes, and adds an offline contract test; it does not change local matching or `Layout()` behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive BOM serialization and API request shape; no changes to local generic matching or layout behavior, with contract covered by a snapshot test.
> 
> **Overview**
> **`pcb bom`** now emits structured **`generic_data`** for inductors, ferrite beads, rectifiers, Zener diodes, and TVS diodes—not only resistors and capacitors—so API parametric matching receives the same electrical attributes already present on schematic instances.
> 
> In **`pcb-sch`**, **`GenericComponent`** gains five tagged variants with serde structs (e.g. inductance/current/DCR for inductors, technology/reverse voltage for rectifiers). **`detect_generic_component`** maps each stdlib generic **`Type`** and instance attributes into those variants when required fields are present. **`BomMatchingKey`** keeps inline enum variants with an explicit **`large_enum_variant`** allow. Local **`matches`** / BOM consolidation behavior for the new families is unchanged (still R/C only).
> 
> An offline **`pcbc bom`** integration test and JSON snapshot lock the serialized shape for a board using all five generics; the changelog documents the matcher payload change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b59304680c21d8c1c9709fc5377f9d0e2bcc8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->