### PR TITLE
Refresh schematic BOM matches during online PCB flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Refresh stale or missing BOM matches during online build, layout, apply, and publish flows while retaining cached fallback.
 - Hydrate evaluated schematics with compatible part and datasheet metadata from the local BOM cache without network access.
 - Added cross-platform `diode://` links that open sandbox layouts in KiCad with live sync and native recovery prompts.
 - The interposer mate constellation is S13: uniform 2×3 blocks with corner mate-detect loops.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Refresh stale or missing BOM matches during online build, layout, apply, and publish flows while retaining cached fallback.
-- Hydrate evaluated schematics with compatible part and datasheet metadata from the local BOM cache without network access.
+- Hydrate schematics from cached BOM matches, with online refresh for stale or missing entries.
 - Added cross-platform `diode://` links that open sandbox layouts in KiCad with live sync and native recovery prompts.
 - The interposer mate constellation is S13: uniform 2×3 blocks with corner mate-detect loops.
 

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -21,6 +21,7 @@ use crate::{
 const BOM_MATCH_TIMEOUT_SECS: u64 = 120;
 const BOM_MATCH_CACHE_NAMESPACE: &str = "bom-match-v2";
 const DEFAULT_BOM_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+const SCHEMATIC_BOM_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BomMatchMode {
@@ -40,6 +41,15 @@ impl Default for BomMatchOptions {
         Self {
             mode: BomMatchMode::Online,
             cache_ttl: DEFAULT_BOM_CACHE_TTL,
+        }
+    }
+}
+
+impl BomMatchOptions {
+    pub const fn for_schematic(mode: BomMatchMode) -> Self {
+        Self {
+            mode,
+            cache_ttl: SCHEMATIC_BOM_CACHE_TTL,
         }
     }
 }
@@ -876,36 +886,43 @@ fn prepare_bom_match_with_cache(
     Ok(prepared)
 }
 
-/// Opportunistically hydrate a schematic from previously cached BOM matches.
+/// Opportunistically hydrate a schematic from BOM matches.
 ///
-/// This path never contacts the API. Cache misses and invalid cache lines leave
-/// the corresponding raw schematic components unchanged.
-pub fn hydrate_schematic_from_bom_cache(source_path: &Path, schematic: &mut Schematic) {
-    if let Err(error) = try_hydrate_schematic_from_bom_cache(source_path, schematic) {
-        log::warn!("Ignoring cached BOM hydration failure: {error:#}");
+/// Online mode refreshes stale and missing cache lines. Any failure falls back
+/// to stale cache data, while unresolved components remain unchanged.
+pub fn hydrate_schematic_from_bom(
+    source_path: &Path,
+    schematic: &mut Schematic,
+    mode: BomMatchMode,
+) {
+    if let Err(error) = try_hydrate_schematic_from_bom(source_path, schematic, mode) {
+        log::warn!("Ignoring BOM hydration failure: {error:#}");
     }
 }
 
-fn try_hydrate_schematic_from_bom_cache(
+fn try_hydrate_schematic_from_bom(
     source_path: &Path,
     schematic: &mut Schematic,
+    mode: BomMatchMode,
 ) -> Result<usize> {
     let ctx = WorkspaceContext::from_path(source_path);
     let strict = ctx.bom_strict()?;
     let mut cache = WriteThroughCache::open(BOM_MATCH_CACHE_NAMESPACE)?;
-    hydrate_schematic_from_bom_cache_with_cache(
+    hydrate_schematic_from_bom_with_cache(
         &ctx,
         schematic,
         strict,
+        mode,
         Some(&mut cache),
         unix_now()?,
     )
 }
 
-fn hydrate_schematic_from_bom_cache_with_cache(
+fn hydrate_schematic_from_bom_with_cache(
     ctx: &WorkspaceContext,
     schematic: &mut Schematic,
     strict: bool,
+    mode: BomMatchMode,
     cache: Option<&mut WriteThroughCache>,
     now: i64,
 ) -> Result<usize> {
@@ -929,10 +946,7 @@ fn hydrate_schematic_from_bom_cache_with_cache(
         None,
         &bom,
         strict,
-        BomMatchOptions {
-            mode: BomMatchMode::Offline,
-            ..Default::default()
-        },
+        BomMatchOptions::for_schematic(mode),
         cache,
         now,
     )?;
@@ -1515,10 +1529,11 @@ mod tests {
             .reference_designator = None;
 
         assert_eq!(
-            hydrate_schematic_from_bom_cache_with_cache(
+            hydrate_schematic_from_bom_with_cache(
                 &context,
                 &mut schematic,
                 true,
+                BomMatchMode::Offline,
                 None,
                 unix_now().unwrap(),
             )
@@ -1528,40 +1543,39 @@ mod tests {
     }
 
     #[test]
-    fn schematic_hydration_reads_cache_without_network() {
+    fn schematic_hydration_refreshes_online_and_reuses_cache_offline() {
         let server = MockServer::start();
         let network = server.mock(|when, then| {
-            when.method(POST).path("/api/boms/match");
-            then.status(500);
+            when.method(POST)
+                .path("/api/boms/match")
+                .query_param("strict", "true");
+            then.status(200).json_body(compatible_response());
         });
         let context = WorkspaceContext::from_api_base_url(server.base_url());
         let tempdir = tempfile::tempdir().unwrap();
         let mut cache = cache_for(&tempdir);
-        let mut schematic = test_schematic();
-        let bom = schematic.bom().filter_excluded();
-        let url = bom_match_url(context.api_base_url(), true);
-        let line = bom_match_request_lines(&url, bom_request_entries(&bom).unwrap())
-            .unwrap()
-            .pop()
-            .unwrap();
-        let response: MatchBomResponse = serde_json::from_value(compatible_response()).unwrap();
-        cache
-            .store_many(&[(line.cache_key, serde_json::to_vec(&response).unwrap())])
-            .unwrap();
+        let now = unix_now().unwrap();
 
-        assert_eq!(
-            hydrate_schematic_from_bom_cache_with_cache(
+        for (mode, expected_mpn, expected_calls) in [
+            (BomMatchMode::Offline, None, 0),
+            (BomMatchMode::Online, Some("API-MPN"), 1),
+            (BomMatchMode::Offline, Some("API-MPN"), 1),
+        ] {
+            let mut schematic = test_schematic();
+            let hydrated = hydrate_schematic_from_bom_with_cache(
                 &context,
                 &mut schematic,
                 true,
+                mode,
                 Some(&mut cache),
-                unix_now().unwrap(),
+                now,
             )
-            .unwrap(),
-            1
-        );
-        assert_eq!(test_component(&schematic).mpn().as_deref(), Some("API-MPN"));
-        network.assert_calls(0);
+            .unwrap();
+
+            assert_eq!(hydrated, usize::from(expected_mpn.is_some()));
+            assert_eq!(test_component(&schematic).mpn().as_deref(), expected_mpn);
+            network.assert_calls(expected_calls);
+        }
     }
 
     #[test]

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -734,13 +734,7 @@ pub fn match_bom_with_context(
     strict: bool,
     options: BomMatchOptions,
 ) -> Result<()> {
-    let mut cache = match WriteThroughCache::open(BOM_MATCH_CACHE_NAMESPACE) {
-        Ok(cache) => Some(cache),
-        Err(error) => {
-            log::warn!("Failed to open local BOM cache: {error:#}");
-            None
-        }
-    };
+    let mut cache = open_bom_cache();
     match_bom_with_cache(
         ctx,
         auth_token,
@@ -750,6 +744,16 @@ pub fn match_bom_with_context(
         cache.as_mut(),
         unix_now()?,
     )
+}
+
+fn open_bom_cache() -> Option<WriteThroughCache> {
+    match WriteThroughCache::open(BOM_MATCH_CACHE_NAMESPACE) {
+        Ok(cache) => Some(cache),
+        Err(error) => {
+            log::warn!("Failed to open local BOM cache: {error:#}");
+            None
+        }
+    }
 }
 
 fn match_bom_with_cache(
@@ -907,13 +911,13 @@ fn try_hydrate_schematic_from_bom(
 ) -> Result<usize> {
     let ctx = WorkspaceContext::from_path(source_path);
     let strict = ctx.bom_strict()?;
-    let mut cache = WriteThroughCache::open(BOM_MATCH_CACHE_NAMESPACE)?;
+    let mut cache = open_bom_cache();
     hydrate_schematic_from_bom_with_cache(
         &ctx,
         schematic,
         strict,
         mode,
-        Some(&mut cache),
+        cache.as_mut(),
         unix_now()?,
     )
 }

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -20,7 +20,7 @@ pub mod scan;
 pub use auth::{AuthArgs, AuthCommand, AuthTokens, execute as execute_auth, login, logout, status};
 pub use bom::{
     BomMatchMode, BomMatchOptions, fetch_and_populate_availability,
-    fetch_and_populate_availability_with_context, hydrate_schematic_from_bom_cache,
+    fetch_and_populate_availability_with_context, hydrate_schematic_from_bom,
     match_bom_with_context,
 };
 pub use component::{SearchArgs, execute as execute_search, execute_component_from_local_dir};

--- a/crates/pcbc/src/build.rs
+++ b/crates/pcbc/src/build.rs
@@ -384,31 +384,6 @@ pub fn print_build_success(file_name: &str, schematic: &Schematic) {
     );
 }
 
-#[instrument(name = "build_file", skip_all, fields(file = %zen_path.file_name().unwrap().to_string_lossy()))]
-pub fn build(
-    zen_path: &Path,
-    inputs: SmallMap<String, JsonValue>,
-    passes: Vec<Box<dyn pcb_zen_core::DiagnosticsPass>>,
-    deny_warnings: bool,
-    has_errors: &mut bool,
-    has_warnings: &mut bool,
-    resolution: ResolutionResult,
-) -> Option<Schematic> {
-    let eval_state =
-        BuildEvalState::new(resolution).with_bom_hydration(pcb_diode_api::BomMatchMode::Online);
-
-    eval_state
-        .build(
-            zen_path,
-            inputs,
-            passes,
-            deny_warnings,
-            has_errors,
-            has_warnings,
-        )
-        .schematic
-}
-
 fn workspace_relative_path(path: &Path, workspace_root: &Path) -> String {
     path.strip_prefix(workspace_root)
         .unwrap_or(path)

--- a/crates/pcbc/src/build.rs
+++ b/crates/pcbc/src/build.rs
@@ -23,7 +23,7 @@ pub(crate) struct BuildEvalState {
     session: pcb_zen_core::lang::eval::EvalSession,
     file_provider: Arc<DefaultFileProvider>,
     resolution: Arc<ResolutionResult>,
-    hydrate_cached_bom: bool,
+    bom_match_mode: Option<pcb_diode_api::BomMatchMode>,
 }
 
 pub(crate) struct BuildResult {
@@ -42,12 +42,12 @@ impl BuildEvalState {
             session: pcb_zen_core::lang::eval::EvalSession::default(),
             file_provider,
             resolution: Arc::new(resolution),
-            hydrate_cached_bom: false,
+            bom_match_mode: None,
         }
     }
 
-    pub(crate) fn with_cached_bom_hydration(mut self) -> Self {
-        self.hydrate_cached_bom = true;
+    pub(crate) fn with_bom_hydration(mut self, mode: pcb_diode_api::BomMatchMode) -> Self {
+        self.bom_match_mode = Some(mode);
         self
     }
 
@@ -125,10 +125,8 @@ impl BuildEvalState {
                 ));
         }
 
-        if self.hydrate_cached_bom
-            && let Some(schematic) = &mut schematic
-        {
-            pcb_diode_api::hydrate_schematic_from_bom_cache(zen_path, schematic);
+        if let (Some(mode), Some(schematic)) = (self.bom_match_mode, &mut schematic) {
+            pcb_diode_api::hydrate_schematic_from_bom(zen_path, schematic, mode);
         }
 
         if diagnostics.diagnostics.is_empty() && schematic.is_none() {
@@ -396,7 +394,8 @@ pub fn build(
     has_warnings: &mut bool,
     resolution: ResolutionResult,
 ) -> Option<Schematic> {
-    let eval_state = BuildEvalState::new(resolution).with_cached_bom_hydration();
+    let eval_state =
+        BuildEvalState::new(resolution).with_bom_hydration(pcb_diode_api::BomMatchMode::Online);
 
     eval_state
         .build(
@@ -460,7 +459,12 @@ pub fn execute(args: BuildArgs) -> Result<()> {
 
     let zen_files = build_input.collect_zen_files(&resolution.workspace_info)?;
 
-    let eval_state = BuildEvalState::new(resolution).with_cached_bom_hydration();
+    let bom_match_mode = if args.offline {
+        pcb_diode_api::BomMatchMode::Offline
+    } else {
+        pcb_diode_api::BomMatchMode::Online
+    };
+    let eval_state = BuildEvalState::new(resolution).with_bom_hydration(bom_match_mode);
 
     // Process each .zen file
     let deny_warnings = args.deny.contains(&"warnings".to_string());

--- a/crates/pcbc/src/layout.rs
+++ b/crates/pcbc/src/layout.rs
@@ -158,8 +158,13 @@ pub(crate) fn prepare_design(args: &LayoutArgs) -> Result<PreparedDesign> {
     let zen_path = &args.file;
     let file_name = zen_path.file_name().unwrap().to_string_lossy().to_string();
 
+    let bom_match_mode = if args.offline {
+        pcb_diode_api::BomMatchMode::Offline
+    } else {
+        pcb_diode_api::BomMatchMode::Online
+    };
     let build_result = BuildEvalState::new(resolution_result)
-        .with_cached_bom_hydration()
+        .with_bom_hydration(bom_match_mode)
         .build(
             zen_path,
             config_inputs,

--- a/crates/pcbc/src/lsp.rs
+++ b/crates/pcbc/src/lsp.rs
@@ -9,7 +9,13 @@ pub fn execute(_args: LspArgs) -> anyhow::Result<()> {
     pcb_zen::lsp_with_custom_request_handler(
         false,
         handle_custom_request,
-        pcb_diode_api::hydrate_schematic_from_bom_cache,
+        |source_path, schematic| {
+            pcb_diode_api::hydrate_schematic_from_bom(
+                source_path,
+                schematic,
+                pcb_diode_api::BomMatchMode::Offline,
+            );
+        },
     )
 }
 

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -319,7 +319,11 @@ pub fn build_board_release(
         };
 
         let mut schematic = eval_output.to_schematic()?;
-        pcb_diode_api::hydrate_schematic_from_bom_cache(&zen_path, &mut schematic);
+        pcb_diode_api::hydrate_schematic_from_bom(
+            &zen_path,
+            &mut schematic,
+            pcb_diode_api::BomMatchMode::Online,
+        );
 
         let info = ReleaseInfo {
             zen_path,
@@ -748,7 +752,7 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> 
         )));
 
         crate::build::BuildEvalState::new(staged_resolution)
-            .with_cached_bom_hydration()
+            .with_bom_hydration(pcb_diode_api::BomMatchMode::Offline)
             .build(
                 &staged_zen_path,
                 Default::default(),
@@ -879,17 +883,27 @@ fn check_bom_offers(info: &ReleaseInfo, spinner: &Spinner, bom: &pcb_sch::bom::B
 
     spinner.set_message("Checking strict BOM offers");
     let ctx = pcb_diode_api::WorkspaceContext::from_path(&info.zen_path);
-    match pcb_diode_api::fetch_and_populate_availability_with_context(
+    let match_result = pcb_diode_api::match_bom_with_context(
         &ctx,
         None,
         &mut sourcing_bom,
         true,
-    ) {
-        Ok(()) => bom_offer_diagnostics(&info.zen_path, &sourcing_bom),
-        Err(error) => pcb_zen_core::Diagnostics {
+        pcb_diode_api::BomMatchOptions::for_schematic(pcb_diode_api::BomMatchMode::Online),
+    );
+    let failure = match match_result {
+        Err(error) => Some(format!("{error:#}")),
+        Ok(()) if sourcing_bom.availability.len() != sourcing_bom.entries.len() => {
+            Some("BOM matching could not complete".to_string())
+        }
+        Ok(()) => None,
+    };
+
+    match failure {
+        None => bom_offer_diagnostics(&info.zen_path, &sourcing_bom),
+        Some(error) => pcb_zen_core::Diagnostics {
             diagnostics: vec![pcb_zen_core::Diagnostic::categorized(
                 &info.zen_path.to_string_lossy(),
-                &format!("Could not check strict BOM offers: {error:#}"),
+                &format!("Could not check strict BOM offers: {error}"),
                 "bom.sourceability.check_failed",
                 starlark::errors::EvalSeverity::Warning,
             )],

--- a/crates/pcbc/src/sim.rs
+++ b/crates/pcbc/src/sim.rs
@@ -9,7 +9,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::build::{build as build_zen, create_diagnostics_passes};
+use crate::build::{BuildEvalState, create_diagnostics_passes};
 use crate::config_input::{CONFIG_ARG_HELP, parse_config_overrides};
 use crate::file_walker;
 
@@ -52,15 +52,24 @@ fn simulate_one(
 ) -> Result<bool> {
     let file_name = zen_path.file_name().unwrap().to_string_lossy().to_string();
 
-    let Some(schematic) = build_zen(
-        zen_path,
-        config_inputs,
-        create_diagnostics_passes(&[], &[]),
-        false,
-        &mut false.clone(),
-        &mut false.clone(),
-        resolution_result,
-    ) else {
+    let bom_match_mode = if args.offline {
+        pcb_diode_api::BomMatchMode::Offline
+    } else {
+        pcb_diode_api::BomMatchMode::Online
+    };
+    let mut has_errors = false;
+    let mut has_warnings = false;
+    let build_result = BuildEvalState::new(resolution_result)
+        .with_bom_hydration(bom_match_mode)
+        .build(
+            zen_path,
+            config_inputs,
+            create_diagnostics_passes(&[], &[]),
+            false,
+            &mut has_errors,
+            &mut has_warnings,
+        );
+    let Some(schematic) = build_result.schematic else {
         anyhow::bail!("Build failed for {file_name}");
     };
 


### PR DESCRIPTION
Build, layout, apply, and publish need current BOM metadata without losing offline operation. This change refreshes stale or missing cache lines once per 24 hours, uses stale data after an error, and keeps `--offline` and LSP cache-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when build, layout, and publish hit the Diode BOM API, though offline/LSP paths and stale-cache fallback limit exposure.
> 
> **Overview**
> **Schematic BOM hydration** no longer reads the local cache only. `hydrate_schematic_from_bom` takes a `BomMatchMode`, uses a **24-hour** schematic cache TTL via `BomMatchOptions::for_schematic`, and in **online** mode refreshes stale or missing lines while still falling back to cached data when the API fails.
> 
> **CLI wiring:** `pcb build` and `pcb layout` hydrate with **online** matching unless `--offline`; **`pcb lsp`** stays **offline** (cache-only). **Publish/release** hydrates schematics online when assembling release info, keeps the staged validation build offline, and runs strict offer checks through `match_bom_with_context` with schematic options (including a warning when matching does not cover every line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a03dcbadfa7efe06d7b2860824dfba75888c6736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->