### PR TITLE
Add a fixture map to pcb ipc interposer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `pcb ipc interposer` generates the test-fixture interposer board for a board-array panel.
+- `pcb ipc interposer` generates the test-fixture interposer board for a board-array panel, with an optional `--fixture-map` JSON of tested boards and contact→land bindings.
 
 ## [0.4.33] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `pcb ipc interposer` generates the test-fixture interposer board for a board-array panel, with an optional `--fixture-map` JSON of tested boards and contact→land bindings.
+- `pcb ipc interposer` generates the test-fixture interposer board for a board-array panel.
 
 ## [0.4.33] - 2026-08-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,6 +4261,7 @@ dependencies = [
  "ipc2581",
  "pcb-ir",
  "pcb-sexpr",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/pcb-interposer/Cargo.toml
+++ b/crates/pcb-interposer/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 anyhow = { workspace = true }
 ipc2581 = { workspace = true }
 pcb-ir = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 pcb-sexpr = { workspace = true }

--- a/crates/pcb-interposer/src/contacts.rs
+++ b/crates/pcb-interposer/src/contacts.rs
@@ -1,0 +1,142 @@
+//! Extract a panel's ICT contacts, instantiated per board.
+//!
+//! The board-array file carries the board's components once (in the
+//! repeated board step) and the placement grid as step repeats; the BOM
+//! carries each component's `Ict` role. This joins the three into one
+//! contact list in the interposer's Y-down sheet frame — one entry per
+//! fixture-facing test point per board instance.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result, bail};
+use ipc2581::Ipc2581;
+
+use crate::pattern::Role;
+
+/// One ICT contact of one board instance.
+#[derive(Debug, Clone)]
+pub struct PanelContact {
+    /// Board instance index, in grid order.
+    pub board: u32,
+    pub refdes: String,
+    /// The component's zen `Path`, when the export carries one.
+    pub path: String,
+    pub role: Role,
+    /// Position in the Y-down sheet frame.
+    pub xy: [f64; 2],
+}
+
+/// Parse an `ict` role name into the fixture vocabulary. Low-speed debug
+/// roles collapse into [`Role::Ls`]; unknown names are `None`.
+fn parse_role(name: &str) -> Option<Role> {
+    Some(match name {
+        "usb_dp" => Role::UsbDp,
+        "usb_dm" => Role::UsbDm,
+        "vusb" => Role::Vusb,
+        "vtarget" => Role::Vtarget,
+        "gnd" => Role::Gnd,
+        "ls" | "swdio" | "swclk" | "nrst" | "swo" => Role::Ls,
+        _ => return None,
+    })
+}
+
+/// Extract every board instance's ICT contacts. `sheet_height` is the
+/// panel height used for the Y flip (from [`crate::panel::extract`]).
+pub fn extract_contacts(ipc: &Ipc2581, sheet_height: f64) -> Result<Vec<PanelContact>> {
+    let ecad = ipc.ecad().context("panel has no ECAD section")?;
+    let steps = &ecad.cad_data.steps;
+    let array = crate::panel::primary_step(ipc, steps).context("panel has no step")?;
+
+    // The generator's fixed shape: array step → grid repeat of the board
+    // cell → the cell places the board step at a constant offset.
+    let find = |name: ipc2581::Symbol| steps.iter().find(|step| step.name == name);
+    let mut grid = None;
+    for repeat in &array.step_repeats {
+        let Some(cell) = find(repeat.step_ref) else {
+            continue;
+        };
+        for inner in &cell.step_repeats {
+            let Some(board_step) = find(inner.step_ref) else {
+                continue;
+            };
+            if !board_step.components.is_empty() {
+                grid = Some((repeat, inner, board_step));
+            }
+        }
+    }
+    let Some((grid, offset, board_step)) = grid else {
+        bail!("panel has no repeated board step with components");
+    };
+    if offset.angle.abs() > 1e-6 || grid.angle.abs() > 1e-6 {
+        bail!("rotated board cells are not supported");
+    }
+
+    let roles = bom_roles(ipc);
+    let mut contacts = Vec::new();
+    let mut unknown = 0usize;
+    for j in 0..grid.ny.max(1) {
+        for i in 0..grid.nx.max(1) {
+            let board = j * grid.nx.max(1) + i;
+            for component in &board_step.components {
+                let Some(ref_des) = component.ref_des else {
+                    continue;
+                };
+                let refdes = ipc.resolve(ref_des).to_string();
+                let Some((ict, path)) = roles.get(&refdes) else {
+                    continue;
+                };
+                let Some(role) = parse_role(ict) else {
+                    unknown += 1;
+                    continue;
+                };
+                let x = component.location.x + offset.x + grid.x + i as f64 * grid.dx;
+                let y = component.location.y + offset.y + grid.y + j as f64 * grid.dy;
+                contacts.push(PanelContact {
+                    board,
+                    refdes: refdes.clone(),
+                    path: path.clone(),
+                    role,
+                    xy: [x, sheet_height - y],
+                });
+            }
+        }
+    }
+    if unknown > 0 {
+        eprintln!("warning: skipped {unknown} contacts with unrecognized ict roles");
+    }
+    Ok(contacts)
+}
+
+/// Designator → (`Ict` role name, zen path) from the BOM.
+fn bom_roles(ipc: &Ipc2581) -> BTreeMap<String, (String, String)> {
+    let mut roles = BTreeMap::new();
+    let Some(bom) = ipc.bom() else {
+        return roles;
+    };
+    for item in &bom.items {
+        let Some(chars) = item.characteristics.as_ref() else {
+            continue;
+        };
+        let mut ict = None;
+        let mut path = String::new();
+        for textual in &chars.textuals {
+            let (Some(name), Some(value)) = (textual.name, textual.value) else {
+                continue;
+            };
+            let name = ipc.resolve(name);
+            if name.eq_ignore_ascii_case("ict") {
+                ict = Some(ipc.resolve(value).to_string());
+            } else if name.eq_ignore_ascii_case("path") {
+                path = ipc.resolve(value).to_string();
+            }
+        }
+        let Some(ict) = ict else { continue };
+        for ref_des in &item.ref_des_list {
+            let refdes = ipc.resolve(ref_des.name).to_string();
+            if !refdes.is_empty() {
+                roles.insert(refdes, (ict.clone(), path.clone()));
+            }
+        }
+    }
+    roles
+}

