### PR TITLE
Keep pcb build BOM hydration cache-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Use API-only generic matching with path-independent group caching and House/Extended provenance.
 - Add offline dependency resolution and BOM hydration to `pcb dfm` and `pcb lsp`.
 - Refresh stale or missing BOM matches during LSP evaluation.
+- Keep `pcb build` BOM hydration cache-only.
 - Better error handling in launcher.
 
 ## [0.4.38] - 2026-08-27

--- a/crates/pcbc/src/build.rs
+++ b/crates/pcbc/src/build.rs
@@ -434,12 +434,9 @@ pub fn execute(args: BuildArgs) -> Result<()> {
 
     let zen_files = build_input.collect_zen_files(&resolution.workspace_info)?;
 
-    let bom_match_mode = if args.offline {
-        pcb_diode_api::BomMatchMode::Offline
-    } else {
-        pcb_diode_api::BomMatchMode::Online
-    };
-    let eval_state = BuildEvalState::new(resolution).with_bom_hydration(bom_match_mode);
+    // Keep builds cache-only until backend TTL support makes refreshes cheap.
+    let eval_state =
+        BuildEvalState::new(resolution).with_bom_hydration(pcb_diode_api::BomMatchMode::Offline);
 
     // Process each .zen file
     let deny_warnings = args.deny.contains(&"warnings".to_string());


### PR DESCRIPTION
Backend TTL support is not ready, so `pcb build` must not refresh BOM matches. Keep build hydration cache-only while leaving online dependency resolution and all other commands unchanged.