### PR TITLE
Speed up IPC DFM geometry checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Report a sharp copper tip narrower than the minimum width when it stands alone.
 - Check netless pads as isolated copper in DFM reports.
 - Ignore nested `NotConnected()` interface members when creating schematic sheet ports.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Allow 0.5 mm plated slots (0.6 mm preferred).
+- Speed up IPC-2581 DFM geometry checks.
 
 ### Fixed
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -7,8 +7,10 @@
 //! one owner are deliberately outside this quantity. Touching, overlapping,
 //! or contained distinct-owner regions measure zero.
 
+use std::sync::OnceLock;
+
 use pcb_ir::geom::BBox;
-use pcb_ir::geom::dfm::{region_clearance, region_clearance_sites};
+use pcb_ir::geom::dfm::{RegionBoundaryIndex, region_clearance_sites, region_clearance_within};
 
 use crate::commands::dfm::design::{ConductorId, Design};
 use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
@@ -19,6 +21,7 @@ use super::{Evaluation, Measured, linework_clearance, violates};
 struct Piece {
     conductor_index: usize,
     region: pcb_ir::geom::ContourSet,
+    boundary: OnceLock<RegionBoundaryIndex>,
 }
 
 pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) -> Evaluation {
@@ -48,6 +51,7 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                 components.into_iter().map(move |region| Piece {
                     conductor_index,
                     region,
+                    boundary: OnceLock::new(),
                 })
             })
             .collect::<Vec<_>>();
@@ -70,7 +74,12 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                 {
                     continue;
                 }
-                let Some(distance) = region_clearance(&left.region, &right.region) else {
+                let right_boundary = right
+                    .boundary
+                    .get_or_init(|| RegionBoundaryIndex::new(&right.region, limit_mm));
+                let Some(distance) =
+                    region_clearance_within(&left.region, &right.region, right_boundary, limit_mm)
+                else {
                     continue;
                 };
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -7,8 +7,6 @@
 //! one owner are deliberately outside this quantity. Touching, overlapping,
 //! or contained distinct-owner regions measure zero.
 
-use std::sync::OnceLock;
-
 use pcb_ir::geom::BBox;
 use pcb_ir::geom::dfm::{
     RegionBoundaryIndex, region_clearance_sites_with_index, region_clearance_within,
@@ -23,7 +21,6 @@ use super::{Evaluation, Measured, linework_clearance, violates};
 struct Piece {
     conductor_index: usize,
     region: pcb_ir::geom::ContourSet,
-    boundary: OnceLock<RegionBoundaryIndex>,
 }
 
 pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) -> Evaluation {
@@ -52,7 +49,6 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                 components.into_iter().map(move |region| Piece {
                     conductor_index,
                     region,
-                    boundary: OnceLock::new(),
                 })
             })
             .collect::<Vec<_>>();
@@ -65,62 +61,80 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                 .then_with(|| left.region.bbox.min.y.total_cmp(&right.region.bbox.min.y))
         });
 
-        for (left_index, left) in pieces.iter().enumerate() {
-            for right in &pieces[left_index + 1..] {
-                if right.region.bbox.min.x - left.region.bbox.max.x >= limit_mm {
-                    break;
-                }
-                if left.conductor_index == right.conductor_index
-                    || left.region.bbox.distance_to(right.region.bbox) >= limit_mm
-                {
-                    continue;
-                }
-                let right_boundary = right
-                    .boundary
-                    .get_or_init(|| RegionBoundaryIndex::new(&right.region, limit_mm));
-                let Some(distance) =
-                    region_clearance_within(&left.region, &right.region, right_boundary, limit_mm)
-                else {
-                    continue;
-                };
+        // The pairs the bounds cannot separate, in sweep order along x. Only
+        // the pieces those pairs measure against need a boundary index.
+        let pairs = pieces
+            .iter()
+            .enumerate()
+            .flat_map(|(left_index, left)| {
+                pieces[left_index + 1..]
+                    .iter()
+                    .enumerate()
+                    .take_while(move |(_, right)| {
+                        right.region.bbox.min.x - left.region.bbox.max.x < limit_mm
+                    })
+                    .filter(move |(_, right)| {
+                        left.conductor_index != right.conductor_index
+                            && left.region.bbox.distance_to(right.region.bbox) < limit_mm
+                    })
+                    .map(move |(offset, _)| (left_index, left_index + 1 + offset))
+            })
+            .collect::<Vec<_>>();
+        let mut queried = vec![false; pieces.len()];
+        for &(_, right_index) in &pairs {
+            queried[right_index] = true;
+        }
+        let boundaries = pieces
+            .iter()
+            .zip(queried)
+            .map(|(piece, queried)| {
+                queried.then(|| RegionBoundaryIndex::new(&piece.region, limit_mm))
+            })
+            .collect::<Vec<_>>();
 
-                let left_id = layer.conductors[left.conductor_index].id;
-                let right_id = layer.conductors[right.conductor_index].id;
-                let mut bbox = BBox::from_point(distance.first);
-                bbox.include_point(distance.second);
-                measured.push(Measured {
-                    distance,
-                    bbox,
-                    layers: vec![layer.layer.clone()],
-                    subjects: vec![
-                        conductor_subject(design, left_id, "first_conductor", &layer.layer.name),
-                        conductor_subject(design, right_id, "second_conductor", &layer.layer.name),
-                    ],
-                    evidence: vec![
-                        Evidence::bounds("first_conductor_component", left.region.bbox),
-                        Evidence::bounds("second_conductor_component", right.region.bbox),
-                    ],
-                    sites: if violates(&distance, limit_mm) {
-                        region_clearance_sites_with_index(
-                            &left.region,
-                            &right.region,
-                            right_boundary,
-                            limit_mm,
-                        )
-                        .into_iter()
-                        .map(|site| {
-                            linework_clearance::report_site(
-                                site,
-                                vec![layer.layer.clone()],
-                                limit_mm,
-                            )
-                        })
-                        .collect()
-                    } else {
-                        Vec::new()
-                    },
-                });
-            }
+        for (left_index, right_index) in pairs {
+            let (left, right) = (&pieces[left_index], &pieces[right_index]);
+            let right_boundary = boundaries[right_index]
+                .as_ref()
+                .expect("every measured piece is indexed");
+            let Some(distance) =
+                region_clearance_within(&left.region, &right.region, right_boundary, limit_mm)
+            else {
+                continue;
+            };
+
+            let left_id = layer.conductors[left.conductor_index].id;
+            let right_id = layer.conductors[right.conductor_index].id;
+            let mut bbox = BBox::from_point(distance.first);
+            bbox.include_point(distance.second);
+            measured.push(Measured {
+                distance,
+                bbox,
+                layers: vec![layer.layer.clone()],
+                subjects: vec![
+                    conductor_subject(design, left_id, "first_conductor", &layer.layer.name),
+                    conductor_subject(design, right_id, "second_conductor", &layer.layer.name),
+                ],
+                evidence: vec![
+                    Evidence::bounds("first_conductor_component", left.region.bbox),
+                    Evidence::bounds("second_conductor_component", right.region.bbox),
+                ],
+                sites: if violates(&distance, limit_mm) {
+                    region_clearance_sites_with_index(
+                        &left.region,
+                        &right.region,
+                        right_boundary,
+                        limit_mm,
+                    )
+                    .into_iter()
+                    .map(|site| {
+                        linework_clearance::report_site(site, vec![layer.layer.clone()], limit_mm)
+                    })
+                    .collect()
+                } else {
+                    Vec::new()
+                },
+            });
         }
     }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -10,7 +10,9 @@
 use std::sync::OnceLock;
 
 use pcb_ir::geom::BBox;
-use pcb_ir::geom::dfm::{RegionBoundaryIndex, region_clearance_sites, region_clearance_within};
+use pcb_ir::geom::dfm::{
+    RegionBoundaryIndex, region_clearance_sites_with_index, region_clearance_within,
+};
 
 use crate::commands::dfm::design::{ConductorId, Design};
 use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
@@ -37,11 +39,10 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
             .iter()
             .map(|conductor| conductor.image.connected_components())
             .collect::<Vec<_>>();
-        for (index, left) in components.iter().enumerate() {
-            checked += components[index + 1..]
-                .iter()
-                .map(|right| left.len() * right.len())
-                .sum::<usize>();
+        let mut earlier_components = 0;
+        for conductor_components in &components {
+            checked += earlier_components * conductor_components.len();
+            earlier_components += conductor_components.len();
         }
 
         let mut pieces = components
@@ -100,16 +101,21 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                         Evidence::bounds("second_conductor_component", right.region.bbox),
                     ],
                     sites: if violates(&distance, limit_mm) {
-                        region_clearance_sites(&left.region, &right.region, limit_mm)
-                            .into_iter()
-                            .map(|site| {
-                                linework_clearance::report_site(
-                                    site,
-                                    vec![layer.layer.clone()],
-                                    limit_mm,
-                                )
-                            })
-                            .collect()
+                        region_clearance_sites_with_index(
+                            &left.region,
+                            &right.region,
+                            right_boundary,
+                            limit_mm,
+                        )
+                        .into_iter()
+                        .map(|site| {
+                            linework_clearance::report_site(
+                                site,
+                                vec![layer.layer.clone()],
+                                limit_mm,
+                            )
+                        })
+                        .collect()
                     } else {
                         Vec::new()
                     },

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -61,8 +61,11 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                 .then_with(|| left.region.bbox.min.y.total_cmp(&right.region.bbox.min.y))
         });
 
-        // The pairs the bounds cannot separate, in sweep order along x. Only
-        // the pieces in those pairs need a boundary index.
+        let boundaries = pieces
+            .iter()
+            .map(|piece| RegionBoundaryIndex::new(&piece.region, limit_mm))
+            .collect::<Vec<_>>();
+        // The pairs the bounds cannot separate, in sweep order along x.
         let pairs = pieces
             .iter()
             .enumerate()
@@ -80,30 +83,13 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                     .map(move |(offset, _)| (left_index, left_index + 1 + offset))
             })
             .collect::<Vec<_>>();
-        let mut queried = vec![false; pieces.len()];
-        for &(left_index, right_index) in &pairs {
-            queried[left_index] = true;
-            queried[right_index] = true;
-        }
-        let boundaries = pieces
-            .iter()
-            .zip(queried)
-            .map(|(piece, queried)| {
-                queried.then(|| RegionBoundaryIndex::new(&piece.region, limit_mm))
-            })
-            .collect::<Vec<_>>();
 
         for (left_index, right_index) in pairs {
             let (left, right) = (&pieces[left_index], &pieces[right_index]);
-            let boundary = |index: usize| {
-                boundaries[index]
-                    .as_ref()
-                    .expect("every paired piece is indexed")
-            };
-            let (left_boundary, right_boundary) = (boundary(left_index), boundary(right_index));
+            let right_boundary = &boundaries[right_index];
             let Some(distance) = region_clearance_within(
                 &left.region,
-                left_boundary,
+                &boundaries[left_index],
                 &right.region,
                 right_boundary,
                 limit_mm,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -62,7 +62,7 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
         });
 
         // The pairs the bounds cannot separate, in sweep order along x. Only
-        // the pieces those pairs measure against need a boundary index.
+        // the pieces in those pairs need a boundary index.
         let pairs = pieces
             .iter()
             .enumerate()
@@ -81,7 +81,8 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
             })
             .collect::<Vec<_>>();
         let mut queried = vec![false; pieces.len()];
