### PR TITLE
feat(std): add schematic option to Board

### DIFF
--- a/lib/std/board_config.zen
+++ b/lib/std/board_config.zen
@@ -1,5 +1,5 @@
 load("units.zen", "Impedance")
-load("properties.zen", "Layout")
+load("properties.zen", "Project")
 
 # Enum Types
 CopperWeight = enum("0.5oz", "1oz", "2oz")
@@ -391,6 +391,7 @@ def Board(
     via_dimensions: list | None = None,
     default: bool = False,
     modifiers: list | None = None,
+    schematic: bool = False,
 ):
     """Define a PCB board with an optional board configuration.
 
@@ -406,8 +407,8 @@ def Board(
                      Values are deduplicated and sorted automatically.
         via_dimensions: Additional via dimensions to append to the base configuration.
                        Values are deduplicated and sorted automatically.
-        layout_hints: Optional list of layout hints for the board
         default: Whether this is the default board configuration
+        schematic: Whether to enable the KiCad schematic for this board
 
     Raises:
         error: If layers is provided but no default board configuration exists for
@@ -457,11 +458,12 @@ def Board(
             config=config,
         )
 
-    # Add layout to the module
-    Layout(
+    # Add the KiCad project to the module
+    Project(
         name=name,
         path=layout_path,
         modifiers=modifiers,
+        schematic=schematic,
     )
 
 


### PR DESCRIPTION
## Summary

- Add a `schematic` boolean argument to `Board`, defaulting to `false`
- Replace the `Layout` property with `Project` and pass the schematic setting through
- Update the Board documentation and comments to describe KiCad project behavior

## Testing

Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default behavior matches the previous Layout-only path; the change is a small std API wiring update with no auth or data-handling impact.
> 
> **Overview**
> **`Board`** now registers the layout path through **`Project`** instead of **`Layout`**, aligning board definitions with the full KiCad project model while keeping the default **layout-only** behavior (`schematic=False`).
> 
> A new **`schematic`** argument on **`Board`** (default **`false`**) is forwarded to **`Project`**, so callers can opt in to schematic registration without changing stackup or **`BoardConfig`** handling. The **`properties.zen`** import switches from **`Layout`** to **`Project`**, and **`Board`** docs/comments describe KiCad project registration rather than layout-only registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b48793a7fc91e486f3850b9d0677d36b54ea6e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->