### PR TITLE
Allow 0.5 mm plated slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Allow 0.5 mm plated slots (0.6 mm preferred).
+
 ## [0.4.46] - 2026-09-02
 
 ### Changed

--- a/crates/pcb-ipc2581-tools/examples/apcb-proto.toml
+++ b/crates/pcb-ipc2581-tools/examples/apcb-proto.toml
@@ -4,7 +4,7 @@ default_profile = "aurora-prototype"
 [pdk]
 id = "apcb-proto"
 name = "AdvancedPCB Aurora prototype"
-revision = "draft-2026-09-01"
+revision = "draft-2026-09-02"
 manufacturer = "AdvancedPCB"
 process = "Aurora 2-10 layer prototype"
 
@@ -33,7 +33,7 @@ limit = { minimum = "0.2 mm" }
 [[rules.drilling.slot_width]]
 id = "drilling.minimum_plated_slot_width"
 select = { plating = "plated" }
-limit = { minimum = "31 mil" }
+limit = { minimum = "0.5 mm", preferred = "0.6 mm" }
 
 [[rules.copper.annular_ring]]
 id = "copper.minimum_via_annular_ring"

--- a/crates/pcb-ipc2581-tools/pdks/standard.toml
+++ b/crates/pcb-ipc2581-tools/pdks/standard.toml
@@ -4,7 +4,7 @@ default_profile = "standard"
 [pdk]
 id = "standard"
 name = "Standard"
-revision = "draft-2026-09-01"
+revision = "draft-2026-09-02"
 manufacturer = "Diode"
 process = "Standard"
 
@@ -34,7 +34,7 @@ limit = { minimum = "0.2 mm" }
 [[rules.drilling.slot_width]]
 id = "drilling.minimum_slot_width"
 select = { plating = "plated" }
-limit = { minimum = "31 mil" }
+limit = { minimum = "0.5 mm", preferred = "0.6 mm" }
 
 [[rules.drilling.slot_width]]
 id = "drilling.minimum_slot_width.nonplated"


### PR DESCRIPTION
The 31 mil plated-slot limit rejects supported 0.6 mm slots. This change sets a 0.5 mm minimum and a 0.6 mm preferred width in the standard and prototype profiles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->