### PR TITLE
Fix Clippy constant chunk warnings

### DIFF
--- a/crates/pcb-diode-api/src/registry/embeddings.rs
+++ b/crates/pcb-diode-api/src/registry/embeddings.rs
@@ -246,7 +246,7 @@ fn lookup_cache<const DIMS: usize>(
                 return Ok(None);
             }
             let mut embedding = [0f32; DIMS];
-            for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+            for (i, chunk) in bytes.as_chunks::<4>().0.iter().enumerate() {
                 embedding[i] = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
             }
             Ok(Some(embedding))

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/vcut.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/vcut.rs
@@ -227,7 +227,7 @@ pub(super) fn parse_kicad_stroke_glyph(raw: &str) -> KiCadStrokeGlyph {
     let mut strokes = Vec::new();
     let mut stroke = Vec::new();
 
-    for pair in bytes[2..].chunks_exact(2) {
+    for pair in bytes[2..].as_chunks::<2>().0 {
         if pair[0] == b' ' && pair[1] == b'R' {
             if stroke.len() >= 2 {
                 strokes.push(std::mem::take(&mut stroke));

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -736,8 +736,10 @@ impl ContourSet {
                 })
             })
             .collect::<Vec<_>>();
-        self.contains_points(&subsamples)
-            .chunks_exact(STRATA * STRATA)
+        let coverage = self.contains_points(&subsamples);
+        let (tiles, _) = coverage.as_chunks::<{ STRATA * STRATA }>();
+        tiles
+            .iter()
             .map(|tile| tile.iter().sum::<f64>() / (STRATA * STRATA) as f64)
             .collect()
     }

--- a/crates/pcb-sexpr/src/kicad/footprint.rs
+++ b/crates/pcb-sexpr/src/kicad/footprint.rs
@@ -191,14 +191,12 @@ pub fn embedded_file_checksum(data: &[u8]) -> String {
     let mut len = 0usize;
     let mut block = [0u8; 16];
 
-    let mut chunks = data.chunks_exact(16);
-    for chunk in &mut chunks {
-        block.copy_from_slice(chunk);
-        hash_mmh3_block(&mut h1, &mut h2, &block);
+    let (chunks, tail) = data.as_chunks::<16>();
+    for chunk in chunks {
+        hash_mmh3_block(&mut h1, &mut h2, chunk);
         len += 16;
     }
 
-    let tail = chunks.remainder();
     if !tail.is_empty() {
         block[..tail.len()].copy_from_slice(tail);
         let padding = 4 - (tail.len() + 4) % 4;

--- a/crates/rectify/src/raster.rs
+++ b/crates/rectify/src/raster.rs
@@ -287,7 +287,7 @@ fn rasterize_polygon_label_into(
         let y = grid_min_y + ((r as f64) + 0.5) * resolution_mm;
         for ring in &poly.rings {
             scanline_intersections(ring, y, &mut xs);
-            for span in xs.chunks_exact(2) {
+            for span in xs.as_chunks::<2>().0 {
                 let start = first_col_with_center_gt(span[0], grid_min_x, resolution_mm)
                     .max(col0 as isize)
                     .min(col1 as isize) as usize;


### PR DESCRIPTION
## Summary
- replace constant-size `chunks_exact` calls with `as_chunks`
- preserve exact chunk and remainder behavior

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo nextest run -p pcb-ir -p rectify -p pcb-diode-api -p pcb-ipc2581-tools`

Fixes [ENG-1203](https://linear.app/diodeinc/issue/ENG-1203/fix-clippy-failures-from-constant-size-chunks-exact)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical iterator API swaps with tests and clippy/nextest verification; no new logic paths beyond equivalent chunk/remainder handling.
> 
> **Overview**
> Resolves Clippy **constant-size `chunks_exact`** warnings (ENG-1203) by switching to **`as_chunks`** in five places, without changing how bytes or coverage vectors are split.
> 
> **Embedding cache** (`pcb-diode-api`): cached blob → `f32` decoding uses `as_chunks::<4>()` instead of `chunks_exact(4)`.
> 
> **KiCad / geometry**: V-cut stroke glyph parsing (`pcb-ipc2581-tools`), stratified **cell coverage** tiling in `ContourSet::cell_coverage` (`pcb-ir`), and scanline span pairs in pad rasterization (`rectify`) use the same pattern for 2- or 9-element chunks.
> 
> **KiCad embedded-file checksum** (`pcb-sexpr`): MMH3 hashing now takes full 16-byte blocks from `as_chunks::<16>()` and handles the remainder via the returned tail slice (replacing `chunks_exact` + `remainder()`), preserving KiCad-compatible padding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0983f048b904fb5521b849bac3008815785dd2fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->