### PR TITLE
Fix IPC DFM copper clearance ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Cache `pcb bom` matches per line with stale-data fallback.
+- Make IPC DFM copper-clearance checks net-aware.
 
 ## [0.4.36] - 2026-08-25
 

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -75,7 +75,8 @@ high-level pass is never allowed to suppress a later authoritative failure.
 | Outline slot width | Materialized filled route outline, then its narrowest maximal inscribed disk | None |
 | Hole-to-hole clearance | Materialized drill circles and overlapping drill spans | Sorted bounds prune pairs already proven clear |
 | Annular ring | Drill circle and final composed copper image on each applicable layer | Batched containment and an indexed copper boundary |
-| Copper width and clearance | Final composed copper image, medial-axis width of each residue | Guarded opening or closing localizes candidates |
+| Copper width | Final composed copper image, medial-axis width of each residue | Guarded opening localizes candidates |
+| Copper clearance | Final composed copper attributed to occurrence-scoped electrical conductors | Sorted bounds prune conductor components already proven clear |
 | Soldermask web | Final composed mask-opening image, medial-axis width of each residue | Guarded closing localizes candidates |
 | V-score and board-edge clearance | Materialized line/profile geometry against final composed copper | Indexed copper boundaries |
 | Board-array spacing | Materialized filled array profiles | Bounding boxes prune pairs already proven clear |
@@ -89,16 +90,23 @@ own uncertainty — so curve tessellation by itself cannot manufacture a
 violation, and the same rule decides every quantity in the table above.
 
 Morphological opening and closing are deliberately candidate stages for width
-and gap checks. Each candidate residue is measured on the medial axis of the
-boundary around it — the Voronoi diagram of the nearby boundary segments —
-as the diameter of its narrowest maximal inscribed disk. Disks tangent only
-to incident segments are corner spokes and carry no width, so one-sided
-residue (the bite an isolated corner sheds) measures nothing; disks that a
-larger disk contains within the flattening tolerance are branches the
-tessellation sprouted and are pruned, so a flattened arc measures its
-diameter while a tapered spur still measures its tip. Bounds and spatial
-indices have the same one-way contract: they can prove work unnecessary, but
-they cannot emit a finding without the exact geometric measurement.
+and soldermask-web checks. Each candidate residue is measured on the medial
+axis of the boundary around it — the Voronoi diagram of the nearby boundary
+segments — as the diameter of its narrowest maximal inscribed disk. Disks
+tangent only to incident segments are corner spokes and carry no width, so
+one-sided residue (the bite an isolated corner sheds) measures nothing; disks
+that a larger disk contains within the flattening tolerance are branches the
+tessellation sprouted and are pruned, so a flattened arc measures its diameter
+while a tapered spur still measures its tip. Bounds and spatial indices have
+the same one-way contract: they can prove work unnecessary, but they cannot
+emit a finding without the exact geometric measurement.
+
+Copper-clearance ownership is retained through that same ordered artwork
+composition. Dark features add material to their owner; clears and final
+cutouts subtract material from every owner already painted. The evaluator
+then measures only pairs of distinct owners. A net is scoped by its
+materialized Step occurrence, so repeated boards do not become electrically
+connected merely because they reuse the same net names.
 
 `--layout-target board` extracts the canonical board step. `board-array`
 materializes the root layout and every nested repeat, so the same evaluators
@@ -126,9 +134,15 @@ when fewer than two exist.
   layer with a matching source land, must retain copper at the hole center;
   missing copper there is a zero-enclosure failure. One finding per hole
   reports the worst layer.
