### PR TITLE
Add built-in standard DFM PDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add the `standard` DFM PDK with copper layer-count checks.
+
 ### Changed
 
 - Cache `pcb bom` matches per line with stale-data fallback.

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -40,18 +40,22 @@ by the retained geometry.
 
 ## DFM process design kits
 
-`dfm check` reads a strict, versioned TOML process design kit. Each length has
-its own `mm` or `mil` unit, and only configured capabilities become rules.
+`dfm check` accepts a built-in process design kit name or a strict, versioned
+TOML file. The built-in `standard` PDK is bundled with `pcb`:
 
 ```bash
 pcb ipc dfm check fabrication-panel.xml \
-  --pdk fab-process.toml \
+  --pdk standard \
   --output dfm-report.json
 ```
 
+`standard` currently supports 2 through 10 copper layers.
+
+Pass a path such as `--pdk ./fab-process.toml` to use a custom PDK. Exact
+built-in names take precedence, so prefix a same-named file with `./`.
+
 See the [DFM format reference](docs/dfm.md) and
-[`examples/dfm-pdk.toml`](examples/dfm-pdk.toml) for the PDK and JSON report
-contracts.
+[`pdks/standard.toml`](pdks/standard.toml) for the PDK and JSON report contracts.
 
 `fab-panel create` supports the common 12 by 18, 16 by 18, 18 by 24, and 21 by
 24 inch fabrication panel sizes through `--panel-size`. The default is 18 by 24

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -1,7 +1,7 @@
 # DFM PDK, waiver, and report formats
 
-`pcb ipc dfm check` turns fabrication capabilities from one TOML PDK into
-geometry checks over an IPC-2581 design and writes one JSON report.
+`pcb ipc dfm check` turns fabrication capabilities from a built-in or file-backed
+TOML PDK into geometry checks over an IPC-2581 design and writes one JSON report.
 
 ## PDK
 
@@ -20,6 +20,10 @@ name = "Example fabrication standard"
 revision = "1"
 # manufacturer = "Example Fabricator"
 # process = "standard"
+
+[capabilities.stackup]
+minimum_copper_layer_count = 2
+maximum_copper_layer_count = 10
 
 [capabilities.drilling]
 minimum_via_hole_diameter = "0.2 mm"
@@ -43,13 +47,15 @@ minimum_web = "3 mil"
 minimum_board_array_spacing = "300 mil"
 ```
 
-Every length is a positive string containing a number and `mm`, `mil`,
-`mils`, or `um`. Units can be mixed in one PDK. Checks normalize lengths to
-millimeters and the report retains both the source spelling and normalized
-value.
+Layer counts are positive integers and refer specifically to conductive layers
+in the physical stackup. When both bounds are configured, the minimum must not
+exceed the maximum. Every dimensional limit is a positive string containing a
+number and `mm`, `mil`, `mils`, or `um`. Units can be mixed in one PDK. Checks
+normalize lengths to millimeters and the report retains both the source
+spelling and normalized value.
 
-Every capability takes either a bare length — the binding minimum — or a
-table with a `preferred` tier the fab would rather see met:
+Every dimensional capability takes either a bare length — the binding minimum
+— or a table with a `preferred` tier the fab would rather see met:
 
 - The minimum lowers to an **error**-severity rule whose id is the
   capability path, e.g. `copper.minimum_via_annular_ring`. Error findings
@@ -70,6 +76,7 @@ high-level pass is never allowed to suppress a later authoritative failure.
 
 | Rules | Authoritative representation | Acceleration only |
 | --- | --- | --- |
+| Copper layer count | Conductive layers in the one physical IPC stackup | None |
 | Hole diameter | Materialized IPC drill primitive and plating class | None |
 | Nominal slot width | IPC slot primitive width | None |
 | Outline slot width | Materialized filled route outline, then its narrowest maximal inscribed disk | None |
@@ -81,13 +88,13 @@ high-level pass is never allowed to suppress a later authoritative failure.
 | V-score and board-edge clearance | Materialized line/profile geometry against final composed copper | Indexed copper boundaries |
 | Board-array spacing | Materialized filled array profiles | Bounding boxes prune pairs already proven clear |
 
-Every check produces one measurement per subject: a signed distance between
-two witness points, carrying the uncertainty of the flattened boundaries it
-was measured against (one flattening tolerance per tessellated curve; zero
-for stated primitives and analytic shapes). The engine applies the single
-verdict — the distance violates the limit only when it falls short beyond its
-own uncertainty — so curve tessellation by itself cannot manufacture a
-violation, and the same rule decides every quantity in the table above.
+Geometric checks produce one signed-distance measurement per subject, between
+two witness points and carrying the uncertainty of the flattened boundaries it
+was measured against (one flattening tolerance per tessellated curve; zero for
+stated primitives and analytic shapes). The engine fails a minimum only when
+the distance falls short beyond its own uncertainty, so curve tessellation by
+itself cannot manufacture a violation. Layer-count checks instead compare one
+exact integer with the configured minimum or maximum.
 
 Morphological opening and closing are deliberately candidate stages for width
 and soldermask-web checks. Each candidate residue is measured on the medial
@@ -118,6 +125,9 @@ when fewer than two exist.
 
 ## Rule semantics
 
+- Copper layer count requires exactly one physical stackup. Every declared
+  copper layer must occur exactly once in it; missing or ambiguous stackup data
+  fails extraction rather than guessing from artwork layer names.
 - Hole diameter rules measure every drilled hole of the rule's class;
   `minimum_slot_width` measures every routed slot. A slot's width is settled
   at extraction: the stated primitive width when present — exact, and
@@ -179,11 +189,17 @@ silently.
 
 ```bash
 pcb ipc dfm check fabrication-panel.xml \
