### PR TITLE
Add DFM command for Zener boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `pcb dfm` for `.zen` boards.
+
 ## [0.4.37] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ pcb new board <NAME> <REPO_URL>              # Create a board repository
 pcb build [PATHS...]                         # Build and validate designs
 pcb sync                                     # Reconcile imports and dependency manifests
 pcb layout <FILE>                            # Generate layout files
+pcb dfm <FILE> --pdk standard                # Check a .zen board for manufacturability
 pcb import <KICAD_SCH|KICAD_PRO> <OUTPUT_DIR> # Import a KiCad schematic or project
 ```
 

--- a/crates/pcbc/src/dfm.rs
+++ b/crates/pcbc/src/dfm.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args;
+use pcb_ipc2581_tools::{LayoutTarget, commands};
+
+use crate::layout::LayoutArgs;
+
+#[derive(Args, Debug)]
+#[command(about = "Run DFM checks for a .zen board")]
+pub struct DfmArgs {
+    /// Path to the board .zen file
+    #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
+    pub file: PathBuf,
+
+    /// Built-in PDK name or fabrication PDK TOML path (built-ins: standard)
+    #[arg(long)]
+    pub pdk: PathBuf,
+}
+
+pub fn execute(args: DfmArgs) -> Result<()> {
+    let layout_args = LayoutArgs {
+        file: args.file.clone(),
+        no_open: true,
+        ..Default::default()
+    };
+    let design = crate::layout::prepare_design(&layout_args)?;
+    let layout = crate::layout::apply_prepared(&layout_args, design)?;
+    let pcb_file = layout
+        .pcb_file_abs
+        .as_deref()
+        .with_context(|| format!("{} does not declare a layout", args.file.display()))?;
+
+    let temporary_dir = tempfile::tempdir().context("failed to create temporary DFM directory")?;
+    let ipc_path = temporary_dir.path().join("ipc2581.xml");
+    crate::release::export_ipc2581(pcb_file, &ipc_path)?;
+
+    commands::dfm::execute_check(
+        &ipc_path,
+        &commands::dfm::CheckOptions {
+            pdk: args.pdk,
+            waivers: None,
+            output: None,
+            layout_target: LayoutTarget::Board,
+        },
+    )
+}

--- a/crates/pcbc/src/main.rs
+++ b/crates/pcbc/src/main.rs
@@ -18,6 +18,7 @@ mod bundle;
 mod changelog;
 mod codegen;
 mod config_input;
+mod dfm;
 mod doc;
 mod drc;
 mod embed_step;
@@ -127,6 +128,9 @@ enum Commands {
     #[command(alias = "l")]
     Layout(layout::LayoutArgs),
 
+    /// Run DFM checks for a .zen board
+    Dfm(dfm::DfmArgs),
+
     /// Format .zen files
     Fmt(fmt::FmtArgs),
 
@@ -235,6 +239,7 @@ fn run() -> anyhow::Result<()> {
         Commands::Doc(args) => doc::execute(args),
         Commands::Changelog(args) => changelog::execute(args),
         Commands::Layout(args) => layout::execute(args),
+        Commands::Dfm(args) => dfm::execute(args),
         Commands::Fmt(args) => fmt::execute(args),
         Commands::Lsp(args) => lsp::execute(args),
         Commands::Open(args) => open::execute(args),

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -1331,6 +1331,26 @@ fn generate_ipc2581(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         .context("No layout directory for IPC-2581 generation")?;
     let ipc2581_path = manufacturing_dir.join("ipc2581.xml");
 
+    export_ipc2581(&kicad_pcb_path, &ipc2581_path)?;
+
+    // Generate HTML export from the IPC-2581 XML file (silently, without printing)
+    let ipc2581_html_path = manufacturing_dir.join("ipc2581.html");
+    let ipc_content = pcb_ipc2581_tools::utils::file::load_ipc_file(&ipc2581_path)
+        .context("Failed to load IPC-2581 file for HTML export")?;
+    let ipc = pcb_ipc2581_tools::ipc2581::Ipc2581::parse(&ipc_content)
+        .context("Failed to parse IPC-2581 file for HTML export")?;
+    let accessor = pcb_ipc2581_tools::accessors::IpcAccessor::new(&ipc);
+    let html = pcb_ipc2581_tools::commands::html_export::generate_html(
+        &accessor,
+        pcb_ipc2581_tools::UnitFormat::Mm,
+    )
+    .context("Failed to generate HTML from IPC-2581")?;
+    fs::write(&ipc2581_html_path, html).context("Failed to write IPC-2581 HTML export")?;
+
+    Ok(())
+}
+
+pub(crate) fn export_ipc2581(kicad_pcb_path: &Path, ipc2581_path: &Path) -> Result<()> {
     KiCadCliBuilder::new()
         .command("pcb")
         .subcommand("export")
@@ -1346,20 +1366,6 @@ fn generate_ipc2581(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
         .arg(kicad_pcb_path.to_string_lossy())
         .run()
         .context("Failed to generate IPC-2581 file")?;
-
-    // Generate HTML export from the IPC-2581 XML file (silently, without printing)
-    let ipc2581_html_path = manufacturing_dir.join("ipc2581.html");
-    let ipc_content = pcb_ipc2581_tools::utils::file::load_ipc_file(&ipc2581_path)
-        .context("Failed to load IPC-2581 file for HTML export")?;
-    let ipc = pcb_ipc2581_tools::ipc2581::Ipc2581::parse(&ipc_content)
-        .context("Failed to parse IPC-2581 file for HTML export")?;
-    let accessor = pcb_ipc2581_tools::accessors::IpcAccessor::new(&ipc);
-    let html = pcb_ipc2581_tools::commands::html_export::generate_html(
-        &accessor,
-        pcb_ipc2581_tools::UnitFormat::Mm,
-    )
-    .context("Failed to generate HTML from IPC-2581")?;
-    fs::write(&ipc2581_html_path, html).context("Failed to write IPC-2581 HTML export")?;
 
     Ok(())
 }

--- a/crates/pcbc/tests/dfm.rs
+++ b/crates/pcbc/tests/dfm.rs
@@ -1,0 +1,51 @@
+#![cfg(not(target_os = "windows"))]
+
+use std::path::Path;
+
+use pcb_test_utils::sandbox::Sandbox;
+use serde_json::Value;
+
+const PCB_TOML: &str = include_str!("../../pcb-layout/tests/resources/simple/pcb.toml");
+const BOARD_ZEN: &str = include_str!("../../pcb-layout/tests/resources/simple/MyBoard.zen");
+const MODULE_ZEN: &str = include_str!("../../pcb-layout/tests/resources/simple/BMI270.zen");
+const FOOTPRINT: &str =
+    include_str!("../../pcb-layout/tests/resources/simple/eda/BMI270.kicad_mod");
+const SYMBOL: &str = include_str!("../../pcb-layout/tests/resources/simple/eda/BMI270.kicad_sym");
+
+#[test]
+fn dfm_resolves_zen_exports_temporary_ipc_and_checks_standard_pdk() {
+    let mut sandbox = Sandbox::new();
+    sandbox
+        .env("SOURCE_DATE_EPOCH", "1787702400")
+        .write("pcb.toml", PCB_TOML)
+        .write("MyBoard.zen", BOARD_ZEN)
+        .write("BMI270.zen", MODULE_ZEN)
+        .write("eda/BMI270.kicad_mod", FOOTPRINT)
+        .write("eda/BMI270.kicad_sym", SYMBOL);
+
+    let output = sandbox
+        .run("pcbc", ["dfm", "MyBoard.zen", "--pdk", "standard"])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .expect("DFM command should run");
+    let report: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should contain only the DFM report");
+
+    assert_eq!(report["pdk"]["path"], "builtin:standard");
+    assert_eq!(report["layout_target"], "board");
+    assert!(
+        report["input"]["path"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("ipc2581.xml"))
+    );
+    assert!(
+        sandbox
+            .default_cwd()
+            .join("build/layout.kicad_pcb")
+            .exists()
+    );
+    assert!(!Path::new(report["input"]["path"].as_str().unwrap()).exists());
+    assert!(!sandbox.default_cwd().join(".pcb/releases").exists());
+}

--- a/crates/pcbc/tests/integration.rs
+++ b/crates/pcbc/tests/integration.rs
@@ -2,6 +2,7 @@ mod apply;
 mod auth_git;
 mod bom;
 mod build;
+mod dfm;
 mod doc;
 mod electrical_checks;
 mod import;

--- a/crates/pcbc/tests/snapshots/simple__help.snap
+++ b/crates/pcbc/tests/snapshots/simple__help.snap
@@ -27,6 +27,7 @@ Commands:
   import      Import a KiCad schematic or project into a Zener board repository
   doc         Generate package documentation
   layout      Layout PCB designs
+  dfm         Run DFM checks for a .zen board
   fmt         Format .zen files
   open        Open PCB layout files
   publish     Publish packages and boards by creating version tags


### PR DESCRIPTION
Users need one command to check a Zener board for manufacturing problems. This change generates the layout, exports temporary IPC-2581 data with the publish pipeline, and runs DFM with the selected PDK.