### PR TITLE
Enforce ICT test-point pitch in KiCad DRC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `pcb layout` enforces 3 mm ICT test-point spacing via a generated KiCad design rule.
+
 ### Changed
 
 - Interposer pogo pads use the Mill-Max 806 footprint.

--- a/crates/pcb-layout/src/design_rules.rs
+++ b/crates/pcb-layout/src/design_rules.rs
@@ -1,0 +1,75 @@
+//! Generate the project's `.kicad_dru` custom design rules.
+//!
+//! `pcb layout` maintains one marker-delimited block in the file and
+//! leaves everything outside it alone — KiCad's Board Setup UI edits
+//! this same file, so hand-written rules must survive regeneration.
+//!
+//! The block carries the ICT test-point pitch rule: footprints synced
+//! with a non-empty `Ict` property carry the `ICT` component class (see
+//! `build_footprint_component_class_patchset`), and the rule holds any
+//! two of them 2 mm apart edge-to-edge — 3 mm center-to-center for the
+//! Ø1 mm ICT pads, the pitch the interposer's pogo footprint courtyard
+//! demands. On boards with no ICT test points the rule matches nothing.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+const BEGIN: &str = "# --- rules managed by pcb layout: begin (do not edit this block) ---";
+const END: &str = "# --- rules managed by pcb layout: end ---";
+// Pad-scoped: physical_clearance would otherwise also measure the
+// footprints' silkscreen text against each other.
+const RULES: &str = r#"(rule "ict-test-point-pitch"
+	(constraint physical_clearance (min 2.0mm))
+	(condition "A.Type == 'Pad' && B.Type == 'Pad' && A.hasComponentClass('ICT') && B.hasComponentClass('ICT')"))"#;
+
+/// Write or refresh the managed rules block in `dru_path`.
+pub fn write_design_rules(dru_path: &Path) -> Result<()> {
+    let block = format!("{BEGIN}\n{RULES}\n{END}");
+    let current = std::fs::read_to_string(dru_path).unwrap_or_default();
+    let next = match (current.find(BEGIN), current.find(END)) {
+        (Some(begin), Some(end)) if end >= begin => {
+            let mut merged = current.clone();
+            merged.replace_range(begin..end + END.len(), &block);
+            merged
+        }
+        _ if current.trim().is_empty() => format!("(version 1)\n\n{block}\n"),
+        _ => format!("{}\n\n{block}\n", current.trim_end()),
+    };
+    if next != current {
+        std::fs::write(dru_path, next).with_context(|| format!("write {}", dru_path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_merges_and_stays_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("board.kicad_dru");
+
+        // Fresh file: version header plus the managed block.
+        write_design_rules(&path).unwrap();
+        let fresh = std::fs::read_to_string(&path).unwrap();
+        assert!(fresh.starts_with("(version 1)\n"));
+        assert!(fresh.contains("ict-test-point-pitch"));
+
+        // Idempotent.
+        write_design_rules(&path).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), fresh);
+
+        // User rules outside the block survive; a stale block is replaced.
+        let user = fresh.replace("2.0mm", "9.9mm")
+            + "(rule \"user-rule\"\n\t(constraint track_width (min 0.15mm)))\n";
+        std::fs::write(&path, &user).unwrap();
+        write_design_rules(&path).unwrap();
+        let merged = std::fs::read_to_string(&path).unwrap();
+        assert!(merged.contains("user-rule"));
+        assert!(merged.contains("2.0mm"));
+        assert!(!merged.contains("9.9mm"));
+        assert_eq!(merged.matches("ict-test-point-pitch").count(), 1);
+    }
+}

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -18,6 +18,7 @@ use include_dir::{Dir, include_dir};
 use pcb_kicad::{PythonScriptBuilder, ensure_board_compatible_with_installed_kicad};
 use pcb_sch::kicad_netlist::{try_format_footprint_with_package_roots, write_fp_lib_table};
 
+mod design_rules;
 mod effective_netlist;
 mod kicad_project_patch;
 mod moved;
