### PR TITLE
ENG-1178 Preserve IPC-2581 assembly source data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Preserve IPC-2581 assembly BOM, package, pin, population, and supporting dictionary source facts in `pcb-ir` imports.
+
 ## [0.4.41] - 2026-08-31
 
 ### Added

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -885,7 +885,7 @@ mod tests {
     <FunctionMode mode="ASSEMBLY"/>
     <BomRef name="assembly-bom"/>
     <DictionaryLineDesc units="INCH">
-      <EntryLineDesc id="line"><LineDesc lineWidth="0.005" lineEnd="ROUND"/></EntryLineDesc>
+      <EntryLineDesc id="line"><LineDesc lineWidth="0.005" lineEnd="NONE"/></EntryLineDesc>
     </DictionaryLineDesc>
     <DictionaryFont units="INCH">
       <EntryFont id="font">
@@ -1059,6 +1059,12 @@ mod tests {
             doc.resolve(doc.content().dictionary_firmware.entries[0].hex_encoded_binary),
             "00"
         );
+        assert_eq!(
+            doc.content().dictionary_line_desc.entries[0]
+                .line_desc
+                .line_end,
+            LineEnd::None
+        );
         let fonts = &doc.content().dictionary_font;
         assert_eq!(fonts.entries.len(), 2);
         let FontDefinition::Embedded(font) = &fonts.entries[0].definition else {
@@ -1131,6 +1137,7 @@ mod tests {
             xml.replace("fontSize=\"12\"", "fontSize=\"0\""),
             xml.replace("height=\"0.1\"", "height=\"-0.1\""),
             xml.replace("populate=\" true \"", "populate=\"yes\""),
+            xml.replace("lineEnd=\"NONE\"", "lineEnd=\"FLAT\""),
         ] {
             assert!(
                 Ipc2581::parse(&invalid).is_err(),

--- a/crates/ipc2581/src/lib.rs
+++ b/crates/ipc2581/src/lib.rs
@@ -98,7 +98,7 @@ pub struct Ipc2581 {
     logistic_header: Option<LogisticHeader>,
     history_record: Option<HistoryRecord>,
     ecad: Option<Ecad>,
-    bom: Option<Bom>,
+    boms: Vec<Bom>,
     avl: Option<Avl>,
 }
 
@@ -145,7 +145,7 @@ impl Ipc2581 {
             logistic_header: parsed.logistic_header,
             history_record: parsed.history_record,
             ecad: parsed.ecad,
-            bom: parsed.bom,
+            boms: parsed.boms,
             avl: parsed.avl,
         })
     }
@@ -182,9 +182,18 @@ impl Ipc2581 {
         self.ecad.as_ref()
     }
 
-    /// Get the BOM section if present
+    /// Get the Content-referenced BOM, or the first BOM if no reference matches.
     pub fn bom(&self) -> Option<&Bom> {
-        self.bom.as_ref()
+        self.content
+            .bom_refs
+            .iter()
+            .find_map(|reference| self.boms.iter().find(|bom| bom.name == *reference))
+            .or_else(|| self.boms.first())
+    }
+
+    /// Get every BOM section in source document order.
+    pub fn boms(&self) -> &[Bom] {
+        &self.boms
     }
 
     /// Get the AVL section if present
@@ -863,8 +872,271 @@ mod tests {
         // Verify other attributes
         assert_eq!(item.quantity, Some(1));
         assert_eq!(item.pin_count, Some(4));
-        assert_eq!(item.ref_des_list.len(), 1);
-        assert_eq!(doc.resolve(item.ref_des_list[0].name), "U4");
+        let references = item.reference_designators().collect::<Vec<_>>();
+        assert_eq!(references.len(), 1);
+        assert_eq!(doc.resolve(references[0].name), "U4");
+    }
+
+    #[test]
+    fn preserves_assembly_bom_and_package_source_facts() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="Owner">
+    <FunctionMode mode="ASSEMBLY"/>
+    <BomRef name="assembly-bom"/>
+    <DictionaryLineDesc units="INCH">
+      <EntryLineDesc id="line"><LineDesc lineWidth="0.005" lineEnd="ROUND"/></EntryLineDesc>
+    </DictionaryLineDesc>
+    <DictionaryFont units="INCH">
+      <EntryFont id="font">
+        <FontDefEmbedded name="assembly-font">
+          <LineDescRef id="line"/>
+          <Glyph charCode="41" lowerLeftX="0" lowerLeftY="0" upperRightX="0.05" upperRightY="0.1">
+            <Line startX="0" startY="0" endX="0.05" endY="0.1"><LineDescRef id="line"/></Line>
+          </Glyph>
+        </FontDefEmbedded>
+      </EntryFont>
+      <EntryFont id="external-font"><FontDefExternal name="Helvetica" urn="urn:font:helvetica"/></EntryFont>
+    </DictionaryFont>
+    <DictionaryStandard units="INCH">
+      <EntryStandard id="land"><Circle diameter="0.02"/></EntryStandard>
+    </DictionaryStandard>
+    <DictionaryFirmware>
+      <EntryFirmware id="firmware"><CachedFirmware hexEncodedBinary="00"/></EntryFirmware>
+    </DictionaryFirmware>
+  </Content>
+  <LogisticHeader>
+    <Role id="Owner" roleFunction="SENDER"/>
+    <Enterprise id="enterprise" code="TEST"/>
+    <Person name="Engineer" enterpriseRef="enterprise" roleRef="Owner"/>
+  </LogisticHeader>
+  <HistoryRecord number="1" origination="2026-01-01T00:00:00Z" software="test" lastChange="2026-01-01T00:00:00Z">
+    <FileRevision fileRevisionId="1" comment="test">
+      <SoftwarePackage name="test" vendor="test" revision="1">
+        <Certification certificationStatus="SELFTEST"/>
+      </SoftwarePackage>
+    </FileRevision>
+  </HistoryRecord>
+  <Bom name="unreferenced-bom">
+    <BomHeader assembly="old" revision="0"/>
+    <BomItem OEMDesignNumberRef="old-part" quantity="1" category="ELECTRICAL">
+      <Characteristics category="ELECTRICAL"/>
+    </BomItem>
+  </Bom>
+  <Bom name="assembly-bom">
+    <BomHeader assembly="main" revision="7" affecting=" 1 ">
+      <StepRef name="board"/>
+    </BomHeader>
+    <BomItem OEMDesignNumberRef="part" quantity="1.5" pinCount="3" category="PROGRAMMABLE" internalPartNumber="internal" description="controller">
+      <RefDes name="U1" packageRef="pkg" populate=" true " layerRef="TOP" modelRef="model">
+        <Tuning value="calibrated" comments="at test"/>
+        <Firmware progName="main" progVersion="2">
+          <File name="main.hex" crc="1234"/>
+          <FirmwareRef id="firmware"/>
+        </Firmware>
+      </RefDes>
+      <MatDes name="adhesive" layerRef="TOP"/>
+      <DocDes name="drawing"/>
+      <ToolDes name="fixture"/>
+      <FindDes number="4" layerRef="TOP" modelRef="model"/>
+      <Characteristics category="PROGRAMMABLE">
+        <Measured definitionSource="vendor" measuredCharacteristicName="Height" measuredCharacteristicValue="1.2" engineeringUnitOfMeasure="mm" engineeringNegativeTolerance="0.1" engineeringPositiveTolerance="0.2"/>
+        <Ranged rangedCharacteristicName="Temperature" rangedCharacteristicLowerValue="-40" rangedCharacteristicUpperValue="85" engineeringUnitOfMeasure="C"/>
+        <Enumerated enumeratedCharacteristicName="Finish" enumeratedCharacteristicValue="matte"/>
+        <Textual textualCharacteristicName="Process" textualCharacteristicValue="reflow"/>
+      </Characteristics>
+      <SpecRef id="assembly-spec"/>
+    </BomItem>
+    <BomItem OEMDesignNumberRef="mechanical" quantity="1" category="MECHANICAL"><Characteristics category="MECHANICAL"/></BomItem>
+    <BomItem OEMDesignNumberRef="material" quantity="1" category="MATERIAL"><Characteristics category="MATERIAL"/></BomItem>
+    <BomItem OEMDesignNumberRef="document" quantity="1" category="DOCUMENT"><Characteristics category="DOCUMENT"/></BomItem>
+    <BomItem OEMDesignNumberRef="electrical" quantity="1" category="ELECTRICAL"><Characteristics category="ELECTRICAL"/></BomItem>
+  </Bom>
+  <Ecad name="design">
+    <CadHeader units="INCH"><Spec name="assembly-spec"/></CadHeader>
+    <CadData>
+      <Layer name="TOP" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+      <Step name="board" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Package name="pkg" type="OTHER" pinOne="1" pinOneOrientation="CENTER" height="0.1" negativeBodyExtension="0.01" comment="body">
+          <Outline>
+            <Polygon>
+              <PolyBegin x="-0.1" y="-0.05"/>
+              <PolyStepSegment x="0.1" y="-0.05"/>
+              <PolyStepSegment x="0.1" y="0.05"/>
+              <PolyStepSegment x="-0.1" y="0.05"/>
+              <PolyStepSegment x="-0.1" y="-0.05"/>
+              <Xform xOffset="0.01" yOffset="0.02" rotation="90" mirror="1"/>
+              <LineDesc lineWidth="0.003" lineEnd="ROUND"/>
+              <FillDesc fillProperty="HOLLOW"/>
+            </Polygon>
+            <LineDesc lineWidth="0.005" lineEnd="ROUND"/>
+          </Outline>
+          <PickupPoint x="0.01" y="0.02"/>
+          <LandPattern>
+            <Pad><Location x="-0.05" y="0"/><Circle diameter="0.02"/></Pad>
+            <Target><Location x="0" y="0"/><Circle diameter="0.01"/></Target>
+          </LandPattern>
+          <SilkScreen>
+            <Marking markingUsage="PIN_ONE">
+              <Location x="-0.1" y="0.05"/>
+              <Polyline><PolyBegin x="0" y="0"/><PolyStepSegment x="0.01" y="0"/><LineDesc lineWidth="0.002" lineEnd="ROUND"/></Polyline>
+            </Marking>
+          </SilkScreen>
+          <AssemblyDrawing>
+            <Outline><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="0" y="0"/></Polygon><LineDescRef id="line"/></Outline>
+            <Marking markingUsage="PARTNAME">
+              <Location x="0" y="0"/>
+              <Text textString="controller" fontSize="12">
+                <BoundingBox lowerLeftX="-0.05" lowerLeftY="-0.01" upperRightX="0.05" upperRightY="0.01"/>
+                <FontRef id="font"/>
+                <Color r="10" g="20" b="30"/>
+              </Text>
+            </Marking>
+          </AssemblyDrawing>
+          <Pin number="1" name="A" type="SURFACE" electricalType="ELECTRICAL" mountType="SURFACE_MOUNT_PAD" pinPolarity="PLUS">
+            <Location x="-0.05" y="0"/><StandardPrimitiveRef id="land"/>
+          </Pin>
+          <Topside>
+            <Pin number="2" type="THRU"><Circle diameter="0.02"/></Pin>
+          </Topside>
+          <OtherSideView>
+            <Outline><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="0" y="0"/></Polygon><LineDescRef id="line"/></Outline>
+          </OtherSideView>
+        </Package>
+        <Component refDes="U1" packageRef="pkg" part="part" layerRef="TOP" mountType="SMT" height="0.08" standoff="0.005">
+          <Location x="1" y="2"/>
+        </Component>
+      </Step>
+    </CadData>
+  </Ecad>
+</IPC-2581>"#;
+
+        validate(xml).expect("assembly source facts conform to IPC-2581C");
+        let doc = Ipc2581::parse(xml).expect("parse assembly source facts");
+        assert_eq!(doc.boms().len(), 2);
+        let bom = doc.bom().expect("Content-referenced BOM");
+        assert_eq!(doc.resolve(bom.name), "assembly-bom");
+        let header = bom.header.as_ref().unwrap();
+        assert_eq!(doc.resolve(header.assembly), "main");
+        assert_eq!(header.affecting, Some(true));
+        assert_eq!(doc.resolve(header.step_refs[0]), "board");
+        assert_eq!(
+            bom.items
+                .iter()
+                .map(|item| item.category)
+                .collect::<Vec<_>>(),
+            vec![
+                Some(BomCategory::Programmable),
+                Some(BomCategory::Mechanical),
+                Some(BomCategory::Material),
+                Some(BomCategory::Document),
+                Some(BomCategory::Electrical),
+            ]
+        );
+        let item = &bom.items[0];
+        assert_eq!(item.quantity, None);
+        assert_eq!(doc.resolve(item.quantity_raw), "1.5");
+        assert_eq!(doc.resolve(item.internal_part_number.unwrap()), "internal");
+        assert!(matches!(&item.designators[1], BomDesignator::Material(_)));
+        assert!(matches!(&item.designators[2], BomDesignator::Document(_)));
+        assert!(matches!(&item.designators[3], BomDesignator::Tool(_)));
+        assert!(matches!(
+            &item.designators[4],
+            BomDesignator::Find(BomFindDesignator { number: 4, .. })
+        ));
+        assert_eq!(doc.resolve(item.spec_refs[0]), "assembly-spec");
+        let reference = item.reference_designators().next().unwrap();
+        assert_eq!(reference.populate, Some(true));
+        assert_eq!(doc.resolve(reference.package_ref.unwrap()), "pkg");
+        assert_eq!(reference.tunings.len(), 1);
+        assert!(matches!(
+            reference.firmwares[0].payload,
+            BomFirmwarePayload::Reference(_)
+        ));
+        assert_eq!(doc.content().dictionary_firmware.entries.len(), 1);
+        assert_eq!(
+            doc.resolve(doc.content().dictionary_firmware.entries[0].hex_encoded_binary),
+            "00"
+        );
+        let fonts = &doc.content().dictionary_font;
+        assert_eq!(fonts.entries.len(), 2);
+        let FontDefinition::Embedded(font) = &fonts.entries[0].definition else {
+            panic!("embedded font");
+        };
+        assert_eq!(doc.resolve(font.name), "assembly-font");
+        assert_eq!(font.glyphs[0].bounding_box.upper_right.y, 2.54);
+        assert!(matches!(font.glyphs[0].shapes[0], FontShape::Shape(_)));
+        assert!(matches!(
+            fonts.entries[1].definition,
+            FontDefinition::External(_)
+        ));
+        let characteristics = item.characteristics.as_ref().unwrap();
+        assert_eq!(characteristics.measured[0].value, Some(1.2));
+        assert_eq!(characteristics.ranged[0].lower_value, Some(-40.0));
+        assert_eq!(characteristics.enumerated.len(), 1);
+        assert_eq!(characteristics.textuals.len(), 1);
+
+        let step = &doc.ecad().unwrap().cad_data.steps[0];
+        let package = &step.packages[0];
+        assert_eq!(package.height, Some(2.54));
+        assert_eq!(package.negative_body_extension, Some(0.254));
+        let outline = package.outline.as_ref().unwrap();
+        assert_eq!(outline.polygon.begin.x, -2.54);
+        assert_eq!(outline.polygon_xform.unwrap().x_offset, 0.254);
+        assert!(outline.polygon_xform.unwrap().mirror);
+        assert_eq!(outline.polygon_line_desc.unwrap().line_width, 0.0762);
+        let LineDescGroup::Inline(outline_line) = &outline.line_desc else {
+            panic!("inline package outline line description");
+        };
+        assert_eq!(outline_line.line_width, 0.127);
+        assert!(outline.polygon_fill_desc.is_some());
+        assert_eq!(package.pickup_point.unwrap().x, 0.254);
+        let land_pattern = package.land_pattern.as_ref().unwrap();
+        assert_eq!(land_pattern.pads.len(), 1);
+        assert!(matches!(
+            &land_pattern.targets[0].shape,
+            StandardShape::Primitive(StandardPrimitive::Circle(_))
+        ));
+        assert_eq!(package.silkscreen.as_ref().unwrap().markings.len(), 1);
+        let assembly_drawing = package.assembly_drawing.as_ref().unwrap();
+        assert!(assembly_drawing.outline.is_some());
+        let FeatureShape::Text(text) = &assembly_drawing.markings[0].feature else {
+            panic!("assembly marking text");
+        };
+        assert_eq!(doc.resolve(text.text_string), "controller");
+        assert_eq!(text.font_size, 12);
+        assert_eq!(doc.resolve(text.font_ref.unwrap()), "font");
+        assert_eq!(text.bounding_box.upper_right.x, 1.27);
+        assert!(matches!(text.color, Some(ColorGroup::Color(_))));
+        assert_eq!(package.pins[0].pin_type, PackagePinType::Surface);
+        assert_eq!(
+            package.pins[0].mount_type,
+            Some(PackagePinMountType::SurfaceMountPad)
+        );
+        assert!(matches!(
+            &package.pins[0].shape,
+            StandardShape::PrimitiveRef(_)
+        ));
+        assert_eq!(package.pins[0].location.unwrap().x, -1.27);
+        assert_eq!(package.topside.as_ref().unwrap().pins.len(), 1);
+        assert!(package.other_side_view.is_some());
+        assert_eq!(step.components[0].height, Some(2.032));
+        assert_eq!(step.components[0].standoff, Some(0.127));
+
+        for invalid in [
+            xml.replace("category=\"PROGRAMMABLE\"", "category=\"UNKNOWN\""),
+            xml.replace("pinCount=\"3\"", "pinCount=\"-1\""),
+            xml.replace("number=\"4\"", "number=\"0\""),
+            xml.replace("fontSize=\"12\"", "fontSize=\"0\""),
+            xml.replace("height=\"0.1\"", "height=\"-0.1\""),
+            xml.replace("populate=\" true \"", "populate=\"yes\""),
+        ] {
+            assert!(
+                Ipc2581::parse(&invalid).is_err(),
+                "schema-invalid assembly values must not be reclassified"
+            );
+        }
     }
 
     #[test]
@@ -923,7 +1195,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_component_accepts_tht_mount_type_alias() {
+    fn parse_component_accepts_only_ipc2581c_mount_types() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="Owner">
@@ -933,7 +1205,7 @@ mod tests {
     <CadHeader units="MILLIMETER"/>
     <CadData>
       <Step name="board" type="BOARD">
-        <Component refDes="J1" part="CONN" layerRef="F.Cu" mountType="THT">
+        <Component refDes="J1" part="CONN" layerRef="F.Cu" mountType="THMT">
           <Location x="0" y="0"/>
         </Component>
       </Step>
@@ -945,5 +1217,6 @@ mod tests {
         let component = &doc.ecad().unwrap().cad_data.steps[0].components[0];
 
         assert_eq!(component.mount_type, MountType::Thmt);
+        assert!(Ipc2581::parse(&xml.replace("THMT", "THT")).is_err());
     }
 }

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -2,6 +2,13 @@ use crate::types::*;
 use crate::{Interner, Ipc2581Error, Result, Symbol};
 use uppsala::{Document, NodeId as Node};
 
+type ShapeStyle = (
+    Option<LineDesc>,
+    Option<Symbol>,
+    Option<FillDesc>,
+    Option<Symbol>,
+);
+
 fn single_feature_offset(locations: &[Point], xform: Option<Xform>) -> Point {
     if locations.len() <= 1 && xform.is_none() {
         locations
@@ -86,7 +93,7 @@ impl<'a> Parser<'a> {
         let mut logistic_header = None;
         let mut history_record = None;
         let mut ecad = None;
-        let mut bom = None;
+        let mut boms = Vec::new();
         let mut avl = None;
 
         for child in self.element_children(&root) {
@@ -95,7 +102,7 @@ impl<'a> Parser<'a> {
                 "LogisticHeader" => logistic_header = Some(self.parse_logistic_header(&child)?),
                 "HistoryRecord" => history_record = Some(self.parse_history_record(&child)?),
                 "Ecad" => ecad = Some(self.parse_ecad(&child)?),
-                "Bom" => bom = Some(self.parse_bom(&child)?),
+                "Bom" => boms.push(self.parse_bom(&child)?),
                 "Avl" => avl = Some(self.parse_avl(&child)?),
                 _ => {}
             }
@@ -110,7 +117,7 @@ impl<'a> Parser<'a> {
             logistic_header,
             history_record,
             ecad,
-            bom,
+            boms,
             avl,
         })
     }
@@ -127,6 +134,8 @@ impl<'a> Parser<'a> {
         let mut dictionary_color = None;
         let mut dictionary_line_desc = None;
         let mut dictionary_fill_desc = None;
+        let mut dictionary_font = None;
+        let mut dictionary_firmware = None;
         let mut dictionary_standard = None;
         let mut dictionary_user = None;
 
@@ -143,6 +152,10 @@ impl<'a> Parser<'a> {
                 }
                 "DictionaryFillDesc" => {
                     dictionary_fill_desc = Some(self.parse_dictionary_fill_desc(&child)?)
+                }
+                "DictionaryFont" => dictionary_font = Some(self.parse_dictionary_font(&child)?),
+                "DictionaryFirmware" => {
+                    dictionary_firmware = Some(self.parse_dictionary_firmware(&child)?)
                 }
                 "DictionaryStandard" => {
                     dictionary_standard = Some(self.parse_dictionary_standard(&child)?)
@@ -166,6 +179,8 @@ impl<'a> Parser<'a> {
             dictionary_color: dictionary_color.unwrap_or_default(),
             dictionary_line_desc: dictionary_line_desc.unwrap_or_default(),
             dictionary_fill_desc: dictionary_fill_desc.unwrap_or_default(),
+            dictionary_font: dictionary_font.unwrap_or_default(),
+            dictionary_firmware: dictionary_firmware.unwrap_or_default(),
             dictionary_standard: dictionary_standard.unwrap_or_default(),
             dictionary_user: dictionary_user.unwrap_or_default(),
         })
@@ -283,7 +298,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_line_desc(&mut self, node: &Node, units: Units) -> Result<LineDesc> {
-        let line_width = self.parse_f64_attr_with_units(node, "lineWidth", "LineDesc", units)?;
+        let line_width =
+            self.parse_non_negative_f64_attr_with_units(node, "lineWidth", "LineDesc", units)?;
         let line_end_str = self.required_attr(node, "lineEnd", "LineDesc")?;
         let line_end = self.parse_line_end(self.interner.resolve(line_end_str))?;
 
@@ -297,6 +313,23 @@ impl<'a> Parser<'a> {
             line_end,
             line_property,
         })
+    }
+
+    fn parse_line_desc_group(
+        &mut self,
+        node: &Node,
+        units: Units,
+        context: &'static str,
+    ) -> Result<LineDescGroup> {
+        let (line_desc, line_desc_ref, _, _) = self.parse_fill_and_line_desc(node, units)?;
+        match (line_desc, line_desc_ref) {
+            (Some(line_desc), None) => Ok(LineDescGroup::Inline(line_desc)),
+            (None, Some(line_desc_ref)) => Ok(LineDescGroup::Ref(line_desc_ref)),
+            (None, None) => Err(Ipc2581Error::MissingElement(context)),
+            (Some(_), Some(_)) => Err(Ipc2581Error::InvalidStructure(format!(
+                "{context} contains multiple LineDescGroup children"
+            ))),
+        }
     }
 
     fn parse_line_end(&self, s: &str) -> Result<LineEnd> {
@@ -348,31 +381,179 @@ impl<'a> Parser<'a> {
         Ok((line_width, line_end, line_property))
     }
 
-    fn parse_dictionary_fill_desc(&mut self, _node: &Node) -> Result<DictionaryFillDesc> {
-        // Simplified for now
-        Ok(DictionaryFillDesc::default())
+    fn parse_dictionary_fill_desc(&mut self, node: &Node) -> Result<DictionaryFillDesc> {
+        let units = self
+            .attr(node, "units")
+            .map(|value| self.parse_units(value))
+            .transpose()?;
+        let fill_units = units.unwrap_or(Units::Millimeter);
+        let mut entries = Vec::new();
+        for child in self.element_children(node) {
+            if self.name(&child) != "EntryFillDesc" {
+                continue;
+            }
+            let id = self.required_attr(&child, "id", "EntryFillDesc")?;
+            let fill = self
+                .element_children(&child)
+                .find(|entry| self.name(entry) == "FillDesc")
+                .ok_or(Ipc2581Error::MissingElement("FillDesc in EntryFillDesc"))?;
+            entries.push(EntryFillDesc {
+                id,
+                fill_desc: self.parse_fill_desc(&fill, fill_units)?,
+            });
+        }
+        Ok(DictionaryFillDesc { units, entries })
     }
 
-    fn parse_fill_desc(&mut self, node: &Node) -> Result<FillDesc> {
+    fn parse_fill_desc(&mut self, node: &Node, units: Units) -> Result<FillDesc> {
         let fill_property_str = self.required_attr(node, "fillProperty", "FillDesc")?;
         let fill_property = self.parse_fill_property(self.interner.resolve(fill_property_str))?;
-
-        let angle1 = self
-            .attr(node, "angle1")
-            .map(|s| s.parse::<f64>())
-            .transpose()
-            .map_err(|_| Ipc2581Error::InvalidAttribute("angle1".to_string()))?;
-
-        let angle2 = self
-            .attr(node, "angle2")
-            .map(|s| s.parse::<f64>())
-            .transpose()
-            .map_err(|_| Ipc2581Error::InvalidAttribute("angle2".to_string()))?;
+        let color = self
+            .element_children(node)
+            .find_map(|child| self.parse_color_group(&child).transpose())
+            .transpose()?;
 
         Ok(FillDesc {
             fill_property,
-            angle1,
-            angle2,
+            line_width: self.parse_optional_non_negative_f64_attr_with_units(
+                node,
+                "lineWidth",
+                units,
+            )?,
+            pitch1: self.parse_optional_non_negative_f64_attr_with_units(node, "pitch1", units)?,
+            pitch2: self.parse_optional_non_negative_f64_attr_with_units(node, "pitch2", units)?,
+            angle1: self.parse_optional_f64_attr(node, "angle1")?,
+            angle2: self.parse_optional_f64_attr(node, "angle2")?,
+            color,
+        })
+    }
+
+    fn parse_color_group(&mut self, node: &Node) -> Result<Option<ColorGroup>> {
+        let color = match self.name(node) {
+            "Color" => Some(ColorGroup::Color(Color {
+                r: self.parse_u8_attr(node, "r", "Color")?,
+                g: self.parse_u8_attr(node, "g", "Color")?,
+                b: self.parse_u8_attr(node, "b", "Color")?,
+            })),
+            "ColorRef" => Some(ColorGroup::Ref(self.required_attr(node, "id", "ColorRef")?)),
+            "ColorTerm" => Some(ColorGroup::Term {
+                name: self.required_attr(node, "name", "ColorTerm")?,
+                comment: self.optional_attr(node, "comment"),
+            }),
+            _ => None,
+        };
+        Ok(color)
+    }
+
+    fn parse_dictionary_firmware(&mut self, node: &Node) -> Result<DictionaryFirmware> {
+        let mut entries = Vec::new();
+        for child in self.element_children(node) {
+            if self.name(&child) != "EntryFirmware" {
+                continue;
+            }
+            let id = self.required_attr(&child, "id", "EntryFirmware")?;
+            let cached = self
+                .element_children(&child)
+                .find(|entry| self.name(entry) == "CachedFirmware")
+                .ok_or(Ipc2581Error::MissingElement(
+                    "CachedFirmware in EntryFirmware",
+                ))?;
+            entries.push(EntryFirmware {
+                id,
+                hex_encoded_binary: self.required_attr(
+                    &cached,
+                    "hexEncodedBinary",
+                    "CachedFirmware",
+                )?,
+            });
+        }
+        Ok(DictionaryFirmware { entries })
+    }
+
+    fn parse_dictionary_font(&mut self, node: &Node) -> Result<DictionaryFont> {
+        let units = self
+            .attr(node, "units")
+            .map(|value| self.parse_units(value))
+            .transpose()?;
+        let font_units = units.unwrap_or(Units::Millimeter);
+        let mut entries = Vec::new();
+        for child in self.element_children(node) {
+            if self.name(&child) != "EntryFont" {
+                continue;
+            }
+            let id = self.required_attr(&child, "id", "EntryFont")?;
+            let definition_node = self
+                .element_children(&child)
+                .find(|entry| matches!(self.name(entry), "FontDefEmbedded" | "FontDefExternal"))
+                .ok_or(Ipc2581Error::MissingElement("FontDef in EntryFont"))?;
+            let definition = match self.name(&definition_node) {
+                "FontDefEmbedded" => FontDefinition::Embedded(
+                    self.parse_embedded_font(&definition_node, font_units)?,
+                ),
+                "FontDefExternal" => FontDefinition::External(ExternalFont {
+                    name: self.required_attr(&definition_node, "name", "FontDefExternal")?,
+                    urn: self.required_attr(&definition_node, "urn", "FontDefExternal")?,
+                }),
+                _ => unreachable!("font definition was filtered above"),
+            };
+            entries.push(EntryFont { id, definition });
+        }
+        Ok(DictionaryFont { units, entries })
+    }
+
+    fn parse_embedded_font(&mut self, node: &Node, units: Units) -> Result<EmbeddedFont> {
+        let name = self.required_attr(node, "name", "FontDefEmbedded")?;
+        let line_desc =
+            self.parse_line_desc_group(node, units, "LineDescGroup in FontDefEmbedded")?;
+        let glyph_nodes = self
+            .element_children(node)
+            .filter(|child| self.name(child) == "Glyph")
+            .collect::<Vec<_>>();
+        let mut glyphs = Vec::with_capacity(glyph_nodes.len());
+        for glyph in glyph_nodes {
+            glyphs.push(self.parse_font_glyph(&glyph, units)?);
+        }
+        Ok(EmbeddedFont {
+            name,
+            line_desc,
+            glyphs,
+        })
+    }
+
+    fn parse_font_glyph(&mut self, node: &Node, units: Units) -> Result<FontGlyph> {
+        let char_code = self.required_attr(node, "charCode", "Glyph")?;
+        let bounding_box = BoundingBox {
+            lower_left: Point {
+                x: self.parse_f64_attr_with_units(node, "lowerLeftX", "Glyph", units)?,
+                y: self.parse_f64_attr_with_units(node, "lowerLeftY", "Glyph", units)?,
+            },
+            upper_right: Point {
+                x: self.parse_f64_attr_with_units(node, "upperRightX", "Glyph", units)?,
+                y: self.parse_f64_attr_with_units(node, "upperRightY", "Glyph", units)?,
+            },
+        };
+        let mut shapes = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Arc" | "Line" | "Polyline" => {
+                    let shape = self.parse_user_shape(&child, units)?.ok_or_else(|| {
+                        Ipc2581Error::InvalidStructure(format!(
+                            "Unsupported {} in Glyph",
+                            self.name(&child)
+                        ))
+                    })?;
+                    shapes.push(FontShape::Shape(shape));
+                }
+                "Outline" => shapes.push(FontShape::Outline(
+                    self.parse_package_outline(&child, units)?,
+                )),
+                _ => {}
+            }
+        }
+        Ok(FontGlyph {
+            char_code,
+            bounding_box,
+            shapes,
         })
     }
 
@@ -396,38 +577,44 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse optional FillDesc and LineDesc children from a primitive node
-    fn parse_fill_and_line_desc(
-        &mut self,
-        node: &Node,
-    ) -> Result<(Option<FillProperty>, Option<Symbol>)> {
-        let mut fill_property = None;
+    fn parse_fill_and_line_desc(&mut self, node: &Node, units: Units) -> Result<ShapeStyle> {
+        let mut line_desc = None;
         let mut line_desc_ref = None;
+        let mut fill_desc = None;
+        let mut fill_desc_ref = None;
 
         for child in self.element_children(node) {
             match self.name(&child) {
-                "FillDesc" => {
-                    let fill_desc = self.parse_fill_desc(&child)?;
-                    fill_property = Some(fill_desc.fill_property);
-                }
+                "LineDesc" => line_desc = Some(self.parse_line_desc(&child, units)?),
                 "LineDescRef" => {
                     if let Some(id) = self.attr(&child, "id") {
                         line_desc_ref = Some(self.interner.intern(id));
+                    }
+                }
+                "FillDesc" => fill_desc = Some(self.parse_fill_desc(&child, units)?),
+                "FillDescRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        fill_desc_ref = Some(self.interner.intern(id));
                     }
                 }
                 _ => {}
             }
         }
 
-        Ok((fill_property, line_desc_ref))
+        Ok((line_desc, line_desc_ref, fill_desc, fill_desc_ref))
     }
 
     /// Wrap a shape with styling (fill_property and line_desc_ref)
-    fn styled<T>(&mut self, node: &Node, shape: T) -> Result<Styled<T>> {
-        let (fill_property, line_desc_ref) = self.parse_fill_and_line_desc(node)?;
+    fn styled<T>(&mut self, node: &Node, shape: T, units: Units) -> Result<Styled<T>> {
+        let (line_desc, line_desc_ref, fill_desc, fill_desc_ref) =
+            self.parse_fill_and_line_desc(node, units)?;
         Ok(Styled {
             shape,
-            fill_property,
+            fill_property: fill_desc.map(|desc| desc.fill_property),
+            line_desc,
             line_desc_ref,
+            fill_desc,
+            fill_desc_ref,
         })
     }
 
@@ -473,6 +660,7 @@ impl<'a> Parser<'a> {
                 Circle {
                     diameter: self.parse_f64_attr_with_units(node, "diameter", "Circle", units)?,
                 },
+                units,
             )?)),
             "RectCenter" => Ok(StandardPrimitive::RectCenter(self.styled(
                 node,
@@ -492,6 +680,7 @@ impl<'a> Parser<'a> {
                         )?,
                     },
                 },
+                units,
             )?)),
             "RectRound" => Ok(StandardPrimitive::RectRound(self.styled(
                 node,
@@ -511,6 +700,7 @@ impl<'a> Parser<'a> {
                     lower_right: self.parse_bool_attr(node, "lowerRight").unwrap_or(false),
                     lower_left: self.parse_bool_attr(node, "lowerLeft").unwrap_or(false),
                 },
+                units,
             )?)),
             "RectCham" => Ok(StandardPrimitive::RectCham(self.styled(
                 node,
@@ -526,6 +716,7 @@ impl<'a> Parser<'a> {
                     lower_right: self.parse_bool_attr(node, "lowerRight").unwrap_or(false),
                     lower_left: self.parse_bool_attr(node, "lowerLeft").unwrap_or(false),
                 },
+                units,
             )?)),
             "RectCorner" => Ok(StandardPrimitive::RectCorner(self.styled(
                 node,
@@ -559,6 +750,7 @@ impl<'a> Parser<'a> {
                         )?,
                     },
                 },
+                units,
             )?)),
             "Butterfly" => {
                 let shape_attr = self.required_attr(node, "shape", "Butterfly")?;
@@ -580,6 +772,7 @@ impl<'a> Parser<'a> {
                             units,
                         )?,
                     },