-        for &(_, right_index) in &pairs {
+        for &(left_index, right_index) in &pairs {
+            queried[left_index] = true;
             queried[right_index] = true;
         }
         let boundaries = pieces
@@ -94,12 +95,19 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
 
         for (left_index, right_index) in pairs {
             let (left, right) = (&pieces[left_index], &pieces[right_index]);
-            let right_boundary = boundaries[right_index]
-                .as_ref()
-                .expect("every measured piece is indexed");
-            let Some(distance) =
-                region_clearance_within(&left.region, &right.region, right_boundary, limit_mm)
-            else {
+            let boundary = |index: usize| {
+                boundaries[index]
+                    .as_ref()
+                    .expect("every paired piece is indexed")
+            };
+            let (left_boundary, right_boundary) = (boundary(left_index), boundary(right_index));
+            let Some(distance) = region_clearance_within(
+                &left.region,
+                left_boundary,
+                &right.region,
+                right_boundary,
+                limit_mm,
+            ) else {
                 continue;
             };
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -21,7 +21,7 @@ use pcb_ir::dialects::ipc::{
 use pcb_ir::dialects::{LayerRole, Side, artwork};
 use pcb_ir::geom::dfm::{Distance, RegionBoundaryIndex, WidthDisk, min_width_disk};
 use pcb_ir::geom::path::ContourBuf;
-use pcb_ir::geom::region::Ring;
+use pcb_ir::geom::region::{Ring, union_rings};
 use pcb_ir::geom::{BBox, ContourSet, FillRule, Point, Polarity, Span, tol};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
@@ -1054,7 +1054,7 @@ fn compose_attributed_copper(
     let owners =
         compose_attributed_owners(document, LayerRole::Copper, &mut CopperAttributionLowering)?;
     let image = ContourSet::from_regularized(
-        pcb_ir::geom::region::union_rings(
+        union_rings(
             owners
                 .iter()
                 .flat_map(|(_, rings)| rings.iter().cloned())

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1051,15 +1051,23 @@ impl ArtworkLowering<Symbol, Option<ConductorId>> for CopperAttributionLowering 
 fn compose_attributed_copper(
     document: &mut GeometryDocument,
 ) -> Result<(ContourSet, Vec<CopperConductor>)> {
-    let composed =
-        compose_attributed_image(document, LayerRole::Copper, &mut CopperAttributionLowering)?;
-    let image = ContourSet::new(composed.image, FillRule::NonZero, tol::REGION_MM);
-    let conductors = composed
-        .owners
+    let owners =
+        compose_attributed_owners(document, LayerRole::Copper, &mut CopperAttributionLowering)?;
+    let image = ContourSet::from_regularized(
+        pcb_ir::geom::region::union_rings(
+            owners
+                .iter()
+                .flat_map(|(_, rings)| rings.iter().cloned())
+                .collect(),
+            FillRule::NonZero,
+        ),
+        tol::REGION_MM,
+    );
+    let conductors = owners
         .into_iter()
         .map(|(id, rings)| CopperConductor {
             id,
-            image: ContourSet::new(rings, FillRule::NonZero, tol::REGION_MM),
+            image: ContourSet::from_regularized(rings, tol::REGION_MM),
         })
         .collect();
     Ok((image, conductors))
@@ -1068,11 +1076,11 @@ fn compose_attributed_copper(
 /// Both copper and soldermask use the canonical ordered paint fold. Source
 /// ownership survives clear features and cutouts, rather than being inferred
 /// afterward from a feature's bounds or an enclosing board profile.
-fn compose_attributed_image<Owner: Clone + Eq + std::hash::Hash>(
+fn compose_attributed_owners<Owner: Clone + Eq + std::hash::Hash>(
     document: &mut GeometryDocument,
     role: LayerRole,
     lowering: &mut impl ArtworkLowering<Symbol, Option<Owner>>,
-) -> Result<artwork::AttributedImage<Owner>> {
+) -> Result<artwork::OwnerImages<Owner>> {
     pcb_ir::dialects::ipc::process::normalize_for_artwork(document);
     pcb_ir::dialects::ipc::validate_artwork_ready(document)
         .map_err(|error| anyhow::anyhow!("layer is not artwork-ready: {error}"))?;
@@ -1089,12 +1097,12 @@ fn compose_attributed_image<Owner: Clone + Eq + std::hash::Hash>(
         meta: layer.layer_function,
     };
     let attributed_artwork = lower_layer_to_artwork_with(document, 0, header, lowering);
-    let (mut composed, _) = artwork::compose_attributed(&attributed_artwork, Clone::clone);
-    let composed = composed
+    let (mut layers, _) =
+        artwork::compose_selected_owners(&attributed_artwork, |owner| Some(owner.clone()));
+    let owners = layers
         .pop()
         .context("attributed artwork composition produced no layer")?;
-    let owners = composed
-        .owners
+    owners
         .into_iter()
         .map(|(id, rings)| {
             Ok((
@@ -1104,11 +1112,7 @@ fn compose_attributed_image<Owner: Clone + Eq + std::hash::Hash>(
                 rings,
             ))
         })
-        .collect::<Result<Vec<_>>>()?;
-    Ok(artwork::AttributedImage {
-        image: composed.image,
-        owners,
-    })
+        .collect()
 }
 
 fn conductor_order(
@@ -1347,7 +1351,7 @@ fn collect_mask_layers(imported: &ImportedDesign, scope: ArtworkScope) -> Result
             let image =
                 crate::copper_balance::composed_copper_image_from_document(document.clone());
             pcb_ir::dialects::ipc::process::expand_feature_placement_groups(&mut document);
-            let composed = compose_attributed_image(
+            let owners = compose_attributed_owners(
                 &mut document,
                 LayerRole::Soldermask,
                 &mut MaskAttributionLowering,
@@ -1359,13 +1363,12 @@ fn collect_mask_layers(imported: &ImportedDesign, scope: ArtworkScope) -> Result
                     side_label(layers::ir_side(layer.side)),
                 ),
                 image,
-                owners: composed
-                    .owners
+                owners: owners
                     .into_iter()
                     .map(|((step, instance_index), rings)| MaskOwner {
                         step,
                         instance_index,
-                        image: ContourSet::new(rings, FillRule::NonZero, tol::REGION_MM),
+                        image: ContourSet::from_regularized(rings, tol::REGION_MM),
                     })
                     .collect(),
             })

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -559,7 +559,8 @@ pub fn compose_attributed<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone + Eq
     compose_selected_attributed(doc, |meta| Some(owner(meta)))
 }
 
-/// Ordered artwork composition for only the owners selected by the caller.
+/// Ordered artwork composition for only the owners selected by the caller,
+/// with each layer's image as the union of its owners.
 ///
 /// Unselected dark objects cannot change a selected owner's image and are
 /// skipped. Clear objects and final cutouts still subtract from selected
@@ -572,6 +573,33 @@ pub(crate) fn compose_selected_attributed<
     doc: &Document<LayerMeta, ObjectMeta>,
     owner: impl Fn(&ObjectMeta) -> Option<Owner>,
 ) -> (Vec<AttributedImage<Owner>>, Vec<Diagnostic>) {
+    let (layers, diagnostics) = compose_selected_owners(doc, owner);
+    let layers = layers
+        .into_iter()
+        .map(|owners| AttributedImage {
+            image: region::union_rings(
+                owners
+                    .iter()
+                    .flat_map(|(_, image)| image.iter().cloned())
+                    .collect(),
+                FillRule::NonZero,
+            ),
+            owners,
+        })
+        .collect();
+    (layers, diagnostics)
+}
+
+/// One layer's owner images in first-paint order; every image is a
+/// regularized ring set.
+pub type OwnerImages<Owner> = Vec<(Owner, Vec<Ring>)>;
+
+/// Each layer's owner images from the ordered paint fold, for only the
+/// owners selected by the caller.
+pub fn compose_selected_owners<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone + Eq + Hash>(
+    doc: &Document<LayerMeta, ObjectMeta>,
+    owner: impl Fn(&ObjectMeta) -> Option<Owner>,
+) -> (Vec<OwnerImages<Owner>>, Vec<Diagnostic>) {
     let doc = expand_native_geometry_to_regions(doc.clone());
     struct OwnerState {
         composer: region::PaintComposer,
@@ -641,21 +669,15 @@ pub(crate) fn compose_selected_attributed<
             }
         }
 
-        let owners = states
-            .into_iter()
-            .filter_map(|(owner, state)| {
-                let image = state.composer.finish();
-                (!image.is_empty()).then_some((owner, image))
-            })
-            .collect::<Vec<_>>();
-        let image = region::union_rings(
-            owners
-                .iter()
-                .flat_map(|(_, image)| image.iter().cloned())
-                .collect(),
-            FillRule::NonZero,
+        layers.push(
+            states
+                .into_iter()
+                .filter_map(|(owner, state)| {
+                    let image = state.composer.finish();
+                    (!image.is_empty()).then_some((owner, image))
+                })
+                .collect::<Vec<_>>(),
         );
-        layers.push(AttributedImage { image, owners });
     }
     (layers, doc.diagnostics)
 }

--- a/crates/pcb-ir/src/geom/bbox.rs
+++ b/crates/pcb-ir/src/geom/bbox.rs
@@ -62,6 +62,14 @@ impl BBox {
         x.hypot(y)
     }
 
+    /// Whether the closed bounds contain the point.
+    pub fn contains_point(&self, point: Point) -> bool {
+        self.min.x <= point.x
+            && point.x <= self.max.x
+            && self.min.y <= point.y
+            && point.y <= self.max.y
+    }
+
     pub fn expand(self, amount: f64) -> Self {
         if self.is_empty() {
             return self;

--- a/crates/pcb-ir/src/geom/bbox.rs
+++ b/crates/pcb-ir/src/geom/bbox.rs
@@ -23,6 +23,14 @@ impl BBox {
         Self { min: p, max: p }
     }
 
+    /// The bounds of the segment between two points.
+    pub fn spanning(a: Point, b: Point) -> Self {
+        Self {
+            min: Point::new(a.x.min(b.x), a.y.min(b.y)),
+            max: Point::new(a.x.max(b.x), a.y.max(b.y)),
+        }
+    }
+
     pub fn include_point(&mut self, p: Point) {
         self.min.x = self.min.x.min(p.x);
         self.min.y = self.min.y.min(p.y);

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -5,95 +5,49 @@
 //! it was measured against. Deciding whether a distance violates a limit is
 //! the caller's policy, via [`Distance::certainly_below`].
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use crate::geom::bbox::BBox;
 use crate::geom::dist;
 use crate::geom::grid::CellGrid;
 use crate::geom::point::Point;
-use crate::geom::region::{ContourSet, Ring, TwoSidedResidualComponent, ring_edges};
+use crate::geom::region::{ContourSet, TwoSidedResidualComponent, ring_edges};
 use crate::geom::tol;
 
 pub use crate::geom::dist::Distance;
 
-/// Exact candidate index over ring or shape bounds. Large enclosing rings
-/// remain queryable even when none of their boundary segments cross a small
-/// region of interest. The returned IDs retain the source ordering.
+/// Candidate index over ring or shape bounds, on a grid of about sixty-four
+/// cells across. Every bounds is registered in each cell it covers, so a
+/// large enclosing ring stays queryable in a small region of interest.
 #[derive(Debug)]
 pub struct BBoxIndex {
     bounds: Vec<BBox>,
-    cells: HashMap<(i64, i64), Vec<usize>>,
-    enclosing: Vec<usize>,
-    pitch: f64,
+    grid: CellGrid,
 }
 
 impl BBoxIndex {
     pub fn new(bounds: Vec<BBox>) -> Self {
         let total = bounds.iter().copied().fold(BBox::empty(), BBox::union);
-        let pitch = if total.is_empty() {
-            2.0
-        } else {
-            (total.width().max(total.height()) / 64.0).max(2.0)
-        };
-        let mut index = Self {
-            bounds,
-            cells: HashMap::new(),
-            enclosing: Vec::new(),
+        let pitch = (total.width().max(total.height()) / 64.0).max(2.0);
+        let grid = CellGrid::new(
             pitch,
-        };
-        for (id, bbox) in index.bounds.iter().enumerate() {
-            if bbox.is_empty() {
-                continue;
-            }
-            let (x0, y0, x1, y1) = index.cells_for(*bbox);
-            if (x1 - x0 + 1).saturating_mul(y1 - y0 + 1) > 256 {
-                index.enclosing.push(id);
-                continue;
-            }
-            for x in x0..=x1 {
-                for y in y0..=y1 {
-                    index.cells.entry((x, y)).or_default().push(id);
-                }
-            }
-        }
-        index
+            total,
+            bounds.iter().enumerate().flat_map(|(id, &bounds)| {
+                CellGrid::cells_of(bounds, pitch).map(move |cell| (id as u32, cell))
+            }),
+        );
+        Self { bounds, grid }
     }
 
-    fn cells_for(&self, bbox: BBox) -> (i64, i64, i64, i64) {
-        let cell = |value: f64| (value / self.pitch).floor() as i64;
-        (
-            cell(bbox.min.x),
-            cell(bbox.min.y),
-            cell(bbox.max.x),
-            cell(bbox.max.y),
-        )
-    }
-
+    /// The ids of the bounds meeting `bbox`, ascending.
     pub fn query(&self, bbox: BBox) -> Vec<usize> {
-        if bbox.is_empty() {
-            return Vec::new();
-        }
-        let (x0, y0, x1, y1) = self.cells_for(bbox);
-        if (x1 - x0 + 1).saturating_mul(y1 - y0 + 1) > 4096 {
-            return self
-                .bounds
-                .iter()
-                .enumerate()
-                .filter_map(|(id, bounds)| bounds.intersects(bbox).then_some(id))
-                .collect();
-        }
-        let mut candidates = self.enclosing.clone();
-        for x in x0..=x1 {
-            for y in y0..=y1 {
-                if let Some(ids) = self.cells.get(&(x, y)) {
-                    candidates.extend(ids);
-                }
-            }
-        }
-        candidates.sort_unstable();
-        candidates.dedup();
-        candidates.retain(|&id| self.bounds[id].intersects(bbox));
-        candidates
+        let mut ids = self.grid.rectangle(bbox).collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids.dedup();
+        ids.into_iter()
+            .map(|id| id as usize)
+            .filter(|&id| self.bounds[id].intersects(bbox))
+            .collect()
     }
 }
 
@@ -124,7 +78,7 @@ impl RegionBoundaryIndex {
         let segments = region.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
         let bounds = segments
             .iter()
-            .map(|&(start, end)| segment_bounds(start, end))
+            .map(|&(start, end)| BBox::spanning(start, end))
             .collect();
         let grid = CellGrid::new(
             pitch,
@@ -187,7 +141,7 @@ impl RegionBoundaryIndex {
     /// minimum a consumer takes is unchanged by the repeats, and of equal
     /// minima it keeps the first, which is always the first cell's copy.
     fn near(&self, start: Point, end: Point, reach: f64) -> impl Iterator<Item = u32> + '_ {
-        let query = segment_bounds(start, end).expand(reach + tol::EPSILON_MM);
+        let query = BBox::spanning(start, end).expand(reach + tol::EPSILON_MM);
         corridor_columns(start, end, reach, self.grid.pitch_mm())
             .flat_map(move |(column, min_row, max_row)| {
                 self.grid.column(column, min_row, max_row).iter().copied()
@@ -244,17 +198,6 @@ impl RegionBoundaryIndex {
     }
 }
 
-fn segment_bounds(start: Point, end: Point) -> BBox {
-    BBox::new(
-        Point::new(start.x.min(end.x), start.y.min(end.y)),
-        Point::new(start.x.max(end.x), start.y.max(end.y)),
-    )
-}
-
-fn grid_cell(value: f64, cell_size_mm: f64) -> i64 {
-    (value / cell_size_mm).floor() as i64
-}
-
 /// Every grid column within `radius_mm` of the segment with the rows it
 /// covers there, so long diagonal segments touch a linear number of cells
 /// instead of their whole bounding box. A zero-length segment yields the
@@ -265,8 +208,8 @@ fn corridor_columns(
     radius_mm: f64,
     cell_size_mm: f64,
 ) -> impl Iterator<Item = (i64, i64, i64)> {
-    let min_column = grid_cell(start.x.min(end.x) - radius_mm, cell_size_mm);
-    let max_column = grid_cell(start.x.max(end.x) + radius_mm, cell_size_mm);
+    let min_column = CellGrid::cell(start.x.min(end.x) - radius_mm, cell_size_mm);
+    let max_column = CellGrid::cell(start.x.max(end.x) + radius_mm, cell_size_mm);
     let delta = end - start;
     (min_column..=max_column).map(move |column| {
         let column_min = column as f64 * cell_size_mm - radius_mm;
@@ -283,8 +226,8 @@ fn corridor_columns(
         };
         let y_at_min = start.y + delta.y * t_min;
         let y_at_max = start.y + delta.y * t_max;
-        let min_row = grid_cell(y_at_min.min(y_at_max) - radius_mm, cell_size_mm);
-        let max_row = grid_cell(y_at_min.max(y_at_max) + radius_mm, cell_size_mm);
+        let min_row = CellGrid::cell(y_at_min.min(y_at_max) - radius_mm, cell_size_mm);
+        let max_row = CellGrid::cell(y_at_min.max(y_at_max) + radius_mm, cell_size_mm);
         (column, min_row, max_row)
     })
 }
@@ -330,22 +273,16 @@ pub fn region_clearance(first: &ContourSet, second: &ContourSet) -> Option<Dista
     if first.is_empty() || second.is_empty() {
         return None;
     }
-
-    let vertices = |region: &ContourSet| {
-        region
-            .rings
-            .iter()
-            .flat_map(|ring| ring.iter())
-            .map(|&[x, y]| Point::new(x, y))
-            .collect::<Vec<_>>()
-    };
-    if let Some(point) = contained_vertex(vertices(first), second)
-        .or_else(|| contained_vertex(vertices(second), first))
-    {
-        return Some(Distance::flattened(0.0, point, point, 2));
-    }
-
-    closest_ring_edges(&first.rings, &second.rings)
+    // Nothing lies farther apart than the span of both bounds.
+    let span = first.bbox.union(second.bbox);
+    let reach = span.width().hypot(span.height());
+    region_clearance_within(
+        first,
+        &RegionBoundaryIndex::new(first, reach),
+        second,
+        &RegionBoundaryIndex::new(second, reach),
+        reach,
+    )
 }
 
 /// Shortest clearance between two filled regions when it is no greater than
@@ -367,15 +304,18 @@ pub fn region_clearance_within(
 
     // Every vertex starts one boundary edge, so a region's vertices inside
     // the other's bounds are among the starts of its edges meeting them.
-    let vertices_within = |boundary: &RegionBoundaryIndex, bounds: BBox| {
-        boundary
-            .segments_meeting(bounds)
-            .map(|(start, _)| start)
-            .collect::<Vec<_>>()
-    };
+    let starts = |segments: Vec<(Point, Point)>| segments.into_iter().map(|(start, _)| start);
     if first.bbox.intersects(second.bbox)
-        && let Some(point) = contained_vertex(vertices_within(first_boundary, second.bbox), second)
-            .or_else(|| contained_vertex(vertices_within(second_boundary, first.bbox), first))
+        && let Some(point) = contained_vertex(
+            starts(first_boundary.segments_meeting(second.bbox).collect()),
+            second,
+        )
+        .or_else(|| {
+            contained_vertex(
+                starts(second_boundary.segments_meeting(first.bbox).collect()),
+                first,
+            )
+        })
     {
         return Some(Distance::flattened(0.0, point, point, 2));
     }
@@ -394,35 +334,18 @@ pub fn region_clearance_within(
 
 /// The first of a subject's `vertices` inside `container`, batched in one
 /// winding sweep.
-fn contained_vertex(vertices: Vec<Point>, container: &ContourSet) -> Option<Point> {
+fn contained_vertex(
+    vertices: impl Iterator<Item = Point>,
+    container: &ContourSet,
+) -> Option<Point> {
     let vertices = vertices
-        .into_iter()
         .filter(|&point| container.bbox.contains_point(point))
         .collect::<Vec<_>>();
-    if vertices.is_empty() {
-        return None;
-    }
     container
         .contains_points_batch(&vertices)
         .into_iter()
         .zip(vertices)
         .find_map(|(inside, vertex)| inside.then_some(vertex))
-}
-
-fn closest_ring_edges(first: &[Ring], second: &[Ring]) -> Option<Distance> {
-    first
-        .iter()
-        .flat_map(ring_edges)
-        .flat_map(|(first_start, first_end)| {
-            second.iter().flat_map(move |ring| {
-                ring_edges(ring).map(move |(second_start, second_end)| {
-                    let (mm, on_first, on_second) =
-                        dist::segments(first_start, first_end, second_start, second_end);
-                    Distance::flattened(mm, on_first, on_second, 2)
-                })
-            })
-        })
-        .min_by(|left, right| left.mm.total_cmp(&right.mm))
 }
 
 /// A connected local clearance failure. The paths are the participating
@@ -791,9 +714,21 @@ fn interval_complement(intervals: &[(f64, f64)]) -> Vec<(f64, f64)> {
     result
 }
 
+/// Lines grouped by shared endpoints, within the region tolerance, in the
+/// order of each group's first line.
 fn connected_line_groups(lines: &[(Point, Point)]) -> Vec<Vec<usize>> {
+    let endpoints = lines.iter().flat_map(|&(a, b)| [a, b]).collect::<Vec<_>>();
+    let bounds = endpoints.iter().fold(BBox::empty(), |bounds, &point| {
+        bounds.union(BBox::from_point(point))
+    });
+    let grid = CellGrid::new(
+        1.0,
+        bounds,
+        endpoints.iter().enumerate().flat_map(|(id, &point)| {
+            CellGrid::cells_of(BBox::from_point(point), 1.0).map(move |cell| (id as u32, cell))
+        }),
+    );
     let mut parents = (0..lines.len()).collect::<Vec<_>>();
-    let mut endpoints: HashMap<(i64, i64), Vec<(Point, usize)>> = HashMap::new();
     fn root(parents: &mut [usize], mut id: usize) -> usize {
         while parents[id] != id {
             parents[id] = parents[parents[id]];
@@ -801,30 +736,22 @@ fn connected_line_groups(lines: &[(Point, Point)]) -> Vec<Vec<usize>> {
         }
         id
     }
-    for (id, &(first, second)) in lines.iter().enumerate() {
-        for point in [first, second] {
-            let key = (
-                (point.x / tol::REGION_MM).round() as i64,
-                (point.y / tol::REGION_MM).round() as i64,
-            );
-            for x in key.0 - 1..=key.0 + 1 {
-                for y in key.1 - 1..=key.1 + 1 {
-                    for &(other_point, other) in endpoints.get(&(x, y)).into_iter().flatten() {
-                        if point.distance_to(other_point) <= tol::REGION_MM {
-                            let (a, b) = (root(&mut parents, id), root(&mut parents, other));
-                            parents[a] = b;
-                        }
-                    }
-                }
+    for (id, &point) in endpoints.iter().enumerate() {
+        for other in grid.rectangle(BBox::from_point(point).expand(tol::REGION_MM)) {
+            if point.distance_to(endpoints[other as usize]) <= tol::REGION_MM {
+                let (a, b) = (
+                    root(&mut parents, id / 2),
+                    root(&mut parents, other as usize / 2),
+                );
+                parents[a] = b;
             }
-            endpoints.entry(key).or_default().push((point, id));
         }
     }
-    let mut positions = HashMap::new();
+    let mut positions = vec![None; lines.len()];
     let mut groups: Vec<Vec<usize>> = Vec::new();
     for id in 0..lines.len() {
         let owner = root(&mut parents, id);
-        let position = *positions.entry(owner).or_insert_with(|| {
+        let position = *positions[owner].get_or_insert_with(|| {
             groups.push(Vec::new());
             groups.len() - 1
         });

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -302,6 +302,41 @@ pub fn region_clearance(first: &ContourSet, second: &ContourSet) -> Option<Dista
     closest_ring_edges(&first.rings, &second.rings)
 }
 
+/// Shortest clearance between two filled regions when it is no greater than
+/// `maximum_mm`.
+///
+/// `second_boundary` must index `second`. Overlapping, contained, or touching
+/// regions have zero clearance. `None` means at least one input is empty or
+/// the clearance is greater than `maximum_mm`.
+pub fn region_clearance_within(
+    first: &ContourSet,
+    second: &ContourSet,
+    second_boundary: &RegionBoundaryIndex,
+    maximum_mm: f64,
+) -> Option<Distance> {
+    if first.is_empty() || second.is_empty() {
+        return None;
+    }
+
+    if first.bbox.intersects(second.bbox)
+        && let Some(point) =
+            contained_vertex(first, second).or_else(|| contained_vertex(second, first))
+    {
+        return Some(Distance::flattened(0.0, point, point, 2));
+    }
+
+    first
+        .rings
+        .iter()
+        .flat_map(ring_edges)
+        .filter_map(|(first_start, first_end)| {
+            second_boundary
+                .segment_nearest_within(first_start, first_end, maximum_mm)
+                .map(|distance| distance.also_flattened(1))
+        })
+        .min_by(|left, right| left.mm.total_cmp(&right.mm))
+}
+
 /// A vertex of `subject` inside `container`, batched in one winding sweep.
 fn contained_vertex(subject: &ContourSet, container: &ContourSet) -> Option<Point> {
     let vertices = subject
@@ -1194,6 +1229,33 @@ mod tests {
         let container = rect_region(-2.0, -2.0, 2.0, 2.0);
         let contained = rect_region(-0.5, -0.5, 0.5, 0.5);
         assert_eq!(region_clearance(&container, &contained).unwrap().mm, 0.0);
+    }
+
+    #[test]
+    fn thresholded_region_clearance_matches_authoritative_measurement() {
+        let left = rect_region(0.0, 0.0, 2.0, 2.0);
+        let right = rect_region(3.5, 0.5, 5.0, 1.5);
+        let index = RegionBoundaryIndex::new(&right, 2.0);
+
+        assert_eq!(
+            region_clearance_within(&left, &right, &index, 2.0),
+            region_clearance(&left, &right)
+        );
+        assert_eq!(region_clearance_within(&left, &right, &index, 1.0), None);
+
+        let crossing = rect_region(1.0, -1.0, 1.5, 3.0);
+        let crossing_index = RegionBoundaryIndex::new(&crossing, 0.1);
+        assert_eq!(
+            region_clearance_within(&left, &crossing, &crossing_index, 0.1),
+            region_clearance(&left, &crossing)
+        );
+
+        let contained = rect_region(0.5, 0.5, 1.5, 1.5);
+        let contained_index = RegionBoundaryIndex::new(&contained, 0.1);
+        assert_eq!(
+            region_clearance_within(&left, &contained, &contained_index, 0.1),
+            region_clearance(&left, &contained)
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -334,7 +334,16 @@ pub fn region_clearance(first: &ContourSet, second: &ContourSet) -> Option<Dista
         return None;
     }
 
-    if let Some(point) = contained_vertex(first, second).or_else(|| contained_vertex(second, first))
+    let vertices = |region: &ContourSet| {
+        region
+            .rings
+            .iter()
+            .flat_map(|ring| ring.iter())
+            .map(|&[x, y]| Point::new(x, y))
+            .collect::<Vec<_>>()
+    };
+    if let Some(point) = contained_vertex(vertices(first), second)
+        .or_else(|| contained_vertex(vertices(second), first))
     {
         return Some(Distance::flattened(0.0, point, point, 2));
     }
@@ -359,9 +368,17 @@ pub fn region_clearance_within(
         return None;
     }
 
+    // Every vertex starts one boundary edge, so a region's vertices inside
+    // the other's bounds are among the starts of its edges meeting them.
+    let vertices_within = |boundary: &RegionBoundaryIndex, bounds: BBox| {
+        boundary
+            .segments_meeting(bounds)
+            .map(|(start, _)| start)
+            .collect::<Vec<_>>()
+    };
     if first.bbox.intersects(second.bbox)
-        && let Some(point) =
-            contained_vertex(first, second).or_else(|| contained_vertex(second, first))
+        && let Some(point) = contained_vertex(vertices_within(first_boundary, second.bbox), second)
+            .or_else(|| contained_vertex(vertices_within(second_boundary, first.bbox), first))
     {
         return Some(Distance::flattened(0.0, point, point, 2));
     }
@@ -378,19 +395,12 @@ pub fn region_clearance_within(
         .min_by(|left, right| left.mm.total_cmp(&right.mm))
 }
 
-/// A vertex of `subject` inside `container`, batched in one winding sweep.
-fn contained_vertex(subject: &ContourSet, container: &ContourSet) -> Option<Point> {
-    let vertices = subject
-        .rings
-        .iter()
-        .flat_map(|ring| ring.iter())
-        .map(|&[x, y]| Point::new(x, y))
-        .filter(|point| {
-            point.x >= container.bbox.min.x
-                && point.x <= container.bbox.max.x
-                && point.y >= container.bbox.min.y
-                && point.y <= container.bbox.max.y
-        })
+/// The first of a subject's `vertices` inside `container`, batched in one
+/// winding sweep.
+fn contained_vertex(vertices: Vec<Point>, container: &ContourSet) -> Option<Point> {
+    let vertices = vertices
+        .into_iter()
+        .filter(|&point| container.bbox.contains_point(point))
         .collect::<Vec<_>>();
     if vertices.is_empty() {
         return None;

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -630,8 +630,8 @@ pub fn region_clearance_sites_with_index(
 
 /// A local required-clearance band around the supplied reference paths.
 pub fn linework_envelope(paths: &[Vec<Point>], radius_mm: f64) -> ContourSet {
-    use crate::geom::path::{ContourBuf, PathCmd};
-    use crate::geom::{Paint, PathArena, StrokeStyle};
+    use crate::geom::path::{ContourBuf, PathCmd, stroke_to_fill};
+    use crate::geom::{FillRule, StrokeStyle};
     let contours = paths
         .iter()
         .filter(|path| path.len() >= 2)
@@ -643,13 +643,9 @@ pub fn linework_envelope(paths: &[Vec<Point>], radius_mm: f64) -> ContourSet {
             )
         })
         .collect::<Vec<_>>();
-    let mut arena = PathArena::default();
-    let path = arena.push_path(Paint::Stroke(StrokeStyle::round(2.0 * radius_mm)), contours);
-    ContourSet::from_painted_paths(
-        &arena,
-        std::iter::once(&arena.paths[path as usize]),
-        tol::REGION_MM,
-    )
+    let band =
+        stroke_to_fill(&contours, StrokeStyle::round(2.0 * radius_mm).into()).unwrap_or_default();
+    ContourSet::from_contours(&band, FillRule::NonZero, tol::REGION_MM)
 }
 
 /// Circular material in the same flattened representation as check images.

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -173,6 +173,17 @@ impl RegionBoundaryIndex {
             .min_by(|left, right| left.mm.total_cmp(&right.mm))
     }
 
+    /// The indexed segments whose bounds meet `bounds`, in boundary order,
+    /// each once.
+    pub fn segments_meeting(&self, bounds: BBox) -> impl Iterator<Item = (Point, Point)> + '_ {
+        let mut ids = self.grid.rectangle(bounds).collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids.dedup();
+        ids.into_iter()
+            .filter(move |&id| self.bounds[id as usize].intersects(bounds))
+            .map(|id| self.segments[id as usize])
+    }
+
     /// Ids of the indexed segments whose bounds come within `reach` of the
     /// query segment, in grid order: column by column, row by row, then by
     /// id. A segment spanning several cells is yielded once per cell. The
@@ -334,11 +345,12 @@ pub fn region_clearance(first: &ContourSet, second: &ContourSet) -> Option<Dista
 /// Shortest clearance between two filled regions when it is no greater than
 /// `maximum_mm`.
 ///
-/// `second_boundary` must index `second`. Overlapping, contained, or touching
-/// regions have zero clearance. `None` means at least one input is empty or
-/// the clearance is greater than `maximum_mm`.
+/// Each boundary index must index its region. Overlapping, contained, or
+/// touching regions have zero clearance. `None` means at least one input is
+/// empty or the clearance is greater than `maximum_mm`.
 pub fn region_clearance_within(
     first: &ContourSet,
+    first_boundary: &RegionBoundaryIndex,
     second: &ContourSet,
     second_boundary: &RegionBoundaryIndex,
     maximum_mm: f64,
@@ -354,10 +366,10 @@ pub fn region_clearance_within(
         return Some(Distance::flattened(0.0, point, point, 2));
     }
 
-    first
-        .rings
-        .iter()
-        .flat_map(ring_edges)
+    // Only the first boundary's edges within reach of the second region's
+    // bounds can come within reach of its boundary.
+    first_boundary
+        .segments_meeting(second.bbox.expand(maximum_mm + tol::EPSILON_MM))
         .filter_map(|(first_start, first_end)| {
             second_boundary
                 .segment_nearest_within(first_start, first_end, maximum_mm)
@@ -1280,25 +1292,31 @@ mod tests {
     fn thresholded_region_clearance_matches_authoritative_measurement() {
         let left = rect_region(0.0, 0.0, 2.0, 2.0);
         let right = rect_region(3.5, 0.5, 5.0, 1.5);
-        let index = RegionBoundaryIndex::new(&right, 2.0);
+        let clearance_within = |first: &ContourSet, second: &ContourSet, maximum_mm: f64| {
+            region_clearance_within(
+                first,
+                &RegionBoundaryIndex::new(first, maximum_mm),
+                second,
+                &RegionBoundaryIndex::new(second, maximum_mm),
+                maximum_mm,
+            )
+        };
 
         assert_eq!(
-            region_clearance_within(&left, &right, &index, 2.0),
+            clearance_within(&left, &right, 2.0),
             region_clearance(&left, &right)
         );
-        assert_eq!(region_clearance_within(&left, &right, &index, 1.0), None);
+        assert_eq!(clearance_within(&left, &right, 1.0), None);
 
         let crossing = rect_region(1.0, -1.0, 1.5, 3.0);
-        let crossing_index = RegionBoundaryIndex::new(&crossing, 0.1);
         assert_eq!(
-            region_clearance_within(&left, &crossing, &crossing_index, 0.1),
+            clearance_within(&left, &crossing, 0.1),
             region_clearance(&left, &crossing)
         );
 
         let contained = rect_region(0.5, 0.5, 1.5, 1.5);
-        let contained_index = RegionBoundaryIndex::new(&contained, 0.1);
         assert_eq!(
-            region_clearance_within(&left, &contained, &contained_index, 0.1),
+            clearance_within(&left, &contained, 0.1),
             region_clearance(&left, &contained)
         );
     }

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -120,10 +120,7 @@ impl RegionBoundaryIndex {
     ///
     /// The radius is a pitch hint, not a limit: queries may pass any distance.
     pub fn new(region: &ContourSet, search_radius_mm: f64) -> Self {
-        let pitch = CellGrid::pitch(
-            search_radius_mm.clamp(MIN_CELL_MM, MAX_CELL_MM),
-            region.bbox,
-        );
+        let pitch = search_radius_mm.clamp(MIN_CELL_MM, MAX_CELL_MM);
         let segments = region.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
         let bounds = segments
             .iter()

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -896,9 +896,16 @@ pub fn thin_features(region: &ContourSet, min_width_mm: f64) -> Vec<ThinPiece> {
     pieces(
         region.disk_feature_violation_components(
             (min_width_mm + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0,
+            reportable_width(min_width_mm),
         ),
         min_width_mm,
     )
+}
+
+/// The widest measurement certainly below `min_mm` once both flattened
+/// walls' uncertainty is counted, as [`pieces`] requires.
+fn reportable_width(min_mm: f64) -> f64 {
+    min_mm - 2.0 * tol::FLATTEN_MM
 }
 
 /// Gaps in the material certainly narrower than `min_gap_mm`, including
@@ -907,7 +914,10 @@ pub fn thin_features(region: &ContourSet, min_width_mm: f64) -> Vec<ThinPiece> {
 /// Largest piece first.
 pub fn thin_gaps(region: &ContourSet, min_gap_mm: f64) -> Vec<ThinPiece> {
     pieces(
-        region.disk_gap_violation_components((min_gap_mm + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0),
+        region.disk_gap_violation_components(
+            (min_gap_mm + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0,
+            reportable_width(min_gap_mm),
+        ),
         min_gap_mm,
     )
 }

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -5,7 +5,7 @@
 //! it was measured against. Deciding whether a distance violates a limit is
 //! the caller's policy, via [`Distance::certainly_below`].
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::geom::bbox::BBox;
 use crate::geom::dist;
@@ -106,6 +106,7 @@ impl BBoxIndex {
 pub struct RegionBoundaryIndex {
     cell_size_mm: f64,
     segments: Vec<(Point, Point)>,
+    bounds: Vec<BBox>,
     cells: HashMap<(i64, i64), Vec<u32>>,
 }
 
@@ -121,6 +122,10 @@ impl RegionBoundaryIndex {
     pub fn new(region: &ContourSet, search_radius_mm: f64) -> Self {
         let cell_size_mm = search_radius_mm.clamp(MIN_CELL_MM, MAX_CELL_MM);
         let segments = region.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
+        let bounds = segments
+            .iter()
+            .map(|&(start, end)| segment_bounds(start, end))
+            .collect();
         let mut cells: HashMap<(i64, i64), Vec<u32>> = HashMap::new();
         for (index, &(start, end)) in segments.iter().enumerate() {
             for cell in corridor_cells(start, end, 0.0, cell_size_mm) {
@@ -130,15 +135,17 @@ impl RegionBoundaryIndex {
         Self {
             cell_size_mm,
             segments,
+            bounds,
             cells,
         }
     }
 
     /// Nearest boundary point no farther than `max_distance_mm` from `point`.
     pub fn nearest_within(&self, point: Point, max_distance_mm: f64) -> Option<Distance> {
-        let cells = corridor_cells(point, point, max_distance_mm, self.cell_size_mm);
-        self.segments_in(cells)
-            .map(|&(start, end)| {
+        indexed_edge_ids_near_in_encounter_order(self, point, point, max_distance_mm)
+            .into_iter()
+            .map(|index| {
+                let (start, end) = self.segments[index as usize];
                 let (mm, boundary) = dist::point_segment(point, start, end);
                 Distance::flattened(mm, point, boundary, 1)
             })
@@ -154,9 +161,10 @@ impl RegionBoundaryIndex {
         end: Point,
         max_distance_mm: f64,
     ) -> Option<Distance> {
-        let cells = corridor_cells(start, end, max_distance_mm, self.cell_size_mm);
-        self.segments_in(cells)
-            .map(|&(edge_start, edge_end)| {
+        indexed_edge_ids_near_in_encounter_order(self, start, end, max_distance_mm)
+            .into_iter()
+            .map(|index| {
+                let (edge_start, edge_end) = self.segments[index as usize];
                 let (mm, on_query, on_boundary) = dist::segments(start, end, edge_start, edge_end);
                 Distance::flattened(mm, on_query, on_boundary, 1)
             })
@@ -211,19 +219,13 @@ impl RegionBoundaryIndex {
             1,
         ))
     }
+}
 
-    /// Every indexed segment registered in any of `cells`. A segment spanning
-    /// several cells is yielded once per cell; every consumer takes a
-    /// minimum, for which repeats are harmless.
-    fn segments_in(
-        &self,
-        cells: impl Iterator<Item = (i64, i64)>,
-    ) -> impl Iterator<Item = &(Point, Point)> {
-        cells
-            .filter_map(|cell| self.cells.get(&cell))
-            .flatten()
-            .map(|&index| &self.segments[index as usize])
-    }
+fn segment_bounds(start: Point, end: Point) -> BBox {
+    BBox::new(
+        Point::new(start.x.min(end.x), start.y.min(end.y)),
+        Point::new(start.x.max(end.x), start.y.max(end.y)),
+    )
 }
 
 fn grid_cell(value: f64, cell_size_mm: f64) -> i64 {
@@ -344,7 +346,16 @@ fn contained_vertex(subject: &ContourSet, container: &ContourSet) -> Option<Poin
         .iter()
         .flat_map(|ring| ring.iter())
         .map(|&[x, y]| Point::new(x, y))
+        .filter(|point| {
+            point.x >= container.bbox.min.x
+                && point.x <= container.bbox.max.x
+                && point.y >= container.bbox.min.y
+                && point.y <= container.bbox.max.y
+        })
         .collect::<Vec<_>>();
+    if vertices.is_empty() {
+        return None;
+    }
     container
         .contains_points_batch(&vertices)
         .into_iter()
@@ -509,9 +520,19 @@ pub fn region_clearance_sites(
     second: &ContourSet,
     minimum_mm: f64,
 ) -> Vec<ClearanceSite> {
-    let lines = first.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
     let index = RegionBoundaryIndex::new(second, minimum_mm);
-    let mut sites = linework_clearance_sites(&lines, second, &index, minimum_mm, 1);
+    region_clearance_sites_with_index(first, second, &index, minimum_mm)
+}
+
+/// Local sites between two filled regions, reusing an index of `second`.
+pub fn region_clearance_sites_with_index(
+    first: &ContourSet,
+    second: &ContourSet,
+    second_boundary: &RegionBoundaryIndex,
+    minimum_mm: f64,
+) -> Vec<ClearanceSite> {
+    let lines = first.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
+    let mut sites = linework_clearance_sites(&lines, second, second_boundary, minimum_mm, 1);
     for overlap in first.intersection(second).connected_components() {
         let Some(point) = overlap
             .rings
@@ -615,14 +636,37 @@ fn indexed_edge_ids_near(
     end: Point,
     reach: f64,
 ) -> Vec<u32> {
-    let mut ids = corridor_cells(start, end, reach, index.cell_size_mm)
-        .filter_map(|cell| index.cells.get(&cell))
-        .flatten()
-        .copied()
-        .collect::<Vec<_>>();
+    let mut ids = indexed_edge_candidates_near(index, start, end, reach);
     ids.sort_unstable();
     ids.dedup();
     ids
+}
+
+fn indexed_edge_ids_near_in_encounter_order(
+    index: &RegionBoundaryIndex,
+    start: Point,
+    end: Point,
+    reach: f64,
+) -> Vec<u32> {
+    let mut ids = indexed_edge_candidates_near(index, start, end, reach);
+    let mut seen = HashSet::new();
+    ids.retain(|id| seen.insert(*id));
+    ids
+}
+
+fn indexed_edge_candidates_near(
+    index: &RegionBoundaryIndex,
+    start: Point,
+    end: Point,
+    reach: f64,
+) -> Vec<u32> {
+    let query = segment_bounds(start, end).expand(reach + tol::EPSILON_MM);
+    corridor_cells(start, end, reach, index.cell_size_mm)
+        .filter_map(|cell| index.cells.get(&cell))
+        .flatten()
+        .copied()
+        .filter(|&id| index.bounds[id as usize].intersects(query))
+        .collect()
 }
 
 fn linear_interval(value: f64, slope: f64, minimum: f64, maximum: f64) -> Option<(f64, f64)> {

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -5,10 +5,11 @@
 //! it was measured against. Deciding whether a distance violates a limit is
 //! the caller's policy, via [`Distance::certainly_below`].
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 
 use crate::geom::bbox::BBox;
 use crate::geom::dist;
+use crate::geom::grid::CellGrid;
 use crate::geom::point::Point;
 use crate::geom::region::{ContourSet, Ring, TwoSidedResidualComponent, ring_edges};
 use crate::geom::tol;
@@ -104,10 +105,9 @@ impl BBoxIndex {
 /// answer counts the region boundary as one flattened input.
 #[derive(Debug, Clone)]
 pub struct RegionBoundaryIndex {
-    cell_size_mm: f64,
     segments: Vec<(Point, Point)>,
     bounds: Vec<BBox>,
-    cells: HashMap<(i64, i64), Vec<u32>>,
+    grid: CellGrid,
 }
 
 /// Grid pitch bounds. Queries stay correct for any pitch; these only keep the
@@ -120,30 +120,32 @@ impl RegionBoundaryIndex {
     ///
     /// The radius is a pitch hint, not a limit: queries may pass any distance.
     pub fn new(region: &ContourSet, search_radius_mm: f64) -> Self {
-        let cell_size_mm = search_radius_mm.clamp(MIN_CELL_MM, MAX_CELL_MM);
+        let pitch = CellGrid::pitch(
+            search_radius_mm.clamp(MIN_CELL_MM, MAX_CELL_MM),
+            region.bbox,
+        );
         let segments = region.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
         let bounds = segments
             .iter()
             .map(|&(start, end)| segment_bounds(start, end))
             .collect();
-        let mut cells: HashMap<(i64, i64), Vec<u32>> = HashMap::new();
-        for (index, &(start, end)) in segments.iter().enumerate() {
-            for cell in corridor_cells(start, end, 0.0, cell_size_mm) {
-                cells.entry(cell).or_default().push(index as u32);
-            }
-        }
+        let grid = CellGrid::new(
+            pitch,
+            region.bbox,
+            segments.iter().enumerate().flat_map(|(id, &(start, end))| {
+                corridor_cells(start, end, 0.0, pitch).map(move |cell| (id as u32, cell))
+            }),
+        );
         Self {
-            cell_size_mm,
             segments,
             bounds,
-            cells,
+            grid,
         }
     }
 
     /// Nearest boundary point no farther than `max_distance_mm` from `point`.
     pub fn nearest_within(&self, point: Point, max_distance_mm: f64) -> Option<Distance> {
-        indexed_edge_ids_near_in_encounter_order(self, point, point, max_distance_mm)
-            .into_iter()
+        self.near(point, point, max_distance_mm)
             .map(|index| {
                 let (start, end) = self.segments[index as usize];
                 let (mm, boundary) = dist::point_segment(point, start, end);
@@ -161,8 +163,7 @@ impl RegionBoundaryIndex {
         end: Point,
         max_distance_mm: f64,
     ) -> Option<Distance> {
-        indexed_edge_ids_near_in_encounter_order(self, start, end, max_distance_mm)
-            .into_iter()
+        self.near(start, end, max_distance_mm)
             .map(|index| {
                 let (edge_start, edge_end) = self.segments[index as usize];
                 let (mm, on_query, on_boundary) = dist::segments(start, end, edge_start, edge_end);
@@ -170,6 +171,20 @@ impl RegionBoundaryIndex {
             })
             .filter(|distance| distance.mm <= max_distance_mm + tol::EPSILON_MM)
             .min_by(|left, right| left.mm.total_cmp(&right.mm))
+    }
+
+    /// Ids of the indexed segments whose bounds come within `reach` of the
+    /// query segment, in grid order: column by column, row by row, then by
+    /// id. A segment spanning several cells is yielded once per cell. The
+    /// minimum a consumer takes is unchanged by the repeats, and of equal
+    /// minima it keeps the first, which is always the first cell's copy.
+    fn near(&self, start: Point, end: Point, reach: f64) -> impl Iterator<Item = u32> + '_ {
+        let query = segment_bounds(start, end).expand(reach + tol::EPSILON_MM);
+        corridor_columns(start, end, reach, self.grid.pitch_mm())
+            .flat_map(move |(column, min_row, max_row)| {
+                self.grid.column(column, min_row, max_row).iter().copied()
+            })
+            .filter(move |&id| self.bounds[id as usize].intersects(query))
     }
 
     /// Parameter intervals along a segment within `distance_mm` of the
@@ -232,19 +247,20 @@ fn grid_cell(value: f64, cell_size_mm: f64) -> i64 {
     (value / cell_size_mm).floor() as i64
 }
 
-/// Every grid cell within `radius_mm` of the segment, column by column, so
-/// long diagonal segments touch a linear number of cells instead of their
-/// whole bounding box. A zero-length segment yields the cells around a point.
-fn corridor_cells(
+/// Every grid column within `radius_mm` of the segment with the rows it
+/// covers there, so long diagonal segments touch a linear number of cells
+/// instead of their whole bounding box. A zero-length segment yields the
+/// cells around a point.
+fn corridor_columns(
     start: Point,
     end: Point,
     radius_mm: f64,
     cell_size_mm: f64,
-) -> impl Iterator<Item = (i64, i64)> {
+) -> impl Iterator<Item = (i64, i64, i64)> {
     let min_column = grid_cell(start.x.min(end.x) - radius_mm, cell_size_mm);
     let max_column = grid_cell(start.x.max(end.x) + radius_mm, cell_size_mm);
     let delta = end - start;
-    (min_column..=max_column).flat_map(move |column| {
+    (min_column..=max_column).map(move |column| {
         let column_min = column as f64 * cell_size_mm - radius_mm;
         let column_max = (column + 1) as f64 * cell_size_mm + radius_mm;
         let (t_min, t_max) = if delta.x.abs() <= f64::EPSILON {
@@ -261,8 +277,19 @@ fn corridor_cells(
         let y_at_max = start.y + delta.y * t_max;
         let min_row = grid_cell(y_at_min.min(y_at_max) - radius_mm, cell_size_mm);
         let max_row = grid_cell(y_at_min.max(y_at_max) + radius_mm, cell_size_mm);
-        (min_row..=max_row).map(move |row| (column, row))
+        (column, min_row, max_row)
     })
+}
+
+/// Every grid cell of the corridor, column by column and row by row.
+fn corridor_cells(
+    start: Point,
+    end: Point,
+    radius_mm: f64,
+    cell_size_mm: f64,
+) -> impl Iterator<Item = (i64, i64)> {
+    corridor_columns(start, end, radius_mm, cell_size_mm)
+        .flat_map(|(column, min_row, max_row)| (min_row..=max_row).map(move |row| (column, row)))
 }
 
 /// Set distance between two closed disks: `max(0, ‖c₁ − c₂‖ − r₁ − r₂)`,
@@ -630,43 +657,17 @@ fn indexed_edges_near(
         .collect()
 }
 
+/// The distinct indexed segments near the query, by id.
 fn indexed_edge_ids_near(
     index: &RegionBoundaryIndex,
     start: Point,
     end: Point,
     reach: f64,
 ) -> Vec<u32> {
-    let mut ids = indexed_edge_candidates_near(index, start, end, reach);
+    let mut ids = index.near(start, end, reach).collect::<Vec<_>>();
     ids.sort_unstable();
     ids.dedup();
     ids
-}
-
-fn indexed_edge_ids_near_in_encounter_order(
-    index: &RegionBoundaryIndex,
-    start: Point,
-    end: Point,
-    reach: f64,
-) -> Vec<u32> {
-    let mut ids = indexed_edge_candidates_near(index, start, end, reach);
-    let mut seen = HashSet::new();
-    ids.retain(|id| seen.insert(*id));
-    ids
-}
-
-fn indexed_edge_candidates_near(
-    index: &RegionBoundaryIndex,
-    start: Point,
-    end: Point,
-    reach: f64,
-) -> Vec<u32> {
-    let query = segment_bounds(start, end).expand(reach + tol::EPSILON_MM);
-    corridor_cells(start, end, reach, index.cell_size_mm)
-        .filter_map(|cell| index.cells.get(&cell))
-        .flatten()
-        .copied()
-        .filter(|&id| index.bounds[id as usize].intersects(query))
-        .collect()
 }
 
 fn linear_interval(value: f64, slope: f64, minimum: f64, maximum: f64) -> Option<(f64, f64)> {

--- a/crates/pcb-ir/src/geom/grid.rs
+++ b/crates/pcb-ir/src/geom/grid.rs
@@ -35,12 +35,14 @@ impl CellGrid {
         bounds: BBox,
         registrations: impl Iterator<Item = (u32, (i64, i64))>,
     ) -> Self {
-        let cell = |value: f64| (value / pitch).floor() as i64;
         let (first_column, column_count) = if bounds.is_empty() {
             (0, 0)
         } else {
-            let first = cell(bounds.min.x);
-            (first, (cell(bounds.max.x) - first + 1) as usize)
+            let first = Self::cell(bounds.min.x, pitch);
+            (
+                first,
+                (Self::cell(bounds.max.x, pitch) - first + 1) as usize,
+            )
         };
         let mut pairs = registrations
             .filter(|&(_, (column, _))| {
@@ -77,22 +79,28 @@ impl CellGrid {
         }
     }
 
+    /// The cell coordinate of a value on a grid of `pitch`.
+    pub fn cell(value: f64, pitch: f64) -> i64 {
+        (value / pitch).floor() as i64
+    }
+
     /// Every cell of a grid of `pitch` that `bounds` meets, column by column
     /// and row by row.
     pub fn cells_of(bounds: BBox, pitch: f64) -> impl Iterator<Item = (i64, i64)> {
-        let cell = move |value: f64| (value / pitch).floor() as i64;
-        let (min_column, max_column) = (cell(bounds.min.x), cell(bounds.max.x));
-        let (min_row, max_row) = (cell(bounds.min.y), cell(bounds.max.y));
+        let (min_column, max_column) = (
+            Self::cell(bounds.min.x, pitch),
+            Self::cell(bounds.max.x, pitch),
+        );
+        let (min_row, max_row) = (
+            Self::cell(bounds.min.y, pitch),
+            Self::cell(bounds.max.y, pitch),
+        );
         (min_column..=max_column)
             .flat_map(move |column| (min_row..=max_row).map(move |row| (column, row)))
     }
 
     pub fn pitch_mm(&self) -> f64 {
         self.pitch
-    }
-
-    pub fn cell_of(&self, value: f64) -> i64 {
-        (value / self.pitch).floor() as i64
     }
 
     /// The ids of the cells of one column from `min_row` through `max_row`,
@@ -115,8 +123,9 @@ impl CellGrid {
     /// The ids of every cell meeting `bounds`, column by column, then row
     /// by row. An id in several cells appears once per cell.
     pub fn rectangle(&self, bounds: BBox) -> impl Iterator<Item = u32> + '_ {
-        let (min_column, max_column) = (self.cell_of(bounds.min.x), self.cell_of(bounds.max.x));
-        let (min_row, max_row) = (self.cell_of(bounds.min.y), self.cell_of(bounds.max.y));
+        let cell = |value: f64| Self::cell(value, self.pitch);
+        let (min_column, max_column) = (cell(bounds.min.x), cell(bounds.max.x));
+        let (min_row, max_row) = (cell(bounds.min.y), cell(bounds.max.y));
         (min_column..=max_column)
             .flat_map(move |column| self.column(column, min_row, max_row).iter().copied())
     }

--- a/crates/pcb-ir/src/geom/grid.rs
+++ b/crates/pcb-ir/src/geom/grid.rs
@@ -2,86 +2,78 @@
 //!
 //! Geometry checks ask "which items lie in these cells" tens of thousands
 //! of times against one static item set. The buckets are stored flat and
-//! compressed: every cell's ids live in one arena, column by column and row
-//! by row, addressed by an offset table. A cell is two array reads, and a
-//! run of cells down one column is a single contiguous slice, so a query
-//! walks its cells without hashing or allocating.
+//! compressed: every occupied cell's ids live in one arena, column by
+//! column and row by row, and only occupied cells are listed, so a region
+//! spanning a whole panel with a few hundred edges costs a few hundred
+//! entries. A run of cells down one column is a single contiguous slice,
+//! found by two binary searches, so a query walks its cells without hashing
+//! or allocating.
 
 use crate::geom::bbox::BBox;
 
 #[derive(Debug, Clone)]
 pub(crate) struct CellGrid {
     pitch: f64,
-    /// Cell coordinates of the first column and row.
-    origin: (i64, i64),
-    columns: i64,
-    rows: i64,
-    /// Column-major cell offsets into `ids`; one longer than the cell count.
-    starts: Vec<u32>,
+    /// Cell coordinate of the first column.
+    first_column: i64,
+    /// Offsets into `rows` and `cell_starts` per column; one longer than
+    /// the column count.
+    columns: Vec<u32>,
+    /// The row of each occupied cell, ascending within its column.
+    rows: Vec<i64>,
+    /// Offsets into `ids` per occupied cell; one longer than the cell count.
+    cell_starts: Vec<u32>,
     ids: Vec<u32>,
 }
 
-/// The offset table is dense, so cells per axis are bounded and the pitch
-/// coarsens beyond that instead of the table growing without limit.
-const MAX_CELLS_PER_AXIS: f64 = 2048.0;
-
 impl CellGrid {
-    /// The pitch a grid over `bounds` uses for a requested pitch.
-    pub fn pitch(requested: f64, bounds: BBox) -> f64 {
-        if bounds.is_empty() {
-            return requested;
-        }
-        requested.max(bounds.width().max(bounds.height()) / MAX_CELLS_PER_AXIS)
-    }
-
     /// Bucket every `(id, cell)` registration over `bounds`. Registrations
-    /// outside the bounds are dropped; a cell lists its ids in registration
-    /// order.
+    /// outside the bounds' columns are dropped; a cell lists its ids in
+    /// registration order.
     pub fn new(
         pitch: f64,
         bounds: BBox,
         registrations: impl Iterator<Item = (u32, (i64, i64))>,
     ) -> Self {
         let cell = |value: f64| (value / pitch).floor() as i64;
-        let (origin, columns, rows) = if bounds.is_empty() {
-            ((0, 0), 0, 0)
+        let (first_column, column_count) = if bounds.is_empty() {
+            (0, 0)
         } else {
-            let origin = (cell(bounds.min.x), cell(bounds.min.y));
-            (
-                origin,
-                cell(bounds.max.x) - origin.0 + 1,
-                cell(bounds.max.y) - origin.1 + 1,
-            )
+            let first = cell(bounds.min.x);
+            (first, (cell(bounds.max.x) - first + 1) as usize)
         };
-        let cells = (columns * rows) as usize;
-        let index = |(column, row): (i64, i64)| {
-            let (column, row) = (column - origin.0, row - origin.1);
-            ((0..columns).contains(&column) && (0..rows).contains(&row))
-                .then(|| (column * rows + row) as u32)
-        };
-        let pairs = registrations
-            .filter_map(|(id, cell)| index(cell).map(|cell| (cell, id)))
+        let mut pairs = registrations
+            .filter(|&(_, (column, _))| {
+                (first_column..first_column + column_count as i64).contains(&column)
+            })
             .collect::<Vec<_>>();
-        // Counting sort by cell keeps each cell's ids in registration order.
-        let mut starts = vec![0u32; cells + 1];
-        for &(cell, _) in &pairs {
-            starts[cell as usize + 1] += 1;
+        // A stable sort keeps each cell's ids in registration order.
+        pairs.sort_by_key(|&(_, cell)| cell);
+
+        let mut columns = vec![0u32; column_count + 1];
+        let mut rows = Vec::new();
+        let mut cell_starts = Vec::new();
+        let mut ids = Vec::with_capacity(pairs.len());
+        let mut previous = None;
+        for &(id, (column, row)) in &pairs {
+            if previous != Some((column, row)) {
+                columns[(column - first_column) as usize + 1] += 1;
+                rows.push(row);
+                cell_starts.push(ids.len() as u32);
+                previous = Some((column, row));
+            }
+            ids.push(id);
         }
-        for cell in 0..cells {
-            starts[cell + 1] += starts[cell];
-        }
-        let mut cursor = starts.clone();
-        let mut ids = vec![0u32; pairs.len()];
-        for &(cell, id) in &pairs {
-            ids[cursor[cell as usize] as usize] = id;
-            cursor[cell as usize] += 1;
+        cell_starts.push(ids.len() as u32);
+        for column in 0..column_count {
+            columns[column + 1] += columns[column];
         }
         Self {
             pitch,
-            origin,
+            first_column,
             columns,
             rows,
-            starts,
+            cell_starts,
             ids,
         }
     }
@@ -107,15 +99,18 @@ impl CellGrid {
     /// The ids of the cells of one column from `min_row` through `max_row`,
     /// row by row. Cells outside the grid are empty.
     pub fn column(&self, column: i64, min_row: i64, max_row: i64) -> &[u32] {
-        let column = column - self.origin.0;
-        let min_row = (min_row - self.origin.1).max(0);
-        let max_row = (max_row - self.origin.1).min(self.rows - 1);
-        if !(0..self.columns).contains(&column) || min_row > max_row {
+        let column = column - self.first_column;
+        if column < 0 || column as usize + 1 >= self.columns.len() {
             return &[];
         }
-        let first = (column * self.rows + min_row) as usize;
-        let last = (column * self.rows + max_row) as usize;
-        &self.ids[self.starts[first] as usize..self.starts[last + 1] as usize]
+        let (first, last) = (
+            self.columns[column as usize] as usize,
+            self.columns[column as usize + 1] as usize,
+        );
+        let rows = &self.rows[first..last];
+        let low = first + rows.partition_point(|&row| row < min_row);
+        let high = first + rows.partition_point(|&row| row <= max_row);
+        &self.ids[self.cell_starts[low] as usize..self.cell_starts[high] as usize]
     }
 
     /// The ids of every cell meeting `bounds`, column by column, then row
@@ -149,20 +144,24 @@ mod tests {
                 (9, (4, 0)),
                 (1, (0, 1)),
                 (2, (0, -1)),
+                (4, (2, 7)),
             ]
             .into_iter(),
         );
 
         assert_eq!(grid.column(0, 0, 0), &[7, 3]);
         assert_eq!(grid.column(0, 0, 1), &[7, 3, 1]);
-        assert_eq!(grid.column(0, -5, 5), &[7, 3, 1]);
+        assert_eq!(grid.column(0, -5, 5), &[2, 7, 3, 1]);
+        assert_eq!(grid.column(0, 2, 5), &[]);
+        assert_eq!(grid.column(1, -5, 5), &[]);
         assert_eq!(grid.column(2, 1, 1), &[5]);
+        assert_eq!(grid.column(2, 1, 9), &[5, 4]);
         assert_eq!(grid.column(4, 0, 0), &[]);
         assert_eq!(grid.column(-1, 0, 0), &[]);
         assert_eq!(
             grid.rectangle(bounds(-1.0, -1.0, 9.0, 9.0))
                 .collect::<Vec<_>>(),
-            vec![7, 3, 1, 5]
+            vec![2, 7, 3, 1, 5, 4]
         );
     }
 
@@ -171,12 +170,5 @@ mod tests {
         let grid = CellGrid::new(1.0, BBox::empty(), [(1, (0, 0))].into_iter());
         assert_eq!(grid.column(0, 0, 0), &[]);
         assert_eq!(grid.rectangle(bounds(0.0, 0.0, 1.0, 1.0)).count(), 0);
-    }
-
-    #[test]
-    fn pitch_coarsens_only_for_extreme_extents() {
-        assert_eq!(CellGrid::pitch(0.5, bounds(0.0, 0.0, 300.0, 200.0)), 0.5);
-        assert_eq!(CellGrid::pitch(0.5, bounds(0.0, 0.0, 4096.0, 10.0)), 2.0);
-        assert_eq!(CellGrid::pitch(0.5, BBox::empty()), 0.5);
     }
 }

--- a/crates/pcb-ir/src/geom/grid.rs
+++ b/crates/pcb-ir/src/geom/grid.rs
@@ -1,0 +1,182 @@
+//! Uniform-grid bucketing for spatial candidate lookup.
+//!
+//! Geometry checks ask "which items lie in these cells" tens of thousands
+//! of times against one static item set. The buckets are stored flat and
+//! compressed: every cell's ids live in one arena, column by column and row
+//! by row, addressed by an offset table. A cell is two array reads, and a
+//! run of cells down one column is a single contiguous slice, so a query
+//! walks its cells without hashing or allocating.
+
+use crate::geom::bbox::BBox;
+
+#[derive(Debug, Clone)]
+pub(crate) struct CellGrid {
+    pitch: f64,
+    /// Cell coordinates of the first column and row.
+    origin: (i64, i64),
+    columns: i64,
+    rows: i64,
+    /// Column-major cell offsets into `ids`; one longer than the cell count.
+    starts: Vec<u32>,
+    ids: Vec<u32>,
+}
+
+/// The offset table is dense, so cells per axis are bounded and the pitch
+/// coarsens beyond that instead of the table growing without limit.
+const MAX_CELLS_PER_AXIS: f64 = 2048.0;
+
+impl CellGrid {
+    /// The pitch a grid over `bounds` uses for a requested pitch.
+    pub fn pitch(requested: f64, bounds: BBox) -> f64 {
+        if bounds.is_empty() {
+            return requested;
+        }
+        requested.max(bounds.width().max(bounds.height()) / MAX_CELLS_PER_AXIS)
+    }
+
+    /// Bucket every `(id, cell)` registration over `bounds`. Registrations
+    /// outside the bounds are dropped; a cell lists its ids in registration
+    /// order.
+    pub fn new(
+        pitch: f64,
+        bounds: BBox,
+        registrations: impl Iterator<Item = (u32, (i64, i64))>,
+    ) -> Self {
+        let cell = |value: f64| (value / pitch).floor() as i64;
+        let (origin, columns, rows) = if bounds.is_empty() {
+            ((0, 0), 0, 0)
+        } else {
+            let origin = (cell(bounds.min.x), cell(bounds.min.y));
+            (
+                origin,
+                cell(bounds.max.x) - origin.0 + 1,
+                cell(bounds.max.y) - origin.1 + 1,
+            )
+        };
+        let cells = (columns * rows) as usize;
+        let index = |(column, row): (i64, i64)| {
+            let (column, row) = (column - origin.0, row - origin.1);
+            ((0..columns).contains(&column) && (0..rows).contains(&row))
+                .then(|| (column * rows + row) as u32)
+        };
+        let pairs = registrations
+            .filter_map(|(id, cell)| index(cell).map(|cell| (cell, id)))
+            .collect::<Vec<_>>();
+        // Counting sort by cell keeps each cell's ids in registration order.
+        let mut starts = vec![0u32; cells + 1];
+        for &(cell, _) in &pairs {
+            starts[cell as usize + 1] += 1;
+        }
+        for cell in 0..cells {
+            starts[cell + 1] += starts[cell];
+        }
+        let mut cursor = starts.clone();
+        let mut ids = vec![0u32; pairs.len()];
+        for &(cell, id) in &pairs {
+            ids[cursor[cell as usize] as usize] = id;
+            cursor[cell as usize] += 1;
+        }
+        Self {
+            pitch,
+            origin,
+            columns,
+            rows,
+            starts,
+            ids,
+        }
+    }
+
+    /// Every cell of a grid of `pitch` that `bounds` meets, column by column
+    /// and row by row.
+    pub fn cells_of(bounds: BBox, pitch: f64) -> impl Iterator<Item = (i64, i64)> {
+        let cell = move |value: f64| (value / pitch).floor() as i64;
+        let (min_column, max_column) = (cell(bounds.min.x), cell(bounds.max.x));
+        let (min_row, max_row) = (cell(bounds.min.y), cell(bounds.max.y));
+        (min_column..=max_column)
+            .flat_map(move |column| (min_row..=max_row).map(move |row| (column, row)))
+    }
+
+    pub fn pitch_mm(&self) -> f64 {
+        self.pitch
+    }
+
+    pub fn cell_of(&self, value: f64) -> i64 {
+        (value / self.pitch).floor() as i64
+    }
+
+    /// The ids of the cells of one column from `min_row` through `max_row`,
+    /// row by row. Cells outside the grid are empty.
+    pub fn column(&self, column: i64, min_row: i64, max_row: i64) -> &[u32] {
+        let column = column - self.origin.0;
+        let min_row = (min_row - self.origin.1).max(0);
+        let max_row = (max_row - self.origin.1).min(self.rows - 1);
+        if !(0..self.columns).contains(&column) || min_row > max_row {
+            return &[];
+        }
+        let first = (column * self.rows + min_row) as usize;
+        let last = (column * self.rows + max_row) as usize;
+        &self.ids[self.starts[first] as usize..self.starts[last + 1] as usize]
+    }
+
+    /// The ids of every cell meeting `bounds`, column by column, then row
+    /// by row. An id in several cells appears once per cell.
+    pub fn rectangle(&self, bounds: BBox) -> impl Iterator<Item = u32> + '_ {
+        let (min_column, max_column) = (self.cell_of(bounds.min.x), self.cell_of(bounds.max.x));
+        let (min_row, max_row) = (self.cell_of(bounds.min.y), self.cell_of(bounds.max.y));
+        (min_column..=max_column)
+            .flat_map(move |column| self.column(column, min_row, max_row).iter().copied())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geom::point::Point;
+
+    fn bounds(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> BBox {
+        BBox::new(Point::new(min_x, min_y), Point::new(max_x, max_y))
+    }
+
+    #[test]
+    fn cells_keep_registration_order_and_ignore_outsiders() {
+        let grid = CellGrid::new(
+            1.0,
+            bounds(0.0, 0.0, 2.5, 1.5),
+            [
+                (7, (0, 0)),
+                (3, (0, 0)),
+                (5, (2, 1)),
+                (9, (4, 0)),
+                (1, (0, 1)),
+                (2, (0, -1)),
+            ]
+            .into_iter(),
+        );
+
+        assert_eq!(grid.column(0, 0, 0), &[7, 3]);
+        assert_eq!(grid.column(0, 0, 1), &[7, 3, 1]);
+        assert_eq!(grid.column(0, -5, 5), &[7, 3, 1]);
+        assert_eq!(grid.column(2, 1, 1), &[5]);
+        assert_eq!(grid.column(4, 0, 0), &[]);
+        assert_eq!(grid.column(-1, 0, 0), &[]);
+        assert_eq!(
+            grid.rectangle(bounds(-1.0, -1.0, 9.0, 9.0))
+                .collect::<Vec<_>>(),
+            vec![7, 3, 1, 5]
+        );
+    }
+
+    #[test]
+    fn empty_bounds_hold_nothing() {
+        let grid = CellGrid::new(1.0, BBox::empty(), [(1, (0, 0))].into_iter());
+        assert_eq!(grid.column(0, 0, 0), &[]);
+        assert_eq!(grid.rectangle(bounds(0.0, 0.0, 1.0, 1.0)).count(), 0);
+    }
+
+    #[test]
+    fn pitch_coarsens_only_for_extreme_extents() {
+        assert_eq!(CellGrid::pitch(0.5, bounds(0.0, 0.0, 300.0, 200.0)), 0.5);
+        assert_eq!(CellGrid::pitch(0.5, bounds(0.0, 0.0, 4096.0, 10.0)), 2.0);
+        assert_eq!(CellGrid::pitch(0.5, BBox::empty()), 0.5);
+    }
+}

--- a/crates/pcb-ir/src/geom/grid.rs
+++ b/crates/pcb-ir/src/geom/grid.rs
@@ -29,7 +29,7 @@ pub(crate) struct CellGrid {
 impl CellGrid {
     /// Bucket every `(id, cell)` registration over `bounds`. Registrations
     /// outside the bounds' columns are dropped; a cell lists its ids in
-    /// registration order.
+    /// ascending order.
     pub fn new(
         pitch: f64,
         bounds: BBox,
@@ -47,8 +47,7 @@ impl CellGrid {
                 (first_column..first_column + column_count as i64).contains(&column)
             })
             .collect::<Vec<_>>();
-        // A stable sort keeps each cell's ids in registration order.
-        pairs.sort_by_key(|&(_, cell)| cell);
+        pairs.sort_unstable_by_key(|&(id, cell)| (cell, id));
 
         let mut columns = vec![0u32; column_count + 1];
         let mut rows = Vec::new();
@@ -133,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn cells_keep_registration_order_and_ignore_outsiders() {
+    fn cells_list_ids_ascending_and_ignore_outsiders() {
         let grid = CellGrid::new(
             1.0,
             bounds(0.0, 0.0, 2.5, 1.5),
@@ -149,9 +148,9 @@ mod tests {
             .into_iter(),
         );
 
-        assert_eq!(grid.column(0, 0, 0), &[7, 3]);
-        assert_eq!(grid.column(0, 0, 1), &[7, 3, 1]);
-        assert_eq!(grid.column(0, -5, 5), &[2, 7, 3, 1]);
+        assert_eq!(grid.column(0, 0, 0), &[3, 7]);
+        assert_eq!(grid.column(0, 0, 1), &[3, 7, 1]);
+        assert_eq!(grid.column(0, -5, 5), &[2, 3, 7, 1]);
         assert_eq!(grid.column(0, 2, 5), &[]);
         assert_eq!(grid.column(1, -5, 5), &[]);
         assert_eq!(grid.column(2, 1, 1), &[5]);
@@ -161,7 +160,7 @@ mod tests {
         assert_eq!(
             grid.rectangle(bounds(-1.0, -1.0, 9.0, 9.0))
                 .collect::<Vec<_>>(),
-            vec![2, 7, 3, 1, 5, 4]
+            vec![2, 3, 7, 1, 5, 4]
         );
     }
 

--- a/crates/pcb-ir/src/geom/mod.rs
+++ b/crates/pcb-ir/src/geom/mod.rs
@@ -10,6 +10,7 @@ pub mod bridge;
 pub mod copper_balance;
 pub mod dfm;
 pub mod dist;
+mod grid;
 pub mod path;
 pub mod pattern;
 mod point;

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -659,17 +659,18 @@ impl ContourSet {
             {
                 return false;
             }
-            if !left
-                .bbox
-                .expand(material_mm.max(void_mm))
-                .intersects(right.bbox)
-            {
+            let same_component = components[left.topology.ring] == components[right.topology.ring];
+            let farthest = if same_component {
+                material_mm.max(void_mm)
+            } else {
+                void_mm
+            };
+            if !left.bbox.expand(farthest).intersects(right.bbox) {
                 return false;
             }
             let (separation, nearest_left, nearest_right) =
                 dist::segments(left.start, left.end, right.start, right.end);
             let across = nearest_right - nearest_left;
-            let same_component = components[left.topology.ring] == components[right.topology.ring];
             let reach = match (
                 same_component,
                 sees_left(left, across),
@@ -1213,43 +1214,48 @@ impl ContourSet {
         two_sided_gap_residual(self, &closing_residual(self, radius))
     }
 
-    /// Connected sub-diameter material residues (opening residue) with the
-    /// local width of each.
+    /// Connected material residues of the opening by `radius` whose local
+    /// width can be under `width_mm`, with the local width of each.
     pub(crate) fn disk_feature_violation_components(
         &self,
         radius: f64,
+        width_mm: f64,
     ) -> Vec<TwoSidedResidualComponent> {
         // Opening is the union of the disks inside a region, and a disk is
-        // connected, so every component opens on its own: one whose walls
-        // never face each other across its material within the disk
-        // diameter opens to itself and has no residue. Separate components
-        // can share a width only where they touch within tolerance. The
-        // snap-rounded width construction moves walls by a tolerance, and
-        // `M \ (X ∩ M)` is `M \ X`, so the opening's clip to the source
-        // is not needed to find what the opening removed.
+        // connected, so every component opens on its own. A width is a disk
+        // touching two facing walls, so it is at least their separation: a
+        // component whose walls never face each other across its material
+        // that closely has no width to find. Separate components share a
+        // width only where they touch within tolerance. The snap-rounded
+        // width construction moves walls by a tolerance, and `M \ (X ∩ M)`
+        // is `M \ X`, so the opening's clip to the source is not needed to
+        // find what the opening removed.
         self.two_sided_residual(radius, |region, radius| {
-            let diameter = 2.0 * (radius + 2.0 * region.tolerance);
+            let facing = width_mm + 4.0 * region.tolerance;
             let touching = 3.0 * region.tolerance + tol::FLATTEN_MM;
-            let candidates = region.facing_components(diameter, touching, 0.0);
+            let candidates = region.facing_components(facing, touching, 0.0);
             candidates.difference(&candidates.disk_erode(radius).disk_dilate(radius))
         })
     }
 
-    /// Connected sub-diameter void residues (closing residue) with the local
-    /// width of each.
+    /// Connected void residues of the closing by `radius` whose local width
+    /// can be under `width_mm`, with the local width of each.
     pub(crate) fn disk_gap_violation_components(
         &self,
         radius: f64,
+        width_mm: f64,
     ) -> Vec<TwoSidedResidualComponent> {
         // Closing fills only void narrower than the disk diameter, between
-        // walls facing across it. A residue point there lies within a radius
-        // of those walls, and the disks that decide it reach a diameter
-        // further, so everything within two diameters comes along as
-        // context and the closing of that neighbourhood is the closing of
-        // the whole region there.
+        // walls facing across it, and a width is at least the separation of
+        // the walls it touches. A residue point lies within a radius of its
+        // walls, and the disks that decide it reach a diameter further, so
+        // everything within two diameters comes along as context and the
+        // closing of that neighbourhood is the closing of the whole region
+        // there.
         self.two_sided_residual(radius, |region, radius| {
-            let diameter = 2.0 * (radius + 2.0 * region.tolerance);
-            let candidates = region.facing_components(0.0, diameter, 2.0 * diameter);
+            let facing = width_mm + 4.0 * region.tolerance;
+            let context = 4.0 * (radius + 2.0 * region.tolerance);
+            let candidates = region.facing_components(0.0, facing, context);
             closing_residual(&candidates, radius)
         })
     }

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -631,11 +631,15 @@ impl ContourSet {
         (components, outers)
     }
 
-    /// The material around walls that face each other across material
-    /// within `material_mm` or across void within `void_mm`: every ring
-    /// within `context_mm` of such a wall, with the outer ring of each
-    /// component so reached. A hole farther away is filled, since nothing
-    /// it does reaches the facing walls. Walls face when they are not
+    /// The material within `reach_mm` of walls that face each other across
+    /// material within `material_mm` or across void within `void_mm`:
+    /// every ring within reach of such a wall, with the outer ring of each
+    /// component so reached, clipped to the reach around the facing walls.
+    /// A hole farther away is filled and material farther away is cut,
+    /// since neither reaches the facing walls; the cut's own edges disturb
+    /// the morphology only within a disk diameter of themselves, so a reach
+    /// of three radii keeps the residue at the facing walls exact. Walls
+    /// face when they are not
     /// incident: on one ring, neither adjacent nor turned the same way,
     /// exactly as the width construction judges a wall pair. Material lies
     /// to the left of travel, so two walls of one component face across
@@ -644,9 +648,9 @@ impl ContourSet {
     /// wall's own line, as at the corners of a notch or of aligned holes,
     /// leaves the side open and both reaches apply. Distinct components
     /// always face across void.
-    fn facing_components(&self, material_mm: f64, void_mm: f64, context_mm: f64) -> Self {
+    fn facing_components(&self, material_mm: f64, void_mm: f64, reach_mm: f64) -> Self {
         let (components, outers) = self.ring_components();
-        let reach = material_mm.max(void_mm).max(context_mm);
+        let reach = material_mm.max(void_mm).max(reach_mm);
         let grid = SegmentGrid::new(source_boundary_segments(self), reach);
         let segments = &grid.segments;
         let sees_left = |wall: &OrientedBoundarySegment, across: Point| {
@@ -685,36 +689,44 @@ impl ContourSet {
             };
             separation <= reach
         };
-        let mut facing = vec![false; self.rings.len()];
+        let mut facing = vec![false; segments.len()];
         for (id, segment) in segments.iter().enumerate() {
             for other in grid.near_ids(segment.bbox.expand(material_mm.max(void_mm))) {
                 let partner = &segments[other as usize];
                 if other as usize <= id
-                    || (facing[segment.topology.ring] && facing[partner.topology.ring])
+                    || (facing[id] && facing[other as usize])
                     || !faces(segment, partner)
                 {
                     continue;
                 }
-                facing[segment.topology.ring] = true;
-                facing[partner.topology.ring] = true;
+                facing[id] = true;
+                facing[other as usize] = true;
             }
         }
-        let mut selected = facing.clone();
+        let mut kept = vec![false; self.rings.len()];
+        let mut windows = Vec::new();
         for segment in segments
             .iter()
-            .filter(|segment| facing[segment.topology.ring])
+            .zip(&facing)
+            .filter_map(|(segment, &facing)| facing.then_some(segment))
         {
-            for other in grid.near_ids(segment.bbox.expand(context_mm)) {
-                selected[segments[other as usize].topology.ring] = true;
+            let window = segment.bbox.expand(reach_mm);
+            windows.push(vec![
+                [window.min.x, window.min.y],
+                [window.max.x, window.min.y],
+                [window.max.x, window.max.y],
+                [window.min.x, window.max.y],
+            ]);
+            for other in grid.near_ids(window) {
+                kept[segments[other as usize].topology.ring] = true;
             }
         }
-        let mut kept = selected;
         for (ring, &component) in components.iter().enumerate() {
             if kept[ring] {
                 kept[outers[component]] = true;
             }
         }
-        Self::from_regularized(
+        let material = Self::from_regularized(
             self.rings
                 .iter()
                 .zip(&kept)
@@ -722,7 +734,8 @@ impl ContourSet {
                 .map(|(ring, _)| ring.clone())
                 .collect(),
             self.tolerance,
-        )
+        );
+        material.intersection(&Self::new(windows, FillRule::NonZero, self.tolerance))
     }
 
     /// Whether the region contains each point, as a one-or-zero indicator.
@@ -1232,16 +1245,17 @@ impl ContourSet {
         // disk touching two facing walls, so it is at least their
         // separation: material whose walls never face each other that
         // closely has no width to find, and only the material within a
-        // diameter of facing walls decides their residue. Separate
-        // components share a width only where they touch within tolerance.
+        // diameter of facing walls decides the residue within a radius of
+        // them, where any width lies. Separate components share a width
+        // only where they touch within tolerance.
         // The snap-rounded width construction moves walls by a tolerance,
         // and `M \ (X ∩ M)` is `M \ X`, so the opening's clip to the
         // source is not needed to find what the opening removed.
         self.two_sided_residual(radius, |region, radius| {
             let facing = width_mm + 4.0 * region.tolerance;
             let touching = 3.0 * region.tolerance + tol::FLATTEN_MM;
-            let context = 2.0 * (radius + 2.0 * region.tolerance);
-            let candidates = region.facing_components(facing, touching, context);
+            let reach = 3.0 * (radius + 2.0 * region.tolerance);
+            let candidates = region.facing_components(facing, touching, reach);
             candidates.difference(&candidates.disk_erode(radius).disk_dilate(radius))
         })
     }
@@ -1262,8 +1276,8 @@ impl ContourSet {
         // there.
         self.two_sided_residual(radius, |region, radius| {
             let facing = width_mm + 4.0 * region.tolerance;
-            let context = 4.0 * (radius + 2.0 * region.tolerance);
-            let candidates = region.facing_components(0.0, facing, context);
+            let reach = 4.0 * (radius + 2.0 * region.tolerance);
+            let candidates = region.facing_components(0.0, facing, reach);
             closing_residual(&candidates, radius)
         })
     }
@@ -2717,11 +2731,15 @@ mod tests {
         let same_bounds = |left: BBox, right: BBox| {
             left.min.distance_to(right.min) < 1e-6 && left.max.distance_to(right.max) < 1e-6
         };
-        let material = region.facing_components(0.2, 0.01, 0.0);
+        // The trace's long walls face across material; a reach past the
+        // whole trace keeps all of it and none of the pads.
+        let material = region.facing_components(0.2, 0.01, 1.0);
         assert_eq!(material.rings.len(), 1);
         assert!(same_bounds(material.bbox, trace.bbox));
 
-        let void = region.facing_components(0.0, 0.2, 0.0);
+        // The pads face each other across their gap, along their whole
+        // aligned edges, and the trace is out of reach.
+        let void = region.facing_components(0.0, 0.2, 0.5);
         assert_eq!(void.rings.len(), 2);
         assert!(same_bounds(void.bbox, pad.bbox.union(neighbour.bbox)));
 
@@ -2732,8 +2750,8 @@ mod tests {
         let notched = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM).difference(
             &ContourSet::rectangle(rect(1.9, 2.0, 2.1, 4.5), tol::REGION_MM),
         );
-        assert_eq!(notched.facing_components(0.0, 0.3, 0.0).rings.len(), 1);
-        assert!(notched.facing_components(0.15, 0.15, 0.0).is_empty());
+        assert_eq!(notched.facing_components(0.0, 0.3, 1.0).rings.len(), 1);
+        assert!(notched.facing_components(0.15, 0.15, 1.0).is_empty());
         let webbed = ContourSet::rectangle(rect(0.0, 0.0, 8.0, 4.0), tol::REGION_MM)
             .difference(&ContourSet::rectangle(
                 rect(1.0, 1.0, 1.9, 3.0),
@@ -2747,10 +2765,13 @@ mod tests {
                 rect(6.0, 1.0, 7.0, 3.0),
                 tol::REGION_MM,
             ));
-        let nearby_web = webbed.facing_components(0.3, 0.0, 0.0);
+        let nearby_web = webbed.facing_components(0.3, 0.0, 1.0);
         assert_eq!(nearby_web.rings.len(), 3);
-        assert!(nearby_web.contains_point(Point::new(6.5, 2.0)));
-        assert!(webbed.facing_components(0.0, 0.15, 0.0).is_empty());
+        assert!(nearby_web.contains_point(Point::new(2.0, 2.0)));
+        assert!(nearby_web.contains_point(Point::new(2.0, 3.5)));
+        assert!(!nearby_web.contains_point(Point::new(6.5, 2.0)));
+        assert!(!nearby_web.contains_point(Point::new(5.0, 3.5)));
+        assert!(webbed.facing_components(0.0, 0.15, 1.0).is_empty());
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -1406,9 +1406,13 @@ struct SegmentGrid {
     cells: HashMap<(i64, i64), Vec<u32>>,
 }
 
+/// Grid pitch changes candidate lookup cost only. A fixed floor prevents a
+/// small DFM limit from dividing a board-length edge into thousands of cells.
+const MIN_SEGMENT_GRID_CELL_MM: f64 = 1.0;
+
 impl SegmentGrid {
     fn new(segments: Vec<OrientedBoundarySegment>, cell_mm: f64) -> Self {
-        let cell_mm = cell_mm.max(tol::REGION_MM);
+        let cell_mm = cell_mm.max(MIN_SEGMENT_GRID_CELL_MM);
         let mut cells: HashMap<(i64, i64), Vec<u32>> = HashMap::new();
         for (index, segment) in segments.iter().enumerate() {
             for cell in Self::cells_of(segment.bbox, cell_mm) {
@@ -2448,6 +2452,18 @@ mod tests {
         assert!((width.disk.width().mm - 0.101).abs() < 1e-9);
 
         assert!(measure(0.103).is_none());
+    }
+
+    #[test]
+    fn segment_grid_uses_coarse_cells_without_losing_local_edges() {
+        let region = ContourSet::rectangle(rect(0.0, 0.0, 400.0, 10.0), tol::REGION_MM);
+        let grid = SegmentGrid::new(source_boundary_segments(&region), 0.05);
+
+        assert_eq!(grid.cell_mm, MIN_SEGMENT_GRID_CELL_MM);
+        let near = grid.near(rect(199.9, -0.1, 200.1, 0.1));
+        assert_eq!(near.len(), 1);
+        assert_eq!(near[0].start.y, 0.0);
+        assert_eq!(near[0].end.y, 0.0);
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -419,6 +419,21 @@ impl ContourSet {
         }
     }
 
+    /// A region from rings that are already regularized, kept as they are.
+    fn from_regularized(rings: Vec<Ring>, tolerance: f64) -> Self {
+        let rings = filter_significant_rings(rings, tolerance);
+        let ring_bounds = rings
+            .iter()
+            .map(|ring| rings_bbox(std::slice::from_ref(ring)))
+            .collect::<Vec<_>>();
+        Self {
+            bbox: ring_bounds.iter().copied().fold(BBox::empty(), BBox::union),
+            rings,
+            ring_bounds,
+            tolerance,
+        }
+    }
+
     pub fn empty(tolerance: f64) -> Self {
         Self {
             bbox: BBox::empty(),
@@ -582,6 +597,126 @@ impl ContourSet {
             .into_iter()
             .map(|shape| Self::new(shape, FillRule::NonZero, self.tolerance))
             .collect()
+    }
+
+    /// The component of each ring, by ring index. Regularized rings nest
+    /// without crossing and holes are wound opposite their outer ring, so
+    /// a hole belongs to the smallest outer ring around it.
+    fn ring_components(&self) -> Vec<usize> {
+        let areas = self.rings.iter().map(ring_signed_area).collect::<Vec<_>>();
+        let mut outers = (0..self.rings.len())
+            .filter(|&ring| areas[ring] > 0.0)
+            .collect::<Vec<_>>();
+        outers.sort_by(|&left, &right| areas[left].total_cmp(&areas[right]));
+        let mut components = vec![usize::MAX; self.rings.len()];
+        for (component, &outer) in outers.iter().enumerate() {
+            components[outer] = component;
+        }
+        for (index, ring) in self.rings.iter().enumerate() {
+            if areas[index] > 0.0 {
+                continue;
+            }
+            let Some(&[x, y]) = ring.first() else {
+                continue;
+            };
+            let point = Point::new(x, y);
+            if let Some(&outer) = outers.iter().find(|&&outer| {
+                self.ring_bounds[outer].contains_point(point)
+                    && ring_contains_point(&self.rings[outer], point)
+            }) {
+                components[index] = components[outer];
+            }
+        }
+        components
+    }
+
+    /// The components in which two boundary walls face each other across
+    /// material within `material_mm` or across void within `void_mm`,
+    /// together with every component within `context_mm` of them. Walls
+    /// face when they are not incident: on one ring, neither adjacent nor
+    /// turned the same way, exactly as the width construction judges a
+    /// wall pair. Material lies to the left of travel, so two walls of one
+    /// component face across material when each has the other's nearest
+    /// point on its left and across void when each has it on its right; a
+    /// nearest point along a wall's own line, as at the corners of a notch
+    /// or of aligned holes, leaves the side open and both reaches apply.
+    /// Distinct components always face across void.
+    fn facing_components(&self, material_mm: f64, void_mm: f64, context_mm: f64) -> Self {
+        let components = self.ring_components();
+        let reach = material_mm.max(void_mm).max(context_mm);
+        let grid = SegmentGrid::new(source_boundary_segments(self), reach);
+        let segments = &grid.segments;
+        let sees_left = |wall: &OrientedBoundarySegment, across: Point| {
+            let along = wall.end - wall.start;
+            let turn = along.x * across.y - along.y * across.x;
+            let scale = 1e-6 * along.length() * across.length();
+            (turn.abs() > scale).then_some(turn > 0.0)
+        };
+        let faces = |left: &OrientedBoundarySegment, right: &OrientedBoundarySegment| {
+            if left.topology.ring == right.topology.ring
+                && (boundary_segments_are_incident(left.topology, right.topology)
+                    || left.tangent.x * right.tangent.x + left.tangent.y * right.tangent.y > 0.0)
+            {
+                return false;
+            }
+            if !left
+                .bbox
+                .expand(material_mm.max(void_mm))
+                .intersects(right.bbox)
+            {
+                return false;
+            }
+            let (separation, nearest_left, nearest_right) =
+                dist::segments(left.start, left.end, right.start, right.end);
+            let across = nearest_right - nearest_left;
+            let same_component = components[left.topology.ring] == components[right.topology.ring];
+            let reach = match (
+                same_component,
+                sees_left(left, across),
+                sees_left(right, -across),
+            ) {
+                (false, ..) | (true, Some(false), Some(false)) => void_mm,
+                (true, Some(true), Some(true)) => material_mm,
+                _ => material_mm.max(void_mm),
+            };
+            separation <= reach
+        };
+        let mut facing = vec![false; self.rings.len()];
+        for (id, segment) in segments.iter().enumerate() {
+            for other in grid.near_ids(segment.bbox.expand(material_mm.max(void_mm))) {
+                let partner = &segments[other as usize];
+                if other as usize <= id
+                    || (facing[segment.topology.ring] && facing[partner.topology.ring])
+                    || !faces(segment, partner)
+                {
+                    continue;
+                }
+                facing[segment.topology.ring] = true;
+                facing[partner.topology.ring] = true;
+            }
+        }
+        let mut selected = facing.clone();
+        for segment in segments
+            .iter()
+            .filter(|segment| facing[segment.topology.ring])
+        {
+            for other in grid.near_ids(segment.bbox.expand(context_mm)) {
+                selected[segments[other as usize].topology.ring] = true;
+            }
+        }
+        let mut kept = vec![false; self.rings.len()];
+        for (ring, &component) in components.iter().enumerate() {
+            kept[component] |= selected[ring];
+        }
+        Self::from_regularized(
+            self.rings
+                .iter()
+                .zip(&components)
+                .filter(|&(_, &component)| kept[component])
+                .map(|(ring, _)| ring.clone())
+                .collect(),
+            self.tolerance,
+        )
     }
 
     /// Whether the region contains each point, as a one-or-zero indicator.
@@ -1084,10 +1219,19 @@ impl ContourSet {
         &self,
         radius: f64,
     ) -> Vec<TwoSidedResidualComponent> {
-        // `M \ (X ∩ M)` is `M \ X`, so the opening's clip to the source is
-        // not needed to find what the opening removed.
+        // Opening is the union of the disks inside a region, and a disk is
+        // connected, so every component opens on its own: one whose walls
+        // never face each other across its material within the disk
+        // diameter opens to itself and has no residue. Separate components
+        // can share a width only where they touch within tolerance. The
+        // snap-rounded width construction moves walls by a tolerance, and
+        // `M \ (X ∩ M)` is `M \ X`, so the opening's clip to the source
+        // is not needed to find what the opening removed.
         self.two_sided_residual(radius, |region, radius| {
-            region.difference(&region.disk_erode(radius).disk_dilate(radius))
+            let diameter = 2.0 * (radius + 2.0 * region.tolerance);
+            let touching = 3.0 * region.tolerance + tol::FLATTEN_MM;
+            let candidates = region.facing_components(diameter, touching, 0.0);
+            candidates.difference(&candidates.disk_erode(radius).disk_dilate(radius))
         })
     }
 
@@ -1097,7 +1241,17 @@ impl ContourSet {
         &self,
         radius: f64,
     ) -> Vec<TwoSidedResidualComponent> {
-        self.two_sided_residual(radius, closing_residual)
+        // Closing fills only void narrower than the disk diameter, between
+        // walls facing across it. A residue point there lies within a radius
+        // of those walls, and the disks that decide it reach a diameter
+        // further, so everything within two diameters comes along as
+        // context and the closing of that neighbourhood is the closing of
+        // the whole region there.
+        self.two_sided_residual(radius, |region, radius| {
+            let diameter = 2.0 * (radius + 2.0 * region.tolerance);
+            let candidates = region.facing_components(0.0, diameter, 2.0 * diameter);
+            closing_residual(&candidates, radius)
+        })
     }
 
     /// Morphological residue of this region, kept only where two distinct
@@ -1465,15 +1619,22 @@ impl SegmentGrid {
         Self { segments, grid }
     }
 
+    /// Ids of the segments whose bounds meet `query`; a segment in several
+    /// cells repeats.
+    fn near_ids(&self, query: BBox) -> impl Iterator<Item = u32> + '_ {
+        self.grid
+            .rectangle(query)
+            .filter(move |&id| self.segments[id as usize].bbox.intersects(query))
+    }
+
     /// The segments whose bounds meet `query`, in index order, each once.
     fn near(&self, query: BBox) -> Vec<OrientedBoundarySegment> {
-        let mut indices = self.grid.rectangle(query).collect::<Vec<_>>();
+        let mut indices = self.near_ids(query).collect::<Vec<_>>();
         indices.sort_unstable();
         indices.dedup();
         indices
             .into_iter()
             .map(|index| self.segments[index as usize])
-            .filter(|segment| segment.bbox.intersects(query))
             .collect()
     }
 }
@@ -1575,47 +1736,20 @@ fn planar_grid_sites(
         .collect()
 }
 
-/// Whether the sites are one cyclic run of consecutive segments of one ring
-/// that turns the same way throughout by less than a half turn: a single
-/// convex corner or arc. Nothing in such a run faces anything else, so a
-/// residue it walls alone is the bite of one corner and has no width.
-fn convex_chain(sites: &[OrientedBoundarySegment]) -> bool {
-    let Some(first) = sites.first() else {
-        return true;
-    };
-    if sites
-        .iter()
-        .any(|site| site.topology.ring != first.topology.ring)
-    {
-        return false;
-    }
-    let ring_len = first.topology.ring_len;
-    let mut run = sites.to_vec();
-    run.sort_by_key(|site| site.topology.index);
-    // A run is contiguous when, read cyclically, exactly one step is not
-    // the next index: the step from its last segment back to its first.
-    let gaps = (0..run.len())
-        .filter(|&position| {
-            let next = run[(position + 1) % run.len()].topology.index;
-            (run[position].topology.index + 1) % ring_len != next
+/// Whether every two sites are incident, and so one wall: segments of one
+/// ring that are adjacent or turned less than a quarter turn from each
+/// other, the same judgement the width construction makes of a wall pair.
+/// Nothing in such a set faces anything else, so a residue it walls alone
+/// is the bite of one corner or gentle arc and has no width. A sharp tip
+/// turns its walls to face each other and is measured.
+fn one_wall(sites: &[OrientedBoundarySegment]) -> bool {
+    sites.iter().enumerate().all(|(position, left)| {
+        sites[position + 1..].iter().all(|right| {
+            left.topology.ring == right.topology.ring
+                && (boundary_segments_are_incident(left.topology, right.topology)
+                    || left.tangent.x * right.tangent.x + left.tangent.y * right.tangent.y > 0.0)
         })
-        .collect::<Vec<_>>();
-    let [gap] = gaps[..] else {
-        return false;
-    };
-    run.rotate_left(gap + 1);
-    let turns = run.windows(2).map(|pair| {
-        let a = pair[0].end - pair[0].start;
-        let b = pair[1].end - pair[1].start;
-        (a.x * b.y - a.y * b.x).atan2(a.x * b.x + a.y * b.y)
-    });
-    let (mut positive, mut negative, mut total) = (false, false, 0.0);
-    for turn in turns {
-        positive |= turn > 0.0;
-        negative |= turn < 0.0;
-        total += turn.abs();
-    }
-    !(positive && negative) && total < std::f64::consts::PI
+    })
 }
 
 /// A maximal inscribed disk of the boundary's Voronoi diagram: its center,
@@ -1669,7 +1803,7 @@ fn component_width(
     reach: f64,
     contact_tolerance: f64,
 ) -> Option<ComponentWidth> {
-    if convex_chain(sites) {
+    if one_wall(sites) {
         return None;
     }
     let origin = component.bbox.min;
@@ -2510,6 +2644,84 @@ mod tests {
         assert!((width.disk.width().mm - 0.101).abs() < 1e-9);
 
         assert!(measure(0.103).is_none());
+    }
+
+    #[test]
+    fn ring_components_group_holes_with_the_smallest_outer_ring_around_them() {
+        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM)
+            .difference(&ContourSet::rectangle(
+                rect(2.0, 2.0, 8.0, 8.0),
+                tol::REGION_MM,
+            ))
+            .union(&ContourSet::rectangle(
+                rect(3.0, 3.0, 7.0, 7.0),
+                tol::REGION_MM,
+            ))
+            .difference(&ContourSet::rectangle(
+                rect(4.0, 4.0, 6.0, 6.0),
+                tol::REGION_MM,
+            ))
+            .union(&ContourSet::rectangle(
+                rect(20.0, 0.0, 30.0, 10.0),
+                tol::REGION_MM,
+            ));
+        assert_eq!(region.rings.len(), 5);
+
+        let components = region.ring_components();
+        let component_of = |min_x: f64| {
+            let ring = region
+                .ring_bounds
+                .iter()
+                .position(|bounds| bounds.min.x == min_x)
+                .unwrap();
+            components[ring]
+        };
+        assert_eq!(component_of(0.0), component_of(2.0));
+        assert_eq!(component_of(3.0), component_of(4.0));
+        assert_ne!(component_of(0.0), component_of(3.0));
+        assert_ne!(component_of(0.0), component_of(20.0));
+        assert_ne!(component_of(3.0), component_of(20.0));
+    }
+
+    #[test]
+    fn facing_components_keep_only_walls_within_reach_of_each_other() {
+        let trace = ContourSet::rectangle(rect(0.0, 0.0, 5.0, 0.1), tol::REGION_MM);
+        let pad = ContourSet::rectangle(rect(10.0, 0.0, 12.0, 2.0), tol::REGION_MM);
+        let neighbour = ContourSet::rectangle(rect(12.15, 0.0, 14.0, 2.0), tol::REGION_MM);
+        let region = trace.union(&pad).union(&neighbour);
+        assert_eq!(region.rings.len(), 3);
+
+        let same_bounds = |left: BBox, right: BBox| {
+            left.min.distance_to(right.min) < 1e-6 && left.max.distance_to(right.max) < 1e-6
+        };
+        let material = region.facing_components(0.2, 0.01, 0.0);
+        assert_eq!(material.rings.len(), 1);
+        assert!(same_bounds(material.bbox, trace.bbox));
+
+        let void = region.facing_components(0.0, 0.2, 0.0);
+        assert_eq!(void.rings.len(), 2);
+        assert!(same_bounds(void.bbox, pad.bbox.union(neighbour.bbox)));
+
+        let with_context = region.facing_components(0.0, 0.2, 10.0);
+        assert_eq!(with_context.rings.len(), 3);
+
+        // A notch faces across void; a plane web between holes across material.
+        let notched = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM).difference(
+            &ContourSet::rectangle(rect(1.9, 2.0, 2.1, 4.5), tol::REGION_MM),
+        );
+        assert_eq!(notched.facing_components(0.0, 0.3, 0.0).rings.len(), 1);
+        assert!(notched.facing_components(0.15, 0.15, 0.0).is_empty());
+        let webbed = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM)
+            .difference(&ContourSet::rectangle(
+                rect(1.0, 1.0, 1.9, 3.0),
+                tol::REGION_MM,
+            ))
+            .difference(&ContourSet::rectangle(
+                rect(2.1, 1.0, 3.0, 3.0),
+                tol::REGION_MM,
+            ));
+        assert_eq!(webbed.facing_components(0.3, 0.0, 0.0).rings.len(), 3);
+        assert!(webbed.facing_components(0.0, 0.15, 0.0).is_empty());
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -301,11 +301,11 @@ fn decimate_ring_inward(ring: &Ring, deviation_mm: f64) -> Ring {
 
 /// The closed edge cycle of one ring, as start/end point pairs.
 pub fn ring_edges(ring: &Ring) -> impl Iterator<Item = (Point, Point)> + '_ {
+    let point = |[x, y]: [f64; 2]| Point::new(x, y);
     ring.iter()
         .copied()
-        .zip(ring.iter().copied().cycle().skip(1))
-        .take(ring.len())
-        .map(|([x0, y0], [x1, y1])| (Point::new(x0, y0), Point::new(x1, y1)))
+        .zip(ring.iter().skip(1).chain(ring.first()).copied())
+        .map(move |(start, end)| (point(start), point(end)))
 }
 
 /// Signed area of one ring (positive when counter-clockwise).
@@ -616,7 +616,7 @@ impl ContourSet {
             let point = Point::new(x, y);
             if let Some(&outer) = outers.iter().find(|&&outer| {
                 self.ring_bounds[outer].contains_point(point)
-                    && ring_contains_point(&self.rings[outer], point)
+                    && ring_winding(&self.rings[outer], point) != 0
             }) {
                 components[index] = components[outer];
             }
@@ -758,13 +758,8 @@ impl ContourSet {
                         && bounds.min.x <= max_x + tol::EPSILON_MM
                         && min_x - tol::EPSILON_MM <= bounds.max.x
                 })
-                .flat_map(|(ring, _)| {
-                    ring.iter()
-                        .copied()
-                        .zip(ring.iter().copied().cycle().skip(1))
-                        .take(ring.len())
-                })
-                .filter_map(move |edge| horizontal_crossing(edge, y))
+                .flat_map(|(ring, _)| ring_edges(ring))
+                .filter_map(move |(start, end)| horizontal_crossing(start, end, y))
         };
         let mut by_height = (0..points.len()).collect::<Vec<_>>();
         by_height.sort_by(|left, right| {
@@ -993,12 +988,11 @@ impl ContourSet {
             return true;
         }
 
-        // Regularized boolean output nests pairwise-disjoint rings, so
-        // even-odd parity across rings coincides with the nonzero fill rule.
-        // A ring whose bounds miss the point cannot enclose it.
-        rings_near(tol::EPSILON_MM).fold(false, |inside, ring| {
-            inside ^ ring_contains_point(ring, point)
-        })
+        // A ring whose bounds miss the point cannot wind around it.
+        rings_near(tol::EPSILON_MM)
+            .map(|ring| ring_winding(ring, point))
+            .sum::<i32>()
+            != 0
     }
 
     /// Whether a closed disk is fully contained in the regularized region.
@@ -1376,17 +1370,29 @@ pub(crate) fn overlay_fill_rule(fill_rule: FillRule) -> OverlayFillRule {
     }
 }
 
-fn horizontal_crossing(([x0, y0], [x1, y1]): ([f64; 2], [f64; 2]), y: f64) -> Option<(f64, i32)> {
+/// Where an edge crosses the horizontal line at `y`, with its direction.
+fn horizontal_crossing(start: Point, end: Point, y: f64) -> Option<(f64, i32)> {
     // Half-open in y so a vertex shared by two edges is counted once, which
     // keeps the winding number honest.
-    let direction = if y0 <= y && y < y1 {
+    let direction = if start.y <= y && y < end.y {
         1
-    } else if y1 <= y && y < y0 {
+    } else if end.y <= y && y < start.y {
         -1
     } else {
         return None;
     };
-    Some((x0 + (y - y0) * (x1 - x0) / (y1 - y0), direction))
+    Some((
+        start.x + (y - start.y) * (end.x - start.x) / (end.y - start.y),
+        direction,
+    ))
+}
+
+/// The winding number of one ring around a point.
+fn ring_winding(ring: &Ring, point: Point) -> i32 {
+    ring_edges(ring)
+        .filter_map(|(start, end)| horizontal_crossing(start, end, point.y))
+        .filter_map(|(x, direction)| (x <= point.x).then_some(direction))
+        .sum()
 }
 
 fn flatten_shapes(shapes: Vec<Shape>) -> Vec<Ring> {
@@ -1431,36 +1437,9 @@ fn ring_to_contour(ring: Ring) -> Option<ContourBuf> {
     Some(ContourBuf::from_parts(bbox, cmds))
 }
 
-fn ring_contains_point(ring: &Ring, point: Point) -> bool {
-    if ring.len() < 3 {
-        return false;
-    }
-
-    let mut inside = false;
-    for index in 0..ring.len() {
-        let [x0, y0] = ring[index];
-        let [x1, y1] = ring[(index + 1) % ring.len()];
-        if (y0 > point.y) != (y1 > point.y) {
-            let crossing_x = x0 + (point.y - y0) * (x1 - x0) / (y1 - y0);
-            if point.x < crossing_x {
-                inside = !inside;
-            }
-        }
-    }
-    inside
-}
-
 fn ring_boundary_distance(ring: &Ring, point: Point) -> f64 {
-    if ring.is_empty() {
-        return f64::INFINITY;
-    }
-
-    (0..ring.len())
-        .map(|index| {
-            let [x0, y0] = ring[index];
-            let [x1, y1] = ring[(index + 1) % ring.len()];
-            dist::point_segment(point, Point::new(x0, y0), Point::new(x1, y1)).0
-        })
+    ring_edges(ring)
+        .map(|(start, end)| dist::point_segment(point, start, end).0)
         .fold(f64::INFINITY, f64::min)
 }
 
@@ -1519,7 +1498,7 @@ fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment>
                         start,
                         end,
                         tangent: metric.edge_tangent(edge, tangent_radius),
-                        bbox: segment_bbox(start, end),
+                        bbox: BBox::spanning(start, end),
                     },
                 )
         })
@@ -1847,7 +1826,7 @@ fn component_width(
                 start,
                 end,
                 tangent: source.tangent,
-                bbox: segment_bbox(start, end),
+                bbox: BBox::spanning(start, end),
             }
         })
         .collect::<Vec<_>>();
@@ -2223,17 +2202,15 @@ fn region_boundary_within_distance(
     end: Point,
     distance: f64,
 ) -> bool {
-    let expanded = segment_bbox(start, end).expand(distance);
-    region.rings.iter().any(|ring| {
-        (0..ring.len()).any(|index| {
-            let [other_start_x, other_start_y] = ring[index];
-            let [other_end_x, other_end_y] = ring[(index + 1) % ring.len()];
-            let other_start = Point::new(other_start_x, other_start_y);
-            let other_end = Point::new(other_end_x, other_end_y);
-            expanded.intersects(segment_bbox(other_start, other_end))
+    let expanded = BBox::spanning(start, end).expand(distance);
+    region
+        .rings
+        .iter()
+        .flat_map(ring_edges)
+        .any(|(other_start, other_end)| {
+            expanded.intersects(BBox::spanning(other_start, other_end))
                 && dist::segments(start, end, other_start, other_end).0 <= distance
         })
-    })
 }
 
 fn boundary_tangents_oppose(
@@ -2614,7 +2591,7 @@ fn regions_within_distance(left: &ContourSet, right: &ContourSet, distance: f64)
             let [left_end_x, left_end_y] = left_ring[(left_index + 1) % left_ring.len()];
             let left_start = Point::new(left_start_x, left_start_y);
             let left_end = Point::new(left_end_x, left_end_y);
-            let left_bbox = segment_bbox(left_start, left_end).expand(threshold);
+            let left_bbox = BBox::spanning(left_start, left_end).expand(threshold);
             for right_ring in &right.rings {
                 for right_index in 0..right_ring.len() {
                     let [right_start_x, right_start_y] = right_ring[right_index];
@@ -2622,7 +2599,7 @@ fn regions_within_distance(left: &ContourSet, right: &ContourSet, distance: f64)
                         right_ring[(right_index + 1) % right_ring.len()];
                     let right_start = Point::new(right_start_x, right_start_y);
                     let right_end = Point::new(right_end_x, right_end_y);
-                    if !left_bbox.intersects(segment_bbox(right_start, right_end)) {
+                    if !left_bbox.intersects(BBox::spanning(right_start, right_end)) {
                         continue;
                     }
                     let (separation, _, _) =
@@ -2635,13 +2612,6 @@ fn regions_within_distance(left: &ContourSet, right: &ContourSet, distance: f64)
         }
     }
     false
-}
-
-fn segment_bbox(start: Point, end: Point) -> BBox {
-    BBox::new(
-        Point::new(start.x.min(end.x), start.y.min(end.y)),
-        Point::new(start.x.max(end.x), start.y.max(end.y)),
-    )
 }
 
 #[cfg(test)]
@@ -2781,7 +2751,7 @@ mod tests {
             start: Point::new(start.0, start.1),
             end: Point::new(end.0, end.1),
             tangent: Point::new(end.0 - start.0, end.1 - start.1),
-            bbox: segment_bbox(Point::new(start.0, start.1), Point::new(end.0, end.1)),
+            bbox: BBox::spanning(Point::new(start.0, start.1), Point::new(end.0, end.1)),
         };
         // A right-to-left host touched at two interior points by other rings.
         let sites = [

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -363,10 +363,12 @@ pub fn rings_area(rings: &[Ring]) -> f64 {
 /// operation is a regularized set operation.
 #[derive(Debug, Clone)]
 pub struct ContourSet {
+    /// Bounds of `rings`, fixed at construction like the rings themselves:
+    /// a region is built through its constructors, never edited in place.
     pub bbox: BBox,
     pub rings: Vec<Ring>,
-    /// Bounds of each ring, indexed like `rings`.
-    pub ring_bounds: Vec<BBox>,
+    /// Bounds of each ring, indexed like `rings` and fixed with them.
+    pub(crate) ring_bounds: Vec<BBox>,
     pub tolerance: f64,
 }
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -599,10 +599,11 @@ impl ContourSet {
             .collect()
     }
 
-    /// The component of each ring, by ring index. Regularized rings nest
-    /// without crossing and holes are wound opposite their outer ring, so
-    /// a hole belongs to the smallest outer ring around it.
-    fn ring_components(&self) -> Vec<usize> {
+    /// The component of each ring, by ring index, and the outer ring of
+    /// each component. Regularized rings nest without crossing and holes
+    /// are wound opposite their outer ring, so a hole belongs to the
+    /// smallest outer ring around it.
+    fn ring_components(&self) -> (Vec<usize>, Vec<usize>) {
         let areas = self.rings.iter().map(ring_signed_area).collect::<Vec<_>>();
         let mut outers = (0..self.rings.len())
             .filter(|&ring| areas[ring] > 0.0)
@@ -627,22 +628,24 @@ impl ContourSet {
                 components[index] = components[outer];
             }
         }
-        components
+        (components, outers)
     }
 
-    /// The components in which two boundary walls face each other across
-    /// material within `material_mm` or across void within `void_mm`,
-    /// together with every component within `context_mm` of them. Walls
-    /// face when they are not incident: on one ring, neither adjacent nor
-    /// turned the same way, exactly as the width construction judges a
-    /// wall pair. Material lies to the left of travel, so two walls of one
-    /// component face across material when each has the other's nearest
-    /// point on its left and across void when each has it on its right; a
-    /// nearest point along a wall's own line, as at the corners of a notch
-    /// or of aligned holes, leaves the side open and both reaches apply.
-    /// Distinct components always face across void.
+    /// The material around walls that face each other across material
+    /// within `material_mm` or across void within `void_mm`: every ring
+    /// within `context_mm` of such a wall, with the outer ring of each
+    /// component so reached. A hole farther away is filled, since nothing
+    /// it does reaches the facing walls. Walls face when they are not
+    /// incident: on one ring, neither adjacent nor turned the same way,
+    /// exactly as the width construction judges a wall pair. Material lies
+    /// to the left of travel, so two walls of one component face across
+    /// material when each has the other's nearest point on its left and
+    /// across void when each has it on its right; a nearest point along a
+    /// wall's own line, as at the corners of a notch or of aligned holes,
+    /// leaves the side open and both reaches apply. Distinct components
+    /// always face across void.
     fn facing_components(&self, material_mm: f64, void_mm: f64, context_mm: f64) -> Self {
-        let components = self.ring_components();
+        let (components, outers) = self.ring_components();
         let reach = material_mm.max(void_mm).max(context_mm);
         let grid = SegmentGrid::new(source_boundary_segments(self), reach);
         let segments = &grid.segments;
@@ -705,15 +708,17 @@ impl ContourSet {
                 selected[segments[other as usize].topology.ring] = true;
             }
         }
-        let mut kept = vec![false; self.rings.len()];
+        let mut kept = selected;
         for (ring, &component) in components.iter().enumerate() {
-            kept[component] |= selected[ring];
+            if kept[ring] {
+                kept[outers[component]] = true;
+            }
         }
         Self::from_regularized(
             self.rings
                 .iter()
-                .zip(&components)
-                .filter(|&(_, &component)| kept[component])
+                .zip(&kept)
+                .filter(|&(_, &keep)| keep)
                 .map(|(ring, _)| ring.clone())
                 .collect(),
             self.tolerance,
@@ -2682,7 +2687,7 @@ mod tests {
             ));
         assert_eq!(region.rings.len(), 5);
 
-        let components = region.ring_components();
+        let (components, _) = region.ring_components();
         let component_of = |min_x: f64| {
             let ring = region
                 .ring_bounds
@@ -2726,7 +2731,7 @@ mod tests {
         );
         assert_eq!(notched.facing_components(0.0, 0.3, 0.0).rings.len(), 1);
         assert!(notched.facing_components(0.15, 0.15, 0.0).is_empty());
-        let webbed = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM)
+        let webbed = ContourSet::rectangle(rect(0.0, 0.0, 8.0, 4.0), tol::REGION_MM)
             .difference(&ContourSet::rectangle(
                 rect(1.0, 1.0, 1.9, 3.0),
                 tol::REGION_MM,
@@ -2734,8 +2739,14 @@ mod tests {
             .difference(&ContourSet::rectangle(
                 rect(2.1, 1.0, 3.0, 3.0),
                 tol::REGION_MM,
+            ))
+            .difference(&ContourSet::rectangle(
+                rect(6.0, 1.0, 7.0, 3.0),
+                tol::REGION_MM,
             ));
-        assert_eq!(webbed.facing_components(0.3, 0.0, 0.0).rings.len(), 3);
+        let nearby_web = webbed.facing_components(0.3, 0.0, 0.0);
+        assert_eq!(nearby_web.rings.len(), 3);
+        assert!(nearby_web.contains_point(Point::new(6.5, 2.0)));
         assert!(webbed.facing_components(0.0, 0.15, 0.0).is_empty());
     }
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -588,6 +588,22 @@ impl ContourSet {
         if self.is_empty() {
             return result;
         }
+        if let [point] = points {
+            let winding = self
+                .rings
+                .iter()
+                .flat_map(|ring| {
+                    ring.iter()
+                        .copied()
+                        .zip(ring.iter().copied().cycle().skip(1))
+                        .take(ring.len())
+                })
+                .filter_map(|edge| horizontal_crossing(edge, point.y))
+                .filter_map(|(x, direction)| (x <= point.x).then_some(direction))
+                .sum::<i32>();
+            result[0] = f64::from(winding != 0);
+            return result;
+        }
         let mut by_height = (0..points.len()).collect::<Vec<_>>();
         by_height.sort_by(|left, right| {
             points[*left]
@@ -616,18 +632,7 @@ impl ContourSet {
             }
             let mut crossings = edges
                 .iter()
-                .filter_map(|([x0, y0], [x1, y1])| {
-                    // Half-open in y so a vertex shared by two edges is counted
-                    // once, which is what keeps the winding number honest.
-                    let direction = if *y0 <= y && y < *y1 {
-                        1
-                    } else if *y1 <= y && y < *y0 {
-                        -1
-                    } else {
-                        return None;
-                    };
-                    Some((x0 + (y - y0) * (x1 - x0) / (y1 - y0), direction))
-                })
+                .filter_map(|&edge| horizontal_crossing(edge, y))
                 .collect::<Vec<_>>();
             crossings.sort_by(|left, right| left.0.total_cmp(&right.0));
             let mut crossing = 0;
@@ -1187,6 +1192,19 @@ pub(crate) fn overlay_fill_rule(fill_rule: FillRule) -> OverlayFillRule {
     }
 }
 
+fn horizontal_crossing(([x0, y0], [x1, y1]): ([f64; 2], [f64; 2]), y: f64) -> Option<(f64, i32)> {
+    // Half-open in y so a vertex shared by two edges is counted once, which
+    // keeps the winding number honest.
+    let direction = if y0 <= y && y < y1 {
+        1
+    } else if y1 <= y && y < y0 {
+        -1
+    } else {
+        return None;
+    };
+    Some((x0 + (y - y0) * (x1 - x0) / (y1 - y0), direction))
+}
+
 fn flatten_shapes(shapes: Vec<Shape>) -> Vec<Ring> {
     shapes.into_iter().flatten().collect()
 }
@@ -1379,6 +1397,9 @@ fn two_sided_residual_components(
     residual: &ContourSet,
     reach: f64,
 ) -> Vec<TwoSidedResidualComponent> {
+    if residual.is_empty() {
+        return Vec::new();
+    }
     let segments = SegmentGrid::new(source_boundary_segments(source), reach);
     let contact_tolerance = source.tolerance.max(residual.tolerance);
     residual

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -406,17 +406,7 @@ impl std::error::Error for GapRegularizationError {}
 
 impl ContourSet {
     pub fn new(rings: Vec<Ring>, fill_rule: FillRule, tolerance: f64) -> Self {
-        let rings = filter_significant_rings(simplify_rings(rings, fill_rule), tolerance);
-        let ring_bounds = rings
-            .iter()
-            .map(|ring| rings_bbox(std::slice::from_ref(ring)))
-            .collect::<Vec<_>>();
-        Self {
-            bbox: ring_bounds.iter().copied().fold(BBox::empty(), BBox::union),
-            rings,
-            ring_bounds,
-            tolerance,
-        }
+        Self::from_regularized(simplify_rings(rings, fill_rule), tolerance)
     }
 
     /// A region from rings a regularized boolean operation produced, kept
@@ -633,26 +623,28 @@ impl ContourSet {
     }
 
     /// The material within `reach_mm` of walls that face each other across
-    /// material within `material_mm` or across void within `void_mm`:
-    /// every ring within reach of such a wall, with the outer ring of each
-    /// component so reached, clipped to the reach around the facing walls.
-    /// A hole farther away is filled and material farther away is cut,
-    /// since neither reaches the facing walls; the cut's own edges disturb
-    /// the morphology only within a disk diameter of themselves, so a reach
-    /// of three radii keeps the residue at the facing walls exact. Walls
-    /// face when they are not
-    /// incident: on one ring, neither adjacent nor turned the same way,
-    /// exactly as the width construction judges a wall pair. Material lies
-    /// to the left of travel, so two walls of one component face across
-    /// material when each has the other's nearest point on its left and
-    /// across void when each has it on its right; a nearest point along a
-    /// wall's own line, as at the corners of a notch or of aligned holes,
-    /// leaves the side open and both reaches apply. Distinct components
-    /// always face across void.
+    /// material within `material_mm` or across void within `void_mm`.
+    ///
+    /// Every ring within reach of such a wall comes along with the outer
+    /// ring of its component, and the material is clipped to the reach
+    /// around the facing walls. A hole farther away is filled and material
+    /// farther away is cut, since neither reaches the facing walls; the
+    /// cut's own edges disturb the morphology only within a disk diameter
+    /// of themselves, so a reach of three radii keeps the residue at the
+    /// facing walls exact.
+    ///
+    /// Walls face when they are not incident: on one ring, neither adjacent
+    /// nor turned the same way, exactly as the width construction judges a
+    /// wall pair. Material lies to the left of travel, so two walls of one
+    /// component face across material when each has the other's nearest
+    /// point on its left and across void when each has it on its right; a
+    /// nearest point along a wall's own line, as at the corners of a notch
+    /// or of aligned holes, leaves the side open and both reaches apply.
+    /// Distinct components always face across void.
     fn facing_components(&self, material_mm: f64, void_mm: f64, reach_mm: f64) -> Self {
         let (components, outers) = self.ring_components();
-        let reach = material_mm.max(void_mm).max(reach_mm);
-        let grid = SegmentGrid::new(source_boundary_segments(self), reach);
+        let pitch = material_mm.max(void_mm).max(reach_mm);
+        let grid = SegmentGrid::new(source_boundary_segments(self), pitch);
         let segments = &grid.segments;
         let sees_left = |wall: &OrientedBoundarySegment, across: Point| {
             let along = wall.end - wall.start;
@@ -772,13 +764,6 @@ impl ContourSet {
                 })
                 .filter_map(move |edge| horizontal_crossing(edge, y))
         };
-        if let [point] = points {
-            let winding = crossings_at(point.y, point.x, point.x)
-                .filter_map(|(x, direction)| (x <= point.x).then_some(direction))
-                .sum::<i32>();
-            result[0] = f64::from(winding != 0);
-            return result;
-        }
         let mut by_height = (0..points.len()).collect::<Vec<_>>();
         by_height.sort_by(|left, right| {
             points[*left]
@@ -1240,18 +1225,16 @@ impl ContourSet {
         radius: f64,
         width_mm: f64,
     ) -> Vec<TwoSidedResidualComponent> {
-        // Opening is the union of the disks inside a region, and a disk is
-        // connected, so every component opens on its own, and the disks
-        // through a residue point reach a diameter from it. A width is a
-        // disk touching two facing walls, so it is at least their
-        // separation: material whose walls never face each other that
-        // closely has no width to find, and only the material within a
-        // diameter of facing walls decides the residue within a radius of
-        // them, where any width lies. Separate components share a width
-        // only where they touch within tolerance.
-        // The snap-rounded width construction moves walls by a tolerance,
-        // and `M \ (X ∩ M)` is `M \ X`, so the opening's clip to the
-        // source is not needed to find what the opening removed.
+        // A width is a disk touching two facing walls, so it is at least
+        // their separation: material whose walls never face each other that
+        // closely has no width to find. Any width lies within a radius of
+        // its walls, and the disks through a residue point reach a diameter
+        // from it, so only the material within a few radii of facing walls
+        // decides the residue there. Separate components share a width only
+        // where they touch within tolerance. The snap-rounded width
+        // construction moves walls by a tolerance, and `M \ (X ∩ M)` is
+        // `M \ X`, so the opening's clip to the source is not needed to
+        // find what the opening removed.
         self.two_sided_residual(radius, |region, radius| {
             let facing = width_mm + 4.0 * region.tolerance;
             let touching = 3.0 * region.tolerance + tol::FLATTEN_MM;
@@ -1268,13 +1251,11 @@ impl ContourSet {
         radius: f64,
         width_mm: f64,
     ) -> Vec<TwoSidedResidualComponent> {
-        // Closing fills only void narrower than the disk diameter, between
-        // walls facing across it, and a width is at least the separation of
-        // the walls it touches. A residue point lies within a radius of its
-        // walls, and the disks that decide it reach a diameter further, so
-        // everything within two diameters comes along as context and the
-        // closing of that neighbourhood is the closing of the whole region
-        // there.
+        // A gap is a disk touching two walls facing across void, so it is
+        // at least their separation. A residue point lies within a radius
+        // of its walls and the disks that decide it reach a diameter
+        // further, so the closing of the material within two diameters of
+        // facing walls is the closing of the whole region there.
         self.two_sided_residual(radius, |region, radius| {
             let facing = width_mm + 4.0 * region.tolerance;
             let reach = 4.0 * (radius + 2.0 * region.tolerance);

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -419,8 +419,9 @@ impl ContourSet {
         }
     }
 
-    /// A region from rings that are already regularized, kept as they are.
-    fn from_regularized(rings: Vec<Ring>, tolerance: f64) -> Self {
+    /// A region from rings a regularized boolean operation produced, kept
+    /// as they are: non-overlapping, holes wound opposite their outer ring.
+    pub fn from_regularized(rings: Vec<Ring>, tolerance: f64) -> Self {
         let rings = filter_significant_rings(rings, tolerance);
         let ring_bounds = rings
             .iter()
@@ -595,7 +596,7 @@ impl ContourSet {
     pub fn connected_components(&self) -> Vec<Self> {
         simplify_shapes(self.rings.clone(), FillRule::NonZero)
             .into_iter()
-            .map(|shape| Self::new(shape, FillRule::NonZero, self.tolerance))
+            .map(|shape| Self::from_regularized(shape, self.tolerance))
             .collect()
     }
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -6,7 +6,6 @@
 //! dilation over filled point sets, shared by every dialect so IPC, Gerber,
 //! SVG, and comparison all use the same geometry semantics.
 
-use std::collections::HashMap;
 use std::fmt;
 
 use boostvoronoi::prelude::{
@@ -28,6 +27,7 @@ use i_overlay::mesh::style::{LineJoin as OutlineLineJoin, OutlineStyle};
 use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
 use crate::geom::dist::{self, Distance};
+use crate::geom::grid::CellGrid;
 use crate::geom::path::{ContourBuf, PathCmd, contours_to_kurbo, stroke_to_fill, transform_cmds};
 use crate::geom::point::Point;
 use crate::geom::store::{Path, PathArena};
@@ -365,6 +365,8 @@ pub fn rings_area(rings: &[Ring]) -> f64 {
 pub struct ContourSet {
     pub bbox: BBox,
     pub rings: Vec<Ring>,
+    /// Bounds of each ring, indexed like `rings`.
+    pub ring_bounds: Vec<BBox>,
     pub tolerance: f64,
 }
 
@@ -405,9 +407,14 @@ impl std::error::Error for GapRegularizationError {}
 impl ContourSet {
     pub fn new(rings: Vec<Ring>, fill_rule: FillRule, tolerance: f64) -> Self {
         let rings = filter_significant_rings(simplify_rings(rings, fill_rule), tolerance);
+        let ring_bounds = rings
+            .iter()
+            .map(|ring| rings_bbox(std::slice::from_ref(ring)))
+            .collect::<Vec<_>>();
         Self {
-            bbox: rings_bbox(&rings),
+            bbox: ring_bounds.iter().copied().fold(BBox::empty(), BBox::union),
             rings,
+            ring_bounds,
             tolerance,
         }
     }
@@ -416,6 +423,7 @@ impl ContourSet {
         Self {
             bbox: BBox::empty(),
             rings: Vec::new(),
+            ring_bounds: Vec::new(),
             tolerance,
         }
     }
@@ -588,17 +596,29 @@ impl ContourSet {
         if self.is_empty() {
             return result;
         }
-        if let [point] = points {
-            let winding = self
-                .rings
+        // Only a ring whose bounds reach the query line crosses it, and a
+        // ring wholly to one side of every point on the line contributes
+        // crossings that balance to nothing, so those rings are skipped.
+        let crossings_at = |y: f64, min_x: f64, max_x: f64| {
+            self.rings
                 .iter()
-                .flat_map(|ring| {
+                .zip(&self.ring_bounds)
+                .filter(move |(_, bounds)| {
+                    bounds.min.y <= y
+                        && y <= bounds.max.y
+                        && bounds.min.x <= max_x + tol::EPSILON_MM
+                        && min_x - tol::EPSILON_MM <= bounds.max.x
+                })
+                .flat_map(|(ring, _)| {
                     ring.iter()
                         .copied()
                         .zip(ring.iter().copied().cycle().skip(1))
                         .take(ring.len())
                 })
-                .filter_map(|edge| horizontal_crossing(edge, point.y))
+                .filter_map(move |edge| horizontal_crossing(edge, y))
+        };
+        if let [point] = points {
+            let winding = crossings_at(point.y, point.x, point.x)
                 .filter_map(|(x, direction)| (x <= point.x).then_some(direction))
                 .sum::<i32>();
             result[0] = f64::from(winding != 0);
@@ -611,16 +631,6 @@ impl ContourSet {
                 .total_cmp(&points[*right].y)
                 .then_with(|| points[*left].x.total_cmp(&points[*right].x))
         });
-        let edges = self
-            .rings
-            .iter()
-            .flat_map(|ring| {
-                ring.iter()
-                    .copied()
-                    .zip(ring.iter().copied().cycle().skip(1))
-                    .take(ring.len())
-            })
-            .collect::<Vec<_>>();
 
         let mut first = 0;
         while first < by_height.len() {
@@ -630,10 +640,13 @@ impl ContourSet {
             {
                 last += 1;
             }
-            let mut crossings = edges
+            let (min_x, max_x) = by_height[first..last]
                 .iter()
-                .filter_map(|&edge| horizontal_crossing(edge, y))
-                .collect::<Vec<_>>();
+                .map(|&point| points[point].x)
+                .fold((f64::INFINITY, f64::NEG_INFINITY), |(low, high), x| {
+                    (low.min(x), high.max(x))
+                });
+            let mut crossings = crossings_at(y, min_x, max_x).collect::<Vec<_>>();
             crossings.sort_by(|left, right| left.0.total_cmp(&right.0));
             let mut crossing = 0;
             let mut winding = 0;
@@ -693,8 +706,7 @@ impl ContourSet {
                 .clamp(0.0, count as f64 - 1.0) as usize
         };
         let mut areas = vec![0.0; columns * rows];
-        for ring in &self.rings {
-            let ring_bbox = rings_bbox(std::slice::from_ref(ring));
+        for (ring, &ring_bbox) in self.rings.iter().zip(&self.ring_bounds) {
             for row in index(ring_bbox.min.y, bounds.min.y, height, rows)
                 ..=index(ring_bbox.max.y, bounds.min.y, height, rows)
             {
@@ -828,17 +840,21 @@ impl ContourSet {
         }
 
         let epsilon = self.tolerance.max(tol::EPSILON_MM);
-        if self
-            .rings
-            .iter()
-            .any(|ring| ring_boundary_distance(ring, point) <= epsilon)
-        {
+        let rings_near = |reach: f64| {
+            self.rings
+                .iter()
+                .zip(&self.ring_bounds)
+                .filter(move |(_, bounds)| bounds.expand(reach).contains_point(point))
+                .map(|(ring, _)| ring)
+        };
+        if rings_near(epsilon).any(|ring| ring_boundary_distance(ring, point) <= epsilon) {
             return true;
         }
 
         // Regularized boolean output nests pairwise-disjoint rings, so
         // even-odd parity across rings coincides with the nonzero fill rule.
-        self.rings.iter().fold(false, |inside, ring| {
+        // A ring whose bounds miss the point cannot enclose it.
+        rings_near(tol::EPSILON_MM).fold(false, |inside, ring| {
             inside ^ ring_contains_point(ring, point)
         })
     }
@@ -1422,9 +1438,8 @@ fn two_sided_residual_components(
 /// Boundary segments bucketed on a uniform grid, so the segments around one
 /// residue component are found without scanning the whole boundary.
 struct SegmentGrid {
-    cell_mm: f64,
     segments: Vec<OrientedBoundarySegment>,
-    cells: HashMap<(i64, i64), Vec<u32>>,
+    grid: CellGrid,
 }
 
 /// Grid pitch changes candidate lookup cost only. A fixed floor prevents a
@@ -1433,34 +1448,24 @@ const MIN_SEGMENT_GRID_CELL_MM: f64 = 1.0;
 
 impl SegmentGrid {
     fn new(segments: Vec<OrientedBoundarySegment>, cell_mm: f64) -> Self {
-        let cell_mm = cell_mm.max(MIN_SEGMENT_GRID_CELL_MM);
-        let mut cells: HashMap<(i64, i64), Vec<u32>> = HashMap::new();
-        for (index, segment) in segments.iter().enumerate() {
-            for cell in Self::cells_of(segment.bbox, cell_mm) {
-                cells.entry(cell).or_default().push(index as u32);
-            }
-        }
-        Self {
-            cell_mm,
-            segments,
-            cells,
-        }
-    }
-
-    fn cells_of(bbox: BBox, cell_mm: f64) -> impl Iterator<Item = (i64, i64)> {
-        let cell = move |value: f64| (value / cell_mm).floor() as i64;
-        let (min_x, max_x) = (cell(bbox.min.x), cell(bbox.max.x));
-        let (min_y, max_y) = (cell(bbox.min.y), cell(bbox.max.y));
-        (min_x..=max_x).flat_map(move |x| (min_y..=max_y).map(move |y| (x, y)))
+        let bounds = segments
+            .iter()
+            .map(|segment| segment.bbox)
+            .fold(BBox::empty(), BBox::union);
+        let pitch = CellGrid::pitch(cell_mm.max(MIN_SEGMENT_GRID_CELL_MM), bounds);
+        let grid = CellGrid::new(
+            pitch,
+            bounds,
+            segments.iter().enumerate().flat_map(|(id, segment)| {
+                CellGrid::cells_of(segment.bbox, pitch).map(move |cell| (id as u32, cell))
+            }),
+        );
+        Self { segments, grid }
     }
 
     /// The segments whose bounds meet `query`, in index order, each once.
     fn near(&self, query: BBox) -> Vec<OrientedBoundarySegment> {
-        let mut indices = Self::cells_of(query, self.cell_mm)
-            .filter_map(|cell| self.cells.get(&cell))
-            .flatten()
-            .copied()
-            .collect::<Vec<_>>();
+        let mut indices = self.grid.rectangle(query).collect::<Vec<_>>();
         indices.sort_unstable();
         indices.dedup();
         indices
@@ -2480,7 +2485,7 @@ mod tests {
         let region = ContourSet::rectangle(rect(0.0, 0.0, 400.0, 10.0), tol::REGION_MM);
         let grid = SegmentGrid::new(source_boundary_segments(&region), 0.05);
 
-        assert_eq!(grid.cell_mm, MIN_SEGMENT_GRID_CELL_MM);
+        assert_eq!(grid.grid.pitch_mm(), MIN_SEGMENT_GRID_CELL_MM);
         let near = grid.near(rect(199.9, -0.1, 200.1, 0.1));
         assert_eq!(near.len(), 1);
         assert_eq!(near[0].start.y, 0.0);

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -655,7 +655,7 @@ impl ContourSet {
         let faces = |left: &OrientedBoundarySegment, right: &OrientedBoundarySegment| {
             if left.topology.ring == right.topology.ring
                 && (boundary_segments_are_incident(left.topology, right.topology)
-                    || left.tangent.x * right.tangent.x + left.tangent.y * right.tangent.y > 0.0)
+                    || left.tangent.x * right.tangent.x + left.tangent.y * right.tangent.y >= 0.0)
             {
                 return false;
             }
@@ -1484,7 +1484,8 @@ fn closing_residual(region: &ContourSet, radius: f64) -> ContourSet {
 }
 
 /// Every source boundary edge longer than the region tolerance, in ring
-/// order.
+/// order. The kept edges are numbered consecutively, so two that meet
+/// across a dropped sub-tolerance edge remain adjacent.
 fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment> {
     source
         .rings
@@ -1495,20 +1496,26 @@ fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment>
             // Keep the two-sided chord local even when the whole ring is
             // smaller than the ordinary geometry resolution.
             let tangent_radius = tol::FLATTEN_MM.min(metric.perimeter() / 8.0);
-            ring_edges(ring)
+            let kept = ring_edges(ring)
                 .enumerate()
                 .filter(|(_, (start, end))| start.distance_to(*end) > source.tolerance)
-                .map(move |(index, (start, end))| OrientedBoundarySegment {
-                    topology: BoundarySegment {
-                        ring: ring_id,
-                        index,
-                        ring_len: ring.len(),
+                .collect::<Vec<_>>();
+            let ring_len = kept.len();
+            kept.into_iter()
+                .enumerate()
+                .map(
+                    move |(index, (edge, (start, end)))| OrientedBoundarySegment {
+                        topology: BoundarySegment {
+                            ring: ring_id,
+                            index,
+                            ring_len,
+                        },
+                        start,
+                        end,
+                        tangent: metric.edge_tangent(edge, tangent_radius),
+                        bbox: segment_bbox(start, end),
                     },
-                    start,
-                    end,
-                    tangent: metric.edge_tangent(index, tangent_radius),
-                    bbox: segment_bbox(start, end),
-                })
+                )
         })
         .collect()
 }
@@ -1743,7 +1750,7 @@ fn planar_grid_sites(
 }
 
 /// Whether every two sites are incident, and so one wall: segments of one
-/// ring that are adjacent or turned less than a quarter turn from each
+/// ring that are adjacent or turned no more than a quarter turn from each
 /// other, the same judgement the width construction makes of a wall pair.
 /// Nothing in such a set faces anything else, so a residue it walls alone
 /// is the bite of one corner or gentle arc and has no width. A sharp tip
@@ -1753,7 +1760,7 @@ fn one_wall(sites: &[OrientedBoundarySegment]) -> bool {
         sites[position + 1..].iter().all(|right| {
             left.topology.ring == right.topology.ring
                 && (boundary_segments_are_incident(left.topology, right.topology)
-                    || left.tangent.x * right.tangent.x + left.tangent.y * right.tangent.y > 0.0)
+                    || left.tangent.x * right.tangent.x + left.tangent.y * right.tangent.y >= 0.0)
         })
     })
 }
@@ -1844,15 +1851,17 @@ fn component_width(
     // Which sites are one wall. A ring's two sides of a channel are
     // traversed in opposite directions, so two segments of one ring face
     // each other only when their directions oppose; ring-adjacent segments
-    // and segments whose resolution-scale tangents are within a quarter turn
-    // are the same wall. The averaged tangent prevents a microscopic reversal
-    // from manufacturing an opposing branch. Segments of different rings are
-    // one wall only where they touch.
+    // and segments whose resolution-scale tangents are no more than a
+    // quarter turn apart are the same wall, as a disk touching both edges
+    // of a square corner is a corner disk, not a width. The averaged
+    // tangent prevents a microscopic reversal from manufacturing an
+    // opposing branch. Segments of different rings are one wall only where
+    // they touch.
     let incident = |i: usize, j: usize| {
         let (a, b) = (&sites[i], &sites[j]);
         if a.topology.ring == b.topology.ring {
             boundary_segments_are_incident(a.topology, b.topology)
-                || a.tangent.x * b.tangent.x + a.tangent.y * b.tangent.y > 0.0
+                || a.tangent.x * b.tangent.x + a.tangent.y * b.tangent.y >= 0.0
         } else {
             [lines[i].start, lines[i].end]
                 .iter()

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -1227,18 +1227,21 @@ impl ContourSet {
         width_mm: f64,
     ) -> Vec<TwoSidedResidualComponent> {
         // Opening is the union of the disks inside a region, and a disk is
-        // connected, so every component opens on its own. A width is a disk
-        // touching two facing walls, so it is at least their separation: a
-        // component whose walls never face each other across its material
-        // that closely has no width to find. Separate components share a
-        // width only where they touch within tolerance. The snap-rounded
-        // width construction moves walls by a tolerance, and `M \ (X ∩ M)`
-        // is `M \ X`, so the opening's clip to the source is not needed to
-        // find what the opening removed.
+        // connected, so every component opens on its own, and the disks
+        // through a residue point reach a diameter from it. A width is a
+        // disk touching two facing walls, so it is at least their
+        // separation: material whose walls never face each other that
+        // closely has no width to find, and only the material within a
+        // diameter of facing walls decides their residue. Separate
+        // components share a width only where they touch within tolerance.
+        // The snap-rounded width construction moves walls by a tolerance,
+        // and `M \ (X ∩ M)` is `M \ X`, so the opening's clip to the
+        // source is not needed to find what the opening removed.
         self.two_sided_residual(radius, |region, radius| {
             let facing = width_mm + 4.0 * region.tolerance;
             let touching = 3.0 * region.tolerance + tol::FLATTEN_MM;
-            let candidates = region.facing_components(facing, touching, 0.0);
+            let context = 2.0 * (radius + 2.0 * region.tolerance);
+            let candidates = region.facing_components(facing, touching, context);
             candidates.difference(&candidates.disk_erode(radius).disk_dilate(radius))
         })
     }

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -1717,15 +1717,50 @@ fn component_width(
                 .any(|point| [lines[j].start, lines[j].end].contains(point))
         }
     };
-    // Any disk within the morphology reach that touches two eligible walls
-    // proves those walls are no farther apart than its diameter. Allow one
-    // contact tolerance at each wall for the snap-rounded residual, then
-    // leave every surviving measurement to the Voronoi construction below.
+    let component_edges = component
+        .rings
+        .iter()
+        .flat_map(ring_edges)
+        .collect::<Vec<_>>();
+    // A maximal disk centered in the component is no larger than the
+    // component's clearance to its nearest wall, which the farthest vertex
+    // from that wall bounds. Both walls of a width therefore lie within that
+    // reach of the component; a corner's own bite is walled by its two edges
+    // alone and never reaches the far side of the feature. Any disk within
+    // the morphology reach that touches two eligible walls also proves those
+    // walls are no farther apart than its diameter. Allow one contact
+    // tolerance at each wall for the snap-rounded residual, and the chord
+    // deviation of a sampled curved axis, then leave every surviving
+    // measurement to the Voronoi construction below.
     let candidate_diameter = 2.0 * (reach + contact_tolerance);
+    let farthest_vertex = |site: &OrientedBoundarySegment| {
+        component
+            .rings
+            .iter()
+            .flat_map(|ring| ring.iter())
+            .map(|&[x, y]| dist::point_segment(Point::new(x, y), site.start, site.end).0)
+            .fold(0.0, f64::max)
+    };
+    let clearance_bound = sites
+        .iter()
+        .map(farthest_vertex)
+        .fold(f64::INFINITY, f64::min)
+        + 2.0 * contact_tolerance
+        + tol::FLATTEN_MM;
+    let within_reach = sites
+        .iter()
+        .map(|site| {
+            component_edges.iter().any(|&(start, end)| {
+                dist::segments(start, end, site.start, site.end).0 <= clearance_bound
+            })
+        })
+        .collect::<Vec<_>>();
     let has_reachable_wall_pair = (0..sites.len())
         .flat_map(|first| (first + 1..sites.len()).map(move |second| (first, second)))
         .any(|(first, second)| {
-            !incident(first, second)
+            within_reach[first]
+                && within_reach[second]
+                && !incident(first, second)
                 && dist::segments(
                     sites[first].start,
                     sites[first].end,
@@ -1764,11 +1799,6 @@ fn component_width(
             second,
         }
     };
-    let component_edges = component
-        .rings
-        .iter()
-        .flat_map(ring_edges)
-        .collect::<Vec<_>>();
 
     // Vertices: tangent to every site around them; a width needs two that
     // are not incident.

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -1084,8 +1084,10 @@ impl ContourSet {
         &self,
         radius: f64,
     ) -> Vec<TwoSidedResidualComponent> {
+        // `M \ (X ∩ M)` is `M \ X`, so the opening's clip to the source is
+        // not needed to find what the opening removed.
         self.two_sided_residual(radius, |region, radius| {
-            region.difference(&region.disk_open(radius))
+            region.difference(&region.disk_erode(radius).disk_dilate(radius))
         })
     }
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -1452,7 +1452,7 @@ impl SegmentGrid {
             .iter()
             .map(|segment| segment.bbox)
             .fold(BBox::empty(), BBox::union);
-        let pitch = CellGrid::pitch(cell_mm.max(MIN_SEGMENT_GRID_CELL_MM), bounds);
+        let pitch = cell_mm.max(MIN_SEGMENT_GRID_CELL_MM);
         let grid = CellGrid::new(
             pitch,
             bounds,

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -18,7 +18,7 @@ use crate::dialects::ipc::{
     ArtworkLowering, ArtworkObjectKind, ArtworkScope, Feature, FeatureDomain, FeatureKind,
     FeatureSpan, HoleShape, PlatingKind, lower_layer_to_artwork_with,
 };
-use crate::geom::{ContourSet, FillRule, Point, Polarity, Span, tol};
+use crate::geom::{ContourSet, Point, Polarity, Span, tol};
 use crate::import::ipc2581::{
     ComponentOccurrence, ComponentOccurrenceId, FeatureOccurrenceId, ImportedDesign, LayerId,
     LayoutOccurrenceId, PopulationState, feature_occurrence_id, is_copper, layer_role,
@@ -824,24 +824,23 @@ impl ImportedDesign {
             meta: definition.layer_function,
         };
         let artwork = lower_layer_to_artwork_with(&document, 0, header, &mut OccurrenceAttribution);
-        let (mut images, _) = artwork::compose_selected_attributed(&artwork, |owner| {
+        let (mut layers, _) = artwork::compose_selected_owners(&artwork, |owner| {
             let owner = (*owner)?;
             self.feature_definition(owner.feature)
                 .filter(|feature| include(feature))
                 .map(|_| owner)
         });
-        let image = images
+        let owners = layers
             .pop()
             .context("attributed physical composition produced no layer")?;
-        image
-            .owners
+        owners
             .into_iter()
             .map(|(owner, rings)| {
                 Ok((
                     *occurrences
                         .get(&owner)
                         .context("composed feature has no canonical occurrence")?,
-                    ContourSet::new(rings, FillRule::NonZero, tol::REGION_MM),
+                    ContourSet::from_regularized(rings, tol::REGION_MM),
                 ))
             })
             .collect()
@@ -1414,7 +1413,7 @@ mod tests {
         let start = imported.geometry.arena.paths.len() as u32;
         imported.geometry.push_path(
             Paint::Fill {
-                rule: FillRule::NonZero,
+                rule: crate::geom::FillRule::NonZero,
             },
             [ContourBuf::new(vec![
                 PathCmd::move_to(Point::new(0.0, 0.0)),


### PR DESCRIPTION
IPC DFM spent most of its time eroding and dilating whole copper and mask layers, then scanning every polygon edge through hashed grid cells. Morphology now runs only on material within reach of two facing walls, boundary queries use a flat sparse grid, and copper clearance measures only edges near the partner, which makes the exhaustive standard-PDK pass about five times faster; witness coordinates can shift at the sub-nanometer level, so a few content-hash finding ids differ.
