### PR TITLE
Fix IPC-2581 assembly hole reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Preserve IPC-2581 hole shapes, transforms, local specifications, and both-side solder-mask evidence in PCBA assembly reports.
+- Fix IPC-2581 hole geometry and manufacturing evidence in PCBA assembly reports.
 
 ## [0.4.45] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve IPC-2581 hole shapes, transforms, local specifications, and both-side solder-mask evidence in PCBA assembly reports.
+
 ## [0.4.45] - 2026-09-02
 
 ### Changed

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -3194,17 +3194,42 @@ impl<'a> Parser<'a> {
         let units = self.ecad_units.unwrap_or(Units::Millimeter);
 
         let name = self.attr(node, "name").map(|s| self.interner.intern(s));
+        let shape = match self.attr(node, "type").unwrap_or("CIRCLE") {
+            "CIRCLE" => ecad::HoleShape::Circle,
+            "SQUARE" => ecad::HoleShape::Square,
+            value => {
+                return Err(Ipc2581Error::InvalidAttribute(format!(
+                    "Invalid Hole type: {value}"
+                )));
+            }
+        };
         let diameter = self.parse_f64_attr_with_units(node, "diameter", "Hole", units)?;
         let plating_status_str = self.required_attr(node, "platingStatus", "Hole")?;
         let plating_status =
             self.parse_plating_status(self.interner.resolve(plating_status_str))?;
         let x = self.parse_f64_attr_with_units(node, "x", "Hole", units)?;
         let y = self.parse_f64_attr_with_units(node, "y", "Hole", units)?;
+        let mut xform = None;
+        let mut spec_refs = Vec::new();
+        for child in self.element_children(node) {
+            match self.name(&child) {
+                "SpecRef" => {
+                    if let Some(id) = self.attr(&child, "id") {
+                        spec_refs.push(self.interner.intern(id));
+                    }
+                }
+                "Xform" => xform = Some(self.parse_xform(&child, units)?),
+                _ => {}
+            }
+        }
 
         Ok(Hole {
             name,
+            shape,
             diameter,
             plating_status,
+            xform,
+            spec_refs,
             x,
             y,
         })

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -666,10 +666,19 @@ pub struct FeaturePrimitiveRef {
 #[derive(Debug, Clone)]
 pub struct Hole {
     pub name: Option<Symbol>,
+    pub shape: HoleShape,
     pub diameter: f64,
     pub plating_status: PlatingStatus,
+    pub xform: Option<super::Xform>,
+    pub spec_refs: Vec<Symbol>,
     pub x: f64,
     pub y: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HoleShape {
+    Circle,
+    Square,
 }
 
 /// Shape definition for a SlotCavity

--- a/crates/ipc2581/src/write.rs
+++ b/crates/ipc2581/src/write.rs
@@ -260,8 +260,11 @@ mod tests {
 
         let hole_mm = Hole {
             name: None,
+            shape: crate::types::HoleShape::Circle,
             diameter: 2.0,
             plating_status: PlatingStatus::NonPlated,
+            xform: None,
+            spec_refs: Vec::new(),
             x: 1.5,
             y: -0.25,
         };

--- a/crates/pcb-ipc2581-tools/src/assembly/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/mod.rs
@@ -196,12 +196,10 @@ pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<A
                 .mask_openings
                 .iter()
                 .filter(|opening| {
-                    (termination.side == pcb_ir::dialects::Side::None
-                        || opening.side == termination.side)
-                        && opening
-                            .lands
-                            .resolved()
-                            .is_some_and(|land| termination.lands.contains(land))
+                    opening
+                        .lands
+                        .resolved()
+                        .is_some_and(|land| termination.lands.contains(land))
                 })
                 .map(|opening| report::MaskEvidence {
                     layer: imported
@@ -663,6 +661,7 @@ fn physical_hole_reports(
             let finished_diameter_mm = hole.finished_diameter.map(canonical_number);
             let kind = match hole.kind {
                 PhysicalHoleKind::Round => report::HoleKind::Round,
+                PhysicalHoleKind::Square => report::HoleKind::Square,
                 PhysicalHoleKind::Slot => report::HoleKind::Slot,
             };
             let plating = hole_plating(hole.plating);

--- a/crates/pcb-ipc2581-tools/src/assembly/report.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/report.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-pub const REPORT_SCHEMA_VERSION: u32 = 3;
+pub const REPORT_SCHEMA_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct AssemblyReport {
@@ -571,6 +571,7 @@ pub struct Hole {
 #[serde(rename_all = "snake_case")]
 pub enum HoleKind {
     Round,
+    Square,
     Slot,
 }
 

--- a/crates/pcb-ipc2581-tools/src/assembly/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/tests.rs
@@ -24,7 +24,7 @@ fn report_xml(xml: &str, target: LayoutTarget) -> report::AssemblyReport {
 fn reports_scoped_components_and_exact_physical_evidence() {
     let report = report(LayoutTarget::BoardArray);
 
-    assert_eq!(report.schema_version, 3);
+    assert_eq!(report.schema_version, 4);
     assert_eq!(report.scope.kind, report::ScopeKind::BoardArray);
     assert_eq!(report.scope.root_step.as_deref(), Some("panel"));
     assert_eq!(report.scope.profile_ids.len(), 1);
@@ -482,6 +482,80 @@ fn repeated_layer_sections_preserve_hole_names() {
 }
 
 #[test]
+fn reports_square_hole_shape_and_xform() {
+    let xml = FIXTURE.replace(
+        "<Hole name=\"U1-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"2.2\" y=\"2\"/>",
+        "<Hole name=\"U1-via\" type=\"SQUARE\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"2\" y=\"2\"><Xform xOffset=\"0.2\"/></Hole>",
+    );
+
+    let report = report_xml(&xml, LayoutTarget::Board);
+    let hole = report
+        .holes
+        .iter()
+        .find(|hole| hole.source_name.as_deref() == Some("U1-via"))
+        .unwrap();
+
+    assert_eq!(hole.kind, report::HoleKind::Square);
+    assert_eq!(hole.location_mm, report::Point { x: 2.2, y: 2.0 });
+    assert_eq!(
+        hole.termination.status,
+        report::AssociationStatus::ExactGeometric
+    );
+    assert_eq!(hole.protection.status, report::ProtectionStatus::Explicit);
+}
+
+#[test]
+fn reports_hole_local_protection_intent() {
+    let xml = FIXTURE
+        .replace(
+            "    </CadHeader>",
+            "      <Spec name=\"open-via\"><General type=\"MATERIAL\"><Property text=\"OPEN\"/></General></Spec>\n    </CadHeader>",
+        )
+        .replace(
+            "<Hole name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"8\" y=\"5\"/>",
+            "<Hole name=\"standalone-via\" diameter=\"0.2\" platingStatus=\"VIA\" plusTol=\"0\" minusTol=\"0\" x=\"8\" y=\"5\"><SpecRef id=\"open-via\"/></Hole>",
+        );
+
+    let report = report_xml(&xml, LayoutTarget::Board);
+    let hole = report
+        .holes
+        .iter()
+        .find(|hole| hole.source_name.as_deref() == Some("standalone-via"))
+        .unwrap();
+
+    assert_eq!(hole.protection.status, report::ProtectionStatus::Explicit);
+    assert_eq!(hole.protection.methods, [report::ProtectionMethod::Open]);
+    assert_eq!(hole.protection.evidence[0].specs, ["open-via"]);
+}
+
+#[test]
+fn reports_both_and_all_mask_openings() {
+    for side in ["BOTH", "ALL"] {
+        let xml = FIXTURE.replace(
+            "<Layer name=\"MASK\" layerFunction=\"SOLDERMASK\" side=\"TOP\" polarity=\"POSITIVE\"/>",
+            &format!(
+                "<Layer name=\"MASK\" layerFunction=\"SOLDERMASK\" side=\"{side}\" polarity=\"POSITIVE\"/>"
+            ),
+        );
+
+        let report = report_xml(&xml, LayoutTarget::Board);
+        let openings = report
+            .terminations
+            .iter()
+            .flat_map(|termination| &termination.mask_openings)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            openings,
+            [&report::MaskEvidence {
+                layer: "MASK".to_owned(),
+                side: report::Side::None,
+            }]
+        );
+    }
+}
+
+#[test]
 fn protection_requires_compatible_span_and_assembly_side() {
     let span = "<Span fromLayer=\"TOP\" toLayer=\"BOTTOM\"/>";
     let disjoint_span = FIXTURE
@@ -776,8 +850,8 @@ fn serialization_is_deterministic() {
     assert_eq!(first, second);
     assert_eq!(
         hex::encode(Sha256::digest(first.as_bytes())),
-        "047ec7cb0494a77bb7a1261584eb0cd97ab15743fb1c9d7bd4c1d6491d46739c",
-        "schema v3 changed without an explicit version change"
+        "603792a48cab06f08eb5c1bb7258767c59a225705d3635d1db85c7b33018f3ff",
+        "schema v4 changed without an explicit version change"
     );
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
@@ -353,8 +353,11 @@ pub(super) fn round_fiducial_features(
 pub(super) fn round_nonplated_hole(x_mm: f64, y_mm: f64, diameter_mm: f64) -> Hole {
     Hole {
         name: None,
+        shape: ipc2581::types::HoleShape::Circle,
         diameter: diameter_mm,
         plating_status: PlatingStatus::NonPlated,
+        xform: None,
+        spec_refs: Vec::new(),
         x: x_mm,
         y: y_mm,
     }

--- a/crates/pcb-ir/src/dialects/ipc/feature.rs
+++ b/crates/pcb-ir/src/dialects/ipc/feature.rs
@@ -26,6 +26,8 @@ pub struct Feature<Symbol> {
     pub source_step_ref: Option<Symbol>,
     /// Source name for named physical features such as holes and slots.
     pub source_name: Option<Symbol>,
+    /// Source-local references declared directly on this feature.
+    pub spec_refs: Span,
     /// Materialized occurrence of `source_step_ref` in the layout graph.
     /// `None` identifies geometry owned directly by the root step.
     pub source_instance: Option<u32>,
@@ -57,6 +59,7 @@ pub struct Feature<Symbol> {
 
     pub line_cap: LineCap,
     pub fill_rule: FillRule,
+    pub hole_shape: HoleShape,
     pub padstack_ref: Option<Symbol>,
     pub primitive_ref: Option<PrimitiveRef<Symbol>>,
     /// Spans `doc.pin_refs`.
@@ -92,6 +95,7 @@ impl<Symbol> Feature<Symbol> {
             source_layer_ref: None,
             source_step_ref: None,
             source_name: None,
+            spec_refs: Span::EMPTY,
             source_instance: None,
             source_placement: None,
             source_step_kind: LayoutStepKind::Unknown,
@@ -114,6 +118,7 @@ impl<Symbol> Feature<Symbol> {
             scale: 1.0,
             line_cap: LineCap::Round,
             fill_rule: FillRule::NonZero,
+            hole_shape: HoleShape::Round,
             padstack_ref: None,
             primitive_ref: None,
             pin_refs: Span::EMPTY,
@@ -190,6 +195,12 @@ pub enum FeatureKind {
     Slot,
     Trace,
     FlattenedBucket,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HoleShape {
+    Round,
+    Square,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -39,8 +39,8 @@ pub use document::{Document, Layer};
 pub use feature::{
     CopperBalanceKind, CopperBalanceVoid, Feature, FeatureBucket, FeatureDomain, FeatureFlags,
     FeatureIntent, FeatureKind, FeatureMaterial, FeatureOperation, FeaturePlacementGroup,
-    FeatureRole, FeatureSet, FeatureSpan, FiducialKind, GeometryUsage, PinRef, PlatingKind,
-    PrimitiveRef, SourceRef,
+    FeatureRole, FeatureSet, FeatureSpan, FiducialKind, GeometryUsage, HoleShape, PinRef,
+    PlatingKind, PrimitiveRef, SourceRef,
 };
 pub use layout::{
     LayoutGraph, LayoutInstance, LayoutMargins, LayoutPurpose, LayoutRepeat, LayoutStep,

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -2,8 +2,9 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context, Result, bail};
 use ipc2581::types::{
-    FillDesc, FillProperty, LayerFunction, LineEnd, LineProperty, PadUse, PlatingStatus, Polarity,
-    PolyStep, SlotShape, StandardPrimitive, UserPrimitive, UserShapeType, Xform,
+    FillDesc, FillProperty, HoleShape as IpcHoleShape, LayerFunction, LineEnd, LineProperty,
+    PadUse, PlatingStatus, Polarity, PolyStep, SlotShape, StandardPrimitive, UserPrimitive,
+    UserShapeType, Xform,
     ecad::{Layer, SetFeature, Step, StepRepeat, StepType},
 };
 use ipc2581::{Interner, Ipc2581, Symbol};
@@ -1883,6 +1884,12 @@ fn source_layer_set_span(source: &GeometryDocument, layer_index: usize) -> Resul
     Ok(span)
 }
 
+fn append_span<T: Clone>(target: &mut Vec<T>, source: &[T], span: Span) -> Span {
+    let start = target.len() as u32;
+    target.extend(span.slice(source).iter().cloned());
+    Span::new(start, span.count)
+}
+
 fn append_transformed_layer(
     target: &mut GeometryDocument,
     source: &GeometryDocument,
@@ -1898,13 +1905,10 @@ fn append_transformed_layer(
 
     for source_set_index in layer.sets.indices() {
         let source_set = &source.feature_sets[source_set_index as usize];
-        let spec_ref_start = target.spec_refs.len() as u32;
-        target.spec_refs.extend(
-            source_set
-                .spec_refs
-                .slice(&source.spec_refs)
-                .iter()
-                .cloned(),
+        let spec_refs = append_span(
+            &mut target.spec_refs,
+            &source.spec_refs,
+            source_set.spec_refs,
         );
         let target_set = target.feature_sets.len() as u32;
         target.feature_sets.push(FeatureSet {
@@ -1918,15 +1922,14 @@ fn append_transformed_layer(
             geometry_usage: source_set.geometry_usage,
             net: source_set.net,
             polarity: source_set.polarity,
-            spec_refs: Span::new(
-                spec_ref_start,
-                target.spec_refs.len() as u32 - spec_ref_start,
-            ),
+            spec_refs,
             features: Span::new(target.features.len() as u32, 0),
             bbox: BBox::empty(),
         });
 
         for feature in source_set.features.slice(&source.features) {
+            let spec_refs =
+                append_span(&mut target.spec_refs, &source.spec_refs, feature.spec_refs);
             let target_placement_group = if let Some(source_group_id) = feature.placement_group {
                 if let Some(&target_group_id) = placement_groups.get(&source_group_id) {
                     Some(target_group_id)
@@ -1978,6 +1981,7 @@ fn append_transformed_layer(
             };
 
             let mut feature = feature.clone();
+            feature.spec_refs = spec_refs;
             if target_placement_group.is_none() {
                 feature.transform = transform.concat(feature.transform);
                 feature.center = transform.transform_point(feature.center);
@@ -1992,13 +1996,8 @@ fn append_transformed_layer(
                 .set_index
                 .checked_add(source_set_offset)
                 .context("Panel source feature set index overflow")?;
-            if !feature.pin_refs.is_empty() {
-                let pin_ref_start = target.pin_refs.len() as u32;
-                target
-                    .pin_refs
-                    .extend(feature.pin_refs.slice(&source.pin_refs).iter().cloned());
-                feature.pin_refs = Span::new(pin_ref_start, feature.pin_refs.count);
-            }
+            feature.pin_refs =
+                append_span(&mut target.pin_refs, &source.pin_refs, feature.pin_refs);
             target.features.push(feature);
             let target_set_record = &mut target.feature_sets[target_set as usize];
             target_set_record.features.count += 1;
@@ -3029,23 +3028,30 @@ fn extract_hole(
     hole: &ipc2581::types::Hole,
     doc: &mut GeometryDocument,
 ) -> GeometryFeature {
+    let placement = ipc_placement(Point::new(hole.x, hole.y), hole.xform);
     let path_start = doc.arena.paths.len() as u32;
-    let center = Point::new(hole.x, hole.y);
-    push_ellipse_path(
-        doc,
-        Affine2::placement(center, 0.0, Mirror::NONE, 1.0),
-        hole.diameter,
-        hole.diameter,
-    );
+    match hole.shape {
+        IpcHoleShape::Circle => {
+            push_ellipse_path(doc, placement.transform, hole.diameter, hole.diameter)
+        }
+        IpcHoleShape::Square => {
+            push_rect_path(doc, placement.transform, hole.diameter, hole.diameter)
+        }
+    }
     let paths = Span::new(path_start, doc.arena.paths.len() as u32 - path_start);
 
     let mut feature = GeometryFeature::new(FeatureKind::Hole, GeometryPolarity::Dark);
     feature.source = source;
     feature.source_name = hole.name;
+    feature.spec_refs = push_spec_refs(doc, &hole.spec_refs);
     feature.bbox = doc.arena.paths_bbox(paths);
     feature.paths = paths;
-    feature.center = center;
-    feature.outer_diameter = hole.diameter;
+    apply_ipc_placement(&mut feature, placement);
+    feature.hole_shape = match hole.shape {
+        IpcHoleShape::Circle => HoleShape::Round,
+        IpcHoleShape::Square => HoleShape::Square,
+    };
+    feature.outer_diameter = hole.diameter * feature.scale;
     feature.padstack_ref = padstack_ref;
     feature.intent.plating = plating_kind(hole.plating_status);
     feature.flags.lowered_to_paths = true;

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -16,7 +16,7 @@ use crate::dialects::Side;
 use crate::dialects::artwork;
 use crate::dialects::ipc::{
     ArtworkLowering, ArtworkObjectKind, ArtworkScope, Feature, FeatureDomain, FeatureKind,
-    FeatureSpan, PlatingKind, lower_layer_to_artwork_with,
+    FeatureSpan, HoleShape, PlatingKind, lower_layer_to_artwork_with,
 };
 use crate::geom::{ContourSet, FillRule, Point, Polarity, Span, tol};
 use crate::import::ipc2581::{
@@ -73,6 +73,7 @@ pub enum AssociationBasis {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PhysicalHoleKind {
     Round,
+    Square,
     Slot,
 }
 
@@ -553,7 +554,10 @@ impl ImportedDesign {
                     layer: layer_id,
                     source_name: feature.source_name,
                     kind: match feature.kind {
-                        FeatureKind::Hole => PhysicalHoleKind::Round,
+                        FeatureKind::Hole => match feature.hole_shape {
+                            HoleShape::Round => PhysicalHoleKind::Round,
+                            HoleShape::Square => PhysicalHoleKind::Square,
+                        },
                         FeatureKind::Slot => PhysicalHoleKind::Slot,
                         _ => unreachable!("physical opening is a hole or slot"),
                     },
@@ -734,6 +738,13 @@ impl ImportedDesign {
         feature: &Feature<Symbol>,
     ) -> Vec<Symbol> {
         let mut spec_refs = layer.spec_refs.clone();
+        spec_refs.extend(
+            feature
+                .spec_refs
+                .slice(&self.geometry.spec_refs)
+                .iter()
+                .map(|reference| reference.spec),
+        );
         if let Some(set) = feature
             .set
             .and_then(|set| self.geometry.feature_sets.get(set as usize))

--- a/crates/pcbc/tests/ipc2581.rs
+++ b/crates/pcbc/tests/ipc2581.rs
@@ -33,7 +33,7 @@ fn assembly_command_matches_the_shared_board_array_report() {
     let (second_json, _) = assembly_report("board-array");
 
     assert_eq!(first_json, second_json);
-    assert_eq!(report["schema_version"], 3);
+    assert_eq!(report["schema_version"], 4);
     assert_eq!(report["scope"]["kind"], "board_array");
     assert_eq!(report["scope"]["area_mm2"], 1_400.0);
     assert_eq!(report["profiles"].as_array().unwrap().len(), 2);


### PR DESCRIPTION
Preserve square hole shapes, hole-local transforms and specifications, and BOTH or ALL solder-mask evidence in assembly reports. This fixes the valid follow-up findings from #1143 and updates the report schema to version 4 for the new square hole kind.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->