### PR TITLE
Structure PDK profile support and rule cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Speed up DFM width and gap checks.
+- Separate DFM profile support, subject selectors, limits, and named conditional cases in PDK schema v2.
 
 ### Fixed
 

--- a/crates/pcb-ipc-wasm/scripts/smoke.mjs
+++ b/crates/pcb-ipc-wasm/scripts/smoke.mjs
@@ -83,6 +83,7 @@ if (!isMainThread) {
     assert.equal(report.pdk.source, pdk.source);
     assert.equal(report.pdk.profile, 'test');
     assert.equal(report.pdk.profile_status, 'executable');
+    assert.deepEqual(report.pdk.support.copper_layers, { exact: null, minimum: 2, maximum: 4 });
     assert.equal(report.layout.kind, 'board');
     assert.equal(report.scene.schema_version, 1);
     assert.ok(report.scene.bounds.min.x <= 0 && report.scene.bounds.max.x >= 30);

--- a/crates/pcb-ipc-wasm/scripts/typecheck.ts
+++ b/crates/pcb-ipc-wasm/scripts/typecheck.ts
@@ -54,6 +54,7 @@ export async function checkUsage(
     expectType<string>(report.pdk.source);
     expectType<string>(report.pdk.profile);
     expectType<"executable" | "metadata_only">(report.pdk.profile_status);
+    expectType<number | null>(report.pdk.support.copper_layers?.minimum ?? null);
     expectType<string | null>(report.pdk.defaults.outer_copper_weight);
     expectType<string>(report.layout.kind);
     expectType<string>(report.scene.passes[0].svg);

--- a/crates/pcb-ipc-wasm/src/api.d.ts
+++ b/crates/pcb-ipc-wasm/src/api.d.ts
@@ -49,6 +49,9 @@ export interface PdkProfileDefaults {
   inner_copper_weight: string | null;
   soldermask_color: string | null;
 }
+export interface PdkProfileSupport {
+  copper_layers: null | { exact: number | null; minimum: number | null; maximum: number | null };
+}
 export interface PdkSourceReference {
   id: string; title: string; url: string;
   revision: string | null; accessed: string | null; note: string | null;
@@ -62,6 +65,7 @@ export interface PdkIdentity {
   producibility_level: "A" | "B" | "C" | null;
   technologies: Array<"rigid" | "flex" | "rigid_flex" | "hdi">;
   coverage: string[];
+  support: PdkProfileSupport;
   defaults: PdkProfileDefaults;
   profile_source: PdkSourceReference | null;
   path: string; sha256: string; source: string;

--- a/crates/pcb-ipc-wasm/tests/pdk.toml
+++ b/crates/pcb-ipc-wasm/tests/pdk.toml
@@ -9,38 +9,32 @@ revision = "2"
 [profiles.test]
 name = "Test"
 
-[[rules.stackup.copper_layer_count]]
-id = "stackup.minimum_copper_layer_count"
-minimum = 2
-
-[[rules.stackup.copper_layer_count]]
-id = "stackup.maximum_copper_layer_count"
-maximum = 4
+[profiles.test.support]
+copper_layers = { minimum = 2, maximum = 4 }
 
 [[rules.drilling.hole_diameter]]
 id = "drilling.minimum_pth_hole_diameter"
-hole = "pth"
-minimum = "1.2 mm"
+select = { hole = "pth" }
+limit = { minimum = "1.2 mm" }
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "drilling.minimum_hole_to_hole_clearance"
-first_hole = "pth"
-second_hole = "pth"
-minimum = "0.2 mm"
+select = { first_hole = "pth", second_hole = "pth" }
+limit = { minimum = "0.2 mm" }
 
 [[rules.copper.feature_width]]
 id = "copper.minimum_feature_width"
-minimum = "0.2 mm"
+limit = { minimum = "0.2 mm" }
 
 [[rules.copper.annular_ring]]
 id = "copper.minimum_pth_annular_ring"
-hole = "pth"
-minimum = "0.2 mm"
+select = { hole = "pth" }
+limit = { minimum = "0.2 mm" }
 
 [[rules.copper.board_edge_clearance]]
 id = "copper.minimum_board_edge_clearance"
-minimum = "0.25 mm"
+limit = { minimum = "0.25 mm" }
 
 [[rules.soldermask.web]]
 id = "soldermask.minimum_web"
-minimum = "0.2 mm"
+limit = { minimum = "0.2 mm" }

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -9,8 +9,8 @@ native vector geometry, and the exact PDK source for external viewers.
 The PDK is strict and versioned. Unknown fields, bare numeric lengths, and
 unsupported schema versions are errors — refusing an unknown rule key
 is deliberate, because silently ignoring a rule the fab requires would
-green-light unchecked boards. A PDK that configures no rules is an error
-rather than a passing report.
+green-light unchecked boards. A profile with neither measurable support bounds
+nor DFM rules is an error rather than a passing report.
 
 ```toml
 schema_version = 2
@@ -31,6 +31,9 @@ name = "1 oz rigid standard"
 technologies = ["rigid"]
 source = "capabilities"
 
+[profiles.standard.support]
+copper_layers = { minimum = 2, maximum = 10 }
+
 [profiles.standard.defaults]
 material = "FR-4"
 board_thickness = "1.6 mm"
@@ -38,64 +41,69 @@ outer_copper_weight = "1 oz"
 inner_copper_weight = "0.5 oz"
 soldermask_color = "green"
 
-[[rules.stackup.copper_layer_count]]
-id = "stackup.layers"
-minimum = 2
-maximum = 10
-
 [[rules.drilling.hole_diameter]]
 id = "drilling.via_hole"
-hole = "via"
-minimum = "0.2 mm"
-preferred = "0.25 mm"
+select = { hole = "via" }
+limit = { minimum = "0.2 mm", preferred = "0.25 mm" }
 source = "capabilities"
 
 [[rules.drilling.slot_width]]
-id = "drilling.plated_slot.2_layer"
-plating = "plated"
-minimum = "0.50 mm"
-when = { minimum_copper_layers = 2, maximum_copper_layers = 2 }
-
-[[rules.drilling.slot_width]]
-id = "drilling.plated_slot.multilayer"
-plating = "plated"
-minimum = "0.35 mm"
-when = { minimum_copper_layers = 3, maximum_copper_layers = 10 }
+id = "drilling.plated_slot"
+select = { plating = "plated" }
+cases = [
+  { id = "2-layer", when = { copper_layers = { exact = 2 } }, limit = { minimum = "0.50 mm" } },
+  { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 10 } }, limit = { minimum = "0.35 mm" } },
+]
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "drilling.via_to_pth"
-first_hole = "via"
-second_hole = "pth"
-minimum = "10 mil"
+select = { first_hole = "via", second_hole = "pth" }
+limit = { minimum = "10 mil" }
 
 [[rules.copper.annular_ring]]
 id = "copper.via_annular_ring"
-hole = "via"
-minimum = "100 um"
-preferred = "0.125 mm"
+select = { hole = "via" }
+limit = { minimum = "100 um", preferred = "0.125 mm" }
 
 [[rules.copper.feature_width]]
-id = "copper.outer_feature_width"
-minimum = "0.10 mm"
-when = { layer = "outer", copper_weight = "1 oz" }
+id = "copper.feature_width"
+cases = [
+  { id = "outer-1oz", when = { copper = { position = "outer", weight = "1 oz" } }, limit = { minimum = "0.10 mm" } },
+]
 ```
 
 One PDK file is a kit with named profiles. A built-in name selects both a kit
 and one profile; a custom file runs its `default_profile`. An executable
 profile lowers only rules whose `profiles` list contains it; an omitted list
-means every profile. A `metadata_only` profile fails closed before checking,
-which lets a kit publish a standard taxonomy without pretending that missing
+means every profile. A `metadata_only` profile fails closed before checking.
+This lets a kit publish a standard taxonomy without claiming that missing
 numeric rules establish compliance.
 
-Every rule has a stable authored `id` and a typed subject selector. Hole rules
-select `via`, `pth`, or `npth`; slots select `plated` or `nonplated`; hole-pair
-rules state both classes. `when` can condition any rule on a copper-layer-count
-range; copper rules can also select `outer`/`inner` layer position and finished
-copper weight. Unsupported condition/rule combinations are errors rather than
-silently ignored selectors. Every overlapping applicable rule is enforced, so
-the strictest requirement is binding without an expression language. A
-condition requiring stackup context fails extraction if the IPC-2581 file has
-no unambiguous physical stackup.
+The schema gives each kind of constraint one place:
+
+- `profile.support` is the hard eligibility envelope for the whole profile.
+  A design outside its copper-layer range fails profile qualification. The
+  engine emits these checks as reserved `profile.support.*` report rules;
+  PDK authors do not write layer-count DFM rules.
+- `select` identifies the physical subjects a rule measures. Hole rules select
+  `via`, `pth`, or `npth`; slots select `plated` or `nonplated`; hole-pair rules
+  state both classes.
+- `limit` defines one unconditional minimum and an optional preferred value.
+- `cases` defines named conditional limits when one value is not enough. A
+  rule uses either `limit` or `cases`, never both.
+- `profile.defaults` records missing-data assumptions. Copper weight defaults
+  are used when a weight-conditioned case has no stated stackup weight.
+
+Case conditions use structured ranges such as
+`copper_layers = { exact = 2 }` or `{ minimum = 3, maximum = 10 }`. Copper
+rules may also condition on `copper = { position = "outer", weight = "1 oz" }`.
+The parser rejects unsupported conditions and any pair of cases whose domains
+overlap. Therefore, at most one case from a rule applies to a design or copper
+layer; non-applicable case rules are reported as skipped. A condition that
+needs stackup context fails extraction when the IPC-2581 file has no
+unambiguous physical stackup. The `technologies` list remains descriptive
+metadata because imported designs do not yet state rigid, flex, and HDI
+technology reliably enough for qualification.
 
 Layer counts are positive integers. Every dimensional minimum is a positive
 string containing a number and `mm`, `mil`, `mils`, or `um`; copper weight is a
@@ -105,13 +113,16 @@ defaults document an order's assumptions in the report; an outer/inner copper
 weight default is also the fallback for a weight-conditioned rule when the
 source stackup does not state that weight.
 
-Every dimensional rule has a binding `minimum` and may add a `preferred` tier:
+Every direct limit or case has a binding `minimum` and may add a `preferred`
+tier:
 
 - The minimum lowers to an **error**-severity rule whose id is the
-  authored rule id. Error findings fail the verdict.
+  authored rule id, or `<id>.<case>` for a named case. Error findings fail the
+  verdict.
 - A preferred tier lowers to a second, **warning**-severity rule under
-  `<id>.preferred`. Warning findings are reported and counted but do
-  not fail the verdict. The preferred value must exceed the minimum.
+  `<id>.preferred` or `<id>.<case>.preferred`. Warning findings are reported
+  and counted but do not fail the verdict. The preferred value must exceed the
+  minimum.
 
 Rule ids, profile metadata, source citations, and the exact PDK TOML are
 retained in the report for auditability.
@@ -123,9 +134,9 @@ highest-level representation that still states the measured quantity exactly,
 and lowers only when fabrication composition can change that quantity. A
 high-level pass is never allowed to suppress a later authoritative failure.
 
-| Rules | Authoritative representation | Acceleration only |
+| Check | Authoritative representation | Acceleration only |
 | --- | --- | --- |
-| Copper layer count | Conductive layers in the one physical IPC stackup | None |
+| Profile copper-layer support | Conductive layers in the one physical IPC stackup | None |
 | Hole diameter | Materialized IPC drill primitive and plating class | None |
 | Nominal slot width | IPC slot primitive width | None |
 | Outline slot width | Materialized filled route outline, then its narrowest maximal inscribed disk | None |
@@ -144,9 +155,9 @@ curve; zero for stated primitives and analytic shapes). A pair of witness
 points does not always encode a length: widths, diameters, and annular
 enclosures retain their own measurement constructions. The engine fails a
 minimum only when the measured value falls short beyond its own uncertainty,
-so curve tessellation by itself cannot manufacture a violation. Layer-count
-checks instead compare one exact integer with the configured minimum or
-maximum.
+so curve tessellation by itself cannot manufacture a violation. Profile
+copper-layer qualification instead compares one exact integer with the
+configured support bounds.
 
 Morphological opening and closing are deliberately candidate stages for width
 and soldermask-web checks. Each candidate residue is measured on the medial
@@ -177,9 +188,10 @@ when fewer than two exist.
 
 ## Rule semantics
 
-- Copper layer count requires exactly one physical stackup. Every declared
-  copper layer must occur exactly once in it; missing or ambiguous stackup data
-  fails extraction rather than guessing from artwork layer names.
+- Profile copper-layer qualification requires exactly one physical stackup.
+  Every declared copper layer must occur exactly once in it; missing or
+  ambiguous stackup data fails extraction rather than guessing from artwork
+  layer names.
 - Hole diameter rules measure every drilled hole of the rule's class. Slot
   width rules measure routed slots of the selected plating class. A slot's width is settled
   at extraction: the stated primitive width when present — exact, and
@@ -299,7 +311,8 @@ A complete report has these fields:
 - `tool`: producer name and version.
 - `input`: original IPC input path, SHA-256, and byte size.
 - `pdk`: resolved kit and profile metadata, assumptions, source citation, path,
-  exact TOML `source`, and SHA-256.
+  exact TOML `source`, SHA-256, and the selected profile's
+  `support.copper_layers` range (`exact`, `minimum`, and `maximum`).
 - `waivers`: file path and SHA-256 plus applied, expired, and unmatched entries;
   `null` when no waiver file was given. See [source identity](#source-identity).
 - `layout_target`: `board` or `board_array`.
@@ -311,8 +324,9 @@ A complete report has these fields:
   geometry: `mm`, `x_right_y_up`, and `ipc_2581_design` in version 1.
 - `summary`: rule counts by status and finding counts by severity and
   waiver state.
-- `rules`: one result per lowered rule: its authored id (plus
-  `.preferred` for warning tiers), severity, source and normalized limit,
+- `rules`: one result per lowered rule. A direct limit uses its authored id; a
+  named case uses `<id>.<case>`; a preferred tier appends `.preferred` to
+  either form. Each result includes severity, source and normalized limit,
   status (`pass`, `warning`, `fail`, or `skipped`), skip reason, and the
   measurement contract shared by all of its findings — `subject` (what one
   checked unit is), `quantity`, `method`, `comparison` (`minimum` or

--- a/crates/pcb-ipc2581-tools/examples/apcb-proto.toml
+++ b/crates/pcb-ipc2581-tools/examples/apcb-proto.toml
@@ -12,56 +12,59 @@ process = "Aurora 2-10 layer prototype"
 name = "Aurora 2-10 layer prototype"
 technologies = ["rigid"]
 
+[profiles.aurora-prototype.support]
+copper_layers = { minimum = 2, maximum = 10 }
+
 [[rules.drilling.hole_diameter]]
 id = "drilling.minimum_via_hole_diameter"
-hole = "via"
-minimum = "0.2 mm"
+select = { hole = "via" }
+limit = { minimum = "0.2 mm" }
 
 [[rules.drilling.hole_diameter]]
 id = "drilling.minimum_pth_hole_diameter"
-hole = "pth"
-minimum = "15 mil"
+select = { hole = "pth" }
+limit = { minimum = "15 mil" }
 
 [[rules.drilling.hole_diameter]]
 id = "drilling.minimum_npth_hole_diameter"
-hole = "npth"
-minimum = "0.2 mm"
+select = { hole = "npth" }
+limit = { minimum = "0.2 mm" }
 
 [[rules.drilling.slot_width]]
 id = "drilling.minimum_plated_slot_width"
-plating = "plated"
-minimum = "31 mil"
+select = { plating = "plated" }
+limit = { minimum = "31 mil" }
 
 [[rules.copper.annular_ring]]
 id = "copper.minimum_via_annular_ring"
-hole = "via"
-minimum = "0.125 mm"
+select = { hole = "via" }
+limit = { minimum = "0.125 mm" }
 
 [[rules.copper.annular_ring]]
 id = "copper.minimum_pth_annular_ring"
-hole = "pth"
-minimum = "7 mil"
+select = { hole = "pth" }
+limit = { minimum = "7 mil" }
 
 [[rules.copper.feature_width]]
 id = "copper.minimum_feature_width"
-minimum = "5 mil"
+limit = { minimum = "5 mil" }
 
 [[rules.copper.clearance]]
 id = "copper.minimum_clearance"
-minimum = "5 mil"
+limit = { minimum = "5 mil" }
 
 [[rules.copper.board_edge_clearance]]
 id = "copper.minimum_board_edge_clearance"
-minimum = "15 mil"
+limit = { minimum = "15 mil" }
 
 [[rules.copper.vscore_clearance]]
 id = "copper.minimum_vscore_clearance"
-minimum = "15 mil"
+limit = { minimum = "15 mil" }
 
 [[rules.soldermask.web]]
 id = "soldermask.minimum_web"
-minimum = "4 mil"
+limit = { minimum = "4 mil" }
 
 [[rules.panelization.board_spacing]]
 id = "panelization.minimum_board_array_spacing"
-minimum = "300 mil"
+limit = { minimum = "300 mil" }

--- a/crates/pcb-ipc2581-tools/examples/dfm-pdk.toml
+++ b/crates/pcb-ipc2581-tools/examples/dfm-pdk.toml
@@ -10,6 +10,9 @@ revision = "2"
 name = "1 oz rigid standard"
 technologies = ["rigid"]
 
+[profiles.standard.support]
+copper_layers = { minimum = 2, maximum = 10 }
+
 [profiles.standard.defaults]
 material = "FR-4"
 board_thickness = "1.6 mm"
@@ -17,43 +20,34 @@ outer_copper_weight = "1 oz"
 inner_copper_weight = "0.5 oz"
 soldermask_color = "green"
 
-[[rules.stackup.copper_layer_count]]
-id = "stackup.layers"
-minimum = 2
-maximum = 10
-
 [[rules.drilling.hole_diameter]]
 id = "drilling.via_hole"
-hole = "via"
-minimum = "0.2 mm"
+select = { hole = "via" }
+limit = { minimum = "0.2 mm" }
 
 [[rules.drilling.slot_width]]
-id = "drilling.plated_slot.2_layer"
-plating = "plated"
-minimum = "0.5 mm"
-when = { minimum_copper_layers = 2, maximum_copper_layers = 2 }
-
-[[rules.drilling.slot_width]]
-id = "drilling.plated_slot.multilayer"
-plating = "plated"
-minimum = "0.35 mm"
-when = { minimum_copper_layers = 3, maximum_copper_layers = 10 }
+id = "drilling.plated_slot"
+select = { plating = "plated" }
+cases = [
+  { id = "2-layer", when = { copper_layers = { exact = 2 } }, limit = { minimum = "0.5 mm" } },
+  { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 10 } }, limit = { minimum = "0.35 mm" } },
+]
 
 [[rules.copper.annular_ring]]
 id = "copper.via_annular_ring"
-hole = "via"
-minimum = "100 um"
-preferred = "0.125 mm"
+select = { hole = "via" }
+limit = { minimum = "100 um", preferred = "0.125 mm" }
 
 [[rules.copper.feature_width]]
 id = "copper.outer_feature_width"
-minimum = "0.10 mm"
-when = { layer = "outer", copper_weight = "1 oz" }
+cases = [
+  { id = "outer-1oz", when = { copper = { position = "outer", weight = "1 oz" } }, limit = { minimum = "0.10 mm" } },
+]
 
 [[rules.copper.clearance]]
 id = "copper.clearance"
-minimum = "0.10 mm"
+limit = { minimum = "0.10 mm" }
 
 [[rules.soldermask.web]]
 id = "soldermask.web"
-minimum = "0.10 mm"
+limit = { minimum = "0.10 mm" }

--- a/crates/pcb-ipc2581-tools/pdks/jlcpcb.toml
+++ b/crates/pcb-ipc2581-tools/pdks/jlcpcb.toml
@@ -28,6 +28,9 @@ outer_copper_weight = "1 oz"
 inner_copper_weight = "0.5 oz"
 soldermask_color = "green"
 
+[profiles.one-ounce-standard-color.support]
+copper_layers = { minimum = 2, maximum = 32 }
+
 [profiles.one-ounce-black-white]
 name = "1 oz, black/white soldermask"
 description = "Standard rigid FR-4 service with the larger published mask-web requirement for black or white mask. Black is assumed when color is absent."
@@ -42,163 +45,127 @@ outer_copper_weight = "1 oz"
 inner_copper_weight = "0.5 oz"
 soldermask_color = "black"
 
-[[rules.stackup.copper_layer_count]]
-id = "jlc.stackup.minimum_copper_layer_count"
-minimum = 2
-source = "jlc-capabilities"
-
-[[rules.stackup.copper_layer_count]]
-id = "jlc.stackup.maximum_copper_layer_count"
-maximum = 32
-source = "jlc-capabilities"
+[profiles.one-ounce-black-white.support]
+copper_layers = { minimum = 2, maximum = 32 }
 
 [[rules.drilling.hole_diameter]]
 id = "jlc.drilling.minimum_via_hole_diameter"
-hole = "via"
-minimum = "0.15 mm"
-preferred = "0.20 mm"
+select = { hole = "via" }
+limit = { minimum = "0.15 mm", preferred = "0.20 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.hole_diameter]]
 id = "jlc.drilling.minimum_pth_hole_diameter"
-hole = "pth"
-minimum = "0.15 mm"
-preferred = "0.50 mm"
+select = { hole = "pth" }
+limit = { minimum = "0.15 mm", preferred = "0.50 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.hole_diameter]]
 id = "jlc.drilling.minimum_npth_hole_diameter"
-hole = "npth"
-minimum = "0.50 mm"
+select = { hole = "npth" }
+limit = { minimum = "0.50 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.slot_width]]
-id = "jlc.drilling.minimum_plated_slot_width.2_layer"
-plating = "plated"
-minimum = "0.50 mm"
-when = { minimum_copper_layers = 2, maximum_copper_layers = 2 }
-source = "jlc-capabilities"
-
-[[rules.drilling.slot_width]]
-id = "jlc.drilling.minimum_plated_slot_width.multilayer"
-plating = "plated"
-minimum = "0.35 mm"
-when = { minimum_copper_layers = 3, maximum_copper_layers = 32 }
+id = "jlc.drilling.minimum_plated_slot_width"
+select = { plating = "plated" }
+cases = [
+  { id = "2-layer", when = { copper_layers = { exact = 2 } }, limit = { minimum = "0.50 mm" } },
+  { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 32 } }, limit = { minimum = "0.35 mm" } },
+]
 source = "jlc-capabilities"
 
 [[rules.drilling.slot_width]]
 id = "jlc.drilling.minimum_nonplated_slot_width"
-plating = "nonplated"
-minimum = "1.0 mm"
+select = { plating = "nonplated" }
+limit = { minimum = "1.0 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "jlc.drilling.minimum_hole_clearance.via_via"
-first_hole = "via"
-second_hole = "via"
-minimum = "0.20 mm"
+select = { first_hole = "via", second_hole = "via" }
+limit = { minimum = "0.20 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "jlc.drilling.minimum_hole_clearance.via_pth"
-first_hole = "via"
-second_hole = "pth"
-minimum = "0.45 mm"
+select = { first_hole = "via", second_hole = "pth" }
+limit = { minimum = "0.45 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "jlc.drilling.minimum_hole_clearance.via_npth"
-first_hole = "via"
-second_hole = "npth"
-minimum = "0.45 mm"
+select = { first_hole = "via", second_hole = "npth" }
+limit = { minimum = "0.45 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "jlc.drilling.minimum_hole_clearance.pth_pth"
-first_hole = "pth"
-second_hole = "pth"
-minimum = "0.45 mm"
+select = { first_hole = "pth", second_hole = "pth" }
+limit = { minimum = "0.45 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "jlc.drilling.minimum_hole_clearance.pth_npth"
-first_hole = "pth"
-second_hole = "npth"
-minimum = "0.45 mm"
+select = { first_hole = "pth", second_hole = "npth" }
+limit = { minimum = "0.45 mm" }
 source = "jlc-capabilities"
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "jlc.drilling.minimum_hole_clearance.npth_npth"
-first_hole = "npth"
-second_hole = "npth"
-minimum = "0.45 mm"
+select = { first_hole = "npth", second_hole = "npth" }
+limit = { minimum = "0.45 mm" }
 source = "jlc-capabilities"
 
 [[rules.copper.annular_ring]]
 id = "jlc.copper.minimum_via_annular_ring"
-hole = "via"
-minimum = "0.05 mm"
-preferred = "0.075 mm"
+select = { hole = "via" }
+limit = { minimum = "0.05 mm", preferred = "0.075 mm" }
 source = "jlc-capabilities"
 
 [[rules.copper.annular_ring]]
-id = "jlc.copper.minimum_pth_annular_ring.2_layer"
-hole = "pth"
-minimum = "0.18 mm"
-preferred = "0.25 mm"
-when = { minimum_copper_layers = 2, maximum_copper_layers = 2 }
-source = "jlc-capabilities"
-
-[[rules.copper.annular_ring]]
-id = "jlc.copper.minimum_pth_annular_ring.multilayer"
-hole = "pth"
-minimum = "0.15 mm"
-preferred = "0.20 mm"
-when = { minimum_copper_layers = 3, maximum_copper_layers = 32 }
+id = "jlc.copper.minimum_pth_annular_ring"
+select = { hole = "pth" }
+cases = [
+  { id = "2-layer", when = { copper_layers = { exact = 2 } }, limit = { minimum = "0.18 mm", preferred = "0.25 mm" } },
+  { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 32 } }, limit = { minimum = "0.15 mm", preferred = "0.20 mm" } },
+]
 source = "jlc-capabilities"
 
 [[rules.copper.feature_width]]
-id = "jlc.copper.minimum_feature_width.2_layer"
-minimum = "0.10 mm"
-when = { minimum_copper_layers = 2, maximum_copper_layers = 2 }
-source = "jlc-capabilities"
-
-[[rules.copper.feature_width]]
-id = "jlc.copper.minimum_feature_width.multilayer"
-minimum = "0.09 mm"
-when = { minimum_copper_layers = 3, maximum_copper_layers = 32 }
+id = "jlc.copper.minimum_feature_width"
+cases = [
+  { id = "2-layer", when = { copper_layers = { exact = 2 } }, limit = { minimum = "0.10 mm" } },
+  { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 32 } }, limit = { minimum = "0.09 mm" } },
+]
 source = "jlc-capabilities"
 
 [[rules.copper.clearance]]
-id = "jlc.copper.minimum_clearance.2_layer"
-minimum = "0.10 mm"
-when = { minimum_copper_layers = 2, maximum_copper_layers = 2 }
-source = "jlc-capabilities"
-
-[[rules.copper.clearance]]
-id = "jlc.copper.minimum_clearance.multilayer"
-minimum = "0.09 mm"
-when = { minimum_copper_layers = 3, maximum_copper_layers = 32 }
+id = "jlc.copper.minimum_clearance"
+cases = [
+  { id = "2-layer", when = { copper_layers = { exact = 2 } }, limit = { minimum = "0.10 mm" } },
+  { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 32 } }, limit = { minimum = "0.09 mm" } },
+]
 source = "jlc-capabilities"
 
 [[rules.copper.board_edge_clearance]]
 id = "jlc.copper.minimum_board_edge_clearance"
-minimum = "0.20 mm"
+limit = { minimum = "0.20 mm" }
 source = "jlc-capabilities"
 
 [[rules.copper.vscore_clearance]]
 id = "jlc.copper.minimum_vscore_clearance"
-minimum = "0.40 mm"
+limit = { minimum = "0.40 mm" }
 source = "jlc-capabilities"
 
 [[rules.soldermask.web]]
 id = "jlc.soldermask.minimum_web.standard_color"
 profiles = ["one-ounce-standard-color"]
-minimum = "0.10 mm"
+limit = { minimum = "0.10 mm" }
 source = "jlc-capabilities"
 
 [[rules.soldermask.web]]
 id = "jlc.soldermask.minimum_web.black_white"
 profiles = ["one-ounce-black-white"]
-minimum = "0.13 mm"
+limit = { minimum = "0.13 mm" }
 source = "jlc-capabilities"

--- a/crates/pcb-ipc2581-tools/pdks/standard.toml
+++ b/crates/pcb-ipc2581-tools/pdks/standard.toml
@@ -13,105 +13,94 @@ name = "Diode standard"
 description = "General-purpose defaults retained from the original Diode DFM PDK."
 technologies = ["rigid"]
 
-[[rules.stackup.copper_layer_count]]
-id = "stackup.minimum_copper_layer_count"
-minimum = 2
-
-[[rules.stackup.copper_layer_count]]
-id = "stackup.maximum_copper_layer_count"
-maximum = 10
+[profiles.standard.support]
+copper_layers = { minimum = 2, maximum = 10 }
 
 [[rules.drilling.hole_diameter]]
 id = "drilling.minimum_via_hole_diameter"
-hole = "via"
-minimum = "0.2 mm"
+select = { hole = "via" }
+limit = { minimum = "0.2 mm" }
 
 [[rules.drilling.hole_diameter]]
 id = "drilling.minimum_pth_hole_diameter"
-hole = "pth"
-minimum = "15 mil"
+select = { hole = "pth" }
+limit = { minimum = "15 mil" }
 
 [[rules.drilling.hole_diameter]]
 id = "drilling.minimum_npth_hole_diameter"
-hole = "npth"
-minimum = "0.2 mm"
+select = { hole = "npth" }
+limit = { minimum = "0.2 mm" }
 
 [[rules.drilling.slot_width]]
 id = "drilling.minimum_slot_width"
-plating = "plated"
-minimum = "31 mil"
+select = { plating = "plated" }
+limit = { minimum = "31 mil" }
 
 [[rules.drilling.slot_width]]
 id = "drilling.minimum_slot_width.nonplated"
-plating = "nonplated"
-minimum = "31 mil"
+select = { plating = "nonplated" }
+limit = { minimum = "31 mil" }
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "drilling.minimum_hole_to_hole_clearance.via_via"
-first_hole = "via"
-second_hole = "via"
-minimum = "10 mil"
+select = { first_hole = "via", second_hole = "via" }
+limit = { minimum = "10 mil" }
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "drilling.minimum_hole_to_hole_clearance.via_pth"
-first_hole = "via"
-second_hole = "pth"
-minimum = "10 mil"
+select = { first_hole = "via", second_hole = "pth" }
+limit = { minimum = "10 mil" }
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "drilling.minimum_hole_to_hole_clearance.via_npth"
-first_hole = "via"
-second_hole = "npth"
-minimum = "10 mil"
+select = { first_hole = "via", second_hole = "npth" }
+limit = { minimum = "10 mil" }
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "drilling.minimum_hole_to_hole_clearance.pth_pth"
-first_hole = "pth"
-second_hole = "pth"
-minimum = "10 mil"
+select = { first_hole = "pth", second_hole = "pth" }
+limit = { minimum = "10 mil" }
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "drilling.minimum_hole_to_hole_clearance.pth_npth"
-first_hole = "pth"
-second_hole = "npth"
-minimum = "10 mil"
+select = { first_hole = "pth", second_hole = "npth" }
+limit = { minimum = "10 mil" }
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "drilling.minimum_hole_to_hole_clearance.npth_npth"
-first_hole = "npth"
-second_hole = "npth"
-minimum = "10 mil"
+select = { first_hole = "npth", second_hole = "npth" }
+limit = { minimum = "10 mil" }
 
 [[rules.copper.annular_ring]]
 id = "copper.minimum_via_annular_ring"
-hole = "via"
-minimum = "0.125 mm"
+select = { hole = "via" }
+limit = { minimum = "0.125 mm" }
 
 [[rules.copper.annular_ring]]
 id = "copper.minimum_pth_annular_ring"
-hole = "pth"
-minimum = "7 mil"
+select = { hole = "pth" }
+limit = { minimum = "7 mil" }
 
 [[rules.copper.feature_width]]
 id = "copper.minimum_feature_width"
-minimum = "5 mil"
+limit = { minimum = "5 mil" }
 
 [[rules.copper.clearance]]
 id = "copper.minimum_copper_clearance"
-minimum = "5 mil"
+limit = { minimum = "5 mil" }
 
 [[rules.copper.board_edge_clearance]]
 id = "copper.minimum_board_edge_clearance"
-minimum = "15 mil"
+limit = { minimum = "15 mil" }
 
 [[rules.copper.vscore_clearance]]
 id = "copper.minimum_vscore_to_copper_clearance"
-minimum = "15 mil"
+limit = { minimum = "15 mil" }
 
 [[rules.soldermask.web]]
 id = "soldermask.minimum_web"
-minimum = "4 mil"
+limit = { minimum = "4 mil" }
 
 [[rules.panelization.board_spacing]]
 id = "panelization.minimum_board_array_spacing"
-minimum = "300 mil"
+limit = { minimum = "300 mil" }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -495,25 +495,20 @@ revision = "1"
 [profiles.test]
 name = "Test"
 
-[[rules.stackup.copper_layer_count]]
-id = "stackup.minimum_copper_layer_count"
-minimum = 2
-
-[[rules.stackup.copper_layer_count]]
-id = "stackup.maximum_copper_layer_count"
-maximum = 4
+[profiles.test.support]
+copper_layers = { minimum = 2, maximum = 4 }
 
 [[rules.copper.vscore_clearance]]
 id = "copper.minimum_vscore_to_copper_clearance"
-minimum = "0.5 mm"
+limit = { minimum = "0.5 mm" }
 
 [[rules.copper.board_edge_clearance]]
 id = "copper.minimum_board_edge_clearance"
-minimum = "0.5 mm"
+limit = { minimum = "0.5 mm" }
 
 [[rules.panelization.board_spacing]]
 id = "panelization.minimum_board_array_spacing"
-minimum = "300 mil"
+limit = { minimum = "300 mil" }
 "#;
 
     fn check(xml: &str, target: LayoutTarget) -> DfmReport {
@@ -555,8 +550,13 @@ minimum = "300 mil"
         assert_eq!(parsed.pdk.manufacturer.as_deref(), Some("Diode"));
         assert_eq!(parsed.pdk.process.as_deref(), Some("Standard"));
         assert_eq!(parsed.default_profile, "standard");
-        assert_eq!(parsed.rules.stackup.copper_layer_count[0].minimum, Some(2));
-        assert_eq!(parsed.rules.stackup.copper_layer_count[1].maximum, Some(10));
+        let support = parsed.profiles["standard"]
+            .support
+            .copper_layers
+            .as_ref()
+            .unwrap();
+        assert_eq!(support.minimum(), Some(2));
+        assert_eq!(support.maximum(), Some(10));
         assert!(!rules::lower(&parsed, None).unwrap().is_empty());
 
         for builtin in builtin_pdks() {
@@ -588,7 +588,7 @@ minimum = "300 mil"
         );
         let two_layer = rules
             .iter()
-            .find(|rule| rule.id == "jlc.copper.minimum_feature_width.2_layer")
+            .find(|rule| rule.id == "jlc.copper.minimum_feature_width.2-layer")
             .unwrap();
         assert_eq!(two_layer.limit.length().millimeters(), 0.10);
         assert_eq!(two_layer.conditions.minimum_copper_layers, Some(2));
@@ -600,6 +600,20 @@ minimum = "300 mil"
         assert_eq!(multilayer.limit.length().millimeters(), 0.09);
         assert_eq!(multilayer.conditions.minimum_copper_layers, Some(3));
         assert_eq!(multilayer.conditions.maximum_copper_layers, Some(32));
+    }
+
+    #[test]
+    fn case_named_preferred_remains_a_required_tier() {
+        let pdk = PDK.replace(
+            "[[rules.copper.board_edge_clearance]]\nid = \"copper.minimum_board_edge_clearance\"\nlimit = { minimum = \"0.5 mm\" }",
+            "[[rules.copper.board_edge_clearance]]\nid = \"copper.minimum_board_edge_clearance\"\ncases = [\n  { id = \"preferred\", when = { copper_layers = { exact = 2 } }, limit = { minimum = \"0.5 mm\" } },\n]",
+        );
+
+        let results = check_with_pdk(BOARD, LayoutTarget::Board, &pdk);
+        let required = rule(&results, "copper.minimum_board_edge_clearance.preferred");
+
+        assert_eq!(required.severity, report::Severity::Error);
+        assert_eq!(required.tier, "required");
     }
 
     #[test]
@@ -787,13 +801,13 @@ reason = "old finding"
     }
 
     #[test]
-    fn copper_layer_count_checks_both_bounds_from_the_physical_stackup() {
+    fn profile_support_checks_both_layer_bounds_from_the_physical_stackup() {
         let below_minimum = check_with_pdk(
             BOARD,
             LayoutTarget::Board,
             &PDK.replace("minimum = 2", "minimum = 3"),
         );
-        let minimum_rule = rule(&below_minimum, "stackup.minimum_copper_layer_count");
+        let minimum_rule = rule(&below_minimum, "profile.support.copper_layers.minimum");
         assert_eq!(minimum_rule.checked, 1);
         assert_eq!(minimum_rule.comparison, "minimum");
         assert_eq!(minimum_rule.limit.normalized_unit, "layers");
@@ -824,9 +838,12 @@ reason = "old finding"
         let above_maximum = check_with_pdk(
             BOARD,
             LayoutTarget::Board,
-            &PDK.replace("maximum = 4", "maximum = 1"),
+            &PDK.replace(
+                "copper_layers = { minimum = 2, maximum = 4 }",
+                "copper_layers = { maximum = 1 }",
+            ),
         );
-        let maximum_rule = rule(&above_maximum, "stackup.maximum_copper_layer_count");
+        let maximum_rule = rule(&above_maximum, "profile.support.copper_layers.maximum");
         assert_eq!(maximum_rule.checked, 1);
         assert_eq!(maximum_rule.comparison, "maximum");
         assert!(matches!(maximum_rule.status, report::RuleStatus::Fail));
@@ -841,7 +858,7 @@ reason = "old finding"
     }
 
     #[test]
-    fn copper_layer_count_rejects_an_incomplete_physical_stackup() {
+    fn profile_support_rejects_an_incomplete_physical_stackup() {
         let ipc = Ipc2581::parse(&BOARD.replace(
             "layerOrGroupRef=\"BOTTOM\"",
             "layerOrGroupRef=\"DIELECTRIC\"",

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -280,8 +280,8 @@ name = "Test"
 
 [[rules.copper.annular_ring]]
 id = "pth-ring"
-hole = "pth"
-minimum = "0.2 mm"
+select = { hole = "pth" }
+limit = { minimum = "0.2 mm" }
 "#,
         )
         .unwrap();

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -172,7 +172,7 @@ name = "Test"
 
 [[rules.copper.clearance]]
 id = "copper-clearance"
-minimum = "0.15 mm"
+limit = { minimum = "0.15 mm" }
 "#;
 
     const BOARD: &str = r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
@@ -161,9 +161,8 @@ mod tests {
           name = "Test"
           [[rules.drilling.hole_to_hole_clearance]]
           id = "hole-clearance"
-          first_hole = "pth"
-          second_hole = "pth"
-          minimum = "0.2 mm"
+          select = { first_hole = "pth", second_hole = "pth" }
+          limit = { minimum = "0.2 mm" }
         "#,
         )
         .unwrap();

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -108,8 +108,8 @@ mod tests {
           name = "Test"
           [[rules.drilling.slot_width]]
           id = "slot-width"
-          plating = "plated"
-          minimum = "0.8 mm"
+          select = { plating = "plated" }
+          limit = { minimum = "0.8 mm" }
         "#,
         )
         .unwrap();

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
@@ -45,6 +45,7 @@ impl Pdk {
             {
                 bail!("profile '{name}' cites unknown source '{source}'");
             }
+            profile.support.validate(name)?;
         }
         for (id, source) in &pdk.sources {
             if source.title.trim().is_empty() || source.url.trim().is_empty() {
@@ -64,13 +65,17 @@ impl Pdk {
     }
 
     pub fn validate_rule_references(&self) -> Result<()> {
-        let mut ids = HashSet::new();
+        let mut authored_ids = HashSet::new();
+        let mut configured_ids = HashSet::from([
+            "profile.support.copper_layers.minimum".to_owned(),
+            "profile.support.copper_layers.maximum".to_owned(),
+        ]);
         for rule in self.rules.all() {
             let metadata = rule.metadata();
             if metadata.id.trim().is_empty() {
                 bail!("PDK rule ids must not be empty");
             }
-            if !ids.insert(metadata.id.clone()) {
+            if !authored_ids.insert(metadata.id.clone()) {
                 bail!("duplicate PDK rule id '{}'", metadata.id);
             }
             for profile in &metadata.profiles {
@@ -84,6 +89,11 @@ impl Pdk {
                 bail!("rule '{}' cites unknown source '{source}'", metadata.id);
             }
             rule.validate()?;
+            for id in rule.configured_ids() {
+                if !configured_ids.insert(id.clone()) {
+                    bail!("duplicate lowered PDK rule id '{id}'");
+                }
+            }
         }
         Ok(())
     }
@@ -118,9 +128,79 @@ pub struct Profile {
     #[serde(default)]
     pub coverage: Vec<String>,
     #[serde(default)]
+    pub support: ProfileSupport,
+    #[serde(default)]
     pub defaults: ProfileDefaults,
     #[serde(default)]
     pub source: Option<String>,
+}
+
+/// Hard, measurable bounds a design must satisfy to use a profile.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileSupport {
+    #[serde(default)]
+    pub copper_layers: Option<CountRange>,
+}
+
+impl ProfileSupport {
+    fn validate(&self, profile: &str) -> Result<()> {
+        if let Some(range) = &self.copper_layers {
+            range.validate(&format!("profile '{profile}' support.copper_layers"))?;
+        }
+        Ok(())
+    }
+}
+
+/// An inclusive positive-integer range. `exact` is shorthand for equal bounds.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CountRange {
+    #[serde(default)]
+    pub exact: Option<u32>,
+    #[serde(default)]
+    pub minimum: Option<u32>,
+    #[serde(default)]
+    pub maximum: Option<u32>,
+}
+
+impl CountRange {
+    fn validate(&self, context: &str) -> Result<()> {
+        if self.exact.is_none() && self.minimum.is_none() && self.maximum.is_none() {
+            bail!("{context} requires exact, minimum, or maximum");
+        }
+        if self.exact.is_some() && (self.minimum.is_some() || self.maximum.is_some()) {
+            bail!("{context} exact cannot be combined with minimum or maximum");
+        }
+        for (name, count) in [
+            ("exact", self.exact),
+            ("minimum", self.minimum),
+            ("maximum", self.maximum),
+        ] {
+            if count == Some(0) {
+                bail!("{context} {name} must be a positive integer");
+            }
+        }
+        if let (Some(minimum), Some(maximum)) = (self.minimum, self.maximum)
+            && minimum > maximum
+        {
+            bail!("{context} minimum ({minimum}) must not exceed maximum ({maximum})");
+        }
+        Ok(())
+    }
+
+    pub fn minimum(&self) -> Option<u32> {
+        self.exact.or(self.minimum)
+    }
+
+    pub fn maximum(&self) -> Option<u32> {
+        self.exact.or(self.maximum)
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        self.minimum().unwrap_or(1) <= other.maximum().unwrap_or(u32::MAX)
+            && other.minimum().unwrap_or(1) <= self.maximum().unwrap_or(u32::MAX)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
@@ -209,8 +289,6 @@ pub struct SourceReference {
 #[serde(deny_unknown_fields)]
 pub struct Rules {
     #[serde(default)]
-    pub stackup: StackupRules,
-    #[serde(default)]
     pub drilling: DrillingRules,
     #[serde(default)]
     pub copper: CopperRules,
@@ -222,16 +300,10 @@ pub struct Rules {
 
 impl Rules {
     fn all(&self) -> impl Iterator<Item = RuleDefinition<'_>> {
-        self.stackup
-            .copper_layer_count
+        self.drilling
+            .hole_diameter
             .iter()
-            .map(RuleDefinition::Count)
-            .chain(
-                self.drilling
-                    .hole_diameter
-                    .iter()
-                    .map(RuleDefinition::HoleDiameter),
-            )
+            .map(RuleDefinition::HoleDiameter)
             .chain(
                 self.drilling
                     .slot_width
@@ -285,7 +357,6 @@ impl Rules {
 }
 
 enum RuleDefinition<'a> {
-    Count(&'a CountRule),
     HoleDiameter(&'a HoleDiameterRule),
     SlotWidth(&'a SlotWidthRule),
     HolePair(&'a HolePairRule),
@@ -297,7 +368,6 @@ enum RuleDefinition<'a> {
 impl RuleDefinition<'_> {
     fn metadata(&self) -> &RuleMetadata {
         match self {
-            Self::Count(rule) => &rule.metadata,
             Self::HoleDiameter(rule) => &rule.metadata,
             Self::SlotWidth(rule) => &rule.metadata,
             Self::HolePair(rule) => &rule.metadata,
@@ -306,41 +376,40 @@ impl RuleDefinition<'_> {
         }
     }
 
-    fn validate(&self) -> Result<()> {
-        let metadata = self.metadata();
-        metadata.when.validate(&metadata.id)?;
-        if metadata.when.layer.is_some()
-            && !matches!(self, Self::AnnularRing(_) | Self::CopperLength(_))
-        {
-            bail!(
-                "rule '{}': layer and copper_weight conditions are supported only for copper rules",
-                metadata.id
-            );
-        }
+    fn limits(&self) -> (Option<&LengthLimit>, &[LengthCase]) {
         match self {
-            Self::Count(rule) => rule.validate(),
-            Self::HoleDiameter(rule) => {
-                validate_length(&rule.metadata, &rule.minimum, rule.preferred.as_ref())
+            Self::HoleDiameter(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::SlotWidth(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::HolePair(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::AnnularRing(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::CopperLength(rule) | Self::OtherLength(rule) => {
+                (rule.limit.as_ref(), &rule.cases)
             }
-            Self::SlotWidth(rule) => {
-                validate_length(&rule.metadata, &rule.minimum, rule.preferred.as_ref())
-            }
-            Self::HolePair(rule) => {
-                validate_length(&rule.metadata, &rule.minimum, rule.preferred.as_ref())
-            }
-            Self::AnnularRing(rule) => {
-                validate_length(&rule.metadata, &rule.minimum, rule.preferred.as_ref())
-            }
-            Self::CopperLength(rule) | Self::OtherLength(rule) => rule.validate(),
         }
     }
-}
 
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct StackupRules {
-    #[serde(default)]
-    pub copper_layer_count: Vec<CountRule>,
+    fn validate(&self) -> Result<()> {
+        let metadata = self.metadata();
+        let (limit, cases) = self.limits();
+        validate_limits(
+            metadata,
+            limit,
+            cases,
+            matches!(self, Self::AnnularRing(_) | Self::CopperLength(_)),
+        )
+    }
+
+    fn configured_ids(&self) -> Vec<String> {
+        let metadata = self.metadata();
+        let (limit, cases) = self.limits();
+        match limit {
+            Some(limit) => limit.ids(&metadata.id),
+            None => cases
+                .iter()
+                .flat_map(|case| case.limit.ids(&format!("{}.{}", metadata.id, case.id)))
+                .collect(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -390,8 +459,6 @@ pub struct RuleMetadata {
     #[serde(default)]
     pub profiles: Vec<String>,
     #[serde(default)]
-    pub when: RuleConditions,
-    #[serde(default)]
     pub source: Option<String>,
 }
 
@@ -405,37 +472,47 @@ impl RuleMetadata {
 #[serde(deny_unknown_fields)]
 pub struct RuleConditions {
     #[serde(default)]
-    pub minimum_copper_layers: Option<u32>,
+    pub copper_layers: Option<CountRange>,
     #[serde(default)]
-    pub maximum_copper_layers: Option<u32>,
-    #[serde(default)]
-    pub layer: Option<LayerPosition>,
-    #[serde(default)]
-    pub copper_weight: Option<CopperWeight>,
+    pub copper: Option<CopperCondition>,
 }
 
 impl RuleConditions {
     fn validate(&self, id: &str) -> Result<()> {
-        for (name, count) in [
-            ("minimum_copper_layers", self.minimum_copper_layers),
-            ("maximum_copper_layers", self.maximum_copper_layers),
-        ] {
-            if count == Some(0) {
-                bail!("rule '{id}' {name} must be a positive integer");
-            }
-        }
-        if let (Some(minimum), Some(maximum)) =
-            (self.minimum_copper_layers, self.maximum_copper_layers)
-            && minimum > maximum
-        {
-            bail!(
-                "rule '{id}' minimum_copper_layers ({minimum}) must not exceed maximum_copper_layers ({maximum})"
-            );
-        }
-        if self.copper_weight.is_some() && self.layer.is_none() {
-            bail!("rule '{id}' copper_weight requires a layer condition");
+        if let Some(range) = &self.copper_layers {
+            range.validate(&format!("rule '{id}' when.copper_layers"))?;
         }
         Ok(())
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        let layers_overlap = match (&self.copper_layers, &other.copper_layers) {
+            (Some(left), Some(right)) => left.overlaps(right),
+            _ => true,
+        };
+        let copper_overlap = match (&self.copper, &other.copper) {
+            (Some(left), Some(right)) => left.overlaps(right),
+            _ => true,
+        };
+        layers_overlap && copper_overlap
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CopperCondition {
+    pub position: LayerPosition,
+    #[serde(default)]
+    pub weight: Option<CopperWeight>,
+}
+
+impl CopperCondition {
+    fn overlaps(&self, other: &Self) -> bool {
+        self.position == other.position
+            && match (&self.weight, &other.weight) {
+                (Some(left), Some(right)) => (left.ounces() - right.ounces()).abs() <= 0.02,
+                _ => true,
+            }
     }
 }
 
@@ -448,73 +525,91 @@ pub enum LayerPosition {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct CountRule {
-    #[serde(flatten)]
-    pub metadata: RuleMetadata,
-    #[serde(default)]
-    pub minimum: Option<u32>,
-    #[serde(default)]
-    pub maximum: Option<u32>,
-}
-
-impl CountRule {
-    fn validate(&self) -> Result<()> {
-        if self.minimum.is_none() && self.maximum.is_none() {
-            bail!(
-                "rule '{}' requires minimum, maximum, or both",
-                self.metadata.id
-            );
-        }
-        for (name, count) in [("minimum", self.minimum), ("maximum", self.maximum)] {
-            if count == Some(0) {
-                bail!(
-                    "rule '{}' {name} must be a positive integer",
-                    self.metadata.id
-                );
-            }
-        }
-        if let (Some(minimum), Some(maximum)) = (self.minimum, self.maximum)
-            && minimum > maximum
-        {
-            bail!(
-                "rule '{}' minimum ({minimum}) must not exceed maximum ({maximum})",
-                self.metadata.id
-            );
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct LengthRule {
-    #[serde(flatten)]
-    pub metadata: RuleMetadata,
+pub struct LengthLimit {
     pub minimum: Length,
     #[serde(default)]
     pub preferred: Option<Length>,
 }
 
-impl LengthRule {
-    fn validate(&self) -> Result<()> {
-        validate_length(&self.metadata, &self.minimum, self.preferred.as_ref())
+impl LengthLimit {
+    fn validate(&self, id: &str) -> Result<()> {
+        if let Some(preferred) = &self.preferred
+            && preferred.millimeters() <= self.minimum.millimeters()
+        {
+            bail!(
+                "rule '{id}': preferred limit {} must exceed the minimum {}",
+                preferred.original(),
+                self.minimum.original()
+            );
+        }
+        Ok(())
+    }
+
+    fn ids(&self, id: &str) -> Vec<String> {
+        std::iter::once(id.to_owned())
+            .chain(self.preferred.as_ref().map(|_| format!("{id}.preferred")))
+            .collect()
     }
 }
 
-fn validate_length(
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LengthCase {
+    pub id: String,
+    #[serde(default)]
+    pub when: RuleConditions,
+    pub limit: LengthLimit,
+}
+
+fn validate_limits(
     metadata: &RuleMetadata,
-    minimum: &Length,
-    preferred: Option<&Length>,
+    limit: Option<&LengthLimit>,
+    cases: &[LengthCase],
+    allow_copper_conditions: bool,
 ) -> Result<()> {
-    if let Some(preferred) = preferred
-        && preferred.millimeters() <= minimum.millimeters()
-    {
-        bail!(
-            "rule '{}': preferred limit {} must exceed the minimum {}",
-            metadata.id,
-            preferred.original(),
-            minimum.original()
-        );
+    match (limit, cases.is_empty()) {
+        (Some(limit), true) => return limit.validate(&metadata.id),
+        (None, false) => {}
+        (Some(_), false) => {
+            bail!(
+                "rule '{}': limit and cases are mutually exclusive",
+                metadata.id
+            )
+        }
+        (None, true) => bail!("rule '{}': requires limit or cases", metadata.id),
+    }
+
+    let mut ids = HashSet::new();
+    for case in cases {
+        if case.id.trim().is_empty() {
+            bail!("rule '{}': case ids must not be empty", metadata.id);
+        }
+        if !ids.insert(&case.id) {
+            bail!("rule '{}': duplicate case id '{}'", metadata.id, case.id);
+        }
+        case.when
+            .validate(&format!("{}.{}", metadata.id, case.id))?;
+        if case.when.copper.is_some() && !allow_copper_conditions {
+            bail!(
+                "rule '{}.{}': when.copper is supported only for copper rules",
+                metadata.id,
+                case.id
+            );
+        }
+        case.limit
+            .validate(&format!("{}.{}", metadata.id, case.id))?;
+    }
+    for (index, left) in cases.iter().enumerate() {
+        for right in &cases[index + 1..] {
+            if left.when.overlaps(&right.when) {
+                bail!(
+                    "rule '{}': cases '{}' and '{}' overlap",
+                    metadata.id,
+                    left.id,
+                    right.id
+                );
+            }
+        }
     }
     Ok(())
 }
@@ -524,10 +619,11 @@ fn validate_length(
 pub struct HoleDiameterRule {
     #[serde(flatten)]
     pub metadata: RuleMetadata,
-    pub hole: HoleKind,
-    pub minimum: Length,
+    pub select: HoleSelector,
     #[serde(default)]
-    pub preferred: Option<Length>,
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -535,10 +631,11 @@ pub struct HoleDiameterRule {
 pub struct SlotWidthRule {
     #[serde(flatten)]
     pub metadata: RuleMetadata,
-    pub plating: SlotPlating,
-    pub minimum: Length,
+    pub select: SlotSelector,
     #[serde(default)]
-    pub preferred: Option<Length>,
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -546,11 +643,11 @@ pub struct SlotWidthRule {
 pub struct HolePairRule {
     #[serde(flatten)]
     pub metadata: RuleMetadata,
-    pub first_hole: HoleKind,
-    pub second_hole: HoleKind,
-    pub minimum: Length,
+    pub select: HolePairSelector,
     #[serde(default)]
-    pub preferred: Option<Length>,
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -558,10 +655,47 @@ pub struct HolePairRule {
 pub struct AnnularRingRule {
     #[serde(flatten)]
     pub metadata: RuleMetadata,
-    pub hole: PlatedHoleKind,
-    pub minimum: Length,
+    pub select: PlatedHoleSelector,
     #[serde(default)]
-    pub preferred: Option<Length>,
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LengthRule {
+    #[serde(flatten)]
+    pub metadata: RuleMetadata,
+    #[serde(default)]
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HoleSelector {
+    pub hole: HoleKind,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SlotSelector {
+    pub plating: SlotPlating,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HolePairSelector {
+    pub first_hole: HoleKind,
+    pub second_hole: HoleKind,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlatedHoleSelector {
+    pub hole: PlatedHoleKind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -707,53 +841,82 @@ revision = "1"
 name = "Standard"
 technologies = ["rigid"]
 
+[profiles.standard.support]
+copper_layers = { minimum = 2, maximum = 10 }
+
 [profiles.standard.defaults]
 outer_copper_weight = "1 oz"
 
-[[rules.stackup.copper_layer_count]]
-id = "layers"
-minimum = 2
-maximum = 10
-
 [[rules.drilling.hole_diameter]]
 id = "via-hole"
-hole = "via"
-minimum = "0.2 mm"
+select = { hole = "via" }
+limit = { minimum = "0.2 mm" }
 
 [[rules.drilling.hole_to_hole_clearance]]
 id = "via-spacing"
-first_hole = "via"
-second_hole = "via"
-minimum = "10 mil"
+select = { first_hole = "via", second_hole = "via" }
+limit = { minimum = "10 mil" }
 
 [[rules.copper.annular_ring]]
 id = "via-ring"
-hole = "via"
-minimum = "100 um"
-preferred = "0.125 mm"
+select = { hole = "via" }
+limit = { minimum = "100 um", preferred = "0.125 mm" }
+
+[[rules.copper.feature_width]]
+id = "copper-width"
+cases = [
+  { id = "2-layer-outer", when = { copper_layers = { exact = 2 }, copper = { position = "outer", weight = "1 oz" } }, limit = { minimum = "0.1 mm" } },
+  { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 10 } }, limit = { minimum = "0.09 mm" } },
+]
 
 [[rules.panelization.board_spacing]]
 id = "array-spacing"
-minimum = "300 mil"
+limit = { minimum = "300 mil" }
 "#;
 
     #[test]
     fn parses_profiles_typed_rules_units_and_tiers() {
         let pdk = Pdk::parse(MIXED_UNIT_PDK).unwrap();
         pdk.validate_rule_references().unwrap();
-        assert_eq!(pdk.rules.stackup.copper_layer_count[0].minimum, Some(2));
-        assert_eq!(pdk.rules.stackup.copper_layer_count[0].maximum, Some(10));
+        let support = pdk.profiles["standard"]
+            .support
+            .copper_layers
+            .as_ref()
+            .unwrap();
+        assert_eq!(support.minimum(), Some(2));
+        assert_eq!(support.maximum(), Some(10));
         assert_eq!(
-            pdk.rules.drilling.hole_diameter[0].minimum.millimeters(),
+            pdk.rules.drilling.hole_diameter[0].select.hole,
+            HoleKind::Via
+        );
+        assert_eq!(
+            pdk.rules.drilling.hole_diameter[0]
+                .limit
+                .as_ref()
+                .unwrap()
+                .minimum
+                .millimeters(),
             0.2
         );
         assert!(
             (pdk.rules.drilling.hole_to_hole_clearance[0]
+                .limit
+                .as_ref()
+                .unwrap()
                 .minimum
                 .millimeters()
                 - 0.254)
                 .abs()
                 < 1e-12
+        );
+        assert_eq!(
+            pdk.rules.copper.feature_width[0].cases[0]
+                .when
+                .copper_layers
+                .as_ref()
+                .unwrap()
+                .exact,
+            Some(2)
         );
         assert_eq!(
             pdk.profiles["standard"]
@@ -792,18 +955,30 @@ minimum = "300 mil"
                 .validate_rule_references()
                 .is_err()
         );
+        let reserved = MIXED_UNIT_PDK.replace(
+            "id = \"via-hole\"",
+            "id = \"profile.support.copper_layers.minimum\"",
+        );
+        assert!(
+            Pdk::parse(&reserved)
+                .unwrap()
+                .validate_rule_references()
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate lowered PDK rule id")
+        );
     }
 
     #[test]
-    fn rejects_schema_v1_bare_lengths_and_invalid_conditions() {
+    fn rejects_old_shapes_bad_ranges_and_overlapping_cases() {
         assert!(
             Pdk::parse(&MIXED_UNIT_PDK.replace("schema_version = 2", "schema_version = 1"))
                 .is_err()
         );
         assert!(Pdk::parse(&MIXED_UNIT_PDK.replace("\"0.2 mm\"", "0.2")).is_err());
         let invalid = MIXED_UNIT_PDK.replace(
-            "id = \"via-hole\"",
-            "id = \"via-hole\"\nwhen = { minimum_copper_layers = 4, maximum_copper_layers = 2 }",
+            "limit = { minimum = \"0.2 mm\" }",
+            "cases = [{ id = \"bad\", when = { copper_layers = { minimum = 4, maximum = 2 } }, limit = { minimum = \"0.2 mm\" } }]",
         );
         assert!(
             Pdk::parse(&invalid)
@@ -812,8 +987,8 @@ minimum = "300 mil"
                 .is_err()
         );
         let unsupported = MIXED_UNIT_PDK.replace(
-            "id = \"via-hole\"",
-            "id = \"via-hole\"\nwhen = { layer = \"outer\" }",
+            "limit = { minimum = \"0.2 mm\" }",
+            "cases = [{ id = \"bad\", when = { copper = { position = \"outer\" } }, limit = { minimum = \"0.2 mm\" } }]",
         );
         assert!(
             Pdk::parse(&unsupported)
@@ -822,6 +997,18 @@ minimum = "300 mil"
                 .unwrap_err()
                 .to_string()
                 .contains("supported only for copper rules")
+        );
+        let overlapping = MIXED_UNIT_PDK.replace(
+            "{ id = \"multilayer\", when = { copper_layers = { minimum = 3, maximum = 10 } }, limit = { minimum = \"0.09 mm\" } }",
+            "{ id = \"overlap\", when = { copper_layers = { minimum = 2, maximum = 10 } }, limit = { minimum = \"0.09 mm\" } }",
+        );
+        assert!(
+            Pdk::parse(&overlapping)
+                .unwrap()
+                .validate_rule_references()
+                .unwrap_err()
+                .to_string()
+                .contains("overlap")
         );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
@@ -105,12 +105,25 @@ pub struct PdkIdentity {
     pub producibility_level: Option<&'static str>,
     pub technologies: Vec<&'static str>,
     pub coverage: Vec<String>,
+    pub support: PdkProfileSupport,
     pub defaults: PdkProfileDefaults,
     pub profile_source: Option<PdkSourceReference>,
     pub path: String,
     pub sha256: String,
     /// Exact resolved UTF-8 PDK TOML used by this check, without reserialization.
     pub source: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PdkProfileSupport {
+    pub copper_layers: Option<PdkCountRange>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PdkCountRange {
+    pub exact: Option<u32>,
+    pub minimum: Option<u32>,
+    pub maximum: Option<u32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -171,6 +184,15 @@ impl PdkIdentity {
                 .map(|technology| technology.label())
                 .collect(),
             coverage: definition.coverage.clone(),
+            support: PdkProfileSupport {
+                copper_layers: definition.support.copper_layers.as_ref().map(|range| {
+                    PdkCountRange {
+                        exact: range.exact,
+                        minimum: range.minimum,
+                        maximum: range.maximum,
+                    }
+                }),
+            },
             defaults: PdkProfileDefaults {
                 material: definition.defaults.material.clone(),
                 board_thickness: definition
@@ -295,7 +317,7 @@ impl RuleResult {
             waived_count: 0,
             skip_reason: None,
             view: rule.kind.view_recipe(),
-            tier: if rule.id.ends_with(".preferred") {
+            tier: if rule.severity == Severity::Warning {
                 "preferred"
             } else {
                 "required"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -10,8 +10,8 @@ use anyhow::Result;
 
 use super::design::HoleClass;
 use super::pdk::{
-    CopperWeight, HoleKind, LayerPosition, Length, Pdk, PlatedHoleKind, Profile, ProfileStatus,
-    RuleConditions, RuleMetadata, SlotPlating,
+    CopperWeight, HoleKind, LayerPosition, Length, LengthCase, LengthLimit, Pdk, PlatedHoleKind,
+    Profile, ProfileStatus, RuleConditions, RuleMetadata, SlotPlating,
 };
 use super::report::{Severity, ViewRecipe};
 
@@ -446,9 +446,9 @@ pub(super) fn pools(rules: &[Rule]) -> Pools {
         .fold(Pools::default(), |union, pools| union | pools)
 }
 
-/// Lower the selected profile's typed rules. Rules with no `profiles` selector
-/// apply to every executable profile in the kit. Required limits are errors;
-/// optional preferred limits become warning rules under `<id>.preferred`.
+/// Lower the selected profile's support envelope and typed rules. Rules with
+/// no `profiles` selector apply to every executable profile in the kit.
+/// Required limits are errors; optional preferred limits become warning rules.
 pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rule>> {
     pdk.validate_rule_references()?;
     let (profile_name, profile) = pdk.selected_profile(selected_profile)?;
@@ -459,39 +459,27 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
     }
 
     let mut rules = Vec::new();
-    for rule in &pdk.rules.stackup.copper_layer_count {
-        if !rule.metadata.applies_to(profile_name) {
-            continue;
-        }
-        let conditions = conditions(&rule.metadata.when, profile);
-        if let Some(limit) = rule.minimum {
+    if let Some(range) = &profile.support.copper_layers {
+        if let Some(limit) = range.minimum() {
             rules.push(Rule {
-                id: if rule.maximum.is_some() {
-                    format!("{}.minimum", rule.metadata.id)
-                } else {
-                    rule.metadata.id.clone()
-                },
-                title: "Minimum copper layer count".to_owned(),
+                id: "profile.support.copper_layers.minimum".to_owned(),
+                title: "Profile minimum copper layer count".to_owned(),
                 severity: Severity::Error,
                 comparison: Comparison::Minimum,
                 limit: LimitValue::Count(limit),
                 kind: RuleKind::CopperLayerCount,
-                conditions: conditions.clone(),
+                conditions: Conditions::default(),
             });
         }
-        if let Some(limit) = rule.maximum {
+        if let Some(limit) = range.maximum() {
             rules.push(Rule {
-                id: if rule.minimum.is_some() {
-                    format!("{}.maximum", rule.metadata.id)
-                } else {
-                    rule.metadata.id.clone()
-                },
-                title: "Maximum copper layer count".to_owned(),
+                id: "profile.support.copper_layers.maximum".to_owned(),
+                title: "Profile maximum copper layer count".to_owned(),
                 severity: Severity::Error,
                 comparison: Comparison::Maximum,
                 limit: LimitValue::Count(limit),
                 kind: RuleKind::CopperLayerCount,
-                conditions,
+                conditions: Conditions::default(),
             });
         }
     }
@@ -499,32 +487,38 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
     for rule in &pdk.rules.drilling.hole_diameter {
         rules.extend(lower_length_rule(
             &rule.metadata,
-            &rule.minimum,
-            rule.preferred.as_ref(),
+            rule.limit.as_ref(),
+            &rule.cases,
             profile_name,
             profile,
-            format!("Minimum {} hole diameter", hole_class(rule.hole).label()),
-            RuleKind::HoleDiameter(hole_class(rule.hole)),
+            format!(
+                "Minimum {} hole diameter",
+                hole_class(rule.select.hole).label()
+            ),
+            RuleKind::HoleDiameter(hole_class(rule.select.hole)),
         ));
     }
     for rule in &pdk.rules.drilling.slot_width {
         rules.extend(lower_length_rule(
             &rule.metadata,
-            &rule.minimum,
-            rule.preferred.as_ref(),
+            rule.limit.as_ref(),
+            &rule.cases,
             profile_name,
             profile,
-            format!("Minimum {} routed slot width", slot_label(rule.plating)),
-            RuleKind::SlotWidth(rule.plating),
+            format!(
+                "Minimum {} routed slot width",
+                slot_label(rule.select.plating)
+            ),
+            RuleKind::SlotWidth(rule.select.plating),
         ));
     }
     for rule in &pdk.rules.drilling.hole_to_hole_clearance {
-        let first = hole_class(rule.first_hole);
-        let second = hole_class(rule.second_hole);
+        let first = hole_class(rule.select.first_hole);
+        let second = hole_class(rule.select.second_hole);
         rules.extend(lower_length_rule(
             &rule.metadata,
-            &rule.minimum,
-            rule.preferred.as_ref(),
+            rule.limit.as_ref(),
+            &rule.cases,
             profile_name,
             profile,
             format!(
@@ -536,11 +530,11 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
         ));
     }
     for rule in &pdk.rules.copper.annular_ring {
-        let class = plated_hole_class(rule.hole);
+        let class = plated_hole_class(rule.select.hole);
         rules.extend(lower_length_rule(
             &rule.metadata,
-            &rule.minimum,
-            rule.preferred.as_ref(),
+            rule.limit.as_ref(),
+            &rule.cases,
             profile_name,
             profile,
             format!("Minimum {} annular ring", class.label()),
@@ -582,8 +576,8 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
         for rule in ruleset {
             rules.extend(lower_length_rule(
                 &rule.metadata,
-                &rule.minimum,
-                rule.preferred.as_ref(),
+                rule.limit.as_ref(),
+                &rule.cases,
                 profile_name,
                 profile,
                 title.to_owned(),
@@ -597,8 +591,8 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
 #[allow(clippy::too_many_arguments)]
 fn lower_length_rule(
     metadata: &RuleMetadata,
-    minimum: &Length,
-    preferred: Option<&Length>,
+    limit: Option<&LengthLimit>,
+    cases: &[LengthCase],
     profile_name: &str,
     profile: &Profile,
     title: String,
@@ -607,19 +601,52 @@ fn lower_length_rule(
     if !metadata.applies_to(profile_name) {
         return Vec::new();
     }
-    let conditions = conditions(&metadata.when, profile);
+    match limit {
+        Some(limit) => lower_limit(
+            &metadata.id,
+            limit,
+            &RuleConditions::default(),
+            profile,
+            title,
+            kind,
+        ),
+        None => cases
+            .iter()
+            .flat_map(|case| {
+                lower_limit(
+                    &format!("{}.{}", metadata.id, case.id),
+                    &case.limit,
+                    &case.when,
+                    profile,
+                    title.clone(),
+                    kind,
+                )
+            })
+            .collect(),
+    }
+}
+
+fn lower_limit(
+    id: &str,
+    limit: &LengthLimit,
+    when: &RuleConditions,
+    profile: &Profile,
+    title: String,
+    kind: RuleKind,
+) -> Vec<Rule> {
+    let conditions = conditions(when, profile);
     let required = Rule {
-        id: metadata.id.clone(),
+        id: id.to_owned(),
         title: title.clone(),
         severity: Severity::Error,
         comparison: Comparison::Minimum,
-        limit: LimitValue::Length(minimum.clone()),
+        limit: LimitValue::Length(limit.minimum.clone()),
         kind,
         conditions: conditions.clone(),
     };
     std::iter::once(required)
-        .chain(preferred.map(|preferred| Rule {
-            id: format!("{}.preferred", metadata.id),
+        .chain(limit.preferred.as_ref().map(|preferred| Rule {
+            id: format!("{id}.preferred"),
             title: format!("{title} (preferred)"),
             severity: Severity::Warning,
             comparison: Comparison::Minimum,
@@ -631,11 +658,15 @@ fn lower_length_rule(
 }
 
 fn conditions(rule: &RuleConditions, profile: &Profile) -> Conditions {
+    let copper_layers = rule.copper_layers.as_ref();
+    let copper = rule.copper.as_ref();
     Conditions {
-        minimum_copper_layers: rule.minimum_copper_layers,
-        maximum_copper_layers: rule.maximum_copper_layers,
-        layer: rule.layer,
-        copper_weight_oz: rule.copper_weight.as_ref().map(CopperWeight::ounces),
+        minimum_copper_layers: copper_layers.and_then(|range| range.minimum()),
+        maximum_copper_layers: copper_layers.and_then(|range| range.maximum()),
+        layer: copper.map(|condition| condition.position),
+        copper_weight_oz: copper
+            .and_then(|condition| condition.weight.as_ref())
+            .map(CopperWeight::ounces),
         assumed_outer_copper_weight_oz: profile
             .defaults
             .outer_copper_weight

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/scene.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/scene.rs
@@ -390,7 +390,7 @@ mod tests {
       name = "Test"
       [[rules.soldermask.web]]
       id = "mask-web"
-      minimum = "0.1 mm"
+      limit = { minimum = "0.1 mm" }
     "#;
 
     #[test]

--- a/crates/pcbc/tests/dfm.rs
+++ b/crates/pcbc/tests/dfm.rs
@@ -167,17 +167,12 @@ revision = "1"
 [profiles.test]
 name = "Test"
 
-[[rules.stackup.copper_layer_count]]
-id = "stackup.minimum_copper_layer_count"
-minimum = 3
-
-[[rules.stackup.copper_layer_count]]
-id = "stackup.maximum_copper_layer_count"
-maximum = 4
+[profiles.test.support]
+copper_layers = { minimum = 3, maximum = 4 }
 
 [[rules.copper.board_edge_clearance]]
 id = "copper.minimum_board_edge_clearance"
-minimum = "1 mm"
+limit = { minimum = "1 mm" }
 "#;
 
 fn read_report(sandbox: &Sandbox, path: &str) -> Value {
@@ -328,6 +323,10 @@ fn ipc_dfm_passing_json_still_includes_native_scene_and_pdk() {
     assert_eq!(report["summary"]["findings"], 0);
     assert!(report["findings"].as_array().unwrap().is_empty());
     assert_eq!(report["pdk"]["source"], pdk);
+    assert_eq!(
+        report["pdk"]["support"]["copper_layers"],
+        serde_json::json!({ "exact": null, "minimum": 2, "maximum": 4 })
+    );
     assert_eq!(report["scene"]["schema_version"], 1);
     let top = report["scene"]["passes"]
         .as_array()
@@ -605,7 +604,7 @@ fn ipc_dfm_geometry_distinguishes_canonical_board_arrays_and_mixed_fab_scope() {
         .write(
             "pdk.toml",
             format!(
-                "{REPORT_PDK}\n[[rules.panelization.board_spacing]]\nid = \"panelization.minimum_board_array_spacing\"\nminimum = \"7.62 mm\"\n"
+                "{REPORT_PDK}\n[[rules.panelization.board_spacing]]\nid = \"panelization.minimum_board_array_spacing\"\nlimit = {{ minimum = \"7.62 mm\" }}\n"
             ),
         );
     let mut spec = FabPanelSpec::INCHES_12_X_18;


### PR DESCRIPTION
This change separates profile support limits from DFM rule selection and groups conditional limits into named cases. It removes authored layer-count rules, rejects overlapping cases, and makes the Diode and JLCPCB PDKs easier to read and validate.