### PR TITLE
ENG-1242 Align Clippy CI and local hooks

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -37,6 +37,14 @@ if ! command -v uv >/dev/null 2>&1; then
   curl -LsSf https://astral.sh/uv/install.sh | sh
   log 'Installed uv'
 fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- prek (pre-commit runner) ------------------------------------------------
+if ! command -v prek >/dev/null 2>&1; then
+  log 'Installing prek'
+  uv tool install prek
+  log 'Installed prek'
+fi
 
 # --- Diode KiCad 10 (signed APT repository) ---------------------------------
 KICAD_APT_URL=https://kicad-mirror.api.diode.computer/apt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo run -p pcb -- fmt --check lib/std
 
       - name: Run Clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   test:
     name: Test (${{ matrix.config.name }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
 
       - id: clippy
         name: clippy
-        entry: cargo clippy --all-targets --all-features -- -D warnings
+        entry: cargo clippy --workspace --all-targets --all-features -- -D warnings
         language: system
         types: [rust]
         pass_filenames: false


### PR DESCRIPTION
## Summary

- run the same workspace-wide, all-target, all-feature Clippy command in CI and prek
- install prek during fresh orb setup

## Verification

- `bash -n .agents/setup`
- `prek validate-config .pre-commit-config.yaml`
- `prek run clippy --all-files`

Linear: [ENG-1242](https://linear.app/diodeinc/issue/ENG-1242/align-clippy-ci-and-local-hooks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes to lint commands and dev environment setup; no runtime or security-sensitive application logic.
> 
> **Overview**
> **Clippy** now runs the same command in GitHub Actions and local **prek** hooks: `cargo clippy --workspace --all-targets --all-features -- -D warnings`. CI gains `--all-targets` and `--all-features`; the pre-commit hook gains `--workspace`.
> 
> Fresh **orb** setup (`.agents/setup`) puts `~/.local/bin` on `PATH` after **uv** install and installs **prek** with `uv tool install prek` when missing, so agents can run the same hooks locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db9180a3bb087c1cd2c85d8b72eae99cd04e7b60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->