### PR TITLE
Hide advice diagnostics from pcb publish (ENG-1255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fetch remote tags before `pcb publish` determines a board version bump.
+- Hide Advice-level diagnostics from `pcb publish` output while preserving warnings and errors.
 - Clarified that `pcb layout --check` validates an existing layout without modifying it; the command now fails when that layout is missing.
 - Reject stackups with an odd number of copper layers before generating an invalid KiCad board.
 - Resolve domain-based package references with `pcb doc --package`.

--- a/crates/pcbc/src/drc.rs
+++ b/crates/pcbc/src/drc.rs
@@ -11,6 +11,22 @@ type ColorFn = fn(String) -> colored::ColoredString;
 
 /// Render diagnostics (filter, print, show summary table)
 pub fn render_diagnostics(diagnostics: &mut pcb_zen_core::Diagnostics, suppress_kinds: &[String]) {
+    render_diagnostics_inner(diagnostics, suppress_kinds, true);
+}
+
+/// Render only warning and error diagnostics.
+pub fn render_warnings_and_errors(
+    diagnostics: &mut pcb_zen_core::Diagnostics,
+    suppress_kinds: &[String],
+) {
+    render_diagnostics_inner(diagnostics, suppress_kinds, false);
+}
+
+fn render_diagnostics_inner(
+    diagnostics: &mut pcb_zen_core::Diagnostics,
+    suppress_kinds: &[String],
+    include_advice: bool,
+) {
     // Apply filter passes
     for pass in [
         &FilterHiddenPass as &dyn DiagnosticsPass,
@@ -30,7 +46,8 @@ pub fn render_diagnostics(diagnostics: &mut pcb_zen_core::Diagnostics, suppress_
     });
 
     for diagnostic in ordered {
-        if !diagnostic.suppressed
+        if (include_advice || !matches!(diagnostic.severity, EvalSeverity::Advice))
+            && !diagnostic.suppressed
             && let Some((severity_str, severity_color)) = match diagnostic.severity {
                 EvalSeverity::Error => Some(("Error", Style::Red)),
                 EvalSeverity::Warning => Some(("Warning", Style::Yellow)),
@@ -56,9 +73,13 @@ pub fn render_diagnostics(diagnostics: &mut pcb_zen_core::Diagnostics, suppress_
     }
 
     // Print summary table
-    if !diagnostics.diagnostics.is_empty() {
+    let mut counts = diagnostics.counts();
+    if !include_advice {
+        counts
+            .retain(|(_, severity, _), _| matches!(severity, Severity::Error | Severity::Warning));
+    }
+    if !counts.is_empty() {
         eprintln!();
-        let counts = diagnostics.counts();
 
         // Show DRC and parity in separate tables, since they represent very different
         // concepts during import. Keep any remaining kinds in an "Other" table.

--- a/crates/pcbc/src/drc.rs
+++ b/crates/pcbc/src/drc.rs
@@ -9,20 +9,8 @@ use std::collections::{BTreeSet, HashMap};
 
 type ColorFn = fn(String) -> colored::ColoredString;
 
-/// Render diagnostics (filter, print, show summary table)
-pub fn render_diagnostics(diagnostics: &mut pcb_zen_core::Diagnostics, suppress_kinds: &[String]) {
-    render_diagnostics_inner(diagnostics, suppress_kinds, true);
-}
-
-/// Render only warning and error diagnostics.
-pub fn render_warnings_and_errors(
-    diagnostics: &mut pcb_zen_core::Diagnostics,
-    suppress_kinds: &[String],
-) {
-    render_diagnostics_inner(diagnostics, suppress_kinds, false);
-}
-
-fn render_diagnostics_inner(
+/// Render diagnostics (filter, print, show summary table).
+pub fn render_diagnostics(
     diagnostics: &mut pcb_zen_core::Diagnostics,
     suppress_kinds: &[String],
     include_advice: bool,

--- a/crates/pcbc/src/import/validate.rs
+++ b/crates/pcbc/src/import/validate.rs
@@ -90,7 +90,7 @@ pub(super) fn validate(
     };
     // Render diagnostics for the user (this is intentionally noisy and useful).
     let mut diagnostics_for_render = diagnostics;
-    crate::drc::render_diagnostics(&mut diagnostics_for_render, &[]);
+    crate::drc::render_diagnostics(&mut diagnostics_for_render, &[], true);
 
     if !summary.schematic_parity_ok {
         print_parity_blocking_recap(&diagnostics_for_render, 50);

--- a/crates/pcbc/src/layout.rs
+++ b/crates/pcbc/src/layout.rs
@@ -141,7 +141,7 @@ pub(crate) fn render_or_bail(
     suppress: &[String],
     message: &str,
 ) -> Result<()> {
-    drc::render_diagnostics(diagnostics, suppress);
+    drc::render_diagnostics(diagnostics, suppress, true);
     if diagnostics.error_count() > 0 {
         anyhow::bail!("{message}");
     }

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -690,7 +690,7 @@ fn review_release_preflight(
     spinner: &Spinner,
     diagnostics: &mut Diagnostics,
 ) -> Result<()> {
-    spinner.suspend(|| crate::drc::render_diagnostics(diagnostics, &info.suppress));
+    spinner.suspend(|| crate::drc::render_warnings_and_errors(diagnostics, &info.suppress));
     let warning_count = diagnostics.warning_count();
     if !confirm_continue_on_warnings(
         spinner,

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -690,7 +690,7 @@ fn review_release_preflight(
     spinner: &Spinner,
     diagnostics: &mut Diagnostics,
 ) -> Result<()> {
-    spinner.suspend(|| crate::drc::render_warnings_and_errors(diagnostics, &info.suppress));
+    spinner.suspend(|| crate::drc::render_diagnostics(diagnostics, &info.suppress, false));
     let warning_count = diagnostics.warning_count();
     if !confirm_continue_on_warnings(
         spinner,
@@ -1502,7 +1502,9 @@ fn run_kicad_drc(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> {
 
     pcb_zen_core::SuppressPass::new(info.suppress.clone()).apply(&mut diagnostics);
     if diagnostics.error_count() > 0 {
-        spinner.suspend(|| crate::drc::render_diagnostics(&mut active_errors(&diagnostics), &[]));
+        spinner.suspend(|| {
+            crate::drc::render_diagnostics(&mut active_errors(&diagnostics), &[], false)
+        });
         std::process::exit(1);
     }
 

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -185,6 +185,38 @@ fn test_publish_board_source_only() {
 }
 
 #[test]
+fn test_publish_board_hides_advice_but_reports_warnings() {
+    let mut sb = Sandbox::new();
+    let board = format!(
+        "{SIMPLE_BOARD_ZEN}\nwarn(\"publish warning\", kind=\"publish.warning\")\n\ndef publish_advice(module):\n    error(\"publish advice\")\n\nbuiltin.add_electrical_check(name=\"publish_advice\", check_fn=publish_advice, severity=\"advice\")\n"
+    );
+    sb.cwd("src")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write("boards/modules/component.zen", SIMPLE_COMPONENT)
+        .write("boards/modules/test.kicad_mod", TEST_KICAD_MOD)
+        .write("boards/modules/datasheet.txt", "test")
+        .write("boards/TestBoard.zen", board)
+        .init_git()
+        .commit("Initial commit")
+        .sync();
+
+    let output = sb
+        .run("pcbc", source_only_args("boards/TestBoard.zen"))
+        .stderr_capture()
+        .stdout_capture()
+        .run()
+        .expect("Failed to run pcb publish command");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(stderr.contains("publish warning"), "{stderr}");
+    assert!(!stdout.contains("publish advice"), "{stdout}");
+    assert!(!stderr.contains("publish advice"), "{stderr}");
+    assert!(!stderr.contains("Advice"), "{stderr}");
+}
+
+#[test]
 fn test_publish_board_with_version() {
     let mut sb = Sandbox::new();
     sb.cwd("src")

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -185,38 +185,6 @@ fn test_publish_board_source_only() {
 }
 
 #[test]
-fn test_publish_board_hides_advice_but_reports_warnings() {
-    let mut sb = Sandbox::new();
-    let board = format!(
-        "{SIMPLE_BOARD_ZEN}\nwarn(\"publish warning\", kind=\"publish.warning\")\n\ndef publish_advice(module):\n    error(\"publish advice\")\n\nbuiltin.add_electrical_check(name=\"publish_advice\", check_fn=publish_advice, severity=\"advice\")\n"
-    );
-    sb.cwd("src")
-        .write("pcb.toml", PCB_TOML)
-        .write("boards/pcb.toml", BOARD_PCB_TOML)
-        .write("boards/modules/component.zen", SIMPLE_COMPONENT)
-        .write("boards/modules/test.kicad_mod", TEST_KICAD_MOD)
-        .write("boards/modules/datasheet.txt", "test")
-        .write("boards/TestBoard.zen", board)
-        .init_git()
-        .commit("Initial commit")
-        .sync();
-
-    let output = sb
-        .run("pcbc", source_only_args("boards/TestBoard.zen"))
-        .stderr_capture()
-        .stdout_capture()
-        .run()
-        .expect("Failed to run pcb publish command");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(stderr.contains("publish warning"), "{stderr}");
-    assert!(!stdout.contains("publish advice"), "{stdout}");
-    assert!(!stderr.contains("publish advice"), "{stderr}");
-    assert!(!stderr.contains("Advice"), "{stderr}");
-}
-
-#[test]
 fn test_publish_board_with_version() {
     let mut sb = Sandbox::new();
     sb.cwd("src")


### PR DESCRIPTION
The `pcb publish` preflight now shows only Warning and Error diagnostics while other DRC workflows keep Advice output. This change adds regression coverage and fixes [ENG-1255](https://linear.app/diodeinc/issue/ENG-1255/stop-pcb-publish-from-printing-advice-diagnostics).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->