### PR TITLE
Add pcb ipc interposer to generate fixture interposer boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `pcb ipc interposer` generates the test-fixture interposer board for a board-array panel.
 - `pcb ipc ict` lists ICT fixture contacts (components with an `Ict` BOM characteristic) as CSV.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `pcb ipc interposer` generates the test-fixture interposer board for a board-array panel.
+
 ## [0.4.33] - 2026-08-21
 
 ### Added
 
-- `pcb ipc interposer` generates the test-fixture interposer board for a board-array panel.
 - `pcb ipc ict` lists ICT fixture contacts (components with an `Ict` BOM characteristic) as CSV.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4254,6 +4254,16 @@ name = "pcb-intern"
 version = "0.1.0"
 
 [[package]]
+name = "pcb-interposer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ipc2581",
+ "pcb-ir",
+ "pcb-sexpr",
+]
+
+[[package]]
 name = "pcb-ipc2581-tools"
 version = "0.4.33"
 dependencies = [
@@ -4589,6 +4599,7 @@ dependencies = [
  "pcb-docgen",
  "pcb-eda",
  "pcb-fmt",
+ "pcb-interposer",
  "pcb-ipc2581-tools",
  "pcb-ir",
  "pcb-kicad",

--- a/crates/pcb-interposer/Cargo.toml
+++ b/crates/pcb-interposer/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pcb-interposer"
+version = "0.1.0"
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Pogo-pin test-fixture interposer generation for assembly panels"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+anyhow = { workspace = true }
+ipc2581 = { workspace = true }
+pcb-ir = { workspace = true }
+
+[dev-dependencies]
+pcb-sexpr = { workspace = true }

--- a/crates/pcb-interposer/src/emit.rs
+++ b/crates/pcb-interposer/src/emit.rs
@@ -1,0 +1,287 @@
+//! Emit the interposer as a KiCad board via `pcb_ir::dialects::kicad`.
+//!
+//! This slice is the deterministic base board: the panel's outline,
+//! tooling holes, and fiducials, the S11 mate lands on the bottom copper,
+//! and a full-sheet bottom GND pour. GND lands join the pour; every other
+//! land is left un-netted until a panel-specific assignment binds it. No
+//! pogo pads and no routing yet.
+
+use pcb_ir::dialects::kicad::{
+    At, Document, Footprint, FootprintAttrs, Graphic, Mount, Pad, PadKind, PadShape, Property,
+    Stroke, UuidGen, Zone, ZoneConnect, ZoneFill,
+};
+use pcb_ir::geom::Point;
+
+use crate::panel::{Outline, Panel};
+use crate::pattern::{Land, Role};
+
+/// Mate land pad diameter.
+const LAND_DIA_MM: f64 = 1.0;
+
+/// Build the `.kicad_pcb` source.
+pub fn board(panel: &Panel, lands: &[Land]) -> String {
+    let mut doc = Document::two_layer();
+    doc.generator = "pcb-interposer".into();
+    let mut uuids = UuidGen::new();
+    let gnd = doc.net("GND");
+
+    for outline in &panel.outline {
+        doc.graphics.push(match *outline {
+            Outline::Line { start, end } => Graphic::Line {
+                start: Point::new(start[0], start[1]),
+                end: Point::new(end[0], end[1]),
+                stroke: Stroke::solid(0.1),
+                layer: "Edge.Cuts".into(),
+                uuid: uuids.next_uuid(),
+            },
+            Outline::Arc { start, mid, end } => Graphic::Arc {
+                start: Point::new(start[0], start[1]),
+                mid: Point::new(mid[0], mid[1]),
+                end: Point::new(end[0], end[1]),
+                stroke: Stroke::solid(0.1),
+                layer: "Edge.Cuts".into(),
+                uuid: uuids.next_uuid(),
+            },
+        });
+    }
+
+    for (index, (at, dia)) in panel.holes.iter().enumerate() {
+        doc.footprints
+            .push(hole_footprint(&mut uuids, index, *at, *dia));
+    }
+    for (index, at) in panel.fids_top.iter().enumerate() {
+        doc.footprints
+            .push(fid_footprint(&mut uuids, index, *at, true));
+    }
+    for (index, at) in panel.fids_bottom.iter().enumerate() {
+        let ordinal = panel.fids_top.len() + index;
+        doc.footprints
+            .push(fid_footprint(&mut uuids, ordinal, *at, false));
+    }
+    for (index, land) in lands.iter().enumerate() {
+        let net = (land.role == Role::Gnd).then(|| (gnd, "GND".to_string()));
+        doc.footprints
+            .push(land_footprint(&mut uuids, index, land, net));
+    }
+
+    doc.zones.push(Zone {
+        net: gnd,
+        net_name: "GND".into(),
+        layers: vec!["B.Cu".into()],
+        uuid: uuids.next_uuid(),
+        name: None,
+        priority: None,
+        hatch_pitch: 0.5,
+        connect_pads: ZoneConnect::Thermal,
+        connect_clearance: 0.25,
+        min_thickness: 0.25,
+        fill: ZoneFill {
+            enabled: true,
+            thermal_gap: 0.3,
+            thermal_bridge_width: 0.4,
+        },
+        polygon: vec![
+            Point::new(0.0, 0.0),
+            Point::new(panel.width, 0.0),
+            Point::new(panel.width, panel.height),
+            Point::new(0.0, panel.height),
+        ],
+    });
+
+    pcb_ir::dialects::kicad::write(&doc)
+}
+
+fn hidden_properties(uuids: &mut UuidGen, reference: &str, top: bool) -> Vec<Property> {
+    let (silk, fab) = if top {
+        ("F.SilkS", "F.Fab")
+    } else {
+        ("B.SilkS", "B.Fab")
+    };
+    vec![
+        Property {
+            key: "Reference".into(),
+            value: reference.into(),
+            at: At::xy(0.0, -1.8),
+            layer: silk.into(),
+            hide: true,
+            uuid: uuids.next_uuid(),
+        },
+        Property {
+            key: "Value".into(),
+            value: String::new(),
+            at: At::xy(0.0, 1.8),
+            layer: fab.into(),
+            hide: true,
+            uuid: uuids.next_uuid(),
+        },
+    ]
+}
+
+fn hole_footprint(uuids: &mut UuidGen, index: usize, at: [f64; 2], dia: f64) -> Footprint {
+    Footprint {
+        lib_id: "Interposer:ToolingHole".into(),
+        layer: "F.Cu".into(),
+        uuid: uuids.next_uuid(),
+        at: At::xy(at[0], at[1]),
+        properties: hidden_properties(uuids, &format!("H{}", index + 1), true),
+        attrs: FootprintAttrs {
+            mount: None,
+            exclude_from_pos_files: true,
+            exclude_from_bom: true,
+        },
+        pads: vec![Pad {
+            number: String::new(),
+            kind: PadKind::NpThruHole,
+            shape: PadShape::Circle,
+            at: At::default(),
+            size: (dia, dia),
+            drill: Some(dia),
+            layers: vec!["*.Cu".into(), "*.Mask".into()],
+            net: None,
+            solder_mask_margin: None,
+            clearance: None,
+            uuid: uuids.next_uuid(),
+        }],
+    }
+}
+
+/// A global fiducial: Ø1 copper dot with a Ø2 mask opening. The pad-level
+/// clearance keeps pour copper outside the mask aperture so the aperture
+/// never bridges the dot with poured GND.
+fn fid_footprint(uuids: &mut UuidGen, index: usize, at: [f64; 2], top: bool) -> Footprint {
+    let (copper, mask) = if top {
+        ("F.Cu", "F.Mask")
+    } else {
+        ("B.Cu", "B.Mask")
+    };
+    Footprint {
+        lib_id: "Interposer:Fiducial_1.0_2.0".into(),
+        layer: copper.into(),
+        uuid: uuids.next_uuid(),
+        at: At::xy(at[0], at[1]),
+        properties: hidden_properties(uuids, &format!("FID{}", index + 1), top),
+        attrs: FootprintAttrs {
+            mount: Some(Mount::Smd),
+            exclude_from_pos_files: true,
+            exclude_from_bom: true,
+        },
+        pads: vec![Pad {
+            number: String::new(),
+            kind: PadKind::Smd,
+            shape: PadShape::Circle,
+            at: At::default(),
+            size: (1.0, 1.0),
+            drill: None,
+            layers: vec![copper.into(), mask.into()],
+            net: None,
+            solder_mask_margin: Some(0.5),
+            clearance: Some(0.6),
+            uuid: uuids.next_uuid(),
+        }],
+    }
+}
+
+fn land_footprint(
+    uuids: &mut UuidGen,
+    index: usize,
+    land: &Land,
+    net: Option<(u32, String)>,
+) -> Footprint {
+    let mut properties = hidden_properties(uuids, &format!("L{}", index + 1), false);
+    properties.push(Property {
+        key: "Ict".into(),
+        value: land.role.name().into(),
+        at: At::xy(0.0, 3.0),
+        layer: "B.Fab".into(),
+        hide: true,
+        uuid: uuids.next_uuid(),
+    });
+    Footprint {
+        lib_id: "Interposer:Mate_Pad_D1.0mm".into(),
+        layer: "B.Cu".into(),
+        uuid: uuids.next_uuid(),
+        at: At::xy(land.xy[0], land.xy[1]),
+        properties,
+        attrs: FootprintAttrs {
+            mount: Some(Mount::Smd),
+            exclude_from_pos_files: true,
+            exclude_from_bom: true,
+        },
+        pads: vec![Pad {
+            number: "1".into(),
+            kind: PadKind::Smd,
+            shape: PadShape::Circle,
+            at: At::default(),
+            size: (LAND_DIA_MM, LAND_DIA_MM),
+            drill: None,
+            layers: vec!["B.Cu".into(), "B.Mask".into()],
+            net,
+            solder_mask_margin: None,
+            clearance: None,
+            uuid: uuids.next_uuid(),
+        }],
+    }
+}
+
+/// The sibling `.kicad_pro`: design rules the later routing passes are
+/// built for, so every interposer artifact carries one consistent rule
+/// set from the start.
+pub fn project() -> String {
+    r##"{
+  "board": {
+    "design_settings": {
+      "rules": {
+        "max_error": 0.005,
+        "min_clearance": 0.1,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.3,
+        "min_hole_clearance": 0.25,
+        "min_hole_to_hole": 0.25,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 1,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.15,
+        "min_via_annular_width": 0.1,
+        "min_via_diameter": 0.5
+      }
+    }
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "name": "Default",
+        "clearance": 0.2,
+        "track_width": 0.25,
+        "via_diameter": 0.6,
+        "via_drill": 0.3
+      },
+      {
+        "name": "USB",
+        "clearance": 0.1,
+        "track_width": 0.2,
+        "via_diameter": 0.6,
+        "via_drill": 0.3
+      }
+    ],
+    "netclass_patterns": [
+      {
+        "netclass": "USB",
+        "pattern": "*USB_DP*"
+      },
+      {
+        "netclass": "USB",
+        "pattern": "*USB_DM*"
+      }
+    ]
+  },
+  "meta": {
+    "version": 3
+  }
+}
+"##
+    .to_string()
+}

