### PR TITLE
Fix pcb doc package URL resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Clarified that `pcb layout --check` validates an existing layout without modifying it; the command now fails when that layout is missing.
 - Reject stackups with an odd number of copper layers before generating an invalid KiCad board.
+- Resolve domain-based package references with `pcb doc --package`.
 
 ## [0.4.43] - 2026-09-01
 

--- a/crates/pcbc/src/doc.rs
+++ b/crates/pcbc/src/doc.rs
@@ -19,7 +19,7 @@ pub struct DocArgs {
     #[arg(default_value = "")]
     pub path: String,
 
-    /// Generate docs from a package (local path, @stdlib, or github.com/user/repo[@version])
+    /// Generate docs from a package (local path, @stdlib, or host/user/repo[@version])
     #[arg(long, value_name = "PACKAGE")]
     pub package: Option<String>,
 }
@@ -39,15 +39,7 @@ pub fn execute(args: DocArgs) -> Result<()> {
         );
     }
 
-    if looks_like_package_path(&args.path) {
-        return run_docgen_for_package(&args.path);
-    }
-
-    anyhow::bail!(
-        "Unknown documentation path '{}'.\n\n\
-         Use `pcb doc --package <PACKAGE>` for package documentation.",
-        args.path
-    )
+    run_docgen_for_package(&args.path)
 }
 
 pub(crate) fn print_markdown(content: &str) {
@@ -56,16 +48,6 @@ pub(crate) fn print_markdown(content: &str) {
     } else {
         println!("{}", content);
     }
-}
-
-/// Check if input looks like a filesystem path or package URL
-fn looks_like_package_path(s: &str) -> bool {
-    s.starts_with('.')
-        || s.starts_with('/')
-        || s.starts_with('@')
-        || s.starts_with("github.com/")
-        || s.starts_with("gitlab.com/")
-        || s.contains('\\')
 }
 
 /// Generate docs for a package specified as local path, @stdlib, or remote URL
@@ -96,8 +78,11 @@ fn run_docgen_for_package(pkg: &str) -> Result<()> {
         return run_docgen(&package_dir, Some(&package_url), filter.as_deref());
     }
 
-    // Handle remote package URLs (github.com/user/repo@version)
-    if pkg.starts_with("github.com/") || pkg.starts_with("gitlab.com/") {
+    // Handle remote package URLs (host/user/repo@version)
+    if matches!(
+        pcb_zen_core::LoadSpec::parse(pkg),
+        Some(pcb_zen_core::LoadSpec::Url { .. })
+    ) {
         let (display_name, requested_version) = parse_remote_package_spec(pkg)?;
         let (module_path, version, filter) =
             resolve_remote_package(display_name, requested_version.as_ref())?;

--- a/crates/pcbc/tests/doc.rs
+++ b/crates/pcbc/tests/doc.rs
@@ -30,8 +30,8 @@ const REMOTE_PACKAGE_TOML: &str = r#"[workspace]
 pcb-version = "0.4"
 "#;
 
-fn seed_remote_package(sb: &mut Sandbox) {
-    let mut fixture = sb.git_fixture("https://github.com/mycompany/components.git");
+fn seed_remote_package(sb: &mut Sandbox, repository: &str) {
+    let mut fixture = sb.git_fixture(repository);
     fixture
         .write("SimpleResistor/pcb.toml", REMOTE_PACKAGE_TOML)
         .write("SimpleResistor/SimpleResistor.zen", SIMPLE_RESISTOR_V1)
@@ -55,7 +55,11 @@ fn run_doc(sb: &mut Sandbox, package: &str) -> Output {
 #[test]
 fn test_pcb_doc_remote_package_defaults_to_latest() {
     let mut sb = Sandbox::new();
-    seed_remote_package(&mut sb);
+    seed_remote_package(&mut sb, "https://github.com/mycompany/components.git");
+    seed_remote_package(
+        &mut sb,
+        "https://code.diode.computer/mycompany/components.git",
+    );
 
     let default_output = run_doc(&mut sb, "github.com/mycompany/components/SimpleResistor");
     let latest_output = run_doc(
@@ -66,11 +70,16 @@ fn test_pcb_doc_remote_package_defaults_to_latest() {
         &mut sb,
         "github.com/mycompany/components/SimpleResistor@1.0.0",
     );
+    let diodehub_output = run_doc(
+        &mut sb,
+        "code.diode.computer/mycompany/components/SimpleResistor@1.0.0",
+    );
 
     for (label, output) in [
         ("default", &default_output),
         ("latest", &latest_output),
         ("pinned", &pinned_output),
+        ("diodehub", &diodehub_output),
     ] {
         assert!(
             output.status.success(),
@@ -88,6 +97,7 @@ fn test_pcb_doc_remote_package_defaults_to_latest() {
     let default_stdout = String::from_utf8_lossy(&default_output.stdout);
     let latest_stdout = String::from_utf8_lossy(&latest_output.stdout);
     let pinned_stdout = String::from_utf8_lossy(&pinned_output.stdout);
+    let diodehub_stdout = String::from_utf8_lossy(&diodehub_output.stdout);
 
     assert_eq!(
         default_stdout, latest_stdout,
@@ -120,6 +130,10 @@ fn test_pcb_doc_remote_package_defaults_to_latest() {
     assert!(
         !pinned_stdout.contains("| value | str | \"4.7kOhm\" |"),
         "explicit version should not resolve the newer tag:\n{pinned_stdout}"
+    );
+    assert!(
+        diodehub_stdout.contains("| value | str | \"1kOhm\" |"),
+        "DiodeHub output should document the pinned package:\n{diodehub_stdout}"
     );
 }
 


### PR DESCRIPTION
This change classifies domain-based package references with the shared package URL parser and removes the GitHub and GitLab allowlist. It lets `pcb doc --package` resolve registry URLs returned by `pcb search` and adds focused DiodeHub coverage for ENG-883.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->