### PR TITLE
Report component-land vias and protection intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Expose drilled holes, termination associations, and explicit via-protection intent in PCBA assembly reports.
+
 ### Changed
 
 - `QR` generic is now a solid silkscreen square with a 5mm, 8mm or 10mm side length

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -3636,6 +3636,7 @@ impl<'a> Parser<'a> {
             "PLATED" => Ok(PlatingStatus::Plated),
             "NONPLATED" => Ok(PlatingStatus::NonPlated),
             "VIA" => Ok(PlatingStatus::Via),
+            "VIA_CAPPED" => Ok(PlatingStatus::ViaCapped),
             _ => Err(Ipc2581Error::InvalidAttribute(format!(
                 "Invalid plating status: {}",
                 s

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -198,6 +198,7 @@ pub enum PlatingStatus {
     Plated,
     NonPlated,
     Via,
+    ViaCapped,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ipc2581/src/write.rs
+++ b/crates/ipc2581/src/write.rs
@@ -77,6 +77,7 @@ pub fn plating_status_attr(plating_status: PlatingStatus) -> &'static str {
         PlatingStatus::Plated => "PLATED",
         PlatingStatus::NonPlated => "NONPLATED",
         PlatingStatus::Via => "VIA",
+        PlatingStatus::ViaCapped => "VIA_CAPPED",
     }
 }
 
@@ -255,6 +256,8 @@ mod tests {
 
     #[test]
     fn hole_renders_units_and_plating() {
+        assert_eq!(plating_status_attr(PlatingStatus::ViaCapped), "VIA_CAPPED");
+
         let hole_mm = Hole {
             name: None,
             diameter: 2.0,

--- a/crates/ipc2581/tests/testcases.rs
+++ b/crates/ipc2581/tests/testcases.rs
@@ -297,7 +297,7 @@ fn validate_testcase1_metadata(doc: &Ipc2581) {
                     for hole in set.holes() {
                         total_drills += 1;
                         match hole.plating_status {
-                            PlatingStatus::Via => via_drills += 1,
+                            PlatingStatus::Via | PlatingStatus::ViaCapped => via_drills += 1,
                             PlatingStatus::Plated => plated_drills += 1,
                             PlatingStatus::NonPlated => nonplated_drills += 1,
                         }

--- a/crates/pcb-ipc2581-tools/docs/assembly-report.md
+++ b/crates/pcb-ipc2581-tools/docs/assembly-report.md
@@ -1,4 +1,4 @@
-# PCBA assembly report v2
+# PCBA assembly report v3
 
 `assembly::build_report` lowers one cached `pcb-ir` imported design into the
 deterministic contract used by the CLI and native library. The report carries
@@ -101,8 +101,26 @@ Packages contain only definitions referenced by components in the selected
 scope. Physical terminations include only pins explicitly marked
 `electricalType="ELECTRICAL"`. Copper replicas collapse only when component,
 pin, padstack, and location identities match exactly. Paste islands link only
-through that same exact identity. No nearest-object or overlap heuristic is
-used.
+through that same exact identity.
+
+`holes` contains stable source-backed drilled-hole facts, including location,
+source name, finished diameter, plating, padstack, net, and layer span. Each
+termination lists its associated `hole_ids`, paste islands, and source-backed
+assembly-side soldermask openings. Source component/pin evidence takes
+precedence when present. Otherwise, a hole associates with a termination only
+when its declared span reaches exactly one land on a known assembly side.
+Multiple exact overlaps are `ambiguous`, and no exact overlap is `unresolved`;
+nearest-object matching is never used. `basis` preserves whether source
+identity or exact geometry produced the candidates.
+
+Via protection is an independent intent assembled from explicit source
+evidence. `VIA_CAPPED` contributes `capped`; `HOLEFILL` contributes `filled` or
+`plugged`. Coating layers contribute no method unless their specification
+values name a protection action. Explicit specification values can identify
+`open`, `tented`, `plugged`, `filled`, and `capped`. Fill material is normalized
+only from specification material and property values, never layer or
+specification names. Missing protection evidence remains `unknown`: geometry
+does not imply fill, protection, factory capability, or quote readiness.
 
 Components remain present when excluded. A preferred BOM item with
 `category="DOCUMENT"` sets `assembly_status` to `excluded` and
@@ -124,6 +142,11 @@ population, a missing reference designator, a populated component without a
 resolved package, or a populated SMT or through-hole component without an
 exact physical termination.
 
+It emits warnings when a hole has ambiguous or conflicting termination
+evidence, or when an associated via has unknown or conflicting protection
+intent.
+
 The complete report contract is declared in `src/assembly/report.rs`. The
 IPC-2581C-valid fixture in `src/assembly/testdata/report.xml` exercises package
-geometry, structural text, board cutouts, and a panel profile.
+geometry, structural text, board cutouts, via protection, and mirrored panel
+repeats.

--- a/crates/pcb-ipc2581-tools/src/assembly/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/mod.rs
@@ -3,15 +3,19 @@
 use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Result, bail};
+use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::assembly as ir;
-use pcb_ir::dialects::ipc::LayoutStepKind;
+use pcb_ir::dialects::ipc::{FeatureSpan, LayoutStepKind, PlatingKind};
 use pcb_ir::geom::path::{ContourBuf, PathCmd, PathOp};
 use pcb_ir::geom::{
     Affine2, BBox, FillRule as IrFillRule, LineCap as IrLineCap, LineJoin as IrLineJoin,
     LinePattern as IrLinePattern, Paint, Point as IrPoint, Polarity as IrPolarity,
 };
 use pcb_ir::import::ipc2581::{ImportedDesign, LayoutOccurrenceId};
-use pcb_ir::import::physical::LandId;
+use pcb_ir::import::physical::{
+    Association, AssociationBasis as PhysicalAssociationBasis, LandId, PhysicalHoleKind,
+    PhysicalTerminationId, PhysicalView,
+};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
@@ -23,9 +27,9 @@ pub use report::AssemblyReport;
 
 /// Build the stable report consumed by native, CLI, and WebAssembly surfaces.
 ///
-/// The report uses only source-backed assembly IR and exact physical
-/// relationships. It performs no geometric matching and applies no quote or
-/// shop policy.
+/// The report uses source-backed assembly IR and conservative physical
+/// relationships. Geometry can establish only a unique exact overlap; the
+/// report applies no quote or shop policy.
 pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<AssemblyReport> {
     let scope = match target {
         LayoutTarget::Board => ir::Scope::Board,
@@ -134,6 +138,7 @@ pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<A
         .map(|land| (land.id, land))
         .collect::<HashMap<LandId, _>>();
     let mut component_terminations = HashMap::<String, Vec<String>>::new();
+    let mut termination_ids = HashMap::<PhysicalTerminationId, String>::new();
     let mut terminations = physical
         .terminations
         .iter()
@@ -149,6 +154,7 @@ pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<A
                 "termination",
                 &(&component_id, &pin, &padstack, location_mm),
             );
+            termination_ids.insert(termination.id, id.clone());
             component_terminations
                 .entry(component_id.clone())
                 .or_default()
@@ -186,6 +192,25 @@ pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<A
                     .then_with(|| left.location_mm.x.total_cmp(&right.location_mm.x))
                     .then_with(|| left.location_mm.y.total_cmp(&right.location_mm.y))
             });
+            let mut mask_openings = physical
+                .mask_openings
+                .iter()
+                .filter(|opening| {
+                    (termination.side == pcb_ir::dialects::Side::None
+                        || opening.side == termination.side)
+                        && opening
+                            .lands
+                            .resolved()
+                            .is_some_and(|land| termination.lands.contains(land))
+                })
+                .map(|opening| report::MaskEvidence {
+                    layer: imported
+                        .resolve(imported.layer_definitions[opening.layer.0 as usize].name)
+                        .to_owned(),
+                    side: physical_side(opening.side),
+                })
+                .collect::<Vec<_>>();
+            mask_openings.sort_by(|left, right| left.layer.cmp(&right.layer));
             report::Termination {
                 id,
                 component_id,
@@ -198,10 +223,22 @@ pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<A
                 population: population(termination.population),
                 lands: layers,
                 paste_islands,
+                mask_openings,
+                hole_ids: Vec::new(),
             }
         })
         .collect::<Vec<_>>();
     terminations.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let (mut holes, mut termination_holes) =
+        physical_hole_reports(imported, &physical, &board_ids, &termination_ids, &mut ids);
+    holes.sort_by(|left, right| left.id.cmp(&right.id));
+    for termination in &mut terminations {
+        termination.hole_ids = termination_holes
+            .remove(&termination.id)
+            .unwrap_or_default();
+        termination.hole_ids.sort();
+    }
 
     for component in &mut components {
         component.termination_ids = component_terminations
@@ -212,6 +249,7 @@ pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<A
     components.sort_by(|left, right| left.id.cmp(&right.id));
 
     let mut diagnostics = component_diagnostics(&components, &mut ids);
+    diagnostics.extend(hole_diagnostics(&holes, &mut ids));
     diagnostics.sort_by(|left, right| {
         left.code
             .cmp(&right.code)
@@ -296,6 +334,7 @@ pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<A
         packages,
         components,
         terminations,
+        holes,
         diagnostics,
     };
     validate_finite_numbers(&serde_value::to_value(&report)?)?;
@@ -601,6 +640,360 @@ fn bom_evidence(
     })
 }
 
+fn physical_hole_reports(
+    imported: &ImportedDesign,
+    physical: &PhysicalView,
+    board_ids: &HashMap<LayoutOccurrenceId, String>,
+    termination_ids: &HashMap<PhysicalTerminationId, String>,
+    ids: &mut IdAllocator,
+) -> (Vec<report::Hole>, HashMap<String, Vec<String>>) {
+    let mut termination_holes = HashMap::<String, Vec<String>>::new();
+    let holes = physical
+        .holes
+        .iter()
+        .map(|hole| {
+            let source_layer = imported
+                .resolve(imported.layer_definitions[hole.layer.0 as usize].name)
+                .to_owned();
+            let source_name = hole
+                .source_name
+                .map(|name| imported.resolve(name).to_owned());
+            let board_id = hole.board.and_then(|board| board_ids.get(&board).cloned());
+            let location_mm = point(hole.at);
+            let finished_diameter_mm = hole.finished_diameter.map(canonical_number);
+            let kind = match hole.kind {
+                PhysicalHoleKind::Round => report::HoleKind::Round,
+                PhysicalHoleKind::Slot => report::HoleKind::Slot,
+            };
+            let plating = hole_plating(hole.plating);
+            let padstack = hole
+                .padstack
+                .map(|padstack| imported.resolve(padstack).to_owned());
+            let net = hole.net.map(|net| imported.resolve(net).to_owned());
+            let span = hole_span(imported, hole.span);
+            let source_specs = hole
+                .spec_refs
+                .iter()
+                .map(|spec| imported.resolve(*spec).to_owned())
+                .collect::<Vec<_>>();
+            let termination =
+                termination_association(&hole.termination, hole.termination_basis, termination_ids);
+            let id = ids.allocate(
+                "hole",
+                &(
+                    &board_id,
+                    &source_layer,
+                    &source_name,
+                    kind,
+                    location_mm,
+                    finished_diameter_mm,
+                    plating,
+                    &padstack,
+                    &net,
+                    &span,
+                    &source_specs,
+                    &termination,
+                ),
+            );
+            if let Association::Resolved(termination) = hole.termination
+                && let Some(termination_id) = termination_ids.get(&termination)
+            {
+                termination_holes
+                    .entry(termination_id.clone())
+                    .or_default()
+                    .push(id.clone());
+            }
+            report::Hole {
+                id: id.clone(),
+                board_id,
+                source_layer,
+                source_name,
+                kind,
+                location_mm,
+                finished_diameter_mm,
+                plating,
+                padstack,
+                net,
+                span,
+                termination,
+                protection: protection_intent(imported, hole, &id, ids),
+            }
+        })
+        .collect();
+    (holes, termination_holes)
+}
+
+fn termination_association(
+    association: &Association<PhysicalTerminationId>,
+    basis: Option<PhysicalAssociationBasis>,
+    termination_ids: &HashMap<PhysicalTerminationId, String>,
+) -> report::TerminationAssociation {
+    let (status, physical_ids) = match association {
+        Association::Resolved(termination) => (
+            match basis {
+                Some(PhysicalAssociationBasis::SourceIdentity) => {
+                    report::AssociationStatus::Explicit
+                }
+                Some(PhysicalAssociationBasis::ExactGeometry) => {
+                    report::AssociationStatus::ExactGeometric
+                }
+                None => report::AssociationStatus::Unsupported,
+            },
+            vec![*termination],
+        ),
+        Association::Ambiguous(terminations) => {
+            (report::AssociationStatus::Ambiguous, terminations.clone())
+        }
+        Association::Conflicting(terminations) => {
+            (report::AssociationStatus::Conflicting, terminations.clone())
+        }
+        Association::Unresolved => (report::AssociationStatus::Unresolved, Vec::new()),
+    };
+    let mut termination_ids = physical_ids
+        .into_iter()
+        .filter_map(|termination| termination_ids.get(&termination).cloned())
+        .collect::<Vec<_>>();
+    termination_ids.sort();
+    report::TerminationAssociation {
+        status,
+        basis: basis.map(|basis| match basis {
+            PhysicalAssociationBasis::SourceIdentity => report::AssociationBasis::SourceIdentity,
+            PhysicalAssociationBasis::ExactGeometry => report::AssociationBasis::ExactGeometry,
+        }),
+        termination_ids,
+    }
+}
+
+fn protection_intent(
+    imported: &ImportedDesign,
+    hole: &pcb_ir::import::physical::PhysicalHole,
+    hole_id: &str,
+    ids: &mut IdAllocator,
+) -> report::ProtectionIntent {
+    let source_layer = imported
+        .resolve(imported.layer_definitions[hole.layer.0 as usize].name)
+        .to_owned();
+    let mut evidence = Vec::new();
+    let source_terms = spec_terms(imported, &hole.spec_refs);
+    if has_protection_action(&source_terms) {
+        evidence.push(report::ProtectionEvidence {
+            id: ids.allocate(
+                "protection-evidence",
+                &(hole_id, "SOURCE_TERMS", &source_layer, &source_terms),
+            ),
+            kind: report::ProtectionEvidenceKind::SourceTerms,
+            layer: source_layer.clone(),
+            side: report::Side::None,
+            span: hole_span(imported, hole.span),
+            specs: hole
+                .spec_refs
+                .iter()
+                .map(|spec| imported.resolve(*spec).to_owned())
+                .collect(),
+            terms: source_terms,
+        });
+    }
+    if hole.plating == PlatingKind::ViaCapped {
+        evidence.push(report::ProtectionEvidence {
+            id: ids.allocate(
+                "protection-evidence",
+                &(hole_id, "VIA_CAPPED", &source_layer),
+            ),
+            kind: report::ProtectionEvidenceKind::ViaCappedPlatingStatus,
+            layer: source_layer,
+            side: report::Side::None,
+            span: hole_span(imported, hole.span),
+            specs: Vec::new(),
+            terms: vec!["VIA_CAPPED".to_owned()],
+        });
+    }
+    evidence.extend(hole.protection.iter().filter_map(|source| {
+        let layer = imported
+            .resolve(imported.layer_definitions[source.layer.0 as usize].name)
+            .to_owned();
+        let specs = source
+            .spec_refs
+            .iter()
+            .map(|spec| imported.resolve(*spec).to_owned())
+            .collect::<Vec<_>>();
+        let terms = spec_terms(imported, &source.spec_refs);
+        let kind = match source.function {
+            LayerFunction::HoleFill => report::ProtectionEvidenceKind::HoleFillLayer,
+            LayerFunction::CoatingCond | LayerFunction::CoatingNonCond
+                if has_protection_action(&terms) =>
+            {
+                report::ProtectionEvidenceKind::SourceTerms
+            }
+            LayerFunction::CoatingCond | LayerFunction::CoatingNonCond => return None,
+            _ => unreachable!("physical protection uses a protection layer"),
+        };
+        Some(report::ProtectionEvidence {
+            id: ids.allocate(
+                "protection-evidence",
+                &(hole_id, source.function.as_str(), &layer, &specs, &terms),
+            ),
+            kind,
+            layer,
+            side: physical_side(source.side),
+            span: hole_span(imported, source.span),
+            specs,
+            terms,
+        })
+    }));
+
+    let mut methods = BTreeSet::new();
+    let mut fill_materials = BTreeSet::new();
+    for source in &evidence {
+        let text = normalized_terms(&source.terms);
+        if contains_term(&text, OPEN_TERMS) {
+            methods.insert(report::ProtectionMethod::Open);
+        }
+        if contains_term(&text, TENT_TERMS) {
+            methods.insert(report::ProtectionMethod::Tented);
+        }
+        if contains_term(&text, PLUG_TERMS) {
+            methods.insert(report::ProtectionMethod::Plugged);
+        }
+        if contains_term(&text, FILL_TERMS) {
+            methods.insert(report::ProtectionMethod::Filled);
+        }
+        if contains_term(&text, CAP_TERMS) {
+            methods.insert(report::ProtectionMethod::Capped);
+        }
+        match source.kind {
+            report::ProtectionEvidenceKind::SourceTerms => {}
+            report::ProtectionEvidenceKind::ViaCappedPlatingStatus => {
+                methods.insert(report::ProtectionMethod::Capped);
+            }
+            report::ProtectionEvidenceKind::HoleFillLayer => {
+                methods.insert(if contains_term(&text, PLUG_TERMS) {
+                    report::ProtectionMethod::Plugged
+                } else {
+                    report::ProtectionMethod::Filled
+                });
+            }
+        }
+        let has_fill = source.kind == report::ProtectionEvidenceKind::HoleFillLayer
+            || contains_term(&text, FILL_TERMS)
+            || contains_term(&text, PLUG_TERMS);
+        if has_fill {
+            if text.contains(" NON CONDUCTIVE ") || text.contains(" NONCONDUCTIVE ") {
+                fill_materials.insert(report::FillMaterial::NonConductive);
+            } else if text.contains(" COPPER ") {
+                fill_materials.insert(report::FillMaterial::Copper);
+            } else if text.contains(" CONDUCTIVE ") {
+                fill_materials.insert(report::FillMaterial::Conductive);
+            }
+        }
+    }
+    let conflicting = fill_materials.len() > 1
+        || (methods.contains(&report::ProtectionMethod::Open) && methods.len() > 1);
+    report::ProtectionIntent {
+        status: if evidence.is_empty() {
+            report::ProtectionStatus::Unknown
+        } else if conflicting {
+            report::ProtectionStatus::Conflicting
+        } else {
+            report::ProtectionStatus::Explicit
+        },
+        methods: methods.into_iter().collect(),
+        fill_material: (fill_materials.len() == 1)
+            .then(|| *fill_materials.first().expect("one fill material")),
+        evidence,
+    }
+}
+
+fn spec_terms(imported: &ImportedDesign, spec_refs: &[ipc2581::Symbol]) -> Vec<String> {
+    let mut terms = BTreeSet::new();
+    for spec_ref in spec_refs {
+        let Some(spec) = imported.specs.get(spec_ref) else {
+            continue;
+        };
+        terms.extend(
+            spec.material
+                .into_iter()
+                .chain(spec.properties.iter().copied())
+                .map(|term| imported.resolve(term).to_owned()),
+        );
+        for item in &spec.items {
+            terms.extend(
+                item.properties
+                    .iter()
+                    .filter_map(|property| property.text)
+                    .map(|term| imported.resolve(term).to_owned()),
+            );
+        }
+    }
+    terms.into_iter().collect()
+}
+
+fn normalized_terms(terms: &[String]) -> String {
+    format!(
+        " {} ",
+        terms
+            .join(" ")
+            .to_ascii_uppercase()
+            .replace(['-', '_'], " ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    )
+}
+
+fn has_protection_action(terms: &[String]) -> bool {
+    let text = normalized_terms(terms);
+    [OPEN_TERMS, TENT_TERMS, PLUG_TERMS, FILL_TERMS, CAP_TERMS]
+        .into_iter()
+        .any(|terms| contains_term(&text, terms))
+}
+
+const OPEN_TERMS: &[&str] = &["OPEN", "OPENED"];
+const TENT_TERMS: &[&str] = &["TENT", "TENTED", "TENTING"];
+const PLUG_TERMS: &[&str] = &["PLUG", "PLUGGED", "PLUGGING"];
+const FILL_TERMS: &[&str] = &["FILL", "FILLED", "FILLING"];
+const CAP_TERMS: &[&str] = &["CAP", "CAPPED", "CAPPING"];
+
+fn contains_term(text: &str, terms: &[&str]) -> bool {
+    text.split_ascii_whitespace()
+        .any(|word| terms.contains(&word))
+}
+
+fn hole_plating(value: PlatingKind) -> report::HolePlating {
+    match value {
+        PlatingKind::Unknown => report::HolePlating::Unknown,
+        PlatingKind::None => report::HolePlating::None,
+        PlatingKind::Plated => report::HolePlating::Plated,
+        PlatingKind::NonPlated => report::HolePlating::NonPlated,
+        PlatingKind::Via => report::HolePlating::Via,
+        PlatingKind::ViaCapped => report::HolePlating::ViaCapped,
+    }
+}
+
+fn hole_span(imported: &ImportedDesign, value: FeatureSpan<ipc2581::Symbol>) -> report::HoleSpan {
+    match value {
+        FeatureSpan::Unknown => report::HoleSpan {
+            kind: report::HoleSpanKind::Unknown,
+            from_layer: None,
+            to_layer: None,
+        },
+        FeatureSpan::Layer(layer) => report::HoleSpan {
+            kind: report::HoleSpanKind::Layer,
+            from_layer: Some(imported.resolve(layer).to_owned()),
+            to_layer: None,
+        },
+        FeatureSpan::ThroughBoard => report::HoleSpan {
+            kind: report::HoleSpanKind::ThroughBoard,
+            from_layer: None,
+            to_layer: None,
+        },
+        FeatureSpan::FromTo { from, to } => report::HoleSpan {
+            kind: report::HoleSpanKind::FromTo,
+            from_layer: from.map(|layer| imported.resolve(layer).to_owned()),
+            to_layer: to.map(|layer| imported.resolve(layer).to_owned()),
+        },
+    }
+}
+
 fn component_diagnostics(
     components: &[report::Component],
     ids: &mut IdAllocator,
@@ -663,6 +1056,72 @@ fn component_diagnostics(
         }
     }
     diagnostics
+}
+
+fn hole_diagnostics(holes: &[report::Hole], ids: &mut IdAllocator) -> Vec<report::Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for hole in holes {
+        let association_code = match hole.termination.status {
+            report::AssociationStatus::Ambiguous => {
+                Some(report::DiagnosticCode::AmbiguousHoleTermination)
+            }
+            report::AssociationStatus::Conflicting => {
+                Some(report::DiagnosticCode::ConflictingHoleTermination)
+            }
+            _ => None,
+        };
+        if let Some(code) = association_code {
+            diagnostics.push(hole_diagnostic(
+                ids,
+                hole,
+                code,
+                "hole cannot be associated with one physical component termination".to_owned(),
+            ));
+        }
+        let component_land_via = matches!(
+            hole.termination.status,
+            report::AssociationStatus::Explicit | report::AssociationStatus::ExactGeometric
+        ) && matches!(
+            hole.plating,
+            report::HolePlating::Via | report::HolePlating::ViaCapped
+        );
+        if component_land_via {
+            let protection = match hole.protection.status {
+                report::ProtectionStatus::Unknown => Some((
+                    report::DiagnosticCode::UnknownViaProtection,
+                    "component-land via has no explicit protection intent",
+                )),
+                report::ProtectionStatus::Conflicting => Some((
+                    report::DiagnosticCode::ConflictingViaProtection,
+                    "component-land via has conflicting protection intent",
+                )),
+                report::ProtectionStatus::Explicit => None,
+            };
+            if let Some((code, message)) = protection {
+                diagnostics.push(hole_diagnostic(ids, hole, code, message.to_owned()));
+            }
+        }
+    }
+    diagnostics
+}
+
+fn hole_diagnostic(
+    ids: &mut IdAllocator,
+    hole: &report::Hole,
+    code: report::DiagnosticCode,
+    message: String,
+) -> report::Diagnostic {
+    report::Diagnostic {
+        id: ids.allocate("assembly-diagnostic", &(code, &hole.id)),
+        severity: report::DiagnosticSeverity::Warning,
+        code,
+        subject: report::DiagnosticSubject {
+            kind: report::DiagnosticSubjectKind::Hole,
+            id: hole.id.clone(),
+            reference_designator: None,
+        },
+        message,
+    }
 }
 
 fn diagnostic(

--- a/crates/pcb-ipc2581-tools/src/assembly/report.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/report.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-pub const REPORT_SCHEMA_VERSION: u32 = 2;
+pub const REPORT_SCHEMA_VERSION: u32 = 3;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct AssemblyReport {
@@ -17,6 +17,7 @@ pub struct AssemblyReport {
     pub packages: Vec<Package>,
     pub components: Vec<Component>,
     pub terminations: Vec<Termination>,
+    pub holes: Vec<Hole>,
     pub diagnostics: Vec<Diagnostic>,
 }
 
@@ -527,6 +528,8 @@ pub struct Termination {
     pub population: Population,
     pub lands: Vec<LandEvidence>,
     pub paste_islands: Vec<PasteEvidence>,
+    pub mask_openings: Vec<MaskEvidence>,
+    pub hole_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -539,6 +542,142 @@ pub struct PasteEvidence {
     pub layer: String,
     pub side: Side,
     pub location_mm: Point,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MaskEvidence {
+    pub layer: String,
+    pub side: Side,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Hole {
+    pub id: String,
+    pub board_id: Option<String>,
+    pub source_layer: String,
+    pub source_name: Option<String>,
+    pub kind: HoleKind,
+    pub location_mm: Point,
+    pub finished_diameter_mm: Option<f64>,
+    pub plating: HolePlating,
+    pub padstack: Option<String>,
+    pub net: Option<String>,
+    pub span: HoleSpan,
+    pub termination: TerminationAssociation,
+    pub protection: ProtectionIntent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HoleKind {
+    Round,
+    Slot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HolePlating {
+    Unknown,
+    None,
+    Plated,
+    NonPlated,
+    Via,
+    ViaCapped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HoleSpan {
+    pub kind: HoleSpanKind,
+    pub from_layer: Option<String>,
+    pub to_layer: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HoleSpanKind {
+    Unknown,
+    Layer,
+    ThroughBoard,
+    FromTo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TerminationAssociation {
+    pub status: AssociationStatus,
+    pub basis: Option<AssociationBasis>,
+    pub termination_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssociationBasis {
+    SourceIdentity,
+    ExactGeometry,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssociationStatus {
+    Explicit,
+    ExactGeometric,
+    Ambiguous,
+    Conflicting,
+    Unresolved,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProtectionIntent {
+    pub status: ProtectionStatus,
+    pub methods: Vec<ProtectionMethod>,
+    pub fill_material: Option<FillMaterial>,
+    pub evidence: Vec<ProtectionEvidence>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtectionStatus {
+    Explicit,
+    Conflicting,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtectionMethod {
+    Open,
+    Tented,
+    Plugged,
+    Filled,
+    Capped,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FillMaterial {
+    NonConductive,
+    Conductive,
+    Copper,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProtectionEvidence {
+    pub id: String,
+    pub kind: ProtectionEvidenceKind,
+    pub layer: String,
+    pub side: Side,
+    pub span: HoleSpan,
+    pub specs: Vec<String>,
+    pub terms: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtectionEvidenceKind {
+    SourceTerms,
+    ViaCappedPlatingStatus,
+    HoleFillLayer,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
@@ -615,6 +754,10 @@ pub enum DiagnosticCode {
     MissingReferenceDesignator,
     MissingPackage,
     MissingPhysicalTerminations,
+    AmbiguousHoleTermination,
+    ConflictingHoleTermination,
+    ConflictingViaProtection,
+    UnknownViaProtection,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -628,4 +771,5 @@ pub struct DiagnosticSubject {
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticSubjectKind {
     Component,
+    Hole,
 }

--- a/crates/pcb-ipc2581-tools/src/assembly/testdata/report.xml
+++ b/crates/pcb-ipc2581-tools/src/assembly/testdata/report.xml
@@ -17,6 +17,7 @@
     <DictionaryStandard units="MILLIMETER">
       <EntryStandard id="land"><Circle diameter="1"/></EntryStandard>
       <EntryStandard id="paste"><Circle diameter="0.6"/></EntryStandard>
+      <EntryStandard id="via-land"><Circle diameter="0.4"/></EntryStandard>
       <EntryStandard id="hollow-inline"><Circle diameter="0.4"><LineDesc lineWidth="0.05" lineEnd="ROUND"/><FillDesc fillProperty="HOLLOW"/></Circle></EntryStandard>
       <EntryStandard id="hollow-ref"><Circle diameter="0.35"><LineDescRef id="fine"/><FillDesc fillProperty="HOLLOW"/></Circle></EntryStandard>
       <EntryStandard id="void-ref"><Circle diameter="0.3"><FillDescRef id="void"/></Circle></EntryStandard>
@@ -57,11 +58,23 @@
     </BomItem>
   </Bom>
   <Ecad name="design">
-    <CadHeader units="MILLIMETER"/>
+    <CadHeader units="MILLIMETER">
+      <Spec name="nc-fill">
+        <General type="MATERIAL"><Property text="NON-CONDUCTIVE EPOXY"/></General>
+      </Spec>
+    </CadHeader>
     <CadData>
       <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
       <Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/>
       <Layer name="PASTE" layerFunction="SOLDERPASTE" side="TOP" polarity="POSITIVE"/>
+      <Layer name="MASK" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>
+      <Layer name="DRILL" layerFunction="DRILL" side="ALL" polarity="POSITIVE">
+        <Span fromLayer="TOP" toLayer="BOTTOM"/>
+      </Layer>
+      <Layer name="NC-FILL" layerFunction="HOLEFILL" side="ALL" polarity="POSITIVE">
+        <SpecRef id="nc-fill"/>
+        <Span fromLayer="TOP" toLayer="BOTTOM"/>
+      </Layer>
       <Step name="board" type="BOARD">
         <PadStackDef name="smt-padstack">
           <PadstackPadDef layerRef="TOP" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef>
@@ -71,6 +84,11 @@
           <PadstackHoleDef name="J1-H1" diameter="0.4" platingStatus="PLATED" plusTol="0" minusTol="0" x="0" y="0"/>
           <PadstackPadDef layerRef="TOP" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef>
           <PadstackPadDef layerRef="BOTTOM" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef>
+        </PadStackDef>
+        <PadStackDef name="via-padstack">
+          <PadstackHoleDef name="via" diameter="0.2" platingStatus="VIA" plusTol="0" minusTol="0" x="0" y="0"/>
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="via-land"/></PadstackPadDef>
+          <PadstackPadDef layerRef="BOTTOM" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="via-land"/></PadstackPadDef>
         </PadStackDef>
         <Datum x="0" y="0"/>
         <Profile>
@@ -144,12 +162,30 @@
           <Set><Pad padstackDefRef="smt-padstack"><Location x="2" y="2"/><StandardPrimitiveRef id="land"/><PinRef componentRef="U1" pin="1"/></Pad></Set>
           <Set><Pad padstackDefRef="smt-padstack"><Location x="4" y="2"/><StandardPrimitiveRef id="land"/><PinRef componentRef="U2" pin="1"/></Pad></Set>
           <Set><Pad padstackDefRef="tht-padstack"><Location x="6" y="2"/><StandardPrimitiveRef id="land"/><PinRef componentRef="J1" pin="1"/></Pad></Set>
+          <Set><Pad padstackDefRef="via-padstack"><Location x="1.8" y="2"/><StandardPrimitiveRef id="via-land"/></Pad></Set>
+          <Set><Pad padstackDefRef="via-padstack"><Location x="2.2" y="2"/><StandardPrimitiveRef id="via-land"/></Pad></Set>
+          <Set><Pad padstackDefRef="via-padstack"><Location x="8" y="5"/><StandardPrimitiveRef id="via-land"/></Pad></Set>
         </LayerFeature>
         <LayerFeature layerRef="BOTTOM">
           <Set><Pad padstackDefRef="tht-padstack"><Location x="6" y="2"/><StandardPrimitiveRef id="land"/><PinRef componentRef="J1" pin="1"/></Pad></Set>
+          <Set><Pad padstackDefRef="via-padstack"><Location x="1.8" y="2"/><StandardPrimitiveRef id="via-land"/></Pad></Set>
+          <Set><Pad padstackDefRef="via-padstack"><Location x="2.2" y="2"/><StandardPrimitiveRef id="via-land"/></Pad></Set>
+          <Set><Pad padstackDefRef="via-padstack"><Location x="8" y="5"/><StandardPrimitiveRef id="via-land"/></Pad></Set>
         </LayerFeature>
         <LayerFeature layerRef="PASTE">
           <Set><Pad padstackDefRef="smt-padstack"><Location x="2" y="2"/><StandardPrimitiveRef id="paste"/><PinRef componentRef="U1" pin="1"/></Pad></Set>
+        </LayerFeature>
+        <LayerFeature layerRef="MASK">
+          <Set><Pad padstackDefRef="smt-padstack"><Location x="2" y="2"/><StandardPrimitiveRef id="land"/><PinRef componentRef="U1" pin="1"/></Pad></Set>
+        </LayerFeature>
+        <LayerFeature layerRef="DRILL">
+          <Set geometry="via-padstack" componentRef="U1"><Hole name="U1-via-capped" diameter="0.2" platingStatus="VIA_CAPPED" plusTol="0" minusTol="0" x="1.8" y="2"/></Set>
+          <Set geometry="via-padstack"><Hole name="U1-via" diameter="0.2" platingStatus="VIA" plusTol="0" minusTol="0" x="2.2" y="2"/></Set>
+          <Set geometry="via-padstack"><Hole name="standalone-via" diameter="0.2" platingStatus="VIA" plusTol="0" minusTol="0" x="8" y="5"/></Set>
+        </LayerFeature>
+        <LayerFeature layerRef="NC-FILL">
+          <Set geometry="via-padstack"><SpecRef id="nc-fill"/><Pad padstackDefRef="via-padstack"><Location x="1.8" y="2"/><StandardPrimitiveRef id="via-land"/></Pad></Set>
+          <Set geometry="via-padstack"><SpecRef id="nc-fill"/><Pad padstackDefRef="via-padstack"><Location x="2.2" y="2"/><StandardPrimitiveRef id="via-land"/></Pad></Set>
         </LayerFeature>
       </Step>
       <Step name="panel" type="PALLET">
@@ -163,7 +199,7 @@
             <PolyStepSegment x="0" y="0"/>
           </Polygon>
         </Profile>
-        <StepRepeat stepRef="board" x="10" y="20" nx="2" ny="1" dx="15" dy="0" angle="13" mirror="false"/>
+        <StepRepeat stepRef="board" x="10" y="20" nx="2" ny="1" dx="15" dy="0" angle="13" mirror="true"/>
       </Step>
     </CadData>
   </Ecad>

--- a/crates/pcb-ipc2581-tools/src/assembly/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/tests.rs
@@ -333,10 +333,15 @@ fn reports_scoped_components_and_exact_physical_evidence() {
 
 #[test]
 fn reports_ambiguous_overlap_without_selecting_a_termination() {
-    let xml = FIXTURE.replace(
-        "name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"8\" y=\"5\"",
-        "name=\"standalone-via\" diameter=\"2.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"3\" y=\"2\"",
-    );
+    let xml = FIXTURE
+        .replace(
+            "name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"8\" y=\"5\"",
+            "name=\"standalone-via\" diameter=\"2.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"3\" y=\"2\"",
+        )
+        .replace(
+            "<Layer name=\"NC-FILL\" layerFunction=\"HOLEFILL\" side=\"ALL\" polarity=\"POSITIVE\">",
+            "<Layer name=\"NC-FILL\" layerFunction=\"HOLEFILL\" side=\"TOP\" polarity=\"POSITIVE\">",
+        );
 
     let report = report_xml(&xml, LayoutTarget::Board);
     let hole = report
@@ -354,6 +359,7 @@ fn reports_ambiguous_overlap_without_selecting_a_termination() {
         Some(report::AssociationBasis::ExactGeometry)
     );
     assert_eq!(hole.termination.termination_ids.len(), 2);
+    assert_eq!(hole.protection.status, report::ProtectionStatus::Explicit);
     assert!(report.diagnostics.iter().any(|diagnostic| {
         diagnostic.code == report::DiagnosticCode::AmbiguousHoleTermination
             && diagnostic.subject.id == hole.id
@@ -397,6 +403,43 @@ fn geometric_association_requires_one_known_reachable_land() {
 }
 
 #[test]
+fn strict_span_reachability_uses_physical_stackup_order() {
+    let xml = FIXTURE
+        .replace(
+            "      <Layer name=\"TOP\" layerFunction=\"SIGNAL\" side=\"TOP\" polarity=\"POSITIVE\"/>",
+            "      <Layer name=\"INNER\" layerFunction=\"SIGNAL\" side=\"INTERNAL\" polarity=\"POSITIVE\"/>\n      <Layer name=\"TOP\" layerFunction=\"SIGNAL\" side=\"TOP\" polarity=\"POSITIVE\"/>",
+        )
+        .replacen(
+            "<Span fromLayer=\"TOP\" toLayer=\"BOTTOM\"/>",
+            "<Span fromLayer=\"INNER\" toLayer=\"BOTTOM\"/>",
+            1,
+        )
+        .replacen(
+            "<Span fromLayer=\"TOP\" toLayer=\"BOTTOM\"/>",
+            "<Span fromLayer=\"TOP\" toLayer=\"TOP\"/>",
+            1,
+        )
+        .replace(
+            "      <Step name=\"board\" type=\"BOARD\">",
+            "      <Stackup name=\"Primary\" overallThickness=\"0.105\" tolPlus=\"0\" tolMinus=\"0\" whereMeasured=\"METAL\" stackupStatus=\"PROPOSED\">\n        <StackupGroup name=\"Primary_Group\" thickness=\"0.105\" tolPlus=\"0\" tolMinus=\"0\">\n          <StackupLayer layerOrGroupRef=\"TOP\" thickness=\"0.035\" tolPlus=\"0\" tolMinus=\"0\" sequence=\"0\"/>\n          <StackupLayer layerOrGroupRef=\"INNER\" thickness=\"0.035\" tolPlus=\"0\" tolMinus=\"0\" sequence=\"1\"/>\n          <StackupLayer layerOrGroupRef=\"BOTTOM\" thickness=\"0.035\" tolPlus=\"0\" tolMinus=\"0\" sequence=\"2\"/>\n        </StackupGroup>\n      </Stackup>\n      <Step name=\"board\" type=\"BOARD\">",
+        );
+
+    let report = report_xml(&xml, LayoutTarget::Board);
+    let via = report
+        .holes
+        .iter()
+        .find(|hole| hole.source_name.as_deref() == Some("U1-via"))
+        .unwrap();
+
+    assert_eq!(
+        via.termination.status,
+        report::AssociationStatus::Unresolved
+    );
+    assert_eq!(via.protection.status, report::ProtectionStatus::Unknown);
+    assert!(via.protection.evidence.is_empty());
+}
+
+#[test]
 fn semantic_hole_ids_survive_source_reordering() {
     let capped = "          <Set geometry=\"via-padstack\" componentRef=\"U1\"><Hole name=\"U1-via-capped\" diameter=\"0.2\" platingStatus=\"VIA_CAPPED\" plusTol=\"0\" minusTol=\"0\" x=\"1.8\" y=\"2\"/></Set>";
     let filled = "          <Set geometry=\"via-padstack\"><Hole name=\"U1-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"2.2\" y=\"2\"/></Set>";
@@ -410,6 +453,60 @@ fn semantic_hole_ids_survive_source_reordering() {
         report(LayoutTarget::Board),
         report_xml(&reordered, LayoutTarget::Board)
     );
+}
+
+#[test]
+fn repeated_layer_sections_preserve_hole_names() {
+    let capped = "<Set geometry=\"via-padstack\" componentRef=\"U1\"><Hole name=\"U1-via-capped\" diameter=\"0.2\" platingStatus=\"VIA_CAPPED\" plusTol=\"0\" minusTol=\"0\" x=\"1.8\" y=\"2\"/></Set>";
+    let split = format!("{capped}</LayerFeature><LayerFeature layerRef=\"DRILL\">");
+    let xml = FIXTURE.replace(capped, &split);
+
+    let report = report_xml(&xml, LayoutTarget::Board);
+
+    assert_eq!(
+        report
+            .holes
+            .iter()
+            .find(|hole| hole.location_mm == report::Point { x: 1.8, y: 2.0 })
+            .and_then(|hole| hole.source_name.as_deref()),
+        Some("U1-via-capped")
+    );
+    assert_eq!(
+        report
+            .holes
+            .iter()
+            .find(|hole| hole.location_mm == report::Point { x: 2.2, y: 2.0 })
+            .and_then(|hole| hole.source_name.as_deref()),
+        Some("U1-via")
+    );
+}
+
+#[test]
+fn protection_requires_compatible_span_and_assembly_side() {
+    let span = "<Span fromLayer=\"TOP\" toLayer=\"BOTTOM\"/>";
+    let disjoint_span = FIXTURE
+        .replacen(span, "<Span fromLayer=\"TOP\" toLayer=\"TOP\"/>", 1)
+        .replacen(span, "<Span fromLayer=\"BOTTOM\" toLayer=\"BOTTOM\"/>", 1);
+    let opposite_side = FIXTURE.replace(
+        "<Layer name=\"NC-FILL\" layerFunction=\"HOLEFILL\" side=\"ALL\" polarity=\"POSITIVE\">",
+        "<Layer name=\"NC-FILL\" layerFunction=\"HOLEFILL\" side=\"BOTTOM\" polarity=\"POSITIVE\">",
+    );
+
+    for xml in [disjoint_span, opposite_side] {
+        let report = report_xml(&xml, LayoutTarget::Board);
+        let via = report
+            .holes
+            .iter()
+            .find(|hole| hole.source_name.as_deref() == Some("U1-via"))
+            .unwrap();
+
+        assert_eq!(
+            via.termination.status,
+            report::AssociationStatus::ExactGeometric
+        );
+        assert_eq!(via.protection.status, report::ProtectionStatus::Unknown);
+        assert!(via.protection.evidence.is_empty());
+    }
 }
 
 #[test]

--- a/crates/pcb-ipc2581-tools/src/assembly/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/tests.rs
@@ -10,8 +10,12 @@ use crate::LayoutTarget;
 const FIXTURE: &str = include_str!("testdata/report.xml");
 
 fn report(target: LayoutTarget) -> report::AssemblyReport {
-    ipc2581::validate(FIXTURE).expect("assembly report fixture conforms to IPC-2581C");
-    let ipc = Ipc2581::parse(FIXTURE).unwrap();
+    report_xml(FIXTURE, target)
+}
+
+fn report_xml(xml: &str, target: LayoutTarget) -> report::AssemblyReport {
+    ipc2581::validate(xml).expect("assembly report fixture conforms to IPC-2581C");
+    let ipc = Ipc2581::parse(xml).unwrap();
     let imported = import_design(&ipc).unwrap();
     build_report(&imported, target).unwrap()
 }
@@ -20,7 +24,7 @@ fn report(target: LayoutTarget) -> report::AssemblyReport {
 fn reports_scoped_components_and_exact_physical_evidence() {
     let report = report(LayoutTarget::BoardArray);
 
-    assert_eq!(report.schema_version, 2);
+    assert_eq!(report.schema_version, 3);
     assert_eq!(report.scope.kind, report::ScopeKind::BoardArray);
     assert_eq!(report.scope.root_step.as_deref(), Some("panel"));
     assert_eq!(report.scope.profile_ids.len(), 1);
@@ -90,6 +94,14 @@ fn reports_scoped_components_and_exact_physical_evidence() {
             && board.area_mm2 == Some(board_profile.area_mm2)
             && board.bounds_mm == Some(board_profile.bounds_mm)
     }));
+    assert!(
+        report
+            .boards
+            .iter()
+            .all(|board| board.transform[0] * board.transform[3]
+                - board.transform[1] * board.transform[2]
+                < 0.0)
+    );
 
     let package = report
         .packages
@@ -248,6 +260,327 @@ fn reports_scoped_components_and_exact_physical_evidence() {
         .unwrap();
     assert_eq!(through.lands.len(), 2);
     assert!(through.paste_islands.is_empty());
+
+    assert_eq!(report.holes.len(), 6);
+    assert_eq!(
+        report
+            .holes
+            .iter()
+            .filter(|hole| {
+                hole.termination.status == report::AssociationStatus::ExactGeometric
+                    && hole.termination.basis == Some(report::AssociationBasis::ExactGeometry)
+            })
+            .count(),
+        2
+    );
+    assert_eq!(
+        report
+            .holes
+            .iter()
+            .filter(|hole| {
+                hole.termination.status == report::AssociationStatus::Explicit
+                    && hole.termination.basis == Some(report::AssociationBasis::SourceIdentity)
+            })
+            .count(),
+        2
+    );
+    assert!(report.holes.iter().all(|hole| hole.source_name.is_some()));
+    assert!(
+        report
+            .holes
+            .iter()
+            .filter(|hole| { hole.termination.status == report::AssociationStatus::ExactGeometric })
+            .all(|hole| {
+                hole.protection.status == report::ProtectionStatus::Explicit
+                    && hole.protection.fill_material == Some(report::FillMaterial::NonConductive)
+                    && hole
+                        .protection
+                        .methods
+                        .contains(&report::ProtectionMethod::Filled)
+            })
+    );
+    assert!(
+        report
+            .holes
+            .iter()
+            .filter(|hole| { hole.plating == report::HolePlating::ViaCapped })
+            .all(|hole| hole
+                .protection
+                .methods
+                .contains(&report::ProtectionMethod::Capped))
+    );
+    assert!(
+        report
+            .holes
+            .iter()
+            .filter(|hole| { hole.termination.status == report::AssociationStatus::Unresolved })
+            .all(|hole| hole.protection.status == report::ProtectionStatus::Unknown)
+    );
+    let u1_termination = report
+        .terminations
+        .iter()
+        .find(|termination| termination.component_id == u1.id)
+        .unwrap();
+    assert_eq!(u1_termination.hole_ids.len(), 2);
+    assert_eq!(
+        u1_termination.mask_openings,
+        [report::MaskEvidence {
+            layer: "MASK".to_owned(),
+            side: report::Side::Top,
+        }]
+    );
+}
+
+#[test]
+fn reports_ambiguous_overlap_without_selecting_a_termination() {
+    let xml = FIXTURE.replace(
+        "name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"8\" y=\"5\"",
+        "name=\"standalone-via\" diameter=\"2.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"3\" y=\"2\"",
+    );
+
+    let report = report_xml(&xml, LayoutTarget::Board);
+    let hole = report
+        .holes
+        .iter()
+        .find(|hole| hole.finished_diameter_mm == Some(2.2))
+        .unwrap();
+
+    assert_eq!(
+        hole.termination.status,
+        report::AssociationStatus::Ambiguous
+    );
+    assert_eq!(
+        hole.termination.basis,
+        Some(report::AssociationBasis::ExactGeometry)
+    );
+    assert_eq!(hole.termination.termination_ids.len(), 2);
+    assert!(report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == report::DiagnosticCode::AmbiguousHoleTermination
+            && diagnostic.subject.id == hole.id
+    }));
+}
+
+#[test]
+fn geometric_association_requires_one_known_reachable_land() {
+    for replacement in [
+        "<Span fromLayer=\"TOP\"/>",
+        "<Span fromLayer=\"BOTTOM\" toLayer=\"BOTTOM\"/>",
+    ] {
+        let xml = FIXTURE.replacen(
+            "<Span fromLayer=\"TOP\" toLayer=\"BOTTOM\"/>",
+            replacement,
+            1,
+        );
+        let report = report_xml(&xml, LayoutTarget::Board);
+        let via = report
+            .holes
+            .iter()
+            .find(|hole| hole.source_name.as_deref() == Some("U1-via"))
+            .unwrap();
+        assert_eq!(
+            via.termination.status,
+            report::AssociationStatus::Unresolved
+        );
+        assert_eq!(via.termination.basis, None);
+    }
+
+    let u1_land = "<Set><Pad padstackDefRef=\"smt-padstack\"><Location x=\"2\" y=\"2\"/><StandardPrimitiveRef id=\"land\"/><PinRef componentRef=\"U1\" pin=\"1\"/></Pad></Set>";
+    let xml = FIXTURE.replacen(u1_land, &format!("{u1_land}\n          {u1_land}"), 1);
+    let report = report_xml(&xml, LayoutTarget::Board);
+    let via = report
+        .holes
+        .iter()
+        .find(|hole| hole.source_name.as_deref() == Some("U1-via"))
+        .unwrap();
+    assert_eq!(via.termination.status, report::AssociationStatus::Ambiguous);
+    assert_eq!(via.termination.termination_ids.len(), 1);
+}
+
+#[test]
+fn semantic_hole_ids_survive_source_reordering() {
+    let capped = "          <Set geometry=\"via-padstack\" componentRef=\"U1\"><Hole name=\"U1-via-capped\" diameter=\"0.2\" platingStatus=\"VIA_CAPPED\" plusTol=\"0\" minusTol=\"0\" x=\"1.8\" y=\"2\"/></Set>";
+    let filled = "          <Set geometry=\"via-padstack\"><Hole name=\"U1-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"2.2\" y=\"2\"/></Set>";
+    let reordered = FIXTURE.replace(
+        &format!("{capped}\n{filled}"),
+        &format!("{filled}\n{capped}"),
+    );
+
+    assert_ne!(reordered, FIXTURE);
+    assert_eq!(
+        report(LayoutTarget::Board),
+        report_xml(&reordered, LayoutTarget::Board)
+    );
+}
+
+#[test]
+fn reports_unknown_and_conflicting_component_land_via_protection() {
+    let unknown_xml = FIXTURE.replace(
+        "name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"8\" y=\"5\"",
+        "name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"2\" y=\"2.3\"",
+    );
+    let unknown = report_xml(&unknown_xml, LayoutTarget::Board);
+    assert!(
+        unknown
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == report::DiagnosticCode::UnknownViaProtection })
+    );
+
+    let plated_xml = unknown_xml.replace(
+        "name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\"",
+        "name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"PLATED\"",
+    );
+    let plated = report_xml(&plated_xml, LayoutTarget::Board);
+    let plated_hole = plated
+        .holes
+        .iter()
+        .find(|hole| hole.location_mm == report::Point { x: 2.0, y: 2.3 })
+        .unwrap();
+    assert_eq!(
+        plated_hole.termination.status,
+        report::AssociationStatus::ExactGeometric
+    );
+    assert!(!plated.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == report::DiagnosticCode::UnknownViaProtection
+            && diagnostic.subject.id == plated_hole.id
+    }));
+
+    let conflicting_xml = FIXTURE.replace("NON-CONDUCTIVE EPOXY", "OPEN NON-CONDUCTIVE EPOXY");
+    let conflicting = report_xml(&conflicting_xml, LayoutTarget::Board);
+    assert!(conflicting.holes.iter().any(|hole| {
+        hole.termination.status == report::AssociationStatus::ExactGeometric
+            && hole.protection.status == report::ProtectionStatus::Conflicting
+    }));
+    assert!(
+        conflicting.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == report::DiagnosticCode::ConflictingViaProtection
+        })
+    );
+}
+
+#[test]
+fn preserves_distinct_explicit_protection_methods_and_fill_materials() {
+    for (term, method, material) in [
+        (
+            "NON-CONDUCTIVE EPOXY",
+            report::ProtectionMethod::Filled,
+            Some(report::FillMaterial::NonConductive),
+        ),
+        (
+            "CONDUCTIVE EPOXY",
+            report::ProtectionMethod::Filled,
+            Some(report::FillMaterial::Conductive),
+        ),
+        (
+            "COPPER FILL",
+            report::ProtectionMethod::Filled,
+            Some(report::FillMaterial::Copper),
+        ),
+        (
+            "NON-CONDUCTIVE PLUGGED EPOXY",
+            report::ProtectionMethod::Plugged,
+            Some(report::FillMaterial::NonConductive),
+        ),
+    ] {
+        let xml = FIXTURE.replace("NON-CONDUCTIVE EPOXY", term);
+        let report = report_xml(&xml, LayoutTarget::Board);
+        assert!(
+            report
+                .holes
+                .iter()
+                .filter(|hole| {
+                    hole.termination.status == report::AssociationStatus::ExactGeometric
+                })
+                .all(|hole| {
+                    hole.protection.methods.contains(&method)
+                        && hole.protection.fill_material == material
+                })
+        );
+    }
+
+    for (function, term, method) in [
+        (
+            "COATINGNONCOND",
+            "TENTED COATING",
+            report::ProtectionMethod::Tented,
+        ),
+        (
+            "COATINGCOND",
+            "CAPPED COATING",
+            report::ProtectionMethod::Capped,
+        ),
+    ] {
+        let xml = FIXTURE
+            .replace(
+                "layerFunction=\"HOLEFILL\"",
+                &format!("layerFunction=\"{function}\""),
+            )
+            .replace("NON-CONDUCTIVE EPOXY", term);
+        let report = report_xml(&xml, LayoutTarget::Board);
+        assert!(
+            report
+                .holes
+                .iter()
+                .filter(|hole| {
+                    hole.termination.status == report::AssociationStatus::ExactGeometric
+                })
+                .all(|hole| {
+                    hole.protection.methods.contains(&method)
+                        && hole.protection.fill_material.is_none()
+                })
+        );
+    }
+
+    let ordinary_coating = FIXTURE
+        .replace(
+            "layerFunction=\"HOLEFILL\"",
+            "layerFunction=\"COATINGCOND\"",
+        )
+        .replace("NON-CONDUCTIVE EPOXY", "ENIG");
+    let report = report_xml(&ordinary_coating, LayoutTarget::Board);
+    let capped = report
+        .holes
+        .iter()
+        .find(|hole| hole.plating == report::HolePlating::ViaCapped)
+        .unwrap();
+    assert_eq!(
+        capped.protection.methods,
+        [report::ProtectionMethod::Capped]
+    );
+    assert_eq!(capped.protection.fill_material, None);
+    let uncapped = report
+        .holes
+        .iter()
+        .find(|hole| hole.source_name.as_deref() == Some("U1-via"))
+        .unwrap();
+    assert_eq!(
+        uncapped.protection.status,
+        report::ProtectionStatus::Unknown
+    );
+}
+
+#[test]
+fn reports_explicit_open_source_terms_without_inferring_fill() {
+    let xml = FIXTURE
+        .replace(
+            "    </CadHeader>",
+            "      <Spec name=\"open-via\"><General type=\"MATERIAL\"><Property text=\"OPEN\"/></General></Spec>\n    </CadHeader>",
+        )
+        .replace(
+            "<Set geometry=\"via-padstack\"><Hole name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"8\" y=\"5\"/></Set>",
+            "<Set geometry=\"via-padstack\"><SpecRef id=\"open-via\"/><Hole name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"8\" y=\"5\"/></Set>",
+        );
+
+    let report = report_xml(&xml, LayoutTarget::Board);
+    let hole = report
+        .holes
+        .iter()
+        .find(|hole| hole.location_mm == report::Point { x: 8.0, y: 5.0 })
+        .unwrap();
+
+    assert_eq!(hole.protection.status, report::ProtectionStatus::Explicit);
+    assert_eq!(hole.protection.methods, [report::ProtectionMethod::Open]);
+    assert_eq!(hole.protection.fill_material, None);
 }
 
 #[test]
@@ -264,6 +597,7 @@ fn board_scope_is_one_canonical_board() {
     assert_eq!(report.boards.len(), 1);
     assert_eq!(report.components.len(), 4);
     assert_eq!(report.terminations.len(), 3);
+    assert_eq!(report.holes.len(), 3);
     assert_eq!(report.summary.paste.islands, 1);
     assert_eq!(report.diagnostics.len(), 1);
 }
@@ -345,8 +679,8 @@ fn serialization_is_deterministic() {
     assert_eq!(first, second);
     assert_eq!(
         hex::encode(Sha256::digest(first.as_bytes())),
-        "b93670440008eee052acf83e6895ad1d1dda4c467132cfcff9ccd9ff30f787d9",
-        "schema v2 changed without an explicit version change"
+        "047ec7cb0494a77bb7a1261584eb0cd97ab15743fb1c9d7bd4c1d6491d46739c",
+        "schema v3 changed without an explicit version change"
     );
 }
 

--- a/crates/pcb-ipc2581-tools/src/assembly/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/tests.rs
@@ -400,10 +400,10 @@ fn geometric_association_requires_one_known_reachable_land() {
 fn semantic_hole_ids_survive_source_reordering() {
     let capped = "          <Set geometry=\"via-padstack\" componentRef=\"U1\"><Hole name=\"U1-via-capped\" diameter=\"0.2\" platingStatus=\"VIA_CAPPED\" plusTol=\"0\" minusTol=\"0\" x=\"1.8\" y=\"2\"/></Set>";
     let filled = "          <Set geometry=\"via-padstack\"><Hole name=\"U1-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"2.2\" y=\"2\"/></Set>";
-    let reordered = FIXTURE.replace(
-        &format!("{capped}\n{filled}"),
-        &format!("{filled}\n{capped}"),
-    );
+    let reordered = FIXTURE
+        .replace(capped, "__CAPPED_VIA__")
+        .replace(filled, capped)
+        .replace("__CAPPED_VIA__", filled);
 
     assert_ne!(reordered, FIXTURE);
     assert_eq!(

--- a/crates/pcb-ir/src/dialects/ipc/feature.rs
+++ b/crates/pcb-ir/src/dialects/ipc/feature.rs
@@ -24,6 +24,8 @@ pub struct Feature<Symbol> {
     pub net: Option<Symbol>,
     pub source_layer_ref: Option<Symbol>,
     pub source_step_ref: Option<Symbol>,
+    /// Source name for named physical features such as holes and slots.
+    pub source_name: Option<Symbol>,
     /// Materialized occurrence of `source_step_ref` in the layout graph.
     /// `None` identifies geometry owned directly by the root step.
     pub source_instance: Option<u32>,
@@ -89,6 +91,7 @@ impl<Symbol> Feature<Symbol> {
             net: None,
             source_layer_ref: None,
             source_step_ref: None,
+            source_name: None,
             source_instance: None,
             source_placement: None,
             source_step_kind: LayoutStepKind::Unknown,

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -732,6 +732,7 @@ fn plating_kind(status: PlatingStatus) -> PlatingKind {
         PlatingStatus::Plated => PlatingKind::Plated,
         PlatingStatus::NonPlated => PlatingKind::NonPlated,
         PlatingStatus::Via => PlatingKind::Via,
+        PlatingStatus::ViaCapped => PlatingKind::ViaCapped,
     }
 }
 
@@ -2350,7 +2351,7 @@ fn extract_pad(
         .and_then(|padstack| padstack.hole_def.as_ref())
         .map(|hole| hole.plating_status)
     {
-        Some(PlatingStatus::Via) => FeatureRole::Via,
+        Some(PlatingStatus::Via | PlatingStatus::ViaCapped) => FeatureRole::Via,
         _ => FeatureRole::Pad,
     };
 

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -3041,6 +3041,7 @@ fn extract_hole(
 
     let mut feature = GeometryFeature::new(FeatureKind::Hole, GeometryPolarity::Dark);
     feature.source = source;
+    feature.source_name = hole.name;
     feature.bbox = doc.arena.paths_bbox(paths);
     feature.paths = paths;
     feature.center = center;
@@ -3077,6 +3078,7 @@ fn extract_slot(
     let paths = Span::new(path_start, doc.arena.paths.len() as u32 - path_start);
     let mut feature = GeometryFeature::new(FeatureKind::Slot, GeometryPolarity::Dark);
     feature.source = source;
+    feature.source_name = slot.name;
     feature.bbox = doc.arena.paths_bbox(paths);
     feature.paths = paths;
     apply_ipc_placement(&mut feature, placement);

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context, Result};
 use ipc2581::types::{
-    LayerFunction, PackagePinElectricalType, PackagePinMountType, PackagePinType, SetFeature,
+    LayerFunction, PackagePinElectricalType, PackagePinMountType, PackagePinType,
 };
 use ipc2581::{Symbol, types::Side as IpcSide};
 
@@ -20,9 +20,8 @@ use crate::dialects::ipc::{
 };
 use crate::geom::{ContourSet, FillRule, Point, Polarity, Span, tol};
 use crate::import::ipc2581::{
-    ComponentOccurrence, ComponentOccurrenceId, FeatureOccurrence, FeatureOccurrenceId,
-    ImportedDesign, LayerId, LayoutOccurrenceId, PopulationState, feature_occurrence_id, is_copper,
-    layer_role,
+    ComponentOccurrence, ComponentOccurrenceId, FeatureOccurrenceId, ImportedDesign, LayerId,
+    LayoutOccurrenceId, PopulationState, feature_occurrence_id, is_copper, layer_role,
 };
 
 /// A relationship whose uncertainty is part of the result rather than hidden
@@ -156,6 +155,7 @@ pub struct PhysicalHole {
     pub kind: PhysicalHoleKind,
     pub at: Point,
     pub finished_diameter: Option<f64>,
+    pub assembly_side: Side,
     pub image: ContourSet,
     pub board: Option<LayoutOccurrenceId>,
     pub plating: PlatingKind,
@@ -234,11 +234,10 @@ impl ImportedDesign {
     }
 
     /// Derive drilled openings and their copper-land relationships without
-    /// materializing paste or mask layers.
+    /// materializing assembly, paste, or mask layers.
     pub fn physical_holes(&self, scope: ArtworkScope) -> Result<Vec<PhysicalHole>> {
         let lands = self.physical_lands(scope)?;
-        let terminations = self.derive_physical_terminations(&lands);
-        self.derive_physical_holes(scope, &lands, &terminations)
+        self.derive_physical_holes(scope, &lands)
     }
 
     /// Derive physical lands, exact electrical terminations, independent paste
@@ -250,7 +249,8 @@ impl ImportedDesign {
         let terminations = self.derive_physical_terminations(&lands);
         let paste_islands = self.paste_islands(scope, &components, &terminations)?;
         let mask_openings = self.mask_openings(scope, &lands)?;
-        let holes = self.derive_physical_holes(scope, &lands, &terminations)?;
+        let mut holes = self.derive_physical_holes(scope, &lands)?;
+        self.attach_hole_assembly_evidence(scope, &lands, &terminations, &mut holes)?;
         Ok(PhysicalView {
             lands,
             terminations,
@@ -503,12 +503,7 @@ impl ImportedDesign {
         &self,
         scope: ArtworkScope,
         lands: &[PhysicalLand],
-        terminations: &[PhysicalTermination],
     ) -> Result<Vec<PhysicalHole>> {
-        let land_by_id = lands
-            .iter()
-            .map(|land| (land.id, land))
-            .collect::<HashMap<_, _>>();
         let mut holes = Vec::new();
         for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
             if !matches!(
@@ -527,14 +522,6 @@ impl ImportedDesign {
                 }
                 let image = self.feature_region(occurrence);
                 let evidence = self.feature_evidence(occurrence.id);
-                let (termination, termination_basis) = self.hole_termination_association(
-                    &occurrence,
-                    &image,
-                    &evidence,
-                    feature.intent.span,
-                    terminations,
-                    &land_by_id,
-                );
                 let mut layer_lands = Vec::new();
                 for copper_layer in lands.iter().map(|land| land.layer).collect::<BTreeSet<_>>() {
                     if !feature_spans_layer(
@@ -564,7 +551,7 @@ impl ImportedDesign {
                 holes.push(PhysicalHole {
                     id: HoleId(occurrence.id),
                     layer: layer_id,
-                    source_name: self.feature_source_name(feature),
+                    source_name: feature.source_name,
                     kind: match feature.kind {
                         FeatureKind::Hole => PhysicalHoleKind::Round,
                         FeatureKind::Slot => PhysicalHoleKind::Slot,
@@ -573,6 +560,7 @@ impl ImportedDesign {
                     at: occurrence.root_from_local.transform_point(feature.center),
                     finished_diameter: (feature.kind == FeatureKind::Hole)
                         .then_some(feature.outer_diameter),
+                    assembly_side: feature.intent.side,
                     image,
                     board: occurrence.board,
                     plating: feature.intent.plating,
@@ -580,31 +568,59 @@ impl ImportedDesign {
                     net: feature.net,
                     span: feature.intent.span,
                     spec_refs: self.feature_spec_refs(layer, feature),
-                    termination,
-                    termination_basis,
+                    termination: Association::Unresolved,
+                    termination_basis: None,
                     protection: Vec::new(),
                     lands: layer_lands,
                 });
             }
         }
-        self.attach_hole_protection(scope, &mut holes)?;
         holes.sort_by_key(|hole| (hole.layer, hole.id));
         Ok(holes)
     }
 
+    fn attach_hole_assembly_evidence(
+        &self,
+        scope: ArtworkScope,
+        lands: &[PhysicalLand],
+        terminations: &[PhysicalTermination],
+        holes: &mut [PhysicalHole],
+    ) -> Result<()> {
+        let stackup = physical_stackup_layers(&self.stackups);
+        let land_by_id = lands
+            .iter()
+            .map(|land| (land.id, land))
+            .collect::<HashMap<_, _>>();
+        for hole in holes.iter_mut() {
+            let evidence = self.feature_evidence(hole.id.0);
+            let (termination, basis) = self.hole_termination_association(
+                hole,
+                &evidence,
+                terminations,
+                &land_by_id,
+                stackup.as_deref(),
+            );
+            if let Some(side) = association_side(&termination, terminations) {
+                hole.assembly_side = side;
+            }
+            hole.termination = termination;
+            hole.termination_basis = basis;
+        }
+        self.attach_hole_protection(scope, holes, stackup.as_deref())
+    }
+
     fn hole_termination_association(
         &self,
-        occurrence: &FeatureOccurrence,
-        image: &ContourSet,
+        hole: &PhysicalHole,
         evidence: &FeatureEvidence,
-        span: FeatureSpan<Symbol>,
         terminations: &[PhysicalTermination],
         land_by_id: &HashMap<LandId, &PhysicalLand>,
+        stackup: Option<&[Symbol]>,
     ) -> (Association<PhysicalTerminationId>, Option<AssociationBasis>) {
         if !evidence.component_refs.is_empty() || evidence.pin.is_some() {
             let candidates = terminations
                 .iter()
-                .filter(|termination| termination.component.layout == occurrence.id.layout)
+                .filter(|termination| termination.component.layout == hole.id.0.layout)
                 .filter(|termination| {
                     evidence.pin.is_none() || evidence.pin == Some(termination.pin)
                 })
@@ -629,11 +645,16 @@ impl ImportedDesign {
                 termination.lands.iter().filter_map(|land| {
                     let land = land_by_id[land];
                     (termination.side != Side::None
-                        && land.board == occurrence.board
+                        && land.board == hole.board
                         && land.side == termination.side
-                        && feature_spans_layer(span, land.layer, &self.layer_definitions)
-                        && land.image.bbox().intersects(image.bbox())
-                        && land.image.intersection(image).area() > tol::REGION_MM.powi(2))
+                        && feature_definitely_spans_layer(
+                            hole.span,
+                            land.layer,
+                            &self.layer_definitions,
+                            stackup,
+                        )
+                        && land.image.bbox().intersects(hole.image.bbox())
+                        && land.image.intersection(&hole.image).area() > tol::REGION_MM.powi(2))
                     .then_some((land.id, termination.id))
                 })
             })
@@ -662,6 +683,7 @@ impl ImportedDesign {
         &self,
         scope: ArtworkScope,
         holes: &mut [PhysicalHole],
+        stackup: Option<&[Symbol]>,
     ) -> Result<()> {
         for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
             if !matches!(
@@ -689,7 +711,9 @@ impl ImportedDesign {
                     .iter_mut()
                     .filter(|hole| hole.board == occurrence.board)
                 {
-                    if hole.image.bbox().intersects(image.bbox())
+                    if protection_side_compatible(hole.assembly_side, evidence.side)
+                        && feature_spans_overlap(hole.span, evidence.span, stackup)
+                        && hole.image.bbox().intersects(image.bbox())
                         && hole.image.intersection(&image).area() > tol::REGION_MM.powi(2)
                     {
                         hole.protection.push(evidence.clone());
@@ -724,27 +748,6 @@ impl ImportedDesign {
         spec_refs.sort_by_key(|spec| self.resolve(*spec));
         spec_refs.dedup();
         spec_refs
-    }
-
-    fn feature_source_name(&self, feature: &Feature<Symbol>) -> Option<Symbol> {
-        let step = self
-            .steps
-            .iter()
-            .find(|step| Some(step.name) == feature.source_step_ref)?;
-        let layer = step
-            .layer_features
-            .iter()
-            .find(|layer| Some(layer.layer_ref) == feature.source_layer_ref)?;
-        match layer
-            .sets
-            .get(feature.source.set_index as usize)?
-            .features
-            .get(feature.source.feature_index as usize)?
-        {
-            SetFeature::Hole(hole) => hole.name,
-            SetFeature::Slot(slot) => slot.name,
-            _ => None,
-        }
     }
 
     fn attributed_feature_images(
@@ -884,6 +887,30 @@ fn association_from_candidates<T: Copy + Ord>(
     }
 }
 
+fn association_side(
+    association: &Association<PhysicalTerminationId>,
+    terminations: &[PhysicalTermination],
+) -> Option<Side> {
+    let ids = match association {
+        Association::Resolved(id) => std::slice::from_ref(id),
+        Association::Ambiguous(ids) | Association::Conflicting(ids) => ids,
+        Association::Unresolved => return None,
+    };
+    let first = ids.first()?;
+    let side = terminations
+        .iter()
+        .find(|termination| termination.id == *first)?
+        .side;
+    (side != Side::None
+        && ids.iter().all(|id| {
+            terminations
+                .iter()
+                .find(|termination| termination.id == *id)
+                .is_some_and(|termination| termination.side == side)
+        }))
+    .then_some(side)
+}
+
 fn exact_termination(
     at: Point,
     pin: Option<Symbol>,
@@ -984,32 +1011,142 @@ fn physical_side(side: Option<IpcSide>) -> Side {
     }
 }
 
+fn protection_side_compatible(assembly_side: Side, protection_side: Side) -> bool {
+    protection_side == Side::None
+        || (assembly_side != Side::None && assembly_side == protection_side)
+}
+
 fn feature_spans_layer(
-    span: crate::dialects::ipc::FeatureSpan<Symbol>,
+    span: FeatureSpan<Symbol>,
     target: LayerId,
     layers: &[ipc2581::types::Layer],
 ) -> bool {
     let target_index = target.0 as usize;
-    match span {
-        crate::dialects::ipc::FeatureSpan::Unknown => false,
-        crate::dialects::ipc::FeatureSpan::ThroughBoard => true,
-        crate::dialects::ipc::FeatureSpan::Layer(layer) => layers
+    if let FeatureSpan::Layer(layer) = span {
+        return layers
             .get(target_index)
-            .is_some_and(|target| target.name == layer),
-        crate::dialects::ipc::FeatureSpan::FromTo {
+            .is_some_and(|target| target.name == layer);
+    }
+    resolved_feature_span(span, layers).is_none_or(|(from, to)| (from..=to).contains(&target_index))
+}
+
+fn feature_definitely_spans_layer(
+    span: FeatureSpan<Symbol>,
+    target: LayerId,
+    layers: &[ipc2581::types::Layer],
+    stackup: Option<&[Symbol]>,
+) -> bool {
+    let Some(target) = layers.get(target.0 as usize).map(|layer| layer.name) else {
+        return false;
+    };
+    let (from, to) = match span {
+        FeatureSpan::Unknown | FeatureSpan::FromTo { from: None, .. } => return false,
+        FeatureSpan::ThroughBoard => return true,
+        FeatureSpan::Layer(layer) => return layer == target,
+        FeatureSpan::FromTo { to: None, .. } => return false,
+        FeatureSpan::FromTo {
             from: Some(from),
             to: Some(to),
-        } => {
-            let Some(from) = layers.iter().position(|layer| layer.name == from) else {
-                return false;
-            };
-            let Some(to) = layers.iter().position(|layer| layer.name == to) else {
-                return false;
-            };
-            (from.min(to)..=from.max(to)).contains(&target_index)
-        }
-        crate::dialects::ipc::FeatureSpan::FromTo { .. } => false,
+        } => (from, to),
+    };
+    if target == from || target == to {
+        return true;
     }
+    let Some(layers) = stackup else {
+        return false;
+    };
+    let Some((from, to)) = span_range_in_stackup([from, to], layers) else {
+        return false;
+    };
+    layers
+        .iter()
+        .position(|layer| *layer == target)
+        .is_some_and(|target| (from..=to).contains(&target))
+}
+
+fn feature_spans_overlap(
+    left: FeatureSpan<Symbol>,
+    right: FeatureSpan<Symbol>,
+    stackup: Option<&[Symbol]>,
+) -> bool {
+    if matches!(left, FeatureSpan::ThroughBoard) {
+        return matches!(right, FeatureSpan::ThroughBoard) || span_endpoints(right).is_some();
+    }
+    if matches!(right, FeatureSpan::ThroughBoard) {
+        return span_endpoints(left).is_some();
+    }
+    let Some(left) = span_endpoints(left) else {
+        return false;
+    };
+    let Some(right) = span_endpoints(right) else {
+        return false;
+    };
+    if left.iter().any(|layer| right.contains(layer)) {
+        return true;
+    }
+    let Some(layers) = stackup else {
+        return false;
+    };
+    let Some(left) = span_range_in_stackup(left, layers) else {
+        return false;
+    };
+    let Some(right) = span_range_in_stackup(right, layers) else {
+        return false;
+    };
+    left.0 <= right.1 && right.0 <= left.1
+}
+
+fn span_endpoints(span: FeatureSpan<Symbol>) -> Option<[Symbol; 2]> {
+    match span {
+        FeatureSpan::Layer(layer) => Some([layer, layer]),
+        FeatureSpan::FromTo {
+            from: Some(from),
+            to: Some(to),
+        } => Some([from, to]),
+        FeatureSpan::Unknown | FeatureSpan::ThroughBoard | FeatureSpan::FromTo { .. } => None,
+    }
+}
+
+fn span_range_in_stackup(span: [Symbol; 2], stackup: &[Symbol]) -> Option<(usize, usize)> {
+    let from = stackup.iter().position(|layer| *layer == span[0])?;
+    let to = stackup.iter().position(|layer| *layer == span[1])?;
+    Some((from.min(to), from.max(to)))
+}
+
+fn physical_stackup_layers(stackups: &[ipc2581::types::Stackup]) -> Option<Vec<Symbol>> {
+    let [stackup] = stackups else {
+        return None;
+    };
+    let mut layers = stackup.layers.iter().collect::<Vec<_>>();
+    if layers.iter().all(|layer| layer.layer_number.is_some()) {
+        layers.sort_by_key(|layer| layer.layer_number);
+    }
+    Some(layers.into_iter().map(|layer| layer.layer_ref).collect())
+}
+
+fn resolved_feature_span(
+    span: FeatureSpan<Symbol>,
+    layers: &[ipc2581::types::Layer],
+) -> Option<(usize, usize)> {
+    let (from, to) = match span {
+        FeatureSpan::Unknown => return None,
+        FeatureSpan::ThroughBoard => (0, layers.len().checked_sub(1)?),
+        FeatureSpan::Layer(layer) => {
+            let layer = layers
+                .iter()
+                .position(|candidate| candidate.name == layer)?;
+            (layer, layer)
+        }
+        FeatureSpan::FromTo {
+            from: Some(from),
+            to: Some(to),
+        } => (
+            layers.iter().position(|layer| layer.name == from)?,
+            layers.iter().position(|layer| layer.name == to)?,
+        ),
+        FeatureSpan::FromTo { .. } => return None,
+    };
+    Some((from.min(to), from.max(to)))
 }
 
 #[cfg(test)]
@@ -1041,6 +1178,55 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("mixes Fill and Stroke paths")
+        );
+    }
+
+    #[test]
+    fn physical_holes_do_not_materialize_assembly_protection_layers() {
+        let xml = physical_fixture().replace(
+            "<Layer name=\"PASTE\" layerFunction=\"SOLDERPASTE\" side=\"TOP\" polarity=\"POSITIVE\"/>",
+            "<Layer name=\"PASTE\" layerFunction=\"HOLEFILL\" side=\"TOP\" polarity=\"POSITIVE\"/>",
+        );
+        let ipc = Ipc2581::parse(&xml).unwrap();
+        let mut imported = import_design(&ipc).unwrap();
+        make_paste_artwork_invalid(&mut imported);
+
+        let holes = imported.physical_holes(ArtworkScope::Board).unwrap();
+        assert_eq!(holes.len(), 1);
+        assert_eq!(holes[0].termination, Association::Unresolved);
+        assert!(holes[0].protection.is_empty());
+        assert!(
+            imported
+                .physical_view(ArtworkScope::Board)
+                .unwrap_err()
+                .to_string()
+                .contains("mixes Fill and Stroke paths")
+        );
+    }
+
+    #[test]
+    fn unresolved_hole_spans_keep_land_links_without_geometry_association() {
+        let xml = physical_fixture().replace(
+            "<Layer name=\"DRILL\" layerFunction=\"DRILL\" side=\"ALL\" polarity=\"POSITIVE\"/>",
+            "<Layer name=\"DRILL\" layerFunction=\"DRILL\" side=\"ALL\" polarity=\"POSITIVE\"><Span fromLayer=\"TOP\"/></Layer>",
+        );
+        Ipc2581::validate(&xml).expect("one-ended drill span conforms to IPC-2581C");
+        let ipc = Ipc2581::parse(&xml).unwrap();
+        let imported = import_design(&ipc).unwrap();
+        let holes = imported.physical_holes(ArtworkScope::Board).unwrap();
+
+        assert_eq!(holes.len(), 1);
+        assert_eq!(holes[0].lands.len(), 2);
+        assert!(
+            holes[0]
+                .lands
+                .iter()
+                .any(|association| matches!(association.land, Association::Resolved(_)))
+        );
+        assert_eq!(holes[0].termination, Association::Unresolved);
+        assert_eq!(
+            imported.physical_view(ArtworkScope::Board).unwrap().holes[0].termination,
+            Association::Unresolved
         );
     }
 

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context, Result};
 use ipc2581::types::{
-    LayerFunction, PackagePinElectricalType, PackagePinMountType, PackagePinType,
+    LayerFunction, PackagePinElectricalType, PackagePinMountType, PackagePinType, SetFeature,
 };
 use ipc2581::{Symbol, types::Side as IpcSide};
 
@@ -16,12 +16,13 @@ use crate::dialects::Side;
 use crate::dialects::artwork;
 use crate::dialects::ipc::{
     ArtworkLowering, ArtworkObjectKind, ArtworkScope, Feature, FeatureDomain, FeatureKind,
-    PlatingKind, lower_layer_to_artwork_with,
+    FeatureSpan, PlatingKind, lower_layer_to_artwork_with,
 };
 use crate::geom::{ContourSet, FillRule, Point, Polarity, Span, tol};
 use crate::import::ipc2581::{
-    ComponentOccurrence, ComponentOccurrenceId, FeatureOccurrenceId, ImportedDesign, LayerId,
-    LayoutOccurrenceId, PopulationState, feature_occurrence_id, is_copper, layer_role,
+    ComponentOccurrence, ComponentOccurrenceId, FeatureOccurrence, FeatureOccurrenceId,
+    ImportedDesign, LayerId, LayoutOccurrenceId, PopulationState, feature_occurrence_id, is_copper,
+    layer_role,
 };
 
 /// A relationship whose uncertainty is part of the result rather than hidden
@@ -63,6 +64,28 @@ pub struct MaskOpeningId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct HoleId(pub FeatureOccurrenceId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssociationBasis {
+    SourceIdentity,
+    ExactGeometry,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhysicalHoleKind {
+    Round,
+    Slot,
+}
+
+#[derive(Debug, Clone)]
+pub struct HoleProtectionEvidence {
+    pub source: FeatureOccurrenceId,
+    pub layer: LayerId,
+    pub function: LayerFunction,
+    pub side: Side,
+    pub span: FeatureSpan<Symbol>,
+    pub spec_refs: Vec<Symbol>,
+}
 
 #[derive(Debug, Clone)]
 pub struct PhysicalLand {
@@ -129,11 +152,20 @@ pub struct MaskOpening {
 pub struct PhysicalHole {
     pub id: HoleId,
     pub layer: LayerId,
+    pub source_name: Option<Symbol>,
+    pub kind: PhysicalHoleKind,
+    pub at: Point,
+    pub finished_diameter: Option<f64>,
     pub image: ContourSet,
     pub board: Option<LayoutOccurrenceId>,
     pub plating: PlatingKind,
     pub padstack: Option<Symbol>,
     pub net: Option<Symbol>,
+    pub span: FeatureSpan<Symbol>,
+    pub spec_refs: Vec<Symbol>,
+    pub termination: Association<PhysicalTerminationId>,
+    pub termination_basis: Option<AssociationBasis>,
+    pub protection: Vec<HoleProtectionEvidence>,
     /// One explicit result per copper layer the opening geometrically reaches.
     pub lands: Vec<LayerLandAssociation>,
 }
@@ -205,7 +237,8 @@ impl ImportedDesign {
     /// materializing paste or mask layers.
     pub fn physical_holes(&self, scope: ArtworkScope) -> Result<Vec<PhysicalHole>> {
         let lands = self.physical_lands(scope)?;
-        self.derive_physical_holes(scope, &lands)
+        let terminations = self.derive_physical_terminations(&lands);
+        self.derive_physical_holes(scope, &lands, &terminations)
     }
 
     /// Derive physical lands, exact electrical terminations, independent paste
@@ -217,7 +250,7 @@ impl ImportedDesign {
         let terminations = self.derive_physical_terminations(&lands);
         let paste_islands = self.paste_islands(scope, &components, &terminations)?;
         let mask_openings = self.mask_openings(scope, &lands)?;
-        let holes = self.derive_physical_holes(scope, &lands)?;
+        let holes = self.derive_physical_holes(scope, &lands, &terminations)?;
         Ok(PhysicalView {
             lands,
             terminations,
@@ -470,7 +503,12 @@ impl ImportedDesign {
         &self,
         scope: ArtworkScope,
         lands: &[PhysicalLand],
+        terminations: &[PhysicalTermination],
     ) -> Result<Vec<PhysicalHole>> {
+        let land_by_id = lands
+            .iter()
+            .map(|land| (land.id, land))
+            .collect::<HashMap<_, _>>();
         let mut holes = Vec::new();
         for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
             if !matches!(
@@ -489,6 +527,14 @@ impl ImportedDesign {
                 }
                 let image = self.feature_region(occurrence);
                 let evidence = self.feature_evidence(occurrence.id);
+                let (termination, termination_basis) = self.hole_termination_association(
+                    &occurrence,
+                    &image,
+                    &evidence,
+                    feature.intent.span,
+                    terminations,
+                    &land_by_id,
+                );
                 let mut layer_lands = Vec::new();
                 for copper_layer in lands.iter().map(|land| land.layer).collect::<BTreeSet<_>>() {
                     if !feature_spans_layer(
@@ -518,17 +564,187 @@ impl ImportedDesign {
                 holes.push(PhysicalHole {
                     id: HoleId(occurrence.id),
                     layer: layer_id,
+                    source_name: self.feature_source_name(feature),
+                    kind: match feature.kind {
+                        FeatureKind::Hole => PhysicalHoleKind::Round,
+                        FeatureKind::Slot => PhysicalHoleKind::Slot,
+                        _ => unreachable!("physical opening is a hole or slot"),
+                    },
+                    at: occurrence.root_from_local.transform_point(feature.center),
+                    finished_diameter: (feature.kind == FeatureKind::Hole)
+                        .then_some(feature.outer_diameter),
                     image,
                     board: occurrence.board,
                     plating: feature.intent.plating,
                     padstack: feature.padstack_ref,
                     net: feature.net,
+                    span: feature.intent.span,
+                    spec_refs: self.feature_spec_refs(layer, feature),
+                    termination,
+                    termination_basis,
+                    protection: Vec::new(),
                     lands: layer_lands,
                 });
             }
         }
+        self.attach_hole_protection(scope, &mut holes)?;
         holes.sort_by_key(|hole| (hole.layer, hole.id));
         Ok(holes)
+    }
+
+    fn hole_termination_association(
+        &self,
+        occurrence: &FeatureOccurrence,
+        image: &ContourSet,
+        evidence: &FeatureEvidence,
+        span: FeatureSpan<Symbol>,
+        terminations: &[PhysicalTermination],
+        land_by_id: &HashMap<LandId, &PhysicalLand>,
+    ) -> (Association<PhysicalTerminationId>, Option<AssociationBasis>) {
+        if !evidence.component_refs.is_empty() || evidence.pin.is_some() {
+            let candidates = terminations
+                .iter()
+                .filter(|termination| termination.component.layout == occurrence.id.layout)
+                .filter(|termination| {
+                    evidence.pin.is_none() || evidence.pin == Some(termination.pin)
+                })
+                .filter(|termination| {
+                    evidence.component_refs.is_empty()
+                        || self
+                            .component_definition(termination.component.component)
+                            .and_then(|component| component.source.ref_des)
+                            .is_some_and(|reference| evidence.component_refs.contains(&reference))
+                })
+                .map(|termination| termination.id)
+                .collect::<BTreeSet<_>>();
+            return (
+                association_from_candidates(candidates, true),
+                Some(AssociationBasis::SourceIdentity),
+            );
+        }
+
+        let candidate_lands = terminations
+            .iter()
+            .flat_map(|termination| {
+                termination.lands.iter().filter_map(|land| {
+                    let land = land_by_id[land];
+                    (termination.side != Side::None
+                        && land.board == occurrence.board
+                        && land.side == termination.side
+                        && feature_spans_layer(span, land.layer, &self.layer_definitions)
+                        && land.image.bbox().intersects(image.bbox())
+                        && land.image.intersection(image).area() > tol::REGION_MM.powi(2))
+                    .then_some((land.id, termination.id))
+                })
+            })
+            .collect::<Vec<_>>();
+        match candidate_lands.as_slice() {
+            [] => (Association::Unresolved, None),
+            [(_, termination)] => (
+                Association::Resolved(*termination),
+                Some(AssociationBasis::ExactGeometry),
+            ),
+            _ => (
+                Association::Ambiguous(
+                    candidate_lands
+                        .into_iter()
+                        .map(|(_, termination)| termination)
+                        .collect::<BTreeSet<_>>()
+                        .into_iter()
+                        .collect(),
+                ),
+                Some(AssociationBasis::ExactGeometry),
+            ),
+        }
+    }
+
+    fn attach_hole_protection(
+        &self,
+        scope: ArtworkScope,
+        holes: &mut [PhysicalHole],
+    ) -> Result<()> {
+        for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
+            if !matches!(
+                layer.layer_function,
+                LayerFunction::HoleFill
+                    | LayerFunction::CoatingCond
+                    | LayerFunction::CoatingNonCond
+            ) {
+                continue;
+            }
+            let layer_id = LayerId(layer_index as u32);
+            for (occurrence, image) in self.attributed_feature_images(layer_id, scope)? {
+                let feature = self
+                    .feature_definition(occurrence.id.feature)
+                    .context("hole protection references a missing feature definition")?;
+                let evidence = HoleProtectionEvidence {
+                    source: occurrence.id,
+                    layer: layer_id,
+                    function: layer.layer_function,
+                    side: feature.intent.side,
+                    span: feature.intent.span,
+                    spec_refs: self.feature_spec_refs(layer, feature),
+                };
+                for hole in holes
+                    .iter_mut()
+                    .filter(|hole| hole.board == occurrence.board)
+                {
+                    if hole.image.bbox().intersects(image.bbox())
+                        && hole.image.intersection(&image).area() > tol::REGION_MM.powi(2)
+                    {
+                        hole.protection.push(evidence.clone());
+                    }
+                }
+            }
+        }
+        for hole in holes {
+            hole.protection
+                .sort_by_key(|evidence| (evidence.layer, evidence.source));
+        }
+        Ok(())
+    }
+
+    fn feature_spec_refs(
+        &self,
+        layer: &ipc2581::types::Layer,
+        feature: &Feature<Symbol>,
+    ) -> Vec<Symbol> {
+        let mut spec_refs = layer.spec_refs.clone();
+        if let Some(set) = feature
+            .set
+            .and_then(|set| self.geometry.feature_sets.get(set as usize))
+        {
+            spec_refs.extend(
+                set.spec_refs
+                    .slice(&self.geometry.spec_refs)
+                    .iter()
+                    .map(|reference| reference.spec),
+            );
+        }
+        spec_refs.sort_by_key(|spec| self.resolve(*spec));
+        spec_refs.dedup();
+        spec_refs
+    }
+
+    fn feature_source_name(&self, feature: &Feature<Symbol>) -> Option<Symbol> {
+        let step = self
+            .steps
+            .iter()
+            .find(|step| Some(step.name) == feature.source_step_ref)?;
+        let layer = step
+            .layer_features
+            .iter()
+            .find(|layer| Some(layer.layer_ref) == feature.source_layer_ref)?;
+        match layer
+            .sets
+            .get(feature.source.set_index as usize)?
+            .features
+            .get(feature.source.feature_index as usize)?
+        {
+            SetFeature::Hole(hole) => hole.name,
+            SetFeature::Slot(slot) => slot.name,
+            _ => None,
+        }
     }
 
     fn attributed_feature_images(
@@ -655,6 +871,19 @@ impl ArtworkLowering<Symbol, Option<FeatureOccurrenceId>> for OccurrenceAttribut
     }
 }
 
+fn association_from_candidates<T: Copy + Ord>(
+    candidates: BTreeSet<T>,
+    source_claimed: bool,
+) -> Association<T> {
+    let candidates = candidates.into_iter().collect::<Vec<_>>();
+    match candidates.as_slice() {
+        [candidate] => Association::Resolved(*candidate),
+        [_, _, ..] => Association::Ambiguous(candidates),
+        [] if source_claimed => Association::Conflicting(Vec::new()),
+        [] => Association::Unresolved,
+    }
+}
+
 fn exact_termination(
     at: Point,
     pin: Option<Symbol>,
@@ -762,8 +991,8 @@ fn feature_spans_layer(
 ) -> bool {
     let target_index = target.0 as usize;
     match span {
-        crate::dialects::ipc::FeatureSpan::Unknown
-        | crate::dialects::ipc::FeatureSpan::ThroughBoard => true,
+        crate::dialects::ipc::FeatureSpan::Unknown => false,
+        crate::dialects::ipc::FeatureSpan::ThroughBoard => true,
         crate::dialects::ipc::FeatureSpan::Layer(layer) => layers
             .get(target_index)
             .is_some_and(|target| target.name == layer),
@@ -772,14 +1001,14 @@ fn feature_spans_layer(
             to: Some(to),
         } => {
             let Some(from) = layers.iter().position(|layer| layer.name == from) else {
-                return true;
+                return false;
             };
             let Some(to) = layers.iter().position(|layer| layer.name == to) else {
-                return true;
+                return false;
             };
             (from.min(to)..=from.max(to)).contains(&target_index)
         }
-        crate::dialects::ipc::FeatureSpan::FromTo { .. } => true,
+        crate::dialects::ipc::FeatureSpan::FromTo { .. } => false,
     }
 }
 

--- a/crates/pcbc/tests/ipc2581.rs
+++ b/crates/pcbc/tests/ipc2581.rs
@@ -33,7 +33,7 @@ fn assembly_command_matches_the_shared_board_array_report() {
     let (second_json, _) = assembly_report("board-array");
 
     assert_eq!(first_json, second_json);
-    assert_eq!(report["schema_version"], 2);
+    assert_eq!(report["schema_version"], 3);
     assert_eq!(report["scope"]["kind"], "board_array");
     assert_eq!(report["scope"]["area_mm2"], 1_400.0);
     assert_eq!(report["profiles"].as_array().unwrap().len(), 2);


### PR DESCRIPTION
Extends `pcb ipc assembly` schema v3 with stable hole identities, conservative component-termination associations, soldermask context, and explicit via-protection evidence. It keeps quote policy outside PCB and reports unknown or ambiguous evidence instead of guessing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->