### PR TITLE
Fix DFM checks for netless fiducial pads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Allow 0.5 mm plated slots (0.6 mm preferred).
 
+### Fixed
+
+- Check netless pads as isolated copper in DFM reports.
+
 ## [0.4.46] - 2026-09-02
 
 ### Changed

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -118,29 +118,39 @@ pub(super) fn conductor_subject(
     role: &'static str,
     layer: &str,
 ) -> Subject {
-    let (kind, name, set_index) = match id {
-        ConductorId::Net { .. } => ("electrical_net", None, None),
+    let (kind, name, set_index, feature_index) = match id {
+        ConductorId::Net { .. } => ("electrical_net", None, None, None),
+        ConductorId::Isolated { occurrence, .. } => {
+            let source = design
+                .imported
+                .feature_definition(occurrence.feature)
+                .expect("isolated pad must reference its imported definition")
+                .source;
+            (
+                "auxiliary_copper",
+                Some("isolated pad".to_owned()),
+                Some(source.set_index),
+                Some(source.feature_index),
+            )
+        }
         ConductorId::Auxiliary {
             source_set_index, ..
         } => (
             "auxiliary_copper",
             Some("auxiliary copper".to_owned()),
             Some(source_set_index),
+            None,
         ),
         ConductorId::Unattributed {
-            source_set_index, ..
+            source_set_index,
+            source_feature_index,
+            ..
         } => (
             "unattributed_copper",
             Some("functional copper without net attribution".to_owned()),
             Some(source_set_index),
+            Some(source_feature_index),
         ),
-    };
-    let feature_index = match id {
-        ConductorId::Unattributed {
-            source_feature_index,
-            ..
-        } => Some(source_feature_index),
-        ConductorId::Net { .. } | ConductorId::Auxiliary { .. } => None,
     };
     Subject {
         role,
@@ -197,12 +207,18 @@ limit = { minimum = "0.15 mm" }
     <FunctionMode mode="FABRICATION"/>
     <StepRef name="board"/>
     <LayerRef name="TOP"/>
+    <DictionaryStandard units="MILLIMETER">
+      <EntryStandard id="pad"><Circle diameter="0.1"/></EntryStandard>
+    </DictionaryStandard>
   </Content>
   <Ecad>
     <CadHeader units="MILLIMETER"/>
     <CadData>
       <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
       <Step name="board" type="BOARD">
+        <PadStackDef name="padstack">
+          <PadstackPadDef layerRef="TOP" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="pad"/></PadstackPadDef>
+        </PadStackDef>
         <LayerFeature layerRef="TOP">
           <Set net="N1"><Features><UserSpecial><Contour><Polygon>
             <PolyBegin x="0" y="0"/>
@@ -311,6 +327,37 @@ limit = { minimum = "0.15 mm" }
                 .to_string()
                 .contains("final functional copper without net attribution"),
             "{error:#}"
+        );
+    }
+
+    #[test]
+    fn checks_netless_pads_as_isolated_copper() {
+        let xml = BOARD.replace(
+            "</Step>",
+            r#"<LayerFeature layerRef="TOP"><Set>
+          <Pad padstackDefRef="padstack"><Location x="3.85" y="0.5"/><PinRef componentRef="FID1" pin="PAD0"/></Pad>
+        </Set></LayerFeature>
+        <LayerFeature layerRef="TOP"><Set>
+          <Pad padstackDefRef="padstack"><Location x="3.65" y="0.5"/><PinRef componentRef="FID2" pin="PAD0"/></Pad>
+        </Set></LayerFeature>
+      </Step>"#,
+        );
+
+        let results = run(&xml);
+
+        assert_eq!(results.findings.len(), 4);
+        assert_eq!(
+            results
+                .findings
+                .iter()
+                .filter(|finding| {
+                    finding
+                        .subjects
+                        .iter()
+                        .any(|subject| subject.name.as_deref() == Some("isolated pad"))
+                })
+                .count(),
+            2
         );
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -187,6 +187,7 @@ fn land_owns_conductor(land: &Land, conductor: ConductorId) -> bool {
             land.net == Some(net) && step == land.step && instance == land.provenance.instance_index
         }
         ConductorId::Auxiliary { .. } => false,
+        ConductorId::Isolated { occurrence, .. } => land.id.0 == occurrence,
         ConductorId::Unattributed {
             step,
             instance,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -629,6 +629,11 @@ pub(super) enum ConductorId {
         instance: Option<u32>,
         net: Symbol,
     },
+    Isolated {
+        step: Option<Symbol>,
+        instance: Option<u32>,
+        occurrence: FeatureOccurrenceId,
+    },
     Auxiliary {
         step: Option<Symbol>,
         instance: Option<u32>,
@@ -646,6 +651,7 @@ impl ConductorId {
     pub fn step(self) -> Option<Symbol> {
         match self {
             Self::Net { step, .. }
+            | Self::Isolated { step, .. }
             | Self::Auxiliary { step, .. }
             | Self::Unattributed { step, .. } => step,
         }
@@ -654,6 +660,7 @@ impl ConductorId {
     pub fn instance(self) -> Option<u32> {
         match self {
             Self::Net { instance, .. }
+            | Self::Isolated { instance, .. }
             | Self::Auxiliary { instance, .. }
             | Self::Unattributed { instance, .. } => instance,
         }
@@ -662,7 +669,7 @@ impl ConductorId {
     pub fn net(self) -> Option<Symbol> {
         match self {
             Self::Net { net, .. } => Some(net),
-            Self::Auxiliary { .. } | Self::Unattributed { .. } => None,
+            Self::Isolated { .. } | Self::Auxiliary { .. } | Self::Unattributed { .. } => None,
         }
     }
 
@@ -1017,6 +1024,14 @@ impl ArtworkLowering<Symbol, Option<ConductorId>> for CopperAttributionLowering 
                 net,
             });
         }
+        if feature.kind == FeatureKind::Padstack {
+            return Some(ConductorId::Isolated {
+                step: feature.source_step_ref,
+                instance: feature.source_instance,
+                occurrence: feature_occurrence_id(feature)
+                    .expect("materialized copper pad must retain its occurrence identity"),
+            });
+        }
         if feature.is_fiducial() || feature.flags.copper_balance.is_some() {
             return Some(ConductorId::Auxiliary {
                 step: feature.source_step_ref,
@@ -1099,7 +1114,15 @@ fn compose_attributed_image<Owner: Clone + Eq + std::hash::Hash>(
 fn conductor_order(
     imported: &ImportedDesign,
     id: ConductorId,
-) -> (u8, &str, Option<u32>, &str, u32, u32) {
+) -> (
+    u8,
+    &str,
+    Option<u32>,
+    &str,
+    u32,
+    u32,
+    Option<FeatureOccurrenceId>,
+) {
     match id {
         ConductorId::Net {
             step,
@@ -1112,18 +1135,39 @@ fn conductor_order(
             imported.resolve(net),
             0,
             0,
+            None,
         ),
+        ConductorId::Isolated {
+            step,
+            instance,
+            occurrence,
+        } => {
+            let source = imported
+                .feature_definition(occurrence.feature)
+                .expect("isolated pad must reference its imported definition")
+                .source;
+            (
+                1,
+                step.map(|step| imported.resolve(step)).unwrap_or(""),
+                instance,
+                "",
+                source.set_index,
+                source.feature_index,
+                Some(occurrence),
+            )
+        }
         ConductorId::Auxiliary {
             step,
             instance,
             source_set_index,
         } => (
-            1,
+            2,
             step.map(|step| imported.resolve(step)).unwrap_or(""),
             instance,
             "",
             source_set_index,
             0,
+            None,
         ),
         ConductorId::Unattributed {
             step,
@@ -1131,12 +1175,13 @@ fn conductor_order(
             source_set_index,
             source_feature_index,
         } => (
-            2,
+            3,
             step.map(|step| imported.resolve(step)).unwrap_or(""),
             instance,
             "",
             source_set_index,
             source_feature_index,
+            None,
         ),
     }
 }


### PR DESCRIPTION
This treats netless padstack copper as isolated conductors, so DFM checks KiCad fiducials instead of aborting. It keeps unattributed traces and fills fail-closed and identifies each isolated pad by its canonical feature occurrence. Fixes ENG-1281.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->