### PR TITLE
ENG-1254 Fetch tags before publish versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fetch remote tags before `pcb publish` determines a board version bump.
 - Clarified that `pcb layout --check` validates an existing layout without modifying it; the command now fails when that layout is missing.
 - Reject stackups with an odd number of copper layers before generating an invalid KiCad board.
 - Resolve domain-based package references with `pcb doc --package`.

--- a/crates/pcb-zen/src/git.rs
+++ b/crates/pcb-zen/src/git.rs
@@ -719,6 +719,14 @@ pub fn fetch_tags(repo_root: &Path, remote: &str) -> anyhow::Result<()> {
     )
 }
 
+/// Fetch tags from remote without deleting local-only tags.
+pub fn fetch_tags_without_pruning(repo_root: &Path, remote: &str) -> anyhow::Result<()> {
+    run_network_in(
+        repo_root,
+        &["fetch", remote, "--tags", "--force", "--quiet"],
+    )
+}
+
 pub fn push_tag(repo_root: &Path, tag_name: &str, remote: &str) -> anyhow::Result<()> {
     run_network_in(repo_root, &["push", remote, tag_name])
 }

--- a/crates/pcbc/src/publish.rs
+++ b/crates/pcbc/src/publish.rs
@@ -530,18 +530,13 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
         return Ok(());
     }
 
-    let remote = if !args.no_push {
-        let r = resolve_remote(&workspace.root, args.force)?;
-        eprintln!("Syncing with {}...", r.cyan());
-        git::fetch_tags(&workspace.root, &r)?;
-        if !args.force {
-            git::fetch_branch(&workspace.root, &r, "main")?;
-            preflight_checks(&workspace.root, &r)?;
-        }
-        Some(r)
-    } else {
-        None
-    };
+    let remote = resolve_remote(&workspace.root, args.force)?;
+    eprintln!("Syncing with {}...", remote.cyan());
+    git::fetch_tags(&workspace.root, &remote)?;
+    if !args.no_push && !args.force {
+        git::fetch_branch(&workspace.root, &remote, "main")?;
+        preflight_checks(&workspace.root, &remote)?;
+    }
 
     // Compute current version from tags (after fetch)
     let tag_prefix = tags::compute_tag_prefix(Some(&package_relative_path), workspace.path());
@@ -573,7 +568,7 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
     )?;
 
     // Upload to API (must succeed before creating tag)
