### PR TITLE
Populate the interposer from the fixture plan

### DIFF
--- a/crates/pcb-interposer/src/emit.rs
+++ b/crates/pcb-interposer/src/emit.rs
@@ -1,10 +1,13 @@
 //! Emit the interposer as a KiCad board via `pcb_ir::dialects::kicad`.
 //!
-//! This slice is the deterministic base board: the panel's outline,
-//! tooling holes, and fiducials, the S11 mate lands on the bottom copper,
-//! and a full-sheet bottom GND pour. GND lands join the pour; every other
-//! land is left un-netted until a panel-specific assignment binds it. No
-//! pogo pads and no routing yet.
+//! The deterministic board: the panel's outline, tooling holes, and
+//! fiducials, the S11 mate lands on the bottom copper, and a full-sheet
+//! bottom GND pour. With a fixture plan, the board is also populated —
+//! a pogo pad on the top face at every tested contact, and the plan's
+//! nets bound on both the pogo and its mate land — so the unrouted
+//! airwires are exactly the routing pass's work list. Without a plan
+//! (no ICT contacts), GND lands join the pour and everything else stays
+//! un-netted.
 
 use pcb_ir::dialects::kicad::{
     At, Document, Footprint, FootprintAttrs, Graphic, Mount, Pad, PadKind, PadShape, Property,
@@ -14,16 +17,32 @@ use pcb_ir::geom::Point;
 
 use crate::panel::{Outline, Panel};
 use crate::pattern::{Land, Role};
+use crate::plan::Plan;
 
 /// Mate land pad diameter.
 const LAND_DIA_MM: f64 = 1.0;
+/// Pogo land pad diameter, matching the Ø1 mm test points it presses on.
+const POGO_DIA_MM: f64 = 1.0;
 
 /// Build the `.kicad_pcb` source.
-pub fn board(panel: &Panel, lands: &[Land]) -> String {
+pub fn board(panel: &Panel, lands: &[Land], plan: Option<&Plan>) -> String {
     let mut doc = Document::two_layer();
     doc.generator = "pcb-interposer".into();
     let mut uuids = UuidGen::new();
     let gnd = doc.net("GND");
+
+    // The plan's nets, keyed both ways: per land index and per contact.
+    let mut land_nets: std::collections::BTreeMap<usize, (u32, String)> = Default::default();
+    let mut contact_nets: Vec<(usize, (u32, String))> = Vec::new();
+    if let Some(plan) = plan {
+        for binding in &plan.bindings {
+            let net = (doc.net(&binding.net), binding.net.clone());
+            if let Some(land) = binding.land {
+                land_nets.insert(land, net.clone());
+            }
+            contact_nets.push((binding.contact, net));
+        }
+    }
 
     for outline in &panel.outline {
         doc.graphics.push(match *outline {
@@ -59,9 +78,19 @@ pub fn board(panel: &Panel, lands: &[Land]) -> String {
             .push(fid_footprint(&mut uuids, ordinal, *at, false));
     }
     for (index, land) in lands.iter().enumerate() {
-        let net = (land.role == Role::Gnd).then(|| (gnd, "GND".to_string()));
+        let net = land_nets
+            .get(&index)
+            .cloned()
+            .or_else(|| (land.role == Role::Gnd).then(|| (gnd, "GND".to_string())));
         doc.footprints
             .push(land_footprint(&mut uuids, index, land, net));
+    }
+    if let Some(plan) = plan {
+        for (ordinal, (contact_index, net)) in contact_nets.iter().enumerate() {
+            let contact = &plan.contacts[*contact_index];
+            doc.footprints
+                .push(pogo_footprint(&mut uuids, ordinal, contact.xy, net.clone()));
+        }
     }
 
     doc.zones.push(Zone {
@@ -176,6 +205,40 @@ fn fid_footprint(uuids: &mut UuidGen, index: usize, at: [f64; 2], top: bool) -> 
             net: None,
             solder_mask_margin: Some(0.5),
             clearance: Some(0.6),
+            uuid: uuids.next_uuid(),
+        }],
+    }
+}
+
+/// A pogo-pin land on the top face, at a tested contact's position.
+fn pogo_footprint(
+    uuids: &mut UuidGen,
+    index: usize,
+    at: [f64; 2],
+    net: (u32, String),
+) -> Footprint {
+    Footprint {
+        lib_id: "Interposer:Pogo_Pad_D1.0mm".into(),
+        layer: "F.Cu".into(),
+        uuid: uuids.next_uuid(),
+        at: At::xy(at[0], at[1]),
+        properties: hidden_properties(uuids, &format!("P{}", index + 1), true),
+        attrs: FootprintAttrs {
+            mount: Some(Mount::Smd),
+            exclude_from_pos_files: false,
+            exclude_from_bom: false,
+        },
+        pads: vec![Pad {
+            number: "1".into(),
+            kind: PadKind::Smd,
+            shape: PadShape::Circle,
+            at: At::default(),
+            size: (POGO_DIA_MM, POGO_DIA_MM),
+            drill: None,
+            layers: vec!["F.Cu".into(), "F.Mask".into()],
+            net: Some(net),
+            solder_mask_margin: None,
+            clearance: None,
             uuid: uuids.next_uuid(),
         }],
     }

--- a/crates/pcb-interposer/src/lib.rs
+++ b/crates/pcb-interposer/src/lib.rs
@@ -24,27 +24,49 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 /// Generate the interposer board for a panel file, returning the
-/// `.kicad_pcb` and `.kicad_pro` sources.
+/// `.kicad_pcb` and `.kicad_pro` sources. When the panel carries ICT
+/// contacts, the board is populated from the fixture plan: pogo pads on
+/// the top face for every tested contact, and nets bound on both ends —
+/// the unrouted airwires are the routing pass's specification.
 pub fn generate(panel_xml: &Path) -> Result<(String, String)> {
-    let ipc = parse(panel_xml)?;
-    let panel = panel::extract(&ipc)?;
-    let lands = pattern::oriented_s11(panel.width, panel.height);
-    Ok((emit::board(&panel, &lands), emit::project()))
+    let (panel, lands, plan) = build(panel_xml)?;
+    Ok((emit::board(&panel, &lands, plan.as_ref()), emit::project()))
 }
 
 /// Compute the fixture map for a panel file: which boards one insertion
 /// tests and which mate land carries which contact, as JSON.
 pub fn fixture_map(panel_xml: &Path) -> Result<String> {
-    let ipc = parse(panel_xml)?;
-    let panel = panel::extract(&ipc)?;
-    let lands = pattern::oriented_s11(panel.width, panel.height);
-    let contacts = contacts::extract_contacts(&ipc, panel.height)?;
-    let plan = plan::plan(contacts, &lands)?;
+    let (panel, lands, plan) = build(panel_xml)?;
+    let plan = plan.context("panel has no ICT contacts to plan")?;
     Ok(plan::to_json(&plan, &panel, &lands))
 }
 
-fn parse(panel_xml: &Path) -> Result<ipc2581::Ipc2581> {
+/// Fixed-feature disks a pogo pad must stay out of: tooling holes (the
+/// A7 tile's corners can sit under the board field on large sheets) and
+/// top-face fiducial mask openings, each grown by the pogo pad radius
+/// plus clearance.
+fn pogo_keepouts(panel: &panel::Panel) -> Vec<([f64; 2], f64)> {
+    let pogo = 0.5;
+    let clear = 0.5;
+    panel
+        .holes
+        .iter()
+        .map(|(at, dia)| (*at, dia / 2.0 + pogo + clear))
+        .chain(panel.fids_top.iter().map(|at| (*at, 1.0 + pogo + clear)))
+        .collect()
+}
+
+fn build(panel_xml: &Path) -> Result<(panel::Panel, Vec<pattern::Land>, Option<plan::Plan>)> {
     let content = std::fs::read_to_string(panel_xml)
         .with_context(|| format!("read panel {}", panel_xml.display()))?;
-    ipc2581::Ipc2581::parse(&content).context("parse IPC-2581 panel")
+    let ipc = ipc2581::Ipc2581::parse(&content).context("parse IPC-2581 panel")?;
+    let panel = panel::extract(&ipc)?;
+    let lands = pattern::oriented_s11(panel.width, panel.height);
+    let contacts = contacts::extract_contacts(&ipc, panel.height)?;
+    let plan = if contacts.is_empty() {
+        None
+    } else {
+        Some(plan::plan(contacts, &lands, &pogo_keepouts(&panel))?)
+    };
+    Ok((panel, lands, plan))
 }

--- a/crates/pcb-interposer/src/plan.rs
+++ b/crates/pcb-interposer/src/plan.rs
@@ -18,7 +18,10 @@
 //! insertion is `min(slot count ÷ per-board count)` over the kinds.
 //! When the panel packs more boards than that, the tested subset is
 //! spread evenly across the sheet — a clumped prefix concentrates every
-//! net far from half the perimeter and routes badly.
+//! net far from half the perimeter and routes badly. A board whose
+//! contact would put a pogo pad inside a fixed-feature keep-out (the A7
+//! tile's corner tooling can sit under the board field on large sheets)
+//! is not selectable.
 //!
 //! **Assignment** runs per kind: demands and slots of one kind form a
 //! square cost matrix (cost = centroid distance, dummy zero-cost rows
@@ -78,7 +81,13 @@ struct DemandRow {
 }
 
 /// Compute the plan for a panel's contacts against the S11 lands.
-pub fn plan(contacts: Vec<PanelContact>, lands: &[Land]) -> Result<Plan> {
+/// `keepouts` are fixed-feature disks (center, radius) a pogo pad must
+/// stay out of.
+pub fn plan(
+    contacts: Vec<PanelContact>,
+    lands: &[Land],
+    keepouts: &[([f64; 2], f64)],
+) -> Result<Plan> {
     if contacts.is_empty() {
         bail!("panel has no ICT contacts; mark test points with the TestPoint `ict` config");
     }
@@ -104,8 +113,26 @@ pub fn plan(contacts: Vec<PanelContact>, lands: &[Land]) -> Result<Plan> {
             testable = testable.min(cap / need);
         }
     }
+    let valid: Vec<u32> = (0..boards_total)
+        .filter(|&board| {
+            contacts
+                .iter()
+                .filter(|contact| contact.board == board)
+                .all(|contact| {
+                    keepouts.iter().all(|(center, radius)| {
+                        let dx = contact.xy[0] - center[0];
+                        let dy = contact.xy[1] - center[1];
+                        (dx * dx + dy * dy).sqrt() >= *radius
+                    })
+                })
+        })
+        .collect();
+    if valid.is_empty() {
+        bail!("every board instance has a contact inside a fixed-feature keep-out");
+    }
+    let testable = testable.min(valid.len());
     let tested: Vec<u32> = (0..testable)
-        .map(|i| (i * boards_total as usize / testable) as u32)
+        .map(|i| valid[i * valid.len() / testable])
         .collect();
 
     let mut demands: Vec<DemandRow> = Vec::new();
@@ -430,7 +457,7 @@ mod tests {
                 xy: [32.0, 50.0],
             },
         ];
-        let plan = plan(contacts, &lands).expect("plans without panicking");
+        let plan = plan(contacts, &lands, &[]).expect("plans without panicking");
         assert_eq!(plan.bindings.len(), 2);
         for binding in &plan.bindings {
             // Both bind to ordinary LS lands.

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -157,7 +157,10 @@ fn generates_a_parseable_interposer() {
     assert_eq!(panel.outline.len(), 8);
 
     let lands = pcb_interposer::pattern::oriented_s11(panel.width, panel.height);
-    let text = pcb_interposer::emit::board(&panel, &lands);
+    let contacts =
+        pcb_interposer::contacts::extract_contacts(&ipc, panel.height).expect("contacts");
+    let plan = pcb_interposer::plan::plan(contacts, &lands, &[]).expect("plan");
+    let text = pcb_interposer::emit::board(&panel, &lands, Some(&plan));
     let root = pcb_sexpr::parse(&text).expect("board parses");
     let SexprKind::List(items) = &root.kind else {
         panic!("root is a list");
@@ -171,16 +174,32 @@ fn generates_a_parseable_interposer() {
             })
             .count()
     };
-    // 5 holes + 2 fids + 112 lands.
-    assert_eq!(count("footprint"), 119);
+    // 5 holes + 2 fids + 112 lands + 12 pogos (2 boards × 6 contacts).
+    assert_eq!(count("footprint"), 131);
     assert_eq!(count("zone"), 1);
     assert_eq!(count("gr_arc"), 4);
     assert_eq!(count("gr_line"), 4);
-    // 24 GND lands plus the net-table entry and the zone reference.
-    assert_eq!(text.matches("(net 1 \"GND\")").count(), 25);
+    // Net table: no-net, GND, and ten planned nets.
+    assert_eq!(count("net"), 12);
+    // GND: the table entry, 24 lands, and 2 gnd pogos.
+    assert_eq!(text.matches("(net 1 \"GND\")").count(), 27);
+    // Every planned net appears on both faces: its pogo pad and its land.
+    for board in [0, 1] {
+        let net = format!("\"B{board}.TP_DP.TP\"");
+        assert_eq!(text.matches(net.as_str()).count(), 3, "table + pogo + land");
+    }
+    assert_eq!(text.matches("Interposer:Pogo_Pad_D1.0mm").count(), 12);
 
     // Deterministic output.
-    assert_eq!(text, pcb_interposer::emit::board(&panel, &lands));
+    assert_eq!(
+        text,
+        pcb_interposer::emit::board(&panel, &lands, Some(&plan))
+    );
+
+    // Without a plan the board stays bare: no pogos, no planned nets.
+    let bare = pcb_interposer::emit::board(&panel, &lands, None);
+    assert!(!bare.contains("Pogo_Pad"));
+    assert!(!bare.contains("B0.TP_DP.TP"));
 }
 
 #[test]
@@ -202,7 +221,7 @@ fn plans_the_fixture_map() {
     assert_eq!(tp1(0).xy[0], tp1(1).xy[0]);
     assert!((tp1(0).xy[1] - tp1(1).xy[1] - 40.0).abs() < 1e-9);
 
-    let plan = pcb_interposer::plan::plan(contacts, &lands).expect("plan");
+    let plan = pcb_interposer::plan::plan(contacts, &lands, &[]).expect("plan");
     assert_eq!(plan.boards_total, 2);
     assert_eq!(plan.tested, vec![0, 1]);
     // 12 contacts bound: 10 to lands, 2 gnd to the pour.


### PR DESCRIPTION
With ICT contacts present, `pcb ipc interposer` now emits a populated board: a pogo pad (`Interposer:Pogo_Pad_D1.0mm`, top face) at every tested contact, with the fixture plan's nets bound on both the pogo and its mate land — opening the board shows the full ratsnest, and the unrouted airwires are exactly the routing pass's specification. Board selection gains fixed-feature keep-outs (the folded A7 tile's corner tooling can sit under the board field on large sheets; a board whose contact collides there is not selected).

All 20 A-series corpus panels emit with 0 DRC violations; unconnected counts reconcile exactly with the plan (bound nets + one GND airwire per tested board). Panels without ICT data still produce the bare board.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fixture board selection and KiCad net/pad emission, which can drop testable boards or produce wrong airwires if keep-outs or net binding are off. No auth or external I/O beyond existing panel generation.
> 
> **Overview**
> When a panel has ICT contacts, interposer generation now emits a **populated** board: Ø1 mm top-face pogo pads at every tested contact, with plan nets bound on both the pogo and its mate land so the ratsnest is the routing work list. Panels without ICT data still emit the bare board.
> 
> Board selection now skips instances whose contacts would put a pogo inside a keep-out around tooling holes and top fiducials (A7-tile corners can sit under the field on large sheets). Shared `build` drives both `generate` and `fixture_map`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a703a99ad56b81ed677634848b5b7fd9706c9197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->