### PR TITLE
Restrict connector house matching to safe pin headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Limit automatic pin-header matching to male vertical through-hole parts.
 - Hydrate schematics from cached BOM matches, with online refresh for stale or missing entries.
 - Added cross-platform `diode://` links that open sandbox layouts in KiCad with live sync and native recovery prompts.
 - The interposer mate constellation is S13: uniform 2×3 blocks with corner mate-detect loops.

--- a/crates/pcb-zen-core/src/convert.rs
+++ b/crates/pcb-zen-core/src/convert.rs
@@ -473,10 +473,7 @@ impl ModuleConverter {
             ) => true,
             Some("connector") => instance
                 .string_attr(&["connector_type", "Connector_type"])
-                .is_some_and(|connector_type| {
-                    connector_type.eq_ignore_ascii_case("pin header")
-                        || connector_type.eq_ignore_ascii_case("terminal block")
-                }),
+                .is_some_and(|connector_type| connector_type.eq_ignore_ascii_case("pin header")),
             _ => false,
         }
     }

--- a/crates/pcb-zen-core/tests/input.rs
+++ b/crates/pcb-zen-core/tests/input.rs
@@ -1173,14 +1173,15 @@ fn errors_for_typed_components_without_house_bom_matching() {
     assert!(
         unspecified
             .iter()
-            .all(|(_, body)| !body.contains("Component 'J1'")),
-        "expected pin header connector to be house-match eligible, got: {unspecified:?}"
+            .any(|(severity, body)| matches!(severity, EvalSeverity::Error)
+                && body.contains("Component 'J2'")),
+        "expected terminal block connector to error, got: {unspecified:?}"
     );
     assert!(
         unspecified
             .iter()
-            .all(|(_, body)| !body.contains("Component 'J2'")),
-        "expected terminal block connector to be house-match eligible, got: {unspecified:?}"
+            .all(|(_, body)| !body.contains("Component 'J1'")),
+        "expected pin header connector to be house-match eligible, got: {unspecified:?}"
     );
 }
 

--- a/lib/std/bom/helpers.zen
+++ b/lib/std/bom/helpers.zen
@@ -23,18 +23,6 @@ def prop(c, names):
     return None
 
 
-def merge_parts(parts: list[dict]) -> dict:
-    """Merge two part lists."""
-    merged = {}
-    for part in parts:
-        for key, value in part.items():
-            if key not in merged:
-                merged[key] = value
-            else:
-                merged[key] += value
-    return merged
-
-
 def set_from_matches(c, matches):
     """Set primary MPN and alternatives from a list of matches.
 

--- a/lib/std/bom/manufacturers/wurth_electronik.zen
+++ b/lib/std/bom/manufacturers/wurth_electronik.zen
@@ -7,32 +7,6 @@ Each function is named after the series and returns (mpn, manufacturer).
 MANUFACTURER = "Würth Elektronik"
 
 
-def WR_PHD_2_54_SMD_MALE_SINGLE(positions: int) -> list[(str, str)]:
-    """WR-PHD 2.54mm pitch SMD Male pin header.
-
-    Series: 610xxx, SMD, 2.54mm pitch, 1 row, vertical
-    Available pins: 4, 6, 10, 14, 16, 24, 32
-
-    Returns:
-        List of alternate (mpn, manufacturer)
-    """
-    available_positions = [4, 6, 10, 14, 16, 24, 32]
-
-    if positions not in available_positions:
-        error(
-            "WR_PHD_2_54_SMD_Male 1-row: pins must be one of "
-            + str(sorted(available_positions))
-            + ", got "
-            + str(positions)
-        )
-
-    prefix = "61000" if positions < 10 else "6100"
-    type1 = "18221"  # Type 1 (preferred)
-    type2 = "18321"  # Type 2 (fallback)
-
-    return [(f"{prefix}{positions}{type1}", MANUFACTURER), (f"{prefix}{positions}{type2}", MANUFACTURER)]
-
-
 def WR_PHD_1_27_THT_MALE_DUAL(pins: int) -> list[(str, str)]:
     """WR-PHD 1.27mm pitch THT Male pin header, 2 rows.
 
@@ -89,35 +63,6 @@ def WR_PHD_2_54_THT_MALE_DUAL(pins: int) -> list[(str, str)]:
     return [(f"6130{pin_str}21121", MANUFACTURER)]
 
 
