### PR TITLE
Reject odd copper layer counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Clarified that `pcb layout --check` validates an existing layout without modifying it; the command now fails when that layout is missing.
+- Reject stackups with an odd number of copper layers before generating an invalid KiCad board.
 
 ## [0.4.43] - 2026-09-01
 

--- a/crates/pcb-zen-core/src/lang/stackup.rs
+++ b/crates/pcb-zen-core/src/lang/stackup.rs
@@ -357,6 +357,9 @@ pub enum StackupError {
     #[error("Stackup must have an odd number of layers, got {0}")]
     EvenLayerCount(usize),
 
+    #[error("Stackup must have an even number of copper layers, got {0}")]
+    OddCopperLayerCount(usize),
+
     #[error("Stackup must start and end with copper layers")]
     MustStartEndWithCopper,
 
@@ -450,6 +453,10 @@ impl Stackup {
         }
         if layers.len().is_multiple_of(2) {
             return Err(StackupError::EvenLayerCount(layers.len()));
+        }
+        let copper_layers = self.copper_layer_count();
+        if !copper_layers.is_multiple_of(2) {
+            return Err(StackupError::OddCopperLayerCount(copper_layers));
         }
         Ok(())
     }
@@ -556,17 +563,9 @@ impl Stackup {
 
     /// Calculate the number of copper layers
     pub fn copper_layer_count(&self) -> usize {
-        if let Some(layers) = &self.layers {
-            let n = layers.len();
-            if n % 2 == 1 {
-                // For odd number of layers: n - (n/2)
-                n - (n / 2)
-            } else {
-                0 // Should not happen if validation passes
-            }
-        } else {
-            0
-        }
+        self.layers.as_deref().map_or(0, |layers| {
+            layers.iter().filter(|layer| layer.is_copper()).count()
+        })
     }
 
     /// Generate KiCad layers S-expression
@@ -1109,6 +1108,45 @@ mod tests {
         assert!(matches!(
             stackup.validate(),
             Err(StackupError::EvenLayerCount(4))
+        ));
+    }
+
+    #[test]
+    fn test_invalid_odd_copper_layers() {
+        let stackup = Stackup {
+            materials: None,
+            layers: Some(vec![
+                Layer::Copper {
+                    thickness: 0.035,
+                    role: CopperRole::Signal,
+                },
+                Layer::Dielectric {
+                    thickness: 0.7,
+                    material: "FR4".to_string(),
+                    form: DielectricForm::Core,
+                },
+                Layer::Copper {
+                    thickness: 0.035,
+                    role: CopperRole::Power,
+                },
+                Layer::Dielectric {
+                    thickness: 0.7,
+                    material: "FR4".to_string(),
+                    form: DielectricForm::Core,
+                },
+                Layer::Copper {
+                    thickness: 0.035,
+                    role: CopperRole::Signal,
+                },
+            ]),
+            silk_screen_color: None,
+            solder_mask_color: None,
+            copper_finish: None,
+        };
+
+        assert!(matches!(
+            stackup.validate(),
+            Err(StackupError::OddCopperLayerCount(3))
         ));
     }
 

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -579,7 +579,7 @@ Board(name="MainBoard", layers=4, layout_path="layout/MainBoard")
 Board(name="my_board", layers=4, layout_path="layout/my_board")
 ```
 
-Key parameters: `name`, `layout_path`, `layers` (2/4/6/8/10), `config` (explicit `BoardConfig`), `outer_copper_weight` (`"1oz"` or `"2oz"`), `copper_finish` (default `"ENIG"`).
+Key parameters: `name`, `layout_path`, `layers` (2/4/6/8/10), `config` (explicit `BoardConfig`), `outer_copper_weight` (`"1oz"` or `"2oz"`), `copper_finish` (default `"ENIG"`). An explicit stackup must contain an even number of copper layers.
 
 When `layers` is provided, `Board()` selects an appropriate default stackup, netclasses, and design rules. An explicit `config` is merged on top. See `@stdlib/board_config.zen` for `BoardConfig`, `Stackup`, `DesignRules`, `NetClass`, and preset stackups.
 


### PR DESCRIPTION
Reject odd copper-layer stackups during shared board configuration validation so KiCad never receives an unloadable board. Simplify copper-layer counting and document the constraint to fix ENG-933.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->