### PR TITLE
Warn on standard soldermask webs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Report the standard PDK's 4 mil soldermask-web threshold as a warning.
+
 ### Fixed
 
 - Refresh netlist-derived symbol assembly properties during schematic reconciliation.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -112,8 +112,8 @@ The schema gives each kind of constraint one place:
   holes; selecting `npth` is a schema error. A
   `rules.copper.hole_clearance` selector chooses the drill class measured to
   unrelated final copper.
-- `limit` defines one unconditional dimensional minimum and optional preferred
-  value, or one required aspect-ratio maximum.
+- `limit` defines an unconditional dimensional minimum, preferred value, or
+  both, or one required aspect-ratio maximum.
 - `cases` defines named conditional limits when one value is not enough. A
   rule uses either `limit` or `cases`, never both.
 - `profile.defaults` records missing-data assumptions. Copper weight defaults
@@ -140,16 +140,17 @@ defaults document an order's assumptions in the report; an outer/inner copper
 weight default is also the fallback for a weight-conditioned rule when the
 source stackup does not state that weight.
 
-Every direct limit or case has a binding `minimum` and may add a `preferred`
-tier:
+Every direct dimensional limit or case has a `minimum`, a `preferred` tier, or
+both:
 
 - The minimum lowers to an **error**-severity rule whose id is the
   authored rule id, or `<id>.<case>` for a named case. Error findings fail the
   verdict.
 - A preferred tier lowers to a second, **warning**-severity rule under
   `<id>.preferred` or `<id>.<case>.preferred`. Warning findings are reported
-  and counted but do not fail the verdict. The preferred value must exceed the
-  minimum.
+  and counted but do not fail the verdict. It may stand alone when the PDK has
+  no binding minimum. When both tiers are present, the preferred value must
+  exceed the minimum.
 
 Each direct or named-case hole-aspect-ratio limit instead has one required
 **error**-severity `maximum`; values above it fail the rule. It has no preferred

--- a/crates/pcb-ipc2581-tools/pdks/standard.toml
+++ b/crates/pcb-ipc2581-tools/pdks/standard.toml
@@ -4,7 +4,7 @@ default_profile = "standard"
 [pdk]
 id = "standard"
 name = "Standard"
-revision = "draft-2026-09-02"
+revision = "draft-2026-09-03"
 manufacturer = "Diode"
 process = "Standard"
 
@@ -99,7 +99,7 @@ limit = { minimum = "15 mil" }
 
 [[rules.soldermask.web]]
 id = "soldermask.minimum_web"
-limit = { minimum = "4 mil" }
+limit = { preferred = "4 mil" }
 
 [[rules.panelization.board_spacing]]
 id = "panelization.minimum_board_array_spacing"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -557,7 +557,14 @@ limit = { minimum = "300 mil" }
             .unwrap();
         assert_eq!(support.minimum(), Some(2));
         assert_eq!(support.maximum(), Some(10));
