### PR TITLE
fix(launcher): improve error recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Better error handling in launcher.
+
 ## [0.4.38] - 2026-08-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,6 +4366,7 @@ dependencies = [
  "objc2-foundation",
  "pcb-diode-uri",
  "pcb-native-dialog",
+ "strip-ansi-escapes",
 ]
 
 [[package]]

--- a/crates/pcb-launcher/Cargo.toml
+++ b/crates/pcb-launcher/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { workspace = true }
 dirs = { workspace = true }
 pcb-diode-uri = { workspace = true }
 pcb-native-dialog = { workspace = true }
+strip-ansi-escapes = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"

--- a/crates/pcb-launcher/src/main.rs
+++ b/crates/pcb-launcher/src/main.rs
@@ -3,11 +3,28 @@
 use anyhow::{Context, Result, bail};
 use pcb_diode_uri::{SandboxFileUri, is_trusted_api_host};
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 
 const LAUNCHER_LOG_MAX_BYTES: u64 = 1024 * 1024;
+const LAUNCH_ERROR_OUTPUT_MAX_BYTES: usize = 8 * 1024;
+const NOT_AUTHENTICATED_FRAGMENT: &str = "not authenticated";
+
+#[derive(Debug)]
+struct PcbCommandFailed {
+    pcb: PathBuf,
+    status: ExitStatus,
+    output_summary: Option<String>,
+}
+
+impl std::fmt::Display for PcbCommandFailed {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{} failed: {}", self.pcb.display(), self.status)
+    }
+}
+
+impl std::error::Error for PcbCommandFailed {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LauncherToolchain {
@@ -116,16 +133,85 @@ fn install_protocol_handler(toolchain: LauncherToolchain) -> Result<()> {
 
 fn launch_pcb(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
     let result = launch_pcb_inner(uri, toolchain);
-    if let Err(error) = &result {
-        report_launch_error(error);
+    let Err(error) = &result else {
+        return result;
+    };
+    append_launcher_error(error);
+    let summary = launch_error_summary(error);
+    if is_not_authenticated(&summary) {
+        let dialog = pcb_native_dialog::ActionDialog {
+            title: "Log in to open in KiCad",
+            message: "PCB is not authenticated. Log in, then open this board again.",
+            action_label: "Log In",
+        };
+        match dialog.show() {
+            Ok(true) => {
+                let login = spawn_auth_login(toolchain);
+                if let Err(error) = &login {
+                    report_launch_error(error);
+                }
+                return login;
+            }
+            Ok(false) => return result,
+            Err(dialog_error) => append_launcher_error(&dialog_error),
+        }
     }
+    show_launch_error(&summary);
     result
+}
+
+fn is_not_authenticated(summary: &str) -> bool {
+    summary
+        .to_ascii_lowercase()
+        .contains(NOT_AUTHENTICATED_FRAGMENT)
+}
+
+fn launch_error_summary(error: &anyhow::Error) -> String {
+    error
+        .downcast_ref::<PcbCommandFailed>()
+        .and_then(|failure| failure.output_summary.as_deref())
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("{error:#}"))
 }
 
 fn report_launch_error(error: &anyhow::Error) {
     append_launcher_error(error);
-    let message = format!("{error:#}\n\nDetails: {}", launcher_log_path().display());
+    show_launch_error(&launch_error_summary(error));
+}
+
+fn show_launch_error(summary: &str) {
+    let message = format!("{summary}\n\nDetails: {}", launcher_log_path().display());
     pcb_native_dialog::show_error("Open in KiCad failed", &message);
+}
+
+fn spawn_auth_login(toolchain: LauncherToolchain) -> Result<()> {
+    let pcb = sibling_pcb_executable()?;
+    let mut log = open_launcher_log()?;
+    let stdout = log
+        .try_clone()
+        .context("failed to clone the launcher log handle")?;
+    writeln!(log, "\n--- pcb auth login started by pcb-launcher ---")
+        .context("failed to write the launcher log")?;
+    let mut command = Command::new(&pcb);
+    command
+        .arg(toolchain.override_arg())
+        .args(["auth", "login"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(log));
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    command
+        .spawn()
+        .with_context(|| format!("failed to start `{}` auth login", pcb.display()))?;
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -151,7 +237,7 @@ fn launch_pcb_inner(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
         .unwrap_or_default();
     writeln!(log, "\n--- pcb-launcher invocation at unix {now} ---")
         .context("failed to write the launcher log")?;
-    let stdout = log
+    let stdout_log = log
         .try_clone()
         .context("failed to clone the launcher log handle")?;
     let mut command = Command::new(&pcb);
@@ -161,8 +247,8 @@ fn launch_pcb_inner(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
         .arg(uri)
         .env("PCB_URL_LAUNCHER", "1")
         .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(log));
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
     #[cfg(target_os = "windows")]
     {
@@ -175,17 +261,86 @@ fn launch_pcb_inner(uri: &str, toolchain: LauncherToolchain) -> Result<()> {
     let mut child = command
         .spawn()
         .with_context(|| format!("failed to start {}", pcb.display()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("failed to capture pcb stdout")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("failed to capture pcb stderr")?;
+    let stdout_thread = std::thread::spawn(move || stream_command_output(stdout, stdout_log));
+    let stderr_thread = std::thread::spawn(move || stream_command_output(stderr, log));
     // Keep the protocol handler alive while pcb opens KiCad. This preserves
     // browser-launched children on Windows and lets every platform surface a
     // non-zero exit instead of silently discarding it.
     let status = child
         .wait()
         .with_context(|| format!("failed to wait for {}", pcb.display()))?;
+    let stdout = stdout_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("pcb stdout reader panicked"))?
+        .context("failed to read pcb stdout")?;
+    let stderr = stderr_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("pcb stderr reader panicked"))?
+        .context("failed to read pcb stderr")?;
     if !status.success() {
-        bail!("{} failed: {status}", pcb.display());
+        return Err(PcbCommandFailed {
+            pcb,
+            status,
+            output_summary: command_output_summary(&stdout, &stderr),
+        }
+        .into());
     }
 
     Ok(())
+}
+
+fn stream_command_output(mut reader: impl Read, mut log: File) -> std::io::Result<Vec<u8>> {
+    let mut tail = Vec::new();
+    let mut buffer = [0; 4096];
+    let mut log_error = None;
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        if log_error.is_none()
+            && let Err(error) = log.write_all(&buffer[..count])
+        {
+            // Continue draining the pipe so a log failure cannot block pcb.
+            log_error = Some(error);
+        }
+        tail.extend_from_slice(&buffer[..count]);
+        if tail.len() > LAUNCH_ERROR_OUTPUT_MAX_BYTES {
+            tail.drain(..tail.len() - LAUNCH_ERROR_OUTPUT_MAX_BYTES);
+        }
+    }
+    match log_error {
+        Some(error) => Err(error),
+        None => Ok(tail),
+    }
+}
+
+fn command_output_summary(stdout: &[u8], stderr: &[u8]) -> Option<String> {
+    let stderr = clean_command_output(stderr);
+    let stdout = clean_command_output(stdout);
+    let summary = if stderr.is_empty() { stdout } else { stderr };
+    (!summary.is_empty()).then_some(summary)
+}
+
+fn clean_command_output(output: &[u8]) -> String {
+    let stripped = strip_ansi_escapes::strip(output);
+    let cleaned: String = String::from_utf8_lossy(&stripped)
+        .chars()
+        .filter(|character| !character.is_control() || matches!(character, '\n' | '\t'))
+        .collect();
+    cleaned
+        .trim()
+        .strip_prefix("Error: ")
+        .unwrap_or(cleaned.trim())
+        .to_owned()
 }
 
 fn validate_uri(uri: &str) -> Result<()> {
@@ -625,8 +780,8 @@ mod macos {
 #[cfg(test)]
 mod tests {
     use super::{
-        LauncherCommand, LauncherToolchain, escape_desktop_exec_path, parse_launcher_args,
-        validate_uri,
+        LauncherCommand, LauncherToolchain, command_output_summary, escape_desktop_exec_path,
+        is_not_authenticated, parse_launcher_args, validate_uri,
     };
     use std::ffi::OsString;
     use std::path::Path;
@@ -698,6 +853,30 @@ mod tests {
         assert_eq!(
             escape_desktop_exec_path(Path::new("/tmp/a\\b\"c`d$e%f")),
             "/tmp/a\\\\\\\\b\\\\\"c\\\\`d\\\\$e%%f"
+        );
+    }
+
+    #[test]
+    fn cleans_and_classifies_command_errors() {
+        let summary = command_output_summary(
+            b"ignored stdout\n",
+            b"\x1b[31mError: Remote sync stopped.\x1b[0m\r\nSandbox lock was reclaimed.\n",
+        );
+
+        assert_eq!(
+            summary.as_deref(),
+            Some("Remote sync stopped.\nSandbox lock was reclaimed.")
+        );
+        assert!(is_not_authenticated(
+            "warning: latest check failed\nError: Not authenticated. Run `pcb auth login`."
+        ));
+    }
+
+    #[test]
+    fn uses_stdout_when_a_failed_command_has_no_stderr() {
+        assert_eq!(
+            command_output_summary(b"Error: useful output\n", b"").as_deref(),
+            Some("useful output")
         );
     }
 

--- a/crates/pcb-native-dialog/src/lib.rs
+++ b/crates/pcb-native-dialog/src/lib.rs
@@ -10,6 +10,28 @@ pub enum Choice {
     Cancel,
 }
 
+/// A native message dialog with one action and Cancel.
+pub struct ActionDialog<'a> {
+    pub title: &'a str,
+    pub message: &'a str,
+    pub action_label: &'a str,
+}
+
+impl ActionDialog<'_> {
+    pub fn show(&self) -> Result<bool> {
+        platform::show_action(self)
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn parse_choice(&self, value: &str) -> Result<bool> {
+        match value.trim() {
+            value if value == self.action_label || value == "OK" || value == "Yes" => Ok(true),
+            "Cancel" | "No" => Ok(false),
+            value => bail!("native dialog returned an unexpected choice: {value:?}"),
+        }
+    }
+}
+
 /// A three-way native dialog: a default confirm button, an alternative
 /// decline button, and Cancel.
 pub struct ConfirmDialog<'a> {
@@ -68,6 +90,44 @@ mod platform {
     use super::*;
     use anyhow::Context;
     use std::process::Command;
+
+    pub fn show_action(dialog: &ActionDialog) -> Result<bool> {
+        let action = applescript_string(dialog.action_label);
+        let show_dialog = format!(
+            "set dialogResult to display dialog (item 1 of argv) buttons {{\"Cancel\", {action}}} default button {action} cancel button \"Cancel\" with title {} with icon caution",
+            applescript_string(dialog.title),
+        );
+        let output = Command::new("osascript")
+            .args([
+                "-e",
+                "on run argv",
+                "-e",
+                "try",
+                "-e",
+                &show_dialog,
+                "-e",
+                "return button returned of dialogResult",
+                "-e",
+                "on error number -128",
+                "-e",
+                "return \"Cancel\"",
+                "-e",
+                "end try",
+                "-e",
+                "end run",
+                "--",
+            ])
+            .arg(dialog.message)
+            .output()
+            .context("failed to show the macOS dialog")?;
+        if !output.status.success() {
+            bail!(
+                "macOS dialog failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        dialog.parse_choice(&String::from_utf8_lossy(&output.stdout))
+    }
 
     pub fn show_confirm(dialog: &ConfirmDialog) -> Result<Choice> {
         let confirm = applescript_string(dialog.confirm_label);
@@ -133,6 +193,41 @@ mod platform {
     use super::*;
     use anyhow::Context;
     use std::process::Command;
+
+    pub fn show_action(dialog: &ActionDialog) -> Result<bool> {
+        let output = Command::new("zenity")
+            .arg("--question")
+            .arg(format!("--title={}", dialog.title))
+            .arg(format!("--ok-label={}", dialog.action_label))
+            .arg("--cancel-label=Cancel")
+            .arg("--text")
+            .arg(dialog.message)
+            .output();
+        match output {
+            Ok(output) if output.status.success() => return Ok(true),
+            Ok(output) if output.status.code() == Some(1) => return Ok(false),
+            _ => {}
+        }
+
+        let status = Command::new("kdialog")
+            .args([
+                "--title",
+                dialog.title,
+                "--yesno",
+                dialog.message,
+                "--yes-label",
+                dialog.action_label,
+                "--no-label",
+                "Cancel",
+            ])
+            .status()
+            .context("failed to show the action dialog with zenity or kdialog")?;
+        match status.code() {
+            Some(0) => Ok(true),
+            Some(1) => Ok(false),
+            code => bail!("kdialog action dialog failed with exit code {code:?}"),
+        }
+    }
 
     pub fn show_confirm(dialog: &ConfirmDialog) -> Result<Choice> {
         match show_zenity(dialog) {
@@ -217,6 +312,20 @@ mod platform {
 
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
+    pub fn show_action(dialog: &ActionDialog) -> Result<bool> {
+        let message = format!("{}\n\nOK \u{2014} {}", dialog.message, dialog.action_label);
+        let output = message_box(dialog.title, &message, "OKCancel", "Warning")
+            .output()
+            .context("failed to show the Windows action dialog")?;
+        if !output.status.success() {
+            bail!(
+                "Windows dialog failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        dialog.parse_choice(&String::from_utf8_lossy(&output.stdout))
+    }
+
     fn message_box(title: &str, message: &str, buttons: &str, icon: &str) -> Command {
         let mut command = Command::new("powershell.exe");
         command
@@ -259,6 +368,10 @@ mod platform {
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 mod platform {
     use super::*;
+
+    pub fn show_action(_dialog: &ActionDialog) -> Result<bool> {
+        bail!("native dialogs are not supported on this platform")
+    }
 
     pub fn show_confirm(_dialog: &ConfirmDialog) -> Result<Choice> {
         bail!("native dialogs are not supported on this platform")

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -1054,6 +1054,7 @@ fn toolchain_list() -> Result<()> {
 fn toolchain_show(offline: bool) -> Result<()> {
     let (request, reason) = configured_toolchain_request(true)?;
     println!("shim: {}", env!("CARGO_PKG_VERSION"));
+    show_launcher_installation()?;
     println!("request: {}", format_request(&request));
     println!("reason: {reason}");
 
@@ -1061,6 +1062,20 @@ fn toolchain_show(offline: bool) -> Result<()> {
         ToolchainRequest::Nightly => show_nightly_toolchain(offline)?,
         ToolchainRequest::Local => show_local_toolchain(),
         _ => show_stable_toolchain(&request, offline)?,
+    }
+    Ok(())
+}
+
+fn show_launcher_installation() -> Result<()> {
+    let shim = std::env::current_exe().context("failed to locate current pcb shim executable")?;
+    let install_dir = shim
+        .parent()
+        .context("current pcb shim has no parent directory")?;
+    let launcher = install_dir.join(executable_name("pcb-launcher"));
+    if launcher.is_file() {
+        println!("launcher: installed ({})", launcher.display());
+    } else {
+        println!("launcher: not installed (expected {})", launcher.display());
     }
     Ok(())
 }

--- a/crates/pcbc/src/remote_sandbox.rs
+++ b/crates/pcbc/src/remote_sandbox.rs
@@ -115,6 +115,7 @@ struct LocalLayout {
     pcb_file: PathBuf,
     sync_session: Option<SyncSession>,
     restored_from_recovery: bool,
+    attached_editor_pid: Option<u32>,
 }
 
 #[derive(Default)]
@@ -129,6 +130,41 @@ enum SyncOutcome {
         reason: RecoverableStopReason,
         error: anyhow::Error,
     },
+}
+
+enum EditorSession {
+    Spawned(pcb_kicad::PcbnewSession),
+    Attached(u32),
+}
+
+impl EditorSession {
+    fn id(&self) -> u32 {
+        match self {
+            Self::Spawned(session) => session.id(),
+            Self::Attached(pid) => *pid,
+        }
+    }
+
+    fn is_running(&mut self) -> Result<bool> {
+        match self {
+            Self::Spawned(session) => Ok(session.try_wait()?.is_none()),
+            Self::Attached(pid) => Ok(editor_process_is_running(*pid)),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum RecoverableSession {
+    Ready(SyncSession),
+    EditorOpen { session: SyncSession, pid: u32 },
+}
+
+impl RecoverableSession {
+    fn updated_at(&self) -> DateTime<Utc> {
+        match self {
+            Self::Ready(session) | Self::EditorOpen { session, .. } => session.manifest.updated_at,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -204,6 +240,9 @@ fn open_layout_and_sync(
         .sync_session
         .clone()
         .context("Remote sync session was not initialized")?;
+    // Start watching before recovery upload so saves made in an already-open
+    // KiCad window during the upload are queued for the sync loop.
+    let watcher = LocalLayoutWatcher::new(&local.local_layout_dir)?;
     restore_recovered_layout_if_needed(client, uri, local, &mut sync_session, &status)
         .with_context(|| {
             format!(
@@ -212,14 +251,19 @@ fn open_layout_and_sync(
             )
         })?;
     let running = install_shutdown_flag()?;
-    status.set_message(format!("Opening {}...", local.pcb_file.display()));
-    let watcher = LocalLayoutWatcher::new(&local.local_layout_dir)?;
-    let mut session = match pcb_kicad::open_pcbnew_session(&local.pcb_file) {
-        Ok(session) => session,
-        Err(err) => {
-            sync_session.mark_complete()?;
-            return Err(err);
-        }
+    status.set_message(match local.attached_editor_pid {
+        Some(_) => format!("Resuming sync for {}...", local.pcb_file.display()),
+        None => format!("Opening {}...", local.pcb_file.display()),
+    });
+    let mut session = match local.attached_editor_pid {
+        Some(pid) => EditorSession::Attached(pid),
+        None => match pcb_kicad::open_pcbnew_session(&local.pcb_file) {
+            Ok(session) => EditorSession::Spawned(session),
+            Err(err) => {
+                sync_session.mark_complete()?;
+                return Err(err);
+            }
+        },
     };
     sync_session.mark_active(session.id())?;
     status.set_message(format!(
@@ -281,15 +325,15 @@ fn run_local_sync_loop(
     uri: &SandboxFileUri,
     local: &LocalLayout,
     lock: &SandboxLockGuard,
-    session: &mut pcb_kicad::PcbnewSession,
+    session: &mut EditorSession,
     watcher: &LocalLayoutWatcher,
     running: &AtomicBool,
     status: &pcb_ui::Spinner,
 ) -> SyncOutcome {
     loop {
-        match session.try_wait() {
-            Ok(Some(_)) => break,
-            Ok(None) => {}
+        match session.is_running() {
+            Ok(true) => {}
+            Ok(false) => break,
             Err(err) => return recoverable_outcome(RecoverableStopReason::SyncFailed, err),
         }
         if !running.load(Ordering::SeqCst) {
@@ -478,14 +522,28 @@ fn sync_layout_down(
     let relative_pcb = remote_relative_path(&remote_layout_dir, &remote_pcb_file)?;
 
     let mut recovered_session = None;
+    let mut attached_editor_pid = None;
     if let Some(status) = restore_status
-        && let Some(session) = latest_recoverable_session(&cache_root)?
+        && let Some(recovery) = latest_recoverable_session(&cache_root)?
     {
-        match prompt_restore_recovery(status, &session)? {
-            Some(RecoveryChoice::Restore) => recovered_session = Some(session),
-            Some(RecoveryChoice::Discard) => mark_recoverable_sessions_prompt_seen(&cache_root),
-            Some(RecoveryChoice::Cancel) => return Ok(None),
-            None => {}
+        match recovery {
+            RecoverableSession::Ready(session) => {
+                match prompt_restore_recovery(status, &session)? {
+                    Some(RecoveryChoice::Restore) => recovered_session = Some(session),
+                    Some(RecoveryChoice::Discard) => {
+                        mark_recoverable_sessions_prompt_seen(&cache_root)
+                    }
+                    Some(RecoveryChoice::Cancel) => return Ok(None),
+                    None => {}
+                }
+            }
+            RecoverableSession::EditorOpen { session, pid } => {
+                if !prompt_resume_existing_editor(status, &session)? {
+                    return Ok(None);
+                }
+                recovered_session = Some(session);
+                attached_editor_pid = Some(pid);
+            }
         }
     }
 
@@ -524,6 +582,7 @@ fn sync_layout_down(
         pcb_file,
         sync_session,
         restored_from_recovery,
+        attached_editor_pid,
     }))
 }
 
@@ -760,11 +819,18 @@ impl SyncSession {
     }
 }
 
-fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> {
+fn latest_recoverable_session(cache_root: &Path) -> Result<Option<RecoverableSession>> {
+    latest_recoverable_session_with(cache_root, editor_process_is_running)
+}
+
+fn latest_recoverable_session_with(
+    cache_root: &Path,
+    editor_is_running: impl Fn(u32) -> bool,
+) -> Result<Option<RecoverableSession>> {
     if !cache_root.exists() {
         return Ok(None);
     }
-    let mut latest: Option<SyncSession> = None;
+    let mut latest: Option<RecoverableSession> = None;
     for entry in fs::read_dir(cache_root)
         .with_context(|| format!("Failed to read {}", cache_root.display()))?
     {
@@ -775,30 +841,66 @@ fn latest_recoverable_session(cache_root: &Path) -> Result<Option<SyncSession>> 
         let Ok(session) = SyncSession::load(entry.path()) else {
             continue;
         };
-        if matches!(
+        let live_editor_pid = if matches!(
             session.manifest.state,
             SyncSessionState::Active | SyncSessionState::Recoverable
-        ) && session
-            .manifest
-            .editor_pid
-            .is_some_and(editor_process_is_running)
-        {
-            bail!(
-                "KiCad is still open for {}. Close that KiCad window before opening this board again.",
-                session.manifest.layout_file.display()
-            );
-        }
-        if !is_recovery_candidate(&session.manifest) {
-            continue;
-        }
+        ) {
+            session
+                .manifest
+                .editor_pid
+                .filter(|pid| editor_is_running(*pid))
+        } else {
+            None
+        };
+        let recovery = match live_editor_pid {
+            Some(pid) => RecoverableSession::EditorOpen { session, pid },
+            None if is_recovery_candidate(&session.manifest) => RecoverableSession::Ready(session),
+            None => continue,
+        };
         if latest
             .as_ref()
-            .is_none_or(|current| session.manifest.updated_at > current.manifest.updated_at)
+            .is_none_or(|current| recovery.updated_at() > current.updated_at())
         {
-            latest = Some(session);
+            latest = Some(recovery);
         }
     }
     Ok(latest)
+}
+
+fn prompt_resume_existing_editor(status: &pcb_ui::Spinner, session: &SyncSession) -> Result<bool> {
+    let board = session
+        .manifest
+        .layout_file
+        .file_name()
+        .unwrap_or(session.manifest.layout_file.as_os_str())
+        .to_string_lossy();
+    let message = format!(
+        "{board} is already open in KiCad, but remote sync stopped.\n\n\
+         Resume syncing the open local board to the sandbox?"
+    );
+    if std::env::var_os(URL_LAUNCHER_ENV).is_some() {
+        return status.suspend(|| {
+            pcb_native_dialog::ActionDialog {
+                title: "Resume KiCad sync?",
+                message: &message,
+                action_label: "Resume Sync",
+            }
+            .show()
+        });
+    }
+    if !crate::tty::is_interactive() {
+        eprintln!(
+            "KiCad is still open for {}. Re-run interactively to resume sync.",
+            session.manifest.layout_file.display()
+        );
+        return Ok(false);
+    }
+    status.suspend(|| {
+        Ok(Confirm::new(&message)
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false))
+    })
 }
 
 fn prompt_restore_recovery(
@@ -1066,7 +1168,12 @@ fn shell_quote(value: &str) -> String {
 mod tests {
     use super::*;
 
-    fn write_session_manifest(cache_root: &Path, state: SyncSessionState, editor_pid: Option<u32>) {
+    fn write_session_manifest(
+        cache_root: &Path,
+        state: SyncSessionState,
+        editor_pid: Option<u32>,
+        prompt_seen: bool,
+    ) {
         let local_layout_dir = cache_root.join("session");
         fs::create_dir(&local_layout_dir).unwrap();
         let layout_file = local_layout_dir.join("layout.kicad_pcb");
@@ -1082,7 +1189,7 @@ mod tests {
             state,
             stop_reason: None,
             editor_pid,
-            prompt_seen: false,
+            prompt_seen,
             started_at: now,
             updated_at: now,
         };
@@ -1093,30 +1200,24 @@ mod tests {
         .unwrap();
     }
 
-    #[cfg(unix)]
     #[test]
-    fn refuses_open_while_tracked_editor_is_running() {
+    fn finds_restored_open_editor_session_for_sync_resume() {
         let cache = tempfile::tempdir().unwrap();
-        let sleep = ["/bin/sleep", "/usr/bin/sleep"]
-            .into_iter()
-            .find(|path| Path::new(path).is_file())
-            .expect("sleep binary");
-        let editor = cache.path().join("pcbnew");
-        fs::copy(sleep, &editor).unwrap();
-        let mut editor = std::process::Command::new(&editor)
-            .arg("30")
-            .spawn()
-            .unwrap();
+        let editor_pid = 42;
         write_session_manifest(
             cache.path(),
-            SyncSessionState::Recoverable,
-            Some(editor.id()),
+            SyncSessionState::Active,
+            Some(editor_pid),
+            true,
         );
 
-        let error = latest_recoverable_session(cache.path()).unwrap_err();
-        let _ = editor.kill();
-        let _ = editor.wait();
-        assert!(error.to_string().contains("KiCad is still open"));
+        let recovery = latest_recoverable_session_with(cache.path(), |pid| pid == editor_pid)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            recovery,
+            RecoverableSession::EditorOpen { pid, .. } if pid == editor_pid
+        ));
     }
 
     #[test]
@@ -1128,10 +1229,13 @@ mod tests {
             cache.path(),
             SyncSessionState::Recoverable,
             Some(std::process::id()),
+            false,
         );
 
-        let session = latest_recoverable_session(cache.path()).unwrap();
-        assert!(session.is_some());
+        let recovery = latest_recoverable_session_with(cache.path(), |_| false)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(recovery, RecoverableSession::Ready(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- show cleaned `pcb` stderr/stdout in launcher failure dialogs while retaining full logs
- offer a native **Log In** action for authentication failures and run `pcb auth login`
- treat a still-open KiCad editor as the live form of the same recovery session, allowing a subsequent open to resume sync instead of launching another editor or requiring KiCad to be killed
- show launcher installed/missing status and its expected path in `pcb toolchain show`

## Verification

- `cargo nextest run -p pcbc remote_sandbox`
- `cargo nextest run -p pcb-native-dialog -p pcb-launcher`
- `cargo nextest run -p pcb`
- `cargo clippy -p pcbc -p pcb-native-dialog -p pcb-launcher --all-targets -- -D warnings`
- `cargo clippy -p pcb --all-targets -- -D warnings`
- `cargo test --doc -p pcb-native-dialog`
- `cargo run -q -p pcb -- toolchain show --offline`
- `git diff --check origin/main...HEAD`

## Release follow-up

Two releases are needed after merge:

1. Dispatch **Release pcb shim version bump** (`.github/workflows/pcb-version-bump.yml`) with `version=pcb/v0.2.7`. The live shim metadata still points to `pcb/v0.2.6`, which predates `pcb-launcher`. This publishes the updated `pcb` shim and `pcb-launcher`, then refreshes `pcb-latest.json`.
2. Dispatch the `pcbc` version-bump workflow (`.github/workflows/pcbc-version-bump.yml`) for the next toolchain version, expected `v0.4.39`. The live-session **Resume Sync** behavior is implemented in `pcbc`, not the launcher binary.

`pcb-native-dialog` is statically linked into both release binaries; it does not require a separate release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote sandbox session recovery and launcher auth/error paths where users open boards from URLs; core eval/build paths are untouched but sync resume and login spawning affect production open-in-KiCad flows.
> 
> **Overview**
> Improves **browser-launched `diode://` opens** by surfacing cleaned `pcb` failure output in native dialogs (full output still logged) and offering **Log In** when errors look like missing auth, which spawns `pcb auth login`.
> 
> When remote sync stopped but **KiCad is still open** for the same board, a later open can **resume syncing** the existing local session instead of failing or spawning another editor—via `EditorSession` attach/resume prompts (including launcher-native **Resume Sync**).
> 
> Adds **`ActionDialog`** in `pcb-native-dialog` for single-action prompts, and **`pcb toolchain show`** now reports whether `pcb-launcher` is installed beside the shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8975c85f30561c05a18cbf72dc460376edfd2168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->