### PR TITLE
Add plated-hole aspect-ratio DFM check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Add canonical assembly IR and derive component placement data from it.
 - Derive physical electrical terminations from exact IPC-2581 pin and padstack identities.
-- Add strict profile-based DFM PDK schema v2, executable JLCPCB 1 oz profiles, and metadata-only IPC 1A-3C profiles.
+- Add strict profile-based DFM PDK schema v2, executable JLCPCB 1 oz profiles, plated-hole aspect-ratio checks, and opinionated partial IPC-informed baselines.
 - Add a deterministic, versioned PCBA assembly report contract over canonical assembly and physical IR.
 - Expose PCBA assembly reports as JSON through `pcb ipc assembly`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Add canonical assembly IR and derive component placement data from it.
 - Derive physical electrical terminations from exact IPC-2581 pin and padstack identities.
-- Add strict profile-based DFM PDK schema v2, executable JLCPCB 1 oz profiles, plated-hole aspect-ratio checks, and opinionated partial IPC-informed baselines.
+- Add strict profile-based DFM PDK schema v2, executable JLCPCB 1 oz profiles, and metadata-only IPC 1A-3C profiles.
+- Add maximum plated-hole aspect-ratio DFM checks and make IPC 1A-3C profiles executable with opinionated partial IPC-informed baselines.
 - Add a deterministic, versioned PCBA assembly report contract over canonical assembly and physical IR.
 - Expose PCBA assembly reports as JSON through `pcb ipc assembly`.
 

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -62,9 +62,10 @@ pcb ipc dfm check fabrication-panel.xml \
 `jlcpcb` selects the standard-color 1 oz rigid FR-4 profile;
 `jlcpcb-1oz-black-white` selects its larger mask-web requirement. The
 `ipc` alias selects the opinionated Class 2 / Producibility Level B default.
-It and the explicit `ipc-1a` through `ipc-3c` profiles are metadata-only because
-IPC does not publish redistributable numeric matrices; they fail closed rather
-than claim IPC compliance.
+It and the explicit `ipc-1a` through `ipc-3c` profiles run Diode's opinionated
+partial baseline for plated-hole aspect ratio. These values are informed by IPC
+design topics, but they are not licensed IPC numeric matrices, do not prove full
+IPC compliance, and do not imply IPC certification.
 
 Pass a path such as `--pdk ./fab-process.toml` to use a custom PDK. Exact
 built-in names take precedence, so prefix a same-named file with `./`.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -47,6 +47,12 @@ select = { hole = "via" }
 limit = { minimum = "0.2 mm", preferred = "0.25 mm" }
 source = "capabilities"
 
+[[rules.drilling.hole_aspect_ratio]]
+id = "drilling.via_aspect_ratio"
+select = { hole = "via" }
+limit = { maximum = 8.0 }
+source = "capabilities"
+
 [[rules.drilling.slot_width]]
 id = "drilling.plated_slot"
 select = { plating = "plated" }
@@ -87,8 +93,10 @@ The schema gives each kind of constraint one place:
   PDK authors do not write layer-count DFM rules.
 - `select` identifies the physical subjects a rule measures. Hole rules select
   `via`, `pth`, or `npth`; slots select `plated` or `nonplated`; hole-pair rules
-  state both classes.
-- `limit` defines one unconditional minimum and an optional preferred value.
+  state both classes. Hole-aspect-ratio rules accept only plated `via` or `pth`
+  holes; selecting `npth` is a schema error.
+- `limit` defines one unconditional dimensional minimum and optional preferred
+  value, or one required aspect-ratio maximum.
 - `cases` defines named conditional limits when one value is not enough. A
   rule uses either `limit` or `cases`, never both.
 - `profile.defaults` records missing-data assumptions. Copper weight defaults
@@ -107,7 +115,9 @@ technology reliably enough for qualification.
 
 Layer counts are positive integers. Every dimensional minimum is a positive
 string containing a number and `mm`, `mil`, `mils`, or `um`; copper weight is a
-positive `oz` string. Units can be mixed. Checks normalize lengths to
+positive `oz` string. A hole-aspect-ratio `limit.maximum` is a positive finite
+unitless number; zero, nonfinite, string-valued, and otherwise malformed ratios
+are rejected. Units can be mixed. Checks normalize lengths to
 millimeters and retain both source spelling and normalized value. Profile
 defaults document an order's assumptions in the report; an outer/inner copper
 weight default is also the fallback for a weight-conditioned rule when the
@@ -124,6 +134,10 @@ tier:
   and counted but do not fail the verdict. The preferred value must exceed the
   minimum.
 
+Each direct or named-case hole-aspect-ratio limit instead has one required
+**error**-severity `maximum`; values above it fail the rule. It has no preferred
+tier.
+
 Rule ids, profile metadata, source citations, and the exact PDK TOML are
 retained in the report for auditability.
 
@@ -138,6 +152,7 @@ high-level pass is never allowed to suppress a later authoritative failure.
 | --- | --- | --- |
 | Profile copper-layer support | Conductive layers in the one physical IPC stackup | None |
 | Hole diameter | Materialized IPC drill primitive and plating class | None |
+| Plated-hole aspect ratio | Physical IPC stackup thickness over the resolved circular drill span, divided by finished hole diameter | None |
 | Nominal slot width | IPC slot primitive width | None |
 | Outline slot width | Materialized filled route outline, then its narrowest maximal inscribed disk | None |
 | Hole-to-hole clearance | Materialized drill circles and overlapping drill spans | Sorted bounds prune pairs already proven clear |
@@ -158,6 +173,11 @@ minimum only when the measured value falls short beyond its own uncertainty,
 so curve tessellation by itself cannot manufacture a violation. Profile
 copper-layer qualification instead compares one exact integer with the
 configured support bounds.
+
+Aspect ratio is a scalar rather than a geometric distance. Its spatial site and
+circle evidence identify the hole, while its measurement records the actual
+unitless ratio, maximum, drilled-span thickness, finished diameter, and
+thickness source. Witness separation does not encode the ratio.
 
 Morphological opening and closing are deliberately candidate stages for width
 and soldermask-web checks. Each candidate residue is measured on the medial
@@ -199,6 +219,16 @@ when fewer than two exist.
   narrowest local width. Drill extraction fails rather than silently
   discarding a hole whose plating class or diameter is missing, or a slot
   whose stated width its outline contradicts.
+- Hole aspect ratio is physical drilled-span thickness divided by finished
+  circular hole diameter. A through hole uses IPC-2581 `overallThickness` when
+  it is positive and finite, otherwise a complete sum of physical stackup
+  layer thicknesses. A resolved blind or buried hole sums only layers from its
+  first copper endpoint through its last endpoint, inclusive. Routed slots and
+  NPTH holes are never subjects. If IPC thickness is incomplete, a selected
+  profile's `defaults.board_thickness` may be assumed only for a declared
+  through hole; the rule reports that assumption. An incomplete resolved span,
+  or an incomplete through span without that default, skips the rule with the
+  precise missing-data reason rather than claiming a pass.
 - Hole-to-hole clearance measures edge-to-edge distance between hole pairs
   whose drill spans overlap; stacked blind and buried vias on disjoint spans
   do not interact.
@@ -276,11 +306,14 @@ which depends on the chosen routing, mouse-bite, or V-cut process. The
 standard-color profile uses the published 0.10 mm mask web; the black/white
 profile uses 0.13 mm.
 
-The nine IPC built-ins model performance Classes 1-3 crossed with
-Producibility Levels A-C and identify IPC's public 0.125-6 oz coverage. They
-are `metadata_only`: IPC publishes the taxonomy, but the numeric Advanced DFM
-profile matrices are licensed data and are not redistributed here. Selecting
-one returns an incomplete-check error instead of claiming IPC compliance.
+The nine `ipc-1a` through `ipc-3c` built-ins preserve performance Classes 1-3
+crossed with Producibility Levels A-C, but they are executable **partial Diode
+baselines**, not IPC profile matrices. They currently check only maximum via
+and PTH aspect ratio: Level A uses 6.0, Level B 8.0, and Level C 10.0, across
+all three performance classes. Each profile assumes 1.6 mm board thickness for
+the through-hole fallback described above. Diode chose these opinionated values
+using IPC design topics as context; they are not licensed IPC numeric matrices,
+do not prove full IPC compliance, and do not imply IPC certification.
 
 Output is UTF-8 JSON on stdout unless `-o` / `--output` is supplied. The
 recommended suffix is `.dfm.json`. Every complete report includes the native
@@ -333,6 +366,8 @@ A complete report has these fields:
   `maximum`), and `checked`, the number of measurements evaluated. `view`
   specifies the diagnostic family, whether it is spatial, and its semantic
   rendering features; `tier` distinguishes required and preferred limits.
