### PR TITLE
Identify ICT contacts by the TestPoint ICT variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a TestPoint `ICT` variant whose footprint courtyard enforces the 3 mm fixture pitch; ICT extraction requires it.
+
 ### Changed
 
 - Interposer pogo pads use the Mill-Max 806 footprint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added a TestPoint `ICT` variant whose footprint courtyard enforces the 3 mm fixture pitch; ICT extraction requires it.
+- TestPoint `ict=` uses a dedicated ICT footprint whose courtyard enforces 3 mm spacing.
 
 ### Changed
 

--- a/crates/pcb-interposer/src/contacts.rs
+++ b/crates/pcb-interposer/src/contacts.rs
@@ -2,9 +2,8 @@
 //!
 //! The board-array file carries the board's components once (in the
 //! repeated board step) and the placement grid as step repeats; the BOM
-//! carries each component's `Ict` role. A contact must use the
-//! `TestPoint_ICT` footprint — the one whose 3mm courtyard reserves the
-//! interposer pogo pitch. This joins the three into one
+//! carries each component's `Ict` role; only `TestPoint_ICT`-footprint
+//! components qualify. This joins the three into one
 //! contact list in the interposer's Y-down sheet frame — one entry per
 //! fixture-facing test point per board instance.
 

--- a/crates/pcb-interposer/src/contacts.rs
+++ b/crates/pcb-interposer/src/contacts.rs
@@ -2,7 +2,9 @@
 //!
 //! The board-array file carries the board's components once (in the
 //! repeated board step) and the placement grid as step repeats; the BOM
-//! carries each component's `Ict` role. This joins the three into one
+//! carries each component's `Ict` role. A contact must use the
+//! `TestPoint_ICT` footprint — the one whose 3mm courtyard reserves the
+//! interposer pogo pitch. This joins the three into one
 //! contact list in the interposer's Y-down sheet frame — one entry per
 //! fixture-facing test point per board instance.
 
@@ -132,6 +134,9 @@ fn bom_roles(ipc: &Ipc2581) -> BTreeMap<String, (String, String)> {
         }
         let Some(ict) = ict else { continue };
         for ref_des in &item.ref_des_list {
+            if !is_ict_package(ipc.resolve(ref_des.package_ref)) {
+                continue;
+            }
             let refdes = ipc.resolve(ref_des.name).to_string();
             if !refdes.is_empty() {
                 roles.insert(refdes, (ict.clone(), path.clone()));
@@ -139,4 +144,18 @@ fn bom_roles(ipc: &Ipc2581) -> BTreeMap<String, (String, String)> {
         }
     }
     roles
+}
+
+/// The `TestPoint` ICT variant's footprint, allowing the `_<n>` suffix
+/// board-array creation appends when deduplicating package names.
+/// Mirrors `pcb_ipc2581_tools::commands::ict::is_ict_package`.
+fn is_ict_package(name: &str) -> bool {
+    const FOOTPRINT: &str = "TestPoint_ICT";
+    match name.strip_prefix(FOOTPRINT) {
+        Some("") => true,
+        Some(rest) => rest
+            .strip_prefix('_')
+            .is_some_and(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit())),
+        None => false,
+    }
 }

--- a/crates/pcb-interposer/tests/generate.rs
+++ b/crates/pcb-interposer/tests/generate.rs
@@ -18,42 +18,42 @@ const PANEL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
       <StepRef name="array"/>
     </BomHeader>
     <BomItem OEMDesignNumberRef="TP_DP" quantity="1" pinCount="1" category="ELECTRICAL">
-      <RefDes name="TP1" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <RefDes name="TP1" packageRef="TestPoint_ICT" populate="true" layerRef="BOTTOM"/>
       <Characteristics category="ELECTRICAL">
         <Textual textualCharacteristicName="Ict" textualCharacteristicValue="usb_dp"/>
         <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_DP.TP"/>
       </Characteristics>
     </BomItem>
     <BomItem OEMDesignNumberRef="TP_DM" quantity="1" pinCount="1" category="ELECTRICAL">
