### PR TITLE
Fix pcb layout --check contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Clarified that `pcb layout --check` validates an existing layout without modifying it; the command now fails when that layout is missing.
+
 ## [0.4.43] - 2026-09-01
 
 ### Added

--- a/crates/pcb-layout/src/lib.rs
+++ b/crates/pcb-layout/src/lib.rs
@@ -603,12 +603,10 @@ pub fn check_layout_sync(
     let Some(layout_dir) = utils::resolve_layout_dir(schematic)? else {
         return Ok(None);
     };
-    let Some(kicad_files) = utils::discover_kicad_files(&layout_dir)? else {
-        return Ok(None);
-    };
+    let kicad_files = utils::require_kicad_files(&layout_dir)?;
     let pcb_file = kicad_files.kicad_pcb();
     if !pcb_file.exists() {
-        return Ok(None);
+        return Err(anyhow::anyhow!("Layout file not found: {}", pcb_file.display()).into());
     }
 
     let source_path = schematic

--- a/crates/pcbc/src/layout.rs
+++ b/crates/pcbc/src/layout.rs
@@ -28,7 +28,7 @@ pub struct LayoutArgs {
     #[arg(long = "offline")]
     pub offline: bool,
 
-    /// Run KiCad DRC checks after layout generation
+    /// Validate the existing layout without modifying it, then run KiCad DRC
     #[arg(long = "check")]
     pub check: bool,
 

--- a/crates/pcbc/tests/layout.rs
+++ b/crates/pcbc/tests/layout.rs
@@ -55,6 +55,16 @@ fn layout_json_output_is_parseable() {
         .write("modules/test.kicad_mod", TEST_KICAD_MOD)
         .write("no-layout.zen", NO_LAYOUT_ZEN);
 
+    let check_output = sandbox
+        .run("pcbc", ["layout", "--check", "board.zen"])
+        .stderr_capture()
+        .stdout_capture()
+        .unchecked()
+        .run()
+        .expect("layout --check command should execute");
+    assert!(!check_output.status.success());
+    assert!(String::from_utf8_lossy(&check_output.stderr).contains("No .kicad_pro file found"));
+
     let output = sandbox
         .run("pcbc", ["layout", "--no-open", "-f", "json", "board.zen"])
         .stderr_capture()


### PR DESCRIPTION
This change states that `pcb layout --check` validates an existing layout without changing it, then runs KiCad DRC. It also fails when the declared KiCad layout is missing, which prevents silent false success in ENG-1236.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->