### PR TITLE
ENG-1148 Inherit symbol descriptions in BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Inherit symbol descriptions for non-generic BOM components.
 - Require external power IOs to have a net symbol or hierarchical label.
 - Complete the E48 and E192 standard value tables used by `e48()` and `e192()`.
 - `pcb build --config` now rejects unknown root configuration keys.

--- a/crates/pcb-zen-core/src/lang/component.rs
+++ b/crates/pcb-zen-core/src/lang/component.rs
@@ -273,6 +273,14 @@ fn property_string<'v>(properties_map: &SmallMap<String, Value<'v>>, key: &str) 
         .and_then(|v| v.unpack_str().and_then(non_empty_string))
 }
 
+fn first_property_string<'v>(
+    properties_map: &SmallMap<String, Value<'v>>,
+    keys: &[&str],
+) -> Option<String> {
+    keys.iter()
+        .find_map(|key| property_string(properties_map, key))
+}
+
 fn non_empty_string(value: &str) -> Option<String> {
     if value.trim().is_empty() {
         None
@@ -2122,37 +2130,26 @@ where
                 symbol_datasheet.as_deref(),
             );
 
-            // If description is not explicitly provided, try to get it from properties, then symbol properties
-            // Skip empty strings - prefer None over empty
+            // Consolidate ctype: check kwarg, then legacy properties (type, Type)
+            let final_ctype = ctype
+                .and_then(|v| v.unpack_str().and_then(non_empty_string))
+                .or_else(|| first_property_string(&properties_map, &["type", "Type"]));
+
+            let symbol_description = final_symbol
+                .properties()
+                .get("Description")
+                .and_then(|value| non_empty_string(value));
+            let value_description = first_property_string(&properties_map, &["value", "Value"]);
+            // Typed components use their parameterized value as the useful BOM description.
+            let fallback_description = if final_ctype.is_some() {
+                value_description.or(symbol_description)
+            } else {
+                symbol_description.or(value_description)
+            };
             let final_description = description_val
-                .and_then(|v| v.unpack_str().map(|s| s.to_owned()))
-                .or_else(|| {
-                    properties_map
-                        .get("description")
-                        .and_then(|v| v.unpack_str().map(|s| s.to_owned()))
-                })
-                .or_else(|| {
-                    properties_map
-                        .get("Description")
-                        .and_then(|v| v.unpack_str().map(|s| s.to_owned()))
-                })
-                .or_else(|| {
-                    properties_map
-                        .get("value")
-                        .and_then(|v| v.unpack_str().map(|s| s.to_owned()))
-                })
-                .or_else(|| {
-                    properties_map
-                        .get("Value")
-                        .and_then(|v| v.unpack_str().map(|s| s.to_owned()))
-                })
-                .or_else(|| {
-                    final_symbol
-                        .properties()
-                        .get("Description")
-                        .filter(|s| !s.is_empty())
-                        .map(|s| s.to_owned())
-                });
+                .and_then(|v| v.unpack_str().and_then(non_empty_string))
+                .or_else(|| first_property_string(&properties_map, &["description", "Description"]))
+                .or(fallback_description);
 
             // Consolidate DNP: module dnp (highest priority), then kwarg, then component properties
             let final_dnp = if module_has_dnp {
@@ -2189,20 +2186,6 @@ where
                         .map(|s| s.to_owned())
                 })
                 .unwrap_or_else(|| "U".to_owned());
-
-            // Consolidate ctype: check kwarg, then legacy properties (type, Type)
-            let final_ctype = ctype
-                .and_then(|v| v.unpack_str().map(|s| s.to_owned()))
-                .or_else(|| {
-                    properties_map
-                        .get("type")
-                        .and_then(|v| v.unpack_str().map(|s| s.to_owned()))
-                })
-                .or_else(|| {
-                    properties_map
-                        .get("Type")
-                        .and_then(|v| v.unpack_str().map(|s| s.to_owned()))
-                });
 
             remove_consolidated_component_properties(&mut properties_map);
 

--- a/crates/pcb-zen-core/tests/component.rs
+++ b/crates/pcb-zen-core/tests/component.rs
@@ -49,6 +49,108 @@ fn frozen_net_id(value: FrozenValue) -> u64 {
         .net_id()
 }
 