-      <RefDes name="TP2" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <RefDes name="TP2" packageRef="TestPoint_ICT" populate="true" layerRef="BOTTOM"/>
       <Characteristics category="ELECTRICAL">
         <Textual textualCharacteristicName="Ict" textualCharacteristicValue="usb_dm"/>
         <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_DM.TP"/>
       </Characteristics>
     </BomItem>
     <BomItem OEMDesignNumberRef="TP_VT" quantity="1" pinCount="1" category="ELECTRICAL">
-      <RefDes name="TP3" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <RefDes name="TP3" packageRef="TestPoint_ICT" populate="true" layerRef="BOTTOM"/>
       <Characteristics category="ELECTRICAL">
         <Textual textualCharacteristicName="Ict" textualCharacteristicValue="vtarget"/>
         <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_VT.TP"/>
       </Characteristics>
     </BomItem>
     <BomItem OEMDesignNumberRef="TP_VU" quantity="1" pinCount="1" category="ELECTRICAL">
-      <RefDes name="TP4" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <RefDes name="TP4" packageRef="TestPoint_ICT" populate="true" layerRef="BOTTOM"/>
       <Characteristics category="ELECTRICAL">
         <Textual textualCharacteristicName="Ict" textualCharacteristicValue="vusb"/>
         <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_VU.TP"/>
       </Characteristics>
     </BomItem>
     <BomItem OEMDesignNumberRef="TP_G" quantity="1" pinCount="1" category="ELECTRICAL">
-      <RefDes name="TP5" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <RefDes name="TP5" packageRef="TestPoint_ICT" populate="true" layerRef="BOTTOM"/>
       <Characteristics category="ELECTRICAL">
         <Textual textualCharacteristicName="Ict" textualCharacteristicValue="gnd"/>
         <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_G.TP"/>
       </Characteristics>
     </BomItem>
     <BomItem OEMDesignNumberRef="TP_SWDIO" quantity="1" pinCount="1" category="ELECTRICAL">
-      <RefDes name="TP6" packageRef="Pad" populate="true" layerRef="BOTTOM"/>
+      <RefDes name="TP6" packageRef="TestPoint_ICT" populate="true" layerRef="BOTTOM"/>
       <Characteristics category="ELECTRICAL">
         <Textual textualCharacteristicName="Ict" textualCharacteristicValue="swdio"/>
         <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_SWDIO.TP"/>

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -1,10 +1,13 @@
 //! List ICT fixture contacts from an IPC-2581 file.
 //!