-        assert!(!rules::lower(&parsed, None).unwrap().is_empty());
+        let standard_rules = rules::lower(&parsed, None).unwrap();
+        assert!(!standard_rules.is_empty());
+        let mask_web = standard_rules
+            .iter()
+            .find(|rule| rule.id == "soldermask.minimum_web.preferred")
+            .unwrap();
+        assert_eq!(mask_web.severity, report::Severity::Warning);
+        assert_eq!(mask_web.limit.length().millimeters(), 0.1016);
 
         for builtin in builtin_pdks() {
             let parsed = pdk::Pdk::parse(builtin.source).unwrap();
@@ -694,6 +701,47 @@ limit = { minimum = "300 mil" }
         assert_eq!(multilayer.limit.length().millimeters(), 0.09);
         assert_eq!(multilayer.conditions.minimum_copper_layers, Some(3));
         assert_eq!(multilayer.conditions.maximum_copper_layers, Some(32));
+    }
+
+    #[test]
+    fn standard_soldermask_web_warns_without_failing_verdict() {
+        let mask_web = r#"
+        <LayerFeature layerRef="F.Mask">
+          <Set polarity="POSITIVE"><Features>
+            <Contour><Polygon>
+              <PolyBegin x="2" y="2"/><PolyStepSegment x="5" y="2"/>
+              <PolyStepSegment x="5" y="8"/><PolyStepSegment x="2" y="8"/>
+            </Polygon></Contour>
+            <Contour><Polygon>
+              <PolyBegin x="5.05" y="2"/><PolyStepSegment x="8" y="2"/>
+              <PolyStepSegment x="8" y="8"/><PolyStepSegment x="5.05" y="8"/>
+            </Polygon></Contour>
+          </Features></Set>
+        </LayerFeature>"#;
+        let copper = r#"        <LayerFeature layerRef="TOP">
+          <Set polarity="POSITIVE">
+            <Features>
+              <Line startX="1" startY="1" endX="29" endY="1">
+                <LineDesc lineWidth="0.2" lineEnd="ROUND"/>
+              </Line>
+            </Features>
+          </Set>
+        </LayerFeature>"#;
+        let board = BOARD.replace(copper, mask_web);
+        let standard = builtin_pdks()
+            .iter()
+            .find(|pdk| pdk.name == "standard")
+            .unwrap();
+
+        let results = check_with_pdk(&board, LayoutTarget::Board, standard.source);
+        let mask_rule = rule(&results, "soldermask.minimum_web.preferred");
+
+        assert!(matches!(results.verdict, report::Verdict::Pass));
+        assert_eq!(results.summary.errors, 0);
+        assert_eq!(results.summary.warnings, 1);
+        assert_eq!(mask_rule.severity, report::Severity::Warning);
+        assert!(matches!(mask_rule.status, report::RuleStatus::Warning));
+        assert_eq!(mask_rule.finding_count, 1);
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
@@ -588,27 +588,33 @@ pub enum LayerPosition {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct LengthLimit {
-    pub minimum: Length,
+    #[serde(default)]
+    pub minimum: Option<Length>,
     #[serde(default)]
     pub preferred: Option<Length>,
 }
 
 impl LengthLimit {
     fn validate(&self, id: &str) -> Result<()> {
-        if let Some(preferred) = &self.preferred
-            && preferred.millimeters() <= self.minimum.millimeters()
+        if self.minimum.is_none() && self.preferred.is_none() {
+            bail!("rule '{id}': limit requires a minimum, preferred, or both");
+        }
+        if let (Some(minimum), Some(preferred)) = (&self.minimum, &self.preferred)
+            && preferred.millimeters() <= minimum.millimeters()
         {
             bail!(
                 "rule '{id}': preferred limit {} must exceed the minimum {}",
                 preferred.original(),
-                self.minimum.original()
+                minimum.original()
             );
         }
         Ok(())
     }
 
     fn ids(&self, id: &str) -> Vec<String> {
-        std::iter::once(id.to_owned())
+        self.minimum
+            .iter()
+            .map(|_| id.to_owned())
             .chain(self.preferred.as_ref().map(|_| format!("{id}.preferred")))
             .collect()
     }
@@ -1110,6 +1116,8 @@ limit = { minimum = "300 mil" }
                 .as_ref()
                 .unwrap()
                 .minimum
+                .as_ref()
+                .unwrap()
                 .millimeters(),
             0.2
         );
@@ -1128,6 +1136,8 @@ limit = { minimum = "300 mil" }
                 .as_ref()
                 .unwrap()
                 .minimum
+                .as_ref()
+                .unwrap()
                 .millimeters()
                 - 0.254)
                 .abs()
@@ -1147,14 +1157,26 @@ limit = { minimum = "300 mil" }
             hole_case.when.copper_layers.as_ref().unwrap().maximum(),
             Some(8)
         );
-        assert_eq!(hole_case.limit.minimum.millimeters(), 0.3);
+        assert_eq!(hole_case.limit.minimum.as_ref().unwrap().millimeters(), 0.3);
         assert_eq!(
             hole_case.limit.preferred.as_ref().unwrap().millimeters(),
             0.4
         );
         let slot_edge = &pdk.rules.drilling.slot_to_board_edge_clearance[0];
         assert_eq!(slot_edge.select.plating, SlotPlating::Nonplated);
