### PR TITLE
Add drilled feature board-edge DFM checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add strict profile-based DFM PDK schema v2, executable JLCPCB 1 oz profiles, and metadata-only IPC 1A-3C profiles.
 - Add maximum plated-hole aspect-ratio DFM checks and make IPC 1A-3C profiles executable with opinionated partial IPC-informed baselines.
 - Add circular drilled-hole-to-unrelated-copper DFM checks and extend the executable IPC 1A-3C partial baselines with opinionated IPC-informed values.
+- Add drilled-feature board-edge DFM checks and extend the executable IPC 1A-3C partial baselines with opinionated IPC-informed values.
 - Add a deterministic, versioned PCBA assembly report contract over canonical assembly and physical IR.
 - Expose PCBA assembly reports as JSON through `pcb ipc assembly`.
 - Preserve external part-library provenance and same-part MPN aliases in IPC-2581 BOM selections.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -66,6 +66,16 @@ id = "drilling.via_to_pth"
 select = { first_hole = "via", second_hole = "pth" }
 limit = { minimum = "10 mil" }
 
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "drilling.npth_to_board_edge"
+select = { hole = "npth" }
+limit = { minimum = "0.30 mm", preferred = "0.40 mm" }
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "drilling.nonplated_slot_to_board_edge"
+select = { plating = "nonplated" }
+limit = { minimum = "0.30 mm" }
+
 [[rules.copper.annular_ring]]
 id = "copper.via_annular_ring"
 select = { hole = "via" }
@@ -163,6 +173,8 @@ high-level pass is never allowed to suppress a later authoritative failure.
 | Nominal slot width | IPC slot primitive width | None |
 | Outline slot width | Materialized filled route outline, then its narrowest maximal inscribed disk | None |
 | Hole-to-hole clearance | Materialized drill circles and overlapping drill spans | Sorted bounds prune pairs already proven clear |
+| Hole-to-board-edge clearance | Analytic drill circle against its enclosing physical board profile, including cutouts | Indexed profile boundaries |
+| Slot-to-board-edge clearance | Materialized filled route outline against its enclosing physical board profile, including cutouts | Indexed profile boundaries |
 | Annular ring | Drill circle and final composed copper image on each applicable layer | Batched containment and an indexed copper boundary |
 | Hole-to-copper clearance | Analytic drill circle and attributed final composed copper on each layer in its drill span | Indexed attributed-copper boundaries |
 | Copper width | Final composed copper image, medial-axis width of each residue | Guarded opening localizes candidates |
@@ -248,6 +260,12 @@ when fewer than two exist.
 - Hole-to-hole clearance measures edge-to-edge distance between hole pairs
   whose drill spans overlap; stacked blind and buried vias on disjoint spans
   do not interact.
+- Hole- and slot-to-board-edge clearance measure true edge-to-edge distance
+  from each circular hole or materialized routed-slot outline to the boundary
+  of its enclosing physical board profile. Profile cutouts are board edges.
+  The profile must have the feature's exact physical occurrence, so a repeated
+  board never measures against another board or its panel outline. A feature
+  crossing or outside its board material has zero clearance.
 - Annular ring measures the radial copper enclosure of each via or PTH hole
   on every applicable layer. A genuine intermediate plane anti-pad with no
   matching source land has no ring to measure. Both terminal layers, and any
@@ -332,13 +350,15 @@ crossed with Producibility Levels A-C, but they are executable **partial Diode
 baselines**, not IPC profile matrices. They check maximum via and PTH aspect
 ratio at 6.0 for Level A, 8.0 for Level B, and 10.0 for Level C. They also
 check via, PTH, and NPTH hole-to-copper clearance at 0.25 mm for Level A,
-0.20 mm for Level B, and 0.15 mm for Level C. These values apply across all
-three performance classes. Each profile assumes 1.6 mm board thickness for the
-through-hole aspect-ratio fallback described above. Diode chose these
-opinionated values using IPC design topics as context; they are not licensed
-IPC numeric matrices, do not prove full IPC compliance, and do not imply IPC
-certification. A pass covers only the checks listed in the selected profile's
-`coverage` metadata.
+0.20 mm for Level B, and 0.15 mm for Level C. They check via, PTH, NPTH,
+plated-slot, and nonplated-slot clearance to the board edge at 0.50 mm for
+Level A, 0.40 mm for Level B, and 0.30 mm for Level C. These values apply
+across all three performance classes. Each profile assumes 1.6 mm board
+thickness for the through-hole aspect-ratio fallback described above. Diode
+chose these opinionated values using IPC design topics as context; they are not
+licensed IPC numeric matrices, do not prove full IPC compliance, and do not
+imply IPC certification. A pass covers only the checks listed in the selected
+profile's `coverage` metadata.
 
 Output is UTF-8 JSON on stdout unless `-o` / `--output` is supplied. The
 recommended suffix is `.dfm.json`. Every complete report includes the native
@@ -461,9 +481,11 @@ consumer's machine to render or validate the report.
 - `sites` retain individual failing regions or layers with their measurement,
   `measurement_kind`, `witnesses`, uncertainty, bounds, layers, subjects, and
   evidence. Nonspatial findings use `sites: []`. Site bounds describe the
-  finding; viewers add their own camera padding. Witness-point separation is
-  not necessarily the measured width or diameter. Scalar aspect-ratio sites
-  have no measurement witnesses; their circle evidence locates the hole.
+  finding; viewers add their own camera padding. `outside_board` identifies a
+  drilled feature that crosses or lies outside its physical board material and
+  therefore has zero clearance. Witness-point separation is not necessarily
+  the measured width or diameter. Scalar aspect-ratio sites have no measurement
+  witnesses; their circle evidence locates the hole.
 - `group_key`, when available, groups proven equivalent causes for display.
   It does not replace the finding id or change the waiver unit. Every finding
   and physical occurrence remains accessible.

--- a/crates/pcb-ipc2581-tools/examples/dfm-pdk.toml
+++ b/crates/pcb-ipc2581-tools/examples/dfm-pdk.toml
@@ -38,6 +38,16 @@ cases = [
   { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 10 } }, limit = { minimum = "0.35 mm" } },
 ]
 
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "drilling.npth_to_board_edge"
+select = { hole = "npth" }
+limit = { minimum = "0.30 mm", preferred = "0.40 mm" }
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "drilling.nonplated_slot_to_board_edge"
+select = { plating = "nonplated" }
+limit = { minimum = "0.30 mm" }
+
 [[rules.copper.annular_ring]]
 id = "copper.via_annular_ring"
 select = { hole = "via" }

--- a/crates/pcb-ipc2581-tools/pdks/ipc.toml
+++ b/crates/pcb-ipc2581-tools/pdks/ipc.toml
@@ -20,7 +20,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm"]
 source = "ipc-design-topics"
 
 [profiles.1a.defaults]
@@ -32,7 +32,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm"]
 source = "ipc-design-topics"
 
 [profiles.1b.defaults]
@@ -44,7 +44,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm"]
 source = "ipc-design-topics"
 
 [profiles.1c.defaults]
@@ -56,7 +56,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm"]
 source = "ipc-design-topics"
 
 [profiles.2a.defaults]
@@ -68,7 +68,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm"]
 source = "ipc-design-topics"
 
 [profiles.2b.defaults]