-    if remote.is_some() {
+    if !args.no_push {
         let ws_name = release_workspace_name(&workspace)?;
         let ctx = pcb_diode_api::WorkspaceContext::from_workspace_root(&workspace.root);
         eprintln!("Uploading release to Diode...");
@@ -606,9 +601,9 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
     eprintln!("{} Created tag {}", "✓".green(), tag_name.bold());
 
     // Push tag to remote
-    if let Some(ref r) = remote {
-        eprintln!("Pushing tag to {}...", r.cyan());
-        git::push_tag(&workspace.root, &tag_name, r).context("Failed to push tag")?;
+    if !args.no_push {
+        eprintln!("Pushing tag to {}...", remote.cyan());
+        git::push_tag(&workspace.root, &tag_name, &remote).context("Failed to push tag")?;
         eprintln!("{} Pushed {}", "✓".green(), tag_name.bold());
     }
 

--- a/crates/pcbc/src/publish.rs
+++ b/crates/pcbc/src/publish.rs
@@ -530,7 +530,11 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
         return Ok(());
     }
 
-    let remote = resolve_remote(&workspace.root, args.force)?;
+    let remote = if args.no_push {
+        resolve_fetch_remote(&workspace.root)?
+    } else {
+        resolve_remote(&workspace.root, args.force)?
+    };
     eprintln!("Syncing with {}...", remote.cyan());
     if args.no_push {
         git::fetch_tags_without_pruning(&workspace.root, &remote)?;
@@ -1055,6 +1059,27 @@ fn resolve_remote(repo_root: &Path, force: bool) -> Result<String> {
     })
 }
 
+fn resolve_fetch_remote(repo_root: &Path) -> Result<String> {
+    if let Some(remote) = git::symbolic_ref_short_head(repo_root)
+        .and_then(|branch| git::get_branch_remote(repo_root, &branch))
+    {
+        return Ok(remote);
+    }
+
+    let remotes = git::run_output(repo_root, &["remote"])?;
+    let remotes: Vec<_> = remotes.lines().collect();
+    if remotes.contains(&"origin") {
+        return Ok("origin".to_string());
+    }
+    match remotes.as_slice() {
+        [remote] => Ok((*remote).to_string()),
+        [] => bail!("No Git remote is configured. Add a remote before publishing."),
+        _ => bail!(
+            "Unable to select a Git remote for publishing. Configure an 'origin' remote or set the current branch's upstream."
+        ),
+    }
+}
+
 /// Preflight checks run after fetching remote state.
 fn preflight_checks(repo_root: &Path, remote: &str) -> Result<()> {
     if git::has_uncommitted_changes(repo_root)? {
@@ -1509,6 +1534,21 @@ P1 = io(Net)
             packages: BTreeMap::new(),
             errors: Vec::new(),
         }
+    }
+
+    #[test]
+    fn fetch_remote_uses_origin_for_untracked_branch() {
+        let mut sb = Sandbox::new();
+        setup_publish_workspace(&mut sb, &[]);
+        sb.cwd("src")
+            .cmd("git", ["switch", "-c", "feature"])
+            .run()
+            .expect("create untracked branch");
+
+        assert_eq!(
+            resolve_fetch_remote(&sb.root_path().join("src")).unwrap(),
+            "origin"
+        );
     }
 
     #[test]

--- a/crates/pcbc/src/publish.rs
+++ b/crates/pcbc/src/publish.rs
@@ -532,10 +532,14 @@ fn publish_board(zen_path: &Path, args: &PublishArgs) -> Result<()> {
 
     let remote = resolve_remote(&workspace.root, args.force)?;
     eprintln!("Syncing with {}...", remote.cyan());
-    git::fetch_tags(&workspace.root, &remote)?;
-    if !args.no_push && !args.force {
-        git::fetch_branch(&workspace.root, &remote, "main")?;
-        preflight_checks(&workspace.root, &remote)?;
+    if args.no_push {
+        git::fetch_tags_without_pruning(&workspace.root, &remote)?;
+    } else {
+        git::fetch_tags(&workspace.root, &remote)?;
+        if !args.force {
+            git::fetch_branch(&workspace.root, &remote, "main")?;
+            preflight_checks(&workspace.root, &remote)?;
+        }
     }
 
     // Compute current version from tags (after fetch)

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -204,10 +204,17 @@ fn test_publish_board_with_version() {
         .run()
         .expect("build failed");
 
-    // Commit the hydrated manifests and tag an existing version
+    // Put the existing version only on the remote, as in a clone whose tags
+    // have not been fetched yet.
     sb.commit("Hydrate manifests").tag("boards/v1.2.3");
+    sb.cmd("git", ["push", "origin", "main", "boards/v1.2.3"])
+        .run()
+        .expect("push existing release");
+    sb.cmd("git", ["tag", "--delete", "boards/v1.2.3"])
+        .run()
+        .expect("delete local release tag");
 
-    // Run source-only publish with bump (creates v1.3.0)
+    // Publish fetches the remote tag before computing the bump (creates v1.3.0).
     let mut args = source_only_args("boards/TB0001.zen");
     args.push("--bump=minor");
     sb.run("pcbc", &args)

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -240,6 +240,40 @@ fn test_publish_board_with_version() {
 }
 
 #[test]
+fn test_publish_board_with_version_preserves_local_only_tags() {
+    let mut sb = Sandbox::new();
+    sb.cwd("src")
+        .ignore_globs(["layout/*", "**/vendor/**", "**/build/**"])
+        .hash_globs(["*.kicad_mod", "**/diodeinc/stdlib/*.zen", "**/netlist.json"])
+        .write(".gitignore", ".pcb")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", TB0001_BOARD_PCB_TOML)
+        .write("boards/modules/LedModule.zen", LED_MODULE_ZEN)
+        .write("boards/TB0001.zen", TEST_BOARD_ZEN)
+        .init_git()
+        .commit("Initial commit")
+        .sync();
+
+    sb.run("pcbc", ["build", "boards/TB0001.zen"])
+        .run()
+        .expect("build failed");
+    sb.commit("Hydrate manifests").tag("boards/v1.2.3");
+
+    let mut args = source_only_args("boards/TB0001.zen");
+    args.push("--bump=patch");
+    sb.run("pcbc", &args)
+        .run()
+        .expect("Failed to run pcb publish command");
+
+    let tags = sb
+        .cmd("git", ["tag", "--list", "boards/v*"])
+        .read()
+        .expect("list release tags");
+    assert!(tags.lines().any(|tag| tag == "boards/v1.2.3"));
+    assert!(tags.lines().any(|tag| tag == "boards/v1.2.4"));
+}
+
+#[test]
 fn test_publish_board_full() {
     let server = MockServer::start();
     let matched_paths = ["C1.C", "C2.C", "LED1.D1.LED", "LED1.R1.R", "R1.R"];

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -258,6 +258,9 @@ fn test_publish_board_with_version_preserves_local_only_tags() {
         .run()
         .expect("build failed");
     sb.commit("Hydrate manifests").tag("boards/v1.2.3");
+    sb.cmd("git", ["switch", "--detach"])
+        .run()
+        .expect("detach HEAD");
 
     let mut args = source_only_args("boards/TB0001.zen");
     args.push("--bump=patch");


### PR DESCRIPTION
Versioned board publishing now fetches remote tags before it calculates the next version, including local-only `--no-push` runs. This prevents stale clones from treating an existing release as the first release while preserving local-only tags for dry runs; see [ENG-1254](https://linear.app/diodeinc/issue/ENG-1254/fetch-tags-before-running-pcb-publish).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->