-def WR_PHD_2_54_SMD_MALE_DUAL(positions: int) -> list[(str, str)]:
-    """WR-PHD 2.54mm pitch SMD Male pin header, 2 rows.
-
-    Series: 610xxx, SMD, 2.54mm pitch, 2 rows, vertical (Straight)
-    Available pins: 4, 6, 8, 10, 12, 14, 16, 20, 22, 24, 26, 32, 34, 36
-
-    Returns:
-        List of alternate (mpn, manufacturer)
-    """
-    available_positions = [4, 6, 8, 10, 12, 14, 16, 20, 22, 24, 26, 32, 34, 36]
-
-    if positions not in available_positions:
-        error(
-            "WR_PHD_2_54_SMD_Male 2-row: pins must be one of "
-            + str(sorted(available_positions))
-            + ", got "
-            + str(positions)
-        )
-
-    # Format pin count with leading zero for single digit
-    pin_str = f"0{positions}" if positions < 10 else str(positions)
-
-    type1_prefix = "6100"  # Type 1 (preferred)
-    type2_prefix = "6103"  # Type 2 (fallback)
-    suffix = "21121"
-
-    return [(f"{type1_prefix}{pin_str}{suffix}", MANUFACTURER), (f"{type2_prefix}{pin_str}{suffix}", MANUFACTURER)]
-
-
 WURTH_ELEKTRONIK_WR_PHD = {
     # 1.27mm pitch, 2 rows, vertical, Male, THT
     ("1.27mm", 2, 2, "Vertical", "Male", "THT"): WR_PHD_1_27_THT_MALE_DUAL(2),
@@ -140,27 +85,4 @@ WURTH_ELEKTRONIK_WR_PHD = {
     ("2.54mm", 2, 5, "Vertical", "Male", "THT"): WR_PHD_2_54_THT_MALE_DUAL(5),
     ("2.54mm", 2, 10, "Vertical", "Male", "THT"): WR_PHD_2_54_THT_MALE_DUAL(10),
     ("2.54mm", 2, 20, "Vertical", "Male", "THT"): WR_PHD_2_54_THT_MALE_DUAL(20),
-    # 2.54mm pitch, 1 row, vertical, Male, SMD
-    ("2.54mm", 1, 4, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_SINGLE(4),
-    ("2.54mm", 1, 6, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_SINGLE(6),
-    ("2.54mm", 1, 10, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_SINGLE(10),
-    ("2.54mm", 1, 14, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_SINGLE(14),
-    ("2.54mm", 1, 16, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_SINGLE(16),
-    ("2.54mm", 1, 24, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_SINGLE(24),
-    ("2.54mm", 1, 32, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_SINGLE(32),
-    # 2.54mm pitch, 2 rows, vertical, Male
-    ("2.54mm", 2, 2, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(4),
-    ("2.54mm", 2, 3, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(6),
-    ("2.54mm", 2, 4, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(8),
-    ("2.54mm", 2, 5, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(10),
-    ("2.54mm", 2, 6, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(12),
-    ("2.54mm", 2, 7, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(14),
-    ("2.54mm", 2, 8, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(16),
-    ("2.54mm", 2, 10, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(20),
-    ("2.54mm", 2, 11, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(22),
-    ("2.54mm", 2, 12, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(24),
-    ("2.54mm", 2, 13, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(26),
-    ("2.54mm", 2, 16, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(32),
-    ("2.54mm", 2, 17, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(34),
-    ("2.54mm", 2, 18, "Vertical", "Male", "SMD"): WR_PHD_2_54_SMD_MALE_DUAL(36),
 }

--- a/lib/std/bom/match_generics.zen
+++ b/lib/std/bom/match_generics.zen
@@ -1127,33 +1127,6 @@ HOUSE_TVS_BY_PKG = {
     ],
 }
 
-# House terminal block catalog
-# Key: (pitch, pins) -> list of (mpn, manufacturer) tuples
-HOUSE_TERMINAL_BLOCKS = {
-    # 2.54mm pitch
-    # LCSC: DORABO DB125-2.54 series (budget option) + TE Connectivity Buchanan 282834 (quality option)
-    ("2.54mm", 2): [("282834-2", "TE Connectivity"), ("DB125-2.54-2P-GN-S", "DORABO")],
-    ("2.54mm", 3): [("282834-3", "TE Connectivity"), ("DB125-2.54-3P-GN-S", "DORABO")],
-    ("2.54mm", 4): [("282834-4", "TE Connectivity"), ("DB125-2.54-4P-GN-S", "DORABO")],
-    ("2.54mm", 5): [("282834-5", "TE Connectivity"), ("DB125-2.54-5P-GN-S", "DORABO")],
-    ("2.54mm", 6): [("282834-6", "TE Connectivity"), ("DB125-2.54-6P-GN-S", "DORABO")],
-    ("2.54mm", 7): [("282834-7", "TE Connectivity"), ("DB125-2.54-7P-GN-S", "DORABO")],
-    ("2.54mm", 8): [("282834-8", "TE Connectivity"), ("DB125-2.54-8P-GN-S", "DORABO")],
-    ("2.54mm", 9): [("282834-9", "TE Connectivity"), ("DB125-2.54-9P-GN-S", "DORABO")],
-    ("2.54mm", 10): [("1-282834-0", "TE Connectivity"), ("DB125-2.54-10P-GN-S", "DORABO")],
-    # 5.0mm pitch - TE Connectivity Buchanan 282836 series + DORABO DB128V-5.0 series
-    ("5.0mm", 2): [("282836-2", "TE Connectivity"), ("DB128V-5.0-2P-GN-S", "DORABO")],
-    ("5.0mm", 3): [("282836-3", "TE Connectivity"), ("DB128V-5.0-3P-GN-S", "DORABO")],
-    ("5.0mm", 4): [("282836-4", "TE Connectivity"), ("DB128V-5.0-4P-GN-S", "DORABO")],
-    ("5.0mm", 5): [("282836-5", "TE Connectivity"), ("DB128V-5.0-5P-GN-S", "DORABO")],
-    ("5.0mm", 6): [("282836-6", "TE Connectivity"), ("DB128V-5.0-6P-GN-S", "DORABO")],
-    ("5.0mm", 7): [("282836-7", "TE Connectivity"), ("DB128V-5.0-7P-GN-S", "DORABO")],
-    ("5.0mm", 8): [("282836-8", "TE Connectivity"), ("DB128V-5.0-8P-GN-S", "DORABO")],
-    ("5.0mm", 9): [("282836-9", "TE Connectivity"), ("DB128V-5.0-9P-GN-S", "DORABO")],
-    ("5.0mm", 10): [("1-282836-0", "TE Connectivity"), ("DB128V-5.0-10P-GN-S", "DORABO")],
-}
-
-
 def assign_house_resistor(c, series_by_pkg):
     """Assign house resistor MPNs."""
     resistance = Resistance(prop(c, ["resistance", "Resistance"]))
@@ -1593,23 +1566,6 @@ def assign_house_crystal(c, house_crystals_by_pkg):
     _no_match_warn("crystal", c, pkg)
 
 
-def assign_house_terminal_block(c, house_terminal_blocks):
-    """Assign house terminal block MPNs."""
-    pins_req = prop(c, ["pins", "Pins"])
-    pitch_req = prop(c, ["pitch", "Pitch"])
-
-    # O(1) lookup using tuple key
-    key = (pitch_req, pins_req)
-    matches = house_terminal_blocks.get(key, [])
-
-    if matches:
-        set_from_matches(c, matches)
-        c.matcher = "assign_house_terminal_block"
-        return
-
-    _no_match_warn("terminal block", c)
-
-
 def assign_house_parts(c):
     """Single modifier that dispatches component matching by type."""
     # Skip if already has MPN
@@ -1639,9 +1595,5 @@ def assign_house_parts(c):
         assign_house_tvs(c, HOUSE_TVS_BY_PKG)
     elif c.type == "crystal":
         assign_house_crystal(c, HOUSE_CRYSTALS_BY_PKG)
-    elif c.type == "connector":
-        connector_type = prop(c, ["connector_type", "Connector_type"])
-        if connector_type == "Pin Header":
-            assign_house_pin_header(c, HOUSE_PH)
-        elif connector_type == "Terminal Block":
-            assign_house_terminal_block(c, HOUSE_TERMINAL_BLOCKS)
+    elif c.type == "connector" and prop(c, ["connector_type", "Connector_type"]) == "Pin Header":
+        assign_house_pin_header(c, HOUSE_PH)

--- a/lib/std/bom/match_generics.zen
+++ b/lib/std/bom/match_generics.zen
@@ -49,7 +49,6 @@ load(
     "tvs",
     "rectifier",
     "zener",
-    "merge_parts",
     "crystal",
 )
 
@@ -583,37 +582,6 @@ HOUSE_CRYSTALS_BY_PKG = {
     ],
 }
 
-# House pin header catalog (Würth Elektronik WR-PHD series)
-# Key: (pitch, rows, pins, orientation) -> [(mpn, manufacturer), ...]
-HOUSE_PH = merge_parts(
-    [
-        WURTH_ELEKTRONIK_WR_PHD,
-        {
-            # 1.27mm pitch, 2 rows, vertical
-            ("1.27mm", 2, 2, "Vertical"): [("62200421121", "Würth Elektronik")],
-            ("1.27mm", 2, 4, "Vertical"): [("62200821121", "Würth Elektronik")],
-            ("1.27mm", 2, 5, "Vertical"): [("62201021121", "Würth Elektronik"), ("ZX-PZ1.27-2-5PZZ", "Megastar")],
-            ("1.27mm", 2, 10, "Vertical"): [("62202021121", "Würth Elektronik")],
-            # 2.54mm pitch, 1 row, vertical
-            ("2.54mm", 1, 2, "Vertical"): [("61300211121", "Würth Elektronik")],
-            ("2.54mm", 1, 3, "Vertical"): [("61300311121", "Würth Elektronik")],
-            ("2.54mm", 1, 4, "Vertical"): [("61300411121", "Würth Elektronik")],
-            ("2.54mm", 1, 5, "Vertical"): [("61300511121", "Würth Elektronik")],
-            ("2.54mm", 1, 6, "Vertical"): [("61300611121", "Würth Elektronik")],
-            ("2.54mm", 1, 8, "Vertical"): [("61300811121", "Würth Elektronik")],
-            ("2.54mm", 1, 10, "Vertical"): [("61301011121", "Würth Elektronik")],
-            ("2.54mm", 1, 15, "Vertical"): [("61301511121", "Würth Elektronik")],
-            # 2.54mm pitch, 2 rows, vertical
-            ("2.54mm", 2, 2, "Vertical"): [("61300421121", "Würth Elektronik")],
-            ("2.54mm", 2, 3, "Vertical"): [("61300621121", "Würth Elektronik")],
-            ("2.54mm", 2, 4, "Vertical"): [("61300821121", "Würth Elektronik")],
-            ("2.54mm", 2, 5, "Vertical"): [("61301021121", "Würth Elektronik")],
-            ("2.54mm", 2, 10, "Vertical"): [("61302021121", "Würth Elektronik")],
-            ("2.54mm", 2, 20, "Vertical"): [("61304021121", "Würth Elektronik")],
-        },
-    ]
-)
-
 # House rectifier diode catalog by technology and package
 HOUSE_RECTIFIERS_BY_PKG = {
     ("PN", "DO-219AB"): [
@@ -1127,6 +1095,7 @@ HOUSE_TVS_BY_PKG = {
     ],
 }
 
+
 def assign_house_resistor(c, series_by_pkg):
     """Assign house resistor MPNs."""
     resistance = Resistance(prop(c, ["resistance", "Resistance"]))
@@ -1371,15 +1340,7 @@ def assign_house_pin_header(c, house_ph):
     gender_req = prop(c, ["gender", "Gender"])
     mount_req = prop(c, ["mount", "Mount"])
 
-    # O(1) lookup using tuple key
-    if mount_req and gender_req:
-        # Generic pin header with mount and gender
-        key = (pitch_req, rows_req, pins_req, orientation_req, gender_req, mount_req)
-    else:
-        # Legacy style pin header (deprecated)
-        key = (pitch_req, rows_req, pins_req, orientation_req)
-
-    # Check for an exact match
+    key = (pitch_req, rows_req, pins_req, orientation_req, gender_req, mount_req)
     matches = house_ph.get(key, [])
 
     if matches:
@@ -1596,4 +1557,4 @@ def assign_house_parts(c):
     elif c.type == "crystal":
         assign_house_crystal(c, HOUSE_CRYSTALS_BY_PKG)
     elif c.type == "connector" and prop(c, ["connector_type", "Connector_type"]) == "Pin Header":
-        assign_house_pin_header(c, HOUSE_PH)
+        assign_house_pin_header(c, WURTH_ELEKTRONIK_WR_PHD)

--- a/lib/std/generics/test/test_PinHeader.zen
+++ b/lib/std/generics/test/test_PinHeader.zen
@@ -55,25 +55,15 @@ for orientation in Orientation.values():
                         )
 
 
-PH_SMD_SINGLE_ROW_PINS = [4, 6, 10, 14, 16, 24, 32]
-PH_SMD_DUAL_ROW_PINS = [2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 16, 17, 18]
 PH_THT_254_SINGLE_ROW_PINS = [2, 3, 4, 5, 6, 8, 10, 15]
 PH_THT_254_DUAL_ROW_PINS = [2, 3, 4, 5, 10, 20]
 PH_THT_127_DUAL_ROW_PINS = [2, 4, 5, 10]
 
-PH_MATCH_CASES = (
-    [
-        ("2.54mm", rows, pins, "Vertical", "Male", "SMD")
-        for rows in [1, 2]
-        for pins in {1: PH_SMD_SINGLE_ROW_PINS, 2: PH_SMD_DUAL_ROW_PINS}[rows]
-    ]
-    + [
-        ("2.54mm", rows, pins, "Vertical", "Male", "THT")
-        for rows in [1, 2]
-        for pins in {1: PH_THT_254_SINGLE_ROW_PINS, 2: PH_THT_254_DUAL_ROW_PINS}[rows]
-    ]
-    + [("1.27mm", 2, pins, "Vertical", "Male", "THT") for pins in PH_THT_127_DUAL_ROW_PINS]
-)
+PH_MATCH_CASES = [
+    ("2.54mm", rows, pins, "Vertical", "Male", "THT")
+    for rows in [1, 2]
+    for pins in {1: PH_THT_254_SINGLE_ROW_PINS, 2: PH_THT_254_DUAL_ROW_PINS}[rows]
+] + [("1.27mm", 2, pins, "Vertical", "Male", "THT") for pins in PH_THT_127_DUAL_ROW_PINS]
 
 for i, (pitch, rows, pins, orientation, gender, mount) in enumerate(PH_MATCH_CASES):
     match_pins = {"P{}".format(n): Net("PH_MATCH_{}_{}".format(i, n)) for n in range(1, pins * rows + 1)}
@@ -88,4 +78,41 @@ for i, (pitch, rows, pins, orientation, gender, mount) in enumerate(PH_MATCH_CAS
         **match_pins,
     )
 
-builtin.add_component_modifier(assign_house_parts)
+PH_NO_MATCH_CASES = [
+    ("2.54mm", 1, 4, "Vertical", "Male", "SMD"),
+    ("2.54mm", 1, 4, "Horizontal", "Male", "THT"),
+    ("2.54mm", 1, 4, "Vertical", "Female", "THT"),
+]
+
+for i, (pitch, rows, pins, orientation, gender, mount) in enumerate(PH_NO_MATCH_CASES):
+    no_match_pins = {"P{}".format(n): Net("PH_NO_MATCH_{}_{}".format(i, n)) for n in range(1, pins * rows + 1)}
+    PinHeader(
+        name="PH_NO_MATCH_" + str(i),
+        mount=mount,
+        pins=pins,
+        rows=rows,
+        orientation=orientation,
+        pitch=pitch,
+        gender=gender,
+        **no_match_pins,
+    )
+
+
+def _check_house_parts(c):
+    if hasattr(c, "mpn") and c.mpn:
+        return
+    if not hasattr(c, "type") or c.type != "connector":
+        return
+
+    assign_house_parts(c)
+
+    mount = c.properties["mount"].value
+    orientation = c.properties["orientation"].value
+    gender = c.properties["gender"].value
+    should_match = mount == "THT" and orientation == "Vertical" and gender == "Male"
+    matched = hasattr(c, "mpn") and c.mpn
+    if bool(matched) != should_match:
+        error("Unexpected pin header house match for " + c.value)
+
+
+builtin.add_component_modifier(_check_house_parts)


### PR DESCRIPTION
Remove stale terminal-block matching and stop automatic matching for pin headers with nonstandard footprints. Keep only male vertical THT pin-header matches at 1.27 mm and 2.54 mm.