### PR TITLE
Interposer IPC-2581 export and final mate lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added `pcb ipc interposer --ipc` to export the finished board as manufacturing IPC-2581 XML with its BOM.
+
+### Changed
+
+- Interposer mate lands are Ø1.5 mm, sized for the fixture bed's 2.54 mm pogo blocks.
+
+### Added
+
 - TestPoint `ict=` uses a dedicated ICT footprint whose courtyard enforces 3 mm spacing.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `pcb ipc interposer --ipc` to export the finished board as manufacturing IPC-2581 XML with its BOM.
-
-### Changed
-
-- Interposer mate lands are Ø1.5 mm, sized for the fixture bed's 2.54 mm pogo blocks.
-
-### Added
-
 - TestPoint `ict=` uses a dedicated ICT footprint whose courtyard enforces 3 mm spacing.
 
 ### Changed
 
+- Interposer mate lands are Ø1.5 mm, sized for the fixture bed's 2.54 mm pogo blocks.
 - Interposer pogo pads use the Mill-Max 806 footprint.
 
 ## [0.4.35] - 2026-08-24

--- a/crates/pcb-interposer/footprints/806-22-001-30-0xx191.kicad_mod
+++ b/crates/pcb-interposer/footprints/806-22-001-30-0xx191.kicad_mod
@@ -24,6 +24,42 @@
 			)
 		)
 	)