+                    units,
                 )?))
             }
             "Diamond" => Ok(StandardPrimitive::Diamond(self.styled(
@@ -590,6 +783,7 @@ impl<'a> Parser<'a> {
                         height: self.parse_f64_attr_with_units(node, "height", "Diamond", units)?,
                     },
                 },
+                units,
             )?)),
             "Donut" => {
                 let shape_attr = self.required_attr(node, "shape", "Donut")?;
@@ -612,6 +806,7 @@ impl<'a> Parser<'a> {
                             units,
                         )?,
                     },
+                    units,
                 )?))
             }
             "Ellipse" => Ok(StandardPrimitive::Ellipse(self.styled(
@@ -622,6 +817,7 @@ impl<'a> Parser<'a> {
                         height: self.parse_f64_attr_with_units(node, "height", "Ellipse", units)?,
                     },
                 },
+                units,
             )?)),
             "Hexagon" => Ok(StandardPrimitive::Hexagon(self.styled(
                 node,
@@ -629,6 +825,7 @@ impl<'a> Parser<'a> {
                     point_to_point:
                         self.parse_f64_attr_with_units(node, "length", "Hexagon", units)?,
                 },
+                units,
             )?)),
             "Moire" => Ok(StandardPrimitive::Moire(Moire {
                 diameter: self.parse_f64_attr_with_units(node, "diameter", "Moire", units)?,
@@ -645,6 +842,7 @@ impl<'a> Parser<'a> {
                     point_to_point:
                         self.parse_f64_attr_with_units(node, "length", "Octagon", units)?,
                 },
+                units,
             )?)),
             "Thermal" => {
                 let shape_attr = self.required_attr(node, "shape", "Thermal")?;
@@ -678,6 +876,7 @@ impl<'a> Parser<'a> {
                             spoke_start_angle: self
                                 .parse_optional_f64_attr(node, "spokeStartAngle")?,
                         },
+                        units,
                     )?,
                 ))
             }
