### PR TITLE
Add drilled-hole-to-copper DFM clearance checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Derive physical electrical terminations from exact IPC-2581 pin and padstack identities.
 - Add strict profile-based DFM PDK schema v2, executable JLCPCB 1 oz profiles, and metadata-only IPC 1A-3C profiles.
 - Add maximum plated-hole aspect-ratio DFM checks and make IPC 1A-3C profiles executable with opinionated partial IPC-informed baselines.
+- Add circular drilled-hole-to-unrelated-copper DFM checks and extend the executable IPC 1A-3C partial baselines with opinionated IPC-informed values.
 - Add a deterministic, versioned PCBA assembly report contract over canonical assembly and physical IR.
 - Expose PCBA assembly reports as JSON through `pcb ipc assembly`.
 

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -63,9 +63,10 @@ pcb ipc dfm check fabrication-panel.xml \
 `jlcpcb-1oz-black-white` selects its larger mask-web requirement. The
 `ipc` alias selects the opinionated Class 2 / Producibility Level B default.
 It and the explicit `ipc-1a` through `ipc-3c` profiles run Diode's opinionated
-partial baseline for plated-hole aspect ratio. These values are informed by IPC
-design topics, but they are not licensed IPC numeric matrices, do not prove full
-IPC compliance, and do not imply IPC certification.
+partial baseline for plated-hole aspect ratio and via, PTH, and NPTH
+hole-to-copper clearance. Diode selected these values with IPC design topics as
+context; they are not licensed IPC numeric matrices, do not prove full IPC
+compliance, and do not imply IPC certification.
 
 Pass a path such as `--pdk ./fab-process.toml` to use a custom PDK. Exact
 built-in names take precedence, so prefix a same-named file with `./`.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -71,6 +71,11 @@ id = "copper.via_annular_ring"
 select = { hole = "via" }
 limit = { minimum = "100 um", preferred = "0.125 mm" }
 
