### PR TITLE
Route the interposer with FreeRouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `pcb route --engine freerouting` to auto-route boards locally via FreeRouting.
-- Added `pcb ipc interposer --route` to auto-route the interposer with FreeRouting.
+- Added `pcb ipc interposer --route` to auto-route the interposer with FreeRouting and stitch the GND pours with vias.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `pcb route --engine freerouting` to auto-route boards locally via FreeRouting.
+- Added `pcb ipc interposer --route` to auto-route the interposer with FreeRouting.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4260,8 +4260,10 @@ dependencies = [
  "anyhow",
  "ipc2581",
  "pcb-ir",
+ "pcb-kicad",
  "pcb-sexpr",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/pcb-interposer/Cargo.toml
+++ b/crates/pcb-interposer/Cargo.toml
@@ -12,7 +12,9 @@ license = "MIT OR Apache-2.0"
 anyhow = { workspace = true }
 ipc2581 = { workspace = true }
 pcb-ir = { workspace = true }
+pcb-kicad = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 pcb-sexpr = { workspace = true }

--- a/crates/pcb-interposer/src/emit.rs
+++ b/crates/pcb-interposer/src/emit.rs
@@ -2,10 +2,9 @@
 //!
 //! The deterministic board: the panel's outline, tooling holes, and
 //! fiducials, the S11 mate lands on the bottom copper, and full-sheet
-//! GND pours on both faces, cross-stitched with a via at each GND land
-//! and GND pogo that sits clear of foreign copper — routed tracks slice
-//! a pour into fragments, and the stitch vias bridge every fragment
-//! through the opposite face. With a fixture plan, the board is also
+//! GND pours on both faces — GND rides the pours, unrouted; the
+//! post-route stitching pass adds the vias that tie the faces together
+//! around whatever copper the router drew. With a fixture plan, the board is also
 //! populated — a pogo pad on the top face at every tested contact, and
 //! the plan's nets bound on both the pogo and its mate land — so the
 //! unrouted airwires are exactly the routing pass's work list. Without a
@@ -14,7 +13,7 @@
 
 use pcb_ir::dialects::kicad::{
     At, Document, Footprint, FootprintAttrs, Graphic, Mount, Pad, PadKind, PadShape, Property,
-    Stroke, UuidGen, Via, Zone, ZoneConnect, ZoneFill,
+    Stroke, UuidGen, Zone, ZoneConnect, ZoneFill,
 };
 use pcb_ir::geom::Point;
 
@@ -96,42 +95,6 @@ pub fn board(panel: &Panel, lands: &[Land], plan: Option<&Plan>) -> String {
         }
     }
 
