### PR TITLE
ENG-1196 Add canonical assembly IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Keep IPC-2581 `DOCUMENT` BOM entries out of component placement exports.
+- Keep IPC-2581 `DOCUMENT` BOM entries out of CPL exports.
 
 ## [0.4.42] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add canonical assembly IR and derive component placement data from it.
+
+### Fixed
+
+- Keep IPC-2581 `DOCUMENT` BOM entries out of component placement exports.
+
 ## [0.4.42] - 2026-09-01
 
 ### Added

--- a/crates/pcb-ipc-wasm/src/lib.rs
+++ b/crates/pcb-ipc-wasm/src/lib.rs
@@ -226,10 +226,8 @@ impl IpcDocument {
                 serde_json::to_vec_pretty(&commands::bom::extract_bom_lines(&self.accessor()))?,
             ),
             ExportOptions::Cpl { side, exclude_dnp } => {
-                let placements = placement::extract_single_board_placements_from_design(
-                    &self.accessor(),
-                    self.design()?,
-                )?;
+                let placements =
+                    placement::extract_single_board_placements_from_design(self.design()?)?;
                 ExportFile::new(
                     "placements.csv",
                     "text/csv",

--- a/crates/pcb-ipc2581-tools/src/commands/cpl.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/cpl.rs
@@ -9,7 +9,9 @@ use std::path::PathBuf;
 use anyhow::Result;
 #[cfg(feature = "cli")]
 use ipc2581::Ipc2581;
-use pcb_ir::dialects::placement::{Document as PlacementDocument, Placement, PlacementSide};
+use pcb_ir::dialects::placement::{
+    Document as PlacementDocument, Placement, PlacementSide, Population,
+};
 
 #[cfg(feature = "cli")]
 use crate::accessors::IpcAccessor;
@@ -81,12 +83,15 @@ fn cpl_layer(side: PlacementSide) -> &'static str {
         PlacementSide::Top => "top",
         PlacementSide::Bottom => "bottom",
         PlacementSide::Internal => "internal",
-        PlacementSide::Unknown => "unknown",
+        PlacementSide::Both
+        | PlacementSide::All
+        | PlacementSide::None
+        | PlacementSide::Unspecified => "unknown",
     }
 }
 
 fn include_component(component: &Placement, options: &CplOptions) -> bool {
-    if options.exclude_dnp && component.populate == Some(false) {
+    if options.exclude_dnp && component.population == Population::DoNotPopulate {
         return false;
     }
 
@@ -108,7 +113,10 @@ fn side_sort_key(side: PlacementSide) -> u8 {
         PlacementSide::Top => 0,
         PlacementSide::Bottom => 1,
         PlacementSide::Internal => 2,
-        PlacementSide::Unknown => 3,
+        PlacementSide::Both
+        | PlacementSide::All
+        | PlacementSide::None
+        | PlacementSide::Unspecified => 3,
     }
 }
 
@@ -163,6 +171,9 @@ fn write_csv_field(output: &mut String, field: &str) {
 
 #[cfg(test)]
 mod tests {
+    use pcb_ir::dialects::assembly::{
+        ComponentDefinitionId, ComponentOccurrenceId, LayoutOccurrenceId, Scope,
+    };
     use pcb_ir::dialects::placement::{PlacementMount, PlacementSide};
     use pcb_ir::geom::Point;
 
@@ -171,8 +182,14 @@ mod tests {
     #[test]
     fn emits_release_cpl_header_and_rows() {
         let document = PlacementDocument {
+            scope: Scope::Board,
+            step: Some("board".to_string()),
             components: vec![
                 Placement {
+                    id: ComponentOccurrenceId {
+                        component: ComponentDefinitionId(0),
+                        layout: LayoutOccurrenceId::Root,
+                    },
                     designator: "R10".to_string(),
                     value: Some("10k".to_string()),
                     package: Some("R_0603".to_string()),
@@ -182,14 +199,16 @@ mod tests {
                     mount: PlacementMount::Smt,
                     at: Point::new(1.0, -2.5),
                     rotation_degrees: 270.0,
-                    x_offset: 0.0,
-                    y_offset: 0.0,
                     mirror: false,
                     face_up: false,
                     scale: 1.0,
-                    populate: Some(true),
+                    population: Population::Populate,
                 },
                 Placement {
+                    id: ComponentOccurrenceId {
+                        component: ComponentDefinitionId(1),
+                        layout: LayoutOccurrenceId::Root,
+                    },
                     designator: "R2".to_string(),
                     value: Some("1k".to_string()),
                     package: Some("R_0603".to_string()),
@@ -199,12 +218,10 @@ mod tests {
                     mount: PlacementMount::Smt,
                     at: Point::new(3.0, 4.0),
                     rotation_degrees: 90.0,
-                    x_offset: 0.0,
-                    y_offset: 0.0,
                     mirror: true,
                     face_up: false,
                     scale: 1.0,
-                    populate: Some(false),
+                    population: Population::DoNotPopulate,
                 },
             ],
         };

--- a/crates/pcb-ipc2581-tools/src/commands/cpl.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/cpl.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 #[cfg(feature = "cli")]
 use ipc2581::Ipc2581;
+use pcb_ir::dialects::assembly::BomCategory;
 use pcb_ir::dialects::placement::{
     Document as PlacementDocument, Placement, PlacementSide, Population,
 };
@@ -91,6 +92,9 @@ fn cpl_layer(side: PlacementSide) -> &'static str {
 }
 
 fn include_component(component: &Placement, options: &CplOptions) -> bool {
+    if component.bom_category == Some(BomCategory::Document) {
+        return false;
+    }
     if options.exclude_dnp && component.population == Population::DoNotPopulate {
         return false;
     }
@@ -193,6 +197,7 @@ mod tests {
                     designator: "R10".to_string(),
                     value: Some("10k".to_string()),
                     package: Some("R_0603".to_string()),
+                    bom_category: Some(BomCategory::Electrical),
                     part: "R10k".to_string(),
                     layer_ref: "F.Cu".to_string(),
                     side: PlacementSide::Top,
@@ -212,6 +217,7 @@ mod tests {
                     designator: "R2".to_string(),
                     value: Some("1k".to_string()),
                     package: Some("R_0603".to_string()),
+                    bom_category: Some(BomCategory::Electrical),
                     part: "R1k".to_string(),
                     layer_ref: "B.Cu".to_string(),
                     side: PlacementSide::Bottom,
@@ -222,6 +228,26 @@ mod tests {
                     face_up: false,
                     scale: 1.0,
                     population: Population::DoNotPopulate,
+                },
+                Placement {
+                    id: ComponentOccurrenceId {
+                        component: ComponentDefinitionId(2),
+                        layout: LayoutOccurrenceId::Root,
+                    },
+                    designator: "TP1".to_string(),
+                    value: None,
+                    package: Some("TestPoint_ICT".to_string()),
+                    bom_category: Some(BomCategory::Document),
+                    part: "TP_GND".to_string(),
+                    layer_ref: "B.Cu".to_string(),
+                    side: PlacementSide::Bottom,
+                    mount: PlacementMount::Smt,
+                    at: Point::new(5.0, 6.0),
+                    rotation_degrees: 0.0,
+                    mirror: true,
+                    face_up: false,
+                    scale: 1.0,
+                    population: Population::Populate,
                 },
             ],
         };

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -193,7 +193,7 @@ pub fn extract_contacts_from_design(
         info.at = Some((land.at.x, land.at.y));
     }
 
-    let placements = extract_single_board_placements_from_design(&accessor, imported)?;
+    let placements = extract_single_board_placements_from_design(imported)?;
     let mut contacts = Vec::new();
     for component in &placements.components {
         let Some((ict, path)) = roles.get(&component.designator) else {
@@ -257,7 +257,10 @@ fn side_sort_key(side: PlacementSide) -> u8 {
         PlacementSide::Top => 0,
         PlacementSide::Bottom => 1,
         PlacementSide::Internal => 2,
-        PlacementSide::Unknown => 3,
+        PlacementSide::Both
+        | PlacementSide::All
+        | PlacementSide::None
+        | PlacementSide::Unspecified => 3,
     }
 }
 
@@ -294,7 +297,10 @@ fn side_name(side: PlacementSide) -> &'static str {
         PlacementSide::Top => "top",
         PlacementSide::Bottom => "bottom",
         PlacementSide::Internal => "internal",
-        PlacementSide::Unknown => "unknown",
+        PlacementSide::Both
+        | PlacementSide::All
+        | PlacementSide::None
+        | PlacementSide::Unspecified => "unknown",
     }
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -354,7 +354,7 @@ mod tests {
     <BomHeader assembly="board" revision="1.0">
       <StepRef name="board"/>
     </BomHeader>
-    <BomItem OEMDesignNumberRef="TP_GND" quantity="1" pinCount="1" category="ELECTRICAL">
+    <BomItem OEMDesignNumberRef="TP_GND" quantity="1" pinCount="1" category="DOCUMENT">
       <RefDes name="TP1" packageRef="TestPoint_ICT" populate="true" layerRef="BOTTOM"/>
       <Characteristics category="ELECTRICAL">
         <Textual textualCharacteristicName="Ict" textualCharacteristicValue="gnd"/>

--- a/crates/pcb-ipc2581-tools/src/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/placement.rs
@@ -1,251 +1,30 @@
-use std::collections::{BTreeMap, BTreeSet};
+use anyhow::Result;
+use pcb_ir::dialects::assembly::Scope;
+use pcb_ir::dialects::placement::{Document as PlacementDocument, lower_single_board};
+use pcb_ir::import::ipc2581::{ImportedDesign, import_design};
 
-use anyhow::{Context, Result, bail};
-use ipc2581::types::{MountType, Side};
-use pcb_ir::dialects::ipc::ArtworkScope;
-use pcb_ir::dialects::placement::{
-    Document as PlacementDocument, Placement, PlacementMount, PlacementSide,
-};
-use pcb_ir::geom::{Affine2, Point};
-use pcb_ir::import::ipc2581::{ImportedDesign, PopulationState, import_design};
-
-use crate::accessors::{CharacteristicsData, IpcAccessor};
+use crate::accessors::IpcAccessor;
 
 pub fn extract_single_board_placements(accessor: &IpcAccessor<'_>) -> Result<PlacementDocument> {
     let ipc = accessor.ipc();
     let imported = import_design(ipc)?;
-    extract_single_board_placements_from_design(accessor, &imported)
+    extract_single_board_placements_from_design(&imported)
 }
 
 pub fn extract_single_board_placements_from_design(
-    accessor: &IpcAccessor<'_>,
     imported: &ImportedDesign,
 ) -> Result<PlacementDocument> {
-    let layer_sides = imported
-        .layer_definitions
-        .iter()
-        .map(|layer| (imported.resolve(layer.name).to_string(), layer.side))
-        .collect::<BTreeMap<_, _>>();
-    let bom_lookup = build_bom_lookup(accessor);
-    let occurrences = imported.component_occurrences(ArtworkScope::ArrayFlattened)?;
-    let root_step = imported.geometry.layout.root_step;
-    let root_has_components = root_step.is_some_and(|root| {
-        occurrences.iter().any(|occurrence| {
-            imported
-                .component_definition(occurrence.id.component)
-                .is_some_and(|component| component.step == root)
-        })
-    });
-    let component_steps = occurrences
-        .iter()
-        .filter_map(|occurrence| {
-            imported
-                .component_definition(occurrence.id.component)
-                .map(|component| component.step)
-        })
-        .collect::<BTreeSet<_>>();
-    let selected_step = if root_has_components {
-        root_step
-    } else {
-        match component_steps
-            .iter()
-            .copied()
-            .collect::<Vec<_>>()
-            .as_slice()
-        {
-            [] => None,
-            [step] => Some(*step),
-            steps => {
-                let names = steps
-                    .iter()
-                    .map(|step| {
-                        imported
-                            .resolve(imported.geometry.layout.steps[*step as usize].source_step_ref)
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                bail!(
-                    "CPL export found multiple component-bearing repeated Steps ({names}); single-board CPL is ambiguous"
-                );
-            }
-        }
-    };
-    let Some(selected_step) = selected_step else {
-        return Ok(PlacementDocument::default());
-    };
-
-    let mut components = Vec::new();
-    let mut emitted = BTreeSet::new();
-    for occurrence in occurrences {
-        let component = imported
-            .component_definition(occurrence.id.component)
-            .context("component occurrence references a missing definition")?;
-        if component.step != selected_step || !emitted.insert(occurrence.id.component) {
-            continue;
-        }
-        let component = &component.source;
-        let Some(ref_des) = component.ref_des else {
-            continue;
-        };
-        let designator = imported.resolve(ref_des).to_string();
-        if designator.is_empty() {
-            continue;
-        }
-
-        let bom = bom_lookup.get(&designator);
-        let component_package = component
-            .package_ref
-            .map(|package_ref| imported.resolve(package_ref).to_string())
-            .filter(|package| !package.is_empty());
-        let package = bom
-            .and_then(|data| data.package.clone())
-            .or(component_package);
-        let value = bom.and_then(|data| data.value.clone());
-        let populate = match occurrence.population {
-            PopulationState::Unspecified => bom.and_then(|data| data.populate),
-            PopulationState::Populate => Some(true),
-            PopulationState::DoNotPopulate => Some(false),
-            PopulationState::Conflicting => {
-                bail!("component '{designator}' has conflicting population state")
-            }
-        };
-        let source_xform = component.xform.unwrap_or_default();
-        let layer_ref = imported.resolve(component.layer_ref).to_string();
-        let side = layer_sides
-            .get(&layer_ref)
-            .copied()
-            .flatten()
-            .map(map_side)
-            .unwrap_or(PlacementSide::Unknown);
-        let transform = occurrence
-            .board_from_component
-            .unwrap_or(occurrence.root_from_component);
-        let placement = decompose_placement(transform)?;
-
-        components.push(Placement {
-            designator,
-            value,
-            package,
-            part: imported.resolve(component.part).to_string(),
-            layer_ref,
-            side,
-            mount: map_mount(component.mount_type),
-            at: placement.at,
-            rotation_degrees: placement.rotation_degrees,
-            x_offset: 0.0,
-            y_offset: 0.0,
-            mirror: placement.mirror,
-            face_up: source_xform.face_up,
-            scale: placement.scale,
-            populate,
-        });
-    }
-
-    Ok(PlacementDocument { components })
-}
-
-struct DecomposedPlacement {
-    at: Point,
-    rotation_degrees: f64,
-    mirror: bool,
-    scale: f64,
-}
-
-fn decompose_placement(transform: Affine2) -> Result<DecomposedPlacement> {
-    let scale = transform.m00.hypot(transform.m10);
-    let other_scale = transform.m01.hypot(transform.m11);
-    let dot = transform.m00 * transform.m01 + transform.m10 * transform.m11;
-    let epsilon = 1e-9 * scale.max(other_scale).max(1.0);
-    if scale <= 0.0 || (scale - other_scale).abs() > epsilon || dot.abs() > epsilon {
-        bail!("component occurrence transform is not a rigid uniform placement");
-    }
-    let mirror = transform.determinant() < 0.0;
-    let signed_scale = if mirror { -scale } else { scale };
-    Ok(DecomposedPlacement {
-        at: Point::new(transform.m02, transform.m12),
-        rotation_degrees: (transform.m10 / signed_scale)
-            .atan2(transform.m00 / signed_scale)
-            .to_degrees(),
-        mirror,
-        scale,
-    })
-}
-
-#[derive(Debug, Clone)]
-struct BomPlacementData {
-    value: Option<String>,
-    package: Option<String>,
-    populate: Option<bool>,
-}
-
-fn build_bom_lookup(accessor: &IpcAccessor<'_>) -> BTreeMap<String, BomPlacementData> {
-    let ipc = accessor.ipc();
-    let mut lookup = BTreeMap::new();
-
-    let Some(bom) = ipc.bom() else {
-        return lookup;
-    };
-
-    for item in &bom.items {
-        let characteristics = item
-            .characteristics
-            .as_ref()
-            .map(|chars| accessor.extract_characteristics(chars))
-            .unwrap_or_else(CharacteristicsData::default);
-
-        for ref_des in item.reference_designators() {
-            let designator = ipc.resolve(ref_des.name).to_string();
-            if designator.is_empty() {
-                continue;
-            }
-
-            let package = ref_des
-                .package_ref
-                .map(|package| ipc.resolve(package).to_string())
-                .filter(|package| !package.is_empty())
-                .or_else(|| characteristics.package.clone());
-
-            lookup.insert(
-                designator,
-                BomPlacementData {
-                    value: characteristics.value.clone(),
-                    package,
-                    populate: ref_des.populate,
-                },
-            );
-        }
-    }
-
-    lookup
-}
-
-fn map_side(side: Side) -> PlacementSide {
-    match side {
-        Side::Top => PlacementSide::Top,
-        Side::Bottom => PlacementSide::Bottom,
-        Side::Internal => PlacementSide::Internal,
-        Side::Both | Side::All | Side::None => PlacementSide::Unknown,
-    }
-}
-
-fn map_mount(mount: MountType) -> PlacementMount {
-    match mount {
-        MountType::Smt => PlacementMount::Smt,
-        MountType::Thmt => PlacementMount::ThroughHole,
-        MountType::Embedded => PlacementMount::Embedded,
-        MountType::PressFit => PlacementMount::PressFit,
-        MountType::WireBonded => PlacementMount::WireBonded,
-        MountType::Glued => PlacementMount::Glued,
-        MountType::Clamped => PlacementMount::Clamped,
-        MountType::Socketed => PlacementMount::Socketed,
-        MountType::Formed => PlacementMount::Formed,
-        MountType::Other => PlacementMount::Other,
-    }
+    lower_single_board(&imported.assembly_document(Scope::BoardArray)?)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use ipc2581::Ipc2581;
+    use pcb_ir::dialects::assembly::BomCategory;
+    use pcb_ir::dialects::placement::PlacementSide;
+    use pcb_ir::geom::Point;
 
     use super::*;
 
@@ -284,6 +63,38 @@ mod tests {
         assert_eq!(component.side, PlacementSide::Top);
         assert_eq!(component.at, Point::new(1.25, 2.5));
         assert_eq!(component.rotation_degrees, 90.0);
+    }
+
+    #[test]
+    fn dm0002_keeps_document_components_out_of_placement() {
+        let compressed = include_bytes!("../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
+        let xml = zstd::decode_all(Cursor::new(compressed)).unwrap();
+        let xml = std::str::from_utf8(&xml).unwrap();
+        let imported = import_design(&Ipc2581::parse(xml).unwrap()).unwrap();
+        let assembly = imported.assembly_document(Scope::Board).unwrap();
+
+        let documents = assembly
+            .components
+            .iter()
+            .filter(|component| {
+                assembly
+                    .preferred_bom_reference(component)
+                    .is_some_and(|reference| {
+                        assembly.bom_item(reference).category == Some(BomCategory::Document)
+                    })
+            })
+            .count();
+        assert_eq!(assembly.components.len(), 59);
+        assert_eq!(documents, 6);
+
+        let placements = extract_single_board_placements_from_design(&imported).unwrap();
+        assert_eq!(placements.components.len(), 53);
+        assert!(
+            placements
+                .components
+                .iter()
+                .all(|component| component.side == PlacementSide::Top)
+        );
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/placement.rs
@@ -66,33 +66,27 @@ mod tests {
     }
 
     #[test]
-    fn dm0002_keeps_document_components_out_of_placement() {
+    fn dm0002_preserves_bom_categories_in_placement() {
         let compressed = include_bytes!("../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
         let xml = zstd::decode_all(Cursor::new(compressed)).unwrap();
         let xml = std::str::from_utf8(&xml).unwrap();
         let imported = import_design(&Ipc2581::parse(xml).unwrap()).unwrap();
-        let assembly = imported.assembly_document(Scope::Board).unwrap();
-
-        let documents = assembly
-            .components
-            .iter()
-            .filter(|component| {
-                assembly
-                    .preferred_bom_reference(component)
-                    .is_some_and(|reference| {
-                        assembly.bom_item(reference).category == Some(BomCategory::Document)
-                    })
-            })
-            .count();
-        assert_eq!(assembly.components.len(), 59);
-        assert_eq!(documents, 6);
 
         let placements = extract_single_board_placements_from_design(&imported).unwrap();
-        assert_eq!(placements.components.len(), 53);
+        assert_eq!(placements.components.len(), 59);
+        assert_eq!(
+            placements
+                .components
+                .iter()
+                .filter(|component| component.bom_category == Some(BomCategory::Document))
+                .count(),
+            6
+        );
         assert!(
             placements
                 .components
                 .iter()
+                .filter(|component| component.bom_category != Some(BomCategory::Document))
                 .all(|component| component.side == PlacementSide::Top)
         );
     }

--- a/crates/pcb-ir/src/dialects/assembly.rs
+++ b/crates/pcb-ir/src/dialects/assembly.rs
@@ -1,0 +1,458 @@
+//! Canonical component assembly data.
+//!
+//! This dialect joins component, BOM, AVL, package, and layout facts without
+//! carrying source-format types or quote policy. Geometry and dimensions are
+//! canonically in millimeters.
+
+use crate::dialects::ipc::LayoutStepKind;
+use crate::geom::{Affine2, Point};
+
+#[derive(Debug, Clone, Default)]
+pub struct Document {
+    pub scope: Scope,
+    pub root_step: Option<u32>,
+    pub steps: Vec<Step>,
+    pub primary_bom: Option<u32>,
+    pub boms: Vec<Bom>,
+    pub avl: Option<Avl>,
+    pub packages: Vec<PackageDefinition>,
+    pub components: Vec<ComponentDefinition>,
+    pub occurrences: Vec<ComponentOccurrence>,
+}
+
+impl Document {
+    pub fn bom_item(&self, reference: BomReferenceId) -> &BomItem {
+        &self.boms[reference.bom as usize].items[reference.item as usize]
+    }
+
+    pub fn bom_designator(&self, reference: BomReferenceId) -> &ReferenceDesignator {
+        match &self.bom_item(reference).designators[reference.designator as usize] {
+            BomDesignator::Reference(designator) => designator,
+            _ => unreachable!("component BOM reference points to a non-reference designator"),
+        }
+    }
+
+    pub fn preferred_bom_reference(
+        &self,
+        component: &ComponentDefinition,
+    ) -> Option<BomReferenceId> {
+        self.primary_bom
+            .and_then(|primary| {
+                component
+                    .bom_references
+                    .iter()
+                    .copied()
+                    .find(|reference| reference.bom == primary)
+            })
+            .or_else(|| component.bom_references.first().copied())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Scope {
+    Board,
+    #[default]
+    BoardArray,
+}
+
+#[derive(Debug, Clone)]
+pub struct Step {
+    pub name: String,
+    pub kind: LayoutStepKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ComponentDefinitionId(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PackageDefinitionId(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BomReferenceId {
+    pub bom: u32,
+    pub item: u32,
+    pub designator: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ComponentOccurrenceId {
+    pub component: ComponentDefinitionId,
+    pub layout: LayoutOccurrenceId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum LayoutOccurrenceId {
+    Root,
+    Instance(u32),
+}
+
+impl LayoutOccurrenceId {
+    pub(crate) fn source_instance(self) -> Option<u32> {
+        match self {
+            Self::Root => None,
+            Self::Instance(instance) => Some(instance),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentDefinition {
+    pub id: ComponentDefinitionId,
+    pub step: u32,
+    pub source_index: u32,
+    pub designator: Option<String>,
+    pub package_ref: Option<String>,
+    pub package: Option<PackageDefinitionId>,
+    pub material_designator: Option<String>,
+    pub layer_ref: String,
+    pub topside_layer_ref: Option<String>,
+    pub side: Side,
+    pub mount: Mount,
+    pub part: String,
+    pub model_ref: Option<String>,
+    pub weight: Option<f64>,
+    pub height: Option<f64>,
+    pub standoff: Option<f64>,
+    pub source_transform: Option<Transform>,
+    pub local_from_component: Affine2,
+    pub nonstandard_attributes: Vec<Attribute>,
+    pub slot_cavity_ref: Option<String>,
+    pub spec_refs: Vec<String>,
+    pub bom_references: Vec<BomReferenceId>,
+    pub population: Population,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ComponentOccurrence {
+    pub id: ComponentOccurrenceId,
+    pub root_from_component: Affine2,
+    pub board: Option<LayoutOccurrenceId>,
+    pub root_from_board: Affine2,
+    pub board_from_component: Option<Affine2>,
+    pub population: Population,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Population {
+    #[default]
+    Unspecified,
+    Populate,
+    DoNotPopulate,
+    Conflicting,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Side {
+    Top,
+    Bottom,
+    Both,
+    Internal,
+    All,
+    None,
+    Unspecified,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Mount {
+    Smt,
+    ThroughHole,
+    Embedded,
+    PressFit,
+    WireBonded,
+    Glued,
+    Clamped,
+    Socketed,
+    Formed,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Transform {
+    pub x_offset: f64,
+    pub y_offset: f64,
+    pub rotation_degrees: f64,
+    pub mirror: bool,
+    pub face_up: bool,
+    pub scale: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Attribute {
+    pub name: String,
+    pub value: Option<String>,
+    pub attribute_type: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageDefinition {
+    pub id: PackageDefinitionId,
+    pub step: u32,
+    pub source_index: u32,
+    pub name: String,
+    pub package_type: String,
+    pub pin_one: Option<String>,
+    pub pin_one_orientation: Option<String>,
+    pub height: Option<f64>,
+    pub negative_body_extension: Option<f64>,
+    pub comment: Option<String>,
+    pub pickup_point: Option<Point>,
+    pub pins: Vec<PackagePin>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackagePin {
+    pub view: PackagePinView,
+    pub number: String,
+    pub name: Option<String>,
+    pub pin_type: PackagePinType,
+    pub electrical_type: Option<PackagePinElectricalType>,
+    pub mount_type: Option<PackagePinMountType>,
+    pub polarity: Option<PackagePinPolarity>,
+    pub location: Option<Point>,
+    pub transform: Option<Transform>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinView {
+    Primary,
+    Topside,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinType {
+    Through,
+    Blind,
+    Surface,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinElectricalType {
+    Electrical,
+    Mechanical,
+    Undefined,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinMountType {
+    SurfaceMountPin,
+    SurfaceMountPad,
+    ThroughHolePin,
+    ThroughHoleHole,
+    PressFit,
+    NonBoard,
+    Hole,
+    WireBond,
+    Undefined,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackagePinPolarity {
+    Plus,
+    Minus,
+    Anode,
+    Cathode,
+}
+
+#[derive(Debug, Clone)]
+pub struct Bom {
+    pub name: String,
+    pub header: Option<BomHeader>,
+    pub items: Vec<BomItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BomHeader {
+    pub assembly: String,
+    pub revision: String,
+    pub affecting: Option<bool>,
+    pub step_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BomItem {
+    pub oem_design_number: String,
+    pub quantity: Option<u32>,
+    pub quantity_raw: String,
+    pub pin_count: Option<u32>,
+    pub pin_count_raw: Option<String>,
+    pub category: Option<BomCategory>,
+    pub internal_part_number: Option<String>,
+    pub description: Option<String>,
+    pub designators: Vec<BomDesignator>,
+    pub characteristics: Option<Characteristics>,
+    pub spec_refs: Vec<String>,
+}
+
+impl BomItem {
+    pub fn textual_characteristic(&self, name: &str) -> Option<&str> {
+        self.characteristics
+            .iter()
+            .flat_map(|characteristics| &characteristics.values)
+            .find_map(|characteristic| match characteristic {
+                Characteristic::Textual {
+                    name: Some(candidate),
+                    value: Some(value),
+                    ..
+                } if candidate.eq_ignore_ascii_case(name) => Some(value.as_str()),
+                _ => None,
+            })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BomCategory {
+    Electrical,
+    Programmable,
+    Mechanical,
+    Material,
+    Document,
+}
+
+#[derive(Debug, Clone)]
+pub enum BomDesignator {
+    Reference(ReferenceDesignator),
+    Material(NamedDesignator),
+    Document(NamedDesignator),
+    Tool(NamedDesignator),
+    Find(FindDesignator),
+}
+
+#[derive(Debug, Clone)]
+pub struct ReferenceDesignator {
+    pub name: String,
+    pub package_ref: Option<String>,
+    pub populate: Option<bool>,
+    pub layer_ref: Option<String>,
+    pub model_ref: Option<String>,
+    pub tunings: Vec<Tuning>,
+    pub firmwares: Vec<Firmware>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NamedDesignator {
+    pub name: String,
+    pub layer_ref: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FindDesignator {
+    pub number: u32,
+    pub number_raw: String,
+    pub layer_ref: Option<String>,
+    pub model_ref: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Tuning {
+    pub value: String,
+    pub comments: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Firmware {
+    pub program_name: String,
+    pub program_version: String,
+    pub file_name: String,
+    pub file_crc: String,
+    pub payload: FirmwarePayload,
+}
+
+#[derive(Debug, Clone)]
+pub enum FirmwarePayload {
+    Reference(String),
+    Cached(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct Characteristics {
+    pub category: Option<BomCategory>,
+    pub values: Vec<Characteristic>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Characteristic {
+    Measured {
+        definition_source: Option<String>,
+        name: Option<String>,
+        value: Option<f64>,
+        engineering_unit: Option<String>,
+        negative_tolerance: Option<f64>,
+        positive_tolerance: Option<f64>,
+    },
+    Ranged {
+        definition_source: Option<String>,
+        name: Option<String>,
+        lower_value: Option<f64>,
+        upper_value: Option<f64>,
+        engineering_unit: Option<String>,
+        negative_tolerance: Option<f64>,
+        positive_tolerance: Option<f64>,
+    },
+    Enumerated {
+        definition_source: Option<String>,
+        name: Option<String>,
+        value: Option<String>,
+    },
+    Textual {
+        definition_source: Option<String>,
+        name: Option<String>,
+        value: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct Avl {
+    pub name: String,
+    pub header: Option<AvlHeader>,
+    pub items: Vec<AvlItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AvlHeader {
+    pub title: String,
+    pub source: String,
+    pub author: String,
+    pub datetime: String,
+    pub version: u32,
+    pub comment: Option<String>,
+    pub modification_ref: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AvlItem {
+    pub oem_design_number: String,
+    pub alternatives: Vec<ApprovedPart>,
+    pub spec_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApprovedPart {
+    pub external_vendor: Option<String>,
+    pub external_mpn: Option<String>,
+    pub qualified: Option<bool>,
+    pub chosen: Option<bool>,
+    pub manufacturer_parts: Vec<ManufacturerPart>,
+    pub vendor_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ManufacturerPart {
+    pub name: String,
+    pub rank: Option<u32>,
+    pub cost: Option<f64>,
+    pub moisture_sensitivity: Option<MoistureSensitivity>,
+    pub available: Option<bool>,
+    pub other: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MoistureSensitivity {
+    Unlimited,
+    OneYear,
+    FourWeeks,
+    Hours168,
+    Hours72,
+    Hours48,
+    Hours24,
+    Bake,
+}

--- a/crates/pcb-ir/src/dialects/mod.rs
+++ b/crates/pcb-ir/src/dialects/mod.rs
@@ -1,4 +1,5 @@
 pub mod artwork;
+pub mod assembly;
 pub mod ipc;
 pub mod kicad;
 pub mod mask;

--- a/crates/pcb-ir/src/dialects/placement.rs
+++ b/crates/pcb-ir/src/dialects/placement.rs
@@ -1,14 +1,36 @@
 //! Component placement data (pick-and-place).
+//!
+//! Placement is a deliberately compact lowering of the assembly dialect.
 
-use crate::geom::Point;
+use std::collections::BTreeSet;
 
-#[derive(Debug, Clone, Default)]
+use anyhow::{Result, bail};
+
+use super::assembly;
+use crate::geom::{Affine2, Point};
+
+pub use super::assembly::{Mount as PlacementMount, Population, Side as PlacementSide};
+
+#[derive(Debug, Clone)]
 pub struct Document {
+    pub scope: assembly::Scope,
+    pub step: Option<String>,
     pub components: Vec<Placement>,
+}
+
+impl Default for Document {
+    fn default() -> Self {
+        Self {
+            scope: assembly::Scope::Board,
+            step: None,
+            components: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct Placement {
+    pub id: assembly::ComponentOccurrenceId,
     pub designator: String,
     pub value: Option<String>,
     pub package: Option<String>,
@@ -18,32 +40,152 @@ pub struct Placement {
     pub mount: PlacementMount,
     pub at: Point,
     pub rotation_degrees: f64,
-    pub x_offset: f64,
-    pub y_offset: f64,
     pub mirror: bool,
     pub face_up: bool,
     pub scale: f64,
-    pub populate: Option<bool>,
+    pub population: Population,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PlacementSide {
-    Top,
-    Bottom,
-    Internal,
-    Unknown,
+/// Lower one canonical board from an assembly document.
+///
+/// Root-step components take precedence. Otherwise the source must contain
+/// exactly one component-bearing repeated step.
+pub fn lower_single_board(source: &assembly::Document) -> Result<Document> {
+    let root_has_components = source.root_step.is_some_and(|root| {
+        source
+            .occurrences
+            .iter()
+            .any(|occurrence| source.components[occurrence.id.component.0 as usize].step == root)
+    });
+    let component_steps = source
+        .occurrences
+        .iter()
+        .map(|occurrence| source.components[occurrence.id.component.0 as usize].step)
+        .collect::<BTreeSet<_>>();
+    let selected_step = if root_has_components {
+        source.root_step
+    } else {
+        match component_steps
+            .iter()
+            .copied()
+            .collect::<Vec<_>>()
+            .as_slice()
+        {
+            [] => None,
+            [step] => Some(*step),
+            steps => {
+                let names = steps
+                    .iter()
+                    .map(|step| source.steps[*step as usize].name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                bail!(
+                    "placement lowering found multiple component-bearing repeated Steps ({names}); single-board placement is ambiguous"
+                );
+            }
+        }
+    };
+    let Some(selected_step) = selected_step else {
+        return Ok(Document::default());
+    };
+
+    let mut components = Vec::new();
+    let mut emitted = BTreeSet::new();
+    for occurrence in &source.occurrences {
+        let component = &source.components[occurrence.id.component.0 as usize];
+        if component.step != selected_step || !emitted.insert(component.id) {
+            continue;
+        }
+        let Some(designator) = component
+            .designator
+            .as_deref()
+            .filter(|designator| !designator.is_empty())
+        else {
+            continue;
+        };
+        let bom_reference = source.preferred_bom_reference(component);
+        if bom_reference.is_some_and(|reference| {
+            source.bom_item(reference).category == Some(assembly::BomCategory::Document)
+        }) {
+            continue;
+        }
+        if occurrence.population == Population::Conflicting {
+            bail!("component '{designator}' has conflicting population state");
+        }
+
+        let bom_item = bom_reference.map(|reference| source.bom_item(reference));
+        let bom_designator = bom_reference.map(|reference| source.bom_designator(reference));
+        let package = bom_designator
+            .and_then(|reference| reference.package_ref.clone())
+            .or_else(|| {
+                bom_item.and_then(|item| {
+                    item.textual_characteristic("package")
+                        .or_else(|| item.textual_characteristic("footprint"))
+                        .map(str::to_owned)
+                })
+            })
+            .or_else(|| component.package_ref.clone());
+        let value = bom_item
+            .and_then(|item| item.textual_characteristic("value"))
+            .map(str::to_owned);
+        let transform = occurrence
+            .board_from_component
+            .unwrap_or(occurrence.root_from_component);
+        let placement = decompose_placement(transform)?;
+
+        components.push(Placement {
+            id: assembly::ComponentOccurrenceId {
+                component: component.id,
+                layout: assembly::LayoutOccurrenceId::Root,
+            },
+            designator: designator.to_owned(),
+            value,
+            package,
+            part: component.part.clone(),
+            layer_ref: component.layer_ref.clone(),
+            side: component.side,
+            mount: component.mount,
+            at: placement.at,
+            rotation_degrees: placement.rotation_degrees,
+            mirror: placement.mirror,
+            face_up: component
+                .source_transform
+                .is_some_and(|transform| transform.face_up),
+            scale: placement.scale,
+            population: occurrence.population,
+        });
+    }
+
+    Ok(Document {
+        scope: assembly::Scope::Board,
+        step: Some(source.steps[selected_step as usize].name.clone()),
+        components,
+    })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PlacementMount {
-    Smt,
-    ThroughHole,
-    Embedded,
-    PressFit,
-    WireBonded,
-    Glued,
-    Clamped,
-    Socketed,
-    Formed,
-    Other,
+struct DecomposedPlacement {
+    at: Point,
+    rotation_degrees: f64,
+    mirror: bool,
+    scale: f64,
+}
+
+fn decompose_placement(transform: Affine2) -> Result<DecomposedPlacement> {
+    let scale = transform.m00.hypot(transform.m10);
+    let other_scale = transform.m01.hypot(transform.m11);
+    let dot = transform.m00 * transform.m01 + transform.m10 * transform.m11;
+    let epsilon = 1e-9 * scale.max(other_scale).max(1.0);
+    if scale <= 0.0 || (scale - other_scale).abs() > epsilon || dot.abs() > epsilon {
+        bail!("component occurrence transform is not a rigid uniform placement");
+    }
+    let mirror = transform.determinant() < 0.0;
+    let signed_scale = if mirror { -scale } else { scale };
+    Ok(DecomposedPlacement {
+        at: Point::new(transform.m02, transform.m12),
+        rotation_degrees: (transform.m10 / signed_scale)
+            .atan2(transform.m00 / signed_scale)
+            .to_degrees(),
+        mirror,
+        scale,
+    })
 }

--- a/crates/pcb-ir/src/dialects/placement.rs
+++ b/crates/pcb-ir/src/dialects/placement.rs
@@ -34,6 +34,7 @@ pub struct Placement {
     pub designator: String,
     pub value: Option<String>,
     pub package: Option<String>,
+    pub bom_category: Option<assembly::BomCategory>,
     pub part: String,
     pub layer_ref: String,
     pub side: PlacementSide,
@@ -104,11 +105,6 @@ pub fn lower_single_board(source: &assembly::Document) -> Result<Document> {
             continue;
         };
         let bom_reference = source.preferred_bom_reference(component);
-        if bom_reference.is_some_and(|reference| {
-            source.bom_item(reference).category == Some(assembly::BomCategory::Document)
-        }) {
-            continue;
-        }
         if occurrence.population == Population::Conflicting {
             bail!("component '{designator}' has conflicting population state");
         }
@@ -141,6 +137,7 @@ pub fn lower_single_board(source: &assembly::Document) -> Result<Document> {
             designator: designator.to_owned(),
             value,
             package,
+            bom_category: bom_item.and_then(|item| item.category),
             part: component.part.clone(),
             layer_ref: component.layer_ref.clone(),
             side: component.side,

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -13,6 +13,13 @@ use crate::geom::Polarity as GeometryPolarity;
 use crate::geom::path::transform_cmds;
 use crate::geom::*;
 
+mod assembly;
+
+pub use crate::dialects::assembly::{
+    BomReferenceId, ComponentDefinitionId, ComponentOccurrenceId, LayoutOccurrenceId,
+    PackageDefinitionId, Population as PopulationState,
+};
+
 pub type GeometryDocument = crate::dialects::ipc::Document<Symbol, LayerFunction>;
 type GeometryLayer = crate::dialects::ipc::Layer<Symbol, LayerFunction>;
 type GeometryFeature = crate::dialects::ipc::Feature<Symbol>;
@@ -51,21 +58,6 @@ pub struct StepLayer {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum LayoutOccurrenceId {
-    Root,
-    Instance(u32),
-}
-
-impl LayoutOccurrenceId {
-    fn source_instance(self) -> Option<u32> {
-        match self {
-            Self::Root => None,
-            Self::Instance(instance) => Some(instance),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct FeatureDefinitionId(pub u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -95,25 +87,6 @@ pub fn feature_occurrence_id(feature: &GeometryFeature) -> Option<FeatureOccurre
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ComponentDefinitionId(pub u32);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct PackageDefinitionId(pub u32);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct BomReferenceId {
-    pub bom: u32,
-    pub item: u32,
-    pub designator: u32,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ComponentOccurrenceId {
-    pub component: ComponentDefinitionId,
-    pub layout: LayoutOccurrenceId,
-}
-
 #[derive(Debug, Clone)]
 pub struct ComponentDefinition {
     pub step: u32,
@@ -140,15 +113,6 @@ pub struct ComponentOccurrence {
     pub root_from_board: Affine2,
     pub board_from_component: Option<Affine2>,
     pub population: PopulationState,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum PopulationState {
-    #[default]
-    Unspecified,
-    Populate,
-    DoNotPopulate,
-    Conflicting,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -5181,6 +5145,33 @@ mod tests {
         assert!(imported.avl.is_some());
         assert_eq!(imported.packages.len(), 3);
         assert_eq!(imported.components.len(), 5);
+
+        let assembly = imported
+            .assembly_document(crate::dialects::assembly::Scope::BoardArray)
+            .unwrap();
+        assert_eq!(assembly.primary_bom, Some(0));
+        assert_eq!(assembly.boms.len(), 3);
+        assert_eq!(assembly.packages.len(), 3);
+        assert_eq!(assembly.components.len(), 5);
+        assert_eq!(assembly.occurrences.len(), 2);
+        assert_eq!(assembly.avl.as_ref().unwrap().items.len(), 1);
+        let assembly_a = assembly
+            .components
+            .iter()
+            .find(|component| component.part == "part-a")
+            .unwrap();
+        assert_eq!(assembly_a.side, crate::dialects::assembly::Side::Top);
+        assert_eq!(assembly_a.mount, crate::dialects::assembly::Mount::Smt);
+        assert_eq!(
+            assembly_a.population,
+            crate::dialects::assembly::Population::DoNotPopulate
+        );
+        let reference = assembly.preferred_bom_reference(assembly_a).unwrap();
+        assert_eq!(assembly.bom_designator(reference).name, "U1");
+        assert_eq!(
+            assembly.bom_item(reference).category,
+            Some(crate::dialects::assembly::BomCategory::Electrical)
+        );
 
         let a = imported
             .components

--- a/crates/pcb-ir/src/import/ipc2581/assembly.rs
+++ b/crates/pcb-ir/src/import/ipc2581/assembly.rs
@@ -1,0 +1,493 @@
+use anyhow::Result;
+use ipc2581::Symbol;
+use ipc2581::types;
+
+use super::ImportedDesign;
+use crate::dialects::assembly as ir;
+use crate::dialects::ipc::ArtworkScope;
+use crate::geom::Point;
+
+impl ImportedDesign {
+    /// Lower source-faithful IPC-2581 assembly data into the canonical
+    /// assembly dialect for one explicit layout scope.
+    pub fn assembly_document(&self, scope: ir::Scope) -> Result<ir::Document> {
+        let artwork_scope = match scope {
+            ir::Scope::Board => ArtworkScope::Board,
+            ir::Scope::BoardArray => ArtworkScope::ArrayFlattened,
+        };
+        let primary_bom = self
+            .content
+            .bom_refs
+            .iter()
+            .find_map(|reference| self.boms.iter().position(|bom| bom.name == *reference))
+            .map(|index| index as u32)
+            .or_else(|| (!self.boms.is_empty()).then_some(0));
+        let occurrences = self
+            .component_occurrences(artwork_scope)?
+            .into_iter()
+            .map(|occurrence| ir::ComponentOccurrence {
+                id: occurrence.id,
+                root_from_component: occurrence.root_from_component,
+                board: occurrence.board,
+                root_from_board: occurrence.root_from_board,
+                board_from_component: occurrence.board_from_component,
+                population: occurrence.population,
+            })
+            .collect();
+
+        Ok(ir::Document {
+            scope,
+            root_step: self
+                .step_occurrences(artwork_scope)?
+                .first()
+                .map(|occurrence| occurrence.step),
+            steps: self
+                .geometry
+                .layout
+                .steps
+                .iter()
+                .map(|step| ir::Step {
+                    name: self.resolve(step.source_step_ref).to_owned(),
+                    kind: step.kind,
+                })
+                .collect(),
+            primary_bom,
+            boms: self.boms.iter().map(|bom| map_bom(self, bom)).collect(),
+            avl: self.avl.as_ref().map(|avl| map_avl(self, avl)),
+            packages: self
+                .packages
+                .iter()
+                .enumerate()
+                .map(|(index, package)| map_package(self, index as u32, package))
+                .collect(),
+            components: self
+                .components
+                .iter()
+                .enumerate()
+                .map(|(index, component)| map_component(self, index as u32, component))
+                .collect(),
+            occurrences,
+        })
+    }
+}
+
+fn map_component(
+    design: &ImportedDesign,
+    index: u32,
+    component: &super::ComponentDefinition,
+) -> ir::ComponentDefinition {
+    let source = &component.source;
+    let side = design
+        .layer_definitions
+        .iter()
+        .find(|layer| layer.name == source.layer_ref)
+        .and_then(|layer| layer.side)
+        .map(map_side)
+        .unwrap_or(ir::Side::Unspecified);
+    ir::ComponentDefinition {
+        id: ir::ComponentDefinitionId(index),
+        step: component.step,
+        source_index: component.source_index,
+        designator: resolve_optional(design, source.ref_des),
+        package_ref: resolve_optional(design, source.package_ref),
+        package: component.package,
+        material_designator: resolve_optional(design, source.mat_des),
+        layer_ref: design.resolve(source.layer_ref).to_owned(),
+        topside_layer_ref: resolve_optional(design, source.layer_ref_topside),
+        side,
+        mount: map_mount(source.mount_type),
+        part: design.resolve(source.part).to_owned(),
+        model_ref: resolve_optional(design, source.model_ref),
+        weight: source.weight,
+        height: source.height,
+        standoff: source.standoff,
+        source_transform: source.xform.map(map_transform),
+        local_from_component: component.local_from_component,
+        nonstandard_attributes: source
+            .nonstandard_attributes
+            .iter()
+            .map(|attribute| ir::Attribute {
+                name: design.resolve(attribute.name).to_owned(),
+                value: resolve_optional(design, attribute.value),
+                attribute_type: resolve_optional(design, attribute.attr_type),
+            })
+            .collect(),
+        slot_cavity_ref: resolve_optional(design, source.slot_cavity_ref),
+        spec_refs: resolve_all(design, &source.spec_refs),
+        bom_references: component.bom_references.clone(),
+        population: component.population,
+    }
+}
+
+fn map_package(
+    design: &ImportedDesign,
+    index: u32,
+    package: &super::PackageDefinition,
+) -> ir::PackageDefinition {
+    let source = &package.source;
+    let mut pins = source
+        .pins
+        .iter()
+        .map(|pin| map_package_pin(design, ir::PackagePinView::Primary, pin))
+        .collect::<Vec<_>>();
+    if let Some(topside) = &source.topside {
+        pins.extend(
+            topside
+                .pins
+                .iter()
+                .map(|pin| map_package_pin(design, ir::PackagePinView::Topside, pin)),
+        );
+    }
+    ir::PackageDefinition {
+        id: ir::PackageDefinitionId(index),
+        step: package.step,
+        source_index: package.source_index,
+        name: design.resolve(source.name).to_owned(),
+        package_type: design.resolve(source.package_type).to_owned(),
+        pin_one: resolve_optional(design, source.pin_one),
+        pin_one_orientation: resolve_optional(design, source.pin_one_orientation),
+        height: source.height,
+        negative_body_extension: source.negative_body_extension,
+        comment: resolve_optional(design, source.comment),
+        pickup_point: source
+            .pickup_point
+            .map(|location| Point::new(location.x, location.y)),
+        pins,
+    }
+}
+
+fn map_package_pin(
+    design: &ImportedDesign,
+    view: ir::PackagePinView,
+    pin: &types::PackagePin,
+) -> ir::PackagePin {
+    ir::PackagePin {
+        view,
+        number: design.resolve(pin.number).to_owned(),
+        name: resolve_optional(design, pin.name),
+        pin_type: match pin.pin_type {
+            types::PackagePinType::Through => ir::PackagePinType::Through,
+            types::PackagePinType::Blind => ir::PackagePinType::Blind,
+            types::PackagePinType::Surface => ir::PackagePinType::Surface,
+        },
+        electrical_type: pin
+            .electrical_type
+            .map(|electrical_type| match electrical_type {
+                types::PackagePinElectricalType::Electrical => {
+                    ir::PackagePinElectricalType::Electrical
+                }
+                types::PackagePinElectricalType::Mechanical => {
+                    ir::PackagePinElectricalType::Mechanical
+                }
+                types::PackagePinElectricalType::Undefined => {
+                    ir::PackagePinElectricalType::Undefined
+                }
+            }),
+        mount_type: pin.mount_type.map(|mount| match mount {
+            types::PackagePinMountType::SurfaceMountPin => ir::PackagePinMountType::SurfaceMountPin,
+            types::PackagePinMountType::SurfaceMountPad => ir::PackagePinMountType::SurfaceMountPad,
+            types::PackagePinMountType::ThroughHolePin => ir::PackagePinMountType::ThroughHolePin,
+            types::PackagePinMountType::ThroughHoleHole => ir::PackagePinMountType::ThroughHoleHole,
+            types::PackagePinMountType::PressFit => ir::PackagePinMountType::PressFit,
+            types::PackagePinMountType::NonBoard => ir::PackagePinMountType::NonBoard,
+            types::PackagePinMountType::Hole => ir::PackagePinMountType::Hole,
+            types::PackagePinMountType::WireBond => ir::PackagePinMountType::WireBond,
+            types::PackagePinMountType::Undefined => ir::PackagePinMountType::Undefined,
+        }),
+        polarity: pin.polarity.map(|polarity| match polarity {
+            types::PackagePinPolarity::Plus => ir::PackagePinPolarity::Plus,
+            types::PackagePinPolarity::Minus => ir::PackagePinPolarity::Minus,
+            types::PackagePinPolarity::Anode => ir::PackagePinPolarity::Anode,
+            types::PackagePinPolarity::Cathode => ir::PackagePinPolarity::Cathode,
+        }),
+        location: pin
+            .location
+            .map(|location| Point::new(location.x, location.y)),
+        transform: pin.xform.map(map_transform),
+    }
+}
+
+fn map_bom(design: &ImportedDesign, bom: &types::Bom) -> ir::Bom {
+    ir::Bom {
+        name: design.resolve(bom.name).to_owned(),
+        header: bom.header.as_ref().map(|header| ir::BomHeader {
+            assembly: design.resolve(header.assembly).to_owned(),
+            revision: design.resolve(header.revision).to_owned(),
+            affecting: header.affecting,
+            step_refs: resolve_all(design, &header.step_refs),
+        }),
+        items: bom
+            .items
+            .iter()
+            .map(|item| ir::BomItem {
+                oem_design_number: design.resolve(item.oem_design_number_ref).to_owned(),
+                quantity: item.quantity,
+                quantity_raw: design.resolve(item.quantity_raw).to_owned(),
+                pin_count: item.pin_count,
+                pin_count_raw: resolve_optional(design, item.pin_count_raw),
+                category: item.category.map(map_bom_category),
+                internal_part_number: resolve_optional(design, item.internal_part_number),
+                description: resolve_optional(design, item.description),
+                designators: item
+                    .designators
+                    .iter()
+                    .map(|designator| map_bom_designator(design, designator))
+                    .collect(),
+                characteristics: item
+                    .characteristics
+                    .as_ref()
+                    .map(|characteristics| map_characteristics(design, characteristics)),
+                spec_refs: resolve_all(design, &item.spec_refs),
+            })
+            .collect(),
+    }
+}
+
+fn map_bom_designator(
+    design: &ImportedDesign,
+    designator: &types::BomDesignator,
+) -> ir::BomDesignator {
+    match designator {
+        types::BomDesignator::Reference(reference) => {
+            ir::BomDesignator::Reference(ir::ReferenceDesignator {
+                name: design.resolve(reference.name).to_owned(),
+                package_ref: resolve_optional(design, reference.package_ref),
+                populate: reference.populate,
+                layer_ref: resolve_optional(design, reference.layer_ref),
+                model_ref: resolve_optional(design, reference.model_ref),
+                tunings: reference
+                    .tunings
+                    .iter()
+                    .map(|tuning| ir::Tuning {
+                        value: design.resolve(tuning.value).to_owned(),
+                        comments: resolve_optional(design, tuning.comments),
+                    })
+                    .collect(),
+                firmwares: reference
+                    .firmwares
+                    .iter()
+                    .map(|firmware| ir::Firmware {
+                        program_name: design.resolve(firmware.program_name).to_owned(),
+                        program_version: design.resolve(firmware.program_version).to_owned(),
+                        file_name: design.resolve(firmware.file.name).to_owned(),
+                        file_crc: design.resolve(firmware.file.crc).to_owned(),
+                        payload: match firmware.payload {
+                            types::BomFirmwarePayload::Reference(value) => {
+                                ir::FirmwarePayload::Reference(design.resolve(value).to_owned())
+                            }
+                            types::BomFirmwarePayload::Cached(value) => {
+                                ir::FirmwarePayload::Cached(design.resolve(value).to_owned())
+                            }
+                        },
+                    })
+                    .collect(),
+            })
+        }
+        types::BomDesignator::Material(named) => {
+            ir::BomDesignator::Material(map_named_designator(design, named))
+        }
+        types::BomDesignator::Document(named) => {
+            ir::BomDesignator::Document(map_named_designator(design, named))
+        }
+        types::BomDesignator::Tool(named) => {
+            ir::BomDesignator::Tool(map_named_designator(design, named))
+        }
+        types::BomDesignator::Find(find) => ir::BomDesignator::Find(ir::FindDesignator {
+            number: find.number,
+            number_raw: design.resolve(find.number_raw).to_owned(),
+            layer_ref: resolve_optional(design, find.layer_ref),
+            model_ref: resolve_optional(design, find.model_ref),
+        }),
+    }
+}
+
+fn map_named_designator(
+    design: &ImportedDesign,
+    named: &types::BomNamedDesignator,
+) -> ir::NamedDesignator {
+    ir::NamedDesignator {
+        name: design.resolve(named.name).to_owned(),
+        layer_ref: resolve_optional(design, named.layer_ref),
+    }
+}
+
+fn map_characteristics(
+    design: &ImportedDesign,
+    characteristics: &types::Characteristics,
+) -> ir::Characteristics {
+    let mut values = Vec::new();
+    values.extend(
+        characteristics
+            .measured
+            .iter()
+            .map(|value| ir::Characteristic::Measured {
+                definition_source: resolve_optional(design, value.definition_source),
+                name: resolve_optional(design, value.name),
+                value: value.value,
+                engineering_unit: resolve_optional(design, value.engineering_unit),
+                negative_tolerance: value.negative_tolerance,
+                positive_tolerance: value.positive_tolerance,
+            }),
+    );
+    values.extend(
+        characteristics
+            .ranged
+            .iter()
+            .map(|value| ir::Characteristic::Ranged {
+                definition_source: resolve_optional(design, value.definition_source),
+                name: resolve_optional(design, value.name),
+                lower_value: value.lower_value,
+                upper_value: value.upper_value,
+                engineering_unit: resolve_optional(design, value.engineering_unit),
+                negative_tolerance: value.negative_tolerance,
+                positive_tolerance: value.positive_tolerance,
+            }),
+    );
+    values.extend(
+        characteristics
+            .enumerated
+            .iter()
+            .map(|value| ir::Characteristic::Enumerated {
+                definition_source: resolve_optional(design, value.definition_source),
+                name: resolve_optional(design, value.name),
+                value: resolve_optional(design, value.value),
+            }),
+    );
+    values.extend(
+        characteristics
+            .textuals
+            .iter()
+            .map(|value| ir::Characteristic::Textual {
+                definition_source: resolve_optional(design, value.definition_source),
+                name: resolve_optional(design, value.name),
+                value: resolve_optional(design, value.value),
+            }),
+    );
+    ir::Characteristics {
+        category: characteristics.category.map(map_bom_category),
+        values,
+    }
+}
+
+fn map_avl(design: &ImportedDesign, avl: &types::Avl) -> ir::Avl {
+    ir::Avl {
+        name: design.resolve(avl.name).to_owned(),
+        header: avl.header.as_ref().map(|header| ir::AvlHeader {
+            title: design.resolve(header.title).to_owned(),
+            source: design.resolve(header.source).to_owned(),
+            author: design.resolve(header.author).to_owned(),
+            datetime: design.resolve(header.datetime).to_owned(),
+            version: header.version,
+            comment: resolve_optional(design, header.comment),
+            modification_ref: resolve_optional(design, header.mod_ref),
+        }),
+        items: avl
+            .items
+            .iter()
+            .map(|item| ir::AvlItem {
+                oem_design_number: design.resolve(item.oem_design_number).to_owned(),
+                alternatives: item
+                    .vmpn_list
+                    .iter()
+                    .map(|part| ir::ApprovedPart {
+                        external_vendor: resolve_optional(design, part.evpl_vendor),
+                        external_mpn: resolve_optional(design, part.evpl_mpn),
+                        qualified: part.qualified,
+                        chosen: part.chosen,
+                        manufacturer_parts: part
+                            .mpns
+                            .iter()
+                            .map(|mpn| ir::ManufacturerPart {
+                                name: design.resolve(mpn.name).to_owned(),
+                                rank: mpn.rank,
+                                cost: mpn.cost,
+                                moisture_sensitivity: mpn
+                                    .moisture_sensitivity
+                                    .map(map_moisture_sensitivity),
+                                available: mpn.availability,
+                                other: resolve_optional(design, mpn.other),
+                            })
+                            .collect(),
+                        vendor_refs: part
+                            .vendors
+                            .iter()
+                            .map(|vendor| design.resolve(vendor.enterprise_ref).to_owned())
+                            .collect(),
+                    })
+                    .collect(),
+                spec_refs: resolve_all(design, &item.spec_refs),
+            })
+            .collect(),
+    }
+}
+
+fn map_side(side: types::Side) -> ir::Side {
+    match side {
+        types::Side::Top => ir::Side::Top,
+        types::Side::Bottom => ir::Side::Bottom,
+        types::Side::Both => ir::Side::Both,
+        types::Side::Internal => ir::Side::Internal,
+        types::Side::All => ir::Side::All,
+        types::Side::None => ir::Side::None,
+    }
+}
+
+fn map_mount(mount: types::MountType) -> ir::Mount {
+    match mount {
+        types::MountType::Smt => ir::Mount::Smt,
+        types::MountType::Thmt => ir::Mount::ThroughHole,
+        types::MountType::Embedded => ir::Mount::Embedded,
+        types::MountType::PressFit => ir::Mount::PressFit,
+        types::MountType::WireBonded => ir::Mount::WireBonded,
+        types::MountType::Glued => ir::Mount::Glued,
+        types::MountType::Clamped => ir::Mount::Clamped,
+        types::MountType::Socketed => ir::Mount::Socketed,
+        types::MountType::Formed => ir::Mount::Formed,
+        types::MountType::Other => ir::Mount::Other,
+    }
+}
+
+fn map_transform(transform: types::Xform) -> ir::Transform {
+    ir::Transform {
+        x_offset: transform.x_offset,
+        y_offset: transform.y_offset,
+        rotation_degrees: transform.rotation,
+        mirror: transform.mirror,
+        face_up: transform.face_up,
+        scale: transform.scale,
+    }
+}
+
+fn map_bom_category(category: types::BomCategory) -> ir::BomCategory {
+    match category {
+        types::BomCategory::Electrical => ir::BomCategory::Electrical,
+        types::BomCategory::Programmable => ir::BomCategory::Programmable,
+        types::BomCategory::Mechanical => ir::BomCategory::Mechanical,
+        types::BomCategory::Material => ir::BomCategory::Material,
+        types::BomCategory::Document => ir::BomCategory::Document,
+    }
+}
+
+fn map_moisture_sensitivity(sensitivity: types::MoistureSensitivity) -> ir::MoistureSensitivity {
+    match sensitivity {
+        types::MoistureSensitivity::Unlimited => ir::MoistureSensitivity::Unlimited,
+        types::MoistureSensitivity::OneYear => ir::MoistureSensitivity::OneYear,
+        types::MoistureSensitivity::FourWeeks => ir::MoistureSensitivity::FourWeeks,
+        types::MoistureSensitivity::Hours168 => ir::MoistureSensitivity::Hours168,
+        types::MoistureSensitivity::Hours72 => ir::MoistureSensitivity::Hours72,
+        types::MoistureSensitivity::Hours48 => ir::MoistureSensitivity::Hours48,
+        types::MoistureSensitivity::Hours24 => ir::MoistureSensitivity::Hours24,
+        types::MoistureSensitivity::Bake => ir::MoistureSensitivity::Bake,
+    }
+}
+
+fn resolve_optional(design: &ImportedDesign, symbol: Option<Symbol>) -> Option<String> {
+    symbol.map(|symbol| design.resolve(symbol).to_owned())
+}
+
+fn resolve_all(design: &ImportedDesign, symbols: &[Symbol]) -> Vec<String> {
+    symbols
+        .iter()
+        .map(|symbol| design.resolve(*symbol).to_owned())
+        .collect()
+}

--- a/crates/pcb-ir/src/lib.rs
+++ b/crates/pcb-ir/src/lib.rs
@@ -10,8 +10,9 @@
 //!   [`dialects::ipc`] (source-faithful IPC-2581 geometry) lowers to
 //!   [`dialects::artwork`] (ordered fabrication object streams), which
 //!   composes to [`dialects::mask`] (final positive layer images).
-//!   [`dialects::nc`] and [`dialects::placement`] carry drill/rout and
-//!   component placement data.
+//!   [`dialects::assembly`] joins source-independent component, BOM, package,
+//!   AVL, and layout facts and lowers to [`dialects::placement`].
+//!   [`dialects::nc`] carries drill and rout data.
 //! - [`render`] turns mask documents into SVG, PNG, or terminal output.
 //!
 //! All geometry is canonically in millimeters.


### PR DESCRIPTION
This adds a source-independent assembly dialect that preserves scoped IPC-2581C component, BOM, AVL, package, pin, and population facts. Placement and CPL now lower through this dialect, which keeps DOCUMENT BOM entries out of machine placements and gives consumers stable identities and explicit scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the shared path for CPL/ICT/WASM placement exports and changes population/side semantics, though behavior is guarded by existing panel tests and a real-board fixture.
> 
> **Overview**
> Introduces a **canonical assembly dialect** in `pcb-ir` that unifies scoped component, BOM, AVL, package, and layout facts, and adds **`ImportedDesign::assembly_document`** to lower IPC-2581 imports into that IR instead of ad hoc accessor logic.
> 
> **CPL, ICT, and WASM placement export** now go through **`lower_single_board`** on the assembly document (board-array scope), replacing the large inline extractor in `pcb-ipc2581-tools`. Placement records gain stable **`ComponentOccurrenceId`**, use the shared **`Population`** enum (including DNP filtering), and drop redundant offset fields; side handling covers the full assembly **`Side`** set.
> 
> **Fix:** components whose preferred BOM line is category **`DOCUMENT`** are **skipped** in placement lowering so paperwork-style BOM rows do not appear in pick-and-place output (covered by a DM0002 regression test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83465309e56779091f0fcae987875e0618462b9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->