### PR TITLE
Add an optional ict fixture role to TestPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `TestPoint` accepts an optional `ict` fixture role that is copied onto the footprint.
 - `pcb ipc dfm check` validates IPC-2581 files against fabrication PDKs.
 
 ### Changed

--- a/lib/std/generics/TestPoint.zen
+++ b/lib/std/generics/TestPoint.zen
@@ -57,8 +57,32 @@ Variant = enum(
     "THTPad_D4.0mm_Drill2.0mm",
 )
 variant = config(Variant, help="Test point style and size")
+ict = config(
+    str,
+    optional=True,
+    allowed=[
+        "swd",
+        "swdio",
+        "swclk",
+        "nrst",
+        "swo",
+        "gnd",
+        "vusb",
+        "vtarget",
+        "usb_dp",
+        "usb_dm",
+        "ls",
+    ],
+    help="Optional ICT fixture role, copied onto the footprint.",
+)
 
 P1 = io(Net)
+
+
+def _properties(base):
+    if ict:
+        base["ict"] = ict
+    return base
 
 
 def _symbol(variant: Variant):
@@ -92,9 +116,11 @@ if "Keystone" in variant.value:
         mpn=_keystone_mpn(variant, color),
         symbol=Symbol(_symbol(variant)),
         footprint=File(_footprint(variant)),
-        properties={
-            "color": color,
-        },
+        properties=_properties(
+            {
+                "color": color,
+            }
+        ),
         pins={
             "1": P1,
         },
@@ -105,9 +131,11 @@ else:
         prefix="TP",
         symbol=Symbol(_symbol(variant)),
         footprint=File(_footprint(variant)),
-        properties={
-            "variant": variant,
-        },
+        properties=_properties(
+            {
+                "variant": variant,
+            }
+        ),
         pins={
             "1": P1,
         },

--- a/lib/std/generics/test/test_TestPoint.zen
+++ b/lib/std/generics/test/test_TestPoint.zen
@@ -14,3 +14,10 @@ for variant in TestPoint.Variant.values():
         variant=variant,
         P1=Net(name + "_P1"),
     )
+
+TestPoint(
+    name="TP_ICT_GND",
+    variant="Pad_D1.0mm",
+    ict="gnd",
+    P1=Net("TP_ICT_GND_P1"),
+)


### PR DESCRIPTION
`TestPoint` takes an optional `ict` config (`swd`, `swdio`, `swclk`, `nrst`, `swo`, `gnd`, `vusb`, `vtarget`, `usb_dp`, `usb_dm`, `ls`) and copies it onto the footprint as an `ict` property. Test-fixture tooling identifies fixture pads by this property instead of scraping names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4b204534fc301f18499120d473bdc97f6f1c0956. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->