### PR TITLE
Make DFM and LSP cache modes consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Use API-only generic matching with path-independent group caching and House/Extended provenance.
 - Add offline dependency resolution and BOM hydration to `pcb dfm`.
+- Refresh stale or missing BOM matches during LSP evaluation.
 - Better error handling in launcher.
 
 ## [0.4.38] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Use API-only generic matching with path-independent group caching and House/Extended provenance.
+- Add offline dependency resolution and BOM hydration to `pcb dfm`.
 - Better error handling in launcher.
 
 ## [0.4.38] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Use API-only generic matching with path-independent group caching and House/Extended provenance.
-- Add offline dependency resolution and BOM hydration to `pcb dfm`.
+- Add offline dependency resolution and BOM hydration to `pcb dfm` and `pcb lsp`.
 - Refresh stale or missing BOM matches during LSP evaluation.
 - Better error handling in launcher.
 

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -79,10 +79,11 @@ pub fn lsp_with_eager(eager: bool) -> anyhow::Result<()> {
     pcb_starlark_lsp::server::stdio_server(ctx).map_err(Into::into)
 }
 
-/// Start the LSP server with `eager`, a custom request handler, and a
-/// post-evaluation schematic hydrator.
+/// Start the LSP server with dependency resolution mode, a custom request
+/// handler, and a post-evaluation schematic hydrator.
 pub fn lsp_with_custom_request_handler<F, H>(
     eager: bool,
+    offline: bool,
     handler: F,
     hydrator: H,
 ) -> anyhow::Result<()>
@@ -95,6 +96,7 @@ where
 {
     let ctx = lsp::LspEvalContext::default()
         .set_eager(eager)
+        .set_offline(offline)
         .with_custom_request_handler(handler)
         .with_schematic_hydrator(hydrator);
     pcb_starlark_lsp::server::stdio_server(ctx).map_err(Into::into)

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -58,6 +58,7 @@ pub struct LspEvalContext {
     inner: EvalContext,
     builtin_docs: HashMap<LspUri, String>,
     file_provider: Arc<dyn FileProvider>,
+    offline: bool,
     resolution_cache: RwLock<HashMap<PathBuf, Arc<ResolutionResult>>>,
     workspace_root_cache: RwLock<HashMap<PathBuf, PathBuf>>,
     open_files: Arc<RwLock<HashMap<PathBuf, String>>>,
@@ -190,6 +191,7 @@ impl Default for LspEvalContext {
             inner,
             builtin_docs,
             file_provider,
+            offline: false,
             resolution_cache: RwLock::new(HashMap::new()),
             workspace_root_cache: RwLock::new(HashMap::new()),
             open_files,
@@ -202,6 +204,11 @@ impl Default for LspEvalContext {
 }
 
 impl LspEvalContext {
+    pub fn set_offline(mut self, offline: bool) -> Self {
+        self.offline = offline;
+        self
+    }
+
     fn diagnostic_target_uri(path: &str) -> Option<lsp_types::Uri> {
         if path.is_empty() {
             return None;
@@ -493,7 +500,7 @@ impl LspEvalContext {
         }
 
         let mut resolution = match crate::get_workspace_info(&self.file_provider, &workspace_root)
-            .and_then(|ws| crate::resolve_workspace_dependencies(ws, &workspace_root, false))
+            .and_then(|ws| crate::resolve_workspace_dependencies(ws, &workspace_root, self.offline))
         {
             Ok(resolution) => resolution,
             Err(err) => {

--- a/crates/pcbc/src/dfm.rs
+++ b/crates/pcbc/src/dfm.rs
@@ -16,12 +16,17 @@ pub struct DfmArgs {
     /// Built-in PDK name or fabrication PDK TOML path (built-ins: standard)
     #[arg(long)]
     pub pdk: PathBuf,
+
+    /// Disable network access (offline mode) - only use vendored dependencies
+    #[arg(long = "offline")]
+    pub offline: bool,
 }
 
 pub fn execute(args: DfmArgs) -> Result<()> {
     let layout_args = LayoutArgs {
         file: args.file.clone(),
         no_open: true,
+        offline: args.offline,
         ..Default::default()
     };
     let design = crate::layout::prepare_design(&layout_args)?;

--- a/crates/pcbc/src/lsp.rs
+++ b/crates/pcbc/src/lsp.rs
@@ -13,7 +13,7 @@ pub fn execute(_args: LspArgs) -> anyhow::Result<()> {
             pcb_diode_api::hydrate_schematic_from_bom(
                 source_path,
                 schematic,
-                pcb_diode_api::BomMatchMode::Offline,
+                pcb_diode_api::BomMatchMode::Online,
             );
         },
     )

--- a/crates/pcbc/src/lsp.rs
+++ b/crates/pcbc/src/lsp.rs
@@ -1,20 +1,27 @@
 use clap::Args;
 
 #[derive(Args)]
-pub struct LspArgs {}
+pub struct LspArgs {
+    /// Disable network access; use vendored dependencies and cached BOM matches
+    #[arg(long = "offline")]
+    pub offline: bool,
+}
 
 const RESOLVE_DATASHEET_METHOD: &str = "pcb/resolveDatasheet";
 
-pub fn execute(_args: LspArgs) -> anyhow::Result<()> {
+pub fn execute(args: LspArgs) -> anyhow::Result<()> {
+    let offline = args.offline;
+    let bom_match_mode = if args.offline {
+        pcb_diode_api::BomMatchMode::Offline
+    } else {
+        pcb_diode_api::BomMatchMode::Online
+    };
     pcb_zen::lsp_with_custom_request_handler(
         false,
-        handle_custom_request,
-        |source_path, schematic| {
-            pcb_diode_api::hydrate_schematic_from_bom(
-                source_path,
-                schematic,
-                pcb_diode_api::BomMatchMode::Online,
-            );
+        offline,
+        move |method, params| handle_custom_request(method, params, offline),
+        move |source_path, schematic| {
+            pcb_diode_api::hydrate_schematic_from_bom(source_path, schematic, bom_match_mode);
         },
     )
 }
@@ -22,9 +29,13 @@ pub fn execute(_args: LspArgs) -> anyhow::Result<()> {
 fn handle_custom_request(
     method: &str,
     params: &serde_json::Value,
+    offline: bool,
 ) -> anyhow::Result<Option<serde_json::Value>> {
     if method != RESOLVE_DATASHEET_METHOD {
         return Ok(None);
+    }
+    if offline {
+        anyhow::bail!("{RESOLVE_DATASHEET_METHOD} is unavailable in offline mode");
     }
 
     let input = pcb_diode_api::datasheet::parse_resolve_request(Some(params))?;
@@ -40,7 +51,7 @@ mod tests {
 
     #[test]
     fn custom_request_handler_ignores_other_methods() {
-        let result = handle_custom_request("pcb/somethingElse", &json!({})).unwrap();
+        let result = handle_custom_request("pcb/somethingElse", &json!({}), false).unwrap();
         assert!(result.is_none());
     }
 }


### PR DESCRIPTION
DFM could not run offline, and LSP could not refresh stale or missing BOM matches. Add `--offline` to `pcb dfm` and `pcb lsp`, use online write-through BOM hydration for LSP by default, and disable LSP network paths in offline mode.