-        assert!((slot_edge.limit.as_ref().unwrap().minimum.millimeters() - 0.381).abs() < 1e-12);
+        assert!(
+            (slot_edge
+                .limit
+                .as_ref()
+                .unwrap()
+                .minimum
+                .as_ref()
+                .unwrap()
+                .millimeters()
+                - 0.381)
+                .abs()
+                < 1e-12
+        );
         assert_eq!(
             pdk.rules.copper.feature_width[0].cases[0]
                 .when
@@ -1287,6 +1309,16 @@ limit = { minimum = "300 mil" }
                 .unwrap()
                 .validate_rule_references()
                 .is_err()
+        );
+
+        let empty_limit = MIXED_UNIT_PDK.replace("limit = { minimum = \"0.2 mm\" }", "limit = {}");
+        assert!(
+            Pdk::parse(&empty_limit)
+                .unwrap()
+                .validate_rule_references()
+                .unwrap_err()
+                .to_string()
+                .contains("requires a minimum, preferred, or both")
         );
 
         let old_hole_shape = MIXED_UNIT_PDK.replace(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -3,8 +3,8 @@
 //! A rule is pure data: an identity, a limit, a severity, and a [`RuleKind`]
 //! naming which measurement the engine runs. Rule ids are the PDK capability
 //! paths, so a report consumer can find every limit's source line in the PDK
-//! verbatim; a capability's preferred tier lowers to a second, warning-level
-//! rule under `<capability>.preferred`.
+//! verbatim; a capability's preferred tier lowers to a warning-level rule
+//! under `<capability>.preferred`, with or without a binding minimum.
 
 use anyhow::Result;
 
@@ -564,7 +564,7 @@ pub(super) fn pools(rules: &[Rule]) -> Pools {
 
 /// Lower the selected profile's support envelope and typed rules. Rules with
 /// no `profiles` selector apply to every executable profile in the kit.
-/// Required limits are errors; optional preferred limits become warning rules.
+/// Required limits are errors; preferred limits become warning rules.
 pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rule>> {
     pdk.validate_rule_references()?;
     let (profile_name, profile) = pdk.selected_profile(selected_profile)?;
@@ -801,16 +801,17 @@ fn lower_limit(
     kind: RuleKind,
 ) -> Vec<Rule> {
     let conditions = conditions(when, profile);
-    let required = Rule {
+    let required = limit.minimum.as_ref().map(|minimum| Rule {
         id: id.to_owned(),
         title: title.clone(),
         severity: Severity::Error,
         comparison: Comparison::Minimum,
-        limit: LimitValue::Length(limit.minimum.clone()),
+        limit: LimitValue::Length(minimum.clone()),
         kind,
         conditions: conditions.clone(),
-    };
-    std::iter::once(required)
+    });
+    required
+        .into_iter()
         .chain(limit.preferred.as_ref().map(|preferred| Rule {
             id: format!("{id}.preferred"),
             title: format!("{title} (preferred)"),
@@ -980,6 +981,34 @@ limit = { minimum = "0.30 mm" }
             RuleKind::HoleToCopperClearance(HoleClass::Via)
         ));
         assert_eq!(lowered[1].limit.length().millimeters(), 0.25);
+    }
+
+    #[test]
+    fn lowers_preferred_only_limit_to_warning() {
+        let pdk = Pdk::parse(
+            r#"schema_version = 2
+default_profile = "standard"
+
+[pdk]
+id = "test"
+name = "Test"
+revision = "1"
+
+[profiles.standard]
+name = "Standard"
+
+[[rules.soldermask.web]]
+id = "soldermask.minimum_web"
+limit = { preferred = "4 mil" }
+"#,
+        )
+        .unwrap();
+
+        let lowered = lower(&pdk, None).unwrap();
+        assert_eq!(lowered.len(), 1);
+        assert_eq!(lowered[0].id, "soldermask.minimum_web.preferred");
+        assert_eq!(lowered[0].severity, Severity::Warning);
+        assert_eq!(lowered[0].limit.length().millimeters(), 0.1016);
     }
 
     const EDGE_CLEARANCE_PDK: &str = r#"


### PR DESCRIPTION
The generic standard PDK should report marginal soldermask webs without blocking otherwise manufacturable boards. This change lets dimensional limits be preferred-only and changes the 4 mil standard soldermask web limit to a warning, with focused verdict tests and documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->