+[[rules.copper.hole_clearance]]
+id = "copper.via_hole_clearance"
+select = { hole = "via" }
+limit = { minimum = "0.20 mm", preferred = "0.25 mm" }
+
 [[rules.copper.feature_width]]
 id = "copper.feature_width"
 cases = [
@@ -94,7 +99,9 @@ The schema gives each kind of constraint one place:
 - `select` identifies the physical subjects a rule measures. Hole rules select
   `via`, `pth`, or `npth`; slots select `plated` or `nonplated`; hole-pair rules
   state both classes. Hole-aspect-ratio rules accept only plated `via` or `pth`
-  holes; selecting `npth` is a schema error.
+  holes; selecting `npth` is a schema error. A
+  `rules.copper.hole_clearance` selector chooses the drill class measured to
+  unrelated final copper.
 - `limit` defines one unconditional dimensional minimum and optional preferred
   value, or one required aspect-ratio maximum.
 - `cases` defines named conditional limits when one value is not enough. A
@@ -157,6 +164,7 @@ high-level pass is never allowed to suppress a later authoritative failure.
 | Outline slot width | Materialized filled route outline, then its narrowest maximal inscribed disk | None |
 | Hole-to-hole clearance | Materialized drill circles and overlapping drill spans | Sorted bounds prune pairs already proven clear |
 | Annular ring | Drill circle and final composed copper image on each applicable layer | Batched containment and an indexed copper boundary |
+| Hole-to-copper clearance | Analytic drill circle and attributed final composed copper on each layer in its drill span | Indexed attributed-copper boundaries |
 | Copper width | Final composed copper image, medial-axis width of each residue | Guarded opening localizes candidates |
 | Copper clearance | Final composed copper attributed to occurrence-scoped electrical conductors | Sorted bounds prune conductor components already proven clear |
 | Soldermask web | Final composed mask-opening image, medial-axis width of each residue | Guarded closing localizes candidates |
@@ -198,6 +206,14 @@ then measures only pairs of distinct owners. A net is scoped by its
 materialized Step occurrence, so repeated boards do not become electrically
 connected merely because they reuse the same net names.
 
+Hole-to-copper clearance uses the same attributed composition. For a via or
+PTH, copper proven to belong to the hole's occurrence-scoped net or a resolved
+physical land is excluded; other-net, auxiliary, and unattributed functional
+copper remains an offender. For an NPTH, every final copper owner is an
+offender, including a same-named net. The rule requires a declared through or
+resolvable layer span and fails extraction when the span is unavailable rather
+than guessing which copper layers the drill intersects.
+
 `--layout-target board` extracts the canonical board step. `board-array`
 materializes the root layout and every nested repeat, so the same evaluators
 operate on a board array or on a fabrication panel without a second DFM code
@@ -238,6 +254,11 @@ when fewer than two exist.
   layer with a matching source land, must retain copper at the hole center;
   missing copper there is a zero-enclosure failure. One finding per hole
   reports the worst layer.
+- Hole-to-copper clearance measures the edge-to-edge distance from each
+  circular drill to the nearest unrelated final copper owner on every copper
+  layer in its declared span. Via and PTH copper is exempt only when net or
+  physical-land identity proves that it belongs to the hole. NPTH copper is
+  never exempt. Missing drill-span identity makes the check incomplete.
 - Copper feature-width rules report narrow copper piece by piece after final
   polarity composition. Copper-clearance rules measure the shortest
   boundary distance between distinct final conductor images. Same-net
@@ -308,12 +329,16 @@ profile uses 0.13 mm.
 
 The nine `ipc-1a` through `ipc-3c` built-ins preserve performance Classes 1-3
 crossed with Producibility Levels A-C, but they are executable **partial Diode
-baselines**, not IPC profile matrices. They currently check only maximum via
-and PTH aspect ratio: Level A uses 6.0, Level B 8.0, and Level C 10.0, across
-all three performance classes. Each profile assumes 1.6 mm board thickness for
-the through-hole fallback described above. Diode chose these opinionated values
-using IPC design topics as context; they are not licensed IPC numeric matrices,
-do not prove full IPC compliance, and do not imply IPC certification.
+baselines**, not IPC profile matrices. They check maximum via and PTH aspect
+ratio at 6.0 for Level A, 8.0 for Level B, and 10.0 for Level C. They also
+check via, PTH, and NPTH hole-to-copper clearance at 0.25 mm for Level A,
+0.20 mm for Level B, and 0.15 mm for Level C. These values apply across all
+three performance classes. Each profile assumes 1.6 mm board thickness for the
+through-hole aspect-ratio fallback described above. Diode chose these
+opinionated values using IPC design topics as context; they are not licensed
+IPC numeric matrices, do not prove full IPC compliance, and do not imply IPC
+certification. A pass covers only the checks listed in the selected profile's
+`coverage` metadata.
 
 Output is UTF-8 JSON on stdout unless `-o` / `--output` is supplied. The
 recommended suffix is `.dfm.json`. Every complete report includes the native

--- a/crates/pcb-ipc2581-tools/examples/dfm-pdk.toml
+++ b/crates/pcb-ipc2581-tools/examples/dfm-pdk.toml
@@ -43,6 +43,11 @@ id = "copper.via_annular_ring"
 select = { hole = "via" }
 limit = { minimum = "100 um", preferred = "0.125 mm" }
 
+[[rules.copper.hole_clearance]]
+id = "copper.via_hole_clearance"
+select = { hole = "via" }
+limit = { minimum = "0.20 mm", preferred = "0.25 mm" }
+
 [[rules.copper.feature_width]]
 id = "copper.outer_feature_width"
 cases = [

--- a/crates/pcb-ipc2581-tools/pdks/ipc.toml
+++ b/crates/pcb-ipc2581-tools/pdks/ipc.toml
@@ -20,7 +20,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm"]
 source = "ipc-design-topics"
 
 [profiles.1a.defaults]
@@ -32,7 +32,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm"]
 source = "ipc-design-topics"
 
 [profiles.1b.defaults]
@@ -44,7 +44,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm"]
 source = "ipc-design-topics"
 
 [profiles.1c.defaults]
@@ -56,7 +56,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm"]
 source = "ipc-design-topics"
 
 [profiles.2a.defaults]
@@ -68,7 +68,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm"]
 source = "ipc-design-topics"
 
 [profiles.2b.defaults]
@@ -80,7 +80,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm"]
 source = "ipc-design-topics"
 
 [profiles.2c.defaults]
@@ -92,7 +92,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm"]
 source = "ipc-design-topics"
 
 [profiles.3a.defaults]
@@ -104,7 +104,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm"]
 source = "ipc-design-topics"
 
 [profiles.3b.defaults]
@@ -116,7 +116,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm"]
 source = "ipc-design-topics"
 
 [profiles.3c.defaults]
@@ -162,4 +162,67 @@ id = "diode.ipc.maximum_pth_aspect_ratio.level_c"
 profiles = ["1c", "2c", "3c"]
 select = { hole = "pth" }
 limit = { maximum = 10.0 }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.via_hole_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { hole = "via" }
+limit = { minimum = "0.25 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.pth_hole_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { hole = "pth" }
+limit = { minimum = "0.25 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.npth_hole_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { hole = "npth" }
+limit = { minimum = "0.25 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.via_hole_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { hole = "via" }
+limit = { minimum = "0.20 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.pth_hole_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { hole = "pth" }
+limit = { minimum = "0.20 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.npth_hole_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { hole = "npth" }
+limit = { minimum = "0.20 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.via_hole_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { hole = "via" }
+limit = { minimum = "0.15 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.pth_hole_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { hole = "pth" }
+limit = { minimum = "0.15 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.hole_clearance]]
+id = "diode.ipc_baseline.copper.npth_hole_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { hole = "npth" }
+limit = { minimum = "0.15 mm" }
 source = "ipc-design-topics"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -574,7 +574,9 @@ limit = { minimum = "300 mil" }
         let parsed = pdk::Pdk::parse(ipc.source).unwrap();
         assert_eq!(parsed.pdk.manufacturer.as_deref(), Some("Diode"));
         for class in 1..=3 {
-            for (level, maximum) in [('a', 6.0), ('b', 8.0), ('c', 10.0)] {
+            for (level, maximum, clearance) in
+                [('a', 6.0, 0.25), ('b', 8.0, 0.20), ('c', 10.0, 0.15)]
+            {
                 let profile = format!("{class}{level}");
                 let definition = &parsed.profiles[&profile];
                 assert_eq!(definition.performance_class, Some(class));
@@ -592,12 +594,45 @@ limit = { minimum = "300 mil" }
                     1.6
                 );
                 let rules = rules::lower(&parsed, Some(&profile)).unwrap();
-                assert_eq!(rules.len(), 2);
-                assert!(rules.iter().all(|rule| rule.limit.ratio() == maximum));
-                assert!(rules.iter().any(|rule| rule.id.contains("via")));
-                assert!(rules.iter().any(|rule| rule.id.contains("pth")));
+                assert_eq!(rules.len(), 5);
+                let aspect_ratio = rules
+                    .iter()
+                    .filter(|rule| matches!(rule.kind, rules::RuleKind::HoleAspectRatio(_)))
+                    .collect::<Vec<_>>();
+                assert_eq!(aspect_ratio.len(), 2);
+                assert!(
+                    aspect_ratio
+                        .iter()
+                        .all(|rule| rule.limit.ratio() == maximum)
+                );
+                assert!(aspect_ratio.iter().any(|rule| rule.id.contains("via")));
+                assert!(aspect_ratio.iter().any(|rule| rule.id.contains("pth")));
+
+                let hole_clearance = rules
+                    .iter()
+                    .filter(|rule| matches!(rule.kind, rules::RuleKind::HoleToCopperClearance(_)))
+                    .collect::<Vec<_>>();
+                assert_eq!(hole_clearance.len(), 3);
+                assert!(
+                    hole_clearance
+                        .iter()
+                        .all(|rule| rule.limit.length().millimeters() == clearance)
+                );
             }
         }
+        let (_, default_ipc) = parsed.selected_profile(Some("2b")).unwrap();
+        assert_eq!(default_ipc.performance_class, Some(2));
+        assert_eq!(
+            default_ipc.producibility_level,
+            Some(pdk::ProducibilityLevel::B)
+        );
+        assert!(
+            default_ipc
+                .description
+                .as_deref()
+                .unwrap()
+                .contains("does not prove IPC compliance")
+        );
 
         let jlc = builtin_pdks()
             .iter()

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -631,7 +631,7 @@ limit = { minimum = "300 mil" }
                 .description
                 .as_deref()
                 .unwrap()
-                .contains("does not prove IPC compliance")
+                .contains("proof of full IPC compliance")
         );
 
         let jlc = builtin_pdks()

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -112,7 +112,12 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
     Evaluation { checked, measured }
 }
 
-fn conductor_subject(design: &Design, id: ConductorId, role: &'static str, layer: &str) -> Subject {
+pub(super) fn conductor_subject(
+    design: &Design,
+    id: ConductorId,
+    role: &'static str,
+    layer: &str,
+) -> Subject {
     let (kind, name, set_index) = match id {
         ConductorId::Net { .. } => ("electrical_net", None, None),
         ConductorId::Auxiliary {
@@ -122,9 +127,20 @@ fn conductor_subject(design: &Design, id: ConductorId, role: &'static str, layer
             Some("auxiliary copper".to_owned()),
             Some(source_set_index),
         ),
-        ConductorId::Unattributed { .. } => {
-            unreachable!("unattributed copper is rejected during DFM extraction")
-        }
+        ConductorId::Unattributed {
+            source_set_index, ..
+        } => (
+            "unattributed_copper",
+            Some("functional copper without net attribution".to_owned()),
+            Some(source_set_index),
+        ),
+    };
+    let feature_index = match id {
+        ConductorId::Unattributed {
+            source_feature_index,
+            ..
+        } => Some(source_feature_index),
+        ConductorId::Net { .. } | ConductorId::Auxiliary { .. } => None,
     };
     Subject {
         role,
@@ -135,7 +151,7 @@ fn conductor_subject(design: &Design, id: ConductorId, role: &'static str, layer
             step: design.resolve(id.step()),
             layer: Some(layer.to_owned()),
             set_index,
-            feature_index: None,
+            feature_index,
             instance_index: id.instance(),
         }),
         provenance: matches!(id, ConductorId::Net { .. }).then(|| SourceLocator {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -293,6 +293,13 @@ limit = {{ minimum = "0.20 mm" }}
     <Layer name="L1" layerFunction="CONDUCTOR" side="INTERNAL" polarity="POSITIVE"/>
     <Layer name="L2" layerFunction="CONDUCTOR" side="BOTTOM" polarity="POSITIVE"/>
     <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE">{span}</Layer>
+    <Stackup name="Primary" overallThickness="0.105" tolPlus="0" tolMinus="0" whereMeasured="METAL" stackupStatus="PROPOSED">
+      <StackupGroup name="Primary_Group" thickness="0.105" tolPlus="0" tolMinus="0">
+        <StackupLayer layerOrGroupRef="L0" thickness="0.035" tolPlus="0" tolMinus="0" sequence="0"/>
+        <StackupLayer layerOrGroupRef="L1" thickness="0.035" tolPlus="0" tolMinus="0" sequence="1"/>
+        <StackupLayer layerOrGroupRef="L2" thickness="0.035" tolPlus="0" tolMinus="0" sequence="2"/>
+      </StackupGroup>
+    </Stackup>
     <Step name="board" type="BOARD"><Datum x="0" y="0"/>
       {}
       <LayerFeature layerRef="DRILL"><Set net="N1" polarity="POSITIVE">
@@ -516,5 +523,34 @@ limit = {{ minimum = "0.20 mm" }}
             .err()
             .expect("an unknown span must fail closed");
         assert!(error.to_string().contains("no resolvable drill span"));
+    }
+
+    #[test]
+    fn does_not_require_a_span_for_a_nonapplicable_named_case() {
+        let xml = board("VIA", None, &[copper(0, Some("N2"), 0.55)]);
+        let source = pdk("via").replace(
+            "limit = { minimum = \"0.20 mm\" }",
+            "cases = [{ id = \"two-layer\", when = { copper_layers = { exact = 2 } }, limit = { minimum = \"0.20 mm\" } }]",
+        );
+        let ipc = Ipc2581::parse(&xml).unwrap();
+        let pdk = Pdk::parse(&source).unwrap();
+        let rules = rules::lower(&pdk, None).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+        let results = checks::run(
+            &rules,
+            &design,
+            None,
+            NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
+        );
+
+        assert!(matches!(
+            results.rules[0].status,
+            crate::commands::dfm::report::RuleStatus::Skipped
+        ));
+        assert_eq!(
+            results.rules[0].skip_reason.as_deref(),
+            Some("rule conditions do not apply to this stackup")
+        );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -1,0 +1,520 @@
+//! Minimum clearance from a circular drilled hole to unrelated final copper.
+//!
+//! For a drill disk `D(c, r)` and one attributed final copper image `M`, the
+//! clearance is `dist(D, M) = max(0, dist(c, M) - r)`. The drill is analytic;
+//! only the composed copper boundary contributes geometric uncertainty. Via
+//! and PTH checks exclude copper proven to belong to the hole's scoped net or
+//! a physically associated land. NPTH checks exclude nothing. Measurements
+//! are made only on copper layers in the declared drill span.
+
+use pcb_ir::geom::dfm::{Distance, circular_region, region_clearance_sites};
+use pcb_ir::geom::{BBox, Point};
+
+use crate::commands::dfm::design::{
+    ConductorId, CopperLayer, Design, Hole, HoleClass, HoleLand, Land,
+};
+use crate::commands::dfm::report::{Evidence, MeasurementKind};
+use crate::commands::dfm::rules::Conditions;
+
+use super::copper_clearance::conductor_subject;
+use super::{
+    Evaluation, Measured, MeasuredSite, hole_subject, holes_of_class, layers, linework_clearance,
+    violates,
+};
+
+pub(super) fn evaluate(
+    limit_mm: f64,
+    class: HoleClass,
+    conditions: &Conditions,
+    design: &Design,
+) -> Evaluation {
+    let mut checked = 0;
+    let mut measured = Vec::new();
+
+    for (hole_index, hole) in holes_of_class(design, class) {
+        let radius_mm = hole.diameter_mm / 2.0;
+        for (copper_index, copper) in design.copper_layers.iter().enumerate() {
+            if !hole.spans_copper(copper_index) || !conditions.applies_to_layer(copper) {
+                continue;
+            }
+            checked += 1;
+            let own_lands = design.hole_lands[hole_index]
+                .iter()
+                .filter(|land| land.copper_index as usize == copper_index)
+                .collect::<Vec<_>>();
+            let nearest = copper
+                .conductors
+                .iter()
+                .zip(&design.conductor_boundaries[copper_index])
+                .filter(|(conductor, _)| !owned_by_hole(hole, copper, &own_lands, conductor.id))
+                .filter_map(|(conductor, boundary)| {
+                    disk_to_copper_clearance(
+                        hole.center,
+                        radius_mm,
+                        &conductor.image,
+                        boundary,
+                        limit_mm,
+                    )
+                    .map(|distance| (conductor, distance))
+                })
+                .min_by(|(_, left), (_, right)| left.mm.total_cmp(&right.mm));
+
+            let Some((offender, distance)) = nearest else {
+                continue;
+            };
+            let finding_layers = layers([&hole.layer, &copper.layer]);
+            let subjects = vec![
+                hole_subject(design, hole, "hole"),
+                conductor_subject(design, offender.id, "offender", &copper.layer.name),
+            ];
+            let evidence = vec![
+                Evidence::circle("drilled_hole", hole.center, hole.diameter_mm),
+                Evidence::bounds("offending_copper", offender.image.bbox),
+            ];
+            let sites = if violates(&distance, limit_mm) {
+                let drill = circular_region(hole.center, radius_mm);
+                let mut sites = region_clearance_sites(&drill, &offender.image, limit_mm)
+                    .into_iter()
+                    .map(|geometry| {
+                        let mut site = linework_clearance::report_site(
+                            geometry,
+                            finding_layers.clone(),
+                            limit_mm,
+                        );
+                        site.subjects = subjects.clone();
+                        site.evidence.push(Evidence::circle(
+                            "drilled_hole",
+                            hole.center,
+                            hole.diameter_mm,
+                        ));
+                        site.evidence.push(Evidence::circle(
+                            "required_copper_keepout",
+                            hole.center,
+                            hole.diameter_mm + 2.0 * limit_mm,
+                        ));
+                        site
+                    })
+                    .collect::<Vec<_>>();
+                if !sites.iter().any(|site| violates(&site.distance, limit_mm)) {
+                    sites.push(fallback_site(
+                        distance,
+                        hole,
+                        limit_mm,
+                        finding_layers.clone(),
+                        subjects.clone(),
+                    ));
+                }
+                sites
+            } else {
+                Vec::new()
+            };
+            let mut bbox = hole.bbox.expand(limit_mm);
+            bbox.include_point(distance.second);
+            measured.push(Measured {
+                distance,
+                bbox,
+                layers: finding_layers,
+                subjects,
+                evidence,
+                sites,
+            });
+        }
+    }
+
+    Evaluation { checked, measured }
+}
+
+fn disk_to_copper_clearance(
+    center: Point,
+    radius_mm: f64,
+    copper: &pcb_ir::geom::ContourSet,
+    boundary: &pcb_ir::geom::dfm::RegionBoundaryIndex,
+    limit_mm: f64,
+) -> Option<Distance> {
+    if copper.contains_point(center) {
+        return Some(Distance::flattened(0.0, center, center, 1));
+    }
+    let nearest = boundary.nearest_within(center, radius_mm + limit_mm)?;
+    let direction = nearest.second - center;
+    let direction = if direction.length() <= f64::EPSILON {
+        Point::new(1.0, 0.0)
+    } else {
+        direction / direction.length()
+    };
+    if nearest.mm <= radius_mm {
+        // The copper boundary lies inside the drill disk, so this point is
+        // shared by both closed regions even when neither center is contained.
+        return Some(Distance::flattened(0.0, nearest.second, nearest.second, 1));
+    }
+    Some(Distance::flattened(
+        nearest.mm - radius_mm,
+        center + direction * radius_mm,
+        nearest.second,
+        1,
+    ))
+}
+
+fn owned_by_hole(
+    hole: &Hole,
+    copper: &CopperLayer,
+    links: &[&HoleLand],
+    conductor: ConductorId,
+) -> bool {
+    if hole.class == HoleClass::Npth {
+        return false;
+    }
+    let hole_owner = hole.net.map(|net| ConductorId::Net {
+        step: hole.step,
+        instance: hole.provenance.instance_index,
+        net,
+    });
+    if hole_owner == Some(conductor) {
+        return true;
+    }
+    links.iter().any(|link| {
+        let land = &copper.lands[link.land_index as usize];
+        land_owns_conductor(land, conductor)
+    })
+}
+
+fn land_owns_conductor(land: &Land, conductor: ConductorId) -> bool {
+    match conductor {
+        ConductorId::Net {
+            step,
+            instance,
+            net,
+        } => {
+            land.net == Some(net) && step == land.step && instance == land.provenance.instance_index
+        }
+        ConductorId::Auxiliary { .. } => false,
+        ConductorId::Unattributed {
+            step,
+            instance,
+            source_set_index,
+            source_feature_index,
+        } => {
+            step == land.step
+                && instance == land.provenance.instance_index
+                && source_set_index == land.source_set_index
+                && source_feature_index == land.source_feature_index
+        }
+    }
+}
+
+fn fallback_site(
+    distance: Distance,
+    hole: &Hole,
+    limit_mm: f64,
+    layers: Vec<crate::commands::dfm::report::LayerRef>,
+    subjects: Vec<crate::commands::dfm::report::Subject>,
+) -> MeasuredSite {
+    let mut bbox = BBox::from_point(distance.first);
+    bbox.include_point(distance.second);
+    bbox = bbox.union(hole.bbox.expand(limit_mm));
+    let mut site = MeasuredSite::new(
+        distance,
+        bbox,
+        layers,
+        vec![
+            Evidence::circle("drilled_hole", hole.center, hole.diameter_mm),
+            Evidence::circle(
+                "required_copper_keepout",
+                hole.center,
+                hole.diameter_mm + 2.0 * limit_mm,
+            ),
+        ],
+        if distance.mm == 0.0 {
+            MeasurementKind::Overlap
+        } else {
+            MeasurementKind::Clearance
+        },
+    );
+    site.subjects = subjects;
+    site.note = Some("The analytic drill clearance is below the configured limit.".to_owned());
+    site
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+    use pcb_ir::dialects::ipc::ArtworkScope;
+
+    use crate::commands::dfm::{checks, design::Design, pdk::Pdk, rules};
+    use crate::ipc2581::Ipc2581;
+
+    fn pdk(hole: &str) -> String {
+        format!(
+            r#"schema_version = 2
+default_profile = "test"
+
+[pdk]
+id = "hole-clearance-test"
+name = "Hole clearance test"
+revision = "1"
+
+[profiles.test]
+name = "Test"
+
+[[rules.copper.hole_clearance]]
+id = "hole-clearance"
+select = {{ hole = "{hole}" }}
+limit = {{ minimum = "0.20 mm" }}
+"#
+        )
+    }
+
+    fn copper(layer: usize, net: Option<&str>, x: f64) -> String {
+        let net = net
+            .map(|net| format!(r#" net="{net}""#))
+            .unwrap_or_default();
+        format!(
+            r#"<LayerFeature layerRef="L{layer}"><Set{net} polarity="POSITIVE"><Features><Contour><Polygon>
+              <PolyBegin x="{x}" y="-0.5"/><PolyStepSegment x="{}" y="-0.5"/>
+              <PolyStepSegment x="{}" y="0.5"/><PolyStepSegment x="{x}" y="0.5"/>
+              <PolyStepSegment x="{x}" y="-0.5"/>
+            </Polygon></Contour></Features></Set></LayerFeature>"#,
+            x + 1.0,
+            x + 1.0,
+        )
+    }
+
+    fn board(plating: &str, span: Option<(usize, usize)>, copper_features: &[String]) -> String {
+        let span = span
+            .map(|(from, to)| format!(r#"<Span fromLayer="L{from}" toLayer="L{to}"/>"#))
+            .unwrap_or_default();
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/>
+    <LayerRef name="L0"/><LayerRef name="L1"/><LayerRef name="L2"/><LayerRef name="DRILL"/>
+  </Content>
+  <Ecad><CadHeader units="MILLIMETER"/><CadData>
+    <Layer name="L0" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+    <Layer name="L1" layerFunction="CONDUCTOR" side="INTERNAL" polarity="POSITIVE"/>
+    <Layer name="L2" layerFunction="CONDUCTOR" side="BOTTOM" polarity="POSITIVE"/>
+    <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE">{span}</Layer>
+    <Step name="board" type="BOARD"><Datum x="0" y="0"/>
+      {}
+      <LayerFeature layerRef="DRILL"><Set net="N1" polarity="POSITIVE">
+        <Hole name="H1" diameter="1" platingStatus="{plating}" x="0" y="0"/>
+      </Set></LayerFeature>
+    </Step>
+  </CadData></Ecad>
+</IPC-2581>"#,
+            copper_features.join("\n")
+        )
+    }
+
+    fn board_with_unowned_land(other_copper: bool) -> String {
+        let other_copper = if other_copper {
+            r#"<Features><Contour><Polygon>
+              <PolyBegin x="0.55" y="-0.5"/><PolyStepSegment x="1.55" y="-0.5"/>
+              <PolyStepSegment x="1.55" y="0.5"/><PolyStepSegment x="0.55" y="0.5"/>
+              <PolyStepSegment x="0.55" y="-0.5"/>
+            </Polygon></Contour></Features>"#
+        } else {
+            ""
+        };
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/>
+    <LayerRef name="L0"/><LayerRef name="DRILL"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="land"><Circle diameter="1.4"/></EntryStandard>
+    </DictionaryStandard>
+  </Content>
+  <Ecad><CadHeader units="MILLIMETER"/><CadData>
+    <Layer name="L0" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+    <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE">
+      <Span fromLayer="L0" toLayer="L0"/>
+    </Layer>
+    <Step name="board" type="BOARD"><Datum x="0" y="0"/>
+      <PadStackDef name="land-stack">
+        <PadstackPadDef layerRef="L0" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef>
+      </PadStackDef>
+      <LayerFeature layerRef="L0"><Set polarity="POSITIVE">
+        <Pad padstackDefRef="land-stack"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></Pad>
+        {other_copper}
+      </Set></LayerFeature>
+      <LayerFeature layerRef="DRILL"><Set geometry="land-stack" polarity="POSITIVE">
+        <Hole name="H1" diameter="1" platingStatus="PLATED" x="0" y="0"/>
+      </Set></LayerFeature>
+    </Step>
+  </CadData></Ecad>
+</IPC-2581>"#
+        )
+    }
+
+    fn run(xml: &str, hole: &str) -> checks::Results {
+        let ipc = Ipc2581::parse(xml).unwrap();
+        let pdk = Pdk::parse(&pdk(hole)).unwrap();
+        let rules = rules::lower(&pdk, None).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+        checks::run(
+            &rules,
+            &design,
+            None,
+            NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
+        )
+    }
+
+    #[test]
+    fn passes_and_fails_edge_to_edge_clearance_with_report_evidence() {
+        let passing = run(
+            &board("VIA", Some((0, 2)), &[copper(0, Some("N2"), 0.8)]),
+            "via",
+        );
+        assert!(passing.findings.is_empty());
+        assert_eq!(passing.rules[0].checked, 3);
+
+        let failing = run(
+            &board("VIA", Some((0, 2)), &[copper(0, Some("N2"), 0.65)]),
+            "via",
+        );
+        assert_eq!(failing.findings.len(), 1);
+        let finding = &failing.findings[0];
+        assert!((finding.measurement.actual_mm().unwrap() - 0.15).abs() < 1e-9);
+        assert_eq!(finding.subjects[0].role, "hole");
+        assert_eq!(finding.subjects[1].role, "offender");
+        assert_eq!(finding.subjects[1].net.as_deref(), Some("N2"));
+        assert_eq!(finding.layers[1].name, "L0");
+        assert_eq!(finding.location.witnesses.len(), 2);
+        assert!(!finding.id.is_empty());
+        assert!(finding.sites.iter().all(|site| {
+            site.evidence
+                .iter()
+                .any(|evidence| evidence.role == "required_copper_keepout")
+        }));
+    }
+
+    #[test]
+    fn hole_clearance_report_includes_spatial_view_and_native_context() {
+        use crate::LayoutTarget;
+        use crate::commands::dfm::{CheckRequest, PdkSource, TextSource, report};
+
+        let xml = board("VIA", Some((0, 2)), &[copper(0, Some("N2"), 0.65)]);
+        let source = pdk("via");
+        let ipc = Ipc2581::parse(&xml).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let checked = crate::commands::dfm::check(
+            &imported,
+            CheckRequest {
+                input: report::FileIdentity::new("board.xml", xml.as_bytes()),
+                pdk: PdkSource::Toml(TextSource {
+                    path: "pdk.toml",
+                    source: &source,
+                }),
+                waivers: None,
+                layout_target: LayoutTarget::Board,
+                generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(checked.verdict, report::Verdict::Fail));
+        assert_eq!(checked.rules[0].view.kind, "hole_to_copper_clearance");
+        assert!(checked.rules[0].view.spatial);
+        assert_eq!(
+            checked.rules[0].view.features,
+            ["copper", "drills", "board_outlines"]
+        );
+        assert!(
+            checked
+                .scene
+                .passes
+                .iter()
+                .any(|pass| { pass.feature == "copper" && pass.layer.as_deref() == Some("L0") })
+        );
+        assert!(
+            checked
+                .scene
+                .passes
+                .iter()
+                .any(|pass| { pass.feature == "drills" && pass.layer.as_deref() == Some("DRILL") })
+        );
+    }
+
+    #[test]
+    fn excludes_own_net_for_vias_and_pths_but_not_unattributed_copper() {
+        for (hole, plating) in [("via", "VIA"), ("pth", "PLATED")] {
+            let own_net = run(
+                &board(plating, Some((0, 2)), &[copper(0, Some("N1"), 0.55)]),
+                hole,
+            );
+            assert!(own_net.findings.is_empty(), "{hole} own net");
+
+            let unattributed = run(
+                &board(plating, Some((0, 2)), &[copper(0, None, 0.55)]),
+                hole,
+            );
+            assert_eq!(unattributed.findings.len(), 1, "{hole} unattributed");
+            assert_eq!(
+                unattributed.findings[0].subjects[1].kind,
+                "unattributed_copper"
+            );
+        }
+    }
+
+    #[test]
+    fn excludes_only_the_resolved_unowned_land_not_other_copper_in_its_set() {
+        let own_land = run(&board_with_unowned_land(false), "pth");
+        assert!(own_land.findings.is_empty());
+
+        let with_other_copper = run(&board_with_unowned_land(true), "pth");
+        assert_eq!(with_other_copper.findings.len(), 1);
+        assert_eq!(
+            with_other_copper.findings[0].subjects[1].kind,
+            "unattributed_copper"
+        );
+        assert_eq!(
+            with_other_copper.findings[0].subjects[1]
+                .source
+                .as_ref()
+                .unwrap()
+                .feature_index,
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn npth_treats_same_net_copper_as_an_offender() {
+        let results = run(
+            &board("NONPLATED", Some((0, 2)), &[copper(0, Some("N1"), 0.55)]),
+            "npth",
+        );
+        assert_eq!(results.findings.len(), 1);
+        assert_eq!(results.findings[0].subjects[1].net.as_deref(), Some("N1"));
+    }
+
+    #[test]
+    fn checks_only_copper_layers_in_the_declared_drill_span() {
+        let outside = run(
+            &board("VIA", Some((0, 1)), &[copper(2, Some("N2"), 0.55)]),
+            "via",
+        );
+        assert_eq!(outside.rules[0].checked, 2);
+        assert!(outside.findings.is_empty());
+
+        let inside = run(
+            &board("VIA", Some((0, 1)), &[copper(1, Some("N2"), 0.55)]),
+            "via",
+        );
+        assert_eq!(inside.findings.len(), 1);
+        assert_eq!(inside.findings[0].layers[1].name, "L1");
+    }
+
+    #[test]
+    fn rejects_a_hole_without_a_resolvable_drill_span() {
+        let xml = board("VIA", None, &[copper(0, Some("N2"), 0.8)]);
+        let ipc = Ipc2581::parse(&xml).unwrap();
+        let pdk = Pdk::parse(&pdk("via")).unwrap();
+        let rules = rules::lower(&pdk, None).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let error = Design::extract(&imported, ArtworkScope::Board, &rules)
+            .err()
+            .expect("an unknown span must fail closed");
+        assert!(error.to_string().contains("no resolvable drill span"));
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -12,6 +12,7 @@ mod annular_ring;
 mod board_array_spacing;
 mod copper_clearance;
 mod hole_aspect_ratio;
+mod hole_clearance;
 mod hole_diameter;
 mod hole_pair_clearance;
 mod layer_count;
@@ -290,7 +291,8 @@ fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
             .then(|| "two or more direct board-array instances".to_owned()),
         RuleKind::HoleDiameter(class)
         | RuleKind::HoleAspectRatio(class)
-        | RuleKind::AnnularRing(class) => design
+        | RuleKind::AnnularRing(class)
+        | RuleKind::HoleToCopperClearance(class) => design
             .holes
             .iter()
             .all(|hole| hole.class != class)
@@ -348,6 +350,9 @@ fn evaluate(rule: &Rule, design: &Design) -> RuleEvaluation {
         }
         RuleKind::AnnularRing(class) => {
             annular_ring::evaluate(limit(), class, &rule.conditions, design).into()
+        }
+        RuleKind::HoleToCopperClearance(class) => {
+            hole_clearance::evaluate(limit(), class, &rule.conditions, design).into()
         }
         RuleKind::LineworkToCopperClearance(linework) => {
             linework_clearance::evaluate(limit(), linework, &rule.conditions, design).into()

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -77,9 +77,6 @@ impl<'a> Design<'a> {
         let (holes, slots) = when(pools.drilled, || {
             collect_drilled(imported, scope, stackup.as_ref())
         })?;
-        if pools.resolved_drill_spans {
-            validate_hole_clearance_spans(&holes, rules)?;
-        }
         let copper_layers = when(pools.copper, || {
             collect_copper_layers(imported, scope, pools.conductor_ownership)
         })?;
@@ -97,7 +94,7 @@ impl<'a> Design<'a> {
             })
             .map(|rule| rule.limit.length().millimeters())
             .fold(1.0, f64::max);
-        Ok(Self {
+        let design = Self {
             imported,
             scope,
             stackup,
@@ -146,7 +143,11 @@ impl<'a> Design<'a> {
             holes,
             slots,
             copper_layers,
-        })
+        };
+        if pools.resolved_drill_spans {
+            validate_hole_clearance_spans(&design, rules)?;
+        }
+        Ok(design)
     }
 
     pub fn resolve(&self, symbol: Option<Symbol>) -> Option<String> {
@@ -224,13 +225,20 @@ impl<'a> Design<'a> {
     }
 }
 
-fn validate_hole_clearance_spans(holes: &[Hole], rules: &[Rule]) -> Result<()> {
-    for hole in holes {
+fn validate_hole_clearance_spans(design: &Design, rules: &[Rule]) -> Result<()> {
+    for hole in &design.holes {
         let selected = rules.iter().any(|rule| {
             matches!(
                 rule.kind,
                 rules::RuleKind::HoleToCopperClearance(class) if class == hole.class
-            )
+            ) && rule.conditions.applies_to_design(design)
+                && design
+                    .copper_layers
+                    .iter()
+                    .enumerate()
+                    .any(|(index, layer)| {
+                        hole.spans_copper(index) && rule.conditions.applies_to_layer(layer)
+                    })
         });
         if selected
             && (!hole.span_declared || hole.drill_span.interpretation == "assumed_whole_stack")

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -48,6 +48,8 @@ pub(super) struct Design<'a> {
     /// One boundary index per copper layer, for clearance and enclosure
     /// queries against the composed copper.
     pub copper_boundaries: Vec<RegionBoundaryIndex>,
+    /// One boundary index per attributed conductor on each copper layer.
+    pub conductor_boundaries: Vec<Vec<RegionBoundaryIndex>>,
     /// Each hole's lands, one per copper layer it owns a land on, indexed
     /// like `holes`.
     pub hole_lands: Vec<Vec<HoleLand>>,
@@ -75,6 +77,9 @@ impl<'a> Design<'a> {
         let (holes, slots) = when(pools.drilled, || {
             collect_drilled(imported, scope, stackup.as_ref())
         })?;
+        if pools.resolved_drill_spans {
+            validate_hole_clearance_spans(&holes, rules)?;
+        }
         let copper_layers = when(pools.copper, || {
             collect_copper_layers(imported, scope, pools.conductor_ownership)
         })?;
@@ -86,7 +91,10 @@ impl<'a> Design<'a> {
         // would let one large hole coarsen every fine-clearance query.
         let boundary_search_mm = rules
             .iter()
-            .filter(|rule| rule.kind.semantics().pools.copper_boundaries)
+            .filter(|rule| {
+                let pools = rule.kind.semantics().pools;
+                pools.copper_boundaries || pools.conductor_boundaries
+            })
             .map(|rule| rule.limit.length().millimeters())
             .fold(1.0, f64::max);
         Ok(Self {
@@ -100,6 +108,23 @@ impl<'a> Design<'a> {
                 let layers = copper_layers.iter();
                 Ok(layers
                     .map(|layer| RegionBoundaryIndex::new(&layer.image, boundary_search_mm))
+                    .collect())
+            })?,
+            conductor_boundaries: when(pools.conductor_boundaries, || {
+                #[cfg(not(target_family = "wasm"))]
+                let layers = copper_layers.par_iter();
+                #[cfg(target_family = "wasm")]
+                let layers = copper_layers.iter();
+                Ok(layers
+                    .map(|layer| {
+                        layer
+                            .conductors
+                            .iter()
+                            .map(|conductor| {
+                                RegionBoundaryIndex::new(&conductor.image, boundary_search_mm)
+                            })
+                            .collect()
+                    })
                     .collect())
             })?,
             hole_lands: when(pools.hole_lands, || {
@@ -197,6 +222,29 @@ impl<'a> Design<'a> {
             },
         }
     }
+}
+
+fn validate_hole_clearance_spans(holes: &[Hole], rules: &[Rule]) -> Result<()> {
+    for hole in holes {
+        let selected = rules.iter().any(|rule| {
+            matches!(
+                rule.kind,
+                rules::RuleKind::HoleToCopperClearance(class) if class == hole.class
+            )
+        });
+        if selected
+            && (!hole.span_declared || hole.drill_span.interpretation == "assumed_whole_stack")
+        {
+            bail!(
+                "{} hole on layer '{}' at ({:.6}, {:.6}) has no resolvable drill span; hole-to-copper clearance cannot be certified",
+                hole.class.label(),
+                hole.layer.name,
+                hole.center.x,
+                hole.center.y
+            );
+        }
+    }
+    Ok(())
 }
 
 fn step_kind(kind: LayoutStepKind) -> &'static str {
@@ -476,6 +524,7 @@ pub(super) struct Hole {
     /// Inclusive ordinal range over the copper stackup the drill spans. A
     /// through-board or unstated span covers every copper layer.
     pub copper_span: (u16, u16),
+    pub span_declared: bool,
     pub drill_span: DrillSpan,
     pub provenance: SourceLocator,
     pub step: Option<Symbol>,
@@ -581,6 +630,7 @@ pub(super) enum ConductorId {
         step: Option<Symbol>,
         instance: Option<u32>,
         source_set_index: u32,
+        source_feature_index: u32,
     },
 }
 
@@ -717,6 +767,7 @@ fn collect_drilled(
                         layer: layer_ref(layer_name, source_layer.layer_function, None),
                         copper_span: copper_span(feature.intent.span, &imported.layer_definitions)
                             .unwrap_or(whole_stack),
+                        span_declared: source_layer.span.is_some(),
                         drill_span: drill_span(
                             feature.intent.span,
                             &imported.layer_definitions,
@@ -726,7 +777,7 @@ fn collect_drilled(
                         provenance: feature_provenance(imported, layer_name, feature),
                         step: feature.source_step_ref,
                         padstack: feature.padstack_ref,
-                        net: feature.net,
+                        net: source_net(&document, feature),
                         source_set_index: feature.source.set_index,
                         source_feature_index: feature.source.feature_index,
                     });
@@ -898,6 +949,15 @@ fn physical_copper_span(
     }
 }
 
+fn source_net(document: &GeometryDocument, feature: &Feature<Symbol>) -> Option<Symbol> {
+    feature.net.or_else(|| {
+        feature
+            .set
+            .and_then(|set| document.feature_sets.get(set as usize))
+            .and_then(|set| set.net)
+    })
+}
+
 fn feature_provenance(
     imported: &ImportedDesign,
     layer: &str,
@@ -955,6 +1015,7 @@ impl ArtworkLowering<Symbol, Option<ConductorId>> for CopperAttributionLowering 
             step: feature.source_step_ref,
             instance: feature.source_instance,
             source_set_index: feature.source.set_index,
+            source_feature_index: feature.source.feature_index,
         })
     }
 }
@@ -1025,7 +1086,7 @@ fn compose_attributed_image<Owner: Clone + Eq + std::hash::Hash>(
 fn conductor_order(
     imported: &ImportedDesign,
     id: ConductorId,
-) -> (u8, &str, Option<u32>, &str, u32) {
+) -> (u8, &str, Option<u32>, &str, u32, u32) {
     match id {
         ConductorId::Net {
             step,
@@ -1036,6 +1097,7 @@ fn conductor_order(
             step.map(|step| imported.resolve(step)).unwrap_or(""),
             instance,
             imported.resolve(net),
+            0,
             0,
         ),
         ConductorId::Auxiliary {
@@ -1048,17 +1110,20 @@ fn conductor_order(
             instance,
             "",
             source_set_index,
+            0,
         ),
         ConductorId::Unattributed {
             step,
             instance,
             source_set_index,
+            source_feature_index,
         } => (
             2,
             step.map(|step| imported.resolve(step)).unwrap_or(""),
             instance,
             "",
             source_set_index,
+            source_feature_index,
         ),
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
@@ -330,6 +330,12 @@ impl Rules {
             )
             .chain(
                 self.copper
+                    .hole_clearance
+                    .iter()
+                    .map(RuleDefinition::HoleClearance),
+            )
+            .chain(
+                self.copper
                     .feature_width
                     .iter()
                     .map(RuleDefinition::CopperLength),
@@ -368,6 +374,7 @@ enum RuleDefinition<'a> {
     SlotWidth(&'a SlotWidthRule),
     HolePair(&'a HolePairRule),
     AnnularRing(&'a AnnularRingRule),
+    HoleClearance(&'a HoleClearanceRule),
     CopperLength(&'a LengthRule),
     OtherLength(&'a LengthRule),
 }
@@ -380,6 +387,7 @@ impl RuleDefinition<'_> {
             Self::SlotWidth(rule) => &rule.metadata,
             Self::HolePair(rule) => &rule.metadata,
             Self::AnnularRing(rule) => &rule.metadata,
+            Self::HoleClearance(rule) => &rule.metadata,
             Self::CopperLength(rule) | Self::OtherLength(rule) => &rule.metadata,
         }
     }
@@ -393,6 +401,7 @@ impl RuleDefinition<'_> {
             Self::SlotWidth(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::HolePair(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::AnnularRing(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::HoleClearance(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::CopperLength(rule) | Self::OtherLength(rule) => {
                 (rule.limit.as_ref(), &rule.cases)
             }
@@ -409,7 +418,10 @@ impl RuleDefinition<'_> {
             metadata,
             limit,
             cases,
-            matches!(self, Self::AnnularRing(_) | Self::CopperLength(_)),
+            matches!(
+                self,
+                Self::AnnularRing(_) | Self::HoleClearance(_) | Self::CopperLength(_)
+            ),
         )
     }
 
@@ -454,6 +466,8 @@ pub struct DrillingRules {
 pub struct CopperRules {
     #[serde(default)]
     pub annular_ring: Vec<AnnularRingRule>,
+    #[serde(default)]
+    pub hole_clearance: Vec<HoleClearanceRule>,
     #[serde(default)]
     pub feature_width: Vec<LengthRule>,
     #[serde(default)]
@@ -754,6 +768,18 @@ pub struct AnnularRingRule {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct HoleClearanceRule {
+    #[serde(flatten)]
+    pub metadata: RuleMetadata,
+    pub select: HoleSelector,
+    #[serde(default)]
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LengthRule {
     #[serde(flatten)]
     pub metadata: RuleMetadata,
@@ -987,6 +1013,11 @@ cases = [
   { id = "multilayer", when = { copper_layers = { minimum = 3, maximum = 10 } }, limit = { minimum = "0.09 mm" } },
 ]
 
+[[rules.copper.hole_clearance]]
+id = "via-copper-clearance"
+select = { hole = "via" }
+limit = { minimum = "0.2 mm", preferred = "0.25 mm" }
+
 [[rules.panelization.board_spacing]]
 id = "array-spacing"
 limit = { minimum = "300 mil" }
@@ -1053,6 +1084,21 @@ limit = { minimum = "300 mil" }
                 .unwrap()
                 .ounces(),
             1.0
+        );
+        assert_eq!(
+            pdk.rules.copper.hole_clearance[0].select.hole,
+            HoleKind::Via
+        );
+        assert_eq!(
+            pdk.rules.copper.hole_clearance[0]
+                .limit
+                .as_ref()
+                .unwrap()
+                .preferred
+                .as_ref()
+                .unwrap()
+                .millimeters(),
+            0.25
         );
     }
 
@@ -1137,6 +1183,29 @@ limit = { minimum = "300 mil" }
                 .to_string()
                 .contains("overlap")
         );
+
+        let malformed = MIXED_UNIT_PDK.replace(
+            "select = { hole = \"via\" }\nlimit = { minimum = \"0.2 mm\", preferred = \"0.25 mm\" }",
+            "select = { hole = \"slot\" }\nlimit = { minimum = \"0.2 mm\", preferred = \"0.25 mm\" }",
+        );
+        assert!(Pdk::parse(&malformed).is_err());
+
+        let invalid_tier = MIXED_UNIT_PDK.replace(
+            "limit = { minimum = \"0.2 mm\", preferred = \"0.25 mm\" }",
+            "limit = { minimum = \"0.2 mm\", preferred = \"0.15 mm\" }",
+        );
+        assert!(
+            Pdk::parse(&invalid_tier)
+                .unwrap()
+                .validate_rule_references()
+                .is_err()
+        );
+
+        let old_hole_shape = MIXED_UNIT_PDK.replace(
+            "select = { hole = \"via\" }\nlimit = { minimum = \"0.2 mm\", preferred = \"0.25 mm\" }",
+            "hole = \"via\"\nminimum = \"0.2 mm\"\npreferred = \"0.25 mm\"",
+        );
+        assert!(Pdk::parse(&old_hole_shape).is_err());
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -145,6 +145,8 @@ pub(super) enum RuleKind {
     HolePairClearance(HoleClass, HoleClass),
     /// Enclosure: radial copper around each hole on the layers it lands on.
     AnnularRing(HoleClass),
+    /// Clearance: a circular drill stays clear of unrelated final copper.
+    HoleToCopperClearance(HoleClass),
     /// Clearance: reference linework stays clear of each copper image.
     LineworkToCopperClearance(Linework),
     /// Clearance: sibling board-array outlines keep their spacing.
@@ -186,7 +188,9 @@ pub(super) struct Pools {
     pub copper: bool,
     pub conductor_ownership: bool,
     pub copper_boundaries: bool,
+    pub conductor_boundaries: bool,
     pub hole_lands: bool,
+    pub resolved_drill_spans: bool,
     pub masks: bool,
     pub scores: bool,
     pub board_outlines: bool,
@@ -203,7 +207,9 @@ impl std::ops::BitOr for Pools {
             copper: self.copper || other.copper,
             conductor_ownership: self.conductor_ownership || other.conductor_ownership,
             copper_boundaries: self.copper_boundaries || other.copper_boundaries,
+            conductor_boundaries: self.conductor_boundaries || other.conductor_boundaries,
             hole_lands: self.hole_lands || other.hole_lands,
+            resolved_drill_spans: self.resolved_drill_spans || other.resolved_drill_spans,
             masks: self.masks || other.masks,
             scores: self.scores || other.scores,
             board_outlines: self.board_outlines || other.board_outlines,
@@ -218,7 +224,9 @@ const DRILLED: Pools = Pools {
     copper: false,
     conductor_ownership: false,
     copper_boundaries: false,
+    conductor_boundaries: false,
     hole_lands: false,
+    resolved_drill_spans: false,
     masks: false,
     scores: false,
     board_outlines: false,
@@ -274,6 +282,12 @@ impl RuleKind {
             Self::AnnularRing(_) => (
                 "annular_ring",
                 "Annular ring",
+                true,
+                &["copper", "drills", "board_outlines"],
+            ),
+            Self::HoleToCopperClearance(_) => (
+                "hole_to_copper_clearance",
+                "Hole-to-copper clearance",
                 true,
                 &["copper", "drills", "board_outlines"],
             ),
@@ -390,6 +404,26 @@ impl RuleKind {
                 pools: Pools {
                     hole_lands: true,
                     ..COPPER_BOUNDARIES
+                },
+            },
+            Self::HoleToCopperClearance(class) => Semantics {
+                subject: "hole_layer_pair",
+                quantity: "hole_edge_to_unrelated_copper_clearance",
+                method: "analytic_circle_to_attributed_composed_copper_distance",
+                finding_title: format!(
+                    "{} hole clearance to unrelated copper is below minimum",
+                    class.label()
+                ),
+                quantity_label: format!(
+                    "{} hole edge-to-unrelated-copper clearance",
+                    class.label()
+                ),
+                witness_roles: Some(["drilled_hole", "offending_copper"]),
+                pools: Pools {
+                    conductor_boundaries: true,
+                    hole_lands: true,
+                    resolved_drill_spans: true,
+                    ..COPPER
                 },
             },
             Self::LineworkToCopperClearance(Linework::VScore) => Semantics {
@@ -587,6 +621,18 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
             profile,
             format!("Minimum {} annular ring", class.label()),
             RuleKind::AnnularRing(class),
+        ));
+    }
+    for rule in &pdk.rules.copper.hole_clearance {
+        let class = hole_class(rule.select.hole);
+        rules.extend(lower_length_rule(
+            &rule.metadata,
+            rule.limit.as_ref(),
+            &rule.cases,
+            profile_name,
+            profile,
+            format!("Minimum {} hole-to-copper clearance", class.label()),
+            RuleKind::HoleToCopperClearance(class),
         ));
     }
     for (ruleset, title, kind) in [
@@ -805,5 +851,62 @@ fn slot_label(plating: SlotPlating) -> &'static str {
     match plating {
         SlotPlating::Plated => "plated",
         SlotPlating::Nonplated => "non-plated",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lowers_profile_selected_hole_clearance_tiers_and_conditions() {
+        let pdk = Pdk::parse(
+            r#"schema_version = 2
+default_profile = "a"
+
+[pdk]
+id = "test"
+name = "Test"
+revision = "1"
+
+[profiles.a]
+name = "A"
+
+[profiles.b]
+name = "B"
+
+[[rules.copper.hole_clearance]]
+id = "via-clearance"
+profiles = ["a"]
+select = { hole = "via" }
+cases = [
+  { id = "outer-1oz", when = { copper = { position = "outer", weight = "1 oz" } }, limit = { minimum = "0.20 mm", preferred = "0.25 mm" } },
+  { id = "inner", when = { copper = { position = "inner" } }, limit = { minimum = "0.18 mm" } },
+]
+
+[[rules.copper.hole_clearance]]
+id = "npth-clearance"
+profiles = ["b"]
+select = { hole = "npth" }
+limit = { minimum = "0.30 mm" }
+"#,
+        )
+        .unwrap();
+
+        let lowered = lower(&pdk, Some("a")).unwrap();
+        assert_eq!(lowered.len(), 3);
+        assert_eq!(lowered[0].id, "via-clearance.outer-1oz");
+        assert_eq!(lowered[1].id, "via-clearance.outer-1oz.preferred");
+        assert_eq!(lowered[2].id, "via-clearance.inner");
+        assert_eq!(lowered[0].severity, Severity::Error);
+        assert_eq!(lowered[1].severity, Severity::Warning);
+        assert_eq!(lowered[0].conditions.layer, Some(LayerPosition::Outer));
+        assert_eq!(lowered[0].conditions.copper_weight_oz, Some(1.0));
+        assert_eq!(lowered[2].conditions.layer, Some(LayerPosition::Inner));
+        assert!(matches!(
+            lowered[0].kind,
+            RuleKind::HoleToCopperClearance(HoleClass::Via)
+        ));
+        assert_eq!(lowered[1].limit.length().millimeters(), 0.25);
     }
 }


### PR DESCRIPTION
This change checks edge-to-edge clearance from circular drilled holes to unrelated final copper and reports stable spatial evidence. It uses structured PDK selectors, limits, and named cases, and it rejects applicable checks when the drill span is missing or unresolved.