@@ -687,6 +886,7 @@ impl<'a> Parser<'a> {
                     base: self.parse_f64_attr_with_units(node, "base", "Triangle", units)?,
                     height: self.parse_f64_attr_with_units(node, "height", "Triangle", units)?,
                 },
+                units,
             )?)),
             "Oval" => Ok(StandardPrimitive::Oval(self.styled(
                 node,
@@ -696,6 +896,7 @@ impl<'a> Parser<'a> {
                         height: self.parse_f64_attr_with_units(node, "height", "Oval", units)?,
                     },
                 },
+                units,
             )?)),
             "Contour" => Ok(StandardPrimitive::Contour(self.parse_contour(node, units)?)),
             name => Err(Ipc2581Error::InvalidStructure(format!(
@@ -822,130 +1023,88 @@ impl<'a> Parser<'a> {
         let mut shapes = Vec::new();
 
         for child in self.element_children(node) {
-            let tag_name = self.name(&child);
-
-            if tag_name == "UserSpecial" {
+            if self.name(&child) == "UserSpecial" {
                 let UserPrimitive::UserSpecial(nested) = self.parse_user_special(&child, units)?;
                 shapes.extend(nested.shapes);
                 continue;
             }
-
-            let shape_type = match tag_name {
-                "Contour" => Some(UserShapeType::Contour(self.parse_contour(&child, units)?)),
-                "Circle" => Some(UserShapeType::Circle(Circle {
-                    diameter: self
-                        .parse_f64_attr_with_units(&child, "diameter", "Circle", units)?,
-                })),
-                "RectCenter" => Some(UserShapeType::RectCenter(RectCenter {
-                    size: Size {
-                        width: self.parse_f64_attr_with_units(
-                            &child,
-                            "width",
-                            "RectCenter",
-                            units,
-                        )?,
-                        height: self.parse_f64_attr_with_units(
-                            &child,
-                            "height",
-                            "RectCenter",
-                            units,
-                        )?,
-                    },
-                })),
-                "Oval" => Some(UserShapeType::Oval(Oval {
-                    size: Size {
-                        width: self.parse_f64_attr_with_units(&child, "width", "Oval", units)?,
-                        height: self.parse_f64_attr_with_units(&child, "height", "Oval", units)?,
-                    },
-                })),
-                "RectRound" => Some(UserShapeType::RectRound(RectRound {
-                    size: Size {
-                        width: self.parse_f64_attr_with_units(
-                            &child,
-                            "width",
-                            "RectRound",
-                            units,
-                        )?,
-                        height: self.parse_f64_attr_with_units(
-                            &child,
-                            "height",
-                            "RectRound",
-                            units,
-                        )?,
-                    },
-                    radius: self.parse_f64_attr_with_units(&child, "radius", "RectRound", units)?,
-                    upper_right: self.parse_bool_attr(&child, "upperRight").unwrap_or(false),
-                    upper_left: self.parse_bool_attr(&child, "upperLeft").unwrap_or(false),
-                    lower_right: self.parse_bool_attr(&child, "lowerRight").unwrap_or(false),
-                    lower_left: self.parse_bool_attr(&child, "lowerLeft").unwrap_or(false),
-                })),
-                "Polygon" => Some(UserShapeType::Polygon(self.parse_polygon(&child, units)?)),
-                "Line" => Some(UserShapeType::Line(crate::types::primitives::Line {
-                    start: Point {
-                        x: self.parse_f64_attr_with_units(&child, "startX", "Line", units)?,
-                        y: self.parse_f64_attr_with_units(&child, "startY", "Line", units)?,
-                    },
-                    end: Point {
-                        x: self.parse_f64_attr_with_units(&child, "endX", "Line", units)?,
-                        y: self.parse_f64_attr_with_units(&child, "endY", "Line", units)?,
-                    },
-                })),
-                "Arc" => Some(UserShapeType::Arc(self.parse_user_arc(&child, units)?)),
-                "Polyline" => Some(UserShapeType::Polyline(
-                    self.parse_user_polyline(&child, units)?,
-                )),
-                "UserPrimitiveRef" => self
-                    .attr(&child, "id")
-                    .map(|id| UserShapeType::UserPrimitiveRef(self.interner.intern(id))),
-                _ => None,
-            };
-
-            if let Some(shape_type) = shape_type {
-                let style_node = if tag_name == "Contour" {
-                    self.element_children(&child)
-                        .find(|n| self.name(n) == "Polygon")
-                        .unwrap_or(child)
-                } else {
-                    child
-                };
-                let (line_desc, line_desc_ref, fill_desc) =
-                    self.parse_user_shape_style(&style_node, units)?;
-
-                shapes.push(UserShape {
-                    shape: shape_type,
-                    line_desc,
-                    line_desc_ref,
-                    fill_desc,
-                });
+            if let Some(shape) = self.parse_user_shape(&child, units)? {
+                shapes.push(shape);
             }
         }
 
         Ok(UserPrimitive::UserSpecial(UserSpecial { shapes }))
     }
 
-    fn parse_user_shape_style(
-        &mut self,
-        node: &Node,
-        units: Units,
-    ) -> Result<(Option<LineDesc>, Option<Symbol>, Option<FillDesc>)> {
-        let mut line_desc = None;
-        let mut line_desc_ref = None;
-        let mut fill_desc = None;
-
-        for child in self.element_children(node) {
-            match self.name(&child) {
-                "LineDesc" => line_desc = Some(self.parse_line_desc(&child, units)?),
-                "LineDescRef" => {
-                    if let Some(id) = self.attr(&child, "id") {
-                        line_desc_ref = Some(self.interner.intern(id));
-                    }
-                }
-                "FillDesc" => fill_desc = Some(self.parse_fill_desc(&child)?),
-                _ => {}
-            }
-        }
-
-        Ok((line_desc, line_desc_ref, fill_desc))
+    fn parse_user_shape(&mut self, node: &Node, units: Units) -> Result<Option<UserShape>> {
+        let tag_name = self.name(node);
+        let shape = match tag_name {
+            "Contour" => Some(UserShapeType::Contour(self.parse_contour(node, units)?)),
+            "Circle" => Some(UserShapeType::Circle(Circle {
+                diameter: self.parse_f64_attr_with_units(node, "diameter", "Circle", units)?,
+            })),
+            "RectCenter" => Some(UserShapeType::RectCenter(RectCenter {
+                size: Size {
+                    width: self.parse_f64_attr_with_units(node, "width", "RectCenter", units)?,
+                    height: self.parse_f64_attr_with_units(node, "height", "RectCenter", units)?,
+                },
+            })),
+            "Oval" => Some(UserShapeType::Oval(Oval {
+                size: Size {
+                    width: self.parse_f64_attr_with_units(node, "width", "Oval", units)?,
+                    height: self.parse_f64_attr_with_units(node, "height", "Oval", units)?,
+                },
+            })),
+            "RectRound" => Some(UserShapeType::RectRound(RectRound {
+                size: Size {
+                    width: self.parse_f64_attr_with_units(node, "width", "RectRound", units)?,
+                    height: self.parse_f64_attr_with_units(node, "height", "RectRound", units)?,
+                },
+                radius: self.parse_f64_attr_with_units(node, "radius", "RectRound", units)?,
+                upper_right: self.parse_bool_attr(node, "upperRight").unwrap_or(false),
+                upper_left: self.parse_bool_attr(node, "upperLeft").unwrap_or(false),
+                lower_right: self.parse_bool_attr(node, "lowerRight").unwrap_or(false),
+                lower_left: self.parse_bool_attr(node, "lowerLeft").unwrap_or(false),
+            })),
+            "Polygon" => Some(UserShapeType::Polygon(self.parse_polygon(node, units)?)),
+            "Line" => Some(UserShapeType::Line(crate::types::primitives::Line {
+                start: Point {
+                    x: self.parse_f64_attr_with_units(node, "startX", "Line", units)?,
+                    y: self.parse_f64_attr_with_units(node, "startY", "Line", units)?,
+                },
+                end: Point {
+                    x: self.parse_f64_attr_with_units(node, "endX", "Line", units)?,
+                    y: self.parse_f64_attr_with_units(node, "endY", "Line", units)?,
+                },
+            })),
+            "Arc" => Some(UserShapeType::Arc(self.parse_user_arc(node, units)?)),
+            "Polyline" => Some(UserShapeType::Polyline(
+                self.parse_user_polyline(node, units)?,
+            )),
+            "UserPrimitiveRef" => self
+                .attr(node, "id")
+                .map(|id| UserShapeType::UserPrimitiveRef(self.interner.intern(id))),
+            _ => None,
+        };
+        let Some(shape) = shape else {
+            return Ok(None);
+        };
+        let style_node = if tag_name == "Contour" {
+            self.element_children(node)
+                .find(|child| self.name(child) == "Polygon")
+                .unwrap_or(*node)
+        } else {
+            *node
+        };
+        let (line_desc, line_desc_ref, fill_desc, fill_desc_ref) =
+            self.parse_fill_and_line_desc(&style_node, units)?;
+        Ok(Some(UserShape {
+            shape,
+            line_desc,
+            line_desc_ref,
+            fill_desc,
+            fill_desc_ref,
+        }))
     }
 
     fn parse_user_polyline(&mut self, node: &Node, units: Units) -> Result<Polyline> {
@@ -1181,7 +1340,6 @@ impl<'a> Parser<'a> {
             "MILLIMETER" => Ok(Units::Millimeter),
             "INCH" => Ok(Units::Inch),
             "MICRON" => Ok(Units::Micron),
-            "MILS" => Ok(Units::Mils),
             _ => Err(Ipc2581Error::InvalidAttribute(format!(
                 "Unknown units: {}",
                 s
@@ -1203,6 +1361,19 @@ impl<'a> Parser<'a> {
 
     fn optional_attr(&mut self, node: &Node, attr: &str) -> Option<Symbol> {
         self.attr(node, attr).map(|s| self.interner.intern(s))
+    }
+
+    fn parse_ipc_integer(&self, value: Symbol, attr: &str, positive: bool) -> Result<u32> {
+        let source = self.interner.resolve(value).trim();
+        let parsed = source.parse::<u32>().map_err(|_| {
+            Ipc2581Error::InvalidAttribute(format!("Invalid integer value for {attr}: {source}"))
+        })?;
+        if parsed > i32::MAX as u32 || (positive && parsed == 0) {
+            return Err(Ipc2581Error::InvalidAttribute(format!(
+                "Integer value for {attr} is outside the IPC-2581C range: {source}"
+            )));
+        }
+        Ok(parsed)
     }
 
     fn parse_f64_attr(
@@ -1231,6 +1402,18 @@ impl<'a> Parser<'a> {
         units: Units,
     ) -> Result<f64> {
         let value = self.parse_f64_attr(node, attr, element)?;
+        Ok(crate::units::to_mm(value, units))
+    }
+
+    fn parse_non_negative_f64_attr_with_units(
+        &self,
+        node: &Node,
+        attr: &'static str,
+        element: &'static str,
+        units: Units,
+    ) -> Result<f64> {
+        let value = self.parse_f64_attr(node, attr, element)?;
+        self.validate_non_negative_f64(value, attr)?;
         Ok(crate::units::to_mm(value, units))
     }
 
@@ -1299,14 +1482,50 @@ impl<'a> Parser<'a> {
             .transpose()
     }
 
+    fn parse_optional_non_negative_f64_attr_with_units(
+        &self,
+        node: &Node,
+        attr: &'static str,
+        units: Units,
+    ) -> Result<Option<f64>> {
+        self.attr(node, attr)
+            .map(|source| {
+                let value = source.parse::<f64>().map_err(|_| {
+                    Ipc2581Error::InvalidAttribute(format!("Invalid f64 value for {attr}"))
+                })?;
+                self.validate_non_negative_f64(value, attr)?;
+                Ok(crate::units::to_mm(value, units))
+            })
+            .transpose()
+    }
+
+    fn parse_optional_non_negative_f64_attr(
+        &self,
+        node: &Node,
+        attr: &'static str,
+    ) -> Result<Option<f64>> {
+        self.attr(node, attr)
+            .map(|source| {
+                let value = source.parse::<f64>().map_err(|_| {
+                    Ipc2581Error::InvalidAttribute(format!("Invalid f64 value for {attr}"))
+                })?;
+                self.validate_non_negative_f64(value, attr)
+            })
+            .transpose()
+    }
+
+    fn validate_non_negative_f64(&self, value: f64, attr: &str) -> Result<f64> {
+        if !value.is_finite() || !(0.0..=3.4e38).contains(&value) {
+            return Err(Ipc2581Error::InvalidAttribute(format!(
+                "Value for {attr} is outside the IPC-2581C non-negative range"
+            )));
+        }
+        Ok(value)
+    }
+
     fn parse_bool_attr(&self, node: &Node, attr: &'static str) -> Result<bool> {
         match self.attr(node, attr) {
-            Some("true") => Ok(true),
-            Some("false") => Ok(false),
-            Some(_) => Err(Ipc2581Error::InvalidAttribute(format!(
-                "Invalid bool value for {}",
-                attr
-            ))),
+            Some(value) => parse_xsd_bool(value, attr),
             None => Err(Ipc2581Error::MissingAttribute {
                 element: "unknown",
                 attr,
@@ -1852,16 +2071,11 @@ impl<'a> Parser<'a> {
             .parse_optional_f64_attr_with_units(node, "dy", units)?
             .unwrap_or(0.0);
         let angle = self.parse_optional_f64_attr(node, "angle")?.unwrap_or(0.0);
-        let mirror = match self.attr(node, "mirror") {
-            Some(value) if value.eq_ignore_ascii_case("true") => true,
-            Some(value) if value.eq_ignore_ascii_case("false") => false,
-            Some(_) => {
-                return Err(Ipc2581Error::InvalidAttribute(
-                    "Invalid bool value for mirror".to_string(),
-                ));
-            }
-            None => false,
-        };
+        let mirror = self
+            .attr(node, "mirror")
+            .map(|value| parse_xsd_bool(value, "mirror"))
+            .transpose()?
+            .unwrap_or(false);
 
         Ok(StepRepeat {
             step_ref,
@@ -1905,16 +2119,385 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_package(&mut self, node: &Node) -> Result<Package> {
+        let units = self.ecad_units.unwrap_or(Units::Millimeter);
         let name = self.required_attr(node, "name", "Package")?;
         let package_type = self.required_attr(node, "type", "Package")?;
-        let pin_one = self.attr(node, "pinOne").map(|s| self.interner.intern(s));
-        let height = self.attr(node, "height").and_then(|s| s.parse().ok());
+        let pin_one = self.optional_attr(node, "pinOne");
+        let pin_one_orientation = self.optional_attr(node, "pinOneOrientation");
+        let height = self.parse_optional_non_negative_f64_attr_with_units(node, "height", units)?;
+        let negative_body_extension = self.parse_optional_non_negative_f64_attr_with_units(
+            node,
+            "negativeBodyExtension",
+            units,
+        )?;
+        let comment = self.optional_attr(node, "comment");
+
+        let mut outline = None;
+        let mut pickup_point = None;
+        let mut land_pattern = None;
+        let mut silkscreen = None;
+        let mut assembly_drawing = None;
+        let mut pins = Vec::new();
+        let mut topside = None;
+        let mut other_side_view = None;
+
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Outline" => outline = Some(self.parse_package_outline(&child, units)?),
+                "PickupPoint" => pickup_point = Some(self.parse_location(&child, units)?),
+                "LandPattern" => {
+                    land_pattern = Some(self.parse_package_land_pattern(&child, units)?)
+                }
+                "SilkScreen" => silkscreen = Some(self.parse_package_silkscreen(&child, units)?),
+                "AssemblyDrawing" => {
+                    assembly_drawing = Some(self.parse_package_assembly_drawing(&child, units)?)
+                }
+                "Pin" => pins.push(self.parse_package_pin(&child, units)?),
+                "Topside" => topside = Some(self.parse_package_side_view(&child, units)?),
+                "OtherSideView" => {
+                    other_side_view = Some(self.parse_package_other_side_view(&child, units)?)
+                }
+                _ => {}
+            }
+        }
 
         Ok(Package {
             name,
             package_type,
             pin_one,
+            pin_one_orientation,
             height,
+            negative_body_extension,
+            comment,
+            outline,
+            pickup_point,
+            land_pattern,
+            silkscreen,
+            assembly_drawing,
+            pins,
+            topside,
+            other_side_view,
+        })
+    }
+
+    fn parse_package_outline(&mut self, node: &Node, units: Units) -> Result<PackageOutline> {
+        let polygon_node = self
+            .element_children(node)
+            .find(|child| self.name(child) == "Polygon")
+            .ok_or(Ipc2581Error::MissingElement("Polygon in Package Outline"))?;
+        let polygon = self.parse_polygon(&polygon_node, units)?;
+        let polygon_xform = self.parse_xform_child(&polygon_node, units)?;
+        let (polygon_line_desc, polygon_line_desc_ref, polygon_fill_desc, polygon_fill_desc_ref) =
+            self.parse_fill_and_line_desc(&polygon_node, units)?;
+        let line_desc =
+            self.parse_line_desc_group(node, units, "LineDescGroup in Package Outline")?;
+        Ok(PackageOutline {
+            polygon,
+            polygon_xform,
+            polygon_line_desc,
+            polygon_line_desc_ref,
+            polygon_fill_desc,
+            polygon_fill_desc_ref,
+            line_desc,
+        })
+    }
+
+    fn parse_package_land_pattern(
+        &mut self,
+        node: &Node,
+        units: Units,
+    ) -> Result<PackageLandPattern> {
+        let mut pads = Vec::new();
+        let mut targets = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Pad" => pads.push(self.parse_pad(&child)?),
+                "Target" => targets.push(self.parse_package_target(&child, units)?),
+                _ => {}
+            }
+        }
+        Ok(PackageLandPattern { pads, targets })
+    }
+
+    fn parse_package_target(&mut self, node: &Node, units: Units) -> Result<PackageTarget> {
+        let xform = self.parse_xform_child(node, units)?;
+        let location_node = self
+            .element_children(node)
+            .find(|child| self.name(child) == "Location")
+            .ok_or(Ipc2581Error::MissingElement("Location in Package Target"))?;
+        let location = self.parse_location(&location_node, units)?;
+        let shape = self
+            .element_children(node)
+            .find_map(|child| self.parse_standard_shape(&child, units).transpose())
+            .transpose()?
+            .ok_or(Ipc2581Error::MissingElement(
+                "StandardShape in Package Target",
+            ))?;
+        Ok(PackageTarget {
+            xform,
+            location,
+            shape,
+        })
+    }
+
+    fn parse_package_silkscreen(&mut self, node: &Node, units: Units) -> Result<PackageSilkscreen> {
+        let mut outlines = Vec::new();
+        let mut markings = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Outline" => outlines.push(self.parse_package_outline(&child, units)?),
+                "Marking" => markings.push(self.parse_package_marking(&child, units)?),
+                _ => {}
+            }
+        }
+        Ok(PackageSilkscreen { outlines, markings })
+    }
+
+    fn parse_package_assembly_drawing(
+        &mut self,
+        node: &Node,
+        units: Units,
+    ) -> Result<PackageAssemblyDrawing> {
+        let mut outline = None;
+        let mut markings = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Outline" => outline = Some(self.parse_package_outline(&child, units)?),
+                "Marking" => markings.push(self.parse_package_marking(&child, units)?),
+                _ => {}
+            }
+        }
+        Ok(PackageAssemblyDrawing { outline, markings })
+    }
+
+    fn parse_package_marking(&mut self, node: &Node, units: Units) -> Result<PackageMarking> {
+        let usage = self.optional_attr(node, "markingUsage");
+        let xform = self.parse_xform_child(node, units)?;
+        let location = self
+            .element_children(node)
+            .find(|child| self.name(child) == "Location")
+            .map(|child| self.parse_location(&child, units))
+            .transpose()?;
+        let feature = self
+            .element_children(node)
+            .find_map(|child| self.parse_feature_shape(&child, units).transpose())
+            .transpose()?
+            .ok_or(Ipc2581Error::MissingElement("Feature in Package Marking"))?;
+        Ok(PackageMarking {
+            usage,
+            xform,
+            location,
+            feature,
+        })
+    }
+
+    fn parse_package_side_view(&mut self, node: &Node, units: Units) -> Result<PackageSideView> {
+        let mut outline = None;
+        let mut land_pattern = None;
+        let mut silkscreen = None;
+        let mut assembly_drawing = None;
+        let mut pins = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Outline" => outline = Some(self.parse_package_outline(&child, units)?),
+                "LandPattern" => {
+                    land_pattern = Some(self.parse_package_land_pattern(&child, units)?)
+                }
+                "SilkScreen" => silkscreen = Some(self.parse_package_silkscreen(&child, units)?),
+                "AssemblyDrawing" => {
+                    assembly_drawing = Some(self.parse_package_assembly_drawing(&child, units)?)
+                }
+                "Pin" => pins.push(self.parse_package_pin(&child, units)?),
+                _ => {}
+            }
+        }
+        Ok(PackageSideView {
+            outline,
+            land_pattern,
+            silkscreen,
+            assembly_drawing,
+            pins,
+        })
+    }
+
+    fn parse_package_other_side_view(
+        &mut self,
+        node: &Node,
+        units: Units,
+    ) -> Result<PackageOtherSideView> {
+        let mut outline = None;
+        let mut silkscreen = None;
+        let mut assembly_drawing = None;
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Outline" => outline = Some(self.parse_package_outline(&child, units)?),
+                "SilkScreen" => silkscreen = Some(self.parse_package_silkscreen(&child, units)?),
+                "AssemblyDrawing" => {
+                    assembly_drawing = Some(self.parse_package_assembly_drawing(&child, units)?)
+                }
+                _ => {}
+            }
+        }
+        Ok(PackageOtherSideView {
+            outline,
+            silkscreen,
+            assembly_drawing,
+        })
+    }
+
+    fn parse_package_pin(&mut self, node: &Node, units: Units) -> Result<PackagePin> {
+        let number = self.required_attr(node, "number", "Pin")?;
+        let name = self.optional_attr(node, "name");
+        let pin_type = match self
+            .required_attr(node, "type", "Pin")
+            .map(|symbol| self.interner.resolve(symbol))?
+        {
+            "THRU" => PackagePinType::Through,
+            "BLIND" => PackagePinType::Blind,
+            "SURFACE" => PackagePinType::Surface,
+            value => {
+                return Err(Ipc2581Error::InvalidAttribute(format!(
+                    "Invalid Pin type: {value}"
+                )));
+            }
+        };
+        let electrical_type = self
+            .attr(node, "electricalType")
+            .map(parse_package_pin_electrical_type)
+            .transpose()?;
+        let mount_type = self
+            .attr(node, "mountType")
+            .map(parse_package_pin_mount_type)
+            .transpose()?;
+        let polarity = self
+            .attr(node, "pinPolarity")
+            .map(parse_package_pin_polarity)
+            .transpose()?;
+        let xform = self.parse_xform_child(node, units)?;
+        let location = self
+            .element_children(node)
+            .find(|child| self.name(child) == "Location")
+            .map(|child| self.parse_location(&child, units))
+            .transpose()?;
+        let shape = self
+            .element_children(node)
+            .find_map(|child| self.parse_standard_shape(&child, units).transpose())
+            .transpose()?
+            .ok_or(Ipc2581Error::MissingElement("StandardShape in Package Pin"))?;
+        Ok(PackagePin {
+            number,
+            name,
+            pin_type,
+            electrical_type,
+            mount_type,
+            polarity,
+            xform,
+            location,
+            shape,
+        })
+    }
+
+    fn parse_standard_shape(&mut self, node: &Node, units: Units) -> Result<Option<StandardShape>> {
+        let shape = match self.name(node) {
+            "StandardPrimitiveRef" => self
+                .attr(node, "id")
+                .map(|id| StandardShape::PrimitiveRef(self.interner.intern(id))),
+            name if is_standard_primitive_name(name) => Some(StandardShape::Primitive(
+                self.parse_standard_primitive(node, units)?,
+            )),
+            _ => None,
+        };
+        Ok(shape)
+    }
+
+    fn parse_feature_shape(&mut self, node: &Node, units: Units) -> Result<Option<FeatureShape>> {
+        let shape = match self.name(node) {
+            "StandardPrimitiveRef" => self
+                .attr(node, "id")
+                .map(|id| FeatureShape::StandardPrimitiveRef(self.interner.intern(id))),
+            "UserPrimitiveRef" => self
+                .attr(node, "id")
+                .map(|id| FeatureShape::UserPrimitiveRef(self.interner.intern(id))),
+            "UserSpecial" => Some(FeatureShape::UserPrimitive(
+                self.parse_user_special(node, units)?,
+            )),
+            "Text" => Some(FeatureShape::Text(self.parse_text(node, units)?)),
+            "Outline" => Some(FeatureShape::Outline(
+                self.parse_package_outline(node, units)?,
+            )),
+            name if is_standard_primitive_name(name) => Some(FeatureShape::StandardPrimitive(
+                self.parse_standard_primitive(node, units)?,
+            )),
+            _ => self
+                .parse_user_shape(node, units)?
+                .map(FeatureShape::UserShape),
+        };
+        Ok(shape)
+    }
+
+    fn parse_text(&mut self, node: &Node, units: Units) -> Result<Text> {
+        let text_string = self.required_attr(node, "textString", "Text")?;
+        let font_size_raw = self.required_attr(node, "fontSize", "Text")?;
+        let font_size = self.parse_ipc_integer(font_size_raw, "fontSize", true)?;
+        let xform = self.parse_xform_child(node, units)?;
+        let bounding_box_node = self
+            .element_children(node)
+            .find(|child| self.name(child) == "BoundingBox")
+            .ok_or(Ipc2581Error::MissingElement("BoundingBox in Text"))?;
+        let bounding_box = BoundingBox {
+            lower_left: Point {
+                x: self.parse_f64_attr_with_units(
+                    &bounding_box_node,
+                    "lowerLeftX",
+                    "BoundingBox",
+                    units,
+                )?,
+                y: self.parse_f64_attr_with_units(
+                    &bounding_box_node,
+                    "lowerLeftY",
+                    "BoundingBox",
+                    units,
+                )?,
+            },
+            upper_right: Point {
+                x: self.parse_f64_attr_with_units(
+                    &bounding_box_node,
+                    "upperRightX",
+                    "BoundingBox",
+                    units,
+                )?,
+                y: self.parse_f64_attr_with_units(
+                    &bounding_box_node,
+                    "upperRightY",
+                    "BoundingBox",
+                    units,
+                )?,
+            },
+        };
+        let font_ref = self
+            .element_children(node)
+            .find(|child| self.name(child) == "FontRef")
+            .map(|child| self.required_attr(&child, "id", "FontRef"))
+            .transpose()?;
+        let color = self
+            .element_children(node)
+            .find_map(|child| self.parse_color_group(&child).transpose())
+            .transpose()?;
+        Ok(Text {
+            text_string,
+            font_size,
+            font_size_raw,
+            xform,
+            bounding_box,
+            font_ref,
+            color,
+        })
+    }
+
+    fn parse_location(&self, node: &Node, units: Units) -> Result<Location> {
+        Ok(Location {
+            x: self.parse_f64_attr_with_units(node, "x", "Location", units)?,
+            y: self.parse_f64_attr_with_units(node, "y", "Location", units)?,
         })
     }
 
@@ -1930,12 +2513,13 @@ impl<'a> Parser<'a> {
                 element: "Component",
                 attr: "mountType",
             },
-        )?);
+        )?)?;
         let part = self.required_attr(node, "part", "Component")?;
         let model_ref = self.optional_attr(node, "modelRef");
-        let weight = self.parse_optional_f64_attr(node, "weight")?;
-        let height = self.parse_optional_f64_attr(node, "height")?;
-        let standoff = self.parse_optional_f64_attr(node, "standoff")?;
+        let weight = self.parse_optional_non_negative_f64_attr(node, "weight")?;
+        let height = self.parse_optional_non_negative_f64_attr_with_units(node, "height", units)?;
+        let standoff =
+            self.parse_optional_non_negative_f64_attr_with_units(node, "standoff", units)?;
 
         let mut nonstandard_attributes = Vec::new();
         let mut xform = None;
@@ -1949,7 +2533,7 @@ impl<'a> Parser<'a> {
                     nonstandard_attributes.push(self.parse_nonstandard_attribute(&child)?);
                 }
                 "Xform" => {
-                    xform = Some(self.parse_xform(&child, units));
+                    xform = Some(self.parse_xform(&child, units)?);
                 }
                 "Location" => {
                     location = Some(Location {
@@ -1989,19 +2573,21 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_mount_type(&self, value: &str) -> MountType {
+    fn parse_mount_type(&self, value: &str) -> Result<MountType> {
         match value {
-            "SMT" => MountType::Smt,
-            "THMT" | "THT" => MountType::Thmt,
-            "EMBEDDED" => MountType::Embedded,
-            "PRESSFIT" => MountType::PressFit,
-            "WIRE_BONDED" => MountType::WireBonded,
-            "GLUED" => MountType::Glued,
-            "CLAMPED" => MountType::Clamped,
-            "SOCKETED" => MountType::Socketed,
-            "FORMED" => MountType::Formed,
-            "OTHER" => MountType::Other,
-            _ => MountType::Other,
+            "SMT" => Ok(MountType::Smt),
+            "THMT" => Ok(MountType::Thmt),
+            "EMBEDDED" => Ok(MountType::Embedded),
+            "PRESSFIT" => Ok(MountType::PressFit),
+            "WIRE_BONDED" => Ok(MountType::WireBonded),
+            "GLUED" => Ok(MountType::Glued),
+            "CLAMPED" => Ok(MountType::Clamped),
+            "SOCKETED" => Ok(MountType::Socketed),
+            "FORMED" => Ok(MountType::Formed),
+            "OTHER" => Ok(MountType::Other),
+            _ => Err(Ipc2581Error::InvalidAttribute(format!(
+                "Invalid Component mountType: {value}"
+            ))),
         }
     }
 
@@ -2208,7 +2794,7 @@ impl<'a> Parser<'a> {
         };
 
         let mut location = None;
-        let xform = self.parse_xform_child(node, units);
+        let xform = self.parse_xform_child(node, units)?;
         let mut shape = None;
         let mut pin_ref = None;
 
@@ -2265,7 +2851,7 @@ impl<'a> Parser<'a> {
                             "Xform must be the first child of Features".to_string(),
                         ));
                     }
-                    xform = Some(self.parse_xform(&child, units));
+                    xform = Some(self.parse_xform(&child, units)?);
                 }
                 "Location" => {
                     if !features.is_empty() {
@@ -2371,8 +2957,8 @@ impl<'a> Parser<'a> {
             .element_children(node)
             .find(|child| self.name(child) == "Polygon")
             .unwrap_or(*node);
-        let (line_desc, line_desc_ref, fill_desc) =
-            self.parse_user_shape_style(&style_node, units)?;
+        let (line_desc, line_desc_ref, fill_desc, fill_desc_ref) =
+            self.parse_fill_and_line_desc(&style_node, units)?;
 
         Ok(ecad::SetFeature::UserPrimitive(
             ecad::FeatureUserPrimitive {
@@ -2382,6 +2968,7 @@ impl<'a> Parser<'a> {
                         line_desc,
                         line_desc_ref,
                         fill_desc,
+                        fill_desc_ref,
                     }],
                 }),
                 x: offset.x,
@@ -2689,7 +3276,7 @@ impl<'a> Parser<'a> {
             SlotShape::Primitive(self.parse_standard_primitive(&primitive_node, units)?)
         };
 
-        let xform = self.parse_xform_child(node, units);
+        let xform = self.parse_xform_child(node, units)?;
 
         let z_axis_dim = has_z_axis_dim(self.doc(), node);
 
@@ -2737,7 +3324,12 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let xform = self.parse_xform_child(node, units);
+        let xform = self.parse_xform_child(node, units)?;
+
+        let feature = self
+            .element_children(node)
+            .find_map(|child| self.parse_feature_shape(&child, units).transpose())
+            .transpose()?;
 
         // Parse inline StandardPrimitiveRef if present
         let standard_primitive_ref = self
@@ -2766,6 +3358,7 @@ impl<'a> Parser<'a> {
             x,
             y,
             xform,
+            feature,
             standard_primitive_ref,
             user_primitive_ref,
             pin_ref,
@@ -3064,43 +3657,81 @@ impl<'a> Parser<'a> {
 
     fn parse_bom(&mut self, node: &Node) -> Result<Bom> {
         let name = self.required_attr(node, "name", "Bom")?;
+        let mut header = None;
+        let mut items = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "BomHeader" => header = Some(self.parse_bom_header(&child)?),
+                "BomItem" => items.push(self.parse_bom_item(&child)?),
+                _ => {}
+            }
+        }
+        Ok(Bom {
+            name,
+            header,
+            items,
+        })
+    }
 
-        let item_nodes = self
-            .element_children(node)
-            .filter(|n| self.name(n) == "BomItem")
-            .collect::<Vec<_>>();
-        let items = item_nodes
-            .into_iter()
-            .map(|n| self.parse_bom_item(&n))
-            .collect::<Result<Vec<_>>>()?;
-
-        Ok(Bom { name, items })
+    fn parse_bom_header(&mut self, node: &Node) -> Result<BomHeader> {
+        let assembly = self.required_attr(node, "assembly", "BomHeader")?;
+        let revision = self.required_attr(node, "revision", "BomHeader")?;
+        let affecting = self
+            .attr(node, "affecting")
+            .map(|value| parse_xsd_bool(value, "affecting"))
+            .transpose()?;
+        let mut step_refs = Vec::new();
+        for child in self.element_children(node) {
+            if self.name(&child) == "StepRef" {
+                step_refs.push(self.required_attr(&child, "name", "StepRef")?);
+            }
+        }
+        Ok(BomHeader {
+            assembly,
+            revision,
+            affecting,
+            step_refs,
+        })
     }
 
     fn parse_bom_item(&mut self, node: &Node) -> Result<BomItem> {
         let oem_design_number_ref = self.required_attr(node, "OEMDesignNumberRef", "BomItem")?;
+        let quantity_raw = self.required_attr(node, "quantity", "BomItem")?;
+        let quantity = self.interner.resolve(quantity_raw).parse().ok();
+        let pin_count_raw = self.optional_attr(node, "pinCount");
+        let pin_count = pin_count_raw
+            .map(|value| self.parse_ipc_integer(value, "pinCount", false))
+            .transpose()?;
+        let category = self
+            .attr(node, "category")
+            .map(parse_bom_category)
+            .transpose()?;
+        let internal_part_number = self.optional_attr(node, "internalPartNumber");
+        let description = self.optional_attr(node, "description");
 
-        let quantity = self.attr(node, "quantity").and_then(|s| s.parse().ok());
-        let pin_count = self.attr(node, "pinCount").and_then(|s| s.parse().ok());
-
-        let category = self.attr(node, "category").map(|s| match s {
-            "ELECTRICAL" => BomCategory::Electrical,
-            "MECHANICAL" => BomCategory::Mechanical,
-            "DOCUMENT" => BomCategory::Document,
-            _ => BomCategory::Electrical, // Default
-        });
-
-        let description = self
-            .attr(node, "description")
-            .map(|s| self.interner.intern(s));
-
-        let mut ref_des_list = Vec::new();
+        let mut designators = Vec::new();
         let mut characteristics = None;
+        let mut spec_refs = Vec::new();
 
         for child in self.element_children(node) {
             match self.name(&child) {
-                "RefDes" => ref_des_list.push(self.parse_bom_ref_des(&child)?),
+                "RefDes" => {
+                    designators.push(BomDesignator::Reference(self.parse_bom_ref_des(&child)?))
+                }
+                "MatDes" => designators.push(BomDesignator::Material(
+                    self.parse_bom_named_designator(&child, "MatDes")?,
+                )),
+                "DocDes" => designators.push(BomDesignator::Document(
+                    self.parse_bom_named_designator(&child, "DocDes")?,
+                )),
+                "ToolDes" => designators.push(BomDesignator::Tool(
+                    self.parse_bom_named_designator(&child, "ToolDes")?,
+                )),
+                "FindDes" => {
+                    designators.push(BomDesignator::Find(self.parse_bom_find_designator(&child)?))
+                }
                 "Characteristics" => characteristics = Some(self.parse_characteristics(&child)?),
+                "SpecRef" => spec_refs.push(self.required_attr(&child, "id", "SpecRef")?),
                 _ => {}
             }
         }
@@ -3108,50 +3739,171 @@ impl<'a> Parser<'a> {
         Ok(BomItem {
             oem_design_number_ref,
             quantity,
+            quantity_raw,
             pin_count,
+            pin_count_raw,
             category,
+            internal_part_number,
             description,
-            ref_des_list,
+            designators,
             characteristics,
+            spec_refs,
         })
     }
 
     fn parse_bom_ref_des(&mut self, node: &Node) -> Result<BomRefDes> {
         let name = self.required_attr(node, "name", "RefDes")?;
-        let package_ref = self.required_attr(node, "packageRef", "RefDes")?;
-        let layer_ref = self.required_attr(node, "layerRef", "RefDes")?;
-
+        let package_ref = self.optional_attr(node, "packageRef");
+        let layer_ref = self.optional_attr(node, "layerRef");
+        let model_ref = self.optional_attr(node, "modelRef");
         let populate = self
             .attr(node, "populate")
-            .map(|s| s == "true")
-            .unwrap_or(true);
+            .map(|value| parse_xsd_bool(value, "populate"))
+            .transpose()?;
+        let mut tunings = Vec::new();
+        let mut firmwares = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Tuning" => tunings.push(BomTuning {
+                    value: self.required_attr(&child, "value", "Tuning")?,
+                    comments: self.optional_attr(&child, "comments"),
+                }),
+                "Firmware" => firmwares.push(self.parse_bom_firmware(&child)?),
+                _ => {}
+            }
+        }
 
         Ok(BomRefDes {
             name,
             package_ref,
             populate,
             layer_ref,
+            model_ref,
+            tunings,
+            firmwares,
+        })
+    }
+
+    fn parse_bom_named_designator(
+        &mut self,
+        node: &Node,
+        element: &'static str,
+    ) -> Result<BomNamedDesignator> {
+        Ok(BomNamedDesignator {
+            name: self.required_attr(node, "name", element)?,
+            layer_ref: self.optional_attr(node, "layerRef"),
+        })
+    }
+
+    fn parse_bom_find_designator(&mut self, node: &Node) -> Result<BomFindDesignator> {
+        let number_raw = self.required_attr(node, "number", "FindDes")?;
+        let number = self.parse_ipc_integer(number_raw, "number", true)?;
+        Ok(BomFindDesignator {
+            number,
+            number_raw,
+            layer_ref: self.optional_attr(node, "layerRef"),
+            model_ref: self.optional_attr(node, "modelRef"),
+        })
+    }
+
+    fn parse_bom_firmware(&mut self, node: &Node) -> Result<BomFirmware> {
+        let program_name = self.required_attr(node, "progName", "Firmware")?;
+        let program_version = self.required_attr(node, "progVersion", "Firmware")?;
+        let mut file = None;
+        let mut payload = None;
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "File" => {
+                    file = Some(BomFirmwareFile {
+                        name: self.required_attr(&child, "name", "File")?,
+                        crc: self.required_attr(&child, "crc", "File")?,
+                    })
+                }
+                "FirmwareRef" => {
+                    payload = Some(BomFirmwarePayload::Reference(self.required_attr(
+                        &child,
+                        "id",
+                        "FirmwareRef",
+                    )?))
+                }
+                "CachedFirmware" => {
+                    payload = Some(BomFirmwarePayload::Cached(self.required_attr(
+                        &child,
+                        "hexEncodedBinary",
+                        "CachedFirmware",
+                    )?))
+                }
+                _ => {}
+            }
+        }
+        Ok(BomFirmware {
+            program_name,
+            program_version,
+            file: file.ok_or(Ipc2581Error::MissingElement("File in Firmware"))?,
+            payload: payload.ok_or(Ipc2581Error::MissingElement("FirmwareGroup in Firmware"))?,
         })
     }
 
     fn parse_characteristics(&mut self, node: &Node) -> Result<Characteristics> {
-        let category = self.attr(node, "category").map(|s| match s {
-            "ELECTRICAL" => BomCategory::Electrical,
-            "MECHANICAL" => BomCategory::Mechanical,
-            "DOCUMENT" => BomCategory::Document,
-            _ => BomCategory::Electrical,
-        });
+        let category = self
+            .attr(node, "category")
+            .map(parse_bom_category)
+            .transpose()?;
+        let mut measured = Vec::new();
+        let mut ranged = Vec::new();
+        let mut enumerated = Vec::new();
+        let mut textuals = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "Measured" => measured.push(self.parse_measured_characteristic(&child)?),
+                "Ranged" => ranged.push(self.parse_ranged_characteristic(&child)?),
+                "Enumerated" => enumerated.push(self.parse_enumerated_characteristic(&child)),
+                "Textual" => textuals.push(self.parse_textual_characteristic(&child)?),
+                _ => {}
+            }
+        }
+        Ok(Characteristics {
+            category,
+            measured,
+            ranged,
+            enumerated,
+            textuals,
+        })
+    }
 
-        let textual_nodes = self
-            .element_children(node)
-            .filter(|n| self.name(n) == "Textual")
-            .collect::<Vec<_>>();
-        let textuals = textual_nodes
-            .into_iter()
-            .map(|n| self.parse_textual_characteristic(&n))
-            .collect::<Result<Vec<_>>>()?;
+    fn parse_measured_characteristic(&mut self, node: &Node) -> Result<MeasuredCharacteristic> {
+        Ok(MeasuredCharacteristic {
+            definition_source: self.optional_attr(node, "definitionSource"),
+            name: self.optional_attr(node, "measuredCharacteristicName"),
+            value: self.parse_optional_f64_attr(node, "measuredCharacteristicValue")?,
+            engineering_unit: self.optional_attr(node, "engineeringUnitOfMeasure"),
+            negative_tolerance: self
+                .parse_optional_f64_attr(node, "engineeringNegativeTolerance")?,
+            positive_tolerance: self
+                .parse_optional_f64_attr(node, "engineeringPositiveTolerance")?,
+        })
+    }
 
-        Ok(Characteristics { category, textuals })
+    fn parse_ranged_characteristic(&mut self, node: &Node) -> Result<RangedCharacteristic> {
+        Ok(RangedCharacteristic {
+            definition_source: self.optional_attr(node, "definitionSource"),
+            name: self.optional_attr(node, "rangedCharacteristicName"),
+            lower_value: self.parse_optional_f64_attr(node, "rangedCharacteristicLowerValue")?,
+            upper_value: self.parse_optional_f64_attr(node, "rangedCharacteristicUpperValue")?,
+            engineering_unit: self.optional_attr(node, "engineeringUnitOfMeasure"),
+            negative_tolerance: self
+                .parse_optional_f64_attr(node, "engineeringNegativeTolerance")?,
+            positive_tolerance: self
+                .parse_optional_f64_attr(node, "engineeringPositiveTolerance")?,
+        })
+    }
+
+    fn parse_enumerated_characteristic(&mut self, node: &Node) -> EnumeratedCharacteristic {
+        EnumeratedCharacteristic {
+            definition_source: self.optional_attr(node, "definitionSource"),
+            name: self.optional_attr(node, "enumeratedCharacteristicName"),
+            value: self.optional_attr(node, "enumeratedCharacteristicValue"),
+        }
     }
 
     fn parse_textual_characteristic(&mut self, node: &Node) -> Result<TextualCharacteristic> {
@@ -3247,9 +3999,15 @@ impl<'a> Parser<'a> {
         let evpl_vendor = self.optional_attr(node, "evplVendor");
         let evpl_mpn = self.optional_attr(node, "evplMpn");
 
-        let qualified = self.attr(node, "qualified").map(|s| s == "true");
+        let qualified = self
+            .attr(node, "qualified")
+            .map(|value| parse_xsd_bool(value, "qualified"))
+            .transpose()?;
 
-        let chosen = self.attr(node, "chosen").map(|s| s == "true");
+        let chosen = self
+            .attr(node, "chosen")
+            .map(|value| parse_xsd_bool(value, "chosen"))
+            .transpose()?;
 
         let mut mpns = Vec::new();
         let mut vendors = Vec::new();
@@ -3283,7 +4041,10 @@ impl<'a> Parser<'a> {
             .attr(node, "moistureSensitivity")
             .and_then(MoistureSensitivity::parse);
 
-        let availability = self.attr(node, "availability").map(|s| s == "true");
+        let availability = self
+            .attr(node, "availability")
+            .map(|value| parse_xsd_bool(value, "availability"))
+            .transpose()?;
 
         let other = self.optional_attr(node, "other");
 
@@ -3303,7 +4064,7 @@ impl<'a> Parser<'a> {
         Ok(AvlVendor { enterprise_ref })
     }
 
-    fn parse_xform(&self, node: &Node, units: Units) -> Xform {
+    fn parse_xform(&self, node: &Node, units: Units) -> Result<Xform> {
         let x_offset = self
             .attr(node, "xOffset")
             .and_then(|s| s.parse::<f64>().ok())
@@ -3320,31 +4081,34 @@ impl<'a> Parser<'a> {
             .unwrap_or(0.0);
         let mirror = self
             .attr(node, "mirror")
-            .map(|s| s == "true")
+            .map(|value| parse_xsd_bool(value, "mirror"))
+            .transpose()?
             .unwrap_or(false);
         let face_up = self
             .attr(node, "faceUp")
-            .map(|s| s == "true")
+            .map(|value| parse_xsd_bool(value, "faceUp"))
+            .transpose()?
             .unwrap_or(false);
         let scale = self
             .attr(node, "scale")
             .and_then(|s| s.parse().ok())
             .unwrap_or(1.0);
 
-        Xform {
+        Ok(Xform {
             x_offset,
             y_offset,
             rotation,
             mirror,
             face_up,
             scale,
-        }
+        })
     }
 
-    fn parse_xform_child(&self, node: &Node, units: Units) -> Option<Xform> {
+    fn parse_xform_child(&self, node: &Node, units: Units) -> Result<Option<Xform>> {
         self.element_children(node)
             .find(|n| self.name(n) == "Xform")
             .map(|n| self.parse_xform(&n, units))
+            .transpose()
     }
 }
 
@@ -3367,10 +4131,68 @@ fn has_z_axis_dim(doc: &Document, node: &Node) -> bool {
 }
 
 fn parse_optional_bool(value: &str) -> Option<bool> {
-    match value {
-        "true" => Some(true),
-        "false" => Some(false),
+    match value.trim() {
+        "true" | "1" => Some(true),
+        "false" | "0" => Some(false),
         _ => None,
+    }
+}
+
+fn parse_xsd_bool(value: &str, attr: &str) -> Result<bool> {
+    parse_optional_bool(value)
+        .ok_or_else(|| Ipc2581Error::InvalidAttribute(format!("Invalid bool value for {attr}")))
+}
+
+fn parse_package_pin_electrical_type(value: &str) -> Result<PackagePinElectricalType> {
+    match value {
+        "ELECTRICAL" => Ok(PackagePinElectricalType::Electrical),
+        "MECHANICAL" => Ok(PackagePinElectricalType::Mechanical),
+        "UNDEFINED" => Ok(PackagePinElectricalType::Undefined),
+        _ => Err(Ipc2581Error::InvalidAttribute(format!(
+            "Invalid Pin electricalType: {value}"
+        ))),
+    }
+}
+
+fn parse_package_pin_mount_type(value: &str) -> Result<PackagePinMountType> {
+    match value {
+        "SURFACE_MOUNT_PIN" => Ok(PackagePinMountType::SurfaceMountPin),
+        "SURFACE_MOUNT_PAD" => Ok(PackagePinMountType::SurfaceMountPad),
+        "THROUGH_HOLE_PIN" => Ok(PackagePinMountType::ThroughHolePin),
+        "THROUGH_HOLE_HOLE" => Ok(PackagePinMountType::ThroughHoleHole),
+        "PRESSFIT" => Ok(PackagePinMountType::PressFit),
+        "NONBOARD" => Ok(PackagePinMountType::NonBoard),
+        "HOLE" => Ok(PackagePinMountType::Hole),
+        "WIRE_BOND" => Ok(PackagePinMountType::WireBond),
+        "UNDEFINED" => Ok(PackagePinMountType::Undefined),
+        _ => Err(Ipc2581Error::InvalidAttribute(format!(
+            "Invalid Pin mountType: {value}"
+        ))),
+    }
+}
+
+fn parse_package_pin_polarity(value: &str) -> Result<PackagePinPolarity> {
+    match value {
+        "PLUS" => Ok(PackagePinPolarity::Plus),
+        "MINUS" => Ok(PackagePinPolarity::Minus),
+        "ANODE" => Ok(PackagePinPolarity::Anode),
+        "CATHODE" => Ok(PackagePinPolarity::Cathode),
+        _ => Err(Ipc2581Error::InvalidAttribute(format!(
+            "Invalid Pin pinPolarity: {value}"
+        ))),
+    }
+}
+
+fn parse_bom_category(value: &str) -> Result<BomCategory> {
+    match value {
+        "ELECTRICAL" => Ok(BomCategory::Electrical),
+        "PROGRAMMABLE" => Ok(BomCategory::Programmable),
+        "MECHANICAL" => Ok(BomCategory::Mechanical),
+        "MATERIAL" => Ok(BomCategory::Material),
+        "DOCUMENT" => Ok(BomCategory::Document),
+        _ => Err(Ipc2581Error::InvalidAttribute(format!(
+            "Invalid BOM category: {value}"
+        ))),
     }
 }
 
@@ -3497,6 +4319,6 @@ pub struct ParsedIpc2581 {
     pub logistic_header: Option<LogisticHeader>,
     pub history_record: Option<HistoryRecord>,
     pub ecad: Option<Ecad>,
-    pub bom: Option<Bom>,
+    pub boms: Vec<Bom>,
     pub avl: Option<Avl>,
 }

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -334,9 +334,9 @@ impl<'a> Parser<'a> {
 
     fn parse_line_end(&self, s: &str) -> Result<LineEnd> {
         match s {
+            "NONE" => Ok(LineEnd::None),
             "ROUND" => Ok(LineEnd::Round),
             "SQUARE" => Ok(LineEnd::Square),
-            "FLAT" => Ok(LineEnd::Flat),
             _ => Err(Ipc2581Error::InvalidAttribute(format!(
                 "Unknown lineEnd: {}",
                 s

--- a/crates/ipc2581/src/types/bom.rs
+++ b/crates/ipc2581/src/types/bom.rs
@@ -4,34 +4,122 @@ use crate::Symbol;
 #[derive(Debug, Clone)]
 pub struct Bom {
     pub name: Symbol,
+    pub header: Option<BomHeader>,
     pub items: Vec<BomItem>,
+}
+
+/// Metadata and Step scope declared by a BOM.
+#[derive(Debug, Clone)]
+pub struct BomHeader {
+    pub assembly: Symbol,
+    pub revision: Symbol,
+    pub affecting: Option<bool>,
+    pub step_refs: Vec<Symbol>,
 }
 
 /// BomItem represents a part in the bill of materials
 #[derive(Debug, Clone)]
 pub struct BomItem {
     pub oem_design_number_ref: Symbol,
+    /// Numeric interpretation of `quantity`, when the source value is an integer.
     pub quantity: Option<u32>,
+    /// Required source `quantity` text, retained even when it is not an integer.
+    pub quantity_raw: Symbol,
+    /// Numeric interpretation of the optional IPC-2581C `pinCount`.
     pub pin_count: Option<u32>,
+    /// Optional source `pinCount` text, retained as source provenance.
+    pub pin_count_raw: Option<Symbol>,
     pub category: Option<BomCategory>,
+    pub internal_part_number: Option<Symbol>,
     pub description: Option<Symbol>,
-    pub ref_des_list: Vec<BomRefDes>,
+    /// BOM designators in source document order.
+    pub designators: Vec<BomDesignator>,
     pub characteristics: Option<Characteristics>,
+    pub spec_refs: Vec<Symbol>,
+}
+
+impl BomItem {
+    pub fn reference_designators(&self) -> impl Iterator<Item = &BomRefDes> {
+        self.designators
+            .iter()
+            .filter_map(|designator| match designator {
+                BomDesignator::Reference(reference) => Some(reference),
+                _ => None,
+            })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum BomDesignator {
+    Reference(BomRefDes),
+    Material(BomNamedDesignator),
+    Document(BomNamedDesignator),
+    Tool(BomNamedDesignator),
+    Find(BomFindDesignator),
 }
 
 /// RefDes reference in BOM
 #[derive(Debug, Clone)]
 pub struct BomRefDes {
     pub name: Symbol,
-    pub package_ref: Symbol,
-    pub populate: bool,
-    pub layer_ref: Symbol,
+    pub package_ref: Option<Symbol>,
+    /// Explicit population state. An absent IPC attribute remains `None`.
+    pub populate: Option<bool>,
+    pub layer_ref: Option<Symbol>,
+    pub model_ref: Option<Symbol>,
+    pub tunings: Vec<BomTuning>,
+    pub firmwares: Vec<BomFirmware>,
+}
+
+/// Named material, document, or tool designator in a BOM item.
+#[derive(Debug, Clone)]
+pub struct BomNamedDesignator {
+    pub name: Symbol,
+    pub layer_ref: Option<Symbol>,
+}
+
+/// Numeric find designator in a BOM item.
+#[derive(Debug, Clone)]
+pub struct BomFindDesignator {
+    pub number: u32,
+    /// Required source `number` text, retained as source provenance.
+    pub number_raw: Symbol,
+    pub layer_ref: Option<Symbol>,
+    pub model_ref: Option<Symbol>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BomTuning {
+    pub value: Symbol,
+    pub comments: Option<Symbol>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BomFirmware {
+    pub program_name: Symbol,
+    pub program_version: Symbol,
+    pub file: BomFirmwareFile,
+    pub payload: BomFirmwarePayload,
+}
+
+#[derive(Debug, Clone)]
+pub struct BomFirmwareFile {
+    pub name: Symbol,
+    pub crc: Symbol,
+}
+
+#[derive(Debug, Clone)]
+pub enum BomFirmwarePayload {
+    Reference(Symbol),
+    Cached(Symbol),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BomCategory {
     Electrical,
+    Programmable,
     Mechanical,
+    Material,
     Document,
 }
 
@@ -39,7 +127,38 @@ pub enum BomCategory {
 #[derive(Debug, Clone)]
 pub struct Characteristics {
     pub category: Option<BomCategory>,
+    pub measured: Vec<MeasuredCharacteristic>,
+    pub ranged: Vec<RangedCharacteristic>,
+    pub enumerated: Vec<EnumeratedCharacteristic>,
     pub textuals: Vec<TextualCharacteristic>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MeasuredCharacteristic {
+    pub definition_source: Option<Symbol>,
+    pub name: Option<Symbol>,
+    pub value: Option<f64>,
+    pub engineering_unit: Option<Symbol>,
+    pub negative_tolerance: Option<f64>,
+    pub positive_tolerance: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RangedCharacteristic {
+    pub definition_source: Option<Symbol>,
+    pub name: Option<Symbol>,
+    pub lower_value: Option<f64>,
+    pub upper_value: Option<f64>,
+    pub engineering_unit: Option<Symbol>,
+    pub negative_tolerance: Option<f64>,
+    pub positive_tolerance: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnumeratedCharacteristic {
+    pub definition_source: Option<Symbol>,
+    pub name: Option<Symbol>,
+    pub value: Option<Symbol>,
 }
 
 /// Textual characteristic with name/value pairs

--- a/crates/ipc2581/src/types/content.rs
+++ b/crates/ipc2581/src/types/content.rs
@@ -13,6 +13,8 @@ pub struct Content {
     pub dictionary_color: DictionaryColor,
     pub dictionary_line_desc: DictionaryLineDesc,
     pub dictionary_fill_desc: DictionaryFillDesc,
+    pub dictionary_font: DictionaryFont,
+    pub dictionary_firmware: DictionaryFirmware,
     pub dictionary_standard: DictionaryStandard,
     pub dictionary_user: DictionaryUser,
 }

--- a/crates/ipc2581/src/types/dictionary.rs
+++ b/crates/ipc2581/src/types/dictionary.rs
@@ -1,4 +1,10 @@
-use super::primitives::{Color, FillDesc, LineDesc, StandardPrimitive, UserPrimitive};
+use super::{
+    ecad::PackageOutline,
+    primitives::{
+        BoundingBox, Color, FillDesc, LineDesc, LineDescGroup, StandardPrimitive, UserPrimitive,
+        UserShape,
+    },
+};
 use crate::Symbol;
 
 /// Dictionary of colors
@@ -37,6 +43,65 @@ pub struct DictionaryFillDesc {
 pub struct EntryFillDesc {
     pub id: Symbol,
     pub fill_desc: FillDesc,
+}
+
+/// Dictionary of cached firmware payloads.
+#[derive(Debug, Clone, Default)]
+pub struct DictionaryFirmware {
+    pub entries: Vec<EntryFirmware>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EntryFirmware {
+    pub id: Symbol,
+    pub hex_encoded_binary: Symbol,
+}
+
+/// Dictionary of embedded or externally referenced fonts.
+#[derive(Debug, Clone, Default)]
+pub struct DictionaryFont {
+    pub units: Option<Units>,
+    pub entries: Vec<EntryFont>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EntryFont {
+    pub id: Symbol,
+    pub definition: FontDefinition,
+}
+
+#[derive(Debug, Clone)]
+pub enum FontDefinition {
+    Embedded(EmbeddedFont),
+    External(ExternalFont),
+}
+
+#[derive(Debug, Clone)]
+pub struct EmbeddedFont {
+    pub name: Symbol,
+    pub line_desc: LineDescGroup,
+    pub glyphs: Vec<FontGlyph>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExternalFont {
+    pub name: Symbol,
+    pub urn: Symbol,
+}
+
+#[derive(Debug, Clone)]
+pub struct FontGlyph {
+    /// Required IPC-2581C `hexBinary` source text.
+    pub char_code: Symbol,
+    pub bounding_box: BoundingBox,
+    pub shapes: Vec<FontShape>,
+}
+
+/// Content allowed by the IPC-2581C `Simple` substitution group in a glyph.
+#[derive(Debug, Clone)]
+pub enum FontShape {
+    Shape(UserShape),
+    Outline(PackageOutline),
 }
 
 /// Dictionary of standard primitives

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -213,7 +213,147 @@ pub struct Package {
     pub name: Symbol,
     pub package_type: Symbol,
     pub pin_one: Option<Symbol>,
+    pub pin_one_orientation: Option<Symbol>,
     pub height: Option<f64>,
+    pub negative_body_extension: Option<f64>,
+    pub comment: Option<Symbol>,
+    pub outline: Option<PackageOutline>,
+    pub pickup_point: Option<super::Location>,
+    pub land_pattern: Option<PackageLandPattern>,
+    pub silkscreen: Option<PackageSilkscreen>,
+    pub assembly_drawing: Option<PackageAssemblyDrawing>,
+    pub pins: Vec<PackagePin>,
+    pub topside: Option<PackageSideView>,
+    pub other_side_view: Option<PackageOtherSideView>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageOutline {
+    pub polygon: super::Polygon,
+    pub polygon_xform: Option<super::Xform>,
+    pub polygon_line_desc: Option<super::LineDesc>,
+    pub polygon_line_desc_ref: Option<Symbol>,
+    pub polygon_fill_desc: Option<super::FillDesc>,
+    pub polygon_fill_desc_ref: Option<Symbol>,
+    pub line_desc: super::LineDescGroup,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageLandPattern {
+    pub pads: Vec<Pad>,
+    pub targets: Vec<PackageTarget>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageTarget {
+    pub xform: Option<super::Xform>,
+    pub location: super::Location,
+    pub shape: StandardShape,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageSilkscreen {
+    pub outlines: Vec<PackageOutline>,
+    pub markings: Vec<PackageMarking>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageAssemblyDrawing {
+    /// The descriptive IPC-2581C document permits this to be absent, while
+    /// the revision C XML Schema requires it. Preserve the source distinction.
+    pub outline: Option<PackageOutline>,
+    pub markings: Vec<PackageMarking>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageMarking {
+    pub usage: Option<Symbol>,
+    pub xform: Option<super::Xform>,
+    pub location: Option<super::Location>,
+    pub feature: FeatureShape,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageSideView {
+    pub outline: Option<PackageOutline>,
+    pub land_pattern: Option<PackageLandPattern>,
+    pub silkscreen: Option<PackageSilkscreen>,
+    pub assembly_drawing: Option<PackageAssemblyDrawing>,
+    pub pins: Vec<PackagePin>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageOtherSideView {
+    pub outline: Option<PackageOutline>,
+    pub silkscreen: Option<PackageSilkscreen>,
+    pub assembly_drawing: Option<PackageAssemblyDrawing>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackagePin {
+    pub number: Symbol,
+    pub name: Option<Symbol>,
+    pub pin_type: PackagePinType,
+    pub electrical_type: Option<PackagePinElectricalType>,
+    pub mount_type: Option<PackagePinMountType>,
+    pub polarity: Option<PackagePinPolarity>,
+    pub xform: Option<super::Xform>,
+    pub location: Option<super::Location>,
+    pub shape: StandardShape,
+}
+
+/// Shape content allowed by the IPC-2581C `StandardShape` substitution group.
+#[derive(Debug, Clone)]
+pub enum StandardShape {
+    Primitive(super::StandardPrimitive),
+    PrimitiveRef(Symbol),
+}
+
+/// Shape content allowed by the broader IPC-2581C `Feature` substitution group.
+#[derive(Debug, Clone)]
+pub enum FeatureShape {
+    StandardPrimitive(super::StandardPrimitive),
+    StandardPrimitiveRef(Symbol),
+    UserPrimitive(super::UserPrimitive),
+    UserPrimitiveRef(Symbol),
+    UserShape(super::UserShape),
+    Text(super::Text),
+    Outline(PackageOutline),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinType {
+    Through,
+    Blind,
+    Surface,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinElectricalType {
+    Electrical,
+    Mechanical,
+    Undefined,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinMountType {
+    SurfaceMountPin,
+    SurfaceMountPad,
+    ThroughHolePin,
+    ThroughHoleHole,
+    PressFit,
+    NonBoard,
+    Hole,
+    WireBond,
+    Undefined,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinPolarity {
+    Plus,
+    Minus,
+    Anode,
+    Cathode,
 }
 
 /// Component instance on the board
@@ -563,6 +703,9 @@ pub struct Pad {
     pub x: Option<f64>,
     pub y: Option<f64>,
     pub xform: Option<super::Xform>,
+    /// Source feature shape, including inline definitions that cannot be
+    /// represented by the reference-only convenience fields below.
+    pub feature: Option<FeatureShape>,
     /// Inline primitive override (takes precedence over padstack definition)
     pub standard_primitive_ref: Option<Symbol>,
     /// Inline user primitive override (takes precedence over padstack definition)

--- a/crates/ipc2581/src/types/primitives.rs
+++ b/crates/ipc2581/src/types/primitives.rs
@@ -1,3 +1,4 @@
+use super::Xform;
 use crate::Symbol;
 use std::str::FromStr;
 
@@ -20,7 +21,10 @@ pub struct Size {
 pub struct Styled<T> {
     pub shape: T,
     pub fill_property: Option<FillProperty>,
+    pub line_desc: Option<LineDesc>,
     pub line_desc_ref: Option<Symbol>,
+    pub fill_desc: Option<FillDesc>,
+    pub fill_desc_ref: Option<Symbol>,
 }
 
 /// Standard geometric primitives
@@ -244,6 +248,13 @@ pub struct LineDesc {
     pub line_property: Option<LineProperty>,
 }
 
+/// IPC-2581C `LineDescGroup` substitution content.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LineDescGroup {
+    Inline(LineDesc),
+    Ref(Symbol),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LineEnd {
     Round,
@@ -265,8 +276,12 @@ pub enum LineProperty {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FillDesc {
     pub fill_property: FillProperty,
+    pub line_width: Option<f64>,
+    pub pitch1: Option<f64>,
+    pub pitch2: Option<f64>,
     pub angle1: Option<f64>,
     pub angle2: Option<f64>,
+    pub color: Option<ColorGroup>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -284,6 +299,36 @@ pub struct Color {
     pub r: u8,
     pub g: u8,
     pub b: u8,
+}
+
+/// IPC-2581C `ColorGroup` substitution content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorGroup {
+    Color(Color),
+    Ref(Symbol),
+    Term {
+        name: Symbol,
+        comment: Option<Symbol>,
+    },
+}
+
+/// IPC-2581C text primitive, with dimensional coordinates normalized to millimeters.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Text {
+    pub text_string: Symbol,
+    pub font_size: u32,
+    /// Required source `fontSize` text, retained as source provenance.
+    pub font_size_raw: Symbol,
+    pub xform: Option<Xform>,
+    pub bounding_box: BoundingBox,
+    pub font_ref: Option<Symbol>,
+    pub color: Option<ColorGroup>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BoundingBox {
+    pub lower_left: Point,
+    pub upper_right: Point,
 }
 
 /// Reference to a dictionary entry
@@ -312,6 +357,7 @@ pub struct UserShape {
     pub line_desc: Option<LineDesc>,
     pub line_desc_ref: Option<Symbol>,
     pub fill_desc: Option<FillDesc>,
+    pub fill_desc_ref: Option<Symbol>,
 }
 
 /// Types of shapes that can appear in UserSpecial

--- a/crates/ipc2581/src/types/primitives.rs
+++ b/crates/ipc2581/src/types/primitives.rs
@@ -257,9 +257,9 @@ pub enum LineDescGroup {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LineEnd {
+    None,
     Round,
     Square,
-    Flat,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ipc2581/src/write.rs
+++ b/crates/ipc2581/src/write.rs
@@ -55,9 +55,9 @@ pub fn polarity_attr(polarity: Polarity) -> &'static str {
 
 pub fn line_end_attr(line_end: LineEnd) -> &'static str {
     match line_end {
+        LineEnd::None => "NONE",
         LineEnd::Round => "ROUND",
         LineEnd::Square => "SQUARE",
-        LineEnd::Flat => "FLAT",
     }
 }
 
@@ -321,6 +321,13 @@ mod tests {
             line_property: None,
         };
         assert!(line(&mut writer, Units::Millimeter, &bad).is_err());
+    }
+
+    #[test]
+    fn line_end_uses_ipc2581c_values() {
+        assert_eq!(line_end_attr(LineEnd::None), "NONE");
+        assert_eq!(line_end_attr(LineEnd::Round), "ROUND");
+        assert_eq!(line_end_attr(LineEnd::Square), "SQUARE");
     }
 
     #[test]

--- a/crates/ipc2581/tests/testcases.rs
+++ b/crates/ipc2581/tests/testcases.rs
@@ -446,7 +446,7 @@ fn validate_testcase1_cross_file_consistency(
     let placed_quantity: u32 = bom
         .items
         .iter()
-        .filter(|item| !item.ref_des_list.is_empty())
+        .filter(|item| item.reference_designators().next().is_some())
         .map(|item| item.quantity.unwrap_or(0))
         .sum();
     assert!(

--- a/crates/pcb-interposer/src/contacts.rs
+++ b/crates/pcb-interposer/src/contacts.rs
@@ -132,8 +132,11 @@ fn bom_roles(ipc: &Ipc2581) -> BTreeMap<String, (String, String)> {
             }
         }
         let Some(ict) = ict else { continue };
-        for ref_des in &item.ref_des_list {
-            if !is_ict_package(ipc.resolve(ref_des.package_ref)) {
+        for ref_des in item.reference_designators() {
+            if !ref_des
+                .package_ref
+                .is_some_and(|package| is_ict_package(ipc.resolve(package)))
+            {
                 continue;
             }
             let refdes = ipc.resolve(ref_des.name).to_string();

--- a/crates/pcb-ipc2581-tools/src/accessors/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/bom.rs
@@ -77,7 +77,7 @@ impl<'a> IpcAccessor<'a> {
             total_unique_parts += 1;
 
             // Count reference designators
-            for ref_des in &item.ref_des_list {
+            for ref_des in item.reference_designators() {
                 if self.ipc.resolve(ref_des.name).is_empty() {
                     continue;
                 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
@@ -330,7 +330,10 @@ pub(super) fn round_fiducial(
                 diameter: diameter_mm,
             },
             fill_property: None,
+            line_desc: None,
             line_desc_ref: None,
+            fill_desc: None,
+            fill_desc_ref: None,
         })),
         pin_ref: None,
     }

--- a/crates/pcb-ipc2581-tools/src/commands/bom.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/bom.rs
@@ -123,7 +123,7 @@ pub fn extract_bom_lines(accessor: &IpcAccessor) -> Vec<BomLine> {
                 .description
                 .map(|symbol| ipc.resolve(symbol).to_string())
                 .or_else(|| characteristics.value.clone());
-            for ref_des in &item.ref_des_list {
+            for ref_des in item.reference_designators() {
                 let designator = ipc.resolve(ref_des.name);
                 if designator.is_empty() {
                     continue;
@@ -137,7 +137,7 @@ pub fn extract_bom_lines(accessor: &IpcAccessor) -> Vec<BomLine> {
                     mpn: avl.primary_mpn.clone(),
                     manufacturer: avl.primary_manufacturer.clone(),
                     description: description.clone(),
-                    dnp: !ref_des.populate,
+                    dnp: ref_des.populate == Some(false),
                     characteristics: characteristics.clone(),
                 });
             }

--- a/crates/pcb-ipc2581-tools/src/commands/bom_edit.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/bom_edit.rs
@@ -230,8 +230,7 @@ fn resolve_selections<'a>(
                         .items
                         .iter()
                         .filter(|item| {
-                            item.ref_des_list
-                                .iter()
+                            item.reference_designators()
                                 .any(|item_refdes| ipc.resolve(item_refdes.name) == refdes)
                         })
                         .collect();

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -88,8 +88,11 @@ pub fn extract_contacts_from_design(
             else {
                 continue;
             };
-            for ref_des in &item.ref_des_list {
-                if !is_ict_package(ipc.resolve(ref_des.package_ref)) {
+            for ref_des in item.reference_designators() {
+                if !ref_des
+                    .package_ref
+                    .is_some_and(|package| is_ict_package(ipc.resolve(package)))
+                {
                     continue;
                 }
                 let designator = ipc.resolve(ref_des.name).to_string();

--- a/crates/pcb-ipc2581-tools/src/commands/info.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/info.rs
@@ -881,15 +881,21 @@ pub fn info_json(accessor: &IpcAccessor) -> serde_json::Value {
 
             let avl_lookup = accessor.lookup_avl(item.oem_design_number_ref);
 
-            for ref_des in &item.ref_des_list {
+            for ref_des in item.reference_designators() {
                 let designator = ipc.resolve(ref_des.name).to_string();
                 if designator.is_empty() {
                     continue;
                 }
 
                 let fallback = component_map.get(&designator);
-                let bom_package = ipc.resolve(ref_des.package_ref).to_string();
-                let bom_layer = ipc.resolve(ref_des.layer_ref).to_string();
+                let bom_package = ref_des
+                    .package_ref
+                    .map(|package| ipc.resolve(package).to_string())
+                    .unwrap_or_default();
+                let bom_layer = ref_des
+                    .layer_ref
+                    .map(|layer| ipc.resolve(layer).to_string())
+                    .unwrap_or_default();
 
                 let package = if !bom_package.is_empty() {
                     bom_package
@@ -913,7 +919,7 @@ pub fn info_json(accessor: &IpcAccessor) -> serde_json::Value {
                     "designator": designator,
                     "package": package,
                     "mpn": mpn,
-                    "dnp": !ref_des.populate,
+                    "dnp": ref_des.populate == Some(false),
                     "layer_ref": layer_ref,
                     "mount_type": canonical_mount_type,
                     "side": side,

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -597,6 +597,7 @@ fn ipc_contour_feature(outer: &ContourBuf, cutout_contours: &[ContourBuf]) -> Re
                 line_desc: None,
                 line_desc_ref: None,
                 fill_desc: None,
+                fill_desc_ref: None,
             }],
         }),
         x: 0.0,

--- a/crates/pcb-ipc2581-tools/src/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/placement.rs
@@ -102,7 +102,7 @@ pub fn extract_single_board_placements_from_design(
             .or(component_package);
         let value = bom.and_then(|data| data.value.clone());
         let populate = match occurrence.population {
-            PopulationState::Unspecified => bom.map(|data| data.populate),
+            PopulationState::Unspecified => bom.and_then(|data| data.populate),
             PopulationState::Populate => Some(true),
             PopulationState::DoNotPopulate => Some(false),
             PopulationState::Conflicting => {
@@ -175,7 +175,7 @@ fn decompose_placement(transform: Affine2) -> Result<DecomposedPlacement> {
 struct BomPlacementData {
     value: Option<String>,
     package: Option<String>,
-    populate: bool,
+    populate: Option<bool>,
 }
 
 fn build_bom_lookup(accessor: &IpcAccessor<'_>) -> BTreeMap<String, BomPlacementData> {
@@ -193,13 +193,15 @@ fn build_bom_lookup(accessor: &IpcAccessor<'_>) -> BTreeMap<String, BomPlacement
             .map(|chars| accessor.extract_characteristics(chars))
             .unwrap_or_else(CharacteristicsData::default);
 
-        for ref_des in &item.ref_des_list {
+        for ref_des in item.reference_designators() {
             let designator = ipc.resolve(ref_des.name).to_string();
             if designator.is_empty() {
                 continue;
             }
 
-            let package = Some(ipc.resolve(ref_des.package_ref).to_string())
+            let package = ref_des
+                .package_ref
+                .map(|package| ipc.resolve(package).to_string())
                 .filter(|package| !package.is_empty())
                 .or_else(|| characteristics.package.clone());
 

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -4299,9 +4299,9 @@ fn map_polarity(polarity: Polarity) -> GeometryPolarity {
 
 fn map_line_cap(line_end: LineEnd) -> LineCap {
     match line_end {
+        LineEnd::None => LineCap::Butt,
         LineEnd::Round => LineCap::Round,
         LineEnd::Square => LineCap::Square,
-        LineEnd::Flat => LineCap::Butt,
     }
 }
 
@@ -4695,7 +4695,7 @@ mod tests {
     <FunctionMode mode="FABRICATION"/>
     <DictionaryLineDesc units="MILLIMETER">
       <EntryLineDesc id="fine">
-        <LineDesc lineWidth="0.15" lineEnd="FLAT"/>
+        <LineDesc lineWidth="0.15" lineEnd="NONE"/>
       </EntryLineDesc>
     </DictionaryLineDesc>
   </Content>

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -27,11 +27,16 @@ pub struct ImportedDesign {
     strings: Interner,
     pub revision: String,
     pub content: ipc2581::types::Content,
+    pub logistic_header: Option<ipc2581::types::LogisticHeader>,
+    pub history_record: Option<ipc2581::types::HistoryRecord>,
+    pub boms: Vec<ipc2581::types::Bom>,
+    pub avl: Option<ipc2581::types::Avl>,
     pub geometry: GeometryDocument,
     pub layer_definitions: Vec<Layer>,
     pub stackups: Vec<ipc2581::types::Stackup>,
     pub steps: Vec<Step>,
     pub step_layers: Vec<StepLayer>,
+    pub packages: Vec<PackageDefinition>,
     pub components: Vec<ComponentDefinition>,
 }
 
@@ -94,6 +99,16 @@ pub fn feature_occurrence_id(feature: &GeometryFeature) -> Option<FeatureOccurre
 pub struct ComponentDefinitionId(pub u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PackageDefinitionId(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BomReferenceId {
+    pub bom: u32,
+    pub item: u32,
+    pub designator: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ComponentOccurrenceId {
     pub component: ComponentDefinitionId,
     pub layout: LayoutOccurrenceId,
@@ -104,8 +119,17 @@ pub struct ComponentDefinition {
     pub step: u32,
     pub source_index: u32,
     pub source: ipc2581::types::Component,
+    pub package: Option<PackageDefinitionId>,
+    pub bom_references: Vec<BomReferenceId>,
     pub local_from_component: Affine2,
     pub population: PopulationState,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageDefinition {
+    pub step: u32,
+    pub source_index: u32,
+    pub source: ipc2581::types::Package,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -823,7 +847,26 @@ pub fn import_design(ipc: &Ipc2581) -> Result<ImportedDesign> {
     }
     crate::dialects::ipc::process::normalize_bounds(&mut geometry);
 
-    let population = population_states(ipc);
+    let mut packages = Vec::new();
+    let mut package_ids = HashMap::new();
+    for step in &ecad.cad_data.steps {
+        let step_id = geometry
+            .layout
+            .steps
+            .iter()
+            .position(|candidate| candidate.source_step_ref == step.name)
+            .context("package step is missing from the layout graph")? as u32;
+        for (source_index, package) in step.packages.iter().enumerate() {
+            let id = PackageDefinitionId(packages.len() as u32);
+            package_ids.insert(package.name, id);
+            packages.push(PackageDefinition {
+                step: step_id,
+                source_index: source_index as u32,
+                source: package.clone(),
+            });
+        }
+    }
+
     let mut components = Vec::new();
     for step in &ecad.cad_data.steps {
         let step_id = geometry
@@ -838,15 +881,22 @@ pub fn import_design(ipc: &Ipc2581) -> Result<ImportedDesign> {
                 Point::new(component.location.x, component.location.y),
                 component.xform,
             );
+            let package = component
+                .package_ref
+                .and_then(|reference| package_ids.get(&reference).copied());
+            let bom_references = component
+                .ref_des
+                .map(|reference| component_bom_references(ipc, step.name, reference))
+                .unwrap_or_default();
+            let population = population_state(ipc.boms(), &bom_references);
             components.push(ComponentDefinition {
                 step: step_id,
                 source_index: source_index as u32,
                 source: component.clone(),
+                package,
+                bom_references,
                 local_from_component: placement.transform,
-                population: component
-                    .ref_des
-                    .and_then(|reference| population.get(&reference).copied())
-                    .unwrap_or_default(),
+                population,
             });
         }
     }
@@ -855,43 +905,117 @@ pub fn import_design(ipc: &Ipc2581) -> Result<ImportedDesign> {
         strings: ipc.interner().clone(),
         revision: ipc.revision().to_owned(),
         content: ipc.content().clone(),
+        logistic_header: ipc.logistic_header().cloned(),
+        history_record: ipc.history_record().cloned(),
+        boms: ipc.boms().to_vec(),
+        avl: ipc.avl().cloned(),
         geometry,
         layer_definitions: ecad.cad_data.layers.clone(),
         stackups: ecad.cad_data.stackups.clone(),
         steps: ecad.cad_data.steps.clone(),
         step_layers,
+        packages,
         components,
     })
 }
 
-fn population_states(ipc: &Ipc2581) -> HashMap<Symbol, PopulationState> {
-    let mut states = HashMap::new();
-    let Some(bom) = ipc.bom() else {
-        return states;
-    };
-    for item in &bom.items {
-        for reference in &item.ref_des_list {
-            let incoming = if reference.populate {
+fn component_bom_references(
+    ipc: &Ipc2581,
+    source_step: Symbol,
+    component: Symbol,
+) -> Vec<BomReferenceId> {
+    let mut matches = Vec::new();
+    for (bom_index, bom) in ipc.boms().iter().enumerate() {
+        if bom.header.as_ref().is_some_and(|header| {
+            !header.step_refs.is_empty() && !header.step_refs.contains(&source_step)
+        }) {
+            continue;
+        }
+        for (item_index, item) in bom.items.iter().enumerate() {
+            for (designator_index, designator) in item.designators.iter().enumerate() {
+                let ipc2581::types::BomDesignator::Reference(reference) = designator else {
+                    continue;
+                };
+                if reference.name == component {
+                    matches.push(BomReferenceId {
+                        bom: bom_index as u32,
+                        item: item_index as u32,
+                        designator: designator_index as u32,
+                    });
+                }
+            }
+        }
+    }
+    matches
+}
+
+fn population_state(
+    boms: &[ipc2581::types::Bom],
+    references: &[BomReferenceId],
+) -> PopulationState {
+    references
+        .iter()
+        .filter_map(|id| bom_reference(boms, *id)?.populate)
+        .map(|populate| {
+            if populate {
                 PopulationState::Populate
             } else {
                 PopulationState::DoNotPopulate
-            };
-            states
-                .entry(reference.name)
-                .and_modify(|state| {
-                    if *state != incoming {
-                        *state = PopulationState::Conflicting;
-                    }
-                })
-                .or_insert(incoming);
-        }
+            }
+        })
+        .fold(
+            PopulationState::Unspecified,
+            |state, incoming| match state {
+                PopulationState::Unspecified => incoming,
+                PopulationState::Conflicting => PopulationState::Conflicting,
+                state if state == incoming => state,
+                PopulationState::Populate | PopulationState::DoNotPopulate => {
+                    PopulationState::Conflicting
+                }
+            },
+        )
+}
+
+fn bom_reference(
+    boms: &[ipc2581::types::Bom],
+    reference: BomReferenceId,
+) -> Option<&ipc2581::types::BomRefDes> {
+    let designator = boms
+        .get(reference.bom as usize)?
+        .items
+        .get(reference.item as usize)?
+        .designators
+        .get(reference.designator as usize)?;
+    match designator {
+        ipc2581::types::BomDesignator::Reference(reference) => Some(reference),
+        _ => None,
     }
-    states
 }
 
 impl ImportedDesign {
     pub fn resolve(&self, symbol: Symbol) -> &str {
         self.strings.resolve(symbol)
+    }
+
+    pub fn bom(&self) -> Option<&ipc2581::types::Bom> {
+        self.content
+            .bom_refs
+            .iter()
+            .find_map(|reference| self.boms.iter().find(|bom| bom.name == *reference))
+            .or_else(|| self.boms.first())
+    }
+
+    pub fn resolve_enterprise(&self, enterprise_ref: Symbol) -> Option<&str> {
+        let enterprise = self
+            .logistic_header
+            .as_ref()?
+            .enterprises
+            .iter()
+            .find(|enterprise| enterprise.id == enterprise_ref)?;
+        match enterprise.name.map(|name| self.resolve(name))? {
+            "Manufacturer" | "NONE" | "N/A" | "" => None,
+            name => Some(name),
+        }
     }
 
     pub fn layer_definition(&self, layer: LayerId) -> Option<&Layer> {
@@ -907,6 +1031,21 @@ impl ImportedDesign {
         component: ComponentDefinitionId,
     ) -> Option<&ComponentDefinition> {
         self.components.get(component.0 as usize)
+    }
+
+    pub fn package_definition(&self, package: PackageDefinitionId) -> Option<&PackageDefinition> {
+        self.packages.get(package.0 as usize)
+    }
+
+    pub fn bom_reference(&self, reference: BomReferenceId) -> Option<&ipc2581::types::BomRefDes> {
+        bom_reference(&self.boms, reference)
+    }
+
+    pub fn bom_item(&self, reference: BomReferenceId) -> Option<&ipc2581::types::BomItem> {
+        self.boms
+            .get(reference.bom as usize)?
+            .items
+            .get(reference.item as usize)
     }
 
     pub fn layer_id(&self, name: &str) -> Option<LayerId> {
@@ -4364,7 +4503,10 @@ mod tests {
         let circle = ipc2581::types::StandardPrimitive::Circle(ipc2581::types::Styled {
             shape: ipc2581::types::Circle { diameter: 1.0 },
             fill_property: Some(FillProperty::Hollow),
+            line_desc: None,
             line_desc_ref: None,
+            fill_desc: None,
+            fill_desc_ref: None,
         });
         let rect = ipc2581::types::StandardPrimitive::RectCenter(ipc2581::types::Styled {
             shape: ipc2581::types::RectCenter {
@@ -4374,7 +4516,10 @@ mod tests {
                 },
             },
             fill_property: Some(FillProperty::Void),
+            line_desc: None,
             line_desc_ref: None,
+            fill_desc: None,
+            fill_desc_ref: None,
         });
 
         assert_eq!(primitive_paint(&circle), PrimitivePaint::Hollow);
@@ -4403,7 +4548,10 @@ mod tests {
                 },
             },
             fill_property: None,
+            line_desc: None,
             line_desc_ref: None,
+            fill_desc: None,
+            fill_desc_ref: None,
         });
 
         let paint =
@@ -4504,9 +4652,14 @@ mod tests {
                 line_desc_ref: None,
                 fill_desc: Some(ipc2581::types::FillDesc {
                     fill_property: FillProperty::Hollow,
+                    line_width: None,
+                    pitch1: None,
+                    pitch2: None,
                     angle1: None,
                     angle2: None,
+                    color: None,
                 }),
+                fill_desc_ref: None,
             }],
         });
 
@@ -4568,6 +4721,7 @@ mod tests {
                     line_desc: None,
                     line_desc_ref: Some(entry.id),
                     fill_desc: None,
+                    fill_desc_ref: None,
                 },
                 ipc2581::types::UserShape {
                     shape: UserShapeType::Polyline(ipc2581::types::Polyline {
@@ -4581,6 +4735,7 @@ mod tests {
                     line_desc: None,
                     line_desc_ref: Some(entry.id),
                     fill_desc: None,
+                    fill_desc_ref: None,
                 },
             ],
         });
@@ -4626,6 +4781,7 @@ mod tests {
                     }),
                     line_desc_ref: None,
                     fill_desc: None,
+                    fill_desc_ref: None,
                 }],
             }),
             x: 10.0,
@@ -4674,6 +4830,7 @@ mod tests {
                         line_desc: None,
                         line_desc_ref: None,
                         fill_desc: None,
+                        fill_desc_ref: None,
                     },
                     ipc2581::types::UserShape {
                         shape: UserShapeType::Contour(ipc2581::types::Contour {
@@ -4683,6 +4840,7 @@ mod tests {
                         line_desc: None,
                         line_desc_ref: None,
                         fill_desc: None,
+                        fill_desc_ref: None,
                     },
                 ],
             }),
@@ -4738,6 +4896,7 @@ mod tests {
                         }),
                         line_desc_ref: None,
                         fill_desc: None,
+                        fill_desc_ref: None,
                     },
                     ipc2581::types::UserShape {
                         shape: UserShapeType::Contour(ipc2581::types::Contour {
@@ -4747,6 +4906,7 @@ mod tests {
                         line_desc: None,
                         line_desc_ref: None,
                         fill_desc: None,
+                        fill_desc_ref: None,
                     },
                 ],
             }),
@@ -4940,6 +5100,167 @@ mod tests {
                 .len(),
             3
         );
+    }
+
+    #[test]
+    fn imported_design_carries_global_bom_and_package_associations() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner">
+    <FunctionMode mode="ASSEMBLY"/>
+    <StepRef name="board-a"/>
+    <StepRef name="board-b"/>
+    <BomRef name="bom-a"/>
+    <BomRef name="bom-b"/>
+    <DictionaryLineDesc units="MILLIMETER">
+      <EntryLineDesc id="line"><LineDesc lineWidth="0" lineEnd="ROUND"/></EntryLineDesc>
+    </DictionaryLineDesc>
+  </Content>
+  <LogisticHeader>
+    <Role id="owner" roleFunction="OWNER"/>
+    <Enterprise id="maker" code="maker" name="Maker"/>
+    <Person name="Engineer" enterpriseRef="maker" roleRef="owner"/>
+  </LogisticHeader>
+  <HistoryRecord number="1" origination="2026-01-01T00:00:00Z" software="test" lastChange="2026-01-01T00:00:00Z">
+    <FileRevision fileRevisionId="1" comment="test">
+      <SoftwarePackage name="test" vendor="test" revision="1"><Certification certificationStatus="SELFTEST"/></SoftwarePackage>
+    </FileRevision>
+  </HistoryRecord>
+  <Bom name="bom-a">
+    <BomHeader assembly="a" revision="1"><StepRef name="board-a"/></BomHeader>
+    <BomItem OEMDesignNumberRef="part-a" quantity="1" category="ELECTRICAL">
+      <RefDes name="U1" packageRef="pkg-a" populate="0" layerRef="TOP"/>
+      <Characteristics category="ELECTRICAL"/>
+    </BomItem>
+  </Bom>
+  <Bom name="bom-b">
+    <BomHeader assembly="b" revision="1"><StepRef name="board-b"/></BomHeader>
+    <BomItem OEMDesignNumberRef="part-b" quantity="1" category="ELECTRICAL">
+      <RefDes name="U3" packageRef="pkg-b" layerRef="TOP"/>
+      <Characteristics category="ELECTRICAL"/>
+    </BomItem>
+  </Bom>
+  <Bom name="not-selected">
+    <BomHeader assembly="other" revision="1"><StepRef name="board-a"/></BomHeader>
+    <BomItem OEMDesignNumberRef="other" quantity="1" category="ELECTRICAL">
+      <RefDes name="U4" packageRef="pkg-a" populate="1" layerRef="TOP"/>
+      <Characteristics category="ELECTRICAL"/>
+    </BomItem>
+  </Bom>
+  <Ecad name="design">
+    <CadHeader units="MILLIMETER"/>
+    <CadData>
+      <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+      <Step name="board-a" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Package name="pkg-a" type="OTHER" pinOneOrientation="OTHER"><Outline><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="0" y="0"/></Polygon><LineDescRef id="line"/></Outline></Package>
+        <Package name="shared-package" type="OTHER" pinOneOrientation="OTHER"><Outline><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="0" y="0"/></Polygon><LineDescRef id="line"/></Outline></Package>
+        <Component refDes="U1" packageRef="pkg-a" part="part-a" layerRef="TOP" mountType="SMT"><Location x="1" y="1"/></Component>
+        <Component refDes="U4" packageRef="pkg-a" part="other" layerRef="TOP" mountType="SMT"><Location x="4" y="4"/></Component>
+      </Step>
+      <Step name="board-b" type="BOARD">
+        <Datum x="0" y="0"/>
+        <Package name="pkg-b" type="OTHER" pinOneOrientation="OTHER"><Outline><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="0" y="0"/></Polygon><LineDescRef id="line"/></Outline></Package>
+        <Component refDes="U3" packageRef="pkg-b" part="part-b" layerRef="TOP" mountType="SMT"><Location x="2" y="2"/></Component>
+        <Component refDes="U1" packageRef="pkg-b" part="part-b-u1" layerRef="TOP" mountType="SMT"><Location x="2.5" y="2.5"/></Component>
+        <Component packageRef="shared-package" part="shared-part" layerRef="TOP" mountType="SMT"><Location x="3" y="3"/></Component>
+      </Step>
+    </CadData>
+  </Ecad>
+  <Avl name="parts">
+    <AvlHeader title="parts" source="test" author="test" datetime="2026-01-01T00:00:00Z" version="1"/>
+    <AvlItem OEMDesignNumber="part-a"/>
+  </Avl>
+</IPC-2581>"#;
+        ipc2581::validate(xml).expect("association fixture conforms to IPC-2581C");
+        let ipc = Ipc2581::parse(xml).unwrap();
+
+        let imported = import_design(&ipc).unwrap();
+        assert_eq!(imported.boms.len(), 3);
+        assert!(imported.logistic_header.is_some());
+        assert!(imported.avl.is_some());
+        assert_eq!(imported.packages.len(), 3);
+        assert_eq!(imported.components.len(), 5);
+
+        let a = imported
+            .components
+            .iter()
+            .find(|component| imported.resolve(component.source.part) == "part-a")
+            .unwrap();
+        assert_eq!(a.population, PopulationState::DoNotPopulate);
+        assert_eq!(a.bom_references.len(), 1);
+        let a_package = imported.package_definition(a.package.unwrap()).unwrap();
+        assert_eq!(imported.resolve(a_package.source.name), "pkg-a");
+        assert_eq!(
+            imported
+                .bom_reference(a.bom_references[0])
+                .unwrap()
+                .populate,
+            Some(false)
+        );
+        assert_eq!(
+            imported.resolve(
+                imported
+                    .bom_item(a.bom_references[0])
+                    .unwrap()
+                    .oem_design_number_ref
+            ),
+            "part-a"
+        );
+
+        let b = imported
+            .components
+            .iter()
+            .find(|component| imported.resolve(component.source.part) == "part-b")
+            .unwrap();
+        assert_eq!(b.population, PopulationState::Unspecified);
+        assert_eq!(b.bom_references.len(), 1);
+        assert_eq!(
+            imported
+                .bom_reference(b.bom_references[0])
+                .unwrap()
+                .populate,
+            None
+        );
+
+        let repeated_refdes = imported
+            .components
+            .iter()
+            .find(|component| imported.resolve(component.source.part) == "part-b-u1")
+            .unwrap();
+        assert_eq!(repeated_refdes.population, PopulationState::Unspecified);
+        assert!(repeated_refdes.bom_references.is_empty());
+
+        let unselected = imported
+            .components
+            .iter()
+            .find(|component| imported.resolve(component.source.part) == "other")
+            .unwrap();
+        assert_eq!(unselected.population, PopulationState::Populate);
+        assert_eq!(unselected.bom_references.len(), 1);
+        assert_eq!(
+            imported.resolve(
+                imported
+                    .bom_item(unselected.bom_references[0])
+                    .unwrap()
+                    .oem_design_number_ref
+            ),
+            "other"
+        );
+
+        let shared = imported
+            .components
+            .iter()
+            .find(|component| imported.resolve(component.source.part) == "shared-part")
+            .unwrap();
+        let shared_package = imported
+            .package_definition(shared.package.unwrap())
+            .unwrap();
+        assert_eq!(
+            imported.resolve(shared_package.source.name),
+            "shared-package"
+        );
+        assert_ne!(shared.step, shared_package.step);
     }
 
     #[test]
@@ -5651,7 +5972,10 @@ mod tests {
             shape: SlotShape::Primitive(StandardPrimitive::Circle(ipc2581::types::Styled {
                 shape: ipc2581::types::Circle { diameter: 1.0 },
                 fill_property: None,
+                line_desc: None,
                 line_desc_ref: None,
+                fill_desc: None,
+                fill_desc_ref: None,
             })),
             plating_status: PlatingStatus::NonPlated,
             z_axis_dim,


### PR DESCRIPTION
This change preserves IPC-2581C BOM, package, pin, population, and dictionary facts through parsing and the source-faithful PCB IR import. It provides the core assembly-data infrastructure for ENG-1178 and keeps existing BOM, placement, ICT, and interposer consumers working with optional source values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad parser and import-model changes can reject previously tolerated XML or shift BOM/DNP/placement behavior for edge-case IPC files; downstream tools were updated but real-world assembly files may still surface regressions.
> 
> **Overview**
> Extends **IPC-2581C parsing** so assembly documents keep source-faithful BOM, package, pin, population, and Content dictionary data instead of collapsing or defaulting values. Documents now hold **multiple BOMs**; `bom()` resolves via `Content` `BomRef` (fallback: first BOM). BOM items gain headers, mixed designator kinds, firmware/tuning, richer characteristics, and retained raw text for quantities and pin counts. **Package** parsing adds outline, land pattern, silkscreen/assembly graphics, pins, and side views; primitives pick up fuller line/fill styling, fonts, firmware dictionaries, and stricter schema checks (XSD booleans, non-negative dimensions, canonical enums—e.g. `THMT` only, no `THT` alias).
> 
> **`pcb-ir` IPC import** carries logistic/history/AVL, all BOMs, indexed **package definitions**, and per-component **BOM linkage** with step-scoped population resolution. CLI and library consumers (`bom`, `placement`, `info`, ICT/interposer) iterate `reference_designators()`, treat optional package/layer refs safely, and treat DNP only when `populate == Some(false)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31556be4daef64ea7c1e1f8b51d8cc02dda97353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->