-- `minimum_feature_width` and `minimum_copper_clearance` report narrow copper
-  and narrow gaps piece by piece per layer after final polarity composition.
-  `soldermask.minimum_web` reports mask webs — gaps between mask openings —
+- `minimum_feature_width` reports narrow copper piece by piece after final
+  polarity composition. `minimum_copper_clearance` measures the shortest
+  boundary distance between distinct final conductor images. Same-net
+  notches and same-net islands are not clearance subjects; touching or
+  overlapping distinct conductors have zero clearance. Functional copper
+  without a net fails extraction when this rule is configured instead of
+  being guessed into an electrical domain. Fiducials and copper-balance
+  support remain explicit auxiliary conductors.
+- `soldermask.minimum_web` reports mask webs — gaps between mask openings —
   narrower than the limit. Morphology finds candidates; the medial-axis
   width decides each finding.
 - V-score and board-edge clearance measure the shortest distance from the

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -1,0 +1,268 @@
+//! Minimum clearance between electrically distinct final copper conductors.
+//!
+//! Copper ownership is resolved while ordered artwork is composed. Each
+//! owner therefore carries exactly the material that survives polarity,
+//! clear features, and final cutouts. Clearance compares connected regions
+//! belonging to different owners; self-notches and disconnected islands of
+//! one owner are deliberately outside this quantity. Touching, overlapping,
+//! or contained distinct-owner regions measure zero.
+
+use pcb_ir::geom::BBox;
+use pcb_ir::geom::dfm::region_clearance;
+
+use crate::commands::dfm::design::{ConductorId, Design};
+use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
+
+use super::{Evaluation, Measured};
+
+struct Piece {
+    conductor_index: usize,
+    region: pcb_ir::geom::ContourSet,
+}
+
+pub(super) fn evaluate(limit_mm: f64, design: &Design) -> Evaluation {
+    let mut checked = 0;
+    let mut measured = Vec::new();
+
+    for layer in &design.copper_layers {
+        let components = layer
+            .conductors
+            .iter()
+            .map(|conductor| conductor.image.connected_components())
+            .collect::<Vec<_>>();
+        for (index, left) in components.iter().enumerate() {
+            checked += components[index + 1..]
+                .iter()
+                .map(|right| left.len() * right.len())
+                .sum::<usize>();
+        }
+
+        let mut pieces = components
+            .into_iter()
+            .enumerate()
+            .flat_map(|(conductor_index, components)| {
+                components.into_iter().map(move |region| Piece {
+                    conductor_index,
+                    region,
+                })
+            })
+            .collect::<Vec<_>>();
+        pieces.sort_by(|left, right| {
+            left.region
+                .bbox
+                .min
+                .x
+                .total_cmp(&right.region.bbox.min.x)
+                .then_with(|| left.region.bbox.min.y.total_cmp(&right.region.bbox.min.y))
+        });
+
+        for (left_index, left) in pieces.iter().enumerate() {
+            for right in &pieces[left_index + 1..] {
+                if right.region.bbox.min.x - left.region.bbox.max.x >= limit_mm {
+                    break;
+                }
+                if left.conductor_index == right.conductor_index
+                    || left.region.bbox.distance_to(right.region.bbox) >= limit_mm
+                {
+                    continue;
+                }
+                let Some(distance) = region_clearance(&left.region, &right.region) else {
+                    continue;
+                };
+
+                let left_id = layer.conductors[left.conductor_index].id;
+                let right_id = layer.conductors[right.conductor_index].id;
+                let mut bbox = BBox::from_point(distance.first);
+                bbox.include_point(distance.second);
+                measured.push(Measured {
+                    distance,
+                    bbox,
+                    layers: vec![layer.layer.clone()],
+                    subjects: vec![
+                        conductor_subject(design, left_id, "first_conductor", &layer.layer.name),
+                        conductor_subject(design, right_id, "second_conductor", &layer.layer.name),
+                    ],
+                    evidence: vec![
+                        Evidence::bounds("first_conductor_component", left.region.bbox),
+                        Evidence::bounds("second_conductor_component", right.region.bbox),
+                    ],
+                });
+            }
+        }
+    }
+
+    Evaluation { checked, measured }
+}
+
+fn conductor_subject(design: &Design, id: ConductorId, role: &'static str, layer: &str) -> Subject {
+    let (kind, name, set_index) = match id {
+        ConductorId::Net { .. } => ("electrical_net", None, None),
+        ConductorId::Auxiliary {
+            source_set_index, ..
+        } => (
+            "auxiliary_copper",
+            Some("auxiliary copper".to_owned()),
+            Some(source_set_index),
+        ),
+        ConductorId::Unattributed { .. } => {
+            unreachable!("unattributed copper is rejected during DFM extraction")
+        }
+    };
+    Subject {
+        role,
+        kind,
+        name,
+        net: design.resolve(id.net()),
+        source: Some(SourceLocator {
+            step: design.resolve(id.step()),
+            layer: Some(layer.to_owned()),
+            set_index,
+            feature_index: None,
+            instance_index: id.instance(),
+        }),
+        ..Subject::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use chrono::NaiveDate;
+    use pcb_ir::dialects::ipc::ArtworkScope;
+
+    use crate::commands::dfm::{checks, design::Design, pdk::Pdk, rules};
+    use crate::ipc2581::Ipc2581;
+
+    const PDK: &str = r#"schema_version = 1
+
+[pdk]
+id = "clearance-test"
+name = "Clearance test"
+revision = "1"
+
+[capabilities.copper]
+minimum_copper_clearance = "0.15 mm"
+"#;
+
+    const BOARD: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+  </Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <LayerFeature layerRef="TOP">
+          <Set net="N1"><Features><UserSpecial><Contour><Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="2" y="0"/>
+            <PolyStepSegment x="2" y="2"/>
+            <PolyStepSegment x="1.05" y="2"/>
+            <PolyStepSegment x="1.05" y="0.5"/>
+            <PolyStepSegment x="0.95" y="0.5"/>
+            <PolyStepSegment x="0.95" y="2"/>
+            <PolyStepSegment x="0" y="2"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon></Contour></UserSpecial></Features></Set>
+          <Set net="N2"><Features><UserSpecial><Contour><Polygon>
+            <PolyBegin x="4" y="0"/><PolyStepSegment x="5" y="0"/>
+            <PolyStepSegment x="5" y="1"/><PolyStepSegment x="4" y="1"/>
+            <PolyStepSegment x="4" y="0"/>
+          </Polygon></Contour></UserSpecial></Features></Set>
+          <Set net="N3"><Features><UserSpecial><Contour><Polygon>
+            <PolyBegin x="5.05" y="0"/><PolyStepSegment x="6.05" y="0"/>
+            <PolyStepSegment x="6.05" y="1"/><PolyStepSegment x="5.05" y="1"/>
+            <PolyStepSegment x="5.05" y="0"/>
+          </Polygon></Contour></UserSpecial></Features></Set>
+          <Set net="N4"><Features><UserSpecial><Contour><Polygon>
+            <PolyBegin x="8" y="0"/><PolyStepSegment x="9" y="0"/>
+            <PolyStepSegment x="9" y="1"/><PolyStepSegment x="8" y="1"/>
+            <PolyStepSegment x="8" y="0"/>
+          </Polygon></Contour></UserSpecial></Features></Set>
+          <Set net="N5"><Features><UserSpecial><Contour><Polygon>
+            <PolyBegin x="8.5" y="0"/><PolyStepSegment x="9.5" y="0"/>
+            <PolyStepSegment x="9.5" y="1"/><PolyStepSegment x="8.5" y="1"/>
+            <PolyStepSegment x="8.5" y="0"/>
+          </Polygon></Contour></UserSpecial></Features></Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+    fn run(xml: &str) -> checks::Results {
+        let ipc = Ipc2581::parse(xml).unwrap();
+        let pdk = Pdk::parse(PDK).unwrap();
+        let rules = rules::lower(&pdk).unwrap();
+        let design = Design::extract(&ipc, ArtworkScope::Board, &rules).unwrap();
+        checks::run(
+            &rules,
+            &design,
+            None,
+            NaiveDate::from_ymd_opt(2026, 8, 25).unwrap(),
+        )
+    }
+
+    #[test]
+    fn ignores_same_net_notches_but_reports_distinct_gaps_and_overlaps() {
+        let results = run(BOARD);
+
+        assert_eq!(results.findings.len(), 2);
+        let pairs = results
+            .findings
+            .iter()
+            .map(|finding| {
+                let mut pair = finding
+                    .subjects
+                    .iter()
+                    .map(|subject| subject.net.clone().unwrap())
+                    .collect::<Vec<_>>();
+                pair.sort();
+                pair
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                vec!["N2".to_owned(), "N3".to_owned()],
+                vec!["N4".to_owned(), "N5".to_owned()],
+            ])
+        );
+        assert!(results.findings.iter().all(|finding| {
+            finding
+                .subjects
+                .iter()
+                .all(|subject| subject.net.as_deref() != Some("N1"))
+        }));
+        let actual = results
+            .findings
+            .iter()
+            .map(|finding| finding.measurement.actual_mm)
+            .collect::<Vec<_>>();
+        assert!(actual.iter().any(|value| value.abs() < 1e-9));
+        assert!(actual.iter().any(|value| (value - 0.05).abs() < 1e-9));
+    }
+
+    #[test]
+    fn rejects_surviving_functional_copper_without_net_ownership() {
+        let xml = BOARD.replace("<Set net=\"N2\">", "<Set>");
+        let ipc = Ipc2581::parse(&xml).unwrap();
+        let pdk = Pdk::parse(PDK).unwrap();
+        let rules = rules::lower(&pdk).unwrap();
+
+        let error = Design::extract(&ipc, ArtworkScope::Board, &rules)
+            .err()
+            .expect("unattributed copper must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("final functional copper without net attribution"),
+            "{error:#}"
+        );
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -10,6 +10,7 @@
 
 mod annular_ring;
 mod board_array_spacing;
+mod copper_clearance;
 mod hole_diameter;
 mod hole_pair_clearance;
 mod linework_clearance;
@@ -33,8 +34,6 @@ use super::report::{
 };
 use super::rules::{Linework, Rule, RuleKind};
 use super::waivers::{self, WaiverFile, WaiverOutcome};
-
-use thin_regions::Residue;
 
 /// Absorbs floating-point unit conversion when a measurement sits exactly
 /// on its limit.
@@ -153,7 +152,7 @@ fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
             .board_outlines
             .is_empty()
             .then(|| "board profile outlines".to_owned()),
-        RuleKind::ThinFeature(_) | RuleKind::ThinGap(_) => None,
+        RuleKind::CopperFeatureWidth | RuleKind::CopperClearance | RuleKind::SoldermaskWeb => None,
     };
     let pools = rule.kind.semantics().pools;
     let layers = (pools.copper && design.copper_layers.is_empty())
@@ -177,8 +176,9 @@ fn evaluate(rule: &Rule, design: &Design) -> Evaluation {
             linework_clearance::evaluate(limit, linework, design)
         }
         RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(limit, design),
-        RuleKind::ThinFeature(sel) => thin_regions::evaluate(limit, sel, Residue::Feature, design),
-        RuleKind::ThinGap(sel) => thin_regions::evaluate(limit, sel, Residue::Gap, design),
+        RuleKind::CopperFeatureWidth => thin_regions::copper_feature_width(limit, design),
+        RuleKind::CopperClearance => copper_clearance::evaluate(limit, design),
+        RuleKind::SoldermaskWeb => thin_regions::soldermask_web(limit, design),
     }
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -1,4 +1,4 @@
-//! Minimum feature width and minimum gap, by mathematical morphology.
+//! Minimum copper feature width and soldermask web width, by morphology.
 //!
 //! Let `M` be one layer's composed image and `B_ρ` the closed disk of
 //! radius `ρ = L/2`. The morphological opening and closing of `M` with
