### PR TITLE
ENG-1199 Expose PCBA assembly report through CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Derive physical electrical terminations from exact IPC-2581 pin and padstack identities.
 - Add strict profile-based DFM PDK schema v2, executable JLCPCB 1 oz profiles, and metadata-only IPC 1A-3C profiles.
 - Add a deterministic, versioned PCBA assembly report contract over canonical assembly and physical IR.
+- Expose PCBA assembly reports as JSON through `pcb ipc assembly`.
 
 ### Changed
 

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -6,6 +6,7 @@ alias provides the same commands.
 | Command | Purpose |
 |---|---|
 | `info` | Report board, layer, drill, and stackup metadata. |
+| `assembly` | Emit the versioned PCBA assembly report as JSON. |
 | `bom` | Export the bill of materials. |
 | `cpl` | Export component placement data. |
 | `html` | Export an HTML board summary. |
@@ -19,6 +20,13 @@ alias provides the same commands.
 | `edit bom` | Add approved alternatives to BOM entries. |
 
 Run `pcb ipc2581 <command> --help` for arguments and output options.
+
+Use `assembly` to emit the complete board-array report, or select one canonical
+board with `--scope board`:
+
+```bash
+pcb ipc assembly design.xml --scope board-array > assembly-report.json
+```
 
 Board-array creation balances copper by default; pass `--no-copper-balance`
 to disable it. Fabrication-panel creation leaves copper unchanged by default;

--- a/crates/pcb-ipc2581-tools/docs/assembly-report.md
+++ b/crates/pcb-ipc2581-tools/docs/assembly-report.md
@@ -6,6 +6,13 @@ report carries design and manufacturing facts only. It does not select a part
 offer, infer commercial process policy, multiply by order quantity, or contain
 prices.
 
+The CLI writes this contract as JSON. It reports the complete board array by
+default; pass `--scope board` to select one canonical board instead.
+
+```bash
+pcb ipc assembly design.xml --scope board-array > assembly-report.json
+```
+
 The report has no generated timestamp or host file path. Repeating a build
 with the same IPC input and scope produces identical JSON. Board, package,
 component, and termination arrays are ordered by stable identifiers;

--- a/crates/pcb-ipc2581-tools/src/assembly/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/tests.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use ipc2581::Ipc2581;
 use pcb_ir::import::ipc2581::import_design;
 
@@ -137,5 +139,27 @@ fn rejects_non_finite_report_numbers() {
     assert_eq!(
         error.to_string(),
         "assembly report contains a non-finite number"
+    );
+}
+
+#[test]
+fn dm0002_excludes_document_objects_from_assembly_work() {
+    let compressed = include_bytes!("../../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
+    let xml = zstd::decode_all(Cursor::new(compressed)).unwrap();
+    let ipc = Ipc2581::parse(std::str::from_utf8(&xml).unwrap()).unwrap();
+    let imported = import_design(&ipc).unwrap();
+
+    let report = build_report(&imported, LayoutTarget::BoardArray).unwrap();
+
+    assert_eq!(report.summary.components.total, 59);
+    assert_eq!(report.summary.components.included, 53);
+    assert_eq!(report.summary.components.excluded, 6);
+    assert_eq!(report.summary.components.included_populated, 53);
+    assert!(
+        report
+            .components
+            .iter()
+            .filter(|component| component.assembly_status == report::AssemblyStatus::Included)
+            .all(|component| component.side == report::Side::Top)
     );
 }

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -23,6 +23,15 @@ enum Commands {
         #[arg(short, long, default_value = "mm")]
         units: UnitFormat,
     },
+    /// Emit the deterministic PCBA assembly report as JSON
+    Assembly {
+        /// IPC-2581 XML file to inspect
+        #[arg(value_hint = clap::ValueHint::FilePath)]
+        file: PathBuf,
+        /// Counting scope: one canonical board or the complete board array
+        #[arg(long, default_value = "board-array")]
+        scope: LayoutTarget,
+    },
     /// Generate Bill of Materials (BOM)
     Bom {
         /// IPC-2581 XML file to inspect
@@ -338,6 +347,17 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             format,
             units,
         } => commands::info::execute(&file, format, units),
+        Commands::Assembly { file, scope } => {
+            let ipc = pcb_ipc2581_tools::ipc2581::Ipc2581::parse_file(&file)?;
+            let imported = pcb_ir::import::ipc2581::import_design(&ipc)?;
+            let report = pcb_ipc2581_tools::assembly::build_report(&imported, scope)?;
+            let output = serde_json::to_vec_pretty(&report)?;
+            pcb_ui::write_stdout(|stdout| {
+                stdout.write_all(&output)?;
+                stdout.write_all(b"\n")
+            })?;
+            Ok(())
+        }
         Commands::Bom {
             file,
             format,

--- a/crates/pcbc/tests/integration.rs
+++ b/crates/pcbc/tests/integration.rs
@@ -8,6 +8,7 @@ mod doc;
 mod electrical_checks;
 mod import;
 mod info;
+mod ipc2581;
 mod layout;
 mod migrate;
 mod moved;

--- a/crates/pcbc/tests/ipc2581.rs
+++ b/crates/pcbc/tests/ipc2581.rs
@@ -1,0 +1,51 @@
+use std::{path::PathBuf, process::Command};
+
+use serde_json::Value;
+
+fn fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../pcb-ipc2581-tools/src/assembly/testdata/report.xml")
+}
+
+fn assembly_report(scope: &str) -> (Vec<u8>, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_pcbc"))
+        .arg("ipc")
+        .arg("assembly")
+        .arg(fixture())
+        .arg("--scope")
+        .arg(scope)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "pcbc failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let report = serde_json::from_slice(&output.stdout).unwrap();
+    (output.stdout, report)
+}
+
+#[test]
+fn assembly_command_matches_the_shared_board_array_report() {
+    let (first_json, report) = assembly_report("board-array");
+    let (second_json, _) = assembly_report("board-array");
+    let expected: Value = serde_json::from_str(include_str!(
+        "../../pcb-ipc2581-tools/src/assembly/testdata/report-v1.json"
+    ))
+    .unwrap();
+
+    assert_eq!(first_json, second_json);
+    assert_eq!(report, expected);
+}
+
+#[test]
+fn assembly_command_selects_canonical_board_scope() {
+    let (_, report) = assembly_report("board");
+
+    assert_eq!(report["scope"]["kind"], "board");
+    assert_eq!(report["summary"]["board_occurrences"], 1);
+    assert_eq!(report["summary"]["components"]["total"], 4);
+    assert_eq!(report["summary"]["terminations"]["total"], 3);
+}


### PR DESCRIPTION
Adds `pcb ipc assembly` to emit the shared versioned PCBA report as deterministic JSON for board or board-array scope. It reuses canonical assembly and physical IR and adds CLI parity plus DM0002 exclusion coverage. WASM remains unchanged.