### PR TITLE
Add pcb ipc ict to list ICT fixture contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `pcb ipc ict` lists ICT fixture contacts (components with an `Ict` BOM characteristic) as CSV.
 - `TestPoint` accepts an optional `ict` fixture role that is copied onto the footprint.
 - `pcb ipc dfm check` validates IPC-2581 files against fabrication PDKs.
 

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -1,0 +1,356 @@
+//! List ICT fixture contacts from an IPC-2581 file.
+//!
+//! A fixture contact is any component whose BOM item carries an `Ict`
+//! characteristic — the `TestPoint` `ict=` config, which layout sync
+//! title-cases onto the footprint and IPC exports emit as a BOM
+//! characteristic. One CSV row per connected pin, at the pad position when
+//! the export carries per-pad nets and the component origin otherwise.
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use ipc2581::Ipc2581;
+use pcb_ir::dialects::placement::PlacementSide;
+
+use crate::accessors::IpcAccessor;
+use crate::commands::cpl::CplSideFilter;
+use crate::placement::extract_single_board_placements;
+
+#[derive(Debug, Clone)]
+pub struct IctOptions {
+    pub output: Option<PathBuf>,
+    pub side: CplSideFilter,
+}
+
+/// One fixture contact: a connected pin of an `Ict`-marked component.
+#[derive(Debug, Clone)]
+pub struct IctContact {
+    pub designator: String,
+    pub pin: String,
+    pub ict: String,
+    pub net: String,
+    pub x: f64,
+    pub y: f64,
+    pub side: PlacementSide,
+    pub path: String,
+}
+
+pub fn execute(file: &Path, options: &IctOptions) -> Result<()> {
+    let ipc = Ipc2581::parse_file(file)?;
+    let contacts = extract_contacts(&ipc)?;
+    let csv = emit_ict_csv(&contacts, options.side);
+
+    if let Some(output) = &options.output {
+        fs::write(output, csv)?;
+    } else {
+        io::stdout().write_all(csv.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+pub fn extract_contacts(ipc: &Ipc2581) -> Result<Vec<IctContact>> {
+    let accessor = IpcAccessor::new(ipc);
+
+    // Designator → (ict role, zen path) from the BOM.
+    let mut roles: BTreeMap<String, (String, String)> = BTreeMap::new();
+    if let Some(bom) = ipc.bom() {
+        for item in &bom.items {
+            let Some(chars) = item.characteristics.as_ref() else {
+                continue;
+            };
+            let data = accessor.extract_characteristics(chars);
+            let Some(ict) = data
+                .properties
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case("ict"))
+                .map(|(_, value)| value.clone())
+            else {
+                continue;
+            };
+            for ref_des in &item.ref_des_list {
+                let designator = ipc.resolve(ref_des.name).to_string();
+                if !designator.is_empty() {
+                    roles.insert(
+                        designator,
+                        (ict.clone(), data.path.clone().unwrap_or_default()),
+                    );
+                }
+            }
+        }
+    }
+
+    // (designator, pin) → net and pad location. Exports carry connectivity
+    // either as LogicalNet pin lists or as per-layer pad Sets (KiCad's
+    // flavor); pad Sets also give the exact pad position, which beats the
+    // component origin.
+    #[derive(Default, Clone)]
+    struct PinInfo {
+        net: String,
+        at: Option<(f64, f64)>,
+    }
+    let mut pins: BTreeMap<(String, String), PinInfo> = BTreeMap::new();
+    if let Some(ecad) = ipc.ecad() {
+        for step in &ecad.cad_data.steps {
+            for net in &step.logical_nets {
+                for pin_ref in &net.pin_refs {
+                    let Some(component_ref) = pin_ref.component_ref else {
+                        continue;
+                    };
+                    let key = (
+                        ipc.resolve(component_ref).to_string(),
+                        ipc.resolve(pin_ref.pin).to_string(),
+                    );
+                    pins.entry(key).or_default().net = ipc.resolve(net.name).to_string();
+                }
+            }
+            for layer_feature in &step.layer_features {
+                for set in &layer_feature.sets {
+                    let Some(net) = set.net else { continue };
+                    for feature in &set.features {
+                        let ipc2581::types::SetFeature::Pad(pad) = feature else {
+                            continue;
+                        };
+                        let Some(pin_ref) = &pad.pin_ref else {
+                            continue;
+                        };
+                        let Some(component_ref) = pin_ref.component_ref else {
+                            continue;
+                        };
+                        let key = (
+                            ipc.resolve(component_ref).to_string(),
+                            ipc.resolve(pin_ref.pin).to_string(),
+                        );
+                        let info = pins.entry(key).or_default();
+                        info.net = ipc.resolve(net).to_string();
+                        if let (Some(x), Some(y)) = (pad.x, pad.y) {
+                            info.at = Some((x, y));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let placements = extract_single_board_placements(&accessor)?;
+    let mut contacts = Vec::new();
+    for component in &placements.components {
+        let Some((ict, path)) = roles.get(&component.designator) else {
+            continue;
+        };
+        let empty = PinInfo::default();
+        let mut rows: Vec<(&String, &PinInfo)> = pins
+            .range((component.designator.clone(), String::new())..)
+            .take_while(|((designator, _), _)| designator == &component.designator)
+            .map(|((_, pin), info)| (pin, info))
+            .collect();
+        // A contact with no connected pin is still a contact — keep it
+        // visible instead of silently dropping it.
+        if rows.is_empty() {
+            rows.push((&EMPTY, &empty));
+        }
+        for (pin, info) in rows {
+            let (x, y) = info.at.unwrap_or((component.at.x, component.at.y));
+            contacts.push(IctContact {
+                designator: component.designator.clone(),
+                pin: pin.clone(),
+                ict: ict.clone(),
+                net: info.net.clone(),
+                x,
+                y,
+                side: component.side,
+                path: path.clone(),
+            });
+        }
+    }
+
+    contacts.sort_by(compare_contacts);
+    Ok(contacts)
+}
+
+static EMPTY: String = String::new();
+
+fn compare_contacts(left: &IctContact, right: &IctContact) -> Ordering {
+    side_sort_key(left.side)
+        .cmp(&side_sort_key(right.side))
+        .then_with(|| natord::compare(&left.designator, &right.designator))
+        .then_with(|| natord::compare(&left.pin, &right.pin))
+}
+
+fn side_sort_key(side: PlacementSide) -> u8 {
+    match side {
+        PlacementSide::Top => 0,
+        PlacementSide::Bottom => 1,
+        PlacementSide::Internal => 2,
+        PlacementSide::Unknown => 3,
+    }
+}
+
+pub fn emit_ict_csv(contacts: &[IctContact], side: CplSideFilter) -> String {
+    let mut output = String::from("Designator,Pin,Ict,Net,X,Y,Side,Path\n");
+    for contact in contacts {
+        let keep = match side {
+            CplSideFilter::Both => true,
+            CplSideFilter::Top => contact.side == PlacementSide::Top,
+            CplSideFilter::Bottom => contact.side == PlacementSide::Bottom,
+        };
+        if !keep {
+            continue;
+        }
+        write_csv_row(
+            &mut output,
+            &[
+                contact.designator.as_str(),
+                contact.pin.as_str(),
+                contact.ict.as_str(),
+                contact.net.as_str(),
+                &format!("{:.6}", contact.x),
+                &format!("{:.6}", contact.y),
+                side_name(contact.side),
+                contact.path.as_str(),
+            ],
+        );
+    }
+    output
+}
+
+fn side_name(side: PlacementSide) -> &'static str {
+    match side {
+        PlacementSide::Top => "top",
+        PlacementSide::Bottom => "bottom",
+        PlacementSide::Internal => "internal",
+        PlacementSide::Unknown => "unknown",
+    }
+}
+
+fn write_csv_row(output: &mut String, fields: &[&str]) {
+    for (index, field) in fields.iter().enumerate() {
+        if index > 0 {
+            output.push(',');
+        }
+        write_csv_field(output, field);
+    }
+    output.push('\n');
+}
+
+fn write_csv_field(output: &mut String, field: &str) {
+    if !field.contains([',', '"', '\n', '\r']) {
+        output.push_str(field);
+        return;
+    }
+
+    output.push('"');
+    for ch in field.chars() {
+        if ch == '"' {
+            output.push('"');
+        }
+        output.push(ch);
+    }
+    output.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="ASSEMBLY"/>
+    <DictionaryStandard units="MILLIMETER"/>
+  </Content>
+  <Bom name="BOM_board">
+    <BomHeader assembly="board" revision="1.0">
+      <StepRef name="board"/>
+    </BomHeader>
+    <BomItem OEMDesignNumberRef="TP_GND" quantity="1" pinCount="1" category="ELECTRICAL">
+      <RefDes name="TP1" packageRef="Pad_D1.0mm" populate="true" layerRef="BOTTOM"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual textualCharacteristicName="Ict" textualCharacteristicValue="gnd"/>
+        <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_GND"/>
+      </Characteristics>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="R10k" quantity="1" pinCount="2" category="ELECTRICAL">
+      <RefDes name="R1" packageRef="R_0603" populate="true" layerRef="TOP"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual textualCharacteristicName="Value" textualCharacteristicValue="10k"/>
+      </Characteristics>
+    </BomItem>
+  </Bom>
+  <Ecad name="ecad">
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+      <Layer name="BOTTOM" layerFunction="CONDUCTOR" side="BOTTOM" polarity="POSITIVE"/>
+      <Stackup name="stackup" overallThickness="1.6" tolPlus="0.0" tolMinus="0.0">
+        <StackupGroup name="group" thickness="1.6" tolPlus="0.0" tolMinus="0.0"/>
+      </Stackup>
+      <Step name="board">
+        <Datum x="0.0" y="0.0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0.0" y="0.0"/>
+            <PolyStepSegment x="10.0" y="0.0"/>
+            <PolyStepSegment x="10.0" y="10.0"/>
+            <PolyStepSegment x="0.0" y="10.0"/>
+            <PolyStepSegment x="0.0" y="0.0"/>
+          </Polygon>
+        </Profile>
+        <LogicalNet name="GND">
+          <PinRef pin="1" componentRef="TP1"/>
+          <PinRef pin="2" componentRef="R1"/>
+        </LogicalNet>
+        <LogicalNet name="SIG">
+          <PinRef pin="1" componentRef="R1"/>
+        </LogicalNet>
+        <Component refDes="TP1" packageRef="Pad_D1.0mm" layerRef="BOTTOM" part="TP_GND" mountType="SMT">
+          <Location x="3.500" y="4.250"/>
+        </Component>
+        <Component refDes="R1" packageRef="R_0603" layerRef="TOP" part="R10k" mountType="SMT">
+          <Location x="1.000" y="2.000"/>
+        </Component>
+        <LayerFeature layerRef="BOTTOM">
+          <Set net="GND">
+            <Pad>
+              <Location x="3.600" y="4.300"/>
+              <PinRef componentRef="TP1" pin="1"/>
+            </Pad>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+    #[test]
+    fn lists_ict_contacts_with_nets() {
+        let ipc = Ipc2581::parse(FIXTURE).expect("fixture parses");
+        let contacts = extract_contacts(&ipc).expect("extracts");
+
+        assert_eq!(contacts.len(), 1);
+        let contact = &contacts[0];
+        assert_eq!(contact.designator, "TP1");
+        assert_eq!(contact.pin, "1");
+        assert_eq!(contact.ict, "gnd");
+        assert_eq!(contact.net, "GND");
+        assert_eq!(contact.side, PlacementSide::Bottom);
+        // The pad Set position wins over the component origin.
+        assert_eq!((contact.x, contact.y), (3.6, 4.3));
+        assert_eq!(contact.path, "TP_GND");
+
+        let csv = emit_ict_csv(&contacts, CplSideFilter::Both);
+        assert_eq!(
+            csv,
+            "Designator,Pin,Ict,Net,X,Y,Side,Path\n\
+             TP1,1,gnd,GND,3.600000,4.300000,bottom,TP_GND\n"
+        );
+        assert_eq!(
+            emit_ict_csv(&contacts, CplSideFilter::Top),
+            "Designator,Pin,Ict,Net,X,Y,Side,Path\n"
+        );
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod dfm;
 pub mod fab_panel;
 pub(crate) mod fabrication;
 pub mod html_export;
+pub mod ict;
 pub mod info;
 pub mod outline;
 pub mod render;

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -34,6 +34,18 @@ enum Commands {
         #[arg(long)]
         offline: bool,
     },
+    /// List ICT fixture contacts (components with an `Ict` BOM characteristic)
+    Ict {
+        /// IPC-2581 XML file to export from
+        #[arg(value_hint = clap::ValueHint::FilePath)]
+        file: PathBuf,
+        /// Output CSV file path. If omitted, writes CSV to stdout.
+        #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
+        output: Option<PathBuf>,
+        /// Component side to include
+        #[arg(long, default_value = "both")]
+        side: commands::cpl::CplSideFilter,
+    },
     /// Generate component placement data (CPL)
     Cpl {
         /// IPC-2581 XML file to export from
@@ -336,6 +348,9 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             format,
             offline,
         } => commands::bom::execute(&file, format, offline),
+        Commands::Ict { file, output, side } => {
+            commands::ict::execute(&file, &commands::ict::IctOptions { output, side })
+        }
         Commands::Cpl {
             file,
             output,


### PR DESCRIPTION
`pcb ipc ict <file.xml>` lists ICT fixture contacts — components whose BOM item carries an `Ict` characteristic (the `TestPoint` `ict=` config) — as CSV: designator, pin, role, net, position, side, and zen path. One row per connected pin, at the pad position when the export carries per-pad nets (KiCad flavor) and the component origin otherwise; `--side` filters like `cpl`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only IPC-2581 parsing and CSV export with no changes to auth, layout sync, or manufacturing pipelines.
> 
> **Overview**
> Adds **`pcb ipc ict`** (IPC-2581 alias **`pcb ipc`**) to export ICT fixture contacts as CSV for test-fixture planning.
> 
> The command finds BOM items with an **`Ict`** characteristic (from `TestPoint` `ict=` / layout sync), joins **logical nets** and **per-pad** connectivity when present, and emits **one row per connected pin** with designator, pin, role, net, **X/Y** (pad position when available, else component origin), side, and zen path. **`--side`** matches **`cpl`**; **`-o`** writes a file or stdout by default.
> 
> Implementation lives in a new **`ict`** command module with unit tests; the changelog documents the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b41b807d7991e0dd0dbdbc68099947e56e001d36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->