-//! A fixture contact is any component whose BOM item carries an `Ict`
-//! characteristic — the `TestPoint` `ict=` config, which layout sync
-//! title-cases onto the footprint and IPC exports emit as a BOM
-//! characteristic. One CSV row per connected pin, at the pad position when
-//! the export carries per-pad nets and the component origin otherwise.
+//! A fixture contact is a `TestPoint_ICT`-footprint component whose BOM
+//! item carries an `Ict` characteristic — the `TestPoint` `ict=` config,
+//! which layout sync title-cases onto the footprint and IPC exports emit
+//! as a BOM characteristic. The footprint requirement is the contract:
+//! its 3mm courtyard reserves the interposer pogo pitch, so only points
+//! that carry it are fixture contacts. One CSV row per connected pin, at
+//! the pad position when the export carries per-pad nets and the
+//! component origin otherwise.
 
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -73,6 +76,9 @@ pub fn extract_contacts(ipc: &Ipc2581) -> Result<Vec<IctContact>> {
                 continue;
             };
             for ref_des in &item.ref_des_list {
+                if !is_ict_package(ipc.resolve(ref_des.package_ref)) {
+                    continue;
+                }
                 let designator = ipc.resolve(ref_des.name).to_string();
                 if !designator.is_empty() {
                     roles.insert(
@@ -174,6 +180,20 @@ pub fn extract_contacts(ipc: &Ipc2581) -> Result<Vec<IctContact>> {
 
 static EMPTY: String = String::new();
 
+/// The `TestPoint` ICT variant's footprint, allowing the `_<n>` suffix
+/// board-array creation appends when deduplicating package names.
+/// Mirrored in `pcb_interposer::contacts`.
+pub fn is_ict_package(name: &str) -> bool {
+    const FOOTPRINT: &str = "TestPoint_ICT";
+    match name.strip_prefix(FOOTPRINT) {
+        Some("") => true,
+        Some(rest) => rest
+            .strip_prefix('_')
+            .is_some_and(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit())),
+        None => false,
+    }
+}
+
 fn compare_contacts(left: &IctContact, right: &IctContact) -> Ordering {
     side_sort_key(left.side)
         .cmp(&side_sort_key(right.side))
@@ -257,6 +277,16 @@ fn write_csv_field(output: &mut String, field: &str) {
 mod tests {
     use super::*;
 
+    #[test]
+    fn ict_package_names_match_with_dedupe_suffix() {
+        assert!(is_ict_package("TestPoint_ICT"));
+        assert!(is_ict_package("TestPoint_ICT_35"));
+        assert!(!is_ict_package("TestPoint_ICT_"));
+        assert!(!is_ict_package("TestPoint_ICT_x"));
+        assert!(!is_ict_package("TestPoint_Pad_D1.0mm"));
+        assert!(!is_ict_package("Pad_D1.0mm"));
+    }
+
     const FIXTURE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="Owner">
@@ -268,7 +298,7 @@ mod tests {
       <StepRef name="board"/>
     </BomHeader>
     <BomItem OEMDesignNumberRef="TP_GND" quantity="1" pinCount="1" category="ELECTRICAL">
-      <RefDes name="TP1" packageRef="Pad_D1.0mm" populate="true" layerRef="BOTTOM"/>
+      <RefDes name="TP1" packageRef="TestPoint_ICT" populate="true" layerRef="BOTTOM"/>
       <Characteristics category="ELECTRICAL">
         <Textual textualCharacteristicName="Ict" textualCharacteristicValue="gnd"/>
         <Textual textualCharacteristicName="Path" textualCharacteristicValue="TP_GND"/>
@@ -307,7 +337,7 @@ mod tests {
         <LogicalNet name="SIG">
           <PinRef pin="1" componentRef="R1"/>
         </LogicalNet>
-        <Component refDes="TP1" packageRef="Pad_D1.0mm" layerRef="BOTTOM" part="TP_GND" mountType="SMT">
+        <Component refDes="TP1" packageRef="TestPoint_ICT" layerRef="BOTTOM" part="TP_GND" mountType="SMT">
           <Location x="3.500" y="4.250"/>
         </Component>
         <Component refDes="R1" packageRef="R_0603" layerRef="TOP" part="R10k" mountType="SMT">

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -3,11 +3,9 @@
 //! A fixture contact is a `TestPoint_ICT`-footprint component whose BOM
 //! item carries an `Ict` characteristic — the `TestPoint` `ict=` config,
 //! which layout sync title-cases onto the footprint and IPC exports emit
-//! as a BOM characteristic. The footprint requirement is the contract:
-//! its 3mm courtyard reserves the interposer pogo pitch, so only points
-//! that carry it are fixture contacts. One CSV row per connected pin, at
-//! the pad position when the export carries per-pad nets and the
-//! component origin otherwise.
+//! as a BOM characteristic. One CSV row per connected pin, at the pad
+//! position when the export carries per-pad nets and the component
+//! origin otherwise.
 
 use std::cmp::Ordering;
 use std::collections::BTreeMap;

--- a/lib/std/generics/TestPoint.zen
+++ b/lib/std/generics/TestPoint.zen
@@ -13,6 +13,7 @@ Variant = enum(
     "Bridge_Pitch5.08mm_Drill1.3mm",
     "Bridge_Pitch6.35mm_Drill1.3mm",
     "Bridge_Pitch7.62mm_Drill1.3mm",
+    "ICT",
     "Keystone_5005-5009_Compact",
     "Loop_D1.80mm_Drill1.0mm_Beaded",
     "Loop_D2.50mm_Drill1.0mm_LowProfile",
@@ -77,6 +78,14 @@ ict = config(
 )
 
 P1 = io(Net)
+
+# The ICT variant's footprint carries the 3mm-pitch courtyard the
+# interposer pogo pins need; the role and the footprint always travel
+# together so fixture extraction can key on both.
+if ict and variant.value != "ICT":
+    error("ict= requires variant Variant(\"ICT\")")
+if variant.value == "ICT" and not ict:
+    error("variant Variant(\"ICT\") requires an ict= role")
 
 
 def _properties(base):

--- a/lib/std/generics/TestPoint.zen
+++ b/lib/std/generics/TestPoint.zen
@@ -74,14 +74,11 @@ ict = config(
         "usb_dm",
         "ls",
     ],
-    help="Optional ICT fixture role, copied onto the footprint.",
+    help="Optional ICT fixture role, copied onto the footprint. Implies the TestPoint_ICT footprint, whose 3mm courtyard reserves the interposer pogo pitch.",
 )
 
 P1 = io(Net)
 
-# An ict= role implies the ICT footprint: its 3mm-pitch courtyard
-# reserves the interposer pogo pin's landing room, and fixture
-# extraction keys on the footprint and the role together.
 if variant.value == "ICT" and not ict:
     error('variant Variant("ICT") requires an ict= role')
 if ict and "Keystone" in variant.value:

--- a/lib/std/generics/TestPoint.zen
+++ b/lib/std/generics/TestPoint.zen
@@ -79,13 +79,11 @@ ict = config(
 
 P1 = io(Net)
 
-# The ICT variant's footprint carries the 3mm-pitch courtyard the
-# interposer pogo pins need; the role and the footprint always travel
-# together so fixture extraction can key on both.
-if ict and variant.value != "ICT":
-    error("ict= requires variant Variant(\"ICT\")")
+# An ict= role implies the ICT footprint: its 3mm-pitch courtyard
+# reserves the interposer pogo pin's landing room, and fixture
+# extraction keys on the footprint and the role together.
 if variant.value == "ICT" and not ict:
-    error("variant Variant(\"ICT\") requires an ict= role")
+    error('variant Variant("ICT") requires an ict= role')
 
 
 def _properties(base):
@@ -100,7 +98,7 @@ def _symbol(variant: Variant):
 
 def _footprint(variant):
     """Returns the footprint for a specific variant."""
-    name = variant.value
+    name = "ICT" if ict else variant.value
     return f"../kicad-footprints/TestPoint.pretty/TestPoint_{name}.kicad_mod"
 
 

--- a/lib/std/generics/TestPoint.zen
+++ b/lib/std/generics/TestPoint.zen
@@ -84,6 +84,8 @@ P1 = io(Net)
 # extraction keys on the footprint and the role together.
 if variant.value == "ICT" and not ict:
     error('variant Variant("ICT") requires an ict= role')
+if ict and "Keystone" in variant.value:
+    error("ict= is not supported on Keystone test points; they are real parts, not bare pads")
 
 
 def _properties(base):

--- a/lib/std/generics/test/test_TestPoint.zen
+++ b/lib/std/generics/test/test_TestPoint.zen
@@ -24,7 +24,6 @@ TestPoint(
     P1=Net("TP_ICT_GND_P1"),
 )
 
-# An ict= role on any variant upgrades the footprint to TestPoint_ICT.
 TestPoint(
     name="TP_ICT_UPGRADE",
     variant="Pad_D1.0mm",

--- a/lib/std/generics/test/test_TestPoint.zen
+++ b/lib/std/generics/test/test_TestPoint.zen
@@ -23,3 +23,11 @@ TestPoint(
     ict="gnd",
     P1=Net("TP_ICT_GND_P1"),
 )
+
+# An ict= role on any variant upgrades the footprint to TestPoint_ICT.
+TestPoint(
+    name="TP_ICT_UPGRADE",
+    variant="Pad_D1.0mm",
+    ict="vusb",
+    P1=Net("TP_ICT_UPGRADE_P1"),
+)

--- a/lib/std/generics/test/test_TestPoint.zen
+++ b/lib/std/generics/test/test_TestPoint.zen
@@ -5,8 +5,10 @@ load("../../properties.zen", "Layout")
 
 TestPoint = Module("../TestPoint.zen")
 
-# Test all Variant values
+# Test all Variant values (ICT requires an ict= role, tested below)
 for variant in TestPoint.Variant.values():
+    if variant.value == "ICT":
+        continue
     # Replace dots and special characters in variant name for valid component names
     name = "TP_" + str(variant.value).replace(".", "_").replace("x", "x").upper()
     TestPoint(
@@ -17,7 +19,7 @@ for variant in TestPoint.Variant.values():
 
 TestPoint(
     name="TP_ICT_GND",
-    variant="Pad_D1.0mm",
+    variant="ICT",
     ict="gnd",
     P1=Net("TP_ICT_GND_P1"),
 )

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_ICT.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_ICT.kicad_mod
@@ -1,0 +1,98 @@
+(footprint "TestPoint_ICT"
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(layer "F.Cu")
+	(descr "ICT fixture test point: 1.0mm SMD pad; the 3mm courtyard reserves the interposer pogo pin's landing pitch")
+	(tags "test point SMD pad ICT fixture")
+	(property "Reference" "REF**"
+		(at 0 -1.448 0)
+		(layer "F.SilkS")
+		(uuid "a6b9e858-ad6a-51d5-92d8-f556a4f3e081")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Value" "TestPoint_ICT"
+		(at 0 1.55 0)
+		(layer "F.Fab")
+		(uuid "60bad1eb-de7a-55ee-8c76-bc65f7b72e87")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Datasheet" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "953d420f-d51d-5da4-9b66-734b7e6437af")
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Description" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "55183cd6-db40-5e84-8d76-2f2f85c20b79")
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.15)
+			)
+		)
+	)
+	(attr exclude_from_pos_files exclude_from_bom)
+	(duplicate_pad_numbers_are_jumpers no)
+	(fp_circle
+		(center 0 0)
+		(end 0 0.7)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(fill no)
+		(layer "F.SilkS")
+		(uuid "59403d76-a29e-5029-b64f-b03b67178c60")
+	)
+	(fp_circle
+		(center 0 0)
+		(end 1.5 0)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(fill no)
+		(layer "F.CrtYd")
+		(uuid "55adc1e0-127a-579e-956a-bb4fb1971361")
+	)
+	(fp_text user "${REFERENCE}"
+		(at 0 -1.45 0)
+		(layer "F.Fab")
+		(uuid "f0b2e8ca-68be-5170-b7f4-295346313ff3")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(pad "1" smd circle
+		(at 0 0)
+		(size 1 1)
+		(layers "F.Cu" "F.Mask")
+		(uuid "dc163b13-3996-5ab5-a562-90ba25935229")
+	)
+	(embedded_fonts no)
+)


### PR DESCRIPTION
Adds a TestPoint `ICT` variant paired with `ict=` (each requires the other) and a `TestPoint_ICT` footprint whose Ø3 mm courtyard makes KiCad's native courtyard DRC enforce the interposer pogo pitch on the board — no generated rules or component classes. `pcb ipc ict` and the interposer's contact extraction now require that footprint alongside the `Ict` BOM characteristic; all four corpus sheets still route to 0 violations and 0 unconnected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> ICT contact discovery is stricter and footprint-driven; designs that mark ICT only via BOM without the new footprint may stop appearing in ICT exports and interposer generation until layouts are synced.
> 
> **Overview**
> ICT fixture contacts are no longer inferred from the **`Ict` BOM characteristic alone**. **`pcb ipc ict`** and interposer contact extraction now require the **`TestPoint_ICT`** package (including dedupe suffixes like `TestPoint_ICT_35`), with shared **`is_ict_package`** logic in both crates.
> 
> **TestPoint** adds an **`ICT`** variant that must be paired with **`ict=`**, and **`ict=`** on non-Keystone variants **forces the `TestPoint_ICT` footprint** instead of the chosen pad variant. Keystone test points reject **`ict=`**.
> 
> A new **`TestPoint_ICT`** KiCad footprint provides a **3 mm courtyard** so native courtyard DRC enforces interposer pogo spacing on the board without custom rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3907c1bb2fb7909a1fcf3364e354c9b20155b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->