--- a/crates/pcb-interposer/src/lib.rs
+++ b/crates/pcb-interposer/src/lib.rs
@@ -13,9 +13,11 @@
 //! bottom copper, and a full-sheet bottom GND pour. Pogo placement and
 //! routing are later, panel-specific passes.
 
+pub mod contacts;
 pub mod emit;
 pub mod panel;
 pub mod pattern;
+pub mod plan;
 
 use std::path::Path;
 
@@ -24,10 +26,25 @@ use anyhow::{Context, Result};
 /// Generate the interposer board for a panel file, returning the
 /// `.kicad_pcb` and `.kicad_pro` sources.
 pub fn generate(panel_xml: &Path) -> Result<(String, String)> {
-    let content = std::fs::read_to_string(panel_xml)
-        .with_context(|| format!("read panel {}", panel_xml.display()))?;
-    let ipc = ipc2581::Ipc2581::parse(&content).context("parse IPC-2581 panel")?;
+    let ipc = parse(panel_xml)?;
     let panel = panel::extract(&ipc)?;
     let lands = pattern::oriented_s11(panel.width, panel.height);
     Ok((emit::board(&panel, &lands), emit::project()))
+}
+
+/// Compute the fixture map for a panel file: which boards one insertion
+/// tests and which mate land carries which contact, as JSON.
+pub fn fixture_map(panel_xml: &Path) -> Result<String> {
+    let ipc = parse(panel_xml)?;
+    let panel = panel::extract(&ipc)?;
+    let lands = pattern::oriented_s11(panel.width, panel.height);
+    let contacts = contacts::extract_contacts(&ipc, panel.height)?;
+    let plan = plan::plan(contacts, &lands)?;
+    Ok(plan::to_json(&plan, &panel, &lands))
+}
+
+fn parse(panel_xml: &Path) -> Result<ipc2581::Ipc2581> {
+    let content = std::fs::read_to_string(panel_xml)
+        .with_context(|| format!("read panel {}", panel_xml.display()))?;
+    ipc2581::Ipc2581::parse(&content).context("parse IPC-2581 panel")
 }

--- a/crates/pcb-interposer/src/panel.rs
+++ b/crates/pcb-interposer/src/panel.rs
@@ -237,7 +237,7 @@ pub fn extract(ipc: &Ipc2581) -> Result<Panel> {
 
 /// The step the file is about: the Content section's first step reference,
 /// falling back to document order.
-fn primary_step<'a>(ipc: &Ipc2581, steps: &'a [Step]) -> Option<&'a Step> {
+pub(crate) fn primary_step<'a>(ipc: &Ipc2581, steps: &'a [Step]) -> Option<&'a Step> {
     ipc.content()
         .step_refs
         .first()

--- a/crates/pcb-interposer/src/pattern.rs
+++ b/crates/pcb-interposer/src/pattern.rs
@@ -53,6 +53,8 @@ impl Role {
 pub struct Land {
     pub xy: [f64; 2],
     pub role: Role,
+    /// Which 2×3/2×4 connector block the land belongs to (0..16).
+    pub block: u32,
 }
 
 /// Dimensions of the A7 mate region at the origin corner of a standard
@@ -141,6 +143,7 @@ fn s11() -> Vec<Land> {
     ];
 
     let mut lands = Vec::new();
+    let mut block = 0u32;
     for (band, (along_y, b0, b1, outer, inward)) in bands.into_iter().enumerate() {
         let structs = &band_structs[band];
         let extents: Vec<f64> = structs
@@ -165,10 +168,11 @@ fn s11() -> Vec<Land> {
                     } else {
                         [along, cross]
                     };
-                    lands.push(Land { xy, role });
+                    lands.push(Land { xy, role, block });
                 }
             }
             pos += extent + gap;
+            block += 1;
         }
     }
     lands

--- a/crates/pcb-interposer/src/plan.rs
+++ b/crates/pcb-interposer/src/plan.rs
@@ -136,6 +136,7 @@ pub fn plan(contacts: Vec<PanelContact>, lands: &[Land]) -> Result<Plan> {
                     net: net_name(contact),
                 });
             }
+            debug_assert_eq!(slot.kind, kind);
         }
     }
     // GND contacts of tested boards ride the pour.
@@ -167,17 +168,19 @@ fn net_name(contact: &PanelContact) -> String {
     format!("B{}.{}", contact.board, name)
 }
 