-    // GND stitch candidates and the non-GND pads a through-via must keep
-    // away from: the faces deliberately overlap in the plane, so a GND
-    // land can sit exactly under a signal pogo — a via there would short
-    // through the board. Skipping a crowded candidate is safe; the land
-    // stays on the pour and the remaining vias still bridge fragments.
-    let (mut stitch, mut foreign): (Vec<[f64; 2]>, Vec<[f64; 2]>) = (Vec::new(), Vec::new());
-    if let Some(plan) = plan {
-        for (contact_index, net) in &contact_nets {
-            let xy = plan.contacts[*contact_index].xy;
-            if net.1 == "GND" {
-                &mut stitch
-            } else {
-                &mut foreign
-            }
-            .push(xy);
-        }
-    }
-    for (index, land) in lands.iter().enumerate() {
-        let gnd_land = !land_nets.contains_key(&index) && land.role == Role::Gnd;
-        if gnd_land { &mut stitch } else { &mut foreign }.push(land.xy);
-    }
-    let clear_of = |points: &[[f64; 2]], xy: [f64; 2], r: f64| {
-        points
-            .iter()
-            .all(|p| (p[0] - xy[0]).hypot(p[1] - xy[1]) >= r)
-    };
-    let mut placed: Vec<[f64; 2]> = Vec::new();
-    for xy in stitch {
-        // 1.2 mm keeps the via's pad, hole, and mask aperture clear of a
-        // Ø1 mm pad; 0.9 mm keeps coincident GND vias' holes apart.
-        if clear_of(&foreign, xy, 1.2) && clear_of(&placed, xy, 0.9) {
-            doc.vias.push(stitch_via(&mut uuids, xy, gnd));
-            placed.push(xy);
-        }
-    }
-
     for layer in ["F.Cu", "B.Cu"] {
         doc.zones.push(Zone {
             net: gnd,
@@ -159,18 +122,6 @@ pub fn board(panel: &Panel, lands: &[Land], plan: Option<&Plan>) -> String {
     }
 
     pcb_ir::dialects::kicad::write(&doc)
-}
-
-/// A GND stitch via, bridging the two pours at a GND land or pogo.
-fn stitch_via(uuids: &mut UuidGen, at: [f64; 2], gnd: u32) -> Via {
-    Via {
-        at: Point::new(at[0], at[1]),
-        size: 0.6,
-        drill: 0.3,
-        layers: ("F.Cu".into(), "B.Cu".into()),
-        net: gnd,
-        uuid: uuids.next_uuid(),
-    }
 }
 
 fn hidden_properties(uuids: &mut UuidGen, reference: &str, top: bool) -> Vec<Property> {

--- a/crates/pcb-interposer/src/emit.rs
+++ b/crates/pcb-interposer/src/emit.rs
@@ -3,13 +3,13 @@
 //! The deterministic board: the panel's outline, tooling holes, and
 //! fiducials, the S11 mate lands on the bottom copper, and full-sheet
 //! GND pours on both faces — GND rides the pours, unrouted; the
-//! post-route stitching pass adds the vias that tie the faces together
-//! around whatever copper the router drew. With a fixture plan, the board is also
-//! populated — a pogo pad on the top face at every tested contact, and
-//! the plan's nets bound on both the pogo and its mate land — so the
-//! unrouted airwires are exactly the routing pass's work list. Without a
-//! plan (no ICT contacts), GND lands join the pour and everything else
-//! stays un-netted.
+//! post-route stitching pass (`crate::stitch`) adds the vias that tie
+//! the faces together around whatever copper the router drew. With a
+//! fixture plan, the board is also populated — a pogo pad on the top
+//! face at every tested contact, and the plan's nets bound on both the
+//! pogo and its mate land — so the unrouted airwires are exactly the
+//! routing pass's work list. Without a plan (no ICT contacts), GND
+//! lands join the pour and everything else stays un-netted.
 
 use pcb_ir::dialects::kicad::{
     At, Document, Footprint, FootprintAttrs, Graphic, Mount, Pad, PadKind, PadShape, Property,

--- a/crates/pcb-interposer/src/emit.rs
+++ b/crates/pcb-interposer/src/emit.rs
@@ -1,17 +1,20 @@
 //! Emit the interposer as a KiCad board via `pcb_ir::dialects::kicad`.
 //!
 //! The deterministic board: the panel's outline, tooling holes, and
-//! fiducials, the S11 mate lands on the bottom copper, and a full-sheet
-//! bottom GND pour. With a fixture plan, the board is also populated —
-//! a pogo pad on the top face at every tested contact, and the plan's
-//! nets bound on both the pogo and its mate land — so the unrouted
-//! airwires are exactly the routing pass's work list. Without a plan
-//! (no ICT contacts), GND lands join the pour and everything else stays
-//! un-netted.
+//! fiducials, the S11 mate lands on the bottom copper, and full-sheet
+//! GND pours on both faces, cross-stitched with a via at each GND land
+//! and GND pogo that sits clear of foreign copper — routed tracks slice
+//! a pour into fragments, and the stitch vias bridge every fragment
+//! through the opposite face. With a fixture plan, the board is also
+//! populated — a pogo pad on the top face at every tested contact, and
+//! the plan's nets bound on both the pogo and its mate land — so the
+//! unrouted airwires are exactly the routing pass's work list. Without a
+//! plan (no ICT contacts), GND lands join the pour and everything else
+//! stays un-netted.
 
 use pcb_ir::dialects::kicad::{
     At, Document, Footprint, FootprintAttrs, Graphic, Mount, Pad, PadKind, PadShape, Property,
-    Stroke, UuidGen, Zone, ZoneConnect, ZoneFill,
+    Stroke, UuidGen, Via, Zone, ZoneConnect, ZoneFill,
 };
 use pcb_ir::geom::Point;
 
@@ -93,31 +96,81 @@ pub fn board(panel: &Panel, lands: &[Land], plan: Option<&Plan>) -> String {
         }
     }
 
-    doc.zones.push(Zone {
-        net: gnd,
-        net_name: "GND".into(),
-        layers: vec!["B.Cu".into()],
-        uuid: uuids.next_uuid(),
-        name: None,
-        priority: None,
-        hatch_pitch: 0.5,
-        connect_pads: ZoneConnect::Thermal,
-        connect_clearance: 0.25,
-        min_thickness: 0.25,
-        fill: ZoneFill {
-            enabled: true,
-            thermal_gap: 0.3,
-            thermal_bridge_width: 0.4,
-        },
-        polygon: vec![
-            Point::new(0.0, 0.0),
-            Point::new(panel.width, 0.0),
-            Point::new(panel.width, panel.height),
-            Point::new(0.0, panel.height),
-        ],
-    });
+    // GND stitch candidates and the non-GND pads a through-via must keep
+    // away from: the faces deliberately overlap in the plane, so a GND
+    // land can sit exactly under a signal pogo — a via there would short
+    // through the board. Skipping a crowded candidate is safe; the land
+    // stays on the pour and the remaining vias still bridge fragments.
+    let (mut stitch, mut foreign): (Vec<[f64; 2]>, Vec<[f64; 2]>) = (Vec::new(), Vec::new());
+    if let Some(plan) = plan {
+        for (contact_index, net) in &contact_nets {
+            let xy = plan.contacts[*contact_index].xy;
+            if net.1 == "GND" {
+                &mut stitch
+            } else {
+                &mut foreign
+            }
+            .push(xy);
+        }
+    }
+    for (index, land) in lands.iter().enumerate() {
+        let gnd_land = !land_nets.contains_key(&index) && land.role == Role::Gnd;
+        if gnd_land { &mut stitch } else { &mut foreign }.push(land.xy);
+    }
+    let clear_of = |points: &[[f64; 2]], xy: [f64; 2], r: f64| {
+        points
+            .iter()
+            .all(|p| (p[0] - xy[0]).hypot(p[1] - xy[1]) >= r)
+    };
+    let mut placed: Vec<[f64; 2]> = Vec::new();
+    for xy in stitch {
+        // 1.2 mm keeps the via's pad, hole, and mask aperture clear of a
+        // Ø1 mm pad; 0.9 mm keeps coincident GND vias' holes apart.
+        if clear_of(&foreign, xy, 1.2) && clear_of(&placed, xy, 0.9) {
+            doc.vias.push(stitch_via(&mut uuids, xy, gnd));
+            placed.push(xy);
+        }
+    }
+
+    for layer in ["F.Cu", "B.Cu"] {
+        doc.zones.push(Zone {
+            net: gnd,
+            net_name: "GND".into(),
+            layers: vec![layer.into()],
+            uuid: uuids.next_uuid(),
+            name: None,
+            priority: None,
+            hatch_pitch: 0.5,
+            connect_pads: ZoneConnect::Thermal,
+            connect_clearance: 0.25,
+            min_thickness: 0.25,
+            fill: ZoneFill {
+                enabled: true,
+                thermal_gap: 0.3,
+                thermal_bridge_width: 0.4,
+            },
+            polygon: vec![
+                Point::new(0.0, 0.0),
+                Point::new(panel.width, 0.0),
+                Point::new(panel.width, panel.height),
+                Point::new(0.0, panel.height),
+            ],
+        });
+    }
 
     pcb_ir::dialects::kicad::write(&doc)
+}
+
+/// A GND stitch via, bridging the two pours at a GND land or pogo.
+fn stitch_via(uuids: &mut UuidGen, at: [f64; 2], gnd: u32) -> Via {
+    Via {
+        at: Point::new(at[0], at[1]),
+        size: 0.6,
+        drill: 0.3,
+        layers: ("F.Cu".into(), "B.Cu".into()),
+        net: gnd,
+        uuid: uuids.next_uuid(),
+    }
 }
 
 fn hidden_properties(uuids: &mut UuidGen, reference: &str, top: bool) -> Vec<Property> {

--- a/crates/pcb-interposer/src/lib.rs
+++ b/crates/pcb-interposer/src/lib.rs
@@ -18,6 +18,7 @@ pub mod emit;
 pub mod panel;
 pub mod pattern;
 pub mod plan;
+pub mod stitch;
 
 use std::path::Path;
 

--- a/crates/pcb-interposer/src/stitch.rs
+++ b/crates/pcb-interposer/src/stitch.rs
@@ -1,0 +1,173 @@
+//! Post-route GND stitching, run on the routed board via KiCad's python.
+//!
+//! One placement rule, borrowed from KiCad master's via-stitch generator:
+//! inflate every copper item — routed tracks, pads, signal and GND alike —
+//! by (via radius + clearance) and walk the merged envelope's contours,
+//! dropping a via every pitch of arc length. That single rule yields a
+//! guard fence along every trace, a ring around every pogo and land (so
+//! every GND pad gets its nearby via), and it is what keeps GND whole:
+//! any pour fragment a routed trace slices off carries fence vias that
+//! bridge it through the opposite face. A second contour — the board
+//! outline deflated — adds the perimeter ring. Candidates are accepted
+//! against one validity mask (board interior minus inflated foreign
+//! copper and holes) with a minimum via-to-via spacing.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+const STITCH_SCRIPT: &str = r#"
+import math
+import sys
+
+import pcbnew
+
+board_path, report_path = sys.argv[1], sys.argv[2]
+
+ERR = pcbnew.FromMM(0.01)
+VIA_WIDTH = pcbnew.FromMM(0.6)
+VIA_DRILL = pcbnew.FromMM(0.3)
+VIA_RADIUS = VIA_WIDTH // 2
+# The board's min hole-to-copper constraint; NPTH pads carry no netclass
+# clearance, so this is what actually bounds a via near a tooling hole.
+HOLE_CLEARANCE = pcbnew.FromMM(0.25)
+# The stitch via's own Default-netclass clearance: pair clearance is the
+# max of both items', so it floors every margin (USB tracks carry less).
+VIA_CLEARANCE = pcbnew.FromMM(0.2)
+# Envelope candidates must sit outside the obstacle mask, whose items
+# are polygonized with outward error; walk a little further out.
+ENVELOPE_EXTRA = pcbnew.FromMM(0.02)
+PITCH = pcbnew.FromMM(2.54)
+MIN_SEP = pcbnew.FromMM(1.8)
+# Copper-to-edge clearance + via radius.
+EDGE_KEEPIN = pcbnew.FromMM(0.65)
+RING_INSET = pcbnew.FromMM(1.0)
+
+board = pcbnew.LoadBoard(board_path)
+gnd = board.FindNet("GND").GetNetCode()
+
+outline = pcbnew.SHAPE_POLY_SET()
+board.GetBoardPolygonOutlines(outline, False)
+
+obstacles = pcbnew.SHAPE_POLY_SET()
+envelope = pcbnew.SHAPE_POLY_SET()
+
+
+def margin(item, layer):
+    clearance = max(item.GetOwnClearance(layer), VIA_CLEARANCE)
+    if hasattr(item, "GetDrillSize") and item.GetDrillSize().x > 0:
+        clearance = max(clearance, HOLE_CLEARANCE)
+    return VIA_RADIUS + clearance + ERR
+
+
+def add(item, layer, poly, extra=0):
+    item.TransformShapeToPolygon(
+        poly, layer, margin(item, layer) + extra, ERR, pcbnew.ERROR_OUTSIDE
+    )
+
+
+for track in board.GetTracks():
+    layer = pcbnew.F_Cu if track.Type() == pcbnew.PCB_VIA_T else track.GetLayer()
+    add(track, layer, envelope, ENVELOPE_EXTRA)
+    if track.GetNetCode() != gnd:
+        add(track, layer, obstacles)
+
+for footprint in board.GetFootprints():
+    for pad in footprint.Pads():
+        layer = pcbnew.F_Cu if pad.IsOnLayer(pcbnew.F_Cu) else pcbnew.B_Cu
+        add(pad, layer, envelope, ENVELOPE_EXTRA)
+        if pad.GetNetCode() != gnd:
+            add(pad, layer, obstacles)
+
+obstacles.Simplify()
+envelope.Simplify()
+
+allowed = pcbnew.SHAPE_POLY_SET(outline)
+allowed.Deflate(EDGE_KEEPIN, pcbnew.CORNER_STRATEGY_ROUND_ALL_CORNERS, ERR)
+allowed.BooleanSubtract(obstacles)
+
+ring = pcbnew.SHAPE_POLY_SET(outline)
+ring.Deflate(RING_INSET, pcbnew.CORNER_STRATEGY_ROUND_ALL_CORNERS, ERR)
+
+
+def chains(poly):
+    for i in range(poly.OutlineCount()):
+        yield poly.COutline(i)
+        for j in range(poly.HoleCount(i)):
+            yield poly.CHole(i, j)
+
+
+def samples(chain):
+    cursor, next_sample = 0.0, PITCH / 2.0
+    for k in range(chain.SegmentCount()):
+        seg = chain.CSegment(k)
+        ax, ay, bx, by = seg.A.x, seg.A.y, seg.B.x, seg.B.y
+        length = math.hypot(bx - ax, by - ay)
+        if length < 1.0:
+            continue
+        while next_sample <= cursor + length:
+            t = (next_sample - cursor) / length
+            yield round(ax + t * (bx - ax)), round(ay + t * (by - ay))
+            next_sample += PITCH
+        cursor += length
+
+
+accepted = []
+buckets = {}
+
+
+def far_enough(x, y):
+    cx, cy = x // MIN_SEP, y // MIN_SEP
+    return all(
+        (ox - x) ** 2 + (oy - y) ** 2 >= MIN_SEP * MIN_SEP
+        for dx in (-1, 0, 1)
+        for dy in (-1, 0, 1)
+        for ox, oy in buckets.get((cx + dx, cy + dy), ())
+    )
+
+
+def place(x, y):
+    if far_enough(x, y) and allowed.Collide(pcbnew.VECTOR2I(x, y)):
+        accepted.append((x, y))
+        buckets.setdefault((x // MIN_SEP, y // MIN_SEP), []).append((x, y))
+
+
+for chain in chains(envelope):
+    for x, y in samples(chain):
+        place(x, y)
+for chain in chains(ring):
+    for x, y in samples(chain):
+        place(x, y)
+
+for x, y in accepted:
+    via = pcbnew.PCB_VIA(board)
+    via.SetViaType(pcbnew.VIATYPE_THROUGH)
+    via.SetPosition(pcbnew.VECTOR2I(x, y))
+    via.SetWidth(VIA_WIDTH)
+    via.SetDrill(VIA_DRILL)
+    via.SetLayerPair(pcbnew.F_Cu, pcbnew.B_Cu)
+    via.SetNetCode(gnd)
+    board.Add(via)
+
+filler = pcbnew.ZONE_FILLER(board)
+if not filler.Fill(board.Zones()):
+    sys.exit("Failed to fill zones after stitching")
+if not pcbnew.SaveBoard(board_path, board):
+    sys.exit("Failed to save stitched board")
+
+with open(report_path, "w") as report:
+    report.write(str(len(accepted)))
+"#;
+
+/// Stitch the routed board's GND with vias and refill its zones.
+/// Returns the number of vias placed.
+pub fn stitch(board_path: &Path) -> Result<usize> {
+    let report = tempfile::NamedTempFile::new().context("create stitch report file")?;
+    pcb_kicad::PythonScriptBuilder::new(STITCH_SCRIPT)
+        .arg(board_path.to_string_lossy())
+        .arg(report.path().to_string_lossy())
+        .run()
+        .context("stitch GND vias")?;
+    let count = std::fs::read_to_string(report.path()).context("read stitch report")?;
+    count.trim().parse().context("parse stitch report")
+}

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -176,7 +176,9 @@ fn generates_a_parseable_interposer() {
     };
     // 5 holes + 2 fids + 112 lands + 12 pogos (2 boards × 6 contacts).
     assert_eq!(count("footprint"), 131);
-    assert_eq!(count("zone"), 1);
+    assert_eq!(count("zone"), 2);
+    // A GND stitch via at each of the 24 GND lands and 2 gnd pogos.
+    assert_eq!(count("via"), 26);
     assert_eq!(count("gr_arc"), 4);
     assert_eq!(count("gr_line"), 4);
     // Net table: no-net, GND, and ten planned nets.

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -177,8 +177,8 @@ fn generates_a_parseable_interposer() {
     // 5 holes + 2 fids + 112 lands + 12 pogos (2 boards × 6 contacts).
     assert_eq!(count("footprint"), 131);
     assert_eq!(count("zone"), 2);
-    // A GND stitch via at each of the 24 GND lands and 2 gnd pogos.
-    assert_eq!(count("via"), 26);
+    // Stitch vias are the route step's job; the emitted board has none.
+    assert_eq!(count("via"), 0);
     assert_eq!(count("gr_arc"), 4);
     assert_eq!(count("gr_line"), 4);
     // Net table: no-net, GND, and ten planned nets.

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -48,9 +48,6 @@ enum Commands {
         /// Auto-route the interposer with FreeRouting (requires Java 25+)
         #[arg(long)]
         route: bool,
-        /// [route] Routing timeout in minutes
-        #[arg(long, default_value = "20")]
-        route_timeout: u32,
     },
     /// List ICT fixture contacts (components with an `Ict` BOM characteristic)
     Ict {
@@ -371,7 +368,6 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             output,
             fixture_map,
             route,
-            route_timeout,
         } => {
             use anyhow::Context as _;
             let (pcb, pro) = pcb_interposer::generate(&input)?;
@@ -391,9 +387,6 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 println!("✓ Wrote fixture map {}", map_path.display());
             }
             if route {
-                if route_timeout > 60 {
-                    anyhow::bail!("--route-timeout cannot exceed 60 minutes");
-                }
                 let board_name = output
                     .file_stem()
                     .context("output path has no file name")?
@@ -403,7 +396,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                     file: input,
                     engine: crate::route::RouteEngine::Freerouting,
                     no_open: true,
-                    timeout: route_timeout,
+                    timeout: 20,
                     project_id: None,
                 };
                 // Stitch whatever board state routing left behind — a

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -407,6 +407,8 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                     project_id: None,
                 };
                 crate::freerouting::execute(&route_args, &output, &pro_path, &board_name)?;
+                let vias = pcb_interposer::stitch::stitch(&output)?;
+                println!("✓ Stitched {vias} GND vias");
             }
             Ok(())
         }

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -406,9 +406,14 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                     timeout: route_timeout,
                     project_id: None,
                 };
-                crate::freerouting::execute(&route_args, &output, &pro_path, &board_name)?;
+                // Stitch whatever board state routing left behind — a
+                // partial result published before a routing error still
+                // gets a coherent GND — then surface the routing error.
+                let routed =
+                    crate::freerouting::execute(&route_args, &output, &pro_path, &board_name);
                 let vias = pcb_interposer::stitch::stitch(&output)?;
                 println!("✓ Stitched {vias} GND vias");
+                routed?;
             }
             Ok(())
         }

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -45,6 +45,12 @@ enum Commands {
         /// Also write the fixture map (tested boards + contact→land bindings) as JSON
         #[arg(long, value_hint = clap::ValueHint::FilePath)]
         fixture_map: Option<PathBuf>,
+        /// Auto-route the interposer with FreeRouting (requires Java 25+)
+        #[arg(long)]
+        route: bool,
+        /// [route] Routing timeout in minutes
+        #[arg(long, default_value = "20")]
+        route_timeout: u32,
     },
     /// List ICT fixture contacts (components with an `Ict` BOM characteristic)
     Ict {
@@ -364,6 +370,8 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             input,
             output,
             fixture_map,
+            route,
+            route_timeout,
         } => {
             use anyhow::Context as _;
             let (pcb, pro) = pcb_interposer::generate(&input)?;
@@ -381,6 +389,24 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 std::fs::write(&map_path, map)
                     .with_context(|| format!("write {}", map_path.display()))?;
                 println!("✓ Wrote fixture map {}", map_path.display());
+            }
+            if route {
+                if route_timeout > 60 {
+                    anyhow::bail!("--route-timeout cannot exceed 60 minutes");
+                }
+                let board_name = output
+                    .file_stem()
+                    .context("output path has no file name")?
+                    .to_string_lossy()
+                    .to_string();
+                let route_args = crate::route::RouteArgs {
+                    file: input,
+                    engine: crate::route::RouteEngine::Freerouting,
+                    no_open: true,
+                    timeout: route_timeout,
+                    project_id: None,
+                };
+                crate::freerouting::execute(&route_args, &output, &pro_path, &board_name)?;
             }
             Ok(())
         }


### PR DESCRIPTION
Adds `pcb ipc interposer --route`: FreeRouting routes the signals locally, then a post-route pass walks the clearance envelope of every pad and routed track plus a board-edge ring, stitching the two GND pours with vias. All 20 A-series corpus panels, 20 repeat runs, and 21 arrays built from real diodehub boards route to 0 DRC violations and 0 unconnected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches board generation and post-route KiCad Python that mutates copper (vias/zones). Geometry/clearance bugs could produce invalid boards, but it is an opt-in CLI path, not auth or data handling.
> 
> **Overview**
> Adds **`pcb ipc interposer --route`**: generate the interposer, run local FreeRouting, then stitch GND so both copper faces stay connected around the routed copper.
> 
> Emission now places **full-sheet GND pours on `F.Cu` and `B.Cu`** (was bottom-only). GND is left unrouted; a new `stitch` pass (KiCad Python) walks the clearance envelope of tracks/pads plus a board-edge ring, places through vias, and refills zones. Stitch still runs if routing fails so a partial board keeps a coherent GND, then the routing error is returned.
> 
> The generate test now expects two zones and no vias on the unrouted board.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b35ce336db1cb24dd244645c5626f104cfb269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->