@@ -776,6 +777,7 @@ pub fn process_layout(
         &netclass_assignments,
         layout_name.as_deref(),
     )?;
+    design_rules::write_design_rules(&paths.pcb.with_extension("kicad_dru"))?;
     patch_pcb_file(
         &paths.pcb,
         board_config.as_ref(),
@@ -1207,6 +1209,7 @@ fn build_pcb_patchset(
         board,
         internal_connectivity_by_path,
     )?);
+    patches.extend(build_footprint_component_class_patchset(board)?);
 
     if let Some(stackup) = board_config.and_then(|config| config.stackup.as_ref()) {
         let board_thickness_iu = stackup_thickness_iu(stackup);
@@ -1296,6 +1299,74 @@ fn build_footprint_internal_connectivity_patchset(
             direct_child_node(footprint, "jumper_pad_groups"),
             groups_text,
         ) {
+            (Some(node), Some(text)) => patches.replace_raw(node.span, text),
+            (Some(node), None) => patches.replace_raw(node.span, String::new()),
+            (None, Some(text)) => insert_footprint_child(&mut patches, footprint, &text),
+            (None, None) => {}
+        }
+    }
+
+    Ok(patches)
+}
+
+/// Stamp the `ICT` component class on every footprint whose `Ict`
+/// property is non-empty (and strip it where the property is gone), so
+/// the generated design rule (see `design_rules`) can pair-match ICT
+/// test points in DRC. Only the `ICT` class is managed; any other
+/// classes on the footprint are kept.
+fn build_footprint_component_class_patchset(
+    board: &pcb_sexpr::Sexpr,
+) -> Result<pcb_sexpr::PatchSet, LayoutError> {
+    const CLASS: &str = "ICT";
+    let root_items = board.as_list().ok_or_else(|| {
+        LayoutError::StackupPatchingError("PCB root is not an S-expression list".to_string())
+    })?;
+
+    let mut patches = pcb_sexpr::PatchSet::new();
+    for item in root_items.iter().skip(1) {
+        let Some(footprint) = item.as_list() else {
+            continue;
+        };
+        if footprint.first().and_then(pcb_sexpr::Sexpr::as_sym) != Some("footprint") {
+            continue;
+        }
+
+        let is_ict = pcb_sexpr::kicad::schematic_properties(footprint)
+            .get("Ict")
+            .is_some_and(|value| !value.is_empty());
+        let existing = direct_child_node(footprint, "component_classes");
+        let mut classes: Vec<String> = existing
+            .and_then(pcb_sexpr::Sexpr::as_list)
+            .map(|node| {
+                node.iter()
+                    .skip(1)
+                    .filter_map(pcb_sexpr::Sexpr::as_list)
+                    .filter(|child| {
+                        child.first().and_then(pcb_sexpr::Sexpr::as_sym) == Some("class")
+                    })
+                    .filter_map(|child| child.get(1).and_then(pcb_sexpr::Sexpr::as_str))
+                    .map(str::to_owned)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let had = classes.iter().any(|class| class == CLASS);
+        match (is_ict, had) {
+            (true, false) => classes.push(CLASS.to_string()),
+            (false, true) => classes.retain(|class| class != CLASS),
+            _ => continue,
+        }
+        classes.sort();
+
+        let text = (!classes.is_empty()).then(|| {
+            let list = classes
+                .iter()
+                .map(|class| format!("(class \"{class}\")"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            format!("(component_classes {list})")
+        });
+        match (existing, text) {
             (Some(node), Some(text)) => patches.replace_raw(node.span, text),
             (Some(node), None) => patches.replace_raw(node.span, String::new()),
             (None, Some(text)) => insert_footprint_child(&mut patches, footprint, &text),
@@ -1642,8 +1713,8 @@ fn stackup_thickness_iu(stackup: &Stackup) -> Option<PcbIu> {
 mod tests {
     use super::{
         PCB_GIT_HASH_PLACEHOLDER, PCB_VERSION_PLACEHOLDER, PcbIu, build_board_properties_patchset,
-        build_footprint_internal_connectivity_patchset, build_stackup_patchset,
-        build_title_block_patchset, patch_pcb_file, stackup_thickness_iu,
+        build_footprint_component_class_patchset, build_footprint_internal_connectivity_patchset,
+        build_stackup_patchset, build_title_block_patchset, patch_pcb_file, stackup_thickness_iu,
     };
     use pcb_zen_core::lang::stackup::{BoardConfig, CopperRole, DielectricForm, Layer, Stackup};
     use std::collections::{BTreeMap, BTreeSet};
@@ -1707,6 +1778,46 @@ mod tests {
         assert!(out.contains(&format!(
             r#"(property "PCB_GIT_HASH" "{PCB_GIT_HASH_PLACEHOLDER}")"#
         )));
+    }
+
+    #[test]
+    fn build_footprint_component_class_patchset_manages_ict_class() {
+        let input = r##"(kicad_pcb
+	(footprint "TP:Pad"
+		(layer "B.Cu")
+		(property "Ict" "usb_dp")
+		(pad "1" smd circle (at 0 0) (size 1 1) (layers "B.Cu"))
+	)
+	(footprint "TP:Pad"
+		(layer "B.Cu")
+		(property "Ict" "")
+		(component_classes (class "ICT") (class "USER"))
+		(pad "1" smd circle (at 0 0) (size 1 1) (layers "B.Cu"))
+	)
+	(footprint "R:R"
+		(layer "F.Cu")
+		(pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu"))
+	)
+)"##;
+
+        let board = pcb_sexpr::parse(input).unwrap();
+        let patches = build_footprint_component_class_patchset(&board).unwrap();
+        let mut out = Vec::new();
+        patches.write_to(input, &mut out).unwrap();
+        let out = String::from_utf8(out).unwrap();
+
+        // The ict footprint gains the class; the retired one keeps only
+        // its foreign class; the resistor stays untouched.
+        assert_eq!(out.matches("(component_classes").count(), 2);
+        assert!(out.contains(r#"(component_classes (class "ICT"))"#));
+        assert!(out.contains(r#"(component_classes (class "USER"))"#));
+
+        // Idempotent: re-running on the output produces no patches.
+        let board = pcb_sexpr::parse(&out).unwrap();
+        let patches = build_footprint_component_class_patchset(&board).unwrap();
+        let mut again = Vec::new();
+        patches.write_to(&out, &mut again).unwrap();
+        assert_eq!(String::from_utf8(again).unwrap(), out);
     }
 
     #[test]


### PR DESCRIPTION
`pcb layout` now stamps the `ICT` component class on footprints whose `Ict` property is set and maintains a managed block in the project's `.kicad_dru` with one rule: ICT pads keep 2 mm edge-to-edge (3 mm center-to-center for the Ø1 mm contacts — the interposer pogo courtyard's pitch). Hand-written rules outside the managed block survive regeneration, and boards without ICT test points match nothing; verified against kicad-cli DRC (violation at 2.5 mm pitch, clean at 3.0 mm).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-time metadata and generated DRC rules only; no auth, routing, or BOM logic changes, with tests for merge and class stamping.
> 
> **Overview**
> **`pcb layout`** now drives KiCad DRC for ICT fixture spacing: footprints with a non-empty **`Ict`** property get the **`ICT`** component class on sync, and the project's **`.kicad_dru`** gains a managed **`ict-test-point-pitch`** rule (2 mm pad edge clearance → ~3 mm center pitch for Ø1 mm pads, matching interposer pogo courtyard).
> 
> A new **`design_rules`** module merges only a marker-delimited block into **`.kicad_dru`**, preserving hand-written rules outside it and staying idempotent on repeat runs. Unit tests cover DRU merge behavior and ICT class add/remove without disturbing other component classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94fc59330aa5080c964d8ee3428d5a0062830edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->