### PR TITLE
Update supported LED colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Add `yellow-green` as a supported `Led` color.
+- Remove `rgb` from the supported `Led` colors.
 - Report the standard PDK's 4 mil soldermask-web threshold as a warning.
 
 ### Fixed

--- a/crates/pcbc/tests/snapshots/release__publish_full.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_full.snap
@@ -123,7 +123,7 @@ Designator,Val,Package,Mid X,Mid Y,Rotation,Layer
     "user": "<USER>"
   }
 }
-=== netlist.json <76356 bytes, sha256: be3143c>
+=== netlist.json <76382 bytes, sha256: 1121a72>
 === src/boards/TestBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcbc/tests/snapshots/release__publish_source_only.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_source_only.snap
@@ -47,7 +47,7 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <76356 bytes, sha256: be3143c>
+=== netlist.json <76382 bytes, sha256: 1121a72>
 === src/boards/TestBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcbc/tests/snapshots/release__publish_with_description.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_with_description.snap
@@ -48,7 +48,7 @@ expression: sb.snapshot_dir(&staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <76356 bytes, sha256: 33a440b>
+=== netlist.json <76382 bytes, sha256: b2198bd>
 === src/boards/DescBoard.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/crates/pcbc/tests/snapshots/release__publish_with_version.snap
+++ b/crates/pcbc/tests/snapshots/release__publish_with_version.snap
@@ -47,7 +47,7 @@ expression: sb.snapshot_dir(staging_dir)
     "user": "<USER>"
   }
 }
-=== netlist.json <75638 bytes, sha256: 07fca91>
+=== netlist.json <75664 bytes, sha256: db81ea0>
 === src/boards/TB0001.zen
 
 load("@stdlib/interfaces.zen", "Gpio")

--- a/lib/std/generics/Led.zen
+++ b/lib/std/generics/Led.zen
@@ -5,7 +5,7 @@ load("../utils.zen", "format_value")
 
 Mount = enum("SMD")
 Package = enum("0201", "0402", "0603", "0805", "1206", "1210", "2010", "2512", "1812")
-Color = enum("red", "green", "blue", "yellow", "white", "amber", "orange", "pink", "uv", "rgb", "other")
+Color = enum("red", "green", "blue", "yellow", "yellow-green", "white", "amber", "orange", "pink", "uv", "other")
 package = config(Package)
 color = config(Color)
 mpn = config(str, optional=True, help="Manufacturer Part Number")
@@ -51,6 +51,7 @@ def _symbol_name(color: Color):
         Color("green"): "LED_Small_Filled_Green",
         Color("blue"): "LED_Small_Filled_Blue",
         Color("yellow"): "LED_Small_Filled_Yellow",
+        Color("yellow-green"): "LED_Small_Filled_Green",
         Color("white"): "LED_Small_Filled_White",
         Color("amber"): "LED_Small_Filled_Amber",
         Color("orange"): "LED_Small_Filled_Orange",
@@ -73,12 +74,12 @@ def _spice_subcircuit_name(color: Color):
         Color("green"): "LED_Green",
         Color("blue"): "LED_Blue",
         Color("yellow"): "LED_Yellow",
+        Color("yellow-green"): "LED_YellowGreen",
         Color("white"): "LED_White",
         Color("amber"): "LED_Amber",
         Color("orange"): "LED_Orange",
         Color("pink"): "LED_Pink",
         Color("uv"): "LED_UV",
-        Color("rgb"): "LED_RGB",
         Color("other"): "LED_Other",
     }
     return subcircuits[color]
@@ -93,12 +94,12 @@ def _spice_args(color: Color, forward_voltage, forward_current):
         Color("green"): "1e-18",  # ~2.2V
         Color("blue"): "1e-20",  # ~3.2V
         Color("yellow"): "1e-17",  # ~2.0V
+        Color("yellow-green"): "5e-18",  # ~2.1V
         Color("white"): "1e-20",  # ~3.2V
         Color("amber"): "5e-18",  # ~2.1V
         Color("orange"): "1e-17",  # ~2.0V
         Color("pink"): "1e-19",  # ~2.8V
         Color("uv"): "1e-21",  # ~3.5V
-        Color("rgb"): "1e-20",  # ~3.2V
         Color("other"): "1e-17",  # ~2.0V
     }
 

--- a/lib/std/generics/spice/Led.lib
+++ b/lib/std/generics/spice/Led.lib
@@ -33,6 +33,12 @@ D1 1 2 LED_YELLOW_MODEL
 .MODEL LED_YELLOW_MODEL D(IS={IS} N={N} RS={RS} CJO={CJO})
 .ENDS LED_Yellow
 
+* Yellow-green LED - ~2.1V forward voltage
+.SUBCKT LED_YellowGreen 1 2 PARAMS: IS=5e-18 N=2.0 RS=1 CJO=10p
+D1 1 2 LED_YELLOW_GREEN_MODEL
+.MODEL LED_YELLOW_GREEN_MODEL D(IS={IS} N={N} RS={RS} CJO={CJO})
+.ENDS LED_YellowGreen
+
 * White LED - ~3.2V forward voltage (similar to blue)
 .SUBCKT LED_White 1 2 PARAMS: IS=1e-20 N=2.0 RS=1 CJO=10p
 D1 1 2 LED_WHITE_MODEL
@@ -62,12 +68,6 @@ D1 1 2 LED_PINK_MODEL
 D1 1 2 LED_UV_MODEL
 .MODEL LED_UV_MODEL D(IS={IS} N={N} RS={RS} CJO={CJO})
 .ENDS LED_UV
-
-* RGB LED - uses blue LED characteristics (highest voltage)
-.SUBCKT LED_RGB 1 2 PARAMS: IS=1e-20 N=2.0 RS=1 CJO=10p
-D1 1 2 LED_RGB_MODEL
-.MODEL LED_RGB_MODEL D(IS={IS} N={N} RS={RS} CJO={CJO})
-.ENDS LED_RGB
 
 * Generic LED - default characteristics (~2.0V)
 .SUBCKT LED_Other 1 2 PARAMS: IS=1e-17 N=2.0 RS=1 CJO=10p


### PR DESCRIPTION
The two-pin LED generic must not advertise RGB support. Replace `rgb` with `yellow-green`, and add the matching schematic and SPICE behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->