### PR TITLE
fix(git): fall back to SSH when probing repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - `pcb ipc ict` lists ICT fixture contacts (components with an `Ict` BOM characteristic) as CSV.
 
+### Fixed
+
+- DiodeHub dependency resolution falls back to SSH when HTTPS authentication is unavailable.
+
 ## [0.4.32] - 2026-08-20
 
 ### Added

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -928,14 +928,13 @@ fn repo_exists(repo_url: &str) -> anyhow::Result<bool> {
         return Ok(true);
     }
 
-    let https_url = format!("https://{}.git", repo_url);
-    match ls_remote(&https_url, "HEAD", false) {
-        Ok(_) => return Ok(true),
-        Err(err) if !is_missing_remote(&err) => return Err(err),
-        Err(_) => {}
+    match with_remote_fallback(repo_url, |url, interactive| {
+        ls_remote(url, "HEAD", interactive)
+    }) {
+        Ok(_) => Ok(true),
+        Err(err) if is_missing_remote(&err) => Ok(false),
+        Err(err) => Err(err),
     }
-
-    Ok(ls_remote(&format_ssh_url(repo_url), "HEAD", true).is_ok())
 }
 
 fn is_missing_remote(err: &anyhow::Error) -> bool {


### PR DESCRIPTION
Restored HTTPS -> SSH fallback when probing repo paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git remote probing used for dependency resolution; a misclassified missing vs auth error could skip or fetch the wrong repo prefix, but the change is small and reuses existing fallback logic.
> 
> **Overview**
> Repository-prefix probing now uses the same HTTPS-then-SSH fallback as other git operations, so DiodeHub deps still resolve when HTTPS auth is missing (e.g. SSH-only Groundplane keys).
> 
> `repo_exists` no longer treats a non-missing HTTPS error as fatal before trying SSH. After both transports fail, missing remotes still map to “does not exist”; other errors still propagate. Changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8735bf2e9e65605de3b3ced4b8e64c1eef5c6a62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->