### PR TITLE
ENG-1321: Preserve authored BOM intent in releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Preserve authored component constraints in release design BOMs while keeping release netlists hydrated.
 - Report a sharp copper tip narrower than the minimum width when it stands alone.
 - Check netless pads as isolated copper in DFM reports.
 - Ignore nested `NotConnected()` interface members when creating schematic sheet ports.

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -59,7 +59,7 @@ struct ReleaseInfo {
     git_hash: String,
     staging_dir: PathBuf,
     layout: Option<ReleaseLayout>,
-    schematic: pcb_sch::Schematic,
+    design_bom: pcb_sch::bom::Bom,
     output_dir: PathBuf,
     output_name: String,
     suppress: Vec<String>,
@@ -251,7 +251,7 @@ pub fn build_board_release(
         let resolution = crate::resolve::resolve(Some(&zen_path), false)?;
         info_spinner.set_message("Evaluating zen file");
 
-        // Evaluate the zen file (still needed for schematic)
+        // Evaluate the zen file for layout discovery and the authored design BOM.
         // Pass resolution so Module() paths resolve correctly
         let eval_result = pcb_zen::eval(&zen_path, resolution.clone(), Default::default());
 
@@ -318,12 +318,7 @@ pub fn build_board_release(
             None => None,
         };
 
-        let mut schematic = eval_output.to_schematic()?;
-        pcb_diode_api::hydrate_schematic_from_bom(
-            &zen_path,
-            &mut schematic,
-            pcb_diode_api::BomMatchMode::Online,
-        );
+        let design_bom = eval_output.to_schematic()?.bom();
 
         let info = ReleaseInfo {
             zen_path,
@@ -332,7 +327,7 @@ pub fn build_board_release(
             git_hash,
             staging_dir,
             layout,
-            schematic,
+            design_bom,
             output_dir,
             output_name,
             suppress,
@@ -752,7 +747,7 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> 
         )));
 
         crate::build::BuildEvalState::new(staged_resolution)
-            .with_bom_hydration(pcb_diode_api::BomMatchMode::Offline)
+            .with_bom_hydration(pcb_diode_api::BomMatchMode::Online)
             .build(
                 &staged_zen_path,
                 Default::default(),
@@ -913,9 +908,6 @@ fn check_bom_offers(info: &ReleaseInfo, spinner: &Spinner, bom: &pcb_sch::bom::B
 
 /// Generate design BOM JSON file (with optional KiCad fallback if layout exists)
 fn generate_design_bom(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> {
-    // Generate BOM entries from the schematic
-    let bom = info.schematic.bom();
-
     // Create bom directory in staging
     let bom_dir = info.staging_dir.join("bom");
     fs::create_dir_all(&bom_dir)?;
@@ -925,7 +917,7 @@ fn generate_design_bom(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnost
         .layout
         .as_ref()
         .map(|l| info.workspace_root().join(l.layout_dir_rel()));
-    let final_bom = generate_bom_with_fallback(bom, layout_path.as_deref())?;
+    let final_bom = generate_bom_with_fallback(info.design_bom.clone(), layout_path.as_deref())?;
 
     let diagnostics = check_bom_offers(info, spinner, &final_bom);
 

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -48,6 +48,24 @@ LedModule(name = "LED1", led_color = "green", VCC = vcc_3v3, GND = gnd, CTRL = l
 Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = vcc_3v3, P2 = led_ctrl)
 "#;
 
+const BOM_INTENT_BOARD_ZEN: &str = r#"
+Resistor = Module("@stdlib/generics/Resistor.zen")
+
+vcc = Net("VCC")
+gnd = Net("GND")
+
+Resistor(name = "GENERIC", value = "1kOhm", package = "0603", P1 = vcc, P2 = gnd)
+Resistor(
+    name = "AUTHORED",
+    value = "10kOhm",
+    package = "0603",
+    mpn = "AUTHORED-MPN",
+    manufacturer = "Authored Manufacturer",
+    P1 = vcc,
+    P2 = gnd,
+)
+"#;
+
 const PCB_TOML: &str = r#"
 [workspace]
 pcb-version = "0.4"
@@ -274,6 +292,111 @@ fn test_publish_board_with_version_preserves_local_only_tags() {
         .expect("list release tags");
     assert!(tags.lines().any(|tag| tag == "boards/v1.2.3"));
     assert!(tags.lines().any(|tag| tag == "boards/v1.2.4"));
+}
+
+#[test]
+fn test_publish_preserves_authored_bom_intent() {
+    let server = MockServer::start();
+    let _bom_match = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/boms/match")
+            .query_param("strict", "true");
+        then.status(200).json_body(serde_json::json!({
+            "results": [
+                {
+                    "designEntry": { "path": "GENERIC.R" },
+                    "offerIds": ["selection"],
+                    "offerStockClasses": { "selection": "PLENTY" },
+                    "match": "MATCH_COMPATIBLE",
+                    "selectedOfferId": "selection"
+                },
+                {
+                    "designEntry": { "path": "AUTHORED.R" },
+                    "offerIds": ["selection"],
+                    "offerStockClasses": { "selection": "PLENTY" },
+                    "match": "MATCH_COMPATIBLE",
+                    "selectedOfferId": "selection"
+                }
+            ],
+            "offers": {
+                "selection": {
+                    "id": "selection",
+                    "geography": "US",
+                    "mpn": "SELECTED-MPN",
+                    "manufacturer": "Selected Manufacturer",
+                    "stockAvailable": 100
+                }
+            }
+        }));
+    });
+
+    let mut sb = Sandbox::new();
+    sb.cwd("src")
+        .env("DIODE_API_URL", server.base_url())
+        .env("NO_PROXY", "127.0.0.1,localhost")
+        .env("no_proxy", "127.0.0.1,localhost")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write("boards/TestBoard.zen", BOM_INTENT_BOARD_ZEN)
+        .init_git()
+        .commit("Initial commit")
+        .sync();
+
+    sb.run("pcbc", ["publish", "boards/TestBoard.zen", "--no-push"])
+        .run()
+        .expect("Failed to run pcb publish command");
+
+    let release_dir = sb
+        .root_path()
+        .join("src")
+        .join(find_staging_dir(&sb, "TestBoard"));
+    let design_bom: Vec<Value> =
+        serde_json::from_reader(File::open(release_dir.join("bom/design_bom.json")).unwrap())
+            .unwrap();
+    let bom_entry = |path| {
+        design_bom
+            .iter()
+            .find(|entry| entry["path"] == path)
+            .unwrap()
+    };
+    let generic_bom = bom_entry("GENERIC.R");
+    assert_eq!(
+        (generic_bom.get("mpn"), generic_bom.get("manufacturer")),
+        (None, None)
+    );
+    assert_eq!(
+        (
+            bom_entry("AUTHORED.R")["mpn"].as_str(),
+            bom_entry("AUTHORED.R")["manufacturer"].as_str()
+        ),
+        (Some("AUTHORED-MPN"), Some("Authored Manufacturer"))
+    );
+
+    let netlist: pcb_sch::Schematic =
+        serde_json::from_reader(File::open(release_dir.join("netlist.json")).unwrap()).unwrap();
+    let component = |path| {
+        netlist
+            .instances
+            .iter()
+            .find_map(|(instance_ref, instance)| {
+                (instance_ref.instance_path.join(".") == path).then_some(instance)
+            })
+            .unwrap()
+    };
+    assert_eq!(
+        (
+            component("GENERIC.R").mpn().as_deref(),
+            component("GENERIC.R").manufacturer().as_deref()
+        ),
+        (Some("SELECTED-MPN"), Some("Selected Manufacturer"))
+    );
+    assert_eq!(
+        (
+            component("AUTHORED.R").mpn().as_deref(),
+            component("AUTHORED.R").manufacturer().as_deref()
+        ),
+        (Some("AUTHORED-MPN"), Some("Authored Manufacturer"))
+    );
 }
 
 #[test]


### PR DESCRIPTION
`pcb publish` now captures the authored BOM before selection hydration, so release design BOMs retain generic constraints and explicit identities. The staged release build hydrates its netlist directly, which removes the cache-warming dependency and keeps downstream metadata available. A focused integration test covers both artifacts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->