@@ -80,7 +80,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm"]
 source = "ipc-design-topics"
 
 [profiles.2c.defaults]
@@ -92,7 +92,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm"]
 source = "ipc-design-topics"
 
 [profiles.3a.defaults]
@@ -104,7 +104,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm"]
 source = "ipc-design-topics"
 
 [profiles.3b.defaults]
@@ -116,7 +116,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm"]
 source = "ipc-design-topics"
 
 [profiles.3c.defaults]
@@ -225,4 +225,109 @@ id = "diode.ipc_baseline.copper.npth_hole_clearance.level_c"
 profiles = ["1c", "2c", "3c"]
 select = { hole = "npth" }
 limit = { minimum = "0.15 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_via_hole_to_board_edge_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { hole = "via" }
+limit = { minimum = "0.50 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_pth_hole_to_board_edge_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { hole = "pth" }
+limit = { minimum = "0.50 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_npth_hole_to_board_edge_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { hole = "npth" }
+limit = { minimum = "0.50 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_plated_slot_to_board_edge_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { plating = "plated" }
+limit = { minimum = "0.50 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_nonplated_slot_to_board_edge_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { plating = "nonplated" }
+limit = { minimum = "0.50 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_via_hole_to_board_edge_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { hole = "via" }
+limit = { minimum = "0.40 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_pth_hole_to_board_edge_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { hole = "pth" }
+limit = { minimum = "0.40 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_npth_hole_to_board_edge_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { hole = "npth" }
+limit = { minimum = "0.40 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_plated_slot_to_board_edge_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { plating = "plated" }
+limit = { minimum = "0.40 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_nonplated_slot_to_board_edge_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { plating = "nonplated" }
+limit = { minimum = "0.40 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_via_hole_to_board_edge_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { hole = "via" }
+limit = { minimum = "0.30 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_pth_hole_to_board_edge_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { hole = "pth" }
+limit = { minimum = "0.30 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_npth_hole_to_board_edge_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { hole = "npth" }
+limit = { minimum = "0.30 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_plated_slot_to_board_edge_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { plating = "plated" }
+limit = { minimum = "0.30 mm" }
+source = "ipc-design-topics"
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_nonplated_slot_to_board_edge_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { plating = "nonplated" }
+limit = { minimum = "0.30 mm" }
 source = "ipc-design-topics"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -561,24 +561,29 @@ limit = { minimum = "300 mil" }
 
         for builtin in builtin_pdks() {
             let parsed = pdk::Pdk::parse(builtin.source).unwrap();
-            let lowered = rules::lower(&parsed, Some(builtin.profile));
-            let (_, profile) = parsed.selected_profile(Some(builtin.profile)).unwrap();
-            if profile.status == pdk::ProfileStatus::MetadataOnly {
-                assert!(lowered.unwrap_err().to_string().contains("metadata-only"));
-            } else {
-                assert!(!lowered.unwrap().is_empty());
-            }
+            assert!(
+                !rules::lower(&parsed, Some(builtin.profile))
+                    .unwrap()
+                    .is_empty()
+            );
         }
 
         let ipc = builtin_pdks().iter().find(|pdk| pdk.name == "ipc").unwrap();
         let parsed = pdk::Pdk::parse(ipc.source).unwrap();
+        assert_eq!(parsed.rules.drilling.hole_to_board_edge_clearance.len(), 9);
+        assert_eq!(parsed.rules.drilling.slot_to_board_edge_clearance.len(), 6);
+        assert_eq!(parsed.rules.drilling.hole_aspect_ratio.len(), 6);
+        assert_eq!(parsed.rules.copper.hole_clearance.len(), 9);
         assert_eq!(parsed.pdk.manufacturer.as_deref(), Some("Diode"));
         for class in 1..=3 {
-            for (level, maximum, clearance) in
-                [('a', 6.0, 0.25), ('b', 8.0, 0.20), ('c', 10.0, 0.15)]
-            {
+            for (level, maximum, copper_clearance, edge_clearance) in [
+                ('a', 6.0, 0.25, 0.50),
+                ('b', 8.0, 0.20, 0.40),
+                ('c', 10.0, 0.15, 0.30),
+            ] {
                 let profile = format!("{class}{level}");
                 let definition = &parsed.profiles[&profile];
+                assert_eq!(definition.status, pdk::ProfileStatus::Executable);
                 assert_eq!(definition.performance_class, Some(class));
                 assert_eq!(
                     definition.producibility_level.unwrap().label(),
@@ -594,7 +599,7 @@ limit = { minimum = "300 mil" }
                     1.6
                 );
                 let rules = rules::lower(&parsed, Some(&profile)).unwrap();
-                assert_eq!(rules.len(), 5);
+                assert_eq!(rules.len(), 10);
                 let aspect_ratio = rules
                     .iter()
                     .filter(|rule| matches!(rule.kind, rules::RuleKind::HoleAspectRatio(_)))
@@ -616,7 +621,32 @@ limit = { minimum = "300 mil" }
                 assert!(
                     hole_clearance
                         .iter()
-                        .all(|rule| rule.limit.length().millimeters() == clearance)
+                        .all(|rule| rule.limit.length().millimeters() == copper_clearance)
+                );
+
+                let hole_to_edge = rules
+                    .iter()
+                    .filter(|rule| {
+                        matches!(rule.kind, rules::RuleKind::HoleToBoardEdgeClearance(_))
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(hole_to_edge.len(), 3);
+                assert!(
+                    hole_to_edge
+                        .iter()
+                        .all(|rule| rule.limit.length().millimeters() == edge_clearance)
+                );
+                let slot_to_edge = rules
+                    .iter()
+                    .filter(|rule| {
+                        matches!(rule.kind, rules::RuleKind::SlotToBoardEdgeClearance(_))
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(slot_to_edge.len(), 2);
+                assert!(
+                    slot_to_edge
+                        .iter()
+                        .all(|rule| rule.limit.length().millimeters() == edge_clearance)
                 );
             }
         }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/drilled_board_edge_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/drilled_board_edge_clearance.rs
@@ -1,0 +1,602 @@
+//! Minimum clearance from drilled features to their physical board edge.
+//!
+//! A hole is an analytic closed disk and a routed slot is its materialized
+//! filled outline. Each feature is paired only with a board profile from the
+//! same physical Step occurrence. The profile region is its outer boundary
+//! minus every cutout. For a feature fully inside that region, the measured
+//! quantity is the Euclidean distance between the feature boundary and the
+//! profile boundary. A feature that crosses or lies outside its board region
+//! has zero clearance.
+
+use pcb_ir::geom::dfm::{Distance, circular_region};
+use pcb_ir::geom::region::ring_edges;
+use pcb_ir::geom::{BBox, Point};
+
+use crate::commands::dfm::design::{BoardOutline, Design, Hole, HoleClass, Slot};
+use crate::commands::dfm::pdk::SlotPlating;
+use crate::commands::dfm::report::{Evidence, EvidenceDisplay, MeasurementKind};
+
+use super::{
+    Evaluation, Measured, MeasuredSite, hole_subject, linework_clearance, slot_matches,
+    slot_subject,
+};
+
+pub(super) fn evaluate_holes(limit_mm: f64, class: HoleClass, design: &Design) -> Evaluation {
+    let holes = design
+        .holes
+        .iter()
+        .filter(|hole| hole.class == class)
+        .collect::<Vec<_>>();
+    let measured = holes
+        .iter()
+        .filter_map(|&hole| {
+            let outline = enclosing_outline(
+                &design.board_outlines,
+                hole.provenance.instance_index,
+                hole.center,
+            );
+            let (distance, outside) = hole_clearance(hole, outline, limit_mm)?;
+            Some(measured_hole(
+                design, hole, outline, distance, outside, limit_mm,
+            ))
+        })
+        .collect();
+    Evaluation {
+        checked: holes.len(),
+        measured,
+    }
+}
+
+pub(super) fn evaluate_slots(limit_mm: f64, plating: SlotPlating, design: &Design) -> Evaluation {
+    let slots = design
+        .slots
+        .iter()
+        .filter(|slot| slot_matches(slot.plating, plating))
+        .collect::<Vec<_>>();
+    let measured = slots
+        .iter()
+        .filter_map(|&slot| {
+            let outline = enclosing_outline(
+                &design.board_outlines,
+                slot.provenance.instance_index,
+                slot.bbox.center(),
+            );
+            let (distance, outside) = slot_clearance(slot, outline, limit_mm)?;
+            Some(measured_slot(
+                design, slot, outline, distance, outside, limit_mm,
+            ))
+        })
+        .collect();
+    Evaluation {
+        checked: slots.len(),
+        measured,
+    }
+}
+
+/// Select only among profiles carrying the feature's occurrence identity.
+/// Containment breaks ties between multiple physical profiles in one Step;
+/// bounds distance gives an outside feature a deterministic related profile.
+fn enclosing_outline(
+    outlines: &[BoardOutline],
+    instance_index: Option<u32>,
+    point: Point,
+) -> Option<&BoardOutline> {
+    outlines
+        .iter()
+        .filter(|outline| outline.instance_index == instance_index)
+        .min_by(|left, right| {
+            let left_outside = !left.region.contains_point(point);
+            let right_outside = !right.region.contains_point(point);
+            left_outside
+                .cmp(&right_outside)
+                .then_with(|| {
+                    left.bbox
+                        .distance_to(BBox::from_point(point))
+                        .total_cmp(&right.bbox.distance_to(BBox::from_point(point)))
+                })
+                .then_with(|| left.region.area().total_cmp(&right.region.area()))
+        })
+}
+
+/// `None` proves the hole clears the limit. A returned distance is either a
+/// sub-limit inner clearance or the required zero for an outside/crossing hole.
+fn hole_clearance(
+    hole: &Hole,
+    outline: Option<&BoardOutline>,
+    limit_mm: f64,
+) -> Option<(Distance, bool)> {
+    let Some(outline) = outline else {
+        return Some((Distance::exact(0.0, hole.center, hole.center), true));
+    };
+    if !outline.region.contains_point(hole.center) {
+        return Some((
+            zero_hole_clearance(hole, outline, broad_search(hole.bbox, outline.bbox)),
+            true,
+        ));
+    }
+    let distance =
+        outline
+            .boundary
+            .circular_enclosure(hole.center, hole.diameter_mm / 2.0, limit_mm)?;
+    if distance.mm <= 0.0 {
+        Some((
+            Distance::flattened(0.0, distance.first, distance.second, 1),
+            true,
+        ))
+    } else {
+        Some((distance, false))
+    }
+}
+
+fn zero_hole_clearance(hole: &Hole, outline: &BoardOutline, search_mm: f64) -> Distance {
+    let Some(nearest) = outline.boundary.nearest_within(hole.center, search_mm) else {
+        return Distance::exact(0.0, hole.center, hole.center);
+    };
+    let radial = nearest.second - hole.center;
+    let direction = if radial.length() <= f64::EPSILON {
+        Point::new(1.0, 0.0)
+    } else {
+        radial / radial.length()
+    };
+    Distance::flattened(
+        0.0,
+        hole.center + direction * (hole.diameter_mm / 2.0),
+        nearest.second,
+        1,
+    )
+}
+
+fn slot_clearance(
+    slot: &Slot,
+    outline: Option<&BoardOutline>,
+    limit_mm: f64,
+) -> Option<(Distance, bool)> {
+    let Some(outline) = outline else {
+        let point = slot.bbox.center();
+        return Some((Distance::exact(0.0, point, point), true));
+    };
+    let outside = !slot.outline.difference(&outline.region).is_empty();
+    let search_mm = if outside {
+        broad_search(slot.bbox, outline.bbox)
+    } else {
+        limit_mm
+    };
+    let distance = slot
+        .outline
+        .rings
+        .iter()
+        .flat_map(ring_edges)
+        .filter_map(|(start, end)| {
+            outline
+                .boundary
+                .segment_nearest_within(start, end, search_mm)
+        })
+        .min_by(|left, right| left.mm.total_cmp(&right.mm))?
+        .also_flattened(1);
+    if outside {
+        Some((
+            Distance::flattened(0.0, distance.first, distance.second, 2),
+            true,
+        ))
+    } else {
+        Some((distance, false))
+    }
+}
+
+fn broad_search(feature: BBox, outline: BBox) -> f64 {
+    let bounds = feature.union(outline);
+    bounds.width().hypot(bounds.height()).max(1.0)
+}
+
+fn measured_hole(
+    design: &Design,
+    hole: &Hole,
+    outline: Option<&BoardOutline>,
+    distance: Distance,
+    outside: bool,
+    limit_mm: f64,
+) -> Measured {
+    let feature = Evidence::circle("drilled_hole", hole.center, hole.diameter_mm);
+    let mut evidence = vec![feature.clone()];
+    let mut site_evidence = vec![
+        feature,
+        Evidence::circle(
+            "required_board_edge_clearance",
+            hole.center,
+            hole.diameter_mm + 2.0 * limit_mm,
+        ),
+    ];
+    let mut subjects = vec![hole_subject(design, hole, "offender")];
+    if let Some(outline) = outline {
+        subjects.push(linework_clearance::outline_subject(outline, "reference"));
+        evidence.push(Evidence::bounds("board_profile", outline.bbox));
+        site_evidence.push(profile_evidence(outline));
+        if outside {
+            let outside_region =
+                circular_region(hole.center, hole.diameter_mm / 2.0).difference(&outline.region);
+            if !outside_region.is_empty() {
+                site_evidence.push(Evidence::region("outside_board_material", &outside_region));
+            }
+        }
+    }
+    let mut site = MeasuredSite::new(
+        distance,
+        local_bounds(hole.bbox, distance, limit_mm),
+        vec![hole.layer.clone()],
+        site_evidence,
+        if outside {
+            MeasurementKind::OutsideBoard
+        } else {
+            MeasurementKind::Clearance
+        },
+    );
+    if outside {
+        site.note = Some(outside_note(outline.is_some()));
+    }
+    Measured {
+        distance,
+        bbox: hole.bbox,
+        layers: vec![hole.layer.clone()],
+        subjects,
+        evidence,
+        sites: vec![site],
+    }
+}
+
+fn measured_slot(
+    design: &Design,
+    slot: &Slot,
+    outline: Option<&BoardOutline>,
+    distance: Distance,
+    outside: bool,
+    limit_mm: f64,
+) -> Measured {
+    let feature = slot_evidence(slot);
+    let mut evidence = vec![Evidence::bounds("routed_slot", slot.bbox)];
+    let mut site_evidence = vec![feature];
+    let clearance_region = slot.outline.disk_dilate(limit_mm);
+    site_evidence.push(Evidence::region(
+        "required_board_edge_clearance",
+        &clearance_region,
+    ));
+    let mut subjects = vec![slot_subject(design, slot, "offender")];
+    if let Some(outline) = outline {
+        subjects.push(linework_clearance::outline_subject(outline, "reference"));
+        evidence.push(Evidence::bounds("board_profile", outline.bbox));
+        site_evidence.push(profile_evidence(outline));
+        if outside {
+            let outside_region = slot.outline.difference(&outline.region);
+            if !outside_region.is_empty() {
+                site_evidence.push(Evidence::region("outside_board_material", &outside_region));
+            }
+        }
+    }
+    let mut site = MeasuredSite::new(
+        distance,
+        local_bounds(slot.bbox, distance, limit_mm),
+        vec![slot.layer.clone()],
+        site_evidence,
+        if outside {
+            MeasurementKind::OutsideBoard
+        } else {
+            MeasurementKind::Clearance
+        },
+    );
+    if outside {
+        site.note = Some(outside_note(outline.is_some()));
+    }
+    Measured {
+        distance,
+        bbox: slot.bbox,
+        layers: vec![slot.layer.clone()],
+        subjects,
+        evidence,
+        sites: vec![site],
+    }
+}
+
+fn slot_evidence(slot: &Slot) -> Evidence {
+    Evidence {
+        display: Some(EvidenceDisplay::Path {
+            paths: slot
+                .native_outline
+                .iter()
+                .map(|contour| pcb_ir::render::svg_path_data(std::slice::from_ref(contour)))
+                .collect(),
+            fill_rule: "evenodd",
+        }),
+        ..Evidence::region("routed_slot", &slot.outline)
+    }
+}
+
+fn profile_evidence(outline: &BoardOutline) -> Evidence {
+    Evidence {
+        display: Some(EvidenceDisplay::Path {
+            paths: vec![pcb_ir::render::svg_path_data(&outline.native_outline)],
+            fill_rule: "evenodd",
+        }),
+        ..Evidence::region("board_profile", &outline.region)
+    }
+}
+
+fn local_bounds(feature: BBox, distance: Distance, limit_mm: f64) -> BBox {
+    feature
+        .union(BBox::from_point(distance.first))
+        .union(BBox::from_point(distance.second))
+        .expand(limit_mm)
+}
+
+fn outside_note(has_profile: bool) -> String {
+    if has_profile {
+        "The drilled feature crosses or lies outside its physical board profile; its clearance is zero."
+    } else {
+        "The drilled feature has no physical board profile in its Step occurrence; its clearance is zero."
+    }
+    .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LayoutTarget;
+    use crate::commands::dfm::report::{Measurement, RuleStatus, Verdict};
+    use crate::commands::dfm::{CheckRequest, PdkSource, TextSource};
+    use crate::ipc2581::Ipc2581;
+    use pcb_ir::import::ipc2581::import_design;
+
+    fn pdk(rules: &str) -> String {
+        format!(
+            r#"schema_version = 2
+default_profile = "test"
+
+[pdk]
+id = "edge-test"
+name = "Edge test"
+revision = "1"
+
+[profiles.test]
+name = "Test"
+
+{rules}
+"#
+        )
+    }
+
+    fn board(features: &str, cutout: &str) -> String {
+        format!(
+            r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/><LayerRef name="DRILL"/><LayerRef name="ROUT"/></Content>
+  <Ecad><CadHeader units="MILLIMETER"/><CadData>
+    <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE"/>
+    <Layer name="ROUT" layerFunction="ROUT" side="ALL" polarity="POSITIVE"/>
+    <Step name="board" type="BOARD">
+      <Profile><Polygon>
+        <PolyBegin x="0" y="0"/><PolyStepSegment x="10" y="0"/>
+        <PolyStepSegment x="10" y="10"/><PolyStepSegment x="0" y="10"/>
+        <PolyStepSegment x="0" y="0"/>
+      </Polygon>{cutout}</Profile>
+      {features}
+    </Step>
+  </CadData></Ecad>
+</IPC-2581>"#
+        )
+    }
+
+    fn check(xml: &str, pdk_source: &str, target: LayoutTarget) -> super::super::super::DfmReport {
+        let imported = import_design(&Ipc2581::parse(xml).unwrap()).unwrap();
+        super::super::super::check(
+            &imported,
+            CheckRequest {
+                input: crate::commands::dfm::report::FileIdentity::new(
+                    "edge-test.xml",
+                    xml.as_bytes(),
+                ),
+                pdk: PdkSource::Toml(TextSource {
+                    path: "edge-test.toml",
+                    source: pdk_source,
+                }),
+                waivers: None,
+                layout_target: target,
+                generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            },
+        )
+        .unwrap()
+    }
+
+    fn actual_mm(measurement: &Measurement) -> f64 {
+        measurement.actual_mm().unwrap()
+    }
+
+    #[test]
+    fn circular_holes_pass_and_fail_on_true_edge_clearance_with_native_evidence() {
+        let xml = board(
+            r#"<LayerFeature layerRef="DRILL"><Set>
+              <Hole name="pass" diameter="1" platingStatus="PLATED" x="5" y="2"/>
+              <Hole name="fail" diameter="1" platingStatus="PLATED" x="0.7" y="2"/>
+            </Set></LayerFeature>"#,
+            "",
+        );
+        let pdk = pdk(r#"[[rules.drilling.hole_to_board_edge_clearance]]
+id = "pth-edge"
+select = { hole = "pth" }
+limit = { minimum = "0.3 mm", preferred = "0.4 mm" }"#);
+        let report = check(&xml, &pdk, LayoutTarget::Board);
+
+        assert!(matches!(report.verdict, Verdict::Fail));
+        assert_eq!(report.rules[0].checked, 2);
+        assert!(matches!(report.rules[0].status, RuleStatus::Fail));
+        assert_eq!(report.rules[1].checked, 2, "preferred tier is lowered");
+        assert_eq!(report.findings.len(), 2);
+        let required = report
+            .findings
+            .iter()
+            .find(|finding| finding.rule_id == "pth-edge")
+            .unwrap();
+        assert!((actual_mm(&required.measurement) - 0.2).abs() < 1e-9);
+        assert_eq!(required.layers[0].name, "DRILL");
+        assert_eq!(required.subjects[0].kind, "plated_hole");
+        assert_eq!(required.subjects[1].kind, "board_outline");
+        assert_eq!(required.location.witnesses.len(), 2);
+        let site = &required.sites[0];
+        assert!(matches!(site.measurement_kind, MeasurementKind::Clearance));
+        assert!(site.evidence.iter().any(|evidence| {
+            evidence.role == "board_profile"
+                && matches!(evidence.display, Some(EvidenceDisplay::Path { .. }))
+        }));
+        assert!(site.evidence.iter().any(|evidence| {
+            evidence.role == "drilled_hole"
+                && evidence.kind == "circle"
+                && evidence.diameter == Some(1.0)
+        }));
+    }
+
+    #[test]
+    fn crossing_and_outside_holes_have_zero_clearance() {
+        let xml = board(
+            r#"<LayerFeature layerRef="DRILL"><Set>
+              <Hole name="crossing" diameter="0.5" platingStatus="NONPLATED" x="0.2" y="2"/>
+              <Hole name="outside" diameter="0.5" platingStatus="NONPLATED" x="-1" y="2"/>
+            </Set></LayerFeature>"#,
+            "",
+        );
+        let pdk = pdk(r#"[[rules.drilling.hole_to_board_edge_clearance]]
+id = "npth-edge"
+select = { hole = "npth" }
+limit = { minimum = "0.3 mm" }"#);
+        let report = check(&xml, &pdk, LayoutTarget::Board);
+
+        assert_eq!(report.rules[0].checked, 2);
+        assert_eq!(report.findings.len(), 2);
+        assert!(
+            report
+                .findings
+                .iter()
+                .all(|finding| actual_mm(&finding.measurement) == 0.0)
+        );
+        assert!(report.findings.iter().all(|finding| matches!(
+            finding.sites[0].measurement_kind,
+            MeasurementKind::OutsideBoard
+        )));
+    }
+
+    #[test]
+    fn profile_cutouts_are_physical_board_edges() {
+        let xml = board(
+            r#"<LayerFeature layerRef="DRILL"><Set>
+              <Hole name="cutout-edge" diameter="0.4" platingStatus="VIA" x="3.7" y="5"/>
+            </Set></LayerFeature>"#,
+            r#"<Cutout>
+              <PolyBegin x="4" y="4"/><PolyStepSegment x="6" y="4"/>
+              <PolyStepSegment x="6" y="6"/><PolyStepSegment x="4" y="6"/>
+              <PolyStepSegment x="4" y="4"/>
+            </Cutout>"#,
+        );
+        let pdk = pdk(r#"[[rules.drilling.hole_to_board_edge_clearance]]
+id = "via-edge"
+select = { hole = "via" }
+limit = { minimum = "0.2 mm" }"#);
+        let report = check(&xml, &pdk, LayoutTarget::Board);
+
+        assert_eq!(report.findings.len(), 1);
+        assert!((actual_mm(&report.findings[0].measurement) - 0.1).abs() < 1e-9);
+        let profile = report.findings[0].sites[0]
+            .evidence
+            .iter()
+            .find(|evidence| evidence.role == "board_profile")
+            .unwrap();
+        assert_eq!(profile.paths.len(), 2, "the cutout ring is retained");
+    }
+
+    #[test]
+    fn materialized_slots_measure_clearance_and_crossing_as_zero() {
+        let xml = board(
+            r#"<LayerFeature layerRef="ROUT"><Set>
+              <SlotCavity name="pass" platingStatus="PLATED"><Location x="5" y="2"/><Oval width="2" height="0.6"/></SlotCavity>
+              <SlotCavity name="fail" platingStatus="PLATED"><Location x="0.8" y="2"/><Oval width="1" height="0.6"/></SlotCavity>
+              <SlotCavity name="crossing" platingStatus="NONPLATED"><Location x="0.2" y="5"/><Oval width="1" height="0.6"/></SlotCavity>
+            </Set></LayerFeature>"#,
+            "",
+        );
+        let pdk = pdk(r#"[[rules.drilling.slot_to_board_edge_clearance]]
+id = "plated-slot-edge"
+select = { plating = "plated" }
+limit = { minimum = "0.4 mm" }
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "nonplated-slot-edge"
+select = { plating = "nonplated" }
+limit = { minimum = "0.4 mm" }"#);
+        let report = check(&xml, &pdk, LayoutTarget::Board);
+
+        assert_eq!(report.rules[0].checked, 2);
+        assert_eq!(report.rules[1].checked, 1);
+        assert_eq!(report.findings.len(), 2);
+        let plated = report
+            .findings
+            .iter()
+            .find(|finding| finding.rule_id == "plated-slot-edge")
+            .unwrap();
+        assert!((actual_mm(&plated.measurement) - 0.3).abs() < 1e-8);
+        assert!(matches!(
+            plated.sites[0].measurement_kind,
+            MeasurementKind::Clearance
+        ));
+        assert!(plated.sites[0].evidence.iter().any(|evidence| {
+            evidence.role == "routed_slot"
+                && matches!(evidence.display, Some(EvidenceDisplay::Path { .. }))
+        }));
+        let nonplated = report
+            .findings
+            .iter()
+            .find(|finding| finding.rule_id == "nonplated-slot-edge")
+            .unwrap();
+        assert_eq!(actual_mm(&nonplated.measurement), 0.0);
+        assert!(matches!(
+            nonplated.sites[0].measurement_kind,
+            MeasurementKind::OutsideBoard
+        ));
+    }
+
+    #[test]
+    fn repeated_features_select_their_own_board_occurrence_not_the_panel() {
+        let xml = r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+          <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="panel"/><LayerRef name="DRILL"/></Content>
+          <Ecad><CadHeader units="MILLIMETER"/><CadData>
+            <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE"/>
+            <Step name="board" type="BOARD">
+              <Profile><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="10" y="0"/><PolyStepSegment x="10" y="10"/><PolyStepSegment x="0" y="10"/><PolyStepSegment x="0" y="0"/></Polygon></Profile>
+              <LayerFeature layerRef="DRILL"><Set><Hole name="edge" diameter="1" platingStatus="PLATED" x="0.7" y="5"/></Set></LayerFeature>
+            </Step>
+            <Step name="panel" type="PALLET">
+              <Profile><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="100" y="0"/><PolyStepSegment x="100" y="50"/><PolyStepSegment x="0" y="50"/><PolyStepSegment x="0" y="0"/></Polygon></Profile>
+              <StepRepeat stepRef="board" x="10" y="10" nx="2" ny="1" dx="30" dy="0"/>
+            </Step>
+          </CadData></Ecad>
+        </IPC-2581>"#;
+        let pdk = pdk(r#"[[rules.drilling.hole_to_board_edge_clearance]]
+id = "pth-edge"
+select = { hole = "pth" }
+limit = { minimum = "0.3 mm" }"#);
+        let report = check(xml, &pdk, LayoutTarget::BoardArray);
+
+        assert_eq!(report.rules[0].checked, 2);
+        assert_eq!(report.findings.len(), 2);
+        let mut instances = std::collections::BTreeSet::new();
+        for finding in &report.findings {
+            assert!((actual_mm(&finding.measurement) - 0.2).abs() < 1e-8);
+            let hole_instance = finding.subjects[0]
+                .provenance
+                .as_ref()
+                .unwrap()
+                .instance_index;
+            let outline_instance = finding.subjects[1]
+                .provenance
+                .as_ref()
+                .unwrap()
+                .instance_index;
+            assert_eq!(hole_instance, outline_instance);
+            instances.insert(hole_instance.unwrap());
+        }
+        assert_eq!(instances.len(), 2);
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/linework_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/linework_clearance.rs
@@ -261,7 +261,7 @@ fn copper_subject(copper: &CopperLayer) -> Subject {
     }
 }
 
-fn outline_subject(outline: &BoardOutline, role: &'static str) -> Subject {
+pub(super) fn outline_subject(outline: &BoardOutline, role: &'static str) -> Subject {
     Subject {
         role,
         kind: "board_outline",

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -11,6 +11,7 @@
 mod annular_ring;
 mod board_array_spacing;
 mod copper_clearance;
+mod drilled_board_edge_clearance;
 mod hole_aspect_ratio;
 mod hole_clearance;
 mod hole_diameter;
@@ -30,7 +31,7 @@ use pcb_ir::geom::dfm::Distance;
 use pcb_ir::geom::{Affine2, BBox, Point};
 use sha2::{Digest, Sha256};
 
-use super::design::{Design, Hole, HoleClass};
+use super::design::{Design, Hole, HoleClass, Slot};
 use super::pdk::SlotPlating;
 use super::report::{
     Evidence, Finding, LayerRef, Location, Measurement, MeasurementKind, ReportBBox, ReportPoint,
@@ -306,7 +307,17 @@ fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
                 )
             })
         }
+        RuleKind::HoleToBoardEdgeClearance(class) => design
+            .holes
+            .iter()
+            .all(|hole| hole.class != class)
+            .then(|| format!("{} holes", class.label())),
         RuleKind::SlotWidth(plating) => design
+            .slots
+            .iter()
+            .all(|slot| !slot_matches(slot.plating, plating))
+            .then(|| format!("{} routed slots", slot_plating_label(plating))),
+        RuleKind::SlotToBoardEdgeClearance(plating) => design
             .slots
             .iter()
             .all(|slot| !slot_matches(slot.plating, plating))
@@ -347,6 +358,12 @@ fn evaluate(rule: &Rule, design: &Design) -> RuleEvaluation {
         RuleKind::SlotWidth(plating) => slot_width::evaluate(limit(), plating, design).into(),
         RuleKind::HolePairClearance(first, second) => {
             hole_pair_clearance::evaluate(limit(), first, second, design).into()
+        }
+        RuleKind::HoleToBoardEdgeClearance(class) => {
+            drilled_board_edge_clearance::evaluate_holes(limit(), class, design).into()
+        }
+        RuleKind::SlotToBoardEdgeClearance(plating) => {
+            drilled_board_edge_clearance::evaluate_slots(limit(), plating, design).into()
         }
         RuleKind::AnnularRing(class) => {
             annular_ring::evaluate(limit(), class, &rule.conditions, design).into()
@@ -613,6 +630,22 @@ fn hole_subject(design: &Design, hole: &Hole, role: &'static str) -> Subject {
     );
     subject.provenance = Some(hole.provenance.clone());
     subject.drill_span = Some(hole.drill_span.clone());
+    subject
+}
+
+fn slot_subject(design: &Design, slot: &Slot, role: &'static str) -> Subject {
+    let mut subject = drilled_subject(
+        design,
+        role,
+        "routed_slot",
+        slot.net,
+        slot.padstack,
+        slot.step,
+        &slot.layer,
+        slot.source_set_index,
+        slot.source_feature_index,
+    );
+    subject.provenance = Some(slot.provenance.clone());
     subject
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -12,7 +12,7 @@ use crate::commands::dfm::report::{Evidence, EvidenceDisplay, MeasurementKind};
 use pcb_ir::geom::BBox;
 use pcb_ir::geom::dfm::thin_features;
 
-use super::{Evaluation, Measured, MeasuredSite, drilled_subject, thin_regions, violates};
+use super::{Evaluation, Measured, MeasuredSite, slot_subject, thin_regions, violates};
 
 pub(super) fn evaluate(limit_mm: f64, plating: SlotPlating, design: &Design) -> Evaluation {
     let slots = design
@@ -23,11 +23,7 @@ pub(super) fn evaluate(limit_mm: f64, plating: SlotPlating, design: &Design) -> 
     let measured = slots
         .iter()
         .map(|&slot: &&Slot| {
-            let mut subject = drilled_subject(
-                design, "offender", "routed_slot", slot.net, slot.padstack, slot.step,
-                &slot.layer, slot.source_set_index, slot.source_feature_index,
-            );
-            subject.provenance = Some(slot.provenance.clone());
+            let subject = slot_subject(design, slot, "offender");
             let sites = if !violates(&slot.width, limit_mm) {
                 Vec::new()
             } else if let Some(nominal) = slot.nominal_width_mm {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -708,6 +708,11 @@ pub(super) struct BoardOutline {
     pub instance_index: Option<u32>,
     /// Outer profile plus cutout rings.
     pub contours: Vec<Ring>,
+    /// Finished board material: the filled outer profile minus every cutout.
+    pub region: ContourSet,
+    pub boundary: RegionBoundaryIndex,
+    /// Native outer and cutout contours in the checked frame.
+    pub native_outline: Vec<ContourBuf>,
     pub bbox: BBox,
 }
 
@@ -1431,26 +1436,35 @@ fn collect_board_outlines(
             )
         })
         .filter_map(|occurrence| {
-            let mut contours = layout
+            let mut native_outline = layout
                 .transformed_path_contours(occurrence.profile.outer_path, occurrence.transform);
+            let outer_count = native_outline.len();
             for cutout in occurrence.profile.cutouts.slice(&layout.profile_cutouts) {
-                contours
+                native_outline
                     .extend(layout.transformed_path_contours(cutout.path, occurrence.transform));
             }
-            let rings = pcb_ir::geom::region::rings_from_contours(&contours);
-            if rings.is_empty() {
+            let outer =
+                ContourSet::from_filled_contours(&native_outline[..outer_count], tol::REGION_MM);
+            let cutouts =
+                ContourSet::from_filled_contours(&native_outline[outer_count..], tol::REGION_MM);
+            let region = outer.difference(&cutouts);
+            if region.is_empty() {
                 return None;
             }
-            let bbox = pcb_ir::geom::region::rings_bbox(&rings);
+            let bbox = region.bbox;
             let name = occurrence
                 .step
                 .and_then(|step| layout.layout.steps.get(step as usize))
                 .map(|step| imported.resolve(step.source_step_ref).to_owned())
                 .unwrap_or_else(|| "board".to_owned());
+            let boundary = RegionBoundaryIndex::new(&region, 1.0);
             Some(BoardOutline {
                 name,
                 instance_index: occurrence.instance,
-                contours: rings,
+                contours: region.rings.clone(),
+                region,
+                boundary,
+                native_outline,
                 bbox,
             })
         })

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
@@ -323,6 +323,18 @@ impl Rules {
                     .map(RuleDefinition::HolePair),
             )
             .chain(
+                self.drilling
+                    .hole_to_board_edge_clearance
+                    .iter()
+                    .map(RuleDefinition::HoleToBoardEdge),
+            )
+            .chain(
+                self.drilling
+                    .slot_to_board_edge_clearance
+                    .iter()
+                    .map(RuleDefinition::SlotToBoardEdge),
+            )
+            .chain(
                 self.copper
                     .annular_ring
                     .iter()
@@ -373,6 +385,8 @@ enum RuleDefinition<'a> {
     HoleAspectRatio(&'a HoleAspectRatioRule),
     SlotWidth(&'a SlotWidthRule),
     HolePair(&'a HolePairRule),
+    HoleToBoardEdge(&'a HoleToBoardEdgeClearanceRule),
+    SlotToBoardEdge(&'a SlotToBoardEdgeClearanceRule),
     AnnularRing(&'a AnnularRingRule),
     HoleClearance(&'a HoleClearanceRule),
     CopperLength(&'a LengthRule),
@@ -386,6 +400,8 @@ impl RuleDefinition<'_> {
             Self::HoleAspectRatio(rule) => &rule.metadata,
             Self::SlotWidth(rule) => &rule.metadata,
             Self::HolePair(rule) => &rule.metadata,
+            Self::HoleToBoardEdge(rule) => &rule.metadata,
+            Self::SlotToBoardEdge(rule) => &rule.metadata,
             Self::AnnularRing(rule) => &rule.metadata,
             Self::HoleClearance(rule) => &rule.metadata,
             Self::CopperLength(rule) | Self::OtherLength(rule) => &rule.metadata,
@@ -400,6 +416,8 @@ impl RuleDefinition<'_> {
             }
             Self::SlotWidth(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::HolePair(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::HoleToBoardEdge(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::SlotToBoardEdge(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::AnnularRing(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::HoleClearance(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::CopperLength(rule) | Self::OtherLength(rule) => {
@@ -459,6 +477,10 @@ pub struct DrillingRules {
     pub slot_width: Vec<SlotWidthRule>,
     #[serde(default)]
     pub hole_to_hole_clearance: Vec<HolePairRule>,
+    #[serde(default)]
+    pub hole_to_board_edge_clearance: Vec<HoleToBoardEdgeClearanceRule>,
+    #[serde(default)]
+    pub slot_to_board_edge_clearance: Vec<SlotToBoardEdgeClearanceRule>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -756,6 +778,30 @@ pub struct HolePairRule {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct HoleToBoardEdgeClearanceRule {
+    #[serde(flatten)]
+    pub metadata: RuleMetadata,
+    pub select: HoleSelector,
+    #[serde(default)]
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SlotToBoardEdgeClearanceRule {
+    #[serde(flatten)]
+    pub metadata: RuleMetadata,
+    pub select: SlotSelector,
+    #[serde(default)]
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnnularRingRule {
     #[serde(flatten)]
     pub metadata: RuleMetadata,
@@ -986,6 +1032,10 @@ copper_layers = { minimum = 2, maximum = 10 }
 [profiles.standard.defaults]
 outer_copper_weight = "1 oz"
 
+[sources.example]
+title = "Example source"
+url = "https://example.com/pdk"
+
 [[rules.drilling.hole_diameter]]
 id = "via-hole"
 select = { hole = "via" }
@@ -1000,6 +1050,22 @@ limit = { maximum = 8.0 }
 id = "via-spacing"
 select = { first_hole = "via", second_hole = "via" }
 limit = { minimum = "10 mil" }
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "npth-edge"
+profiles = ["standard"]
+source = "example"
+select = { hole = "npth" }
+cases = [
+  { id = "2-to-8-layer", when = { copper_layers = { minimum = 2, maximum = 8 } }, limit = { minimum = "0.3 mm", preferred = "0.4 mm" } },
+]
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "nonplated-slot-edge"
+profiles = ["standard"]
+source = "example"
+select = { plating = "nonplated" }
+limit = { minimum = "15 mil" }
 
 [[rules.copper.annular_ring]]
 id = "via-ring"
@@ -1067,6 +1133,28 @@ limit = { minimum = "300 mil" }
                 .abs()
                 < 1e-12
         );
+        let hole_edge = &pdk.rules.drilling.hole_to_board_edge_clearance[0];
+        assert_eq!(hole_edge.select.hole, HoleKind::Npth);
+        assert_eq!(hole_edge.metadata.profiles, ["standard"]);
+        assert_eq!(hole_edge.metadata.source.as_deref(), Some("example"));
+        let hole_case = &hole_edge.cases[0];
+        assert_eq!(hole_case.id, "2-to-8-layer");
+        assert_eq!(
+            hole_case.when.copper_layers.as_ref().unwrap().minimum(),
+            Some(2)
+        );
+        assert_eq!(
+            hole_case.when.copper_layers.as_ref().unwrap().maximum(),
+            Some(8)
+        );
+        assert_eq!(hole_case.limit.minimum.millimeters(), 0.3);
+        assert_eq!(
+            hole_case.limit.preferred.as_ref().unwrap().millimeters(),
+            0.4
+        );
+        let slot_edge = &pdk.rules.drilling.slot_to_board_edge_clearance[0];
+        assert_eq!(slot_edge.select.plating, SlotPlating::Nonplated);
+        assert!((slot_edge.limit.as_ref().unwrap().minimum.millimeters() - 0.381).abs() < 1e-12);
         assert_eq!(
             pdk.rules.copper.feature_width[0].cases[0]
                 .when
@@ -1245,5 +1333,67 @@ limit = { minimum = "300 mil" }
             .unwrap()
             .validate_rule_references()
             .unwrap();
+    }
+
+    #[test]
+    fn rejects_malformed_board_edge_clearance_rules() {
+        assert!(
+            Pdk::parse(&MIXED_UNIT_PDK.replace(
+                "select = { hole = \"npth\" }",
+                "select = { hole = \"pad\" }"
+            ))
+            .is_err()
+        );
+        assert!(
+            Pdk::parse(&MIXED_UNIT_PDK.replace(
+                "select = { plating = \"nonplated\" }",
+                "select = { plating = \"unplated\" }"
+            ))
+            .is_err()
+        );
+        assert!(
+            Pdk::parse(&MIXED_UNIT_PDK.replace(
+                "select = { hole = \"npth\" }",
+                "select = { plating = \"nonplated\" }"
+            ))
+            .is_err()
+        );
+
+        let invalid_tier = MIXED_UNIT_PDK.replace(
+            "minimum = \"0.3 mm\", preferred = \"0.4 mm\"",
+            "minimum = \"0.3 mm\", preferred = \"0.2 mm\"",
+        );
+        assert!(
+            Pdk::parse(&invalid_tier)
+                .unwrap()
+                .validate_rule_references()
+                .unwrap_err()
+                .to_string()
+                .contains("preferred limit")
+        );
+        let unsupported_condition = MIXED_UNIT_PDK.replace(
+            "when = { copper_layers = { minimum = 2, maximum = 8 } }",
+            "when = { copper = { position = \"outer\" } }",
+        );
+        assert!(
+            Pdk::parse(&unsupported_condition)
+                .unwrap()
+                .validate_rule_references()
+                .unwrap_err()
+                .to_string()
+                .contains("supported only for copper rules")
+        );
+        let limit_and_cases = MIXED_UNIT_PDK.replace(
+            "cases = [\n  { id = \"2-to-8-layer\"",
+            "limit = { minimum = \"0.3 mm\" }\ncases = [\n  { id = \"2-to-8-layer\"",
+        );
+        assert!(
+            Pdk::parse(&limit_and_cases)
+                .unwrap()
+                .validate_rule_references()
+                .unwrap_err()
+                .to_string()
+                .contains("mutually exclusive")
+        );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
@@ -416,6 +416,7 @@ pub enum MeasurementKind {
     Clearance,
     RadialEnclosure,
     Overlap,
+    OutsideBoard,
     MissingCopper,
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -143,6 +143,10 @@ pub(super) enum RuleKind {
     SlotWidth(SlotPlating),
     /// Clearance: holes with overlapping spans keep edge-to-edge distance.
     HolePairClearance(HoleClass, HoleClass),
+    /// Clearance: each circular hole stays inside and clear of its board profile.
+    HoleToBoardEdgeClearance(HoleClass),
+    /// Clearance: each routed slot stays inside and clear of its board profile.
+    SlotToBoardEdgeClearance(SlotPlating),
     /// Enclosure: radial copper around each hole on the layers it lands on.
     AnnularRing(HoleClass),
     /// Clearance: a circular drill stays clear of unrelated final copper.
@@ -279,6 +283,18 @@ impl RuleKind {
                 true,
                 &["drills", "board_outlines"],
             ),
+            Self::HoleToBoardEdgeClearance(_) => (
+                "hole_to_board_edge_clearance",
+                "Hole-to-board-edge clearance",
+                true,
+                &["drills", "board_outlines"],
+            ),
+            Self::SlotToBoardEdgeClearance(_) => (
+                "slot_to_board_edge_clearance",
+                "Slot-to-board-edge clearance",
+                true,
+                &["drills", "board_outlines"],
+            ),
             Self::AnnularRing(_) => (
                 "annular_ring",
                 "Annular ring",
@@ -393,6 +409,36 @@ impl RuleKind {
                 ),
                 witness_roles: Some(["first_hole_boundary", "second_hole_boundary"]),
                 pools: DRILLED,
+            },
+            Self::HoleToBoardEdgeClearance(class) => Semantics {
+                subject: "hole",
+                quantity: "hole_edge_to_board_edge_clearance",
+                method: "circle_to_enclosing_physical_profile_boundary",
+                finding_title: format!("{} hole is too close to the board edge", class.label()),
+                quantity_label: format!("{} hole-to-board-edge clearance", class.label()),
+                witness_roles: Some(["hole_boundary", "board_outline"]),
+                pools: Pools {
+                    board_outlines: true,
+                    ..DRILLED
+                },
+            },
+            Self::SlotToBoardEdgeClearance(plating) => Semantics {
+                subject: "slot",
+                quantity: "slot_edge_to_board_edge_clearance",
+                method: "materialized_slot_to_enclosing_physical_profile_boundary",
+                finding_title: format!(
+                    "{} slot is too close to the board edge",
+                    slot_label(plating)
+                ),
+                quantity_label: format!(
+                    "{} routed-slot-to-board-edge clearance",
+                    slot_label(plating)
+                ),
+                witness_roles: Some(["slot_boundary", "board_outline"]),
+                pools: Pools {
+                    board_outlines: true,
+                    ..DRILLED
+                },
             },
             Self::AnnularRing(class) => Semantics {
                 subject: "hole_layer_pair",
@@ -524,7 +570,7 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
     let (profile_name, profile) = pdk.selected_profile(selected_profile)?;
     if profile.status == ProfileStatus::MetadataOnly {
         anyhow::bail!(
-            "PDK profile '{profile_name}' is metadata-only; licensed numeric IPC profile rules are required before it can run DFM checks"
+            "PDK profile '{profile_name}' is metadata-only; executable numeric rules are required before it can run DFM checks"
         );
     }
 
@@ -609,6 +655,32 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
                 second.label()
             ),
             RuleKind::HolePairClearance(first, second),
+        ));
+    }
+    for rule in &pdk.rules.drilling.hole_to_board_edge_clearance {
+        let class = hole_class(rule.select.hole);
+        rules.extend(lower_length_rule(
+            &rule.metadata,
+            rule.limit.as_ref(),
+            &rule.cases,
+            profile_name,
+            profile,
+            format!("Minimum {} hole-to-board-edge clearance", class.label()),
+            RuleKind::HoleToBoardEdgeClearance(class),
+        ));
+    }
+    for rule in &pdk.rules.drilling.slot_to_board_edge_clearance {
+        rules.extend(lower_length_rule(
+            &rule.metadata,
+            rule.limit.as_ref(),
+            &rule.cases,
+            profile_name,
+            profile,
+            format!(
+                "Minimum {} routed-slot-to-board-edge clearance",
+                slot_label(rule.select.plating)
+            ),
+            RuleKind::SlotToBoardEdgeClearance(rule.select.plating),
         ));
     }
     for rule in &pdk.rules.copper.annular_ring {
@@ -908,5 +980,73 @@ limit = { minimum = "0.30 mm" }
             RuleKind::HoleToCopperClearance(HoleClass::Via)
         ));
         assert_eq!(lowered[1].limit.length().millimeters(), 0.25);
+    }
+
+    const EDGE_CLEARANCE_PDK: &str = r#"
+schema_version = 2
+default_profile = "primary"
+
+[pdk]
+id = "edge-clearance"
+name = "Edge clearance"
+revision = "1"
+
+[profiles.primary]
+name = "Primary"
+technologies = ["rigid"]
+
+[profiles.secondary]
+name = "Secondary"
+technologies = ["rigid"]
+
+[[rules.drilling.hole_to_board_edge_clearance]]
+id = "via-edge"
+profiles = ["primary"]
+select = { hole = "via" }
+cases = [
+  { id = "4-to-12-layer", when = { copper_layers = { minimum = 4, maximum = 12 } }, limit = { minimum = "0.3 mm", preferred = "0.4 mm" } },
+]
+
+[[rules.drilling.slot_to_board_edge_clearance]]
+id = "plated-slot-edge"
+profiles = ["primary"]
+select = { plating = "plated" }
+limit = { minimum = "0.5 mm" }
+"#;
+
+    #[test]
+    fn lowers_typed_board_edge_clearance_rules_and_tiers() {
+        let pdk = Pdk::parse(EDGE_CLEARANCE_PDK).unwrap();
+        let rules = lower(&pdk, Some("primary")).unwrap();
+        assert_eq!(rules.len(), 3);
+
+        let required = &rules[0];
+        assert_eq!(required.id, "via-edge.4-to-12-layer");
+        assert!(matches!(
+            required.kind,
+            RuleKind::HoleToBoardEdgeClearance(HoleClass::Via)
+        ));
+        assert_eq!(required.severity, Severity::Error);
+        assert_eq!(required.limit.length().millimeters(), 0.3);
+        assert_eq!(required.conditions.minimum_copper_layers, Some(4));
+        assert_eq!(required.conditions.maximum_copper_layers, Some(12));
+
+        let preferred = &rules[1];
+        assert_eq!(preferred.id, "via-edge.4-to-12-layer.preferred");
+        assert!(matches!(
+            preferred.kind,
+            RuleKind::HoleToBoardEdgeClearance(HoleClass::Via)
+        ));
+        assert_eq!(preferred.severity, Severity::Warning);
+        assert_eq!(preferred.limit.length().millimeters(), 0.4);
+
+        assert_eq!(rules[2].id, "plated-slot-edge");
+        assert!(matches!(
+            rules[2].kind,
+            RuleKind::SlotToBoardEdgeClearance(SlotPlating::Plated)
+        ));
+        assert_eq!(rules[2].limit.length().millimeters(), 0.5);
+
+        assert!(lower(&pdk, Some("secondary")).unwrap().is_empty());
     }
 }


### PR DESCRIPTION
This change checks minimum clearance from circular holes and routed slots to each feature's physical board edge, including cutouts and repeated board occurrences. It reports crossing or outside features as zero clearance and preserves spatial evidence for review. The bundled IPC profiles run a clearly labeled partial Diode baseline for via, PTH, NPTH, plated slots, and nonplated slots; they do not claim full IPC compliance.