-  --pdk fab-process.toml \
+  --pdk standard \
   --waivers waivers.toml \
   --layout-target board-array \
   --output dfm-report.json
 ```
+
+`--pdk` accepts an exact built-in name or a TOML file path. `standard` is
+bundled with `pcb`; use a path such as `./standard` when a file has the same
+name as a built-in. Reports identify built-ins with paths such as
+`builtin:standard`. Custom PDK files otherwise use the same parser, rules, and
+report pipeline.
 
 `--layout-target` is `board` or `board-array` and defaults to `board-array`.
 Omit `--output` to write JSON to stdout. The report is written before the
@@ -216,9 +232,8 @@ The report is a self-contained record of what was checked:
   `.preferred` for warning tiers), severity, source and normalized limit,
   status (`pass`, `warning`, `fail`, or `skipped`), skip reason, and the
   measurement contract shared by all of its findings — `subject` (what one
-  checked unit is), `quantity`, `method`, and `checked`, the number of
-  measurements evaluated. Every rule requires its measured quantity to be at
-  least its limit.
+  checked unit is), `quantity`, `method`, `comparison` (`minimum` or
+  `maximum`), and `checked`, the number of measurements evaluated.
 - `findings`: violations in deterministic rule/location order.
 
 Each finding is intentionally a fat record:
@@ -232,8 +247,9 @@ Each finding is intentionally a fat record:
   a waived violation that shrinks or grows in place keeps its waiver.
 - `rule_id`, `severity`, `title`, and `message` identify and explain the
   violation; `waived` and `waiver_reason` record acceptance.
-- `measurement` carries `actual_mm`, `required_mm`, and the signed
-  `margin_mm`; its quantity, method, and comparison live on the rule.
+- `measurement` carries `actual_mm`, `required_mm`, and signed `margin_mm` for
+  geometry, or the corresponding `actual_count`, `required_count`, and
+  `margin_count` for discrete counts. A nonnegative margin passes.
 - `location` carries a representative point, bounding box, and role-labelled
   geometric witnesses.
 - `layers` identify every involved manufacturing layer: name, IPC-2581
@@ -246,6 +262,6 @@ Each finding is intentionally a fat record:
   evidence; circle, segment, and bounds fields are populated as applicable
   and otherwise remain `null`.
 
-Within schema version 1, new optional fields and new `kind`, `role`,
+Within schema version 1, new fields and new `kind`, `role`,
 `status`, rule, and method values may be added. Removing or changing the
 meaning of an existing field requires a new schema version.

--- a/crates/pcb-ipc2581-tools/pdks/standard.toml
+++ b/crates/pcb-ipc2581-tools/pdks/standard.toml
@@ -1,9 +1,11 @@
 schema_version = 1
 
 [pdk]
-id = "example-fab-standard"
-name = "Example fabrication standard"
-revision = "1"
+id = "standard"
+name = "Standard"
+revision = "draft-2026-08-21"
+manufacturer = "Diode"
+process = "Standard"
 
 [capabilities.stackup]
 minimum_copper_layer_count = 2
@@ -11,21 +13,21 @@ maximum_copper_layer_count = 10
 
 [capabilities.drilling]
 minimum_via_hole_diameter = "0.2 mm"
-minimum_pth_hole_diameter = "0.2 mm"
+minimum_pth_hole_diameter = "15 mil"
 minimum_npth_hole_diameter = "0.2 mm"
-minimum_slot_width = "0.8 mm"
+minimum_slot_width = "31 mil"
 minimum_hole_to_hole_clearance = "10 mil"
 
 [capabilities.copper]
-minimum_via_annular_ring = { minimum = "100 um", preferred = "0.125 mm" }
-minimum_pth_annular_ring = "0.125 mm"
-minimum_feature_width = "0.09 mm"
-minimum_copper_clearance = "0.09 mm"
-minimum_board_edge_clearance = "0.25 mm"
+minimum_via_annular_ring = "0.125 mm"
+minimum_pth_annular_ring = "7 mil"
+minimum_feature_width = "5 mil"
+minimum_copper_clearance = "5 mil"
+minimum_board_edge_clearance = "15 mil"
 minimum_vscore_to_copper_clearance = "15 mil"
 
 [capabilities.soldermask]
-minimum_web = "3 mil"
+minimum_web = "4 mil"
 
 [capabilities.panelization]
 minimum_board_array_spacing = "300 mil"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -1,5 +1,6 @@
 //! PDK-driven manufacturability checks for IPC-2581 geometry.
 
+use std::borrow::Cow;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -10,6 +11,7 @@ use crate::LayoutTarget;
 use crate::ipc2581::Ipc2581;
 use crate::utils::file as file_utils;
 
+mod builtin_pdks;
 mod checks;
 mod design;
 mod pdk;
@@ -25,6 +27,12 @@ pub struct CheckOptions {
     pub layout_target: LayoutTarget,
 }
 
+/// PDK source bytes plus the stable identity echoed into reports.
+struct LoadedPdk {
+    path: String,
+    bytes: Cow<'static, [u8]>,
+}
+
 /// A parsed waiver file plus the identity the report echoes back.
 struct LoadedWaivers {
     path: String,
@@ -35,19 +43,18 @@ struct LoadedWaivers {
 pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<()> {
     let input_bytes = std::fs::read(file)
         .with_context(|| format!("failed to read IPC-2581 file {}", file.display()))?;
-    let pdk_bytes = std::fs::read(&options.pdk)
-        .with_context(|| format!("failed to read PDK file {}", options.pdk.display()))?;
-    let pdk_source = std::str::from_utf8(&pdk_bytes)
-        .with_context(|| format!("PDK file {} is not UTF-8", options.pdk.display()))?;
+    let loaded_pdk = load_pdk(&options.pdk)?;
+    let pdk_source = std::str::from_utf8(&loaded_pdk.bytes)
+        .with_context(|| format!("PDK {} is not UTF-8", loaded_pdk.path))?;
     let pdk = pdk::Pdk::parse(pdk_source)
-        .with_context(|| format!("failed to parse PDK file {}", options.pdk.display()))?;
+        .with_context(|| format!("failed to parse PDK {}", loaded_pdk.path))?;
 
-    let rules = rules::lower(&pdk)
-        .with_context(|| format!("failed to lower PDK file {}", options.pdk.display()))?;
+    let rules =
+        rules::lower(&pdk).with_context(|| format!("failed to lower PDK {}", loaded_pdk.path))?;
     if rules.is_empty() {
         bail!(
             "PDK {} configures no DFM rules; add at least one capability",
-            options.pdk.display()
+            loaded_pdk.path
         );
     }
 
@@ -99,11 +106,7 @@ pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<()> {
             sha256: sha256(&input_bytes),
             size_bytes: input_bytes.len() as u64,
         },
-        pdk: report::PdkIdentity::from_pdk(
-            &pdk,
-            options.pdk.display().to_string(),
-            sha256(&pdk_bytes),
-        ),
+        pdk: report::PdkIdentity::from_pdk(&pdk, loaded_pdk.path, sha256(&loaded_pdk.bytes)),
         layout_target: match options.layout_target {
             LayoutTarget::Board => "board",
             LayoutTarget::BoardArray => "board_array",
@@ -146,6 +149,22 @@ pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<()> {
         annotations(summary)
     );
     Ok(())
+}
+
+fn load_pdk(reference: &Path) -> Result<LoadedPdk> {
+    if let Some(pdk) = reference.to_str().and_then(builtin_pdks::find) {
+        return Ok(LoadedPdk {
+            path: format!("builtin:{}", pdk.name),
+            bytes: Cow::Borrowed(pdk.source.as_bytes()),
+        });
+    }
+
+    let bytes = std::fs::read(reference)
+        .with_context(|| format!("failed to read PDK file {}", reference.display()))?;
+    Ok(LoadedPdk {
+        path: reference.display().to_string(),
+        bytes: Cow::Owned(bytes),
+    })
 }
 
 /// The non-verdict counts worth surfacing next to the pass/fail line.
@@ -286,6 +305,10 @@ id = "scope-test"
 name = "Scope test"
 revision = "1"
 
+[capabilities.stackup]
+minimum_copper_layer_count = 2
+maximum_copper_layer_count = 4
+
 [capabilities.copper]
 minimum_vscore_to_copper_clearance = "0.5 mm"
 minimum_board_edge_clearance = "0.5 mm"
@@ -295,8 +318,12 @@ minimum_board_array_spacing = "300 mil"
 "#;
 
     fn check(xml: &str, scope: ArtworkScope) -> checks::Results {
+        check_with_pdk(xml, scope, PDK)
+    }
+
+    fn check_with_pdk(xml: &str, scope: ArtworkScope, pdk_source: &str) -> checks::Results {
         let ipc = Ipc2581::parse(xml).unwrap();
-        let pdk = pdk::Pdk::parse(PDK).unwrap();
+        let pdk = pdk::Pdk::parse(pdk_source).unwrap();
         let rules = rules::lower(&pdk).unwrap();
         let design = design::Design::extract(&ipc, scope, &rules).unwrap();
         checks::run(
@@ -309,6 +336,120 @@ minimum_board_array_spacing = "300 mil"
 
     fn rule<'a>(results: &'a checks::Results, id: &str) -> &'a report::RuleResult {
         results.rules.iter().find(|rule| rule.id == id).unwrap()
+    }
+
+    #[test]
+    fn loads_the_embedded_standard_pdk() {
+        let loaded = load_pdk(Path::new("standard")).unwrap();
+        let parsed = pdk::Pdk::parse(std::str::from_utf8(&loaded.bytes).unwrap()).unwrap();
+
+        assert_eq!(loaded.path, "builtin:standard");
+        assert_eq!(parsed.pdk.id, "standard");
+        assert_eq!(parsed.pdk.name, "Standard");
+        assert_eq!(parsed.pdk.manufacturer.as_deref(), Some("Diode"));
+        assert_eq!(parsed.pdk.process.as_deref(), Some("Standard"));
+        assert_eq!(
+            parsed.capabilities.stackup.minimum_copper_layer_count,
+            Some(2)
+        );
+        assert_eq!(
+            parsed.capabilities.stackup.maximum_copper_layer_count,
+            Some(10)
+        );
+        assert!(!rules::lower(&parsed).unwrap().is_empty());
+    }
+
+    #[test]
+    fn still_loads_a_pdk_from_a_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("custom.toml");
+        std::fs::write(&path, PDK).unwrap();
+
+        let loaded = load_pdk(&path).unwrap();
+
+        assert_eq!(loaded.path, path.display().to_string());
+        assert_eq!(&*loaded.bytes, PDK.as_bytes());
+    }
+
+    #[test]
+    fn copper_layer_count_checks_both_bounds_from_the_physical_stackup() {
+        let below_minimum = check_with_pdk(
+            BOARD,
+            ArtworkScope::Board,
+            &PDK.replace(
+                "minimum_copper_layer_count = 2",
+                "minimum_copper_layer_count = 3",
+            ),
+        );
+        let minimum_rule = rule(&below_minimum, "stackup.minimum_copper_layer_count");
+        assert_eq!(minimum_rule.checked, 1);
+        assert_eq!(minimum_rule.comparison, "minimum");
+        assert_eq!(minimum_rule.limit.normalized_unit, "layers");
+        assert_eq!(minimum_rule.limit.normalized_value, 3.0);
+        assert!(matches!(minimum_rule.status, report::RuleStatus::Fail));
+        let minimum_finding = below_minimum
+            .findings
+            .iter()
+            .find(|finding| finding.rule_id == minimum_rule.id)
+            .unwrap();
+        assert!(matches!(
+            minimum_finding.measurement,
+            report::Measurement::Count {
+                actual_count: 2,
+                required_count: 3,
+                margin_count: -1,
+            }
+        ));
+        assert_eq!(
+            minimum_finding
+                .layers
+                .iter()
+                .map(|layer| layer.name.as_str())
+                .collect::<Vec<_>>(),
+            ["TOP", "BOTTOM"]
+        );
+
+        let above_maximum = check_with_pdk(
+            BOARD,
+            ArtworkScope::Board,
+            &PDK.replace(
+                "minimum_copper_layer_count = 2\nmaximum_copper_layer_count = 4",
+                "minimum_copper_layer_count = 1\nmaximum_copper_layer_count = 1",
+            ),
+        );
+        let maximum_rule = rule(&above_maximum, "stackup.maximum_copper_layer_count");
+        assert_eq!(maximum_rule.checked, 1);
+        assert_eq!(maximum_rule.comparison, "maximum");
+        assert!(matches!(maximum_rule.status, report::RuleStatus::Fail));
+        assert!(above_maximum.findings.iter().any(|finding| matches!(
+            finding.measurement,
+            report::Measurement::Count {
+                actual_count: 2,
+                required_count: 1,
+                margin_count: -1,
+            }
+        )));
+    }
+
+    #[test]
+    fn copper_layer_count_rejects_an_incomplete_physical_stackup() {
+        let ipc = Ipc2581::parse(&BOARD.replace(
+            "layerOrGroupRef=\"BOTTOM\"",
+            "layerOrGroupRef=\"DIELECTRIC\"",
+        ))
+        .unwrap();
+        let pdk = pdk::Pdk::parse(PDK).unwrap();
+        let rules = rules::lower(&pdk).unwrap();
+
+        let error = design::Design::extract(&ipc, ArtworkScope::Board, &rules)
+            .err()
+            .unwrap();
+
+        assert!(
+            error
+                .to_string()
+                .contains("omits declared copper layer(s): BOTTOM")
+        );
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/builtin_pdks.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/builtin_pdks.rs
@@ -1,0 +1,24 @@
+pub(super) struct BuiltinPdk {
+    pub name: &'static str,
+    pub source: &'static str,
+}
+
+const BUILTIN_PDKS: &[BuiltinPdk] = &[BuiltinPdk {
+    name: "standard",
+    source: include_str!("../../../pdks/standard.toml"),
+}];
+
+pub(super) fn find(name: &str) -> Option<&'static BuiltinPdk> {
+    BUILTIN_PDKS.iter().find(|pdk| pdk.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_are_exact_references() {
+        assert!(find("standard").is_some());
+        assert!(find("./standard").is_none());
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -262,7 +262,7 @@ minimum_pth_annular_ring = "0.2 mm"
         let rule = rule();
         let design =
             Design::extract(ipc, ArtworkScope::Board, std::slice::from_ref(&rule)).unwrap();
-        evaluate(rule.limit.millimeters(), HoleClass::Pth, &design)
+        evaluate(rule.limit.length().millimeters(), HoleClass::Pth, &design)
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -242,7 +242,7 @@ minimum_copper_clearance = "0.15 mm"
         let actual = results
             .findings
             .iter()
-            .map(|finding| finding.measurement.actual_mm)
+            .map(|finding| finding.measurement.actual_mm().unwrap())
             .collect::<Vec<_>>();
         assert!(actual.iter().any(|value| value.abs() < 1e-9));
         assert!(actual.iter().any(|value| (value - 0.05).abs() < 1e-9));

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/layer_count.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/layer_count.rs
@@ -1,0 +1,27 @@
+//! Copper layer count from the physical IPC-2581 stackup.
+//!
+//! The stackup extractor has already required one unambiguous stackup and a
+//! one-to-one match with every declared copper layer. This evaluator therefore
+//! measures one exact integer, independent of layout materialization.
+
+use super::CountEvaluation;
+use crate::commands::dfm::design::Design;
+use crate::commands::dfm::report::Subject;
+
+pub(super) fn evaluate(design: &Design) -> CountEvaluation {
+    let stackup = design
+        .stackup
+        .as_ref()
+        .expect("layer-count rules request stackup extraction");
+    CountEvaluation {
+        actual: u32::try_from(stackup.copper_layers.len())
+            .expect("IPC-2581 copper layer count fits in u32"),
+        layers: stackup.copper_layers.clone(),
+        subjects: vec![Subject {
+            role: "measured",
+            kind: "stackup",
+            name: Some(stackup.name.clone()),
+            ..Subject::default()
+        }],
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -13,6 +13,7 @@ mod board_array_spacing;
 mod copper_clearance;
 mod hole_diameter;
 mod hole_pair_clearance;
+mod layer_count;
 mod linework_clearance;
 mod slot_width;
 mod thin_regions;
@@ -32,7 +33,7 @@ use super::report::{
     Evidence, Finding, LayerRef, Location, Measurement, RuleResult, RuleStatus, SourceLocator,
     Subject, Witness,
 };
-use super::rules::{Linework, Rule, RuleKind};
+use super::rules::{Comparison, Linework, Rule, RuleKind};
 use super::waivers::{self, WaiverFile, WaiverOutcome};
 
 /// Absorbs floating-point unit conversion when a measurement sits exactly
@@ -64,6 +65,23 @@ struct Evaluation {
     measured: Vec<Measured>,
 }
 
+struct CountEvaluation {
+    actual: u32,
+    layers: Vec<LayerRef>,
+    subjects: Vec<Subject>,
+}
+
+enum RuleEvaluation {
+    Distance(Evaluation),
+    Count(CountEvaluation),
+}
+
+impl From<Evaluation> for RuleEvaluation {
+    fn from(evaluation: Evaluation) -> Self {
+        Self::Distance(evaluation)
+    }
+}
+
 pub(super) fn run(
     rules: &[Rule],
     design: &Design,
@@ -77,24 +95,38 @@ pub(super) fn run(
             Some(reason) => result.skip(reason),
             None => {
                 let evaluation = evaluate(rule, design);
-                let limit = rule.limit.millimeters();
-                match evaluation.checked {
-                    // A nominally populated pool can still yield nothing to
-                    // measure (e.g. hole pairs with disjoint spans); an
-                    // unexercised rule must not read as validated.
-                    0 => result.skip(format!(
-                        "no measurable {} subjects in the selected layout target",
-                        rule.kind.semantics().subject
-                    )),
-                    checked => {
-                        result.checked = checked;
-                        results.findings.extend(
-                            evaluation
-                                .measured
-                                .into_iter()
-                                .filter(|measured| violates(&measured.distance, limit))
-                                .map(|measured| finding(rule, measured)),
-                        );
+                match evaluation {
+                    RuleEvaluation::Distance(evaluation) => {
+                        debug_assert_eq!(rule.comparison, Comparison::Minimum);
+                        let limit = rule.limit.length().millimeters();
+                        match evaluation.checked {
+                            // A nominally populated pool can still yield nothing to
+                            // measure (e.g. hole pairs with disjoint spans); an
+                            // unexercised rule must not read as validated.
+                            0 => result.skip(format!(
+                                "no measurable {} subjects in the selected layout target",
+                                rule.kind.semantics().subject
+                            )),
+                            checked => {
+                                result.checked = checked;
+                                results.findings.extend(
+                                    evaluation
+                                        .measured
+                                        .into_iter()
+                                        .filter(|measured| violates(&measured.distance, limit))
+                                        .map(|measured| finding(rule, measured)),
+                                );
+                            }
+                        }
+                    }
+                    RuleEvaluation::Count(evaluation) => {
+                        result.checked = 1;
+                        let limit = rule.limit.count();
+                        if violates_count(evaluation.actual, rule.comparison, limit) {
+                            results
+                                .findings
+                                .push(count_finding(rule, evaluation, limit));
+                        }
                     }
                 }
             }
@@ -126,10 +158,18 @@ fn violates(distance: &Distance, limit_mm: f64) -> bool {
     distance.certainly_below(limit_mm - COMPARISON_EPSILON_MM)
 }
 
+fn violates_count(actual: u32, comparison: Comparison, limit: u32) -> bool {
+    match comparison {
+        Comparison::Minimum => actual < limit,
+        Comparison::Maximum => actual > limit,
+    }
+}
+
 /// The one skip policy: a rule is skipped when its subject pool or a
 /// required layer pool is empty for the selected layout target.
 fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
     let subjects = match rule.kind {
+        RuleKind::CopperLayerCount => None,
         RuleKind::BoardArrayPairClearance if design.scope != ArtworkScope::ArrayFlattened => {
             return Some("board-array spacing requires --layout-target board-array".to_owned());
         }
@@ -165,20 +205,21 @@ fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
         .map(|what| format!("no {what} in the selected layout target"))
 }
 
-fn evaluate(rule: &Rule, design: &Design) -> Evaluation {
-    let limit = rule.limit.millimeters();
+fn evaluate(rule: &Rule, design: &Design) -> RuleEvaluation {
+    let limit = || rule.limit.length().millimeters();
     match rule.kind {
-        RuleKind::HoleDiameter(class) => hole_diameter::evaluate(class, design),
-        RuleKind::SlotWidth => slot_width::evaluate(design),
-        RuleKind::HolePairClearance => hole_pair_clearance::evaluate(limit, design),
-        RuleKind::AnnularRing(class) => annular_ring::evaluate(limit, class, design),
+        RuleKind::CopperLayerCount => RuleEvaluation::Count(layer_count::evaluate(design)),
+        RuleKind::HoleDiameter(class) => hole_diameter::evaluate(class, design).into(),
+        RuleKind::SlotWidth => slot_width::evaluate(design).into(),
+        RuleKind::HolePairClearance => hole_pair_clearance::evaluate(limit(), design).into(),
+        RuleKind::AnnularRing(class) => annular_ring::evaluate(limit(), class, design).into(),
         RuleKind::LineworkToCopperClearance(linework) => {
-            linework_clearance::evaluate(limit, linework, design)
+            linework_clearance::evaluate(limit(), linework, design).into()
         }
-        RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(limit, design),
-        RuleKind::CopperFeatureWidth => thin_regions::copper_feature_width(limit, design),
-        RuleKind::CopperClearance => copper_clearance::evaluate(limit, design),
-        RuleKind::SoldermaskWeb => thin_regions::soldermask_web(limit, design),
+        RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(limit(), design).into(),
+        RuleKind::CopperFeatureWidth => thin_regions::copper_feature_width(limit(), design).into(),
+        RuleKind::CopperClearance => copper_clearance::evaluate(limit(), design).into(),
+        RuleKind::SoldermaskWeb => thin_regions::soldermask_web(limit(), design).into(),
     }
 }
 
@@ -186,9 +227,11 @@ fn evaluate(rule: &Rule, design: &Design) -> Evaluation {
 /// and witness roles come from the rule kind; the location is the measured
 /// distance itself.
 fn finding(rule: &Rule, measured: Measured) -> Finding {
-    let limit = rule.limit.millimeters();
+    let limit = rule.limit.length().millimeters();
     let semantics = rule.kind.semantics();
-    let [first_role, second_role] = semantics.witness_roles;
+    let [first_role, second_role] = semantics
+        .witness_roles
+        .expect("distance-valued rules define witness roles");
     let distance = measured.distance;
     let layer_names = measured
         .layers
@@ -212,7 +255,7 @@ fn finding(rule: &Rule, measured: Measured) -> Finding {
             "{} is {:.6} mm{on_layers}; the PDK requires at least {limit:.6} mm",
             semantics.quantity_label, distance.mm
         ),
-        measurement: Measurement::minimum(distance.mm, limit),
+        measurement: Measurement::minimum_distance(distance.mm, limit),
         location: Location {
             point: Some(distance.midpoint().into()),
             bounding_box: Some(measured.bbox.into()),
@@ -224,6 +267,38 @@ fn finding(rule: &Rule, measured: Measured) -> Finding {
         layers: measured.layers,
         subjects: measured.subjects,
         evidence: measured.evidence,
+    }
+}
+
+fn count_finding(rule: &Rule, measured: CountEvaluation, limit: u32) -> Finding {
+    let (title, requirement, measurement) = match rule.comparison {
+        Comparison::Minimum => (
+            "Copper layer count is below the minimum",
+            format!("requires at least {limit}"),
+            Measurement::minimum_count(measured.actual, limit),
+        ),
+        Comparison::Maximum => (
+            "Copper layer count exceeds the maximum",
+            format!("permits at most {limit}"),
+            Measurement::maximum_count(measured.actual, limit),
+        ),
+    };
+    Finding {
+        id: String::new(),
+        rule_id: rule.id.clone(),
+        severity: rule.severity,
+        waived: false,
+        waiver_reason: None,
+        title: title.to_owned(),
+        message: format!(
+            "copper layer count is {}; the PDK {requirement}",
+            measured.actual
+        ),
+        measurement,
+        location: Location::default(),
+        layers: measured.layers,
+        subjects: measured.subjects,
+        evidence: Vec::new(),
     }
 }
 
@@ -349,7 +424,7 @@ mod tests {
             waiver_reason: None,
             title: String::new(),
             message: String::new(),
-            measurement: Measurement::minimum(0.0, 1.0),
+            measurement: Measurement::minimum_distance(0.0, 1.0),
             location: Location {
                 point: Some(ReportPoint { x, y: 0.0 }),
                 bounding_box: None,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -8,7 +8,7 @@
 //! drilled feature whose plating, diameter, or outline the file does not
 //! state is an error, never a quietly dropped subject.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result, bail};
 use ipc2581::Symbol;
@@ -34,6 +34,7 @@ use super::rules::{self, Rule};
 pub(super) struct Design<'a> {
     pub ipc: &'a Ipc2581,
     pub scope: ArtworkScope,
+    pub stackup: Option<PhysicalStackup>,
     pub holes: Vec<Hole>,
     pub slots: Vec<Slot>,
     pub copper_layers: Vec<CopperLayer>,
@@ -70,11 +71,12 @@ impl<'a> Design<'a> {
         let boundary_search_mm = rules
             .iter()
             .filter(|rule| rule.kind.semantics().pools.copper_boundaries)
-            .map(|rule| rule.limit.millimeters())
+            .map(|rule| rule.limit.length().millimeters())
             .fold(1.0, f64::max);
         Ok(Self {
             ipc,
             scope,
+            stackup: when(pools.stackup, || collect_physical_stackup(ipc).map(Some))?,
             copper_boundaries: when(pools.copper_boundaries, || {
                 Ok(copper_layers
                     .par_iter()
@@ -103,6 +105,87 @@ impl<'a> Design<'a> {
     pub fn resolve(&self, symbol: Option<Symbol>) -> Option<String> {
         symbol.map(|symbol| self.ipc.resolve(symbol).to_owned())
     }
+}
+
+#[derive(Debug)]
+pub(super) struct PhysicalStackup {
+    pub name: String,
+    pub copper_layers: Vec<LayerRef>,
+}
+
+fn collect_physical_stackup(ipc: &Ipc2581) -> Result<PhysicalStackup> {
+    let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
+    let stackup = match ecad.cad_data.stackups.as_slice() {
+        [stackup] => stackup,
+        [] => bail!("IPC-2581 file carries no physical stackup"),
+        stackups => bail!(
+            "IPC-2581 file carries {} physical stackups; layer-count DFM requires exactly one",
+            stackups.len()
+        ),
+    };
+
+    let mut copper_by_name = HashMap::new();
+    for layer in ecad
+        .cad_data
+        .layers
+        .iter()
+        .filter(|layer| layers::is_copper(layer.layer_function))
+    {
+        if copper_by_name.insert(layer.name, layer).is_some() {
+            bail!(
+                "IPC-2581 file declares copper layer '{}' more than once",
+                ipc.resolve(layer.name)
+            );
+        }
+    }
+    if copper_by_name.is_empty() {
+        bail!("IPC-2581 file declares no copper layers");
+    }
+
+    let mut seen = HashSet::new();
+    let mut ordered = Vec::new();
+    for stackup_layer in &stackup.layers {
+        let Some(layer) = copper_by_name.get(&stackup_layer.layer_ref).copied() else {
+            continue;
+        };
+        if !seen.insert(layer.name) {
+            bail!(
+                "physical stackup '{}' contains copper layer '{}' more than once",
+                ipc.resolve(stackup.name),
+                ipc.resolve(layer.name)
+            );
+        }
+        ordered.push(layer);
+    }
+
+    let mut missing = copper_by_name
+        .keys()
+        .filter(|name| !seen.contains(name))
+        .map(|name| ipc.resolve(*name))
+        .collect::<Vec<_>>();
+    missing.sort_unstable();
+    if !missing.is_empty() {
+        bail!(
+            "physical stackup '{}' omits declared copper layer(s): {}",
+            ipc.resolve(stackup.name),
+            missing.join(", ")
+        );
+    }
+
+    let total = ordered.len();
+    let copper_layers = ordered
+        .into_iter()
+        .enumerate()
+        .map(|(ordinal, layer)| {
+            let side = side_label(layers::ir_side(layer.side))
+                .unwrap_or_else(|| stack_side(ordinal, total));
+            layer_ref(ipc.resolve(layer.name), layer.layer_function, Some(side))
+        })
+        .collect();
+    Ok(PhysicalStackup {
+        name: ipc.resolve(stackup.name).to_owned(),
+        copper_layers,
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
@@ -19,6 +19,30 @@ impl Pdk {
                 pdk.schema_version
             );
         }
+        let stackup = &pdk.capabilities.stackup;
+        for (name, count) in [
+            (
+                "stackup.minimum_copper_layer_count",
+                stackup.minimum_copper_layer_count,
+            ),
+            (
+                "stackup.maximum_copper_layer_count",
+                stackup.maximum_copper_layer_count,
+            ),
+        ] {
+            if count == Some(0) {
+                bail!("{name} must be a positive integer");
+            }
+        }
+        if let (Some(minimum), Some(maximum)) = (
+            stackup.minimum_copper_layer_count,
+            stackup.maximum_copper_layer_count,
+        ) && minimum > maximum
+        {
+            bail!(
+                "stackup.minimum_copper_layer_count ({minimum}) must not exceed stackup.maximum_copper_layer_count ({maximum})"
+            );
+        }
         Ok(pdk)
     }
 }
@@ -39,6 +63,8 @@ pub struct PdkIdentity {
 #[serde(deny_unknown_fields)]
 pub struct Capabilities {
     #[serde(default)]
+    pub stackup: StackupCapabilities,
+    #[serde(default)]
     pub drilling: DrillingCapabilities,
     #[serde(default)]
     pub copper: CopperCapabilities,
@@ -46,6 +72,15 @@ pub struct Capabilities {
     pub soldermask: SoldermaskCapabilities,
     #[serde(default)]
     pub panelization: PanelizationCapabilities,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StackupCapabilities {
+    #[serde(default)]
+    pub minimum_copper_layer_count: Option<u32>,
+    #[serde(default)]
+    pub maximum_copper_layer_count: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -194,6 +229,10 @@ id = "example"
 name = "Example process"
 revision = "1"
 
+[capabilities.stackup]
+minimum_copper_layer_count = 2
+maximum_copper_layer_count = 10
+
 [capabilities.drilling]
 minimum_via_hole_diameter = "0.2 mm"
 minimum_hole_to_hole_clearance = "10 mil"
@@ -209,6 +248,11 @@ minimum_board_array_spacing = "300 mil"
     #[test]
     fn parses_mixed_units_and_tiers_into_canonical_millimeters() {
         let pdk = Pdk::parse(MIXED_UNIT_PDK).unwrap();
+        assert_eq!(pdk.capabilities.stackup.minimum_copper_layer_count, Some(2));
+        assert_eq!(
+            pdk.capabilities.stackup.maximum_copper_layer_count,
+            Some(10)
+        );
         let drilling = &pdk.capabilities.drilling;
         assert_eq!(
             drilling
@@ -264,6 +308,28 @@ minimum_board_array_spacing = "300 mil"
                 &MIXED_UNIT_PDK.replace("preferred = \"0.125 mm\"", "prefered = \"0.125 mm\"")
             )
             .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_copper_layer_ranges() {
+        assert!(
+            Pdk::parse(&MIXED_UNIT_PDK.replace(
+                "minimum_copper_layer_count = 2",
+                "minimum_copper_layer_count = 0"
+            ))
+            .unwrap_err()
+            .to_string()
+            .contains("must be a positive integer")
+        );
+        assert!(
+            Pdk::parse(&MIXED_UNIT_PDK.replace(
+                "minimum_copper_layer_count = 2",
+                "minimum_copper_layer_count = 12"
+            ))
+            .unwrap_err()
+            .to_string()
+            .contains("must not exceed")
         );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
@@ -1,8 +1,8 @@
 use pcb_ir::geom::{BBox, Point};
 use serde::Serialize;
 
-use super::pdk::{Length, Pdk};
-use super::rules::Rule;
+use super::pdk::Pdk;
+use super::rules::{LimitValue, Rule};
 
 pub const REPORT_SCHEMA_VERSION: u32 = 1;
 
@@ -108,10 +108,11 @@ pub struct RuleResult {
     pub severity: Severity,
     pub status: RuleStatus,
     pub limit: RuleLimit,
+    /// Whether values below or above the limit violate this rule.
+    pub comparison: &'static str,
     /// What one `checked` unit is, e.g. `hole` or `copper_layer`.
     pub subject: &'static str,
-    /// The quantity every finding of this rule measures; every rule requires
-    /// the measured value to be at least its limit.
+    /// The quantity every finding of this rule measures.
     pub quantity: &'static str,
     /// How the quantity is measured.
     pub method: &'static str,
@@ -130,7 +131,8 @@ impl RuleResult {
             title: rule.title.clone(),
             severity: rule.severity,
             status: RuleStatus::Pass,
-            limit: RuleLimit::from_length(&rule.limit),
+            limit: RuleLimit::from_value(&rule.limit),
+            comparison: rule.comparison.label(),
             subject: semantics.subject,
             quantity: semantics.quantity,
             method: semantics.method,
@@ -178,11 +180,18 @@ pub struct RuleLimit {
 }
 
 impl RuleLimit {
-    fn from_length(length: &Length) -> Self {
-        Self {
-            pdk_value: length.original().to_owned(),
-            normalized_value: length.millimeters(),
-            normalized_unit: "mm",
+    fn from_value(value: &LimitValue) -> Self {
+        match value {
+            LimitValue::Length(length) => Self {
+                pdk_value: length.original().to_owned(),
+                normalized_value: length.millimeters(),
+                normalized_unit: "mm",
+            },
+            LimitValue::Count(count) => Self {
+                pdk_value: count.to_string(),
+                normalized_value: f64::from(*count),
+                normalized_unit: "layers",
+            },
         }
     }
 }
@@ -210,21 +219,53 @@ pub enum Severity {
     Warning,
 }
 
-/// The one measurement that gates a finding, in report millimeters. The
-/// quantity, method, and comparison live on the finding's rule.
+/// The one measurement that gates a finding. The quantity, method, unit, and
+/// comparison live on the finding's rule.
 #[derive(Debug, Serialize)]
-pub struct Measurement {
-    pub actual_mm: f64,
-    pub required_mm: f64,
-    pub margin_mm: f64,
+#[serde(untagged)]
+pub enum Measurement {
+    Distance {
+        actual_mm: f64,
+        required_mm: f64,
+        margin_mm: f64,
+    },
+    Count {
+        actual_count: u32,
+        required_count: u32,
+        margin_count: i64,
+    },
 }
 
 impl Measurement {
-    pub fn minimum(actual_mm: f64, required_mm: f64) -> Self {
-        Self {
+    pub fn minimum_distance(actual_mm: f64, required_mm: f64) -> Self {
+        Self::Distance {
             actual_mm,
             required_mm,
             margin_mm: actual_mm - required_mm,
+        }
+    }
+
+    pub fn minimum_count(actual_count: u32, required_count: u32) -> Self {
+        Self::Count {
+            actual_count,
+            required_count,
+            margin_count: i64::from(actual_count) - i64::from(required_count),
+        }
+    }
+
+    pub fn maximum_count(actual_count: u32, required_count: u32) -> Self {
+        Self::Count {
+            actual_count,
+            required_count,
+            margin_count: i64::from(required_count) - i64::from(actual_count),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn actual_mm(&self) -> Option<f64> {
+        match self {
+            Self::Distance { actual_mm, .. } => Some(*actual_mm),
+            Self::Count { .. } => None,
         }
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -9,7 +9,7 @@
 use anyhow::{Result, bail};
 
 use super::design::HoleClass;
-use super::pdk::{Length, Limit, Pdk};
+use super::pdk::{Length, Limit as LengthLimit, Pdk};
 use super::report::Severity;
 
 #[derive(Debug, Clone)]
@@ -17,14 +17,54 @@ pub(super) struct Rule {
     pub id: String,
     pub title: String,
     pub severity: Severity,
-    pub limit: Length,
+    pub comparison: Comparison,
+    pub limit: LimitValue,
     pub kind: RuleKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Comparison {
+    Minimum,
+    Maximum,
+}
+
+impl Comparison {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Minimum => "minimum",
+            Self::Maximum => "maximum",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum LimitValue {
+    Length(Length),
+    Count(u32),
+}
+
+impl LimitValue {
+    pub fn length(&self) -> &Length {
+        match self {
+            Self::Length(length) => length,
+            Self::Count(_) => unreachable!("a count-valued rule has no length limit"),
+        }
+    }
+
+    pub fn count(&self) -> u32 {
+        match self {
+            Self::Count(count) => *count,
+            Self::Length(_) => unreachable!("a length-valued rule has no count limit"),
+        }
+    }
 }
 
 /// The measurement semantics of a rule: a size, a clearance, an enclosure,
 /// or a morphological residue over one of the design's entity pools.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RuleKind {
+    /// Count: conductive layers in the one physical stackup.
+    CopperLayerCount,
     /// Size: each hole's drilled diameter meets the limit.
     HoleDiameter(HoleClass),
     /// Size: each routed slot's width meets the limit.
@@ -61,7 +101,7 @@ pub(super) struct Semantics {
     pub method: &'static str,
     pub finding_title: String,
     pub quantity_label: String,
-    pub witness_roles: [&'static str; 2],
+    pub witness_roles: Option<[&'static str; 2]>,
     pub pools: Pools,
 }
 
@@ -69,6 +109,7 @@ pub(super) struct Semantics {
 /// the configured rules, so a rule set pays only for what it measures.
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct Pools {
+    pub stackup: bool,
     pub drilled: bool,
     pub copper: bool,
     pub conductor_ownership: bool,
@@ -85,6 +126,7 @@ impl std::ops::BitOr for Pools {
 
     fn bitor(self, other: Self) -> Self {
         Self {
+            stackup: self.stackup || other.stackup,
             drilled: self.drilled || other.drilled,
             copper: self.copper || other.copper,
             conductor_ownership: self.conductor_ownership || other.conductor_ownership,
@@ -99,6 +141,7 @@ impl std::ops::BitOr for Pools {
 }
 
 const DRILLED: Pools = Pools {
+    stackup: false,
     drilled: true,
     copper: false,
     conductor_ownership: false,
@@ -118,6 +161,7 @@ const COPPER_BOUNDARIES: Pools = Pools {
     ..COPPER
 };
 const NONE: Pools = Pools {
+    stackup: false,
     drilled: false,
     ..DRILLED
 };
@@ -125,13 +169,25 @@ const NONE: Pools = Pools {
 impl RuleKind {
     pub fn semantics(self) -> Semantics {
         match self {
+            Self::CopperLayerCount => Semantics {
+                subject: "stackup",
+                quantity: "copper_layer_count",
+                method: "physical_stackup_conductive_layer_count",
+                finding_title: "Copper layer count is outside the supported range".to_owned(),
+                quantity_label: "copper layer count".to_owned(),
+                witness_roles: None,
+                pools: Pools {
+                    stackup: true,
+                    ..NONE
+                },
+            },
             Self::HoleDiameter(class) => Semantics {
                 subject: "hole",
                 quantity: "hole_diameter",
                 method: "ipc_hole_diameter",
                 finding_title: format!("{} hole is below minimum diameter", class.label()),
                 quantity_label: format!("{} hole diameter", class.label()),
-                witness_roles: ["hole_boundary", "hole_boundary"],
+                witness_roles: Some(["hole_boundary", "hole_boundary"]),
                 pools: DRILLED,
             },
             Self::SlotWidth => Semantics {
@@ -140,7 +196,7 @@ impl RuleKind {
                 method: "ipc_slot_width_or_outline_medial_axis_width",
                 finding_title: "Slot is below minimum width".to_owned(),
                 quantity_label: "routed slot width".to_owned(),
-                witness_roles: ["first_slot_boundary", "second_slot_boundary"],
+                witness_roles: Some(["first_slot_boundary", "second_slot_boundary"]),
                 pools: DRILLED,
             },
             Self::HolePairClearance => Semantics {
@@ -149,7 +205,7 @@ impl RuleKind {
                 method: "circle_edge_distance",
                 finding_title: "Hole-to-hole clearance is below minimum".to_owned(),
                 quantity_label: "hole edge-to-edge clearance".to_owned(),
-                witness_roles: ["first_hole_boundary", "second_hole_boundary"],
+                witness_roles: Some(["first_hole_boundary", "second_hole_boundary"]),
                 pools: DRILLED,
             },
             Self::AnnularRing(class) => Semantics {
@@ -158,7 +214,7 @@ impl RuleKind {
                 method: "maximal_centered_disk_minus_hole_radius",
                 finding_title: format!("{} annular ring is below minimum", class.label()),
                 quantity_label: format!("{} annular ring", class.label()),
-                witness_roles: ["hole_boundary", "copper_boundary"],
+                witness_roles: Some(["hole_boundary", "copper_boundary"]),
                 pools: Pools {
                     hole_lands: true,
                     ..COPPER_BOUNDARIES
@@ -170,7 +226,7 @@ impl RuleKind {
                 method: "segment_to_filled_region_boundary",
                 finding_title: "V-score centerline is too close to copper".to_owned(),
                 quantity_label: "V-score centerline-to-copper clearance".to_owned(),
-                witness_roles: ["vscore_centerline", "copper_boundary"],
+                witness_roles: Some(["vscore_centerline", "copper_boundary"]),
                 pools: Pools {
                     scores: true,
                     drilled: false,
@@ -183,7 +239,7 @@ impl RuleKind {
                 method: "segment_to_filled_region_boundary",
                 finding_title: "Board edge is too close to copper".to_owned(),
                 quantity_label: "board-edge-to-copper clearance".to_owned(),
-                witness_roles: ["board_outline", "copper_boundary"],
+                witness_roles: Some(["board_outline", "copper_boundary"]),
                 pools: Pools {
                     board_outlines: true,
                     drilled: false,
@@ -196,7 +252,7 @@ impl RuleKind {
                 method: "filled_profile_boundary_distance",
                 finding_title: "Board arrays are too close together".to_owned(),
                 quantity_label: "board-array outline spacing".to_owned(),
-                witness_roles: ["first_board_array", "second_board_array"],
+                witness_roles: Some(["first_board_array", "second_board_array"]),
                 pools: Pools {
                     board_arrays: true,
                     ..NONE
@@ -208,7 +264,7 @@ impl RuleKind {
                 method: "opening_candidate_then_medial_axis_width",
                 finding_title: "Copper feature is below minimum width".to_owned(),
                 quantity_label: "copper feature width".to_owned(),
-                witness_roles: ["first_boundary", "second_boundary"],
+                witness_roles: Some(["first_boundary", "second_boundary"]),
                 pools: Pools {
                     drilled: false,
                     ..COPPER
@@ -220,7 +276,7 @@ impl RuleKind {
                 method: "distinct_conductor_boundary_distance",
                 finding_title: "Copper spacing is below minimum".to_owned(),
                 quantity_label: "copper-to-copper clearance".to_owned(),
-                witness_roles: ["first_conductor", "second_conductor"],
+                witness_roles: Some(["first_conductor", "second_conductor"]),
                 pools: Pools {
                     drilled: false,
                     conductor_ownership: true,
@@ -233,7 +289,7 @@ impl RuleKind {
                 method: "closing_candidate_then_medial_axis_width",
                 finding_title: "Soldermask web is below minimum".to_owned(),
                 quantity_label: "soldermask web width".to_owned(),
-                witness_roles: ["first_boundary", "second_boundary"],
+                witness_roles: Some(["first_boundary", "second_boundary"]),
                 pools: Pools {
                     masks: true,
                     ..NONE
@@ -256,11 +312,12 @@ pub(super) fn pools(rules: &[Rule]) -> Pools {
 /// warning-severity rule under `<path>.preferred` and must exceed the
 /// minimum.
 pub(super) fn lower(pdk: &Pdk) -> Result<Vec<Rule>> {
+    let stackup = &pdk.capabilities.stackup;
     let drilling = &pdk.capabilities.drilling;
     let copper = &pdk.capabilities.copper;
     let soldermask = &pdk.capabilities.soldermask;
     let panelization = &pdk.capabilities.panelization;
-    let table: [(&Option<Limit>, &str, &str, RuleKind); 13] = [
+    let table: [(&Option<LengthLimit>, &str, &str, RuleKind); 13] = [
         (
             &drilling.minimum_via_hole_diameter,
             "drilling.minimum_via_hole_diameter",
@@ -350,7 +407,8 @@ pub(super) fn lower(pdk: &Pdk) -> Result<Vec<Rule>> {
             id: id.to_owned(),
             title: title.to_owned(),
             severity: Severity::Error,
-            limit: limit.minimum().clone(),
+            comparison: Comparison::Minimum,
+            limit: LimitValue::Length(limit.minimum().clone()),
             kind,
         });
         if let Some(preferred) = limit.preferred() {
@@ -365,8 +423,34 @@ pub(super) fn lower(pdk: &Pdk) -> Result<Vec<Rule>> {
                 id: format!("{id}.preferred"),
                 title: format!("{title} (preferred)"),
                 severity: Severity::Warning,
-                limit: preferred.clone(),
+                comparison: Comparison::Minimum,
+                limit: LimitValue::Length(preferred.clone()),
                 kind,
+            });
+        }
+    }
+    for (limit, id, title, comparison) in [
+        (
+            stackup.minimum_copper_layer_count,
+            "stackup.minimum_copper_layer_count",
+            "Minimum copper layer count",
+            Comparison::Minimum,
+        ),
+        (
+            stackup.maximum_copper_layer_count,
+            "stackup.maximum_copper_layer_count",
+            "Maximum copper layer count",
+            Comparison::Maximum,
+        ),
+    ] {
+        if let Some(limit) = limit {
+            rules.push(Rule {
+                id: id.to_owned(),
+                title: title.to_owned(),
+                severity: Severity::Error,
+                comparison,
+                limit: LimitValue::Count(limit),
+                kind: RuleKind::CopperLayerCount,
             });
         }
     }

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -227,8 +227,8 @@ enum DfmCommands {
         /// IPC-2581 XML file to check
         #[arg(value_hint = clap::ValueHint::FilePath)]
         file: PathBuf,
-        /// Fabrication process design kit (TOML)
-        #[arg(long, value_hint = clap::ValueHint::FilePath)]
+        /// Built-in PDK name or fabrication PDK TOML path (built-ins: standard)
+        #[arg(long)]
         pdk: PathBuf,
         /// Waiver file of accepted finding ids (TOML)
         #[arg(long, value_hint = clap::ValueHint::FilePath)]


### PR DESCRIPTION
Users can now run IPC DFM without managing a local PDK file. This adds the built-in `standard` PDK, keeps file-based PDKs supported, and checks that the physical copper layer count is within configured limits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DFM PDK loading, rule lowering, and report JSON shape (new fields and measurement variants); behavior changes for designs with incomplete stackups when layer-count rules are enabled.
> 
> **Overview**
> Adds a bundled **`standard`** fabrication PDK so `pcb ipc dfm check --pdk standard` works without a local TOML file. File-backed PDKs are unchanged; exact built-in names win over paths (use `./standard` to load a same-named file). Reports record built-ins as `builtin:standard`.
> 
> **Stackup layer-count rules** are new: PDKs can set `[capabilities.stackup]` `minimum_copper_layer_count` / `maximum_copper_layer_count`. The checker counts conductive layers from the single physical IPC stackup (fails closed on missing, duplicate, or ambiguous stackup data rather than inferring from layer names). JSON reports gain rule **`comparison`** (`minimum` / `maximum`) and **count** measurements (`actual_count`, `required_count`, `margin_count`) alongside existing distance fields.
> 
> Docs, examples, and changelog point at `pdks/standard.toml` (2–10 copper layers plus Diode-oriented drilling/copper/mask limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97009acf17aceab22e7f88fe9e7f3ae7f87ff5ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->