### PR TITLE
Add WASM support for IPC import, export, and DFM

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -19,6 +19,24 @@ permissions:
   packages: read
 
 jobs:
+  ipc:
+    name: Portable IPC libraries
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          target: wasm32-unknown-unknown
+          cache-bin: false
+
+      - name: Check portable Rust libraries
+        run: cargo check --locked --target wasm32-unknown-unknown -p ipc2581 -p pcb-ir -p gerberx2 -p pcb-ipc2581-tools --no-default-features
+
   wasm:
     name: Evaluate publish bundles
     runs-on: blacksmith-16vcpu-ubuntu-2404

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   ipc:
-    name: Portable IPC libraries
+    name: IPC, IR, and DFM runtime
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
@@ -34,8 +34,25 @@ jobs:
           target: wasm32-unknown-unknown
           cache-bin: false
 
+      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        with:
+          tool: wasm-pack
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
       - name: Check portable Rust libraries
         run: cargo check --locked --target wasm32-unknown-unknown -p ipc2581 -p pcb-ir -p gerberx2 -p pcb-ipc2581-tools --no-default-features
+
+      - name: Build IPC WASM package
+        run: ./bin/build-wasm-bundle.sh ipc
+
+      - name: Exercise IPC and DFM in JavaScript
+        run: node crates/pcb-ipc-wasm/scripts/smoke.mjs
+
+      - name: Check TypeScript API usage
+        run: npx --yes --package typescript@5.9.3 tsc --noEmit --strict --module nodenext --moduleResolution nodenext --target es2022 --lib es2022,dom crates/pcb-ipc-wasm/scripts/typecheck.ts
 
   wasm:
     name: Evaluate publish bundles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Add self-contained DFM JSON reports with native geometry and PDK source.
-- Support WASM builds for IPC and IR tooling.
+- Add WASM APIs for IPC-2581 import, export, and DFM.
 
 ### Fixed
 
+- Include standalone board outlines in Gerber exports.
 - Inherit symbol descriptions for non-generic BOM components.
 - Require external power IOs to have a net symbol or hierarchical label.
 - Complete the E48 and E192 standard value tables used by `e48()` and `e192()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Added
 
 - Add self-contained DFM JSON reports with native geometry and PDK source.
+- Support WASM builds for IPC and IR tooling.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,12 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,37 +1853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "font-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "fontconfig-parser"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
-dependencies = [
- "roxmltree 0.20.0",
-]
-
-[[package]]
-name = "fontdb"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
-dependencies = [
- "fontconfig-parser",
- "log",
- "memmap2",
- "slotmap",
- "tinyvec",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,16 +2129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "glam"
 version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,18 +2199,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "harfrust"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
-dependencies = [
- "bitflags 2.13.1",
- "bytemuck",
- "read-fonts",
- "smallvec",
 ]
 
 [[package]]
@@ -3019,10 +2960,12 @@ dependencies = [
  "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
+ "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -3475,15 +3418,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memmap2"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memmem"
@@ -5389,17 +5323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "read-fonts"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
-dependencies = [
- "bytemuck",
- "font-types",
- "once_cell",
-]
-
-[[package]]
 name = "rectify"
 version = "0.4.40"
 dependencies = [
@@ -5547,15 +5470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
 dependencies = [
  "bytemuck",
- "gif",
- "image-webp",
  "log",
  "pico-args",
  "rgb",
  "svgtypes",
  "tiny-skia",
  "usvg",
- "zune-jpeg",
 ]
 
 [[package]]
@@ -5609,12 +5529,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "roxmltree"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "roxmltree"
@@ -6583,29 +6497,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
-name = "skrifa"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
-dependencies = [
- "bytemuck",
- "read-fonts",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "smallvec"
@@ -7626,12 +7521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7653,12 +7542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-script"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7674,12 +7557,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
-
-[[package]]
-name = "unicode-vo"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -7791,26 +7668,17 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
 dependencies = [
- "base64 0.23.0",
  "data-url",
- "flate2",
- "fontdb",
- "harfrust",
  "imagesize",
  "kurbo",
  "log",
  "pico-args",
- "roxmltree 0.21.1",
+ "roxmltree",
  "simplecss",
  "siphasher",
- "skrifa",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
- "xmlwriter",
 ]
 
 [[package]]
@@ -8034,12 +7902,6 @@ checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wezterm-bidi"
@@ -8575,12 +8437,6 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
-
-[[package]]
-name = "xmlwriter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,6 +3863,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -4209,6 +4218,26 @@ dependencies = [
  "pcb-sexpr",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "pcb-ipc-wasm"
+version = "0.4.40"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "console_error_panic_hook",
+ "console_log",
+ "ipc2581",
+ "log",
+ "pcb-ipc2581-tools",
+ "pcb-ir",
+ "ruzstd",
+ "serde",
+ "serde-value",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6207,6 +6236,16 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 rand = "0.10"
 serde-wasm-bindgen = "0.6"
+serde-value = "0.7"
 self-replace = "1.5"
 serial_test = "4.0"
 smallvec = "1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ pcb-sim = { path = "crates/pcb-sim" }
 pcb-diode-api = { path = "crates/pcb-diode-api" }
 pcb-diode-uri = { path = "crates/pcb-diode-uri" }
 pcb-native-dialog = { path = "crates/pcb-native-dialog" }
-pcb-ipc2581-tools = { path = "crates/pcb-ipc2581-tools" }
+pcb-ipc2581-tools = { path = "crates/pcb-ipc2581-tools", default-features = false }
 pcb-docgen = { path = "crates/pcb-docgen" }
 
 anyhow = "1.0"
@@ -146,7 +146,7 @@ boostvoronoi = "0.12.1"
 sha2 = "0.11"
 semver = { version = "1.0", features = ["serde"] }
 kurbo = "0.13"
-resvg = "0.48"
+resvg = { version = "0.48", default-features = false }
 zstd = "0.13"
 jiff = "0.2"
 blake3 = "1.8"

--- a/bin/build-wasm-bundle.sh
+++ b/bin/build-wasm-bundle.sh
@@ -3,16 +3,20 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-rm -rf target/wasm-bundle
+case "${1:-zen}" in
+  zen) crate=pcb-zen-wasm; bundle_dir=target/wasm-bundle ;;
+  ipc) crate=pcb-ipc-wasm; bundle_dir=target/ipc-wasm-bundle ;;
+  *) echo "Usage: $0 [zen|ipc]" >&2; exit 2 ;;
+esac
+
+rm -rf "$bundle_dir"
 
 wasm-pack build \
   --target web \
   --release \
-  --out-dir ../../target/wasm-bundle \
-  --out-name pcb_zen_wasm \
-  crates/pcb-zen-wasm
+  --scope diodeinc \
+  --out-dir "../../$bundle_dir" \
+  --out-name "${crate//-/_}" \
+  "crates/$crate"
 
-# wasm-pack doesn't support overriding package name
-cd target/wasm-bundle
-jq '.name = "@diodeinc/pcb-zen-wasm"' package.json > package.json.tmp && mv package.json.tmp package.json
-rm -f .gitignore
+rm -f "$bundle_dir/.gitignore"

--- a/crates/gerberx2/README.md
+++ b/crates/gerberx2/README.md
@@ -12,6 +12,10 @@ Gerber constructs without flattening native macros or block apertures.
 This crate contains no CLI or IPC-2581 conversion policy. Higher-level export
 and comparison logic belongs in the consuming crate.
 
+Parsing strings, extracting PCB IR artwork, and writing Gerber are available
+on `wasm32-unknown-unknown`. Only the native `parse_file` convenience method
+requires filesystem access.
+
 Run the tests with:
 
 ```bash

--- a/crates/gerberx2/src/lib.rs
+++ b/crates/gerberx2/src/lib.rs
@@ -13,6 +13,7 @@ pub use write::{
 };
 
 use parse::Parser;
+#[cfg(not(target_family = "wasm"))]
 use std::path::Path;
 use thiserror::Error;
 