+  `assumptions` lists profile defaults actually used while evaluating that
+  rule, and is empty when no assumption was needed.
 - `findings`: violations in deterministic rule/location order.
 - `scene`: required native artwork for the complete checked layout; see
   [native scene](#native-scene).
@@ -377,7 +412,10 @@ consumer's machine to render or validate the report.
   violation; `waived` and `waiver_reason` record acceptance.
 - `measurement` carries `actual_mm`, `required_mm`, and signed `margin_mm` for
   geometry, or the corresponding `actual_count`, `required_count`, and
-  `margin_count` for discrete counts. A nonnegative margin satisfies the limit.
+  `margin_count` for discrete counts. Aspect-ratio measurements instead carry
+  `actual_ratio`, `maximum_ratio`, signed `margin_ratio`,
+  `drilled_span_thickness_mm`, `finished_hole_diameter_mm`, and
+  `thickness_source`. A nonnegative margin satisfies the limit.
   Signed annular enclosure can be negative. Do not clamp measurements or
   recompute the verdict from rounded display values.
 - `location` carries a representative point, bounding box, and role-labelled
@@ -399,7 +437,8 @@ consumer's machine to render or validate the report.
   `measurement_kind`, `witnesses`, uncertainty, bounds, layers, subjects, and
   evidence. Nonspatial findings use `sites: []`. Site bounds describe the
   finding; viewers add their own camera padding. Witness-point separation is
-  not necessarily the measured width or diameter.
+  not necessarily the measured width or diameter. Scalar aspect-ratio sites
+  have no measurement witnesses; their circle evidence locates the hole.
 - `group_key`, when available, groups proven equivalent causes for display.
   It does not replace the finding id or change the waiver unit. Every finding
   and physical occurrence remains accessible.

--- a/crates/pcb-ipc2581-tools/examples/dfm-pdk.toml
+++ b/crates/pcb-ipc2581-tools/examples/dfm-pdk.toml
@@ -25,6 +25,11 @@ id = "drilling.via_hole"
 select = { hole = "via" }
 limit = { minimum = "0.2 mm" }
 
+[[rules.drilling.hole_aspect_ratio]]
+id = "drilling.via_aspect_ratio"
+select = { hole = "via" }
+limit = { maximum = 8.0 }
+
 [[rules.drilling.slot_width]]
 id = "drilling.plated_slot"
 select = { plating = "plated" }

--- a/crates/pcb-ipc2581-tools/pdks/ipc.toml
+++ b/crates/pcb-ipc2581-tools/pdks/ipc.toml
@@ -2,96 +2,164 @@ schema_version = 2
 default_profile = "2b"
 
 [pdk]
-id = "ipc-advanced-dfm-profiles"
-name = "IPC Advanced DFM Profiles"
-revision = "public-metadata-2026-09-01"
-manufacturer = "IPC"
-process = "Advanced DFM Profiles"
+id = "diode-ipc-informed-baselines"
+name = "Diode opinionated IPC-informed DFM baselines"
+revision = "2026-09-01"
+manufacturer = "Diode"
+process = "Partial IPC-informed baseline"
 
-[sources.ipc-profiles]
-title = "Design & Manufacturing Confirmed to IPC Standards"
+[sources.ipc-design-topics]
+title = "IPC design and manufacturing profile topics"
 url = "https://www.electronics.org/design-manufacturing-confirmed-ipc-standards"
 accessed = "2026-09-01"
-note = "IPC states that the profiles draw on IPC-2221, IPC-2222, IPC-2226, IPC-2152, IPC-6012, IPC-7351, and IPC-J-STD-001. Public material defines the taxonomy and copper-weight coverage but does not publish the licensed numeric rule matrices."
+note = "IPC public material identifies the class/producibility taxonomy and relevant design topics. Diode chose the numeric baseline values in this PDK; they are not licensed IPC numeric matrices, do not establish full IPC compliance, and do not imply IPC certification."
 
 [profiles.1a]
-name = "IPC Class 1 / Producibility Level A"
-status = "metadata_only"
+name = "IPC Class 1 / Producibility Level A — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 1
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.1a.defaults]
+board_thickness = "1.6 mm"
 
 [profiles.1b]
-name = "IPC Class 1 / Producibility Level B"
-status = "metadata_only"
+name = "IPC Class 1 / Producibility Level B — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 1
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.1b.defaults]
+board_thickness = "1.6 mm"
 
 [profiles.1c]
-name = "IPC Class 1 / Producibility Level C"
-status = "metadata_only"
+name = "IPC Class 1 / Producibility Level C — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 1
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.1c.defaults]
+board_thickness = "1.6 mm"
 
 [profiles.2a]
-name = "IPC Class 2 / Producibility Level A"
-status = "metadata_only"
+name = "IPC Class 2 / Producibility Level A — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 2
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.2a.defaults]
+board_thickness = "1.6 mm"
 
 [profiles.2b]
-name = "IPC Class 2 / Producibility Level B"
-description = "Opinionated default IPC taxonomy profile; numeric rules require licensed IPC profile data."
-status = "metadata_only"
+name = "IPC Class 2 / Producibility Level B — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 2
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.2b.defaults]
+board_thickness = "1.6 mm"
 
 [profiles.2c]
-name = "IPC Class 2 / Producibility Level C"
-status = "metadata_only"
+name = "IPC Class 2 / Producibility Level C — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 2
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.2c.defaults]
+board_thickness = "1.6 mm"
 
 [profiles.3a]
-name = "IPC Class 3 / Producibility Level A"
-status = "metadata_only"
+name = "IPC Class 3 / Producibility Level A — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 3
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.3a.defaults]
+board_thickness = "1.6 mm"
 
 [profiles.3b]
-name = "IPC Class 3 / Producibility Level B"
-status = "metadata_only"
+name = "IPC Class 3 / Producibility Level B — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 3
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.3b.defaults]
+board_thickness = "1.6 mm"
 
 [profiles.3c]
-name = "IPC Class 3 / Producibility Level C"
-status = "metadata_only"
+name = "IPC Class 3 / Producibility Level C — Diode partial baseline"
+description = "Diode's opinionated partial baseline informed by IPC design topics; not an IPC numeric matrix, certification, or proof of full IPC compliance."
 performance_class = 3
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["outer copper: 0.125-6 oz", "inner copper: 0.125-6 oz"]
-source = "ipc-profiles"
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio"]
+source = "ipc-design-topics"
+
+[profiles.3c.defaults]
+board_thickness = "1.6 mm"
+
+[[rules.drilling.hole_aspect_ratio]]
+id = "diode.ipc.maximum_via_aspect_ratio.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { hole = "via" }
+limit = { maximum = 6.0 }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_aspect_ratio]]
+id = "diode.ipc.maximum_pth_aspect_ratio.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { hole = "pth" }
+limit = { maximum = 6.0 }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_aspect_ratio]]
+id = "diode.ipc.maximum_via_aspect_ratio.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { hole = "via" }
+limit = { maximum = 8.0 }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_aspect_ratio]]
+id = "diode.ipc.maximum_pth_aspect_ratio.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { hole = "pth" }
+limit = { maximum = 8.0 }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_aspect_ratio]]
+id = "diode.ipc.maximum_via_aspect_ratio.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { hole = "via" }
+limit = { maximum = 10.0 }
+source = "ipc-design-topics"
+
+[[rules.drilling.hole_aspect_ratio]]
+id = "diode.ipc.maximum_pth_aspect_ratio.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { hole = "pth" }
+limit = { maximum = 10.0 }
+source = "ipc-design-topics"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -539,7 +539,7 @@ limit = { minimum = "300 mil" }
     }
 
     #[test]
-    fn loads_the_embedded_pdks_and_keeps_ipc_profiles_non_executable() {
+    fn loads_embedded_pdks_and_lowers_partial_ipc_baselines() {
         let builtin = builtin_pdks()
             .iter()
             .find(|pdk| pdk.name == "standard")
@@ -567,6 +567,35 @@ limit = { minimum = "300 mil" }
                 assert!(lowered.unwrap_err().to_string().contains("metadata-only"));
             } else {
                 assert!(!lowered.unwrap().is_empty());
+            }
+        }
+
+        let ipc = builtin_pdks().iter().find(|pdk| pdk.name == "ipc").unwrap();
+        let parsed = pdk::Pdk::parse(ipc.source).unwrap();
+        assert_eq!(parsed.pdk.manufacturer.as_deref(), Some("Diode"));
+        for class in 1..=3 {
+            for (level, maximum) in [('a', 6.0), ('b', 8.0), ('c', 10.0)] {
+                let profile = format!("{class}{level}");
+                let definition = &parsed.profiles[&profile];
+                assert_eq!(definition.performance_class, Some(class));
+                assert_eq!(
+                    definition.producibility_level.unwrap().label(),
+                    level.to_ascii_uppercase().to_string()
+                );
+                assert_eq!(
+                    definition
+                        .defaults
+                        .board_thickness
+                        .as_ref()
+                        .unwrap()
+                        .millimeters(),
+                    1.6
+                );
+                let rules = rules::lower(&parsed, Some(&profile)).unwrap();
+                assert_eq!(rules.len(), 2);
+                assert!(rules.iter().all(|rule| rule.limit.ratio() == maximum));
+                assert!(rules.iter().any(|rule| rule.id.contains("via")));
+                assert!(rules.iter().any(|rule| rule.id.contains("pth")));
             }
         }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
