### PR TITLE
Orient missing schematic symbols from net symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Hydrate schematics from cached BOM matches, with online refresh for stale or missing entries.
 - Added cross-platform `diode://` links that open sandbox layouts in KiCad with live sync and native recovery prompts.
 - The interposer mate constellation is S13: uniform 2×3 blocks with corner mate-detect loops.
+- Orient newly generated missing schematic symbols from attached net-symbol pin directions.
 
 ## [0.4.37] - 2026-08-26
 

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -154,15 +154,24 @@ pub(crate) fn reconcile_document(
                 .with_context(|| format!("placement page '{page_id}' is absent"))
         })
         .transpose()?;
+    let net_symbol_specs = net_symbols::specs(netlist)?;
     for slot in &project_slots {
+        let selected = selected_existing.get(slot);
+        let page_index = if let Some(selected) = selected {
+            selected.page_index
+        } else if let Some(placement_page) = placement_page {
+            placement_page
+        } else {
+            hierarchy.page_for_new_component(slot.component_path())?
+        };
         project_component_slot(
             &mut document,
             netlist,
             &instances,
             slot,
-            selected_existing.get(slot),
-            placement_page,
-            &hierarchy,
+            selected,
+            page_index,
+            &net_symbol_specs,
         )?;
     }
     if complete {
@@ -172,7 +181,6 @@ pub(crate) fn reconcile_document(
     let mut placed = placed_symbols_from_document(&document, &expected_slots)?;
     pack_generated_symbols(&mut document, netlist, &mut placed, &relocatable_slots)?;
 
-    let net_symbol_specs = net_symbols::specs(netlist)?;
     add_hierarchy_connectivity(
         &mut document,
         netlist,
@@ -384,8 +392,8 @@ fn project_component_slot(
     instances: &BTreeMap<String, &Instance>,
     slot: &SymbolSlotKey,
     selected: Option<&ExistingSymbol>,
-    placement_page: Option<usize>,
-    hierarchy: &hierarchy::HierarchyPlan,
+    page_index: usize,
+    net_symbol_specs: &BTreeMap<String, net_symbols::NetSymbolSpec>,
 ) -> Result<()> {
     let instance = instances.get(slot.component_path()).with_context(|| {
         format!(
@@ -400,13 +408,6 @@ fn project_component_slot(
                 slot.component_path()
             )
         })?;
-    let page_index = if let Some(selected) = selected {
-        selected.page_index
-    } else if let Some(placement_page) = placement_page {
-        placement_page
-    } else {
-        hierarchy.page_for_new_component(slot.component_path())?
-    };
 
     if document.pages.iter().any(|page| {
         page.items.iter().any(|item| {
@@ -422,7 +423,10 @@ fn project_component_slot(
 
     let previous = selected.map(|selected| &selected.symbol);
     let at = previous.map(|symbol| symbol.at).unwrap_or_default();
-    let rotation = previous.map(|symbol| symbol.rotation).unwrap_or_default();
+    let rotation = match previous {
+        Some(symbol) => symbol.rotation,
+        None => initial_component_rotation(netlist, slot, &definition, net_symbol_specs)?,
+    };
     let mirror = previous.and_then(|symbol| symbol.mirror);
     let symbol =
         build_component_symbol(instance, slot, &definition, at, rotation, mirror, previous)?;
@@ -464,6 +468,112 @@ fn project_component_slot(
             .push(SchItem::Symbol(symbol));
     }
     Ok(())
+}
+
+fn initial_component_rotation(
+    netlist: &Schematic,
+    slot: &SymbolSlotKey,
+    definition: &SymbolDefinition,
+    net_symbol_specs: &BTreeMap<String, net_symbols::NetSymbolSpec>,
+) -> Result<Rotation> {
+    let unplaced = Symbol {
+        id: String::new(),
+        lib_id: definition.lib_id.clone(),
+        unit: slot.unit(),
+        body_style: 1,
+        at: Point::default(),
+        rotation: Rotation::default(),
+        mirror: None,
+        fields_autoplaced: false,
+        fields: BTreeMap::new(),
+        pins: Vec::new(),
+        unsupported: Vec::new(),
+    };
+    let pins = symbol::ParsedSymbolDefinition::parse(definition)?.placed_pins(&unplaced)?;
+    let mut constraints = Vec::new();
+    for net in named_connected_nets(netlist) {
+        let Some(spec) = net_symbol_specs.get(&net.name) else {
+            continue;
+        };
+        for port in &net.ports {
+            let Some((component_ref, pin_name)) = netlist.component_ref_and_pin_for_port(port)
+            else {
+                continue;
+            };
+            if crate::canonical_component_path(&component_ref.instance_path).as_deref()
+                != Some(slot.component_path())
+            {
+                continue;
+            }
+            let pin_numbers = component_slots::port_pad_numbers(netlist, port);
+            let mut matches = pins.iter().filter(|pin| {
+                !pin.hidden
+                    && ((!pin_name.is_empty() && !pin.name.is_empty() && pin.name == pin_name)
+                        || !pin.numbers.is_disjoint(&pin_numbers))
+            });
+            if let Some(pin) = matches.next()
+                && matches.next().is_none()
+            {
+                constraints.push((pin.outward_spin, spec.pin_outward_spin));
+            }
+        }
+    }
+
+    let rotations = [
+        Rotation::Deg0,
+        Rotation::Deg90,
+        Rotation::Deg180,
+        Rotation::Deg270,
+    ];
+    // Opposite outward directions put the component and net-symbol bodies on
+    // opposite sides of their shared connection point.
+    let scores = rotations.map(|rotation| {
+        let score = constraints
+            .iter()
+            .filter(|(pin_spin, net_spin)| {
+                rotate_spin(*pin_spin, rotation) == opposite_spin(*net_spin)
+            })
+            .count();
+        (rotation, score)
+    });
+
+    let best_score = scores
+        .iter()
+        .map(|(_, score)| *score)
+        .max()
+        .expect("four candidate rotations");
+    let mut best = scores
+        .into_iter()
+        .filter(|(_, score)| *score == best_score)
+        .map(|(rotation, _)| rotation);
+    let rotation = best.next().expect("at least one best rotation");
+    // A non-unique optimum is less informative than the stable default.
+    Ok(if best.next().is_none() {
+        rotation
+    } else {
+        Rotation::default()
+    })
+}
+
+fn rotate_spin(mut spin: LabelSpin, rotation: Rotation) -> LabelSpin {
+    for _ in 0..rotation.degrees() / 90 {
+        spin = match spin {
+            LabelSpin::Left => LabelSpin::Bottom,
+            LabelSpin::Up => LabelSpin::Left,
+            LabelSpin::Right => LabelSpin::Up,
+            LabelSpin::Bottom => LabelSpin::Right,
+        };
+    }
+    spin
+}
+
+fn opposite_spin(spin: LabelSpin) -> LabelSpin {
+    match spin {
+        LabelSpin::Left => LabelSpin::Right,
+        LabelSpin::Up => LabelSpin::Bottom,
+        LabelSpin::Right => LabelSpin::Left,
+        LabelSpin::Bottom => LabelSpin::Up,
+    }
 }
 
 fn remove_component_slot(document: &mut SchDocument, slot: &SymbolSlotKey) {

--- a/crates/pcb-kicad-sch/src/net_symbols.rs
+++ b/crates/pcb-kicad-sch/src/net_symbols.rs
@@ -5,7 +5,7 @@ use pcb_sch::{ATTR_SYMBOL_FORMAT_VERSION, AttributeValue, InstanceKind, Schemati
 use serde_json::{Map, Value};
 
 use crate::{
-    Point, Rotation, Symbol, SymbolDefinition,
+    LabelSpin, Point, Rotation, Symbol, SymbolDefinition,
     component_slots::{self, SYMBOL_PATH_ATTR, SYMBOL_VALUE_ATTR, validate_symbol_library_version},
     connectivity::named_connected_nets,
     symbol,
@@ -17,6 +17,7 @@ pub(crate) struct NetSymbolSpec {
     pub definition: SymbolDefinition,
     pub unit: u32,
     pub pin_offset: Point,
+    pub pin_outward_spin: LabelSpin,
 }
 
 pub(crate) fn specs(netlist: &Schematic) -> Result<BTreeMap<String, NetSymbolSpec>> {
@@ -68,6 +69,7 @@ pub(crate) fn specs(netlist: &Schematic) -> Result<BTreeMap<String, NetSymbolSpe
                     definition,
                     unit: *unit,
                     pin_offset: pin.point,
+                    pin_outward_spin: pin.outward_spin,
                 },
             ))
         })

--- a/crates/pcb-kicad-sch/test-data/analysis/initial_orientation.zen
+++ b/crates/pcb-kicad-sch/test-data/analysis/initial_orientation.zen
@@ -1,0 +1,34 @@
+"""Initial schematic symbol orientation regression design."""
+
+Project(name="InitialOrientation", path="kicad", layout=False)
+
+Resistor = Module("@stdlib/generics/Resistor.zen")
+
+Resistor(
+    name="R_SINGLE",
+    value="1kohms",
+    package="0402",
+    P1=Ground("VCC_LIKE_NAME"),
+    P2=Net("SINGLE_SIGNAL"),
+)
+Resistor(
+    name="R_BOTH",
+    value="2kohms",
+    package="0402",
+    P1=Ground("BOTH_LOW"),
+    P2=Power("BOTH_HIGH"),
+)
+Resistor(
+    name="R_TIED",
+    value="3kohms",
+    package="0402",
+    P1=Ground("TIE_A"),
+    P2=Ground("TIE_B"),
+)
+Resistor(
+    name="R_NONE",
+    value="4kohms",
+    package="0402",
+    P1=Net("NONE_A"),
+    P2=Net("NONE_B"),
+)

--- a/crates/pcb-kicad-sch/tests/editor_core.rs
+++ b/crates/pcb-kicad-sch/tests/editor_core.rs
@@ -10,7 +10,7 @@ use pcb_kicad_sch::{
     deterministic_uuid,
     reconcile::{plan_reconciliation, plan_repairs},
 };
-use pcb_sch::Schematic;
+use pcb_sch::{AttributeValue, Schematic};
 
 #[test]
 fn editor_core_plans_applies_analyzes_and_reopens_in_memory() {
@@ -151,6 +151,47 @@ fn generated_hierarchy_connects_sheet_ports_without_label_bridges() {
         }
         assert!(labels.count() > 0);
     }
+}
+
+#[test]
+fn missing_symbols_use_attached_net_symbol_orientation() {
+    let mut netlist = common::compile_fixture("analysis", "initial_orientation.zen");
+    netlist.net_mut("VCC_LIKE_NAME").unwrap().properties.insert(
+        "__symbol_value".into(),
+        AttributeValue::String(
+            r#"(symbol "Custom:Side" (power global)
+                  (symbol "Side_1_1"
+                    (pin power_in line (at 0 0 180) (length 0)
+                      (name "") (number "1"))))"#
+                .into(),
+        ),
+    );
+    let document = plan_reconciliation(None, &netlist, "InitialOrientation.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    let rotation = |path: &str| {
+        document.pages[0]
+            .items
+            .iter()
+            .find_map(|item| match item {
+                SchItem::Symbol(symbol) if symbol.field_value("Path") == Some(path) => {
+                    Some(symbol.rotation)
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("missing managed symbol {path}"))
+    };
+
+    // The custom symbol's visible pin points right, so resistor pin 1 points
+    // left even though the net has a VCC-like name.
+    assert_eq!(rotation("R_SINGLE.R"), pcb_kicad_sch::Rotation::Deg90);
+    // Default GND and VCC symbols on opposite ends agree on this rotation.
+    assert_eq!(rotation("R_BOTH.R"), pcb_kicad_sch::Rotation::Deg180);
+    // Two equal GND constraints conflict, while ordinary nets do not constrain
+    // orientation; both cases retain the deterministic default.
+    assert_eq!(rotation("R_TIED.R"), pcb_kicad_sch::Rotation::Deg0);
+    assert_eq!(rotation("R_NONE.R"), pcb_kicad_sch::Rotation::Deg0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- score 0°/90°/180°/270° candidate rotations from attached net-symbol visible-pin directions
- retain 0° for ties or unconstrained symbols while preserving existing symbol geometry
- cover sideways, multiple-constraint, tied, and unconstrained cases

## Tests
- `cargo test -p pcb-kicad-sch`
- `cargo clippy -p pcb-kicad-sch --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schematic auto-layout behavior change for newly projected symbols only; existing placements and connectivity logic are unchanged aside from earlier net-symbol spec loading.
> 
> **Overview**
> When schematic reconciliation **creates a new component symbol** (no existing placement to reuse), it now picks an initial **0°/90°/180°/270°** rotation instead of always defaulting to 0°.
> 
> **Net symbol specs** gain the visible power-input pin’s **outward direction** (`pin_outward_spin`). For each uniquely matched pin on that component that ties to a net with a net symbol, the composer scores rotations where the component pin faces **opposite** the net symbol’s pin—so bodies sit on opposite sides of the connection. **Ambiguous ties** or **no constraints** still use the stable default rotation; **existing** symbols keep their saved rotation.
> 
> Changelog and an integration test (`initial_orientation.zen`) cover custom power symbols, dual power ends, conflicting GND constraints, and unconstrained signal nets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc8a0cd8c0c8c3c9ba029281741e2f5b268c321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->