@@ -55,6 +56,7 @@ impl GerberX2 {
         parser.parse()
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub fn parse_file(path: impl AsRef<Path>) -> Result<Self> {
         let source = std::fs::read_to_string(path)?;
         Self::parse(&source)

--- a/crates/ipc2581/README.md
+++ b/crates/ipc2581/README.md
@@ -18,6 +18,11 @@ for layer in &document.ecad().unwrap().cad_data.layers {
 Call `validate_file` to validate a document against the vendored IPC-2581C XML
 schema before parsing it.
 
+The string APIs (`Ipc2581::parse`, `validate`, XML editing, and fragment
+writers) also work on `wasm32-unknown-unknown`, including XSD validation. File
+helpers are available only on native targets. No browser APIs or filesystem
+are needed to parse XML.
+
 ```bash
 cargo test -p ipc2581
 ```

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -12,6 +12,7 @@ pub use uppsala::XmlWriter;
 
 use checksum::validate_checksum;
 use parse::Parser;
+#[cfg(not(target_family = "wasm"))]
 use std::path::Path;
 use std::sync::LazyLock;
 use thiserror::Error;
@@ -82,6 +83,7 @@ pub fn validate(xml: &str) -> Result<()> {
 }
 
 /// Validate an IPC-2581 XML file against the vendored IPC-2581C XML Schema.
+#[cfg(not(target_family = "wasm"))]
 pub fn validate_file(path: impl AsRef<Path>) -> Result<()> {
     let xml = std::fs::read_to_string(path)?;
     validate(&xml)
@@ -107,6 +109,7 @@ impl Ipc2581 {
     }
 
     /// Validate an IPC-2581 XML file against the vendored IPC-2581C XML Schema.
+    #[cfg(not(target_family = "wasm"))]
     pub fn validate_file(path: impl AsRef<Path>) -> Result<()> {
         validate_file(path)
     }
@@ -148,6 +151,7 @@ impl Ipc2581 {
     }
 
     /// Parse IPC-2581 from file
+    #[cfg(not(target_family = "wasm"))]
     pub fn parse_file(path: impl AsRef<Path>) -> Result<Self> {
         let xml = std::fs::read_to_string(path)?;
         Self::parse(&xml)

--- a/crates/pcb-ipc-wasm/Cargo.toml
+++ b/crates/pcb-ipc-wasm/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "pcb-ipc-wasm"
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+authors = { workspace = true }
+description = "WebAssembly bindings for IPC-2581 import, export, and DFM"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+console_error_panic_hook = { workspace = true }
+console_log = { workspace = true }
+ipc2581 = { workspace = true }
+log = { workspace = true }
+pcb-ir = { workspace = true }
+pcb-ipc2581-tools = { workspace = true, default-features = false }
+ruzstd = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+serde-value = { workspace = true }
+wasm-bindgen = { workspace = true }

--- a/crates/pcb-ipc-wasm/README.md
+++ b/crates/pcb-ipc-wasm/README.md
@@ -1,0 +1,94 @@
+# pcb-ipc-wasm
+
+In-memory IPC-2581 import, export, and DFM for browsers, Web Workers, and Node.
+No filesystem, network service, native libraries, or shared-memory threads.
+
+## Build and test
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack --locked
+./bin/build-wasm-bundle.sh ipc
+node crates/pcb-ipc-wasm/scripts/smoke.mjs
+npx --yes --package typescript@5.9.3 tsc --noEmit --strict --module nodenext --moduleResolution nodenext --target es2022 --lib es2022,dom crates/pcb-ipc-wasm/scripts/typecheck.ts
+```
+
+This uses the same browser-bundle builder as [pcb-zen-wasm](../pcb-zen-wasm/README.md),
+writing to `target/ipc-wasm-bundle`. It does not publish anything. The smoke test
+requires Node 24+ and checks all formats, compressed input, DFM/waivers, malformed
+input, and a worker.
+
+## Use
+
+```ts
+import init, { IpcDocument } from "./target/ipc-wasm-bundle/pcb_ipc_wasm.js";
+
+await init();
+const pcb = IpcDocument.fromBytes(new Uint8Array(await file.arrayBuffer()), {
+  name: file.name,
+  validate: true, // Optional IPC-2581C XSD validation.
+});
+try {
+  const [gerbers] = pcb.export({ format: "gerber", zip: true });
+  const report = pcb.checkDfm({ pdk: "standard" });
+  // gerbers.data is Uint8Array; report.verdict is "pass" or "fail".
+} finally {
+  pcb.free();
+}
+```
+
+Use `new IpcDocument(xml, options?)` for strings. `fromBytes` detects UTF-8 XML
+or Zstandard from the bytes, including concatenated/skippable frames. Names
+are report labels; no path is opened. Geometry is imported and cached on demand.
+All methods are synchronous; use a Web Worker for large exports or DFM. Results
+are owned copies and remain valid after `free()`.
+
+| API | Result |
+| --- | --- |
+| `validate()` | Validate the source against the bundled IPC-2581C XSD. |
+| `info()` | The native `ipc info --format json` summary. |
+| `layers()` | Source layer names accepted by SVG/PNG export. |
+| `export(options)` | `{ name, mediaType, data: Uint8Array }[]`. |
+| `checkDfm(options?)` | The full native DFM report, including evidence and waivers. |
+| `builtinPdks()` | Bundled PDK names and TOML sources. |
+
+Export formats: `ipc2581`, `gerber` (Gerber X2 and XNC, optionally zipped),
+`svg`, `png`, `dxf`, `bom` (JSON), `cpl` (CSV), `ict` (CSV), and `html`.
+SVG/PNG require `layer`; rendering uses the native sizing and profile defaults.
+IPC export returns original XML unless `mode` selects a native projection.
+`layoutTarget` defaults to `board-array`; `board` selects the canonical board.
+CPL keeps the native single-board semantics. The generated package includes
+TypeScript declarations (TS 5.7+); unknown options and enum values throw errors.
+Raw IR snapshots, editing, and panel generation are deliberately outside this API.
+
+Custom PDKs and waivers are supplied as text:
+
+```ts
+const report = pcb.checkDfm({
+  pdk: { name: "fab.toml", source: pdkToml },
+  waivers: { name: "waivers.toml", source: waiverToml },
+  generatedAt: "2026-08-30T12:00:00Z", // Optional; controls UTC waiver expiry.
+});
+```
+
+All native PDK checks are available. Violations return a `fail` verdict; invalid
+inputs or unsupported geometry throw JavaScript `Error`s. Reports preserve the
+native schema, vector scene, exact PDK source, and input/PDK/waiver hashes,
+including compressed input bytes. See the [DFM contract](../pcb-ipc2581-tools/docs/dfm.md).
+
+## Portable Rust crates
+
+```sh
+cargo check --target wasm32-unknown-unknown \
+  -p ipc2581 -p pcb-ir -p gerberx2 -p pcb-ipc2581-tools --no-default-features
+```
+
+The full `pcb-ir` geometry/import/dialect stack remains portable, including
+KiCad data/writing, rendering, DFM geometry, and copper balancing. Disable the
+tools crate's default `cli` feature to exclude filesystem commands, terminal UI,
+network BOM enrichment, and native dependencies. Native DFM/balancing keep
+parallel execution; WASM executes the same algorithms serially.
+
+Custom PDKs are limited to 1 MiB. Zstandard decoding is bounded to 256 MiB; the importer limits layout
+depth to 64 and expanded instances to 100,000. These checks prevent simple input
+amplification, but do not guarantee a fixed runtime or memory budget.

--- a/crates/pcb-ipc-wasm/scripts/smoke.mjs
+++ b/crates/pcb-ipc-wasm/scripts/smoke.mjs
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { constants, zstdCompressSync } from 'node:zlib';
+import { Worker, isMainThread, parentPort, workerData } from 'node:worker_threads';
+
+// Exercise the browser ES-module package without a DOM, filesystem imports in
+// WASM, or shared memory. The same tests can load the generated Node package.
+const repoRoot = resolve(import.meta.dirname, '../../..');
+const packageDir = isMainThread ? resolve(process.argv[2] ?? `${repoRoot}/target/ipc-wasm-bundle`) : workerData.packageDir;
+const api = await import(pathToFileURL(resolve(packageDir, 'pcb_ipc_wasm.js')));
+if (typeof api.default === 'function') {
+  await api.default({ module_or_path: await readFile(resolve(packageDir, 'pcb_ipc_wasm_bg.wasm')) });
+}
+const { IpcDocument, builtinPdks } = api;
+const xml = await readFile(new URL('../tests/board.xml', import.meta.url), 'utf8');
+const pdk = { name: 'process.toml', source: await readFile(new URL('../tests/pdk.toml', import.meta.url), 'utf8') };
+const generatedAt = '2026-08-30T12:00:00Z';
+const text = file => new TextDecoder().decode(file.data);
+const hash = bytes => createHash('sha256').update(bytes).digest('hex');
+
+if (!isMainThread) {
+  const document = new IpcDocument(xml);
+  try {
+    const report = document.checkDfm({ pdk, generatedAt });
+    parentPort.postMessage({ verdict: report.verdict, ids: report.findings.map(f => f.id), scene: report.scene });
+  } finally {
+    document.free();
+  }
+} else {
+  const document = new IpcDocument(xml, { name: 'fixture.xml', validate: true });
+  try {
+    assert.equal(document.info().board_dimensions.width_mm, 30);
+    assert.equal(document.info().layers.copper, 2);
+    assert.ok(document.layers().includes('TOP'));
+    assert.equal(builtinPdks()[0].name, 'standard');
+    assert.ok(builtinPdks()[0].source.includes('[pdk]'));
+    const bom = JSON.parse(text(document.export({ format: 'bom' })[0]));
+    assert.equal(bom[0].designator, 'J1');
+    assert.equal(bom[0].characteristics.value, 'Connector');
+
+    const svg = document.export({ format: 'svg', layer: 'TOP' })[0];
+    assert.ok(svg.data instanceof Uint8Array);
+    assert.equal(svg.mediaType, 'image/svg+xml');
+    assert.match(text(svg), /<svg/);
+    const png = document.export({ format: 'png', layer: 'TOP' })[0];
+    assert.deepEqual([...png.data.slice(0, 8)], [137, 80, 78, 71, 13, 10, 26, 10]);
+    const pngHeader = new DataView(png.data.buffer, png.data.byteOffset);
+    assert.equal(Math.max(pngHeader.getUint32(16), pngHeader.getUint32(20)), 3200);
+    assert.match(text(document.export({ format: 'dxf' })[0]), /ENTITIES/);
+    assert.match(text(document.export({ format: 'cpl' })[0]), /J1,Connector,connector,5\.000000,5\.000000/);
+    assert.match(text(document.export({ format: 'ict' })[0]), /Designator/);
+    assert.match(text(document.export({ format: 'html' })[0]), /<html/);
+    assert.equal(text(document.export({ format: 'ipc2581' })[0]), xml);
+    const fabrication = new IpcDocument(text(document.export({ format: 'ipc2581', mode: 'fabrication' })[0]), { validate: true });
+    assert.equal(fabrication.info().mode, 'FABRICATION');
+    assert.equal(JSON.parse(text(fabrication.export({ format: 'bom' })[0])).length, 0);
+    fabrication.free();
+
+    const files = document.export({ format: 'gerber' });
+    assert.ok(files.some(f => f.name.endsWith('.gtl')));
+    assert.ok(files.some(f => f.name === 'PTH.drl' && text(f).includes('M48')));
+    assert.ok(files.some(f => f.name.endsWith('.gm1')), 'plain-board package must include its outline');
+    assert.deepEqual(files, document.export({ format: 'gerber', layoutTarget: 'board' }));
+    const archive = document.export({ format: 'gerber', zip: true })[0];
+    assert.equal(archive.mediaType, 'application/zip');
+    assert.deepEqual([...archive.data.slice(0, 4)], [80, 75, 3, 4]);
+    for (const file of files) assert.ok(Buffer.from(archive.data).includes(Buffer.from(file.name)));
+    assert.deepEqual(archive.data, document.export({ format: 'gerber', zip: true })[0].data);
+
+    const report = document.checkDfm({ pdk, generatedAt });
+    assert.equal(report.verdict, 'fail');
+    assert.equal(report.summary.errors, 3);
+    assert.equal(report.input.path, 'fixture.xml');
+    assert.equal(report.input.sha256, hash(xml));
+    assert.equal(report.input.size_bytes, Buffer.byteLength(xml));
+    assert.equal(report.pdk.sha256, hash(pdk.source));
+    assert.equal(report.pdk.source, pdk.source);
+    assert.equal(report.layout.kind, 'board');
+    assert.equal(report.scene.schema_version, 1);
+    assert.ok(report.scene.bounds.min.x <= 0 && report.scene.bounds.max.x >= 30);
+    assert.ok(report.scene.passes.some(pass => pass.layer === 'TOP'));
+    for (const pass of report.scene.passes) assert.match(pass.svg, /<svg/);
+    for (const finding of report.findings) {
+      assert.ok(finding.sites.length > 0);
+      for (const site of finding.sites) {
+        assert.equal(typeof site.id, 'string');
+        assert.ok(site.bounding_box.min.x <= site.bounding_box.max.x);
+      }
+    }
+    assert.deepEqual(report.findings.map(f => f.rule_id).sort(), [
+      'copper.minimum_feature_width', 'drilling.minimum_pth_hole_diameter', 'soldermask.minimum_web',
+    ]);
+    assert.equal(report.rules.find(r => r.id === 'copper.minimum_pth_annular_ring').checked, 2);
+    assert.deepEqual(report, document.checkDfm({ pdk, generatedAt }));
+    const waivers = { name: 'waivers.toml', source: report.findings.map(f =>
+      `[[waiver]]\nfinding = "${f.id}"\nreason = "test"\nexpires = "2026-08-31"\n`).join('\n') };
+    const waived = document.checkDfm({ pdk, generatedAt, waivers });
+    assert.equal(waived.verdict, 'pass');
+    assert.equal(waived.summary.waived, 3);
+    assert.equal(waived.findings.length, 3);
+    const expired = document.checkDfm({ pdk, generatedAt: '2026-08-31T00:00:00Z', waivers });
+    assert.equal(expired.verdict, 'fail');
+    assert.equal(expired.waivers.expired.length, 3);
+    const defaultReport = document.checkDfm();
+    assert.equal(defaultReport.pdk.path, 'builtin:standard');
+    assert.ok(Date.parse(defaultReport.generated_at) > Date.parse('2026-01-01T00:00:00Z'));
+
+    // The compressed input's identity is the original bytes, not decompressed
+    // text. Test concatenated and skippable frames as well as ordinary XML.
+    const split = Math.floor(xml.length / 2);
+    const skippable = Buffer.from([0x50, 0x2a, 0x4d, 0x18, 3, 0, 0, 0, 1, 2, 3]);
+    const checksumOptions = { params: { [constants.ZSTD_c_checksumFlag]: 1 } };
+    const checksummed = zstdCompressSync(xml, checksumOptions);
+    const firstFrame = zstdCompressSync(xml.slice(0, split), checksumOptions);
+    const lastFrame = zstdCompressSync(xml.slice(split), checksumOptions);
+    const withoutSize = zstdCompressSync(xml, { params: { [constants.ZSTD_c_contentSizeFlag]: 0 } });
+    for (const bytes of [Buffer.from(xml), zstdCompressSync(xml), checksummed, withoutSize, Buffer.concat([
+      skippable, firstFrame, skippable, lastFrame,
+    ])]) {
+      const decoded = IpcDocument.fromBytes(bytes, { name: 'input.xml.zst' });
+      assert.equal(text(decoded.export({ format: 'ipc2581' })[0]), xml);
+      assert.equal(decoded.checkDfm({ pdk, generatedAt }).input.sha256, hash(bytes));
+      decoded.free();
+    }
+    const corruptChecksum = Buffer.from(checksummed);
+    corruptChecksum[corruptChecksum.length - 1] ^= 1;
+    assert.throws(() => IpcDocument.fromBytes(corruptChecksum), /checksum/i);
+    const corruptLastFrame = Buffer.from(lastFrame);
+    corruptLastFrame[corruptLastFrame.length - 1] ^= 1;
+    assert.throws(() => IpcDocument.fromBytes(Buffer.concat([
+      firstFrame, skippable, corruptLastFrame,
+    ])), /checksum/i);
+    // A short single-segment frame stores its content size in byte 5.
+    // Alter only that field, leaving otherwise valid, decodable XML intact.
+    const smallXml = '<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581"><Content roleRef="owner"><FunctionMode mode="BOM"/></Content></IPC-2581>';
+    const wrongSize = zstdCompressSync(smallXml);
+    assert.equal(wrongSize[4], 0x20);
+    assert.equal(wrongSize[5], Buffer.byteLength(smallXml));
+    wrongSize[5] += 1;
+    assert.throws(() => IpcDocument.fromBytes(wrongSize), /content size/i);
+    assert.throws(() => IpcDocument.fromBytes(Buffer.concat([
+      zstdCompressSync(''), wrongSize,
+    ])), /content size/i);
+    const real = IpcDocument.fromBytes(await readFile(new URL('../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst', import.meta.url)));
+    assert.ok(real.layers().length > 2);
+    assert.ok(JSON.parse(text(real.export({ format: 'bom' })[0])).length > 0);
+    real.free();
+
+    // Boundary errors must be catchable Error objects and leave the instance
+    // usable. These inputs must not reach a panicking index or OS stub.
+    const invalid = [
+      () => new IpcDocument('<broken>'),
+      () => new IpcDocument(xml, { validte: true }),
+      () => IpcDocument.fromBytes(Uint8Array.of(255, 254)),
+      () => IpcDocument.fromBytes(Uint8Array.of(0x28, 0xb5, 0x2f, 0xfd)),
+      () => IpcDocument.fromBytes(Buffer.concat([zstdCompressSync(xml), Buffer.from('garbage')])),
+      () => document.export({ format: 'svg', layer: 'missing' }),
+      () => document.export({ format: 'bom', side: 'top' }),
+      () => document.export({ format: 'html', zip: true }),
+      () => document.export({ format: 'png', layer: 'TOP', maxDimension: 0 }),
+      () => document.export({ format: 'svg', layer: 'TOP', layoutTarget: 'typo' }),
+      () => document.export({ format: 'svg', layer: 'TOP', includeProfile: false }),
+      () => document.export({ format: 'unsupported' }),
+      () => document.checkDfm({ pdk: 'missing' }),
+      () => document.checkDfm({ pdk: { source: 'bad TOML' } }),
+      () => document.checkDfm({ pdk: { source: ' '.repeat(1024 * 1024 + 1) } }),
+      () => document.checkDfm({ generatedAt: 'yesterday' }),
+      () => document.checkDfm({ generatedAT: generatedAt }),
+    ];
+    for (const invoke of invalid) assert.throws(invoke, error => error instanceof Error, invoke.toString());
+    const hugeRepeat = xml.replace('<StepRef name="board"/>', '<StepRef name="panel"/>')
+      .replace('</CadData>', '<Step name="panel" type="PALLET"><StepRepeat stepRef="board" x="0" y="0" nx="4294967295" ny="1"/></Step></CadData>');
+    const oversized = new IpcDocument(hugeRepeat);
+    try {
+      assert.throws(() => oversized.export({ format: 'gerber' }), /limit|exceed|too many/i);
+    } finally { oversized.free(); }
+    assert.equal(document.info().revision, 'C');
+
+    const fromWorker = await new Promise((resolveResult, reject) => {
+      const worker = new Worker(new URL(import.meta.url), { workerData: { packageDir } });
+      worker.once('message', resolveResult);
+      worker.once('error', reject);
+      worker.once('exit', code => { if (code !== 0) reject(new Error(`worker exited ${code}`)); });
+    });
+    assert.equal(fromWorker.verdict, report.verdict);
+    assert.deepEqual(fromWorker.ids, report.findings.map(f => f.id));
+    assert.deepEqual(fromWorker.scene, report.scene);
+    console.log('IPC WASM: import, all exports, DFM/waivers, malformed input, and worker checks passed');
+  } finally {
+    document.free();
+  }
+}

--- a/crates/pcb-ipc-wasm/scripts/typecheck.ts
+++ b/crates/pcb-ipc-wasm/scripts/typecheck.ts
@@ -1,0 +1,91 @@
+// Compile against the generated package. smoke.mjs covers actual execution.
+import init, {
+  IpcDocument,
+  builtinPdks,
+  type DfmReport,
+  type ExportFile,
+  type ExportOptions,
+} from "../../../target/ipc-wasm-bundle/pcb_ipc_wasm.js";
+
+function expectType<T>(_value: T): void {}
+
+export async function checkUsage(
+  module: WebAssembly.Module,
+  xml: string,
+  bytes: Uint8Array,
+  pdkToml: string,
+  waiverToml: string,
+): Promise<void> {
+  await init({ module_or_path: module });
+  const pcb = new IpcDocument(xml, { name: "board.xml", validate: true });
+  const decoded = IpcDocument.fromBytes(bytes, { name: "board.xml.zst" });
+  try {
+    pcb.validate();
+    expectType<string>(pcb.info().revision);
+    expectType<string[]>(pcb.layers());
+    const exports = [
+      { format: "ipc2581", mode: "fabrication" },
+      { format: "gerber", layoutTarget: "board-array", zip: true },
+      { format: "svg", layer: "F.Cu" },
+      { format: "png", layer: "F.Cu" },
+      { format: "dxf" },
+      { format: "bom" },
+      { format: "cpl", side: "both", excludeDnp: true },
+      { format: "ict", side: "bottom" },
+      { format: "html" },
+    ] satisfies ExportOptions[];
+    for (const options of exports) {
+      const files = pcb.export(options);
+      expectType<ExportFile[]>(files);
+      for (const file of files) {
+        new TextDecoder().decode(file.data);
+        new Blob([file.data], { type: file.mediaType });
+      }
+    }
+    expectType<DfmReport>(pcb.checkDfm({ pdk: builtinPdks()[0].name }));
+    const report = pcb.checkDfm({
+      pdk: { name: "fab.toml", source: pdkToml },
+      waivers: { name: "waivers.toml", source: waiverToml },
+      layoutTarget: "board-array",
+      generatedAt: "2026-08-30T12:00:00Z",
+    });
+    expectType<"pass" | "fail">(report.verdict);
+    expectType<string>(report.input.sha256);
+    expectType<string>(report.pdk.source);
+    expectType<string>(report.layout.kind);
+    expectType<string>(report.scene.passes[0].svg);
+    expectType<number>(report.scene.bounds.min.x);
+    for (const finding of report.findings) {
+      expectType<number>(finding.sites[0].bounding_box.max.y);
+    }
+    if (report.waivers) expectType<string[]>(report.waivers.expired);
+  } finally {
+    decoded.free();
+    pcb.free();
+  }
+}
+
+export function rejectInvalidOptions(pcb: IpcDocument, bytes: Uint8Array): void {
+  // @ts-expect-error Bytes use fromBytes.
+  new IpcDocument(bytes);
+  // @ts-expect-error Unknown import option.
+  IpcDocument.fromBytes(bytes, { validateXml: true });
+  // @ts-expect-error Export requires its format.
+  pcb.export();
+  // @ts-expect-error PNG requires a layer.
+  pcb.export({ format: "png" });
+  // @ts-expect-error zip applies only to Gerber.
+  pcb.export({ format: "svg", layer: "F.Cu", zip: true });
+  // @ts-expect-error Unsupported side.
+  pcb.export({ format: "cpl", side: "left" });
+  // @ts-expect-error Input layout names use kebab-case.
+  pcb.checkDfm({ layoutTarget: "board_array" });
+  // @ts-expect-error Waivers are text, not paths.
+  pcb.checkDfm({ waivers: "waivers.toml" });
+  // @ts-expect-error Custom PDKs require source text.
+  pcb.checkDfm({ pdk: { name: "fab.toml" } });
+  // @ts-expect-error Report verdict retains its type.
+  expectType<number>(pcb.checkDfm().verdict);
+  // @ts-expect-error Binary exports are typed, not any.
+  expectType<string>(pcb.export({ format: "bom" })[0].data);
+}

--- a/crates/pcb-ipc-wasm/src/api.d.ts
+++ b/crates/pcb-ipc-wasm/src/api.d.ts
@@ -1,0 +1,90 @@
+/// <reference lib="esnext.disposable" />
+
+/** Options are strict: unknown keys and unsupported enum values throw Error. */
+export interface ImportOptions { name?: string; validate?: boolean; }
+export type LayoutTarget = "board" | "board-array";
+export type SideFilter = "both" | "top" | "bottom";
+export type ViewMode = "bom" | "assembly" | "fabrication" | "stackup" | "test" | "stencil" | "dfx";
+
+export interface IpcInfo {
+  revision: string;
+  mode: string;
+  level: string | null;
+  source_units?: string | null;
+  board_dimensions?: { width_mm: number; height_mm: number; width_inch: number; height_inch: number };
+  board_array?: { step_name: string; board_count: number; board_instances: number; [key: string]: unknown };
+  components?: { total: number; smt: number; tht: number; other: number };
+  [key: string]: unknown;
+}
+
+export type ExportOptions =
+  | { format: "ipc2581"; mode?: ViewMode }
+  | { format: "gerber"; layoutTarget?: LayoutTarget; zip?: boolean }
+  | { format: "svg"; layer: string; layoutTarget?: LayoutTarget }
+  | { format: "png"; layer: string; layoutTarget?: LayoutTarget }
+  | { format: "dxf"; layoutTarget?: LayoutTarget }
+  | { format: "bom" }
+  | { format: "cpl"; side?: SideFilter; excludeDnp?: boolean }
+  | { format: "ict"; side?: SideFilter }
+  | { format: "html" };
+export interface ExportFile { name: string; mediaType: string; data: Uint8Array<ArrayBuffer>; }
+
+/** Names are report labels only. No method reads paths or fetches URLs. */
+export interface TextInput { source: string; name?: string; }
+export type PdkInput = string | TextInput;
+export interface BuiltinPdk { name: string; source: string; }
+export interface DfmOptions {
+  /** A built-in name (default: standard) or custom TOML. */
+  pdk?: PdkInput;
+  waivers?: TextInput;
+  layoutTarget?: LayoutTarget;
+  /** RFC 3339; defaults to the host clock. Controls waiver expiry in UTC. */
+  generatedAt?: string;
+}
+export interface FileIdentity { path: string; sha256: string; size_bytes: number; }
+export interface PdkIdentity {
+  id: string; name: string; revision: string;
+  manufacturer: string | null; process: string | null;
+  path: string; sha256: string; source: string;
+}
+export interface DfmSummary {
+  rules_configured: number; rules_passed: number; rules_warned: number;
+  rules_failed: number; rules_skipped: number; findings: number;
+  errors: number; warnings: number; waived: number;
+}
+export interface DfmFinding {
+  id: string; rule_id: string; severity: "error" | "warning";
+  message: string; waived: boolean; waiver_reason: string | null;
+  measurement: Record<string, unknown>;
+  layers: Array<Record<string, unknown>>;
+  subjects: Array<Record<string, unknown>>;
+  evidence: unknown;
+  sites: Array<{ id: string; bounding_box: DfmBounds; [key: string]: unknown }>;
+  group_key: string | null;
+  [key: string]: unknown;
+}
+export interface DfmBounds { min: { x: number; y: number }; max: { x: number; y: number }; }
+export interface DfmScene {
+  schema_version: number;
+  bounds: DfmBounds;
+  passes: Array<{ label: string; feature: string; layer: string | null; color: string; svg: string }>;
+}
+/** Preserves the native DFM JSON schema, including snake_case field names. */
+export interface DfmReport {
+  schema_version: number;
+  generated_at: string;
+  verdict: "pass" | "fail";
+  input: FileIdentity;
+  pdk: PdkIdentity;
+  layout_target: "board" | "board_array";
+  layout: {
+    kind: string; selected_step: string | null; coordinate_frame: string;
+    bounding_box: DfmBounds | null; instances: Array<Record<string, unknown>>;
+  };
+  scene: DfmScene;
+  summary: DfmSummary;
+  findings: DfmFinding[];
+  rules: Array<{ id: string; status: "pass" | "warning" | "fail" | "skipped"; [key: string]: unknown }>;
+  waivers: null | { path: string; sha256: string; applied: number; expired: string[]; unmatched: string[] };
+  [key: string]: unknown;
+}

--- a/crates/pcb-ipc-wasm/src/lib.rs
+++ b/crates/pcb-ipc-wasm/src/lib.rs
@@ -1,0 +1,407 @@
+//! In-memory IPC-2581 import, export, and DFM bindings.
+
+mod options;
+
+#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
+const TYPESCRIPT: &str = include_str!("api.d.ts");
+
+use std::cell::OnceCell;
+use std::io::{Cursor, Read};
+
+use anyhow::{Context, Result, bail};
+use ipc2581::Ipc2581;
+use pcb_ipc2581_tools::accessors::IpcAccessor;
+use pcb_ipc2581_tools::commands::{self, dfm};
+use pcb_ipc2581_tools::{UnitFormat, geometry, manufacturing, placement};
+use pcb_ir::import::ipc2581::{ImportedDesign, import_design};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use wasm_bindgen::prelude::*;
+
+use options::*;
+
+const MAX_DECOMPRESSED_BYTES: u64 = 256 * 1024 * 1024;
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    console_error_panic_hook::set_once();
+    console_log::init_with_level(log::Level::Warn).ok();
+}
+
+/// Parsed source with lazily cached geometry shared by exports and DFM.
+#[wasm_bindgen]
+pub struct IpcDocument {
+    xml: String,
+    ipc: Ipc2581,
+    input: dfm::report::FileIdentity,
+    imported: OnceCell<ImportedDesign>,
+}
+
+#[wasm_bindgen]
+impl IpcDocument {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        xml: &str,
+        #[wasm_bindgen(unchecked_optional_param_type = "ImportOptions")] options: Option<JsValue>,
+    ) -> Result<IpcDocument, JsError> {
+        Self::parse(xml.to_owned(), xml.as_bytes(), read_options(options)?).map_err(js_error)
+    }
+
+    /// Accept UTF-8 XML or Zstandard, detected from bytes rather than the name.
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(
+        bytes: &[u8],
+        #[wasm_bindgen(unchecked_optional_param_type = "ImportOptions")] options: Option<JsValue>,
+    ) -> Result<IpcDocument, JsError> {
+        Self::parse(
+            decode_xml(bytes).map_err(js_error)?,
+            bytes,
+            read_options(options)?,
+        )
+        .map_err(js_error)
+    }
+
+    /// Validate the source against the bundled IPC-2581C schema.
+    pub fn validate(&self) -> Result<(), JsError> {
+        Ipc2581::validate(&self.xml).map_err(js_error)
+    }
+
+    /// The native IPC info JSON summary.
+    #[wasm_bindgen(unchecked_return_type = "IpcInfo")]
+    pub fn info(&self) -> Result<JsValue, JsError> {
+        to_js(&commands::info::info_json(&self.accessor()))
+    }
+
+    /// Source layer names accepted by SVG and PNG export.
+    pub fn layers(&self) -> Vec<String> {
+        self.ipc.ecad().map_or_else(Vec::new, |ecad| {
+            ecad.cad_data
+                .layers
+                .iter()
+                .map(|layer| self.ipc.resolve(layer.name).to_owned())
+                .collect()
+        })
+    }
+
+    /// All formats return owned bytes, including multi-file Gerber/XNC output.
+    #[wasm_bindgen(js_name = export, unchecked_return_type = "ExportFile[]")]
+    pub fn export_files(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "ExportOptions")] options: JsValue,
+    ) -> Result<JsValue, JsError> {
+        to_js(
+            &self
+                .export_data(parse_options(options)?)
+                .map_err(js_error)?,
+        )
+    }
+
+    /// Violations return a report with verdict "fail". Invalid input throws.
+    #[wasm_bindgen(js_name = checkDfm, unchecked_return_type = "DfmReport")]
+    pub fn check_dfm(
+        &self,
+        #[wasm_bindgen(unchecked_optional_param_type = "DfmOptions")] options: Option<JsValue>,
+    ) -> Result<JsValue, JsError> {
+        let options: DfmOptions = read_options(options)?;
+        let generated_at = match options.generated_at {
+            Some(ref value) => chrono::DateTime::parse_from_rfc3339(value)
+                .context("generatedAt must be an RFC 3339 timestamp")
+                .map_err(js_error)?
+                .with_timezone(&chrono::Utc),
+            None => current_time().map_err(js_error)?,
+        };
+        let pdk = match &options.pdk {
+            PdkInput::Builtin(name) => dfm::PdkSource::Builtin(name),
+            PdkInput::Toml(input) => dfm::PdkSource::Toml(dfm::TextSource {
+                path: input.name.as_deref().unwrap_or("pdk.toml"),
+                source: &input.source,
+            }),
+        };
+        to_js(
+            &dfm::check(
+                self.design().map_err(js_error)?,
+                dfm::CheckRequest {
+                    input: self.input.clone(),
+                    pdk,
+                    waivers: options.waivers.as_ref().map(|input| dfm::TextSource {
+                        path: input.name.as_deref().unwrap_or("waivers.toml"),
+                        source: &input.source,
+                    }),
+                    layout_target: options.layout_target,
+                    generated_at,
+                },
+            )
+            .map_err(js_error)?,
+        )
+    }
+}
+
+impl IpcDocument {
+    fn parse(xml: String, original: &[u8], options: ImportOptions) -> Result<Self> {
+        if options.validate {
+            Ipc2581::validate(&xml).context("IPC-2581 schema validation failed")?;
+        }
+        Ok(Self {
+            ipc: Ipc2581::parse(&xml).context("failed to parse IPC-2581 XML")?,
+            input: dfm::report::FileIdentity::new(
+                options.name.unwrap_or_else(|| "board.xml".into()),
+                original,
+            ),
+            xml,
+            imported: OnceCell::new(),
+        })
+    }
+
+    fn accessor(&self) -> IpcAccessor<'_> {
+        IpcAccessor::new(&self.ipc)
+    }
+
+    fn design(&self) -> Result<&ImportedDesign> {
+        if self.imported.get().is_none() {
+            let imported =
+                import_design(&self.ipc).context("failed to import physical PCB design")?;
+            let _ = self.imported.set(imported);
+        }
+        Ok(self.imported.get().expect("design was initialized"))
+    }
+
+    fn export_data(&self, options: ExportOptions) -> Result<Vec<ExportFile>> {
+        let file = match options {
+            ExportOptions::Ipc2581 { mode } => ExportFile::new(
+                "board.xml",
+                "application/xml",
+                match mode {
+                    Some(mode) => commands::view::filter_by_mode(&self.xml, mode)?,
+                    None => self.xml.clone(),
+                },
+            ),
+            ExportOptions::Gerber { layout_target, zip } => {
+                let package = manufacturing::build_manufacturing_package_from_design(
+                    self.design()?,
+                    layout_target.artwork_scope(),
+                )?;
+                if zip {
+                    ExportFile::new("manufacturing.zip", "application/zip", package.to_zip()?)
+                } else {
+                    return Ok(package
+                        .files
+                        .into_iter()
+                        .map(|file| ExportFile::new(file.filename, "text/plain", file.contents))
+                        .collect());
+                }
+            }
+            ExportOptions::Svg {
+                layer,
+                layout_target,
+            } => {
+                let scope = layout_target.artwork_scope();
+                let geometry = geometry::render::prepare_layer(self.design()?, &layer, scope)?;
+                ExportFile::new(
+                    format!("{}.svg", safe_name(&layer)),
+                    "image/svg+xml",
+                    geometry::render::render_layer_svg(&geometry, true, scope.profile_set()),
+                )
+            }
+            ExportOptions::Png {
+                layer,
+                layout_target,
+            } => {
+                let scope = layout_target.artwork_scope();
+                let geometry = geometry::render::prepare_layer(self.design()?, &layer, scope)?;
+                ExportFile::new(
+                    format!("{}.png", safe_name(&layer)),
+                    "image/png",
+                    geometry::render::render_layer_png(&geometry, true, scope.profile_set())
+                        .map_err(anyhow::Error::msg)?,
+                )
+            }
+            ExportOptions::Dxf { layout_target } => ExportFile::new(
+                "outline.dxf",
+                "image/vnd.dxf",
+                commands::outline::export_dxf(&self.ipc, layout_target, false)?,
+            ),
+            ExportOptions::Bom {} => ExportFile::new(
+                "bom.json",
+                "application/json",
+                serde_json::to_vec_pretty(&commands::bom::extract_bom_lines(&self.accessor()))?,
+            ),
+            ExportOptions::Cpl { side, exclude_dnp } => {
+                let placements = placement::extract_single_board_placements_from_design(
+                    &self.accessor(),
+                    self.design()?,
+                )?;
+                ExportFile::new(
+                    "placements.csv",
+                    "text/csv",
+                    commands::cpl::emit_cpl_csv(
+                        &placements,
+                        &commands::cpl::CplOptions {
+                            output: None,
+                            side,
+                            exclude_dnp,
+                        },
+                    ),
+                )
+            }
+            ExportOptions::Ict { side } => ExportFile::new(
+                "ict.csv",
+                "text/csv",
+                commands::ict::emit_ict_csv(
+                    &commands::ict::extract_contacts_from_design(&self.ipc, self.design()?)?,
+                    side,
+                ),
+            ),
+            ExportOptions::Html {} => ExportFile::new(
+                "board.html",
+                "text/html",
+                commands::html_export::generate_html(&self.accessor(), UnitFormat::Mm)?,
+            ),
+        };
+        Ok(vec![file])
+    }
+}
+
+#[wasm_bindgen(js_name = builtinPdks, unchecked_return_type = "BuiltinPdk[]")]
+pub fn builtin_pdks() -> Result<JsValue, JsError> {
+    to_js(dfm::builtin_pdks())
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExportFile {
+    name: String,
+    media_type: &'static str,
+    #[serde(serialize_with = "serialize_bytes")]
+    data: Vec<u8>,
+}
+
+impl ExportFile {
+    fn new(name: impl Into<String>, media_type: &'static str, data: impl Into<Vec<u8>>) -> Self {
+        Self {
+            name: name.into(),
+            media_type,
+            data: data.into(),
+        }
+    }
+}
+
+fn serialize_bytes<S: serde::Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_bytes(bytes)
+}
+
+fn to_js<T: Serialize + ?Sized>(value: &T) -> Result<JsValue, JsError> {
+    value
+        .serialize(
+            &serde_wasm_bindgen::Serializer::json_compatible().serialize_bytes_as_arrays(false),
+        )
+        .map_err(js_error)
+}
+
+fn read_options<T: DeserializeOwned + Default>(value: Option<JsValue>) -> Result<T, JsError> {
+    match value {
+        Some(value) if !value.is_null() && !value.is_undefined() => parse_options(value),
+        _ => Ok(T::default()),
+    }
+}
+
+fn parse_options<T: DeserializeOwned>(value: JsValue) -> Result<T, JsError> {
+    // Direct struct deserialization skips unknown JS keys. Preserve every key
+    // and number first, so strict serde validation sees the original input.
+    let value: serde_value::Value = serde_wasm_bindgen::from_value(value).map_err(js_error)?;
+    value.deserialize_into().map_err(js_error)
+}
+
+fn js_error(error: impl std::fmt::Display) -> JsError {
+    JsError::new(&format!("{error:#}"))
+}
+
+fn safe_name(name: &str) -> String {
+    name.chars()
+        .map(|ch| {
+            if ch.is_control() || matches!(ch, '/' | '\\' | ':') {
+                '_'
+            } else {
+                ch
+            }
+        })
+        .collect()
+}
+
+fn decode_xml(bytes: &[u8]) -> Result<String> {
+    if is_zstd_frame(bytes) || is_skippable_frame(bytes) {
+        let mut input = Cursor::new(bytes);
+        let mut decoded = Vec::new();
+        while (input.position() as usize) < bytes.len() {
+            let remaining = &bytes[input.position() as usize..];
+            if is_skippable_frame(remaining) {
+                let length = remaining
+                    .get(4..8)
+                    .context("truncated Zstandard skippable frame")?;
+                let length = u32::from_le_bytes(length.try_into().unwrap()) as u64;
+                let end = input.position() + 8 + length;
+                if end > bytes.len() as u64 {
+                    bail!("truncated Zstandard skippable frame");
+                }
+                input.set_position(end);
+                continue;
+            }
+            if !is_zstd_frame(remaining) {
+                bail!("invalid trailing data in Zstandard IPC input");
+            }
+            let frame_start = decoded.len();
+            let mut decoder = ruzstd::decoding::StreamingDecoder::new(&mut input)
+                .context("invalid Zstandard IPC input")?;
+            // content_size() returns zero both for an absent size and an
+            // explicitly empty frame. The header type is private in ruzstd;
+            // bits 7-6 (size flag) or bit 5 (single segment) imply a size.
+            // Successful decoder initialization guarantees this byte exists.
+            let expected_size = (remaining[4] & 0xe0 != 0).then(|| decoder.decoder.content_size());
+            (&mut decoder)
+                .take(MAX_DECOMPRESSED_BYTES - decoded.len() as u64 + 1)
+                .read_to_end(&mut decoded)
+                .context("failed to decompress IPC input")?;
+            if decoded.len() as u64 > MAX_DECOMPRESSED_BYTES {
+                bail!("decompressed IPC input exceeds 256 MiB");
+            }
+            if let Some(expected) = expected_size
+                && expected != (decoded.len() - frame_start) as u64
+            {
+                bail!("Zstandard IPC input content size mismatch");
+            }
+            // ruzstd reads the optional checksum but leaves verification to
+            // its caller. Check each frame after collecting all its bytes.
+            if let Some(expected) = decoder.decoder.get_checksum_from_data()
+                && decoder.decoder.get_calculated_checksum() != Some(expected)
+            {
+                bail!("Zstandard IPC input checksum mismatch");
+            }
+        }
+        String::from_utf8(decoded).context("IPC XML is not UTF-8")
+    } else {
+        String::from_utf8(bytes.to_vec()).context("IPC XML is not UTF-8")
+    }
+}
+
+fn is_zstd_frame(bytes: &[u8]) -> bool {
+    bytes.starts_with(&[0x28, 0xb5, 0x2f, 0xfd])
+}
+
+fn is_skippable_frame(bytes: &[u8]) -> bool {
+    matches!(bytes, [0x50..=0x5f, 0x2a, 0x4d, 0x18, ..])
+}
+
+#[cfg(target_arch = "wasm32")]
+fn current_time() -> Result<chrono::DateTime<chrono::Utc>> {
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_namespace = Date, js_name = now)]
+        fn now() -> f64;
+    }
+    chrono::DateTime::from_timestamp_millis(now() as i64)
+        .context("host returned an invalid current time")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn current_time() -> Result<chrono::DateTime<chrono::Utc>> {
+    Ok(chrono::Utc::now())
+}

--- a/crates/pcb-ipc-wasm/src/options.rs
+++ b/crates/pcb-ipc-wasm/src/options.rs
@@ -1,0 +1,86 @@
+use pcb_ipc2581_tools::commands::cpl::CplSideFilter;
+use pcb_ipc2581_tools::{LayoutTarget, ViewMode};
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct ImportOptions {
+    pub name: Option<String>,
+    pub validate: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "format",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum ExportOptions {
+    Ipc2581 {
+        #[serde(default)]
+        mode: Option<ViewMode>,
+    },
+    Gerber {
+        #[serde(default)]
+        layout_target: LayoutTarget,
+        #[serde(default)]
+        zip: bool,
+    },
+    Svg {
+        layer: String,
+        #[serde(default)]
+        layout_target: LayoutTarget,
+    },
+    Png {
+        layer: String,
+        #[serde(default)]
+        layout_target: LayoutTarget,
+    },
+    Dxf {
+        #[serde(default)]
+        layout_target: LayoutTarget,
+    },
+    Bom {},
+    Cpl {
+        #[serde(default)]
+        side: CplSideFilter,
+        #[serde(default)]
+        exclude_dnp: bool,
+    },
+    Ict {
+        #[serde(default)]
+        side: CplSideFilter,
+    },
+    Html {},
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum PdkInput {
+    Builtin(String),
+    Toml(TextInput),
+}
+
+impl Default for PdkInput {
+    fn default() -> Self {
+        Self::Builtin("standard".to_owned())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TextInput {
+    pub source: String,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct DfmOptions {
+    pub pdk: PdkInput,
+    pub waivers: Option<TextInput>,
+    pub layout_target: LayoutTarget,
+    pub generated_at: Option<String>,
+}

--- a/crates/pcb-ipc-wasm/tests/board.xml
+++ b/crates/pcb-ipc-wasm/tests/board.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="designer">
+    <FunctionMode mode="ASSEMBLY"/>
+    <StepRef name="board"/>
+    <LayerRef name="TOP"/>
+    <LayerRef name="BOTTOM"/>
+    <LayerRef name="F.Mask"/>
+    <LayerRef name="B.Mask"/>
+    <LayerRef name="DRILL"/>
+    <BomRef name="bom"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="land"><Circle diameter="2"/></EntryStandard>
+    </DictionaryStandard>
+  </Content>
+  <LogisticHeader>
+    <Role id="designer" roleFunction="DESIGNER"/>
+    <Enterprise id="enterprise" name="Example" code="EXAMPLE"/>
+    <Person name="designer" enterpriseRef="enterprise" roleRef="designer"/>
+  </LogisticHeader>
+  <HistoryRecord number="1" origination="2026-08-01T00:00:00Z" software="test" lastChange="2026-08-01T00:00:00Z">
+    <FileRevision fileRevisionId="1" comment="WASM integration fixture">
+      <SoftwarePackage name="test" vendor="test" revision="1">
+        <Certification certificationStatus="SELFTEST"/>
+      </SoftwarePackage>
+    </FileRevision>
+  </HistoryRecord>
+  <Bom name="bom">
+    <BomHeader assembly="board" revision="1"><StepRef name="board"/></BomHeader>
+    <BomItem OEMDesignNumberRef="TEST-PART" quantity="1" category="ELECTRICAL" pinCount="1">
+      <RefDes name="J1" packageRef="connector" populate="true" layerRef="TOP"/>
+      <Characteristics category="ELECTRICAL"><Textual definitionSource="test" textualCharacteristicName="Value" textualCharacteristicValue="Connector"/><Textual definitionSource="test" textualCharacteristicName="Package" textualCharacteristicValue="connector"/></Characteristics>
+    </BomItem>
+  </Bom>
+  <Ecad name="wasm-test">
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Layer name="CORE" layerFunction="DIELECTRIC" side="INTERNAL" polarity="POSITIVE"/>
+      <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+      <Layer name="F.Mask" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+      <Layer name="B.Mask" layerFunction="SOLDERMASK" side="BOTTOM" polarity="POSITIVE"/>
+      <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE"><Span fromLayer="TOP" toLayer="BOTTOM"/></Layer>
+      <Stackup name="Primary" overallThickness="1.57" tolPlus="0" tolMinus="0" whereMeasured="METAL" stackupStatus="PROPOSED">
+        <StackupGroup name="Primary_Group" thickness="1.57" tolPlus="0" tolMinus="0">
+          <StackupLayer layerOrGroupRef="TOP" thickness="0.035" tolPlus="0" tolMinus="0" sequence="0"/>
+          <StackupLayer layerOrGroupRef="CORE" thickness="1.5" tolPlus="0" tolMinus="0" sequence="1"/>
+          <StackupLayer layerOrGroupRef="BOTTOM" thickness="0.035" tolPlus="0" tolMinus="0" sequence="2"/>
+        </StackupGroup>
+      </Stackup>
+      <Step name="board" type="BOARD">
+        <PadStackDef name="padstack">
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef>
+          <PadstackPadDef layerRef="BOTTOM" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef>
+          <PadstackPadDef layerRef="F.Mask" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef>
+          <PadstackPadDef layerRef="B.Mask" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef>
+        </PadStackDef>
+        <Datum x="0" y="0"/>
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="30" y="0"/>
+            <PolyStepSegment x="30" y="20"/>
+            <PolyStepSegment x="0" y="20"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+        </Profile>
+        <Package name="connector" type="OTHER" pinOne="1" pinOneOrientation="OTHER">
+          <Outline><Polygon><PolyBegin x="-1" y="-1"/><PolyStepSegment x="1" y="-1"/><PolyStepSegment x="1" y="1"/><PolyStepSegment x="-1" y="1"/><PolyStepSegment x="-1" y="-1"/></Polygon><LineDesc lineWidth="0.1" lineEnd="ROUND"/></Outline>
+        </Package>
+        <Component refDes="J1" packageRef="connector" part="TEST-PART" layerRef="TOP" mountType="THMT">
+          <Location x="5" y="5"/>
+        </Component>
+        <LayerFeature layerRef="TOP">
+          <Set net="GND"><Pad padstackDefRef="padstack"><Location x="5" y="5"/><StandardPrimitiveRef id="land"/><PinRef componentRef="J1" pin="1"/></Pad></Set>
+          <Set net="GND"><Features><Line startX="10" startY="10" endX="20" endY="10"><LineDesc lineWidth="0.1" lineEnd="ROUND"/></Line></Features></Set>
+        </LayerFeature>
+        <LayerFeature layerRef="BOTTOM">
+          <Set net="GND"><Pad padstackDefRef="padstack"><Location x="5" y="5"/><StandardPrimitiveRef id="land"/><PinRef componentRef="J1" pin="1"/></Pad></Set>
+        </LayerFeature>
+        <LayerFeature layerRef="F.Mask">
+          <Set><Pad padstackDefRef="padstack"><Location x="5" y="5"/><StandardPrimitiveRef id="land"/><PinRef componentRef="J1" pin="1"/></Pad></Set>
+          <Set><Pad padstackDefRef="padstack"><Location x="7.1" y="5"/><StandardPrimitiveRef id="land"/></Pad></Set>
+        </LayerFeature>
+        <LayerFeature layerRef="B.Mask">
+          <Set><Pad padstackDefRef="padstack"><Location x="5" y="5"/><StandardPrimitiveRef id="land"/><PinRef componentRef="J1" pin="1"/></Pad></Set>
+        </LayerFeature>
+        <LayerFeature layerRef="DRILL">
+          <Set net="GND"><Hole name="H1" diameter="1" platingStatus="PLATED" x="5" y="5" plusTol="0" minusTol="0"/></Set>
+        </LayerFeature>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>

--- a/crates/pcb-ipc-wasm/tests/pdk.toml
+++ b/crates/pcb-ipc-wasm/tests/pdk.toml
@@ -1,0 +1,22 @@
+schema_version = 1
+
+[pdk]
+id = "wasm-test"
+name = "WASM integration process"
+revision = "1"
+
+[capabilities.stackup]
+minimum_copper_layer_count = 2
+maximum_copper_layer_count = 4
+
+[capabilities.drilling]
+minimum_pth_hole_diameter = "1.2 mm"
+minimum_hole_to_hole_clearance = "0.2 mm"
+
+[capabilities.copper]
+minimum_feature_width = "0.2 mm"
+minimum_pth_annular_ring = "0.2 mm"
+minimum_board_edge_clearance = "0.25 mm"
+
+[capabilities.soldermask]
+minimum_web = "0.2 mm"

--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -6,30 +6,58 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 
+[features]
+default = ["cli"]
+cli = [
+    "dep:clap",
+    "dep:colored",
+    "dep:comfy-table",
+    "dep:pcb-diode-api",
+    "dep:pcb-sch",
+    "dep:pcb-ui",
+    "dep:tempfile",
+    "dep:uuid",
+    "dep:zstd",
+    "pcb-sch/table",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true }
-clap = { workspace = true }
-colored = { workspace = true }
-comfy-table = { workspace = true }
+clap = { workspace = true, optional = true }
+colored = { workspace = true, optional = true }
+comfy-table = { workspace = true, optional = true }
 ipc2581 = { workspace = true }
 gerberx2 = { workspace = true }
 hex = { workspace = true }
-jiff = { workspace = true }
+jiff = { workspace = true, features = ["js"] }
 log = { workspace = true }
 minijinja = { workspace = true }
 natord = { workspace = true }
 pcb-ir = { workspace = true }
-pcb-sch = { workspace = true, features = ["table"] }
+pcb-sch = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-rayon = { workspace = true }
 sha2 = { workspace = true }
-tempfile = { workspace = true }
+tempfile = { workspace = true, optional = true }
 toml = { workspace = true }
 uppsala = { workspace = true }
-uuid = { workspace = true, features = ["serde"] }
-zstd = { workspace = true }
-pcb-diode-api = { workspace = true }
-pcb-ui = { workspace = true }
+uuid = { workspace = true, features = ["serde"], optional = true }
+zstd = { workspace = true, optional = true }
+pcb-diode-api = { workspace = true, optional = true }
+pcb-ui = { workspace = true, optional = true }
 zip = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+rayon = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[[example]]
+name = "board_array_balancing_region"
+required-features = ["cli"]
+
+[[example]]
+name = "gerber_copper_svg"
+required-features = ["cli"]

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -132,3 +132,18 @@ layout.
 ```bash
 cargo test -p pcb-ipc2581-tools
 ```
+
+## In-memory library and WebAssembly
+
+Disable the default `cli` feature for `wasm32-unknown-unknown`. This excludes
+terminal output, network availability lookups, native Zstandard, and file
+command wrappers; native CLI behavior remains enabled by default.
+
+Import/export and DFM use the same implementations in both environments.
+`manufacturing::build_manufacturing_package_from_design` reuses an imported
+design; the resulting package exposes individual files and `to_zip()` for an
+in-memory archive.
+
+```bash
+cargo check -p pcb-ipc2581-tools --no-default-features --target wasm32-unknown-unknown
+```

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -142,7 +142,10 @@ command wrappers; native CLI behavior remains enabled by default.
 Import/export and DFM use the same implementations in both environments.
 `manufacturing::build_manufacturing_package_from_design` reuses an imported
 design; the resulting package exposes individual files and `to_zip()` for an
-in-memory archive.
+in-memory archive. `geometry::render::prepare_layer` prepares a layer for the
+shared SVG/PNG renderers.
+
+For browser and Node.js bindings, see [`pcb-ipc-wasm`](../pcb-ipc-wasm/README.md).
 
 ```bash
 cargo check -p pcb-ipc2581-tools --no-default-features --target wasm32-unknown-unknown

--- a/crates/pcb-ipc2581-tools/src/accessors/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/bom.rs
@@ -1,10 +1,16 @@
 use std::collections::BTreeMap;
 
 use ipc2581::types::{BomCategory, Characteristics};
-use pcb_sch::bom::Alternative;
 use serde::{Deserialize, Serialize};
 
 use super::IpcAccessor;
+
+/// A manufacturer-qualified alternative from IPC characteristics or AVL data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Alternative {
+    pub mpn: String,
+    pub manufacturer: String,
+}
 
 /// BOM statistics
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,7 +35,7 @@ impl BomStats {
 /// This is an intermediate representation that decouples raw IPC-2581
 /// data from the output format. Commands can use this to build their
 /// own domain-specific models.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct CharacteristicsData {
     pub package: Option<String>,
     pub value: Option<String>,

--- a/crates/pcb-ipc2581-tools/src/accessors/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/mod.rs
@@ -16,7 +16,7 @@ pub use board::{
     BoardArrayBoardMargin, BoardArrayDimensions, BoardArrayGridInfo, BoardArrayInfo,
     BoardArrayMargins, BoardDimensions, StackupInfo,
 };
-pub use bom::{AvlLookup, BomStats, CharacteristicsData};
+pub use bom::{Alternative, AvlLookup, BomStats, CharacteristicsData};
 pub use components::ComponentStats;
 pub use drills::{DrillHoleType, DrillSize, DrillStats, DrillTypeDistribution};
 pub use layers::{LayerStats, NetStats};

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
+#[cfg(feature = "cli")]
 use std::io::{self, Write};
+#[cfg(feature = "cli")]
 use std::path::Path;
 
 use super::board_array_auto::{
@@ -10,6 +12,7 @@ use crate::copper_balance::CopperBalanceReport;
 use crate::generated::GeneratedLayerFeature;
 use crate::geometry;
 use crate::ipc2581::Ipc2581;
+#[cfg(feature = "cli")]
 use crate::utils::file as file_utils;
 use crate::utils::format::fmt_num;
 use anyhow::{Context, Result, bail};
@@ -403,6 +406,7 @@ struct VcutLine {
     end_y_mm: f64,
 }
 
+#[cfg(feature = "cli")]
 pub fn execute(
     input: &Path,
     output: &Path,
@@ -416,6 +420,7 @@ pub fn execute(
     Ok(())
 }
 
+#[cfg(feature = "cli")]
 pub fn execute_auto(
     input: &Path,
     output: &Path,
@@ -429,6 +434,7 @@ pub fn execute_auto(
     Ok(())
 }
 
+#[cfg(feature = "cli")]
 fn print_copper_balance_summary(report: Option<&CopperBalanceReport>) {
     if let Some(report) = report {
         for line in report.summary_lines() {
@@ -437,6 +443,7 @@ fn print_copper_balance_summary(report: Option<&CopperBalanceReport>) {
     }
 }
 
+#[cfg(feature = "cli")]
 fn write_board_array_output(output: &Path, content: &str) -> Result<()> {
     if output.as_os_str() == "-" {
         io::stdout().lock().write_all(content.as_bytes())?;

--- a/crates/pcb-ipc2581-tools/src/commands/board_array_auto.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array_auto.rs
@@ -1,7 +1,5 @@
 use std::cmp::Ordering;
 
-use clap::ValueEnum;
-
 use super::board_array::BoardMarginMm;
 use crate::utils::format::fmt_num;
 
@@ -14,7 +12,8 @@ const AUTO_SHEETS: [AutoSheetSize; 4] = [
 const AUTO_MIN_EDGE_RAIL_MM: f64 = 5.0;
 const AUTO_MAX_GRID_COUNT: u32 = 10;
 
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AutoSheetSize {
     A7,
     A6,

--- a/crates/pcb-ipc2581-tools/src/commands/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/bom.rs
@@ -1,19 +1,28 @@
+#[cfg(feature = "cli")]
 use std::collections::HashMap;
+#[cfg(feature = "cli")]
 use std::io::{self, Write};
+#[cfg(feature = "cli")]
 use std::path::Path;
 
-use anyhow::Context;
-use anyhow::Result;
+#[cfg(feature = "cli")]
+use anyhow::{Context, Result};
+#[cfg(feature = "cli")]
 use pcb_sch::bom::{
-    Alternative, Bom, BomEntry, Capacitor, GenericComponent, Resistor, trim_description,
+    Alternative as SchAlternative, Bom, BomEntry, Capacitor, GenericComponent, Resistor,
+    trim_description,
 };
 
+#[cfg(feature = "cli")]
 use crate::OutputFormat;
 use crate::accessors::{CharacteristicsData, IpcAccessor};
+#[cfg(feature = "cli")]
 use crate::utils::file as file_utils;
+use serde::Serialize;
 
 /// Build GenericComponent from extracted characteristics
 /// Reuses the same logic as detect_generic_component in pcb-sch
+#[cfg(feature = "cli")]
 fn build_generic_component(data: &CharacteristicsData) -> Option<GenericComponent> {
     match data.component_type.as_deref()? {
         "resistor" => {
@@ -41,20 +50,13 @@ fn build_generic_component(data: &CharacteristicsData) -> Option<GenericComponen
     }
 }
 
-/// Convert accessor Alternative to bom Alternative
-fn to_sch_alternative(alt: &Alternative) -> Alternative {
-    Alternative {
-        mpn: alt.mpn.clone(),
-        manufacturer: alt.manufacturer.clone(),
-    }
-}
-
+#[cfg(feature = "cli")]
 pub fn execute(file: &Path, format: OutputFormat, offline: bool) -> Result<()> {
     let content = file_utils::load_ipc_file(file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
     let accessor = IpcAccessor::new(&ipc);
 
-    let mut bom = extract_bom_from_ipc(&accessor)?;
+    let mut bom = extract_bom_from_ipc(&accessor);
 
     if !offline {
         use pcb_ui::prelude::*;
@@ -90,131 +92,206 @@ pub fn execute(file: &Path, format: OutputFormat, offline: bool) -> Result<()> {
     Ok(())
 }
 
-/// Extract BOM data from IPC-2581 and convert to pcb_sch::Bom format
-fn extract_bom_from_ipc(accessor: &IpcAccessor) -> Result<Bom> {
-    let ipc = accessor.ipc();
-    let mut entries = HashMap::new();
-    let mut designators = HashMap::new();
+/// One populated or DNP component instance, resolved through the IPC BOM and AVL.
+#[derive(Debug, Clone, Serialize)]
+pub struct BomLine {
+    pub designator: String,
+    pub path: String,
+    pub mpn: Option<String>,
+    pub manufacturer: Option<String>,
+    pub description: Option<String>,
+    pub dnp: bool,
+    /// All extracted characteristics, including the original engineering-unit
+    /// strings used by the CLI's typed generic-component adapter.
+    pub characteristics: CharacteristicsData,
+}
 
-    // Get BOM from IPC-2581
-    if let Some(bom_section) = ipc.bom() {
-        for item in &bom_section.items {
-            // Skip items with DOCUMENT category (e.g., test points marked exclude_from_bom in KiCad)
+/// Resolve BOM instances without network requests or filesystem access.
+/// DOCUMENT entries are excluded; DNP entries remain explicitly marked.
+pub fn extract_bom_lines(accessor: &IpcAccessor) -> Vec<BomLine> {
+    let ipc = accessor.ipc();
+    let mut lines = Vec::new();
+    if let Some(bom) = ipc.bom() {
+        for item in &bom.items {
             if matches!(item.category, Some(ipc2581::types::BomCategory::Document)) {
                 continue;
             }
-
-            // Extract characteristics from BomItem using accessor
-            let characteristics_data = item
+            let mut characteristics = item
                 .characteristics
                 .as_ref()
                 .map(|chars| accessor.extract_characteristics(chars))
                 .unwrap_or_default();
-
-            let CharacteristicsData {
-                package,
-                value,
-                path: component_path,
-                alternatives: textual_alternatives,
-                properties,
-                ..
-            } = &characteristics_data;
-
-            // AVL provides canonical MPN and Manufacturer via Enterprise references
-            let avl_lookup = accessor.lookup_avl(item.oem_design_number_ref);
-
-            // Merge alternatives: AVL takes precedence, then textual characteristics
-            let mut alternatives: Vec<Alternative> = avl_lookup
-                .alternatives
-                .iter()
-                .map(to_sch_alternative)
-                .collect();
-            alternatives.extend(textual_alternatives.iter().map(to_sch_alternative));
-
-            // Use BomItem description attribute if present, otherwise fallback to value
+            let mut avl = accessor.lookup_avl(item.oem_design_number_ref);
+            avl.alternatives.append(&mut characteristics.alternatives);
+            characteristics.alternatives = avl.alternatives;
             let description = item
                 .description
-                .map(|sym| ipc.resolve(sym).to_string())
-                .or(value.clone());
-
-            // Build generic component data if available
-            let generic_data = build_generic_component(&characteristics_data);
-
-            // Build entry
-            let entry = BomEntry {
-                mpn: avl_lookup.primary_mpn,
-                alternatives,
-                manufacturer: avl_lookup.primary_manufacturer,
-                package: package.clone(),
-                value: value.clone(),
-                description: trim_description(description),
-                generic_data,
-                dnp: false, // Will be set per ref_des
-                skip_bom: false,
-                properties: properties.clone(),
-            };
-
-            // Process reference designators
+                .map(|symbol| ipc.resolve(symbol).to_string())
+                .or_else(|| characteristics.value.clone());
             for ref_des in &item.ref_des_list {
-                let designator = ipc.resolve(ref_des.name).to_string();
+                let designator = ipc.resolve(ref_des.name);
                 if designator.is_empty() {
                     continue;
                 }
-
-                // Use Path from characteristics, or fallback to ipc::designator format
-                let path = component_path
-                    .clone()
-                    .unwrap_or_else(|| format!("ipc::{}", designator));
-
-                let mut entry_with_dnp = entry.clone();
-                entry_with_dnp.dnp = !ref_des.populate;
-
-                entries.insert(path.clone(), entry_with_dnp);
-                designators.insert(path, designator);
+                lines.push(BomLine {
+                    designator: designator.to_string(),
+                    path: characteristics
+                        .path
+                        .clone()
+                        .unwrap_or_else(|| format!("ipc::{designator}")),
+                    mpn: avl.primary_mpn.clone(),
+                    manufacturer: avl.primary_manufacturer.clone(),
+                    description: description.clone(),
+                    dnp: !ref_des.populate,
+                    characteristics: characteristics.clone(),
+                });
             }
         }
     }
-
-    // If BOM section is empty or missing, try to extract from ECAD components
-    if entries.is_empty()
-        && let Some(ecad) = ipc.ecad()
-        && let Some(step) = ecad.cad_data.steps.first()
+    if lines.is_empty()
+        && let Some(step) = accessor.first_step()
     {
         for component in &step.components {
-            let Some(ref_des_symbol) = component.ref_des else {
+            let Some(ref_des) = component.ref_des else {
                 continue;
             };
-            let ref_des = ipc.resolve(ref_des_symbol).to_string();
-
-            // Skip empty designators (invalid/placeholder entries)
-            if ref_des.is_empty() {
+            let designator = ipc.resolve(ref_des);
+            if designator.is_empty() {
                 continue;
             }
-
-            let path = format!("ipc::{}", ref_des);
-
-            let package = component
-                .package_ref
-                .map(|package_ref| ipc.resolve(package_ref).to_string())
-                .filter(|package| !package.is_empty());
-
-            let entry = BomEntry {
+            lines.push(BomLine {
+                designator: designator.to_string(),
+                path: format!("ipc::{designator}"),
                 mpn: Some(ipc.resolve(component.part).to_string()).filter(|part| !part.is_empty()),
-                alternatives: Vec::new(),
                 manufacturer: None,
-                package,
-                value: None,
                 description: None,
-                generic_data: None,
                 dnp: false,
-                skip_bom: false,
-                properties: std::collections::BTreeMap::new(),
-            };
-
-            entries.insert(path.clone(), entry);
-            designators.insert(path, ref_des);
+                characteristics: CharacteristicsData {
+                    package: component
+                        .package_ref
+                        .map(|package| ipc.resolve(package).to_string())
+                        .filter(|package| !package.is_empty()),
+                    ..Default::default()
+                },
+            });
         }
     }
+    lines
+}
 
-    Ok(Bom::new(entries, designators))
+#[cfg(feature = "cli")]
+fn extract_bom_from_ipc(accessor: &IpcAccessor) -> Bom {
+    let mut entries = HashMap::new();
+    let mut designators = HashMap::new();
+    for line in extract_bom_lines(accessor) {
+        let generic_data = build_generic_component(&line.characteristics);
+        entries.insert(
+            line.path.clone(),
+            BomEntry {
+                mpn: line.mpn,
+                alternatives: line
+                    .characteristics
+                    .alternatives
+                    .into_iter()
+                    .map(|alt| SchAlternative {
+                        mpn: alt.mpn,
+                        manufacturer: alt.manufacturer,
+                    })
+                    .collect(),
+                manufacturer: line.manufacturer,
+                package: line.characteristics.package,
+                value: line.characteristics.value,
+                description: trim_description(line.description),
+                generic_data,
+                dnp: line.dnp,
+                skip_bom: false,
+                properties: line.characteristics.properties,
+            },
+        );
+        designators.insert(line.path, line.designator);
+    }
+    Bom::new(entries, designators)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portable_bom_resolves_avl_and_keeps_dnp_instances() {
+        let ipc = ipc2581::Ipc2581::parse(
+            r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner"><FunctionMode mode="ASSEMBLY"/></Content>
+  <LogisticHeader>
+    <Enterprise id="mfr" name="Example Components" code="MFR"/>
+  </LogisticHeader>
+  <Bom name="bom">
+    <BomHeader assembly="board" revision="1"/>
+    <BomItem OEMDesignNumberRef="R" quantity="2" category="ELECTRICAL" description="  resistor description  ">
+      <RefDes name="R10" packageRef="R0402" populate="false" layerRef="F.Cu"/>
+      <RefDes name="R2" packageRef="R0402" populate="true" layerRef="F.Cu"/>
+      <Characteristics category="ELECTRICAL">
+        <Textual definitionSource="pcb" textualCharacteristicName="Package" textualCharacteristicValue="0402"/>
+        <Textual definitionSource="pcb" textualCharacteristicName="Value" textualCharacteristicValue="1kohm"/>
+        <Textual definitionSource="pcb" textualCharacteristicName="Type" textualCharacteristicValue="resistor"/>
+        <Textual definitionSource="pcb" textualCharacteristicName="Resistance" textualCharacteristicValue="1kohm"/>
+        <Textual definitionSource="pcb" textualCharacteristicName="Voltage" textualCharacteristicValue="50V"/>
+        <Textual definitionSource="pcb" textualCharacteristicName="Tolerance" textualCharacteristicValue="1%"/>
+        <Textual definitionSource="pcb" textualCharacteristicName="Alternatives" textualCharacteristicValue="{&quot;mpn&quot;:&quot;TEXTUAL&quot;,&quot;manufacturer&quot;:&quot;Example Components&quot;}"/>
+      </Characteristics>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="TP" quantity="1" category="DOCUMENT">
+      <RefDes name="TP1" packageRef="TestPoint" populate="true" layerRef="F.Cu"/>
+    </BomItem>
+  </Bom>
+  <Avl name="avl">
+    <AvlItem OEMDesignNumber="R">
+      <AvlVmpn qualified="true" chosen="false"><AvlMpn name="ALTERNATIVE"/><AvlVendor enterpriseRef="mfr"/></AvlVmpn>
+      <AvlVmpn qualified="true" chosen="true"><AvlMpn name="PRIMARY"/><AvlVendor enterpriseRef="mfr"/></AvlVmpn>
+    </AvlItem>
+  </Avl>
+</IPC-2581>"#,
+        )
+        .unwrap();
+        let accessor = IpcAccessor::new(&ipc);
+        let lines = extract_bom_lines(&accessor);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].designator, "R10");
+        assert!(lines[0].dnp);
+        assert!(!lines[1].dnp);
+        assert_eq!(lines[1].path, "ipc::R2");
+        assert_eq!(lines[1].mpn.as_deref(), Some("PRIMARY"));
+        assert_eq!(lines[1].manufacturer.as_deref(), Some("Example Components"));
+        assert_eq!(lines[1].characteristics.alternatives[0].mpn, "ALTERNATIVE");
+        assert_eq!(lines[1].characteristics.alternatives[1].mpn, "TEXTUAL");
+        assert_eq!(lines[1].characteristics.package.as_deref(), Some("0402"));
+        assert_eq!(lines[1].characteristics.properties["Tolerance"], "1%");
+        let serialized = serde_json::to_value(&lines).unwrap();
+        assert_eq!(serialized[0]["dnp"], true);
+        assert_eq!(serialized[0]["characteristics"]["resistance"], "1kohm");
+        assert_eq!(serialized[0]["characteristics"]["voltage"], "50V");
+        assert_eq!(
+            serialized[0]["characteristics"]["component_type"],
+            "resistor"
+        );
+        assert_eq!(
+            serde_json::to_string(&lines).unwrap(),
+            serde_json::to_string(&extract_bom_lines(&accessor)).unwrap(),
+        );
+
+        #[cfg(feature = "cli")]
+        {
+            let bom = extract_bom_from_ipc(&accessor);
+            assert!(bom.entries["ipc::R10"].dnp);
+            assert_eq!(bom.entries["ipc::R2"].alternatives[1].mpn, "TEXTUAL");
+            assert_eq!(
+                bom.entries["ipc::R2"].description.as_deref(),
+                Some("resistor description")
+            );
+            assert!(matches!(
+                bom.entries["ipc::R2"].generic_data,
+                Some(GenericComponent::Resistor(_))
+            ));
+        }
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/cpl.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/cpl.rs
@@ -19,8 +19,10 @@ use crate::accessors::IpcAccessor;
 use crate::placement::extract_single_board_placements;
 
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum CplSideFilter {
+    #[default]
     Both,
     Top,
     Bottom,

--- a/crates/pcb-ipc2581-tools/src/commands/cpl.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/cpl.rs
@@ -1,17 +1,25 @@
 use std::cmp::Ordering;
+#[cfg(feature = "cli")]
 use std::fs;
+#[cfg(feature = "cli")]
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+#[cfg(feature = "cli")]
+use std::path::Path;
+use std::path::PathBuf;
 
+#[cfg(feature = "cli")]
 use anyhow::Result;
-use clap::ValueEnum;
+#[cfg(feature = "cli")]
 use ipc2581::Ipc2581;
 use pcb_ir::dialects::placement::{Document as PlacementDocument, Placement, PlacementSide};
 
+#[cfg(feature = "cli")]
 use crate::accessors::IpcAccessor;
+#[cfg(feature = "cli")]
 use crate::placement::extract_single_board_placements;
 
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CplSideFilter {
     Both,
     Top,
@@ -25,6 +33,7 @@ pub struct CplOptions {
     pub exclude_dnp: bool,
 }
 
+#[cfg(feature = "cli")]
 pub fn execute(file: &Path, options: &CplOptions) -> Result<()> {
     let ipc = Ipc2581::parse_file(file)?;
     let accessor = IpcAccessor::new(&ipc);

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -1,30 +1,163 @@
 //! PDK-driven manufacturability checks for IPC-2581 geometry.
 
-use std::borrow::Cow;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+#[cfg(feature = "cli")]
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result, bail, ensure};
+use pcb_ir::import::ipc2581::ImportedDesign;
+#[cfg(any(feature = "cli", test))]
 use pcb_ir::import::ipc2581::import_design;
+#[cfg(feature = "cli")]
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use crate::LayoutTarget;
+#[cfg(any(feature = "cli", test))]
 use crate::ipc2581::Ipc2581;
+#[cfg(feature = "cli")]
 use crate::utils::file as file_utils;
 
 mod builtin_pdks;
 mod checks;
 mod design;
 mod pdk;
-mod report;
+pub mod report;
 mod rules;
 mod scene;
 mod waivers;
 
+#[cfg(feature = "cli")]
 const MAX_REPORT_BYTES: usize = 128 * 1024 * 1024;
 const MAX_PDK_BYTES: usize = 1024 * 1024;
 
+pub use builtin_pdks::BuiltinPdk;
+pub use report::DfmReport;
+
+/// UTF-8 source and the caller-provided identity echoed into a report.
+/// `path` is a label; the in-memory API never reads it from a filesystem.
+#[derive(Debug, Clone, Copy)]
+pub struct TextSource<'a> {
+    pub path: &'a str,
+    pub source: &'a str,
+}
+
+/// A bundled PDK name or a caller-provided TOML document.
+#[derive(Debug)]
+pub enum PdkSource<'a> {
+    Builtin(&'a str),
+    Toml(TextSource<'a>),
+}
+
+/// Inputs to one DFM run over an already imported physical design.
+///
+/// The host supplies the source identity and timestamp so this API performs
+/// no filesystem, environment, or clock access. Waivers expire on the UTC
+/// date of `generated_at`; supplying the same inputs yields the same report.
+#[derive(Debug)]
+pub struct CheckRequest<'a> {
+    pub input: report::FileIdentity,
+    pub pdk: PdkSource<'a>,
+    pub waivers: Option<TextSource<'a>>,
+    pub layout_target: LayoutTarget,
+    pub generated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// The bundled PDKs, including their exact TOML source.
+pub fn builtin_pdks() -> &'static [BuiltinPdk] {
+    builtin_pdks::BUILTIN_PDKS
+}
+
+/// Run DFM in memory, reusing the canonical imported design.
+///
+/// Manufacturing violations are successful results with a `fail` verdict;
+/// only invalid inputs or geometry that cannot be checked return an error.
+pub fn check(imported: &ImportedDesign, request: CheckRequest<'_>) -> Result<DfmReport> {
+    let (pdk_path, pdk_source) = match request.pdk {
+        PdkSource::Builtin(name) => {
+            let pdk = builtin_pdks::find(name)
+                .with_context(|| format!("unknown built-in PDK '{name}'"))?;
+            (format!("builtin:{}", pdk.name), pdk.source)
+        }
+        PdkSource::Toml(source) => (source.path.to_owned(), source.source),
+    };
+    ensure!(
+        pdk_source.len() <= MAX_PDK_BYTES,
+        "PDK {pdk_path} exceeds the {MAX_PDK_BYTES} byte limit"
+    );
+    let pdk =
+        pdk::Pdk::parse(pdk_source).with_context(|| format!("failed to parse PDK {pdk_path}"))?;
+    let rules = rules::lower(&pdk).with_context(|| format!("failed to lower PDK {pdk_path}"))?;
+    if rules.is_empty() {
+        bail!("PDK {pdk_path} configures no DFM rules; add at least one capability");
+    }
+    let waivers = request
+        .waivers
+        .map(|source| {
+            waivers::WaiverFile::parse(source.source)
+                .with_context(|| format!("failed to parse waiver file {}", source.path))
+        })
+        .transpose()?;
+
+    let design = design::Design::extract(imported, request.layout_target.artwork_scope(), &rules)?;
+    let checked = checks::run(
+        &rules,
+        &design,
+        waivers.as_ref(),
+        request.generated_at.date_naive(),
+    );
+    let summary = summarize(&checked);
+    let layout = design.report_layout();
+    let scene = scene::export(&design, &layout, &checked.rules, &checked.findings)?;
+    Ok(DfmReport {
+        schema_version: report::REPORT_SCHEMA_VERSION,
+        generated_at: request.generated_at.to_rfc3339(),
+        verdict: if summary.errors > 0 {
+            report::Verdict::Fail
+        } else {
+            report::Verdict::Pass
+        },
+        tool: report::ToolIdentity {
+            name: "pcb",
+            version: env!("CARGO_PKG_VERSION"),
+        },
+        input: request.input,
+        pdk: report::PdkIdentity::from_pdk(
+            &pdk,
+            pdk_path,
+            sha256(pdk_source.as_bytes()),
+            pdk_source.to_owned(),
+        ),
+        layout_target: match request.layout_target {
+            LayoutTarget::Board => "board",
+            LayoutTarget::BoardArray => "board_array",
+        },
+        layout,
+        coordinate_system: report::CoordinateSystem {
+            unit: "mm",
+            axes: "x_right_y_up",
+            origin: "ipc_2581_design",
+        },
+        waivers: checked
+            .waivers
+            .zip(request.waivers)
+            .map(|(outcome, source)| report::WaiversApplied {
+                path: source.path.to_owned(),
+                sha256: sha256(source.source.as_bytes()),
+                applied: outcome.applied,
+                expired: outcome.expired,
+                unmatched: outcome.unmatched,
+            }),
+        summary,
+        rules: checked.rules,
+        findings: checked.findings,
+        scene,
+    })
+}
+
+#[cfg(feature = "cli")]
 #[derive(Debug)]
 pub struct CheckOptions {
     pub pdk: PathBuf,
@@ -33,20 +166,8 @@ pub struct CheckOptions {
     pub layout_target: LayoutTarget,
 }
 
-/// PDK source bytes plus the stable identity echoed into reports.
-struct LoadedPdk {
-    path: String,
-    bytes: Cow<'static, [u8]>,
-}
-
-/// A parsed waiver file plus the identity the report echoes back.
-struct LoadedWaivers {
-    path: String,
-    sha256: String,
-    file: waivers::WaiverFile,
-}
-
 /// Reject an invalid destination before any layout preparation or output write.
+#[cfg(feature = "cli")]
 pub fn validate_output(file: &Path, options: &CheckOptions) -> Result<()> {
     let Some(output) = options.output.as_deref() else {
         return Ok(());
@@ -92,6 +213,7 @@ pub fn validate_output(file: &Path, options: &CheckOptions) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "cli")]
 pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<()> {
     validate_output(file, options)?;
     let report = match build_report(file, options) {
@@ -122,6 +244,7 @@ pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<()> {
 
 /// Preparation failures produce an incomplete report, never a passing result.
 /// This also handles `.zen` layout/export errors before the IPC input exists.
+#[cfg(feature = "cli")]
 pub fn write_error_report(
     file: &Path,
     options: &CheckOptions,
@@ -147,136 +270,59 @@ pub fn write_error_report(
     write_report(options, &incomplete)
 }
 
-fn build_report(file: &Path, options: &CheckOptions) -> Result<report::DfmReport> {
+#[cfg(feature = "cli")]
+fn build_report(file: &Path, options: &CheckOptions) -> Result<DfmReport> {
     let input_bytes = std::fs::read(file)
         .with_context(|| format!("failed to read IPC-2581 file {}", file.display()))?;
-    let input = report::FileIdentity {
-        path: file.display().to_string(),
-        sha256: sha256(&input_bytes),
-        size_bytes: input_bytes.len() as u64,
+    let input = report::FileIdentity::new(file.display().to_string(), &input_bytes);
+    let pdk_path = options.pdk.display().to_string();
+    let pdk_source = if builtin_pdks::find(&pdk_path).is_none() {
+        let bytes = std::fs::read(&options.pdk)
+            .with_context(|| format!("failed to read PDK file {pdk_path}"))?;
+        Some(String::from_utf8(bytes).with_context(|| format!("PDK {pdk_path} is not UTF-8"))?)
+    } else {
+        None
     };
-    let content = file_utils::ipc_text(file, &input_bytes)?;
-    let loaded_pdk = load_pdk(&options.pdk)?;
-    let pdk_source = std::str::from_utf8(&loaded_pdk.bytes)
-        .with_context(|| format!("PDK {} is not UTF-8", loaded_pdk.path))?;
-    let pdk = pdk::Pdk::parse(pdk_source)
-        .with_context(|| format!("failed to parse PDK {}", loaded_pdk.path))?;
-
-    let rules =
-        rules::lower(&pdk).with_context(|| format!("failed to lower PDK {}", loaded_pdk.path))?;
-    if rules.is_empty() {
-        bail!(
-            "PDK {} configures no DFM rules; add at least one capability",
-            loaded_pdk.path
-        );
-    }
-
     let waivers = options
         .waivers
         .as_deref()
-        .map(|path| -> Result<LoadedWaivers> {
+        .map(|path| -> Result<_> {
             let bytes = std::fs::read(path)
                 .with_context(|| format!("failed to read waiver file {}", path.display()))?;
-            let source = std::str::from_utf8(&bytes)
+            let source = String::from_utf8(bytes)
                 .with_context(|| format!("waiver file {} is not UTF-8", path.display()))?;
-            let file = waivers::WaiverFile::parse(source)
-                .with_context(|| format!("failed to parse waiver file {}", path.display()))?;
-            Ok(LoadedWaivers {
-                path: path.display().to_string(),
-                sha256: sha256(&bytes),
-                file,
-            })
+            Ok((path.display().to_string(), source))
         })
         .transpose()?;
 
     let generated_at = generation_time();
+    let content = file_utils::ipc_text(file, &input_bytes)?;
     let ipc = Ipc2581::parse(&content).context("failed to parse IPC-2581 file")?;
     drop(content);
     drop(input_bytes);
     let imported = import_design(&ipc).context("failed to import IPC-2581 physical design")?;
-    let design = design::Design::extract(&imported, options.layout_target.artwork_scope(), &rules)?;
-    let checked = checks::run(
-        &rules,
-        &design,
-        waivers.as_ref().map(|loaded| &loaded.file),
-        generated_at.date_naive(),
-    );
-
-    let summary = summarize(&checked);
-    let failed = summary.errors > 0;
-    let layout = design.report_layout();
-    let scene = scene::export(&design, &layout, &checked.rules, &checked.findings)?;
-    Ok(report::DfmReport {
-        schema_version: report::REPORT_SCHEMA_VERSION,
-        generated_at: generated_at.to_rfc3339(),
-        verdict: if failed {
-            report::Verdict::Fail
-        } else {
-            report::Verdict::Pass
+    check(
+        &imported,
+        CheckRequest {
+            input,
+            pdk: match pdk_source.as_deref() {
+                Some(source) => PdkSource::Toml(TextSource {
+                    path: &pdk_path,
+                    source,
+                }),
+                None => PdkSource::Builtin(&pdk_path),
+            },
+            waivers: waivers
+                .as_ref()
+                .map(|(path, source)| TextSource { path, source }),
+            layout_target: options.layout_target,
+            generated_at,
         },
-        tool: report::ToolIdentity {
-            name: "pcb",
-            version: env!("CARGO_PKG_VERSION"),
-        },
-        input,
-        pdk: report::PdkIdentity::from_pdk(
-            &pdk,
-            loaded_pdk.path,
-            sha256(&loaded_pdk.bytes),
-            pdk_source.to_owned(),
-        ),
-        layout_target: match options.layout_target {
-            LayoutTarget::Board => "board",
-            LayoutTarget::BoardArray => "board_array",
-        },
-        layout,
-        coordinate_system: report::CoordinateSystem {
-            unit: "mm",
-            axes: "x_right_y_up",
-            origin: "ipc_2581_design",
-        },
-        waivers: checked
-            .waivers
-            .as_ref()
-            .zip(waivers.as_ref())
-            .map(|(outcome, loaded)| report::WaiversApplied {
-                path: loaded.path.clone(),
-                sha256: loaded.sha256.clone(),
-                applied: outcome.applied,
-                expired: outcome.expired.clone(),
-                unmatched: outcome.unmatched.clone(),
-            }),
-        summary,
-        rules: checked.rules,
-        findings: checked.findings,
-        scene,
-    })
-}
-
-fn load_pdk(reference: &Path) -> Result<LoadedPdk> {
-    let loaded = if let Some(pdk) = reference.to_str().and_then(builtin_pdks::find) {
-        LoadedPdk {
-            path: format!("builtin:{}", pdk.name),
-            bytes: Cow::Borrowed(pdk.source.as_bytes()),
-        }
-    } else {
-        LoadedPdk {
-            path: reference.display().to_string(),
-            bytes: Cow::Owned(
-                std::fs::read(reference)
-                    .with_context(|| format!("failed to read PDK file {}", reference.display()))?,
-            ),
-        }
-    };
-    ensure!(
-        loaded.bytes.len() <= MAX_PDK_BYTES,
-        "PDK {} exceeds the {MAX_PDK_BYTES} byte limit",
-        loaded.path
-    );
-    Ok(loaded)
+    )
 }
 
 /// The non-verdict counts worth surfacing next to the pass/fail line.
+#[cfg(feature = "cli")]
 fn annotations(summary: &report::Summary) -> String {
     let mut notes = String::new();
     if summary.rules_skipped > 0 {
@@ -293,6 +339,7 @@ fn annotations(summary: &report::Summary) -> String {
 
 /// Report generation time, honoring `SOURCE_DATE_EPOCH` so CI reports can be
 /// byte-stable.
+#[cfg(feature = "cli")]
 fn generation_time() -> chrono::DateTime<chrono::Utc> {
     std::env::var("SOURCE_DATE_EPOCH")
         .ok()
@@ -334,6 +381,7 @@ fn summarize(checked: &checks::Results) -> report::Summary {
     }
 }
 
+#[cfg(feature = "cli")]
 fn write_report(options: &CheckOptions, report: &impl Serialize) -> Result<()> {
     let mut bytes = serde_json::to_vec_pretty(report)?;
     bytes.push(b'\n');
@@ -451,34 +499,40 @@ minimum_board_edge_clearance = "0.5 mm"
 minimum_board_array_spacing = "300 mil"
 "#;
 
-    fn check(xml: &str, scope: ArtworkScope) -> checks::Results {
-        check_with_pdk(xml, scope, PDK)
+    fn check(xml: &str, target: LayoutTarget) -> DfmReport {
+        check_with_pdk(xml, target, PDK)
     }
 
-    fn check_with_pdk(xml: &str, scope: ArtworkScope, pdk_source: &str) -> checks::Results {
+    fn check_with_pdk(xml: &str, target: LayoutTarget, pdk_source: &str) -> DfmReport {
         let ipc = Ipc2581::parse(xml).unwrap();
-        let pdk = pdk::Pdk::parse(pdk_source).unwrap();
-        let rules = rules::lower(&pdk).unwrap();
         let imported = import_design(&ipc).unwrap();
-        let design = design::Design::extract(&imported, scope, &rules).unwrap();
-        checks::run(
-            &rules,
-            &design,
-            None,
-            NaiveDate::from_ymd_opt(2026, 8, 21).unwrap(),
+        super::check(
+            &imported,
+            CheckRequest {
+                input: report::FileIdentity::new("board.xml", xml.as_bytes()),
+                pdk: PdkSource::Toml(TextSource {
+                    path: "pdk.toml",
+                    source: pdk_source,
+                }),
+                waivers: None,
+                layout_target: target,
+                generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            },
         )
+        .unwrap()
     }
 
-    fn rule<'a>(results: &'a checks::Results, id: &str) -> &'a report::RuleResult {
+    fn rule<'a>(results: &'a DfmReport, id: &str) -> &'a report::RuleResult {
         results.rules.iter().find(|rule| rule.id == id).unwrap()
     }
 
     #[test]
     fn loads_the_embedded_standard_pdk() {
-        let loaded = load_pdk(Path::new("standard")).unwrap();
-        let parsed = pdk::Pdk::parse(std::str::from_utf8(&loaded.bytes).unwrap()).unwrap();
-
-        assert_eq!(loaded.path, "builtin:standard");
+        let builtin = builtin_pdks()
+            .iter()
+            .find(|pdk| pdk.name == "standard")
+            .unwrap();
+        let parsed = pdk::Pdk::parse(builtin.source).unwrap();
         assert_eq!(parsed.pdk.id, "standard");
         assert_eq!(parsed.pdk.name, "Standard");
         assert_eq!(parsed.pdk.manufacturer.as_deref(), Some("Diode"));
@@ -495,28 +549,141 @@ minimum_board_array_spacing = "300 mil"
     }
 
     #[test]
-    fn still_loads_a_pdk_from_a_file() {
+    fn in_memory_report_keeps_source_identity_and_waiver_dates() {
+        let imported = import_design(&Ipc2581::parse(BOARD).unwrap()).unwrap();
+        let pdk_source = PDK.replace(
+            "minimum_copper_layer_count = 2",
+            "minimum_copper_layer_count = 3",
+        );
+        let run = |waivers, day| {
+            super::check(
+                &imported,
+                CheckRequest {
+                    input: report::FileIdentity::new("board.xml", BOARD.as_bytes()),
+                    pdk: PdkSource::Toml(TextSource {
+                        path: "pdk.toml",
+                        source: &pdk_source,
+                    }),
+                    waivers,
+                    layout_target: LayoutTarget::Board,
+                    generated_at: NaiveDate::from_ymd_opt(2026, 8, day)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap()
+                        .and_utc(),
+                },
+            )
+            .unwrap()
+        };
+        let initial = run(None, 30);
+        assert!(matches!(initial.verdict, report::Verdict::Fail));
+        assert_eq!(initial.summary.errors, 1);
+        assert_eq!(initial.input.sha256, sha256(BOARD.as_bytes()));
+        assert_eq!(initial.pdk.sha256, sha256(pdk_source.as_bytes()));
+        assert_eq!(initial.generated_at, "2026-08-30T00:00:00+00:00");
+        let id = &initial.findings[0].id;
+        let source = format!(
+            r#"[[waiver]]
+finding = "{id}"
+reason = "approved by fab"
+expires = "2026-08-31"
+
+[[waiver]]
+finding = "dfm-stale"
+reason = "old finding"
+"#
+        );
+        let waivers = Some(TextSource {
+            path: "waivers.toml",
+            source: &source,
+        });
+        let active = run(waivers, 30);
+        assert!(matches!(active.verdict, report::Verdict::Pass));
+        assert_eq!(active.summary.errors, 0);
+        assert_eq!(active.summary.findings, 1);
+        assert_eq!(active.summary.waived, 1);
+        assert_eq!(active.findings[0].id, *id);
+        assert_eq!(
+            active.findings[0].waiver_reason.as_deref(),
+            Some("approved by fab")
+        );
+        assert!(active.findings[0].waived);
+        let applied = active.waivers.unwrap();
+        assert_eq!(applied.path, "waivers.toml");
+        assert_eq!(applied.sha256, sha256(source.as_bytes()));
+        assert_eq!(applied.applied, 1);
+        assert!(applied.expired.is_empty());
+        assert_eq!(applied.unmatched, ["dfm-stale"]);
+
+        let expired = run(waivers, 31);
+        assert!(matches!(expired.verdict, report::Verdict::Fail));
+        assert_eq!(expired.summary.errors, 1);
+        assert_eq!(expired.summary.waived, 0);
+        assert!(!expired.findings[0].waived);
+        assert_eq!(expired.waivers.unwrap().expired, std::slice::from_ref(id));
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn cli_report_matches_in_memory_report_for_compressed_input() {
         let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("custom.toml");
-        std::fs::write(&path, PDK).unwrap();
-
-        let loaded = load_pdk(&path).unwrap();
-
-        assert_eq!(loaded.path, path.display().to_string());
-        assert_eq!(&*loaded.bytes, PDK.as_bytes());
+        let input = directory.path().join("board.xml.zst");
+        let pdk = directory.path().join("custom.toml");
+        let output = directory.path().join("report.json");
+        let pdk_source = PDK.replace(
+            "minimum_copper_layer_count = 2",
+            "minimum_copper_layer_count = 3",
+        );
+        let bytes = zstd::encode_all(BOARD.as_bytes(), 0).unwrap();
+        std::fs::write(&input, &bytes).unwrap();
+        std::fs::write(&pdk, &pdk_source).unwrap();
+        let error = execute_check(
+            &input,
+            &CheckOptions {
+                pdk: pdk.clone(),
+                waivers: None,
+                output: Some(output.clone()),
+                layout_target: LayoutTarget::Board,
+            },
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("DFM check failed with 1 error finding(s)")
+        );
+        let cli: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(output).unwrap()).unwrap();
+        let mut report = check_with_pdk(BOARD, LayoutTarget::Board, &pdk_source);
+        report.input = report::FileIdentity::new(input.display().to_string(), &bytes);
+        report.pdk.path = pdk.display().to_string();
+        report.generated_at = cli["generated_at"].as_str().unwrap().to_owned();
+        assert_eq!(cli, serde_json::to_value(report).unwrap());
     }
 
     #[test]
     fn rejects_oversize_pdk_source() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("oversize.toml");
-        std::fs::write(&path, vec![b' '; MAX_PDK_BYTES + 1]).unwrap();
-
-        let error = load_pdk(&path).err().unwrap();
+        let imported = import_design(&Ipc2581::parse(BOARD).unwrap()).unwrap();
+        let source = " ".repeat(MAX_PDK_BYTES + 1);
+        let error = super::check(
+            &imported,
+            CheckRequest {
+                input: report::FileIdentity::new("board.xml", BOARD.as_bytes()),
+                pdk: PdkSource::Toml(TextSource {
+                    path: "oversize.toml",
+                    source: &source,
+                }),
+                waivers: None,
+                layout_target: LayoutTarget::Board,
+                generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            },
+        )
+        .unwrap_err();
 
         assert!(error.to_string().contains("exceeds the 1048576 byte limit"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn report_serialization_failure_preserves_existing_output() {
         struct Unserializable;
@@ -546,6 +713,7 @@ minimum_board_array_spacing = "300 mil"
         assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn report_persistence_failure_preserves_destination_and_cleans_temporary_file() {
         let directory = tempfile::tempdir().unwrap();
@@ -574,7 +742,7 @@ minimum_board_array_spacing = "300 mil"
     fn copper_layer_count_checks_both_bounds_from_the_physical_stackup() {
         let below_minimum = check_with_pdk(
             BOARD,
-            ArtworkScope::Board,
+            LayoutTarget::Board,
             &PDK.replace(
                 "minimum_copper_layer_count = 2",
                 "minimum_copper_layer_count = 3",
@@ -610,7 +778,7 @@ minimum_board_array_spacing = "300 mil"
 
         let above_maximum = check_with_pdk(
             BOARD,
-            ArtworkScope::Board,
+            LayoutTarget::Board,
             &PDK.replace(
                 "minimum_copper_layer_count = 2\nmaximum_copper_layer_count = 4",
                 "minimum_copper_layer_count = 1\nmaximum_copper_layer_count = 1",
@@ -675,9 +843,9 @@ minimum_board_array_spacing = "300 mil"
         .unwrap()
         .xml;
 
-        let board_results = check(BOARD, ArtworkScope::Board);
-        let array_results = check(&array, ArtworkScope::ArrayFlattened);
-        let fab_results = check(&fab, ArtworkScope::ArrayFlattened);
+        let board_results = check(BOARD, LayoutTarget::Board);
+        let array_results = check(&array, LayoutTarget::BoardArray);
+        let fab_results = check(&fab, LayoutTarget::BoardArray);
 
         let board_edge = "copper.minimum_board_edge_clearance";
         let vscore = "copper.minimum_vscore_to_copper_clearance";

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/builtin_pdks.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/builtin_pdks.rs
@@ -1,4 +1,5 @@
 /// A bundled process definition, addressable by its exact `name`.
+#[derive(serde::Serialize)]
 pub struct BuiltinPdk {
     pub name: &'static str,
     pub source: &'static str,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/builtin_pdks.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/builtin_pdks.rs
@@ -1,9 +1,10 @@
-pub(super) struct BuiltinPdk {
+/// A bundled process definition, addressable by its exact `name`.
+pub struct BuiltinPdk {
     pub name: &'static str,
     pub source: &'static str,
 }
 
-const BUILTIN_PDKS: &[BuiltinPdk] = &[BuiltinPdk {
+pub(super) const BUILTIN_PDKS: &[BuiltinPdk] = &[BuiltinPdk {
     name: "standard",
     source: include_str!("../../../pdks/standard.toml"),
 }];

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -35,6 +35,7 @@
 use pcb_ir::geom::dfm::{BBoxIndex, Distance, circular_region};
 use pcb_ir::geom::region::difference_rings;
 use pcb_ir::geom::{BBox, ContourSet, FillRule, Point};
+#[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 
 use crate::commands::dfm::design::{CopperLayer, Design, Hole, HoleClass, HoleLand, Land};
@@ -57,8 +58,12 @@ pub(super) fn evaluate(limit_mm: f64, class: HoleClass, design: &Design) -> Eval
     let copper_layers = &design.copper_layers;
     let hole_lands = &design.hole_lands;
     let boundaries = &design.copper_boundaries;
-    let ring_indices = copper_layers
-        .par_iter()
+    #[cfg(not(target_family = "wasm"))]
+    let layers = copper_layers.par_iter();
+    #[cfg(target_family = "wasm")]
+    let layers = copper_layers.iter();
+    let ring_indices = layers
+        .clone()
         .map(|layer| {
             BBoxIndex::new(
                 layer
@@ -79,13 +84,15 @@ pub(super) fn evaluate(limit_mm: f64, class: HoleClass, design: &Design) -> Eval
         .iter()
         .map(|(_, hole)| hole.center)
         .collect::<Vec<_>>();
-    let contains = copper_layers
-        .par_iter()
+    let contains = layers
         .map(|layer| layer.image.contains_points_batch(&centers))
         .collect::<Vec<_>>();
 
+    #[cfg(not(target_family = "wasm"))]
+    let holes = holes.par_iter();
+    #[cfg(target_family = "wasm")]
+    let holes = holes.iter();
     let per_hole = holes
-        .par_iter()
         .enumerate()
         .map(|(position, &(hole_index, hole))| {
             let radius = hole.diameter_mm / 2.0;

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -33,59 +33,63 @@ use pcb_ir::geom::dfm::{
     RegionBoundaryIndex, ThinPiece, circular_region, thin_features, thin_gaps,
 };
 use pcb_ir::geom::{BBox, ContourSet, Point, tol};
+#[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 
 use super::{Evaluation, Measured, MeasuredSite};
-use crate::commands::dfm::design::{CopperConductor, Design, MaskOwner};
+use crate::commands::dfm::design::{CopperConductor, CopperLayer, Design, MaskLayer, MaskOwner};
 use crate::commands::dfm::report::{Evidence, LayerRef, MeasurementKind, SourceLocator, Subject};
 
 pub(super) fn copper_feature_width(limit_mm: f64, design: &Design) -> Evaluation {
+    let measure = |layer: &CopperLayer| {
+        thin_features(&layer.image, limit_mm)
+            .into_iter()
+            .map(move |piece| {
+                let mut measured = measured_piece(&piece, limit_mm, &layer.layer, "copper_image");
+                // Prove ownership against final composed material. A bounding box
+                // is only a broad phase; overlapping owners remain ambiguous.
+                let construction =
+                    piece
+                        .sites
+                        .iter()
+                        .fold(piece.candidate.clone(), |region, site| {
+                            region.union(&circular_region(site.disk.center, site.disk.radius_mm))
+                        });
+                let owner = unique_copper_owner(&construction, &layer.conductors);
+                if let Some(owner) = owner {
+                    measured.subjects[0].provenance =
+                        copper_subject(design, owner, &layer.layer).provenance;
+                }
+                for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
+                    let local_owner = owner.or_else(|| {
+                        let local = piece
+                            .candidate
+                            .intersection(&ContourSet::rectangle(
+                                geometry.bbox.expand(limit_mm / 2.0),
+                                tol::REGION_MM,
+                            ))
+                            .union(&circular_region(
+                                geometry.disk.center,
+                                geometry.disk.radius_mm,
+                            ));
+                        unique_copper_owner(&local, &layer.conductors)
+                    });
+                    if let Some(owner) = local_owner {
+                        site.subjects = vec![copper_subject(design, owner, &layer.layer)];
+                    }
+                }
+                measured
+            })
+            .collect::<Vec<_>>()
+    };
+    #[cfg(not(target_family = "wasm"))]
     let measured = design
         .copper_layers
         .par_iter()
-        .flat_map_iter(|layer| {
-            thin_features(&layer.image, limit_mm)
-                .into_iter()
-                .map(move |piece| {
-                    let mut measured =
-                        measured_piece(&piece, limit_mm, &layer.layer, "copper_image");
-                    // Prove ownership against final composed material. A bounding box
-                    // is only a broad phase; overlapping owners remain ambiguous.
-                    let construction =
-                        piece
-                            .sites
-                            .iter()
-                            .fold(piece.candidate.clone(), |region, site| {
-                                region
-                                    .union(&circular_region(site.disk.center, site.disk.radius_mm))
-                            });
-                    let owner = unique_copper_owner(&construction, &layer.conductors);
-                    if let Some(owner) = owner {
-                        measured.subjects[0].provenance =
-                            copper_subject(design, owner, &layer.layer).provenance;
-                    }
-                    for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
-                        let local_owner = owner.or_else(|| {
-                            let local = piece
-                                .candidate
-                                .intersection(&ContourSet::rectangle(
-                                    geometry.bbox.expand(limit_mm / 2.0),
-                                    tol::REGION_MM,
-                                ))
-                                .union(&circular_region(
-                                    geometry.disk.center,
-                                    geometry.disk.radius_mm,
-                                ));
-                            unique_copper_owner(&local, &layer.conductors)
-                        });
-                        if let Some(owner) = local_owner {
-                            site.subjects = vec![copper_subject(design, owner, &layer.layer)];
-                        }
-                    }
-                    measured
-                })
-        })
+        .flat_map_iter(measure)
         .collect();
+    #[cfg(target_family = "wasm")]
+    let measured = design.copper_layers.iter().flat_map(measure).collect();
     Evaluation {
         checked: design.copper_layers.len(),
         measured,
@@ -93,51 +97,55 @@ pub(super) fn copper_feature_width(limit_mm: f64, design: &Design) -> Evaluation
 }
 
 pub(super) fn soldermask_web(limit_mm: f64, design: &Design) -> Evaluation {
+    let measure = |layer: &MaskLayer| {
+        let boundaries = layer
+            .owners
+            .iter()
+            .map(|owner| {
+                (
+                    owner.image.bbox,
+                    RegionBoundaryIndex::new(&owner.image, limit_mm),
+                )
+            })
+            .collect::<Vec<_>>();
+        thin_gaps(&layer.image, limit_mm)
+            .into_iter()
+            .map(move |piece| {
+                let mut measured =
+                    measured_piece(&piece, limit_mm, &layer.layer, "soldermask_image");
+                let mut aggregate_owner = None;
+                let mut one_owner = true;
+                for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
+                    let Some(owners) = wall_owners(&geometry.walls, &boundaries) else {
+                        one_owner = false;
+                        continue;
+                    };
+                    if owners.len() != 1 || aggregate_owner.is_some_and(|owner| owners[0] != owner)
+                    {
+                        one_owner = false;
+                    }
+                    aggregate_owner = aggregate_owner.or_else(|| owners.first().copied());
+                    site.subjects = owners
+                        .into_iter()
+                        .map(|index| mask_subject(design, &layer.owners[index], &layer.layer))
+                        .collect();
+                }
+                if one_owner && let Some(index) = aggregate_owner {
+                    measured.subjects[0].provenance =
+                        mask_subject(design, &layer.owners[index], &layer.layer).provenance;
+                }
+                measured
+            })
+            .collect::<Vec<_>>()
+    };
+    #[cfg(not(target_family = "wasm"))]
     let measured = design
         .mask_layers
         .par_iter()
-        .flat_map_iter(|layer| {
-            let boundaries = layer
-                .owners
-                .iter()
-                .map(|owner| {
-                    (
-                        owner.image.bbox,
-                        RegionBoundaryIndex::new(&owner.image, limit_mm),
-                    )
-                })
-                .collect::<Vec<_>>();
-            thin_gaps(&layer.image, limit_mm)
-                .into_iter()
-                .map(move |piece| {
-                    let mut measured =
-                        measured_piece(&piece, limit_mm, &layer.layer, "soldermask_image");
-                    let mut aggregate_owner = None;
-                    let mut one_owner = true;
-                    for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
-                        let Some(owners) = wall_owners(&geometry.walls, &boundaries) else {
-                            one_owner = false;
-                            continue;
-                        };
-                        if owners.len() != 1
-                            || aggregate_owner.is_some_and(|owner| owners[0] != owner)
-                        {
-                            one_owner = false;
-                        }
-                        aggregate_owner = aggregate_owner.or_else(|| owners.first().copied());
-                        site.subjects = owners
-                            .into_iter()
-                            .map(|index| mask_subject(design, &layer.owners[index], &layer.layer))
-                            .collect();
-                    }
-                    if one_owner && let Some(index) = aggregate_owner {
-                        measured.subjects[0].provenance =
-                            mask_subject(design, &layer.owners[index], &layer.layer).provenance;
-                    }
-                    measured
-                })
-        })
+        .flat_map_iter(measure)
         .collect();
+    #[cfg(target_family = "wasm")]
+    let measured = design.mask_layers.iter().flat_map(measure).collect();
     Evaluation {
         checked: design.mask_layers.len(),
         measured,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -23,6 +23,7 @@ use pcb_ir::geom::dfm::{Distance, RegionBoundaryIndex, WidthDisk, min_width_disk
 use pcb_ir::geom::path::ContourBuf;
 use pcb_ir::geom::region::Ring;
 use pcb_ir::geom::{BBox, ContourSet, FillRule, Point, Polarity, Span, tol};
+#[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 
 use crate::geometry::GeometryDocument;
@@ -90,8 +91,11 @@ impl<'a> Design<'a> {
                 collect_physical_stackup(imported).map(Some)
             })?,
             copper_boundaries: when(pools.copper_boundaries, || {
-                Ok(copper_layers
-                    .par_iter()
+                #[cfg(not(target_family = "wasm"))]
+                let layers = copper_layers.par_iter();
+                #[cfg(target_family = "wasm")]
+                let layers = copper_layers.iter();
+                Ok(layers
                     .map(|layer| RegionBoundaryIndex::new(&layer.image, boundary_search_mm))
                     .collect())
             })?,
@@ -878,8 +882,11 @@ fn collect_copper_layers(
         .filter(|(_, layer)| layers::is_copper(layer.layer_function))
         .collect::<Vec<_>>();
     let total = copper_layers.len();
+    #[cfg(not(target_family = "wasm"))]
+    let copper_layers = copper_layers.into_par_iter();
+    #[cfg(target_family = "wasm")]
+    let copper_layers = copper_layers.into_iter();
     copper_layers
-        .into_par_iter()
         .enumerate()
         .map(|(ordinal, (layer_index, layer))| {
             let name = imported.resolve(layer.name);
@@ -978,13 +985,17 @@ impl ArtworkLowering<Symbol, Option<(Option<Symbol>, Option<u32>)>> for MaskAttr
 }
 
 fn collect_mask_layers(imported: &ImportedDesign, scope: ArtworkScope) -> Result<Vec<MaskLayer>> {
-    imported
+    let layers = imported
         .layer_definitions
         .iter()
         .enumerate()
         .filter(|(_, layer)| layer.layer_function == LayerFunction::Soldermask)
-        .collect::<Vec<_>>()
-        .into_par_iter()
+        .collect::<Vec<_>>();
+    #[cfg(not(target_family = "wasm"))]
+    let layers = layers.into_par_iter();
+    #[cfg(target_family = "wasm")]
+    let layers = layers.into_iter();
+    layers
         .map(|(layer_index, layer)| {
             let name = imported.resolve(layer.name);
             let mut document = imported

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
@@ -71,7 +71,7 @@ pub struct ToolIdentity {
     pub version: &'static str,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct FileIdentity {
     pub path: String,
     pub sha256: String,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
@@ -78,6 +78,18 @@ pub struct FileIdentity {
     pub size_bytes: u64,
 }
 
+impl FileIdentity {
+    /// Identify the original input bytes, before decoding or decompression.
+    /// `path` is a caller-provided label and is never opened by this method.
+    pub fn new(path: impl Into<String>, bytes: &[u8]) -> Self {
+        Self {
+            path: path.into(),
+            sha256: super::sha256(bytes),
+            size_bytes: bytes.len() as u64,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct PdkIdentity {
     pub id: String,
@@ -92,7 +104,7 @@ pub struct PdkIdentity {
 }
 
 impl PdkIdentity {
-    pub fn from_pdk(pdk: &Pdk, path: String, sha256: String, source: String) -> Self {
+    pub(super) fn from_pdk(pdk: &Pdk, path: String, sha256: String, source: String) -> Self {
         Self {
             id: pdk.pdk.id.clone(),
             name: pdk.pdk.name.clone(),
@@ -186,7 +198,7 @@ pub struct RuleResult {
 }
 
 impl RuleResult {
-    pub fn new(rule: &Rule) -> Self {
+    pub(super) fn new(rule: &Rule) -> Self {
         let semantics = rule.kind.semantics();
         Self {
             id: rule.id.clone(),

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/scene.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/scene.rs
@@ -113,12 +113,7 @@ fn native_artwork(
 ) -> Result<
     pcb_ir::dialects::artwork::Document<ipc2581::types::LayerFunction, Option<ipc2581::Symbol>>,
 > {
-    let layer_id = design
-        .imported
-        .layer_id(layer)
-        .with_context(|| format!("DFM scene references unknown layer {layer}"))?;
-    let mut geometry = design.imported.materialize_layer(layer_id, design.scope)?;
-    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry);
+    let geometry = geometry::render::prepare_layer(design.imported, layer, design.scope)?;
     Ok(geometry::render::layer_artwork(
         &geometry,
         false,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
@@ -47,27 +47,26 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
         .iter()
         .map(|layer| ipc.resolve(layer.name).to_string())
         .collect::<Vec<_>>();
+    let extract = |layer_name: &String| {
+        composed_copper_image(ipc, layer_name)
+            .map(|image| (layer_name.clone(), image.intersection(&usable_region)))
+    };
+    #[cfg(not(target_family = "wasm"))]
     let copper_images = std::thread::scope(|scope| {
         let extractions = layer_names
             .iter()
-            .map(|layer_name| {
-                scope.spawn(|| {
-                    composed_copper_image(ipc, layer_name)
-                        .map(|image| image.intersection(&usable_region))
-                })
-            })
+            .map(|layer_name| scope.spawn(|| extract(layer_name)))
             .collect::<Vec<_>>();
-        layer_names
-            .iter()
-            .zip(extractions)
-            .map(|(layer_name, extraction)| {
-                let image = extraction
-                    .join()
-                    .expect("copper-image extraction panicked")?;
-                Ok((layer_name.clone(), image))
-            })
+        extractions
+            .into_iter()
+            .map(|extraction| extraction.join().expect("copper-image extraction panicked"))
             .collect::<Result<Vec<_>>>()
     })?;
+    #[cfg(target_family = "wasm")]
+    let copper_images = layer_names
+        .iter()
+        .map(extract)
+        .collect::<Result<Vec<_>>>()?;
     // Copper found outside the placed panels joins the shared obstacle set,
     // so unexpected overhang shrinks the certified safe region for every
     // layer instead of failing the solve. Each layer keeps its own overhang:

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -1,5 +1,9 @@
-use std::collections::{HashMap, HashSet};
+#[cfg(feature = "cli")]
+use std::collections::HashMap;
+use std::collections::HashSet;
+#[cfg(feature = "cli")]
 use std::io::{self, Write};
+#[cfg(feature = "cli")]
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -12,13 +16,16 @@ use pcb_ir::geom::{BBox, Point};
 use super::EdgeInsetsMm;
 use crate::copper_balance::CopperBalanceReport;
 use crate::geometry;
+#[cfg(feature = "cli")]
 use crate::utils::file as file_utils;
 
 mod balance;
 mod packing;
 mod xml;
 
-use packing::{MAX_ITEM_COUNT, Size, pack};
+#[cfg(feature = "cli")]
+use packing::MAX_ITEM_COUNT;
+use packing::{Size, pack};
 
 const DEFAULT_EDGE_MARGIN_MM: EdgeInsetsMm = EdgeInsetsMm::new(50.8, 25.4, 50.8, 25.4);
 const DEFAULT_PANEL_GAP_MM: f64 = 7.62;
@@ -211,6 +218,7 @@ pub struct FabPanelCreation {
     pub copper_balance: Option<CopperBalanceReport>,
 }
 
+#[cfg(feature = "cli")]
 pub fn execute(
     inputs: &[PathBuf],
     output: &Path,
@@ -269,7 +277,7 @@ fn create_fab_panel_xml(source_xml: &[String], occurrences: &[usize]) -> Result<
         .map(|creation| creation.xml)
 }
 
-pub(crate) fn create_fab_panel(
+pub fn create_fab_panel(
     source_xml: &[String],
     occurrences: &[usize],
     spec: FabPanelSpec,
@@ -278,31 +286,35 @@ pub(crate) fn create_fab_panel(
     if occurrences.is_empty() {
         bail!("at least one assembly panel is required");
     }
-
     // Reduce every source to manufacturing content once, up front: assembling
     // already-stripped sources keeps the fabrication panel a pure composition
     // and avoids stripping the much larger composed document.
+    let strip = |(source_index, xml): (usize, &String)| {
+        super::fabrication::strip_non_manufacturing(xml).with_context(|| {
+            format!(
+                "failed to reduce assembly panel input {} to manufacturing content",
+                source_index + 1
+            )
+        })
+    };
+    #[cfg(not(target_family = "wasm"))]
     let source_xml = std::thread::scope(|scope| {
         let strips = source_xml
             .iter()
-            .map(|xml| scope.spawn(|| super::fabrication::strip_non_manufacturing(xml)))
+            .enumerate()
+            .map(|source| scope.spawn(move || strip(source)))
             .collect::<Vec<_>>();
         strips
             .into_iter()
-            .enumerate()
-            .map(|(source_index, strip)| {
-                strip
-                    .join()
-                    .expect("assembly panel stripping panicked")
-                    .with_context(|| {
-                        format!(
-                            "failed to reduce assembly panel input {} to manufacturing content",
-                            source_index + 1
-                        )
-                    })
-            })
+            .map(|strip| strip.join().expect("assembly panel stripping panicked"))
             .collect::<Result<Vec<_>>>()
     })?;
+    #[cfg(target_family = "wasm")]
+    let source_xml = source_xml
+        .iter()
+        .enumerate()
+        .map(strip)
+        .collect::<Result<Vec<_>>>()?;
 
     let stackups = source_xml
         .iter()

--- a/crates/pcb-ipc2581-tools/src/commands/html_export.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/html_export.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "cli")]
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -10,11 +11,13 @@ use serde::Serialize;
 use crate::UnitFormat;
 use crate::accessors::{ColorInfo, IpcAccessor, StackupLayerType, SurfaceFinishInfo};
 use crate::geometry;
+#[cfg(feature = "cli")]
 use crate::utils::file as file_utils;
 
 type GeometryDocument =
     pcb_ir::dialects::ipc::Document<ipc2581::Symbol, ipc2581::types::LayerFunction>;
 
+#[cfg(feature = "cli")]
 pub fn execute(
     input_file: &Path,
     output_file: Option<&Path>,

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -9,9 +9,13 @@
 
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+#[cfg(feature = "cli")]
 use std::fs;
+#[cfg(feature = "cli")]
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+#[cfg(feature = "cli")]
+use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::{Result, bail};
 use ipc2581::Ipc2581;
@@ -43,6 +47,7 @@ pub struct IctContact {
     pub path: String,
 }
 
+#[cfg(feature = "cli")]
 pub fn execute(file: &Path, options: &IctOptions) -> Result<()> {
     let ipc = Ipc2581::parse_file(file)?;
     let contacts = extract_contacts(&ipc)?;
@@ -62,7 +67,8 @@ pub fn extract_contacts(ipc: &Ipc2581) -> Result<Vec<IctContact>> {
     extract_contacts_from_design(ipc, &imported)
 }
 
-fn extract_contacts_from_design(
+/// Extract contacts while reusing a previously imported design.
+pub fn extract_contacts_from_design(
     ipc: &Ipc2581,
     imported: &ImportedDesign,
 ) -> Result<Vec<IctContact>> {

--- a/crates/pcb-ipc2581-tools/src/commands/info.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/info.rs
@@ -1,26 +1,34 @@
 use std::collections::{BTreeMap, BTreeSet};
+#[cfg(feature = "cli")]
 use std::path::Path;
 
+#[cfg(feature = "cli")]
+use crate::accessors::{BoardArrayInfo, StackupLayerType, SurfaceFinishInfo};
+#[cfg(feature = "cli")]
 use anyhow::Result;
+#[cfg(feature = "cli")]
 use colored::Colorize;
+#[cfg(feature = "cli")]
 use comfy_table::presets::UTF8_FULL_CONDENSED;
+#[cfg(feature = "cli")]
 use comfy_table::{Cell, Color, Table};
 use serde::Serialize;
 use serde_json::json;
 
-use crate::accessors::{
-    BoardArrayInfo, ColorInfo, DrillHoleType, DrillStats, IpcAccessor, StackupLayerType,
-    SurfaceFinishInfo,
-};
+use crate::accessors::{ColorInfo, DrillHoleType, DrillStats, IpcAccessor};
+#[cfg(feature = "cli")]
 use crate::utils::{file as file_utils, units};
+#[cfg(feature = "cli")]
 use crate::{OutputFormat, UnitFormat};
 
 /// Format a drill diameter in both mm and mils
+#[cfg(feature = "cli")]
 fn format_diameter(mm: f64) -> String {
     let mils = mm / 0.0254;
     format!("{:.3}mm ({:.1} mil)", mm, mils)
 }
 
+#[cfg(feature = "cli")]
 pub fn execute(file: &Path, format: OutputFormat, units: UnitFormat) -> Result<()> {
     let content = file_utils::load_ipc_file(file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
@@ -33,9 +41,8 @@ pub fn execute(file: &Path, format: OutputFormat, units: UnitFormat) -> Result<(
 }
 
 /// Format color with unicode block swatch
+#[cfg(feature = "cli")]
 fn format_color_with_swatch(color: &ColorInfo) -> String {
-    use colored::Colorize;
-
     let swatch = if let Some((r, g, b)) = color.rgb_color() {
         "■".truecolor(r, g, b)
     } else {
@@ -50,8 +57,8 @@ fn format_color_with_swatch(color: &ColorInfo) -> String {
 }
 
 /// Format surface finish with color swatch for well-known finishes
+#[cfg(feature = "cli")]
 fn format_surface_finish_with_swatch(finish: &SurfaceFinishInfo) -> String {
-    use colored::Colorize;
     let (r, g, b) = finish.rgb_color();
     let swatch = "■".truecolor(r, g, b);
     format!("{} {}", swatch, finish.name)
@@ -145,6 +152,7 @@ fn canonical_soldermask_kind(color: Option<&ColorInfo>) -> SoldermaskKind {
     SoldermaskKind::Other
 }
 
+#[cfg(feature = "cli")]
 fn output_text(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<()> {
     // Board Summary header
     println!("{}", "Board Summary".bold());
@@ -523,6 +531,7 @@ fn output_text(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "cli")]
 fn print_board_array_summary(
     board_array: &BoardArrayInfo,
     accessor: &IpcAccessor,
@@ -581,6 +590,7 @@ fn print_board_array_summary(
     println!();
 }
 
+#[cfg(feature = "cli")]
 fn print_drill_distribution(title: &str, drills: &DrillStats) {
     println!("{}", title.bold());
     let mut drill_table = Table::new();
@@ -649,7 +659,14 @@ fn drill_stats_json(drills: &DrillStats) -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "cli")]
 fn output_json(accessor: &IpcAccessor) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(&info_json(accessor))?);
+    Ok(())
+}
+
+/// Extract the same board, assembly, and fabrication summary emitted by `ipc info --format json`.
+pub fn info_json(accessor: &IpcAccessor) -> serde_json::Value {
     let ipc = accessor.ipc();
     let content = ipc.content();
     let layer_side_map: BTreeMap<_, _> = ipc
@@ -929,6 +946,5 @@ fn output_json(accessor: &IpcAccessor) -> Result<()> {
 
     info["component_placements"] = json!(component_placements);
 
-    println!("{}", serde_json::to_string_pretty(&info)?);
-    Ok(())
+    info
 }

--- a/crates/pcb-ipc2581-tools/src/commands/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/mod.rs
@@ -3,6 +3,7 @@ use anyhow::{Result, bail};
 pub mod board_array;
 pub mod board_array_auto;
 pub mod bom;
+#[cfg(feature = "cli")]
 pub mod bom_edit;
 pub mod cpl;
 pub mod dfm;
@@ -12,6 +13,7 @@ pub mod html_export;
 pub mod ict;
 pub mod info;
 pub mod outline;
+#[cfg(feature = "cli")]
 pub mod render;
 pub mod view;
 pub mod warp;

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -1,15 +1,20 @@
+#[cfg(feature = "cli")]
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+#[cfg(feature = "cli")]
+use anyhow::Context;
+use anyhow::{Result, bail};
 use pcb_ir::dialects::ipc::{ProfileSet, profile_occurrences_for};
 
 use crate::LayoutTarget;
 use crate::geometry;
 use crate::ipc2581::Ipc2581;
+#[cfg(feature = "cli")]
 use crate::utils::file as file_utils;
 
 /// Options for exporting IPC-2581 profile outlines.
 #[derive(Debug, Clone)]
+#[cfg(feature = "cli")]
 pub struct OutlineOptions {
     pub output: PathBuf,
     pub layout_target: LayoutTarget,
@@ -19,20 +24,11 @@ pub struct OutlineOptions {
 }
 
 /// Export Step/Profile outlines as a DXF file.
+#[cfg(feature = "cli")]
 pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = Ipc2581::parse(&content)?;
-    let layout = geometry::extract_layout(&ipc)?;
-    let profile_set = if options.nested_outlines {
-        ProfileSet::LayoutBoundaries
-    } else {
-        options.layout_target.artwork_scope().profile_set()
-    };
-    if profile_occurrences_for(&layout, profile_set).is_empty() {
-        bail!("IPC-2581 primary step and repeated child steps have no board Profile outline");
-    }
-
-    let dxf = geometry::dxf::render_profile_set_dxf(&layout, profile_set);
+    let dxf = export_dxf(&ipc, options.layout_target, options.nested_outlines)?;
     std::fs::write(&options.output, dxf)
         .with_context(|| format!("Failed to write DXF to {}", options.output.display()))?;
     println!(
@@ -40,6 +36,25 @@ pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
         options.output.display()
     );
     Ok(())
+}
+
+/// Export Step/Profile outlines as in-memory DXF text.
+pub fn export_dxf(
+    ipc: &Ipc2581,
+    layout_target: LayoutTarget,
+    nested_outlines: bool,
+) -> Result<String> {
+    let layout = geometry::extract_layout(ipc)?;
+    let profile_set = if nested_outlines {
+        ProfileSet::LayoutBoundaries
+    } else {
+        layout_target.artwork_scope().profile_set()
+    };
+    if profile_occurrences_for(&layout, profile_set).is_empty() {
+        bail!("IPC-2581 primary step and repeated child steps have no board Profile outline");
+    }
+
+    Ok(geometry::dxf::render_profile_set_dxf(&layout, profile_set))
 }
 
 #[cfg(test)]

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -25,8 +25,8 @@ pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
     let view = options.layout_target.artwork_scope();
-    let mut geometry = geometry::extract_layer_for_view(&ipc, &options.layer, view)?;
-    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry);
+    let imported = pcb_ir::import::ipc2581::import_design(&ipc)?;
+    let geometry = geometry::render::prepare_layer(&imported, &options.layer, view)?;
 
     match target {
         RenderTarget::Svg => render_svg(&geometry, options, view)?,

--- a/crates/pcb-ipc2581-tools/src/commands/view.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/view.rs
@@ -1,10 +1,16 @@
+#[cfg(feature = "cli")]
 use std::path::Path;
 
-use anyhow::{Context, Result};
+#[cfg(feature = "cli")]
+use anyhow::Context;
+use anyhow::Result;
+#[cfg(feature = "cli")]
+use ipc2581::Ipc2581;
 use ipc2581::edit::{self, Doc};
-use ipc2581::{Ipc2581, Mode, XmlWriter};
+use ipc2581::{Mode, XmlWriter};
 
 use crate::ViewMode;
+#[cfg(feature = "cli")]
 use crate::utils::file as file_utils;
 
 /// Defines which sections to exclude for each mode
@@ -72,6 +78,7 @@ fn excluded_sections(mode: Mode) -> &'static [&'static str] {
     }
 }
 
+#[cfg(feature = "cli")]
 pub fn execute(input: &Path, mode: ViewMode, output: &Path) -> Result<()> {
     let content = file_utils::load_ipc_file(input)?;
     let mut filtered_xml = filter_by_mode(&content, mode)?;
@@ -95,7 +102,8 @@ pub fn execute(input: &Path, mode: ViewMode, output: &Path) -> Result<()> {
     Ok(())
 }
 
-fn filter_by_mode(xml: &str, mode: ViewMode) -> Result<String> {
+/// Project XML to a function mode, preserving retained content without adding a history record.
+pub fn filter_by_mode(xml: &str, mode: ViewMode) -> Result<String> {
     if matches!(mode, ViewMode::Fabrication) {
         return super::fabrication::strip_non_manufacturing(xml);
     }

--- a/crates/pcb-ipc2581-tools/src/commands/warp.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/warp.rs
@@ -1,15 +1,21 @@
 //! Report estimated panel bow and twist.
 
+#[cfg(feature = "cli")]
 use std::path::Path;
 
+#[cfg(feature = "cli")]
 use anyhow::{Context, Result};
 
+#[cfg(feature = "cli")]
 use crate::ipc2581::Ipc2581;
-use crate::warp::{self, WarpAnalysis};
+#[cfg(feature = "cli")]
+use crate::warp;
+use crate::warp::WarpAnalysis;
 
 /// Bow beyond which IPC-6012 rejects a board carrying surface-mount parts.
 const SURFACE_MOUNT_LIMIT_PERCENT: f64 = 0.75;
 
+#[cfg(feature = "cli")]
 pub fn execute(file: &Path, report: Option<&Path>) -> Result<()> {
     let xml = std::fs::read_to_string(file)
         .with_context(|| format!("failed to read {}", file.display()))?;

--- a/crates/pcb-ipc2581-tools/src/geometry/render.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/render.rs
@@ -1,16 +1,35 @@
+use anyhow::Context;
 use ipc2581::Symbol;
 
 pub use crate::layers::layer_role;
 use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::artwork::{Geometry, Object, PaintOrder, PaintStage};
-use pcb_ir::dialects::ipc::{ProfileSet, profile_occurrences_for};
+use pcb_ir::dialects::ipc::{ArtworkScope, ProfileSet, profile_occurrences_for};
 use pcb_ir::dialects::{LayerRole, Side, mask};
 use pcb_ir::geom::{BBox, Paint, Polarity, Span, StrokeStyle};
+use pcb_ir::import::ipc2581::ImportedDesign;
 
 type GeometryDocument = pcb_ir::dialects::ipc::Document<Symbol, LayerFunction>;
 type ArtworkDocument = pcb_ir::dialects::artwork::Document<LayerFunction, Option<Symbol>>;
 
 const DISPLAY_PROFILE_STROKE_WIDTH_MM: f64 = 0.1;
+
+/// Materialize and normalize a layer using the same artwork rules as Gerber export.
+pub fn prepare_layer(
+    imported: &ImportedDesign,
+    layer_name: &str,
+    view: ArtworkScope,
+) -> anyhow::Result<GeometryDocument> {
+    let layer = imported
+        .layer_id(layer_name)
+        .with_context(|| format!("IPC-2581 layer '{layer_name}' was not found"))?;
+    let mut geometry = imported.materialize_layer(layer, view)?;
+    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry);
+    pcb_ir::dialects::ipc::validate_artwork_ready(&geometry)
+        .map_err(anyhow::Error::msg)
+        .with_context(|| format!("IPC-2581 layer '{layer_name}' is not artwork-ready"))?;
+    Ok(geometry)
+}
 
 pub fn render_layer_svg(
     geometry: &GeometryDocument,

--- a/crates/pcb-ipc2581-tools/src/geometry/render.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/render.rs
@@ -30,6 +30,7 @@ pub fn render_layer_png(
     pcb_ir::render::artwork_png(&artwork, &pcb_ir::render::RenderOptions::default())
 }
 
+#[cfg(feature = "cli")]
 pub fn render_layer_terminal(
     geometry: &GeometryDocument,
     include_profiles: bool,

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "cli")]
 use std::fmt::Write as _;
+#[cfg(feature = "cli")]
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -18,18 +20,25 @@ use pcb_ir::dialects::artwork::{
     Aperture, ApertureShape, Geometry as ArtworkGeometry, GridRepeat, Object as ArtworkObject,
     PaintOrder, PaintStage,
 };
+#[cfg(feature = "cli")]
+use pcb_ir::dialects::ipc::relief;
 use pcb_ir::dialects::ipc::{
     ArtworkLowering, ArtworkObjectKind, ArtworkScope, CopperBalanceKind, Feature, FeatureBucket,
     FeatureDomain, FeatureOperation, FeatureRole, FiducialKind, LayoutPurpose, PlatingKind,
     PrimitiveRef, ProfileSet, lower_layer_to_artwork_objects_with, lower_layer_to_artwork_with,
-    profile_occurrences_for, relief,
+    profile_occurrences_for,
 };
 use pcb_ir::dialects::{LayerRole, Side as IrSide};
-use pcb_ir::geom::path::{ContourBuf, PathCmd, PathOp};
+use pcb_ir::geom::path::ContourBuf;
+#[cfg(feature = "cli")]
+use pcb_ir::geom::path::{PathCmd, PathOp};
 use pcb_ir::geom::{
-    Affine2, Arc, BBox, LineCap, LineJoin, LinePattern, Paint, Point, Polarity, Span, StrokeStyle,
+    Affine2, BBox, LineCap, LineJoin, LinePattern, Paint, Point, Polarity, Span, StrokeStyle,
 };
 use pcb_ir::import::ipc2581::{ImportedDesign, LayerId, import_design};
+
+#[cfg(feature = "cli")]
+use pcb_ir::geom::Arc;
 
 type IpcGeometryDocument = pcb_ir::dialects::ipc::Document<ipc2581::Symbol, LayerFunction>;
 
@@ -810,6 +819,11 @@ fn board_array_profile_gerber_files(
 ) -> Result<Vec<GerberX2File>> {
     let doc = &imported.geometry;
     let score_lines = geometry::board_array_vscore_lines_from_design(imported)?;
+    #[cfg(not(feature = "cli"))]
+    if relief_debug_dir.is_some() {
+        bail!("filesystem debug output requires the cli feature");
+    }
+    #[cfg(feature = "cli")]
     let profile = if let Some(debug_dir) = relief_debug_dir {
         let (profile, relief_debug) =
             geometry::board_array_fabrication_profile_from_design_with_debug(
@@ -822,6 +836,9 @@ fn board_array_profile_gerber_files(
     } else {
         geometry::board_array_fabrication_profile_from_design(imported, doc, &score_lines)?
     };
+    #[cfg(not(feature = "cli"))]
+    let profile =
+        geometry::board_array_fabrication_profile_from_design(imported, doc, &score_lines)?;
     if profile.purpose == LayoutPurpose::Product {
         let mut contour_groups = profile.array_outlines;
         contour_groups.push(profile.material_removal);
@@ -899,6 +916,7 @@ fn profile_gerber_file(
     }))
 }
 
+#[cfg(feature = "cli")]
 fn write_vscore_relief_debug(output_dir: &Path, debug: &relief::VScoreReliefDebug) -> Result<()> {
     let Some(svg) = render_vscore_relief_debug_svg(debug) else {
         return Ok(());
@@ -918,6 +936,7 @@ fn write_vscore_relief_debug(output_dir: &Path, debug: &relief::VScoreReliefDebu
     })
 }
 
+#[cfg(feature = "cli")]
 fn render_vscore_relief_debug_svg(debug: &relief::VScoreReliefDebug) -> Option<String> {
     if debug.entries.is_empty() {
         return None;
@@ -1041,6 +1060,7 @@ fn render_vscore_relief_debug_svg(debug: &relief::VScoreReliefDebug) -> Option<S
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg(feature = "cli")]
 struct DebugSvgPathStyle {
     class_name: &'static str,
     fill: &'static str,
@@ -1049,6 +1069,7 @@ struct DebugSvgPathStyle {
     extra_attrs: &'static str,
 }
 
+#[cfg(feature = "cli")]
 fn write_debug_path(
     svg: &mut String,
     entry_index: usize,
@@ -1066,6 +1087,7 @@ fn write_debug_path(
     .unwrap();
 }
 
+#[cfg(feature = "cli")]
 fn debug_path_data(payloads: &[ContourBuf]) -> Option<String> {
     let mut data = String::new();
     for payload in payloads {
@@ -1074,6 +1096,7 @@ fn debug_path_data(payloads: &[ContourBuf]) -> Option<String> {
     (!data.is_empty()).then_some(data)
 }
 
+#[cfg(feature = "cli")]
 fn append_debug_path_cmds(data: &mut String, cmds: &[PathCmd]) {
     let mut current = Point::default();
     for cmd in cmds {
@@ -1112,6 +1135,7 @@ fn append_debug_path_cmds(data: &mut String, cmds: &[PathCmd]) {
     }
 }
 
+#[cfg(feature = "cli")]
 fn write_debug_arc(data: &mut String, start: Point, end: Point, center: Point, clockwise: bool) {
     let radius = start.distance_to(center);
     if radius <= 1e-9 {
@@ -1132,6 +1156,7 @@ fn write_debug_arc(data: &mut String, start: Point, end: Point, center: Point, c
     write_debug_svg_arc(data, radius, large_arc, sweep_flag, end);
 }
 
+#[cfg(feature = "cli")]
 fn write_debug_svg_arc(data: &mut String, radius: f64, large_arc: u8, sweep_flag: u8, end: Point) {
     write!(
         data,
@@ -1144,12 +1169,14 @@ fn write_debug_svg_arc(data: &mut String, radius: f64, large_arc: u8, sweep_flag
     .unwrap();
 }
 
+#[cfg(feature = "cli")]
 fn payloads_bbox(payloads: &[ContourBuf]) -> BBox {
     payloads
         .iter()
         .fold(BBox::empty(), |bbox, payload| bbox.union(payload.bbox))
 }
 
+#[cfg(feature = "cli")]
 fn debug_num(value: f64) -> String {
     let mut text = format!("{value:.6}");
     while text.contains('.') && text.ends_with('0') {
@@ -1602,10 +1629,10 @@ fn fiducial_aperture_function(feature: &Feature<ipc2581::Symbol>) -> Vec<String>
 mod tests {
     use super::*;
     use crate::ipc2581 as ipc;
-    use crate::manufacturing::{
-        ManufacturingExportOptions, ManufacturingFileKind, build_manufacturing_package,
-        export_manufacturing_package,
-    };
+    #[cfg(feature = "cli")]
+    use crate::manufacturing::{ManufacturingExportOptions, export_manufacturing_package};
+    use crate::manufacturing::{ManufacturingFileKind, build_manufacturing_package};
+    #[cfg(feature = "cli")]
     use std::io::{Cursor, Read};
 
     #[test]
@@ -2743,6 +2770,7 @@ mod tests {
         assert!(npth.contents.contains("X3.0Y4.0"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn gerber_export_writes_zip_when_output_has_zip_extension() {
         let ipc = ipc::Ipc2581::parse(
@@ -3110,6 +3138,7 @@ mod tests {
         assert!(score.contents.contains("%TA.AperFunction,Other,Score*%"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn real_board_export_parseback_and_svg_paths_smoke() {
         let compressed = include_bytes!("../../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -89,6 +89,18 @@ pub(crate) fn build_gerber_x2_files_from_design_with_options(
     view: ArtworkScope,
     options: &GerberExportOptions,
 ) -> Result<Vec<GerberX2File>> {
+    // With no repeated instances, a board-array request denotes this board
+    // itself. Use the board path so its Step/Profile remains authoritative
+    // even when the source has no BOARD_OUTLINE layer artwork.
+    let view = if view == ArtworkScope::ArrayFlattened
+        && imported.geometry.layout.repeats.is_empty()
+        && pcb_ir::dialects::ipc::root_step(&imported.geometry)
+            .is_some_and(|(_, step)| step.kind == pcb_ir::dialects::ipc::LayoutStepKind::Board)
+    {
+        ArtworkScope::Board
+    } else {
+        view
+    };
     let mut files = Vec::new();
     let plans = export_layer_plans(imported, &imported.layer_definitions);
     let has_profile_plan = plans
@@ -2311,6 +2323,72 @@ mod tests {
         assert!(edge_cuts.contents.contains("%TA.AperFunction,Profile*%"));
         assert!(edge_cuts.contents.contains("%ADD10C,0.05*%"));
         gerberx2::GerberX2::parse(&edge_cuts.contents).unwrap();
+    }
+
+    #[test]
+    fn standalone_profile_export_matches_both_layout_targets() {
+        for outline_layer in [
+            "",
+            r#"<Layer name="Edge.Cuts" layerFunction="BOARD_OUTLINE" side="ALL" polarity="POSITIVE"/>"#,
+        ] {
+            let ipc = ipc::Ipc2581::parse(&format!(
+                r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/></Content>
+  <Ecad>
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      {outline_layer}
+      <Step name="board" type="BOARD">
+        <Profile>
+          <Polygon>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="10" y="0"/>
+            <PolyStepSegment x="10" y="5"/>
+            <PolyStepSegment x="0" y="5"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+          <Cutout>
+            <PolyBegin x="2" y="2"/>
+            <PolyStepSegment x="3" y="2"/>
+            <PolyStepSegment x="3" y="3"/>
+            <PolyStepSegment x="2" y="3"/>
+            <PolyStepSegment x="2" y="2"/>
+          </Cutout>
+        </Profile>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#,
+            ))
+            .unwrap();
+            let board = build_manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
+            let array = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+            assert_eq!(
+                board
+                    .files
+                    .iter()
+                    .map(|f| (&f.filename, &f.contents))
+                    .collect::<Vec<_>>(),
+                array
+                    .files
+                    .iter()
+                    .map(|f| (&f.filename, &f.contents))
+                    .collect::<Vec<_>>(),
+            );
+            let profile = &array
+                .files
+                .iter()
+                .find(|f| f.filename == "Edge_Cuts.gm1")
+                .unwrap()
+                .contents;
+            assert!(profile.contains("%TF.FileFunction,Profile,NP*%"));
+            assert!(profile.contains("%TF.Part,Single*%"));
+            let parsed = gerberx2::GerberX2::parse(profile).unwrap();
+            let geometry = gerberx2::geometry::extract_document(&parsed);
+            geometry.validate().unwrap();
+            assert_eq!(geometry.layers[0].objects.count, 8);
+        }
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -47,11 +47,13 @@ pub enum UnitFormat {
 /// outlines. `board-array` is the root step of the file with every repeat
 /// materialized, and is identical to `board` for a plain board file.
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum LayoutTarget {
     /// The canonical source board, as if it were fabricated alone.
     Board,
     /// The file's root step with every nested repeat materialized.
+    #[default]
     #[cfg_attr(feature = "cli", value(name = "board-array", alias = "panel"))]
     BoardArray,
 }
@@ -66,7 +68,8 @@ impl LayoutTarget {
 }
 
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ViewMode {
     Bom,
     Assembly,

--- a/crates/pcb-ipc2581-tools/src/lib.rs
+++ b/crates/pcb-ipc2581-tools/src/lib.rs
@@ -1,4 +1,3 @@
-use clap::ValueEnum;
 use ipc2581::Mode;
 
 pub mod accessors;
@@ -19,20 +18,23 @@ pub mod xnc;
 // Re-export ipc2581 for external use
 pub use ipc2581;
 
-#[derive(ValueEnum, Debug, Clone, Copy)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy)]
 pub enum OutputFormat {
     Text,
     Json,
 }
 
-#[derive(ValueEnum, Debug, Clone, Copy)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy)]
 pub enum RenderFormat {
     Auto,
     Svg,
     Png,
 }
 
-#[derive(ValueEnum, Debug, Clone, Copy)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy)]
 pub enum UnitFormat {
     Mm,
     Mil,
@@ -44,12 +46,13 @@ pub enum UnitFormat {
 /// One vocabulary, one default, for every command that produces artwork or
 /// outlines. `board-array` is the root step of the file with every repeat
 /// materialized, and is identical to `board` for a plain board file.
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LayoutTarget {
     /// The canonical source board, as if it were fabricated alone.
     Board,
     /// The file's root step with every nested repeat materialized.
-    #[value(name = "board-array", alias = "panel")]
+    #[cfg_attr(feature = "cli", value(name = "board-array", alias = "panel"))]
     BoardArray,
 }
 
@@ -62,7 +65,8 @@ impl LayoutTarget {
     }
 }
 
-#[derive(ValueEnum, Debug, Clone, Copy)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy)]
 pub enum ViewMode {
     Bom,
     Assembly,

--- a/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
+++ b/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "cli")]
 use std::fs;
-use std::io::{BufWriter, Write};
+#[cfg(feature = "cli")]
+use std::io::BufWriter;
+use std::io::{Cursor, Seek, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -9,7 +12,9 @@ use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::import::ipc2581::{ImportedDesign, import_design};
 use zip::{ZipWriter, write::FileOptions};
 
-use crate::{gerber, ipc2581 as ipc};
+use crate::gerber;
+#[cfg(feature = "cli")]
+use crate::ipc2581 as ipc;
 
 #[derive(Debug, Clone)]
 pub struct ManufacturingExportOptions {
@@ -21,6 +26,13 @@ pub struct ManufacturingExportOptions {
 #[derive(Debug, Clone)]
 pub struct ManufacturingPackage {
     pub files: Vec<ManufacturingFile>,
+}
+
+impl ManufacturingPackage {
+    /// Serialize the complete manufacturing package to an in-memory ZIP archive.
+    pub fn to_zip(&self) -> Result<Vec<u8>> {
+        Ok(write_zip(self, Cursor::new(Vec::new()))?.into_inner())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -36,6 +48,7 @@ pub enum ManufacturingFileKind {
     Xnc,
 }
 
+#[cfg(feature = "cli")]
 pub fn export_manufacturing_package(
     ipc: &Ipc2581,
     options: &ManufacturingExportOptions,
@@ -50,7 +63,15 @@ pub fn build_manufacturing_package(
     view: ArtworkScope,
 ) -> Result<ManufacturingPackage> {
     let imported = import_design(ipc)?;
-    build_manufacturing_package_inner(&imported, view, None)
+    build_manufacturing_package_from_design(&imported, view)
+}
+
+/// Export an already-imported design without repeating IPC ingestion.
+pub fn build_manufacturing_package_from_design(
+    imported: &ImportedDesign,
+    view: ArtworkScope,
+) -> Result<ManufacturingPackage> {
+    build_manufacturing_package_inner(imported, view, None)
 }
 
 pub fn build_manufacturing_package_with_options(
@@ -87,6 +108,7 @@ fn build_manufacturing_package_inner(
     Ok(ManufacturingPackage { files })
 }
 
+#[cfg(feature = "cli")]
 pub fn write_manufacturing_package(package: &ManufacturingPackage, output: &Path) -> Result<()> {
     if output
         .extension()
@@ -98,6 +120,7 @@ pub fn write_manufacturing_package(package: &ManufacturingPackage, output: &Path
     }
 }
 
+#[cfg(feature = "cli")]
 fn write_manufacturing_directory(package: &ManufacturingPackage, output_dir: &Path) -> Result<()> {
     fs::create_dir_all(output_dir).with_context(|| {
         format!(
@@ -116,6 +139,7 @@ fn write_manufacturing_directory(package: &ManufacturingPackage, output_dir: &Pa
     Ok(())
 }
 
+#[cfg(feature = "cli")]
 fn write_manufacturing_zip(package: &ManufacturingPackage, output_zip: &Path) -> Result<()> {
     if let Some(parent) = output_zip.parent()
         && !parent.as_os_str().is_empty()
@@ -134,22 +158,22 @@ fn write_manufacturing_zip(package: &ManufacturingPackage, output_zip: &Path) ->
             output_zip.display()
         )
     })?;
-    let mut zip = ZipWriter::new(BufWriter::new(zip_file));
+    write_zip(package, BufWriter::new(zip_file))?;
+    Ok(())
+}
+
+fn write_zip<W: Write + Seek>(package: &ManufacturingPackage, writer: W) -> Result<W> {
+    let mut zip = ZipWriter::new(writer);
     for file in &package.files {
         zip.start_file(&file.filename, FileOptions::<()>::default())
             .with_context(|| format!("failed to add {} to manufacturing zip", file.filename))?;
         zip.write_all(file.contents.as_bytes())
             .with_context(|| format!("failed to write {} to manufacturing zip", file.filename))?;
     }
-    zip.finish().with_context(|| {
-        format!(
-            "failed to finalize manufacturing zip {}",
-            output_zip.display()
-        )
-    })?;
-    Ok(())
+    zip.finish().context("failed to finalize manufacturing zip")
 }
 
+#[cfg(feature = "cli")]
 pub fn execute_file_with_options(
     input_file: &Path,
     options: &ManufacturingExportOptions,
@@ -157,4 +181,41 @@ pub fn execute_file_with_options(
     let content = crate::utils::file::load_ipc_file(input_file)?;
     let ipc = ipc::Ipc2581::parse(&content)?;
     export_manufacturing_package(&ipc, options)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn in_memory_zip_preserves_every_filename_and_contents() {
+        let package = ManufacturingPackage {
+            files: vec![
+                ManufacturingFile {
+                    filename: "PTH.drl".to_owned(),
+                    kind: ManufacturingFileKind::Xnc,
+                    contents: "M48\nMETRIC\nT01C0.6\n%\nT01\nX1.0Y2.0\nM30\n".to_owned(),
+                },
+                ManufacturingFile {
+                    filename: "NPTH.drl".to_owned(),
+                    kind: ManufacturingFileKind::Xnc,
+                    contents: "M48\nMETRIC\nT01C2.0\n%\nT01\nX3.0Y4.0\nM30\n".to_owned(),
+                },
+            ],
+        };
+        let zipped = package.to_zip().unwrap();
+        assert_eq!(zipped, package.to_zip().unwrap());
+        let mut archive = zip::ZipArchive::new(Cursor::new(zipped)).unwrap();
+        assert_eq!(archive.len(), package.files.len());
+        for file in &package.files {
+            let mut restored = String::new();
+            archive
+                .by_name(&file.filename)
+                .unwrap()
+                .read_to_string(&mut restored)
+                .unwrap();
+            assert_eq!(restored, file.contents);
+        }
+    }
 }

--- a/crates/pcb-ipc2581-tools/src/manufacturing/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/manufacturing/mod.rs
@@ -3,6 +3,10 @@ mod export;
 
 pub use export::{
     ManufacturingExportOptions, ManufacturingFile, ManufacturingFileKind, ManufacturingPackage,
-    build_manufacturing_package, build_manufacturing_package_with_options,
+    build_manufacturing_package, build_manufacturing_package_from_design,
+    build_manufacturing_package_with_options,
+};
+#[cfg(feature = "cli")]
+pub use export::{
     execute_file_with_options, export_manufacturing_package, write_manufacturing_package,
 };

--- a/crates/pcb-ipc2581-tools/src/utils/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/utils/mod.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "cli")]
 pub mod color;
+#[cfg(feature = "cli")]
 pub mod file;
 pub mod format;
 pub mod history;

--- a/crates/pcb-ir/Cargo.toml
+++ b/crates/pcb-ir/Cargo.toml
@@ -15,12 +15,14 @@ pcb-sexpr = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = { workspace = true }
 boostvoronoi = { workspace = true }
 i_overlay = { workspace = true }
 ipc2581 = { workspace = true }
 kurbo = { workspace = true }
 resvg = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+base64 = { workspace = true }
 terminal_size = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -38,6 +38,33 @@ const CONTAINMENT_AREA_TOLERANCE_MM2: f64 = 1e-3;
 const SPATIAL_SOLVE_ITERATIONS: usize = 512;
 const SQRT_3: f64 = 1.732_050_807_568_877_2;
 
+/// Independent per-layer work, in source order. Browsers cannot spawn native
+/// threads; use the identical solve serially there, without requiring workers
+/// or shared WebAssembly memory. Native builds retain per-layer concurrency.
+fn map_layers<T: Send, R: Send>(
+    items: impl IntoIterator<Item = T>,
+    solve: impl Fn(T) -> R + Sync,
+) -> Vec<R> {
+    #[cfg(target_family = "wasm")]
+    {
+        items.into_iter().map(solve).collect()
+    }
+    #[cfg(not(target_family = "wasm"))]
+    {
+        std::thread::scope(|scope| {
+            let solve = &solve;
+            let handles = items
+                .into_iter()
+                .map(|item| scope.spawn(move || solve(item)))
+                .collect::<Vec<_>>();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("copper-balance solve panicked"))
+                .collect()
+        })
+    }
+}
+
 /// Fixed geometry constraints for a dense perforated copper plane.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DenseCopperBalanceProfile {
@@ -614,37 +641,28 @@ pub fn generate_spatial_dense_copper_balance(
             region_sources.len() - 1
         })
         .collect::<Vec<_>>();
-    let uniform = std::thread::scope(|scope| {
-        let solves = request
+    let uniform = map_layers(
+        request
             .layers
             .iter()
             .zip(&layer_regions)
-            .zip(&density_domain_areas)
-            .map(|((layer, region_index), density_domain_area_mm2)| {
-                let voidable = &region_voidable[*region_index];
-                let lattice = &region_lattices[*region_index];
-                scope.spawn(move || {
-                    generate_dense_copper_balance_with_lattice(
-                        profile,
-                        DenseCopperBalanceRequest {
-                            safe_region: layer.safe_region,
-                            density_domain_area_mm2: *density_domain_area_mm2,
-                            existing_copper_area_mm2: layer.existing_copper.area(),
-                            target_density: layer.target_density,
-                            lattice_origin: request.lattice_origin,
-                        },
-                        layer.safe_region.clone(),
-                        voidable,
-                        lattice,
-                    )
-                })
-            })
-            .collect::<Vec<_>>();
-        solves
-            .into_iter()
-            .map(|solve| solve.join().expect("uniform copper-balance solve panicked"))
-            .collect::<Vec<_>>()
-    });
+            .zip(&density_domain_areas),
+        |((layer, region_index), density_domain_area_mm2)| {
+            generate_dense_copper_balance_with_lattice(
+                profile,
+                DenseCopperBalanceRequest {
+                    safe_region: layer.safe_region,
+                    density_domain_area_mm2: *density_domain_area_mm2,
+                    existing_copper_area_mm2: layer.existing_copper.area(),
+                    target_density: layer.target_density,
+                    lattice_origin: request.lattice_origin,
+                },
+                layer.safe_region.clone(),
+                &region_voidable[*region_index],
+                &region_lattices[*region_index],
+            )
+        },
+    );
 
     let mut panel_samples =
         hex_aligned_lattice_centers(request.panel_region.bbox, request.lattice_origin, profile)
@@ -704,29 +722,29 @@ pub fn generate_spatial_dense_copper_balance(
         density_kernel.smooth(&lattice_cell_coverage(&panel_samples, region, profile))
     };
 
-    let (fixed_density, region_available_density, partial_void_density) =
-        std::thread::scope(|scope| {
-            let fixed = request
-                .layers
-                .iter()
-                .map(|layer| scope.spawn(|| smooth_coverage(layer.existing_copper)))
-                .collect::<Vec<_>>();
-            let available = region_sources
-                .iter()
-                .map(|region| scope.spawn(|| smooth_coverage(region)))
-                .collect::<Vec<_>>();
-            let partial = uniform
-                .iter()
-                .map(|result| scope.spawn(|| smooth_coverage(&result.edge_void_emission.region)))
-                .collect::<Vec<_>>();
-            let join_all = |handles: Vec<std::thread::ScopedJoinHandle<'_, Vec<f64>>>| {
-                handles
-                    .into_iter()
-                    .map(|handle| handle.join().expect("coverage sampling panicked"))
-                    .collect::<Vec<_>>()
-            };
-            (join_all(fixed), join_all(available), join_all(partial))
-        });
+    let mut coverage = map_layers(
+        request
+            .layers
+            .iter()
+            .map(|layer| layer.existing_copper)
+            .chain(region_sources.iter().copied())
+            .chain(
+                uniform
+                    .iter()
+                    .map(|result| &result.edge_void_emission.region),
+            ),
+        smooth_coverage,
+    )
+    .into_iter();
+    let fixed_density = coverage
+        .by_ref()
+        .take(request.layers.len())
+        .collect::<Vec<_>>();
+    let region_available_density = coverage
+        .by_ref()
+        .take(region_sources.len())
+        .collect::<Vec<_>>();
+    let partial_void_density = coverage.collect::<Vec<_>>();
 
     let lower = profile.min_void_radius_mm.powi(2);
     let upper = profile.max_void_radius_mm.powi(2);
@@ -831,62 +849,43 @@ pub fn generate_spatial_dense_copper_balance(
         // from target: the moment below is the copper the panel carries, and
         // subtracting the targets would leave it blind to whatever imbalance
         // the boards were designed with.
-        let density = std::thread::scope(|scope| {
-            let uniform = &uniform;
-            let active_sites = &active_sites;
-            let fixed_density = &fixed_density;
-            let region_available_density = &region_available_density;
-            let layer_regions = &layer_regions;
-            let partial_void_density = &partial_void_density;
-            let density_kernel = &density_kernel;
-            let evaluation_points = &evaluation_points;
-            let handles = void_scratch
-                .iter_mut()
-                .enumerate()
-                .map(|(layer_index, void_fraction)| {
-                    let squared_radii = &squared_radii;
-                    scope.spawn(move || {
-                        let void_density = match uniform[layer_index].solution.mode {
+        let density = map_layers(
+            void_scratch.iter_mut().enumerate(),
+            |(layer_index, void_fraction)| {
+                let void_density = match uniform[layer_index].solution.mode {
+                    DenseCopperBalanceMode::Perforated { .. } => {
+                        for (sample_index, radius_squared) in active_sites[layer_index]
+                            .iter()
+                            .zip(&squared_radii[layer_index])
+                        {
+                            void_fraction[*sample_index] =
+                                void_fraction_per_radius_squared * radius_squared;
+                        }
+                        density_kernel.smooth(void_fraction)
+                    }
+                    DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => {
+                        vec![0.0; evaluation_points.len()]
+                    }
+                };
+                fixed_density[layer_index]
+                    .iter()
+                    .enumerate()
+                    .map(|(site_index, fixed)| {
+                        let available = &region_available_density[layer_regions[layer_index]];
+                        let generated_density = match uniform[layer_index].solution.mode {
+                            DenseCopperBalanceMode::None => 0.0,
+                            DenseCopperBalanceMode::Solid => available[site_index],
                             DenseCopperBalanceMode::Perforated { .. } => {
-                                for (sample_index, radius_squared) in active_sites[layer_index]
-                                    .iter()
-                                    .zip(&squared_radii[layer_index])
-                                {
-                                    void_fraction[*sample_index] =
-                                        void_fraction_per_radius_squared * radius_squared;
-                                }
-                                density_kernel.smooth(void_fraction)
-                            }
-                            DenseCopperBalanceMode::None | DenseCopperBalanceMode::Solid => {
-                                vec![0.0; evaluation_points.len()]
+                                available[site_index]
+                                    - partial_void_density[layer_index][site_index]
+                                    - void_density[site_index]
                             }
                         };
-                        fixed_density[layer_index]
-                            .iter()
-                            .enumerate()
-                            .map(|(site_index, fixed)| {
-                                let available =
-                                    &region_available_density[layer_regions[layer_index]];
-                                let generated_density = match uniform[layer_index].solution.mode {
-                                    DenseCopperBalanceMode::None => 0.0,
-                                    DenseCopperBalanceMode::Solid => available[site_index],
-                                    DenseCopperBalanceMode::Perforated { .. } => {
-                                        available[site_index]
-                                            - partial_void_density[layer_index][site_index]
-                                            - void_density[site_index]
-                                    }
-                                };
-                                fixed + generated_density
-                            })
-                            .collect::<Vec<_>>()
+                        fixed + generated_density
                     })
-                })
-                .collect::<Vec<_>>();
-            handles
-                .into_iter()
-                .map(|handle| handle.join().expect("spatial density pass panicked"))
-                .collect::<Vec<_>>()
-        });
+                    .collect::<Vec<_>>()
+            },
+        );
         // The panel's copper moment about its mid-plane, reported before and
         // after so the summary can say what the settlement bought.
         let stack_moment = (0..evaluation_points.len())
@@ -903,45 +902,34 @@ pub fn generate_spatial_dense_copper_balance(
             initial_reading.get_or_insert(achieved_reading);
         }
 
-        let proposals = std::thread::scope(|scope| {
-            let active_sites = &active_sites;
-            let density_kernel = &density_kernel;
-            let handles = squared_radii
+        let proposals = map_layers(
+            squared_radii
                 .iter()
                 .zip(influence_scratch.iter_mut())
-                .enumerate()
-                .map(|(layer_index, (radii, influence))| {
-                    let density = &density;
-                    let layers = request.layers;
-                    scope.spawn(move || {
-                        if radii.is_empty() {
-                            return Vec::new();
-                        }
-                        // Its own density error. The moment is not here: the
-                        // settlement already spent what the stack was owed.
-                        let residual = density[layer_index]
-                            .iter()
-                            .map(|density| density - layers[layer_index].target_density)
-                            .collect::<Vec<_>>();
-                        density_kernel.smooth_adjoint_into(&residual, influence);
-                        radii
-                            .iter()
-                            .enumerate()
-                            .map(|(local_index, radius_squared)| {
-                                radius_squared
-                                    + step
-                                        * void_fraction_per_radius_squared
-                                        * influence[active_sites[layer_index][local_index]]
-                            })
-                            .collect::<Vec<_>>()
+                .enumerate(),
+            |(layer_index, (radii, influence))| {
+                if radii.is_empty() {
+                    return Vec::new();
+                }
+                // Its own density error. The moment is not here: the
+                // settlement already spent what the stack was owed.
+                let residual = density[layer_index]
+                    .iter()
+                    .map(|density| density - request.layers[layer_index].target_density)
+                    .collect::<Vec<_>>();
+                density_kernel.smooth_adjoint_into(&residual, influence);
+                radii
+                    .iter()
+                    .enumerate()
+                    .map(|(local_index, radius_squared)| {
+                        radius_squared
+                            + step
+                                * void_fraction_per_radius_squared
+                                * influence[active_sites[layer_index][local_index]]
                     })
-                })
-                .collect::<Vec<_>>();
-            handles
-                .into_iter()
-                .map(|handle| handle.join().expect("spatial update pass panicked"))
-                .collect::<Vec<_>>()
-        });
+                    .collect::<Vec<_>>()
+            },
+        );
         // Each layer keeps the copper area the settlement asked for, so it
         // redistributes within the panel and never spends against the stack.
         let update = squared_radii

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -1970,6 +1970,22 @@ fn append_layout_repeats(
             repeat,
         );
 
+        // Bound expansion where it happens, including nested repeats. Empty
+        // repeats keep their metadata without iterating a potentially huge ny.
+        if repeat.nx == 0 || repeat.ny == 0 {
+            continue;
+        }
+        if stack.len() >= 64 {
+            bail!("IPC layout nesting exceeds the limit of 64 Steps");
+        }
+        if (repeat.nx as usize)
+            .checked_mul(repeat.ny as usize)
+            .and_then(|count| doc.layout.instances.len().checked_add(count))
+            .is_none_or(|count| count > 100_000)
+        {
+            bail!("IPC layout exceeds the limit of 100000 Step instances");
+        }
+
         let mut pending_panel_instances = Vec::new();
         for iy in 0..repeat.ny {
             for ix in 0..repeat.nx {
@@ -5125,6 +5141,28 @@ mod tests {
         assert_eq!(doc.layout.instances.len(), 2);
         assert_eq!(panel_step_count(&doc), 1);
         assert_eq!(board_instance_count(&doc), 2);
+    }
+
+    #[test]
+    fn layout_expansion_bounds_large_repeats_and_skips_empty_repeats() {
+        for (nx, ny) in [
+            (u32::MAX, 1),
+            (u32::MAX, u32::MAX),
+            (0, u32::MAX),
+            (u32::MAX, 0),
+        ] {
+            let xml = panel_layer_fixture()
+                .replace("nx=\"2\" ny=\"1\"", &format!("nx=\"{nx}\" ny=\"{ny}\""));
+            let ipc = Ipc2581::parse(&xml).unwrap();
+            let result = extract_layout(&ipc);
+            if nx == 0 || ny == 0 {
+                let layout = result.unwrap();
+                assert_eq!(layout.layout.repeats.len(), 1);
+                assert!(layout.layout.instances.is_empty());
+            } else {
+                assert!(result.unwrap_err().to_string().contains("limit"));
+            }
+        }
     }
 
     #[test]

--- a/crates/pcb-ir/src/lib.rs
+++ b/crates/pcb-ir/src/lib.rs
@@ -15,6 +15,11 @@
 //! - [`render`] turns mask documents into SVG, PNG, or terminal output.
 //!
 //! All geometry is canonically in millimeters.
+//!
+//! All dialects, imports, geometry passes, and SVG/PNG renderers support
+//! `wasm32-unknown-unknown`. Copper balancing runs sequentially on WebAssembly;
+//! native builds retain parallel per-layer solves. Terminal renderers are
+//! available only on native targets. Rasterization requires no system fonts.
 
 pub mod dialects;
 pub mod geom;

--- a/crates/pcb-ir/src/render/mod.rs
+++ b/crates/pcb-ir/src/render/mod.rs
@@ -6,10 +6,12 @@
 
 mod png;
 mod svg;
+#[cfg(not(target_family = "wasm"))]
 mod term;
 
 pub use png::{artwork_png, png};
 pub use svg::{artwork_svg, svg, svg_path_data};
+#[cfg(not(target_family = "wasm"))]
 pub use term::{artwork_to_terminal, can_render_to_terminal, to_terminal, write_kitty_png};
 
 use crate::dialects::{artwork, mask};

--- a/crates/pcb-zen-wasm/README.md
+++ b/crates/pcb-zen-wasm/README.md
@@ -3,8 +3,9 @@
 `pcb-zen-wasm` exposes the Zener evaluator to browser applications through
 WebAssembly.
 
-[`bin/build-wasm-bundle.sh`](../../bin/build-wasm-bundle.sh) builds and publishes
-the npm package with `wasm-pack`.
+[`bin/build-wasm-bundle.sh`](../../bin/build-wasm-bundle.sh) builds a local browser
+bundle with `wasm-pack` in `target/wasm-bundle`. It does not publish anything.
+Pass `ipc` to the same script to build the [IPC bindings](../pcb-ipc-wasm/README.md).
 
 To test a generated bundle against a `pcb publish` release archive, run:
 

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -34,7 +34,7 @@ pcb-layout = { workspace = true }
 pcb-sim = { workspace = true }
 pcb-diode-api = { workspace = true }
 pcb-docgen = { workspace = true }
-pcb-ipc2581-tools = { workspace = true }
+pcb-ipc2581-tools = { workspace = true, features = ["cli"] }
 pcb-interposer = { path = "../pcb-interposer" }
 pcb-eda = { workspace = true }
 pcb-sexpr = { workspace = true }

--- a/crates/pcbc/tests/dfm.rs
+++ b/crates/pcbc/tests/dfm.rs
@@ -44,7 +44,7 @@ fn dfm_resolves_zen_exports_temporary_ipc_and_checks_standard_pdk() {
         .write("eda/BMI270.kicad_sym", SYMBOL);
 
     let output = run_pcbc(&mut sandbox, ["dfm", "MyBoard.zen", "--pdk", "standard"]);
-    let report: Value =
+    let mut report: Value =
         serde_json::from_slice(&output.stdout).expect("stdout should contain only the DFM report");
 
     assert_eq!(report["pdk"]["path"], "builtin:standard");
@@ -81,10 +81,17 @@ fn dfm_resolves_zen_exports_temporary_ipc_and_checks_standard_pdk() {
     );
     assert!(file_output.stdout.is_empty());
     assert_eq!(file_output.status.code(), output.status.code());
-    let file_report = read_report(&sandbox, "report.dfm.json");
+    let mut file_report = read_report(&sandbox, "report.dfm.json");
     assert!(!Path::new(file_report["input"]["path"].as_str().unwrap()).exists());
-    // Each .zen invocation exports a new temporary IPC file. The checked
-    // geometry, fabrication settings, and diagnostics must still agree.
+    // Each .zen run asks KiCad for new IPC, which can reorder independent
+    // features. Compare scene metadata here; the fixed-IPC test below checks
+    // exact SVG parity as well as the full checked geometry.
+    for generated in [&mut report, &mut file_report] {
+        for pass in generated["scene"]["passes"].as_array_mut().unwrap() {
+            let svg = pass.as_object_mut().unwrap().remove("svg").unwrap();
+            assert!(svg.as_str().unwrap().starts_with("<svg "));
+        }
+    }
     for field in [
         "pdk",
         "layout_target",


### PR DESCRIPTION
Native dependencies prevent the IPC stack from running in WebAssembly. This change makes the core crates portable and adds typed APIs for IPC-2581 import, export, and DFM, with the same build process as Zener.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new WASM surface parses and decompresses untrusted IPC input and runs fabrication/DFM on it; mitigated by bounds checks and CI smoke/type tests, but export and DFM correctness still affect manufacturing outputs.
> 
> **Overview**
> Adds a **`pcb-ipc-wasm`** package that exposes in-memory **IPC-2581** workflows in JavaScript: parse XML or Zstd bytes, optional XSD validation, **info/layers**, multi-format **export** (Gerber/XNC with optional ZIP, SVG/PNG, DXF, BOM, CPL, ICT, HTML, filtered IPC), and full **DFM** reports with built-in or custom PDK TOML and waivers. Strict option parsing and bounded Zstd decoding (256 MiB) are part of the WASM surface.
> 
> The IPC stack is made **`wasm32-unknown-unknown` portable**: `ipc2581` / `gerberx2` keep string APIs on WASM while gating filesystem helpers; **`pcb-ipc2581-tools`** splits behind a default **`cli`** feature (terminal, network BOM, native zstd, rayon parallelism) and exposes shared library entry points (`extract_bom_lines`, `info_json`, in-memory `dfm::check`, `build_manufacturing_package_from_design` + `to_zip()`, `export_dxf`, `filter_by_mode`). DFM and balancing run the same logic serially on WASM. Workspace tweaks trim native-only deps (`resvg` / tools default features off where needed).
> 
> **CI** gains a dedicated WASM job: `cargo check` the portable crates, build the IPC bundle via **`./bin/build-wasm-bundle.sh ipc`**, Node smoke tests (exports, DFM/waivers, malformed input, worker), and strict TypeScript checking. **`build-wasm-bundle.sh`** now selects **zen vs ipc** bundles (wasm-pack `--scope diodeinc` replaces manual `package.json` patching).
> 
> **Gerber manufacturing** now emits standalone board outlines (Step/Profile) for plain boards even when `board-array` layout is requested and there are no repeats—documented in the changelog alongside the WASM addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fee874c0bb565c1443877c6238cb6f131a363be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->