@@ -13,7 +13,7 @@
 //! `M`, so the residue `M \ (M ∘ B_ρ)` is exactly the material through
 //! which no disk of diameter `L` passes — the sub-minimum features.
 //! Dually, the closing residue `(M • B_ρ) \ M` is exactly the complement
-//! material narrower than `L` — the sub-minimum gaps, notches, and webs.
+//! material narrower than `L`, used here for soldermask webs.
 //!
 //! Morphology is the conservative broad phase: it runs with an offset guard
 //! large enough to retain candidates across curve/offset tessellation. A
@@ -23,56 +23,52 @@
 //! and is discarded. Thus the composed image supplies the authoritative
 //! measurement while morphology only localizes the work.
 //!
-//! For copper, `Residue::Feature` flags copper that will not survive
-//! etching and `Residue::Gap` flags spacing that will not resolve. A
-//! soldermask image is the mask *openings*, so `Residue::Gap` flags the
-//! web of mask remaining between them.
+//! The opening residue flags copper that will not survive etching. A
+//! soldermask image is the mask *openings*, so its closing residue flags the
+//! web of mask remaining between them. Copper clearance is a separate
+//! electrical-conductor boundary-distance check; morphology must not
+//! reinterpret a same-net notch as spacing between conductors.
 
 use pcb_ir::geom::ContourSet;
 use pcb_ir::geom::dfm::{ThinPiece, thin_features, thin_gaps};
 use rayon::prelude::*;
 
+use super::{Evaluation, Measured};
 use crate::commands::dfm::design::Design;
 use crate::commands::dfm::report::{Evidence, LayerRef, Subject};
-use crate::commands::dfm::rules::ImageSel;
 
