### PR TITLE
Fix LCSC IDs for case-insensitive distributor names

### DIFF
--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -331,7 +331,7 @@ fn build_availability_summary(
     target_qty: i32,
 ) -> AvailabilitySummary {
     let lcsc_part_ids = match (offer.distributor.as_deref(), &offer.distributor_part_id) {
-        (Some("lcsc"), Some(id)) => {
+        (Some(distributor), Some(id)) if distributor.eq_ignore_ascii_case("lcsc") => {
             let id = if id.starts_with('C') {
                 id.clone()
             } else {


### PR DESCRIPTION
The BOM table omitted LCSC part IDs when the API returned the distributor name in uppercase. Match the distributor name without case sensitivity so valid LCSC IDs appear with global stock and pricing.