+	(property "Mpn" "806-22-001-30-012191"
+		(at 0 0 0)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "1c7a0000-0000-4000-8000-000000000001")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Manufacturer" "Mill-Max"
+		(at 0 0 0)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "1c7a0000-0000-4000-8000-000000000002")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Datasheet" "https://www.mill-max.com/products/datasheet/806-22-001-30-012191"
+		(at 0 0 0)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "1c7a0000-0000-4000-8000-000000000003")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
 	(property "KiLib_Generator" "package/explicit_land_pattern"
 		(at 0 0 0)
 		(layer "F.Fab")

--- a/crates/pcb-interposer/src/emit.rs
+++ b/crates/pcb-interposer/src/emit.rs
@@ -22,8 +22,10 @@ use crate::pattern::{Land, Role};
 use crate::plan::Plan;
 use crate::pogo::PogoTemplate;
 
-/// Mate land pad diameter.
-const LAND_DIA_MM: f64 = 1.0;
+/// Mate land pad diameter: the target for the fixture bed's 2.54 mm
+/// pitch pogo blocks — tip plus alignment margin, with ~1 mm of copper
+/// gap left between neighbors.
+const LAND_DIA_MM: f64 = 1.5;
 
 /// Build the `.kicad_pcb` source.
 pub fn board(panel: &Panel, lands: &[Land], plan: Option<&Plan>) -> String {
@@ -234,7 +236,7 @@ fn land_footprint(
         uuid: uuids.next_uuid(),
     });
     Footprint {
-        lib_id: "Interposer:Mate_Pad_D1.0mm".into(),
+        lib_id: "Interposer:Mate_Pad_D1.5mm".into(),
         layer: "B.Cu".into(),
         uuid: uuids.next_uuid(),
         at: At::xy(land.xy[0], land.xy[1]),

--- a/crates/pcb-interposer/src/stitch.rs
+++ b/crates/pcb-interposer/src/stitch.rs
@@ -169,7 +169,12 @@ if not filler.Fill(board.Zones()):
 RESCUE_STEP = pcbnew.FromMM(0.4)
 RESCUE_SEP = pcbnew.FromMM(0.7)
 gnd_pads = [
-    (pad.GetPosition().x, pad.GetPosition().y, pad.IsOnLayer(pcbnew.F_Cu))
+    (
+        pad.GetPosition().x,
+        pad.GetPosition().y,
+        pad.IsOnLayer(pcbnew.F_Cu),
+        max(pad.GetSize().x, pad.GetSize().y) // 2,
+    )
     for footprint in board.GetFootprints()
     for pad in footprint.Pads()
     if pad.GetNetCode() == gnd
@@ -200,14 +205,15 @@ for zone in board.Zones():
         for layer in (pcbnew.F_Cu, pcbnew.B_Cu):
             if zone.IsOnLayer(layer):
                 gnd_fills[layer] = zone.GetFilledPolysList(layer)
-for x, y, top in gnd_pads:
+for x, y, top, radius in gnd_pads:
     layer = pcbnew.F_Cu if top else pcbnew.B_Cu
     fill = gnd_fills.get(layer)
     if fill is None:
         continue
     # A connected pad has fill copper (spokes or solid) overlapping it,
-    # so the fill comes within the pad's radius of its center.
-    touched = fill.Collide(pcbnew.VECTOR2I(x, y), pcbnew.FromMM(1.0))
+    # so the fill comes within the pad's own radius of its center; an
+    # orphan's nearest fill sits a full thermal gap further out.
+    touched = fill.Collide(pcbnew.VECTOR2I(x, y), radius + pcbnew.FromMM(0.05))
     if not touched and all(
         (ox - x) ** 2 + (oy - y) ** 2 >= RESCUE_SEP * RESCUE_SEP for ox, oy in accepted
     ):
@@ -226,7 +232,7 @@ for zone in board.Zones():
             on_top = layer == pcbnew.F_Cu
             pads_in = [
                 (x, y)
-                for x, y, top in gnd_pads
+                for x, y, top, _ in gnd_pads
                 if top == on_top and island.Collide(pcbnew.VECTOR2I(x, y))
             ]
             if not pads_in:

--- a/crates/pcb-interposer/src/stitch.rs
+++ b/crates/pcb-interposer/src/stitch.rs
@@ -72,12 +72,15 @@ for track in board.GetTracks():
     if track.GetNetCode() != gnd:
         add(track, layer, obstacles)
 
+gnd_land_centers = []
 for footprint in board.GetFootprints():
     for pad in footprint.Pads():
         layer = pcbnew.F_Cu if pad.IsOnLayer(pcbnew.F_Cu) else pcbnew.B_Cu
         add(pad, layer, envelope, ENVELOPE_EXTRA)
         if pad.GetNetCode() != gnd:
             add(pad, layer, obstacles)
+        elif layer == pcbnew.B_Cu:
+            gnd_land_centers.append((pad.GetPosition().x, pad.GetPosition().y))
 
 obstacles.Simplify()
 envelope.Simplify()
@@ -130,8 +133,15 @@ def place(x, y):
     if far_enough(x, y) and allowed.Collide(pcbnew.VECTOR2I(x, y)):
         accepted.append((x, y))
         buckets.setdefault((x // MIN_SEP, y // MIN_SEP), []).append((x, y))
+        return True
+    return False
 
 
+# A via in each GND mate land (same net, pressure contact — no solder)
+# guarantees its pour pocket bridges the faces even where routed traces
+# and neighboring lands squeeze out every contour candidate.
+for x, y in gnd_land_centers:
+    place(x, y)
 for chain in chains(envelope):
     for x, y in samples(chain):
         place(x, y)
@@ -152,6 +162,96 @@ for x, y in accepted:
 filler = pcbnew.ZONE_FILLER(board)
 if not filler.Fill(board.Zones()):
     sys.exit("Failed to fill zones after stitching")
+
+# Rescue pass: a routed-trace pocket can sever a fill island holding a
+# GND pad from every via (a top pogo pad can't take one in-pad). Any
+# island with a GND pad and no via gets one dropped inside it.
+RESCUE_STEP = pcbnew.FromMM(0.4)
+RESCUE_SEP = pcbnew.FromMM(0.7)
+gnd_pads = [
+    (pad.GetPosition().x, pad.GetPosition().y, pad.IsOnLayer(pcbnew.F_Cu))
+    for footprint in board.GetFootprints()
+    for pad in footprint.Pads()
+    if pad.GetNetCode() == gnd
+]
+rescued = 0
+
+
+def add_via(pt):
+    global rescued
+    via = pcbnew.PCB_VIA(board)
+    via.SetViaType(pcbnew.VIATYPE_THROUGH)
+    via.SetPosition(pt)
+    via.SetWidth(VIA_WIDTH)
+    via.SetDrill(VIA_DRILL)
+    via.SetLayerPair(pcbnew.F_Cu, pcbnew.B_Cu)
+    via.SetNetCode(gnd)
+    board.Add(via)
+    accepted.append((pt.x, pt.y))
+    rescued += 1
+
+
+# A pad ringed by foreign traces at minimum clearance gets no spokes,
+# no fill, and leaves no legal spot beside it — the only bridge left is
+# a via in the pad itself. Fixture pads tolerate that.
+gnd_fills = {}
+for zone in board.Zones():
+    if zone.GetNetCode() == gnd:
+        for layer in (pcbnew.F_Cu, pcbnew.B_Cu):
+            if zone.IsOnLayer(layer):
+                gnd_fills[layer] = zone.GetFilledPolysList(layer)
+for x, y, top in gnd_pads:
+    layer = pcbnew.F_Cu if top else pcbnew.B_Cu
+    fill = gnd_fills.get(layer)
+    if fill is None:
+        continue
+    # A connected pad has fill copper (spokes or solid) overlapping it,
+    # so the fill comes within the pad's radius of its center.
+    touched = fill.Collide(pcbnew.VECTOR2I(x, y), pcbnew.FromMM(1.0))
+    if not touched and all(
+        (ox - x) ** 2 + (oy - y) ** 2 >= RESCUE_SEP * RESCUE_SEP for ox, oy in accepted
+    ):
+        add_via(pcbnew.VECTOR2I(x, y))
+
+for zone in board.Zones():
+    if zone.GetNetCode() != gnd:
+        continue
+    for layer in (pcbnew.F_Cu, pcbnew.B_Cu):
+        if not zone.IsOnLayer(layer):
+            continue
+        fill = zone.GetFilledPolysList(layer)
+        for i in range(fill.OutlineCount()):
+            island = pcbnew.SHAPE_POLY_SET()
+            island.AddOutline(fill.COutline(i))
+            on_top = layer == pcbnew.F_Cu
+            pads_in = [
+                (x, y)
+                for x, y, top in gnd_pads
+                if top == on_top and island.Collide(pcbnew.VECTOR2I(x, y))
+            ]
+            if not pads_in:
+                continue
+            if any(island.Collide(pcbnew.VECTOR2I(x, y)) for x, y in accepted):
+                continue
+            box = island.BBox()
+            done = False
+            y = box.GetY()
+            while not done and y <= box.GetBottom():
+                x = box.GetX()
+                while not done and x <= box.GetRight():
+                    pt = pcbnew.VECTOR2I(x, y)
+                    clear = all(
+                        (ox - x) ** 2 + (oy - y) ** 2 >= RESCUE_SEP * RESCUE_SEP
+                        for ox, oy in accepted
+                    )
+                    if clear and island.Collide(pt) and allowed.Collide(pt):
+                        add_via(pt)
+                        done = True
+                    x += RESCUE_STEP
+                y += RESCUE_STEP
+
+if rescued and not filler.Fill(board.Zones()):
+    sys.exit("Failed to refill zones after rescue vias")
 if not pcbnew.SaveBoard(board_path, board):
     sys.exit("Failed to save stitched board")
 

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -48,6 +48,9 @@ enum Commands {
         /// Auto-route the interposer with FreeRouting (requires Java 25+)
         #[arg(long)]
         route: bool,
+        /// Also export the finished board as manufacturing IPC-2581 XML
+        #[arg(long, value_hint = clap::ValueHint::FilePath)]
+        ipc: Option<PathBuf>,
     },
     /// List ICT fixture contacts (components with an `Ict` BOM characteristic)
     Ict {
@@ -368,6 +371,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             output,
             fixture_map,
             route,
+            ipc,
         } => {
             use anyhow::Context as _;
             let (pcb, pro) = pcb_interposer::generate(&input)?;
@@ -407,6 +411,24 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 let vias = pcb_interposer::stitch::stitch(&output)?;
                 println!("✓ Stitched {vias} GND vias");
                 routed?;
+            }
+            if let Some(ipc_path) = ipc {
+                pcb_kicad::KiCadCliBuilder::new()
+                    .command("pcb")
+                    .subcommand("export")
+                    .subcommand("ipc2581")
+                    .arg("--output")
+                    .arg(ipc_path.to_string_lossy())
+                    .arg("--bom-col-int-id")
+                    .arg("Path")
+                    .arg("--bom-col-mfg-pn")
+                    .arg("Mpn")
+                    .arg("--bom-col-mfg")
+                    .arg("Manufacturer")
+                    .arg(output.to_string_lossy())
+                    .run()
+                    .context("export interposer IPC-2581")?;
+                println!("✓ Wrote IPC-2581 {}", ipc_path.display());
             }
             Ok(())
         }


### PR DESCRIPTION
Adds `pcb ipc interposer --ipc` to export the finished board as manufacturing IPC-2581 XML (kicad-cli, with Mpn/Manufacturer/Path BOM columns as in `pcb release`; the vendored pogo footprint pins Mill-Max 806-22-001-30-012191, giving a proper 64-line BOM). Mate lands are finalized at Ø1.5 mm for the fixture bed's 2.54 mm pogo blocks, with GND-land vias and a connectivity rescue pass in the stitcher so the tighter land gaps can't strand a pour pocket; all four corpus sheets DRC at 0/0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interposer pad geometry and GND stitching behavior on routed boards, which affects fixture connectivity and manufacturing outputs rather than core auth or runtime paths.
> 
> **Overview**
> Adds **`pcb ipc interposer --ipc`** so the finished interposer can be exported as manufacturing IPC-2581 XML (via KiCad CLI) with BOM columns aligned to release: **Path**, **Mpn**, and **Manufacturer**. The vendored Mill-Max 806 footprint now carries those hidden fab properties so the pogo line items populate correctly in that BOM.
> 
> **Mate lands** are finalized at **Ø1.5 mm** (`LAND_DIA_MM` and `Interposer:Mate_Pad_D1.5mm`), targeting the fixture bed’s 2.54 mm pogo blocks with usable copper spacing.
> 
> The **GND stitcher** places a via at each bottom-side GND mate land, then runs a **rescue pass** after zone fill: isolated GND pads or fill islands without an existing via get an in-pad or grid-placed via, with a second fill if any rescue vias were added—so tighter land spacing does not strand pour pockets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604a1dfecf87a93fdfa4ea96848372a1f6e3223c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->