-use super::{Evaluation, Measured};
-
-/// Which morphological residue the rule reports.
-#[derive(Clone, Copy)]
-pub(super) enum Residue {
-    Feature,
-    Gap,
+pub(super) fn copper_feature_width(limit_mm: f64, design: &Design) -> Evaluation {
+    evaluate(
+        limit_mm,
+        design
+            .copper_layers
+            .iter()
+            .map(|layer| (&layer.layer, &layer.image))
+            .collect(),
+        "copper_image",
+        thin_features,
+    )
 }
 
-pub(super) fn evaluate(
+pub(super) fn soldermask_web(limit_mm: f64, design: &Design) -> Evaluation {
+    evaluate(
+        limit_mm,
+        design
+            .mask_layers
+            .iter()
+            .map(|layer| (&layer.layer, &layer.image))
+            .collect(),
+        "soldermask_image",
+        thin_gaps,
+    )
+}
+
+fn evaluate(
     limit_mm: f64,
-    sel: ImageSel,
-    residue: Residue,
-    design: &Design,
+    images: Vec<(&LayerRef, &ContourSet)>,
+    offender_kind: &'static str,
+    thin: fn(&ContourSet, f64) -> Vec<ThinPiece>,
 ) -> Evaluation {
-    let (images, offender_kind): (Vec<(&LayerRef, &ContourSet)>, &'static str) = match sel {
-        ImageSel::Copper => (
-            design
-                .copper_layers
-                .iter()
-                .map(|layer| (&layer.layer, &layer.image))
-                .collect(),
-            "copper_image",
-        ),
-        ImageSel::Soldermask => (
-            design
-                .mask_layers
-                .iter()
-                .map(|layer| (&layer.layer, &layer.image))
-                .collect(),
-            "soldermask_image",
-        ),
-    };
-    let thin: fn(&ContourSet, f64) -> Vec<ThinPiece> = match residue {
-        Residue::Feature => thin_features,
-        Residue::Gap => thin_gaps,
-    };
     let measured = images
         .par_iter()
         .flat_map_iter(|(layer, image)| {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -13,14 +13,15 @@ use std::collections::HashMap;
 use anyhow::{Context, Result, bail};
 use ipc2581::Symbol;
 use ipc2581::types::LayerFunction;
-use pcb_ir::dialects::Side;
 use pcb_ir::dialects::ipc::{
-    ArtworkScope, FeatureDomain, FeatureKind, FeatureSpan, LayoutStepKind, PlatingKind,
-    ProfileOccurrenceRole, profile_occurrences_for,
+    ArtworkLowering, ArtworkObjectKind, ArtworkScope, Feature, FeatureDomain, FeatureKind,
+    FeatureSpan, LayoutStepKind, PlatingKind, ProfileOccurrenceRole, lower_layer_to_artwork_with,
+    profile_occurrences_for,
 };
+use pcb_ir::dialects::{LayerRole, Side, artwork};
 use pcb_ir::geom::dfm::{Distance, RegionBoundaryIndex, min_width};
 use pcb_ir::geom::region::Ring;
-use pcb_ir::geom::{BBox, ContourSet, Point, Polarity, tol};
+use pcb_ir::geom::{BBox, ContourSet, FillRule, Point, Polarity, Span, tol};
 use rayon::prelude::*;
 
 use crate::geometry::{self, GeometryDocument};
@@ -57,7 +58,9 @@ impl<'a> Design<'a> {
     pub fn extract(ipc: &'a Ipc2581, scope: ArtworkScope, rules: &[Rule]) -> Result<Self> {
         let pools = rules::pools(rules);
         let (holes, slots) = when(pools.drilled, || collect_drilled(ipc, scope))?;
-        let copper_layers = when(pools.copper, || collect_copper_layers(ipc, scope))?;
+        let copper_layers = when(pools.copper, || {
+            collect_copper_layers(ipc, scope, pools.conductor_ownership)
+        })?;
         let layout = when(pools.board_outlines || pools.board_arrays, || {
             geometry::extract_layout(ipc).map(Some)
         })?;
@@ -206,7 +209,65 @@ pub(super) struct Land {
 pub(super) struct CopperLayer {
     pub layer: LayerRef,
     pub image: ContourSet,
+    pub conductors: Vec<CopperConductor>,
     pub lands: Vec<Land>,
+}
+
+/// Electrical ownership of one final copper image. Net identity is scoped by
+/// its materialized Step occurrence so repeated boards do not accidentally
+/// share every same-named net.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum ConductorId {
+    Net {
+        step: Option<Symbol>,
+        instance: Option<u32>,
+        net: Symbol,
+    },
+    Auxiliary {
+        step: Option<Symbol>,
+        instance: Option<u32>,
+        source_set_index: u32,
+    },
+    Unattributed {
+        step: Option<Symbol>,
+        instance: Option<u32>,
+        source_set_index: u32,
+    },
+}
+
+impl ConductorId {
+    pub fn step(self) -> Option<Symbol> {
+        match self {
+            Self::Net { step, .. }
+            | Self::Auxiliary { step, .. }
+            | Self::Unattributed { step, .. } => step,
+        }
+    }
+
+    pub fn instance(self) -> Option<u32> {
+        match self {
+            Self::Net { instance, .. }
+            | Self::Auxiliary { instance, .. }
+            | Self::Unattributed { instance, .. } => instance,
+        }
+    }
+
+    pub fn net(self) -> Option<Symbol> {
+        match self {
+            Self::Net { net, .. } => Some(net),
+            Self::Auxiliary { .. } | Self::Unattributed { .. } => None,
+        }
+    }
+
+    fn is_unattributed(self) -> bool {
+        matches!(self, Self::Unattributed { .. })
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct CopperConductor {
+    pub id: ConductorId,
+    pub image: ContourSet,
 }
 
 #[derive(Debug)]
@@ -404,7 +465,119 @@ fn hole_class(plating: PlatingKind) -> Option<HoleClass> {
     }
 }
 
-fn collect_copper_layers(ipc: &Ipc2581, scope: ArtworkScope) -> Result<Vec<CopperLayer>> {
+struct CopperAttributionLowering;
+
+impl ArtworkLowering<Symbol, Option<ConductorId>> for CopperAttributionLowering {
+    fn object_meta(
+        &mut self,
+        feature: &Feature<Symbol>,
+        _kind: ArtworkObjectKind,
+    ) -> Option<ConductorId> {
+        if let Some(net) = feature.net {
+            return Some(ConductorId::Net {
+                step: feature.source_step_ref,
+                instance: feature.source_instance,
+                net,
+            });
+        }
+        if feature.is_fiducial() || feature.flags.copper_balance.is_some() {
+            return Some(ConductorId::Auxiliary {
+                step: feature.source_step_ref,
+                instance: feature.source_instance,
+                source_set_index: feature.source.set_index,
+            });
+        }
+        Some(ConductorId::Unattributed {
+            step: feature.source_step_ref,
+            instance: feature.source_instance,
+            source_set_index: feature.source.set_index,
+        })
+    }
+}
+
+fn compose_attributed_copper(
+    document: &mut GeometryDocument,
+) -> Result<(ContourSet, Vec<CopperConductor>)> {
+    pcb_ir::dialects::ipc::process::normalize_for_artwork(document);
+    pcb_ir::dialects::ipc::validate_artwork_ready(document)
+        .map_err(|error| anyhow::anyhow!("copper layer is not artwork-ready: {error}"))?;
+    let layer = document
+        .layers
+        .first()
+        .context("extracted copper document has no layer")?;
+    let header = artwork::Layer {
+        name: layer.name.clone(),
+        role: LayerRole::Copper,
+        side: Side::None,
+        objects: Span::EMPTY,
+        bbox: layer.bbox,
+        meta: layer.layer_function,
+    };
+    let attributed_artwork =
+        lower_layer_to_artwork_with(document, 0, header, &mut CopperAttributionLowering);
+    let (mut composed, _) = artwork::compose_attributed(&attributed_artwork, |owner| *owner);
+    let composed = composed
+        .pop()
+        .context("attributed copper composition produced no layer")?;
+    let image = ContourSet::new(composed.image, FillRule::NonZero, tol::REGION_MM);
+    let conductors = composed
+        .owners
+        .into_iter()
+        .map(|(id, rings)| {
+            Ok(CopperConductor {
+                id: id.context(
+                    "structural artwork instance survived copper ownership materialization",
+                )?,
+                image: ContourSet::new(rings, FillRule::NonZero, tol::REGION_MM),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok((image, conductors))
+}
+
+fn conductor_order(ipc: &Ipc2581, id: ConductorId) -> (u8, &str, Option<u32>, &str, u32) {
+    match id {
+        ConductorId::Net {
+            step,
+            instance,
+            net,
+        } => (
+            0,
+            step.map(|step| ipc.resolve(step)).unwrap_or(""),
+            instance,
+            ipc.resolve(net),
+            0,
+        ),
+        ConductorId::Auxiliary {
+            step,
+            instance,
+            source_set_index,
+        } => (
+            1,
+            step.map(|step| ipc.resolve(step)).unwrap_or(""),
+            instance,
+            "",
+            source_set_index,
+        ),
+        ConductorId::Unattributed {
+            step,
+            instance,
+            source_set_index,
+        } => (
+            2,
+            step.map(|step| ipc.resolve(step)).unwrap_or(""),
+            instance,
+            "",
+            source_set_index,
+        ),
+    }
+}
+
+fn collect_copper_layers(
+    ipc: &Ipc2581,
+    scope: ArtworkScope,
+    require_conductor_ownership: bool,
+) -> Result<Vec<CopperLayer>> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let copper_layers = ecad
         .cad_data
@@ -444,13 +617,30 @@ fn collect_copper_layers(ipc: &Ipc2581, scope: ArtworkScope) -> Result<Vec<Coppe
                     source_feature_index: feature.source.feature_index,
                 });
             }
+            let (image, mut conductors) = compose_attributed_copper(&mut document)?;
+            conductors.sort_by_key(|conductor| conductor_order(ipc, conductor.id));
+            if require_conductor_ownership
+                && let Some(conductor) = conductors
+                    .iter()
+                    .find(|conductor| conductor.id.is_unattributed())
+            {
+                let id = conductor.id;
+                bail!(
+                    "IPC-2581 copper layer '{name}' has final functional copper without net attribution in Step '{}'{}; copper clearance cannot be certified",
+                    id.step().map(|step| ipc.resolve(step)).unwrap_or("<root>"),
+                    id.instance()
+                        .map(|instance| format!(", layout instance {instance}"))
+                        .unwrap_or_default()
+                );
+            }
             // The file's side attribute is authoritative; the stackup
             // position is the fallback for files that omit it.
             let side =
                 side_label(layers::ir_side(layer.side)).unwrap_or(stack_side(ordinal, total));
             Ok(CopperLayer {
                 layer: layer_ref(name, layer.layer_function, Some(side)),
-                image: crate::copper_balance::composed_copper_image_from_document(document),
+                image,
+                conductors,
                 lands,
             })
         })

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -37,22 +37,18 @@ pub(super) enum RuleKind {
     LineworkToCopperClearance(Linework),
     /// Clearance: sibling board-array outlines keep their spacing.
     BoardArrayPairClearance,
-    /// Residue: image material narrower than the limit.
-    ThinFeature(ImageSel),
-    /// Residue: gaps in the image narrower than the limit.
-    ThinGap(ImageSel),
+    /// Width: final composed copper material narrower than the limit.
+    CopperFeatureWidth,
+    /// Clearance: final copper owned by distinct electrical conductors.
+    CopperClearance,
+    /// Residue: final soldermask material between openings narrower than the limit.
+    SoldermaskWeb,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Linework {
     VScore,
     BoardEdge,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ImageSel {
-    Copper,
-    Soldermask,
 }
 
 /// Everything the engine and report know about a rule kind, in one table:
@@ -75,6 +71,7 @@ pub(super) struct Semantics {
 pub(super) struct Pools {
     pub drilled: bool,
     pub copper: bool,
+    pub conductor_ownership: bool,
     pub copper_boundaries: bool,
     pub hole_lands: bool,
     pub masks: bool,
@@ -90,6 +87,7 @@ impl std::ops::BitOr for Pools {
         Self {
             drilled: self.drilled || other.drilled,
             copper: self.copper || other.copper,
+            conductor_ownership: self.conductor_ownership || other.conductor_ownership,
             copper_boundaries: self.copper_boundaries || other.copper_boundaries,
             hole_lands: self.hole_lands || other.hole_lands,
             masks: self.masks || other.masks,
@@ -103,6 +101,7 @@ impl std::ops::BitOr for Pools {
 const DRILLED: Pools = Pools {
     drilled: true,
     copper: false,
+    conductor_ownership: false,
     copper_boundaries: false,
     hole_lands: false,
     masks: false,
@@ -203,7 +202,7 @@ impl RuleKind {
                     ..NONE
                 },
             },
-            Self::ThinFeature(ImageSel::Copper) => Semantics {
+            Self::CopperFeatureWidth => Semantics {
                 subject: "copper_layer",
                 quantity: "copper_feature_width",
                 method: "opening_candidate_then_medial_axis_width",
@@ -215,31 +214,20 @@ impl RuleKind {
                     ..COPPER
                 },
             },
-            Self::ThinGap(ImageSel::Copper) => Semantics {
-                subject: "copper_layer",
+            Self::CopperClearance => Semantics {
+                subject: "conductor_pair",
                 quantity: "copper_to_copper_clearance",
-                method: "closing_candidate_then_medial_axis_width",
+                method: "distinct_conductor_boundary_distance",
                 finding_title: "Copper spacing is below minimum".to_owned(),
                 quantity_label: "copper-to-copper clearance".to_owned(),
-                witness_roles: ["first_boundary", "second_boundary"],
+                witness_roles: ["first_conductor", "second_conductor"],
                 pools: Pools {
                     drilled: false,
+                    conductor_ownership: true,
                     ..COPPER
                 },
             },
-            Self::ThinFeature(ImageSel::Soldermask) => Semantics {
-                subject: "soldermask_layer",
-                quantity: "soldermask_feature_width",
-                method: "opening_candidate_then_medial_axis_width",
-                finding_title: "Soldermask feature is below minimum width".to_owned(),
-                quantity_label: "soldermask feature width".to_owned(),
-                witness_roles: ["first_boundary", "second_boundary"],
-                pools: Pools {
-                    masks: true,
-                    ..NONE
-                },
-            },
-            Self::ThinGap(ImageSel::Soldermask) => Semantics {
+            Self::SoldermaskWeb => Semantics {
                 subject: "soldermask_layer",
                 quantity: "soldermask_web_width",
                 method: "closing_candidate_then_medial_axis_width",
@@ -319,13 +307,13 @@ pub(super) fn lower(pdk: &Pdk) -> Result<Vec<Rule>> {
             &copper.minimum_feature_width,
             "copper.minimum_feature_width",
             "Minimum copper feature width",
-            RuleKind::ThinFeature(ImageSel::Copper),
+            RuleKind::CopperFeatureWidth,
         ),
         (
             &copper.minimum_copper_clearance,
             "copper.minimum_copper_clearance",
             "Minimum copper-to-copper clearance",
-            RuleKind::ThinGap(ImageSel::Copper),
+            RuleKind::CopperClearance,
         ),
         (
             &copper.minimum_vscore_to_copper_clearance,
@@ -343,7 +331,7 @@ pub(super) fn lower(pdk: &Pdk) -> Result<Vec<Rule>> {
             &soldermask.minimum_web,
             "soldermask.minimum_web",
             "Minimum soldermask web",
-            RuleKind::ThinGap(ImageSel::Soldermask),
+            RuleKind::SoldermaskWeb,
         ),
         (
             &panelization.minimum_board_array_spacing,

--- a/crates/pcb-ipc2581-tools/src/geometry/extract.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/extract.rs
@@ -595,12 +595,14 @@ pub fn extract_layer_for_view(
         None => extract_step_layer_local(ipc, step, &ecad.cad_data.layers, layer, layer_name)?,
     };
 
-    match view {
-        ArtworkScope::Board | ArtworkScope::ArrayLocal | ArtworkScope::ArraySupport => {
-            append_step_only_layout_geometry(&mut doc, step)
-        }
-        ArtworkScope::ArrayFlattened => {
-            append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?
+    if doc.layout.is_empty() {
+        match view {
+            ArtworkScope::Board | ArtworkScope::ArrayLocal | ArtworkScope::ArraySupport => {
+                append_step_only_layout_geometry(&mut doc, step)
+            }
+            ArtworkScope::ArrayFlattened => {
+                append_layout_geometry(&mut doc, ipc, &ecad.cad_data.steps, step)?
+            }
         }
     }
     populate_ipc_specs(&mut doc, ipc);
@@ -695,11 +697,15 @@ fn extract_panel_layer(
     mode: PanelLayerMode,
 ) -> Result<GeometryDocument> {
     let mut doc = GeometryDocument::new();
+    append_panel_geometry(&mut doc, ipc, steps, panel)?;
+    let root_layout_step = doc
+        .layout
+        .root_step
+        .context("panel layout has no root step")?;
     let feature_start = doc.features.len() as u32;
     let set_start = doc.feature_sets.len() as u32;
     let mut layer_bbox = BBox::empty();
     let mut append_state = LayerAppendState::default();
-    let mut stack = vec![panel.name];
 
     layer_bbox = layer_bbox.union(append_step_layer_tree(
         &mut doc,
@@ -711,10 +717,13 @@ fn extract_panel_layer(
             layer,
             layer_name,
         },
-        panel,
-        Affine2::identity(),
+        LayerTreeOccurrence {
+            step: panel,
+            layout_step: root_layout_step,
+            source_instance: None,
+            transform: Affine2::identity(),
+        },
         mode,
-        &mut stack,
     )?);
 
     let feature_count = doc.features.len() as u32 - feature_start;
@@ -748,64 +757,87 @@ enum PanelLayerMode {
     Flattened,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct LayerTreeOccurrence<'a> {
+    step: &'a Step,
+    layout_step: u32,
+    source_instance: Option<u32>,
+    transform: Affine2,
+}
+
 fn append_step_layer_tree(
     doc: &mut GeometryDocument,
     append_state: &mut LayerAppendState,
     context: LayerMaterializeContext<'_>,
-    step: &Step,
-    transform: Affine2,
+    occurrence: LayerTreeOccurrence<'_>,
     mode: PanelLayerMode,
-    stack: &mut Vec<Symbol>,
 ) -> Result<BBox> {
-    if mode == PanelLayerMode::SupportOnly && is_board_step(step) {
+    if mode == PanelLayerMode::SupportOnly && is_board_step(occurrence.step) {
         return Ok(BBox::empty());
     }
 
     let step_doc = extract_step_layer_local(
         context.ipc,
-        step,
+        occurrence.step,
         context.layers,
         context.layer,
         context.layer_name,
     )?;
     doc.diagnostics.extend(step_doc.diagnostics.iter().cloned());
-    let mut bbox = append_state.append_layer(doc, &step_doc, 0, transform)?;
+    let mut bbox = append_state.append_layer(
+        doc,
+        &step_doc,
+        0,
+        occurrence.transform,
+        occurrence.source_instance,
+    )?;
 
-    for repeat in &step.step_repeats {
+    // Materialize from the canonical layout graph. This keeps the transform
+    // and occurrence identity attached to copied artwork instead of deriving
+    // them through an independent StepRepeat traversal.
+    let children = doc
+        .layout
+        .repeats
+        .iter()
+        .filter(|repeat| {
+            repeat.parent_step == occurrence.layout_step
+                && repeat.parent_instance == occurrence.source_instance
+        })
+        .flat_map(|repeat| repeat.instances.indices())
+        .map(|instance_index| {
+            let instance = &doc.layout.instances[instance_index as usize];
+            (
+                instance_index,
+                instance.child_step,
+                instance.source_step_ref,
+                instance.transform,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for (instance_index, child_layout_step, source_step_ref, instance_transform) in children {
         let source_step = context
             .steps
             .iter()
-            .find(|step| step.name == repeat.step_ref)
+            .find(|step| step.name == source_step_ref)
             .with_context(|| {
                 format!(
-                    "StepRepeat references unknown Step '{}'",
-                    context.ipc.resolve(repeat.step_ref)
+                    "layout instance references unknown Step '{}'",
+                    context.ipc.resolve(source_step_ref)
                 )
             })?;
-
-        if stack.contains(&source_step.name) {
-            bail!(
-                "StepRepeat cycle references Step '{}'",
-                context.ipc.resolve(source_step.name)
-            );
-        }
-
-        stack.push(source_step.name);
-        for iy in 0..repeat.ny {
-            for ix in 0..repeat.nx {
-                let instance_transform = transform.concat(step_repeat_transform(repeat, ix, iy));
-                bbox = bbox.union(append_step_layer_tree(
-                    doc,
-                    append_state,
-                    context,
-                    source_step,
-                    instance_transform,
-                    mode,
-                    stack,
-                )?);
-            }
-        }
-        stack.pop();
+        bbox = bbox.union(append_step_layer_tree(
+            doc,
+            append_state,
+            context,
+            LayerTreeOccurrence {
+                step: source_step,
+                layout_step: child_layout_step,
+                source_instance: Some(instance_index),
+                transform: instance_transform,
+            },
+            mode,
+        )?);
     }
 
     Ok(bbox)
@@ -1201,11 +1233,18 @@ impl LayerAppendState {
         source: &GeometryDocument,
         layer_index: usize,
         transform: Affine2,
+        source_instance: Option<u32>,
     ) -> Result<BBox> {
         let source_set_offset = self.next_source_set_index;
         let source_set_span = source_layer_set_span(source, layer_index)?;
-        let bbox =
-            append_transformed_layer(target, source, layer_index, transform, source_set_offset)?;
+        let bbox = append_transformed_layer(
+            target,
+            source,
+            layer_index,
+            transform,
+            source_set_offset,
+            source_instance,
+        )?;
         self.next_source_set_index = self
             .next_source_set_index
             .checked_add(source_set_span)
@@ -1233,6 +1272,7 @@ fn append_transformed_layer(
     layer_index: usize,
     transform: Affine2,
     source_set_offset: u32,
+    source_instance: Option<u32>,
 ) -> Result<BBox> {
     let layer = &source.layers[layer_index];
     let mut layer_bbox = BBox::empty();
@@ -1325,6 +1365,7 @@ fn append_transformed_layer(
             feature.bbox = bbox;
             feature.paths = paths;
             feature.placement_group = target_placement_group;
+            feature.source_instance = source_instance;
             feature.set = Some(target_set);
             feature.source.set_index = feature
                 .source
@@ -4541,6 +4582,8 @@ mod tests {
         assert!(traces.iter().all(|feature| feature.paths.count > 0));
         assert_eq!(traces[0].source.set_index, 0);
         assert_eq!(traces[1].source.set_index, 1);
+        assert_eq!(traces[0].source_instance, Some(0));
+        assert_eq!(traces[1].source_instance, Some(1));
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -9,6 +9,9 @@
 pub mod compare;
 pub mod legalize;
 
+use std::collections::HashMap;
+use std::hash::Hash;
+
 use crate::dialects::mask;
 use crate::dialects::{LayerRole, Side};
 use crate::geom::path::ContourBuf;
@@ -533,10 +536,109 @@ pub fn paint_ordered<ObjectMeta>(objects: &[Object<ObjectMeta>]) -> Vec<&Object<
     painted
 }
 
+/// One fully composed layer image together with the surviving material
+/// attributed to each caller-defined owner. Owner images may overlap when
+/// different source objects claim the same physical copper; their union is
+/// always exactly `image`.
+#[derive(Debug)]
+pub struct AttributedImage<Owner> {
+    pub image: Vec<Ring>,
+    pub owners: Vec<(Owner, Vec<Ring>)>,
+}
+
+/// Ordered artwork composition with caller-defined ownership.
+///
+/// Dark objects add material to their owner. Clear objects and final cutouts
+/// subtract from every owner painted before them. This is the same canonical
+/// paint fold used by [`compose_to_mask`], with labels retained instead of
+/// discarded after unioning.
+pub fn compose_attributed<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone + Eq + Hash>(
+    doc: &Document<LayerMeta, ObjectMeta>,
+    owner: impl Fn(&ObjectMeta) -> Owner,
+) -> (Vec<AttributedImage<Owner>>, Vec<Diagnostic>) {
+    let doc = expand_native_geometry_to_regions(doc.clone());
+    struct OwnerState {
+        composer: region::PaintComposer,
+        bbox: BBox,
+    }
+
+    let mut layers = Vec::with_capacity(doc.layers.len());
+    for layer in &doc.layers {
+        let objects = paint_ordered(layer.objects.slice(&doc.objects));
+        let has_material = objects
+            .iter()
+            .any(|object| object.order.stage != PaintStage::FinalCutout);
+        // Preserve first-paint order for deterministic attributed output and
+        // retain constant-time lookup for later objects of the same owner.
+        let mut owner_indices: HashMap<Owner, usize> = HashMap::new();
+        let mut states: Vec<(Owner, OwnerState)> = Vec::new();
+        for object in objects {
+            let image = object_image_rings(&doc, object);
+            if image.is_empty() {
+                continue;
+            }
+            let polarity = if object.order.stage == PaintStage::FinalCutout && has_material {
+                Polarity::Clear
+            } else {
+                object.polarity
+            };
+            match polarity {
+                Polarity::Dark => {
+                    let owner = owner(&object.meta);
+                    let index = match owner_indices.get(&owner) {
+                        Some(&index) => index,
+                        None => {
+                            let index = states.len();
+                            owner_indices.insert(owner.clone(), index);
+                            states.push((
+                                owner,
+                                OwnerState {
+                                    composer: region::PaintComposer::default(),
+                                    bbox: BBox::empty(),
+                                },
+                            ));
+                            index
+                        }
+                    };
+                    let state = &mut states[index].1;
+                    state.bbox = state.bbox.union(object.bbox);
+                    state.composer.push(Polarity::Dark, image);
+                }
+                Polarity::Clear => {
+                    for state in states
+                        .iter_mut()
+                        .map(|(_, state)| state)
+                        .filter(|state| state.bbox.intersects(object.bbox))
+                    {
+                        state.composer.push(Polarity::Clear, image.clone());
+                    }
+                }
+            }
+        }
+
+        let owners = states
+            .into_iter()
+            .filter_map(|(owner, state)| {
+                let image = state.composer.finish();
+                (!image.is_empty()).then_some((owner, image))
+            })
+            .collect::<Vec<_>>();
+        let image = region::union_rings(
+            owners
+                .iter()
+                .flat_map(|(_, image)| image.iter().cloned())
+                .collect(),
+            FillRule::NonZero,
+        );
+        layers.push(AttributedImage { image, owners });
+    }
+    (layers, doc.diagnostics)
+}
+
 pub fn compose_to_mask<LayerMeta: Clone, ObjectMeta: Clone>(
     doc: &Document<LayerMeta, ObjectMeta>,
 ) -> mask::Document<LayerMeta> {
-    let doc = expand_native_geometry_to_regions(doc.clone());
+    let (images, diagnostics) = compose_attributed(doc, |_| ());
     let mut mask = mask::Document::new();
 
     for layer in &doc.layers {
@@ -550,32 +652,14 @@ pub fn compose_to_mask<LayerMeta: Clone, ObjectMeta: Clone>(
         });
     }
 
-    for (layer_index, layer) in doc.layers.iter().enumerate() {
-        let objects = paint_ordered(layer.objects.slice(&doc.objects));
-        let has_material = objects
-            .iter()
-            .any(|object| object.order.stage != PaintStage::FinalCutout);
-        let mut composer = region::PaintComposer::default();
-        for object in objects {
-            let image = object_image_rings(&doc, object);
-            if image.is_empty() {
-                continue;
-            }
-            let polarity = if object.order.stage == PaintStage::FinalCutout && has_material {
-                Polarity::Clear
-            } else {
-                object.polarity
-            };
-            composer.push(polarity, image);
-        }
-
-        let contours = region::rings_to_contours(composer.finish());
+    for (layer_index, image) in images.into_iter().enumerate() {
+        let contours = region::rings_to_contours(image.image);
         if !contours.is_empty() {
             mask.push_shape(layer_index as u32, FillRule::NonZero, contours);
         }
     }
 
-    mask.diagnostics.extend(doc.diagnostics);
+    mask.diagnostics.extend(diagnostics);
     mask
 }
 
@@ -1236,6 +1320,85 @@ mod tests {
         // The dark-drawn final cutout removes material.
         assert!(!image.contains_point(Point::new(0.5, 0.5)));
         assert!(image.contains_point(Point::new(9.0, 9.0)));
+    }
+
+    #[test]
+    fn attributed_composition_preserves_owner_claims_through_clear_and_overlay() {
+        let mut doc = Document::<(), &'static str>::new();
+        let layer = doc.push_layer(Layer::new("F.Cu", LayerRole::Copper, Side::Top));
+        let rect = |doc: &mut Document<(), &'static str>, x0, y0, x1, y1| {
+            doc.push_path(
+                Paint::Fill {
+                    rule: FillRule::NonZero,
+                },
+                vec![ContourBuf::new(vec![
+                    PathCmd::move_to(Point::new(x0, y0)),
+                    PathCmd::line_to(Point::new(x1, y0)),
+                    PathCmd::line_to(Point::new(x1, y1)),
+                    PathCmd::line_to(Point::new(x0, y1)),
+                    PathCmd::close(),
+                ])],
+            )
+        };
+        let object = |polarity, path, stage, meta| {
+            let mut object = Object::new(polarity, Geometry::Region { path });
+            object.order = PaintOrder { stage };
+            object.meta = meta;
+            object
+        };
+
+        let base = rect(&mut doc, 0.0, 0.0, 10.0, 10.0);
+        doc.push_object(layer, object(Polarity::Dark, base, PaintStage::Base, "A"));
+        let clear = rect(&mut doc, 3.0, 3.0, 7.0, 7.0);
+        doc.push_object(
+            layer,
+            object(Polarity::Clear, clear, PaintStage::Base, "ignored"),
+        );
+        let overlay = rect(&mut doc, 4.0, 4.0, 6.0, 6.0);
+        doc.push_object(
+            layer,
+            object(Polarity::Dark, overlay, PaintStage::Overlay, "B"),
+        );
+        let overlap = rect(&mut doc, 8.0, 8.0, 9.0, 9.0);
+        doc.push_object(
+            layer,
+            object(Polarity::Dark, overlap, PaintStage::Overlay, "C"),
+        );
+
+        let (mut layers, diagnostics) = compose_attributed(&doc, |meta| *meta);
+        assert!(diagnostics.is_empty());
+        let composed = layers.remove(0);
+        let physical = region::ContourSet::new(
+            composed.image,
+            FillRule::NonZero,
+            crate::geom::tol::REGION_MM,
+        );
+        assert_eq!(
+            composed
+                .owners
+                .iter()
+                .map(|(owner, _)| *owner)
+                .collect::<Vec<_>>(),
+            ["A", "B", "C"]
+        );
+        let owners = composed
+            .owners
+            .into_iter()
+            .map(|(owner, rings)| {
+                (
+                    owner,
+                    region::ContourSet::new(rings, FillRule::NonZero, crate::geom::tol::REGION_MM),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        assert!(owners["A"].contains_point(Point::new(2.0, 2.0)));
+        assert!(!owners["A"].contains_point(Point::new(5.0, 5.0)));
+        assert!(owners["B"].contains_point(Point::new(5.0, 5.0)));
+        assert!(owners["A"].contains_point(Point::new(8.5, 8.5)));
+        assert!(owners["C"].contains_point(Point::new(8.5, 8.5)));
+        assert!(physical.contains_point(Point::new(5.0, 5.0)));
+        assert!(physical.contains_point(Point::new(8.5, 8.5)));
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/feature.rs
+++ b/crates/pcb-ir/src/dialects/ipc/feature.rs
@@ -24,6 +24,9 @@ pub struct Feature<Symbol> {
     pub net: Option<Symbol>,
     pub source_layer_ref: Option<Symbol>,
     pub source_step_ref: Option<Symbol>,
+    /// Materialized occurrence of `source_step_ref` in the layout graph.
+    /// `None` identifies geometry owned directly by the root step.
+    pub source_instance: Option<u32>,
     pub source_step_kind: LayoutStepKind,
     /// Index into `doc.feature_sets`, when the feature came from a set.
     pub set: Option<u32>,
@@ -84,6 +87,7 @@ impl<Symbol> Feature<Symbol> {
             net: None,
             source_layer_ref: None,
             source_step_ref: None,
+            source_instance: None,
             source_step_kind: LayoutStepKind::Unknown,
             set: None,
             placement_group: None,


### PR DESCRIPTION
IPC DFM treated same-net notches as copper-clearance defects. This change preserves conductor ownership through IPC artwork composition and checks clearance only between distinct conductors.