### PR TITLE
Handle closed CLI output pipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,13 +38,8 @@ Never run `cargo insta accept` without explicit user approval.
 - Keep Git history linear: before pushing, fetch and rebase local commits onto `origin/main`, then fast-forward push; never create merge commits.
 - In `.zen` files, remember Zener is Starlark-based, not Python: do not use f-strings.
 - Language behavior may come from the pinned `diodeinc/starlark-rust` fork in `Cargo.toml`; check that fork when local code does not explain Starlark behavior.
-
-## CLI Output
-
-- Use `anstream`'s `print!`, `println!`, `eprint!`, and `eprintln!` replacements for incidental CLI text so a closed output pipe does not panic.
-- For primary, structured, protocol, or binary stdout (such as JSON, CSV, tables, XML, and images), keep renderers fallible over `std::io::Write` and call them through `pcb_ui::write_stdout` at the CLI boundary. It treats only `BrokenPipe` as successful termination and preserves other I/O errors.
-- Do not add a process-wide `BrokenPipe` catch or custom printer wrapper; PCB also uses unrelated child-process and network pipes whose failures must remain visible.
-- Gate `anstream`, `pcb-ui`, and their macro imports behind the CLI feature in crates that also support non-CLI or WASM builds.
+- Use `anstream` macros for incidental CLI output; for primary structured or binary stdout, keep renderers fallible over `std::io::Write` and call them through `pcb_ui::write_stdout` so only `BrokenPipe` is ignored.
+- Do not catch `BrokenPipe` process-wide, and gate CLI output dependencies and imports in crates that also support non-CLI or WASM builds.
 
 ## Documentation Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,13 @@ Never run `cargo insta accept` without explicit user approval.
 - In `.zen` files, remember Zener is Starlark-based, not Python: do not use f-strings.
 - Language behavior may come from the pinned `diodeinc/starlark-rust` fork in `Cargo.toml`; check that fork when local code does not explain Starlark behavior.
 
+## CLI Output
+
+- Use `anstream`'s `print!`, `println!`, `eprint!`, and `eprintln!` replacements for incidental CLI text so a closed output pipe does not panic.
+- For primary, structured, protocol, or binary stdout (such as JSON, CSV, tables, XML, and images), keep renderers fallible over `std::io::Write` and call them through `pcb_ui::write_stdout` at the CLI boundary. It treats only `BrokenPipe` as successful termination and preserves other I/O errors.
+- Do not add a process-wide `BrokenPipe` catch or custom printer wrapper; PCB also uses unrelated child-process and network pipes whose failures must remain visible.
+- Gate `anstream`, `pcb-ui`, and their macro imports behind the CLI feature in crates that also support non-CLI or WASM builds.
+
 ## Documentation Rules
 
 - For user-visible changes, add one succinct `CHANGELOG.md` entry under `Unreleased` per logical change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Require external power IOs to have a net symbol or hierarchical label.
 - Complete the E48 and E192 standard value tables used by `e48()` and `e192()`.
 - `pcb build --config` now rejects unknown root configuration keys.
