### PR TITLE
fix(launcher): suppress routine signing output

### DIFF
--- a/crates/pcb-launcher/src/main.rs
+++ b/crates/pcb-launcher/src/main.rs
@@ -474,11 +474,16 @@ fn escape_desktop_exec_path(path: &Path) -> String {
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn run_checked(command: &mut Command, description: &str) -> Result<()> {
-    let status = command
-        .status()
+    let output = command
+        .output()
         .with_context(|| format!("failed to {description}"))?;
-    if !status.success() {
-        bail!("failed to {description}: {status}");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let details = stderr.trim();
+        if details.is_empty() {
+            bail!("failed to {description}: {}", output.status);
+        }
+        bail!("failed to {description}: {details}");
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- suppress successful `codesign` and installer command output
- preserve captured stderr in errors when a checked command fails

## Verification

- `cargo nextest run -p pcb-launcher`
- `cargo clippy -p pcb-launcher -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in install-time subprocess handling; improves diagnostics without touching auth or launch flows.
> 
> **Overview**
> Updates **`run_checked`** (macOS/Windows install paths such as `codesign`, `lsregister`, and `reg.exe`) to use **`Command::output()`** instead of **`status()`**, so successful signing and registration steps no longer print to the user’s terminal.
> 
> When a checked command fails, errors now include **trimmed stderr** when present, falling back to the exit status only if stderr is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614cb49e7b8bf9adcfc716d22b2533ed3221527f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->