### PR TITLE
DFM: authoritative measurements, medial-axis widths, single-verdict engine

### DIFF
--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -80,13 +80,20 @@ high-level pass is never allowed to suppress a later authoritative failure.
 | V-score and board-edge clearance | Materialized line/profile geometry against final composed copper | Indexed copper boundaries |
 | Board-array spacing | Materialized filled array profiles | Bounding boxes prune pairs already proven clear |
 
+Every check produces one measurement per subject: a signed distance between
+two witness points, carrying the uncertainty of the flattened boundaries it
+was measured against (one flattening tolerance per tessellated curve; zero
+for stated primitives and analytic shapes). The engine applies the single
+verdict — the distance violates the limit only when it falls short beyond its
+own uncertainty — so curve tessellation by itself cannot manufacture a
+violation, and the same rule decides every quantity in the table above.
+
 Morphological opening and closing are deliberately candidate stages for width
-and gap checks. A candidate becomes a finding only when the distance between
-two nonincident, opposing source-boundary branches is below the limit. The
-comparison includes the flattening uncertainty of both boundaries, so curve
-tessellation by itself cannot manufacture a violation. Bounds and spatial
-indices have the same one-way contract: they can prove work unnecessary, but
-they cannot emit a finding without the exact geometric measurement.
+and gap checks. A candidate becomes a measurement only when two nonincident,
+opposing source-boundary branches wall it; their exact separation is the
+width. Bounds and spatial indices have the same one-way contract: they can
+prove work unnecessary, but they cannot emit a finding without the exact
+geometric measurement.
 
 `--layout-target board` extracts the canonical board step. `board-array`
 materializes the root layout and every nested repeat, so the same evaluators
@@ -99,10 +106,12 @@ when fewer than two exist.
 ## Rule semantics
 
 - Hole diameter rules measure every drilled hole of the rule's class;
-  `minimum_slot_width` measures every routed slot. It uses a stated nominal
-  width when present and the filled route outline otherwise. Drill
-  extraction fails rather than silently discarding a hole whose plating
-  class or diameter is missing.
+  `minimum_slot_width` measures every routed slot. A slot's width is settled
+  at extraction: the stated primitive width when present — exact, and
+  verified against the materialized outline — and otherwise the outline's
+  narrowest local width. Drill extraction fails rather than silently
+  discarding a hole whose plating class or diameter is missing, or a slot
+  whose stated width its outline contradicts.
 - Hole-to-hole clearance measures edge-to-edge distance between hole pairs
   whose drill spans overlap; stacked blind and buried vias on disjoint spans
   do not interact.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -72,11 +72,11 @@ high-level pass is never allowed to suppress a later authoritative failure.
 | --- | --- | --- |
 | Hole diameter | Materialized IPC drill primitive and plating class | None |
 | Nominal slot width | IPC slot primitive width | None |
-| Outline slot width | Materialized filled route outline, then opposing-boundary distance | Morphological opening localizes candidates |
+| Outline slot width | Materialized filled route outline, then its narrowest maximal inscribed disk | None |
 | Hole-to-hole clearance | Materialized drill circles and overlapping drill spans | Sorted bounds prune pairs already proven clear |
 | Annular ring | Drill circle and final composed copper image on each applicable layer | Batched containment and an indexed copper boundary |
-| Copper width and clearance | Final composed copper image | Guarded opening or closing localizes candidates |
-| Soldermask web | Final composed mask-opening image | Guarded closing localizes candidates |
+| Copper width and clearance | Final composed copper image, medial-axis width of each residue | Guarded opening or closing localizes candidates |
+| Soldermask web | Final composed mask-opening image, medial-axis width of each residue | Guarded closing localizes candidates |
 | V-score and board-edge clearance | Materialized line/profile geometry against final composed copper | Indexed copper boundaries |
 | Board-array spacing | Materialized filled array profiles | Bounding boxes prune pairs already proven clear |
 
@@ -89,11 +89,16 @@ own uncertainty — so curve tessellation by itself cannot manufacture a
 violation, and the same rule decides every quantity in the table above.
 
 Morphological opening and closing are deliberately candidate stages for width
-and gap checks. A candidate becomes a measurement only when two nonincident,
-opposing source-boundary branches wall it; their exact separation is the
-width. Bounds and spatial indices have the same one-way contract: they can
-prove work unnecessary, but they cannot emit a finding without the exact
-geometric measurement.
+and gap checks. Each candidate residue is measured on the medial axis of the
+boundary around it — the Voronoi diagram of the nearby boundary segments —
+as the diameter of its narrowest maximal inscribed disk. Disks tangent only
+to incident segments are corner spokes and carry no width, so one-sided
+residue (the bite an isolated corner sheds) measures nothing; disks that a
+larger disk contains within the flattening tolerance are branches the
+tessellation sprouted and are pruned, so a flattened arc measures its
+diameter while a tapered spur still measures its tip. Bounds and spatial
+indices have the same one-way contract: they can prove work unnecessary, but
+they cannot emit a finding without the exact geometric measurement.
 
 `--layout-target board` extracts the canonical board step. `board-array`
 materializes the root layout and every nested repeat, so the same evaluators
@@ -124,8 +129,8 @@ when fewer than two exist.
 - `minimum_feature_width` and `minimum_copper_clearance` report narrow copper
   and narrow gaps piece by piece per layer after final polarity composition.
   `soldermask.minimum_web` reports mask webs — gaps between mask openings —
-  narrower than the limit. Morphology finds candidates; opposing-boundary
-  distance decides each finding.
+  narrower than the limit. Morphology finds candidates; the medial-axis
+  width decides each finding.
 - V-score and board-edge clearance measure the shortest distance from the
   centerlines or profile outlines (cutouts included) to each layer's
   composed copper image.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -100,9 +100,9 @@ when fewer than two exist.
 
 - Hole diameter rules measure every drilled hole of the rule's class;
   `minimum_slot_width` measures every routed slot. It uses a stated nominal
-  width when present and the filled route outline otherwise. A class-specific
-  drill rule fails extraction rather than silently discarding a hole whose
-  plating class is unknown.
+  width when present and the filled route outline otherwise. Drill
+  extraction fails rather than silently discarding a hole whose plating
+  class or diameter is missing.
 - Hole-to-hole clearance measures edge-to-edge distance between hole pairs
   whose drill spans overlap; stacked blind and buried vias on disjoint spans
   do not interact.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -61,22 +61,62 @@ table with a `preferred` tier the fab would rather see met:
 Rule ids are the PDK capability paths, so every reported limit can be traced
 to its PDK line verbatim.
 
+## Evaluation model
+
+Each rule has one verdict-producing evaluator. The evaluator uses the
+highest-level representation that still states the measured quantity exactly,
+and lowers only when fabrication composition can change that quantity. A
+high-level pass is never allowed to suppress a later authoritative failure.
+
+| Rules | Authoritative representation | Acceleration only |
+| --- | --- | --- |
+| Hole diameter | Materialized IPC drill primitive and plating class | None |
+| Nominal slot width | IPC slot primitive width | None |
+| Outline slot width | Materialized filled route outline, then opposing-boundary distance | Morphological opening localizes candidates |
+| Hole-to-hole clearance | Materialized drill circles and overlapping drill spans | Sorted bounds prune pairs already proven clear |
+| Annular ring | Drill circle and final composed copper image on each applicable layer | Batched containment and an indexed copper boundary |
+| Copper width and clearance | Final composed copper image | Guarded opening or closing localizes candidates |
+| Soldermask web | Final composed mask-opening image | Guarded closing localizes candidates |
+| V-score and board-edge clearance | Materialized line/profile geometry against final composed copper | Indexed copper boundaries |
+| Board-array spacing | Materialized filled array profiles | Bounding boxes prune pairs already proven clear |
+
+Morphological opening and closing are deliberately candidate stages for width
+and gap checks. A candidate becomes a finding only when the distance between
+two nonincident, opposing source-boundary branches is below the limit. The
+comparison includes the flattening uncertainty of both boundaries, so curve
+tessellation by itself cannot manufacture a violation. Bounds and spatial
+indices have the same one-way contract: they can prove work unnecessary, but
+they cannot emit a finding without the exact geometric measurement.
+
+`--layout-target board` extracts the canonical board step. `board-array`
+materializes the root layout and every nested repeat, so the same evaluators
+operate on a board array or on a fabrication panel without a second DFM code
+path. Instance transforms therefore affect only extracted coordinates and
+subject multiplicity. The board-array-spacing rule is intentionally narrower:
+it compares direct sibling array instances of a fabrication panel and skips
+when fewer than two exist.
+
 ## Rule semantics
 
 - Hole diameter rules measure every drilled hole of the rule's class;
-  `minimum_slot_width` measures every routed slot with a stated width.
+  `minimum_slot_width` measures every routed slot. It uses a stated nominal
+  width when present and the filled route outline otherwise. A class-specific
+  drill rule fails extraction rather than silently discarding a hole whose
+  plating class is unknown.
 - Hole-to-hole clearance measures edge-to-edge distance between hole pairs
   whose drill spans overlap; stacked blind and buried vias on disjoint spans
   do not interact.
 - Annular ring measures the radial copper enclosure of each via or PTH hole
-  on every spanned copper layer where the hole has a matching land or its
-  center lies in copper. Layers where no copper reaches the hole — a plane
-  anti-pad, a removed unused land — have no ring to measure. One finding per
-  hole reports the worst layer.
-- `minimum_feature_width` and `minimum_copper_clearance` are morphological:
-  copper narrower than the limit, and gaps in copper narrower than the
-  limit, are reported piece by piece per layer. `soldermask.minimum_web`
-  reports mask webs — gaps between mask openings — narrower than the limit.
+  on every applicable layer. A genuine intermediate plane anti-pad with no
+  matching source land has no ring to measure. Both terminal layers, and any
+  layer with a matching source land, must retain copper at the hole center;
+  missing copper there is a zero-enclosure failure. One finding per hole
+  reports the worst layer.
+- `minimum_feature_width` and `minimum_copper_clearance` report narrow copper
+  and narrow gaps piece by piece per layer after final polarity composition.
+  `soldermask.minimum_web` reports mask webs — gaps between mask openings —
+  narrower than the limit. Morphology finds candidates; opposing-boundary
+  distance decides each finding.
 - V-score and board-edge clearance measure the shortest distance from the
   centerlines or profile outlines (cutouts included) to each layer's
   composed copper image.

--- a/crates/pcb-ipc2581-tools/examples/apcb-proto.toml
+++ b/crates/pcb-ipc2581-tools/examples/apcb-proto.toml
@@ -1,0 +1,29 @@
+schema_version = 1
+
+[pdk]
+id = "apcb-proto"
+name = "AdvancedPCB Aurora prototype"
+revision = "draft-2026-08-21"
+manufacturer = "AdvancedPCB"
+process = "Aurora 2-10 layer prototype"
+
+[capabilities.drilling]
+minimum_via_hole_diameter = "0.2 mm"
+minimum_pth_hole_diameter = "15 mil"
+minimum_npth_hole_diameter = "0.2 mm"
+minimum_slot_width = "31 mil"
+minimum_hole_to_hole_clearance = "10 mil"
+
+[capabilities.copper]
+minimum_via_annular_ring = "0.125 mm"
+minimum_pth_annular_ring = "7 mil"
+minimum_feature_width = "5 mil"
+minimum_copper_clearance = "5 mil"
+minimum_board_edge_clearance = "15 mil"
+minimum_vscore_to_copper_clearance = "15 mil"
+
+[capabilities.soldermask]
+minimum_web = "4 mil"
+
+[capabilities.panelization]
+minimum_board_array_spacing = "300 mil"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -72,14 +72,13 @@ pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<()> {
     let generated_at = generation_time();
     let content = file_utils::ipc_text(file, &input_bytes)?;
     let ipc = Ipc2581::parse(&content).context("failed to parse IPC-2581 file")?;
-    let design = design::Design::extract(&ipc, &rules, options.layout_target.artwork_scope())?;
+    let design = design::Design::new(&ipc, options.layout_target.artwork_scope());
     let checked = checks::run(
         &rules,
         &design,
-        &ipc,
         waivers.as_ref().map(|loaded| &loaded.file),
         generated_at.date_naive(),
-    );
+    )?;
 
     let summary = summarize(&checked);
     let failed = summary.errors > 0;
@@ -299,14 +298,14 @@ minimum_board_array_spacing = "300 mil"
         let ipc = Ipc2581::parse(xml).unwrap();
         let pdk = pdk::Pdk::parse(PDK).unwrap();
         let rules = rules::lower(&pdk).unwrap();
-        let design = design::Design::extract(&ipc, &rules, scope).unwrap();
+        let design = design::Design::new(&ipc, scope);
         checks::run(
             &rules,
             &design,
-            &ipc,
             None,
             NaiveDate::from_ymd_opt(2026, 8, 21).unwrap(),
         )
+        .unwrap()
     }
 
     fn rule<'a>(results: &'a checks::Results, id: &str) -> &'a report::RuleResult {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -72,13 +72,13 @@ pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<()> {
     let generated_at = generation_time();
     let content = file_utils::ipc_text(file, &input_bytes)?;
     let ipc = Ipc2581::parse(&content).context("failed to parse IPC-2581 file")?;
-    let design = design::Design::new(&ipc, options.layout_target.artwork_scope());
+    let design = design::Design::extract(&ipc, options.layout_target.artwork_scope(), &rules)?;
     let checked = checks::run(
         &rules,
         &design,
         waivers.as_ref().map(|loaded| &loaded.file),
         generated_at.date_naive(),
-    )?;
+    );
 
     let summary = summarize(&checked);
     let failed = summary.errors > 0;
@@ -298,14 +298,13 @@ minimum_board_array_spacing = "300 mil"
         let ipc = Ipc2581::parse(xml).unwrap();
         let pdk = pdk::Pdk::parse(PDK).unwrap();
         let rules = rules::lower(&pdk).unwrap();
-        let design = design::Design::new(&ipc, scope);
+        let design = design::Design::extract(&ipc, scope, &rules).unwrap();
         checks::run(
             &rules,
             &design,
             None,
             NaiveDate::from_ymd_opt(2026, 8, 21).unwrap(),
         )
-        .unwrap()
     }
 
     fn rule<'a>(results: &'a checks::Results, id: &str) -> &'a report::RuleResult {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -221,3 +221,146 @@ fn write_report(output: Option<&Path>, report: &str) -> Result<()> {
 fn sha256(bytes: &[u8]) -> String {
     hex::encode(Sha256::digest(bytes))
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+    use pcb_ir::dialects::ipc::ArtworkScope;
+
+    use super::*;
+    use crate::commands::EdgeInsetsMm;
+    use crate::commands::board_array::{BoardArrayCreateOptions, create_board_array};
+    use crate::commands::fab_panel::{FabPanelSpec, create_fab_panel};
+
+    const BOARD: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+    <LayerRef name="F.Mask"/>
+    <LayerRef name="BOTTOM"/>
+    <LayerRef name="B.Mask"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+      <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+      <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
+      <Stackup name="Primary" overallThickness="0.07" tolPlus="0" tolMinus="0" whereMeasured="METAL" stackupStatus="PROPOSED">
+        <StackupGroup name="Primary_Group" thickness="0.07" tolPlus="0" tolMinus="0">
+          <StackupLayer layerOrGroupRef="TOP" thickness="0.035" tolPlus="0" tolMinus="0" sequence="0"/>
+          <StackupLayer layerOrGroupRef="BOTTOM" thickness="0.035" tolPlus="0" tolMinus="0" sequence="1"/>
+        </StackupGroup>
+      </Stackup>
+      <Step name="board" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="30" y="0"/>
+            <PolyStepSegment x="30" y="30"/>
+            <PolyStepSegment x="0" y="30"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+        </Profile>
+        <LayerFeature layerRef="TOP">
+          <Set polarity="POSITIVE">
+            <Features>
+              <Line startX="1" startY="1" endX="29" endY="1">
+                <LineDesc lineWidth="0.2" lineEnd="ROUND"/>
+              </Line>
+            </Features>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+    const PDK: &str = r#"schema_version = 1
+
+[pdk]
+id = "scope-test"
+name = "Scope test"
+revision = "1"
+
+[capabilities.copper]
+minimum_vscore_to_copper_clearance = "0.5 mm"
+minimum_board_edge_clearance = "0.5 mm"
+
+[capabilities.panelization]
+minimum_board_array_spacing = "300 mil"
+"#;
+
+    fn check(xml: &str, scope: ArtworkScope) -> checks::Results {
+        let ipc = Ipc2581::parse(xml).unwrap();
+        let pdk = pdk::Pdk::parse(PDK).unwrap();
+        let rules = rules::lower(&pdk).unwrap();
+        let design = design::Design::extract(&ipc, &rules, scope).unwrap();
+        checks::run(
+            &rules,
+            &design,
+            &ipc,
+            None,
+            NaiveDate::from_ymd_opt(2026, 8, 21).unwrap(),
+        )
+    }
+
+    fn rule<'a>(results: &'a checks::Results, id: &str) -> &'a report::RuleResult {
+        results.rules.iter().find(|rule| rule.id == id).unwrap()
+    }
+
+    #[test]
+    fn one_evaluator_scales_through_board_array_and_fab_panel_lowering() {
+        let array = create_board_array(
+            BOARD,
+            &BoardArrayCreateOptions {
+                columns: 2,
+                rows: 2,
+                board_margin_mm: EdgeInsetsMm::all(0.0),
+                edge_rail_mm: EdgeInsetsMm::all(5.0),
+            },
+            false,
+        )
+        .unwrap()
+        .xml;
+        let fab = create_fab_panel(
+            std::slice::from_ref(&array),
+            &[0, 0],
+            FabPanelSpec::default(),
+            false,
+        )
+        .unwrap()
+        .xml;
+
+        let board_results = check(BOARD, ArtworkScope::Board);
+        let array_results = check(&array, ArtworkScope::ArrayFlattened);
+        let fab_results = check(&fab, ArtworkScope::ArrayFlattened);
+
+        let board_edge = "copper.minimum_board_edge_clearance";
+        let vscore = "copper.minimum_vscore_to_copper_clearance";
+        let spacing = "panelization.minimum_board_array_spacing";
+
+        assert_eq!(rule(&board_results, board_edge).checked, 2);
+        assert_eq!(rule(&array_results, board_edge).checked, 8);
+        assert_eq!(rule(&fab_results, board_edge).checked, 16);
+
+        assert_eq!(rule(&board_results, vscore).checked, 0);
+        assert!(rule(&array_results, vscore).checked > 0);
+        assert_eq!(
+            rule(&fab_results, vscore).checked,
+            2 * rule(&array_results, vscore).checked
+        );
+
+        assert_eq!(rule(&board_results, spacing).checked, 0);
+        assert_eq!(rule(&array_results, spacing).checked, 0);
+        assert_eq!(rule(&fab_results, spacing).checked, 1);
+        assert_eq!(rule(&fab_results, spacing).finding_count, 0);
+        assert!(board_results.findings.is_empty());
+        assert!(array_results.findings.is_empty());
+        assert!(fab_results.findings.is_empty());
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -32,15 +32,14 @@
 //! over the boundary segments, searched only to `r + A_min` since farther
 //! boundaries cannot violate.
 
-use anyhow::Result;
 use pcb_ir::geom::BBox;
 use pcb_ir::geom::dfm::Distance;
 use rayon::prelude::*;
 
-use crate::commands::dfm::design::{CopperLayer, Hole, HoleClass, HoleLand, Land};
+use crate::commands::dfm::design::{CopperLayer, Design, Hole, HoleClass, HoleLand, Land};
 use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
 
-use super::{Context, Evaluation, Measured, hole_subject, holes_of_class, layers};
+use super::{Evaluation, Measured, hole_subject, holes_of_class, layers};
 
 /// One copper layer on which a hole has a ring to measure.
 struct RingSubject<'a> {
@@ -49,12 +48,11 @@ struct RingSubject<'a> {
     in_copper: bool,
 }
 
-pub(super) fn evaluate(limit_mm: f64, class: HoleClass, ctx: &Context) -> Result<Evaluation> {
-    let design = ctx.design;
-    let holes = holes_of_class(design, class)?;
-    let copper_layers = design.copper_layers()?;
-    let hole_lands = design.hole_lands()?;
-    let boundaries = ctx.copper_boundaries()?;
+pub(super) fn evaluate(limit_mm: f64, class: HoleClass, design: &Design) -> Evaluation {
+    let holes = holes_of_class(design, class);
+    let copper_layers = &design.copper_layers;
+    let hole_lands = &design.hole_lands;
+    let boundaries = &design.copper_boundaries;
     let centers = holes
         .iter()
         .map(|(_, hole)| hole.center)
@@ -103,23 +101,23 @@ pub(super) fn evaluate(limit_mm: f64, class: HoleClass, ctx: &Context) -> Result
                 .filter_map(|(subject, enclosure)| enclosure.map(|enclosure| (subject, enclosure)))
                 .min_by(|(_, left), (_, right)| left.mm.total_cmp(&right.mm))
                 .map(|(subject, enclosure)| {
-                    measured(ctx, hole, subject, enclosure, radius + limit_mm)
+                    measured(design, hole, subject, enclosure, radius + limit_mm)
                 });
             (enclosures.len(), worst)
         })
         .collect::<Vec<_>>();
 
-    Ok(Evaluation {
+    Evaluation {
         checked: per_hole.iter().map(|(checked, _)| checked).sum(),
         measured: per_hole
             .into_iter()
             .filter_map(|(_, measured)| measured)
             .collect(),
-    })
+    }
 }
 
 fn measured(
-    ctx: &Context,
+    design: &Design,
     hole: &Hole,
     subject: &RingSubject,
     enclosure: Distance,
@@ -136,13 +134,13 @@ fn measured(
         |land| Subject {
             role: "land",
             kind: "padstack_land",
-            name: ctx.resolve(land.primitive_ref),
-            reference_designator: ctx.resolve(land.reference_designator),
-            pin: ctx.resolve(land.pin),
-            net: ctx.resolve(land.net),
-            padstack_ref: ctx.resolve(Some(land.padstack)),
+            name: design.resolve(land.primitive_ref),
+            reference_designator: design.resolve(land.reference_designator),
+            pin: design.resolve(land.pin),
+            net: design.resolve(land.net),
+            padstack_ref: design.resolve(Some(land.padstack)),
             source: Some(SourceLocator {
-                step: ctx.resolve(land.step),
+                step: design.resolve(land.step),
                 layer: Some(copper.layer.name.clone()),
                 set_index: Some(land.source_set_index),
                 feature_index: Some(land.source_feature_index),
@@ -157,7 +155,7 @@ fn measured(
         distance: enclosure,
         bbox: BBox::from_point(hole.center).expand(required_radius_mm),
         layers: layers([&hole.layer, &copper.layer]),
-        subjects: vec![hole_subject(ctx, hole, "hole"), land_subject],
+        subjects: vec![hole_subject(design, hole, "hole"), land_subject],
         evidence: [
             Evidence::circle("drilled_hole", hole.center, hole.diameter_mm),
             Evidence::circle(
@@ -176,7 +174,6 @@ fn measured(
 mod tests {
     use pcb_ir::dialects::ipc::ArtworkScope;
 
-    use crate::commands::dfm::design::Design;
     use crate::commands::dfm::pdk::Pdk;
     use crate::commands::dfm::rules::{self, Rule};
     use crate::ipc2581::Ipc2581;
@@ -263,9 +260,9 @@ minimum_pth_annular_ring = "0.2 mm"
 
     fn evaluate_pth(ipc: &Ipc2581) -> Evaluation {
         let rule = rule();
-        let design = Design::new(ipc, ArtworkScope::Board);
-        let ctx = Context::new(&design, std::slice::from_ref(&rule));
-        evaluate(rule.limit.millimeters(), HoleClass::Pth, &ctx).unwrap()
+        let design =
+            Design::extract(ipc, ArtworkScope::Board, std::slice::from_ref(&rule)).unwrap();
+        evaluate(rule.limit.millimeters(), HoleClass::Pth, &design)
     }
 
     #[test]
@@ -296,20 +293,5 @@ minimum_pth_annular_ring = "0.2 mm"
         let measured = &evaluation.measured[0];
         assert_eq!(measured.layers[1].name, "L1");
         assert_eq!(measured.distance.mm, 0.0);
-    }
-
-    #[test]
-    fn thin_ring_is_measured_with_its_witnesses() {
-        let evaluation = evaluate_pth(&board(2, &[0, 1], None));
-        let limit = rule().limit.millimeters();
-
-        // 2 mm square around a 1 mm hole: 0.5 mm ring, comfortably above 0.2.
-        assert_eq!(evaluation.checked, 2);
-        assert!(
-            evaluation
-                .measured
-                .iter()
-                .all(|measured| !measured.distance.certainly_below(limit))
-        );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -16,219 +16,124 @@
 //! requires
 //!
 //! ```text
-//! a ≥ A_min    on every spanned copper layer where p ∈ M,
+//! a ≥ A_min    on every copper layer the hole must land on,
 //! ```
 //!
 //! equivalently `D(p, r + A_min) ⊆ M` — the indexed form of a morphological
-//! erosion test. For `p ∉ M`, an intermediate layer with no matching land is
-//! an anti-pad or removed unused land and has no ring to measure. A terminal
-//! layer, or any layer carrying a matching source land, is required to retain
-//! copper at `p`; absence there is an authoritative zero-enclosure failure.
-//! One finding per hole reports the layer minimizing `a`.
+//! erosion test. The layers a hole must land on are the spanned layers
+//! holding copper at `p`, plus spanned layers carrying a matching source
+//! land or at an end of the drill span even without copper there: absence
+//! on those is a zero enclosure. A spanned intermediate layer with neither
+//! is a plane anti-pad or a removed unused land and has no ring to measure.
+//! One measurement per hole reports the layer minimizing `a`.
 //!
 //! Computation: `p ∈ M` by a batched winding-number sweep over all hole
 //! centers; `d(p, ∂M)` by a nearest-boundary query against a uniform grid
 //! over the boundary segments, searched only to `r + A_min` since farther
-//! boundaries cannot violate. The polygon flattening tolerance is
-//! subtracted from the requirement so arc discretization cannot
-//! manufacture violations.
+//! boundaries cannot violate.
 
-use pcb_ir::geom::dfm::CircularEnclosureMeasurement;
-use pcb_ir::geom::{BBox, tol};
+use anyhow::Result;
+use pcb_ir::geom::BBox;
+use pcb_ir::geom::dfm::Distance;
 use rayon::prelude::*;
 
-use crate::commands::dfm::design::{CopperLayer, Design, Hole, HoleClass, Land};
-use crate::commands::dfm::report::{
-    Evidence, Finding, Location, Measurement, SourceLocator, Subject, Witness,
-};
-use crate::commands::dfm::rules::Rule;
+use crate::commands::dfm::design::{CopperLayer, Hole, HoleClass, HoleLand, Land};
+use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
 
-use super::{
-    COMPARISON_EPSILON_MM, Context, blank_finding, hole_subject, holes_of_class, unique_layers,
-};
-
-/// One (hole, copper layer) enclosure violation.
-struct AnnularViolation<'a> {
-    copper_index: usize,
-    land: Option<&'a Land>,
-    enclosure: Enclosure,
-}
-
-/// The measured enclosure on one layer the hole is required to have copper
-/// on. No copper at the hole center is a zero enclosure with no boundary
-/// witnesses; otherwise the signed radial measurement stands.
-enum Enclosure {
-    Measured(CircularEnclosureMeasurement),
-    MissingCopper,
-}
-
-impl Enclosure {
-    fn millimeters(&self) -> f64 {
-        match self {
-            Self::Measured(measurement) => measurement.enclosure_mm,
-            Self::MissingCopper => 0.0,
-        }
-    }
-}
-
-pub(super) fn evaluate(rule: &Rule, class: HoleClass, ctx: &Context) -> (usize, Vec<Finding>) {
-    let design = ctx.design;
-    let holes = holes_of_class(design, class);
-    let limit = rule.limit.millimeters();
-    let tolerance = tol::FLATTEN_MM + COMPARISON_EPSILON_MM;
-    let centers = holes.iter().map(|hole| hole.center).collect::<Vec<_>>();
-    let contains = design
-        .copper_layers
-        .par_iter()
-        .map(|layer| layer.image.contains_points_batch(&centers))
-        .collect::<Vec<_>>();
-    let boundaries = ctx.copper_boundaries();
-
-    let per_hole = holes
-        .par_iter()
-        .enumerate()
-        .map(|(hole_index, hole)| {
-            let radius = hole.diameter_mm / 2.0;
-            let violations = ring_subjects(design, hole, &contains, hole_index)
-                .map(|subject| {
-                    let enclosure = if subject.in_copper {
-                        boundaries[subject.copper_index]
-                            .circular_enclosure(hole.center, radius, limit - tolerance)
-                            .filter(|measurement| measurement.enclosure_mm + tolerance < limit)
-                            .map(Enclosure::Measured)
-                    } else {
-                        Some(Enclosure::MissingCopper)
-                    };
-                    enclosure.map(|enclosure| AnnularViolation {
-                        copper_index: subject.copper_index,
-                        land: subject.land,
-                        enclosure,
-                    })
-                })
-                .collect::<Vec<_>>();
-            let worst = violations.iter().flatten().min_by(|left, right| {
-                left.enclosure
-                    .millimeters()
-                    .total_cmp(&right.enclosure.millimeters())
-            });
-            (
-                violations.len(),
-                worst.map(|worst| annular_finding(rule, class, hole, ctx, worst)),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    (
-        per_hole.iter().map(|(checked, _)| checked).sum(),
-        per_hole
-            .into_iter()
-            .filter_map(|(_, finding)| finding)
-            .collect(),
-    )
-}
+use super::{Context, Evaluation, Measured, hole_subject, holes_of_class, layers};
 
 /// One copper layer on which a hole has a ring to measure.
 struct RingSubject<'a> {
-    copper_index: usize,
+    copper: &'a CopperLayer,
     land: Option<&'a Land>,
     in_copper: bool,
 }
 
-/// Layers where the hole must carry copper, hence has a ring to measure:
-/// spanned layers holding copper at the center, plus spanned layers with a
-/// source land or at an end of the drill span even without it. A spanned
-/// intermediate layer with neither is a plane anti-pad or a removed unused
-/// land, and is not a subject.
-fn ring_subjects<'a>(
-    design: &'a Design,
-    hole: &'a Hole,
-    contains: &'a [Vec<bool>],
-    hole_index: usize,
-) -> impl Iterator<Item = RingSubject<'a>> + 'a {
-    design
-        .copper_layers
+pub(super) fn evaluate(limit_mm: f64, class: HoleClass, ctx: &Context) -> Result<Evaluation> {
+    let design = ctx.design;
+    let holes = holes_of_class(design, class)?;
+    let copper_layers = design.copper_layers()?;
+    let hole_lands = design.hole_lands()?;
+    let boundaries = ctx.copper_boundaries()?;
+    let centers = holes
         .iter()
+        .map(|(_, hole)| hole.center)
+        .collect::<Vec<_>>();
+    let contains = copper_layers
+        .par_iter()
+        .map(|layer| layer.image.contains_points_batch(&centers))
+        .collect::<Vec<_>>();
+
+    let per_hole = holes
+        .par_iter()
         .enumerate()
-        .filter(move |(copper_index, _)| hole.spans_copper(*copper_index as u16))
-        .filter_map(move |(copper_index, copper)| {
-            let land = hole
-                .land_on(copper_index)
-                .map(|link| &copper.lands[link.land_index as usize]);
-            let in_copper = contains[copper_index][hole_index];
-            let required =
-                land.is_some() || hole.terminates_on(copper_index, design.copper_layers.len());
-            (in_copper || required).then_some(RingSubject {
-                copper_index,
-                land,
-                in_copper,
-            })
+        .map(|(position, &(hole_index, hole))| {
+            let radius = hole.diameter_mm / 2.0;
+            let enclosures = copper_layers
+                .iter()
+                .enumerate()
+                .filter(|(copper_index, _)| hole.spans_copper(*copper_index))
+                .filter_map(|(copper_index, copper)| {
+                    let land = hole_lands[hole_index]
+                        .iter()
+                        .find(|link| link.copper_index as usize == copper_index)
+                        .map(|link: &HoleLand| &copper.lands[link.land_index as usize]);
+                    let in_copper = contains[copper_index][position];
+                    let required = land.is_some() || hole.terminates_on(copper_index);
+                    (in_copper || required).then_some((
+                        copper_index,
+                        RingSubject {
+                            copper,
+                            land,
+                            in_copper,
+                        },
+                    ))
+                })
+                .map(|(copper_index, subject)| {
+                    let enclosure = if subject.in_copper {
+                        boundaries[copper_index].circular_enclosure(hole.center, radius, limit_mm)
+                    } else {
+                        Some(Distance::exact(0.0, hole.center, hole.center))
+                    };
+                    (subject, enclosure)
+                })
+                .collect::<Vec<_>>();
+            let worst = enclosures
+                .iter()
+                .filter_map(|(subject, enclosure)| enclosure.map(|enclosure| (subject, enclosure)))
+                .min_by(|(_, left), (_, right)| left.mm.total_cmp(&right.mm))
+                .map(|(subject, enclosure)| {
+                    measured(ctx, hole, subject, enclosure, radius + limit_mm)
+                });
+            (enclosures.len(), worst)
         })
+        .collect::<Vec<_>>();
+
+    Ok(Evaluation {
+        checked: per_hole.iter().map(|(checked, _)| checked).sum(),
+        measured: per_hole
+            .into_iter()
+            .filter_map(|(_, measured)| measured)
+            .collect(),
+    })
 }
 
-fn annular_finding(
-    rule: &Rule,
-    class: HoleClass,
-    hole: &Hole,
+fn measured(
     ctx: &Context,
-    violation: &AnnularViolation,
-) -> Finding {
-    let limit = rule.limit.millimeters();
-    let copper = &ctx.design.copper_layers[violation.copper_index];
-    let required_radius = hole.diameter_mm / 2.0 + limit;
-    let enclosure_mm = violation.enclosure.millimeters();
-    let (location_point, witnesses, detail) = match &violation.enclosure {
-        Enclosure::Measured(measurement) => (
-            measurement
-                .cutout_boundary
-                .midpoint(measurement.material_boundary),
-            vec![
-                Witness::new("hole_boundary", measurement.cutout_boundary),
-                Witness::new("copper_boundary", measurement.material_boundary),
-            ],
-            if enclosure_mm < 0.0 {
-                format!(
-                    "the drilled hole breaches the copper image by {:.6} mm",
-                    -enclosure_mm
-                )
-            } else {
-                format!("only {enclosure_mm:.6} mm of copper remains outside the drilled hole")
-            },
-        ),
-        Enclosure::MissingCopper => (
-            hole.center,
-            Vec::new(),
-            "no composed copper remains at the required hole center".to_owned(),
-        ),
-    };
-    Finding {
-        title: format!("{} annular ring is below minimum", class.label()),
-        message: format!(
-            "{} minimum radial copper enclosure is {enclosure_mm:.6} mm on {}; the PDK requires {limit:.6} mm ({detail})",
-            class.label(),
-            copper.layer.name,
-        ),
-        measurement: Measurement::minimum(enclosure_mm, limit),
-        location: Location {
-            point: Some(location_point.into()),
-            bounding_box: Some(BBox::from_point(hole.center).expand(required_radius).into()),
-            witnesses,
+    hole: &Hole,
+    subject: &RingSubject,
+    enclosure: Distance,
+    required_radius_mm: f64,
+) -> Measured {
+    let copper = subject.copper;
+    let land_subject = subject.land.map_or_else(
+        || Subject {
+            role: "land",
+            kind: "composed_copper",
+            name: Some(copper.layer.name.clone()),
+            ..Subject::default()
         },
-        layers: unique_layers(&hole.layer, &copper.layer),
-        subjects: annular_ring_subjects(ctx, hole, copper, violation.land),
-        evidence: annular_ring_evidence(hole, violation.land, 2.0 * required_radius),
-        ..blank_finding(rule)
-    }
-}
-
-fn annular_ring_subjects(
-    ctx: &Context,
-    hole: &Hole,
-    copper: &CopperLayer,
-    land: Option<&Land>,
-) -> Vec<Subject> {
-    let mut subjects = vec![hole_subject(ctx, hole, "hole")];
-    subjects.push(match land {
-        Some(land) => Subject {
+        |land| Subject {
             role: "land",
             kind: "padstack_land",
             name: ctx.resolve(land.primitive_ref),
@@ -244,44 +149,36 @@ fn annular_ring_subjects(
                 instance_index: None,
             }),
         },
-        None => Subject {
-            role: "land",
-            kind: "composed_copper",
-            name: Some(copper.layer.name.clone()),
-            ..Subject::default()
-        },
-    });
-    subjects
-}
-
-fn annular_ring_evidence(
-    hole: &Hole,
-    land: Option<&Land>,
-    required_diameter_mm: f64,
-) -> Vec<Evidence> {
-    let mut evidence = vec![
-        Evidence::circle("drilled_hole", hole.center, hole.diameter_mm),
-        Evidence::circle(
-            "required_copper_envelope",
-            hole.center,
-            required_diameter_mm,
-        ),
-    ];
-    if let Some(land) = land {
-        evidence.push(Evidence::bounds("source_padstack_land_bounds", land.bbox));
+    );
+    let land_evidence = subject
+        .land
+        .map(|land| Evidence::bounds("source_padstack_land_bounds", land.bbox));
+    Measured {
+        distance: enclosure,
+        bbox: BBox::from_point(hole.center).expand(required_radius_mm),
+        layers: layers([&hole.layer, &copper.layer]),
+        subjects: vec![hole_subject(ctx, hole, "hole"), land_subject],
+        evidence: [
+            Evidence::circle("drilled_hole", hole.center, hole.diameter_mm),
+            Evidence::circle(
+                "required_copper_envelope",
+                hole.center,
+                2.0 * required_radius_mm,
+            ),
+        ]
+        .into_iter()
+        .chain(land_evidence)
+        .collect(),
     }
-    evidence
 }
 
 #[cfg(test)]
 mod tests {
     use pcb_ir::dialects::ipc::ArtworkScope;
-    use pcb_ir::geom::{ContourSet, FillRule, Point, shapes, tol};
 
-    use crate::commands::dfm::design::{Design, Hole};
+    use crate::commands::dfm::design::Design;
     use crate::commands::dfm::pdk::Pdk;
-    use crate::commands::dfm::report::LayerRef;
-    use crate::commands::dfm::rules;
+    use crate::commands::dfm::rules::{self, Rule};
     use crate::ipc2581::Ipc2581;
 
     use super::*;
@@ -303,123 +200,116 @@ minimum_pth_annular_ring = "0.2 mm"
         rules::lower(&pdk).unwrap().remove(0)
     }
 
-    fn ipc() -> Ipc2581 {
-        Ipc2581::parse(
+    /// A 1 mm plated hole at the origin through copper layers `L0..Ln`,
+    /// with a 2 mm copper square on each layer named in `copper_on`, and
+    /// an optional drill span.
+    fn board(layer_count: usize, copper_on: &[usize], span: Option<(usize, usize)>) -> Ipc2581 {
+        let layer_names = (0..layer_count).map(|index| format!("L{index}"));
+        let refs = layer_names
+            .clone()
+            .map(|name| format!(r#"<LayerRef name="{name}"/>"#))
+            .collect::<String>();
+        let layers = layer_names
+            .clone()
+            .map(|name| {
+                format!(
+                    r#"<Layer name="{name}" layerFunction="CONDUCTOR" side="INTERNAL" polarity="POSITIVE"/>"#
+                )
+            })
+            .collect::<String>();
+        let drill_span = span
+            .map(|(from, to)| format!(r#"<Span fromLayer="L{from}" toLayer="L{to}"/>"#))
+            .unwrap_or_default();
+        let copper = copper_on
+            .iter()
+            .map(|index| {
+                format!(
+                    r#"<LayerFeature layerRef="L{index}"><Set polarity="POSITIVE"><Features><Contour><Polygon>
+                      <PolyBegin x="-1" y="-1"/><PolyStepSegment x="1" y="-1"/><PolyStepSegment x="1" y="1"/>
+                      <PolyStepSegment x="-1" y="1"/><PolyStepSegment x="-1" y="-1"/>
+                    </Polygon></Contour></Features></Set></LayerFeature>"#
+                )
+            })
+            .collect::<String>();
+        Ipc2581::parse(&format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="owner">
     <FunctionMode mode="FABRICATION"/>
     <StepRef name="board"/>
+    {refs}
+    <LayerRef name="DRILL"/>
   </Content>
   <Ecad>
     <CadHeader units="MILLIMETER"/>
     <CadData>
-      <Step name="board" type="BOARD"/>
+      {layers}
+      <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE">{drill_span}</Layer>
+      <Step name="board" type="BOARD">
+        <Datum x="0" y="0"/>
+        {copper}
+        <LayerFeature layerRef="DRILL">
+          <Set polarity="POSITIVE">
+            <Hole name="H1" diameter="1" platingStatus="PLATED" x="0" y="0"/>
+          </Set>
+        </LayerFeature>
+      </Step>
     </CadData>
   </Ecad>
-</IPC-2581>"#,
-        )
+</IPC-2581>"#
+        ))
         .unwrap()
     }
 
-    fn copper_layer(name: &str, diameter_mm: Option<f64>) -> CopperLayer {
-        let image = diameter_mm.map_or_else(
-            || ContourSet::empty(tol::REGION_MM),
-            |diameter| {
-                ContourSet::from_contours(
-                    &[shapes::circle(diameter).unwrap()],
-                    FillRule::NonZero,
-                    tol::REGION_MM,
-                )
-            },
-        );
-        CopperLayer {
-            layer: LayerRef {
-                name: name.to_owned(),
-                function: "CONDUCTOR".to_owned(),
-                side: None,
-            },
-            image,
-            lands: Vec::new(),
-        }
-    }
-
-    fn through_hole_design(layer_diameters: &[Option<f64>]) -> Design {
-        let center = Point::ZERO;
-        Design {
-            scope: ArtworkScope::Board,
-            holes: vec![Hole {
-                class: HoleClass::Pth,
-                center,
-                diameter_mm: 1.0,
-                bbox: BBox::from_point(center).expand(0.5),
-                layer: LayerRef {
-                    name: "DRILL".to_owned(),
-                    function: "DRILL".to_owned(),
-                    side: None,
-                },
-                copper_span: None,
-                step: None,
-                padstack: None,
-                net: None,
-                lands: Vec::new(),
-                source_set_index: 0,
-                source_feature_index: 0,
-            }],
-            slots: Vec::new(),
-            copper_layers: layer_diameters
-                .iter()
-                .enumerate()
-                .map(|(index, diameter)| copper_layer(&format!("L{index}"), *diameter))
-                .collect(),
-            mask_layers: Vec::new(),
-            scores: Vec::new(),
-            board_outlines: Vec::new(),
-            board_arrays: Vec::new(),
-        }
+    fn evaluate_pth(ipc: &Ipc2581) -> Evaluation {
+        let rule = rule();
+        let design = Design::new(ipc, ArtworkScope::Board);
+        let ctx = Context::new(&design, std::slice::from_ref(&rule));
+        evaluate(rule.limit.millimeters(), HoleClass::Pth, &ctx).unwrap()
     }
 
     #[test]
     fn missing_terminal_copper_is_a_zero_enclosure_violation() {
-        let rule = rule();
-        let ipc = ipc();
-        let design = through_hole_design(&[None, None, Some(2.0)]);
-        let ctx = Context::new(&design, &ipc, std::slice::from_ref(&rule));
+        let evaluation = evaluate_pth(&board(3, &[2], None));
 
-        let (checked, findings) = evaluate(&rule, HoleClass::Pth, &ctx);
-
-        assert_eq!(checked, 2);
-        assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].measurement.actual_mm, 0.0);
-        assert!(findings[0].message.contains("no composed copper remains"));
+        assert_eq!(evaluation.checked, 2);
+        assert_eq!(evaluation.measured.len(), 1);
+        let measured = &evaluation.measured[0];
+        assert_eq!(measured.distance.mm, 0.0);
+        assert_eq!(measured.layers[1].name, "L0");
     }
 
     #[test]
     fn intermediate_antipad_without_a_source_land_is_not_an_annular_subject() {
-        let rule = rule();
-        let ipc = ipc();
-        let design = through_hole_design(&[Some(2.0), None, Some(2.0)]);
-        let ctx = Context::new(&design, &ipc, std::slice::from_ref(&rule));
+        let evaluation = evaluate_pth(&board(3, &[0, 2], None));
 
-        let (checked, findings) = evaluate(&rule, HoleClass::Pth, &ctx);
-
-        assert_eq!(checked, 2);
-        assert!(findings.is_empty());
+        assert_eq!(evaluation.checked, 2);
+        assert!(evaluation.measured.is_empty());
     }
 
     #[test]
     fn known_blind_span_requires_copper_at_its_own_terminal_layers() {
-        let rule = rule();
-        let ipc = ipc();
-        let mut design = through_hole_design(&[None, None, Some(2.0), None]);
-        design.holes[0].copper_span = Some((1, 2));
-        let ctx = Context::new(&design, &ipc, std::slice::from_ref(&rule));
+        let evaluation = evaluate_pth(&board(4, &[2], Some((1, 2))));
 
-        let (checked, findings) = evaluate(&rule, HoleClass::Pth, &ctx);
+        assert_eq!(evaluation.checked, 2);
+        assert_eq!(evaluation.measured.len(), 1);
+        let measured = &evaluation.measured[0];
+        assert_eq!(measured.layers[1].name, "L1");
+        assert_eq!(measured.distance.mm, 0.0);
+    }
 
-        assert_eq!(checked, 2);
-        assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].layers[1].name, "L1");
-        assert_eq!(findings[0].measurement.actual_mm, 0.0);
+    #[test]
+    fn thin_ring_is_measured_with_its_witnesses() {
+        let evaluation = evaluate_pth(&board(2, &[0, 1], None));
+        let limit = rule().limit.millimeters();
+
+        // 2 mm square around a 1 mm hole: 0.5 mm ring, comfortably above 0.2.
+        assert_eq!(evaluation.checked, 2);
+        assert!(
+            evaluation
+                .measured
+                .iter()
+                .all(|measured| !measured.distance.certainly_below(limit))
+        );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -20,10 +20,11 @@
 //! ```
 //!
 //! equivalently `D(p, r + A_min) ⊆ M` — the indexed form of a morphological
-//! erosion test. For `p ∉ M` the artwork deliberately places no copper at
-//! the hole — a plane anti-pad, a thermal-relief clearance, a removed
-//! unused land — so there is no ring to measure and the layer is not
-//! checked. One finding per hole reports the layer minimizing `a`.
+//! erosion test. For `p ∉ M`, an intermediate layer with no matching land is
+//! an anti-pad or removed unused land and has no ring to measure. A terminal
+//! layer, or any layer carrying a matching source land, is required to retain
+//! copper at `p`; absence there is an authoritative zero-enclosure failure.
+//! One finding per hole reports the layer minimizing `a`.
 //!
 //! Computation: `p ∈ M` by a batched winding-number sweep over all hole
 //! centers; `d(p, ∂M)` by a nearest-boundary query against a uniform grid
@@ -50,8 +51,15 @@ struct AnnularViolation<'a> {
     copper_index: usize,
     land: Option<&'a Land>,
     enclosure_mm: f64,
-    cutout_boundary: Point,
-    material_boundary: Point,
+    geometry: AnnularViolationGeometry,
+}
+
+enum AnnularViolationGeometry {
+    Boundary {
+        cutout_boundary: Point,
+        material_boundary: Point,
+    },
+    MissingCopper,
 }
 
 pub(super) fn evaluate(rule: &Rule, class: HoleClass, ctx: &Context) -> (usize, Vec<Finding>) {
@@ -78,10 +86,32 @@ pub(super) fn evaluate(rule: &Rule, class: HoleClass, ctx: &Context) -> (usize, 
                 if !hole.spans_copper(copper_index as u16) {
                     continue;
                 }
+                let land = hole
+                    .land_on(copper_index)
+                    .map(|link| &copper.lands[link.land_index as usize]);
                 if !contains[copper_index][hole_index] {
-                    // No copper at the hole here — a plane anti-pad, a
-                    // thermal-relief clearance, or a removed unused land.
-                    // There is no ring to measure.
+                    // Intermediate layers without a source land are plane
+                    // anti-pads or removed unused lands. A terminal layer or
+                    // intended land with no composed copper is not allowed to
+                    // disappear from an annular-ring check.
+                    if land.is_none()
+                        && !hole.terminates_on(copper_index, design.copper_layers.len())
+                    {
+                        continue;
+                    }
+                    checked += 1;
+                    let violation = AnnularViolation {
+                        copper_index,
+                        land,
+                        enclosure_mm: 0.0,
+                        geometry: AnnularViolationGeometry::MissingCopper,
+                    };
+                    if worst
+                        .as_ref()
+                        .is_none_or(|current| violation.enclosure_mm < current.enclosure_mm)
+                    {
+                        worst = Some(violation);
+                    }
                     continue;
                 }
                 checked += 1;
@@ -90,12 +120,12 @@ pub(super) fn evaluate(rule: &Rule, class: HoleClass, ctx: &Context) -> (usize, 
                     .filter(|measurement| measurement.enclosure_mm + tolerance < limit)
                     .map(|measurement| AnnularViolation {
                         copper_index,
-                        land: hole
-                            .land_on(copper_index)
-                            .map(|link| &copper.lands[link.land_index as usize]),
+                        land,
                         enclosure_mm: measurement.enclosure_mm,
-                        cutout_boundary: measurement.cutout_boundary,
-                        material_boundary: measurement.material_boundary,
+                        geometry: AnnularViolationGeometry::Boundary {
+                            cutout_boundary: measurement.cutout_boundary,
+                            material_boundary: measurement.material_boundary,
+                        },
                     });
                 if let Some(violation) = violation
                     && worst
@@ -131,23 +161,36 @@ fn annular_finding(
     let limit = rule.limit.millimeters();
     let copper = &ctx.design.copper_layers[violation.copper_index];
     let required_radius = hole.diameter_mm / 2.0 + limit;
-    let witnesses = vec![
-        Witness::new("hole_boundary", violation.cutout_boundary),
-        Witness::new("copper_boundary", violation.material_boundary),
-    ];
-    let location_point = violation
-        .cutout_boundary
-        .midpoint(violation.material_boundary);
-    let detail = if violation.enclosure_mm < 0.0 {
-        format!(
-            "the drilled hole breaches the copper image by {:.6} mm",
-            -violation.enclosure_mm
-        )
-    } else {
-        format!(
-            "only {:.6} mm of copper remains outside the drilled hole",
-            violation.enclosure_mm
-        )
+    let (location_point, witnesses, detail) = match violation.geometry {
+        AnnularViolationGeometry::Boundary {
+            cutout_boundary,
+            material_boundary,
+        } => {
+            let detail = if violation.enclosure_mm < 0.0 {
+                format!(
+                    "the drilled hole breaches the copper image by {:.6} mm",
+                    -violation.enclosure_mm
+                )
+            } else {
+                format!(
+                    "only {:.6} mm of copper remains outside the drilled hole",
+                    violation.enclosure_mm
+                )
+            };
+            (
+                cutout_boundary.midpoint(material_boundary),
+                vec![
+                    Witness::new("hole_boundary", cutout_boundary),
+                    Witness::new("copper_boundary", material_boundary),
+                ],
+                detail,
+            )
+        }
+        AnnularViolationGeometry::MissingCopper => (
+            hole.center,
+            Vec::new(),
+            "no composed copper remains at the required hole center".to_owned(),
+        ),
     };
     Finding {
         title: format!("{} annular ring is below minimum", class.label()),
@@ -222,4 +265,155 @@ fn annular_ring_evidence(
         evidence.push(Evidence::bounds("source_padstack_land_bounds", land.bbox));
     }
     evidence
+}
+
+#[cfg(test)]
+mod tests {
+    use pcb_ir::dialects::ipc::ArtworkScope;
+    use pcb_ir::geom::{ContourSet, FillRule, Point, shapes, tol};
+
+    use crate::commands::dfm::design::{Design, Hole};
+    use crate::commands::dfm::pdk::Pdk;
+    use crate::commands::dfm::report::LayerRef;
+    use crate::commands::dfm::rules;
+    use crate::ipc2581::Ipc2581;
+
+    use super::*;
+
+    fn rule() -> Rule {
+        let pdk = Pdk::parse(
+            r#"schema_version = 1
+
+[pdk]
+id = "test"
+name = "Test"
+revision = "1"
+
+[capabilities.copper]
+minimum_pth_annular_ring = "0.2 mm"
+"#,
+        )
+        .unwrap();
+        rules::lower(&pdk).unwrap().remove(0)
+    }
+
+    fn ipc() -> Ipc2581 {
+        Ipc2581::parse(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Step name="board" type="BOARD"/>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+        )
+        .unwrap()
+    }
+
+    fn copper_layer(name: &str, diameter_mm: Option<f64>) -> CopperLayer {
+        let image = diameter_mm.map_or_else(
+            || ContourSet::empty(tol::REGION_MM),
+            |diameter| {
+                ContourSet::from_contours(
+                    &[shapes::circle(diameter).unwrap()],
+                    FillRule::NonZero,
+                    tol::REGION_MM,
+                )
+            },
+        );
+        CopperLayer {
+            layer: LayerRef {
+                name: name.to_owned(),
+                function: "CONDUCTOR".to_owned(),
+                side: None,
+            },
+            image,
+            lands: Vec::new(),
+        }
+    }
+
+    fn through_hole_design(layer_diameters: &[Option<f64>]) -> Design {
+        let center = Point::ZERO;
+        Design {
+            scope: ArtworkScope::Board,
+            holes: vec![Hole {
+                class: HoleClass::Pth,
+                center,
+                diameter_mm: 1.0,
+                bbox: BBox::from_point(center).expand(0.5),
+                layer: LayerRef {
+                    name: "DRILL".to_owned(),
+                    function: "DRILL".to_owned(),
+                    side: None,
+                },
+                copper_span: None,
+                step: None,
+                padstack: None,
+                net: None,
+                lands: Vec::new(),
+                source_set_index: 0,
+                source_feature_index: 0,
+            }],
+            slots: Vec::new(),
+            copper_layers: layer_diameters
+                .iter()
+                .enumerate()
+                .map(|(index, diameter)| copper_layer(&format!("L{index}"), *diameter))
+                .collect(),
+            mask_layers: Vec::new(),
+            scores: Vec::new(),
+            board_outlines: Vec::new(),
+            board_arrays: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn missing_terminal_copper_is_a_zero_enclosure_violation() {
+        let rule = rule();
+        let ipc = ipc();
+        let design = through_hole_design(&[None, None, Some(2.0)]);
+        let ctx = Context::new(&design, &ipc, std::slice::from_ref(&rule));
+
+        let (checked, findings) = evaluate(&rule, HoleClass::Pth, &ctx);
+
+        assert_eq!(checked, 2);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].measurement.actual_mm, 0.0);
+        assert!(findings[0].message.contains("no composed copper remains"));
+    }
+
+    #[test]
+    fn intermediate_antipad_without_a_source_land_is_not_an_annular_subject() {
+        let rule = rule();
+        let ipc = ipc();
+        let design = through_hole_design(&[Some(2.0), None, Some(2.0)]);
+        let ctx = Context::new(&design, &ipc, std::slice::from_ref(&rule));
+
+        let (checked, findings) = evaluate(&rule, HoleClass::Pth, &ctx);
+
+        assert_eq!(checked, 2);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn known_blind_span_requires_copper_at_its_own_terminal_layers() {
+        let rule = rule();
+        let ipc = ipc();
+        let mut design = through_hole_design(&[None, None, Some(2.0), None]);
+        design.holes[0].copper_span = Some((1, 2));
+        let ctx = Context::new(&design, &ipc, std::slice::from_ref(&rule));
+
+        let (checked, findings) = evaluate(&rule, HoleClass::Pth, &ctx);
+
+        assert_eq!(checked, 2);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].layers[1].name, "L1");
+        assert_eq!(findings[0].measurement.actual_mm, 0.0);
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -33,10 +33,11 @@
 //! subtracted from the requirement so arc discretization cannot
 //! manufacture violations.
 
-use pcb_ir::geom::{BBox, Point, tol};
+use pcb_ir::geom::dfm::CircularEnclosureMeasurement;
+use pcb_ir::geom::{BBox, tol};
 use rayon::prelude::*;
 
-use crate::commands::dfm::design::{CopperLayer, Hole, HoleClass, Land};
+use crate::commands::dfm::design::{CopperLayer, Design, Hole, HoleClass, Land};
 use crate::commands::dfm::report::{
     Evidence, Finding, Location, Measurement, SourceLocator, Subject, Witness,
 };
@@ -46,20 +47,28 @@ use super::{
     COMPARISON_EPSILON_MM, Context, blank_finding, hole_subject, holes_of_class, unique_layers,
 };
 
-/// One (hole, copper layer) enclosure violation candidate.
+/// One (hole, copper layer) enclosure violation.
 struct AnnularViolation<'a> {
     copper_index: usize,
     land: Option<&'a Land>,
-    enclosure_mm: f64,
-    geometry: AnnularViolationGeometry,
+    enclosure: Enclosure,
 }
 
-enum AnnularViolationGeometry {
-    Boundary {
-        cutout_boundary: Point,
-        material_boundary: Point,
-    },
+/// The measured enclosure on one layer the hole is required to have copper
+/// on. No copper at the hole center is a zero enclosure with no boundary
+/// witnesses; otherwise the signed radial measurement stands.
+enum Enclosure {
+    Measured(CircularEnclosureMeasurement),
     MissingCopper,
+}
+
+impl Enclosure {
+    fn millimeters(&self) -> f64 {
+        match self {
+            Self::Measured(measurement) => measurement.enclosure_mm,
+            Self::MissingCopper => 0.0,
+        }
+    }
 }
 
 pub(super) fn evaluate(rule: &Rule, class: HoleClass, ctx: &Context) -> (usize, Vec<Finding>) {
@@ -80,63 +89,30 @@ pub(super) fn evaluate(rule: &Rule, class: HoleClass, ctx: &Context) -> (usize, 
         .enumerate()
         .map(|(hole_index, hole)| {
             let radius = hole.diameter_mm / 2.0;
-            let mut checked = 0;
-            let mut worst: Option<AnnularViolation> = None;
-            for (copper_index, copper) in design.copper_layers.iter().enumerate() {
-                if !hole.spans_copper(copper_index as u16) {
-                    continue;
-                }
-                let land = hole
-                    .land_on(copper_index)
-                    .map(|link| &copper.lands[link.land_index as usize]);
-                if !contains[copper_index][hole_index] {
-                    // Intermediate layers without a source land are plane
-                    // anti-pads or removed unused lands. A terminal layer or
-                    // intended land with no composed copper is not allowed to
-                    // disappear from an annular-ring check.
-                    if land.is_none()
-                        && !hole.terminates_on(copper_index, design.copper_layers.len())
-                    {
-                        continue;
-                    }
-                    checked += 1;
-                    let violation = AnnularViolation {
-                        copper_index,
-                        land,
-                        enclosure_mm: 0.0,
-                        geometry: AnnularViolationGeometry::MissingCopper,
+            let violations = ring_subjects(design, hole, &contains, hole_index)
+                .map(|subject| {
+                    let enclosure = if subject.in_copper {
+                        boundaries[subject.copper_index]
+                            .circular_enclosure(hole.center, radius, limit - tolerance)
+                            .filter(|measurement| measurement.enclosure_mm + tolerance < limit)
+                            .map(Enclosure::Measured)
+                    } else {
+                        Some(Enclosure::MissingCopper)
                     };
-                    if worst
-                        .as_ref()
-                        .is_none_or(|current| violation.enclosure_mm < current.enclosure_mm)
-                    {
-                        worst = Some(violation);
-                    }
-                    continue;
-                }
-                checked += 1;
-                let violation = boundaries[copper_index]
-                    .circular_enclosure(hole.center, radius, limit - tolerance)
-                    .filter(|measurement| measurement.enclosure_mm + tolerance < limit)
-                    .map(|measurement| AnnularViolation {
-                        copper_index,
-                        land,
-                        enclosure_mm: measurement.enclosure_mm,
-                        geometry: AnnularViolationGeometry::Boundary {
-                            cutout_boundary: measurement.cutout_boundary,
-                            material_boundary: measurement.material_boundary,
-                        },
-                    });
-                if let Some(violation) = violation
-                    && worst
-                        .as_ref()
-                        .is_none_or(|current| violation.enclosure_mm < current.enclosure_mm)
-                {
-                    worst = Some(violation);
-                }
-            }
+                    enclosure.map(|enclosure| AnnularViolation {
+                        copper_index: subject.copper_index,
+                        land: subject.land,
+                        enclosure,
+                    })
+                })
+                .collect::<Vec<_>>();
+            let worst = violations.iter().flatten().min_by(|left, right| {
+                left.enclosure
+                    .millimeters()
+                    .total_cmp(&right.enclosure.millimeters())
+            });
             (
-                checked,
+                violations.len(),
                 worst.map(|worst| annular_finding(rule, class, hole, ctx, worst)),
             )
         })
@@ -151,42 +127,74 @@ pub(super) fn evaluate(rule: &Rule, class: HoleClass, ctx: &Context) -> (usize, 
     )
 }
 
+/// One copper layer on which a hole has a ring to measure.
+struct RingSubject<'a> {
+    copper_index: usize,
+    land: Option<&'a Land>,
+    in_copper: bool,
+}
+
+/// Layers where the hole must carry copper, hence has a ring to measure:
+/// spanned layers holding copper at the center, plus spanned layers with a
+/// source land or at an end of the drill span even without it. A spanned
+/// intermediate layer with neither is a plane anti-pad or a removed unused
+/// land, and is not a subject.
+fn ring_subjects<'a>(
+    design: &'a Design,
+    hole: &'a Hole,
+    contains: &'a [Vec<bool>],
+    hole_index: usize,
+) -> impl Iterator<Item = RingSubject<'a>> + 'a {
+    design
+        .copper_layers
+        .iter()
+        .enumerate()
+        .filter(move |(copper_index, _)| hole.spans_copper(*copper_index as u16))
+        .filter_map(move |(copper_index, copper)| {
+            let land = hole
+                .land_on(copper_index)
+                .map(|link| &copper.lands[link.land_index as usize]);
+            let in_copper = contains[copper_index][hole_index];
+            let required =
+                land.is_some() || hole.terminates_on(copper_index, design.copper_layers.len());
+            (in_copper || required).then_some(RingSubject {
+                copper_index,
+                land,
+                in_copper,
+            })
+        })
+}
+
 fn annular_finding(
     rule: &Rule,
     class: HoleClass,
     hole: &Hole,
     ctx: &Context,
-    violation: AnnularViolation,
+    violation: &AnnularViolation,
 ) -> Finding {
     let limit = rule.limit.millimeters();
     let copper = &ctx.design.copper_layers[violation.copper_index];
     let required_radius = hole.diameter_mm / 2.0 + limit;
-    let (location_point, witnesses, detail) = match violation.geometry {
-        AnnularViolationGeometry::Boundary {
-            cutout_boundary,
-            material_boundary,
-        } => {
-            let detail = if violation.enclosure_mm < 0.0 {
+    let enclosure_mm = violation.enclosure.millimeters();
+    let (location_point, witnesses, detail) = match &violation.enclosure {
+        Enclosure::Measured(measurement) => (
+            measurement
+                .cutout_boundary
+                .midpoint(measurement.material_boundary),
+            vec![
+                Witness::new("hole_boundary", measurement.cutout_boundary),
+                Witness::new("copper_boundary", measurement.material_boundary),
+            ],
+            if enclosure_mm < 0.0 {
                 format!(
                     "the drilled hole breaches the copper image by {:.6} mm",
-                    -violation.enclosure_mm
+                    -enclosure_mm
                 )
             } else {
-                format!(
-                    "only {:.6} mm of copper remains outside the drilled hole",
-                    violation.enclosure_mm
-                )
-            };
-            (
-                cutout_boundary.midpoint(material_boundary),
-                vec![
-                    Witness::new("hole_boundary", cutout_boundary),
-                    Witness::new("copper_boundary", material_boundary),
-                ],
-                detail,
-            )
-        }
-        AnnularViolationGeometry::MissingCopper => (
+                format!("only {enclosure_mm:.6} mm of copper remains outside the drilled hole")
+            },
+        ),
+        Enclosure::MissingCopper => (
             hole.center,
             Vec::new(),
             "no composed copper remains at the required hole center".to_owned(),
@@ -195,13 +203,11 @@ fn annular_finding(
     Finding {
         title: format!("{} annular ring is below minimum", class.label()),
         message: format!(
-            "{} minimum radial copper enclosure is {:.6} mm on {}; the PDK requires {:.6} mm ({detail})",
+            "{} minimum radial copper enclosure is {enclosure_mm:.6} mm on {}; the PDK requires {limit:.6} mm ({detail})",
             class.label(),
-            violation.enclosure_mm,
             copper.layer.name,
-            limit
         ),
-        measurement: Measurement::minimum(violation.enclosure_mm, limit),
+        measurement: Measurement::minimum(enclosure_mm, limit),
         location: Location {
             point: Some(location_point.into()),
             bounding_box: Some(BBox::from_point(hole.center).expand(required_radius).into()),

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
@@ -23,57 +23,51 @@
 //! clear without walking its boundary segments; every pair counts as
 //! checked either way.
 
-use pcb_ir::geom::dfm::region_clearance;
+use anyhow::Result;
+use pcb_ir::geom::dfm::{Distance, region_clearance};
 
 use crate::commands::dfm::design::BoardArray;
-use crate::commands::dfm::report::{Evidence, Finding, SourceLocator, Subject};
-use crate::commands::dfm::rules::Rule;
+use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
 
-use super::{ClearanceViolation, Context, violates_minimum};
+use super::{Context, Evaluation, Measured};
 
-pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
-    let arrays = &ctx.design.board_arrays;
-    let limit = rule.limit.millimeters();
+pub(super) fn evaluate(limit_mm: f64, ctx: &Context) -> Result<Evaluation> {
+    let arrays = ctx.design.board_arrays()?;
     let pairs = arrays.iter().enumerate().flat_map(|(index, first)| {
         arrays[index + 1..]
             .iter()
             .map(move |second| (first, second))
     });
-    let findings = pairs
+    let measured = pairs
         .clone()
         .filter(|(first, second)| {
-            violates_minimum(first.region.bbox.distance_to(second.region.bbox), limit)
+            let bound = first.region.bbox.distance_to(second.region.bbox);
+            Distance::exact(
+                bound,
+                first.region.bbox.center(),
+                second.region.bbox.center(),
+            )
+            .certainly_below(limit_mm)
         })
-        .map(|(first, second)| {
-            let clearance = region_clearance(&first.region, &second.region)
-                .expect("board arrays are extracted with non-empty profiles");
-            (first, second, clearance)
-        })
-        .filter(|(_, _, clearance)| violates_minimum(clearance.distance_mm, limit))
-        .map(|(first, second, clearance)| {
-            ClearanceViolation {
-                rule,
-                title: "Board arrays are too close together",
-                message: format!(
-                    "board-array outlines are {:.6} mm apart; the PDK requires at least {:.6} mm",
-                    clearance.distance_mm, limit
-                ),
-                witness_roles: ["first_board_array", "second_board_array"],
-                clearance,
-                layers: Vec::new(),
-                subjects: vec![
-                    board_array_subject(first, "first"),
-                    board_array_subject(second, "second"),
-                ],
-                evidence: vec![
-                    Evidence::bounds("first_board_array", first.region.bbox),
-                    Evidence::bounds("second_board_array", second.region.bbox),
-                ],
-            }
-            .into_finding()
+        .map(|(first, second)| Measured {
+            distance: region_clearance(&first.region, &second.region)
+                .expect("board arrays are extracted with non-empty profiles"),
+            bbox: first.region.bbox.union(second.region.bbox),
+            layers: Vec::new(),
+            subjects: vec![
+                board_array_subject(first, "first"),
+                board_array_subject(second, "second"),
+            ],
+            evidence: vec![
+                Evidence::bounds("first_board_array", first.region.bbox),
+                Evidence::bounds("second_board_array", second.region.bbox),
+            ],
         })
         .collect();
-    (pairs.count(), findings)
+    Ok(Evaluation {
+        checked: pairs.count(),
+        measured,
+    })
 }
 
 fn board_array_subject(array: &BoardArray, role: &'static str) -> Subject {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
@@ -23,16 +23,15 @@
 //! clear without walking its boundary segments; every pair counts as
 //! checked either way.
 
-use anyhow::Result;
 use pcb_ir::geom::dfm::{Distance, region_clearance};
 
-use crate::commands::dfm::design::BoardArray;
+use crate::commands::dfm::design::{BoardArray, Design};
 use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
 
-use super::{Context, Evaluation, Measured};
+use super::{Evaluation, Measured};
 
-pub(super) fn evaluate(limit_mm: f64, ctx: &Context) -> Result<Evaluation> {
-    let arrays = ctx.design.board_arrays()?;
+pub(super) fn evaluate(limit_mm: f64, design: &Design) -> Evaluation {
+    let arrays = &design.board_arrays;
     let pairs = arrays.iter().enumerate().flat_map(|(index, first)| {
         arrays[index + 1..]
             .iter()
@@ -64,10 +63,10 @@ pub(super) fn evaluate(limit_mm: f64, ctx: &Context) -> Result<Evaluation> {
             ],
         })
         .collect();
-    Ok(Evaluation {
+    Evaluation {
         checked: pairs.count(),
         measured,
-    })
+    }
 }
 
 fn board_array_subject(array: &BoardArray, role: &'static str) -> Subject {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
@@ -20,7 +20,7 @@
 //! child that places a single board is per-board packaging, not an array,
 //! and is excluded at extraction.
 
-use pcb_ir::geom::dfm::region_clearance;
+use pcb_ir::geom::dfm::{bbox_clearance_lower_bound, region_clearance};
 
 use crate::commands::dfm::design::BoardArray;
 use crate::commands::dfm::report::{Evidence, Finding, SourceLocator, Subject};
@@ -36,10 +36,19 @@ pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
     for first_index in 0..arrays.len() {
         let first = &arrays[first_index];
         for second in &arrays[first_index + 1..] {
+            checked += 1;
+            // Bounds are a conservative broad phase: their distance is a
+            // lower bound on profile distance, so a passing bound proves the
+            // exact profiles pass without walking their boundary segments.
+            if !violates_minimum(
+                bbox_clearance_lower_bound(first.region.bbox, second.region.bbox),
+                limit,
+            ) {
+                continue;
+            }
             let Some(clearance) = region_clearance(&first.region, &second.region) else {
                 continue;
             };
-            checked += 1;
             if !violates_minimum(clearance.distance_mm, limit) {
                 continue;
             }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
@@ -18,9 +18,12 @@
 //! The check requires `dist(Aᵢ, Aⱼ) ≥ L` for every unordered pair of
 //! direct board-array instances of the panel's root step. A panel-kind
 //! child that places a single board is per-board packaging, not an array,
-//! and is excluded at extraction.
+//! and is excluded at extraction. Bounds distance is a lower bound on
+//! region distance, so a pair whose bounds already clear `L` is proven
+//! clear without walking its boundary segments; every pair counts as
+//! checked either way.
 
-use pcb_ir::geom::dfm::{bbox_clearance_lower_bound, region_clearance};
+use pcb_ir::geom::dfm::region_clearance;
 
 use crate::commands::dfm::design::BoardArray;
 use crate::commands::dfm::report::{Evidence, Finding, SourceLocator, Subject};
@@ -31,52 +34,46 @@ use super::{ClearanceViolation, Context, violates_minimum};
 pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
     let arrays = &ctx.design.board_arrays;
     let limit = rule.limit.millimeters();
-    let mut checked = 0;
-    let mut findings = Vec::new();
-    for first_index in 0..arrays.len() {
-        let first = &arrays[first_index];
-        for second in &arrays[first_index + 1..] {
-            checked += 1;
-            // Bounds are a conservative broad phase: their distance is a
-            // lower bound on profile distance, so a passing bound proves the
-            // exact profiles pass without walking their boundary segments.
-            if !violates_minimum(
-                bbox_clearance_lower_bound(first.region.bbox, second.region.bbox),
-                limit,
-            ) {
-                continue;
+    let pairs = arrays.iter().enumerate().flat_map(|(index, first)| {
+        arrays[index + 1..]
+            .iter()
+            .map(move |second| (first, second))
+    });
+    let findings = pairs
+        .clone()
+        .filter(|(first, second)| {
+            violates_minimum(first.region.bbox.distance_to(second.region.bbox), limit)
+        })
+        .map(|(first, second)| {
+            let clearance = region_clearance(&first.region, &second.region)
+                .expect("board arrays are extracted with non-empty profiles");
+            (first, second, clearance)
+        })
+        .filter(|(_, _, clearance)| violates_minimum(clearance.distance_mm, limit))
+        .map(|(first, second, clearance)| {
+            ClearanceViolation {
+                rule,
+                title: "Board arrays are too close together",
+                message: format!(
+                    "board-array outlines are {:.6} mm apart; the PDK requires at least {:.6} mm",
+                    clearance.distance_mm, limit
+                ),
+                witness_roles: ["first_board_array", "second_board_array"],
+                clearance,
+                layers: Vec::new(),
+                subjects: vec![
+                    board_array_subject(first, "first"),
+                    board_array_subject(second, "second"),
+                ],
+                evidence: vec![
+                    Evidence::bounds("first_board_array", first.region.bbox),
+                    Evidence::bounds("second_board_array", second.region.bbox),
+                ],
             }
-            let Some(clearance) = region_clearance(&first.region, &second.region) else {
-                continue;
-            };
-            if !violates_minimum(clearance.distance_mm, limit) {
-                continue;
-            }
-            findings.push(
-                ClearanceViolation {
-                    rule,
-                    title: "Board arrays are too close together",
-                    message: format!(
-                        "board-array outlines are {:.6} mm apart; the PDK requires at least {:.6} mm",
-                        clearance.distance_mm, limit
-                    ),
-                    witness_roles: ["first_board_array", "second_board_array"],
-                    clearance,
-                    layers: Vec::new(),
-                    subjects: vec![
-                        board_array_subject(first, "first"),
-                        board_array_subject(second, "second"),
-                    ],
-                    evidence: vec![
-                        Evidence::bounds("first_board_array", first.region.bbox),
-                        Evidence::bounds("second_board_array", second.region.bbox),
-                    ],
-                }
-                .into_finding(),
-            );
-        }
-    }
-    (checked, findings)
+            .into_finding()
+        })
+        .collect();
+    (pairs.count(), findings)
 }
 
 fn board_array_subject(array: &BoardArray, role: &'static str) -> Subject {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_diameter.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_diameter.rs
@@ -10,17 +10,16 @@
 //! dₕ ≥ D_min    for every hole h of the rule's plating class.
 //! ```
 
-use anyhow::Result;
 use pcb_ir::geom::Point;
 use pcb_ir::geom::dfm::Distance;
 
-use crate::commands::dfm::design::HoleClass;
+use crate::commands::dfm::design::{Design, HoleClass};
 use crate::commands::dfm::report::Evidence;
 
-use super::{Context, Evaluation, Measured, hole_subject, holes_of_class};
+use super::{Evaluation, Measured, hole_subject, holes_of_class};
 
-pub(super) fn evaluate(class: HoleClass, ctx: &Context) -> Result<Evaluation> {
-    let holes = holes_of_class(ctx.design, class)?;
+pub(super) fn evaluate(class: HoleClass, design: &Design) -> Evaluation {
+    let holes = holes_of_class(design, class);
     let measured = holes
         .iter()
         .map(|(_, hole)| {
@@ -33,7 +32,7 @@ pub(super) fn evaluate(class: HoleClass, ctx: &Context) -> Result<Evaluation> {
                 ),
                 bbox: hole.bbox,
                 layers: vec![hole.layer.clone()],
-                subjects: vec![hole_subject(ctx, hole, "offender")],
+                subjects: vec![hole_subject(design, hole, "offender")],
                 evidence: vec![Evidence::circle(
                     "drilled_hole",
                     hole.center,
@@ -42,8 +41,8 @@ pub(super) fn evaluate(class: HoleClass, ctx: &Context) -> Result<Evaluation> {
             }
         })
         .collect();
-    Ok(Evaluation {
+    Evaluation {
         checked: holes.len(),
         measured,
-    })
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_diameter.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_diameter.rs
@@ -2,51 +2,48 @@
 //!
 //! Model each drilled hole `h` as the closed disk `D(cₕ, rₕ)`. The measured
 //! quantity is the finished diameter `dₕ = 2·rₕ` as the source `Hole`
-//! element declares it — no geometry is derived. The check is the pointwise
-//! predicate
+//! element declares it — exact, no geometry is derived — witnessed by the
+//! two boundary points on the hole's horizontal diameter. The check is the
+//! pointwise predicate
 //!
 //! ```text
-//! dₕ ≥ D_min    for every hole h of the rule's plating class,
+//! dₕ ≥ D_min    for every hole h of the rule's plating class.
 //! ```
-//!
-//! with the engine's shared comparison epsilon absorbing floating-point
-//! unit conversion.
+
+use anyhow::Result;
+use pcb_ir::geom::Point;
+use pcb_ir::geom::dfm::Distance;
 
 use crate::commands::dfm::design::HoleClass;
-use crate::commands::dfm::report::{Evidence, Finding, Location, Measurement};
-use crate::commands::dfm::rules::Rule;
+use crate::commands::dfm::report::Evidence;
 
-use super::{Context, blank_finding, hole_subject, holes_of_class, violates_minimum};
+use super::{Context, Evaluation, Measured, hole_subject, holes_of_class};
 
-pub(super) fn evaluate(rule: &Rule, class: HoleClass, ctx: &Context) -> (usize, Vec<Finding>) {
-    let holes = holes_of_class(ctx.design, class);
-    let limit = rule.limit.millimeters();
-    let findings = holes
+pub(super) fn evaluate(class: HoleClass, ctx: &Context) -> Result<Evaluation> {
+    let holes = holes_of_class(ctx.design, class)?;
+    let measured = holes
         .iter()
-        .filter(|hole| violates_minimum(hole.diameter_mm, limit))
-        .map(|hole| Finding {
-            title: format!("{} hole is below minimum diameter", class.label()),
-            message: format!(
-                "{} hole diameter is {:.6} mm; the PDK requires at least {:.6} mm",
-                class.label(),
-                hole.diameter_mm,
-                limit
-            ),
-            measurement: Measurement::minimum(hole.diameter_mm, limit),
-            location: Location {
-                point: Some(hole.center.into()),
-                bounding_box: Some(hole.bbox.into()),
-                witnesses: Vec::new(),
-            },
-            layers: vec![hole.layer.clone()],
-            subjects: vec![hole_subject(ctx, hole, "offender")],
-            evidence: vec![Evidence::circle(
-                "drilled_hole",
-                hole.center,
-                hole.diameter_mm,
-            )],
-            ..blank_finding(rule)
+        .map(|(_, hole)| {
+            let radius = Point::new(hole.diameter_mm / 2.0, 0.0);
+            Measured {
+                distance: Distance::exact(
+                    hole.diameter_mm,
+                    hole.center - radius,
+                    hole.center + radius,
+                ),
+                bbox: hole.bbox,
+                layers: vec![hole.layer.clone()],
+                subjects: vec![hole_subject(ctx, hole, "offender")],
+                evidence: vec![Evidence::circle(
+                    "drilled_hole",
+                    hole.center,
+                    hole.diameter_mm,
+                )],
+            }
         })
-        .collect::<Vec<_>>();
-    (holes.len(), findings)
+        .collect();
+    Ok(Evaluation {
+        checked: holes.len(),
+        measured,
+    })
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
@@ -20,55 +20,38 @@
 //! thereby *proven* clear, not left unexamined, so `checked` counts the
 //! holes entering the sweep: every hole is decided against every other.
 
+use anyhow::Result;
 use pcb_ir::geom::dfm::disk_clearance;
 
-use crate::commands::dfm::report::{Evidence, Finding};
-use crate::commands::dfm::rules::Rule;
+use crate::commands::dfm::report::Evidence;
 
-use super::{
-    COMPARISON_EPSILON_MM, ClearanceViolation, Context, hole_subject, unique_layers,
-    violates_minimum,
-};
+use super::{COMPARISON_EPSILON_MM, Context, Evaluation, Measured, hole_subject, layers};
 
-pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
-    let holes = &ctx.design.holes;
-    let limit = rule.limit.millimeters();
-    let mut findings = Vec::new();
-    for first_index in 0..holes.len() {
-        let first = &holes[first_index];
-        for second in &holes[first_index + 1..] {
-            if second.bbox.min.x - first.bbox.max.x >= limit - COMPARISON_EPSILON_MM {
-                break;
-            }
-            let y_gap = (second.bbox.min.y - first.bbox.max.y)
-                .max(first.bbox.min.y - second.bbox.max.y)
-                .max(0.0);
-            if y_gap >= limit - COMPARISON_EPSILON_MM {
-                continue;
-            }
-            if !first.span_overlaps(second) {
-                continue;
-            }
-            let clearance = disk_clearance(
-                first.center,
-                first.diameter_mm / 2.0,
-                second.center,
-                second.diameter_mm / 2.0,
-            );
-            if !violates_minimum(clearance.distance_mm, limit) {
-                continue;
-            }
-            findings.push(
-                ClearanceViolation {
-                    rule,
-                    title: "Hole-to-hole clearance is below minimum",
-                    message: format!(
-                        "hole edges are {:.6} mm apart; the PDK requires at least {:.6} mm",
-                        clearance.distance_mm, limit
+pub(super) fn evaluate(limit_mm: f64, ctx: &Context) -> Result<Evaluation> {
+    let holes = ctx.design.holes()?;
+    let reach = limit_mm - COMPARISON_EPSILON_MM;
+    let measured = holes
+        .iter()
+        .enumerate()
+        .flat_map(|(index, first)| {
+            holes[index + 1..]
+                .iter()
+                .take_while(move |second| second.bbox.min.x - first.bbox.max.x < reach)
+                .filter(move |second| {
+                    let y_gap = (second.bbox.min.y - first.bbox.max.y)
+                        .max(first.bbox.min.y - second.bbox.max.y)
+                        .max(0.0);
+                    y_gap < reach && first.span_overlaps(second)
+                })
+                .map(move |second| Measured {
+                    distance: disk_clearance(
+                        first.center,
+                        first.diameter_mm / 2.0,
+                        second.center,
+                        second.diameter_mm / 2.0,
                     ),
-                    witness_roles: ["first_hole_boundary", "second_hole_boundary"],
-                    clearance,
-                    layers: unique_layers(&first.layer, &second.layer),
+                    bbox: first.bbox.union(second.bbox),
+                    layers: layers([&first.layer, &second.layer]),
                     subjects: vec![
                         hole_subject(ctx, first, "first"),
                         hole_subject(ctx, second, "second"),
@@ -77,10 +60,11 @@ pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
                         Evidence::circle("first_hole", first.center, first.diameter_mm),
                         Evidence::circle("second_hole", second.center, second.diameter_mm),
                     ],
-                }
-                .into_finding(),
-            );
-        }
-    }
-    (holes.len(), findings)
+                })
+        })
+        .collect();
+    Ok(Evaluation {
+        checked: holes.len(),
+        measured,
+    })
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
@@ -20,15 +20,15 @@
 //! thereby *proven* clear, not left unexamined, so `checked` counts the
 //! holes entering the sweep: every hole is decided against every other.
 
-use anyhow::Result;
 use pcb_ir::geom::dfm::disk_clearance;
 
+use crate::commands::dfm::design::Design;
 use crate::commands::dfm::report::Evidence;
 
-use super::{COMPARISON_EPSILON_MM, Context, Evaluation, Measured, hole_subject, layers};
+use super::{COMPARISON_EPSILON_MM, Evaluation, Measured, hole_subject, layers};
 
-pub(super) fn evaluate(limit_mm: f64, ctx: &Context) -> Result<Evaluation> {
-    let holes = ctx.design.holes()?;
+pub(super) fn evaluate(limit_mm: f64, design: &Design) -> Evaluation {
+    let holes = &design.holes;
     let reach = limit_mm - COMPARISON_EPSILON_MM;
     let measured = holes
         .iter()
@@ -53,8 +53,8 @@ pub(super) fn evaluate(limit_mm: f64, ctx: &Context) -> Result<Evaluation> {
                     bbox: first.bbox.union(second.bbox),
                     layers: layers([&first.layer, &second.layer]),
                     subjects: vec![
-                        hole_subject(ctx, first, "first"),
-                        hole_subject(ctx, second, "second"),
+                        hole_subject(design, first, "first"),
+                        hole_subject(design, second, "second"),
                     ],
                     evidence: vec![
                         Evidence::circle("first_hole", first.center, first.diameter_mm),
@@ -63,8 +63,8 @@ pub(super) fn evaluate(limit_mm: f64, ctx: &Context) -> Result<Evaluation> {
                 })
         })
         .collect();
-    Ok(Evaluation {
+    Evaluation {
         checked: holes.len(),
         measured,
-    })
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/linework_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/linework_clearance.rs
@@ -18,34 +18,54 @@
 //! intersects it iff it crosses its boundary). Otherwise `S` is disjoint
 //! from `M` and `dist(S, M) = dist(S, ∂M)`, the minimum segment-to-segment
 //! distance against the indexed boundary, searched only within `L` since
-//! farther boundaries cannot violate.
+//! farther boundaries cannot violate. A profile's rings are flattened
+//! curves and count toward the measurement's uncertainty; a score line is
+//! exact.
 
-use pcb_ir::geom::Point;
-use pcb_ir::geom::dfm::ClearanceMeasurement;
+use std::ops::Range;
+
+use anyhow::Result;
+use pcb_ir::geom::dfm::Distance;
 use pcb_ir::geom::region::ring_edges;
+use pcb_ir::geom::{BBox, Point};
 
 use crate::commands::dfm::design::{BoardOutline, CopperLayer, Design};
-use crate::commands::dfm::report::{Evidence, Finding, LayerRef, SourceLocator, Subject};
-use crate::commands::dfm::rules::{Linework, Rule};
+use crate::commands::dfm::report::{Evidence, LayerRef, SourceLocator, Subject};
+use crate::commands::dfm::rules::Linework;
 
-use super::{ClearanceViolation, Context, unique_layers, violates_minimum};
+use super::{Context, Evaluation, Measured, layers};
 
-/// One reference item: a V-score centerline or a board outline, as bare
-/// segments plus its report identity.
+/// One reference item: a V-score centerline or a board outline, as a range
+/// of bare segments plus its report identity.
 struct LineworkItem {
-    segments: Vec<(Point, Point)>,
+    segments: Range<usize>,
+    flattened_boundaries: u32,
     layer: Option<LayerRef>,
     subject: Subject,
     evidence: Evidence,
 }
 
-fn linework_items(linework: Linework, design: &Design) -> Vec<LineworkItem> {
-    match linework {
+/// The reference items and their segments, flattened into one pool so the
+/// endpoint containment sweep runs once per layer.
+struct LineworkPool {
+    items: Vec<LineworkItem>,
+    segments: Vec<(Point, Point)>,
+}
+
+fn linework_items(linework: Linework, design: &Design) -> Result<LineworkPool> {
+    let mut segments = Vec::new();
+    let mut push = |item_segments: Vec<(Point, Point)>| {
+        let start = segments.len();
+        segments.extend(item_segments);
+        start..segments.len()
+    };
+    let items = match linework {
         Linework::VScore => design
-            .scores
+            .scores()?
             .iter()
             .map(|score| LineworkItem {
-                segments: vec![(score.start, score.end)],
+                segments: push(vec![(score.start, score.end)]),
+                flattened_boundaries: 0,
                 layer: Some(score.layer.clone()),
                 subject: Subject {
                     role: "reference",
@@ -57,97 +77,70 @@ fn linework_items(linework: Linework, design: &Design) -> Vec<LineworkItem> {
             })
             .collect(),
         Linework::BoardEdge => design
-            .board_outlines
+            .board_outlines()?
             .iter()
             .map(|outline| LineworkItem {
-                segments: outline.contours.iter().flat_map(ring_edges).collect(),
+                segments: push(outline.contours.iter().flat_map(ring_edges).collect()),
+                flattened_boundaries: 1,
                 layer: None,
                 subject: outline_subject(outline, "reference"),
                 evidence: Evidence::bounds("board_outline", outline.bbox),
             })
             .collect(),
-    }
+    };
+    Ok(LineworkPool { items, segments })
 }
 
-pub(super) fn evaluate(rule: &Rule, linework: Linework, ctx: &Context) -> (usize, Vec<Finding>) {
+pub(super) fn evaluate(limit_mm: f64, linework: Linework, ctx: &Context) -> Result<Evaluation> {
     let design = ctx.design;
-    let items = linework_items(linework, design);
-    let (title, witness_role, reference_label) = match linework {
-        Linework::VScore => (
-            "V-score centerline is too close to copper",
-            "vscore_centerline",
-            "V-score centerline",
-        ),
-        Linework::BoardEdge => (
-            "Board edge is too close to copper",
-            "board_outline",
-            "board edge",
-        ),
-    };
-    let limit = rule.limit.millimeters();
-    let boundaries = ctx.copper_boundaries();
-    let endpoints = items
+    let copper_layers = design.copper_layers()?;
+    let boundaries = ctx.copper_boundaries()?;
+    let pool = linework_items(linework, design)?;
+    let (items, segments) = (&pool.items, &pool.segments);
+    let endpoints = segments
         .iter()
-        .flat_map(|item| item.segments.iter().flat_map(|&(start, end)| [start, end]))
+        .flat_map(|&(start, end)| [start, end])
         .collect::<Vec<_>>();
 
-    let mut checked = 0;
-    let mut findings = Vec::new();
-    for (copper_index, copper) in design.copper_layers.iter().enumerate() {
-        let inside = copper.image.contains_points_batch(&endpoints);
-        let mut cursor = 0;
-        for item in &items {
-            checked += 1;
-            let mut nearest: Option<ClearanceMeasurement> = None;
-            for &(start, end) in &item.segments {
-                let (start_inside, end_inside) = (inside[cursor], inside[cursor + 1]);
-                cursor += 2;
-                let candidate = if start_inside || end_inside {
-                    let point = if start_inside { start } else { end };
-                    Some(ClearanceMeasurement {
-                        distance_mm: 0.0,
-                        first: point,
-                        second: point,
+    let measured = copper_layers
+        .iter()
+        .enumerate()
+        .flat_map(|(copper_index, copper)| {
+            let inside = copper.image.contains_points_batch(&endpoints);
+            items.iter().filter_map(move |item| {
+                let nearest = item
+                    .segments
+                    .clone()
+                    .filter_map(|segment_index| {
+                        let (start, end) = segments[segment_index];
+                        let (start_inside, end_inside) =
+                            (inside[2 * segment_index], inside[2 * segment_index + 1]);
+                        // A segment touching copper measures zero at the
+                        // contained endpoint; otherwise both ends are outside
+                        // and the boundary distance is the set distance.
+                        match (start_inside, end_inside) {
+                            (true, _) => Some(Distance::flattened(0.0, start, start, 1)),
+                            (_, true) => Some(Distance::flattened(0.0, end, end, 1)),
+                            _ => boundaries[copper_index]
+                                .segment_nearest_within(start, end, limit_mm),
+                        }
                     })
-                } else {
-                    boundaries[copper_index].segment_nearest_within(start, end, limit)
-                };
-                if let Some(candidate) = candidate
-                    && nearest
-                        .as_ref()
-                        .is_none_or(|current| candidate.distance_mm < current.distance_mm)
-                {
-                    nearest = Some(candidate);
-                }
-            }
-            let Some(clearance) = nearest else {
-                continue;
-            };
-            if !violates_minimum(clearance.distance_mm, limit) {
-                continue;
-            }
-            findings.push(
-                ClearanceViolation {
-                    rule,
-                    title,
-                    message: format!(
-                        "{reference_label} is {:.6} mm from copper on {}; the PDK requires at least {:.6} mm",
-                        clearance.distance_mm, copper.layer.name, limit
-                    ),
-                    witness_roles: [witness_role, "copper_boundary"],
-                    clearance,
-                    layers: match &item.layer {
-                        Some(layer) => unique_layers(layer, &copper.layer),
-                        None => vec![copper.layer.clone()],
-                    },
+                    .min_by(|left, right| left.mm.total_cmp(&right.mm))?;
+                let distance = nearest.also_flattened(item.flattened_boundaries);
+                Some(Measured {
+                    distance,
+                    bbox: BBox::from_point(distance.first).union(BBox::from_point(distance.second)),
+                    layers: layers(item.layer.iter().chain([&copper.layer])),
                     subjects: vec![item.subject.clone(), copper_subject(copper)],
                     evidence: vec![item.evidence.clone()],
-                }
-                .into_finding(),
-            );
-        }
-    }
-    (checked, findings)
+                })
+            })
+        })
+        .collect();
+    Ok(Evaluation {
+        checked: copper_layers.len() * items.len(),
+        measured,
+    })
 }
 
 fn copper_subject(copper: &CopperLayer) -> Subject {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/linework_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/linework_clearance.rs
@@ -24,7 +24,6 @@
 
 use std::ops::Range;
 
-use anyhow::Result;
 use pcb_ir::geom::dfm::Distance;
 use pcb_ir::geom::region::ring_edges;
 use pcb_ir::geom::{BBox, Point};
@@ -33,7 +32,7 @@ use crate::commands::dfm::design::{BoardOutline, CopperLayer, Design};
 use crate::commands::dfm::report::{Evidence, LayerRef, SourceLocator, Subject};
 use crate::commands::dfm::rules::Linework;
 
-use super::{Context, Evaluation, Measured, layers};
+use super::{Evaluation, Measured, layers};
 
 /// One reference item: a V-score centerline or a board outline, as a range
 /// of bare segments plus its report identity.
@@ -52,7 +51,7 @@ struct LineworkPool {
     segments: Vec<(Point, Point)>,
 }
 
-fn linework_items(linework: Linework, design: &Design) -> Result<LineworkPool> {
+fn linework_items(linework: Linework, design: &Design) -> LineworkPool {
     let mut segments = Vec::new();
     let mut push = |item_segments: Vec<(Point, Point)>| {
         let start = segments.len();
@@ -61,7 +60,7 @@ fn linework_items(linework: Linework, design: &Design) -> Result<LineworkPool> {
     };
     let items = match linework {
         Linework::VScore => design
-            .scores()?
+            .scores
             .iter()
             .map(|score| LineworkItem {
                 segments: push(vec![(score.start, score.end)]),
@@ -77,7 +76,7 @@ fn linework_items(linework: Linework, design: &Design) -> Result<LineworkPool> {
             })
             .collect(),
         Linework::BoardEdge => design
-            .board_outlines()?
+            .board_outlines
             .iter()
             .map(|outline| LineworkItem {
                 segments: push(outline.contours.iter().flat_map(ring_edges).collect()),
@@ -88,14 +87,13 @@ fn linework_items(linework: Linework, design: &Design) -> Result<LineworkPool> {
             })
             .collect(),
     };
-    Ok(LineworkPool { items, segments })
+    LineworkPool { items, segments }
 }
 
-pub(super) fn evaluate(limit_mm: f64, linework: Linework, ctx: &Context) -> Result<Evaluation> {
-    let design = ctx.design;
-    let copper_layers = design.copper_layers()?;
-    let boundaries = ctx.copper_boundaries()?;
-    let pool = linework_items(linework, design)?;
+pub(super) fn evaluate(limit_mm: f64, linework: Linework, design: &Design) -> Evaluation {
+    let copper_layers = &design.copper_layers;
+    let boundaries = &design.copper_boundaries;
+    let pool = linework_items(linework, design);
     let (items, segments) = (&pool.items, &pool.segments);
     let endpoints = segments
         .iter()
@@ -137,10 +135,10 @@ pub(super) fn evaluate(limit_mm: f64, linework: Linework, ctx: &Context) -> Resu
             })
         })
         .collect();
-    Ok(Evaluation {
+    Evaluation {
         checked: copper_layers.len() * items.len(),
         measured,
-    })
+    }
 }
 
 fn copper_subject(copper: &CopperLayer) -> Subject {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -19,21 +19,19 @@ mod thin_regions;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-use anyhow::Result;
 use chrono::NaiveDate;
 use ipc2581::Symbol;
 use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::geom::BBox;
-use pcb_ir::geom::dfm::{Distance, RegionBoundaryIndex};
-use rayon::prelude::*;
+use pcb_ir::geom::dfm::Distance;
 use sha2::{Digest, Sha256};
 
-use super::design::{Design, Hole, HoleClass, Pool, force};
+use super::design::{Design, Hole, HoleClass};
 use super::report::{
     Evidence, Finding, LayerRef, Location, Measurement, RuleResult, RuleStatus, SourceLocator,
     Subject, Witness,
 };
-use super::rules::{ImageSel, Linework, Rule, RuleKind};
+use super::rules::{Linework, Rule, RuleKind};
 use super::waivers::{self, WaiverFile, WaiverOutcome};
 
 use thin_regions::Residue;
@@ -72,15 +70,14 @@ pub(super) fn run(
     design: &Design,
     waiver_file: Option<&WaiverFile>,
     today: NaiveDate,
-) -> Result<Results> {
-    let ctx = Context::new(design, rules);
+) -> Results {
     let mut results = Results::default();
     for rule in rules {
         let mut result = RuleResult::new(rule);
-        match skip_reason(rule, design)? {
+        match skip_reason(rule, design) {
             Some(reason) => result.skip(reason),
             None => {
-                let evaluation = evaluate(rule, &ctx)?;
+                let evaluation = evaluate(rule, design);
                 let limit = rule.limit.millimeters();
                 match evaluation.checked {
                     // A nominally populated pool can still yield nothing to
@@ -120,7 +117,7 @@ pub(super) fn run(
             result.finish(total, waived);
         }
     }
-    Ok(results)
+    results
 }
 
 /// The one verdict: a distance violates a minimum when it is certainly
@@ -131,74 +128,57 @@ fn violates(distance: &Distance, limit_mm: f64) -> bool {
 }
 
 /// The one skip policy: a rule is skipped when its subject pool or a
-/// required layer pool is empty for the selected layout target. This is
-/// also the only place that knows which pools a rule kind reads; pools are
-/// extracted on first touch.
-fn skip_reason(rule: &Rule, design: &Design) -> Result<Option<String>> {
+/// required layer pool is empty for the selected layout target.
+fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
     let subjects = match rule.kind {
         RuleKind::BoardArrayPairClearance if design.scope != ArtworkScope::ArrayFlattened => {
-            return Ok(Some(
-                "board-array spacing requires --layout-target board-array".to_owned(),
-            ));
+            return Some("board-array spacing requires --layout-target board-array".to_owned());
         }
-        RuleKind::BoardArrayPairClearance => (design.board_arrays()?.len() < 2)
+        RuleKind::BoardArrayPairClearance => (design.board_arrays.len() < 2)
             .then(|| "two or more direct board-array instances".to_owned()),
         RuleKind::HoleDiameter(class) | RuleKind::AnnularRing(class) => design
-            .holes()?
+            .holes
             .iter()
             .all(|hole| hole.class != class)
             .then(|| format!("{} holes", class.label())),
         RuleKind::HolePairClearance => {
-            (design.holes()?.len() < 2).then(|| "two or more holes".to_owned())
+            (design.holes.len() < 2).then(|| "two or more holes".to_owned())
         }
-        RuleKind::SlotWidth => design
-            .slots()?
-            .is_empty()
-            .then(|| "routed slots".to_owned()),
+        RuleKind::SlotWidth => design.slots.is_empty().then(|| "routed slots".to_owned()),
         RuleKind::LineworkToCopperClearance(Linework::VScore) => design
-            .scores()?
+            .scores
             .is_empty()
             .then(|| "V-score centerlines".to_owned()),
         RuleKind::LineworkToCopperClearance(Linework::BoardEdge) => design
-            .board_outlines()?
+            .board_outlines
             .is_empty()
             .then(|| "board profile outlines".to_owned()),
         RuleKind::ThinFeature(_) | RuleKind::ThinGap(_) => None,
     };
-    let layers = match rule.kind {
-        RuleKind::AnnularRing(_)
-        | RuleKind::LineworkToCopperClearance(_)
-        | RuleKind::ThinFeature(ImageSel::Copper)
-        | RuleKind::ThinGap(ImageSel::Copper) => design
-            .copper_layers()?
-            .is_empty()
-            .then(|| "copper layers".to_owned()),
-        RuleKind::ThinFeature(ImageSel::Soldermask) | RuleKind::ThinGap(ImageSel::Soldermask) => {
-            design
-                .mask_layers()?
-                .is_empty()
-                .then(|| "soldermask layers".to_owned())
-        }
-        _ => None,
-    };
-    Ok(subjects
+    let pools = rule.kind.pools();
+    let layers = (pools.copper && design.copper_layers.is_empty())
+        .then(|| "copper layers".to_owned())
+        .or_else(|| {
+            (pools.masks && design.mask_layers.is_empty()).then(|| "soldermask layers".to_owned())
+        });
+    subjects
         .or(layers)
-        .map(|what| format!("no {what} in the selected layout target")))
+        .map(|what| format!("no {what} in the selected layout target"))
 }
 
-fn evaluate(rule: &Rule, ctx: &Context) -> Result<Evaluation> {
+fn evaluate(rule: &Rule, design: &Design) -> Evaluation {
     let limit = rule.limit.millimeters();
     match rule.kind {
-        RuleKind::HoleDiameter(class) => hole_diameter::evaluate(class, ctx),
-        RuleKind::SlotWidth => slot_width::evaluate(ctx),
-        RuleKind::HolePairClearance => hole_pair_clearance::evaluate(limit, ctx),
-        RuleKind::AnnularRing(class) => annular_ring::evaluate(limit, class, ctx),
+        RuleKind::HoleDiameter(class) => hole_diameter::evaluate(class, design),
+        RuleKind::SlotWidth => slot_width::evaluate(design),
+        RuleKind::HolePairClearance => hole_pair_clearance::evaluate(limit, design),
+        RuleKind::AnnularRing(class) => annular_ring::evaluate(limit, class, design),
         RuleKind::LineworkToCopperClearance(linework) => {
-            linework_clearance::evaluate(limit, linework, ctx)
+            linework_clearance::evaluate(limit, linework, design)
         }
-        RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(limit, ctx),
-        RuleKind::ThinFeature(sel) => thin_regions::evaluate(limit, sel, Residue::Feature, ctx),
-        RuleKind::ThinGap(sel) => thin_regions::evaluate(limit, sel, Residue::Gap, ctx),
+        RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(limit, design),
+        RuleKind::ThinFeature(sel) => thin_regions::evaluate(limit, sel, Residue::Feature, design),
+        RuleKind::ThinGap(sel) => thin_regions::evaluate(limit, sel, Residue::Gap, design),
     }
 }
 
@@ -247,66 +227,20 @@ fn finding(rule: &Rule, measured: Measured) -> Finding {
     }
 }
 
-/// Shared evaluation state: the design, and one boundary index per copper
-/// layer, built on first use and reused by every rule that queries copper.
-struct Context<'a> {
-    design: &'a Design<'a>,
-    boundary_search_mm: f64,
-    copper_boundaries: Pool<Vec<RegionBoundaryIndex>>,
-}
-
-impl<'a> Context<'a> {
-    fn new(design: &'a Design<'a>, rules: &[Rule]) -> Self {
-        // A pitch hint for the boundary grids, from the rule limits alone:
-        // queries stay correct at any pitch, and sizing cells by hole radii
-        // would let one large hole coarsen every fine-clearance query.
-        let boundary_search_mm = rules
-            .iter()
-            .map(|rule| match rule.kind {
-                RuleKind::AnnularRing(_) | RuleKind::LineworkToCopperClearance(_) => {
-                    rule.limit.millimeters()
-                }
-                _ => 0.0,
-            })
-            .fold(1.0, f64::max);
-        Self {
-            design,
-            boundary_search_mm,
-            copper_boundaries: Pool::new(),
-        }
-    }
-
-    fn copper_boundaries(&self) -> Result<&[RegionBoundaryIndex]> {
-        force(&self.copper_boundaries, || {
-            Ok(self
-                .design
-                .copper_layers()?
-                .par_iter()
-                .map(|layer| RegionBoundaryIndex::new(&layer.image, self.boundary_search_mm))
-                .collect())
-        })
-        .map(Vec::as_slice)
-    }
-
-    fn resolve(&self, symbol: Option<Symbol>) -> Option<String> {
-        symbol.map(|symbol| self.design.ipc.resolve(symbol).to_owned())
-    }
-}
-
 /// Holes of one plating class, with their indices into the hole pool.
-fn holes_of_class<'a>(design: &'a Design<'a>, class: HoleClass) -> Result<Vec<(usize, &'a Hole)>> {
-    Ok(design
-        .holes()?
+fn holes_of_class<'a>(design: &'a Design<'a>, class: HoleClass) -> Vec<(usize, &'a Hole)> {
+    design
+        .holes
         .iter()
         .enumerate()
         .filter(|(_, hole)| hole.class == class)
-        .collect())
+        .collect()
 }
 
 /// The shared subject shape of every drilled feature (holes and slots).
 #[allow(clippy::too_many_arguments)]
 fn drilled_subject(
-    ctx: &Context,
+    design: &Design,
     role: &'static str,
     kind: &'static str,
     net: Option<Symbol>,
@@ -319,10 +253,10 @@ fn drilled_subject(
     Subject {
         role,
         kind,
-        net: ctx.resolve(net),
-        padstack_ref: ctx.resolve(padstack),
+        net: design.resolve(net),
+        padstack_ref: design.resolve(padstack),
         source: Some(SourceLocator {
-            step: ctx.resolve(step),
+            step: design.resolve(step),
             layer: Some(layer.name.clone()),
             set_index: Some(set_index),
             feature_index: Some(feature_index),
@@ -332,9 +266,9 @@ fn drilled_subject(
     }
 }
 
-fn hole_subject(ctx: &Context, hole: &Hole, role: &'static str) -> Subject {
+fn hole_subject(design: &Design, hole: &Hole, role: &'static str) -> Subject {
     drilled_subject(
-        ctx,
+        design,
         role,
         hole.class.subject_kind(),
         hole.net,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -1,11 +1,12 @@
 //! The rule engine: one evaluator per measurement kind, uniform bookkeeping.
 //!
-//! Every rule reduces to enumerating entities, taking one measurement per
-//! subject, and comparing it against the rule's limit. Each check lives in
-//! its own module, whose docstring defines the measurement mathematically.
-//! The engine here owns the shared policy — skip reasons, checked counts,
-//! finding order, stable ids, waivers, statuses — so each check only
-//! measures, and may assume its subject pools are non-empty.
+//! Every rule reduces to enumerating subjects and taking one [`Distance`]
+//! per subject. Each check lives in its own module, whose docstring defines
+//! the measurement mathematically, and returns those measurements with the
+//! report identity of what was measured. The engine here owns everything
+//! else — the verdict against the limit, finding text, witness roles, skip
+//! reasons, checked counts, finding order, stable ids, waivers, statuses —
+//! so a check only measures, and may assume its subject pools are non-empty.
 
 mod annular_ring;
 mod board_array_spacing;
@@ -17,28 +18,28 @@ mod thin_regions;
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
+use anyhow::Result;
 use chrono::NaiveDate;
 use ipc2581::Symbol;
 use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::geom::BBox;
-use pcb_ir::geom::dfm::{ClearanceMeasurement, RegionBoundaryIndex};
+use pcb_ir::geom::dfm::{Distance, RegionBoundaryIndex};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::ipc2581::Ipc2581;
-
-use super::design::{Design, Hole, HoleClass};
+use super::design::{Design, Hole, HoleClass, Pool, force};
 use super::report::{
     Evidence, Finding, LayerRef, Location, Measurement, RuleResult, RuleStatus, SourceLocator,
     Subject, Witness,
 };
-use super::rules::{Linework, Rule, RuleKind};
+use super::rules::{ImageSel, Linework, Rule, RuleKind};
 use super::waivers::{self, WaiverFile, WaiverOutcome};
 
 use thin_regions::Residue;
 
+/// Absorbs floating-point unit conversion when a measurement sits exactly
+/// on its limit.
 const COMPARISON_EPSILON_MM: f64 = 1e-6;
 
 #[derive(Default)]
@@ -48,32 +49,59 @@ pub(super) struct Results {
     pub(super) waivers: Option<WaiverOutcome>,
 }
 
+/// One subject measured by a check: the distance and what it is about.
+struct Measured {
+    distance: Distance,
+    /// The extent the finding points at: the subject, or the violating piece.
+    bbox: BBox,
+    layers: Vec<LayerRef>,
+    subjects: Vec<Subject>,
+    evidence: Vec<Evidence>,
+}
+
+/// What one check did for one rule. `checked` is the number of subjects
+/// decided, including those a broad phase proved clear without measuring;
+/// `measured` holds every candidate the engine must still judge.
+struct Evaluation {
+    checked: usize,
+    measured: Vec<Measured>,
+}
+
 pub(super) fn run(
     rules: &[Rule],
     design: &Design,
-    ipc: &Ipc2581,
     waiver_file: Option<&WaiverFile>,
     today: NaiveDate,
-) -> Results {
-    let ctx = Context::new(design, ipc, rules);
+) -> Result<Results> {
+    let ctx = Context::new(design, rules);
     let mut results = Results::default();
     for rule in rules {
         let mut result = RuleResult::new(rule);
-        match skip_reason(rule, design) {
+        match skip_reason(rule, design)? {
             Some(reason) => result.skip(reason),
-            None => match evaluate(rule, &ctx) {
-                // A nominally populated pool can still yield nothing to
-                // measure (e.g. hole pairs with disjoint spans); an
-                // unexercised rule must not read as validated.
-                (0, _) => result.skip(format!(
-                    "no measurable {} subjects in the selected layout target",
-                    rule.kind.subject()
-                )),
-                (checked, findings) => {
-                    result.checked = checked;
-                    results.findings.extend(findings);
+            None => {
+                let evaluation = evaluate(rule, &ctx)?;
+                let limit = rule.limit.millimeters();
+                match evaluation.checked {
+                    // A nominally populated pool can still yield nothing to
+                    // measure (e.g. hole pairs with disjoint spans); an
+                    // unexercised rule must not read as validated.
+                    0 => result.skip(format!(
+                        "no measurable {} subjects in the selected layout target",
+                        rule.kind.subject()
+                    )),
+                    checked => {
+                        result.checked = checked;
+                        results.findings.extend(
+                            evaluation
+                                .measured
+                                .into_iter()
+                                .filter(|measured| violates(&measured.distance, limit))
+                                .map(|measured| finding(rule, measured)),
+                        );
+                    }
                 }
-            },
+            }
         }
         results.rules.push(result);
     }
@@ -92,78 +120,143 @@ pub(super) fn run(
             result.finish(total, waived);
         }
     }
-    results
+    Ok(results)
+}
+
+/// The one verdict: a distance violates a minimum when it is certainly
+/// below it, beyond both its own geometric uncertainty and the comparison
+/// epsilon.
+fn violates(distance: &Distance, limit_mm: f64) -> bool {
+    distance.certainly_below(limit_mm - COMPARISON_EPSILON_MM)
 }
 
 /// The one skip policy: a rule is skipped when its subject pool or a
-/// required layer pool is empty for the selected layout target.
-fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
-    let no = |what: &str| Some(format!("no {what} in the selected layout target"));
-    match rule.kind {
+/// required layer pool is empty for the selected layout target. This is
+/// also the only place that knows which pools a rule kind reads; pools are
+/// extracted on first touch.
+fn skip_reason(rule: &Rule, design: &Design) -> Result<Option<String>> {
+    let subjects = match rule.kind {
         RuleKind::BoardArrayPairClearance if design.scope != ArtworkScope::ArrayFlattened => {
-            return Some("board-array spacing requires --layout-target board-array".to_owned());
+            return Ok(Some(
+                "board-array spacing requires --layout-target board-array".to_owned(),
+            ));
         }
-        RuleKind::BoardArrayPairClearance if design.board_arrays.len() < 2 => {
-            return no("two or more direct board-array instances");
+        RuleKind::BoardArrayPairClearance => (design.board_arrays()?.len() < 2)
+            .then(|| "two or more direct board-array instances".to_owned()),
+        RuleKind::HoleDiameter(class) | RuleKind::AnnularRing(class) => design
+            .holes()?
+            .iter()
+            .all(|hole| hole.class != class)
+            .then(|| format!("{} holes", class.label())),
+        RuleKind::HolePairClearance => {
+            (design.holes()?.len() < 2).then(|| "two or more holes".to_owned())
         }
-        RuleKind::HoleDiameter(class) | RuleKind::AnnularRing(class)
-            if holes_of_class(design, class).is_empty() =>
-        {
-            return no(&format!("{} holes", class.label()));
+        RuleKind::SlotWidth => design
+            .slots()?
+            .is_empty()
+            .then(|| "routed slots".to_owned()),
+        RuleKind::LineworkToCopperClearance(Linework::VScore) => design
+            .scores()?
+            .is_empty()
+            .then(|| "V-score centerlines".to_owned()),
+        RuleKind::LineworkToCopperClearance(Linework::BoardEdge) => design
+            .board_outlines()?
+            .is_empty()
+            .then(|| "board profile outlines".to_owned()),
+        RuleKind::ThinFeature(_) | RuleKind::ThinGap(_) => None,
+    };
+    let layers = match rule.kind {
+        RuleKind::AnnularRing(_)
+        | RuleKind::LineworkToCopperClearance(_)
+        | RuleKind::ThinFeature(ImageSel::Copper)
+        | RuleKind::ThinGap(ImageSel::Copper) => design
+            .copper_layers()?
+            .is_empty()
+            .then(|| "copper layers".to_owned()),
+        RuleKind::ThinFeature(ImageSel::Soldermask) | RuleKind::ThinGap(ImageSel::Soldermask) => {
+            design
+                .mask_layers()?
+                .is_empty()
+                .then(|| "soldermask layers".to_owned())
         }
-        RuleKind::HolePairClearance if design.holes.len() < 2 => {
-            return no("two or more holes");
-        }
-        RuleKind::SlotWidth if design.slots.is_empty() => {
-            return no("routed slots");
-        }
-        RuleKind::LineworkToCopperClearance(Linework::VScore) if design.scores.is_empty() => {
-            return no("V-score centerlines");
-        }
-        RuleKind::LineworkToCopperClearance(Linework::BoardEdge)
-            if design.board_outlines.is_empty() =>
-        {
-            return no("board profile outlines");
-        }
-        _ => {}
-    }
-    let needs = rule.kind.needs();
-    if needs.copper && design.copper_layers.is_empty() {
-        return no("copper layers");
-    }
-    if needs.masks && design.mask_layers.is_empty() {
-        return no("soldermask layers");
-    }
-    None
+        _ => None,
+    };
+    Ok(subjects
+        .or(layers)
+        .map(|what| format!("no {what} in the selected layout target")))
 }
 
-fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
+fn evaluate(rule: &Rule, ctx: &Context) -> Result<Evaluation> {
+    let limit = rule.limit.millimeters();
     match rule.kind {
-        RuleKind::HoleDiameter(class) => hole_diameter::evaluate(rule, class, ctx),
-        RuleKind::SlotWidth => slot_width::evaluate(rule, ctx),
-        RuleKind::HolePairClearance => hole_pair_clearance::evaluate(rule, ctx),
-        RuleKind::AnnularRing(class) => annular_ring::evaluate(rule, class, ctx),
+        RuleKind::HoleDiameter(class) => hole_diameter::evaluate(class, ctx),
+        RuleKind::SlotWidth => slot_width::evaluate(ctx),
+        RuleKind::HolePairClearance => hole_pair_clearance::evaluate(limit, ctx),
+        RuleKind::AnnularRing(class) => annular_ring::evaluate(limit, class, ctx),
         RuleKind::LineworkToCopperClearance(linework) => {
-            linework_clearance::evaluate(rule, linework, ctx)
+            linework_clearance::evaluate(limit, linework, ctx)
         }
-        RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(rule, ctx),
-        RuleKind::ThinFeature(sel) => thin_regions::evaluate(rule, sel, Residue::Feature, ctx),
-        RuleKind::ThinGap(sel) => thin_regions::evaluate(rule, sel, Residue::Gap, ctx),
+        RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(limit, ctx),
+        RuleKind::ThinFeature(sel) => thin_regions::evaluate(limit, sel, Residue::Feature, ctx),
+        RuleKind::ThinGap(sel) => thin_regions::evaluate(limit, sel, Residue::Gap, ctx),
     }
 }
 
-/// Shared evaluation state: the design, the interner for resolving entity
-/// symbols into report strings, and one boundary index per copper layer,
-/// built lazily and reused by every rule that queries copper.
+/// Render one violating measurement as a finding. Titles, message shape,
+/// and witness roles come from the rule kind; the location is the measured
+/// distance itself.
+fn finding(rule: &Rule, measured: Measured) -> Finding {
+    let limit = rule.limit.millimeters();
+    let [first_role, second_role] = rule.kind.witness_roles();
+    let distance = measured.distance;
+    let layer_names = measured
+        .layers
+        .iter()
+        .map(|layer| layer.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let on_layers = measured
+        .layers
+        .first()
+        .map(|_| format!(" on {layer_names}"))
+        .unwrap_or_default();
+    Finding {
+        id: String::new(),
+        rule_id: rule.id.clone(),
+        severity: rule.severity,
+        waived: false,
+        waiver_reason: None,
+        title: rule.kind.finding_title(),
+        message: format!(
+            "{} is {:.6} mm{on_layers}; the PDK requires at least {limit:.6} mm",
+            rule.kind.quantity_label(),
+            distance.mm
+        ),
+        measurement: Measurement::minimum(distance.mm, limit),
+        location: Location {
+            point: Some(distance.midpoint().into()),
+            bounding_box: Some(measured.bbox.into()),
+            witnesses: vec![
+                Witness::new(first_role, distance.first),
+                Witness::new(second_role, distance.second),
+            ],
+        },
+        layers: measured.layers,
+        subjects: measured.subjects,
+        evidence: measured.evidence,
+    }
+}
+
+/// Shared evaluation state: the design, and one boundary index per copper
+/// layer, built on first use and reused by every rule that queries copper.
 struct Context<'a> {
-    design: &'a Design,
-    ipc: &'a Ipc2581,
+    design: &'a Design<'a>,
     boundary_search_mm: f64,
-    copper_boundaries: OnceLock<Vec<RegionBoundaryIndex>>,
+    copper_boundaries: Pool<Vec<RegionBoundaryIndex>>,
 }
 
 impl<'a> Context<'a> {
-    fn new(design: &'a Design, ipc: &'a Ipc2581, rules: &[Rule]) -> Self {
+    fn new(design: &'a Design<'a>, rules: &[Rule]) -> Self {
         // A pitch hint for the boundary grids, from the rule limits alone:
         // queries stay correct at any pitch, and sizing cells by hole radii
         // would let one large hole coarsen every fine-clearance query.
@@ -178,91 +271,36 @@ impl<'a> Context<'a> {
             .fold(1.0, f64::max);
         Self {
             design,
-            ipc,
             boundary_search_mm,
-            copper_boundaries: OnceLock::new(),
+            copper_boundaries: Pool::new(),
         }
     }
 
-    fn copper_boundaries(&self) -> &[RegionBoundaryIndex] {
-        let search_mm = self.boundary_search_mm;
-        let copper_layers = &self.design.copper_layers;
-        self.copper_boundaries.get_or_init(|| {
-            copper_layers
+    fn copper_boundaries(&self) -> Result<&[RegionBoundaryIndex]> {
+        force(&self.copper_boundaries, || {
+            Ok(self
+                .design
+                .copper_layers()?
                 .par_iter()
-                .map(|layer| RegionBoundaryIndex::new(&layer.image, search_mm))
-                .collect()
+                .map(|layer| RegionBoundaryIndex::new(&layer.image, self.boundary_search_mm))
+                .collect())
         })
+        .map(Vec::as_slice)
     }
 
     fn resolve(&self, symbol: Option<Symbol>) -> Option<String> {
-        symbol.map(|symbol| self.ipc.resolve(symbol).to_owned())
+        symbol.map(|symbol| self.design.ipc.resolve(symbol).to_owned())
     }
 }
 
-/// A clearance finding under construction: measurement plus report identity.
-struct ClearanceViolation<'a> {
-    rule: &'a Rule,
-    title: &'static str,
-    message: String,
-    witness_roles: [&'static str; 2],
-    clearance: ClearanceMeasurement,
-    layers: Vec<LayerRef>,
-    subjects: Vec<Subject>,
-    evidence: Vec<Evidence>,
-}
-
-impl ClearanceViolation<'_> {
-    fn into_finding(self) -> Finding {
-        let bbox =
-            BBox::from_point(self.clearance.first).union(BBox::from_point(self.clearance.second));
-        Finding {
-            title: self.title.to_owned(),
-            message: self.message,
-            measurement: Measurement::minimum(
-                self.clearance.distance_mm,
-                self.rule.limit.millimeters(),
-            ),
-            location: Location {
-                point: Some(self.clearance.first.midpoint(self.clearance.second).into()),
-                bounding_box: Some(bbox.into()),
-                witnesses: vec![
-                    Witness::new(self.witness_roles[0], self.clearance.first),
-                    Witness::new(self.witness_roles[1], self.clearance.second),
-                ],
-            },
-            layers: self.layers,
-            subjects: self.subjects,
-            evidence: self.evidence,
-            ..blank_finding(self.rule)
-        }
-    }
-}
-
-/// The rule-derived identity fields every finding starts from.
-fn blank_finding(rule: &Rule) -> Finding {
-    Finding {
-        id: String::new(),
-        rule_id: rule.id.clone(),
-        severity: rule.severity,
-        waived: false,
-        waiver_reason: None,
-        title: String::new(),
-        message: String::new(),
-        measurement: Measurement::minimum(0.0, 0.0),
-        location: Location::default(),
-        layers: Vec::new(),
-        subjects: Vec::new(),
-        evidence: Vec::new(),
-    }
-}
-
-fn holes_of_class(design: &Design, class: HoleClass) -> Vec<&Hole> {
-    design
-        .holes
+/// Holes of one plating class, with their indices into the hole pool.
+fn holes_of_class<'a>(design: &'a Design<'a>, class: HoleClass) -> Result<Vec<(usize, &'a Hole)>> {
+    Ok(design
+        .holes()?
         .iter()
-        .filter(|hole| hole.class == class)
-        .collect()
+        .enumerate()
+        .filter(|(_, hole)| hole.class == class)
+        .collect())
 }
 
 /// The shared subject shape of every drilled feature (holes and slots).
@@ -308,16 +346,11 @@ fn hole_subject(ctx: &Context, hole: &Hole, role: &'static str) -> Subject {
     )
 }
 
-fn unique_layers(first: &LayerRef, second: &LayerRef) -> Vec<LayerRef> {
-    if first.name == second.name {
-        vec![first.clone()]
-    } else {
-        vec![first.clone(), second.clone()]
-    }
-}
-
-fn violates_minimum(actual: f64, required: f64) -> bool {
-    actual + COMPARISON_EPSILON_MM < required
+/// The layers a finding spans, each named once.
+fn layers<'a>(layers: impl IntoIterator<Item = &'a LayerRef>) -> Vec<LayerRef> {
+    let mut layers = layers.into_iter().cloned().collect::<Vec<_>>();
+    layers.dedup_by(|left, right| left.name == right.name);
+    layers
 }
 
 /// Sort findings into rule/location order and give each an id hashed from

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -85,7 +85,7 @@ pub(super) fn run(
                     // unexercised rule must not read as validated.
                     0 => result.skip(format!(
                         "no measurable {} subjects in the selected layout target",
-                        rule.kind.subject()
+                        rule.kind.semantics().subject
                     )),
                     checked => {
                         result.checked = checked;
@@ -155,7 +155,7 @@ fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
             .then(|| "board profile outlines".to_owned()),
         RuleKind::ThinFeature(_) | RuleKind::ThinGap(_) => None,
     };
-    let pools = rule.kind.pools();
+    let pools = rule.kind.semantics().pools;
     let layers = (pools.copper && design.copper_layers.is_empty())
         .then(|| "copper layers".to_owned())
         .or_else(|| {
@@ -187,7 +187,8 @@ fn evaluate(rule: &Rule, design: &Design) -> Evaluation {
 /// distance itself.
 fn finding(rule: &Rule, measured: Measured) -> Finding {
     let limit = rule.limit.millimeters();
-    let [first_role, second_role] = rule.kind.witness_roles();
+    let semantics = rule.kind.semantics();
+    let [first_role, second_role] = semantics.witness_roles;
     let distance = measured.distance;
     let layer_names = measured
         .layers
@@ -206,11 +207,10 @@ fn finding(rule: &Rule, measured: Measured) -> Finding {
         severity: rule.severity,
         waived: false,
         waiver_reason: None,
-        title: rule.kind.finding_title(),
+        title: semantics.finding_title,
         message: format!(
             "{} is {:.6} mm{on_layers}; the PDK requires at least {limit:.6} mm",
-            rule.kind.quantity_label(),
-            distance.mm
+            semantics.quantity_label, distance.mm
         ),
         measurement: Measurement::minimum(distance.mm, limit),
         location: Location {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -1,44 +1,25 @@
 //! Minimum routed slot width.
 //!
-//! IPC can state a slot as an oval primitive with nominal tool width `w`, or
-//! as an arbitrary filled outline `S`. The primitive width is the
-//! authoritative source instruction and is compared directly. For an outline,
-//! conservative morphological opening localizes sub-minimum material and the
-//! final verdict uses exact distance between the two opposing outline
-//! branches. Thus every materialized slot is checked without inferring a
-//! nominal tool size that the source never supplied.
+//! A routed slot's width is fixed at extraction ([`Slot::width`]): the
+//! stated primitive width when the source gives one — exact, and verified
+//! against the materialized outline — and otherwise the outline's narrowest
+//! local width, the separation of its two facing walls. The check is the
+//! pointwise predicate `wₛ ≥ W_min` for every slot `s`.
 
-use pcb_ir::geom::dfm::thin_features;
+use anyhow::Result;
 
-use crate::commands::dfm::design::{Slot, SlotWidth};
-use crate::commands::dfm::report::{Evidence, Finding, Location, Measurement, Witness};
-use crate::commands::dfm::rules::Rule;
+use crate::commands::dfm::design::Slot;
+use crate::commands::dfm::report::Evidence;
 
-use super::{Context, blank_finding, drilled_subject, violates_minimum};
+use super::{Context, Evaluation, Measured, drilled_subject};
 
-/// Where one slot is narrower than the limit, in the terms its width basis
-/// supplies.
-struct SlotViolation {
-    width_mm: f64,
-    detail: &'static str,
-    location: Location,
-    evidence: Vec<Evidence>,
-}
-
-pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
-    let slots = &ctx.design.slots;
-    let limit = rule.limit.millimeters();
-    let findings = slots
+pub(super) fn evaluate(ctx: &Context) -> Result<Evaluation> {
+    let slots = ctx.design.slots()?;
+    let measured = slots
         .iter()
-        .filter_map(|slot| Some((slot, slot_violation(slot, limit)?)))
-        .map(|(slot, violation)| Finding {
-            title: "Slot is below minimum width".to_owned(),
-            message: format!(
-                "{} is {:.6} mm; the PDK requires at least {limit:.6} mm",
-                violation.detail, violation.width_mm
-            ),
-            measurement: Measurement::minimum(violation.width_mm, limit),
-            location: violation.location,
+        .map(|slot: &Slot| Measured {
+            distance: slot.width,
+            bbox: slot.bbox,
             layers: vec![slot.layer.clone()],
             subjects: vec![drilled_subject(
                 ctx,
@@ -51,46 +32,11 @@ pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
                 slot.source_set_index,
                 slot.source_feature_index,
             )],
-            evidence: violation.evidence,
-            ..blank_finding(rule)
+            evidence: vec![Evidence::bounds("routed_slot", slot.bbox)],
         })
         .collect();
-    (slots.len(), findings)
-}
-
-/// A nominal width is compared as stated. An outline is measured by
-/// [`thin_features`], which owns the verdict for geometric widths; its
-/// narrowest reported piece is the slot's width.
-fn slot_violation(slot: &Slot, limit: f64) -> Option<SlotViolation> {
-    match &slot.width {
-        SlotWidth::Nominal(width_mm) => violates_minimum(*width_mm, limit).then(|| SlotViolation {
-            width_mm: *width_mm,
-            detail: "nominal routed slot width",
-            location: Location {
-                point: Some(slot.center.into()),
-                bounding_box: Some(slot.bbox.into()),
-                witnesses: Vec::new(),
-            },
-            evidence: vec![Evidence::bounds("routed_slot", slot.bbox)],
-        }),
-        SlotWidth::Geometry(geometry) => thin_features(geometry, limit)
-            .into_iter()
-            .min_by(|left, right| left.width_mm.total_cmp(&right.width_mm))
-            .map(|piece| SlotViolation {
-                width_mm: piece.width_mm,
-                detail: "minimum local width of routed slot outline",
-                location: Location {
-                    point: Some(piece.first.midpoint(piece.second).into()),
-                    bounding_box: Some(piece.bbox.into()),
-                    witnesses: vec![
-                        Witness::new("first_slot_boundary", piece.first),
-                        Witness::new("second_slot_boundary", piece.second),
-                    ],
-                },
-                evidence: vec![
-                    Evidence::bounds("routed_slot", slot.bbox),
-                    Evidence::bounds("subminimum_slot_region", piece.bbox),
-                ],
-            }),
-    }
+    Ok(Evaluation {
+        checked: slots.len(),
+        measured,
+    })
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -6,15 +6,13 @@
 //! local width, the separation of its two facing walls. The check is the
 //! pointwise predicate `wₛ ≥ W_min` for every slot `s`.
 
-use anyhow::Result;
-
-use crate::commands::dfm::design::Slot;
+use crate::commands::dfm::design::{Design, Slot};
 use crate::commands::dfm::report::Evidence;
 
-use super::{Context, Evaluation, Measured, drilled_subject};
+use super::{Evaluation, Measured, drilled_subject};
 
-pub(super) fn evaluate(ctx: &Context) -> Result<Evaluation> {
-    let slots = ctx.design.slots()?;
+pub(super) fn evaluate(design: &Design) -> Evaluation {
+    let slots = &design.slots;
     let measured = slots
         .iter()
         .map(|slot: &Slot| Measured {
@@ -22,7 +20,7 @@ pub(super) fn evaluate(ctx: &Context) -> Result<Evaluation> {
             bbox: slot.bbox,
             layers: vec![slot.layer.clone()],
             subjects: vec![drilled_subject(
-                ctx,
+                design,
                 "offender",
                 "routed_slot",
                 slot.net,
@@ -35,8 +33,8 @@ pub(super) fn evaluate(ctx: &Context) -> Result<Evaluation> {
             evidence: vec![Evidence::bounds("routed_slot", slot.bbox)],
         })
         .collect();
-    Ok(Evaluation {
+    Evaluation {
         checked: slots.len(),
         measured,
-    })
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -10,77 +10,87 @@
 
 use pcb_ir::geom::dfm::thin_features;
 
-use crate::commands::dfm::design::SlotWidth;
+use crate::commands::dfm::design::{Slot, SlotWidth};
 use crate::commands::dfm::report::{Evidence, Finding, Location, Measurement, Witness};
 use crate::commands::dfm::rules::Rule;
 
 use super::{Context, blank_finding, drilled_subject, violates_minimum};
+
+/// Where one slot is narrower than the limit, in the terms its width basis
+/// supplies.
+struct SlotViolation {
+    width_mm: f64,
+    detail: &'static str,
+    location: Location,
+    evidence: Vec<Evidence>,
+}
 
 pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
     let slots = &ctx.design.slots;
     let limit = rule.limit.millimeters();
     let findings = slots
         .iter()
-        .filter_map(|slot| {
-            let (actual, detail, point, bbox, witnesses, evidence) = match &slot.width {
-                SlotWidth::Nominal(actual) if violates_minimum(*actual, limit) => (
-                    *actual,
-                    "nominal routed slot width",
-                    slot.center,
-                    slot.bbox,
-                    Vec::new(),
-                    vec![Evidence::bounds("routed_slot", slot.bbox)],
-                ),
-                SlotWidth::Nominal(_) => return None,
-                SlotWidth::Geometry(geometry) => {
-                    let piece = thin_features(geometry, limit)
-                        .into_iter()
-                        .filter(|piece| violates_minimum(piece.width_mm, limit))
-                        .min_by(|left, right| left.width_mm.total_cmp(&right.width_mm))?;
-                    (
-                        piece.width_mm,
-                        "minimum local width of routed slot outline",
-                        piece.first.midpoint(piece.second),
-                        piece.bbox,
-                        vec![
-                            Witness::new("first_slot_boundary", piece.first),
-                            Witness::new("second_slot_boundary", piece.second),
-                        ],
-                        vec![
-                            Evidence::bounds("routed_slot", slot.bbox),
-                            Evidence::bounds("subminimum_slot_region", piece.bbox),
-                        ],
-                    )
-                }
-            };
-            Some(Finding {
-                title: "Slot is below minimum width".to_owned(),
-                message: format!(
-                    "{detail} is {:.6} mm; the PDK requires at least {:.6} mm",
-                    actual, limit
-                ),
-                measurement: Measurement::minimum(actual, limit),
-                location: Location {
-                    point: Some(point.into()),
-                    bounding_box: Some(bbox.into()),
-                    witnesses,
-                },
-                layers: vec![slot.layer.clone()],
-                subjects: vec![drilled_subject(
-                    ctx,
-                    "offender",
-                    "routed_slot",
-                    slot.net,
-                    slot.padstack,
-                    slot.step,
-                    &slot.layer,
-                    slot.source_set_index,
-                    slot.source_feature_index,
-                )],
-                evidence,
-                ..blank_finding(rule)
-            })
+        .filter_map(|slot| Some((slot, slot_violation(slot, limit)?)))
+        .map(|(slot, violation)| Finding {
+            title: "Slot is below minimum width".to_owned(),
+            message: format!(
+                "{} is {:.6} mm; the PDK requires at least {limit:.6} mm",
+                violation.detail, violation.width_mm
+            ),
+            measurement: Measurement::minimum(violation.width_mm, limit),
+            location: violation.location,
+            layers: vec![slot.layer.clone()],
+            subjects: vec![drilled_subject(
+                ctx,
+                "offender",
+                "routed_slot",
+                slot.net,
+                slot.padstack,
+                slot.step,
+                &slot.layer,
+                slot.source_set_index,
+                slot.source_feature_index,
+            )],
+            evidence: violation.evidence,
+            ..blank_finding(rule)
         })
-        .collect::<Vec<_>>();
+        .collect();
     (slots.len(), findings)
+}
+
+/// A nominal width is compared as stated. An outline is measured by
+/// [`thin_features`], which owns the verdict for geometric widths; its
+/// narrowest reported piece is the slot's width.
+fn slot_violation(slot: &Slot, limit: f64) -> Option<SlotViolation> {
+    match &slot.width {
+        SlotWidth::Nominal(width_mm) => violates_minimum(*width_mm, limit).then(|| SlotViolation {
+            width_mm: *width_mm,
+            detail: "nominal routed slot width",
+            location: Location {
+                point: Some(slot.center.into()),
+                bounding_box: Some(slot.bbox.into()),
+                witnesses: Vec::new(),
+            },
+            evidence: vec![Evidence::bounds("routed_slot", slot.bbox)],
+        }),
+        SlotWidth::Geometry(geometry) => thin_features(geometry, limit)
+            .into_iter()
+            .min_by(|left, right| left.width_mm.total_cmp(&right.width_mm))
+            .map(|piece| SlotViolation {
+                width_mm: piece.width_mm,
+                detail: "minimum local width of routed slot outline",
+                location: Location {
+                    point: Some(piece.first.midpoint(piece.second).into()),
+                    bounding_box: Some(piece.bbox.into()),
+                    witnesses: vec![
+                        Witness::new("first_slot_boundary", piece.first),
+                        Witness::new("second_slot_boundary", piece.second),
+                    ],
+                },
+                evidence: vec![
+                    Evidence::bounds("routed_slot", slot.bbox),
+                    Evidence::bounds("subminimum_slot_region", piece.bbox),
+                ],
+            }),
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -1,18 +1,17 @@
 //! Minimum routed slot width.
 //!
-//! A routed slot is the Minkowski sum of its routing centerline `P` with
-//! the cutting tool's disk: `S = P ⊕ D(0, w/2)`, so the slot's width `w`
-//! equals the tool diameter — the minor dimension of the slot's oval
-//! primitive. The check is the pointwise predicate
-//!
-//! ```text
-//! wₛ ≥ W_min    for every slot s with a stated primitive width.
-//! ```
-//!
-//! Outline-shaped slots state no nominal width and are not measured; they
-//! are absent from the checked count rather than silently passed as zero.
+//! IPC can state a slot as an oval primitive with nominal tool width `w`, or
+//! as an arbitrary filled outline `S`. The primitive width is the
+//! authoritative source instruction and is compared directly. For an outline,
+//! conservative morphological opening localizes sub-minimum material and the
+//! final verdict uses exact distance between the two opposing outline
+//! branches. Thus every materialized slot is checked without inferring a
+//! nominal tool size that the source never supplied.
 
-use crate::commands::dfm::report::{Evidence, Finding, Location, Measurement};
+use pcb_ir::geom::dfm::thin_features;
+
+use crate::commands::dfm::design::SlotWidth;
+use crate::commands::dfm::report::{Evidence, Finding, Location, Measurement, Witness};
 use crate::commands::dfm::rules::Rule;
 
 use super::{Context, blank_finding, drilled_subject, violates_minimum};
@@ -22,33 +21,65 @@ pub(super) fn evaluate(rule: &Rule, ctx: &Context) -> (usize, Vec<Finding>) {
     let limit = rule.limit.millimeters();
     let findings = slots
         .iter()
-        .filter(|slot| violates_minimum(slot.width_mm, limit))
-        .map(|slot| Finding {
-            title: "Slot is below minimum width".to_owned(),
-            message: format!(
-                "routed slot width is {:.6} mm; the PDK requires at least {:.6} mm",
-                slot.width_mm, limit
-            ),
-            measurement: Measurement::minimum(slot.width_mm, limit),
-            location: Location {
-                point: Some(slot.center.into()),
-                bounding_box: Some(slot.bbox.into()),
-                witnesses: Vec::new(),
-            },
-            layers: vec![slot.layer.clone()],
-            subjects: vec![drilled_subject(
-                ctx,
-                "offender",
-                "routed_slot",
-                slot.net,
-                slot.padstack,
-                slot.step,
-                &slot.layer,
-                slot.source_set_index,
-                slot.source_feature_index,
-            )],
-            evidence: vec![Evidence::bounds("routed_slot", slot.bbox)],
-            ..blank_finding(rule)
+        .filter_map(|slot| {
+            let (actual, detail, point, bbox, witnesses, evidence) = match &slot.width {
+                SlotWidth::Nominal(actual) if violates_minimum(*actual, limit) => (
+                    *actual,
+                    "nominal routed slot width",
+                    slot.center,
+                    slot.bbox,
+                    Vec::new(),
+                    vec![Evidence::bounds("routed_slot", slot.bbox)],
+                ),
+                SlotWidth::Nominal(_) => return None,
+                SlotWidth::Geometry(geometry) => {
+                    let piece = thin_features(geometry, limit)
+                        .into_iter()
+                        .filter(|piece| violates_minimum(piece.width_mm, limit))
+                        .min_by(|left, right| left.width_mm.total_cmp(&right.width_mm))?;
+                    (
+                        piece.width_mm,
+                        "minimum local width of routed slot outline",
+                        piece.first.midpoint(piece.second),
+                        piece.bbox,
+                        vec![
+                            Witness::new("first_slot_boundary", piece.first),
+                            Witness::new("second_slot_boundary", piece.second),
+                        ],
+                        vec![
+                            Evidence::bounds("routed_slot", slot.bbox),
+                            Evidence::bounds("subminimum_slot_region", piece.bbox),
+                        ],
+                    )
+                }
+            };
+            Some(Finding {
+                title: "Slot is below minimum width".to_owned(),
+                message: format!(
+                    "{detail} is {:.6} mm; the PDK requires at least {:.6} mm",
+                    actual, limit
+                ),
+                measurement: Measurement::minimum(actual, limit),
+                location: Location {
+                    point: Some(point.into()),
+                    bounding_box: Some(bbox.into()),
+                    witnesses,
+                },
+                layers: vec![slot.layer.clone()],
+                subjects: vec![drilled_subject(
+                    ctx,
+                    "offender",
+                    "routed_slot",
+                    slot.net,
+                    slot.padstack,
+                    slot.step,
+                    &slot.layer,
+                    slot.source_set_index,
+                    slot.source_feature_index,
+                )],
+                evidence,
+                ..blank_finding(rule)
+            })
         })
         .collect::<Vec<_>>();
     (slots.len(), findings)

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -17,27 +17,26 @@
 //!
 //! Morphology is the conservative broad phase: it runs with an offset guard
 //! large enough to retain candidates across curve/offset tessellation. A
-//! candidate becomes a finding only after exact segment distance between its
-//! two opposing source-boundary branches is below `L`. One-sided opening or
-//! closing residue — the bite an isolated corner sheds — has no opposing
-//! branches and is discarded. Thus the composed image supplies the
-//! authoritative verdict while morphology only localizes the work.
+//! candidate becomes a measurement only when two opposing source-boundary
+//! branches wall it; their exact separation is the piece's width. One-sided
+//! residue — the bite an isolated corner sheds — has no opposing branches
+//! and is discarded. Thus the composed image supplies the authoritative
+//! measurement while morphology only localizes the work.
 //!
 //! For copper, `Residue::Feature` flags copper that will not survive
 //! etching and `Residue::Gap` flags spacing that will not resolve. A
 //! soldermask image is the mask *openings*, so `Residue::Gap` flags the
 //! web of mask remaining between them.
 
+use anyhow::Result;
 use pcb_ir::geom::ContourSet;
 use pcb_ir::geom::dfm::{ThinPiece, thin_features, thin_gaps};
 use rayon::prelude::*;
 
-use crate::commands::dfm::report::{
-    Evidence, Finding, LayerRef, Location, Measurement, Subject, Witness,
-};
-use crate::commands::dfm::rules::{ImageSel, Rule};
+use crate::commands::dfm::report::{Evidence, LayerRef, Subject};
+use crate::commands::dfm::rules::ImageSel;
 
-use super::{Context, blank_finding};
+use super::{Context, Evaluation, Measured};
 
 /// Which morphological residue the rule reports.
 #[derive(Clone, Copy)]
@@ -47,100 +46,52 @@ pub(super) enum Residue {
 }
 
 pub(super) fn evaluate(
-    rule: &Rule,
+    limit_mm: f64,
     sel: ImageSel,
     residue: Residue,
     ctx: &Context,
-) -> (usize, Vec<Finding>) {
-    let images: Vec<(&LayerRef, &ContourSet)> = match sel {
-        ImageSel::Copper => ctx
-            .design
-            .copper_layers
-            .iter()
-            .map(|layer| (&layer.layer, &layer.image))
-            .collect(),
-        ImageSel::Soldermask => ctx
-            .design
-            .mask_layers
-            .iter()
-            .map(|layer| (&layer.layer, &layer.image))
-            .collect(),
-    };
-    let limit = rule.limit.millimeters();
-    let (title, noun, offender_kind) = match (sel, residue) {
-        (ImageSel::Copper, Residue::Feature) => (
-            "Copper feature is below minimum width",
-            "copper feature",
+) -> Result<Evaluation> {
+    let (images, offender_kind): (Vec<(&LayerRef, &ContourSet)>, &'static str) = match sel {
+        ImageSel::Copper => (
+            ctx.design
+                .copper_layers()?
+                .iter()
+                .map(|layer| (&layer.layer, &layer.image))
+                .collect(),
             "copper_image",
         ),
-        (ImageSel::Copper, Residue::Gap) => (
-            "Copper spacing is below minimum",
-            "copper-to-copper gap",
-            "copper_image",
-        ),
-        (ImageSel::Soldermask, Residue::Feature) => (
-            "Soldermask feature is below minimum width",
-            "soldermask feature",
-            "soldermask_image",
-        ),
-        (ImageSel::Soldermask, Residue::Gap) => (
-            "Soldermask web is below minimum",
-            "soldermask web",
+        ImageSel::Soldermask => (
+            ctx.design
+                .mask_layers()?
+                .iter()
+                .map(|layer| (&layer.layer, &layer.image))
+                .collect(),
             "soldermask_image",
         ),
     };
-
-    let findings = images
+    let thin: fn(&ContourSet, f64) -> Vec<ThinPiece> = match residue {
+        Residue::Feature => thin_features,
+        Residue::Gap => thin_gaps,
+    };
+    let measured = images
         .par_iter()
-        .map(|(layer, image)| {
-            let pieces = match residue {
-                Residue::Feature => thin_features(image, limit),
-                Residue::Gap => thin_gaps(image, limit),
-            };
-            pieces
-                .into_iter()
-                .map(|piece| thin_finding(rule, layer, &piece, title, noun, offender_kind))
-                .collect::<Vec<_>>()
+        .flat_map_iter(|(layer, image)| {
+            thin(image, limit_mm).into_iter().map(|piece| Measured {
+                distance: piece.width,
+                bbox: piece.bbox,
+                layers: vec![(*layer).clone()],
+                subjects: vec![Subject {
+                    role: "offender",
+                    kind: offender_kind,
+                    name: Some(layer.name.clone()),
+                    ..Subject::default()
+                }],
+                evidence: vec![Evidence::bounds("thin_piece", piece.bbox)],
+            })
         })
-        .flatten()
-        .collect::<Vec<_>>();
-    (images.len(), findings)
-}
-
-fn thin_finding(
-    rule: &Rule,
-    layer: &LayerRef,
-    piece: &ThinPiece,
-    title: &str,
-    noun: &str,
-    offender_kind: &'static str,
-) -> Finding {
-    Finding {
-        title: title.to_owned(),
-        message: format!(
-            "{noun} measures {:.6} mm over {:.6} mm on {}; the PDK requires at least {:.6} mm",
-            piece.width_mm,
-            piece.length_mm,
-            layer.name,
-            rule.limit.millimeters()
-        ),
-        measurement: Measurement::minimum(piece.width_mm, rule.limit.millimeters()),
-        location: Location {
-            point: Some(piece.bbox.center().into()),
-            bounding_box: Some(piece.bbox.into()),
-            witnesses: vec![
-                Witness::new("first_boundary", piece.first),
-                Witness::new("second_boundary", piece.second),
-            ],
-        },
-        layers: vec![layer.clone()],
-        subjects: vec![Subject {
-            role: "offender",
-            kind: offender_kind,
-            name: Some(layer.name.clone()),
-            ..Subject::default()
-        }],
-        evidence: vec![Evidence::bounds("thin_piece", piece.bbox)],
-        ..blank_finding(rule)
-    }
+        .collect();
+    Ok(Evaluation {
+        checked: images.len(),
+        measured,
+    })
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -28,15 +28,15 @@
 //! soldermask image is the mask *openings*, so `Residue::Gap` flags the
 //! web of mask remaining between them.
 
-use anyhow::Result;
 use pcb_ir::geom::ContourSet;
 use pcb_ir::geom::dfm::{ThinPiece, thin_features, thin_gaps};
 use rayon::prelude::*;
 
+use crate::commands::dfm::design::Design;
 use crate::commands::dfm::report::{Evidence, LayerRef, Subject};
 use crate::commands::dfm::rules::ImageSel;
 
-use super::{Context, Evaluation, Measured};
+use super::{Evaluation, Measured};
 
 /// Which morphological residue the rule reports.
 #[derive(Clone, Copy)]
@@ -49,20 +49,20 @@ pub(super) fn evaluate(
     limit_mm: f64,
     sel: ImageSel,
     residue: Residue,
-    ctx: &Context,
-) -> Result<Evaluation> {
+    design: &Design,
+) -> Evaluation {
     let (images, offender_kind): (Vec<(&LayerRef, &ContourSet)>, &'static str) = match sel {
         ImageSel::Copper => (
-            ctx.design
-                .copper_layers()?
+            design
+                .copper_layers
                 .iter()
                 .map(|layer| (&layer.layer, &layer.image))
                 .collect(),
             "copper_image",
         ),
         ImageSel::Soldermask => (
-            ctx.design
-                .mask_layers()?
+            design
+                .mask_layers
                 .iter()
                 .map(|layer| (&layer.layer, &layer.image))
                 .collect(),
@@ -90,8 +90,8 @@ pub(super) fn evaluate(
             })
         })
         .collect();
-    Ok(Evaluation {
+    Evaluation {
         checked: images.len(),
         measured,
-    })
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -15,12 +15,13 @@
 //! Dually, the closing residue `(M • B_ρ) \ M` is exactly the complement
 //! material narrower than `L` — the sub-minimum gaps, notches, and webs.
 //!
-//! Each connected residue component is one finding, with the
-//! isoperimetric width estimate `w = 2·area / perimeter` (exact for long
-//! ribbons) compared against `L`. Residue at the arc-flattening scale is
-//! dropped as noise, and so is one-sided residue — the bite an isolated
-//! corner or shallow arc sheds, whose perimeter mostly leaves the source
-//! boundary — since a violation is walled by material on both sides.
+//! Morphology is the conservative broad phase: it runs with an offset guard
+//! large enough to retain candidates across curve/offset tessellation. A
+//! candidate becomes a finding only after exact segment distance between its
+//! two opposing source-boundary branches is below `L`. One-sided opening or
+//! closing residue — the bite an isolated corner sheds — has no opposing
+//! branches and is discarded. Thus the composed image supplies the
+//! authoritative verdict while morphology only localizes the work.
 //!
 //! For copper, `Residue::Feature` flags copper that will not survive
 //! etching and `Residue::Gap` flags spacing that will not resolve. A
@@ -31,10 +32,12 @@ use pcb_ir::geom::ContourSet;
 use pcb_ir::geom::dfm::{ThinPiece, thin_features, thin_gaps};
 use rayon::prelude::*;
 
-use crate::commands::dfm::report::{Evidence, Finding, LayerRef, Location, Measurement, Subject};
+use crate::commands::dfm::report::{
+    Evidence, Finding, LayerRef, Location, Measurement, Subject, Witness,
+};
 use crate::commands::dfm::rules::{ImageSel, Rule};
 
-use super::{Context, blank_finding};
+use super::{Context, blank_finding, violates_minimum};
 
 /// Which morphological residue the rule reports.
 #[derive(Clone, Copy)]
@@ -96,6 +99,7 @@ pub(super) fn evaluate(
             };
             pieces
                 .into_iter()
+                .filter(|piece| violates_minimum(piece.width_mm, limit))
                 .map(|piece| thin_finding(rule, layer, &piece, title, noun, offender_kind))
                 .collect::<Vec<_>>()
         })
@@ -125,7 +129,10 @@ fn thin_finding(
         location: Location {
             point: Some(piece.bbox.center().into()),
             bounding_box: Some(piece.bbox.into()),
-            witnesses: Vec::new(),
+            witnesses: vec![
+                Witness::new("first_boundary", piece.first),
+                Witness::new("second_boundary", piece.second),
+            ],
         },
         layers: vec![layer.clone()],
         subjects: vec![Subject {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -37,7 +37,7 @@ use crate::commands::dfm::report::{
 };
 use crate::commands::dfm::rules::{ImageSel, Rule};
 
-use super::{Context, blank_finding, violates_minimum};
+use super::{Context, blank_finding};
 
 /// Which morphological residue the rule reports.
 #[derive(Clone, Copy)]
@@ -99,7 +99,6 @@ pub(super) fn evaluate(
             };
             pieces
                 .into_iter()
-                .filter(|piece| violates_minimum(piece.width_mm, limit))
                 .map(|piece| thin_finding(rule, layer, &piece, title, noun, offender_kind))
                 .collect::<Vec<_>>()
         })

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -28,7 +28,7 @@ use crate::ipc2581::Ipc2581;
 use crate::layers;
 
 use super::report::LayerRef;
-use super::rules::{self, Rule, RuleKind};
+use super::rules::{self, Rule};
 
 pub(super) struct Design<'a> {
     pub ipc: &'a Ipc2581,
@@ -66,12 +66,8 @@ impl<'a> Design<'a> {
         // would let one large hole coarsen every fine-clearance query.
         let boundary_search_mm = rules
             .iter()
-            .map(|rule| match rule.kind {
-                RuleKind::AnnularRing(_) | RuleKind::LineworkToCopperClearance(_) => {
-                    rule.limit.millimeters()
-                }
-                _ => 0.0,
-            })
+            .filter(|rule| rule.kind.semantics().pools.copper_boundaries)
+            .map(|rule| rule.limit.millimeters())
             .fold(1.0, f64::max);
         Ok(Self {
             ipc,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1,17 +1,16 @@
 //! The checkable design: entity pools extracted from one IPC-2581 file for
 //! one layout target, in plain millimeters.
 //!
-//! Pools are extracted on first touch and cached for the run, so a rule set
-//! pays only for the pools it reads. Each pool is a flat vector in source
-//! order; derived facts that relate pools (a hole's lands) are side tables
-//! indexed like their primary pool. Extraction fails closed: a drilled
-//! feature whose plating, diameter, or outline the file does not state is
-//! an error, never a quietly dropped subject.
+//! Exactly the pools the configured rules read are extracted; the rest stay
+//! empty. Each pool is a flat vector in source order; derived facts that
+//! relate pools (a hole's lands, a copper layer's boundary index) are side
+//! tables indexed like their primary pool. Extraction fails closed: a
+//! drilled feature whose plating, diameter, or outline the file does not
+//! state is an error, never a quietly dropped subject.
 
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use ipc2581::Symbol;
 use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::Side;
@@ -19,7 +18,7 @@ use pcb_ir::dialects::ipc::{
     ArtworkScope, FeatureDomain, FeatureKind, FeatureSpan, LayoutStepKind, PlatingKind,
     ProfileOccurrenceRole, profile_occurrences_for,
 };
-use pcb_ir::geom::dfm::{Distance, min_width};
+use pcb_ir::geom::dfm::{Distance, RegionBoundaryIndex, min_width};
 use pcb_ir::geom::region::Ring;
 use pcb_ir::geom::{BBox, ContourSet, Point, Polarity, tol};
 use rayon::prelude::*;
@@ -29,101 +28,81 @@ use crate::ipc2581::Ipc2581;
 use crate::layers;
 
 use super::report::LayerRef;
-
-/// A lazily extracted pool. Extraction errors are kept and re-raised on
-/// every touch.
-pub(super) type Pool<T> = OnceLock<Result<T>>;
-
-pub(super) fn force<T>(pool: &Pool<T>, build: impl FnOnce() -> Result<T>) -> Result<&T> {
-    pool.get_or_init(build)
-        .as_ref()
-        .map_err(|error| anyhow!("{error:#}"))
-}
+use super::rules::{self, Rule, RuleKind};
 
 pub(super) struct Design<'a> {
     pub ipc: &'a Ipc2581,
     pub scope: ArtworkScope,
-    drilled: Pool<(Vec<Hole>, Vec<Slot>)>,
-    copper_layers: Pool<Vec<CopperLayer>>,
-    mask_layers: Pool<Vec<MaskLayer>>,
-    scores: Pool<Vec<Score>>,
-    layout: Pool<GeometryDocument>,
-    board_outlines: Pool<Vec<BoardOutline>>,
-    board_arrays: Pool<Vec<BoardArray>>,
-    hole_lands: Pool<Vec<Vec<HoleLand>>>,
+    pub holes: Vec<Hole>,
+    pub slots: Vec<Slot>,
+    pub copper_layers: Vec<CopperLayer>,
+    /// One boundary index per copper layer, for clearance and enclosure
+    /// queries against the composed copper.
+    pub copper_boundaries: Vec<RegionBoundaryIndex>,
+    /// Each hole's lands, one per copper layer it owns a land on, indexed
+    /// like `holes`.
+    pub hole_lands: Vec<Vec<HoleLand>>,
+    pub mask_layers: Vec<MaskLayer>,
+    pub scores: Vec<Score>,
+    pub board_outlines: Vec<BoardOutline>,
+    pub board_arrays: Vec<BoardArray>,
+}
+
+/// Build a pool only when a rule reads it.
+fn when<T: Default>(wanted: bool, build: impl FnOnce() -> Result<T>) -> Result<T> {
+    if wanted { build() } else { Ok(T::default()) }
 }
 
 impl<'a> Design<'a> {
-    pub fn new(ipc: &'a Ipc2581, scope: ArtworkScope) -> Self {
-        Self {
+    pub fn extract(ipc: &'a Ipc2581, scope: ArtworkScope, rules: &[Rule]) -> Result<Self> {
+        let pools = rules::pools(rules);
+        let (holes, slots) = when(pools.drilled, || collect_drilled(ipc, scope))?;
+        let copper_layers = when(pools.copper, || collect_copper_layers(ipc, scope))?;
+        let layout = when(pools.board_outlines || pools.board_arrays, || {
+            geometry::extract_layout(ipc).map(Some)
+        })?;
+        // A pitch hint for the boundary grids, from the rule limits alone:
+        // queries stay correct at any pitch, and sizing cells by hole radii
+        // would let one large hole coarsen every fine-clearance query.
+        let boundary_search_mm = rules
+            .iter()
+            .map(|rule| match rule.kind {
+                RuleKind::AnnularRing(_) | RuleKind::LineworkToCopperClearance(_) => {
+                    rule.limit.millimeters()
+                }
+                _ => 0.0,
+            })
+            .fold(1.0, f64::max);
+        Ok(Self {
             ipc,
             scope,
-            drilled: Pool::new(),
-            copper_layers: Pool::new(),
-            mask_layers: Pool::new(),
-            scores: Pool::new(),
-            layout: Pool::new(),
-            board_outlines: Pool::new(),
-            board_arrays: Pool::new(),
-            hole_lands: Pool::new(),
-        }
-    }
-
-    fn drilled(&self) -> Result<&(Vec<Hole>, Vec<Slot>)> {
-        force(&self.drilled, || collect_drilled(self.ipc, self.scope))
-    }
-
-    pub fn holes(&self) -> Result<&[Hole]> {
-        self.drilled().map(|(holes, _)| holes.as_slice())
-    }
-
-    pub fn slots(&self) -> Result<&[Slot]> {
-        self.drilled().map(|(_, slots)| slots.as_slice())
-    }
-
-    pub fn copper_layers(&self) -> Result<&[CopperLayer]> {
-        force(&self.copper_layers, || {
-            collect_copper_layers(self.ipc, self.scope)
+            copper_boundaries: when(pools.copper_boundaries, || {
+                Ok(copper_layers
+                    .par_iter()
+                    .map(|layer| RegionBoundaryIndex::new(&layer.image, boundary_search_mm))
+                    .collect())
+            })?,
+            hole_lands: when(pools.hole_lands, || Ok(link_lands(&holes, &copper_layers)))?,
+            mask_layers: when(pools.masks, || collect_mask_layers(ipc, scope))?,
+            scores: when(pools.scores, || collect_scores(ipc, scope))?,
+            board_outlines: layout
+                .as_ref()
+                .filter(|_| pools.board_outlines)
+                .map(|layout| collect_board_outlines(ipc, layout, scope))
+                .unwrap_or_default(),
+            board_arrays: layout
+                .as_ref()
+                .filter(|_| pools.board_arrays)
+                .map(|layout| collect_board_arrays(ipc, layout))
+                .unwrap_or_default(),
+            holes,
+            slots,
+            copper_layers,
         })
-        .map(Vec::as_slice)
     }
 
-    pub fn mask_layers(&self) -> Result<&[MaskLayer]> {
-        force(&self.mask_layers, || {
-            collect_mask_layers(self.ipc, self.scope)
-        })
-        .map(Vec::as_slice)
-    }
-
-    pub fn scores(&self) -> Result<&[Score]> {
-        force(&self.scores, || collect_scores(self.ipc, self.scope)).map(Vec::as_slice)
-    }
-
-    fn layout(&self) -> Result<&GeometryDocument> {
-        force(&self.layout, || geometry::extract_layout(self.ipc))
-    }
-
-    pub fn board_outlines(&self) -> Result<&[BoardOutline]> {
-        force(&self.board_outlines, || {
-            Ok(collect_board_outlines(self.ipc, self.layout()?, self.scope))
-        })
-        .map(Vec::as_slice)
-    }
-
-    pub fn board_arrays(&self) -> Result<&[BoardArray]> {
-        force(&self.board_arrays, || {
-            Ok(collect_board_arrays(self.ipc, self.layout()?))
-        })
-        .map(Vec::as_slice)
-    }
-
-    /// Each hole's lands, one per copper layer it owns a land on, indexed
-    /// like [`Design::holes`].
-    pub fn hole_lands(&self) -> Result<&[Vec<HoleLand>]> {
-        force(&self.hole_lands, || {
-            Ok(link_lands(self.holes()?, self.copper_layers()?))
-        })
-        .map(Vec::as_slice)
+    pub fn resolve(&self, symbol: Option<Symbol>) -> Option<String> {
+        symbol.map(|symbol| self.ipc.resolve(symbol).to_owned())
     }
 }
 
@@ -372,7 +351,9 @@ fn slot_width(stated_mm: f64, measured: Distance) -> Result<Distance> {
     if !(stated_mm > 0.0 && stated_mm.is_finite()) {
         return Ok(measured);
     }
-    if (measured.mm - stated_mm).abs() > measured.uncertainty_mm {
+    // The outline's width is short by up to its uncertainty, plus the
+    // flattening slack the medial-axis pruning allows.
+    if (measured.mm - stated_mm).abs() > measured.uncertainty_mm + tol::FLATTEN_MM {
         bail!(
             "states width {stated_mm:.6} mm but its outline measures {:.6} mm",
             measured.mm
@@ -729,23 +710,20 @@ mod tests {
     }
 
     #[test]
-    fn stated_oval_width_is_exact() {
-        let ipc = slot_fixture(
+    fn slot_width_is_stated_when_given_and_measured_otherwise() {
+        let oval = slot_fixture(
             r#"<Location x="10" y="20"/>
               <Oval width="1.8" height="0.6"/>"#,
         );
-
-        let (_, slots) = collect_drilled(&ipc, ArtworkScope::Board).unwrap();
-
+        let (_, slots) = collect_drilled(&oval, ArtworkScope::Board).unwrap();
         assert_eq!(slots.len(), 1);
-        let width = slots[0].width;
-        assert!((width.mm - 0.6).abs() < 1e-9);
-        assert_eq!(width.uncertainty_mm, 0.0, "a stated width is exact");
-    }
+        assert!((slots[0].width.mm - 0.6).abs() < 1e-9);
+        assert_eq!(
+            slots[0].width.uncertainty_mm, 0.0,
+            "a stated width is exact"
+        );
 
-    #[test]
-    fn outline_slot_width_is_measured() {
-        let ipc = slot_fixture(
+        let outline = slot_fixture(
             r#"<Outline>
                 <Polygon>
                   <PolyBegin x="10" y="20"/>
@@ -757,9 +735,7 @@ mod tests {
                 <LineDesc lineWidth="0" lineEnd="ROUND"/>
               </Outline>"#,
         );
-
-        let (_, slots) = collect_drilled(&ipc, ArtworkScope::Board).unwrap();
-
+        let (_, slots) = collect_drilled(&outline, ArtworkScope::Board).unwrap();
         assert_eq!(slots.len(), 1);
         let width = slots[0].width;
         assert!(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1,18 +1,17 @@
-//! The checked design: fat entity pools extracted once from IPC-2581.
+//! The checkable design: entity pools extracted from one IPC-2581 file for
+//! one layout target, in plain millimeters.
 //!
-//! Extraction resolves the semantics rules need — hole spans, hole-to-land
-//! links, composed layer images — so the engine measures geometry without
-//! re-deriving identity. Only the pools the configured rules read are built.
-//! Entities carry interned [`Symbol`]s; strings are resolved only when a
-//! finding is emitted.
-//!
-//! Copper layers form the design's stackup: the pool is ordered top to
-//! bottom as the file lists it, and drill spans are resolved to inclusive
-//! ordinal ranges over that pool.
+//! Pools are extracted on first touch and cached for the run, so a rule set
+//! pays only for the pools it reads. Each pool is a flat vector in source
+//! order; derived facts that relate pools (a hole's lands) are side tables
+//! indexed like their primary pool. Extraction fails closed: a drilled
+//! feature whose plating, diameter, or outline the file does not state is
+//! an error, never a quietly dropped subject.
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use ipc2581::Symbol;
 use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::Side;
@@ -20,6 +19,7 @@ use pcb_ir::dialects::ipc::{
     ArtworkScope, FeatureDomain, FeatureKind, FeatureSpan, LayoutStepKind, PlatingKind,
     ProfileOccurrenceRole, profile_occurrences_for,
 };
+use pcb_ir::geom::dfm::{Distance, min_width};
 use pcb_ir::geom::region::Ring;
 use pcb_ir::geom::{BBox, ContourSet, Point, Polarity, tol};
 use rayon::prelude::*;
@@ -29,63 +29,101 @@ use crate::ipc2581::Ipc2581;
 use crate::layers;
 
 use super::report::LayerRef;
-use super::rules::Rule;
 
-pub(super) struct Design {
-    pub scope: ArtworkScope,
-    pub holes: Vec<Hole>,
-    pub slots: Vec<Slot>,
-    pub copper_layers: Vec<CopperLayer>,
-    pub mask_layers: Vec<MaskLayer>,
-    pub scores: Vec<Score>,
-    pub board_outlines: Vec<BoardOutline>,
-    pub board_arrays: Vec<BoardArray>,
+/// A lazily extracted pool. Extraction errors are kept and re-raised on
+/// every touch.
+pub(super) type Pool<T> = OnceLock<Result<T>>;
+
+pub(super) fn force<T>(pool: &Pool<T>, build: impl FnOnce() -> Result<T>) -> Result<&T> {
+    pool.get_or_init(build)
+        .as_ref()
+        .map_err(|error| anyhow!("{error:#}"))
 }
 
-impl Design {
-    pub fn extract(ipc: &Ipc2581, rules: &[Rule], scope: ArtworkScope) -> Result<Self> {
-        let needs = super::rules::needs(rules);
-        let (mut holes, slots) = if needs.holes || needs.slots {
-            collect_drilled(ipc, scope)?
-        } else {
-            (Vec::new(), Vec::new())
-        };
-        let copper_layers = if needs.copper {
-            collect_copper_layers(ipc, scope)?
-        } else {
-            Vec::new()
-        };
-        link_lands(&mut holes, &copper_layers);
-        let wants_arrays = needs.board_arrays && scope == ArtworkScope::ArrayFlattened;
-        let layout = if needs.board_outlines || wants_arrays {
-            Some(geometry::extract_layout(ipc)?)
-        } else {
-            None
-        };
-        Ok(Self {
+pub(super) struct Design<'a> {
+    pub ipc: &'a Ipc2581,
+    pub scope: ArtworkScope,
+    drilled: Pool<(Vec<Hole>, Vec<Slot>)>,
+    copper_layers: Pool<Vec<CopperLayer>>,
+    mask_layers: Pool<Vec<MaskLayer>>,
+    scores: Pool<Vec<Score>>,
+    layout: Pool<GeometryDocument>,
+    board_outlines: Pool<Vec<BoardOutline>>,
+    board_arrays: Pool<Vec<BoardArray>>,
+    hole_lands: Pool<Vec<Vec<HoleLand>>>,
+}
+
+impl<'a> Design<'a> {
+    pub fn new(ipc: &'a Ipc2581, scope: ArtworkScope) -> Self {
+        Self {
+            ipc,
             scope,
-            holes,
-            slots,
-            copper_layers,
-            mask_layers: if needs.masks {
-                collect_mask_layers(ipc, scope)?
-            } else {
-                Vec::new()
-            },
-            scores: if needs.scores {
-                collect_scores(ipc, scope)?
-            } else {
-                Vec::new()
-            },
-            board_outlines: match &layout {
-                Some(layout) if needs.board_outlines => collect_board_outlines(ipc, layout, scope),
-                _ => Vec::new(),
-            },
-            board_arrays: match &layout {
-                Some(layout) if wants_arrays => collect_board_arrays(ipc, layout),
-                _ => Vec::new(),
-            },
+            drilled: Pool::new(),
+            copper_layers: Pool::new(),
+            mask_layers: Pool::new(),
+            scores: Pool::new(),
+            layout: Pool::new(),
+            board_outlines: Pool::new(),
+            board_arrays: Pool::new(),
+            hole_lands: Pool::new(),
+        }
+    }
+
+    fn drilled(&self) -> Result<&(Vec<Hole>, Vec<Slot>)> {
+        force(&self.drilled, || collect_drilled(self.ipc, self.scope))
+    }
+
+    pub fn holes(&self) -> Result<&[Hole]> {
+        self.drilled().map(|(holes, _)| holes.as_slice())
+    }
+
+    pub fn slots(&self) -> Result<&[Slot]> {
+        self.drilled().map(|(_, slots)| slots.as_slice())
+    }
+
+    pub fn copper_layers(&self) -> Result<&[CopperLayer]> {
+        force(&self.copper_layers, || {
+            collect_copper_layers(self.ipc, self.scope)
         })
+        .map(Vec::as_slice)
+    }
+
+    pub fn mask_layers(&self) -> Result<&[MaskLayer]> {
+        force(&self.mask_layers, || {
+            collect_mask_layers(self.ipc, self.scope)
+        })
+        .map(Vec::as_slice)
+    }
+
+    pub fn scores(&self) -> Result<&[Score]> {
+        force(&self.scores, || collect_scores(self.ipc, self.scope)).map(Vec::as_slice)
+    }
+
+    fn layout(&self) -> Result<&GeometryDocument> {
+        force(&self.layout, || geometry::extract_layout(self.ipc))
+    }
+
+    pub fn board_outlines(&self) -> Result<&[BoardOutline]> {
+        force(&self.board_outlines, || {
+            Ok(collect_board_outlines(self.ipc, self.layout()?, self.scope))
+        })
+        .map(Vec::as_slice)
+    }
+
+    pub fn board_arrays(&self) -> Result<&[BoardArray]> {
+        force(&self.board_arrays, || {
+            Ok(collect_board_arrays(self.ipc, self.layout()?))
+        })
+        .map(Vec::as_slice)
+    }
+
+    /// Each hole's lands, one per copper layer it owns a land on, indexed
+    /// like [`Design::holes`].
+    pub fn hole_lands(&self) -> Result<&[Vec<HoleLand>]> {
+        force(&self.hole_lands, || {
+            Ok(link_lands(self.holes()?, self.copper_layers()?))
+        })
+        .map(Vec::as_slice)
     }
 }
 
@@ -121,51 +159,34 @@ pub(super) struct Hole {
     pub diameter_mm: f64,
     pub bbox: BBox,
     pub layer: LayerRef,
-    /// Inclusive ordinal range over the copper stackup the drill spans.
-    /// `None` spans the whole board (or the span is unknown).
-    pub copper_span: Option<(u16, u16)>,
+    /// Inclusive ordinal range over the copper stackup the drill spans. A
+    /// through-board or unstated span covers every copper layer.
+    pub copper_span: (u16, u16),
     pub step: Option<Symbol>,
     pub padstack: Option<Symbol>,
     pub net: Option<Symbol>,
-    /// Lands this hole owns, one per copper layer, linked at extraction.
-    pub lands: Vec<HoleLand>,
     pub source_set_index: u32,
     pub source_feature_index: u32,
 }
 
 impl Hole {
-    pub fn spans_copper(&self, copper_ordinal: u16) -> bool {
-        self.copper_span
-            .is_none_or(|(low, high)| (low..=high).contains(&copper_ordinal))
+    pub fn spans_copper(&self, copper_index: usize) -> bool {
+        let (low, high) = self.copper_span;
+        (usize::from(low)..=usize::from(high)).contains(&copper_index)
     }
 
-    /// Whether two drill spans coexist at some board depth. Unknown spans
-    /// conservatively overlap everything.
+    /// Whether two drill spans coexist at some board depth.
     pub fn span_overlaps(&self, other: &Hole) -> bool {
-        match (self.copper_span, other.copper_span) {
-            (Some((self_low, self_high)), Some((other_low, other_high))) => {
-                self_low <= other_high && other_low <= self_high
-            }
-            _ => true,
-        }
+        let (self_low, self_high) = self.copper_span;
+        let (other_low, other_high) = other.copper_span;
+        self_low <= other_high && other_low <= self_high
     }
 
-    pub fn land_on(&self, copper_index: usize) -> Option<&HoleLand> {
-        self.lands
-            .iter()
-            .find(|land| land.copper_index as usize == copper_index)
-    }
-
-    /// Whether `copper_index` is an end of the drill span: the layers the
-    /// plating barrel must land on. An unknown span terminates on the
-    /// outermost of the `copper_layer_count` layers.
-    pub fn terminates_on(&self, copper_index: usize, copper_layer_count: usize) -> bool {
-        let (low, high) = self
-            .copper_span
-            .map_or((0, copper_layer_count - 1), |(low, high)| {
-                (usize::from(low), usize::from(high))
-            });
-        copper_index == low || copper_index == high
+    /// Whether `copper_index` is an end of the drill span: a layer the
+    /// plating barrel must land on.
+    pub fn terminates_on(&self, copper_index: usize) -> bool {
+        let (low, high) = self.copper_span;
+        copper_index == usize::from(low) || copper_index == usize::from(high)
     }
 }
 
@@ -176,21 +197,13 @@ pub(super) struct HoleLand {
     pub land_index: u32,
 }
 
-/// The authoritative width basis retained for one routed slot.
-#[derive(Debug, Clone)]
-pub(super) enum SlotWidth {
-    /// Exact source primitive width (normally an IPC `Oval`).
-    Nominal(f64),
-    /// Final materialized slot image when the source states only an outline.
-    Geometry(ContourSet),
-}
-
-/// A routed slot on a drill layer. Primitive widths stay semantic; arbitrary
-/// outlines retain their materialized filled geometry for local-width checks.
+/// A routed slot on a drill layer. Its width is settled at extraction: the
+/// stated primitive width when the source gives one (exact, verified
+/// against the materialized outline), otherwise the outline's narrowest
+/// local width.
 #[derive(Debug, Clone)]
 pub(super) struct Slot {
-    pub width: SlotWidth,
-    pub center: Point,
+    pub width: Distance,
     pub bbox: BBox,
     pub layer: LayerRef,
     pub step: Option<Symbol>,
@@ -253,6 +266,13 @@ pub(super) struct BoardArray {
 
 fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec<Slot>)> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
+    let copper_count = ecad
+        .cad_data
+        .layers
+        .iter()
+        .filter(|layer| layers::is_copper(layer.layer_function))
+        .count();
+    let whole_stack = (0, copper_count.max(1) as u16 - 1);
     let mut holes = Vec::new();
     let mut slots = Vec::new();
     for source_layer in ecad.cad_data.layers.iter().filter(|layer| {
@@ -288,35 +308,28 @@ fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec
                         diameter_mm: feature.outer_diameter,
                         bbox: BBox::from_point(feature.center).expand(feature.outer_diameter / 2.0),
                         layer: layer_ref(layer_name, source_layer.layer_function, None),
-                        copper_span: copper_span(feature.intent.span, &ecad.cad_data.layers),
+                        copper_span: copper_span(feature.intent.span, &ecad.cad_data.layers)
+                            .unwrap_or(whole_stack),
                         step: feature.source_step_ref,
                         padstack: feature.padstack_ref,
                         net: feature.net,
-                        lands: Vec::new(),
                         source_set_index: feature.source.set_index,
                         source_feature_index: feature.source.feature_index,
                     });
                 }
                 FeatureKind::Slot => {
-                    let width = if feature.outer_diameter > 0.0
-                        && feature.outer_diameter.is_finite()
-                    {
-                        SlotWidth::Nominal(feature.outer_diameter)
-                    } else {
-                        let contours = document.placed_feature_contours(feature);
-                        let geometry = ContourSet::from_filled_contours(&contours, tol::REGION_MM);
-                        if geometry.is_empty() {
-                            bail!(
-                                "routed slot on layer '{layer_name}' at ({:.6}, {:.6}) has neither a nominal width nor outline geometry",
-                                feature.bbox.center().x,
-                                feature.bbox.center().y
-                            );
-                        }
-                        SlotWidth::Geometry(geometry)
+                    let at = format!(
+                        "routed slot on layer '{layer_name}' at ({:.6}, {:.6})",
+                        feature.bbox.center().x,
+                        feature.bbox.center().y
+                    );
+                    let contours = document.placed_feature_contours(feature);
+                    let outline = ContourSet::from_filled_contours(&contours, tol::REGION_MM);
+                    let Some(measured) = min_width(&outline) else {
+                        bail!("{at} has no measurable outline");
                     };
                     slots.push(Slot {
-                        width,
-                        center: feature.bbox.center(),
+                        width: slot_width(feature.outer_diameter, measured).with_context(|| at)?,
                         bbox: feature.bbox,
                         layer: layer_ref(layer_name, source_layer.layer_function, None),
                         step: feature.source_step_ref,
@@ -340,14 +353,32 @@ fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec
             .then_with(|| left.diameter_mm.total_cmp(&right.diameter_mm))
     });
     slots.sort_by(|left, right| {
-        left.center
+        left.bbox
+            .min
             .x
-            .total_cmp(&right.center.x)
-            .then_with(|| left.center.y.total_cmp(&right.center.y))
+            .total_cmp(&right.bbox.min.x)
+            .then_with(|| left.bbox.min.y.total_cmp(&right.bbox.min.y))
             .then_with(|| left.bbox.max.x.total_cmp(&right.bbox.max.x))
             .then_with(|| left.bbox.max.y.total_cmp(&right.bbox.max.y))
     });
     Ok((holes, slots))
+}
+
+/// A slot's width: the stated primitive width when the source gives one,
+/// otherwise the outline's measured minimum width. A stated width is exact,
+/// and the outline must agree with it within the measurement's uncertainty;
+/// a file that states one width and draws another is inconsistent.
+fn slot_width(stated_mm: f64, measured: Distance) -> Result<Distance> {
+    if !(stated_mm > 0.0 && stated_mm.is_finite()) {
+        return Ok(measured);
+    }
+    if (measured.mm - stated_mm).abs() > measured.uncertainty_mm {
+        bail!(
+            "states width {stated_mm:.6} mm but its outline measures {:.6} mm",
+            measured.mm
+        );
+    }
+    Ok(Distance::exact(stated_mm, measured.first, measured.second))
 }
 
 /// Resolve a drill span to an inclusive ordinal range over the copper
@@ -494,13 +525,15 @@ fn collect_mask_layers(ipc: &Ipc2581, scope: ArtworkScope) -> Result<Vec<MaskLay
 
 /// Attach each hole to its land on every copper layer it spans: same
 /// padstack, same step, compatible net, overlapping bounds, nearest center.
+/// The result is indexed like `holes`.
 ///
 /// Lands are gridded by their bounds so each hole only meets the handful of
 /// lands around it, not every instance of its padstack on the layer.
-fn link_lands(holes: &mut [Hole], copper_layers: &[CopperLayer]) {
+fn link_lands(holes: &[Hole], copper_layers: &[CopperLayer]) -> Vec<Vec<HoleLand>> {
     const CELL_MM: f64 = 1.0;
     let cell = |value: f64| (value / CELL_MM).floor() as i64;
     let mut candidates: Vec<u32> = Vec::new();
+    let mut hole_lands = vec![Vec::new(); holes.len()];
     for (copper_index, copper) in copper_layers.iter().enumerate() {
         let mut grid: HashMap<(i64, i64), Vec<u32>> = HashMap::new();
         for (land_index, land) in copper.lands.iter().enumerate() {
@@ -510,8 +543,8 @@ fn link_lands(holes: &mut [Hole], copper_layers: &[CopperLayer]) {
                 }
             }
         }
-        for hole in holes.iter_mut() {
-            if !hole.spans_copper(copper_index as u16) {
+        for (hole_index, hole) in holes.iter().enumerate() {
+            if !hole.spans_copper(copper_index) {
                 continue;
             }
             let Some(padstack) = hole.padstack else {
@@ -540,13 +573,14 @@ fn link_lands(holes: &mut [Hole], copper_layers: &[CopperLayer]) {
                         .total_cmp(&right.center.distance_to(hole.center))
                 });
             if let Some((land_index, _)) = best {
-                hole.lands.push(HoleLand {
+                hole_lands[hole_index].push(HoleLand {
                     copper_index: copper_index as u32,
                     land_index,
                 });
             }
         }
     }
+    hole_lands
 }
 
 fn collect_scores(ipc: &Ipc2581, scope: ArtworkScope) -> Result<Vec<Score>> {
@@ -663,8 +697,6 @@ fn layer_ref(name: &str, function: LayerFunction, side: Option<&'static str>) ->
 
 #[cfg(test)]
 mod tests {
-    use pcb_ir::geom::dfm::thin_features;
-
     use super::*;
 
     fn slot_fixture(shape: &str) -> Ipc2581 {
@@ -697,7 +729,7 @@ mod tests {
     }
 
     #[test]
-    fn retains_nominal_oval_slot_width() {
+    fn stated_oval_width_is_exact() {
         let ipc = slot_fixture(
             r#"<Location x="10" y="20"/>
               <Oval width="1.8" height="0.6"/>"#,
@@ -706,14 +738,13 @@ mod tests {
         let (_, slots) = collect_drilled(&ipc, ArtworkScope::Board).unwrap();
 
         assert_eq!(slots.len(), 1);
-        let SlotWidth::Nominal(width) = slots[0].width else {
-            panic!("oval slot must retain its nominal width")
-        };
-        assert!((width - 0.6).abs() < 1e-9);
+        let width = slots[0].width;
+        assert!((width.mm - 0.6).abs() < 1e-9);
+        assert_eq!(width.uncertainty_mm, 0.0, "a stated width is exact");
     }
 
     #[test]
-    fn retains_and_measures_outline_slot_geometry() {
+    fn outline_slot_width_is_measured() {
         let ipc = slot_fixture(
             r#"<Outline>
                 <Polygon>
@@ -730,15 +761,28 @@ mod tests {
         let (_, slots) = collect_drilled(&ipc, ArtworkScope::Board).unwrap();
 
         assert_eq!(slots.len(), 1);
-        let SlotWidth::Geometry(geometry) = &slots[0].width else {
-            panic!("outline slot must retain materialized geometry")
-        };
-        let violations = thin_features(geometry, 0.8);
-        assert_eq!(violations.len(), 1);
+        let width = slots[0].width;
         assert!(
-            (violations[0].width_mm - 0.6).abs() < 1e-8,
+            (width.mm - 0.6).abs() < 1e-8,
             "measured width was {}",
-            violations[0].width_mm
+            width.mm
         );
+        assert!(
+            width.uncertainty_mm > 0.0,
+            "a measured outline carries uncertainty"
+        );
+    }
+
+    #[test]
+    fn stated_width_must_match_the_outline() {
+        let ipc = slot_fixture(
+            r#"<Location x="10" y="20"/>
+              <Oval width="1.8" height="0.6"/>"#,
+        );
+        let oval = collect_drilled(&ipc, ArtworkScope::Board)
+            .unwrap()
+            .1
+            .remove(0);
+        assert!(slot_width(0.9, oval.width).is_err());
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use ipc2581::Symbol;
 use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::Side;
@@ -29,7 +29,7 @@ use crate::ipc2581::Ipc2581;
 use crate::layers;
 
 use super::report::LayerRef;
-use super::rules::Rule;
+use super::rules::{Needs, Rule};
 
 pub(super) struct Design {
     pub scope: ArtworkScope,
@@ -46,7 +46,7 @@ impl Design {
     pub fn extract(ipc: &Ipc2581, rules: &[Rule], scope: ArtworkScope) -> Result<Self> {
         let needs = super::rules::needs(rules);
         let (mut holes, slots) = if needs.holes || needs.slots {
-            collect_drilled(ipc, scope)?
+            collect_drilled(ipc, scope, needs)?
         } else {
             (Vec::new(), Vec::new())
         };
@@ -94,6 +94,7 @@ pub(super) enum HoleClass {
     Via,
     Pth,
     Npth,
+    Unknown,
 }
 
 impl HoleClass {
@@ -102,6 +103,7 @@ impl HoleClass {
             Self::Via => "via",
             Self::Pth => "PTH",
             Self::Npth => "NPTH",
+            Self::Unknown => "unclassified",
         }
     }
 
@@ -110,6 +112,7 @@ impl HoleClass {
             Self::Via => "via_hole",
             Self::Pth => "plated_hole",
             Self::Npth => "nonplated_hole",
+            Self::Unknown => "unclassified_hole",
         }
     }
 }
@@ -155,6 +158,19 @@ impl Hole {
             .iter()
             .find(|land| land.copper_index as usize == copper_index)
     }
+
+    /// A plated hole must have copper enclosure on both terminal layers of
+    /// its known span. Unknown/through-board spans conservatively terminate
+    /// on the outermost copper layers.
+    pub fn terminates_on(&self, copper_index: usize, copper_layer_count: usize) -> bool {
+        if copper_layer_count == 0 {
+            return false;
+        }
+        match self.copper_span {
+            Some((low, high)) => copper_index == low as usize || copper_index == high as usize,
+            None => copper_index == 0 || copper_index + 1 == copper_layer_count,
+        }
+    }
 }
 
 /// One hole's land on one copper layer, by pool indices.
@@ -164,11 +180,20 @@ pub(super) struct HoleLand {
     pub land_index: u32,
 }
 
-/// A routed slot on a drill layer. Only slots whose primitive states a width
-/// are measurable; outline-shaped slots carry no nominal width.
+/// The authoritative width basis retained for one routed slot.
+#[derive(Debug, Clone)]
+pub(super) enum SlotWidth {
+    /// Exact source primitive width (normally an IPC `Oval`).
+    Nominal(f64),
+    /// Final materialized slot image when the source states only an outline.
+    Geometry(ContourSet),
+}
+
+/// A routed slot on a drill layer. Primitive widths stay semantic; arbitrary
+/// outlines retain their materialized filled geometry for local-width checks.
 #[derive(Debug, Clone)]
 pub(super) struct Slot {
-    pub width_mm: f64,
+    pub width: SlotWidth,
     pub center: Point,
     pub bbox: BBox,
     pub layer: LayerRef,
@@ -230,7 +255,11 @@ pub(super) struct BoardArray {
     pub region: ContourSet,
 }
 
-fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec<Slot>)> {
+fn collect_drilled(
+    ipc: &Ipc2581,
+    scope: ArtworkScope,
+    needs: Needs,
+) -> Result<(Vec<Hole>, Vec<Slot>)> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let mut holes = Vec::new();
     let mut slots = Vec::new();
@@ -244,16 +273,28 @@ fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec
         let mut document = geometry::extract_layer_for_view(ipc, layer_name, scope)
             .with_context(|| format!("failed to extract drill layer '{layer_name}'"))?;
         pcb_ir::dialects::ipc::process::expand_feature_placement_groups(&mut document);
-        for feature in document.features.iter().filter(|feature| {
-            feature.is_drill_like()
-                && feature.outer_diameter.is_finite()
-                && feature.outer_diameter > 0.0
-        }) {
+        for feature in document
+            .features
+            .iter()
+            .filter(|feature| feature.is_drill_like())
+        {
             match feature.kind {
-                FeatureKind::Hole => {
-                    let Some(class) = hole_class(feature.intent.plating) else {
-                        continue;
-                    };
+                FeatureKind::Hole if needs.holes => {
+                    if !feature.outer_diameter.is_finite() || feature.outer_diameter <= 0.0 {
+                        bail!(
+                            "drilled hole on layer '{layer_name}' at ({:.6}, {:.6}) has no positive finite diameter",
+                            feature.center.x,
+                            feature.center.y
+                        );
+                    }
+                    let class = hole_class(feature.intent.plating);
+                    if class == HoleClass::Unknown && needs.classified_holes {
+                        bail!(
+                            "drilled hole on layer '{layer_name}' at ({:.6}, {:.6}) has unknown plating; class-specific DFM rules cannot certify it",
+                            feature.center.x,
+                            feature.center.y
+                        );
+                    }
                     holes.push(Hole {
                         class,
                         center: feature.center,
@@ -269,9 +310,25 @@ fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec
                         source_feature_index: feature.source.feature_index,
                     });
                 }
-                FeatureKind::Slot => {
+                FeatureKind::Slot if needs.slots => {
+                    let width = if feature.outer_diameter.is_finite()
+                        && feature.outer_diameter > 0.0
+                    {
+                        SlotWidth::Nominal(feature.outer_diameter)
+                    } else {
+                        let contours = document.placed_feature_contours(feature);
+                        let geometry = ContourSet::from_filled_contours(&contours, tol::REGION_MM);
+                        if geometry.is_empty() {
+                            bail!(
+                                "routed slot on layer '{layer_name}' at ({:.6}, {:.6}) has neither a nominal width nor measurable outline geometry",
+                                feature.bbox.center().x,
+                                feature.bbox.center().y
+                            );
+                        }
+                        SlotWidth::Geometry(geometry)
+                    };
                     slots.push(Slot {
-                        width_mm: feature.outer_diameter,
+                        width,
                         center: feature.bbox.center(),
                         bbox: feature.bbox,
                         layer: layer_ref(layer_name, source_layer.layer_function, None),
@@ -281,6 +338,9 @@ fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec
                         source_set_index: feature.source.set_index,
                         source_feature_index: feature.source.feature_index,
                     });
+                }
+                FeatureKind::Hole | FeatureKind::Slot => {
+                    continue;
                 }
                 _ => {}
             }
@@ -300,7 +360,7 @@ fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec
             .x
             .total_cmp(&right.center.x)
             .then_with(|| left.center.y.total_cmp(&right.center.y))
-            .then_with(|| left.width_mm.total_cmp(&right.width_mm))
+            .then_with(|| slot_width_hint(&left.width).total_cmp(&slot_width_hint(&right.width)))
     });
     Ok((holes, slots))
 }
@@ -342,12 +402,19 @@ fn copper_span(span: FeatureSpan<Symbol>, layers: &[ipc2581::types::Layer]) -> O
     Some((first?, last?))
 }
 
-fn hole_class(plating: PlatingKind) -> Option<HoleClass> {
+fn slot_width_hint(width: &SlotWidth) -> f64 {
+    match width {
+        SlotWidth::Nominal(width) => *width,
+        SlotWidth::Geometry(geometry) => geometry.bbox.width().min(geometry.bbox.height()),
+    }
+}
+
+fn hole_class(plating: PlatingKind) -> HoleClass {
     match plating {
-        PlatingKind::Via | PlatingKind::ViaCapped => Some(HoleClass::Via),
-        PlatingKind::Plated => Some(HoleClass::Pth),
-        PlatingKind::NonPlated => Some(HoleClass::Npth),
-        PlatingKind::Unknown | PlatingKind::None => None,
+        PlatingKind::Via | PlatingKind::ViaCapped => HoleClass::Via,
+        PlatingKind::Plated => HoleClass::Pth,
+        PlatingKind::NonPlated => HoleClass::Npth,
+        PlatingKind::Unknown | PlatingKind::None => HoleClass::Unknown,
     }
 }
 
@@ -613,5 +680,103 @@ fn layer_ref(name: &str, function: LayerFunction, side: Option<&'static str>) ->
         name: name.to_owned(),
         function: function.as_str().to_owned(),
         side,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pcb_ir::geom::dfm::thin_features;
+
+    use super::*;
+
+    fn slot_fixture(shape: &str) -> Ipc2581 {
+        Ipc2581::parse(&format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="ROUT"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="ROUT" layerFunction="ROUT" side="ALL" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <LayerFeature layerRef="ROUT">
+          <Set>
+            <SlotCavity name="S1" platingStatus="PLATED" plusTol="0" minusTol="0">
+              {shape}
+            </SlotCavity>
+          </Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn retains_nominal_oval_slot_width() {
+        let ipc = slot_fixture(
+            r#"<Location x="10" y="20"/>
+              <Oval width="1.8" height="0.6"/>"#,
+        );
+
+        let (_, slots) = collect_drilled(
+            &ipc,
+            ArtworkScope::Board,
+            Needs {
+                slots: true,
+                ..Needs::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(slots.len(), 1);
+        let SlotWidth::Nominal(width) = slots[0].width else {
+            panic!("oval slot must retain its nominal width")
+        };
+        assert!((width - 0.6).abs() < 1e-9);
+    }
+
+    #[test]
+    fn retains_and_measures_outline_slot_geometry() {
+        let ipc = slot_fixture(
+            r#"<Outline>
+                <Polygon>
+                  <PolyBegin x="10" y="20"/>
+                  <PolyStepSegment x="10.6" y="20"/>
+                  <PolyStepSegment x="10.6" y="21.8"/>
+                  <PolyStepSegment x="10" y="21.8"/>
+                  <PolyStepSegment x="10" y="20"/>
+                </Polygon>
+                <LineDesc lineWidth="0" lineEnd="ROUND"/>
+              </Outline>"#,
+        );
+
+        let (_, slots) = collect_drilled(
+            &ipc,
+            ArtworkScope::Board,
+            Needs {
+                slots: true,
+                ..Needs::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(slots.len(), 1);
+        let SlotWidth::Geometry(geometry) = &slots[0].width else {
+            panic!("outline slot must retain materialized geometry")
+        };
+        let violations = thin_features(geometry, 0.8);
+        assert_eq!(violations.len(), 1);
+        assert!(
+            (violations[0].width_mm - 0.6).abs() < 1e-8,
+            "measured width was {}",
+            violations[0].width_mm
+        );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -29,7 +29,7 @@ use crate::ipc2581::Ipc2581;
 use crate::layers;
 
 use super::report::LayerRef;
-use super::rules::{Needs, Rule};
+use super::rules::Rule;
 
 pub(super) struct Design {
     pub scope: ArtworkScope,
@@ -46,7 +46,7 @@ impl Design {
     pub fn extract(ipc: &Ipc2581, rules: &[Rule], scope: ArtworkScope) -> Result<Self> {
         let needs = super::rules::needs(rules);
         let (mut holes, slots) = if needs.holes || needs.slots {
-            collect_drilled(ipc, scope, needs)?
+            collect_drilled(ipc, scope)?
         } else {
             (Vec::new(), Vec::new())
         };
@@ -94,7 +94,6 @@ pub(super) enum HoleClass {
     Via,
     Pth,
     Npth,
-    Unknown,
 }
 
 impl HoleClass {
@@ -103,7 +102,6 @@ impl HoleClass {
             Self::Via => "via",
             Self::Pth => "PTH",
             Self::Npth => "NPTH",
-            Self::Unknown => "unclassified",
         }
     }
 
@@ -112,7 +110,6 @@ impl HoleClass {
             Self::Via => "via_hole",
             Self::Pth => "plated_hole",
             Self::Npth => "nonplated_hole",
-            Self::Unknown => "unclassified_hole",
         }
     }
 }
@@ -159,17 +156,16 @@ impl Hole {
             .find(|land| land.copper_index as usize == copper_index)
     }
 
-    /// A plated hole must have copper enclosure on both terminal layers of
-    /// its known span. Unknown/through-board spans conservatively terminate
-    /// on the outermost copper layers.
+    /// Whether `copper_index` is an end of the drill span: the layers the
+    /// plating barrel must land on. An unknown span terminates on the
+    /// outermost of the `copper_layer_count` layers.
     pub fn terminates_on(&self, copper_index: usize, copper_layer_count: usize) -> bool {
-        if copper_layer_count == 0 {
-            return false;
-        }
-        match self.copper_span {
-            Some((low, high)) => copper_index == low as usize || copper_index == high as usize,
-            None => copper_index == 0 || copper_index + 1 == copper_layer_count,
-        }
+        let (low, high) = self
+            .copper_span
+            .map_or((0, copper_layer_count - 1), |(low, high)| {
+                (usize::from(low), usize::from(high))
+            });
+        copper_index == low || copper_index == high
     }
 }
 
@@ -255,11 +251,7 @@ pub(super) struct BoardArray {
     pub region: ContourSet,
 }
 
-fn collect_drilled(
-    ipc: &Ipc2581,
-    scope: ArtworkScope,
-    needs: Needs,
-) -> Result<(Vec<Hole>, Vec<Slot>)> {
+fn collect_drilled(ipc: &Ipc2581, scope: ArtworkScope) -> Result<(Vec<Hole>, Vec<Slot>)> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let mut holes = Vec::new();
     let mut slots = Vec::new();
@@ -279,22 +271,17 @@ fn collect_drilled(
             .filter(|feature| feature.is_drill_like())
         {
             match feature.kind {
-                FeatureKind::Hole if needs.holes => {
-                    if !feature.outer_diameter.is_finite() || feature.outer_diameter <= 0.0 {
-                        bail!(
-                            "drilled hole on layer '{layer_name}' at ({:.6}, {:.6}) has no positive finite diameter",
-                            feature.center.x,
-                            feature.center.y
-                        );
+                FeatureKind::Hole => {
+                    let at = format!(
+                        "drilled hole on layer '{layer_name}' at ({:.6}, {:.6})",
+                        feature.center.x, feature.center.y
+                    );
+                    if !(feature.outer_diameter > 0.0 && feature.outer_diameter.is_finite()) {
+                        bail!("{at} has no positive finite diameter");
                     }
-                    let class = hole_class(feature.intent.plating);
-                    if class == HoleClass::Unknown && needs.classified_holes {
-                        bail!(
-                            "drilled hole on layer '{layer_name}' at ({:.6}, {:.6}) has unknown plating; class-specific DFM rules cannot certify it",
-                            feature.center.x,
-                            feature.center.y
-                        );
-                    }
+                    let Some(class) = hole_class(feature.intent.plating) else {
+                        bail!("{at} has unknown plating; DFM rules cannot certify it");
+                    };
                     holes.push(Hole {
                         class,
                         center: feature.center,
@@ -310,9 +297,9 @@ fn collect_drilled(
                         source_feature_index: feature.source.feature_index,
                     });
                 }
-                FeatureKind::Slot if needs.slots => {
-                    let width = if feature.outer_diameter.is_finite()
-                        && feature.outer_diameter > 0.0
+                FeatureKind::Slot => {
+                    let width = if feature.outer_diameter > 0.0
+                        && feature.outer_diameter.is_finite()
                     {
                         SlotWidth::Nominal(feature.outer_diameter)
                     } else {
@@ -320,7 +307,7 @@ fn collect_drilled(
                         let geometry = ContourSet::from_filled_contours(&contours, tol::REGION_MM);
                         if geometry.is_empty() {
                             bail!(
-                                "routed slot on layer '{layer_name}' at ({:.6}, {:.6}) has neither a nominal width nor measurable outline geometry",
+                                "routed slot on layer '{layer_name}' at ({:.6}, {:.6}) has neither a nominal width nor outline geometry",
                                 feature.bbox.center().x,
                                 feature.bbox.center().y
                             );
@@ -338,9 +325,6 @@ fn collect_drilled(
                         source_set_index: feature.source.set_index,
                         source_feature_index: feature.source.feature_index,
                     });
-                }
-                FeatureKind::Hole | FeatureKind::Slot => {
-                    continue;
                 }
                 _ => {}
             }
@@ -360,7 +344,8 @@ fn collect_drilled(
             .x
             .total_cmp(&right.center.x)
             .then_with(|| left.center.y.total_cmp(&right.center.y))
-            .then_with(|| slot_width_hint(&left.width).total_cmp(&slot_width_hint(&right.width)))
+            .then_with(|| left.bbox.max.x.total_cmp(&right.bbox.max.x))
+            .then_with(|| left.bbox.max.y.total_cmp(&right.bbox.max.y))
     });
     Ok((holes, slots))
 }
@@ -402,19 +387,12 @@ fn copper_span(span: FeatureSpan<Symbol>, layers: &[ipc2581::types::Layer]) -> O
     Some((first?, last?))
 }
 
-fn slot_width_hint(width: &SlotWidth) -> f64 {
-    match width {
-        SlotWidth::Nominal(width) => *width,
-        SlotWidth::Geometry(geometry) => geometry.bbox.width().min(geometry.bbox.height()),
-    }
-}
-
-fn hole_class(plating: PlatingKind) -> HoleClass {
+fn hole_class(plating: PlatingKind) -> Option<HoleClass> {
     match plating {
-        PlatingKind::Via | PlatingKind::ViaCapped => HoleClass::Via,
-        PlatingKind::Plated => HoleClass::Pth,
-        PlatingKind::NonPlated => HoleClass::Npth,
-        PlatingKind::Unknown | PlatingKind::None => HoleClass::Unknown,
+        PlatingKind::Via | PlatingKind::ViaCapped => Some(HoleClass::Via),
+        PlatingKind::Plated => Some(HoleClass::Pth),
+        PlatingKind::NonPlated => Some(HoleClass::Npth),
+        PlatingKind::Unknown | PlatingKind::None => None,
     }
 }
 
@@ -725,15 +703,7 @@ mod tests {
               <Oval width="1.8" height="0.6"/>"#,
         );
 
-        let (_, slots) = collect_drilled(
-            &ipc,
-            ArtworkScope::Board,
-            Needs {
-                slots: true,
-                ..Needs::default()
-            },
-        )
-        .unwrap();
+        let (_, slots) = collect_drilled(&ipc, ArtworkScope::Board).unwrap();
 
         assert_eq!(slots.len(), 1);
         let SlotWidth::Nominal(width) = slots[0].width else {
@@ -757,15 +727,7 @@ mod tests {
               </Outline>"#,
         );
 
-        let (_, slots) = collect_drilled(
-            &ipc,
-            ArtworkScope::Board,
-            Needs {
-                slots: true,
-                ..Needs::default()
-            },
-        )
-        .unwrap();
+        let (_, slots) = collect_drilled(&ipc, ArtworkScope::Board).unwrap();
 
         assert_eq!(slots.len(), 1);
         let SlotWidth::Geometry(geometry) = &slots[0].width else {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
@@ -124,15 +124,16 @@ pub struct RuleResult {
 
 impl RuleResult {
     pub fn new(rule: &Rule) -> Self {
+        let semantics = rule.kind.semantics();
         Self {
             id: rule.id.clone(),
             title: rule.title.clone(),
             severity: rule.severity,
             status: RuleStatus::Pass,
             limit: RuleLimit::from_length(&rule.limit),
-            subject: rule.kind.subject(),
-            quantity: rule.kind.quantity(),
-            method: rule.kind.method(),
+            subject: semantics.subject,
+            quantity: semantics.quantity,
+            method: semantics.method,
             checked: 0,
             finding_count: 0,
             waived_count: 0,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -164,15 +164,98 @@ impl RuleKind {
     pub fn method(self) -> &'static str {
         match self {
             Self::HoleDiameter(_) => "ipc_hole_diameter",
-            Self::SlotWidth => "ipc_slot_width_or_outline_boundary_distance",
+            Self::SlotWidth => "ipc_slot_width_or_outline_medial_axis_width",
             Self::HolePairClearance => "circle_edge_distance",
             Self::AnnularRing(_) => "maximal_centered_disk_minus_hole_radius",
             Self::LineworkToCopperClearance(_) => "segment_to_filled_region_boundary",
             Self::BoardArrayPairClearance => "filled_profile_boundary_distance",
-            Self::ThinFeature(_) => "opening_candidate_then_boundary_distance",
-            Self::ThinGap(_) => "closing_candidate_then_boundary_distance",
+            Self::ThinFeature(_) => "opening_candidate_then_medial_axis_width",
+            Self::ThinGap(_) => "closing_candidate_then_medial_axis_width",
         }
     }
+}
+
+/// The entity pools a rule reads. Extraction builds exactly the union over
+/// the configured rules, so a rule set pays only for what it measures.
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct Pools {
+    pub drilled: bool,
+    pub copper: bool,
+    pub copper_boundaries: bool,
+    pub hole_lands: bool,
+    pub masks: bool,
+    pub scores: bool,
+    pub board_outlines: bool,
+    pub board_arrays: bool,
+}
+
+impl std::ops::BitOr for Pools {
+    type Output = Self;
+
+    fn bitor(self, other: Self) -> Self {
+        Self {
+            drilled: self.drilled || other.drilled,
+            copper: self.copper || other.copper,
+            copper_boundaries: self.copper_boundaries || other.copper_boundaries,
+            hole_lands: self.hole_lands || other.hole_lands,
+            masks: self.masks || other.masks,
+            scores: self.scores || other.scores,
+            board_outlines: self.board_outlines || other.board_outlines,
+            board_arrays: self.board_arrays || other.board_arrays,
+        }
+    }
+}
+
+impl RuleKind {
+    pub fn pools(self) -> Pools {
+        let none = Pools::default();
+        match self {
+            Self::HoleDiameter(_) | Self::HolePairClearance | Self::SlotWidth => Pools {
+                drilled: true,
+                ..none
+            },
+            Self::AnnularRing(_) => Pools {
+                drilled: true,
+                copper: true,
+                copper_boundaries: true,
+                hole_lands: true,
+                ..none
+            },
+            Self::LineworkToCopperClearance(Linework::VScore) => Pools {
+                scores: true,
+                copper: true,
+                copper_boundaries: true,
+                ..none
+            },
+            Self::LineworkToCopperClearance(Linework::BoardEdge) => Pools {
+                board_outlines: true,
+                copper: true,
+                copper_boundaries: true,
+                ..none
+            },
+            Self::BoardArrayPairClearance => Pools {
+                board_arrays: true,
+                ..none
+            },
+            Self::ThinFeature(ImageSel::Copper) | Self::ThinGap(ImageSel::Copper) => Pools {
+                copper: true,
+                ..none
+            },
+            Self::ThinFeature(ImageSel::Soldermask) | Self::ThinGap(ImageSel::Soldermask) => {
+                Pools {
+                    masks: true,
+                    ..none
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn pools(rules: &[Rule]) -> Pools {
+    rules
+        .iter()
+        .map(|rule| rule.kind.pools())
+        .fold(Pools::default(), |union, pools| union | pools)
 }
 
 /// Lower every configured capability to its rules. Absent capabilities lower

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -56,32 +56,71 @@ pub(super) enum ImageSel {
 }
 
 impl RuleKind {
-    pub fn needs(self) -> Needs {
-        let mut needs = Needs::default();
+    /// The title every finding of this rule carries.
+    pub fn finding_title(self) -> String {
         match self {
-            Self::HoleDiameter(_) | Self::HolePairClearance => needs.holes = true,
-            Self::SlotWidth => needs.slots = true,
-            Self::AnnularRing(_) => {
-                needs.holes = true;
-                needs.copper = true;
+            Self::HoleDiameter(class) => {
+                format!("{} hole is below minimum diameter", class.label())
             }
+            Self::SlotWidth => "Slot is below minimum width".to_owned(),
+            Self::HolePairClearance => "Hole-to-hole clearance is below minimum".to_owned(),
+            Self::AnnularRing(class) => format!("{} annular ring is below minimum", class.label()),
             Self::LineworkToCopperClearance(Linework::VScore) => {
-                needs.scores = true;
-                needs.copper = true;
+                "V-score centerline is too close to copper".to_owned()
             }
             Self::LineworkToCopperClearance(Linework::BoardEdge) => {
-                needs.board_outlines = true;
-                needs.copper = true;
+                "Board edge is too close to copper".to_owned()
             }
-            Self::BoardArrayPairClearance => needs.board_arrays = true,
-            Self::ThinFeature(ImageSel::Copper) | Self::ThinGap(ImageSel::Copper) => {
-                needs.copper = true;
+            Self::BoardArrayPairClearance => "Board arrays are too close together".to_owned(),
+            Self::ThinFeature(ImageSel::Copper) => {
+                "Copper feature is below minimum width".to_owned()
             }
-            Self::ThinFeature(ImageSel::Soldermask) | Self::ThinGap(ImageSel::Soldermask) => {
-                needs.masks = true;
+            Self::ThinGap(ImageSel::Copper) => "Copper spacing is below minimum".to_owned(),
+            Self::ThinFeature(ImageSel::Soldermask) => {
+                "Soldermask feature is below minimum width".to_owned()
             }
+            Self::ThinGap(ImageSel::Soldermask) => "Soldermask web is below minimum".to_owned(),
         }
-        needs
+    }
+
+    /// The measured quantity as prose, for finding messages.
+    pub fn quantity_label(self) -> String {
+        match self {
+            Self::HoleDiameter(class) => format!("{} hole diameter", class.label()),
+            Self::SlotWidth => "routed slot width".to_owned(),
+            Self::HolePairClearance => "hole edge-to-edge clearance".to_owned(),
+            Self::AnnularRing(class) => format!("{} annular ring", class.label()),
+            Self::LineworkToCopperClearance(Linework::VScore) => {
+                "V-score centerline-to-copper clearance".to_owned()
+            }
+            Self::LineworkToCopperClearance(Linework::BoardEdge) => {
+                "board-edge-to-copper clearance".to_owned()
+            }
+            Self::BoardArrayPairClearance => "board-array outline spacing".to_owned(),
+            Self::ThinFeature(ImageSel::Copper) => "copper feature width".to_owned(),
+            Self::ThinGap(ImageSel::Copper) => "copper-to-copper clearance".to_owned(),
+            Self::ThinFeature(ImageSel::Soldermask) => "soldermask feature width".to_owned(),
+            Self::ThinGap(ImageSel::Soldermask) => "soldermask web width".to_owned(),
+        }
+    }
+
+    /// The roles of a finding's two witness points: the ends of the measured
+    /// distance.
+    pub fn witness_roles(self) -> [&'static str; 2] {
+        match self {
+            Self::HoleDiameter(_) => ["hole_boundary", "hole_boundary"],
+            Self::SlotWidth => ["first_slot_boundary", "second_slot_boundary"],
+            Self::HolePairClearance => ["first_hole_boundary", "second_hole_boundary"],
+            Self::AnnularRing(_) => ["hole_boundary", "copper_boundary"],
+            Self::LineworkToCopperClearance(Linework::VScore) => {
+                ["vscore_centerline", "copper_boundary"]
+            }
+            Self::LineworkToCopperClearance(Linework::BoardEdge) => {
+                ["board_outline", "copper_boundary"]
+            }
+            Self::BoardArrayPairClearance => ["first_board_array", "second_board_array"],
+            Self::ThinFeature(_) | Self::ThinGap(_) => ["first_boundary", "second_boundary"],
+        }
     }
 
     /// What one `checked` unit is for this rule.
@@ -125,7 +164,7 @@ impl RuleKind {
     pub fn method(self) -> &'static str {
         match self {
             Self::HoleDiameter(_) => "ipc_hole_diameter",
-            Self::SlotWidth => "ipc_nominal_or_outline_boundary_distance",
+            Self::SlotWidth => "ipc_slot_width_or_outline_boundary_distance",
             Self::HolePairClearance => "circle_edge_distance",
             Self::AnnularRing(_) => "maximal_centered_disk_minus_hole_radius",
             Self::LineworkToCopperClearance(_) => "segment_to_filled_region_boundary",
@@ -134,40 +173,6 @@ impl RuleKind {
             Self::ThinGap(_) => "closing_candidate_then_boundary_distance",
         }
     }
-}
-
-/// Which entity pools the configured rules read; extraction builds exactly
-/// this union.
-#[derive(Debug, Clone, Copy, Default)]
-pub(super) struct Needs {
-    pub holes: bool,
-    pub slots: bool,
-    pub copper: bool,
-    pub masks: bool,
-    pub scores: bool,
-    pub board_outlines: bool,
-    pub board_arrays: bool,
-}
-
-impl Needs {
-    fn union(self, other: Self) -> Self {
-        Self {
-            holes: self.holes || other.holes,
-            slots: self.slots || other.slots,
-            copper: self.copper || other.copper,
-            masks: self.masks || other.masks,
-            scores: self.scores || other.scores,
-            board_outlines: self.board_outlines || other.board_outlines,
-            board_arrays: self.board_arrays || other.board_arrays,
-        }
-    }
-}
-
-pub(super) fn needs(rules: &[Rule]) -> Needs {
-    rules
-        .iter()
-        .map(|rule| rule.kind.needs())
-        .fold(Needs::default(), Needs::union)
 }
 
 /// Lower every configured capability to its rules. Absent capabilities lower

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -55,124 +55,18 @@ pub(super) enum ImageSel {
     Soldermask,
 }
 
-impl RuleKind {
-    /// The title every finding of this rule carries.
-    pub fn finding_title(self) -> String {
-        match self {
-            Self::HoleDiameter(class) => {
-                format!("{} hole is below minimum diameter", class.label())
-            }
-            Self::SlotWidth => "Slot is below minimum width".to_owned(),
-            Self::HolePairClearance => "Hole-to-hole clearance is below minimum".to_owned(),
-            Self::AnnularRing(class) => format!("{} annular ring is below minimum", class.label()),
-            Self::LineworkToCopperClearance(Linework::VScore) => {
-                "V-score centerline is too close to copper".to_owned()
-            }
-            Self::LineworkToCopperClearance(Linework::BoardEdge) => {
-                "Board edge is too close to copper".to_owned()
-            }
-            Self::BoardArrayPairClearance => "Board arrays are too close together".to_owned(),
-            Self::ThinFeature(ImageSel::Copper) => {
-                "Copper feature is below minimum width".to_owned()
-            }
-            Self::ThinGap(ImageSel::Copper) => "Copper spacing is below minimum".to_owned(),
-            Self::ThinFeature(ImageSel::Soldermask) => {
-                "Soldermask feature is below minimum width".to_owned()
-            }
-            Self::ThinGap(ImageSel::Soldermask) => "Soldermask web is below minimum".to_owned(),
-        }
-    }
-
-    /// The measured quantity as prose, for finding messages.
-    pub fn quantity_label(self) -> String {
-        match self {
-            Self::HoleDiameter(class) => format!("{} hole diameter", class.label()),
-            Self::SlotWidth => "routed slot width".to_owned(),
-            Self::HolePairClearance => "hole edge-to-edge clearance".to_owned(),
-            Self::AnnularRing(class) => format!("{} annular ring", class.label()),
-            Self::LineworkToCopperClearance(Linework::VScore) => {
-                "V-score centerline-to-copper clearance".to_owned()
-            }
-            Self::LineworkToCopperClearance(Linework::BoardEdge) => {
-                "board-edge-to-copper clearance".to_owned()
-            }
-            Self::BoardArrayPairClearance => "board-array outline spacing".to_owned(),
-            Self::ThinFeature(ImageSel::Copper) => "copper feature width".to_owned(),
-            Self::ThinGap(ImageSel::Copper) => "copper-to-copper clearance".to_owned(),
-            Self::ThinFeature(ImageSel::Soldermask) => "soldermask feature width".to_owned(),
-            Self::ThinGap(ImageSel::Soldermask) => "soldermask web width".to_owned(),
-        }
-    }
-
-    /// The roles of a finding's two witness points: the ends of the measured
-    /// distance.
-    pub fn witness_roles(self) -> [&'static str; 2] {
-        match self {
-            Self::HoleDiameter(_) => ["hole_boundary", "hole_boundary"],
-            Self::SlotWidth => ["first_slot_boundary", "second_slot_boundary"],
-            Self::HolePairClearance => ["first_hole_boundary", "second_hole_boundary"],
-            Self::AnnularRing(_) => ["hole_boundary", "copper_boundary"],
-            Self::LineworkToCopperClearance(Linework::VScore) => {
-                ["vscore_centerline", "copper_boundary"]
-            }
-            Self::LineworkToCopperClearance(Linework::BoardEdge) => {
-                ["board_outline", "copper_boundary"]
-            }
-            Self::BoardArrayPairClearance => ["first_board_array", "second_board_array"],
-            Self::ThinFeature(_) | Self::ThinGap(_) => ["first_boundary", "second_boundary"],
-        }
-    }
-
-    /// What one `checked` unit is for this rule.
-    pub fn subject(self) -> &'static str {
-        match self {
-            Self::HoleDiameter(_) | Self::HolePairClearance => "hole",
-            Self::SlotWidth => "slot",
-            Self::AnnularRing(_) => "hole_layer_pair",
-            Self::LineworkToCopperClearance(Linework::VScore) => "score_layer_pair",
-            Self::LineworkToCopperClearance(Linework::BoardEdge) => "outline_layer_pair",
-            Self::BoardArrayPairClearance => "array_pair",
-            Self::ThinFeature(ImageSel::Copper) | Self::ThinGap(ImageSel::Copper) => "copper_layer",
-            Self::ThinFeature(ImageSel::Soldermask) | Self::ThinGap(ImageSel::Soldermask) => {
-                "soldermask_layer"
-            }
-        }
-    }
-
-    /// The measured quantity every finding of this rule reports.
-    pub fn quantity(self) -> &'static str {
-        match self {
-            Self::HoleDiameter(_) => "hole_diameter",
-            Self::SlotWidth => "slot_width",
-            Self::HolePairClearance => "hole_edge_to_hole_edge_clearance",
-            Self::AnnularRing(_) => "annular_ring",
-            Self::LineworkToCopperClearance(Linework::VScore) => {
-                "vscore_centerline_to_copper_clearance"
-            }
-            Self::LineworkToCopperClearance(Linework::BoardEdge) => {
-                "board_edge_to_copper_clearance"
-            }
-            Self::BoardArrayPairClearance => "board_array_outline_spacing",
-            Self::ThinFeature(ImageSel::Copper) => "copper_feature_width",
-            Self::ThinGap(ImageSel::Copper) => "copper_to_copper_clearance",
-            Self::ThinFeature(ImageSel::Soldermask) => "soldermask_feature_width",
-            Self::ThinGap(ImageSel::Soldermask) => "soldermask_web_width",
-        }
-    }
-
-    /// How the quantity is measured.
-    pub fn method(self) -> &'static str {
-        match self {
-            Self::HoleDiameter(_) => "ipc_hole_diameter",
-            Self::SlotWidth => "ipc_slot_width_or_outline_medial_axis_width",
-            Self::HolePairClearance => "circle_edge_distance",
-            Self::AnnularRing(_) => "maximal_centered_disk_minus_hole_radius",
-            Self::LineworkToCopperClearance(_) => "segment_to_filled_region_boundary",
-            Self::BoardArrayPairClearance => "filled_profile_boundary_distance",
-            Self::ThinFeature(_) => "opening_candidate_then_medial_axis_width",
-            Self::ThinGap(_) => "closing_candidate_then_medial_axis_width",
-        }
-    }
+/// Everything the engine and report know about a rule kind, in one table:
+/// what one `checked` unit is, the measured quantity and method, how a
+/// finding is titled and phrased, the roles of its two witness points, and
+/// the pools it reads.
+pub(super) struct Semantics {
+    pub subject: &'static str,
+    pub quantity: &'static str,
+    pub method: &'static str,
+    pub finding_title: String,
+    pub quantity_label: String,
+    pub witness_roles: [&'static str; 2],
+    pub pools: Pools,
 }
 
 /// The entity pools a rule reads. Extraction builds exactly the union over
@@ -206,47 +100,157 @@ impl std::ops::BitOr for Pools {
     }
 }
 
+const DRILLED: Pools = Pools {
+    drilled: true,
+    copper: false,
+    copper_boundaries: false,
+    hole_lands: false,
+    masks: false,
+    scores: false,
+    board_outlines: false,
+    board_arrays: false,
+};
+const COPPER: Pools = Pools {
+    copper: true,
+    ..DRILLED
+};
+const COPPER_BOUNDARIES: Pools = Pools {
+    copper_boundaries: true,
+    ..COPPER
+};
+const NONE: Pools = Pools {
+    drilled: false,
+    ..DRILLED
+};
+
 impl RuleKind {
-    pub fn pools(self) -> Pools {
-        let none = Pools::default();
+    pub fn semantics(self) -> Semantics {
         match self {
-            Self::HoleDiameter(_) | Self::HolePairClearance | Self::SlotWidth => Pools {
-                drilled: true,
-                ..none
+            Self::HoleDiameter(class) => Semantics {
+                subject: "hole",
+                quantity: "hole_diameter",
+                method: "ipc_hole_diameter",
+                finding_title: format!("{} hole is below minimum diameter", class.label()),
+                quantity_label: format!("{} hole diameter", class.label()),
+                witness_roles: ["hole_boundary", "hole_boundary"],
+                pools: DRILLED,
             },
-            Self::AnnularRing(_) => Pools {
-                drilled: true,
-                copper: true,
-                copper_boundaries: true,
-                hole_lands: true,
-                ..none
+            Self::SlotWidth => Semantics {
+                subject: "slot",
+                quantity: "slot_width",
+                method: "ipc_slot_width_or_outline_medial_axis_width",
+                finding_title: "Slot is below minimum width".to_owned(),
+                quantity_label: "routed slot width".to_owned(),
+                witness_roles: ["first_slot_boundary", "second_slot_boundary"],
+                pools: DRILLED,
             },
-            Self::LineworkToCopperClearance(Linework::VScore) => Pools {
-                scores: true,
-                copper: true,
-                copper_boundaries: true,
-                ..none
+            Self::HolePairClearance => Semantics {
+                subject: "hole",
+                quantity: "hole_edge_to_hole_edge_clearance",
+                method: "circle_edge_distance",
+                finding_title: "Hole-to-hole clearance is below minimum".to_owned(),
+                quantity_label: "hole edge-to-edge clearance".to_owned(),
+                witness_roles: ["first_hole_boundary", "second_hole_boundary"],
+                pools: DRILLED,
             },
-            Self::LineworkToCopperClearance(Linework::BoardEdge) => Pools {
-                board_outlines: true,
-                copper: true,
-                copper_boundaries: true,
-                ..none
+            Self::AnnularRing(class) => Semantics {
+                subject: "hole_layer_pair",
+                quantity: "annular_ring",
+                method: "maximal_centered_disk_minus_hole_radius",
+                finding_title: format!("{} annular ring is below minimum", class.label()),
+                quantity_label: format!("{} annular ring", class.label()),
+                witness_roles: ["hole_boundary", "copper_boundary"],
+                pools: Pools {
+                    hole_lands: true,
+                    ..COPPER_BOUNDARIES
+                },
             },
-            Self::BoardArrayPairClearance => Pools {
-                board_arrays: true,
-                ..none
+            Self::LineworkToCopperClearance(Linework::VScore) => Semantics {
+                subject: "score_layer_pair",
+                quantity: "vscore_centerline_to_copper_clearance",
+                method: "segment_to_filled_region_boundary",
+                finding_title: "V-score centerline is too close to copper".to_owned(),
+                quantity_label: "V-score centerline-to-copper clearance".to_owned(),
+                witness_roles: ["vscore_centerline", "copper_boundary"],
+                pools: Pools {
+                    scores: true,
+                    drilled: false,
+                    ..COPPER_BOUNDARIES
+                },
             },
-            Self::ThinFeature(ImageSel::Copper) | Self::ThinGap(ImageSel::Copper) => Pools {
-                copper: true,
-                ..none
+            Self::LineworkToCopperClearance(Linework::BoardEdge) => Semantics {
+                subject: "outline_layer_pair",
+                quantity: "board_edge_to_copper_clearance",
+                method: "segment_to_filled_region_boundary",
+                finding_title: "Board edge is too close to copper".to_owned(),
+                quantity_label: "board-edge-to-copper clearance".to_owned(),
+                witness_roles: ["board_outline", "copper_boundary"],
+                pools: Pools {
+                    board_outlines: true,
+                    drilled: false,
+                    ..COPPER_BOUNDARIES
+                },
             },
-            Self::ThinFeature(ImageSel::Soldermask) | Self::ThinGap(ImageSel::Soldermask) => {
-                Pools {
+            Self::BoardArrayPairClearance => Semantics {
+                subject: "array_pair",
+                quantity: "board_array_outline_spacing",
+                method: "filled_profile_boundary_distance",
+                finding_title: "Board arrays are too close together".to_owned(),
+                quantity_label: "board-array outline spacing".to_owned(),
+                witness_roles: ["first_board_array", "second_board_array"],
+                pools: Pools {
+                    board_arrays: true,
+                    ..NONE
+                },
+            },
+            Self::ThinFeature(ImageSel::Copper) => Semantics {
+                subject: "copper_layer",
+                quantity: "copper_feature_width",
+                method: "opening_candidate_then_medial_axis_width",
+                finding_title: "Copper feature is below minimum width".to_owned(),
+                quantity_label: "copper feature width".to_owned(),
+                witness_roles: ["first_boundary", "second_boundary"],
+                pools: Pools {
+                    drilled: false,
+                    ..COPPER
+                },
+            },
+            Self::ThinGap(ImageSel::Copper) => Semantics {
+                subject: "copper_layer",
+                quantity: "copper_to_copper_clearance",
+                method: "closing_candidate_then_medial_axis_width",
+                finding_title: "Copper spacing is below minimum".to_owned(),
+                quantity_label: "copper-to-copper clearance".to_owned(),
+                witness_roles: ["first_boundary", "second_boundary"],
+                pools: Pools {
+                    drilled: false,
+                    ..COPPER
+                },
+            },
+            Self::ThinFeature(ImageSel::Soldermask) => Semantics {
+                subject: "soldermask_layer",
+                quantity: "soldermask_feature_width",
+                method: "opening_candidate_then_medial_axis_width",
+                finding_title: "Soldermask feature is below minimum width".to_owned(),
+                quantity_label: "soldermask feature width".to_owned(),
+                witness_roles: ["first_boundary", "second_boundary"],
+                pools: Pools {
                     masks: true,
-                    ..none
-                }
-            }
+                    ..NONE
+                },
+            },
+            Self::ThinGap(ImageSel::Soldermask) => Semantics {
+                subject: "soldermask_layer",
+                quantity: "soldermask_web_width",
+                method: "closing_candidate_then_medial_axis_width",
+                finding_title: "Soldermask web is below minimum".to_owned(),
+                quantity_label: "soldermask web width".to_owned(),
+                witness_roles: ["first_boundary", "second_boundary"],
+                pools: Pools {
+                    masks: true,
+                    ..NONE
+                },
+            },
         }
     }
 }
@@ -254,7 +258,7 @@ impl RuleKind {
 pub(super) fn pools(rules: &[Rule]) -> Pools {
     rules
         .iter()
-        .map(|rule| rule.kind.pools())
+        .map(|rule| rule.kind.semantics().pools)
         .fold(Pools::default(), |union, pools| union | pools)
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -59,10 +59,15 @@ impl RuleKind {
     pub fn needs(self) -> Needs {
         let mut needs = Needs::default();
         match self {
-            Self::HoleDiameter(_) | Self::HolePairClearance => needs.holes = true,
+            Self::HoleDiameter(_) => {
+                needs.holes = true;
+                needs.classified_holes = true;
+            }
+            Self::HolePairClearance => needs.holes = true,
             Self::SlotWidth => needs.slots = true,
             Self::AnnularRing(_) => {
                 needs.holes = true;
+                needs.classified_holes = true;
                 needs.copper = true;
             }
             Self::LineworkToCopperClearance(Linework::VScore) => {
@@ -125,13 +130,13 @@ impl RuleKind {
     pub fn method(self) -> &'static str {
         match self {
             Self::HoleDiameter(_) => "ipc_hole_diameter",
-            Self::SlotWidth => "ipc_slot_width",
+            Self::SlotWidth => "ipc_nominal_or_outline_boundary_distance",
             Self::HolePairClearance => "circle_edge_distance",
             Self::AnnularRing(_) => "maximal_centered_disk_minus_hole_radius",
             Self::LineworkToCopperClearance(_) => "segment_to_filled_region_boundary",
             Self::BoardArrayPairClearance => "filled_profile_boundary_distance",
-            Self::ThinFeature(_) => "morphological_opening_residue",
-            Self::ThinGap(_) => "morphological_closing_residue",
+            Self::ThinFeature(_) => "opening_candidate_then_boundary_distance",
+            Self::ThinGap(_) => "closing_candidate_then_boundary_distance",
         }
     }
 }
@@ -141,6 +146,9 @@ impl RuleKind {
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct Needs {
     pub holes: bool,
+    /// Class-specific rules cannot certify a hole whose plating intent is
+    /// absent or unknown; extraction fails closed when this is set.
+    pub classified_holes: bool,
     pub slots: bool,
     pub copper: bool,
     pub masks: bool,
@@ -153,6 +161,7 @@ impl Needs {
     fn union(self, other: Self) -> Self {
         Self {
             holes: self.holes || other.holes,
+            classified_holes: self.classified_holes || other.classified_holes,
             slots: self.slots || other.slots,
             copper: self.copper || other.copper,
             masks: self.masks || other.masks,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -59,15 +59,10 @@ impl RuleKind {
     pub fn needs(self) -> Needs {
         let mut needs = Needs::default();
         match self {
-            Self::HoleDiameter(_) => {
-                needs.holes = true;
-                needs.classified_holes = true;
-            }
-            Self::HolePairClearance => needs.holes = true,
+            Self::HoleDiameter(_) | Self::HolePairClearance => needs.holes = true,
             Self::SlotWidth => needs.slots = true,
             Self::AnnularRing(_) => {
                 needs.holes = true;
-                needs.classified_holes = true;
                 needs.copper = true;
             }
             Self::LineworkToCopperClearance(Linework::VScore) => {
@@ -146,9 +141,6 @@ impl RuleKind {
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct Needs {
     pub holes: bool,
-    /// Class-specific rules cannot certify a hole whose plating intent is
-    /// absent or unknown; extraction fails closed when this is set.
-    pub classified_holes: bool,
     pub slots: bool,
     pub copper: bool,
     pub masks: bool,
@@ -161,7 +153,6 @@ impl Needs {
     fn union(self, other: Self) -> Self {
         Self {
             holes: self.holes || other.holes,
-            classified_holes: self.classified_holes || other.classified_holes,
             slots: self.slots || other.slots,
             copper: self.copper || other.copper,
             masks: self.masks || other.masks,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -269,7 +269,7 @@ fn create_fab_panel_xml(source_xml: &[String], occurrences: &[usize]) -> Result<
         .map(|creation| creation.xml)
 }
 
-fn create_fab_panel(
+pub(crate) fn create_fab_panel(
     source_xml: &[String],
     occurrences: &[usize],
     spec: FabPanelSpec,

--- a/crates/pcb-ir/src/geom/bbox.rs
+++ b/crates/pcb-ir/src/geom/bbox.rs
@@ -48,6 +48,20 @@ impl BBox {
             && self.max.y >= other.min.y
     }
 
+    /// Euclidean separation of two bounds: zero when they touch or overlap.
+    /// Each enclosed region is a subset of its bounds, so this is a lower
+    /// bound on the regions' clearance: a bound that meets a minimum proves
+    /// the regions meet it too.
+    pub fn distance_to(self, other: BBox) -> f64 {
+        let x = (other.min.x - self.max.x)
+            .max(self.min.x - other.max.x)
+            .max(0.0);
+        let y = (other.min.y - self.max.y)
+            .max(self.min.y - other.max.y)
+            .max(0.0);
+        x.hypot(y)
+    }
+
     pub fn expand(self, amount: f64) -> Self {
         if self.is_empty() {
             return self;

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -559,18 +559,6 @@ mod tests {
     }
 
     #[test]
-    fn short_gaps_are_not_filtered_out_of_clearance() {
-        let left = rect_region(0.0, 0.0, 0.05, 0.05);
-        let right = rect_region(0.11, 0.0, 0.16, 0.05);
-        let region = left.union(&right);
-
-        let findings = thin_gaps(&region, 0.1);
-
-        assert_eq!(findings.len(), 1);
-        assert!((findings[0].width.mm - 0.06).abs() < 1e-9);
-    }
-
-    #[test]
     fn exact_minimums_are_not_morphology_false_positives() {
         let feature = rect_region(0.0, 0.0, 1.0, 0.1);
         let disk = ContourSet::from_filled_contours(
@@ -599,12 +587,49 @@ mod tests {
             tol::REGION_MM,
         );
         let width = min_width(&stadium).expect("a stadium has facing walls");
-        assert!((width.mm - 0.6).abs() < 1e-6, "width {}", width.mm);
+        // The flattened arc's inscribed disk is its apothem, short of the
+        // true radius by at most one flattening tolerance per side.
+        assert!(
+            (0.0..=width.uncertainty_mm).contains(&(0.6 - width.mm)),
+            "width {}",
+            width.mm
+        );
         assert_eq!(width.uncertainty_mm, 2.0 * tol::FLATTEN_MM);
 
         let plate = rect_region(0.0, 0.0, 10.0, 3.0);
         assert!((min_width(&plate).unwrap().mm - 3.0).abs() < 1e-9);
         assert!(min_width(&ContourSet::empty(tol::REGION_MM)).is_none());
+    }
+
+    #[test]
+    fn tapered_tip_is_measured_at_its_tip() {
+        // A plate with a trapezoidal spur narrowing from 0.4 mm to 0.05 mm:
+        // the tip is the width, though its walls are far from parallel.
+        let region = ContourSet::from_contours(
+            &[ContourBuf::new(vec![
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(10.0, 0.0)),
+                PathCmd::line_to(Point::new(10.0, 4.8)),
+                PathCmd::line_to(Point::new(12.0, 4.975)),
+                PathCmd::line_to(Point::new(12.0, 5.025)),
+                PathCmd::line_to(Point::new(10.0, 5.2)),
+                PathCmd::line_to(Point::new(10.0, 10.0)),
+                PathCmd::line_to(Point::new(0.0, 10.0)),
+                PathCmd::close(),
+            ])],
+            FillRule::NonZero,
+            tol::REGION_MM,
+        );
+
+        let findings = thin_features(&region, 0.1);
+
+        assert_eq!(findings.len(), 1);
+        let width = findings[0].width;
+        assert!((width.mm - 0.05).abs() < 0.01, "width {}", width.mm);
+        assert!(
+            width.first.x > 11.5 && width.second.x > 11.5,
+            "witnesses at the tip"
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -1,4 +1,9 @@
 //! Geometry measurements shared by manufacturability checks.
+//!
+//! Every query here answers with a [`Distance`]: a signed length between
+//! two witness points, carrying the uncertainty of the flattened boundaries
+//! it was measured against. Deciding whether a distance violates a limit is
+//! the caller's policy, via [`Distance::certainly_below`].
 
 use std::collections::HashMap;
 
@@ -8,25 +13,14 @@ use crate::geom::point::Point;
 use crate::geom::region::{ContourSet, Ring, TwoSidedResidualComponent, ring_edges};
 use crate::geom::tol;
 
-pub use crate::geom::dist::ClearanceMeasurement;
-
-/// The minimum radial material enclosure around a circular cutout whose
-/// center lies in the material.
-///
-/// `enclosure_mm` is signed. A positive value is material outside the cutout;
-/// a negative value is the amount by which the cutout breaches the material.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct CircularEnclosureMeasurement {
-    pub enclosure_mm: f64,
-    pub cutout_boundary: Point,
-    pub material_boundary: Point,
-}
+pub use crate::geom::dist::Distance;
 
 /// Uniform-grid index over a region's boundary segments.
 ///
 /// DFM rules ask whether thousands of points and segments lie within a small
 /// clearance of the same composed layer boundary. This keeps those queries
-/// local instead of walking every polygon edge for every query.
+/// local instead of walking every polygon edge for every query. Every
+/// answer counts the region boundary as one flattened input.
 #[derive(Debug, Clone)]
 pub struct RegionBoundaryIndex {
     cell_size_mm: f64,
@@ -48,9 +42,9 @@ impl RegionBoundaryIndex {
         let segments = region.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
         let mut cells: HashMap<(i64, i64), Vec<u32>> = HashMap::new();
         for (index, &(start, end)) in segments.iter().enumerate() {
-            corridor_cells(start, end, 0.0, cell_size_mm, |cell| {
+            for cell in corridor_cells(start, end, 0.0, cell_size_mm) {
                 cells.entry(cell).or_default().push(index as u32);
-            });
+            }
         }
         Self {
             cell_size_mm,
@@ -60,34 +54,15 @@ impl RegionBoundaryIndex {
     }
 
     /// Nearest boundary point no farther than `max_distance_mm` from `point`.
-    pub fn nearest_within(
-        &self,
-        point: Point,
-        max_distance_mm: f64,
-    ) -> Option<ClearanceMeasurement> {
-        let min_x = grid_cell(point.x - max_distance_mm, self.cell_size_mm);
-        let max_x = grid_cell(point.x + max_distance_mm, self.cell_size_mm);
-        let min_y = grid_cell(point.y - max_distance_mm, self.cell_size_mm);
-        let max_y = grid_cell(point.y + max_distance_mm, self.cell_size_mm);
-        let mut nearest: Option<ClearanceMeasurement> = None;
-        for x in min_x..=max_x {
-            for y in min_y..=max_y {
-                for &index in self.cells.get(&(x, y)).into_iter().flatten() {
-                    let (start, end) = self.segments[index as usize];
-                    let (distance_mm, boundary) = dist::point_segment(point, start, end);
-                    if distance_mm <= max_distance_mm + tol::EPSILON_MM
-                        && nearest.is_none_or(|current| distance_mm < current.distance_mm)
-                    {
-                        nearest = Some(ClearanceMeasurement {
-                            distance_mm,
-                            first: point,
-                            second: boundary,
-                        });
-                    }
-                }
-            }
-        }
-        nearest
+    pub fn nearest_within(&self, point: Point, max_distance_mm: f64) -> Option<Distance> {
+        let cells = corridor_cells(point, point, max_distance_mm, self.cell_size_mm);
+        self.segments_in(cells)
+            .map(|&(start, end)| {
+                let (mm, boundary) = dist::point_segment(point, start, end);
+                Distance::flattened(mm, point, boundary, 1)
+            })
+            .filter(|distance| distance.mm <= max_distance_mm + tol::EPSILON_MM)
+            .min_by(|left, right| left.mm.total_cmp(&right.mm))
     }
 
     /// Nearest boundary point no farther than `max_distance_mm` from the
@@ -97,25 +72,15 @@ impl RegionBoundaryIndex {
         start: Point,
         end: Point,
         max_distance_mm: f64,
-    ) -> Option<ClearanceMeasurement> {
-        let mut nearest: Option<ClearanceMeasurement> = None;
-        corridor_cells(start, end, max_distance_mm, self.cell_size_mm, |cell| {
-            for &index in self.cells.get(&cell).into_iter().flatten() {
-                let (edge_start, edge_end) = self.segments[index as usize];
-                let (distance_mm, on_query, on_boundary) =
-                    dist::segments(start, end, edge_start, edge_end);
-                if distance_mm <= max_distance_mm + tol::EPSILON_MM
-                    && nearest.is_none_or(|current| distance_mm < current.distance_mm)
-                {
-                    nearest = Some(ClearanceMeasurement {
-                        distance_mm,
-                        first: on_query,
-                        second: on_boundary,
-                    });
-                }
-            }
-        });
-        nearest
+    ) -> Option<Distance> {
+        let cells = corridor_cells(start, end, max_distance_mm, self.cell_size_mm);
+        self.segments_in(cells)
+            .map(|&(edge_start, edge_end)| {
+                let (mm, on_query, on_boundary) = dist::segments(start, end, edge_start, edge_end);
+                Distance::flattened(mm, on_query, on_boundary, 1)
+            })
+            .filter(|distance| distance.mm <= max_distance_mm + tol::EPSILON_MM)
+            .min_by(|left, right| left.mm.total_cmp(&right.mm))
     }
 
     /// The radial material enclosure of a circular cutout whose center lies
@@ -123,15 +88,16 @@ impl RegionBoundaryIndex {
     ///
     /// The largest disk centered at `center` inside the material has radius
     /// `d(center, boundary)`, so the enclosure is that distance minus the
-    /// cutout radius. `None` means the enclosure exceeds `max_enclosure_mm`;
-    /// comparing the returned measurement against a limit is the caller's
-    /// policy.
+    /// cutout radius: signed, negative by the depth the cutout breaches the
+    /// material. The witnesses are the cutout boundary and the material
+    /// boundary along the nearest direction. `None` means the enclosure
+    /// exceeds `max_enclosure_mm`.
     pub fn circular_enclosure(
         &self,
         center: Point,
         cutout_radius_mm: f64,
         max_enclosure_mm: f64,
-    ) -> Option<CircularEnclosureMeasurement> {
+    ) -> Option<Distance> {
         let search = (cutout_radius_mm + max_enclosure_mm).max(0.0);
         let nearest = self.nearest_within(center, search)?;
         let direction = nearest.second - center;
@@ -140,11 +106,25 @@ impl RegionBoundaryIndex {
         } else {
             direction / direction.length()
         };
-        Some(CircularEnclosureMeasurement {
-            enclosure_mm: nearest.distance_mm - cutout_radius_mm,
-            cutout_boundary: center + direction * cutout_radius_mm,
-            material_boundary: nearest.second,
-        })
+        Some(Distance::flattened(
+            nearest.mm - cutout_radius_mm,
+            center + direction * cutout_radius_mm,
+            nearest.second,
+            1,
+        ))
+    }
+
+    /// Every indexed segment registered in any of `cells`. A segment spanning
+    /// several cells is yielded once per cell; every consumer takes a
+    /// minimum, for which repeats are harmless.
+    fn segments_in(
+        &self,
+        cells: impl Iterator<Item = (i64, i64)>,
+    ) -> impl Iterator<Item = &(Point, Point)> {
+        cells
+            .filter_map(|cell| self.cells.get(&cell))
+            .flatten()
+            .map(|&index| &self.segments[index as usize])
     }
 }
 
@@ -152,20 +132,19 @@ fn grid_cell(value: f64, cell_size_mm: f64) -> i64 {
     (value / cell_size_mm).floor() as i64
 }
 
-/// Visit every grid cell within `radius_mm` of the segment, column by
-/// column, so long diagonal segments touch a linear number of cells instead
-/// of their whole bounding box.
+/// Every grid cell within `radius_mm` of the segment, column by column, so
+/// long diagonal segments touch a linear number of cells instead of their
+/// whole bounding box. A zero-length segment yields the cells around a point.
 fn corridor_cells(
     start: Point,
     end: Point,
     radius_mm: f64,
     cell_size_mm: f64,
-    mut visit: impl FnMut((i64, i64)),
-) {
+) -> impl Iterator<Item = (i64, i64)> {
     let min_column = grid_cell(start.x.min(end.x) - radius_mm, cell_size_mm);
     let max_column = grid_cell(start.x.max(end.x) + radius_mm, cell_size_mm);
     let delta = end - start;
-    for column in min_column..=max_column {
+    (min_column..=max_column).flat_map(move |column| {
         let column_min = column as f64 * cell_size_mm - radius_mm;
         let column_max = (column + 1) as f64 * cell_size_mm + radius_mm;
         let (t_min, t_max) = if delta.x.abs() <= f64::EPSILON {
@@ -182,53 +161,44 @@ fn corridor_cells(
         let y_at_max = start.y + delta.y * t_max;
         let min_row = grid_cell(y_at_min.min(y_at_max) - radius_mm, cell_size_mm);
         let max_row = grid_cell(y_at_min.max(y_at_max) + radius_mm, cell_size_mm);
-        for row in min_row..=max_row {
-            visit((column, row));
-        }
-    }
+        (min_row..=max_row).map(move |row| (column, row))
+    })
 }
 
 /// Set distance between two closed disks: `max(0, ‖c₁ − c₂‖ − r₁ − r₂)`,
-/// with the boundary witness points along the center line.
+/// with the boundary witness points along the center line. Exact.
 pub fn disk_clearance(
     first_center: Point,
     first_radius_mm: f64,
     second_center: Point,
     second_radius_mm: f64,
-) -> ClearanceMeasurement {
+) -> Distance {
     let delta = second_center - first_center;
     let length = delta.length();
     if length <= f64::EPSILON {
-        return ClearanceMeasurement {
-            distance_mm: 0.0,
-            first: first_center,
-            second: second_center,
-        };
+        return Distance::exact(0.0, first_center, second_center);
     }
     let direction = delta / length;
-    ClearanceMeasurement {
-        distance_mm: (length - first_radius_mm - second_radius_mm).max(0.0),
-        first: first_center + direction * first_radius_mm,
-        second: second_center - direction * second_radius_mm,
-    }
+    Distance::exact(
+        (length - first_radius_mm - second_radius_mm).max(0.0),
+        first_center + direction * first_radius_mm,
+        second_center - direction * second_radius_mm,
+    )
 }
 
 /// Shortest boundary-to-boundary clearance between two filled regions.
 ///
-/// Overlapping, contained, or touching regions have zero clearance. `None`
-/// means at least one input is empty.
-pub fn region_clearance(first: &ContourSet, second: &ContourSet) -> Option<ClearanceMeasurement> {
+/// Overlapping, contained, or touching regions have zero clearance. Both
+/// boundaries count as flattened inputs. `None` means at least one input is
+/// empty: an empty set has no nearest point.
+pub fn region_clearance(first: &ContourSet, second: &ContourSet) -> Option<Distance> {
     if first.is_empty() || second.is_empty() {
         return None;
     }
 
     if let Some(point) = contained_vertex(first, second).or_else(|| contained_vertex(second, first))
     {
-        return Some(ClearanceMeasurement {
-            distance_mm: 0.0,
-            first: point,
-            second: point,
-        });
+        return Some(Distance::flattened(0.0, point, point, 2));
     }
 
     closest_ring_edges(&first.rings, &second.rings)
@@ -249,24 +219,20 @@ fn contained_vertex(subject: &ContourSet, container: &ContourSet) -> Option<Poin
         .find_map(|(inside, vertex)| inside.then_some(vertex))
 }
 
-fn closest_ring_edges(first: &[Ring], second: &[Ring]) -> Option<ClearanceMeasurement> {
+fn closest_ring_edges(first: &[Ring], second: &[Ring]) -> Option<Distance> {
     first
         .iter()
         .flat_map(ring_edges)
         .flat_map(|(first_start, first_end)| {
             second.iter().flat_map(move |ring| {
                 ring_edges(ring).map(move |(second_start, second_end)| {
-                    let (distance_mm, on_first, on_second) =
+                    let (mm, on_first, on_second) =
                         dist::segments(first_start, first_end, second_start, second_end);
-                    ClearanceMeasurement {
-                        distance_mm,
-                        first: on_first,
-                        second: on_second,
-                    }
+                    Distance::flattened(mm, on_first, on_second, 2)
                 })
             })
         })
-        .min_by(|left, right| left.distance_mm.total_cmp(&right.distance_mm))
+        .min_by(|left, right| left.mm.total_cmp(&right.mm))
 }
 
 /// One contiguous sub-minimum piece of material or clearance.
@@ -282,12 +248,10 @@ pub struct ThinPiece {
     pub bbox: BBox,
     pub area_mm2: f64,
     /// Exact separation of the two opposing source-boundary branches in the
-    /// flattened polygon representation.
-    pub width_mm: f64,
+    /// flattened polygon representation; both branches count as flattened.
+    pub width: Distance,
     /// Approximate longitudinal extent (half the residue perimeter).
     pub length_mm: f64,
-    pub first: Point,
-    pub second: Point,
 }
 
 /// Opening and closing use tessellated round offsets. Widening the candidate
@@ -296,14 +260,9 @@ pub struct ThinPiece {
 /// then decides the verdict and discards the extra candidates.
 const MORPHOLOGY_CANDIDATE_GUARD_MM: f64 = 2.0 * tol::STROKE_OUTLINE_MM + tol::FLATTEN_MM;
 
-/// Two flattened source boundaries determine a local width. Each may lie up
-/// to one chord tolerance inside its source curve, so a result within this
-/// band of the limit is geometrically indeterminate rather than a finding.
-const TWO_BOUNDARY_UNCERTAINTY_MM: f64 = 2.0 * tol::FLATTEN_MM + tol::EPSILON_MM;
-
-/// Filled material narrower than `min_width_mm`. Only two-sided residue is
-/// reported, so the bite an isolated convex arc sheds under the opening is
-/// not a thin feature.
+/// Filled material certainly narrower than `min_width_mm`. Only two-sided
+/// residue is reported, so the bite an isolated convex arc sheds under the
+/// opening is not a thin feature. Largest piece first.
 pub fn thin_features(region: &ContourSet, min_width_mm: f64) -> Vec<ThinPiece> {
     pieces(
         region.disk_feature_violation_components(
@@ -313,9 +272,10 @@ pub fn thin_features(region: &ContourSet, min_width_mm: f64) -> Vec<ThinPiece> {
     )
 }
 
-/// Gaps in the material narrower than `min_gap_mm`, including boundary
-/// notches. Only two-sided residue is reported, so the bite an isolated
-/// concave corner sheds under the closing is not clearance.
+/// Gaps in the material certainly narrower than `min_gap_mm`, including
+/// boundary notches. Only two-sided residue is reported, so the bite an
+/// isolated concave corner sheds under the closing is not clearance.
+/// Largest piece first.
 pub fn thin_gaps(region: &ContourSet, min_gap_mm: f64) -> Vec<ThinPiece> {
     pieces(
         region.disk_gap_violation_components((min_gap_mm + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0),
@@ -323,24 +283,32 @@ pub fn thin_gaps(region: &ContourSet, min_gap_mm: f64) -> Vec<ThinPiece> {
     )
 }
 
+/// The narrowest local width of a filled region: the least separation of
+/// any two facing boundary branches. An opening wide enough to erase the
+/// whole region makes every piece of it a candidate. `None` when no two
+/// branches face each other (an empty region, or a single point).
+pub fn min_width(region: &ContourSet) -> Option<Distance> {
+    let erase_all = 2.0 * region.bbox.width().max(region.bbox.height());
+    thin_features(region, erase_all)
+        .into_iter()
+        .map(|piece| piece.width)
+        .min_by(|left, right| left.mm.total_cmp(&right.mm))
+}
+
 /// Convert the conservative opening/closing candidates into authoritative
 /// measurements. A candidate is reportable only when the exact distance
-/// between its opposing source-boundary branches violates the requested
-/// minimum; this is what prevents offset tessellation from creating findings.
-/// Pieces are ordered largest first.
+/// between its opposing source-boundary branches is certainly below the
+/// requested minimum; this is what prevents offset tessellation from
+/// creating findings.
 fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<ThinPiece> {
     let mut pieces = components
         .into_iter()
-        .filter(|component| {
-            component.clearance.distance_mm + TWO_BOUNDARY_UNCERTAINTY_MM < minimum_mm
-        })
+        .filter(|component| component.width.certainly_below(minimum_mm))
         .map(|component| ThinPiece {
             bbox: component.region.bbox,
             area_mm2: component.region.area(),
-            width_mm: component.clearance.distance_mm,
+            width: component.width,
             length_mm: region_perimeter(&component.region) / 2.0,
-            first: component.clearance.first,
-            second: component.clearance.second,
         })
         .collect::<Vec<_>>();
     pieces.sort_by(|a, b| b.area_mm2.total_cmp(&a.area_mm2));
@@ -386,7 +354,7 @@ mod tests {
         let right = rect_region(3.5, 0.5, 5.0, 1.5);
 
         let between_regions = region_clearance(&left, &right).unwrap();
-        assert!((between_regions.distance_mm - 1.5).abs() < 1e-9);
+        assert!((between_regions.mm - 1.5).abs() < 1e-9);
         assert!((between_regions.first.x - 2.0).abs() < 1e-9);
         assert!((between_regions.second.x - 3.5).abs() < 1e-9);
 
@@ -394,12 +362,12 @@ mod tests {
         let from_segment = index
             .segment_nearest_within(Point::new(-1.0, 3.0), Point::new(3.0, 3.0), 1.5)
             .unwrap();
-        assert!((from_segment.distance_mm - 1.0).abs() < 1e-9);
+        assert!((from_segment.mm - 1.0).abs() < 1e-9);
 
         let crossing = index
             .segment_nearest_within(Point::new(-1.0, 1.0), Point::new(3.0, 1.0), 0.5)
             .unwrap();
-        assert_eq!(crossing.distance_mm, 0.0);
+        assert_eq!(crossing.mm, 0.0);
     }
 
     #[test]
@@ -407,27 +375,20 @@ mod tests {
         let origin = rect_region(0.0, 0.0, 1.0, 1.0);
         let diagonal = rect_region(2.0, 3.0, 3.0, 4.0);
         let clearance = region_clearance(&origin, &diagonal).unwrap();
-        assert!((clearance.distance_mm - 5.0_f64.sqrt()).abs() < 1e-9);
+        assert!((clearance.mm - 5.0_f64.sqrt()).abs() < 1e-9);
         assert!((origin.bbox.distance_to(diagonal.bbox) - 5.0_f64.sqrt()).abs() < 1e-9);
 
         let horizontal = rect_region(-2.0, -0.25, 2.0, 0.25);
         let vertical = rect_region(-0.25, -2.0, 0.25, 2.0);
         assert_eq!(
-            region_clearance(&horizontal, &vertical)
-                .unwrap()
-                .distance_mm,
+            region_clearance(&horizontal, &vertical).unwrap().mm,
             0.0,
             "crossing regions overlap even when neither contains the other"
         );
 
         let container = rect_region(-2.0, -2.0, 2.0, 2.0);
         let contained = rect_region(-0.5, -0.5, 0.5, 0.5);
-        assert_eq!(
-            region_clearance(&container, &contained)
-                .unwrap()
-                .distance_mm,
-            0.0
-        );
+        assert_eq!(region_clearance(&container, &contained).unwrap().mm, 0.0);
     }
 
     #[test]
@@ -447,7 +408,7 @@ mod tests {
         let near_middle = index
             .nearest_within(Point::new(40.3, 40.0), 0.5)
             .expect("mid-segment boundary within reach");
-        assert!((near_middle.distance_mm - 0.3 / 2.0_f64.sqrt()).abs() < 1e-6);
+        assert!((near_middle.mm - 0.3 / 2.0_f64.sqrt()).abs() < 1e-6);
     }
 
     #[test]
@@ -468,9 +429,10 @@ mod tests {
         let measurement = index
             .circular_enclosure(Point::new(1.3, 0.0), 1.35, 0.125)
             .expect("hole extending beyond copper must measure");
-        assert!((measurement.enclosure_mm + 0.15).abs() < tol::FLATTEN_MM);
-        assert!((measurement.cutout_boundary.x - 2.65).abs() < tol::FLATTEN_MM);
-        assert!((measurement.material_boundary.x - 2.5).abs() < tol::FLATTEN_MM);
+        assert!((measurement.mm + 0.15).abs() < tol::FLATTEN_MM);
+        assert_eq!(measurement.uncertainty_mm, tol::FLATTEN_MM);
+        assert!((measurement.first.x - 2.65).abs() < tol::FLATTEN_MM);
+        assert!((measurement.second.x - 2.5).abs() < tol::FLATTEN_MM);
     }
 
     #[test]
@@ -481,8 +443,8 @@ mod tests {
         let measurement = index
             .circular_enclosure(Point::default(), 1.0, 0.6)
             .expect("the short side of a rectangular land must set the enclosure");
-        assert!((measurement.enclosure_mm - 0.5).abs() < 1e-9);
-        assert!((measurement.material_boundary.y.abs() - 1.5).abs() < 1e-9);
+        assert!((measurement.mm - 0.5).abs() < 1e-9);
+        assert!((measurement.second.y.abs() - 1.5).abs() < 1e-9);
     }
 
     #[test]
@@ -525,9 +487,9 @@ mod tests {
         assert_eq!(findings.len(), 1);
         let piece = &findings[0];
         assert!(
-            (piece.width_mm - 0.05).abs() < 0.02,
+            (piece.width.mm - 0.05).abs() < 0.02,
             "width {}",
-            piece.width_mm
+            piece.width.mm
         );
         assert!(piece.length_mm > 1.5, "length {}", piece.length_mm);
     }
@@ -570,9 +532,9 @@ mod tests {
 
         assert_eq!(gaps.len(), 1);
         assert!(
-            (gaps[0].width_mm - 0.06).abs() < 0.02,
+            (gaps[0].width.mm - 0.06).abs() < 0.02,
             "width {}",
-            gaps[0].width_mm
+            gaps[0].width.mm
         );
         assert!(thin_features(&region, 0.1).is_empty());
     }
@@ -584,8 +546,16 @@ mod tests {
         let findings = thin_features(&island, 0.1);
 
         assert_eq!(findings.len(), 1);
-        assert!((findings[0].width_mm - 0.05).abs() < 1e-9);
-        assert!((findings[0].first.distance_to(findings[0].second) - 0.05).abs() < 1e-9);
+        assert!((findings[0].width.mm - 0.05).abs() < 1e-9);
+        assert!(
+            (findings[0]
+                .width
+                .first
+                .distance_to(findings[0].width.second)
+                - 0.05)
+                .abs()
+                < 1e-9
+        );
     }
 
     #[test]
@@ -597,7 +567,7 @@ mod tests {
         let findings = thin_gaps(&region, 0.1);
 
         assert_eq!(findings.len(), 1);
-        assert!((findings[0].width_mm - 0.06).abs() < 1e-9);
+        assert!((findings[0].width.mm - 0.06).abs() < 1e-9);
     }
 
     #[test]
@@ -622,6 +592,22 @@ mod tests {
     }
 
     #[test]
+    fn min_width_is_limit_free() {
+        let stadium = ContourSet::from_contours(
+            &[shapes::obround(1.8, 0.6, true).expect("valid obround")],
+            FillRule::NonZero,
+            tol::REGION_MM,
+        );
+        let width = min_width(&stadium).expect("a stadium has facing walls");
+        assert!((width.mm - 0.6).abs() < 1e-6, "width {}", width.mm);
+        assert_eq!(width.uncertainty_mm, 2.0 * tol::FLATTEN_MM);
+
+        let plate = rect_region(0.0, 0.0, 10.0, 3.0);
+        assert!((min_width(&plate).unwrap().mm - 3.0).abs() < 1e-9);
+        assert!(min_width(&ContourSet::empty(tol::REGION_MM)).is_none());
+    }
+
+    #[test]
     fn widths_are_invariant_under_quarter_turns() {
         let left = rect_region(0.0, 0.0, 4.0, 2.0);
         let right = rect_region(4.06, 0.0, 8.0, 2.0);
@@ -641,6 +627,6 @@ mod tests {
 
         assert_eq!(original.len(), 1);
         assert_eq!(turned.len(), 1);
-        assert!((original[0].width_mm - turned[0].width_mm).abs() < 1e-9);
+        assert!((original[0].width.mm - turned[0].width.mm).abs() < 1e-9);
     }
 }

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -8,14 +8,7 @@ use crate::geom::point::Point;
 use crate::geom::region::{ContourSet, Ring, TwoSidedResidualComponent, ring_edges};
 use crate::geom::tol;
 
-/// The shortest separation between two pieces of geometry, with the points
-/// that realize it. Distances are expressed in the IR's canonical millimeters.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ClearanceMeasurement {
-    pub distance_mm: f64,
-    pub first: Point,
-    pub second: Point,
-}
+pub use crate::geom::dist::ClearanceMeasurement;
 
 /// The minimum radial material enclosure around a circular cutout whose
 /// center lies in the material.
@@ -220,20 +213,6 @@ pub fn disk_clearance(
     }
 }
 
-/// Euclidean separation of two axis-aligned bounds. Because each enclosed
-/// region is a subset of its bounds, this is a conservative lower bound on
-/// region-to-region clearance: a value meeting a minimum proves the exact
-/// regions meet it too.
-pub fn bbox_clearance_lower_bound(first: BBox, second: BBox) -> f64 {
-    let x = (second.min.x - first.max.x)
-        .max(first.min.x - second.max.x)
-        .max(0.0);
-    let y = (second.min.y - first.max.y)
-        .max(first.min.y - second.max.y)
-        .max(0.0);
-    x.hypot(y)
-}
-
 /// Shortest boundary-to-boundary clearance between two filled regions.
 ///
 /// Overlapping, contained, or touching regions have zero clearance. `None`
@@ -348,30 +327,33 @@ pub fn thin_gaps(region: &ContourSet, min_gap_mm: f64) -> Vec<ThinPiece> {
 /// measurements. A candidate is reportable only when the exact distance
 /// between its opposing source-boundary branches violates the requested
 /// minimum; this is what prevents offset tessellation from creating findings.
+/// Pieces are ordered largest first.
 fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<ThinPiece> {
     let mut pieces = components
         .into_iter()
-        .filter(|component| component.distance_mm + TWO_BOUNDARY_UNCERTAINTY_MM < minimum_mm)
-        .filter_map(|component| {
-            let perimeter = component
-                .region
-                .rings
-                .iter()
-                .flat_map(ring_edges)
-                .map(|(start, end)| start.distance_to(end))
-                .sum::<f64>();
-            (perimeter > 0.0).then(|| ThinPiece {
-                bbox: component.region.bbox,
-                area_mm2: component.region.area(),
-                width_mm: component.distance_mm,
-                length_mm: perimeter / 2.0,
-                first: component.first,
-                second: component.second,
-            })
+        .filter(|component| {
+            component.clearance.distance_mm + TWO_BOUNDARY_UNCERTAINTY_MM < minimum_mm
+        })
+        .map(|component| ThinPiece {
+            bbox: component.region.bbox,
+            area_mm2: component.region.area(),
+            width_mm: component.clearance.distance_mm,
+            length_mm: region_perimeter(&component.region) / 2.0,
+            first: component.clearance.first,
+            second: component.clearance.second,
         })
         .collect::<Vec<_>>();
     pieces.sort_by(|a, b| b.area_mm2.total_cmp(&a.area_mm2));
     pieces
+}
+
+fn region_perimeter(region: &ContourSet) -> f64 {
+    region
+        .rings
+        .iter()
+        .flat_map(ring_edges)
+        .map(|(start, end)| start.distance_to(end))
+        .sum()
 }
 
 #[cfg(test)]
@@ -426,9 +408,7 @@ mod tests {
         let diagonal = rect_region(2.0, 3.0, 3.0, 4.0);
         let clearance = region_clearance(&origin, &diagonal).unwrap();
         assert!((clearance.distance_mm - 5.0_f64.sqrt()).abs() < 1e-9);
-        assert!(
-            (bbox_clearance_lower_bound(origin.bbox, diagonal.bbox) - 5.0_f64.sqrt()).abs() < 1e-9
-        );
+        assert!((origin.bbox.distance_to(diagonal.bbox) - 5.0_f64.sqrt()).abs() < 1e-9);
 
         let horizontal = rect_region(-2.0, -0.25, 2.0, 0.25);
         let vertical = rect_region(-0.25, -2.0, 0.25, 2.0);

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::geom::bbox::BBox;
 use crate::geom::dist;
 use crate::geom::point::Point;
-use crate::geom::region::{ContourSet, Ring, ring_edges, ring_signed_area, rings_bbox};
+use crate::geom::region::{ContourSet, Ring, TwoSidedResidualComponent, ring_edges};
 use crate::geom::tol;
 
 /// The shortest separation between two pieces of geometry, with the points
@@ -220,6 +220,20 @@ pub fn disk_clearance(
     }
 }
 
+/// Euclidean separation of two axis-aligned bounds. Because each enclosed
+/// region is a subset of its bounds, this is a conservative lower bound on
+/// region-to-region clearance: a value meeting a minimum proves the exact
+/// regions meet it too.
+pub fn bbox_clearance_lower_bound(first: BBox, second: BBox) -> f64 {
+    let x = (second.min.x - first.max.x)
+        .max(first.min.x - second.max.x)
+        .max(0.0);
+    let y = (second.min.y - first.max.y)
+        .max(first.min.y - second.max.y)
+        .max(0.0);
+    x.hypot(y)
+}
+
 /// Shortest boundary-to-boundary clearance between two filled regions.
 ///
 /// Overlapping, contained, or touching regions have zero clearance. `None`
@@ -288,21 +302,35 @@ fn closest_ring_edges(first: &[Ring], second: &[Ring]) -> Option<ClearanceMeasur
 pub struct ThinPiece {
     pub bbox: BBox,
     pub area_mm2: f64,
-    /// Estimated width (2·area/perimeter — exact for long ribbons).
+    /// Exact separation of the two opposing source-boundary branches in the
+    /// flattened polygon representation.
     pub width_mm: f64,
-    /// Estimated length (half the perimeter — exact for long ribbons).
+    /// Approximate longitudinal extent (half the residue perimeter).
     pub length_mm: f64,
+    pub first: Point,
+    pub second: Point,
 }
+
+/// Opening and closing use tessellated round offsets. Widening the candidate
+/// threshold by the full two-offset plus source-flattening error makes the
+/// morphological stage conservative; exact source-boundary distance below
+/// then decides the verdict and discards the extra candidates.
+const MORPHOLOGY_CANDIDATE_GUARD_MM: f64 = 2.0 * tol::STROKE_OUTLINE_MM + tol::FLATTEN_MM;
+
+/// Two flattened source boundaries determine a local width. Each may lie up
+/// to one chord tolerance inside its source curve, so a result within this
+/// band of the limit is geometrically indeterminate rather than a finding.
+const TWO_BOUNDARY_UNCERTAINTY_MM: f64 = 2.0 * tol::FLATTEN_MM + tol::EPSILON_MM;
 
 /// Filled material narrower than `min_width_mm`. Only two-sided residue is
 /// reported, so the bite an isolated convex arc sheds under the opening is
 /// not a thin feature.
 pub fn thin_features(region: &ContourSet, min_width_mm: f64) -> Vec<ThinPiece> {
-    let boundary = RegionBoundaryIndex::new(region, min_width_mm);
     pieces(
-        &region.difference(&region.disk_open(min_width_mm / 2.0)),
+        region.disk_feature_violation_components(
+            (min_width_mm + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0,
+        ),
         min_width_mm,
-        &boundary,
     )
 }
 
@@ -310,80 +338,40 @@ pub fn thin_features(region: &ContourSet, min_width_mm: f64) -> Vec<ThinPiece> {
 /// notches. Only two-sided residue is reported, so the bite an isolated
 /// concave corner sheds under the closing is not clearance.
 pub fn thin_gaps(region: &ContourSet, min_gap_mm: f64) -> Vec<ThinPiece> {
-    let boundary = RegionBoundaryIndex::new(region, min_gap_mm);
     pieces(
-        &region.disk_close(min_gap_mm / 2.0).difference(region),
+        region.disk_gap_violation_components((min_gap_mm + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0),
         min_gap_mm,
-        &boundary,
     )
 }
 
-/// A violation is bounded by source material along both long sides, so its
-/// perimeter lies on the source boundary almost everywhere; a single-corner
-/// or single-arc bite touches it on at most one wall and two legs.
-const TWO_SIDED_CONTACT_FRACTION: f64 = 0.75;
-
-/// Extract reportable pieces from a residue region, dropping numeric noise —
-/// flattening-scale ribbons along long edges — and one-sided pieces whose
-/// perimeter mostly leaves the source boundary.
-fn pieces(
-    residue: &ContourSet,
-    min_width_mm: f64,
-    source_boundary: &RegionBoundaryIndex,
-) -> Vec<ThinPiece> {
-    let noise_width = 2.0 * tol::FLATTEN_MM;
-    let min_length = 2.0 * min_width_mm;
-    let min_area = 0.25 * min_width_mm * min_width_mm;
-
-    let mut pieces: Vec<ThinPiece> = residue
-        .rings
-        .iter()
-        .filter_map(|ring| {
-            let area = ring_signed_area(ring);
-            if area <= 0.0 {
-                return None; // holes of residue pieces
-            }
-            let perimeter: f64 = ring_edges(ring)
+/// Convert the conservative opening/closing candidates into authoritative
+/// measurements. A candidate is reportable only when the exact distance
+/// between its opposing source-boundary branches violates the requested
+/// minimum; this is what prevents offset tessellation from creating findings.
+fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<ThinPiece> {
+    let mut pieces = components
+        .into_iter()
+        .filter(|component| component.distance_mm + TWO_BOUNDARY_UNCERTAINTY_MM < minimum_mm)
+        .filter_map(|component| {
+            let perimeter = component
+                .region
+                .rings
+                .iter()
+                .flat_map(ring_edges)
                 .map(|(start, end)| start.distance_to(end))
-                .sum();
-            if perimeter <= 0.0 {
-                return None;
-            }
-            let piece = ThinPiece {
-                bbox: rings_bbox(std::slice::from_ref(ring)),
-                area_mm2: area,
-                width_mm: 2.0 * area / perimeter,
+                .sum::<f64>();
+            (perimeter > 0.0).then(|| ThinPiece {
+                bbox: component.region.bbox,
+                area_mm2: component.region.area(),
+                width_mm: component.distance_mm,
                 length_mm: perimeter / 2.0,
-            };
-            let long_side = piece.bbox.width().max(piece.bbox.height());
-            (piece.width_mm >= noise_width
-                && long_side >= min_length
-                && area >= min_area
-                && boundary_contact_fraction(source_boundary, ring) >= TWO_SIDED_CONTACT_FRACTION)
-                .then_some(piece)
+                first: component.first,
+                second: component.second,
+            })
         })
-        .collect();
+        .collect::<Vec<_>>();
     pieces.sort_by(|a, b| b.area_mm2.total_cmp(&a.area_mm2));
     pieces
-}
-
-/// The fraction of the ring's perimeter that lies on the source boundary,
-/// judged edge midpoints against the indexed boundary at flattening scale.
-fn boundary_contact_fraction(source_boundary: &RegionBoundaryIndex, ring: &Ring) -> f64 {
-    let contact_eps = 2.0 * tol::FLATTEN_MM;
-    let mut perimeter = 0.0;
-    let mut contact = 0.0;
-    for (start, end) in ring_edges(ring) {
-        let length = start.distance_to(end);
-        perimeter += length;
-        if source_boundary
-            .nearest_within(start.midpoint(end), contact_eps)
-            .is_some()
-        {
-            contact += length;
-        }
-    }
-    contact / perimeter
 }
 
 #[cfg(test)]
@@ -430,6 +418,36 @@ mod tests {
             .segment_nearest_within(Point::new(-1.0, 1.0), Point::new(3.0, 1.0), 0.5)
             .unwrap();
         assert_eq!(crossing.distance_mm, 0.0);
+    }
+
+    #[test]
+    fn region_clearance_handles_diagonal_separation_crossing_and_containment() {
+        let origin = rect_region(0.0, 0.0, 1.0, 1.0);
+        let diagonal = rect_region(2.0, 3.0, 3.0, 4.0);
+        let clearance = region_clearance(&origin, &diagonal).unwrap();
+        assert!((clearance.distance_mm - 5.0_f64.sqrt()).abs() < 1e-9);
+        assert!(
+            (bbox_clearance_lower_bound(origin.bbox, diagonal.bbox) - 5.0_f64.sqrt()).abs() < 1e-9
+        );
+
+        let horizontal = rect_region(-2.0, -0.25, 2.0, 0.25);
+        let vertical = rect_region(-0.25, -2.0, 0.25, 2.0);
+        assert_eq!(
+            region_clearance(&horizontal, &vertical)
+                .unwrap()
+                .distance_mm,
+            0.0,
+            "crossing regions overlap even when neither contains the other"
+        );
+
+        let container = rect_region(-2.0, -2.0, 2.0, 2.0);
+        let contained = rect_region(-0.5, -0.5, 0.5, 0.5);
+        assert_eq!(
+            region_clearance(&container, &contained)
+                .unwrap()
+                .distance_mm,
+            0.0
+        );
     }
 
     #[test]
@@ -577,5 +595,72 @@ mod tests {
             gaps[0].width_mm
         );
         assert!(thin_features(&region, 0.1).is_empty());
+    }
+
+    #[test]
+    fn small_islands_are_not_filtered_out_of_feature_width() {
+        let island = rect_region(0.0, 0.0, 0.05, 0.05);
+
+        let findings = thin_features(&island, 0.1);
+
+        assert_eq!(findings.len(), 1);
+        assert!((findings[0].width_mm - 0.05).abs() < 1e-9);
+        assert!((findings[0].first.distance_to(findings[0].second) - 0.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn short_gaps_are_not_filtered_out_of_clearance() {
+        let left = rect_region(0.0, 0.0, 0.05, 0.05);
+        let right = rect_region(0.11, 0.0, 0.16, 0.05);
+        let region = left.union(&right);
+
+        let findings = thin_gaps(&region, 0.1);
+
+        assert_eq!(findings.len(), 1);
+        assert!((findings[0].width_mm - 0.06).abs() < 1e-9);
+    }
+
+    #[test]
+    fn exact_minimums_are_not_morphology_false_positives() {
+        let feature = rect_region(0.0, 0.0, 1.0, 0.1);
+        let disk = ContourSet::from_filled_contours(
+            &[shapes::circle(0.1).expect("valid circle")],
+            tol::REGION_MM,
+        );
+        let undersized_disk = ContourSet::from_filled_contours(
+            &[shapes::circle(0.08).expect("valid circle")],
+            tol::REGION_MM,
+        );
+        let left = rect_region(2.0, 0.0, 3.0, 1.0);
+        let right = rect_region(3.1, 0.0, 4.1, 1.0);
+
+        assert!(thin_features(&feature, 0.1).is_empty());
+        let disk_findings = thin_features(&disk, 0.1);
+        assert!(disk_findings.is_empty(), "findings: {disk_findings:?}");
+        assert_eq!(thin_features(&undersized_disk, 0.1).len(), 1);
+        assert!(thin_gaps(&left.union(&right), 0.1).is_empty());
+    }
+
+    #[test]
+    fn widths_are_invariant_under_quarter_turns() {
+        let left = rect_region(0.0, 0.0, 4.0, 2.0);
+        let right = rect_region(4.06, 0.0, 8.0, 2.0);
+        let region = left.union(&right);
+        let rotated = ContourSet::new(
+            region
+                .rings
+                .iter()
+                .map(|ring| ring.iter().map(|[x, y]| [-y, *x]).collect())
+                .collect(),
+            FillRule::NonZero,
+            tol::REGION_MM,
+        );
+
+        let original = thin_gaps(&region, 0.1);
+        let turned = thin_gaps(&rotated, 0.1);
+
+        assert_eq!(original.len(), 1);
+        assert_eq!(turned.len(), 1);
+        assert!((original[0].width_mm - turned[0].width_mm).abs() < 1e-9);
     }
 }

--- a/crates/pcb-ir/src/geom/dist.rs
+++ b/crates/pcb-ir/src/geom/dist.rs
@@ -1,14 +1,65 @@
 //! Euclidean distance primitives with closest-point witnesses.
 
 use crate::geom::point::Point;
+use crate::geom::tol;
 
-/// The shortest separation between two pieces of geometry, with the points
-/// that realize it. Distances are expressed in the IR's canonical millimeters.
+/// A measured length between two witness points, in the IR's canonical
+/// millimeters, with the uncertainty its inputs carry.
+///
+/// Flattening places each curved boundary up to [`tol::FLATTEN_MM`] from
+/// its source, so a length measured against `n` flattened boundaries is
+/// known only to within `n · FLATTEN_MM`. A consumer comparing against a
+/// minimum uses [`Distance::certainly_below`], so tessellation alone can
+/// never manufacture a violation. `mm` is signed where the quantity is: a
+/// negative enclosure is the depth of a breach.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ClearanceMeasurement {
-    pub distance_mm: f64,
+pub struct Distance {
+    pub mm: f64,
+    pub uncertainty_mm: f64,
     pub first: Point,
     pub second: Point,
+}
+
+impl Distance {
+    /// A length taken from exact geometry: stated primitives, or analytic
+    /// shapes such as disks.
+    pub fn exact(mm: f64, first: Point, second: Point) -> Self {
+        Self {
+            mm,
+            uncertainty_mm: 0.0,
+            first,
+            second,
+        }
+    }
+
+    /// A length measured against `flattened_boundaries` tessellated curves.
+    pub fn flattened(mm: f64, first: Point, second: Point, flattened_boundaries: u32) -> Self {
+        Self {
+            mm,
+            uncertainty_mm: f64::from(flattened_boundaries) * tol::FLATTEN_MM,
+            first,
+            second,
+        }
+    }
+
+    /// The same length, with `flattened_boundaries` more tessellated inputs
+    /// counted toward its uncertainty.
+    pub fn also_flattened(self, flattened_boundaries: u32) -> Self {
+        Self {
+            uncertainty_mm: self.uncertainty_mm + f64::from(flattened_boundaries) * tol::FLATTEN_MM,
+            ..self
+        }
+    }
+
+    /// Whether the length falls short of `limit_mm` even at the top of its
+    /// uncertainty band.
+    pub fn certainly_below(&self, limit_mm: f64) -> bool {
+        self.mm + self.uncertainty_mm < limit_mm
+    }
+
+    pub fn midpoint(&self) -> Point {
+        self.first.midpoint(self.second)
+    }
 }
 
 /// Distance from a point to a closed segment, with the closest point on the

--- a/crates/pcb-ir/src/geom/dist.rs
+++ b/crates/pcb-ir/src/geom/dist.rs
@@ -2,6 +2,15 @@
 
 use crate::geom::point::Point;
 
+/// The shortest separation between two pieces of geometry, with the points
+/// that realize it. Distances are expressed in the IR's canonical millimeters.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClearanceMeasurement {
+    pub distance_mm: f64,
+    pub first: Point,
+    pub second: Point,
+}
+
 /// Distance from a point to a closed segment, with the closest point on the
 /// segment.
 pub fn point_segment(point: Point, start: Point, end: Point) -> (f64, Point) {

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -6,6 +6,7 @@
 //! dilation over filled point sets, shared by every dialect so IPC, Gerber,
 //! SVG, and comparison all use the same geometry semantics.
 
+use std::collections::HashMap;
 use std::fmt;
 
 use boostvoronoi::prelude::{
@@ -1106,10 +1107,10 @@ fn closing_residual(region: &ContourSet, radius: f64) -> ContourSet {
     region.disk_close(radius).difference(region)
 }
 
-/// Every source boundary edge longer than the region tolerance, sorted by
-/// minimum x so a query can stop scanning once edges start past its bounds.
+/// Every source boundary edge longer than the region tolerance, in ring
+/// order.
 fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment> {
-    let mut segments = source
+    source
         .rings
         .iter()
         .enumerate()
@@ -1128,9 +1129,7 @@ fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment>
                     bbox: segment_bbox(start, end),
                 })
         })
-        .collect::<Vec<_>>();
-    segments.sort_by(|left, right| left.bbox.min.x.total_cmp(&right.bbox.min.x));
-    segments
+        .collect()
 }
 
 /// Each connected component of `residual` that two distinct source-boundary
@@ -1149,13 +1148,13 @@ fn two_sided_residual_components(
     residual: &ContourSet,
     reach: f64,
 ) -> Vec<TwoSidedResidualComponent> {
-    let segments = source_boundary_segments(source);
+    let segments = SegmentGrid::new(source_boundary_segments(source), reach);
     let contact_tolerance = source.tolerance.max(residual.tolerance);
     residual
         .connected_components()
         .into_iter()
         .filter_map(|component| {
-            let sites = segments_near(&segments, component.bbox.expand(reach));
+            let sites = segments.near(component.bbox.expand(reach));
             component_width(&sites, &component, reach, contact_tolerance).map(|width| {
                 TwoSidedResidualComponent {
                     region: component,
@@ -1166,17 +1165,52 @@ fn two_sided_residual_components(
         .collect()
 }
 
-/// The segments (sorted by minimum x) whose bounds meet `query`.
-fn segments_near(
-    segments: &[OrientedBoundarySegment],
-    query: BBox,
-) -> Vec<OrientedBoundarySegment> {
-    let candidate_end = segments.partition_point(|segment| segment.bbox.min.x <= query.max.x);
-    segments[..candidate_end]
-        .iter()
-        .filter(|segment| segment.bbox.intersects(query))
-        .copied()
-        .collect()
+/// Boundary segments bucketed on a uniform grid, so the segments around one
+/// residue component are found without scanning the whole boundary.
+struct SegmentGrid {
+    cell_mm: f64,
+    segments: Vec<OrientedBoundarySegment>,
+    cells: HashMap<(i64, i64), Vec<u32>>,
+}
+
+impl SegmentGrid {
+    fn new(segments: Vec<OrientedBoundarySegment>, cell_mm: f64) -> Self {
+        let cell_mm = cell_mm.max(tol::REGION_MM);
+        let mut cells: HashMap<(i64, i64), Vec<u32>> = HashMap::new();
+        for (index, segment) in segments.iter().enumerate() {
+            for cell in Self::cells_of(segment.bbox, cell_mm) {
+                cells.entry(cell).or_default().push(index as u32);
+            }
+        }
+        Self {
+            cell_mm,
+            segments,
+            cells,
+        }
+    }
+
+    fn cells_of(bbox: BBox, cell_mm: f64) -> impl Iterator<Item = (i64, i64)> {
+        let cell = move |value: f64| (value / cell_mm).floor() as i64;
+        let (min_x, max_x) = (cell(bbox.min.x), cell(bbox.max.x));
+        let (min_y, max_y) = (cell(bbox.min.y), cell(bbox.max.y));
+        (min_x..=max_x).flat_map(move |x| (min_y..=max_y).map(move |y| (x, y)))
+    }
+
+    /// The segments whose bounds meet `query`, in index order, each once.
+    fn near(&self, query: BBox) -> Vec<OrientedBoundarySegment> {
+        let mut indices = Self::cells_of(query, self.cell_mm)
+            .filter_map(|cell| self.cells.get(&cell))
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
+        indices.sort_unstable();
+        indices.dedup();
+        indices
+            .into_iter()
+            .map(|index| self.segments[index as usize])
+            .filter(|segment| segment.bbox.intersects(query))
+            .collect()
+    }
 }
 
 /// A boundary segment snapped to the tolerance grid, with its topology.
@@ -1203,7 +1237,7 @@ fn planar_grid_sites(
         point != line.start
             && point != line.end
             && orient(line.start, line.end, point) == 0
-            && (line.start.x..=line.end.x).contains(&point.x)
+            && (line.start.x.min(line.end.x)..=line.start.x.max(line.end.x)).contains(&point.x)
             && (line.start.y.min(line.end.y)..=line.start.y.max(line.end.y)).contains(&point.y)
     };
     let length2 = |line: &VoronoiLine<i32>| {
@@ -1215,17 +1249,19 @@ fn planar_grid_sites(
         orient(a.start, a.end, b.start).signum() * orient(a.start, a.end, b.end).signum() < 0
             && orient(b.start, b.end, a.start).signum() * orient(b.start, b.end, a.end).signum() < 0
     };
-    // Oriented start ≤ end so a segment and its reverse are one site.
+    // Sites keep their ring's traversal direction; a segment and its
+    // reverse are one site.
+    let key = |line: &VoronoiLine<i32>| {
+        let (a, b) = ((line.start.x, line.start.y), (line.end.x, line.end.y));
+        (a.min(b), a.max(b))
+    };
     let snapped = sites
         .iter()
         .map(|site| {
-            let (a, b) = (quantize(site.start), quantize(site.end));
-            let (start, end) = if (a.x, a.y) <= (b.x, b.y) {
-                (a, b)
-            } else {
-                (b, a)
-            };
-            (VoronoiLine::new(start, end), site.topology)
+            (
+                VoronoiLine::new(quantize(site.start), quantize(site.end)),
+                site.topology,
+            )
         })
         .filter(|(line, _)| line.start != line.end)
         .collect::<Vec<_>>();
@@ -1252,7 +1288,7 @@ fn planar_grid_sites(
                 .map(|pair| (VoronoiLine::new(pair[0], pair[1]), topology))
                 .collect::<Vec<_>>()
         })
-        .filter(|(line, _)| seen.insert((line.start.x, line.start.y, line.end.x, line.end.y)))
+        .filter(|(line, _)| seen.insert(key(line)))
         .collect::<Vec<_>>();
     split
         .iter()
@@ -1375,15 +1411,24 @@ fn component_width(
     if lines.len() < 2 {
         return None;
     }
-    // Incidence on the grid: sites of one source segment, ring-adjacent
-    // sites, and sites sharing a grid point (snapping can collapse the
-    // segment between two and make them neighbors) are the same wall.
+    // Which sites are one wall. A ring's two sides of a channel are
+    // traversed in opposite directions, so two segments of one ring face
+    // each other only when their directions oppose; ring-adjacent segments
+    // and segments running within a quarter turn of each other — chords of
+    // one curve, however a sub-tolerance stub between them snapped — are
+    // the same wall. Segments of different rings are one wall only where
+    // they touch.
     let incident = |i: usize, j: usize| {
-        let (a, b) = (&lines[i], &lines[j]);
-        boundary_segments_are_incident(sites[i].topology, sites[j].topology)
-            || [a.start, a.end]
+        let (a, b) = (&sites[i], &sites[j]);
+        if a.topology.ring == b.topology.ring {
+            let (da, db) = (a.end - a.start, b.end - b.start);
+            boundary_segments_are_incident(a.topology, b.topology)
+                || da.x * db.x + da.y * db.y > 0.0
+        } else {
+            [lines[i].start, lines[i].end]
                 .iter()
-                .any(|point| [b.start, b.end].contains(point))
+                .any(|point| [lines[j].start, lines[j].end].contains(point))
+        }
     };
     let diagram = VoronoiBuilder::<i32>::default()
         .with_segments(lines.iter())

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -1203,7 +1203,7 @@ fn planar_grid_sites(
         point != line.start
             && point != line.end
             && orient(line.start, line.end, point) == 0
-            && (line.start.x.min(line.end.x)..=line.start.x.max(line.end.x)).contains(&point.x)
+            && (line.start.x..=line.end.x).contains(&point.x)
             && (line.start.y.min(line.end.y)..=line.start.y.max(line.end.y)).contains(&point.y)
     };
     let length2 = |line: &VoronoiLine<i32>| {
@@ -1211,13 +1211,21 @@ fn planar_grid_sites(
         let dy = i128::from(line.end.y) - i128::from(line.start.y);
         dx * dx + dy * dy
     };
+    let crosses = |a: &VoronoiLine<i32>, b: &VoronoiLine<i32>| {
+        orient(a.start, a.end, b.start).signum() * orient(a.start, a.end, b.end).signum() < 0
+            && orient(b.start, b.end, a.start).signum() * orient(b.start, b.end, a.end).signum() < 0
+    };
+    // Oriented start ≤ end so a segment and its reverse are one site.
     let snapped = sites
         .iter()
         .map(|site| {
-            (
-                VoronoiLine::new(quantize(site.start), quantize(site.end)),
-                site.topology,
-            )
+            let (a, b) = (quantize(site.start), quantize(site.end));
+            let (start, end) = if (a.x, a.y) <= (b.x, b.y) {
+                (a, b)
+            } else {
+                (b, a)
+            };
+            (VoronoiLine::new(start, end), site.topology)
         })
         .filter(|(line, _)| line.start != line.end)
         .collect::<Vec<_>>();
@@ -1225,6 +1233,7 @@ fn planar_grid_sites(
         .iter()
         .flat_map(|(line, _)| [line.start, line.end])
         .collect::<Vec<_>>();
+    let mut seen = std::collections::HashSet::new();
     let split = snapped
         .iter()
         .flat_map(|&(line, topology)| {
@@ -1233,11 +1242,7 @@ fn planar_grid_sites(
                 .copied()
                 .filter(|&point| on_interior(&line, point))
                 .collect::<Vec<_>>();
-            let along = |point: VoronoiPoint<i32>| {
-                (i128::from(point.x) - i128::from(line.start.x)).abs()
-                    + (i128::from(point.y) - i128::from(line.start.y)).abs()
-            };
-            stations.sort_by_key(|&point| along(point));
+            stations.sort_by_key(|point| (point.x, point.y));
             stations.dedup();
             std::iter::once(line.start)
                 .chain(stations)
@@ -1247,26 +1252,8 @@ fn planar_grid_sites(
                 .map(|pair| (VoronoiLine::new(pair[0], pair[1]), topology))
                 .collect::<Vec<_>>()
         })
+        .filter(|(line, _)| seen.insert((line.start.x, line.start.y, line.end.x, line.end.y)))
         .collect::<Vec<_>>();
-    let mut seen = std::collections::HashSet::new();
-    let split = split
-        .into_iter()
-        .filter(|(line, _)| {
-            let key = if (line.start.x, line.start.y) <= (line.end.x, line.end.y) {
-                (line.start.x, line.start.y, line.end.x, line.end.y)
-            } else {
-                (line.end.x, line.end.y, line.start.x, line.start.y)
-            };
-            seen.insert(key)
-        })
-        .collect::<Vec<_>>();
-    let crosses = |a: &VoronoiLine<i32>, b: &VoronoiLine<i32>| {
-        let o1 = orient(a.start, a.end, b.start).signum();
-        let o2 = orient(a.start, a.end, b.end).signum();
-        let o3 = orient(b.start, b.end, a.start).signum();
-        let o4 = orient(b.start, b.end, a.end).signum();
-        o1 * o2 < 0 && o3 * o4 < 0
-    };
     split
         .iter()
         .enumerate()
@@ -1279,6 +1266,49 @@ fn planar_grid_sites(
         })
         .map(|(_, site)| *site)
         .collect()
+}
+
+/// Whether the sites are one cyclic run of consecutive segments of one ring
+/// that turns the same way throughout by less than a half turn: a single
+/// convex corner or arc. Nothing in such a run faces anything else, so a
+/// residue it walls alone is the bite of one corner and has no width.
+fn convex_chain(sites: &[OrientedBoundarySegment]) -> bool {
+    let Some(first) = sites.first() else {
+        return true;
+    };
+    if sites
+        .iter()
+        .any(|site| site.topology.ring != first.topology.ring)
+    {
+        return false;
+    }
+    let ring_len = first.topology.ring_len;
+    let mut run = sites.to_vec();
+    run.sort_by_key(|site| site.topology.index);
+    // A run is contiguous when, read cyclically, exactly one step is not
+    // the next index: the step from its last segment back to its first.
+    let gaps = (0..run.len())
+        .filter(|&position| {
+            let next = run[(position + 1) % run.len()].topology.index;
+            (run[position].topology.index + 1) % ring_len != next
+        })
+        .collect::<Vec<_>>();
+    let [gap] = gaps[..] else {
+        return false;
+    };
+    run.rotate_left(gap + 1);
+    let turns = run.windows(2).map(|pair| {
+        let a = pair[0].end - pair[0].start;
+        let b = pair[1].end - pair[1].start;
+        (a.x * b.y - a.y * b.x).atan2(a.x * b.x + a.y * b.y)
+    });
+    let (mut positive, mut negative, mut total) = (false, false, 0.0);
+    for turn in turns {
+        positive |= turn > 0.0;
+        negative |= turn < 0.0;
+        total += turn.abs();
+    }
+    !(positive && negative) && total < std::f64::consts::PI
 }
 
 /// A maximal inscribed disk of the boundary's Voronoi diagram: its center,
@@ -1314,6 +1344,9 @@ fn component_width(
     reach: f64,
     contact_tolerance: f64,
 ) -> Option<Distance> {
+    if convex_chain(sites) {
+        return None;
+    }
     let origin = component.bbox.min;
     let units_per_mm = 1.0 / contact_tolerance;
     let quantize = |point: Point| {
@@ -1339,35 +1372,46 @@ fn component_width(
             }
         })
         .collect::<Vec<_>>();
-    let sites = sites.as_slice();
     if lines.len() < 2 {
         return None;
     }
+    // Incidence on the grid: sites of one source segment, ring-adjacent
+    // sites, and sites sharing a grid point (snapping can collapse the
+    // segment between two and make them neighbors) are the same wall.
+    let incident = |i: usize, j: usize| {
+        let (a, b) = (&lines[i], &lines[j]);
+        boundary_segments_are_incident(sites[i].topology, sites[j].topology)
+            || [a.start, a.end]
+                .iter()
+                .any(|point| [b.start, b.end].contains(point))
+    };
     let diagram = VoronoiBuilder::<i32>::default()
         .with_segments(lines.iter())
         .and_then(VoronoiBuilder::build)
         .expect("snap-rounded boundary segments do not cross");
+    // A cell's site index, and its point when the site is a segment end.
     let site_of = |cell: VoronoiCellIndex| {
         let cell = diagram.cell(cell).expect("diagram cell");
-        let site = &sites[cell.source_index().usize()];
+        let index = cell.source_index().usize();
         let point = match cell.source_category() {
-            SourceCategory::SegmentStart => Some(site.start),
-            SourceCategory::SegmentEnd => Some(site.end),
+            SourceCategory::SegmentStart => Some(sites[index].start),
+            SourceCategory::SegmentEnd => Some(sites[index].end),
             SourceCategory::Segment | SourceCategory::SinglePoint => None,
         };
-        (site, point)
+        (index, point)
     };
-    let disk =
-        |center: Point, first: &OrientedBoundarySegment, second: &OrientedBoundarySegment| {
-            let (first_distance, first) = dist::point_segment(center, first.start, first.end);
-            let (second_distance, second) = dist::point_segment(center, second.start, second.end);
-            InscribedDisk {
-                center,
-                radius: (first_distance + second_distance) / 2.0,
-                first,
-                second,
-            }
-        };
+    let disk = |center: Point, first: usize, second: usize| {
+        let (first_distance, first) =
+            dist::point_segment(center, sites[first].start, sites[first].end);
+        let (second_distance, second) =
+            dist::point_segment(center, sites[second].start, sites[second].end);
+        InscribedDisk {
+            center,
+            radius: (first_distance + second_distance) / 2.0,
+            first,
+            second,
+        }
+    };
     let component_edges = component
         .rings
         .iter()
@@ -1377,7 +1421,6 @@ fn component_width(
     // Vertices: tangent to every site around them; a width needs two that
     // are not incident.
     let at_vertices = diagram.vertices().iter().filter_map(|vertex| {
-        let center = unquantize([vertex.x(), vertex.y()]);
         let around = diagram
             .edge_rot_next_iterator(vertex.get_incident_edge().ok()?)
             .filter_map(|edge| diagram.edge(edge).ok()?.cell().ok())
@@ -1386,21 +1429,20 @@ fn component_width(
         around
             .iter()
             .enumerate()
-            .flat_map(|(index, first)| {
-                around[index + 1..]
+            .flat_map(|(position, &first)| {
+                around[position + 1..]
                     .iter()
-                    .map(move |second| (first, second))
+                    .map(move |&second| (first, second))
             })
-            .find(|(first, second)| {
-                !boundary_segments_are_incident(first.topology, second.topology)
-            })
-            .map(|(first, second)| (disk(center, first, second), false))
+            .find(|&(first, second)| !incident(first, second))
+            .map(|(first, second)| disk(unquantize([vertex.x(), vertex.y()]), first, second))
     });
 
-    // Edges between non-incident sites, sampled along their length, at the
-    // apex of a parabola (reflex vertex against a segment) or point–point
-    // bisector, and where they cross the component boundary.
-    let along_edges = diagram.edges().iter().flat_map(|edge| {
+    // Edges between non-incident sites, sampled along their length and at
+    // the apex of a parabola (reflex vertex against a segment) or of a
+    // point–point bisector; plus where they cross the component boundary.
+    let (mut on_axis, mut on_boundary) = (Vec::new(), Vec::new());
+    for edge in diagram.edges() {
         let twin = edge.twin().expect("diagram edge twin");
         let (first, first_point) = site_of(edge.cell().expect("diagram edge cell"));
         let (second, second_point) = site_of(
@@ -1409,60 +1451,55 @@ fn component_width(
                 .and_then(|twin| twin.cell())
                 .expect("twin cell"),
         );
-        let skip = edge.id() > twin
-            || !edge.is_primary()
-            || boundary_segments_are_incident(first.topology, second.topology);
-        let samples = if skip {
-            Vec::new()
-        } else {
+        if edge.id() > twin || !edge.is_primary() || incident(first, second) {
+            continue;
+        }
+        let samples =
             voronoi_edge_samples(&diagram, edge.id(), &lines, component, reach, units_per_mm)
                 .expect("voronoi edge samples")
                 .into_iter()
                 .map(unquantize)
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+        let foot = |point: Point, site: usize| {
+            dist::point_segment(point, sites[site].start, sites[site].end).1
         };
         let apex = match (first_point, second_point) {
             (Some(point), Some(other)) => Some(point.midpoint(other)),
-            (Some(point), None) => {
-                Some(point.midpoint(dist::point_segment(point, second.start, second.end).1))
-            }
-            (None, Some(point)) => {
-                Some(point.midpoint(dist::point_segment(point, first.start, first.end).1))
-            }
+            (Some(point), None) => Some(point.midpoint(foot(point, second))),
+            (None, Some(point)) => Some(point.midpoint(foot(point, first))),
             (None, None) => None,
-        }
-        .filter(|_| !samples.is_empty());
-        let crossings = samples
-            .windows(2)
-            .flat_map(|pair| {
-                component_edges.iter().filter_map(move |&(start, end)| {
-                    let (distance, on_edge, _) = dist::segments(pair[0], pair[1], start, end);
-                    (distance <= contact_tolerance).then_some(on_edge)
-                })
+        };
+        on_boundary.extend(samples.windows(2).flat_map(|pair| {
+            component_edges.iter().filter_map(move |&(start, end)| {
+                let (distance, on_edge, _) = dist::segments(pair[0], pair[1], start, end);
+                (distance <= contact_tolerance).then(|| disk(on_edge, first, second))
             })
-            .collect::<Vec<_>>();
-        samples
-            .into_iter()
-            .chain(apex)
-            .map(|center| (disk(center, first, second), false))
-            .chain(
-                crossings
-                    .into_iter()
-                    .map(|center| (disk(center, first, second), true)),
-            )
-            .collect::<Vec<_>>()
-    });
+        }));
+        on_axis.extend(
+            samples
+                .into_iter()
+                .chain(apex)
+                .map(|center| disk(center, first, second)),
+        );
+    }
+    on_axis.extend(at_vertices);
 
-    let candidates = at_vertices.chain(along_edges).collect::<Vec<_>>();
-    let centers = candidates
-        .iter()
-        .map(|(disk, _)| disk.center)
-        .collect::<Vec<_>>();
-    let present = candidates
+    // A disk is maximal only if its radius is its clearance to every site;
+    // the builder's degenerate edges can put a center next to a wall it
+    // does not touch.
+    let clearance = |center: Point| {
+        sites
+            .iter()
+            .map(|site| dist::point_segment(center, site.start, site.end).0)
+            .fold(f64::INFINITY, f64::min)
+    };
+    let centers = on_axis.iter().map(|disk| disk.center).collect::<Vec<_>>();
+    let present = on_axis
         .into_iter()
         .zip(component.contains_points_batch(&centers))
-        .filter(|((_, on_boundary), inside)| *inside || *on_boundary)
-        .map(|((disk, _), _)| disk)
+        .filter_map(|(disk, inside)| inside.then_some(disk))
+        .chain(on_boundary)
+        .filter(|disk| disk.radius <= clearance(disk.center) + contact_tolerance)
         .collect::<Vec<_>>();
     // A disk inside a larger present disk up to the flattening tolerance is
     // a branch the flattening sprouted, not a width of the source. Only
@@ -1479,7 +1516,8 @@ fn component_width(
         .iter()
         .filter(|disk| !pruned(disk))
         .map(|disk| disk.width())
-        .filter(|width| width.mm > contact_tolerance)
+        // Below two grid units a width is snapping noise, not geometry.
+        .filter(|width| width.mm > 2.0 * contact_tolerance)
         .min_by(|left, right| left.mm.total_cmp(&right.mm))
 }
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -275,11 +275,11 @@ pub struct DiskGapRegularization {
     pub removed: ContourSet,
 }
 
-/// One connected opening/closing residue bounded by two distinct source
-/// boundary branches. `width` is the exact separation of those branches in
-/// the flattened polygon representation — the authoritative local width of
-/// the material or void `region` represents — counting both branches as
-/// flattened inputs.
+/// One connected opening/closing residue that two distinct source boundary
+/// branches wall. `width` is the diameter of the narrowest maximal inscribed
+/// disk inside it — the local width of the material or void `region`
+/// represents, exact for the flattened polygon representation — counting
+/// both branches as flattened inputs.
 #[derive(Debug, Clone)]
 pub(crate) struct TwoSidedResidualComponent {
     pub region: ContourSet,
@@ -874,33 +874,30 @@ impl ContourSet {
     /// concavity. An empty result proves no two facing boundary branches fail
     /// the rolling-disk test.
     pub fn disk_gap_violations(&self, radius: f64) -> Self {
-        let rings = self
-            .two_sided_residual(radius, WallTest::Opposing, closing_residual)
-            .into_iter()
-            .flat_map(|component| component.region.rings)
-            .collect();
-        Self::new(rings, FillRule::NonZero, self.tolerance)
+        if self.is_empty() || !(radius > 0.0 && radius.is_finite()) {
+            return Self::empty(self.tolerance);
+        }
+        two_sided_gap_residual(self, &closing_residual(self, radius))
     }
 
     /// Connected sub-diameter material residues (opening residue) with the
-    /// exact separation of the two parallel source-boundary branches walling
-    /// each.
+    /// local width of each.
     pub(crate) fn disk_feature_violation_components(
         &self,
         radius: f64,
     ) -> Vec<TwoSidedResidualComponent> {
-        self.two_sided_residual(radius, WallTest::Parallel, |region, radius| {
+        self.two_sided_residual(radius, |region, radius| {
             region.difference(&region.disk_open(radius))
         })
     }
 
-    /// Connected sub-diameter void residues (closing residue) with the exact
-    /// separation of the two parallel source-boundary branches walling each.
+    /// Connected sub-diameter void residues (closing residue) with the local
+    /// width of each.
     pub(crate) fn disk_gap_violation_components(
         &self,
         radius: f64,
     ) -> Vec<TwoSidedResidualComponent> {
-        self.two_sided_residual(radius, WallTest::Parallel, closing_residual)
+        self.two_sided_residual(radius, closing_residual)
     }
 
     /// Morphological residue of this region, kept only where two distinct
@@ -908,13 +905,12 @@ impl ContourSet {
     fn two_sided_residual(
         &self,
         radius: f64,
-        walls: WallTest,
         residual: impl FnOnce(&Self, f64) -> Self,
     ) -> Vec<TwoSidedResidualComponent> {
         if self.is_empty() || !(radius > 0.0 && radius.is_finite()) {
             return Vec::new();
         }
-        two_sided_residual_components(self, &residual(self, radius), walls)
+        two_sided_residual_components(self, &residual(self, radius), radius)
     }
 
     pub fn to_contours(&self) -> Vec<ContourBuf> {
@@ -1110,20 +1106,6 @@ fn closing_residual(region: &ContourSet, radius: f64) -> ContourSet {
     region.disk_close(radius).difference(region)
 }
 
-/// When two boundary segments of one ring count as opposite walls of a
-/// residue. Segments on distinct rings always do.
-#[derive(Debug, Clone, Copy)]
-enum WallTest {
-    /// Tangents oppose. Conservative: any facing pair is a void, which is
-    /// what a gap certificate or regularization keep-out must not miss.
-    Opposing,
-    /// Tangents oppose and the closest-pair separation is normal to both,
-    /// so the measured distance is a width between parallel walls rather
-    /// than a chord between oblique edges of one curve. Required wherever
-    /// the distance itself is the verdict.
-    Parallel,
-}
-
 /// Every source boundary edge longer than the region tolerance, sorted by
 /// minimum x so a query can stop scanning once edges start past its bounds.
 fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment> {
@@ -1151,12 +1133,21 @@ fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment>
     segments
 }
 
-/// Each connected component of `residual` that is walled by two facing
-/// source-boundary branches, with the exact separation of those branches.
+/// Each connected component of `residual` that two distinct source-boundary
+/// branches wall, with its local width.
+///
+/// A point of the residue is nearer than `reach` to the source boundary —
+/// no disk of that radius covers it — so the boundary segments within
+/// `reach` of the component are every segment its inscribed disks can
+/// touch, and their Voronoi diagram restricted to the component is the
+/// medial axis there. The narrowest maximal inscribed disk on that axis is
+/// the component's width. Disks tangent only to incident segments are
+/// corner spokes, not widths: discarding those leaves one-sided residue —
+/// the bite an isolated corner sheds — with no width at all.
 fn two_sided_residual_components(
     source: &ContourSet,
     residual: &ContourSet,
-    walls: WallTest,
+    reach: f64,
 ) -> Vec<TwoSidedResidualComponent> {
     let segments = source_boundary_segments(source);
     let contact_tolerance = source.tolerance.max(residual.tolerance);
@@ -1164,8 +1155,8 @@ fn two_sided_residual_components(
         .connected_components()
         .into_iter()
         .filter_map(|component| {
-            let contacts = contacting_segments(&segments, &component, contact_tolerance);
-            opposing_boundary_clearance(&contacts, contact_tolerance, walls).map(|width| {
+            let sites = segments_near(&segments, component.bbox.expand(reach));
+            component_width(&sites, &component, reach, contact_tolerance).map(|width| {
                 TwoSidedResidualComponent {
                     region: component,
                     width,
@@ -1175,74 +1166,392 @@ fn two_sided_residual_components(
         .collect()
 }
 
-/// The source boundary segments touching `component`.
-fn contacting_segments<'a>(
-    segments: &'a [OrientedBoundarySegment],
-    component: &ContourSet,
-    contact_tolerance: f64,
-) -> Vec<&'a OrientedBoundarySegment> {
-    let query = component.bbox.expand(contact_tolerance);
+/// The segments (sorted by minimum x) whose bounds meet `query`.
+fn segments_near(
+    segments: &[OrientedBoundarySegment],
+    query: BBox,
+) -> Vec<OrientedBoundarySegment> {
     let candidate_end = segments.partition_point(|segment| segment.bbox.min.x <= query.max.x);
     segments[..candidate_end]
         .iter()
-        .filter(|segment| {
-            segment.bbox.intersects(query)
-                && region_boundary_within_distance(
-                    component,
-                    segment.start,
-                    segment.end,
-                    contact_tolerance,
-                )
-        })
+        .filter(|segment| segment.bbox.intersects(query))
+        .copied()
         .collect()
 }
 
-/// The closest pair of contact segments that are two distinct walls facing
-/// each other across the residue, or `None` when the residue is one-sided.
-fn opposing_boundary_clearance(
-    contacts: &[&OrientedBoundarySegment],
-    contact_tolerance: f64,
-    walls: WallTest,
-) -> Option<Distance> {
-    contacts
+/// A boundary segment snapped to the tolerance grid, with its topology.
+type GridSite = (VoronoiLine<i32>, BoundarySegment);
+
+/// The sites snap-rounded to a planar set on the tolerance grid. The
+/// Voronoi builder accepts segments that meet only at endpoints, while
+/// regularized rings may touch along a seam (two rings sharing an edge),
+/// at a vertex on another ring's edge, or fold into hairpins narrower than
+/// the tolerance. On the grid, points within tolerance are one point:
+/// zero-length and duplicate segments drop, a segment splits where another
+/// endpoint lies on it, and of two segments that still cross — noise at
+/// tolerance scale — the shorter drops. Pieces keep their parent's topology
+/// and so remain incident to each other and to its neighbors.
+fn planar_grid_sites(
+    sites: &[OrientedBoundarySegment],
+    quantize: impl Fn(Point) -> VoronoiPoint<i32>,
+) -> Vec<GridSite> {
+    let orient = |a: VoronoiPoint<i32>, b: VoronoiPoint<i32>, c: VoronoiPoint<i32>| -> i128 {
+        (i128::from(b.x) - i128::from(a.x)) * (i128::from(c.y) - i128::from(a.y))
+            - (i128::from(b.y) - i128::from(a.y)) * (i128::from(c.x) - i128::from(a.x))
+    };
+    let on_interior = |line: &VoronoiLine<i32>, point: VoronoiPoint<i32>| {
+        point != line.start
+            && point != line.end
+            && orient(line.start, line.end, point) == 0
+            && (line.start.x.min(line.end.x)..=line.start.x.max(line.end.x)).contains(&point.x)
+            && (line.start.y.min(line.end.y)..=line.start.y.max(line.end.y)).contains(&point.y)
+    };
+    let length2 = |line: &VoronoiLine<i32>| {
+        let dx = i128::from(line.end.x) - i128::from(line.start.x);
+        let dy = i128::from(line.end.y) - i128::from(line.start.y);
+        dx * dx + dy * dy
+    };
+    let snapped = sites
+        .iter()
+        .map(|site| {
+            (
+                VoronoiLine::new(quantize(site.start), quantize(site.end)),
+                site.topology,
+            )
+        })
+        .filter(|(line, _)| line.start != line.end)
+        .collect::<Vec<_>>();
+    let endpoints = snapped
+        .iter()
+        .flat_map(|(line, _)| [line.start, line.end])
+        .collect::<Vec<_>>();
+    let split = snapped
+        .iter()
+        .flat_map(|&(line, topology)| {
+            let mut stations = endpoints
+                .iter()
+                .copied()
+                .filter(|&point| on_interior(&line, point))
+                .collect::<Vec<_>>();
+            let along = |point: VoronoiPoint<i32>| {
+                (i128::from(point.x) - i128::from(line.start.x)).abs()
+                    + (i128::from(point.y) - i128::from(line.start.y)).abs()
+            };
+            stations.sort_by_key(|&point| along(point));
+            stations.dedup();
+            std::iter::once(line.start)
+                .chain(stations)
+                .chain(std::iter::once(line.end))
+                .collect::<Vec<_>>()
+                .windows(2)
+                .map(|pair| (VoronoiLine::new(pair[0], pair[1]), topology))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut seen = std::collections::HashSet::new();
+    let split = split
+        .into_iter()
+        .filter(|(line, _)| {
+            let key = if (line.start.x, line.start.y) <= (line.end.x, line.end.y) {
+                (line.start.x, line.start.y, line.end.x, line.end.y)
+            } else {
+                (line.end.x, line.end.y, line.start.x, line.start.y)
+            };
+            seen.insert(key)
+        })
+        .collect::<Vec<_>>();
+    let crosses = |a: &VoronoiLine<i32>, b: &VoronoiLine<i32>| {
+        let o1 = orient(a.start, a.end, b.start).signum();
+        let o2 = orient(a.start, a.end, b.end).signum();
+        let o3 = orient(b.start, b.end, a.start).signum();
+        let o4 = orient(b.start, b.end, a.end).signum();
+        o1 * o2 < 0 && o3 * o4 < 0
+    };
+    split
         .iter()
         .enumerate()
-        .flat_map(|(index, left)| {
-            contacts[index + 1..].iter().filter_map(move |right| {
-                facing_wall_clearance(left, right, contact_tolerance, walls)
+        .filter(|(index, (line, _))| {
+            !split.iter().enumerate().any(|(other_index, (other, _))| {
+                other_index != *index
+                    && crosses(line, other)
+                    && (length2(other), other_index) > (length2(line), *index)
             })
         })
+        .map(|(_, site)| *site)
+        .collect()
+}
+
+/// A maximal inscribed disk of the boundary's Voronoi diagram: its center,
+/// radius, and the two tangency points on distinct walls.
+#[derive(Debug, Clone, Copy)]
+struct InscribedDisk {
+    center: Point,
+    radius: f64,
+    first: Point,
+    second: Point,
+}
+
+impl InscribedDisk {
+    fn width(self) -> Distance {
+        Distance::flattened(2.0 * self.radius, self.first, self.second, 2)
+    }
+}
+
+/// The narrowest maximal inscribed disk of `sites` inside `component`, as a
+/// width between its two tangency points.
+///
+/// Candidates are the Voronoi vertices, and every non-incident edge sampled
+/// along its length, at the apex of a parabolic or point–point edge, and
+/// where it crosses the component boundary — the clearance along an edge is
+/// linear or convex, so its minimum over the inside is at one of those.
+/// Flattening a curve sprouts axis branches the source does not have, whose
+/// disks sit inside a neighbor's disk up to the flattening tolerance; those
+/// are pruned, so a flattened arc measures its diameter and a taper keeps
+/// its tip.
+fn component_width(
+    sites: &[OrientedBoundarySegment],
+    component: &ContourSet,
+    reach: f64,
+    contact_tolerance: f64,
+) -> Option<Distance> {
+    let origin = component.bbox.min;
+    let units_per_mm = 1.0 / contact_tolerance;
+    let quantize = |point: Point| {
+        VoronoiPoint::new(
+            ((point.x - origin.x) * units_per_mm).round() as i32,
+            ((point.y - origin.y) * units_per_mm).round() as i32,
+        )
+    };
+    let unquantize =
+        |[x, y]: [f64; 2]| Point::new(x / units_per_mm + origin.x, y / units_per_mm + origin.y);
+    let grid = planar_grid_sites(sites, quantize);
+    let lines = grid.iter().map(|(line, _)| *line).collect::<Vec<_>>();
+    let sites = grid
+        .iter()
+        .map(|(line, topology)| {
+            let start = unquantize([f64::from(line.start.x), f64::from(line.start.y)]);
+            let end = unquantize([f64::from(line.end.x), f64::from(line.end.y)]);
+            OrientedBoundarySegment {
+                topology: *topology,
+                start,
+                end,
+                bbox: segment_bbox(start, end),
+            }
+        })
+        .collect::<Vec<_>>();
+    let sites = sites.as_slice();
+    if lines.len() < 2 {
+        return None;
+    }
+    let diagram = VoronoiBuilder::<i32>::default()
+        .with_segments(lines.iter())
+        .and_then(VoronoiBuilder::build)
+        .expect("snap-rounded boundary segments do not cross");
+    let site_of = |cell: VoronoiCellIndex| {
+        let cell = diagram.cell(cell).expect("diagram cell");
+        let site = &sites[cell.source_index().usize()];
+        let point = match cell.source_category() {
+            SourceCategory::SegmentStart => Some(site.start),
+            SourceCategory::SegmentEnd => Some(site.end),
+            SourceCategory::Segment | SourceCategory::SinglePoint => None,
+        };
+        (site, point)
+    };
+    let disk =
+        |center: Point, first: &OrientedBoundarySegment, second: &OrientedBoundarySegment| {
+            let (first_distance, first) = dist::point_segment(center, first.start, first.end);
+            let (second_distance, second) = dist::point_segment(center, second.start, second.end);
+            InscribedDisk {
+                center,
+                radius: (first_distance + second_distance) / 2.0,
+                first,
+                second,
+            }
+        };
+    let component_edges = component
+        .rings
+        .iter()
+        .flat_map(ring_edges)
+        .collect::<Vec<_>>();
+
+    // Vertices: tangent to every site around them; a width needs two that
+    // are not incident.
+    let at_vertices = diagram.vertices().iter().filter_map(|vertex| {
+        let center = unquantize([vertex.x(), vertex.y()]);
+        let around = diagram
+            .edge_rot_next_iterator(vertex.get_incident_edge().ok()?)
+            .filter_map(|edge| diagram.edge(edge).ok()?.cell().ok())
+            .map(|cell| site_of(cell).0)
+            .collect::<Vec<_>>();
+        around
+            .iter()
+            .enumerate()
+            .flat_map(|(index, first)| {
+                around[index + 1..]
+                    .iter()
+                    .map(move |second| (first, second))
+            })
+            .find(|(first, second)| {
+                !boundary_segments_are_incident(first.topology, second.topology)
+            })
+            .map(|(first, second)| (disk(center, first, second), false))
+    });
+
+    // Edges between non-incident sites, sampled along their length, at the
+    // apex of a parabola (reflex vertex against a segment) or point–point
+    // bisector, and where they cross the component boundary.
+    let along_edges = diagram.edges().iter().flat_map(|edge| {
+        let twin = edge.twin().expect("diagram edge twin");
+        let (first, first_point) = site_of(edge.cell().expect("diagram edge cell"));
+        let (second, second_point) = site_of(
+            diagram
+                .edge(twin)
+                .and_then(|twin| twin.cell())
+                .expect("twin cell"),
+        );
+        let skip = edge.id() > twin
+            || !edge.is_primary()
+            || boundary_segments_are_incident(first.topology, second.topology);
+        let samples = if skip {
+            Vec::new()
+        } else {
+            voronoi_edge_samples(&diagram, edge.id(), &lines, component, reach, units_per_mm)
+                .expect("voronoi edge samples")
+                .into_iter()
+                .map(unquantize)
+                .collect::<Vec<_>>()
+        };
+        let apex = match (first_point, second_point) {
+            (Some(point), Some(other)) => Some(point.midpoint(other)),
+            (Some(point), None) => {
+                Some(point.midpoint(dist::point_segment(point, second.start, second.end).1))
+            }
+            (None, Some(point)) => {
+                Some(point.midpoint(dist::point_segment(point, first.start, first.end).1))
+            }
+            (None, None) => None,
+        }
+        .filter(|_| !samples.is_empty());
+        let crossings = samples
+            .windows(2)
+            .flat_map(|pair| {
+                component_edges.iter().filter_map(move |&(start, end)| {
+                    let (distance, on_edge, _) = dist::segments(pair[0], pair[1], start, end);
+                    (distance <= contact_tolerance).then_some(on_edge)
+                })
+            })
+            .collect::<Vec<_>>();
+        samples
+            .into_iter()
+            .chain(apex)
+            .map(|center| (disk(center, first, second), false))
+            .chain(
+                crossings
+                    .into_iter()
+                    .map(|center| (disk(center, first, second), true)),
+            )
+            .collect::<Vec<_>>()
+    });
+
+    let candidates = at_vertices.chain(along_edges).collect::<Vec<_>>();
+    let centers = candidates
+        .iter()
+        .map(|(disk, _)| disk.center)
+        .collect::<Vec<_>>();
+    let present = candidates
+        .into_iter()
+        .zip(component.contains_points_batch(&centers))
+        .filter(|((_, on_boundary), inside)| *inside || *on_boundary)
+        .map(|((disk, _), _)| disk)
+        .collect::<Vec<_>>();
+    // A disk inside a larger present disk up to the flattening tolerance is
+    // a branch the flattening sprouted, not a width of the source. Only
+    // present disks prune: a void's exterior axis must not swallow a slit
+    // thinner than the tolerance.
+    let pruned = |disk: &InscribedDisk| {
+        present.iter().any(|other| {
+            other.radius > disk.radius
+                && disk.center.distance_to(other.center) + disk.radius
+                    <= other.radius + tol::FLATTEN_MM
+        })
+    };
+    present
+        .iter()
+        .filter(|disk| !pruned(disk))
+        .map(|disk| disk.width())
+        .filter(|width| width.mm > contact_tolerance)
         .min_by(|left, right| left.mm.total_cmp(&right.mm))
 }
 
-/// The separation of two boundary segments when they are opposite walls of
-/// the same residue. Incident segments and segments closer than the contact
-/// tolerance are the same wall. Segments on distinct rings always face each
-/// other across material or void; segments on one ring must pass `walls`,
-/// so the rounded bite of one smooth corner is not a width.
-fn facing_wall_clearance(
-    left: &OrientedBoundarySegment,
-    right: &OrientedBoundarySegment,
-    contact_tolerance: f64,
-    walls: WallTest,
-) -> Option<Distance> {
-    if boundary_segments_are_incident(left.topology, right.topology) {
-        return None;
-    }
-    let (mm, first, second) = dist::segments(left.start, left.end, right.start, right.end);
-    let clearance = Distance::flattened(mm, first, second, 2);
-    let left_tangent = left.end - left.start;
-    let right_tangent = right.end - right.start;
-    let same_ring_walls = match walls {
-        WallTest::Opposing => tangents_oppose(left_tangent, right_tangent),
-        WallTest::Parallel => {
-            tangents_oppose(left_tangent, right_tangent)
-                && separation_is_normal(clearance, left_tangent, contact_tolerance)
-                && separation_is_normal(clearance, right_tangent, contact_tolerance)
-        }
-    };
-    (mm > contact_tolerance && (left.topology.ring != right.topology.ring || same_ring_walls))
-        .then_some(clearance)
+/// The closing residue kept only where two distinct source-boundary
+/// branches wall it — the balancing certificate's conservative notion of a
+/// narrow void. Contacts on distinct rings always face each other across
+/// void, whatever their relative angle; same-ring contacts must oppose, so
+/// the rounded bite of one smooth concavity is not mistaken for a gap.
+fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> ContourSet {
+    let source_segments = source
+        .rings
+        .iter()
+        .enumerate()
+        .flat_map(|(ring_id, ring)| {
+            (0..ring.len()).filter_map(move |index| {
+                let [start_x, start_y] = ring[index];
+                let [end_x, end_y] = ring[(index + 1) % ring.len()];
+                let start = Point::new(start_x, start_y);
+                let end = Point::new(end_x, end_y);
+                (start.distance_to(end) > source.tolerance).then_some(OrientedBoundarySegment {
+                    topology: BoundarySegment {
+                        ring: ring_id,
+                        index,
+                        ring_len: ring.len(),
+                    },
+                    start,
+                    end,
+                    bbox: segment_bbox(start, end),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    let contact_tolerance = source.tolerance.max(residual.tolerance);
+
+    let rings = residual
+        .connected_components()
+        .into_iter()
+        .filter(|component| {
+            let contacts = source_segments
+                .iter()
+                .filter(|segment| {
+                    segment
+                        .bbox
+                        .expand(contact_tolerance)
+                        .intersects(component.bbox)
+                        && region_boundary_within_distance(
+                            component,
+                            segment.start,
+                            segment.end,
+                            contact_tolerance,
+                        )
+                })
+                .collect::<Vec<_>>();
+            contacts.iter().enumerate().any(|(index, left)| {
+                contacts[index + 1..].iter().any(|right| {
+                    let (separation, _, _) =
+                        dist::segments(left.start, left.end, right.start, right.end);
+                    // Contacts on distinct rings always face each other across
+                    // void, whatever their relative angle. Same-ring pairs
+                    // must additionally oppose so the rounded bite of one
+                    // smooth concavity is not mistaken for a gap; walls at
+                    // exactly 90° remain ambiguous there by construction.
+                    !boundary_segments_are_incident(left.topology, right.topology)
+                        && separation > contact_tolerance
+                        && (left.topology.ring != right.topology.ring
+                            || boundary_tangents_oppose(left, right))
+                })
+            })
+        })
+        .flat_map(|component| component.rings)
+        .collect();
+    ContourSet::new(rings, FillRule::NonZero, residual.tolerance)
 }
 
 fn region_boundary_within_distance(
@@ -1253,24 +1562,24 @@ fn region_boundary_within_distance(
 ) -> bool {
     let expanded = segment_bbox(start, end).expand(distance);
     region.rings.iter().any(|ring| {
-        ring_edges(ring).any(|(other_start, other_end)| {
+        (0..ring.len()).any(|index| {
+            let [other_start_x, other_start_y] = ring[index];
+            let [other_end_x, other_end_y] = ring[(index + 1) % ring.len()];
+            let other_start = Point::new(other_start_x, other_start_y);
+            let other_end = Point::new(other_end_x, other_end_y);
             expanded.intersects(segment_bbox(other_start, other_end))
                 && dist::segments(start, end, other_start, other_end).0 <= distance
         })
     })
 }
 
-fn tangents_oppose(left: Point, right: Point) -> bool {
-    left.x * right.x + left.y * right.y < 0.0
-}
-
-/// Whether the closest-pair separation is normal to a wall within the
-/// contact tolerance (at least the flattening chord error): the component
-/// of the separation along the wall's tangent is negligible.
-fn separation_is_normal(clearance: Distance, tangent: Point, contact_tolerance: f64) -> bool {
-    let separation = clearance.second - clearance.first;
-    let along = (tangent.x * separation.x + tangent.y * separation.y).abs() / tangent.length();
-    along <= contact_tolerance.max(tol::FLATTEN_MM)
+fn boundary_tangents_oppose(
+    left: &OrientedBoundarySegment,
+    right: &OrientedBoundarySegment,
+) -> bool {
+    let left_tangent = left.end - left.start;
+    let right_tangent = right.end - right.start;
+    left_tangent.x * right_tangent.x + left_tangent.y * right_tangent.y < 0.0
 }
 
 /// Keep-out whose removal widens every narrow void: a radius-`radius` tube
@@ -1368,7 +1677,14 @@ fn narrow_void_medial_axis_keep_out(
         if boundary_segments_are_incident(*left_boundary, *right_boundary) {
             continue;
         }
-        let samples = voronoi_edge_samples(&diagram, edge.id(), &segments, source, radius)?;
+        let samples = voronoi_edge_samples(
+            &diagram,
+            edge.id(),
+            &segments,
+            source,
+            radius,
+            VORONOI_COORDINATES_PER_MM,
+        )?;
         let mut commands = Vec::with_capacity(samples.len());
         for sample in samples {
             let point = Point::new(
@@ -1454,6 +1770,7 @@ fn voronoi_edge_samples(
     segments: &[VoronoiLine<i32>],
     region: &ContourSet,
     radius: f64,
+    units_per_mm: f64,
 ) -> Result<Vec<[f64; 2]>, GapRegularizationError> {
     let edge = diagram.edge(edge_id).map_err(gap_regularization_error)?;
     let affine = SimpleAffine::default();
@@ -1470,7 +1787,7 @@ fn voronoi_edge_samples(
             affine.transform(end.x(), end.y()),
         ]
     } else {
-        clip_infinite_voronoi_edge(diagram, edge_id, segments, region, radius)?
+        clip_infinite_voronoi_edge(diagram, edge_id, segments, region, radius, units_per_mm)?
     };
 
     if edge.is_curved() {
@@ -1493,7 +1810,7 @@ fn voronoi_edge_samples(
         VoronoiVisualUtils::discretize(
             &point,
             segment,
-            tol::FLATTEN_MM * VORONOI_COORDINATES_PER_MM,
+            tol::FLATTEN_MM * units_per_mm,
             &affine,
             &mut samples,
         );
@@ -1507,6 +1824,7 @@ fn clip_infinite_voronoi_edge(
     segments: &[VoronoiLine<i32>],
     region: &ContourSet,
     radius: f64,
+    units_per_mm: f64,
 ) -> Result<Vec<[f64; 2]>, GapRegularizationError> {
     let edge = diagram.edge(edge_id).map_err(gap_regularization_error)?;
     let cell = edge.cell().map_err(gap_regularization_error)?;
@@ -1549,8 +1867,7 @@ fn clip_infinite_voronoi_edge(
         };
         (origin, direction)
     };
-    let reach =
-        (region.bbox.width().max(region.bbox.height()) + 4.0 * radius) * VORONOI_COORDINATES_PER_MM;
+    let reach = (region.bbox.width().max(region.bbox.height()) + 4.0 * radius) * units_per_mm;
     let direction_scale = direction[0].abs().max(direction[1].abs());
     if direction_scale == 0.0 {
         return Err(GapRegularizationError(

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -1278,7 +1278,13 @@ fn planar_grid_sites(
                 .copied()
                 .filter(|&point| on_interior(&line, point))
                 .collect::<Vec<_>>();
-            stations.sort_by_key(|point| (point.x, point.y));
+            // Collinear with the segment, so distance from its start orders
+            // them along it whichever way it runs.
+            let along = |point: &VoronoiPoint<i32>| {
+                (i64::from(point.x) - i64::from(line.start.x)).abs()
+                    + (i64::from(point.y) - i64::from(line.start.y)).abs()
+            };
+            stations.sort_by_key(along);
             stations.dedup();
             std::iter::once(line.start)
                 .chain(stations)
@@ -2070,6 +2076,41 @@ fn segment_bbox(start: Point, end: Point) -> BBox {
 mod tests {
     use super::*;
     use crate::geom::shapes;
+
+    #[test]
+    fn planar_sites_split_along_the_segment_whichever_way_it_runs() {
+        let site = |start: (f64, f64), end: (f64, f64), index: usize| OrientedBoundarySegment {
+            topology: BoundarySegment {
+                ring: index / 10,
+                index,
+                ring_len: 10,
+            },
+            start: Point::new(start.0, start.1),
+            end: Point::new(end.0, end.1),
+            bbox: segment_bbox(Point::new(start.0, start.1), Point::new(end.0, end.1)),
+        };
+        // A right-to-left host touched at two interior points by other rings.
+        let sites = [
+            site((10.0, 0.0), (0.0, 0.0), 0),
+            site((7.0, 5.0), (7.0, 0.0), 10),
+            site((3.0, 5.0), (3.0, 0.0), 20),
+        ];
+        let grid = planar_grid_sites(&sites, |point| {
+            VoronoiPoint::new(point.x as i32, point.y as i32)
+        });
+
+        let host = grid
+            .iter()
+            .filter(|(_, topology)| topology.index == 0)
+            .map(|(line, _)| line)
+            .collect::<Vec<_>>();
+        assert_eq!(host.len(), 3);
+        assert_eq!(host[0].start, VoronoiPoint::new(10, 0));
+        for pair in host.windows(2) {
+            assert_eq!(pair[0].end, pair[1].start, "pieces chain along the host");
+        }
+        assert_eq!(host[2].end, VoronoiPoint::new(0, 0));
+    }
 
     #[test]
     fn inward_decimation_only_shrinks_and_respects_deviation() {

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -26,7 +26,7 @@ use i_overlay::mesh::style::{LineJoin as OutlineLineJoin, OutlineStyle};
 
 use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
-use crate::geom::dist::{self, ClearanceMeasurement};
+use crate::geom::dist::{self, Distance};
 use crate::geom::path::{ContourBuf, PathCmd, contours_to_kurbo, stroke_to_fill, transform_cmds};
 use crate::geom::point::Point;
 use crate::geom::store::{Path, PathArena};
@@ -276,13 +276,14 @@ pub struct DiskGapRegularization {
 }
 
 /// One connected opening/closing residue bounded by two distinct source
-/// boundary branches. `clearance` is the exact separation of those branches
-/// in the flattened polygon representation: the authoritative local width of
-/// the material or void `region` represents.
+/// boundary branches. `width` is the exact separation of those branches in
+/// the flattened polygon representation — the authoritative local width of
+/// the material or void `region` represents — counting both branches as
+/// flattened inputs.
 #[derive(Debug, Clone)]
 pub(crate) struct TwoSidedResidualComponent {
     pub region: ContourSet,
-    pub clearance: ClearanceMeasurement,
+    pub width: Distance,
 }
 
 /// Failure to construct a narrow void's medial axis for gap regularization.
@@ -1164,10 +1165,10 @@ fn two_sided_residual_components(
         .into_iter()
         .filter_map(|component| {
             let contacts = contacting_segments(&segments, &component, contact_tolerance);
-            opposing_boundary_clearance(&contacts, contact_tolerance, walls).map(|clearance| {
+            opposing_boundary_clearance(&contacts, contact_tolerance, walls).map(|width| {
                 TwoSidedResidualComponent {
                     region: component,
-                    clearance,
+                    width,
                 }
             })
         })
@@ -1202,7 +1203,7 @@ fn opposing_boundary_clearance(
     contacts: &[&OrientedBoundarySegment],
     contact_tolerance: f64,
     walls: WallTest,
-) -> Option<ClearanceMeasurement> {
+) -> Option<Distance> {
     contacts
         .iter()
         .enumerate()
@@ -1211,7 +1212,7 @@ fn opposing_boundary_clearance(
                 facing_wall_clearance(left, right, contact_tolerance, walls)
             })
         })
-        .min_by(|left, right| left.distance_mm.total_cmp(&right.distance_mm))
+        .min_by(|left, right| left.mm.total_cmp(&right.mm))
 }
 
 /// The separation of two boundary segments when they are opposite walls of
@@ -1224,16 +1225,12 @@ fn facing_wall_clearance(
     right: &OrientedBoundarySegment,
     contact_tolerance: f64,
     walls: WallTest,
-) -> Option<ClearanceMeasurement> {
+) -> Option<Distance> {
     if boundary_segments_are_incident(left.topology, right.topology) {
         return None;
     }
-    let (distance_mm, first, second) = dist::segments(left.start, left.end, right.start, right.end);
-    let clearance = ClearanceMeasurement {
-        distance_mm,
-        first,
-        second,
-    };
+    let (mm, first, second) = dist::segments(left.start, left.end, right.start, right.end);
+    let clearance = Distance::flattened(mm, first, second, 2);
     let left_tangent = left.end - left.start;
     let right_tangent = right.end - right.start;
     let same_ring_walls = match walls {
@@ -1244,8 +1241,7 @@ fn facing_wall_clearance(
                 && separation_is_normal(clearance, right_tangent, contact_tolerance)
         }
     };
-    (distance_mm > contact_tolerance
-        && (left.topology.ring != right.topology.ring || same_ring_walls))
+    (mm > contact_tolerance && (left.topology.ring != right.topology.ring || same_ring_walls))
         .then_some(clearance)
 }
 
@@ -1271,11 +1267,7 @@ fn tangents_oppose(left: Point, right: Point) -> bool {
 /// Whether the closest-pair separation is normal to a wall within the
 /// contact tolerance (at least the flattening chord error): the component
 /// of the separation along the wall's tangent is negligible.
-fn separation_is_normal(
-    clearance: ClearanceMeasurement,
-    tangent: Point,
-    contact_tolerance: f64,
-) -> bool {
+fn separation_is_normal(clearance: Distance, tangent: Point, contact_tolerance: f64) -> bool {
     let separation = clearance.second - clearance.first;
     let along = (tangent.x * separation.x + tangent.y * separation.y).abs() / tangent.length();
     along <= contact_tolerance.max(tol::FLATTEN_MM)

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -26,7 +26,7 @@ use i_overlay::mesh::style::{LineJoin as OutlineLineJoin, OutlineStyle};
 
 use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
-use crate::geom::dist;
+use crate::geom::dist::{self, ClearanceMeasurement};
 use crate::geom::path::{ContourBuf, PathCmd, contours_to_kurbo, stroke_to_fill, transform_cmds};
 use crate::geom::point::Point;
 use crate::geom::store::{Path, PathArena};
@@ -276,15 +276,13 @@ pub struct DiskGapRegularization {
 }
 
 /// One connected opening/closing residue bounded by two distinct source
-/// boundary branches. The boundary measurement is exact for the flattened
-/// polygon representation and is the authoritative local width of the
-/// material or void represented by `region`.
+/// boundary branches. `clearance` is the exact separation of those branches
+/// in the flattened polygon representation: the authoritative local width of
+/// the material or void `region` represents.
 #[derive(Debug, Clone)]
 pub(crate) struct TwoSidedResidualComponent {
     pub region: ContourSet,
-    pub distance_mm: f64,
-    pub first: Point,
-    pub second: Point,
+    pub clearance: ClearanceMeasurement,
 }
 
 /// Failure to construct a narrow void's medial axis for gap regularization.
@@ -875,42 +873,47 @@ impl ContourSet {
     /// concavity. An empty result proves no two facing boundary branches fail
     /// the rolling-disk test.
     pub fn disk_gap_violations(&self, radius: f64) -> Self {
-        if self.is_empty() || radius <= 0.0 || !radius.is_finite() {
-            return Self::empty(self.tolerance);
-        }
-        let closing_residual = self.disk_close(radius).difference(self);
-        let rings =
-            two_sided_residual_components(self, &closing_residual, same_ring_tangents_oppose)
-                .into_iter()
-                .flat_map(|component| component.region.rings)
-                .collect();
+        let rings = self
+            .two_sided_residual(radius, WallTest::Opposing, closing_residual)
+            .into_iter()
+            .flat_map(|component| component.region.rings)
+            .collect();
         Self::new(rings, FillRule::NonZero, self.tolerance)
     }
 
-    /// Connected sub-diameter material residues and their exact opposing
-    /// source-boundary measurements.
+    /// Connected sub-diameter material residues (opening residue) with the
+    /// exact separation of the two parallel source-boundary branches walling
+    /// each.
     pub(crate) fn disk_feature_violation_components(
         &self,
         radius: f64,
     ) -> Vec<TwoSidedResidualComponent> {
-        if self.is_empty() || radius <= 0.0 || !radius.is_finite() {
-            return Vec::new();
-        }
-        let opening_residual = self.difference(&self.disk_open(radius));
-        two_sided_residual_components(self, &opening_residual, same_ring_boundaries_face_across)
+        self.two_sided_residual(radius, WallTest::Parallel, |region, radius| {
+            region.difference(&region.disk_open(radius))
+        })
     }
 
-    /// Connected sub-diameter void residues and their exact opposing
-    /// source-boundary measurements.
+    /// Connected sub-diameter void residues (closing residue) with the exact
+    /// separation of the two parallel source-boundary branches walling each.
     pub(crate) fn disk_gap_violation_components(
         &self,
         radius: f64,
     ) -> Vec<TwoSidedResidualComponent> {
-        if self.is_empty() || radius <= 0.0 || !radius.is_finite() {
+        self.two_sided_residual(radius, WallTest::Parallel, closing_residual)
+    }
+
+    /// Morphological residue of this region, kept only where two distinct
+    /// source-boundary branches wall it. A degenerate disk has no residue.
+    fn two_sided_residual(
+        &self,
+        radius: f64,
+        walls: WallTest,
+        residual: impl FnOnce(&Self, f64) -> Self,
+    ) -> Vec<TwoSidedResidualComponent> {
+        if self.is_empty() || !(radius > 0.0 && radius.is_finite()) {
             return Vec::new();
         }
-        let closing_residual = self.disk_close(radius).difference(self);
-        two_sided_residual_components(self, &closing_residual, same_ring_boundaries_face_across)
+        two_sided_residual_components(self, &residual(self, radius), walls)
     }
 
     pub fn to_contours(&self) -> Vec<ContourBuf> {
@@ -1102,32 +1105,36 @@ struct OrientedBoundarySegment {
     bbox: BBox,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct BoundaryPairMeasurement {
-    distance_mm: f64,
-    first: Point,
-    second: Point,
+fn closing_residual(region: &ContourSet, radius: f64) -> ContourSet {
+    region.disk_close(radius).difference(region)
 }
 
-type SameRingBoundaryPredicate =
-    fn(&OrientedBoundarySegment, &OrientedBoundarySegment, BoundaryPairMeasurement, f64) -> bool;
+/// When two boundary segments of one ring count as opposite walls of a
+/// residue. Segments on distinct rings always do.
+#[derive(Debug, Clone, Copy)]
+enum WallTest {
+    /// Tangents oppose. Conservative: any facing pair is a void, which is
+    /// what a gap certificate or regularization keep-out must not miss.
+    Opposing,
+    /// Tangents oppose and the closest-pair separation is normal to both,
+    /// so the measured distance is a width between parallel walls rather
+    /// than a chord between oblique edges of one curve. Required wherever
+    /// the distance itself is the verdict.
+    Parallel,
+}
 
-fn two_sided_residual_components(
-    source: &ContourSet,
-    residual: &ContourSet,
-    same_ring_qualifies: SameRingBoundaryPredicate,
-) -> Vec<TwoSidedResidualComponent> {
-    let mut source_segments = source
+/// Every source boundary edge longer than the region tolerance, sorted by
+/// minimum x so a query can stop scanning once edges start past its bounds.
+fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment> {
+    let mut segments = source
         .rings
         .iter()
         .enumerate()
         .flat_map(|(ring_id, ring)| {
-            (0..ring.len()).filter_map(move |index| {
-                let [start_x, start_y] = ring[index];
-                let [end_x, end_y] = ring[(index + 1) % ring.len()];
-                let start = Point::new(start_x, start_y);
-                let end = Point::new(end_x, end_y);
-                (start.distance_to(end) > source.tolerance).then_some(OrientedBoundarySegment {
+            ring_edges(ring)
+                .enumerate()
+                .filter(|(_, (start, end))| start.distance_to(*end) > source.tolerance)
+                .map(move |(index, (start, end))| OrientedBoundarySegment {
                     topology: BoundarySegment {
                         ring: ring_id,
                         index,
@@ -1137,76 +1144,109 @@ fn two_sided_residual_components(
                     end,
                     bbox: segment_bbox(start, end),
                 })
-            })
         })
         .collect::<Vec<_>>();
-    source_segments.sort_by(|left, right| left.bbox.min.x.total_cmp(&right.bbox.min.x));
-    let contact_tolerance = source.tolerance.max(residual.tolerance);
+    segments.sort_by(|left, right| left.bbox.min.x.total_cmp(&right.bbox.min.x));
+    segments
+}
 
+/// Each connected component of `residual` that is walled by two facing
+/// source-boundary branches, with the exact separation of those branches.
+fn two_sided_residual_components(
+    source: &ContourSet,
+    residual: &ContourSet,
+    walls: WallTest,
+) -> Vec<TwoSidedResidualComponent> {
+    let segments = source_boundary_segments(source);
+    let contact_tolerance = source.tolerance.max(residual.tolerance);
     residual
         .connected_components()
         .into_iter()
         .filter_map(|component| {
-            let query = component.bbox.expand(contact_tolerance);
-            let candidate_end =
-                source_segments.partition_point(|segment| segment.bbox.min.x <= query.max.x);
-            let contacts = source_segments[..candidate_end]
-                .iter()
-                .filter(|segment| {
-                    segment.bbox.max.x >= query.min.x
-                        && segment.bbox.max.y >= query.min.y
-                        && segment.bbox.min.y <= query.max.y
-                        && region_boundary_within_distance(
-                            &component,
-                            segment.start,
-                            segment.end,
-                            contact_tolerance,
-                        )
-                })
-                .collect::<Vec<_>>();
-            let closest = contacts
-                .iter()
-                .enumerate()
-                .flat_map(|(index, left)| {
-                    contacts[index + 1..].iter().filter_map(move |right| {
-                        qualifying_boundary_pair(
-                            left,
-                            right,
-                            contact_tolerance,
-                            same_ring_qualifies,
-                        )
-                    })
-                })
-                .min_by(|left, right| left.distance_mm.total_cmp(&right.distance_mm));
-            closest.map(|measurement| TwoSidedResidualComponent {
-                region: component,
-                distance_mm: measurement.distance_mm,
-                first: measurement.first,
-                second: measurement.second,
+            let contacts = contacting_segments(&segments, &component, contact_tolerance);
+            opposing_boundary_clearance(&contacts, contact_tolerance, walls).map(|clearance| {
+                TwoSidedResidualComponent {
+                    region: component,
+                    clearance,
+                }
             })
         })
         .collect()
 }
 
-fn qualifying_boundary_pair(
+/// The source boundary segments touching `component`.
+fn contacting_segments<'a>(
+    segments: &'a [OrientedBoundarySegment],
+    component: &ContourSet,
+    contact_tolerance: f64,
+) -> Vec<&'a OrientedBoundarySegment> {
+    let query = component.bbox.expand(contact_tolerance);
+    let candidate_end = segments.partition_point(|segment| segment.bbox.min.x <= query.max.x);
+    segments[..candidate_end]
+        .iter()
+        .filter(|segment| {
+            segment.bbox.intersects(query)
+                && region_boundary_within_distance(
+                    component,
+                    segment.start,
+                    segment.end,
+                    contact_tolerance,
+                )
+        })
+        .collect()
+}
+
+/// The closest pair of contact segments that are two distinct walls facing
+/// each other across the residue, or `None` when the residue is one-sided.
+fn opposing_boundary_clearance(
+    contacts: &[&OrientedBoundarySegment],
+    contact_tolerance: f64,
+    walls: WallTest,
+) -> Option<ClearanceMeasurement> {
+    contacts
+        .iter()
+        .enumerate()
+        .flat_map(|(index, left)| {
+            contacts[index + 1..].iter().filter_map(move |right| {
+                facing_wall_clearance(left, right, contact_tolerance, walls)
+            })
+        })
+        .min_by(|left, right| left.distance_mm.total_cmp(&right.distance_mm))
+}
+
+/// The separation of two boundary segments when they are opposite walls of
+/// the same residue. Incident segments and segments closer than the contact
+/// tolerance are the same wall. Segments on distinct rings always face each
+/// other across material or void; segments on one ring must pass `walls`,
+/// so the rounded bite of one smooth corner is not a width.
+fn facing_wall_clearance(
     left: &OrientedBoundarySegment,
     right: &OrientedBoundarySegment,
     contact_tolerance: f64,
-    same_ring_qualifies: SameRingBoundaryPredicate,
-) -> Option<BoundaryPairMeasurement> {
+    walls: WallTest,
+) -> Option<ClearanceMeasurement> {
     if boundary_segments_are_incident(left.topology, right.topology) {
         return None;
     }
     let (distance_mm, first, second) = dist::segments(left.start, left.end, right.start, right.end);
-    let measurement = BoundaryPairMeasurement {
+    let clearance = ClearanceMeasurement {
         distance_mm,
         first,
         second,
     };
+    let left_tangent = left.end - left.start;
+    let right_tangent = right.end - right.start;
+    let same_ring_walls = match walls {
+        WallTest::Opposing => tangents_oppose(left_tangent, right_tangent),
+        WallTest::Parallel => {
+            tangents_oppose(left_tangent, right_tangent)
+                && separation_is_normal(clearance, left_tangent, contact_tolerance)
+                && separation_is_normal(clearance, right_tangent, contact_tolerance)
+        }
+    };
     (distance_mm > contact_tolerance
-        && (left.topology.ring != right.topology.ring
-            || same_ring_qualifies(left, right, measurement, contact_tolerance)))
-    .then_some(measurement)
+        && (left.topology.ring != right.topology.ring || same_ring_walls))
+        .then_some(clearance)
 }
 
 fn region_boundary_within_distance(
@@ -1217,61 +1257,28 @@ fn region_boundary_within_distance(
 ) -> bool {
     let expanded = segment_bbox(start, end).expand(distance);
     region.rings.iter().any(|ring| {
-        (0..ring.len()).any(|index| {
-            let [other_start_x, other_start_y] = ring[index];
-            let [other_end_x, other_end_y] = ring[(index + 1) % ring.len()];
-            let other_start = Point::new(other_start_x, other_start_y);
-            let other_end = Point::new(other_end_x, other_end_y);
+        ring_edges(ring).any(|(other_start, other_end)| {
             expanded.intersects(segment_bbox(other_start, other_end))
                 && dist::segments(start, end, other_start, other_end).0 <= distance
         })
     })
 }
 
-fn same_ring_boundaries_face_across(
-    left: &OrientedBoundarySegment,
-    right: &OrientedBoundarySegment,
-    measurement: BoundaryPairMeasurement,
-    contact_tolerance: f64,
-) -> bool {
-    let left_tangent = left.end - left.start;
-    let right_tangent = right.end - right.start;
-    let separation = measurement.second - measurement.first;
-    let (left_length, right_length, separation_length) = (
-        left_tangent.length(),
-        right_tangent.length(),
-        separation.length(),
-    );
-    if left_length <= f64::EPSILON
-        || right_length <= f64::EPSILON
-        || separation_length <= f64::EPSILON
-    {
-        return false;
-    }
-
-    let left_unit = left_tangent / left_length;
-    let right_unit = right_tangent / right_length;
-    let separation_unit = separation / separation_length;
-    let normal_slack = contact_tolerance.max(tol::FLATTEN_MM);
-
-    left_unit.x * right_unit.x + left_unit.y * right_unit.y < 0.0
-        && (left_unit.x * separation_unit.x + left_unit.y * separation_unit.y).abs()
-            * separation_length
-            <= normal_slack
-        && (right_unit.x * separation_unit.x + right_unit.y * separation_unit.y).abs()
-            * separation_length
-            <= normal_slack
+fn tangents_oppose(left: Point, right: Point) -> bool {
+    left.x * right.x + left.y * right.y < 0.0
 }
 
-fn same_ring_tangents_oppose(
-    left: &OrientedBoundarySegment,
-    right: &OrientedBoundarySegment,
-    _measurement: BoundaryPairMeasurement,
-    _contact_tolerance: f64,
+/// Whether the closest-pair separation is normal to a wall within the
+/// contact tolerance (at least the flattening chord error): the component
+/// of the separation along the wall's tangent is negligible.
+fn separation_is_normal(
+    clearance: ClearanceMeasurement,
+    tangent: Point,
+    contact_tolerance: f64,
 ) -> bool {
-    let left_tangent = left.end - left.start;
-    let right_tangent = right.end - right.start;
-    left_tangent.x * right_tangent.x + left_tangent.y * right_tangent.y < 0.0
+    let separation = clearance.second - clearance.first;
+    let along = (tangent.x * separation.x + tangent.y * separation.y).abs() / tangent.length();
+    along <= contact_tolerance.max(tol::FLATTEN_MM)
 }
 
 /// Keep-out whose removal widens every narrow void: a radius-`radius` tube

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -275,6 +275,18 @@ pub struct DiskGapRegularization {
     pub removed: ContourSet,
 }
 
+/// One connected opening/closing residue bounded by two distinct source
+/// boundary branches. The boundary measurement is exact for the flattened
+/// polygon representation and is the authoritative local width of the
+/// material or void represented by `region`.
+#[derive(Debug, Clone)]
+pub(crate) struct TwoSidedResidualComponent {
+    pub region: ContourSet,
+    pub distance_mm: f64,
+    pub first: Point,
+    pub second: Point,
+}
+
 /// Failure to construct a narrow void's medial axis for gap regularization.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GapRegularizationError(String);
@@ -863,14 +875,42 @@ impl ContourSet {
     /// concavity. An empty result proves no two facing boundary branches fail
     /// the rolling-disk test.
     pub fn disk_gap_violations(&self, radius: f64) -> Self {
-        if self.is_empty() || radius <= 0.0 {
-            return Self::empty(self.tolerance);
-        }
-        if !radius.is_finite() {
+        if self.is_empty() || radius <= 0.0 || !radius.is_finite() {
             return Self::empty(self.tolerance);
         }
         let closing_residual = self.disk_close(radius).difference(self);
-        two_sided_gap_residual(self, &closing_residual)
+        let rings =
+            two_sided_residual_components(self, &closing_residual, same_ring_tangents_oppose)
+                .into_iter()
+                .flat_map(|component| component.region.rings)
+                .collect();
+        Self::new(rings, FillRule::NonZero, self.tolerance)
+    }
+
+    /// Connected sub-diameter material residues and their exact opposing
+    /// source-boundary measurements.
+    pub(crate) fn disk_feature_violation_components(
+        &self,
+        radius: f64,
+    ) -> Vec<TwoSidedResidualComponent> {
+        if self.is_empty() || radius <= 0.0 || !radius.is_finite() {
+            return Vec::new();
+        }
+        let opening_residual = self.difference(&self.disk_open(radius));
+        two_sided_residual_components(self, &opening_residual, same_ring_boundaries_face_across)
+    }
+
+    /// Connected sub-diameter void residues and their exact opposing
+    /// source-boundary measurements.
+    pub(crate) fn disk_gap_violation_components(
+        &self,
+        radius: f64,
+    ) -> Vec<TwoSidedResidualComponent> {
+        if self.is_empty() || radius <= 0.0 || !radius.is_finite() {
+            return Vec::new();
+        }
+        let closing_residual = self.disk_close(radius).difference(self);
+        two_sided_residual_components(self, &closing_residual, same_ring_boundaries_face_across)
     }
 
     pub fn to_contours(&self) -> Vec<ContourBuf> {
@@ -1062,8 +1102,22 @@ struct OrientedBoundarySegment {
     bbox: BBox,
 }
 
-fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> ContourSet {
-    let source_segments = source
+#[derive(Debug, Clone, Copy)]
+struct BoundaryPairMeasurement {
+    distance_mm: f64,
+    first: Point,
+    second: Point,
+}
+
+type SameRingBoundaryPredicate =
+    fn(&OrientedBoundarySegment, &OrientedBoundarySegment, BoundaryPairMeasurement, f64) -> bool;
+
+fn two_sided_residual_components(
+    source: &ContourSet,
+    residual: &ContourSet,
+    same_ring_qualifies: SameRingBoundaryPredicate,
+) -> Vec<TwoSidedResidualComponent> {
+    let mut source_segments = source
         .rings
         .iter()
         .enumerate()
@@ -1086,46 +1140,73 @@ fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> Contour
             })
         })
         .collect::<Vec<_>>();
+    source_segments.sort_by(|left, right| left.bbox.min.x.total_cmp(&right.bbox.min.x));
     let contact_tolerance = source.tolerance.max(residual.tolerance);
 
-    let rings = residual
+    residual
         .connected_components()
         .into_iter()
-        .filter(|component| {
-            let contacts = source_segments
+        .filter_map(|component| {
+            let query = component.bbox.expand(contact_tolerance);
+            let candidate_end =
+                source_segments.partition_point(|segment| segment.bbox.min.x <= query.max.x);
+            let contacts = source_segments[..candidate_end]
                 .iter()
                 .filter(|segment| {
-                    segment
-                        .bbox
-                        .expand(contact_tolerance)
-                        .intersects(component.bbox)
+                    segment.bbox.max.x >= query.min.x
+                        && segment.bbox.max.y >= query.min.y
+                        && segment.bbox.min.y <= query.max.y
                         && region_boundary_within_distance(
-                            component,
+                            &component,
                             segment.start,
                             segment.end,
                             contact_tolerance,
                         )
                 })
                 .collect::<Vec<_>>();
-            contacts.iter().enumerate().any(|(index, left)| {
-                contacts[index + 1..].iter().any(|right| {
-                    let (separation, _, _) =
-                        dist::segments(left.start, left.end, right.start, right.end);
-                    // Contacts on distinct rings always face each other across
-                    // void, whatever their relative angle. Same-ring pairs
-                    // must additionally oppose so the rounded bite of one
-                    // smooth concavity is not mistaken for a gap; walls at
-                    // exactly 90° remain ambiguous there by construction.
-                    !boundary_segments_are_incident(left.topology, right.topology)
-                        && separation > contact_tolerance
-                        && (left.topology.ring != right.topology.ring
-                            || boundary_tangents_oppose(left, right))
+            let closest = contacts
+                .iter()
+                .enumerate()
+                .flat_map(|(index, left)| {
+                    contacts[index + 1..].iter().filter_map(move |right| {
+                        qualifying_boundary_pair(
+                            left,
+                            right,
+                            contact_tolerance,
+                            same_ring_qualifies,
+                        )
+                    })
                 })
+                .min_by(|left, right| left.distance_mm.total_cmp(&right.distance_mm));
+            closest.map(|measurement| TwoSidedResidualComponent {
+                region: component,
+                distance_mm: measurement.distance_mm,
+                first: measurement.first,
+                second: measurement.second,
             })
         })
-        .flat_map(|component| component.rings)
-        .collect();
-    ContourSet::new(rings, FillRule::NonZero, residual.tolerance)
+        .collect()
+}
+
+fn qualifying_boundary_pair(
+    left: &OrientedBoundarySegment,
+    right: &OrientedBoundarySegment,
+    contact_tolerance: f64,
+    same_ring_qualifies: SameRingBoundaryPredicate,
+) -> Option<BoundaryPairMeasurement> {
+    if boundary_segments_are_incident(left.topology, right.topology) {
+        return None;
+    }
+    let (distance_mm, first, second) = dist::segments(left.start, left.end, right.start, right.end);
+    let measurement = BoundaryPairMeasurement {
+        distance_mm,
+        first,
+        second,
+    };
+    (distance_mm > contact_tolerance
+        && (left.topology.ring != right.topology.ring
+            || same_ring_qualifies(left, right, measurement, contact_tolerance)))
+    .then_some(measurement)
 }
 
 fn region_boundary_within_distance(
@@ -1147,9 +1228,46 @@ fn region_boundary_within_distance(
     })
 }
 
-fn boundary_tangents_oppose(
+fn same_ring_boundaries_face_across(
     left: &OrientedBoundarySegment,
     right: &OrientedBoundarySegment,
+    measurement: BoundaryPairMeasurement,
+    contact_tolerance: f64,
+) -> bool {
+    let left_tangent = left.end - left.start;
+    let right_tangent = right.end - right.start;
+    let separation = measurement.second - measurement.first;
+    let (left_length, right_length, separation_length) = (
+        left_tangent.length(),
+        right_tangent.length(),
+        separation.length(),
+    );
+    if left_length <= f64::EPSILON
+        || right_length <= f64::EPSILON
+        || separation_length <= f64::EPSILON
+    {
+        return false;
+    }
+
+    let left_unit = left_tangent / left_length;
+    let right_unit = right_tangent / right_length;
+    let separation_unit = separation / separation_length;
+    let normal_slack = contact_tolerance.max(tol::FLATTEN_MM);
+
+    left_unit.x * right_unit.x + left_unit.y * right_unit.y < 0.0
+        && (left_unit.x * separation_unit.x + left_unit.y * separation_unit.y).abs()
+            * separation_length
+            <= normal_slack
+        && (right_unit.x * separation_unit.x + right_unit.y * separation_unit.y).abs()
+            * separation_length
+            <= normal_slack
+}
+
+fn same_ring_tangents_oppose(
+    left: &OrientedBoundarySegment,
+    right: &OrientedBoundarySegment,
+    _measurement: BoundaryPairMeasurement,
+    _contact_tolerance: f64,
 ) -> bool {
     let left_tangent = left.end - left.start;
     let right_tangent = right.end - right.start;


### PR DESCRIPTION
DFM rules now measure the final composed copper and decide every verdict with one uncertainty-aware rule; slivers and gaps are measured on the medial axis, which catches the angled and curved sub-limit gaps the parallel-wall heuristic missed. Checks only measure, the engine owns verdicts and finding text, and extraction builds just the pools the rules read.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how DFM verdicts are computed (geometry, uncertainty, annular-ring and sliver semantics) and fails extraction on previously skipped drill/slot data, so false pass/fail and report-text churn are likely.
> 
> **Overview**
> Unifies DFM so every rule returns one `Distance` (witnesses plus flattening uncertainty) and the engine applies a **single verdict**: a limit is violated only when the measurement is *certainly* below it. Checks no longer emit findings; they measure, and titles, skip policy, and waivers live in the engine.
> 
> Width and gap checks treat morphology as a conservative candidate stage. Authoritative width is the **narrowest maximal inscribed disk** on the residue’s medial axis, so tapered tips and non-parallel walls measure correctly while one-sided corner bites and tessellation branches do not. Extraction fails closed on incomplete drills and inconsistent slot widths, and annular ring now treats missing copper on terminal (or land-bearing) layers as zero enclosure rather than skipping them.
> 
> The same evaluators run on board, flattened array, and fab panel. Broad-phase bounds/indices may only prove work unnecessary; they cannot emit a finding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7393274e9786201f9c465c680d91ed4e84bd575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->