+- PCB commands now exit cleanly when an output pipe closes early.
 
 ## [0.4.40] - 2026-08-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,6 +4055,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 name = "pcb"
 version = "0.2.7"
 dependencies = [
+ "anstream",
  "anyhow",
  "clap",
  "dirs",
@@ -4109,6 +4110,7 @@ dependencies = [
 name = "pcb-diode-api"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "arboard",
  "atomicwrites",
@@ -4172,6 +4174,7 @@ dependencies = [
 name = "pcb-docgen"
 version = "0.1.0"
 dependencies = [
+ "anstream",
  "anyhow",
  "pcb-zen",
  "pcb-zen-core",
@@ -4184,6 +4187,7 @@ dependencies = [
 name = "pcb-eda"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "pcb-sexpr",
  "regex",
@@ -4211,6 +4215,7 @@ version = "0.1.0"
 name = "pcb-interposer"
 version = "0.1.0"
 dependencies = [
+ "anstream",
  "anyhow",
  "ipc2581",
  "pcb-ir",
@@ -4244,6 +4249,7 @@ dependencies = [
 name = "pcb-ipc2581-tools"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "chrono",
  "clap",
@@ -4327,6 +4333,7 @@ dependencies = [
 name = "pcb-launcher"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "dirs",
  "objc2",
@@ -4366,6 +4373,7 @@ dependencies = [
 name = "pcb-native-dialog"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
 ]
 
@@ -4425,6 +4433,7 @@ dependencies = [
 name = "pcb-starlark-lsp"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "derivative",
  "derive_more 2.1.1",
@@ -4465,6 +4474,7 @@ dependencies = [
 name = "pcb-ui"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "colored",
  "indicatif",
@@ -4476,6 +4486,7 @@ dependencies = [
 name = "pcb-zen"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "ariadne",
  "dirs",
@@ -4519,6 +4530,7 @@ name = "pcb-zen-core"
 version = "0.4.40"
 dependencies = [
  "allocative",
+ "anstream",
  "anyhow",
  "ariadne",
  "dirs",
@@ -4574,6 +4586,7 @@ dependencies = [
 name = "pcbc"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "atomicwrites",
  "base64 0.23.0",
@@ -5355,6 +5368,7 @@ dependencies = [
 name = "rectify"
 version = "0.4.40"
 dependencies = [
+ "anstream",
  "anyhow",
  "base64 0.23.0",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ pcb-ipc2581-tools = { path = "crates/pcb-ipc2581-tools", default-features = fals
 pcb-docgen = { path = "crates/pcb-docgen" }
 
 anyhow = "1.0"
+anstream = "1.0"
 atomicwrites = "0.4"
 arboard = { version = "3.6", default-features = false }
 ariadne = { version = "0.6", features = ["auto-color"] }

--- a/crates/pcb-diode-api/Cargo.toml
+++ b/crates/pcb-diode-api/Cargo.toml
@@ -12,6 +12,7 @@ tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }
 atomicwrites = { workspace = true }
 arboard = { workspace = true }
 base64 = { workspace = true }

--- a/crates/pcb-diode-api/src/component_api.rs
+++ b/crates/pcb-diode-api/src/component_api.rs
@@ -348,7 +348,7 @@ fn output_component_response<T: for<'de> Deserialize<'de>>(
     print_pretty: impl FnOnce(&T),
 ) -> Result<()> {
     if matches!(format, ComponentOutputFormat::Json) {
-        write_component_json_response(&mut io::stdout(), &response.body)?;
+        pcb_ui::write_stdout(|stdout| write_component_json_response(stdout, &response.body))?;
         if response.status.is_success() {
             return Ok(());
         }
@@ -368,7 +368,7 @@ fn output_component_response<T: for<'de> Deserialize<'de>>(
     Ok(())
 }
 
-fn write_component_json_response(writer: &mut impl Write, body: &str) -> io::Result<()> {
+fn write_component_json_response(writer: &mut (impl Write + ?Sized), body: &str) -> io::Result<()> {
     writer.write_all(body.as_bytes())?;
     writer.flush()
 }

--- a/crates/pcb-diode-api/src/git_auth.rs
+++ b/crates/pcb-diode-api/src/git_auth.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use url::Url;
 
@@ -74,7 +74,6 @@ struct MintedGitCredential {
 
 pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
     let stdin = io::stdin();
-    let mut stdout = io::stdout().lock();
 
     match args.operation.as_str() {
         "configure" => {
@@ -85,17 +84,20 @@ pub fn execute(args: GitAuthArgs, ctx: &WorkspaceContext) -> Result<()> {
         }
         "unconfigure" => pcb_zen::git::unconfigure_diodehub_credentials_globally()?,
         "capability" => {
-            writeln!(stdout, "version 0")?;
-            writeln!(stdout, "capability {AUTHTYPE_CAPABILITY}")?;
+            pcb_ui::write_stdout(|stdout| {
+                writeln!(stdout, "version 0")?;
+                writeln!(stdout, "capability {AUTHTYPE_CAPABILITY}")
+            })?;
         }
         "get" => {
             let host = args.host.as_deref().unwrap_or(DEFAULT_DIODEHUB_HOST);
             let result = read_credential_request(stdin.lock())
-                .and_then(|request| provide_credential(ctx, host, request, &mut stdout));
+                .and_then(|request| provide_credential(ctx, host, request));
             if let Err(error) = result {
-                writeln!(stdout, "quit=true")?;
-                writeln!(stdout)?;
-                stdout.flush()?;
+                pcb_ui::write_stdout(|stdout| {
+                    writeln!(stdout, "quit=true")?;
+                    writeln!(stdout)
+                })?;
                 eprintln!("pcb auth git: {error:#}");
             }
         }
@@ -112,7 +114,6 @@ fn provide_credential(
     ctx: &WorkspaceContext,
     configured_host: &str,
     request: CredentialRequest,
-    output: &mut impl Write,
 ) -> Result<()> {
     if request.protocol.as_deref() != Some(b"https") {
         return Ok(());
@@ -139,12 +140,13 @@ fn provide_credential(
     let path = std::str::from_utf8(path).context("Git credential path is not UTF-8")?;
     let credential = exchange_credential(ctx, configured_host, path)?;
 
-    writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
-    writeln!(output, "authtype=Bearer")?;
-    writeln!(output, "credential={}", credential.token)?;
-    writeln!(output, "password_expiry_utc={}", credential.expires_at)?;
-    writeln!(output)?;
-    output.flush()?;
+    pcb_ui::write_stdout(|output| {
+        writeln!(output, "capability[]={AUTHTYPE_CAPABILITY}")?;
+        writeln!(output, "authtype=Bearer")?;
+        writeln!(output, "credential={}", credential.token)?;
+        writeln!(output, "password_expiry_utc={}", credential.expires_at)?;
+        writeln!(output)
+    })?;
 
     Ok(())
 }

--- a/crates/pcb-diode-api/src/lib.rs
+++ b/crates/pcb-diode-api/src/lib.rs
@@ -1,3 +1,7 @@
+// Use pipe-safe replacements for the standard printing macros in CLI command modules.
+#[macro_use(println, eprint, eprintln)]
+extern crate anstream;
+
 use anyhow::{Context, Result};
 use rusqlite::auto_extension::{RawAutoExtension, register_auto_extension};
 

--- a/crates/pcb-docgen/Cargo.toml
+++ b/crates/pcb-docgen/Cargo.toml
@@ -6,6 +6,7 @@ description = "Generate documentation from Zener source files"
 
 [dependencies]
 anyhow = "1"
+anstream = { workspace = true }
 pcb-zen = { path = "../pcb-zen" }
 pcb-zen-core = { path = "../pcb-zen-core" }
 starlark = { workspace = true }

--- a/crates/pcb-docgen/src/lib.rs
+++ b/crates/pcb-docgen/src/lib.rs
@@ -3,6 +3,10 @@
 //! This crate parses `.zen` files from a package directory, extracts docstrings
 //! and module signatures, and generates markdown documentation.
 
+// Use pipe-safe replacements for standard printing macros in CLI output paths.
+#[macro_use(eprintln)]
+extern crate anstream;
+
 mod parser;
 mod render;
 mod signature;

--- a/crates/pcb-eda/Cargo.toml
+++ b/crates/pcb-eda/Cargo.toml
@@ -9,6 +9,7 @@ description = "EDA tool integration for PCB design"
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }
 serde = { workspace = true }
 pcb-sexpr = { workspace = true }
 tracing = { workspace = true }

--- a/crates/pcb-eda/src/lib.rs
+++ b/crates/pcb-eda/src/lib.rs
@@ -1,3 +1,7 @@
+// Use pipe-safe replacements for standard printing macros in CLI output paths.
+#[macro_use(eprintln)]
+extern crate anstream;
+
 pub mod kicad;
 
 use anyhow::Result;

--- a/crates/pcb-interposer/Cargo.toml
+++ b/crates/pcb-interposer/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }
 ipc2581 = { workspace = true }
 pcb-ir = { workspace = true }
 pcb-kicad = { workspace = true }

--- a/crates/pcb-interposer/src/lib.rs
+++ b/crates/pcb-interposer/src/lib.rs
@@ -14,6 +14,10 @@
 //! full-sheet GND pours. Pogo placement and routing are later,
 //! panel-specific passes.
 
+// Use pipe-safe replacements for standard printing macros in CLI output paths.
+#[macro_use(eprintln)]
+extern crate anstream;
+
 pub mod contacts;
 pub mod emit;
 pub mod panel;

--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 [features]
 default = ["cli"]
 cli = [
+    "dep:anstream",
     "dep:clap",
     "dep:colored",
     "dep:comfy-table",
@@ -23,6 +24,7 @@ cli = [
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true, optional = true }
 chrono = { workspace = true }
 clap = { workspace = true, optional = true }
 colored = { workspace = true, optional = true }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -1,7 +1,5 @@
 use std::collections::HashSet;
 #[cfg(feature = "cli")]
-use std::io::{self, Write};
-#[cfg(feature = "cli")]
 use std::path::Path;
 
 use super::board_array_auto::{
@@ -446,7 +444,7 @@ fn print_copper_balance_summary(report: Option<&CopperBalanceReport>) {
 #[cfg(feature = "cli")]
 fn write_board_array_output(output: &Path, content: &str) -> Result<()> {
     if output.as_os_str() == "-" {
-        io::stdout().lock().write_all(content.as_bytes())?;
+        pcb_ui::write_stdout(|stdout| stdout.write_all(content.as_bytes()))?;
         eprintln!("✓ Created IPC-2581 board array on stdout");
     } else {
         file_utils::save_ipc_file(output, content)?;

--- a/crates/pcb-ipc2581-tools/src/commands/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/bom.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "cli")]
 use std::collections::HashMap;
 #[cfg(feature = "cli")]
-use std::io::{self, Write};
-#[cfg(feature = "cli")]
 use std::path::Path;
 
 #[cfg(feature = "cli")]
@@ -79,15 +77,12 @@ pub fn execute(file: &Path, format: OutputFormat, offline: bool) -> Result<()> {
         spinner.finish();
     }
 
-    let mut writer = io::stdout().lock();
-    match format {
+    pcb_ui::write_stdout(|writer| match format {
         OutputFormat::Json => {
-            write!(writer, "{}", bom.ungrouped_json())?;
+            write!(writer, "{}", bom.ungrouped_json())
         }
-        OutputFormat::Text => {
-            bom.write_table(writer)?;
-        }
-    };
+        OutputFormat::Text => bom.write_table(writer),
+    })?;
 
     Ok(())
 }

--- a/crates/pcb-ipc2581-tools/src/commands/cpl.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/cpl.rs
@@ -2,8 +2,6 @@ use std::cmp::Ordering;
 #[cfg(feature = "cli")]
 use std::fs;
 #[cfg(feature = "cli")]
-use std::io::{self, Write};
-#[cfg(feature = "cli")]
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -45,7 +43,7 @@ pub fn execute(file: &Path, options: &CplOptions) -> Result<()> {
     if let Some(output) = &options.output {
         fs::write(output, cpl)?;
     } else {
-        io::stdout().write_all(cpl.as_bytes())?;
+        pcb_ui::write_stdout(|stdout| stdout.write_all(cpl.as_bytes()))?;
     }
 
     Ok(())

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -411,9 +411,7 @@ fn write_report(options: &CheckOptions, report: &impl Serialize) -> Result<()> {
                 .with_context(|| format!("failed to replace DFM report {}", path.display()))?;
             Ok(())
         }
-        None => std::io::stdout()
-            .lock()
-            .write_all(&bytes)
+        None => pcb_ui::write_stdout(|stdout| stdout.write_all(&bytes))
             .context("failed to write DFM report to stdout"),
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -2,8 +2,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 #[cfg(feature = "cli")]
-use std::io::{self, Write};
-#[cfg(feature = "cli")]
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -259,7 +257,7 @@ pub fn execute(
         }
     }
     if output.as_os_str() == "-" {
-        io::stdout().lock().write_all(creation.xml.as_bytes())?;
+        pcb_ui::write_stdout(|stdout| stdout.write_all(creation.xml.as_bytes()))?;
         eprintln!("✓ Created IPC-2581 fabrication panel on stdout");
     } else {
         file_utils::save_ipc_file(output, &creation.xml)?;

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -12,8 +12,6 @@ use std::collections::BTreeMap;
 #[cfg(feature = "cli")]
 use std::fs;
 #[cfg(feature = "cli")]
-use std::io::{self, Write};
-#[cfg(feature = "cli")]
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -56,7 +54,7 @@ pub fn execute(file: &Path, options: &IctOptions) -> Result<()> {
     if let Some(output) = &options.output {
         fs::write(output, csv)?;
     } else {
-        io::stdout().write_all(csv.as_bytes())?;
+        pcb_ui::write_stdout(|stdout| stdout.write_all(csv.as_bytes()))?;
     }
 
     Ok(())

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -123,9 +122,7 @@ fn render_png(
             output.display()
         );
     } else {
-        std::io::stdout()
-            .lock()
-            .write_all(&png)
+        pcb_ui::write_stdout(|stdout| stdout.write_all(&png))
             .context("Failed to write PNG to stdout")?;
     }
 

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -1,3 +1,8 @@
+// Use pipe-safe replacements for standard printing macros in CLI output paths.
+#[cfg(feature = "cli")]
+#[macro_use(print, println, eprintln)]
+extern crate anstream;
+
 use ipc2581::Mode;
 
 pub mod accessors;

--- a/crates/pcb-launcher/Cargo.toml
+++ b/crates/pcb-launcher/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }
 dirs = { workspace = true }
 pcb-diode-uri = { workspace = true }
 pcb-native-dialog = { workspace = true }

--- a/crates/pcb-launcher/src/main.rs
+++ b/crates/pcb-launcher/src/main.rs
@@ -1,5 +1,9 @@
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
+// Use pipe-safe replacements for the standard printing macros throughout the launcher.
+#[macro_use(eprintln)]
+extern crate anstream;
+
 use anyhow::{Context, Result, bail};
 use pcb_diode_uri::{SandboxFileUri, is_trusted_api_host};
 use std::fs::{self, File, OpenOptions};

--- a/crates/pcb-native-dialog/Cargo.toml
+++ b/crates/pcb-native-dialog/Cargo.toml
@@ -9,3 +9,4 @@ authors = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }

--- a/crates/pcb-native-dialog/src/lib.rs
+++ b/crates/pcb-native-dialog/src/lib.rs
@@ -378,7 +378,7 @@ mod platform {
     }
 
     pub fn show_error(title: &str, message: &str) {
-        eprintln!("{title}: {message}");
+        anstream::eprintln!("{title}: {message}");
     }
 }
 

--- a/crates/pcb-starlark-lsp/Cargo.toml
+++ b/crates/pcb-starlark-lsp/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }
 derivative = { workspace = true }
 dupe = { workspace = true }
 derive_more = { workspace = true }

--- a/crates/pcb-starlark-lsp/src/lib.rs
+++ b/crates/pcb-starlark-lsp/src/lib.rs
@@ -18,6 +18,10 @@
 //! The server that allows IDEs to evaluate and interpret starlark code according
 //! to the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/).
 
+// Use pipe-safe replacements for standard printing macros in CLI output paths.
+#[macro_use(eprintln)]
+extern crate anstream;
+
 // Lints that don't necessarily make sense
 #[allow(clippy::needless_lifetimes)]
 #[allow(clippy::type_complexity)]

--- a/crates/pcb-ui/Cargo.toml
+++ b/crates/pcb-ui/Cargo.toml
@@ -9,6 +9,7 @@ description = "Consistent UI components for Diode PCB tools"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+anstream = { workspace = true }
 indicatif = { workspace = true }
 colored = { workspace = true }
 terminal_size = { workspace = true }

--- a/crates/pcb-ui/src/lib.rs
+++ b/crates/pcb-ui/src/lib.rs
@@ -23,7 +23,7 @@ pub use progress::{ProgressBar, ProgressBarBuilder};
 pub use spinner::{Spinner, SpinnerBuilder};
 pub use style::{Style, StyledText, icons};
 pub use terminal::{
-    Alignment, TerminalSize, clear_line, get_terminal_size, pad_text, truncate_text,
+    Alignment, TerminalSize, clear_line, get_terminal_size, pad_text, truncate_text, write_stdout,
 };
 
 // Re-export commonly used items from dependencies

--- a/crates/pcb-ui/src/terminal.rs
+++ b/crates/pcb-ui/src/terminal.rs
@@ -1,3 +1,5 @@
+use std::io::{self, Write};
+
 use terminal_size::terminal_size as get_size;
 use unicode_width::UnicodeWidthChar;
 
@@ -35,7 +37,24 @@ pub fn get_terminal_size() -> Option<TerminalSize> {
 
 /// Clear the current line
 pub fn clear_line() {
-    print!("\r\x1b[K");
+    anstream::print!("\r\x1b[K");
+}
+
+/// Write primary command output to stdout.
+///
+/// A downstream consumer closing the pipe is normal termination; all other
+/// write and flush errors are returned to the caller.
+pub fn write_stdout(write: impl FnOnce(&mut dyn Write) -> io::Result<()>) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    ignore_broken_pipe(write(&mut stdout).and_then(|()| stdout.flush()))
+}
+
+fn ignore_broken_pipe(result: io::Result<()>) -> io::Result<()> {
+    match result {
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        result => result,
+    }
 }
 
 /// Calculate the display width of a string, accounting for Unicode characters
@@ -104,6 +123,17 @@ pub enum Alignment {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ignores_broken_pipe() {
+        assert!(ignore_broken_pipe(Err(io::ErrorKind::BrokenPipe.into())).is_ok());
+    }
+
+    #[test]
+    fn preserves_other_output_errors() {
+        let result = ignore_broken_pipe(Err(io::ErrorKind::WriteZero.into()));
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::WriteZero);
+    }
 
     #[test]
     fn test_text_width() {

--- a/crates/pcb-zen-core/Cargo.toml
+++ b/crates/pcb-zen-core/Cargo.toml
@@ -24,6 +24,7 @@ table = ["pcb-sch/table"]
 
 [dependencies]
 allocative = { workspace = true }
+anstream = { workspace = true }
 pagable = { workspace = true }
 
 starlark = { workspace = true }

--- a/crates/pcb-zen-core/src/lib.rs
+++ b/crates/pcb-zen-core/src/lib.rs
@@ -1,3 +1,7 @@
+// Use pipe-safe replacements for standard printing macros in CLI output paths.
+#[macro_use(eprintln)]
+extern crate anstream;
+
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},

--- a/crates/pcb-zen/Cargo.toml
+++ b/crates/pcb-zen/Cargo.toml
@@ -17,6 +17,7 @@ name = "integration"
 path = "tests/integration.rs"
 
 [dependencies]
+anstream = { workspace = true }
 starlark = { workspace = true }
 pcb-starlark-lsp = { workspace = true }
 starlark_syntax = { workspace = true }

--- a/crates/pcb-zen/src/lib.rs
+++ b/crates/pcb-zen/src/lib.rs
@@ -1,3 +1,7 @@
+// Use pipe-safe replacements for standard printing macros in CLI output paths.
+#[macro_use(eprintln)]
+extern crate anstream;
+
 pub mod ast_utils;
 pub mod cache_index;
 pub mod diagnostics;

--- a/crates/pcb-zen/src/tree.rs
+++ b/crates/pcb-zen/src/tree.rs
@@ -46,6 +46,5 @@ where
     F: FnMut(&Id) -> (String, Vec<Id>),
 {
     let tree = build_tree(root_label, roots, visit);
-    print!("{}", tree);
-    Ok(())
+    pcb_ui::write_stdout(|stdout| write!(stdout, "{tree}"))
 }

--- a/crates/pcb/Cargo.toml
+++ b/crates/pcb/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }
 clap = { workspace = true }
 dirs = { workspace = true }
 fslock = { workspace = true }

--- a/crates/pcb/src/main.rs
+++ b/crates/pcb/src/main.rs
@@ -1,3 +1,7 @@
+// Use pipe-safe replacements for the standard printing macros throughout the CLI.
+#[macro_use(println, eprintln)]
+extern crate anstream;
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use semver::Version;

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -23,6 +23,7 @@ path = "tests/integration.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }
 atomicwrites = { workspace = true }
 clap = { workspace = true }
 glam = { workspace = true }

--- a/crates/pcbc/src/bom.rs
+++ b/crates/pcbc/src/bom.rs
@@ -1,4 +1,3 @@
-use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use crate::build::create_diagnostics_passes;
@@ -146,11 +145,10 @@ pub fn execute(args: BomArgs) -> Result<()> {
     }
     spinner.finish();
 
-    let mut writer = io::stdout().lock();
-    match args.format {
-        BomFormat::Json => write!(writer, "{}", bom.ungrouped_json())?,
-        BomFormat::Table => bom.write_table(writer)?,
-    };
+    pcb_ui::write_stdout(|writer| match args.format {
+        BomFormat::Json => write!(writer, "{}", bom.ungrouped_json()),
+        BomFormat::Table => bom.write_table(writer),
+    })?;
 
     Ok(())
 }

--- a/crates/pcbc/src/gerber.rs
+++ b/crates/pcbc/src/gerber.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -205,9 +204,7 @@ fn render(file: &Path, output: Option<&Path>, format: RenderFormat) -> Result<()
                     .with_context(|| format!("Failed to write PNG to {}", output.display()))?;
                 println!("✓ Gerber layer rendered to {}", output.display());
             } else {
-                std::io::stdout()
-                    .lock()
-                    .write_all(&png)
+                pcb_ui::write_stdout(|stdout| stdout.write_all(&png))
                     .context("Failed to write PNG to stdout")?;
             }
         }

--- a/crates/pcbc/src/info.rs
+++ b/crates/pcbc/src/info.rs
@@ -9,6 +9,7 @@ use pcb_zen_core::resolution::ResolutionResult;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::env;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 #[derive(Args, Debug)]
@@ -94,11 +95,14 @@ pub fn execute(args: InfoArgs) -> Result<()> {
     match args.format {
         OutputFormat::Human => {
             let external_dependencies = external_dependencies(&workspace_info, &resolution)?;
-            print_human_readable(&workspace_info, &external_dependencies);
+            pcb_ui::write_stdout(|stdout| {
+                print_human_readable(stdout, &workspace_info, &external_dependencies)
+            })?;
         }
         OutputFormat::Json => {
             populate_package_file_discovery(&mut workspace_info)?;
-            print_json(&info_json(&workspace_info, &resolution)?)?;
+            let json = serde_json::to_string_pretty(&info_json(&workspace_info, &resolution)?)?;
+            pcb_ui::write_stdout(|stdout| writeln!(stdout, "{json}"))?;
         }
     }
 
@@ -308,21 +312,22 @@ fn discover_package_files(package_dir: &Path) -> Result<(Vec<PathBuf>, Vec<Symbo
 }
 
 fn print_human_readable(
+    writer: &mut (impl Write + ?Sized),
     ws: &WorkspaceInfo,
     external_dependencies: &BTreeMap<String, PackageMetadata>,
-) {
+) -> io::Result<()> {
     // Header
-    println!("{}", "Workspace".with_style(Style::Blue).bold());
-    println!("Root: {}", ws.root.display());
+    writeln!(writer, "{}", "Workspace".with_style(Style::Blue).bold())?;
+    writeln!(writer, "Root: {}", ws.root.display())?;
 
     if let Some(repo) = ws.repository() {
-        println!("Repository: {}", repo.with_style(Style::Cyan));
+        writeln!(writer, "Repository: {}", repo.with_style(Style::Cyan))?;
     }
     if let Some(pcb_version) = ws.pcb_version() {
-        println!("Toolchain: pcb >= {}", pcb_version);
+        writeln!(writer, "Toolchain: pcb >= {}", pcb_version)?;
     }
 
-    println!();
+    writeln!(writer)?;
 
     // Separate boards from other packages
     let all_packages = ws.all_packages();
@@ -336,13 +341,14 @@ fn print_human_readable(
 
     // Boards section (like V1)
     if boards.is_empty() {
-        println!("No boards discovered");
+        writeln!(writer, "No boards discovered")?;
     } else {
-        println!(
+        writeln!(
+            writer,
             "{} ({})",
             "Boards".with_style(Style::Blue).bold(),
             boards.len()
-        );
+        )?;
 
         for pkg in &boards {
             if let Some(board) = &pkg.config.board {
@@ -364,10 +370,16 @@ fn print_human_readable(
                 // Use package version (which is board version for board packages)
                 let version_str = format_version(&pkg.version, false);
 
-                println!("  {} {} - {}", board.name.bold(), version_str, zen_path);
+                writeln!(
+                    writer,
+                    "  {} {} - {}",
+                    board.name.bold(),
+                    version_str,
+                    zen_path
+                )?;
 
                 if !board.description.is_empty() {
-                    println!("    {}", board.description);
+                    writeln!(writer, "    {}", board.description)?;
                 }
             }
         }
@@ -375,33 +387,40 @@ fn print_human_readable(
 
     // Packages section (non-boards)
     if !other_packages.is_empty() {
-        println!();
-        println!(
+        writeln!(writer)?;
+        writeln!(
+            writer,
             "{} ({})",
             "Packages".with_style(Style::Blue).bold(),
             other_packages.len()
-        );
+        )?;
 
         for pkg in &other_packages {
-            print_package_line(pkg);
+            print_package_line(writer, pkg)?;
         }
     }
 
     if !external_dependencies.is_empty() {
-        println!();
-        println!(
+        writeln!(writer)?;
+        writeln!(
+            writer,
             "{} ({})",
             "External dependencies".with_style(Style::Blue).bold(),
             external_dependencies.len()
-        );
+        )?;
 
         for (coord, dep) in external_dependencies {
-            print_external_dependency_line(coord, dep);
+            print_external_dependency_line(writer, coord, dep)?;
         }
     }
+
+    Ok(())
 }
 
-fn print_package_line(pkg: &WorkspacePackage) {
+fn print_package_line(
+    writer: &mut (impl Write + ?Sized),
+    pkg: &WorkspacePackage,
+) -> io::Result<()> {
     let is_root = pkg.rel_path.as_os_str().is_empty();
 
     // Package name (last segment of relative path, or "root")
@@ -446,29 +465,35 @@ fn print_package_line(pkg: &WorkspacePackage) {
         format!(" {}", rel_path.dimmed())
     };
 
-    println!(
+    writeln!(
+        writer,
         "  {} {}{}{}{}",
         name.bold(),
         version_str,
         root_str,
         path_str,
         extras_str
-    );
+    )
 }
 
-fn print_external_dependency_line(coord: &str, dep: &PackageMetadata) {
+fn print_external_dependency_line(
+    writer: &mut (impl Write + ?Sized),
+    coord: &str,
+    dep: &PackageMetadata,
+) -> io::Result<()> {
     let module_path = coord.rsplit_once('@').map_or(coord, |(path, _)| path);
     let version = dep.version.as_deref().unwrap_or("unknown");
     let source = dep.source.as_str();
     let path = dep.rel_path.to_string_lossy();
 
-    println!(
+    writeln!(
+        writer,
         "  {} {} {} {}",
         module_path.bold(),
         format!("(v{version})").green(),
         format!("[{source}]").dimmed(),
         path.dimmed()
-    );
+    )
 }
 
 impl PackageSource {
@@ -481,12 +506,6 @@ impl PackageSource {
             PackageSource::Other => "other",
         }
     }
-}
-
-fn print_json<T: Serialize>(info: &T) -> Result<()> {
-    let json = serde_json::to_string_pretty(info)?;
-    println!("{json}");
-    Ok(())
 }
 
 /// Format version string with dirty indicator

--- a/crates/pcbc/src/main.rs
+++ b/crates/pcbc/src/main.rs
@@ -2,6 +2,10 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+// Use pipe-safe replacements for the standard printing macros throughout the CLI.
+#[macro_use(print, println, eprint, eprintln)]
+extern crate anstream;
+
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use env_logger::Env;

--- a/crates/pcbc/src/sim.rs
+++ b/crates/pcbc/src/sim.rs
@@ -108,7 +108,7 @@ fn simulate_one(
 
     // --netlist: print to stdout and return (skip ngspice)
     if args.netlist {
-        std::io::stdout().write_all(&buf)?;
+        pcb_ui::write_stdout(|stdout| stdout.write_all(&buf))?;
         return Ok(true);
     }
 

--- a/crates/pcbc/tests/broken_pipe.rs
+++ b/crates/pcbc/tests/broken_pipe.rs
@@ -1,0 +1,33 @@
+#![cfg(not(target_os = "windows"))]
+
+use pcb_test_utils::sandbox::Sandbox;
+
+#[test]
+fn print_macros_exit_cleanly_when_output_pipe_closes() {
+    let source = (0..20_000)
+        .map(|index| format!("value_{index}=[1,2,3]\n"))
+        .collect::<String>();
+    let mut sandbox = Sandbox::new();
+    sandbox.write("large.zen", source);
+
+    let command = format!(
+        "\"{}\" fmt --diff large.zen | head -n 1 >/dev/null",
+        env!("CARGO_BIN_EXE_pcbc")
+    );
+    let output = sandbox
+        .cmd("bash", ["-o", "pipefail", "-c", &command])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .expect("run pcb fmt through head");
+
+    assert!(
+        output.status.success(),
+        "pcb fmt failed after its output pipe closed: {output:?}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("panicked"),
+        "pcb fmt panicked after its output pipe closed: {output:?}"
+    );
+}

--- a/crates/pcbc/tests/info.rs
+++ b/crates/pcbc/tests/info.rs
@@ -58,6 +58,39 @@ fn test_pcb_info_empty_workspace() {
 }
 
 #[test]
+fn test_pcb_info_exits_cleanly_when_output_pipe_closes() {
+    let mut sandbox = Sandbox::new();
+    let board_manifest = format!(
+        "[board]\nname = \"LargeBoard\"\npath = \"board.zen\"\ndescription = \"{}\"\n",
+        "x".repeat(2 * 1024 * 1024)
+    );
+    sandbox
+        .write("pcb.toml", WORKSPACE_PCB_TOML)
+        .write("boards/large/pcb.toml", board_manifest);
+
+    let command = format!(
+        "\"{}\" info | head -n 1 >/dev/null",
+        env!("CARGO_BIN_EXE_pcbc")
+    );
+    let output = sandbox
+        .cmd("bash", ["-o", "pipefail", "-c", &command])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .expect("run pcb info through head");
+
+    assert!(
+        output.status.success(),
+        "pcb info failed after its output pipe closed: {output:?}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("panicked"),
+        "pcb info panicked after its output pipe closed: {output:?}"
+    );
+}
+
+#[test]
 fn test_pcb_info_single_board() {
     let output = Sandbox::new()
         .write("pcb.toml", WORKSPACE_PCB_TOML)

--- a/crates/pcbc/tests/integration.rs
+++ b/crates/pcbc/tests/integration.rs
@@ -1,6 +1,7 @@
 mod apply;
 mod auth_git;
 mod bom;
+mod broken_pipe;
 mod build;
 mod dfm;
 mod doc;

--- a/crates/rectify/Cargo.toml
+++ b/crates/rectify/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+anstream = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
 serde = { workspace = true }

--- a/crates/rectify/src/main.rs
+++ b/crates/rectify/src/main.rs
@@ -1,6 +1,10 @@
 //! `pcb rectify` — infer and patch KiCad footprint 3D model rotate/offset from
 //! STEP geometry. Rust port of `research/pose3d/solver.py`.
 
+// Use pipe-safe replacements for the standard printing macros throughout the CLI.
+#[macro_use(println, eprintln)]
+extern crate anstream;
+
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Summary

- use pipe-safe `anstream` print macros across PCB's CLI-facing crates
- route structured, binary, and protocol output through a fallible stdout writer that treats only `BrokenPipe` as normal termination
- add regressions for `pcb info` and macro-based output piped through `head`

Linear: ENG-1115

## Testing

- `cargo nextest run --workspace` (2,200 passed, 1 skipped)
- `cargo test --workspace --doc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Broad but mechanical CLI I/O changes with targeted tests; no auth, data, or design-semantics impact beyond cleaner exit when pipes close.
> 
> **Overview**
> **PCB CLIs no longer fail or panic when a consumer closes stdout early** (for example `pcbc info | head`). Incidental output uses **`anstream`** print macros; primary JSON, binary, CSV, and protocol writes go through **`pcb_ui::write_stdout`**, which treats only **`BrokenPipe`** as success and still surfaces other I/O errors.
> 
> Command paths across **`pcbc`**, **`pcb`**, IPC-2581 tools, git credential helper output, BOM/sim/gerber/info, and related crates were updated to use this pattern. **`AGENTS.md`** documents the convention; **`CHANGELOG`** notes the user-visible fix. **`pcb-ipc2581-tools`** gates optional **`anstream`** behind the **`cli`** feature. Integration tests pipe **`pcbc info`** and **`pcbc fmt --diff`** through **`head`** to guard regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b39d8d7099a11959a3bb368a0858e5a753df72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->