--- a/crates/pcb-interposer/src/lib.rs
+++ b/crates/pcb-interposer/src/lib.rs
@@ -28,6 +28,7 @@ pub fn generate(panel_xml: &Path) -> Result<(String, String)> {
         .with_context(|| format!("read panel {}", panel_xml.display()))?;
     let ipc = ipc2581::Ipc2581::parse(&content).context("parse IPC-2581 panel")?;
     let panel = panel::extract(&ipc)?;
-    let lands = pattern::oriented_s11(panel.width, panel.height);
+    let lands = pattern::oriented_s11(panel.width, panel.height)
+        .context("panel cannot contain the A7 fixture tile")?;
     Ok((emit::board(&panel, &lands), emit::project()))
 }

--- a/crates/pcb-interposer/src/lib.rs
+++ b/crates/pcb-interposer/src/lib.rs
@@ -28,7 +28,6 @@ pub fn generate(panel_xml: &Path) -> Result<(String, String)> {
         .with_context(|| format!("read panel {}", panel_xml.display()))?;
     let ipc = ipc2581::Ipc2581::parse(&content).context("parse IPC-2581 panel")?;
     let panel = panel::extract(&ipc)?;
-    let lands = pattern::oriented_s11(panel.width, panel.height)
-        .context("panel cannot contain the A7 fixture tile")?;
+    let lands = pattern::oriented_s11(panel.width, panel.height);
     Ok((emit::board(&panel, &lands), emit::project()))
 }

--- a/crates/pcb-interposer/src/lib.rs
+++ b/crates/pcb-interposer/src/lib.rs
@@ -1,0 +1,33 @@
+//! Pogo-pin test-fixture interposer generation.
+//!
+//! An interposer is a PCB the same size as an assembly panel that sits
+//! between the panel and the test fixture: pogo pins on its top face reach
+//! the panel's ICT test points, and a fixed land constellation on its
+//! bottom face mates the fixture's A7-sized connector plate.
+//!
+//! This crate generates the deterministic part of that board from a
+//! generated assembly-panel IPC-2581 file (`pcbc ipc2581 board-array
+//! create` output): the panel's exact outline, tooling holes, and global
+//! fiducials — inherited, so they cannot drift from the panel — plus the
+//! folded-A7 tile's corner tooling, the S11 mate constellation on the
+//! bottom copper, and a full-sheet bottom GND pour. Pogo placement and
+//! routing are later, panel-specific passes.
+
+pub mod emit;
+pub mod panel;
+pub mod pattern;
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Generate the interposer board for a panel file, returning the
+/// `.kicad_pcb` and `.kicad_pro` sources.
+pub fn generate(panel_xml: &Path) -> Result<(String, String)> {
+    let content = std::fs::read_to_string(panel_xml)
+        .with_context(|| format!("read panel {}", panel_xml.display()))?;
+    let ipc = ipc2581::Ipc2581::parse(&content).context("parse IPC-2581 panel")?;
+    let panel = panel::extract(&ipc)?;
+    let lands = pattern::oriented_s11(panel.width, panel.height);
+    Ok((emit::board(&panel, &lands), emit::project()))
+}

--- a/crates/pcb-interposer/src/panel.rs
+++ b/crates/pcb-interposer/src/panel.rs
@@ -177,8 +177,11 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
 
     // The folded A7 tile's corner tooling (fixture connector plate
     // registration); exactly coincident holes collapse.
-    let (mate_w, mate_h) = mate_dims(width, height);
+    let (mate_w, mate_h) = mate_dims(width, height).with_context(|| {
+        format!("panel ({width} × {height} mm) cannot contain the 74 × 105 mm A7 fixture tile")
+    })?;
     let inset = CORNER_TOOLING_INSET_MM;
+    let mut tile_holes: Vec<[f64; 2]> = Vec::new();
     for xy in [
         [inset, inset],
         [mate_w - inset, inset],
@@ -190,8 +193,21 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
             .any(|(hole, _)| (hole[0] - xy[0]).abs() < EPS && (hole[1] - xy[1]).abs() < EPS)
         {
             holes.push((xy, CORNER_TOOLING_DIA_MM));
+            tile_holes.push(xy);
         }
     }
+    // On off-series sheets a tile hole can land next to one of the panel's
+    // fiducials. The tile is the fixture contract and cannot move, so the
+    // colliding fiducial copy is dropped instead — the others carry the
+    // registration.
+    let clear_of_tile = |fid: &[f64; 2]| {
+        tile_holes.iter().all(|hole| {
+            let d = ((hole[0] - fid[0]).powi(2) + (hole[1] - fid[1]).powi(2)).sqrt();
+            d >= CORNER_TOOLING_DIA_MM / 2.0 + 1.5
+        })
+    };
+    fids_top.retain(clear_of_tile);
+    fids_bottom.retain(clear_of_tile);
 
     Ok(Panel {
         width,

--- a/crates/pcb-interposer/src/panel.rs
+++ b/crates/pcb-interposer/src/panel.rs
@@ -91,7 +91,8 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
             || ((width - b).abs() < 0.1 && (height - a).abs() < 0.1)
     }) {
         bail!(
-            "unsupported panel size {width} × {height} mm; interposers exist for the standard              A7/A6/A5/A4 board-array sheets"
+            "unsupported panel size {width} × {height} mm; interposers exist for the \
+             standard A7/A6/A5/A4 board-array sheets"
         );
     }
     // Y-up IPC frame → Y-down KiCad frame.
