### PR TITLE
Reject unknown pcb build config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Complete the E48 and E192 standard value tables used by `e48()` and `e192()`.
+- `pcb build --config` now rejects unknown root configuration keys.
 
 ## [0.4.40] - 2026-08-28
 

--- a/crates/pcb-zen-core/src/lang/eval.rs
+++ b/crates/pcb-zen-core/src/lang/eval.rs
@@ -1588,7 +1588,7 @@ impl EvalContext {
                         }
                     }
 
-                    let signature = extra
+                    let signature: Vec<ParameterInfo> = extra
                         .module
                         .signature()
                         .iter()
@@ -1626,6 +1626,22 @@ impl EvalContext {
                             }
                         })
                         .collect();
+
+                    let mut unknown_inputs: Vec<_> = self
+                        .json_inputs
+                        .keys()
+                        .filter(|name| !signature.iter().any(|param| param.name == **name))
+                        .cloned()
+                        .collect();
+                    unknown_inputs.sort();
+                    if !unknown_inputs.is_empty() {
+                        diagnostics.push(Diagnostic::new(
+                            format!("Unknown root input(s): {}", unknown_inputs.join(", ")),
+                            EvalSeverity::Error,
+                            source_path,
+                        ));
+                    }
+
                     // Process pending children after parent is frozen
                     let module_path = extra.module.path().clone();
                     let is_root = module_path.segments.is_empty();

--- a/crates/pcbc/tests/build.rs
+++ b/crates/pcbc/tests/build.rs
@@ -395,6 +395,23 @@ fn test_build_with_config_overrides() {
 }
 
 #[test]
+fn test_build_rejects_unknown_config_override() {
+    let output = Sandbox::new()
+        .with_workspace()
+        .write("board.zen", CONFIGURABLE_BUILD_ZEN)
+        .snapshot_run(
+            "pcbc",
+            ["build", "--config", "frequency=100MHz", "board.zen"],
+        );
+
+    assert!(output.contains("Exit Code: 1"), "{output}");
+    assert!(
+        output.contains("Unknown root input(s): frequency"),
+        "{output}"
+    );
+}
+
+#[test]
 fn test_diodes_build() {
     let output = Sandbox::new()
         .with_workspace()


### PR DESCRIPTION
Reject unknown root inputs after evaluation so `pcb build --config` fails when a key does not match the module signature. This prevents removed or misspelled configuration keys from producing successful builds and adds a regression test for ENG-1102.