### PR TITLE
Hydrate schematics from cached BOM matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Hydrate evaluated schematics with compatible part and datasheet metadata from the local BOM cache without network access.
 - Added cross-platform `diode://` links that open sandbox layouts in KiCad with live sync and native recovery prompts.
 - The interposer mate constellation is S13: uniform 2×3 blocks with corner mate-detect loops.
 

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -3,10 +3,15 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
+    path::Path,
     time::Duration,
 };
 
-use pcb_sch::bom::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer, SourcingStockClass};
+use pcb_sch::{
+    AttributeValue, InstanceKind, Schematic,
+    bom::{Availability, AvailabilitySummary, BOARD_QUANTITY, Offer, SourcingStockClass},
+};
+use pcb_zen_core::{attrs, lang::part::PartValue};
 
 use crate::{
     WorkspaceContext,
@@ -172,7 +177,13 @@ struct MatchBomResponse {
 #[derive(Debug, Default)]
 struct PreparedBomMatch {
     availability: HashMap<String, Availability>,
-    selected_parts: HashMap<String, (String, String)>,
+    selected: HashMap<String, SelectedBomMetadata>,
+}
+
+#[derive(Debug, Default)]
+struct SelectedBomMetadata {
+    compatible_part: Option<(String, String)>,
+    datasheet_url: Option<String>,
 }
 
 struct PreparedBomResponse {
@@ -193,11 +204,14 @@ impl PreparedBomResponse {
 impl PreparedBomMatch {
     fn extend(&mut self, other: Self) {
         self.availability.extend(other.availability);
-        self.selected_parts.extend(other.selected_parts);
+        self.selected.extend(other.selected);
     }
 
     fn apply(self, bom: &mut pcb_sch::bom::Bom) {
-        for (path, (mpn, manufacturer)) in self.selected_parts {
+        for (path, selected) in self.selected {
+            let Some((mpn, manufacturer)) = selected.compatible_part else {
+                continue;
+            };
             let entry = bom
                 .entries
                 .get_mut(&path)
@@ -206,6 +220,87 @@ impl PreparedBomMatch {
             entry.manufacturer = Some(manufacturer);
         }
         bom.availability = self.availability;
+    }
+
+    fn apply_to_schematic(&self, schematic: &mut Schematic) -> usize {
+        let mut hydrated = 0;
+
+        for (instance_ref, instance) in &mut schematic.instances {
+            if instance.kind != InstanceKind::Component {
+                continue;
+            }
+
+            let path = instance_ref.instance_path.join(".");
+            let Some(selected) = self.selected.get(&path) else {
+                continue;
+            };
+
+            let has_authored_identity = [
+                attrs::PART,
+                attrs::MPN,
+                "Mpn",
+                attrs::MANUFACTURER,
+                "Manufacturer",
+            ]
+            .iter()
+            .any(|key| instance.attributes.contains_key(*key));
+            let has_authored_datasheet = [attrs::DATASHEET, "Datasheet"]
+                .iter()
+                .any(|key| instance.attributes.contains_key(*key))
+                || instance
+                    .attributes
+                    .get(attrs::PART)
+                    .and_then(|value| match value {
+                        AttributeValue::Json(value) => Some(value.clone()),
+                        AttributeValue::String(value) => serde_json::from_str(value).ok(),
+                        _ => None,
+                    })
+                    .and_then(|value| value.get("datasheet").cloned())
+                    .and_then(|value| value.as_str().map(str::to_owned))
+                    .is_some_and(|value| !value.trim().is_empty());
+
+            let projected_datasheet = selected
+                .datasheet_url
+                .as_ref()
+                .filter(|_| !has_authored_datasheet);
+            let mut changed = false;
+
+            if let Some((mpn, manufacturer)) = &selected.compatible_part
+                && !has_authored_identity
+            {
+                let part = PartValue::new(
+                    mpn.clone(),
+                    manufacturer.clone(),
+                    Vec::new(),
+                    projected_datasheet.cloned(),
+                );
+
+                instance
+                    .attributes
+                    .insert(attrs::MPN.into(), AttributeValue::String(mpn.clone()));
+                instance.attributes.insert(
+                    attrs::MANUFACTURER.into(),
+                    AttributeValue::String(manufacturer.clone()),
+                );
+                instance.attributes.insert(
+                    attrs::PART.into(),
+                    AttributeValue::Json(part.to_json_value()),
+                );
+                changed = true;
+            }
+
+            if let Some(datasheet) = projected_datasheet {
+                instance.attributes.insert(
+                    attrs::DATASHEET.into(),
+                    AttributeValue::String(datasheet.clone()),
+                );
+                changed = true;
+            }
+
+            hydrated += usize::from(changed);
+        }
+
+        hydrated
     }
 }
 
@@ -348,7 +443,7 @@ fn prepare_bom_match_for_paths(
 
     let mut seen_paths = HashSet::with_capacity(expected_paths.len());
     let mut availability = HashMap::with_capacity(expected_paths.len());
-    let mut selected_parts = HashMap::new();
+    let mut selected = HashMap::new();
     let mut retry_paths = HashSet::new();
 
     for bom_line in &match_response.results {
@@ -397,7 +492,7 @@ fn prepare_bom_match_for_paths(
                 .get(selected_offer_id)
                 .with_context(|| format!("BOM match response omitted offer {selected_offer_id}"))?;
 
-            if bom_line.match_status == BomMatchStatus::Compatible {
+            let compatible_part = if bom_line.match_status == BomMatchStatus::Compatible {
                 let mpn = selected_offer
                     .mpn
                     .as_deref()
@@ -410,9 +505,32 @@ fn prepare_bom_match_for_paths(
                     .map(str::trim)
                     .filter(|value| !value.is_empty())
                     .context("Selected compatible offer omitted its manufacturer")?;
-                selected_parts.insert(
+                Some((mpn.to_string(), manufacturer.to_string()))
+            } else {
+                None
+            };
+
+            let datasheet_url = if matches!(
+                bom_line.match_status,
+                BomMatchStatus::Exact | BomMatchStatus::Compatible
+            ) {
+                selected_offer
+                    .datasheet_url
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_owned)
+            } else {
+                None
+            };
+
+            if compatible_part.is_some() || datasheet_url.is_some() {
+                selected.insert(
                     path.to_string(),
-                    (mpn.to_string(), manufacturer.to_string()),
+                    SelectedBomMetadata {
+                        compatible_part,
+                        datasheet_url,
+                    },
                 );
             }
         }
@@ -459,7 +577,7 @@ fn prepare_bom_match_for_paths(
     Ok(PreparedBomResponse {
         prepared: PreparedBomMatch {
             availability,
-            selected_parts,
+            selected,
         },
         retry_paths,
     })
@@ -633,6 +751,19 @@ fn match_bom_with_cache(
     cache: Option<&mut WriteThroughCache>,
     now: i64,
 ) -> Result<()> {
+    prepare_bom_match_with_cache(ctx, auth_token, bom, strict, options, cache, now)?.apply(bom);
+    Ok(())
+}
+
+fn prepare_bom_match_with_cache(
+    ctx: &WorkspaceContext,
+    auth_token: Option<&str>,
+    bom: &pcb_sch::bom::Bom,
+    strict: bool,
+    options: BomMatchOptions,
+    cache: Option<&mut WriteThroughCache>,
+    now: i64,
+) -> Result<PreparedBomMatch> {
     let url = bom_match_url(ctx.api_base_url(), strict);
     let mut lines = bom_match_request_lines(&url, bom_request_entries(bom)?)?;
     for line in &mut lines {
@@ -659,8 +790,7 @@ fn match_bom_with_cache(
                 prepared.extend(cached.prepared);
             }
         }
-        prepared.apply(bom);
-        return Ok(());
+        return Ok(prepared);
     }
 
     let mut refresh_lines = Vec::new();
@@ -675,8 +805,7 @@ fn match_bom_with_cache(
     }
 
     if refresh_lines.is_empty() {
-        prepared.apply(bom);
-        return Ok(());
+        return Ok(prepared);
     }
 
     let refresh_entries = refresh_lines
@@ -744,8 +873,70 @@ fn match_bom_with_cache(
         }
         log::warn!("BOM matching incomplete; using available lines: {error:#}");
     }
-    prepared.apply(bom);
-    Ok(())
+    Ok(prepared)
+}
+
+/// Opportunistically hydrate a schematic from previously cached BOM matches.
+///
+/// This path never contacts the API. Cache misses and invalid cache lines leave
+/// the corresponding raw schematic components unchanged.
+pub fn hydrate_schematic_from_bom_cache(source_path: &Path, schematic: &mut Schematic) {
+    if let Err(error) = try_hydrate_schematic_from_bom_cache(source_path, schematic) {
+        log::warn!("Ignoring cached BOM hydration failure: {error:#}");
+    }
+}
+
+fn try_hydrate_schematic_from_bom_cache(
+    source_path: &Path,
+    schematic: &mut Schematic,
+) -> Result<usize> {
+    let ctx = WorkspaceContext::from_path(source_path);
+    let strict = ctx.bom_strict()?;
+    let mut cache = WriteThroughCache::open(BOM_MATCH_CACHE_NAMESPACE)?;
+    hydrate_schematic_from_bom_cache_with_cache(
+        &ctx,
+        schematic,
+        strict,
+        Some(&mut cache),
+        unix_now()?,
+    )
+}
+
+fn hydrate_schematic_from_bom_cache_with_cache(
+    ctx: &WorkspaceContext,
+    schematic: &mut Schematic,
+    strict: bool,
+    cache: Option<&mut WriteThroughCache>,
+    now: i64,
+) -> Result<usize> {
+    let mut component_paths = HashSet::new();
+    for (instance_ref, instance) in &schematic.instances {
+        if instance.kind != InstanceKind::Component {
+            continue;
+        }
+        let path = instance_ref.instance_path.join(".");
+        if path.is_empty()
+            || instance.reference_designator.is_none()
+            || !component_paths.insert(path)
+        {
+            return Ok(0);
+        }
+    }
+
+    let bom = schematic.bom().filter_excluded();
+    let prepared = prepare_bom_match_with_cache(
+        ctx,
+        None,
+        &bom,
+        strict,
+        BomMatchOptions {
+            mode: BomMatchMode::Offline,
+            ..Default::default()
+        },
+        cache,
+        now,
+    )?;
+    Ok(prepared.apply_to_schematic(schematic))
 }
 
 /// Component key for pricing requests
@@ -947,6 +1138,7 @@ mod tests {
 
     use httpmock::{Method::POST, MockServer};
     use pcb_sch::bom::{Bom, BomEntry, GenericComponent, Resistor};
+    use pcb_sch::{AttributeValue, Instance, InstanceRef, ModuleRef, Schematic};
 
     use super::*;
 
@@ -1011,6 +1203,37 @@ mod tests {
             HashMap::from([("root.U1".to_string(), entry)]),
             HashMap::from([("root.U1".to_string(), "U1".to_string())]),
         )
+    }
+
+    fn test_schematic() -> Schematic {
+        let module = ModuleRef::new("/tmp/root.zen", "Root");
+        let instance_ref = InstanceRef::new(module.clone(), vec!["root".into(), "U1".into()]);
+        let mut instance = Instance::component(module);
+        instance.reference_designator = Some("U1".to_string());
+        instance
+            .attributes
+            .insert("package".into(), AttributeValue::String("0603".into()));
+        instance
+            .attributes
+            .insert("value".into(), AttributeValue::String("10kOhm".into()));
+        instance
+            .attributes
+            .insert("type".into(), AttributeValue::String("resistor".into()));
+        instance
+            .attributes
+            .insert("resistance".into(), AttributeValue::String("10kOhm".into()));
+
+        let mut schematic = Schematic::default();
+        schematic.instances.insert(instance_ref, instance);
+        schematic
+    }
+
+    fn test_component(schematic: &Schematic) -> &Instance {
+        schematic
+            .instances
+            .values()
+            .find(|instance| instance.kind == InstanceKind::Component)
+            .unwrap()
     }
 
     fn compatible_response_for(path: &str, offer_id: &str, mpn: &str) -> serde_json::Value {
@@ -1209,6 +1432,180 @@ mod tests {
             selected_offer.datasheet_url.as_deref(),
             Some("https://example.com/API-MPN.pdf")
         );
+    }
+
+    #[test]
+    fn compatible_match_hydrates_missing_schematic_metadata() {
+        let response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
+        let mut schematic = test_schematic();
+        let prepared = prepare_bom_match(&schematic.bom(), &response).unwrap();
+
+        assert_eq!(prepared.apply_to_schematic(&mut schematic), 1);
+
+        let component = test_component(&schematic);
+        assert_eq!(component.mpn().as_deref(), Some("API-MPN"));
+        assert_eq!(
+            component.manufacturer().as_deref(),
+            Some("API Manufacturer")
+        );
+        assert_eq!(
+            component.string_attr(&["datasheet"]).as_deref(),
+            Some("https://example.com/API-MPN.pdf")
+        );
+    }
+
+    #[test]
+    fn hydration_preserves_authored_part_and_datasheet() {
+        let response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
+        let mut schematic = test_schematic();
+        let component = schematic.instances.values_mut().next().unwrap();
+        component.attributes.insert(
+            "part".into(),
+            AttributeValue::Json(serde_json::json!({
+                "mpn": "AUTHORED-MPN",
+                "manufacturer": "Authored Manufacturer",
+                "qualifications": [],
+                "datasheet": "https://example.com/authored.pdf"
+            })),
+        );
+        let prepared = prepare_bom_match_for_paths(
+            &test_bom(),
+            &response,
+            &HashSet::from(["root.U1".to_string()]),
+        )
+        .unwrap()
+        .into_complete()
+        .unwrap();
+
+        assert_eq!(prepared.apply_to_schematic(&mut schematic), 0);
+
+        let component = test_component(&schematic);
+        assert_eq!(component.mpn().as_deref(), Some("AUTHORED-MPN"));
+        let AttributeValue::Json(part) = &component.attributes[attrs::PART] else {
+            panic!("authored part should remain structured JSON");
+        };
+        assert_eq!(
+            part["datasheet"].as_str(),
+            Some("https://example.com/authored.pdf")
+        );
+    }
+
+    #[test]
+    fn fuzzy_match_does_not_hydrate_schematic() {
+        let mut response = compatible_response();
+        response["results"][0]["match"] = serde_json::json!("MATCH_FUZZY");
+        let response: MatchBomResponse = serde_json::from_value(response).unwrap();
+        let mut schematic = test_schematic();
+        let prepared = prepare_bom_match(&schematic.bom(), &response).unwrap();
+
+        assert_eq!(prepared.apply_to_schematic(&mut schematic), 0);
+        assert!(test_component(&schematic).part().is_none());
+        assert!(
+            test_component(&schematic)
+                .string_attr(&["datasheet"])
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exact_match_only_hydrates_missing_datasheet() {
+        let mut response = compatible_response();
+        response["results"][0]["match"] = serde_json::json!("MATCH_EXACT");
+        let response: MatchBomResponse = serde_json::from_value(response).unwrap();
+        let mut schematic = test_schematic();
+        let prepared = prepare_bom_match(&schematic.bom(), &response).unwrap();
+
+        assert_eq!(prepared.apply_to_schematic(&mut schematic), 1);
+
+        let component = test_component(&schematic);
+        assert!(component.part().is_none());
+        assert_eq!(
+            component.string_attr(&["datasheet"]).as_deref(),
+            Some("https://example.com/API-MPN.pdf")
+        );
+    }
+
+    #[test]
+    fn schematic_cache_miss_leaves_raw_schematic_unchanged() {
+        let context = WorkspaceContext::from_api_base_url("https://api.example.com");
+        let mut schematic = test_schematic();
+        let before = serde_json::to_value(&schematic).unwrap();
+
+        assert_eq!(
+            hydrate_schematic_from_bom_cache_with_cache(
+                &context,
+                &mut schematic,
+                true,
+                None,
+                unix_now().unwrap(),
+            )
+            .unwrap(),
+            0
+        );
+        assert_eq!(serde_json::to_value(&schematic).unwrap(), before);
+    }
+
+    #[test]
+    fn incomplete_schematic_is_left_unchanged() {
+        let context = WorkspaceContext::from_api_base_url("https://api.example.com");
+        let mut schematic = test_schematic();
+        schematic
+            .instances
+            .values_mut()
+            .next()
+            .unwrap()
+            .reference_designator = None;
+        let before = serde_json::to_value(&schematic).unwrap();
+
+        assert_eq!(
+            hydrate_schematic_from_bom_cache_with_cache(
+                &context,
+                &mut schematic,
+                true,
+                None,
+                unix_now().unwrap(),
+            )
+            .unwrap(),
+            0
+        );
+        assert_eq!(serde_json::to_value(&schematic).unwrap(), before);
+    }
+
+    #[test]
+    fn schematic_hydration_reads_cache_without_network() {
+        let server = MockServer::start();
+        let network = server.mock(|when, then| {
+            when.method(POST).path("/api/boms/match");
+            then.status(500);
+        });
+        let context = WorkspaceContext::from_api_base_url(server.base_url());
+        let tempdir = tempfile::tempdir().unwrap();
+        let mut cache = cache_for(&tempdir);
+        let mut schematic = test_schematic();
+        let bom = schematic.bom().filter_excluded();
+        let url = bom_match_url(context.api_base_url(), true);
+        let line = bom_match_request_lines(&url, bom_request_entries(&bom).unwrap())
+            .unwrap()
+            .pop()
+            .unwrap();
+        let response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
+        cache
+            .store_many(&[(line.cache_key, serde_json::to_vec(&response).unwrap())])
+            .unwrap();
+
+        assert_eq!(
+            hydrate_schematic_from_bom_cache_with_cache(
+                &context,
+                &mut schematic,
+                true,
+                Some(&mut cache),
+                unix_now().unwrap(),
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(test_component(&schematic).mpn().as_deref(), Some("API-MPN"));
+        network.assert_calls(0);
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -1435,118 +1435,76 @@ mod tests {
     }
 
     #[test]
-    fn compatible_match_hydrates_missing_schematic_metadata() {
+    fn schematic_hydration_respects_match_status() {
+        let cases = [
+            (
+                "MATCH_COMPATIBLE",
+                Some("API-MPN"),
+                Some("API Manufacturer"),
+                Some("https://example.com/API-MPN.pdf"),
+            ),
+            (
+                "MATCH_EXACT",
+                None,
+                None,
+                Some("https://example.com/API-MPN.pdf"),
+            ),
+            ("MATCH_FUZZY", None, None, None),
+        ];
+
+        for (status, expected_mpn, expected_manufacturer, expected_datasheet) in cases {
+            let mut response = compatible_response();
+            response["results"][0]["match"] = serde_json::json!(status);
+            let response: MatchBomResponse = serde_json::from_value(response).unwrap();
+            let mut schematic = test_schematic();
+            prepare_bom_match(&schematic.bom(), &response)
+                .unwrap()
+                .apply_to_schematic(&mut schematic);
+
+            let component = test_component(&schematic);
+            assert_eq!(component.mpn().as_deref(), expected_mpn, "{status}");
+            assert_eq!(
+                component.manufacturer().as_deref(),
+                expected_manufacturer,
+                "{status}"
+            );
+            assert_eq!(
+                component.string_attr(&["datasheet"]).as_deref(),
+                expected_datasheet,
+                "{status}"
+            );
+        }
+    }
+
+    #[test]
+    fn hydration_does_not_replace_authored_metadata() {
         let response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
         let mut schematic = test_schematic();
-        let prepared = prepare_bom_match(&schematic.bom(), &response).unwrap();
-
-        assert_eq!(prepared.apply_to_schematic(&mut schematic), 1);
-
-        let component = test_component(&schematic);
-        assert_eq!(component.mpn().as_deref(), Some("API-MPN"));
-        assert_eq!(
-            component.manufacturer().as_deref(),
-            Some("API Manufacturer")
-        );
-        assert_eq!(
-            component.string_attr(&["datasheet"]).as_deref(),
-            Some("https://example.com/API-MPN.pdf")
-        );
-    }
-
-    #[test]
-    fn hydration_preserves_authored_part_and_datasheet() {
-        let response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
-        let mut schematic = test_schematic();
-        let component = schematic.instances.values_mut().next().unwrap();
-        component.attributes.insert(
-            "part".into(),
-            AttributeValue::Json(serde_json::json!({
-                "mpn": "AUTHORED-MPN",
-                "manufacturer": "Authored Manufacturer",
-                "qualifications": [],
-                "datasheet": "https://example.com/authored.pdf"
-            })),
-        );
-        let prepared = prepare_bom_match_for_paths(
-            &test_bom(),
-            &response,
-            &HashSet::from(["root.U1".to_string()]),
-        )
-        .unwrap()
-        .into_complete()
-        .unwrap();
-
-        assert_eq!(prepared.apply_to_schematic(&mut schematic), 0);
-
-        let component = test_component(&schematic);
-        assert_eq!(component.mpn().as_deref(), Some("AUTHORED-MPN"));
-        let AttributeValue::Json(part) = &component.attributes[attrs::PART] else {
-            panic!("authored part should remain structured JSON");
-        };
-        assert_eq!(
-            part["datasheet"].as_str(),
-            Some("https://example.com/authored.pdf")
-        );
-    }
-
-    #[test]
-    fn fuzzy_match_does_not_hydrate_schematic() {
-        let mut response = compatible_response();
-        response["results"][0]["match"] = serde_json::json!("MATCH_FUZZY");
-        let response: MatchBomResponse = serde_json::from_value(response).unwrap();
-        let mut schematic = test_schematic();
-        let prepared = prepare_bom_match(&schematic.bom(), &response).unwrap();
-
-        assert_eq!(prepared.apply_to_schematic(&mut schematic), 0);
-        assert!(test_component(&schematic).part().is_none());
-        assert!(
-            test_component(&schematic)
-                .string_attr(&["datasheet"])
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn exact_match_only_hydrates_missing_datasheet() {
-        let mut response = compatible_response();
-        response["results"][0]["match"] = serde_json::json!("MATCH_EXACT");
-        let response: MatchBomResponse = serde_json::from_value(response).unwrap();
-        let mut schematic = test_schematic();
-        let prepared = prepare_bom_match(&schematic.bom(), &response).unwrap();
-
-        assert_eq!(prepared.apply_to_schematic(&mut schematic), 1);
-
-        let component = test_component(&schematic);
-        assert!(component.part().is_none());
-        assert_eq!(
-            component.string_attr(&["datasheet"]).as_deref(),
-            Some("https://example.com/API-MPN.pdf")
-        );
-    }
-
-    #[test]
-    fn schematic_cache_miss_leaves_raw_schematic_unchanged() {
-        let context = WorkspaceContext::from_api_base_url("https://api.example.com");
-        let mut schematic = test_schematic();
+        schematic
+            .instances
+            .values_mut()
+            .next()
+            .unwrap()
+            .attributes
+            .insert(
+                "part".into(),
+                AttributeValue::Json(serde_json::json!({
+                    "mpn": "AUTHORED-MPN",
+                    "manufacturer": "Authored Manufacturer",
+                    "qualifications": [],
+                    "datasheet": "https://example.com/authored.pdf"
+                })),
+            );
         let before = serde_json::to_value(&schematic).unwrap();
 
-        assert_eq!(
-            hydrate_schematic_from_bom_cache_with_cache(
-                &context,
-                &mut schematic,
-                true,
-                None,
-                unix_now().unwrap(),
-            )
-            .unwrap(),
-            0
-        );
+        prepare_bom_match(&schematic.bom(), &response)
+            .unwrap()
+            .apply_to_schematic(&mut schematic);
         assert_eq!(serde_json::to_value(&schematic).unwrap(), before);
     }
 
     #[test]
-    fn incomplete_schematic_is_left_unchanged() {
+    fn incomplete_schematic_does_not_reach_panicking_bom_conversion() {
         let context = WorkspaceContext::from_api_base_url("https://api.example.com");
         let mut schematic = test_schematic();
         schematic
@@ -1555,7 +1513,6 @@ mod tests {
             .next()
             .unwrap()
             .reference_designator = None;
-        let before = serde_json::to_value(&schematic).unwrap();
 
         assert_eq!(
             hydrate_schematic_from_bom_cache_with_cache(
@@ -1568,7 +1525,6 @@ mod tests {
             .unwrap(),
             0
         );
-        assert_eq!(serde_json::to_value(&schematic).unwrap(), before);
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/endpoint.rs
+++ b/crates/pcb-diode-api/src/endpoint.rs
@@ -229,17 +229,4 @@ mod tests {
         assert_eq!(scope.web_base_url(), default_web_base_url());
         assert!(!scope.use_legacy_auth_file());
     }
-
-    #[test]
-    fn reads_bom_matching_mode_from_workspace() {
-        let tempdir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            tempdir.path().join("pcb.toml"),
-            "[workspace.bom]\nstrict = false\n",
-        )
-        .unwrap();
-
-        let context = WorkspaceContext::from_workspace_root(tempdir.path());
-        assert!(!context.bom_strict().unwrap());
-    }
 }

--- a/crates/pcb-diode-api/src/endpoint.rs
+++ b/crates/pcb-diode-api/src/endpoint.rs
@@ -73,6 +73,14 @@ impl WorkspaceContext {
         &self.endpoint.web_base_url
     }
 
+    pub(crate) fn bom_strict(&self) -> Result<bool> {
+        let Some(workspace_root) = &self.workspace_root else {
+            return Ok(true);
+        };
+        let config = PcbToml::from_path(&workspace_root.join("pcb.toml"))?;
+        Ok(config.workspace.unwrap_or_default().bom.strict)
+    }
+
     pub(crate) fn use_legacy_auth_file(&self) -> bool {
         self.endpoint.use_legacy_auth_file
     }
@@ -220,5 +228,18 @@ mod tests {
         assert_eq!(scope.api_base_url(), "https://registry.diode.computer");
         assert_eq!(scope.web_base_url(), default_web_base_url());
         assert!(!scope.use_legacy_auth_file());
+    }
+
+    #[test]
+    fn reads_bom_matching_mode_from_workspace() {
+        let tempdir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tempdir.path().join("pcb.toml"),
+            "[workspace.bom]\nstrict = false\n",
+        )
+        .unwrap();
+
+        let context = WorkspaceContext::from_workspace_root(tempdir.path());
+        assert!(!context.bom_strict().unwrap());
     }
 }

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -20,7 +20,8 @@ pub mod scan;
 pub use auth::{AuthArgs, AuthCommand, AuthTokens, execute as execute_auth, login, logout, status};
 pub use bom::{
     BomMatchMode, BomMatchOptions, fetch_and_populate_availability,
-    fetch_and_populate_availability_with_context, match_bom_with_context,
+    fetch_and_populate_availability_with_context, hydrate_schematic_from_bom_cache,
+    match_bom_with_context,
 };
 pub use component::{SearchArgs, execute as execute_search, execute_component_from_local_dir};
 pub use component_api::{ComponentArgs, execute_component};

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -79,16 +79,23 @@ pub fn lsp_with_eager(eager: bool) -> anyhow::Result<()> {
     pcb_starlark_lsp::server::stdio_server(ctx).map_err(Into::into)
 }
 
-/// Start the LSP server with `eager` and a custom request handler.
-pub fn lsp_with_custom_request_handler<F>(eager: bool, handler: F) -> anyhow::Result<()>
+/// Start the LSP server with `eager`, a custom request handler, and a
+/// post-evaluation schematic hydrator.
+pub fn lsp_with_custom_request_handler<F, H>(
+    eager: bool,
+    handler: F,
+    hydrator: H,
+) -> anyhow::Result<()>
 where
     F: Fn(&str, &serde_json::Value) -> anyhow::Result<Option<serde_json::Value>>
         + Send
         + Sync
         + 'static,
+    H: Fn(&Path, &mut Schematic) + Send + Sync + 'static,
 {
     let ctx = lsp::LspEvalContext::default()
         .set_eager(eager)
-        .with_custom_request_handler(handler);
+        .with_custom_request_handler(handler)
+        .with_schematic_hydrator(hydrator);
     pcb_starlark_lsp::server::stdio_server(ctx).map_err(Into::into)
 }

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -1586,36 +1586,6 @@ mod tests {
     }
 
     #[test]
-    fn viewer_hydrates_a_copy_without_mutating_the_eval_cache() {
-        let path = std::env::temp_dir().join("hydrated-viewer.zen");
-        let ctx = LspEvalContext::default().with_schematic_hydrator(|_, schematic| {
-            schematic
-                .symbols
-                .insert("hydrated".into(), "from cache".into());
-        });
-        ctx.set_last_schematic(&path, pcb_sch::Schematic::default());
-
-        let request = Request {
-            id: RequestId::from(1),
-            method: "viewer/getState".into(),
-            params: json!({ "uri": LspUri::File(path.clone()) }),
-        };
-        let response = ctx
-            .handle_custom_request(&request, &lsp_types::InitializeParams::default())
-            .expect("viewer request should be handled")
-            .response_result
-            .expect("viewer request should succeed");
-        let hydrated: pcb_sch::Schematic =
-            serde_json::from_value(response["state"].clone()).unwrap();
-
-        assert_eq!(
-            hydrated.symbols.get("hydrated").map(String::as_str),
-            Some("from cache")
-        );
-        assert!(ctx.get_last_schematic(&path).unwrap().symbols.is_empty());
-    }
-
-    #[test]
     fn lsp_uses_file_scope_for_navigation_and_evaluation() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let root = dir.path().canonicalize()?;

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -66,10 +66,12 @@ pub struct LspEvalContext {
     /// the shared session module tree can be contaminated by other files.
     last_schematics: Arc<RwLock<HashMap<PathBuf, pcb_sch::Schematic>>>,
     custom_request_handler: Option<Arc<CustomRequestHandler>>,
+    schematic_hydrator: Option<Arc<SchematicHydrator>>,
 }
 
 type CustomRequestHandler =
     dyn Fn(&str, &JsonValue) -> anyhow::Result<Option<JsonValue>> + Send + Sync;
+type SchematicHydrator = dyn Fn(&Path, &mut pcb_sch::Schematic) + Send + Sync;
 
 #[derive(Default)]
 struct NetlistSubscription {
@@ -194,6 +196,7 @@ impl Default for LspEvalContext {
             netlist_subscriptions: Arc::new(RwLock::new(HashMap::new())),
             last_schematics: Arc::new(RwLock::new(HashMap::new())),
             custom_request_handler: None,
+            schematic_hydrator: None,
         }
     }
 }
@@ -221,6 +224,20 @@ impl LspEvalContext {
     {
         self.custom_request_handler = Some(Arc::new(handler));
         self
+    }
+
+    pub fn with_schematic_hydrator<F>(mut self, hydrator: F) -> Self
+    where
+        F: Fn(&Path, &mut pcb_sch::Schematic) + Send + Sync + 'static,
+    {
+        self.schematic_hydrator = Some(Arc::new(hydrator));
+        self
+    }
+
+    fn hydrate_schematic(&self, source_path: &Path, schematic: &mut pcb_sch::Schematic) {
+        if let Some(hydrator) = &self.schematic_hydrator {
+            hydrator(source_path, schematic);
+        }
     }
 
     fn open_file_contents(&self, path: &Path) -> Option<String> {
@@ -417,6 +434,10 @@ impl LspEvalContext {
             .output
             .as_ref()
             .and_then(|output| output.to_schematic().ok())
+            .map(|mut schematic| {
+                self.hydrate_schematic(path_buf, &mut schematic);
+                schematic
+            })
             .and_then(|schematic| serde_json::to_value(&schematic).ok());
 
         let diagnostics = eval_result
@@ -1137,7 +1158,8 @@ impl LspContext for LspEvalContext {
                             // Try the cached schematic first (populated during
                             // parse_file_with_contents) so we can return the
                             // schematic without a redundant full evaluation.
-                            if let Some(cached) = self.get_last_schematic(path_buf) {
+                            if let Some(mut cached) = self.get_last_schematic(path_buf) {
+                                self.hydrate_schematic(path_buf, &mut cached);
                                 serde_json::to_value(&cached).ok()
                             } else {
                                 // Fallback: evaluate from scratch using the
@@ -1159,6 +1181,10 @@ impl LspContext for LspEvalContext {
                                 eval_result
                                     .output
                                     .and_then(|fmv| fmv.to_schematic().ok())
+                                    .map(|mut schematic| {
+                                        self.hydrate_schematic(path_buf, &mut schematic);
+                                        schematic
+                                    })
                                     .and_then(|schematic| serde_json::to_value(&schematic).ok())
                             }
                         }
@@ -1557,6 +1583,36 @@ mod tests {
 
         assert_eq!(ctx.get_netlist_inputs(&path), None);
         assert!(ctx.watched_symbol_paths().is_empty());
+    }
+
+    #[test]
+    fn viewer_hydrates_a_copy_without_mutating_the_eval_cache() {
+        let path = std::env::temp_dir().join("hydrated-viewer.zen");
+        let ctx = LspEvalContext::default().with_schematic_hydrator(|_, schematic| {
+            schematic
+                .symbols
+                .insert("hydrated".into(), "from cache".into());
+        });
+        ctx.set_last_schematic(&path, pcb_sch::Schematic::default());
+
+        let request = Request {
+            id: RequestId::from(1),
+            method: "viewer/getState".into(),
+            params: json!({ "uri": LspUri::File(path.clone()) }),
+        };
+        let response = ctx
+            .handle_custom_request(&request, &lsp_types::InitializeParams::default())
+            .expect("viewer request should be handled")
+            .response_result
+            .expect("viewer request should succeed");
+        let hydrated: pcb_sch::Schematic =
+            serde_json::from_value(response["state"].clone()).unwrap();
+
+        assert_eq!(
+            hydrated.symbols.get("hydrated").map(String::as_str),
+            Some("from cache")
+        );
+        assert!(ctx.get_last_schematic(&path).unwrap().symbols.is_empty());
     }
 
     #[test]

--- a/crates/pcbc/src/build.rs
+++ b/crates/pcbc/src/build.rs
@@ -23,6 +23,7 @@ pub(crate) struct BuildEvalState {
     session: pcb_zen_core::lang::eval::EvalSession,
     file_provider: Arc<DefaultFileProvider>,
     resolution: Arc<ResolutionResult>,
+    hydrate_cached_bom: bool,
 }
 
 pub(crate) struct BuildResult {
@@ -41,7 +42,13 @@ impl BuildEvalState {
             session: pcb_zen_core::lang::eval::EvalSession::default(),
             file_provider,
             resolution: Arc::new(resolution),
+            hydrate_cached_bom: false,
         }
+    }
+
+    pub(crate) fn with_cached_bom_hydration(mut self) -> Self {
+        self.hydrate_cached_bom = true;
+        self
     }
 
     fn eval(
@@ -95,7 +102,7 @@ impl BuildEvalState {
             None
         };
 
-        let schematic = output.as_ref().and_then(|eval_output| {
+        let mut schematic = output.as_ref().and_then(|eval_output| {
             let _span = info_span!("to_schematic").entered();
             let schematic_result = eval_output.to_schematic_with_diagnostics();
             diagnostics
@@ -116,6 +123,12 @@ impl BuildEvalState {
                 .extend(pcbc::kicad_schematic::linked_schematic_diagnostics(
                     schematic, zen_path,
                 ));
+        }
+
+        if self.hydrate_cached_bom
+            && let Some(schematic) = &mut schematic
+        {
+            pcb_diode_api::hydrate_schematic_from_bom_cache(zen_path, schematic);
         }
 
         if diagnostics.diagnostics.is_empty() && schematic.is_none() {
@@ -383,7 +396,7 @@ pub fn build(
     has_warnings: &mut bool,
     resolution: ResolutionResult,
 ) -> Option<Schematic> {
-    let eval_state = BuildEvalState::new(resolution);
+    let eval_state = BuildEvalState::new(resolution).with_cached_bom_hydration();
 
     eval_state
         .build(
@@ -447,7 +460,7 @@ pub fn execute(args: BuildArgs) -> Result<()> {
 
     let zen_files = build_input.collect_zen_files(&resolution.workspace_info)?;
 
-    let eval_state = BuildEvalState::new(resolution);
+    let eval_state = BuildEvalState::new(resolution).with_cached_bom_hydration();
 
     // Process each .zen file
     let deny_warnings = args.deny.contains(&"warnings".to_string());

--- a/crates/pcbc/src/layout.rs
+++ b/crates/pcbc/src/layout.rs
@@ -158,14 +158,16 @@ pub(crate) fn prepare_design(args: &LayoutArgs) -> Result<PreparedDesign> {
     let zen_path = &args.file;
     let file_name = zen_path.file_name().unwrap().to_string_lossy().to_string();
 
-    let build_result = BuildEvalState::new(resolution_result).build(
-        zen_path,
-        config_inputs,
-        create_diagnostics_passes(&args.suppress, &[]),
-        false,
-        &mut false.clone(),
-        &mut false.clone(),
-    );
+    let build_result = BuildEvalState::new(resolution_result)
+        .with_cached_bom_hydration()
+        .build(
+            zen_path,
+            config_inputs,
+            create_diagnostics_passes(&args.suppress, &[]),
+            false,
+            &mut false.clone(),
+            &mut false.clone(),
+        );
     let Some(schematic) = build_result.schematic else {
         anyhow::bail!("Build failed");
     };

--- a/crates/pcbc/src/lsp.rs
+++ b/crates/pcbc/src/lsp.rs
@@ -6,7 +6,11 @@ pub struct LspArgs {}
 const RESOLVE_DATASHEET_METHOD: &str = "pcb/resolveDatasheet";
 
 pub fn execute(_args: LspArgs) -> anyhow::Result<()> {
-    pcb_zen::lsp_with_custom_request_handler(false, handle_custom_request)
+    pcb_zen::lsp_with_custom_request_handler(
+        false,
+        handle_custom_request,
+        pcb_diode_api::hydrate_schematic_from_bom_cache,
+    )
 }
 
 fn handle_custom_request(

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -318,7 +318,8 @@ pub fn build_board_release(
             None => None,
         };
 
-        let schematic = eval_output.to_schematic()?;
+        let mut schematic = eval_output.to_schematic()?;
+        pcb_diode_api::hydrate_schematic_from_bom_cache(&zen_path, &mut schematic);
 
         let info = ReleaseInfo {
             zen_path,
@@ -746,14 +747,16 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> 
             zen_file_rel.display().to_string(),
         )));
 
-        crate::build::BuildEvalState::new(staged_resolution).build(
-            &staged_zen_path,
-            Default::default(),
-            passes,
-            false, // don't deny warnings - we'll prompt user instead
-            &mut has_errors,
-            &mut has_warnings,
-        )
+        crate::build::BuildEvalState::new(staged_resolution)
+            .with_cached_bom_hydration()
+            .build(
+                &staged_zen_path,
+                Default::default(),
+                passes,
+                false, // don't deny warnings - we'll prompt user instead
+                &mut has_errors,
+                &mut has_warnings,
+            )
     });
 
     let crate::build::BuildResult {


### PR DESCRIPTION
Evaluated schematics need selected part metadata from the BOM cache in downstream PCB flows. This change applies valid cached compatible-part and datasheet selections to build, LSP, layout, apply, and publish output; cache misses and errors keep the raw schematic, and this hydration path does not call the API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how schematic part metadata is derived in build, LSP, layout, and publish paths; incorrect hydration could show wrong MPNs/datasheets, though authored fields and offline-only scope limit blast radius.
> 
> **Overview**
> Evaluated schematics can now pick up **compatible MPN/manufacturer** and **datasheet URLs** from the existing per-line BOM match cache, with **no API calls**. Hydration runs after build, layout, LSP evaluation/viewer state, and publish staging when enabled.
> 
> BOM match preparation now tracks **selected metadata** (compatible part + datasheet) separately from availability, and can return a prepared match without mutating a BOM. Schematic updates **respect authored** part/MPN/manufacturer/datasheet fields; **MATCH_COMPATIBLE** fills identity, **MATCH_EXACT** can still add a datasheet, and fuzzy/failed lines are skipped. Incomplete schematics (missing designators, duplicate paths) bail out safely; cache errors are logged and leave the raw schematic unchanged. Workspace **`[workspace.bom] strict`** is read for offline cache lookup keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157a8feffc5667c4ed024b239b372861e2356f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->