-/// Pick the member's land inside a slot: DP/DM by role, bank members in
-/// land order, units directly.
+/// Pick the member's land inside a slot. Pair slots match the contact's
+/// polarity; every other slot hands out lands in member order (an
+/// unpaired `usb_dp`/`usb_dm` contact degrades to a plain LS demand and
+/// takes an ordinary LS land).
 fn land_for(role: Role, member: usize, slot: &Slot, lands: &[Land]) -> usize {
-    match role {
-        Role::UsbDp | Role::UsbDm => *slot
+    if slot.kind == Kind::Pair {
+        return *slot
             .lands
             .iter()
             .find(|&&land| lands[land].role == role)
-            .expect("pair slot carries both polarities"),
-        _ => slot.lands[member.min(slot.lands.len() - 1)],
+            .expect("pair slot carries both polarities");
     }
+    slot.lands[member.min(slot.lands.len() - 1)]
 }
 
 /// Group the constellation into slots by connector block.
@@ -406,6 +409,35 @@ mod tests {
     fn identity_matching_is_cheapest() {
         let cost = vec![vec![0, 9, 9], vec![9, 0, 9], vec![9, 9, 0]];
         assert_eq!(hungarian(&cost), vec![Some(0), Some(1), Some(2)]);
+    }
+
+    #[test]
+    fn unpaired_polarity_degrades_to_ls() {
+        use crate::contacts::PanelContact;
+        let lands = crate::pattern::oriented_s11(74.0, 105.0);
+        // One board with a lone usb_dp and no usb_dm.
+        let contacts = vec![
+            PanelContact {
+                board: 0,
+                refdes: "TP1".into(),
+                path: "TP_DP.TP".into(),
+                role: Role::UsbDp,
+                xy: [30.0, 50.0],
+            },
+            PanelContact {
+                board: 0,
+                refdes: "TP2".into(),
+                path: "TP_SWDIO.TP".into(),
+                role: Role::Ls,
+                xy: [32.0, 50.0],
+            },
+        ];
+        let plan = plan(contacts, &lands).expect("plans without panicking");
+        assert_eq!(plan.bindings.len(), 2);
+        for binding in &plan.bindings {
+            // Both bind to ordinary LS lands.
+            assert_eq!(lands[binding.land.unwrap()].role, Role::Ls);
+        }
     }
 
     #[test]

--- a/crates/pcb-interposer/src/plan.rs
+++ b/crates/pcb-interposer/src/plan.rs
@@ -1,0 +1,421 @@
+//! The fixture plan: which boards one insertion tests, and which mate
+//! land carries which contact.
+//!
+//! Demands per board: the USB pair is one unsplittable ordered demand
+//! (`usb_dp` + `usb_dm` onto a kit's DP/DM lands), `vtarget` pads bank up
+//! to two onto one kit's Vt column, `vusb` and low-speed contacts are unit
+//! demands, and `gnd` is never assigned — it rides the pour. A panel
+//! repeats one board design, so capacity is a per-kind count against
+//! S11's fixed budget (8 kits, 48 LS lands); when the panel packs more
+//! boards than fit, the tested subset is spread evenly across the sheet —
+//! a clumped prefix concentrates every net far from half the perimeter.
+//!
+//! Assignment is per-kind Hungarian matching on demand-to-slot distance,
+//! so the plan is deterministic and globally cheapest per kind.
+
+use anyhow::{Result, bail};
+
+use crate::contacts::PanelContact;
+use crate::pattern::{Land, Role};
+
+/// One assignment row: a contact bound to a land under a net name.
+#[derive(Debug, Clone)]
+pub struct Binding {
+    /// Index into the plan's `contacts`.
+    pub contact: usize,
+    /// Index into the constellation's lands; `None` for `gnd` contacts,
+    /// which the pour carries.
+    pub land: Option<usize>,
+    pub net: String,
+}
+
+/// The computed fixture plan for one panel.
+#[derive(Debug)]
+pub struct Plan {
+    pub boards_total: u32,
+    /// Board instance indices one fixture insertion tests.
+    pub tested: Vec<u32>,
+    pub contacts: Vec<PanelContact>,
+    pub bindings: Vec<Binding>,
+}
+
+/// Slot kinds a demand can occupy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Pair,
+    VtBank,
+    Vusb,
+    Ls,
+}
+
+/// A slot: one or two lands acting as a unit, with a centroid for costs.
+struct Slot {
+    kind: Kind,
+    lands: Vec<usize>,
+    at: [f64; 2],
+}
+
+/// A demand: one or two contacts of one board needing a slot of `kind`.
+struct DemandRow {
+    kind: Kind,
+    contacts: Vec<usize>,
+    at: [f64; 2],
+}
+
+/// Compute the plan for a panel's contacts against the S11 lands.
+pub fn plan(contacts: Vec<PanelContact>, lands: &[Land]) -> Result<Plan> {
+    if contacts.is_empty() {
+        bail!("panel has no ICT contacts; mark test points with the TestPoint `ict` config");
+    }
+    let slots = derive_slots(lands);
+    let capacity = |kind: Kind| slots.iter().filter(|slot| slot.kind == kind).count();
+
+    // Per-board demand template — every instance repeats the same design,
+    // so board 0's demands are everyone's.
+    let boards_total = contacts.iter().map(|c| c.board).max().unwrap_or(0) + 1;
+    let per_board = board_demands(&contacts, 0);
+    let mut testable = boards_total as usize;
+    for kind in [Kind::Pair, Kind::VtBank, Kind::Vusb, Kind::Ls] {
+        let need = per_board
+            .iter()
+            .filter(|demand| demand.kind == kind)
+            .count();
+        if need > 0 {
+            let cap = capacity(kind);
+            if cap < need {
+                bail!(
+                    "one board needs {need} {kind:?} slots but the constellation has {cap}; \
+                     the panel is untestable"
+                );
+            }
+            testable = testable.min(cap / need);
+        }
+    }
+    // Spread the tested subset across the sheet.
+    let tested: Vec<u32> = (0..testable)
+        .map(|i| (i * boards_total as usize / testable) as u32)
+        .collect();
+
+    // Demands for every tested board, then per-kind Hungarian.
+    let mut demands: Vec<DemandRow> = Vec::new();
+    for &board in &tested {
+        demands.extend(board_demands(&contacts, board));
+    }
+    let mut bindings: Vec<Binding> = Vec::new();
+    for kind in [Kind::Pair, Kind::VtBank, Kind::Vusb, Kind::Ls] {
+        let kind_demands: Vec<&DemandRow> = demands.iter().filter(|d| d.kind == kind).collect();
+        let kind_slots: Vec<&Slot> = slots.iter().filter(|s| s.kind == kind).collect();
+        if kind_demands.is_empty() {
+            continue;
+        }
+        // Square cost matrix: dummy demand rows fill unused slots at zero
+        // cost, so real demands always win their cheapest real slot.
+        let n = kind_slots.len();
+        let cost: Vec<Vec<i64>> = (0..n)
+            .map(|i| {
+                (0..n)
+                    .map(|j| match kind_demands.get(i) {
+                        Some(demand) => {
+                            let dx = demand.at[0] - kind_slots[j].at[0];
+                            let dy = demand.at[1] - kind_slots[j].at[1];
+                            ((dx * dx + dy * dy).sqrt() * 1000.0) as i64
+                        }
+                        None => 0,
+                    })
+                    .collect()
+            })
+            .collect();
+        let matching = hungarian(&cost);
+        for (i, demand) in kind_demands.iter().enumerate() {
+            let slot = kind_slots[matching[i].expect("square matching is total")];
+            for (member, contact_index) in demand.contacts.iter().enumerate() {
+                let contact = &contacts[*contact_index];
+                bindings.push(Binding {
+                    contact: *contact_index,
+                    land: Some(land_for(contact.role, member, slot, lands)),
+                    net: net_name(contact),
+                });
+            }
+        }
+    }
+    // GND contacts of tested boards ride the pour.
+    for (index, contact) in contacts.iter().enumerate() {
+        if contact.role == Role::Gnd && tested.contains(&contact.board) {
+            bindings.push(Binding {
+                contact: index,
+                land: None,
+                net: "GND".into(),
+            });
+        }
+    }
+    bindings.sort_by_key(|binding| binding.contact);
+
+    Ok(Plan {
+        boards_total,
+        tested,
+        contacts,
+        bindings,
+    })
+}
+
+fn net_name(contact: &PanelContact) -> String {
+    let name = if contact.path.is_empty() {
+        contact.refdes.clone()
+    } else {
+        contact.path.clone()
+    };
+    format!("B{}.{}", contact.board, name)
+}
+
+/// Pick the member's land inside a slot: DP/DM by role, bank members in
+/// land order, units directly.
+fn land_for(role: Role, member: usize, slot: &Slot, lands: &[Land]) -> usize {
+    match role {
+        Role::UsbDp | Role::UsbDm => *slot
+            .lands
+            .iter()
+            .find(|&&land| lands[land].role == role)
+            .expect("pair slot carries both polarities"),
+        _ => slot.lands[member.min(slot.lands.len() - 1)],
+    }
+}
+
+/// Group the constellation into slots by connector block.
+fn derive_slots(lands: &[Land]) -> Vec<Slot> {
+    let blocks = lands.iter().map(|land| land.block).max().unwrap_or(0) + 1;
+    let mut slots = Vec::new();
+    for block in 0..blocks {
+        let members: Vec<usize> = (0..lands.len())
+            .filter(|&i| lands[i].block == block)
+            .collect();
+        let of = |role: Role| -> Vec<usize> {
+            members
+                .iter()
+                .copied()
+                .filter(|&i| lands[i].role == role)
+                .collect()
+        };
+        let centroid = |ids: &[usize]| -> [f64; 2] {
+            let n = ids.len().max(1) as f64;
+            [
+                ids.iter().map(|&i| lands[i].xy[0]).sum::<f64>() / n,
+                ids.iter().map(|&i| lands[i].xy[1]).sum::<f64>() / n,
+            ]
+        };
+        let (dp, dm) = (of(Role::UsbDp), of(Role::UsbDm));
+        if let (Some(&dp), Some(&dm)) = (dp.first(), dm.first()) {
+            slots.push(Slot {
+                kind: Kind::Pair,
+                at: centroid(&[dp, dm]),
+                lands: vec![dp, dm],
+            });
+        }
+        let vt = of(Role::Vtarget);
+        if !vt.is_empty() {
+            slots.push(Slot {
+                kind: Kind::VtBank,
+                at: centroid(&vt),
+                lands: vt,
+            });
+        }
+        for land in of(Role::Vusb) {
+            slots.push(Slot {
+                kind: Kind::Vusb,
+                at: lands[land].xy,
+                lands: vec![land],
+            });
+        }
+        for land in of(Role::Ls) {
+            slots.push(Slot {
+                kind: Kind::Ls,
+                at: lands[land].xy,
+                lands: vec![land],
+            });
+        }
+    }
+    slots
+}
+
+/// One board instance's demands, in a deterministic order.
+fn board_demands(contacts: &[PanelContact], board: u32) -> Vec<DemandRow> {
+    let mine: Vec<usize> = (0..contacts.len())
+        .filter(|&i| contacts[i].board == board)
+        .collect();
+    let of = |role: Role| -> Vec<usize> {
+        mine.iter()
+            .copied()
+            .filter(|&i| contacts[i].role == role)
+            .collect()
+    };
+    let centroid = |ids: &[usize]| -> [f64; 2] {
+        let n = ids.len().max(1) as f64;
+        [
+            ids.iter().map(|&i| contacts[i].xy[0]).sum::<f64>() / n,
+            ids.iter().map(|&i| contacts[i].xy[1]).sum::<f64>() / n,
+        ]
+    };
+
+    let mut demands = Vec::new();
+    let (dp, dm) = (of(Role::UsbDp), of(Role::UsbDm));
+    let pairs = dp.len().min(dm.len());
+    for pair in 0..pairs {
+        let members = vec![dp[pair], dm[pair]];
+        demands.push(DemandRow {
+            kind: Kind::Pair,
+            at: centroid(&members),
+            contacts: members,
+        });
+    }
+    // Unpaired polarity pads degrade to low-speed contacts.
+    let mut ls: Vec<usize> = of(Role::Ls);
+    ls.extend(dp.into_iter().skip(pairs));
+    ls.extend(dm.into_iter().skip(pairs));
+    for chunk in of(Role::Vtarget).chunks(2) {
+        demands.push(DemandRow {
+            kind: Kind::VtBank,
+            at: centroid(chunk),
+            contacts: chunk.to_vec(),
+        });
+    }
+    for contact in of(Role::Vusb) {
+        demands.push(DemandRow {
+            kind: Kind::Vusb,
+            at: contacts[contact].xy,
+            contacts: vec![contact],
+        });
+    }
+    for contact in ls {
+        demands.push(DemandRow {
+            kind: Kind::Ls,
+            at: contacts[contact].xy,
+            contacts: vec![contact],
+        });
+    }
+    demands
+}
+
+/// Square-matrix Hungarian algorithm (Jonker–Volgenant potentials);
+/// returns each row's matched column. O(n³), exact.
+fn hungarian(cost: &[Vec<i64>]) -> Vec<Option<usize>> {
+    let n = cost.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let mut u = vec![0i64; n + 1];
+    let mut v = vec![0i64; n + 1];
+    let mut p = vec![0usize; n + 1];
+    let mut way = vec![0usize; n + 1];
+    for i in 1..=n {
+        p[0] = i;
+        let mut j0 = 0usize;
+        let mut minv = vec![i64::MAX; n + 1];
+        let mut used = vec![false; n + 1];
+        loop {
+            used[j0] = true;
+            let i0 = p[j0];
+            let mut delta = i64::MAX;
+            let mut j1 = 0usize;
+            for j in 1..=n {
+                if used[j] {
+                    continue;
+                }
+                let cur = cost[i0 - 1][j - 1] - u[i0] - v[j];
+                if cur < minv[j] {
+                    minv[j] = cur;
+                    way[j] = j0;
+                }
+                if minv[j] < delta {
+                    delta = minv[j];
+                    j1 = j;
+                }
+            }
+            for j in 0..=n {
+                if used[j] {
+                    u[p[j]] += delta;
+                    v[j] -= delta;
+                } else {
+                    minv[j] -= delta;
+                }
+            }
+            j0 = j1;
+            if p[j0] == 0 {
+                break;
+            }
+        }
+        loop {
+            let j1 = way[j0];
+            p[j0] = p[j1];
+            j0 = j1;
+            if j0 == 0 {
+                break;
+            }
+        }
+    }
+    let mut match_row = vec![None; n];
+    for j in 1..=n {
+        if p[j] != 0 {
+            match_row[p[j] - 1] = Some(j - 1);
+        }
+    }
+    match_row
+}
+
+/// Serialize a plan as the fixture-map JSON document.
+pub fn to_json(plan: &Plan, panel: &crate::panel::Panel, lands: &[Land]) -> String {
+    let bindings: Vec<serde_json::Value> = plan
+        .bindings
+        .iter()
+        .map(|binding| {
+            let contact = &plan.contacts[binding.contact];
+            let land = binding.land.map(|index| {
+                let land = &lands[index];
+                serde_json::json!({
+                    "index": index,
+                    "x": land.xy[0],
+                    "y": land.xy[1],
+                    "role": land.role.name(),
+                    "block": land.block,
+                })
+            });
+            serde_json::json!({
+                "board": contact.board,
+                "refdes": contact.refdes,
+                "path": contact.path,
+                "role": contact.role.name(),
+                "x": contact.xy[0],
+                "y": contact.xy[1],
+                "net": binding.net,
+                "land": land,
+            })
+        })
+        .collect();
+    let doc = serde_json::json!({
+        "panel": { "width": panel.width, "height": panel.height },
+        "boards_total": plan.boards_total,
+        "boards_tested": plan.tested,
+        "bindings": bindings,
+    });
+    serde_json::to_string_pretty(&doc).expect("fixture map serializes") + "\n"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_matching_is_cheapest() {
+        let cost = vec![vec![0, 9, 9], vec![9, 0, 9], vec![9, 9, 0]];
+        assert_eq!(hungarian(&cost), vec![Some(0), Some(1), Some(2)]);
+    }
+
+    #[test]
+    fn s11_slot_budget() {
+        let lands = crate::pattern::oriented_s11(74.0, 105.0);
+        let slots = derive_slots(&lands);
+        let count = |kind: Kind| slots.iter().filter(|slot| slot.kind == kind).count();
+        assert_eq!(count(Kind::Pair), 8);
+        assert_eq!(count(Kind::VtBank), 8);
+        assert_eq!(count(Kind::Vusb), 8);
+        assert_eq!(count(Kind::Ls), 48);
+    }
+}

--- a/crates/pcb-interposer/src/plan.rs
+++ b/crates/pcb-interposer/src/plan.rs
@@ -1,17 +1,32 @@
 //! The fixture plan: which boards one insertion tests, and which mate
-//! land carries which contact.
+//! land carries which contact. [`plan`] is a pure function of the
+//! contact list and the constellation — same inputs, same plan, no IO.
 //!
-//! Demands per board: the USB pair is one unsplittable ordered demand
-//! (`usb_dp` + `usb_dm` onto a kit's DP/DM lands), `vtarget` pads bank up
-//! to two onto one kit's Vt column, `vusb` and low-speed contacts are unit
-//! demands, and `gnd` is never assigned — it rides the pour. A panel
-//! repeats one board design, so capacity is a per-kind count against
-//! S11's fixed budget (8 kits, 48 LS lands); when the panel packs more
-//! boards than fit, the tested subset is spread evenly across the sheet —
-//! a clumped prefix concentrates every net far from half the perimeter.
+//! **Slots** are the supply side, derived from the constellation by
+//! connector block. Each 2×3 kit yields one `Pair` slot (its DP+DM
+//! lands, unsplittable), one `VtBank` slot (its two Vt lands), and one
+//! `Vusb` unit slot; each low-speed land is its own `Ls` unit slot.
+//! S11 therefore supplies 8 pair, 8 bank, 8 vusb, and 48 LS slots.
 //!
-//! Assignment is per-kind Hungarian matching on demand-to-slot distance,
-//! so the plan is deterministic and globally cheapest per kind.
+//! **Demands** are the ask side, built per board instance from its
+//! contacts: `usb_dp`+`usb_dm` pair up into one `Pair` demand (an
+//! unpaired polarity pad degrades to a plain LS demand); `vtarget` pads
+//! chunk into `VtBank` demands of up to two; `vusb` and low-speed
+//! contacts are unit demands; `gnd` is never a demand — it rides the
+//! bottom pour. A panel repeats one board design, so board 0's demand
+//! counts are every board's, and the number of testable boards per
+//! insertion is `min(slot count ÷ per-board count)` over the kinds.
+//! When the panel packs more boards than that, the tested subset is
+//! spread evenly across the sheet — a clumped prefix concentrates every
+//! net far from half the perimeter and routes badly.
+//!
+//! **Assignment** runs per kind: demands and slots of one kind form a
+//! square cost matrix (cost = centroid distance, dummy zero-cost rows
+//! filling unused slots) solved exactly by the Hungarian algorithm, so
+//! each kind's total wire length is minimal. Within a matched slot,
+//! pair members take the land of their own polarity and bank members
+//! take lands in order. Every binding gets a stable net name,
+//! `B{board}.{path}`.
 
 use anyhow::{Result, bail};
 
@@ -70,8 +85,6 @@ pub fn plan(contacts: Vec<PanelContact>, lands: &[Land]) -> Result<Plan> {
     let slots = derive_slots(lands);
     let capacity = |kind: Kind| slots.iter().filter(|slot| slot.kind == kind).count();
 
-    // Per-board demand template — every instance repeats the same design,
-    // so board 0's demands are everyone's.
     let boards_total = contacts.iter().map(|c| c.board).max().unwrap_or(0) + 1;
     let per_board = board_demands(&contacts, 0);
     let mut testable = boards_total as usize;
@@ -91,12 +104,10 @@ pub fn plan(contacts: Vec<PanelContact>, lands: &[Land]) -> Result<Plan> {
             testable = testable.min(cap / need);
         }
     }
-    // Spread the tested subset across the sheet.
     let tested: Vec<u32> = (0..testable)
         .map(|i| (i * boards_total as usize / testable) as u32)
         .collect();
 
-    // Demands for every tested board, then per-kind Hungarian.
     let mut demands: Vec<DemandRow> = Vec::new();
     for &board in &tested {
         demands.extend(board_demands(&contacts, board));
@@ -108,8 +119,6 @@ pub fn plan(contacts: Vec<PanelContact>, lands: &[Land]) -> Result<Plan> {
         if kind_demands.is_empty() {
             continue;
         }
-        // Square cost matrix: dummy demand rows fill unused slots at zero
-        // cost, so real demands always win their cheapest real slot.
         let n = kind_slots.len();
         let cost: Vec<Vec<i64>> = (0..n)
             .map(|i| {
@@ -136,10 +145,8 @@ pub fn plan(contacts: Vec<PanelContact>, lands: &[Land]) -> Result<Plan> {
                     net: net_name(contact),
                 });
             }
-            debug_assert_eq!(slot.kind, kind);
         }
     }
-    // GND contacts of tested boards ride the pour.
     for (index, contact) in contacts.iter().enumerate() {
         if contact.role == Role::Gnd && tested.contains(&contact.board) {
             bindings.push(Binding {
@@ -168,10 +175,8 @@ fn net_name(contact: &PanelContact) -> String {
     format!("B{}.{}", contact.board, name)
 }
 
-/// Pick the member's land inside a slot. Pair slots match the contact's
-/// polarity; every other slot hands out lands in member order (an
-/// unpaired `usb_dp`/`usb_dm` contact degrades to a plain LS demand and
-/// takes an ordinary LS land).
+/// Pick the member's land inside a slot: by polarity in pair slots, in
+/// member order everywhere else.
 fn land_for(role: Role, member: usize, slot: &Slot, lands: &[Land]) -> usize {
     if slot.kind == Kind::Pair {
         return *slot
@@ -269,7 +274,6 @@ fn board_demands(contacts: &[PanelContact], board: u32) -> Vec<DemandRow> {
             contacts: members,
         });
     }
-    // Unpaired polarity pads degrade to low-speed contacts.
     let mut ls: Vec<usize> = of(Role::Ls);
     ls.extend(dp.into_iter().skip(pairs));
     ls.extend(dm.into_iter().skip(pairs));
@@ -404,12 +408,6 @@ pub fn to_json(plan: &Plan, panel: &crate::panel::Panel, lands: &[Land]) -> Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn identity_matching_is_cheapest() {
-        let cost = vec![vec![0, 9, 9], vec![9, 0, 9], vec![9, 9, 0]];
-        assert_eq!(hungarian(&cost), vec![Some(0), Some(1), Some(2)]);
-    }
 
     #[test]
     fn unpaired_polarity_degrades_to_ls() {

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -13,6 +13,53 @@ const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
     <StepRef name="array"/>
     <DictionaryStandard units="MILLIMETER"/>
   </Content>
+  <Bom name="BOM_board">
+    <BomHeader assembly="board" revision="1.0">
+      <StepRef name="array"/>
+    </BomHeader>
+    <BomItem OEMDesignNumberRef="TP_DP" quantity="1" pinCount="1" category="ELECTRICAL">
+      <RefDes name="TP1" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual textualCharacteristicName="Ict" textualCharacteristicValue="usb_dp"/>
+        <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_DP.TP"/>
+      </Characteristics>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="TP_DM" quantity="1" pinCount="1" category="ELECTRICAL">
+      <RefDes name="TP2" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual textualCharacteristicName="Ict" textualCharacteristicValue="usb_dm"/>
+        <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_DM.TP"/>
+      </Characteristics>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="TP_VT" quantity="1" pinCount="1" category="ELECTRICAL">
+      <RefDes name="TP3" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual textualCharacteristicName="Ict" textualCharacteristicValue="vtarget"/>
+        <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_VT.TP"/>
+      </Characteristics>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="TP_VU" quantity="1" pinCount="1" category="ELECTRICAL">
+      <RefDes name="TP4" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual textualCharacteristicName="Ict" textualCharacteristicValue="vusb"/>
+        <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_VU.TP"/>
+      </Characteristics>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="TP_G" quantity="1" pinCount="1" category="ELECTRICAL">
+      <RefDes name="TP5" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual textualCharacteristicName="Ict" textualCharacteristicValue="gnd"/>
+        <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_G.TP"/>
+      </Characteristics>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="TP_SWDIO" quantity="1" pinCount="1" category="ELECTRICAL">
+      <RefDes name="TP6" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual textualCharacteristicName="Ict" textualCharacteristicValue="swdio"/>
+        <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_SWDIO.TP"/>
+      </Characteristics>
+    </BomItem>
+  </Bom>
   <Ecad name="ecad">
     <CadHeader units="MILLIMETER"/>
     <CadData>
@@ -22,8 +69,34 @@ const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
       <Stackup name="stackup" overallThickness="1.6" tolPlus="0.0" tolMinus="0.0">
         <StackupGroup name="group" thickness="1.6" tolPlus="0.0" tolMinus="0.0"/>
       </Stackup>
+      <Step name="layout">
+        <Datum x="0.0" y="0.0"/>
+        <Component refDes="TP1" layerRef="BOTTOM" part="TP_DP" mountType="SMT">
+          <Location x="5.0" y="5.0"/>
+        </Component>
+        <Component refDes="TP2" layerRef="BOTTOM" part="TP_DM" mountType="SMT">
+          <Location x="7.0" y="5.0"/>
+        </Component>
+        <Component refDes="TP3" layerRef="BOTTOM" part="TP_VT" mountType="SMT">
+          <Location x="9.0" y="5.0"/>
+        </Component>
+        <Component refDes="TP4" layerRef="BOTTOM" part="TP_VU" mountType="SMT">
+          <Location x="11.0" y="5.0"/>
+        </Component>
+        <Component refDes="TP5" layerRef="BOTTOM" part="TP_G" mountType="SMT">
+          <Location x="13.0" y="5.0"/>
+        </Component>
+        <Component refDes="TP6" layerRef="BOTTOM" part="TP_SWDIO" mountType="SMT">
+          <Location x="15.0" y="5.0"/>
+        </Component>
+      </Step>
+      <Step name="board_cell">
+        <Datum x="0.0" y="0.0"/>
+        <StepRepeat stepRef="layout" x="2.0" y="3.0" nx="1" ny="1" dx="0" dy="0" angle="0.00" mirror="false"/>
+      </Step>
       <Step name="array">
         <Datum x="0.0" y="0.0"/>
+        <StepRepeat stepRef="board_cell" x="10.0" y="10.0" nx="1" ny="2" dx="0" dy="40.0" angle="0.00" mirror="false"/>
         <Profile>
           <Polygon>
             <PolyBegin x="0.0" y="3.0"/>
@@ -108,6 +181,78 @@ fn generates_a_parseable_interposer() {
 
     // Deterministic output.
     assert_eq!(text, pcb_interposer::emit::board(&panel, &lands));
+}
+
+#[test]
+fn plans_the_fixture_map() {
+    let ipc = ipc2581::Ipc2581::parse(PANEL).expect("panel fixture parses");
+    let panel = pcb_interposer::panel::extract(&ipc).expect("panel extracts");
+    let lands = pcb_interposer::pattern::oriented_s11(panel.width, panel.height);
+    let contacts =
+        pcb_interposer::contacts::extract_contacts(&ipc, panel.height).expect("contacts");
+    // 2 board instances × 6 marked components.
+    assert_eq!(contacts.len(), 12);
+    // Board 1 sits one grid pitch below board 0 in the Y-down frame.
+    let tp1 = |board: u32| {
+        contacts
+            .iter()
+            .find(|c| c.board == board && c.refdes == "TP1")
+            .unwrap()
+    };
+    assert_eq!(tp1(0).xy[0], tp1(1).xy[0]);
+    assert!((tp1(0).xy[1] - tp1(1).xy[1] - 40.0).abs() < 1e-9);
+
+    let plan = pcb_interposer::plan::plan(contacts, &lands).expect("plan");
+    assert_eq!(plan.boards_total, 2);
+    assert_eq!(plan.tested, vec![0, 1]);
+    // 12 contacts bound: 10 to lands, 2 gnd to the pour.
+    assert_eq!(plan.bindings.len(), 12);
+    assert_eq!(plan.bindings.iter().filter(|b| b.land.is_none()).count(), 2);
+    for binding in &plan.bindings {
+        let contact = &plan.contacts[binding.contact];
+        match binding.land {
+            None => assert_eq!(binding.net, "GND"),
+            Some(land) => {
+                // Role-faithful: a contact lands on its own role's land
+                // (low-speed collapses onto Ls).
+                let land_role = lands[land].role;
+                let expected = match contact.role {
+                    pcb_interposer::pattern::Role::Vtarget => {
+                        pcb_interposer::pattern::Role::Vtarget
+                    }
+                    role => role,
+                };
+                assert_eq!(land_role, expected);
+                assert_eq!(
+                    binding.net,
+                    format!(
+                        "B{}.{}.TP",
+                        contact.board,
+                        contact.path.trim_end_matches(".TP")
+                    )
+                );
+            }
+        }
+    }
+    // The USB pair of one board shares a kit block.
+    let block_of = |refdes: &str| {
+        let binding = plan
+            .bindings
+            .iter()
+            .find(|b| {
+                let c = &plan.contacts[b.contact];
+                c.board == 0 && c.refdes == refdes
+            })
+            .unwrap();
+        lands[binding.land.unwrap()].block
+    };
+    assert_eq!(block_of("TP1"), block_of("TP2"));
+
+    // The JSON document is deterministic.
+    let json = pcb_interposer::plan::to_json(&plan, &panel, &lands);
+    let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    assert_eq!(value["boards_total"], 2);
+    assert_eq!(value["bindings"].as_array().unwrap().len(), 12);
 }
 
 #[test]

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -42,6 +42,9 @@ enum Commands {
         /// Output `.kicad_pcb` path; a sibling `.kicad_pro` is written too
         #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
         output: PathBuf,
+        /// Also write the fixture map (tested boards + contact→land bindings) as JSON
+        #[arg(long, value_hint = clap::ValueHint::FilePath)]
+        fixture_map: Option<PathBuf>,
     },
     /// List ICT fixture contacts (components with an `Ict` BOM characteristic)
     Ict {
@@ -357,7 +360,11 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             format,
             offline,
         } => commands::bom::execute(&file, format, offline),
-        Commands::Interposer { input, output } => {
+        Commands::Interposer {
+            input,
+            output,
+            fixture_map,
+        } => {
             use anyhow::Context as _;
             let (pcb, pro) = pcb_interposer::generate(&input)?;
             std::fs::write(&output, pcb).with_context(|| format!("write {}", output.display()))?;
@@ -369,6 +376,12 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 output.display(),
                 pro_path.display()
             );
+            if let Some(map_path) = fixture_map {
+                let map = pcb_interposer::fixture_map(&input)?;
+                std::fs::write(&map_path, map)
+                    .with_context(|| format!("write {}", map_path.display()))?;
+                println!("✓ Wrote fixture map {}", map_path.display());
+            }
             Ok(())
         }
         Commands::Ict { file, output, side } => {


### PR DESCRIPTION
`pcb ipc interposer <array.xml> -o out.kicad_pcb --fixture-map map.json` now also emits the panel's test plan: contacts per board instance (from the array's step repeats and `Ict` BOM roles), demands bundled per board (USB pairs, vtarget banks, units), capacity against S11's budget with the tested subset spread evenly across the sheet, and per-kind Hungarian matching binding each contact to its mate land under a stable net name (`B{board}.{path}`); `gnd` contacts ride the pour.

Smoke on real panels: mockingbird A7 2/2 boards tested, A6 4/4, A5 8 of 12, A4 8 of 24 (spread), kit contacts land in one block. The map is the document fixture wiring and the routing slice consume.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New assignment logic (capacity, subset selection, Hungarian matching) can mis-bind contacts or drop boards if slot/demand grouping is wrong; CLI is additive and existing board emit is unchanged.
> 
> **Overview**
> Adds an optional `--fixture-map` JSON output to `pcb ipc interposer` that records which board instances one insertion tests and which S11 mate land each ICT contact binds to.
> 
> Contacts are instantiated from the panel’s step-repeat grid plus BOM `Ict`/`Path` roles. Demands are grouped per board (USB pairs, vtarget banks of two, unit vusb/LS; unpaired polarity falls back to LS; GND rides the pour). Testable count is the S11 slot budget divided by per-board demand; extra boards are sampled evenly across the sheet. Per-kind Hungarian matching assigns slots by centroid distance, with stable nets `B{board}.{path}`.
> 
> Lands now carry a connector `block` so USB pairs stay in one kit. Existing KiCad emit is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d0b9df76efdf8bf98a88f4abb2f6c8fbccc071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->