@@ -196,6 +197,7 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
     // registration); exactly coincident holes collapse.
     let (mate_w, mate_h) = mate_dims(width, height);
     let inset = CORNER_TOOLING_INSET_MM;
+    let mut tile_holes: Vec<[f64; 2]> = Vec::new();
     for xy in [
         [inset, inset],
         [mate_w - inset, inset],
@@ -207,8 +209,21 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
             .any(|(hole, _)| (hole[0] - xy[0]).abs() < EPS && (hole[1] - xy[1]).abs() < EPS)
         {
             holes.push((xy, CORNER_TOOLING_DIA_MM));
+            tile_holes.push(xy);
         }
     }
+    // Rail fiducials can land next to a tile corner hole (their positions
+    // depend on the packed board's dimensions). The tile is the fixture
+    // contract and cannot move, so the colliding fiducial copy is dropped
+    // instead — the others carry the registration.
+    let clear_of_tile = |fid: &[f64; 2]| {
+        tile_holes.iter().all(|hole| {
+            let d = ((hole[0] - fid[0]).powi(2) + (hole[1] - fid[1]).powi(2)).sqrt();
+            d >= CORNER_TOOLING_DIA_MM / 2.0 + 1.5
+        })
+    };
+    fids_top.retain(clear_of_tile);
+    fids_bottom.retain(clear_of_tile);
 
     Ok(Panel {
         width,

--- a/crates/pcb-interposer/src/panel.rs
+++ b/crates/pcb-interposer/src/panel.rs
@@ -1,0 +1,214 @@
+//! Read an assembly panel's fixed features from its IPC-2581 file.
+//!
+//! The interposer stacks under the assembly panel on the same tooling
+//! pins, so its outline, tooling holes, and global fiducials are
+//! *inherited* from the generated panel (`pcbc ipc2581 board-array
+//! create` output) rather than recomputed — they cannot drift. On top of
+//! the panel's holes we add the folded A7 tile's corner tooling, the
+//! fixture connector plate's registration; exactly coincident holes
+//! collapse, so holes either overlap perfectly or not at all.
+//!
+//! IPC-2581 is Y-up while KiCad boards are Y-down; everything returned
+//! here is already flipped into the KiCad sheet frame.
+
+use anyhow::{Context, Result, bail};
+use ipc2581::Ipc2581;
+use ipc2581::types::{
+    FiducialKind, LayerFunction, PlatingStatus, PolyStep, SetFeature, Side, Step,
+};
+
+use crate::pattern::mate_dims;
+
+/// Corner tooling matches the board-array generator's spec.
+const CORNER_TOOLING_DIA_MM: f64 = 2.1;
+const CORNER_TOOLING_INSET_MM: f64 = 3.0;
+const EPS: f64 = 1e-6;
+
+/// The panel's fixed features, in the KiCad sheet frame.
+pub struct Panel {
+    pub width: f64,
+    pub height: f64,
+    /// Board outline as drawable primitives.
+    pub outline: Vec<Outline>,
+    /// NPTH tooling holes: (center, drill diameter).
+    pub holes: Vec<([f64; 2], f64)>,
+    /// Global fiducial centers per face.
+    pub fids_top: Vec<[f64; 2]>,
+    pub fids_bottom: Vec<[f64; 2]>,
+}
+
+/// One outline primitive. Arcs carry a KiCad-style mid point.
+#[derive(Debug, Clone, Copy)]
+pub enum Outline {
+    Line {
+        start: [f64; 2],
+        end: [f64; 2],
+    },
+    Arc {
+        start: [f64; 2],
+        mid: [f64; 2],
+        end: [f64; 2],
+    },
+}
+
+/// Extract the panel features from a parsed IPC-2581 file.
+pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
+    let ecad = ipc.ecad().context("panel has no ECAD section")?;
+    let step = primary_step(ipc, &ecad.cad_data.steps).context("panel has no step")?;
+    let profile = step
+        .profile
+        .as_ref()
+        .context("panel step has no board profile")?;
+
+    // Sheet dimensions from the profile bounding box; the generator anchors
+    // the array at the origin.
+    let mut points: Vec<[f64; 2]> = vec![[profile.polygon.begin.x, profile.polygon.begin.y]];
+    for poly_step in &profile.polygon.steps {
+        match poly_step {
+            PolyStep::Segment(segment) => points.push([segment.point.x, segment.point.y]),
+            PolyStep::Curve(curve) => points.push([curve.point.x, curve.point.y]),
+        }
+    }
+    let (x0, y0, x1, y1) = points.iter().fold(
+        (f64::MAX, f64::MAX, f64::MIN, f64::MIN),
+        |(x0, y0, x1, y1), p| (x0.min(p[0]), y0.min(p[1]), x1.max(p[0]), y1.max(p[1])),
+    );
+    if x0.abs() > 0.1 || y0.abs() > 0.1 {
+        bail!("panel profile does not start at the origin (found {x0}, {y0})");
+    }
+    let (width, height) = (x1, y1);
+    // Y-up IPC frame → Y-down KiCad frame.
+    let flip = |p: [f64; 2]| [p[0], height - p[1]];
+
+    let mut outline = Vec::new();
+    let mut cursor = [profile.polygon.begin.x, profile.polygon.begin.y];
+    for poly_step in &profile.polygon.steps {
+        match poly_step {
+            PolyStep::Segment(segment) => {
+                let end = [segment.point.x, segment.point.y];
+                outline.push(Outline::Line {
+                    start: flip(cursor),
+                    end: flip(end),
+                });
+                cursor = end;
+            }
+            PolyStep::Curve(curve) => {
+                let end = [curve.point.x, curve.point.y];
+                let center = [curve.center.x, curve.center.y];
+                // Mid point of the sweep in the source frame; a pure Y flip
+                // then carries all three points into the KiCad frame (the
+                // three-point arc needs no direction flag).
+                let a0 = (cursor[1] - center[1]).atan2(cursor[0] - center[0]);
+                let a1 = (end[1] - center[1]).atan2(end[0] - center[0]);
+                let radius =
+                    ((cursor[0] - center[0]).powi(2) + (cursor[1] - center[1]).powi(2)).sqrt();
+                let sweep = if curve.clockwise {
+                    // Decreasing angle in the Y-up frame.
+                    let mut sweep = a1 - a0;
+                    if sweep > -EPS {
+                        sweep -= std::f64::consts::TAU;
+                    }
+                    sweep
+                } else {
+                    let mut sweep = a1 - a0;
+                    if sweep < EPS {
+                        sweep += std::f64::consts::TAU;
+                    }
+                    sweep
+                };
+                let am = a0 + sweep / 2.0;
+                let mid = [center[0] + radius * am.cos(), center[1] + radius * am.sin()];
+                outline.push(Outline::Arc {
+                    start: flip(cursor),
+                    mid: flip(mid),
+                    end: flip(end),
+                });
+                cursor = end;
+            }
+        }
+    }
+
+    // Tooling holes and global fiducials from the array step's features.
+    let drill_layers: Vec<_> = ecad
+        .cad_data
+        .layers
+        .iter()
+        .filter(|layer| layer.layer_function == LayerFunction::Drill)
+        .map(|layer| layer.name)
+        .collect();
+    let copper_side = |name: ipc2581::Symbol| -> Option<Side> {
+        ecad.cad_data
+            .layers
+            .iter()
+            .find(|layer| layer.name == name && layer.layer_function == LayerFunction::Conductor)
+            .and_then(|layer| layer.side)
+    };
+
+    let mut holes: Vec<([f64; 2], f64)> = Vec::new();
+    let mut fids_top = Vec::new();
+    let mut fids_bottom = Vec::new();
+    for layer_feature in &step.layer_features {
+        let on_drill = drill_layers.contains(&layer_feature.layer_ref);
+        let side = copper_side(layer_feature.layer_ref);
+        for set in &layer_feature.sets {
+            for feature in &set.features {
+                match feature {
+                    SetFeature::Hole(hole)
+                        if on_drill && hole.plating_status == PlatingStatus::NonPlated =>
+                    {
+                        holes.push((flip([hole.x, hole.y]), hole.diameter));
+                    }
+                    SetFeature::Fiducial(fiducial) if fiducial.kind == FiducialKind::Global => {
+                        let at = flip([fiducial.location.x, fiducial.location.y]);
+                        match side {
+                            Some(Side::Top) => fids_top.push(at),
+                            Some(Side::Bottom) => fids_bottom.push(at),
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    if holes.is_empty() {
+        bail!("panel has no non-plated tooling holes; is this a board-array file?");
+    }
+
+    // The folded A7 tile's corner tooling (fixture connector plate
+    // registration); exactly coincident holes collapse.
+    let (mate_w, mate_h) = mate_dims(width, height);
+    let inset = CORNER_TOOLING_INSET_MM;
+    for xy in [
+        [inset, inset],
+        [mate_w - inset, inset],
+        [mate_w - inset, mate_h - inset],
+        [inset, mate_h - inset],
+    ] {
+        if !holes
+            .iter()
+            .any(|(hole, _)| (hole[0] - xy[0]).abs() < EPS && (hole[1] - xy[1]).abs() < EPS)
+        {
+            holes.push((xy, CORNER_TOOLING_DIA_MM));
+        }
+    }
+
+    Ok(Panel {
+        width,
+        height,
+        outline,
+        holes,
+        fids_top,
+        fids_bottom,
+    })
+}
+
+/// The step the file is about: the Content section's first step reference,
+/// falling back to document order.
+fn primary_step<'a>(ipc: &Ipc2581, steps: &'a [Step]) -> Option<&'a Step> {
+    ipc.content()
+        .step_refs
+        .first()
+        .and_then(|step_ref| steps.iter().find(|step| step.name == *step_ref))
+        .or_else(|| steps.first())
+}

--- a/crates/pcb-interposer/src/panel.rs
+++ b/crates/pcb-interposer/src/panel.rs
@@ -25,6 +25,7 @@ const CORNER_TOOLING_INSET_MM: f64 = 3.0;
 const EPS: f64 = 1e-6;
 
 /// The panel's fixed features, in the KiCad sheet frame.
+#[derive(Debug)]
 pub struct Panel {
     pub width: f64,
     pub height: f64,
@@ -77,6 +78,22 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
         bail!("panel profile does not start at the origin (found {x0}, {y0})");
     }
     let (width, height) = (x1, y1);
+    // Only standard A-series panels: the fixture plate and its
+    // registration are a fixed contract per sheet size.
+    let standard = [
+        (74.0, 105.0),
+        (105.0, 148.0),
+        (148.0, 210.0),
+        (210.0, 297.0),
+    ];
+    if !standard.iter().any(|(a, b)| {
+        ((width - a).abs() < 0.1 && (height - b).abs() < 0.1)
+            || ((width - b).abs() < 0.1 && (height - a).abs() < 0.1)
+    }) {
+        bail!(
+            "unsupported panel size {width} × {height} mm; interposers exist for the standard              A7/A6/A5/A4 board-array sheets"
+        );
+    }
     // Y-up IPC frame → Y-down KiCad frame.
     let flip = |p: [f64; 2]| [p[0], height - p[1]];
 
@@ -177,11 +194,8 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
 
     // The folded A7 tile's corner tooling (fixture connector plate
     // registration); exactly coincident holes collapse.
-    let (mate_w, mate_h) = mate_dims(width, height).with_context(|| {
-        format!("panel ({width} × {height} mm) cannot contain the 74 × 105 mm A7 fixture tile")
-    })?;
+    let (mate_w, mate_h) = mate_dims(width, height);
     let inset = CORNER_TOOLING_INSET_MM;
-    let mut tile_holes: Vec<[f64; 2]> = Vec::new();
     for xy in [
         [inset, inset],
         [mate_w - inset, inset],
@@ -193,21 +207,8 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
             .any(|(hole, _)| (hole[0] - xy[0]).abs() < EPS && (hole[1] - xy[1]).abs() < EPS)
         {
             holes.push((xy, CORNER_TOOLING_DIA_MM));
-            tile_holes.push(xy);
         }
     }
-    // On off-series sheets a tile hole can land next to one of the panel's
-    // fiducials. The tile is the fixture contract and cannot move, so the
-    // colliding fiducial copy is dropped instead — the others carry the
-    // registration.
-    let clear_of_tile = |fid: &[f64; 2]| {
-        tile_holes.iter().all(|hole| {
-            let d = ((hole[0] - fid[0]).powi(2) + (hole[1] - fid[1]).powi(2)).sqrt();
-            d >= CORNER_TOOLING_DIA_MM / 2.0 + 1.5
-        })
-    };
-    fids_top.retain(clear_of_tile);
-    fids_bottom.retain(clear_of_tile);
 
     Ok(Panel {
         width,

--- a/crates/pcb-interposer/src/pattern.rs
+++ b/crates/pcb-interposer/src/pattern.rs
@@ -1,0 +1,261 @@
+//! The committed S11 mate constellation.
+//!
+//! The interposer's bottom face carries a fixed land pattern the fixture's
+//! A7-sized connector plate mates against — a hardware contract, identical
+//! on every interposer. S11 places structures around all four edges of the
+//! folded A7 tile: per band, `[LS-array, kit, kit, LS-array]` with
+//! symmetric gaps. A *kit* is a 2×3 block carrying one board's USB pair,
+//! power, and ground (inner column Vt Vt Gnd, outer Dp Dm Vusb); an
+//! *LS-array* is a 2×4 block of low-speed lands with a ground seeded in.
+//! The trailing array of the bottom band is a spare all-GND block. Only
+//! 2×3 and 2×4 blocks at 2.54 mm pitch appear — standard pogo-array
+//! connectors.
+//!
+//! Totals: 16 blocks, 112 lands — 8 USB pairs, 16 Vtarget, 8 Vusb, 48
+//! low-speed, and 24 ground.
+
+/// A7 tile dimensions, portrait.
+pub const A7_W: f64 = 74.0;
+pub const A7_H: f64 = 105.0;
+/// Keep-out from the tile edges.
+pub const MARGIN: f64 = 5.0;
+/// The standard 0.1" pogo-array pitch.
+pub const PITCH_254: f64 = 2.54;
+
+/// Electrical role of one mate land.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    UsbDp,
+    UsbDm,
+    Vusb,
+    Vtarget,
+    Gnd,
+    Ls,
+}
+
+impl Role {
+    /// The `ict` vocabulary name for this role.
+    pub fn name(self) -> &'static str {
+        match self {
+            Role::UsbDp => "usb_dp",
+            Role::UsbDm => "usb_dm",
+            Role::Vusb => "vusb",
+            Role::Vtarget => "vtarget",
+            Role::Gnd => "gnd",
+            Role::Ls => "ls",
+        }
+    }
+}
+
+/// One land of the constellation, in the sheet frame (millimeters, Y
+/// down, origin at the sheet corner the A7 tile folds onto).
+#[derive(Debug, Clone, Copy)]
+pub struct Land {
+    pub xy: [f64; 2],
+    pub role: Role,
+}
+
+/// Dimensions of the A7 mate region at the origin corner of a sheet, by
+/// the ISO fold rule: each halving cuts the sheet's long side, so the A7
+/// descendant alternates orientation per fold. A7 → 74×105, A6 → 105×74,
+/// A5 → 74×105.
+pub fn mate_dims(sheet_w: f64, sheet_h: f64) -> (f64, f64) {
+    let (mut w, mut h) = (sheet_w, sheet_h);
+    while w * h > A7_W * A7_H * 1.02 {
+        if w >= h {
+            w /= 2.0;
+        } else {
+            h /= 2.0;
+        }
+    }
+    (w, h)
+}
+
+/// The S11 constellation oriented for a sheet: generated in the canonical
+/// portrait 74×105 frame, then rotated 90° (never mirrored — the mate is
+/// a rigid contract) when the sheet's folded A7 tile is landscape.
+pub fn oriented_s11(sheet_w: f64, sheet_h: f64) -> Vec<Land> {
+    let mut lands = s11();
+    let (mw, mh) = mate_dims(sheet_w, sheet_h);
+    if mw > mh {
+        for land in &mut lands {
+            land.xy = [land.xy[1], A7_W - land.xy[0]];
+        }
+    }
+    lands
+}
+
+/// One structure: rows of (inner, outer) roles, walked along the band.
+type Rows = Vec<(Role, Role)>;
+
+fn kit() -> Rows {
+    vec![
+        (Role::Vtarget, Role::UsbDp),
+        (Role::Vtarget, Role::UsbDm),
+        (Role::Gnd, Role::Vusb),
+    ]
+}
+
+fn ls_array(extra_gnd: usize) -> Rows {
+    (0..4)
+        .map(|row| {
+            let inner = match row {
+                3 if extra_gnd > 0 => Role::Gnd,
+                2 if extra_gnd > 1 => Role::Gnd,
+                _ => Role::Ls,
+            };
+            (inner, Role::Ls)
+        })
+        .collect()
+}
+
+/// The canonical portrait-frame S11 pattern.
+fn s11() -> Vec<Land> {
+    let gnd_array: Rows = (0..4).map(|_| (Role::Gnd, Role::Gnd)).collect();
+
+    // Per band, walking the band axis: [array, kit, kit, array]. Bands in
+    // order: right, top, left, bottom. The spare all-GND array is the
+    // trailing array of the bottom band (the quiet origin corner).
+    let band_structs: [[Rows; 4]; 4] = [
+        [ls_array(2), kit(), kit(), ls_array(1)],
+        [ls_array(1), kit(), kit(), ls_array(1)],
+        [ls_array(1), kit(), kit(), ls_array(1)],
+        [ls_array(1), kit(), kit(), gnd_array],
+    ];
+    // (along_y, band span start..end, outer row coordinate, inward sign);
+    // the inner row sits one pitch further inward.
+    let bands = [
+        (
+            true,
+            MARGIN + 1.5,
+            A7_H - MARGIN - 1.5,
+            A7_W - MARGIN - 1.5,
+            -1.0,
+        ),
+        (false, 13.0, A7_W - 13.0, A7_H - MARGIN - 2.5, -1.0),
+        (true, MARGIN + 1.5, A7_H - MARGIN - 1.5, MARGIN + 1.5, 1.0),
+        (false, 13.0, A7_W - 13.0, MARGIN + 2.5, 1.0),
+    ];
+
+    let mut lands = Vec::new();
+    for (band, (along_y, b0, b1, outer, inward)) in bands.into_iter().enumerate() {
+        let structs = &band_structs[band];
+        let extents: Vec<f64> = structs
+            .iter()
+            .map(|rows| (rows.len() - 1) as f64 * PITCH_254)
+            .collect();
+        let total: f64 = extents.iter().sum();
+        // Symmetric spacing: equal gaps between structures, equal margins.
+        let gap = ((b1 - b0) - total) / 5.0;
+        let mut pos = b0 + gap;
+        for (rows, extent) in structs.iter().zip(&extents) {
+            for (row, (inner, outer_role)) in rows.iter().enumerate() {
+                for (role, is_outer) in [(*inner, false), (*outer_role, true)] {
+                    let cross = if is_outer {
+                        outer
+                    } else {
+                        outer + inward * PITCH_254
+                    };
+                    let along = pos + row as f64 * PITCH_254;
+                    let xy = if along_y {
+                        [cross, along]
+                    } else {
+                        [along, cross]
+                    };
+                    lands.push(Land { xy, role });
+                }
+            }
+            pos += extent + gap;
+        }
+    }
+    lands
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn role_count(lands: &[Land], role: Role) -> usize {
+        lands.iter().filter(|land| land.role == role).count()
+    }
+
+    #[test]
+    fn s11_land_budget() {
+        let lands = s11();
+        assert_eq!(lands.len(), 112);
+        assert_eq!(role_count(&lands, Role::UsbDp), 8);
+        assert_eq!(role_count(&lands, Role::UsbDm), 8);
+        assert_eq!(role_count(&lands, Role::Vusb), 8);
+        assert_eq!(role_count(&lands, Role::Vtarget), 16);
+        assert_eq!(role_count(&lands, Role::Gnd), 24);
+        assert_eq!(role_count(&lands, Role::Ls), 48);
+    }
+
+    #[test]
+    fn s11_uses_the_254_pitch_and_only_2x3_or_2x4_blocks() {
+        let lands = s11();
+        // Nearest-neighbor distance is exactly one pitch for every land.
+        for a in &lands {
+            let nearest = lands
+                .iter()
+                .filter(|b| (b.xy[0] - a.xy[0]).abs() > 1e-9 || (b.xy[1] - a.xy[1]).abs() > 1e-9)
+                .map(|b| ((b.xy[0] - a.xy[0]).powi(2) + (b.xy[1] - a.xy[1]).powi(2)).sqrt())
+                .fold(f64::INFINITY, f64::min);
+            assert!((nearest - PITCH_254).abs() < 1e-6, "land at {:?}", a.xy);
+        }
+        // Connected components under one-pitch adjacency are 2×3 or 2×4.
+        let mut seen = vec![false; lands.len()];
+        let mut sizes = Vec::new();
+        for start in 0..lands.len() {
+            if seen[start] {
+                continue;
+            }
+            let mut stack = vec![start];
+            let mut size = 0;
+            seen[start] = true;
+            while let Some(i) = stack.pop() {
+                size += 1;
+                for (j, other) in lands.iter().enumerate() {
+                    if seen[j] {
+                        continue;
+                    }
+                    let d = ((other.xy[0] - lands[i].xy[0]).powi(2)
+                        + (other.xy[1] - lands[i].xy[1]).powi(2))
+                    .sqrt();
+                    if d < PITCH_254 * 1.1 {
+                        seen[j] = true;
+                        stack.push(j);
+                    }
+                }
+            }
+            sizes.push(size);
+        }
+        assert_eq!(sizes.len(), 16);
+        assert!(sizes.iter().all(|size| *size == 6 || *size == 8));
+    }
+
+    #[test]
+    fn s11_respects_the_tile_margin() {
+        for land in s11() {
+            assert!(land.xy[0] >= MARGIN - 1e-9 && land.xy[0] <= A7_W - MARGIN + 1e-9);
+            assert!(land.xy[1] >= MARGIN - 1e-9 && land.xy[1] <= A7_H - MARGIN + 1e-9);
+        }
+    }
+
+    #[test]
+    fn fold_orientation_rotates_landscape_mates() {
+        // A7 and A5 sheets fold to a portrait tile: canonical frame.
+        for (w, h) in [(74.0, 105.0), (148.0, 210.0)] {
+            assert_eq!(mate_dims(w, h), (74.0, 105.0));
+            let lands = oriented_s11(w, h);
+            assert!(lands.iter().all(|l| l.xy[0] <= A7_W));
+        }
+        // A6 folds to a landscape tile: rotated, never mirrored.
+        assert_eq!(mate_dims(105.0, 148.0), (105.0, 74.0));
+        let lands = oriented_s11(105.0, 148.0);
+        assert_eq!(lands.len(), 112);
+        assert!(lands.iter().all(|l| l.xy[0] <= A7_H && l.xy[1] <= A7_W));
+        // A rigid rotation preserves the land budget per role.
+        assert_eq!(lands.iter().filter(|l| l.role == Role::Gnd).count(), 24);
+    }
+}

--- a/crates/pcb-interposer/src/pattern.rs
+++ b/crates/pcb-interposer/src/pattern.rs
@@ -55,17 +55,14 @@ pub struct Land {
     pub role: Role,
 }
 
-/// Dimensions of the A7 mate region at the origin corner of a sheet, by
-/// the ISO fold rule: each halving cuts the sheet's long side, so the A7
-/// descendant alternates orientation per fold. A7 → 74×105, A6 → 105×74,
-/// A5 → 74×105, A4 → 105×74. The fold decides only the orientation; the
-/// returned dimensions are the exact A7 tile — the fixture-plate contract
-/// — even when repeated halving leaves a remainder (297 mm halves to
-/// 74.25). Off-series sheets where the fold-parity orientation does not
-/// fit fall back to the orientation that does; `None` when the sheet
-/// cannot contain the tile at all.
-pub fn mate_dims(sheet_w: f64, sheet_h: f64) -> Option<(f64, f64)> {
-    let fits = |w: f64, h: f64| w <= sheet_w + 1e-6 && h <= sheet_h + 1e-6;
+/// Dimensions of the A7 mate region at the origin corner of a standard
+/// A-series sheet, by the ISO fold rule: each halving cuts the sheet's
+/// long side, so the A7 descendant alternates orientation per fold. A7 →
+/// 74×105, A6 → 105×74, A5 → 74×105, A4 → 105×74. The fold decides only
+/// the orientation; the returned dimensions are the exact A7 tile — the
+/// fixture-plate contract — even when repeated halving leaves a
+/// remainder (297 mm halves to 74.25).
+pub fn mate_dims(sheet_w: f64, sheet_h: f64) -> (f64, f64) {
     let (mut w, mut h) = (sheet_w, sheet_h);
     while w * h > A7_W * A7_H * 1.05 {
         if w >= h {
@@ -74,29 +71,21 @@ pub fn mate_dims(sheet_w: f64, sheet_h: f64) -> Option<(f64, f64)> {
             h /= 2.0;
         }
     }
-    let parity = if w >= h { (A7_H, A7_W) } else { (A7_W, A7_H) };
-    if fits(parity.0, parity.1) {
-        Some(parity)
-    } else if fits(parity.1, parity.0) {
-        Some((parity.1, parity.0))
-    } else {
-        None
-    }
+    if w >= h { (A7_H, A7_W) } else { (A7_W, A7_H) }
 }
 
 /// The S11 constellation oriented for a sheet: generated in the canonical
 /// portrait 74×105 frame, then rotated 90° (never mirrored — the mate is
-/// a rigid contract) when the sheet's folded A7 tile is landscape. `None`
-/// when the sheet cannot contain the tile.
-pub fn oriented_s11(sheet_w: f64, sheet_h: f64) -> Option<Vec<Land>> {
-    let (mw, mh) = mate_dims(sheet_w, sheet_h)?;
+/// a rigid contract) when the sheet's folded A7 tile is landscape.
+pub fn oriented_s11(sheet_w: f64, sheet_h: f64) -> Vec<Land> {
+    let (mw, mh) = mate_dims(sheet_w, sheet_h);
     let mut lands = s11();
     if mw > mh {
         for land in &mut lands {
             land.xy = [land.xy[1], A7_W - land.xy[0]];
         }
     }
-    Some(lands)
+    lands
 }
 
 /// One structure: rows of (inner, outer) roles, walked along the band.
@@ -260,34 +249,22 @@ mod tests {
     fn fold_orientation_rotates_landscape_mates() {
         // A7 and A5 sheets fold to a portrait tile: canonical frame.
         for (w, h) in [(74.0, 105.0), (148.0, 210.0)] {
-            assert_eq!(mate_dims(w, h), Some((74.0, 105.0)));
-            let lands = oriented_s11(w, h).unwrap();
+            assert_eq!(mate_dims(w, h), (74.0, 105.0));
+            let lands = oriented_s11(w, h);
             assert!(lands.iter().all(|l| l.xy[0] <= A7_W));
         }
         // A6 and A4 fold to a landscape tile: rotated, never mirrored.
         // A4's 297 mm side halves to 74.25, but the tile stays the exact
         // A7 contract.
-        assert_eq!(mate_dims(105.0, 148.0), Some((105.0, 74.0)));
-        assert_eq!(mate_dims(210.0, 297.0), Some((105.0, 74.0)));
+        assert_eq!(mate_dims(105.0, 148.0), (105.0, 74.0));
+        assert_eq!(mate_dims(210.0, 297.0), (105.0, 74.0));
         // A rotated sheet rotates its whole fold chain with it.
-        assert_eq!(mate_dims(297.0, 210.0), Some((74.0, 105.0)));
-        assert_eq!(mate_dims(148.0, 105.0), Some((74.0, 105.0)));
-        let lands = oriented_s11(105.0, 148.0).unwrap();
+        assert_eq!(mate_dims(297.0, 210.0), (74.0, 105.0));
+        assert_eq!(mate_dims(148.0, 105.0), (74.0, 105.0));
+        let lands = oriented_s11(105.0, 148.0);
         assert_eq!(lands.len(), 112);
         assert!(lands.iter().all(|l| l.xy[0] <= A7_H && l.xy[1] <= A7_W));
         // A rigid rotation preserves the land budget per role.
         assert_eq!(lands.iter().filter(|l| l.role == Role::Gnd).count(), 24);
-    }
-
-    #[test]
-    fn off_series_sheets_fit_or_refuse() {
-        // Fold parity says portrait, but only the landscape tile fits a
-        // 290×88 custom array.
-        assert_eq!(mate_dims(290.0, 88.0), Some((105.0, 74.0)));
-        // Too small for either orientation: refuse rather than hang the
-        // tile off the board.
-        assert_eq!(mate_dims(94.0, 82.0), None);
-        assert_eq!(mate_dims(70.8, 141.4), None);
-        assert!(oriented_s11(94.0, 82.0).is_none());
     }
 }

--- a/crates/pcb-interposer/src/pattern.rs
+++ b/crates/pcb-interposer/src/pattern.rs
@@ -58,31 +58,45 @@ pub struct Land {
 /// Dimensions of the A7 mate region at the origin corner of a sheet, by
 /// the ISO fold rule: each halving cuts the sheet's long side, so the A7
 /// descendant alternates orientation per fold. A7 → 74×105, A6 → 105×74,
-/// A5 → 74×105.
-pub fn mate_dims(sheet_w: f64, sheet_h: f64) -> (f64, f64) {
+/// A5 → 74×105, A4 → 105×74. The fold decides only the orientation; the
+/// returned dimensions are the exact A7 tile — the fixture-plate contract
+/// — even when repeated halving leaves a remainder (297 mm halves to
+/// 74.25). Off-series sheets where the fold-parity orientation does not
+/// fit fall back to the orientation that does; `None` when the sheet
+/// cannot contain the tile at all.
+pub fn mate_dims(sheet_w: f64, sheet_h: f64) -> Option<(f64, f64)> {
+    let fits = |w: f64, h: f64| w <= sheet_w + 1e-6 && h <= sheet_h + 1e-6;
     let (mut w, mut h) = (sheet_w, sheet_h);
-    while w * h > A7_W * A7_H * 1.02 {
+    while w * h > A7_W * A7_H * 1.05 {
         if w >= h {
             w /= 2.0;
         } else {
             h /= 2.0;
         }
     }
-    (w, h)
+    let parity = if w >= h { (A7_H, A7_W) } else { (A7_W, A7_H) };
+    if fits(parity.0, parity.1) {
+        Some(parity)
+    } else if fits(parity.1, parity.0) {
+        Some((parity.1, parity.0))
+    } else {
+        None
+    }
 }
 
 /// The S11 constellation oriented for a sheet: generated in the canonical
 /// portrait 74×105 frame, then rotated 90° (never mirrored — the mate is
-/// a rigid contract) when the sheet's folded A7 tile is landscape.
-pub fn oriented_s11(sheet_w: f64, sheet_h: f64) -> Vec<Land> {
+/// a rigid contract) when the sheet's folded A7 tile is landscape. `None`
+/// when the sheet cannot contain the tile.
+pub fn oriented_s11(sheet_w: f64, sheet_h: f64) -> Option<Vec<Land>> {
+    let (mw, mh) = mate_dims(sheet_w, sheet_h)?;
     let mut lands = s11();
-    let (mw, mh) = mate_dims(sheet_w, sheet_h);
     if mw > mh {
         for land in &mut lands {
             land.xy = [land.xy[1], A7_W - land.xy[0]];
         }
     }
-    lands
+    Some(lands)
 }
 
 /// One structure: rows of (inner, outer) roles, walked along the band.
@@ -246,16 +260,34 @@ mod tests {
     fn fold_orientation_rotates_landscape_mates() {
         // A7 and A5 sheets fold to a portrait tile: canonical frame.
         for (w, h) in [(74.0, 105.0), (148.0, 210.0)] {
-            assert_eq!(mate_dims(w, h), (74.0, 105.0));
-            let lands = oriented_s11(w, h);
+            assert_eq!(mate_dims(w, h), Some((74.0, 105.0)));
+            let lands = oriented_s11(w, h).unwrap();
             assert!(lands.iter().all(|l| l.xy[0] <= A7_W));
         }
-        // A6 folds to a landscape tile: rotated, never mirrored.
-        assert_eq!(mate_dims(105.0, 148.0), (105.0, 74.0));
-        let lands = oriented_s11(105.0, 148.0);
+        // A6 and A4 fold to a landscape tile: rotated, never mirrored.
+        // A4's 297 mm side halves to 74.25, but the tile stays the exact
+        // A7 contract.
+        assert_eq!(mate_dims(105.0, 148.0), Some((105.0, 74.0)));
+        assert_eq!(mate_dims(210.0, 297.0), Some((105.0, 74.0)));
+        // A rotated sheet rotates its whole fold chain with it.
+        assert_eq!(mate_dims(297.0, 210.0), Some((74.0, 105.0)));
+        assert_eq!(mate_dims(148.0, 105.0), Some((74.0, 105.0)));
+        let lands = oriented_s11(105.0, 148.0).unwrap();
         assert_eq!(lands.len(), 112);
         assert!(lands.iter().all(|l| l.xy[0] <= A7_H && l.xy[1] <= A7_W));
         // A rigid rotation preserves the land budget per role.
         assert_eq!(lands.iter().filter(|l| l.role == Role::Gnd).count(), 24);
+    }
+
+    #[test]
+    fn off_series_sheets_fit_or_refuse() {
+        // Fold parity says portrait, but only the landscape tile fits a
+        // 290×88 custom array.
+        assert_eq!(mate_dims(290.0, 88.0), Some((105.0, 74.0)));
+        // Too small for either orientation: refuse rather than hang the
+        // tile off the board.
+        assert_eq!(mate_dims(94.0, 82.0), None);
+        assert_eq!(mate_dims(70.8, 141.4), None);
+        assert!(oriented_s11(94.0, 82.0).is_none());
     }
 }

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -3,8 +3,9 @@
 use pcb_sexpr::SexprKind;
 
 /// A miniature "panel": A7-sized rounded-rect profile, two NPTH tooling
-/// holes (one exactly on an A7-tile corner spot, which must dedupe), and
-/// one global fiducial per face.
+/// holes (one exactly on an A7-tile corner spot, which must dedupe), one
+/// global fiducial per face, and a second top fiducial sitting on a tile
+/// corner spot (which must be dropped in favor of the tile hole).
 const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="Owner">
@@ -48,6 +49,10 @@ const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
               <Location x="10.0" y="3.85"/>
               <Circle diameter="1"/>
             </GlobalFiducial>
+            <GlobalFiducial>
+              <Location x="71.5" y="3.5"/>
+              <Circle diameter="1"/>
+            </GlobalFiducial>
           </Set>
         </LayerFeature>
         <LayerFeature layerRef="BOTTOM">
@@ -72,11 +77,14 @@ fn generates_a_parseable_interposer() {
     // The hole at (3, 102) Y-up is (3, 3) Y-down — an exact A7-tile corner
     // spot, so only three tile holes are added on top of the panel's two.
     assert_eq!(panel.holes.len(), 5);
+    // The fiducial at (71.5, 101.5) sits on the tile corner hole spot and
+    // is dropped; the tile hole is the fixture contract.
     assert_eq!(panel.fids_top.len(), 1);
     assert_eq!(panel.fids_bottom.len(), 1);
     assert_eq!(panel.outline.len(), 8);
 
-    let lands = pcb_interposer::pattern::oriented_s11(panel.width, panel.height);
+    let lands =
+        pcb_interposer::pattern::oriented_s11(panel.width, panel.height).expect("tile fits");
     let text = pcb_interposer::emit::board(&panel, &lands);
     let root = pcb_sexpr::parse(&text).expect("board parses");
     let SexprKind::List(items) = &root.kind else {

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -3,8 +3,9 @@
 use pcb_sexpr::SexprKind;
 
 /// A miniature "panel": A7-sized rounded-rect profile, two NPTH tooling
-/// holes (one exactly on an A7-tile corner spot, which must dedupe), and
-/// one global fiducial per face.
+/// holes (one exactly on an A7-tile corner spot, which must dedupe), one
+/// global fiducial per face, and a second top fiducial sitting on a tile
+/// corner spot (which must yield to the tile hole).
 const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="Owner">
@@ -48,6 +49,10 @@ const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
               <Location x="10.0" y="3.85"/>
               <Circle diameter="1"/>
             </GlobalFiducial>
+            <GlobalFiducial>
+              <Location x="71.5" y="3.5"/>
+              <Circle diameter="1"/>
+            </GlobalFiducial>
           </Set>
         </LayerFeature>
         <LayerFeature layerRef="BOTTOM">
@@ -72,6 +77,8 @@ fn generates_a_parseable_interposer() {
     // The hole at (3, 102) Y-up is (3, 3) Y-down — an exact A7-tile corner
     // spot, so only three tile holes are added on top of the panel's two.
     assert_eq!(panel.holes.len(), 5);
+    // The fiducial near the (71, 102) tile corner hole is dropped; the
+    // tile is the fixture contract.
     assert_eq!(panel.fids_top.len(), 1);
     assert_eq!(panel.fids_bottom.len(), 1);
     assert_eq!(panel.outline.len(), 8);

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -1,0 +1,121 @@
+//! End-to-end: a board-array style panel in, a parseable interposer out.
+
+use pcb_sexpr::SexprKind;
+
+/// A miniature "panel": A7-sized rounded-rect profile, two NPTH tooling
+/// holes (one exactly on an A7-tile corner spot, which must dedupe), and
+/// one global fiducial per face.
+const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="array"/>
+    <DictionaryStandard units="MILLIMETER"/>
+  </Content>
+  <Ecad name="ecad">
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+      <Layer name="BOTTOM" layerFunction="CONDUCTOR" side="BOTTOM" polarity="POSITIVE"/>
+      <Layer name="Board_Array_Drill" layerFunction="DRILL" polarity="POSITIVE"/>
+      <Stackup name="stackup" overallThickness="1.6" tolPlus="0.0" tolMinus="0.0">
+        <StackupGroup name="group" thickness="1.6" tolPlus="0.0" tolMinus="0.0"/>
+      </Stackup>
+      <Step name="array">
+        <Datum x="0.0" y="0.0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0.0" y="3.0"/>
+            <PolyStepSegment x="0.0" y="102.0"/>
+            <PolyStepCurve x="3.0" y="105.0" centerX="3.0" centerY="102.0" clockwise="true"/>
+            <PolyStepSegment x="71.0" y="105.0"/>
+            <PolyStepCurve x="74.0" y="102.0" centerX="71.0" centerY="102.0" clockwise="true"/>
+            <PolyStepSegment x="74.0" y="3.0"/>
+            <PolyStepCurve x="71.0" y="0.0" centerX="71.0" centerY="3.0" clockwise="true"/>
+            <PolyStepSegment x="3.0" y="0.0"/>
+            <PolyStepCurve x="0.0" y="3.0" centerX="3.0" centerY="3.0" clockwise="true"/>
+          </Polygon>
+        </Profile>
+        <LayerFeature layerRef="Board_Array_Drill">
+          <Set polarity="POSITIVE">
+            <Hole name="t0" type="CIRCLE" diameter="2.1" platingStatus="NONPLATED" plusTol="0" minusTol="0" x="3.0" y="102.0"/>
+            <Hole name="t1" type="CIRCLE" diameter="2.0" platingStatus="NONPLATED" plusTol="0" minusTol="0" x="20.0" y="2.5"/>
+          </Set>
+        </LayerFeature>
+        <LayerFeature layerRef="TOP">
+          <Set polarity="POSITIVE">
+            <GlobalFiducial>
+              <Location x="10.0" y="3.85"/>
+              <Circle diameter="1"/>
+            </GlobalFiducial>
+          </Set>
+        </LayerFeature>
+        <LayerFeature layerRef="BOTTOM">
+          <Set polarity="POSITIVE">
+            <GlobalFiducial>
+              <Location x="11.0" y="3.85"/>
+              <Circle diameter="1"/>
+            </GlobalFiducial>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+#[test]
+fn generates_a_parseable_interposer() {
+    let ipc = ipc2581::Ipc2581::parse(PANEL).expect("panel fixture parses");
+    let panel = pcb_interposer::panel::extract(&ipc).expect("panel extracts");
+
+    assert_eq!((panel.width, panel.height), (74.0, 105.0));
+    // The hole at (3, 102) Y-up is (3, 3) Y-down — an exact A7-tile corner
+    // spot, so only three tile holes are added on top of the panel's two.
+    assert_eq!(panel.holes.len(), 5);
+    assert_eq!(panel.fids_top.len(), 1);
+    assert_eq!(panel.fids_bottom.len(), 1);
+    assert_eq!(panel.outline.len(), 8);
+
+    let lands = pcb_interposer::pattern::oriented_s11(panel.width, panel.height);
+    let text = pcb_interposer::emit::board(&panel, &lands);
+    let root = pcb_sexpr::parse(&text).expect("board parses");
+    let SexprKind::List(items) = &root.kind else {
+        panic!("root is a list");
+    };
+    let count = |name: &str| {
+        items
+            .iter()
+            .filter(|item| {
+                matches!(&item.kind, SexprKind::List(children)
+                    if children.first().and_then(|c| c.as_atom()) == Some(name))
+            })
+            .count()
+    };
+    // 5 holes + 2 fids + 112 lands.
+    assert_eq!(count("footprint"), 119);
+    assert_eq!(count("zone"), 1);
+    assert_eq!(count("gr_arc"), 4);
+    assert_eq!(count("gr_line"), 4);
+    // 24 GND lands plus the net-table entry and the zone reference.
+    assert_eq!(text.matches("(net 1 \"GND\")").count(), 25);
+
+    // Deterministic output.
+    assert_eq!(text, pcb_interposer::emit::board(&panel, &lands));
+}
+
+#[test]
+fn arc_midpoints_stay_on_the_radius() {
+    let ipc = ipc2581::Ipc2581::parse(PANEL).expect("panel fixture parses");
+    let panel = pcb_interposer::panel::extract(&ipc).expect("panel extracts");
+    for outline in &panel.outline {
+        if let pcb_interposer::panel::Outline::Arc { start, mid, end } = outline {
+            // All fixture arcs are 3 mm corner rounds; the mid point must
+            // sit on the same circle as the endpoints.
+            let chord = ((end[0] - start[0]).powi(2) + (end[1] - start[1]).powi(2)).sqrt();
+            assert!((chord - 3.0 * std::f64::consts::SQRT_2).abs() < 1e-9);
+            let to_mid = ((mid[0] - start[0]).powi(2) + (mid[1] - start[1]).powi(2)).sqrt();
+            // Start-to-mid spans half the 90° sweep.
+            assert!((to_mid - 2.0 * 3.0 * (std::f64::consts::PI / 8.0).sin()).abs() < 1e-9);
+        }
+    }
+}

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -3,9 +3,8 @@
 use pcb_sexpr::SexprKind;
 
 /// A miniature "panel": A7-sized rounded-rect profile, two NPTH tooling
-/// holes (one exactly on an A7-tile corner spot, which must dedupe), one
-/// global fiducial per face, and a second top fiducial sitting on a tile
-/// corner spot (which must be dropped in favor of the tile hole).
+/// holes (one exactly on an A7-tile corner spot, which must dedupe), and
+/// one global fiducial per face.
 const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="Owner">
@@ -49,10 +48,6 @@ const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
               <Location x="10.0" y="3.85"/>
               <Circle diameter="1"/>
             </GlobalFiducial>
-            <GlobalFiducial>
-              <Location x="71.5" y="3.5"/>
-              <Circle diameter="1"/>
-            </GlobalFiducial>
           </Set>
         </LayerFeature>
         <LayerFeature layerRef="BOTTOM">
@@ -77,14 +72,11 @@ fn generates_a_parseable_interposer() {
     // The hole at (3, 102) Y-up is (3, 3) Y-down — an exact A7-tile corner
     // spot, so only three tile holes are added on top of the panel's two.
     assert_eq!(panel.holes.len(), 5);
-    // The fiducial at (71.5, 101.5) sits on the tile corner hole spot and
-    // is dropped; the tile hole is the fixture contract.
     assert_eq!(panel.fids_top.len(), 1);
     assert_eq!(panel.fids_bottom.len(), 1);
     assert_eq!(panel.outline.len(), 8);
 
-    let lands =
-        pcb_interposer::pattern::oriented_s11(panel.width, panel.height).expect("tile fits");
+    let lands = pcb_interposer::pattern::oriented_s11(panel.width, panel.height);
     let text = pcb_interposer::emit::board(&panel, &lands);
     let root = pcb_sexpr::parse(&text).expect("board parses");
     let SexprKind::List(items) = &root.kind else {
@@ -109,6 +101,14 @@ fn generates_a_parseable_interposer() {
 
     // Deterministic output.
     assert_eq!(text, pcb_interposer::emit::board(&panel, &lands));
+}
+
+#[test]
+fn refuses_non_standard_panel_sizes() {
+    let custom = PANEL.replace("74.0", "94.0").replace("105.0", "82.0");
+    let ipc = ipc2581::Ipc2581::parse(&custom).expect("fixture parses");
+    let err = pcb_interposer::panel::extract(&ipc).unwrap_err();
+    assert!(err.to_string().contains("unsupported panel size"), "{err}");
 }
 
 #[test]

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -34,6 +34,7 @@ pcb-sim = { workspace = true }
 pcb-diode-api = { workspace = true }
 pcb-docgen = { workspace = true }
 pcb-ipc2581-tools = { workspace = true }
+pcb-interposer = { path = "../pcb-interposer" }
 pcb-eda = { workspace = true }
 pcb-sexpr = { workspace = true }
 pcb-component-gen = { workspace = true }

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -34,6 +34,15 @@ enum Commands {
         #[arg(long)]
         offline: bool,
     },
+    /// Generate the test-fixture interposer board for a board-array panel
+    Interposer {
+        /// Board-array IPC-2581 XML file (`board-array create` output)
+        #[arg(value_hint = clap::ValueHint::FilePath)]
+        input: PathBuf,
+        /// Output `.kicad_pcb` path; a sibling `.kicad_pro` is written too
+        #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
+        output: PathBuf,
+    },
     /// List ICT fixture contacts (components with an `Ict` BOM characteristic)
     Ict {
         /// IPC-2581 XML file to export from
@@ -348,6 +357,20 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             format,
             offline,
         } => commands::bom::execute(&file, format, offline),
+        Commands::Interposer { input, output } => {
+            use anyhow::Context as _;
+            let (pcb, pro) = pcb_interposer::generate(&input)?;
+            std::fs::write(&output, pcb).with_context(|| format!("write {}", output.display()))?;
+            let pro_path = output.with_extension("kicad_pro");
+            std::fs::write(&pro_path, pro)
+                .with_context(|| format!("write {}", pro_path.display()))?;
+            println!(
+                "✓ Wrote interposer {} and {}",
+                output.display(),
+                pro_path.display()
+            );
+            Ok(())
+        }
         Commands::Ict { file, output, side } => {
             commands::ict::execute(&file, &commands::ict::IctOptions { output, side })
         }


### PR DESCRIPTION
New `pcb-interposer` crate: `pcb ipc interposer <array.xml> -o out.kicad_pcb` generates the deterministic base interposer for an assembly panel — the panel's exact outline, tooling holes, and global fiducials (inherited from the input, so they cannot drift), the folded A7 tile's corner tooling with exact dedupe, the committed S11 mate constellation on the bottom copper (112 lands in 2×3/2×4 blocks at 2.54 mm pitch, fold-oriented per sheet), and a full-sheet bottom GND pour, plus a sibling `.kicad_pro`. Built on the `pcb-ir` kicad dialect; no pogo placement or routing yet.

All 15 real corpus panels generate boards passing `kicad-cli pcb drc` with 0 violations and 0 unconnected items.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New manufacturing-fixture geometry and KiCad emission with a fixed hardware mate contract. Wrong outline, hole, or land placement would produce unusable fixtures, but this is not auth or data-handling code.
> 
> **Overview**
> Adds `pcb ipc interposer` to turn a board-array IPC-2581 panel into the **deterministic base interposer** KiCad board (plus sibling `.kicad_pro`). Pogo placement and routing are not included yet.
> 
> The new `pcb-interposer` crate inherits outline, NPTH tooling, and global fiducials from the panel (Y-up → KiCad Y-down), then adds folded-A7 corner tooling with hole dedupe and drops colliding fiducials. Bottom copper gets the committed **S11 mate constellation** (112 lands in 2×3/2×4 blocks at 2.54 mm, fold-oriented for A7–A4 sheets) and a full-sheet GND pour; only GND lands are netted.
> 
> Non-standard sheet sizes are rejected. Tests cover land budget, pitch/blocks, fold orientation, and end-to-end s-expr emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc88cbbd272e9d6503689fd55087dde3f84fe6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->