@@ -135,7 +135,7 @@ mod tests {
     <Layer name="INNER2" layerFunction="SIGNAL" side="INTERNAL" polarity="POSITIVE"/>
     <Layer name="INNER1" layerFunction="SIGNAL" side="INTERNAL" polarity="POSITIVE"/>
     <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
-    <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE"/>
+    <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE"><Span fromLayer="TOP" toLayer="BOTTOM"/></Layer>
     <Layer name="BLIND" layerFunction="DRILL" side="ALL" polarity="POSITIVE"><Span fromLayer="TOP" toLayer="INNER1"/></Layer>
     <Layer name="BURIED" layerFunction="DRILL" side="ALL" polarity="POSITIVE"><Span fromLayer="INNER1" toLayer="INNER2"/></Layer>
     <Stackup name="Primary" overallThickness="1.6" whereMeasured="METAL">

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
@@ -1,0 +1,395 @@
+//! Maximum plated-hole aspect ratio.
+//!
+//! For each circular plated hole `h`, the finished drilled diameter `dₕ` is
+//! stated by IPC-2581 and the physical stackup supplies the thickness `tₕ`
+//! traversed by its drill span. The scalar measurement is
+//!
+//! ```text
+//! aₕ = tₕ / dₕ ≤ A_max.
+//! ```
+//!
+//! Through holes use the finished total stackup thickness. A resolved blind
+//! or buried span sums only physical stackup layers between its two copper
+//! endpoints, inclusive. The selected profile's board-thickness default may
+//! replace incomplete IPC thickness only for a declared through hole.
+
+use crate::commands::dfm::design::{Design, HoleClass, SpanThickness, ThicknessSource};
+use crate::commands::dfm::report::Evidence;
+use crate::commands::dfm::rules::Conditions;
+
+use super::{RatioEvaluation, RatioMeasured, hole_subject, holes_of_class};
+
+pub(super) fn evaluate(
+    class: HoleClass,
+    conditions: &Conditions,
+    design: &Design,
+) -> RatioEvaluation {
+    let holes = holes_of_class(design, class);
+    let stackup = design
+        .stackup
+        .as_ref()
+        .expect("hole aspect-ratio rules request physical stackup extraction");
+    let mut measured = Vec::with_capacity(holes.len());
+    let mut assumptions = Vec::new();
+
+    for (_, hole) in &holes {
+        let thickness = match stackup.span_thickness(&hole.drill_span) {
+            Ok(thickness) => thickness,
+            Err(reason) if hole.drill_span.interpretation == "declared_through_board" => {
+                let Some(default) = conditions.assumed_board_thickness.as_ref() else {
+                    return incomplete(holes.len(), hole, class, reason, assumptions);
+                };
+                let assumption = format!(
+                    "IPC-2581 through-hole thickness is incomplete ({reason}); used selected profile defaults.board_thickness = '{}'.",
+                    default.original()
+                );
+                if assumptions.is_empty() {
+                    assumptions.push(assumption.clone());
+                }
+                SpanThickness {
+                    millimeters: default.millimeters(),
+                    source: ThicknessSource::ProfileDefaultBoardThickness,
+                }
+            }
+            Err(reason) => return incomplete(holes.len(), hole, class, reason, assumptions),
+        };
+        let actual_ratio = thickness.millimeters / hole.diameter_mm;
+        if !(actual_ratio.is_finite() && actual_ratio > 0.0) {
+            return incomplete(
+                holes.len(),
+                hole,
+                class,
+                "computed ratio is not positive and finite".to_owned(),
+                assumptions,
+            );
+        }
+        let thickness_source = thickness.source.label();
+        let subject = hole_subject(design, hole, "offender");
+        let evidence = vec![Evidence::circle(
+            "drilled_hole",
+            hole.center,
+            hole.diameter_mm,
+        )];
+        measured.push(RatioMeasured {
+            actual_ratio,
+            drilled_span_thickness_mm: thickness.millimeters,
+            finished_hole_diameter_mm: hole.diameter_mm,
+            thickness_source,
+            center: hole.center,
+            bbox: hole.bbox,
+            layers: vec![hole.layer.clone()],
+            subjects: vec![subject],
+            evidence,
+            note: format!(
+                "Aspect ratio uses {:.6} mm drilled-span thickness from {thickness_source} and {:.6} mm finished circular hole diameter.",
+                thickness.millimeters, hole.diameter_mm
+            ),
+        });
+    }
+
+    RatioEvaluation {
+        checked: holes.len(),
+        measured,
+        incomplete_reason: None,
+        assumptions,
+    }
+}
+
+fn incomplete(
+    checked: usize,
+    hole: &crate::commands::dfm::design::Hole,
+    class: HoleClass,
+    reason: String,
+    assumptions: Vec<String>,
+) -> RatioEvaluation {
+    RatioEvaluation {
+        checked,
+        measured: Vec::new(),
+        incomplete_reason: Some(format!(
+            "incomplete physical thickness data for {} hole at ({:.6}, {:.6}): {reason}",
+            class.label(),
+            hole.center.x,
+            hole.center.y
+        )),
+        assumptions,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::LayoutTarget;
+    use crate::commands::dfm::{
+        CheckRequest, PdkSource, TextSource, check,
+        report::{DfmReport, Measurement, RuleResult, RuleStatus, Verdict},
+    };
+    use crate::ipc2581::Ipc2581;
+    use pcb_ir::import::ipc2581::import_design;
+
+    const BOARD: &str = r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/>
+    <LayerRef name="TOP"/><LayerRef name="INNER1"/><LayerRef name="INNER2"/><LayerRef name="BOTTOM"/>
+    <LayerRef name="DRILL"/><LayerRef name="BLIND"/><LayerRef name="BURIED"/>
+  </Content>
+  <Ecad><CadHeader units="MILLIMETER"/><CadData>
+    <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+    <Layer name="INNER2" layerFunction="SIGNAL" side="INTERNAL" polarity="POSITIVE"/>
+    <Layer name="INNER1" layerFunction="SIGNAL" side="INTERNAL" polarity="POSITIVE"/>
+    <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
+    <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE"/>
+    <Layer name="BLIND" layerFunction="DRILL" side="ALL" polarity="POSITIVE"><Span fromLayer="TOP" toLayer="INNER1"/></Layer>
+    <Layer name="BURIED" layerFunction="DRILL" side="ALL" polarity="POSITIVE"><Span fromLayer="INNER1" toLayer="INNER2"/></Layer>
+    <Stackup name="Primary" overallThickness="1.6" whereMeasured="METAL">
+      <StackupGroup name="Primary_Group" thickness="1.6">
+        <StackupLayer layerOrGroupRef="TOP" thickness="0.05" sequence="0"/>
+        <StackupLayer layerOrGroupRef="D1" thickness="0.20" sequence="1"/>
+        <StackupLayer layerOrGroupRef="INNER1" thickness="0.05" sequence="2"/>
+        <StackupLayer layerOrGroupRef="D2" thickness="0.40" sequence="3"/>
+        <StackupLayer layerOrGroupRef="INNER2" thickness="0.05" sequence="4"/>
+        <StackupLayer layerOrGroupRef="D3" thickness="0.80" sequence="5"/>
+        <StackupLayer layerOrGroupRef="BOTTOM" thickness="0.05" sequence="6"/>
+      </StackupGroup>
+    </Stackup>
+    <Step name="board" type="BOARD">
+      <LayerFeature layerRef="DRILL"><Set><Hole name="PTH" diameter="0.2" platingStatus="PLATED" x="1" y="1"/></Set></LayerFeature>
+      <LayerFeature layerRef="BLIND"><Set><Hole name="BLIND" diameter="0.03" platingStatus="VIA" x="2" y="2"/></Set></LayerFeature>
+      <LayerFeature layerRef="BURIED"><Set><Hole name="BURIED" diameter="0.05" platingStatus="VIA" x="3" y="3"/></Set></LayerFeature>
+    </Step>
+  </CadData></Ecad>
+</IPC-2581>"#;
+
+    const PTH_PDK: &str = r#"schema_version = 2
+default_profile = "test"
+[pdk]
+id = "test"
+name = "Test"
+revision = "1"
+[profiles.test]
+name = "Test"
+[[rules.drilling.hole_aspect_ratio]]
+id = "pth-aspect-ratio"
+select = { hole = "pth" }
+limit = { maximum = 8.0 }
+"#;
+
+    const PTH_PDK_WITH_DEFAULT: &str = r#"schema_version = 2
+default_profile = "test"
+[pdk]
+id = "test"
+name = "Test"
+revision = "1"
+[profiles.test]
+name = "Test"
+[profiles.test.defaults]
+board_thickness = "1.6 mm"
+[[rules.drilling.hole_aspect_ratio]]
+id = "pth-aspect-ratio"
+select = { hole = "pth" }
+limit = { maximum = 8.0 }
+"#;
+
+    const VIA_PDK_WITH_DEFAULT: &str = r#"schema_version = 2
+default_profile = "test"
+[pdk]
+id = "test"
+name = "Test"
+revision = "1"
+[profiles.test]
+name = "Test"
+[profiles.test.defaults]
+board_thickness = "1.6 mm"
+[[rules.drilling.hole_aspect_ratio]]
+id = "via-aspect-ratio"
+select = { hole = "via" }
+cases = [
+  { id = "4-layer", when = { copper_layers = { exact = 4 } }, limit = { maximum = 8.0 } },
+]
+"#;
+
+    fn run(xml: &str, pdk: &str) -> DfmReport {
+        let ipc = Ipc2581::parse(xml).unwrap();
+        let imported = import_design(&ipc).unwrap();
+        check(
+            &imported,
+            CheckRequest {
+                input: crate::commands::dfm::report::FileIdentity::new("board.xml", xml.as_bytes()),
+                pdk: PdkSource::Toml(TextSource {
+                    path: "test.toml",
+                    source: pdk,
+                }),
+                waivers: None,
+                layout_target: LayoutTarget::Board,
+                generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            },
+        )
+        .unwrap()
+    }
+
+    fn only_rule(report: &DfmReport) -> &RuleResult {
+        assert_eq!(report.rules.len(), 1);
+        &report.rules[0]
+    }
+
+    #[test]
+    fn through_hole_passes_at_boundary_and_prefers_explicit_overall_thickness() {
+        let pdk = PTH_PDK_WITH_DEFAULT.replace("1.6 mm", "3.2 mm");
+        let report = run(BOARD, &pdk);
+        let rule = only_rule(&report);
+        assert!(matches!(report.verdict, Verdict::Pass));
+        assert!(matches!(rule.status, RuleStatus::Pass));
+        assert_eq!(rule.checked, 1);
+        assert_eq!(rule.comparison, "maximum");
+        assert_eq!(rule.subject, "hole");
+        assert_eq!(rule.limit.normalized_unit, "ratio");
+        assert_eq!(rule.limit.normalized_value, 8.0);
+        assert!(rule.assumptions.is_empty());
+    }
+
+    #[test]
+    fn through_hole_failure_and_report_json_expose_scalar_evidence() {
+        let report = run(
+            &BOARD.replace("diameter=\"0.2\"", "diameter=\"0.16\""),
+            PTH_PDK,
+        );
+        assert!(matches!(report.verdict, Verdict::Fail));
+        let rule = only_rule(&report);
+        assert!(matches!(rule.status, RuleStatus::Fail));
+        let finding = &report.findings[0];
+        assert!(matches!(
+            finding.measurement,
+            Measurement::Ratio {
+                actual_ratio: 10.0,
+                maximum_ratio: 8.0,
+                drilled_span_thickness_mm: 1.6,
+                finished_hole_diameter_mm: 0.16,
+                thickness_source: "ipc_2581_overall_thickness",
+                ..
+            }
+        ));
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["rules"][0]["comparison"], "maximum");
+        assert_eq!(json["rules"][0]["subject"], "hole");
+        assert_eq!(json["findings"][0]["measurement"]["actual_ratio"], 10.0);
+        assert_eq!(json["findings"][0]["measurement"]["maximum_ratio"], 8.0);
+        assert_eq!(
+            json["findings"][0]["measurement"]["thickness_source"],
+            "ipc_2581_overall_thickness"
+        );
+        assert_eq!(
+            json["findings"][0]["subjects"][0]["drill_span"],
+            serde_json::json!({
+                "first_copper_index": 0,
+                "last_copper_index": 3,
+                "interpretation": "declared_through_board"
+            })
+        );
+        assert_eq!(
+            json["findings"][0]["sites"][0]["measurement_kind"],
+            "aspect_ratio"
+        );
+        assert_eq!(
+            json["findings"][0]["sites"][0]["witnesses"],
+            serde_json::json!([])
+        );
+        assert_eq!(json["findings"][0]["evidence"][0]["kind"], "circle");
+    }
+
+    #[test]
+    fn through_hole_uses_and_reports_profile_default_fallback() {
+        let xml = BOARD
+            .replace(" overallThickness=\"1.6\"", "")
+            .replace(
+                "layerOrGroupRef=\"D1\" thickness=\"0.20\"",
+                "layerOrGroupRef=\"D1\"",
+            )
+            .replace("diameter=\"0.2\"", "diameter=\"0.16\"");
+        let report = run(&xml, PTH_PDK_WITH_DEFAULT);
+        let rule = only_rule(&report);
+        assert_eq!(rule.assumptions.len(), 1);
+        assert!(rule.assumptions[0].contains("defaults.board_thickness = '1.6 mm'"));
+        assert!(matches!(
+            report.findings[0].measurement,
+            Measurement::Ratio {
+                actual_ratio: 10.0,
+                thickness_source: "profile_default_board_thickness",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn through_hole_with_missing_thickness_and_no_default_is_skipped() {
+        let xml = BOARD.replace(" overallThickness=\"1.6\"", "").replace(
+            "layerOrGroupRef=\"D1\" thickness=\"0.20\"",
+            "layerOrGroupRef=\"D1\"",
+        );
+        let report = run(&xml, PTH_PDK);
+        let rule = only_rule(&report);
+        assert!(matches!(rule.status, RuleStatus::Skipped));
+        assert_eq!(rule.checked, 0);
+        assert!(
+            rule.skip_reason
+                .as_deref()
+                .unwrap()
+                .contains("physical stackup layer 'D1' has no thickness")
+        );
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn blind_and_buried_holes_use_only_their_physical_spans() {
+        let report = run(BOARD, VIA_PDK_WITH_DEFAULT);
+        let rule = only_rule(&report);
+        assert_eq!(rule.checked, 2);
+        assert_eq!(report.findings.len(), 2);
+        let measurements = report
+            .findings
+            .iter()
+            .map(|finding| match finding.measurement {
+                Measurement::Ratio {
+                    actual_ratio,
+                    drilled_span_thickness_mm,
+                    thickness_source,
+                    ..
+                } => (actual_ratio, drilled_span_thickness_mm, thickness_source),
+                _ => panic!("expected ratio measurement"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            measurements,
+            [
+                (10.0, 0.30, "ipc_2581_stackup_layer_thicknesses"),
+                (10.0, 0.50, "ipc_2581_stackup_layer_thicknesses"),
+            ]
+        );
+        let spans = report
+            .findings
+            .iter()
+            .map(|finding| {
+                let span = finding.subjects[0].drill_span.as_ref().unwrap();
+                (span.first_copper_index, span.last_copper_index)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(spans, [(0, 1), (1, 2)]);
+    }
+
+    #[test]
+    fn missing_blind_span_thickness_skips_instead_of_using_board_default() {
+        let xml = BOARD.replace(
+            "layerOrGroupRef=\"D2\" thickness=\"0.40\"",
+            "layerOrGroupRef=\"D2\"",
+        );
+        let report = run(&xml, VIA_PDK_WITH_DEFAULT);
+        let rule = only_rule(&report);
+        assert!(matches!(report.verdict, Verdict::Pass));
+        assert!(matches!(rule.status, RuleStatus::Skipped));
+        assert_eq!(rule.checked, 0);
+        assert!(rule.assumptions.is_empty());
+        assert!(
+            rule.skip_reason
+                .as_deref()
+                .unwrap()
+                .contains("physical stackup layer 'D2' has no thickness")
+        );
+        assert!(report.findings.is_empty());
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
@@ -339,6 +339,7 @@ cases = [
     fn blind_and_buried_holes_use_only_their_physical_spans() {
         let report = run(BOARD, VIA_PDK_WITH_DEFAULT);
         let rule = only_rule(&report);
+        assert_eq!(rule.id, "via-aspect-ratio.4-layer");
         assert_eq!(rule.checked, 2);
         assert_eq!(report.findings.len(), 2);
         let measurements = report

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -11,6 +11,7 @@
 mod annular_ring;
 mod board_array_spacing;
 mod copper_clearance;
+mod hole_aspect_ratio;
 mod hole_diameter;
 mod hole_pair_clearance;
 mod layer_count;
@@ -105,9 +106,30 @@ struct CountEvaluation {
     subjects: Vec<Subject>,
 }
 
+struct RatioMeasured {
+    actual_ratio: f64,
+    drilled_span_thickness_mm: f64,
+    finished_hole_diameter_mm: f64,
+    thickness_source: &'static str,
+    center: Point,
+    bbox: BBox,
+    layers: Vec<LayerRef>,
+    subjects: Vec<Subject>,
+    evidence: Vec<Evidence>,
+    note: String,
+}
+
+struct RatioEvaluation {
+    checked: usize,
+    measured: Vec<RatioMeasured>,
+    incomplete_reason: Option<String>,
+    assumptions: Vec<String>,
+}
+
 enum RuleEvaluation {
     Distance(Evaluation),
     Count(CountEvaluation),
+    Ratio(RatioEvaluation),
 }
 
 impl From<Evaluation> for RuleEvaluation {
@@ -162,6 +184,28 @@ pub(super) fn run(
                                 .push(count_finding(rule, evaluation, limit));
                         }
                     }
+                    RuleEvaluation::Ratio(evaluation) => {
+                        debug_assert_eq!(rule.comparison, Comparison::Maximum);
+                        result.assumptions = evaluation.assumptions;
+                        if let Some(reason) = evaluation.incomplete_reason {
+                            result.skip(reason);
+                        } else if evaluation.checked == 0 {
+                            result.skip(format!(
+                                "no measurable {} subjects in the selected layout target",
+                                rule.kind.semantics().subject
+                            ));
+                        } else {
+                            result.checked = evaluation.checked;
+                            let maximum = rule.limit.ratio();
+                            results.findings.extend(
+                                evaluation
+                                    .measured
+                                    .into_iter()
+                                    .filter(|measured| measured.actual_ratio > maximum)
+                                    .map(|measured| ratio_finding(rule, measured, maximum)),
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -173,7 +217,10 @@ pub(super) fn run(
     for finding in &results.findings {
         assert_eq!(
             !finding.sites.is_empty(),
-            matches!(finding.measurement, Measurement::Distance { .. }),
+            matches!(
+                finding.measurement,
+                Measurement::Distance { .. } | Measurement::Ratio { .. }
+            ),
             "finding {} violates the spatial-site contract",
             finding.rule_id,
         );
@@ -241,7 +288,9 @@ fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
         }
         RuleKind::BoardArrayPairClearance => (design.board_arrays.len() < 2)
             .then(|| "two or more direct board-array instances".to_owned()),
-        RuleKind::HoleDiameter(class) | RuleKind::AnnularRing(class) => design
+        RuleKind::HoleDiameter(class)
+        | RuleKind::HoleAspectRatio(class)
+        | RuleKind::AnnularRing(class) => design
             .holes
             .iter()
             .all(|hole| hole.class != class)
@@ -290,6 +339,9 @@ fn evaluate(rule: &Rule, design: &Design) -> RuleEvaluation {
     match rule.kind {
         RuleKind::CopperLayerCount => RuleEvaluation::Count(layer_count::evaluate(design)),
         RuleKind::HoleDiameter(class) => hole_diameter::evaluate(limit(), class, design).into(),
+        RuleKind::HoleAspectRatio(class) => {
+            RuleEvaluation::Ratio(hole_aspect_ratio::evaluate(class, &rule.conditions, design))
+        }
         RuleKind::SlotWidth(plating) => slot_width::evaluate(limit(), plating, design).into(),
         RuleKind::HolePairClearance(first, second) => {
             hole_pair_clearance::evaluate(limit(), first, second, design).into()
@@ -449,6 +501,56 @@ fn count_finding(rule: &Rule, measured: CountEvaluation, limit: u32) -> Finding 
         subjects: measured.subjects,
         evidence: Vec::new(),
         sites: Vec::new(),
+        group_key: None,
+    }
+}
+
+fn ratio_finding(rule: &Rule, measured: RatioMeasured, maximum: f64) -> Finding {
+    let semantics = rule.kind.semantics();
+    let measurement = Measurement::maximum_ratio(
+        measured.actual_ratio,
+        maximum,
+        measured.drilled_span_thickness_mm,
+        measured.finished_hole_diameter_mm,
+        measured.thickness_source,
+    );
+    let site = Site {
+        id: String::new(),
+        measurement: measurement.clone(),
+        measurement_kind: MeasurementKind::AspectRatio,
+        uncertainty_mm: 0.0,
+        witnesses: Vec::new(),
+        bounding_box: measured.bbox.into(),
+        layers: measured.layers.clone(),
+        subjects: measured.subjects.clone(),
+        evidence: measured.evidence.clone(),
+        note: Some(measured.note),
+    };
+    Finding {
+        id: String::new(),
+        rule_id: rule.id.clone(),
+        severity: rule.severity,
+        waived: false,
+        waiver_reason: None,
+        title: semantics.finding_title,
+        message: format!(
+            "{} is {:.6} ({:.6} mm drilled span / {:.6} mm finished diameter); the PDK permits at most {maximum:.6}; thickness source is {}",
+            semantics.quantity_label,
+            measured.actual_ratio,
+            measured.drilled_span_thickness_mm,
+            measured.finished_hole_diameter_mm,
+            measured.thickness_source,
+        ),
+        measurement,
+        location: Location {
+            point: Some(measured.center.into()),
+            bounding_box: Some(measured.bbox.into()),
+            witnesses: Vec::new(),
+        },
+        layers: measured.layers,
+        subjects: measured.subjects,
+        evidence: measured.evidence,
+        sites: vec![site],
         group_key: None,
     }
 }
@@ -697,6 +799,7 @@ fn repeat_group_key(finding: &Finding, inverse: Affine2) -> Option<String> {
         let measurement = match site.measurement {
             Measurement::Distance { actual_mm, required_mm, .. } => [quantize(actual_mm), quantize(required_mm)],
             Measurement::Count { actual_count, required_count, .. } => [f64::from(actual_count), f64::from(required_count)],
+            Measurement::Ratio { actual_ratio, maximum_ratio, .. } => [quantize(actual_ratio), quantize(maximum_ratio)],
         };
         let evidence = site.evidence.iter().map(|evidence| serde_json::json!({
             "role": evidence.role, "kind": evidence.kind,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -69,7 +69,12 @@ impl<'a> Design<'a> {
         rules: &[Rule],
     ) -> Result<Self> {
         let pools = rules::pools(rules);
-        let (holes, slots) = when(pools.drilled, || collect_drilled(imported, scope))?;
+        let stackup = when(pools.stackup, || {
+            collect_physical_stackup(imported).map(Some)
+        })?;
+        let (holes, slots) = when(pools.drilled, || {
+            collect_drilled(imported, scope, stackup.as_ref())
+        })?;
         let copper_layers = when(pools.copper, || {
             collect_copper_layers(imported, scope, pools.conductor_ownership)
         })?;
@@ -87,9 +92,7 @@ impl<'a> Design<'a> {
         Ok(Self {
             imported,
             scope,
-            stackup: when(pools.stackup, || {
-                collect_physical_stackup(imported).map(Some)
-            })?,
+            stackup,
             copper_boundaries: when(pools.copper_boundaries, || {
                 #[cfg(not(target_family = "wasm"))]
                 let layers = copper_layers.par_iter();
@@ -211,6 +214,114 @@ fn step_kind(kind: LayoutStepKind) -> &'static str {
 pub(super) struct PhysicalStackup {
     pub name: String,
     pub copper_layers: Vec<LayerRef>,
+    overall_thickness_mm: Option<f64>,
+    layers: Vec<PhysicalStackupLayer>,
+}
+
+#[derive(Debug)]
+struct PhysicalStackupLayer {
+    layer_ref: Symbol,
+    name: String,
+    thickness_mm: Option<f64>,
+    copper_index: Option<u16>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ThicknessSource {
+    IpcOverallThickness,
+    IpcStackupLayerThicknesses,
+    ProfileDefaultBoardThickness,
+}
+
+impl ThicknessSource {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::IpcOverallThickness => "ipc_2581_overall_thickness",
+            Self::IpcStackupLayerThicknesses => "ipc_2581_stackup_layer_thicknesses",
+            Self::ProfileDefaultBoardThickness => "profile_default_board_thickness",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct SpanThickness {
+    pub millimeters: f64,
+    pub source: ThicknessSource,
+}
+
+impl PhysicalStackup {
+    pub fn span_thickness(&self, span: &DrillSpan) -> std::result::Result<SpanThickness, String> {
+        match span.interpretation {
+            "declared_through_board" => self.total_thickness(),
+            "declared_layer_span" => {
+                let first = self
+                    .layers
+                    .iter()
+                    .position(|layer| layer.copper_index == Some(span.first_copper_index))
+                    .ok_or_else(|| {
+                        format!(
+                            "physical stackup has no copper layer at drill-span index {}",
+                            span.first_copper_index
+                        )
+                    })?;
+                let last = self
+                    .layers
+                    .iter()
+                    .position(|layer| layer.copper_index == Some(span.last_copper_index))
+                    .ok_or_else(|| {
+                        format!(
+                            "physical stackup has no copper layer at drill-span index {}",
+                            span.last_copper_index
+                        )
+                    })?;
+                self.layer_thicknesses(first.min(last), first.max(last))
+            }
+            _ => Err(
+                "drill span is not resolved in the physical stackup; board-thickness fallback is permitted only for a through hole"
+                    .to_owned(),
+            ),
+        }
+    }
+
+    fn total_thickness(&self) -> std::result::Result<SpanThickness, String> {
+        if let Some(thickness) = self.overall_thickness_mm
+            && thickness.is_finite()
+            && thickness > 0.0
+        {
+            return Ok(SpanThickness {
+                millimeters: thickness,
+                source: ThicknessSource::IpcOverallThickness,
+            });
+        }
+        self.layer_thicknesses(0, self.layers.len().saturating_sub(1))
+    }
+
+    fn layer_thicknesses(
+        &self,
+        first: usize,
+        last: usize,
+    ) -> std::result::Result<SpanThickness, String> {
+        let mut total = 0.0;
+        for layer in &self.layers[first..=last] {
+            let thickness = layer.thickness_mm.ok_or_else(|| {
+                format!("physical stackup layer '{}' has no thickness", layer.name)
+            })?;
+            if !thickness.is_finite() || thickness < 0.0 {
+                return Err(format!(
+                    "physical stackup layer '{}' has a negative or non-finite thickness",
+                    layer.name
+                ));
+            }
+            total += thickness;
+        }
+        if !(total.is_finite() && total > 0.0) {
+            return Err("physical drilled span has no positive finite thickness".to_owned());
+        }
+        Ok(SpanThickness {
+            millimeters: total,
+            source: ThicknessSource::IpcStackupLayerThicknesses,
+        })
+    }
 }
 
 fn collect_physical_stackup(imported: &ImportedDesign) -> Result<PhysicalStackup> {
@@ -218,7 +329,7 @@ fn collect_physical_stackup(imported: &ImportedDesign) -> Result<PhysicalStackup
         [stackup] => stackup,
         [] => bail!("IPC-2581 file carries no physical stackup"),
         stackups => bail!(
-            "IPC-2581 file carries {} physical stackups; layer-count DFM requires exactly one",
+            "IPC-2581 file carries {} physical stackups; physical-stackup DFM requires exactly one",
             stackups.len()
         ),
     };
@@ -242,18 +353,55 @@ fn collect_physical_stackup(imported: &ImportedDesign) -> Result<PhysicalStackup
 
     let mut seen = HashSet::new();
     let mut ordered = Vec::new();
-    for stackup_layer in &stackup.layers {
-        let Some(layer) = copper_by_name.get(&stackup_layer.layer_ref).copied() else {
-            continue;
-        };
-        if !seen.insert(layer.name) {
+    let mut physical_layers = Vec::new();
+    let mut copper_ordinal = 0u16;
+    let mut stackup_layers = stackup.layers.iter().collect::<Vec<_>>();
+    if stackup_layers
+        .iter()
+        .all(|layer| layer.layer_number.is_some())
+    {
+        stackup_layers.sort_by_key(|layer| layer.layer_number);
+        if stackup_layers
+            .windows(2)
+            .any(|pair| pair[0].layer_number == pair[1].layer_number)
+        {
             bail!(
-                "physical stackup '{}' contains copper layer '{}' more than once",
-                imported.resolve(stackup.name),
-                imported.resolve(layer.name)
+                "physical stackup '{}' has duplicate layer sequence numbers",
+                imported.resolve(stackup.name)
             );
         }
-        ordered.push(layer);
+    }
+    for stackup_layer in stackup_layers {
+        let copper_index =
+            if let Some(layer) = copper_by_name.get(&stackup_layer.layer_ref).copied() {
+                if !seen.insert(layer.name) {
+                    bail!(
+                        "physical stackup '{}' contains copper layer '{}' more than once",
+                        imported.resolve(stackup.name),
+                        imported.resolve(layer.name)
+                    );
+                }
+                ordered.push(layer);
+                let index = copper_ordinal;
+                copper_ordinal = copper_ordinal
+                    .checked_add(1)
+                    .context("physical stackup has too many copper layers")?;
+                Some(index)
+            } else {
+                None
+            };
+        physical_layers.push(PhysicalStackupLayer {
+            layer_ref: stackup_layer.layer_ref,
+            name: imported.resolve(stackup_layer.layer_ref).to_owned(),
+            thickness_mm: stackup_layer.thickness,
+            copper_index,
+        });
+    }
+    if physical_layers.is_empty() {
+        bail!(
+            "physical stackup '{}' contains no layers",
+            imported.resolve(stackup.name)
+        );
     }
 
     let mut missing = copper_by_name
@@ -287,6 +435,8 @@ fn collect_physical_stackup(imported: &ImportedDesign) -> Result<PhysicalStackup
     Ok(PhysicalStackup {
         name: imported.resolve(stackup.name).to_owned(),
         copper_layers,
+        overall_thickness_mm: stackup.overall_thickness,
+        layers: physical_layers,
     })
 }
 
@@ -513,6 +663,7 @@ pub(super) struct BoardArray {
 fn collect_drilled(
     imported: &ImportedDesign,
     scope: ArtworkScope,
+    stackup: Option<&PhysicalStackup>,
 ) -> Result<(Vec<Hole>, Vec<Slot>)> {
     let copper_count = imported
         .layer_definitions
@@ -570,6 +721,7 @@ fn collect_drilled(
                             feature.intent.span,
                             &imported.layer_definitions,
                             whole_stack,
+                            stackup,
                         ),
                         provenance: feature_provenance(imported, layer_name, feature),
                         step: feature.source_step_ref,
@@ -701,8 +853,12 @@ fn drill_span(
     span: FeatureSpan<Symbol>,
     layers: &[ipc2581::types::Layer],
     whole_stack: (u16, u16),
+    stackup: Option<&PhysicalStackup>,
 ) -> DrillSpan {
-    let resolved = copper_span(span, layers);
+    let resolved = match stackup {
+        Some(stackup) => physical_copper_span(span, stackup),
+        None => copper_span(span, layers),
+    };
     let (first_copper_index, last_copper_index) = resolved.unwrap_or(whole_stack);
     DrillSpan {
         first_copper_index,
@@ -712,6 +868,31 @@ fn drill_span(
             _ if resolved.is_some() => "declared_layer_span",
             _ => "assumed_whole_stack",
         },
+    }
+}
+
+fn physical_copper_span(
+    span: FeatureSpan<Symbol>,
+    stackup: &PhysicalStackup,
+) -> Option<(u16, u16)> {
+    let copper_index = |name: Symbol| {
+        stackup
+            .layers
+            .iter()
+            .find(|layer| layer.layer_ref == name)
+            .and_then(|layer| layer.copper_index)
+    };
+    match span {
+        FeatureSpan::Layer(layer) => copper_index(layer).map(|index| (index, index)),
+        FeatureSpan::FromTo {
+            from: Some(from),
+            to: Some(to),
+        } => {
+            let from = copper_index(from)?;
+            let to = copper_index(to)?;
+            Some((from.min(to), from.max(to)))
+        }
+        FeatureSpan::Unknown | FeatureSpan::ThroughBoard | FeatureSpan::FromTo { .. } => None,
     }
 }
 
@@ -1371,7 +1552,7 @@ mod tests {
               <Oval width="1.8" height="0.6"/>"#,
         );
         let oval = import_design(&oval).unwrap();
-        let (_, slots) = collect_drilled(&oval, ArtworkScope::Board).unwrap();
+        let (_, slots) = collect_drilled(&oval, ArtworkScope::Board, None).unwrap();
         assert_eq!(slots.len(), 1);
         assert!((slots[0].width.mm - 0.6).abs() < 1e-9);
         assert_eq!(
@@ -1415,7 +1596,7 @@ mod tests {
               </Outline>"#,
         );
         let outline = import_design(&outline).unwrap();
-        let (_, slots) = collect_drilled(&outline, ArtworkScope::Board).unwrap();
+        let (_, slots) = collect_drilled(&outline, ArtworkScope::Board, None).unwrap();
         assert_eq!(slots.len(), 1);
         let width = slots[0].width;
         assert!(
@@ -1449,7 +1630,7 @@ mod tests {
               <Oval width="1.8" height="0.6"/>"#,
         );
         let imported = import_design(&ipc).unwrap();
-        let oval = collect_drilled(&imported, ArtworkScope::Board)
+        let oval = collect_drilled(&imported, ArtworkScope::Board, None)
             .unwrap()
             .1
             .remove(0);

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -860,13 +860,15 @@ fn drill_span(
         None => copper_span(span, layers),
     };
     let (first_copper_index, last_copper_index) = resolved.unwrap_or(whole_stack);
+    let declared_through = matches!(span, FeatureSpan::ThroughBoard)
+        || resolved.is_some_and(|resolved| resolved == whole_stack);
     DrillSpan {
         first_copper_index,
         last_copper_index,
-        interpretation: match span {
-            FeatureSpan::ThroughBoard => "declared_through_board",
-            _ if resolved.is_some() => "declared_layer_span",
-            _ => "assumed_whole_stack",
+        interpretation: match (declared_through, resolved) {
+            (true, _) => "declared_through_board",
+            (false, Some(_)) => "declared_layer_span",
+            (false, None) => "assumed_whole_stack",
         },
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
@@ -306,6 +306,12 @@ impl Rules {
             .map(RuleDefinition::HoleDiameter)
             .chain(
                 self.drilling
+                    .hole_aspect_ratio
+                    .iter()
+                    .map(RuleDefinition::HoleAspectRatio),
+            )
+            .chain(
+                self.drilling
                     .slot_width
                     .iter()
                     .map(RuleDefinition::SlotWidth),
@@ -358,6 +364,7 @@ impl Rules {
 
 enum RuleDefinition<'a> {
     HoleDiameter(&'a HoleDiameterRule),
+    HoleAspectRatio(&'a HoleAspectRatioRule),
     SlotWidth(&'a SlotWidthRule),
     HolePair(&'a HolePairRule),
     AnnularRing(&'a AnnularRingRule),
@@ -369,6 +376,7 @@ impl RuleDefinition<'_> {
     fn metadata(&self) -> &RuleMetadata {
         match self {
             Self::HoleDiameter(rule) => &rule.metadata,
+            Self::HoleAspectRatio(rule) => &rule.metadata,
             Self::SlotWidth(rule) => &rule.metadata,
             Self::HolePair(rule) => &rule.metadata,
             Self::AnnularRing(rule) => &rule.metadata,
@@ -379,6 +387,9 @@ impl RuleDefinition<'_> {
     fn limits(&self) -> (Option<&LengthLimit>, &[LengthCase]) {
         match self {
             Self::HoleDiameter(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::HoleAspectRatio(_) => {
+                unreachable!("an aspect-ratio rule has no length limits")
+            }
             Self::SlotWidth(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::HolePair(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::AnnularRing(rule) => (rule.limit.as_ref(), &rule.cases),
@@ -390,6 +401,9 @@ impl RuleDefinition<'_> {
 
     fn validate(&self) -> Result<()> {
         let metadata = self.metadata();
+        if let Self::HoleAspectRatio(rule) = self {
+            return validate_ratio_limits(metadata, rule.limit.as_ref(), &rule.cases);
+        }
         let (limit, cases) = self.limits();
         validate_limits(
             metadata,
@@ -401,6 +415,16 @@ impl RuleDefinition<'_> {
 
     fn configured_ids(&self) -> Vec<String> {
         let metadata = self.metadata();
+        if let Self::HoleAspectRatio(rule) = self {
+            return if rule.limit.is_some() {
+                vec![metadata.id.clone()]
+            } else {
+                rule.cases
+                    .iter()
+                    .map(|case| format!("{}.{}", metadata.id, case.id))
+                    .collect()
+            };
+        }
         let (limit, cases) = self.limits();
         match limit {
             Some(limit) => limit.ids(&metadata.id),
@@ -417,6 +441,8 @@ impl RuleDefinition<'_> {
 pub struct DrillingRules {
     #[serde(default)]
     pub hole_diameter: Vec<HoleDiameterRule>,
+    #[serde(default)]
+    pub hole_aspect_ratio: Vec<HoleAspectRatioRule>,
     #[serde(default)]
     pub slot_width: Vec<SlotWidthRule>,
     #[serde(default)]
@@ -561,6 +587,21 @@ pub struct LengthCase {
     pub limit: LengthLimit,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RatioLimit {
+    pub maximum: Ratio,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RatioCase {
+    pub id: String,
+    #[serde(default)]
+    pub when: RuleConditions,
+    pub limit: RatioLimit,
+}
+
 fn validate_limits(
     metadata: &RuleMetadata,
     limit: Option<&LengthLimit>,
@@ -579,34 +620,71 @@ fn validate_limits(
         (None, true) => bail!("rule '{}': requires limit or cases", metadata.id),
     }
 
-    let mut ids = HashSet::new();
     for case in cases {
-        if case.id.trim().is_empty() {
-            bail!("rule '{}': case ids must not be empty", metadata.id);
-        }
-        if !ids.insert(&case.id) {
-            bail!("rule '{}': duplicate case id '{}'", metadata.id, case.id);
-        }
-        case.when
-            .validate(&format!("{}.{}", metadata.id, case.id))?;
-        if case.when.copper.is_some() && !allow_copper_conditions {
-            bail!(
-                "rule '{}.{}': when.copper is supported only for copper rules",
-                metadata.id,
-                case.id
-            );
-        }
         case.limit
             .validate(&format!("{}.{}", metadata.id, case.id))?;
     }
+    validate_cases(
+        metadata,
+        cases.iter().map(|case| (case.id.as_str(), &case.when)),
+        allow_copper_conditions,
+    )
+}
+
+fn validate_ratio_limits(
+    metadata: &RuleMetadata,
+    limit: Option<&RatioLimit>,
+    cases: &[RatioCase],
+) -> Result<()> {
+    match (limit, cases.is_empty()) {
+        (Some(_), true) => return Ok(()),
+        (None, false) => {}
+        (Some(_), false) => {
+            bail!(
+                "rule '{}': limit and cases are mutually exclusive",
+                metadata.id
+            )
+        }
+        (None, true) => bail!("rule '{}': requires limit or cases", metadata.id),
+    }
+    validate_cases(
+        metadata,
+        cases.iter().map(|case| (case.id.as_str(), &case.when)),
+        false,
+    )
+}
+
+fn validate_cases<'a>(
+    metadata: &RuleMetadata,
+    cases: impl Iterator<Item = (&'a str, &'a RuleConditions)>,
+    allow_copper_conditions: bool,
+) -> Result<()> {
+    let cases = cases.collect::<Vec<_>>();
+    let mut ids = HashSet::new();
+    for (id, when) in &cases {
+        if id.trim().is_empty() {
+            bail!("rule '{}': case ids must not be empty", metadata.id);
+        }
+        if !ids.insert(*id) {
+            bail!("rule '{}': duplicate case id '{}'", metadata.id, id);
+        }
+        when.validate(&format!("{}.{}", metadata.id, id))?;
+        if when.copper.is_some() && !allow_copper_conditions {
+            bail!(
+                "rule '{}.{}': when.copper is supported only for copper rules",
+                metadata.id,
+                id
+            );
+        }
+    }
     for (index, left) in cases.iter().enumerate() {
         for right in &cases[index + 1..] {
-            if left.when.overlaps(&right.when) {
+            if left.1.overlaps(right.1) {
                 bail!(
                     "rule '{}': cases '{}' and '{}' overlap",
                     metadata.id,
-                    left.id,
-                    right.id
+                    left.0,
+                    right.0
                 );
             }
         }
@@ -624,6 +702,18 @@ pub struct HoleDiameterRule {
     pub limit: Option<LengthLimit>,
     #[serde(default)]
     pub cases: Vec<LengthCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HoleAspectRatioRule {
+    #[serde(flatten)]
+    pub metadata: RuleMetadata,
+    pub select: PlatedHoleSelector,
+    #[serde(default)]
+    pub limit: Option<RatioLimit>,
+    #[serde(default)]
+    pub cases: Vec<RatioCase>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -718,6 +808,29 @@ pub enum PlatedHoleKind {
 pub enum SlotPlating {
     Plated,
     Nonplated,
+}
+
+/// A positive finite unitless PDK ratio.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(try_from = "f64")]
+pub struct Ratio(f64);
+
+impl Ratio {
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for Ratio {
+    type Error = String;
+
+    fn try_from(value: f64) -> std::result::Result<Self, Self::Error> {
+        if value.is_finite() && value > 0.0 {
+            Ok(Self(value))
+        } else {
+            Err("ratio must be a positive finite unitless number".to_owned())
+        }
+    }
 }
 
 /// A dimensional PDK value with its source spelling retained for auditability.
@@ -852,6 +965,11 @@ id = "via-hole"
 select = { hole = "via" }
 limit = { minimum = "0.2 mm" }
 
+[[rules.drilling.hole_aspect_ratio]]
+id = "via-aspect-ratio"
+select = { hole = "via" }
+limit = { maximum = 8.0 }
+
 [[rules.drilling.hole_to_hole_clearance]]
 id = "via-spacing"
 select = { first_hole = "via", second_hole = "via" }
@@ -897,6 +1015,15 @@ limit = { minimum = "300 mil" }
                 .minimum
                 .millimeters(),
             0.2
+        );
+        assert_eq!(
+            pdk.rules.drilling.hole_aspect_ratio[0]
+                .limit
+                .as_ref()
+                .unwrap()
+                .maximum
+                .value(),
+            8.0
         );
         assert!(
             (pdk.rules.drilling.hole_to_hole_clearance[0]
@@ -1010,5 +1137,44 @@ limit = { minimum = "300 mil" }
                 .to_string()
                 .contains("overlap")
         );
+    }
+
+    #[test]
+    fn rejects_npth_and_invalid_hole_aspect_ratios() {
+        assert!(
+            Pdk::parse(&MIXED_UNIT_PDK.replace(
+                "select = { hole = \"via\" }\nlimit = { maximum = 8.0 }",
+                "select = { hole = \"npth\" }\nlimit = { maximum = 8.0 }"
+            ))
+            .is_err()
+        );
+        for invalid in ["0.0", "-1.0", "inf", "nan", "\"8.0\""] {
+            assert!(
+                Pdk::parse(
+                    &MIXED_UNIT_PDK.replace("maximum = 8.0", &format!("maximum = {invalid}"))
+                )
+                .is_err(),
+                "accepted invalid ratio {invalid}"
+            );
+        }
+        assert!(
+            Pdk::parse(&MIXED_UNIT_PDK.replace(
+                "select = { hole = \"via\" }\nlimit = { maximum = 8.0 }",
+                "hole = \"via\"\nmaximum = 8.0"
+            ))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn validates_named_hole_aspect_ratio_cases() {
+        let pdk = MIXED_UNIT_PDK.replace(
+            "limit = { maximum = 8.0 }",
+            "cases = [\n  { id = \"2-layer\", when = { copper_layers = { exact = 2 } }, limit = { maximum = 8.0 } },\n  { id = \"multilayer\", when = { copper_layers = { minimum = 3 } }, limit = { maximum = 10.0 } },\n]",
+        );
+        Pdk::parse(&pdk)
+            .unwrap()
+            .validate_rule_references()
+            .unwrap();
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
@@ -295,6 +295,8 @@ pub struct RuleResult {
     pub finding_count: usize,
     pub waived_count: usize,
     pub skip_reason: Option<String>,
+    /// Input assumptions actually used while evaluating this rule.
+    pub assumptions: Vec<String>,
     pub view: ViewRecipe,
     pub tier: &'static str,
 }
@@ -316,6 +318,7 @@ impl RuleResult {
             finding_count: 0,
             waived_count: 0,
             skip_reason: None,
+            assumptions: Vec::new(),
             view: rule.kind.view_recipe(),
             tier: if rule.severity == Severity::Warning {
                 "preferred"
@@ -374,6 +377,11 @@ impl RuleLimit {
                 normalized_value: f64::from(*count),
                 normalized_unit: "layers",
             },
+            LimitValue::Ratio(ratio) => Self {
+                pdk_value: ratio.value().to_string(),
+                normalized_value: ratio.value(),
+                normalized_unit: "ratio",
+            },
         }
     }
 }
@@ -402,6 +410,7 @@ pub struct Finding {
 #[serde(rename_all = "snake_case")]
 pub enum MeasurementKind {
     Diameter,
+    AspectRatio,
     NominalWidth,
     InscribedWidth,
     Clearance,
@@ -449,6 +458,14 @@ pub enum Measurement {
         required_count: u32,
         margin_count: i64,
     },
+    Ratio {
+        actual_ratio: f64,
+        maximum_ratio: f64,
+        margin_ratio: f64,
+        drilled_span_thickness_mm: f64,
+        finished_hole_diameter_mm: f64,
+        thickness_source: &'static str,
+    },
 }
 
 impl Measurement {
@@ -476,11 +493,28 @@ impl Measurement {
         }
     }
 
+    pub fn maximum_ratio(
+        actual_ratio: f64,
+        maximum_ratio: f64,
+        drilled_span_thickness_mm: f64,
+        finished_hole_diameter_mm: f64,
+        thickness_source: &'static str,
+    ) -> Self {
+        Self::Ratio {
+            actual_ratio,
+            maximum_ratio,
+            margin_ratio: maximum_ratio - actual_ratio,
+            drilled_span_thickness_mm,
+            finished_hole_diameter_mm,
+            thickness_source,
+        }
+    }
+
     #[cfg(test)]
     pub fn actual_mm(&self) -> Option<f64> {
         match self {
             Self::Distance { actual_mm, .. } => Some(*actual_mm),
-            Self::Count { .. } => None,
+            Self::Count { .. } | Self::Ratio { .. } => None,
         }
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -11,7 +11,8 @@ use anyhow::Result;
 use super::design::HoleClass;
 use super::pdk::{
     CopperWeight, HoleKind, LayerPosition, Length, LengthCase, LengthLimit, Pdk, PlatedHoleKind,
-    Profile, ProfileStatus, RuleConditions, RuleMetadata, SlotPlating,
+    Profile, ProfileStatus, Ratio, RatioCase, RatioLimit, RuleConditions, RuleMetadata,
+    SlotPlating,
 };
 use super::report::{Severity, ViewRecipe};
 
@@ -32,6 +33,7 @@ pub(super) struct Conditions {
     pub maximum_copper_layers: Option<u32>,
     pub layer: Option<LayerPosition>,
     pub copper_weight_oz: Option<f64>,
+    pub assumed_board_thickness: Option<Length>,
     pub assumed_outer_copper_weight_oz: Option<f64>,
     pub assumed_inner_copper_weight_oz: Option<f64>,
 }
@@ -95,20 +97,34 @@ impl Comparison {
 pub(super) enum LimitValue {
     Length(Length),
     Count(u32),
+    Ratio(Ratio),
 }
 
 impl LimitValue {
     pub fn length(&self) -> &Length {
         match self {
             Self::Length(length) => length,
-            Self::Count(_) => unreachable!("a count-valued rule has no length limit"),
+            Self::Count(_) | Self::Ratio(_) => {
+                unreachable!("a non-length-valued rule has no length limit")
+            }
         }
     }
 
     pub fn count(&self) -> u32 {
         match self {
             Self::Count(count) => *count,
-            Self::Length(_) => unreachable!("a length-valued rule has no count limit"),
+            Self::Length(_) | Self::Ratio(_) => {
+                unreachable!("a non-count-valued rule has no count limit")
+            }
+        }
+    }
+
+    pub fn ratio(&self) -> f64 {
+        match self {
+            Self::Ratio(ratio) => ratio.value(),
+            Self::Length(_) | Self::Count(_) => {
+                unreachable!("a non-ratio-valued rule has no ratio limit")
+            }
         }
     }
 }
@@ -121,6 +137,8 @@ pub(super) enum RuleKind {
     CopperLayerCount,
     /// Size: each hole's drilled diameter meets the limit.
     HoleDiameter(HoleClass),
+    /// Ratio: drilled physical span thickness divided by finished hole diameter.
+    HoleAspectRatio(HoleClass),
     /// Size: each routed slot's width meets the limit.
     SlotWidth(SlotPlating),
     /// Clearance: holes with overlapping spans keep edge-to-edge distance.
@@ -235,6 +253,12 @@ impl RuleKind {
                 true,
                 &["drills", "board_outlines"],
             ),
+            Self::HoleAspectRatio(_) => (
+                "hole_aspect_ratio",
+                "Plated-hole aspect ratio",
+                true,
+                &["drills", "board_outlines"],
+            ),
             Self::SlotWidth(_) => (
                 "slot_width",
                 "Slot width",
@@ -317,6 +341,18 @@ impl RuleKind {
                 quantity_label: format!("{} hole diameter", class.label()),
                 witness_roles: Some(["hole_boundary", "hole_boundary"]),
                 pools: DRILLED,
+            },
+            Self::HoleAspectRatio(class) => Semantics {
+                subject: "hole",
+                quantity: "plated_hole_aspect_ratio",
+                method: "physical_drilled_span_thickness_over_finished_hole_diameter",
+                finding_title: format!("{} hole exceeds maximum aspect ratio", class.label()),
+                quantity_label: format!("{} hole aspect ratio", class.label()),
+                witness_roles: None,
+                pools: Pools {
+                    stackup: true,
+                    ..DRILLED
+                },
             },
             Self::SlotWidth(plating) => Semantics {
                 subject: "slot",
@@ -498,6 +534,18 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
             RuleKind::HoleDiameter(hole_class(rule.select.hole)),
         ));
     }
+    for rule in &pdk.rules.drilling.hole_aspect_ratio {
+        let class = plated_hole_class(rule.select.hole);
+        rules.extend(lower_ratio_rule(
+            &rule.metadata,
+            rule.limit.as_ref(),
+            &rule.cases,
+            profile_name,
+            profile,
+            format!("Maximum {} hole aspect ratio", class.label()),
+            RuleKind::HoleAspectRatio(class),
+        ));
+    }
     for rule in &pdk.rules.drilling.slot_width {
         rules.extend(lower_length_rule(
             &rule.metadata,
@@ -657,6 +705,63 @@ fn lower_limit(
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
+fn lower_ratio_rule(
+    metadata: &RuleMetadata,
+    limit: Option<&RatioLimit>,
+    cases: &[RatioCase],
+    profile_name: &str,
+    profile: &Profile,
+    title: String,
+    kind: RuleKind,
+) -> Vec<Rule> {
+    if !metadata.applies_to(profile_name) {
+        return Vec::new();
+    }
+    match limit {
+        Some(limit) => vec![lower_ratio_limit(
+            &metadata.id,
+            limit,
+            &RuleConditions::default(),
+            profile,
+            title,
+            kind,
+        )],
+        None => cases
+            .iter()
+            .map(|case| {
+                lower_ratio_limit(
+                    &format!("{}.{}", metadata.id, case.id),
+                    &case.limit,
+                    &case.when,
+                    profile,
+                    title.clone(),
+                    kind,
+                )
+            })
+            .collect(),
+    }
+}
+
+fn lower_ratio_limit(
+    id: &str,
+    limit: &RatioLimit,
+    when: &RuleConditions,
+    profile: &Profile,
+    title: String,
+    kind: RuleKind,
+) -> Rule {
+    Rule {
+        id: id.to_owned(),
+        title,
+        severity: Severity::Error,
+        comparison: Comparison::Maximum,
+        limit: LimitValue::Ratio(limit.maximum.clone()),
+        kind,
+        conditions: conditions(when, profile),
+    }
+}
+
 fn conditions(rule: &RuleConditions, profile: &Profile) -> Conditions {
     let copper_layers = rule.copper_layers.as_ref();
     let copper = rule.copper.as_ref();
@@ -667,6 +772,7 @@ fn conditions(rule: &RuleConditions, profile: &Profile) -> Conditions {
         copper_weight_oz: copper
             .and_then(|condition| condition.weight.as_ref())
             .map(CopperWeight::ounces),
+        assumed_board_thickness: profile.defaults.board_thickness.clone(),
         assumed_outer_copper_weight_oz: profile
             .defaults
             .outer_copper_weight


### PR DESCRIPTION
This PR adds a maximum plated-hole aspect-ratio DFM check for vias and PTH holes. It catches holes that are too deep for their finished diameter. The check uses resolved through-board and blind or buried spans, and it reports the profile fallback when through-board thickness is incomplete.