### PR TITLE
Add a kicad dialect to pcb-ir for generated boards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4291,6 +4291,7 @@ dependencies = [
  "boostvoronoi",
  "i_overlay",
  "kurbo",
+ "pcb-sexpr",
  "resvg",
  "terminal_size",
 ]

--- a/crates/pcb-ir/Cargo.toml
+++ b/crates/pcb-ir/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT OR Apache-2.0"
 keywords = ["pcb", "gerber", "ipc-2581", "geometry", "eda"]
 categories = ["graphics", "rendering", "hardware-support"]
 
+[dev-dependencies]
+pcb-sexpr = { workspace = true }
+
 [dependencies]
 base64 = { workspace = true }
 boostvoronoi = { workspace = true }

--- a/crates/pcb-ir/src/dialects/kicad/mod.rs
+++ b/crates/pcb-ir/src/dialects/kicad/mod.rs
@@ -1,0 +1,411 @@
+//! Generated KiCad board documents (`.kicad_pcb`), millimeters.
+//!
+//! Writer-oriented: this dialect models what board *generators* produce —
+//! layers, nets, footprints with pads, tracks, vias, zones, and board
+//! graphics — not everything KiCad can read back. Coordinates are KiCad
+//! layout coordinates (millimeters, Y down). [`write`] serializes a
+//! document into KiCad 9/10 s-expression text.
+//!
+//! Identity is deterministic by design: every element carries a `uuid`
+//! string (KiCad requires one), and [`UuidGen`] hands out well-formed
+//! sequential UUIDs so re-generating the same board yields the same file.
+
+mod write;
+
+pub use write::write;
+
+use crate::geom::Point;
+
+/// A complete `.kicad_pcb` document.
+#[derive(Debug, Clone)]
+pub struct Document {
+    /// KiCad file format version stamp (e.g. `20260206` for KiCad 10).
+    pub version: u32,
+    pub generator: String,
+    pub generator_version: String,
+    /// Overall board thickness for the `general` section.
+    pub thickness_mm: f64,
+    pub paper: String,
+    pub layers: Vec<Layer>,
+    pub setup: Setup,
+    /// Net table; the net *number* is the index. Index 0 is KiCad's
+    /// "no net" and should stay the empty string.
+    pub nets: Vec<String>,
+    pub footprints: Vec<Footprint>,
+    pub segments: Vec<Segment>,
+    pub arcs: Vec<TrackArc>,
+    pub vias: Vec<Via>,
+    pub zones: Vec<Zone>,
+    pub graphics: Vec<Graphic>,
+}
+
+impl Default for Document {
+    fn default() -> Self {
+        Self {
+            version: 20260206,
+            generator: "pcb-ir".into(),
+            generator_version: env!("CARGO_PKG_VERSION").into(),
+            thickness_mm: 1.6,
+            paper: "A4".into(),
+            layers: Vec::new(),
+            setup: Setup::default(),
+            nets: vec![String::new()],
+            footprints: Vec::new(),
+            segments: Vec::new(),
+            arcs: Vec::new(),
+            vias: Vec::new(),
+            zones: Vec::new(),
+            graphics: Vec::new(),
+        }
+    }
+}
+
+impl Document {
+    /// A document with the standard two-copper-layer stack (KiCad 10
+    /// ordinals: F.Cu = 0, B.Cu = 2).
+    pub fn two_layer() -> Self {
+        Self {
+            layers: vec![
+                Layer::signal(0, "F.Cu"),
+                Layer::signal(2, "B.Cu"),
+                Layer::user(13, "F.Paste"),
+                Layer::user(15, "B.Paste"),
+                Layer::named_user(5, "F.SilkS", "F.Silkscreen"),
+                Layer::named_user(7, "B.SilkS", "B.Silkscreen"),
+                Layer::user(1, "F.Mask"),
+                Layer::user(3, "B.Mask"),
+                Layer::user(25, "Edge.Cuts"),
+                Layer::named_user(29, "B.CrtYd", "B.Courtyard"),
+                Layer::named_user(31, "F.CrtYd", "F.Courtyard"),
+                Layer::user(33, "B.Fab"),
+                Layer::user(35, "F.Fab"),
+            ],
+            ..Self::default()
+        }
+    }
+
+    /// Intern a net name, returning its net number.
+    pub fn net(&mut self, name: &str) -> u32 {
+        if let Some(index) = self.nets.iter().position(|net| net == name) {
+            return index as u32;
+        }
+        self.nets.push(name.to_string());
+        (self.nets.len() - 1) as u32
+    }
+}
+
+/// One entry of the board's layer table.
+#[derive(Debug, Clone)]
+pub struct Layer {
+    pub ordinal: u32,
+    /// Canonical KiCad name (`F.Cu`, `Edge.Cuts`, …).
+    pub canonical: String,
+    pub kind: LayerKind,
+    /// Optional user-facing rename (`F.Silkscreen` for `F.SilkS`).
+    pub user_name: Option<String>,
+}
+
+impl Layer {
+    pub fn signal(ordinal: u32, canonical: &str) -> Self {
+        Self {
+            ordinal,
+            canonical: canonical.into(),
+            kind: LayerKind::Signal,
+            user_name: None,
+        }
+    }
+
+    pub fn user(ordinal: u32, canonical: &str) -> Self {
+        Self {
+            ordinal,
+            canonical: canonical.into(),
+            kind: LayerKind::User,
+            user_name: None,
+        }
+    }
+
+    pub fn named_user(ordinal: u32, canonical: &str, user_name: &str) -> Self {
+        Self {
+            user_name: Some(user_name.into()),
+            ..Self::user(ordinal, canonical)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerKind {
+    Signal,
+    Power,
+    Mixed,
+    Jumper,
+    User,
+}
+
+/// Board `setup` section. Only the knobs generators set; everything else
+/// keeps KiCad's defaults on load.
+#[derive(Debug, Clone)]
+pub struct Setup {
+    pub pad_to_mask_clearance: f64,
+    pub allow_soldermask_bridges_in_footprints: bool,
+}
+
+impl Default for Setup {
+    fn default() -> Self {
+        Self {
+            pad_to_mask_clearance: 0.0,
+            allow_soldermask_bridges_in_footprints: false,
+        }
+    }
+}
+
+/// Position with rotation, KiCad `(at x y rot)`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct At {
+    pub x: f64,
+    pub y: f64,
+    /// Degrees. KiCad omits the third element when zero; the writer does
+    /// the same.
+    pub rot: f64,
+}
+
+impl At {
+    pub fn xy(x: f64, y: f64) -> Self {
+        Self { x, y, rot: 0.0 }
+    }
+}
+
+/// A footprint instance. Pad positions are footprint-relative, exactly as
+/// KiCad stores them; pad rotation is absolute (it includes the parent's),
+/// again matching the file format.
+#[derive(Debug, Clone)]
+pub struct Footprint {
+    /// Library id, e.g. `Interposer:Pad_D1.0mm`.
+    pub lib_id: String,
+    pub layer: String,
+    pub uuid: String,
+    pub at: At,
+    pub properties: Vec<Property>,
+    pub attrs: FootprintAttrs,
+    pub pads: Vec<Pad>,
+}
+
+/// A footprint property (`Reference`, `Value`, or a custom field).
+#[derive(Debug, Clone)]
+pub struct Property {
+    pub key: String,
+    pub value: String,
+    /// Footprint-relative text position.
+    pub at: At,
+    pub layer: String,
+    pub hide: bool,
+    pub uuid: String,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FootprintAttrs {
+    pub mount: Option<Mount>,
+    pub exclude_from_pos_files: bool,
+    pub exclude_from_bom: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mount {
+    Smd,
+    ThroughHole,
+}
+
+#[derive(Debug, Clone)]
+pub struct Pad {
+    /// Pad number; empty is legal (tooling holes).
+    pub number: String,
+    pub kind: PadKind,
+    pub shape: PadShape,
+    pub at: At,
+    pub size: (f64, f64),
+    /// Drill diameter for through-hole pad kinds.
+    pub drill: Option<f64>,
+    pub layers: Vec<String>,
+    pub net: Option<(u32, String)>,
+    pub solder_mask_margin: Option<f64>,
+    /// Pad-level clearance override.
+    pub clearance: Option<f64>,
+    pub uuid: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PadKind {
+    Smd,
+    ThruHole,
+    NpThruHole,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PadShape {
+    Circle,
+    Rect,
+    Oval,
+    RoundRect {
+        /// Corner radius as a ratio of the smaller pad dimension.
+        ratio: f64,
+    },
+}
+
+/// A straight track segment.
+#[derive(Debug, Clone)]
+pub struct Segment {
+    pub start: Point,
+    pub end: Point,
+    pub width: f64,
+    pub layer: String,
+    pub net: u32,
+    pub uuid: String,
+}
+
+/// A curved track segment through `mid`.
+#[derive(Debug, Clone)]
+pub struct TrackArc {
+    pub start: Point,
+    pub mid: Point,
+    pub end: Point,
+    pub width: f64,
+    pub layer: String,
+    pub net: u32,
+    pub uuid: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Via {
+    pub at: Point,
+    /// Pad (annular) diameter.
+    pub size: f64,
+    pub drill: f64,
+    pub layers: (String, String),
+    pub net: u32,
+    pub uuid: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Zone {
+    pub net: u32,
+    pub net_name: String,
+    pub layers: Vec<String>,
+    pub uuid: String,
+    pub name: Option<String>,
+    pub priority: Option<u32>,
+    /// Hatch display pitch (`(hatch edge …)`).
+    pub hatch_pitch: f64,
+    pub connect_pads: ZoneConnect,
+    /// Zone-to-pad clearance.
+    pub connect_clearance: f64,
+    pub min_thickness: f64,
+    pub fill: ZoneFill,
+    /// Zone outline.
+    pub polygon: Vec<Point>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZoneConnect {
+    Thermal,
+    Solid,
+    ThruHoleOnly,
+    None,
+}
+
+/// Fill settings only — computed fill polygons are KiCad's job, not the
+/// generator's.
+#[derive(Debug, Clone)]
+pub struct ZoneFill {
+    pub enabled: bool,
+    pub thermal_gap: f64,
+    pub thermal_bridge_width: f64,
+}
+
+impl Default for ZoneFill {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            thermal_gap: 0.5,
+            thermal_bridge_width: 0.5,
+        }
+    }
+}
+
+/// Board-level graphic items.
+#[derive(Debug, Clone)]
+pub enum Graphic {
+    Line {
+        start: Point,
+        end: Point,
+        stroke: Stroke,
+        layer: String,
+        uuid: String,
+    },
+    Rect {
+        start: Point,
+        end: Point,
+        stroke: Stroke,
+        fill: bool,
+        layer: String,
+        uuid: String,
+    },
+    Circle {
+        center: Point,
+        /// A point on the circumference, KiCad's radius encoding.
+        end: Point,
+        stroke: Stroke,
+        fill: bool,
+        layer: String,
+        uuid: String,
+    },
+    Arc {
+        start: Point,
+        mid: Point,
+        end: Point,
+        stroke: Stroke,
+        layer: String,
+        uuid: String,
+    },
+    Poly {
+        pts: Vec<Point>,
+        stroke: Stroke,
+        fill: bool,
+        layer: String,
+        uuid: String,
+    },
+    Text {
+        text: String,
+        at: At,
+        layer: String,
+        /// Font (width, height).
+        size: (f64, f64),
+        thickness: f64,
+        uuid: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Stroke {
+    pub width: f64,
+}
+
+impl Stroke {
+    pub fn solid(width: f64) -> Self {
+        Self { width }
+    }
+}
+
+/// Deterministic well-formed UUIDs, so regenerating a board reproduces the
+/// same file byte for byte.
+#[derive(Debug, Default)]
+pub struct UuidGen(u64);
+
+impl UuidGen {
+    pub fn new() -> Self {
+        Self(0)
+    }
+
+    pub fn next_uuid(&mut self) -> String {
+        self.0 += 1;
+        format!("00000000-0000-4000-8000-{:012x}", self.0)
+    }
+}

--- a/crates/pcb-ir/src/dialects/kicad/write.rs
+++ b/crates/pcb-ir/src/dialects/kicad/write.rs
@@ -117,10 +117,12 @@ fn write_footprint(w: &mut Writer, footprint: &super::Footprint) {
             "property",
             &format!("{} {}", quote(&property.key), quote(&property.value)),
         );
+        // Properties always carry the angle, even when zero — pcbnew's shape.
         w.line(&format!(
-            "(at {} {} 0)",
+            "(at {} {} {})",
             num(property.at.x),
-            num(property.at.y)
+            num(property.at.y),
+            num(property.at.rot)
         ));
         w.line(&format!("(layer {})", quote(&property.layer)));
         if property.hide {

--- a/crates/pcb-ir/src/dialects/kicad/write.rs
+++ b/crates/pcb-ir/src/dialects/kicad/write.rs
@@ -1,0 +1,469 @@
+//! Serialize a [`Document`] into `.kicad_pcb` s-expression text.
+//!
+//! Output follows KiCad's own file conventions — tab indentation, one node
+//! per line, quoted strings, numbers trimmed to at most six decimals — so
+//! generated boards diff cleanly against pcbnew re-saves.
+
+use super::{At, Document, Graphic, LayerKind, Mount, Pad, PadKind, PadShape, ZoneConnect};
+use crate::geom::Point;
+
+/// Render the document as complete `.kicad_pcb` text.
+pub fn write(document: &Document) -> String {
+    let mut w = Writer::default();
+    w.open("kicad_pcb");
+    w.line(&format!("(version {})", document.version));
+    w.line(&format!("(generator {})", quote(&document.generator)));
+    w.line(&format!(
+        "(generator_version {})",
+        quote(&document.generator_version)
+    ));
+    w.open("general");
+    w.line(&format!("(thickness {})", num(document.thickness_mm)));
+    w.line("(legacy_teardrops no)");
+    w.close();
+    w.line(&format!("(paper {})", quote(&document.paper)));
+
+    w.open("layers");
+    for layer in &document.layers {
+        let kind = match layer.kind {
+            LayerKind::Signal => "signal",
+            LayerKind::Power => "power",
+            LayerKind::Mixed => "mixed",
+            LayerKind::Jumper => "jumper",
+            LayerKind::User => "user",
+        };
+        let mut entry = format!("({} {} {kind}", layer.ordinal, quote(&layer.canonical));
+        if let Some(user_name) = &layer.user_name {
+            entry.push(' ');
+            entry.push_str(&quote(user_name));
+        }
+        entry.push(')');
+        w.line(&entry);
+    }
+    w.close();
+
+    w.open("setup");
+    w.line(&format!(
+        "(pad_to_mask_clearance {})",
+        num(document.setup.pad_to_mask_clearance)
+    ));
+    w.line(&format!(
+        "(allow_soldermask_bridges_in_footprints {})",
+        yes_no(document.setup.allow_soldermask_bridges_in_footprints)
+    ));
+    w.close();
+
+    for (index, name) in document.nets.iter().enumerate() {
+        w.line(&format!("(net {index} {})", quote(name)));
+    }
+
+    for footprint in &document.footprints {
+        write_footprint(&mut w, footprint);
+    }
+    for graphic in &document.graphics {
+        write_graphic(&mut w, graphic);
+    }
+    for segment in &document.segments {
+        w.open("segment");
+        w.line(&format!("(start {})", xy(segment.start)));
+        w.line(&format!("(end {})", xy(segment.end)));
+        w.line(&format!("(width {})", num(segment.width)));
+        w.line(&format!("(layer {})", quote(&segment.layer)));
+        w.line(&format!("(net {})", segment.net));
+        w.line(&format!("(uuid {})", quote(&segment.uuid)));
+        w.close();
+    }
+    for arc in &document.arcs {
+        w.open("arc");
+        w.line(&format!("(start {})", xy(arc.start)));
+        w.line(&format!("(mid {})", xy(arc.mid)));
+        w.line(&format!("(end {})", xy(arc.end)));
+        w.line(&format!("(width {})", num(arc.width)));
+        w.line(&format!("(layer {})", quote(&arc.layer)));
+        w.line(&format!("(net {})", arc.net));
+        w.line(&format!("(uuid {})", quote(&arc.uuid)));
+        w.close();
+    }
+    for via in &document.vias {
+        w.open("via");
+        w.line(&format!("(at {})", xy(via.at)));
+        w.line(&format!("(size {})", num(via.size)));
+        w.line(&format!("(drill {})", num(via.drill)));
+        w.line(&format!(
+            "(layers {} {})",
+            quote(&via.layers.0),
+            quote(&via.layers.1)
+        ));
+        w.line(&format!("(net {})", via.net));
+        w.line(&format!("(uuid {})", quote(&via.uuid)));
+        w.close();
+    }
+    for zone in &document.zones {
+        write_zone(&mut w, zone);
+    }
+
+    w.line("(embedded_fonts no)");
+    w.close();
+    w.finish()
+}
+
+fn write_footprint(w: &mut Writer, footprint: &super::Footprint) {
+    w.open_with("footprint", &quote(&footprint.lib_id));
+    w.line(&format!("(layer {})", quote(&footprint.layer)));
+    w.line(&format!("(uuid {})", quote(&footprint.uuid)));
+    w.line(&format!("(at {})", at(footprint.at)));
+    for property in &footprint.properties {
+        w.open_with(
+            "property",
+            &format!("{} {}", quote(&property.key), quote(&property.value)),
+        );
+        w.line(&format!(
+            "(at {} {} 0)",
+            num(property.at.x),
+            num(property.at.y)
+        ));
+        w.line(&format!("(layer {})", quote(&property.layer)));
+        if property.hide {
+            w.line("(hide yes)");
+        }
+        w.line(&format!("(uuid {})", quote(&property.uuid)));
+        w.line("(effects (font (size 1 1) (thickness 0.15)))");
+        w.close();
+    }
+    let attrs = &footprint.attrs;
+    if attrs.mount.is_some() || attrs.exclude_from_pos_files || attrs.exclude_from_bom {
+        let mut entry = String::from("(attr");
+        match attrs.mount {
+            Some(Mount::Smd) => entry.push_str(" smd"),
+            Some(Mount::ThroughHole) => entry.push_str(" through_hole"),
+            None => {}
+        }
+        if attrs.exclude_from_pos_files {
+            entry.push_str(" exclude_from_pos_files");
+        }
+        if attrs.exclude_from_bom {
+            entry.push_str(" exclude_from_bom");
+        }
+        entry.push(')');
+        w.line(&entry);
+    }
+    for pad in &footprint.pads {
+        write_pad(w, pad);
+    }
+    w.close();
+}
+
+fn write_pad(w: &mut Writer, pad: &Pad) {
+    let kind = match pad.kind {
+        PadKind::Smd => "smd",
+        PadKind::ThruHole => "thru_hole",
+        PadKind::NpThruHole => "np_thru_hole",
+    };
+    let shape = match pad.shape {
+        PadShape::Circle => "circle",
+        PadShape::Rect => "rect",
+        PadShape::Oval => "oval",
+        PadShape::RoundRect { .. } => "roundrect",
+    };
+    w.open_with("pad", &format!("{} {kind} {shape}", quote(&pad.number)));
+    w.line(&format!("(at {})", at(pad.at)));
+    w.line(&format!("(size {} {})", num(pad.size.0), num(pad.size.1)));
+    if let Some(drill) = pad.drill {
+        w.line(&format!("(drill {})", num(drill)));
+    }
+    if let PadShape::RoundRect { ratio } = pad.shape {
+        w.line(&format!("(roundrect_rratio {})", num(ratio)));
+    }
+    let layers = pad
+        .layers
+        .iter()
+        .map(|layer| quote(layer))
+        .collect::<Vec<_>>()
+        .join(" ");
+    w.line(&format!("(layers {layers})"));
+    if let Some((net, name)) = &pad.net {
+        w.line(&format!("(net {net} {})", quote(name)));
+    }
+    if let Some(margin) = pad.solder_mask_margin {
+        w.line(&format!("(solder_mask_margin {})", num(margin)));
+    }
+    if let Some(clearance) = pad.clearance {
+        w.line(&format!("(clearance {})", num(clearance)));
+    }
+    w.line(&format!("(uuid {})", quote(&pad.uuid)));
+    w.close();
+}
+
+fn write_zone(w: &mut Writer, zone: &super::Zone) {
+    w.open("zone");
+    w.line(&format!("(net {})", zone.net));
+    w.line(&format!("(net_name {})", quote(&zone.net_name)));
+    if let [layer] = zone.layers.as_slice() {
+        w.line(&format!("(layer {})", quote(layer)));
+    } else {
+        let layers = zone
+            .layers
+            .iter()
+            .map(|layer| quote(layer))
+            .collect::<Vec<_>>()
+            .join(" ");
+        w.line(&format!("(layers {layers})"));
+    }
+    w.line(&format!("(uuid {})", quote(&zone.uuid)));
+    if let Some(name) = &zone.name {
+        w.line(&format!("(name {})", quote(name)));
+    }
+    if let Some(priority) = zone.priority {
+        w.line(&format!("(priority {priority})"));
+    }
+    w.line(&format!("(hatch edge {})", num(zone.hatch_pitch)));
+    let mode = match zone.connect_pads {
+        ZoneConnect::Thermal => None,
+        ZoneConnect::Solid => Some("yes"),
+        ZoneConnect::ThruHoleOnly => Some("thru_hole_only"),
+        ZoneConnect::None => Some("no"),
+    };
+    match mode {
+        Some(mode) => w.open_with("connect_pads", mode),
+        None => w.open("connect_pads"),
+    }
+    w.line(&format!("(clearance {})", num(zone.connect_clearance)));
+    w.close();
+    w.line(&format!("(min_thickness {})", num(zone.min_thickness)));
+    w.line("(filled_areas_thickness no)");
+    w.open_with("fill", yes_no(zone.fill.enabled));
+    w.line(&format!("(thermal_gap {})", num(zone.fill.thermal_gap)));
+    w.line(&format!(
+        "(thermal_bridge_width {})",
+        num(zone.fill.thermal_bridge_width)
+    ));
+    w.close();
+    w.open("polygon");
+    w.open("pts");
+    for point in &zone.polygon {
+        w.line(&format!("(xy {})", xy(*point)));
+    }
+    w.close();
+    w.close();
+    w.close();
+}
+
+fn write_graphic(w: &mut Writer, graphic: &Graphic) {
+    match graphic {
+        Graphic::Line {
+            start,
+            end,
+            stroke,
+            layer,
+            uuid,
+        } => {
+            w.open("gr_line");
+            w.line(&format!("(start {})", xy(*start)));
+            w.line(&format!("(end {})", xy(*end)));
+            w.line(&format!(
+                "(stroke (width {}) (type solid))",
+                num(stroke.width)
+            ));
+            w.line(&format!("(layer {})", quote(layer)));
+            w.line(&format!("(uuid {})", quote(uuid)));
+            w.close();
+        }
+        Graphic::Rect {
+            start,
+            end,
+            stroke,
+            fill,
+            layer,
+            uuid,
+        } => {
+            w.open("gr_rect");
+            w.line(&format!("(start {})", xy(*start)));
+            w.line(&format!("(end {})", xy(*end)));
+            w.line(&format!(
+                "(stroke (width {}) (type solid))",
+                num(stroke.width)
+            ));
+            w.line(&format!("(fill {})", yes_no(*fill)));
+            w.line(&format!("(layer {})", quote(layer)));
+            w.line(&format!("(uuid {})", quote(uuid)));
+            w.close();
+        }
+        Graphic::Circle {
+            center,
+            end,
+            stroke,
+            fill,
+            layer,
+            uuid,
+        } => {
+            w.open("gr_circle");
+            w.line(&format!("(center {})", xy(*center)));
+            w.line(&format!("(end {})", xy(*end)));
+            w.line(&format!(
+                "(stroke (width {}) (type solid))",
+                num(stroke.width)
+            ));
+            w.line(&format!("(fill {})", yes_no(*fill)));
+            w.line(&format!("(layer {})", quote(layer)));
+            w.line(&format!("(uuid {})", quote(uuid)));
+            w.close();
+        }
+        Graphic::Arc {
+            start,
+            mid,
+            end,
+            stroke,
+            layer,
+            uuid,
+        } => {
+            w.open("gr_arc");
+            w.line(&format!("(start {})", xy(*start)));
+            w.line(&format!("(mid {})", xy(*mid)));
+            w.line(&format!("(end {})", xy(*end)));
+            w.line(&format!(
+                "(stroke (width {}) (type solid))",
+                num(stroke.width)
+            ));
+            w.line(&format!("(layer {})", quote(layer)));
+            w.line(&format!("(uuid {})", quote(uuid)));
+            w.close();
+        }
+        Graphic::Poly {
+            pts,
+            stroke,
+            fill,
+            layer,
+            uuid,
+        } => {
+            w.open("gr_poly");
+            w.open("pts");
+            for point in pts {
+                w.line(&format!("(xy {})", xy(*point)));
+            }
+            w.close();
+            w.line(&format!(
+                "(stroke (width {}) (type solid))",
+                num(stroke.width)
+            ));
+            w.line(&format!("(fill {})", yes_no(*fill)));
+            w.line(&format!("(layer {})", quote(layer)));
+            w.line(&format!("(uuid {})", quote(uuid)));
+            w.close();
+        }
+        Graphic::Text {
+            text,
+            at: position,
+            layer,
+            size,
+            thickness,
+            uuid,
+        } => {
+            w.open_with("gr_text", &quote(text));
+            w.line(&format!("(at {})", at(*position)));
+            w.line(&format!("(layer {})", quote(layer)));
+            w.line(&format!("(uuid {})", quote(uuid)));
+            w.line(&format!(
+                "(effects (font (size {} {}) (thickness {})))",
+                num(size.0),
+                num(size.1),
+                num(*thickness)
+            ));
+            w.close();
+        }
+    }
+}
+
+/// Format a number the way KiCad does: at most six decimals, trailing
+/// zeros trimmed, negative zero normalized.
+fn num(value: f64) -> String {
+    let value = if value == 0.0 { 0.0 } else { value };
+    let formatted = format!("{value:.6}");
+    let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
+    if trimmed.is_empty() || trimmed == "-" {
+        "0".into()
+    } else {
+        trimmed.into()
+    }
+}
+
+fn xy(point: Point) -> String {
+    format!("{} {}", num(point.x), num(point.y))
+}
+
+fn at(at: At) -> String {
+    if at.rot == 0.0 {
+        format!("{} {}", num(at.x), num(at.y))
+    } else {
+        format!("{} {} {}", num(at.x), num(at.y), num(at.rot))
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}
+
+fn quote(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Tab-indented node writer matching pcbnew's output shape.
+#[derive(Default)]
+struct Writer {
+    out: String,
+    depth: usize,
+}
+
+impl Writer {
+    fn open(&mut self, name: &str) {
+        self.indent();
+        self.out.push('(');
+        self.out.push_str(name);
+        self.out.push('\n');
+        self.depth += 1;
+    }
+
+    /// Open a node that carries inline arguments after its name.
+    fn open_with(&mut self, name: &str, args: &str) {
+        self.indent();
+        self.out.push('(');
+        self.out.push_str(name);
+        self.out.push(' ');
+        self.out.push_str(args);
+        self.out.push('\n');
+        self.depth += 1;
+    }
+
+    fn line(&mut self, content: &str) {
+        self.indent();
+        self.out.push_str(content);
+        self.out.push('\n');
+    }
+
+    fn close(&mut self) {
+        self.depth -= 1;
+        self.indent();
+        self.out.push_str(")\n");
+    }
+
+    fn indent(&mut self) {
+        for _ in 0..self.depth {
+            self.out.push('\t');
+        }
+    }
+
+    fn finish(self) -> String {
+        debug_assert_eq!(self.depth, 0);
+        self.out
+    }
+}

--- a/crates/pcb-ir/src/dialects/mod.rs
+++ b/crates/pcb-ir/src/dialects/mod.rs
@@ -1,5 +1,6 @@
 pub mod artwork;
 pub mod ipc;
+pub mod kicad;
 pub mod mask;
 pub mod nc;
 pub mod placement;

--- a/crates/pcb-ir/tests/kicad_write.rs
+++ b/crates/pcb-ir/tests/kicad_write.rs
@@ -34,7 +34,11 @@ fn sample() -> Document {
             Property {
                 key: "Reference".into(),
                 value: "P1".into(),
-                at: At::xy(0.0, -1.4),
+                at: At {
+                    x: 0.0,
+                    y: -1.4,
+                    rot: 90.0,
+                },
                 layer: "F.SilkS".into(),
                 hide: true,
                 uuid: uuids.next_uuid(),
@@ -185,6 +189,9 @@ fn output_is_deterministic_and_kicad_shaped() {
     assert!(text.trim_end().ends_with(')'));
     // Numbers trim like pcbnew's: no trailing zeros, no float noise.
     assert!(text.contains("(at 10 20.5)"));
+    // Property rotation survives, and zero angles are still written out.
+    assert!(text.contains("(at 0 -1.4 90)"));
+    assert!(text.contains("(at 0 1.4 0)"));
     assert!(text.contains("(size 2.1 2.1)"));
 }
 

--- a/crates/pcb-ir/tests/kicad_write.rs
+++ b/crates/pcb-ir/tests/kicad_write.rs
@@ -1,0 +1,211 @@
+//! The kicad dialect writer produces well-formed, deterministic board text.
+
+use pcb_ir::dialects::kicad::{
+    self, At, Document, Footprint, FootprintAttrs, Graphic, Mount, Pad, PadKind, PadShape,
+    Property, Segment, Stroke, UuidGen, Via, Zone, ZoneConnect, ZoneFill,
+};
+use pcb_ir::geom::Point;
+use pcb_sexpr::SexprKind;
+
+/// A small but representative board: outline, an SMT pad footprint with a
+/// bound net, an NPTH tooling hole, one track, a terminal via, and a GND
+/// zone.
+fn sample() -> Document {
+    let mut doc = Document::two_layer();
+    let mut uuids = UuidGen::new();
+    let gnd = doc.net("GND");
+    let sig = doc.net("B0.TP1");
+
+    doc.graphics.push(Graphic::Rect {
+        start: Point::new(0.0, 0.0),
+        end: Point::new(74.0, 105.0),
+        stroke: Stroke::solid(0.1),
+        fill: false,
+        layer: "Edge.Cuts".into(),
+        uuid: uuids.next_uuid(),
+    });
+
+    doc.footprints.push(Footprint {
+        lib_id: "Interposer:Pad_D1.0mm".into(),
+        layer: "F.Cu".into(),
+        uuid: uuids.next_uuid(),
+        at: At::xy(10.0, 20.5),
+        properties: vec![
+            Property {
+                key: "Reference".into(),
+                value: "P1".into(),
+                at: At::xy(0.0, -1.4),
+                layer: "F.SilkS".into(),
+                hide: true,
+                uuid: uuids.next_uuid(),
+            },
+            Property {
+                key: "Value".into(),
+                value: String::new(),
+                at: At::xy(0.0, 1.4),
+                layer: "F.Fab".into(),
+                hide: true,
+                uuid: uuids.next_uuid(),
+            },
+        ],
+        attrs: FootprintAttrs {
+            mount: Some(Mount::Smd),
+            exclude_from_pos_files: true,
+            exclude_from_bom: true,
+        },
+        pads: vec![Pad {
+            number: "1".into(),
+            kind: PadKind::Smd,
+            shape: PadShape::Circle,
+            at: At::default(),
+            size: (1.0, 1.0),
+            drill: None,
+            layers: vec!["F.Cu".into(), "F.Mask".into()],
+            net: Some((sig, "B0.TP1".into())),
+            solder_mask_margin: None,
+            clearance: None,
+            uuid: uuids.next_uuid(),
+        }],
+    });
+
+    doc.footprints.push(Footprint {
+        lib_id: "Interposer:ToolingHole".into(),
+        layer: "F.Cu".into(),
+        uuid: uuids.next_uuid(),
+        at: At::xy(3.0, 3.0),
+        properties: Vec::new(),
+        attrs: FootprintAttrs {
+            mount: None,
+            exclude_from_pos_files: true,
+            exclude_from_bom: true,
+        },
+        pads: vec![Pad {
+            number: String::new(),
+            kind: PadKind::NpThruHole,
+            shape: PadShape::Circle,
+            at: At::default(),
+            size: (2.1, 2.1),
+            drill: Some(2.1),
+            layers: vec!["*.Cu".into(), "*.Mask".into()],
+            net: None,
+            solder_mask_margin: None,
+            clearance: None,
+            uuid: uuids.next_uuid(),
+        }],
+    });
+
+    doc.segments.push(Segment {
+        start: Point::new(10.0, 20.5),
+        end: Point::new(14.25, 24.75),
+        width: 0.25,
+        layer: "F.Cu".into(),
+        net: sig,
+        uuid: uuids.next_uuid(),
+    });
+    doc.vias.push(Via {
+        at: Point::new(14.25, 24.75),
+        size: 0.6,
+        drill: 0.3,
+        layers: ("F.Cu".into(), "B.Cu".into()),
+        net: sig,
+        uuid: uuids.next_uuid(),
+    });
+    doc.zones.push(Zone {
+        net: gnd,
+        net_name: "GND".into(),
+        layers: vec!["B.Cu".into()],
+        uuid: uuids.next_uuid(),
+        name: None,
+        priority: None,
+        hatch_pitch: 0.5,
+        connect_pads: ZoneConnect::Thermal,
+        connect_clearance: 0.25,
+        min_thickness: 0.25,
+        fill: ZoneFill {
+            enabled: true,
+            thermal_gap: 0.3,
+            thermal_bridge_width: 0.4,
+        },
+        polygon: vec![
+            Point::new(0.0, 0.0),
+            Point::new(74.0, 0.0),
+            Point::new(74.0, 105.0),
+            Point::new(0.0, 105.0),
+        ],
+    });
+    doc
+}
+
+#[test]
+fn writes_a_parseable_board() {
+    let text = kicad::write(&sample());
+    // For validating against real KiCad tooling out of band.
+    if let Some(path) = std::env::var_os("KICAD_WRITE_DUMP") {
+        std::fs::write(path, &text).unwrap();
+    }
+    let root = pcb_sexpr::parse(&text).expect("writer output parses as s-expressions");
+
+    let SexprKind::List(items) = &root.kind else {
+        panic!("root is a list");
+    };
+    assert_eq!(items[0].as_atom(), Some("kicad_pcb"));
+
+    let count = |name: &str| {
+        items
+            .iter()
+            .filter(|item| {
+                matches!(&item.kind, SexprKind::List(children)
+                    if children.first().and_then(|c| c.as_atom()) == Some(name))
+            })
+            .count()
+    };
+    assert_eq!(count("net"), 3);
+    assert_eq!(count("footprint"), 2);
+    assert_eq!(count("segment"), 1);
+    assert_eq!(count("via"), 1);
+    assert_eq!(count("zone"), 1);
+    assert_eq!(count("gr_rect"), 1);
+    assert_eq!(count("layers"), 1);
+}
+
+#[test]
+fn output_is_deterministic_and_kicad_shaped() {
+    let text = kicad::write(&sample());
+    assert_eq!(text, kicad::write(&sample()));
+
+    // Spot-check the exact shapes pcbnew expects.
+    assert!(text.starts_with("(kicad_pcb\n\t(version 20260206)\n"));
+    assert!(text.contains("\t(net 0 \"\")\n"));
+    assert!(text.contains("\t(net 1 \"GND\")\n"));
+    assert!(text.contains("(pad \"1\" smd circle\n"));
+    assert!(text.contains("(pad \"\" np_thru_hole circle\n"));
+    assert!(text.contains("(attr smd exclude_from_pos_files exclude_from_bom)"));
+    assert!(text.contains("(hatch edge 0.5)"));
+    assert!(text.contains("(fill yes\n"));
+    assert!(text.trim_end().ends_with(')'));
+    // Numbers trim like pcbnew's: no trailing zeros, no float noise.
+    assert!(text.contains("(at 10 20.5)"));
+    assert!(text.contains("(size 2.1 2.1)"));
+}
+
+#[test]
+fn number_formatting_matches_kicad() {
+    // Exercised through a segment width, which passes straight through num().
+    let mut doc = Document::two_layer();
+    let mut uuids = UuidGen::new();
+    for width in [0.1234567, 1.0, 0.25, -0.0] {
+        doc.segments.push(Segment {
+            start: Point::new(0.0, 0.0),
+            end: Point::new(1.0, 1.0),
+            width,
+            layer: "F.Cu".into(),
+            net: 0,
+            uuid: uuids.next_uuid(),
+        });
+    }
+    let text = kicad::write(&doc);
+    assert!(text.contains("(width 0.123457)"));
+    assert!(text.contains("(width 1)"));
+    assert!(text.contains("(width 0.25)"));
+    assert!(text.contains("(width 0)"));
+}


### PR DESCRIPTION
A writer-oriented `.kicad_pcb` document model in `pcb_ir::dialects::kicad` — layers, nets, footprints with pads, tracks, vias, zones, board graphics — plus `kicad::write` serializing to pcbnew-style s-expression text with deterministic UUIDs, so regenerating a board reproduces the same file byte for byte.

Board generators (e.g. the pogo-pin interposer) target this instead of hand-formatting s-expressions, and it's the writer half needed for IPC-2581→KiCad lowering later. Tests round-trip the output through `pcb-sexpr`; a generated sample loads, zone-fills, and passes DRC in KiCad 10.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7d64a2c2a7dc7f932f1d7c495946c2b91bbe8417. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->