### PR TITLE
Speed up IPC-2581 assembly analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Speed up IPC-2581 assembly analysis by avoiding unrelated copper composition and repeated land scans.
+
 ### Fixed
 
 - Fix IPC-2581 hole geometry and manufacturing evidence in PCBA assembly reports.

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -556,6 +556,22 @@ pub fn compose_attributed<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone + Eq
     doc: &Document<LayerMeta, ObjectMeta>,
     owner: impl Fn(&ObjectMeta) -> Owner,
 ) -> (Vec<AttributedImage<Owner>>, Vec<Diagnostic>) {
+    compose_selected_attributed(doc, |meta| Some(owner(meta)))
+}
+
+/// Ordered artwork composition for only the owners selected by the caller.
+///
+/// Unselected dark objects cannot change a selected owner's image and are
+/// skipped. Clear objects and final cutouts still subtract from selected
+/// owners in source paint order.
+pub(crate) fn compose_selected_attributed<
+    LayerMeta: Clone,
+    ObjectMeta: Clone,
+    Owner: Clone + Eq + Hash,
+>(
+    doc: &Document<LayerMeta, ObjectMeta>,
+    owner: impl Fn(&ObjectMeta) -> Option<Owner>,
+) -> (Vec<AttributedImage<Owner>>, Vec<Diagnostic>) {
     let doc = expand_native_geometry_to_regions(doc.clone());
     struct OwnerState {
         composer: region::PaintComposer,
@@ -573,18 +589,27 @@ pub fn compose_attributed<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone + Eq
         let mut owner_indices: HashMap<Owner, usize> = HashMap::new();
         let mut states: Vec<(Owner, OwnerState)> = Vec::new();
         for object in objects {
-            let image = object_image_rings(&doc, object);
-            if image.is_empty() {
-                continue;
-            }
             let polarity = if object.order.stage == PaintStage::FinalCutout && has_material {
                 Polarity::Clear
             } else {
                 object.polarity
             };
+            let selected_owner = match polarity {
+                Polarity::Dark => {
+                    let Some(owner) = owner(&object.meta) else {
+                        continue;
+                    };
+                    Some(owner)
+                }
+                Polarity::Clear => None,
+            };
+            let image = object_image_rings(&doc, object);
+            if image.is_empty() {
+                continue;
+            }
             match polarity {
                 Polarity::Dark => {
-                    let owner = owner(&object.meta);
+                    let owner = selected_owner.expect("dark object has a selected owner");
                     let index = match owner_indices.get(&owner) {
                         Some(&index) => index,
                         None => {
@@ -1399,6 +1424,31 @@ mod tests {
         assert!(owners["C"].contains_point(Point::new(8.5, 8.5)));
         assert!(physical.contains_point(Point::new(5.0, 5.0)));
         assert!(physical.contains_point(Point::new(8.5, 8.5)));
+
+        let (mut selected, diagnostics) =
+            compose_selected_attributed(&doc, |meta| (*meta != "C").then_some(*meta));
+        assert!(diagnostics.is_empty());
+        let selected = selected.remove(0);
+        assert_eq!(
+            selected
+                .owners
+                .iter()
+                .map(|(owner, _)| *owner)
+                .collect::<Vec<_>>(),
+            ["A", "B"]
+        );
+        let selected = selected
+            .owners
+            .into_iter()
+            .map(|(owner, rings)| {
+                (
+                    owner,
+                    region::ContourSet::new(rings, FillRule::NonZero, crate::geom::tol::REGION_MM),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        assert!(!selected["A"].contains_point(Point::new(5.0, 5.0)));
+        assert!(selected["B"].contains_point(Point::new(5.0, 5.0)));
     }
 
     #[test]

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -4,7 +4,7 @@
 //! geometry remains owned once by the canonical IPC document and final images
 //! are composed on demand for the requested layout scope.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use anyhow::{Context, Result};
 use ipc2581::types::{
@@ -273,7 +273,7 @@ impl ImportedDesign {
             }
             let layer_id = LayerId(layer_index as u32);
             let side = physical_side(layer.side);
-            for (occurrence, image) in self.attributed_feature_images(layer_id, scope)? {
+            for (occurrence, image) in self.attributed_land_images(layer_id, scope)? {
                 let source = occurrence.id;
                 let feature = self
                     .feature_definition(source.feature)
@@ -505,6 +505,10 @@ impl ImportedDesign {
         scope: ArtworkScope,
         lands: &[PhysicalLand],
     ) -> Result<Vec<PhysicalHole>> {
+        let mut lands_by_layer = BTreeMap::<_, Vec<_>>::new();
+        for land in lands {
+            lands_by_layer.entry(land.layer).or_default().push(land);
+        }
         let mut holes = Vec::new();
         for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
             if !matches!(
@@ -524,7 +528,7 @@ impl ImportedDesign {
                 let image = self.feature_region(occurrence);
                 let evidence = self.feature_evidence(occurrence.id);
                 let mut layer_lands = Vec::new();
-                for copper_layer in lands.iter().map(|land| land.layer).collect::<BTreeSet<_>>() {
+                for (&copper_layer, candidates) in &lands_by_layer {
                     if !feature_spans_layer(
                         feature.intent.span,
                         copper_layer,
@@ -532,10 +536,6 @@ impl ImportedDesign {
                     ) {
                         continue;
                     }
-                    let candidates = lands
-                        .iter()
-                        .filter(|land| land.layer == copper_layer)
-                        .collect::<Vec<_>>();
                     let land = associate_land_candidates(
                         &image,
                         occurrence.board,
@@ -766,6 +766,27 @@ impl ImportedDesign {
         layer: LayerId,
         scope: ArtworkScope,
     ) -> Result<Vec<(crate::import::ipc2581::FeatureOccurrence, ContourSet)>> {
+        self.attributed_feature_images_where(layer, scope, |_| true)
+    }
+
+    fn attributed_land_images(
+        &self,
+        layer: LayerId,
+        scope: ArtworkScope,
+    ) -> Result<Vec<(crate::import::ipc2581::FeatureOccurrence, ContourSet)>> {
+        self.attributed_feature_images_where(layer, scope, |feature| {
+            feature.kind == FeatureKind::Padstack
+                && feature.polarity == Polarity::Dark
+                && feature.intent.domain == FeatureDomain::Copper
+        })
+    }
+
+    fn attributed_feature_images_where(
+        &self,
+        layer: LayerId,
+        scope: ArtworkScope,
+        include: impl Fn(&Feature<Symbol>) -> bool,
+    ) -> Result<Vec<(crate::import::ipc2581::FeatureOccurrence, ContourSet)>> {
         let definition = self
             .layer_definition(layer)
             .context("layer id is outside the imported design")?;
@@ -787,14 +808,18 @@ impl ImportedDesign {
             meta: definition.layer_function,
         };
         let artwork = lower_layer_to_artwork_with(&document, 0, header, &mut OccurrenceAttribution);
-        let (mut images, _) = artwork::compose_attributed(&artwork, |owner| *owner);
+        let (mut images, _) = artwork::compose_selected_attributed(&artwork, |owner| {
+            let owner = (*owner)?;
+            self.feature_definition(owner.feature)
+                .filter(|feature| include(feature))
+                .map(|_| owner)
+        });
         let image = images
             .pop()
             .context("attributed physical composition produced no layer")?;
         image
             .owners
             .into_iter()
-            .filter_map(|(owner, rings)| owner.map(|owner| (owner, rings)))
             .map(|(owner, rings)| {
                 Ok((
                     *occurrences

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -463,6 +463,19 @@ impl ImportedDesign {
         scope: ArtworkScope,
         lands: &[PhysicalLand],
     ) -> Result<Vec<MaskOpening>> {
+        let mut lands_by_context = HashMap::<_, Vec<_>>::new();
+        for land in lands {
+            lands_by_context
+                .entry((land.board, land.side))
+                .or_default()
+                .push(land);
+            if land.side != Side::None {
+                lands_by_context
+                    .entry((land.board, Side::None))
+                    .or_default()
+                    .push(land);
+            }
+        }
         let mut openings = Vec::new();
         for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
             if layer.layer_function != LayerFunction::Soldermask {
@@ -474,6 +487,9 @@ impl ImportedDesign {
                 let source = occurrence.id;
                 let evidence = self.feature_evidence(source);
                 let board = occurrence.board;
+                let candidates = lands_by_context
+                    .get(&(board, side))
+                    .map_or(&[][..], Vec::as_slice);
                 for (island, image) in image.connected_components().into_iter().enumerate() {
                     openings.push(MaskOpening {
                         id: MaskOpeningId {
@@ -484,13 +500,13 @@ impl ImportedDesign {
                         side,
                         image: image.clone(),
                         board,
-                        lands: associate_land(
+                        lands: associate_land_candidates(
                             &image,
                             board,
                             side,
                             &evidence,
                             &Association::Unresolved,
-                            lands,
+                            candidates,
                         ),
                     });
                 }
@@ -965,18 +981,6 @@ fn exact_termination(
                 && termination.at == at
         })
         .map(|termination| termination.id)
-}
-
-fn associate_land(
-    image: &ContourSet,
-    board: Option<LayoutOccurrenceId>,
-    side: Side,
-    evidence: &FeatureEvidence,
-    component: &Association<ComponentOccurrenceId>,
-    lands: &[PhysicalLand],
-) -> Association<LandId> {
-    let candidates = lands.iter().collect::<Vec<_>>();
-    associate_land_candidates(image, board, side, evidence, component, &candidates)
 }
 
 fn associate_land_candidates(

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -542,7 +542,7 @@ impl ImportedDesign {
                         Side::None,
                         &evidence,
                         &Association::Unresolved,
-                        &candidates,
+                        candidates,
                     );
                     layer_lands.push(LayerLandAssociation {
                         layer: copper_layer,


### PR DESCRIPTION
Skip unrelated copper owners during physical-land composition and index lands by layer during hole association. This addresses #1144 with one exact assembly path and no new modes, flags, or report changes. Representative fixtures run 21–34% faster with byte-identical JSON output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->