+const DESCRIBED_SYMBOL: &str = r#"(kicad_symbol_lib
+  (version 20231120)
+  (generator "test")
+  (symbol "Described"
+    (property "Reference" "U")
+    (property "Value" "Described")
+    (property "Description" "Symbol description")
+    (property "Manufacturer_Name" "Acme")
+    (property "Manufacturer_Part_Number" "ACME-1")
+    (symbol "Described_1_1"
+      (pin passive line (at 0 0 0) (length 2.54) (name "P") (number "1"))
+    )
+  )
+)"#;
+
+#[test]
+fn untyped_component_prefers_symbol_description_over_value() {
+    let component = eval_single_root_component_with_files(vec![
+        ("described.kicad_sym", DESCRIBED_SYMBOL),
+        (
+            "test.zen",
+            r#"
+Component(
+    name = "U1",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0603_1608Metric.kicad_mod"),
+    symbol = Symbol(library = "described.kicad_sym"),
+    pins = {"P": Net("P")},
+    properties = {"value": "32MHz"},
+)
+"#,
+        ),
+    ]);
+
+    assert_eq!(component.description(), Some("Symbol description"));
+}
+
+#[test]
+fn typed_component_prefers_value_over_symbol_description() {
+    let component = eval_single_root_component_with_files(vec![
+        ("described.kicad_sym", DESCRIBED_SYMBOL),
+        (
+            "test.zen",
+            r#"
+Component(
+    name = "R1",
+    type = "resistor",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0603_1608Metric.kicad_mod"),
+    symbol = Symbol(library = "described.kicad_sym"),
+    pins = {"P": Net("P")},
+    properties = {"value": "1k"},
+)
+"#,
+        ),
+    ]);
+
+    assert_eq!(component.description(), Some("1k"));
+}
+
+#[test]
+fn explicit_description_overrides_typed_component_value() {
+    let component = eval_single_root_component_with_files(vec![
+        ("described.kicad_sym", DESCRIBED_SYMBOL),
+        (
+            "test.zen",
+            r#"
+Component(
+    name = "R1",
+    type = "resistor",
+    description = "Explicit description",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0603_1608Metric.kicad_mod"),
+    symbol = Symbol(library = "described.kicad_sym"),
+    pins = {"P": Net("P")},
+    properties = {"value": "1k"},
+)
+"#,
+        ),
+    ]);
+
+    assert_eq!(component.description(), Some("Explicit description"));
+}
+
+#[test]
+fn typed_component_uses_symbol_description_without_value() {
+    let component = eval_single_root_component_with_files(vec![
+        ("described.kicad_sym", DESCRIBED_SYMBOL),
+        (
+            "test.zen",
+            r#"
+Component(
+    name = "R1",
+    type = "resistor",
+    footprint = File("@kicad-footprints/Resistor_SMD.pretty/R_0603_1608Metric.kicad_mod"),
+    symbol = Symbol(library = "described.kicad_sym"),
+    pins = {"P": Net("P")},
+)
+"#,
+        ),
+    ]);
+
+    assert_eq!(component.description(), Some("Symbol description"));
+}
+
 const EXPLICIT_JUMPER_SYMBOL: &str = r#"(kicad_symbol_lib
   (version 20251024)
   (generator "test")

--- a/crates/pcbc/tests/bom.rs
+++ b/crates/pcbc/tests/bom.rs
@@ -410,3 +410,59 @@ fn test_bom_module_dnp_propagation() {
         .snapshot_run("pcbc", ["bom", "boards/ModuleDnp.zen", "-f", "json"]);
     assert_snapshot!("bom_module_dnp_json", output);
 }
+
+#[test]
+fn bom_json_uses_symbol_description_for_untyped_component() {
+    const SYMBOL: &str = r#"(kicad_symbol_lib (version 20231120) (generator kicad_symbol_editor)
+  (symbol "TCXO"
+    (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "TCXO" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (property "Description" "Temperature-compensated crystal oscillator" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (property "Manufacturer_Name" "Acme" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (property "Manufacturer_Part_Number" "ACME-TCXO-32" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+    (symbol "TCXO_1_1"
+      (pin input line (at -2.54 0 0) (length 2.54)
+        (name "EN" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))))))"#;
+    const BOARD: &str = r#"enable = Net("ENABLE")
+Component(
+    name = "oscillator",
+    symbol = Symbol(library = "TCXO.kicad_sym"),
+    footprint = "Package_DirectFET:DirectFET_L4",
+    properties = {"value": "32MHz"},
+    pins = {"EN": enable},
+)
+"#;
+
+    let mut sandbox = Sandbox::new();
+    sandbox
+        .write("pcb.toml", "[workspace]\n")
+        .write("TCXO.kicad_sym", SYMBOL)
+        .write("TCXO.zen", BOARD);
+
+    let output = sandbox
+        .run("pcbc", ["bom", "TCXO.zen", "-f", "json"])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .expect("BOM command should run");
+    assert!(
+        output.status.success(),
+        "BOM command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bom: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("BOM output should be valid JSON");
+    let entry = &bom[0];
+    assert_eq!(entry["value"], "32MHz");
+    assert_eq!(
+        entry["description"],
+        "Temperature-compensated crystal oscillator"
+    );
+    assert_eq!(entry["manufacturer"], "Acme");
+    assert_eq!(entry["mpn"], "ACME-TCXO-32");
+}


### PR DESCRIPTION
Component descriptions now inherit the selected symbol description before they fall back to the component value. This change removes duplicated fallback logic and adds regression coverage for [ENG-1148](https://linear.app/diodeinc/issue/ENG-1148/symbol-description-is-not-inherited-in-bom).