### PR TITLE
Open DFM reports in the web viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Open DFM reports with `pcb open` or `pcb dfm --open`.
+
 ### Changed
 
 - Add `yellow-green` as a supported `Led` color.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +762,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
@@ -4673,6 +4685,7 @@ dependencies = [
  "tempfile",
  "termimad",
  "thiserror 2.0.20",
+ "tiny_http",
  "toml",
  "toml_edit",
  "tracing",
@@ -7283,6 +7296,18 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.27.0"
 thiserror = "2.0.20"
+tiny_http = "0.12.0"
 toml = "1"
 toml_edit = "0.25"
 uuid = { version = "1.26", features = ["v4", "v5", "js"] }

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -324,6 +324,8 @@ silently.
 ```bash
 pcb ipc dfm check board.xml --pdk standard -o board.dfm.json
 pcb dfm board.zen --pdk standard -o board.dfm.json
+pcb dfm board.zen --pdk standard --open
+pcb open board.dfm.json
 ```
 
 `pcb dfm` prepares and synchronizes the board's KiCad layout before exporting
@@ -365,6 +367,17 @@ Output is UTF-8 JSON on stdout unless `-o` / `--output` is supplied. The
 recommended suffix is `.dfm.json`. Every complete report includes the native
 scene and PDK source for viewing without companion files. PCB generates no
 DFM HTML or viewer application.
+
+`pcb open <report.dfm.json>` opens an existing report in
+`https://dfm.diode.computer`. A one-shot local page redirects the same browser
+tab with the compressed report in a temporary URL fragment. The viewer removes
+the fragment before loading the report, and no report bytes are uploaded.
+`pcb dfm --open` performs the same handoff after generating the report. With
+`-o`, it saves and opens that file; without `-o`, it uses a temporary report
+instead of writing JSON to stdout. Fresh `pass`, `fail`, and `incomplete`
+reports are all opened, while the DFM command keeps its normal exit status.
+Reports over 16 MiB or encoded URLs over 900 KiB must be selected in the
+viewer manually.
 
 A completed report is written before the command returns a failing status.
 Only unwaived error findings fail its verdict. Preparation and output errors

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -172,6 +172,12 @@ pub struct CheckOptions {
     pub layout_target: LayoutTarget,
 }
 
+#[cfg(feature = "cli")]
+pub enum CheckOutcome {
+    Passed,
+    Failed(anyhow::Error),
+}
+
 /// Reject an invalid destination before any layout preparation or output write.
 #[cfg(feature = "cli")]
 pub fn validate_output(file: &Path, options: &CheckOptions) -> Result<()> {
@@ -220,32 +226,32 @@ pub fn validate_output(file: &Path, options: &CheckOptions) -> Result<()> {
 }
 
 #[cfg(feature = "cli")]
-pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<()> {
+pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<CheckOutcome> {
     validate_output(file, options)?;
     let report = match build_report(file, options) {
         Ok(checked) => checked,
         Err(error) => {
             write_error_report(file, options, &error)
                 .with_context(|| format!("DFM check was incomplete: {error:#}"))?;
-            return Err(error);
+            return Ok(CheckOutcome::Failed(error));
         }
     };
     write_report(options, &report)?;
 
     let summary = &report.summary;
     if summary.errors > 0 {
-        bail!(
+        return Ok(CheckOutcome::Failed(anyhow::anyhow!(
             "DFM check failed with {} error finding(s){}",
             summary.errors,
             annotations(summary)
-        );
+        )));
     }
     eprintln!(
         "✓ DFM check passed ({} rule(s){})",
         summary.rules_configured,
         annotations(summary)
     );
-    Ok(())
+    Ok(CheckOutcome::Passed)
 }
 
 /// Preparation failures produce an incomplete report, never a passing result.
@@ -841,7 +847,7 @@ reason = "old finding"
         let bytes = zstd::encode_all(BOARD.as_bytes(), 0).unwrap();
         std::fs::write(&input, &bytes).unwrap();
         std::fs::write(&pdk, &pdk_source).unwrap();
-        let error = execute_check(
+        let outcome = execute_check(
             &input,
             &CheckOptions {
                 pdk: pdk.clone(),
@@ -850,7 +856,10 @@ reason = "old finding"
                 layout_target: LayoutTarget::Board,
             },
         )
-        .unwrap_err();
+        .unwrap();
+        let CheckOutcome::Failed(error) = outcome else {
+            panic!("expected the DFM check to fail");
+        };
         assert!(
             error
                 .to_string()

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -67,6 +67,7 @@ toml_edit = { workspace = true }
 zip = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
+tiny_http = { workspace = true }
 ignore = { workspace = true }
 semver = { workspace = true }
 rayon = { workspace = true }
@@ -86,10 +87,10 @@ notify = { workspace = true }
 mimalloc = { workspace = true, optional = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
 httpmock = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
 pcb-test-utils = { workspace = true }
-zstd = { workspace = true }

--- a/crates/pcbc/src/dfm.rs
+++ b/crates/pcbc/src/dfm.rs
@@ -21,29 +21,76 @@ pub struct DfmArgs {
     #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
     pub output: Option<PathBuf>,
 
+    /// Open the report in dfm.diode.computer after writing it
+    #[arg(long)]
+    pub open: bool,
+
     /// Disable network access (offline mode) - only use vendored dependencies
     #[arg(long = "offline")]
     pub offline: bool,
 }
 
 pub fn execute(args: DfmArgs) -> Result<()> {
+    let temporary_output = if args.open && args.output.is_none() {
+        Some(tempfile::tempdir().context("failed to create temporary DFM report directory")?)
+    } else {
+        None
+    };
+    let output = args.output.clone().or_else(|| {
+        temporary_output.as_ref().map(|directory| {
+            let filename = args
+                .file
+                .with_extension("dfm.json")
+                .file_name()
+                .unwrap_or_default()
+                .to_owned();
+            directory.path().join(filename)
+        })
+    });
     let options = commands::dfm::CheckOptions {
         pdk: args.pdk.clone(),
         waivers: None,
-        output: args.output.clone(),
+        output,
         layout_target: LayoutTarget::Board,
     };
     commands::dfm::validate_output(&args.file, &options)?;
-    let (_temporary_dir, ipc_path) = match export_layout(&args) {
-        Ok(exported) => exported,
+    let dfm_result = match export_layout(&args) {
+        Ok((_temporary_dir, ipc_path)) => {
+            match commands::dfm::execute_check(&ipc_path, &options)? {
+                commands::dfm::CheckOutcome::Passed => Ok(()),
+                commands::dfm::CheckOutcome::Failed(error) => Err(error),
+            }
+        }
         Err(error) => {
             commands::dfm::write_error_report(&args.file, &options, &error)
                 .with_context(|| format!("DFM check was incomplete: {error:#}"))?;
-            return Err(error);
+            Err(error)
         }
     };
 
-    commands::dfm::execute_check(&ipc_path, &options)
+    if !args.open {
+        return dfm_result;
+    }
+
+    if let Err(open_error) = crate::open::open_dfm_report(
+        options
+            .output
+            .as_deref()
+            .expect("--open always selects a report file"),
+    ) {
+        if let Some(directory) = temporary_output {
+            let _ = directory.keep();
+            anstream::eprintln!(
+                "DFM report kept at {}",
+                options.output.as_deref().unwrap().display()
+            );
+        }
+        if dfm_result.is_ok() {
+            return Err(open_error);
+        }
+        anstream::eprintln!("Warning: {open_error:#}");
+    }
+    dfm_result
 }
 
 fn export_layout(args: &DfmArgs) -> Result<(tempfile::TempDir, PathBuf)> {

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -573,7 +573,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 waivers,
                 layout_target,
                 output,
-            } => commands::dfm::execute_check(
+            } => match commands::dfm::execute_check(
                 &file,
                 &commands::dfm::CheckOptions {
                     pdk,
@@ -581,7 +581,10 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                     output,
                     layout_target,
                 },
-            ),
+            )? {
+                commands::dfm::CheckOutcome::Passed => Ok(()),
+                commands::dfm::CheckOutcome::Failed(error) => Err(error),
+            },
         },
         Commands::Warp { file, report } => commands::warp::execute(&file, report.as_deref()),
         Commands::Gerber {

--- a/crates/pcbc/src/open.rs
+++ b/crates/pcbc/src/open.rs
@@ -1,11 +1,24 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Args;
 use pcb_layout::utils;
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tiny_http::{Header, Method, Response, Server};
+use uuid::Uuid;
+
+const DFM_REPORT_SUFFIX: &str = ".dfm.json";
+const DFM_VIEWER_URL: &str = "https://dfm.diode.computer/";
+const MAX_DFM_REPORT_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_DFM_URL_BYTES: usize = 900 * 1024;
+const DFM_BRIDGE_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Args, Debug)]
 pub struct OpenArgs {
-    /// Path to .zen/.kicad_pcb file or diode:// sandbox URI
+    /// Path to .zen/.kicad_pcb/.dfm.json file or diode:// sandbox URI
     #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
     pub file: PathBuf,
 
@@ -20,31 +33,28 @@ pub fn execute(args: OpenArgs) -> Result<()> {
         return crate::remote_sandbox::execute_open(uri, args);
     }
 
+    if is_dfm_report_path(&args.file) {
+        return open_dfm_report(&args.file);
+    }
+
     if crate::sandbox_uri::is_kicad_pcb_path(&args.file) {
         return open_pcb_file(&args.file);
     }
 
     crate::file_walker::require_zen_file(&args.file)?;
-
-    // Resolve dependencies before evaluating
     let resolution_result = crate::resolve::resolve(Some(&args.file), args.offline)?;
-
     let zen_path = &args.file;
     let file_name = zen_path.file_name().unwrap().to_string_lossy();
-
-    // Evaluate the zen file
     let eval_result = pcb_zen::eval(zen_path, resolution_result, Default::default());
 
     let Some(output) = eval_result.output else {
         anyhow::bail!("Build failed for {}", file_name);
     };
-
     let Some(schematic) = output.to_schematic_with_diagnostics().output else {
         anyhow::bail!("Build failed for {}", file_name);
     };
     let layout_dir = utils::resolve_layout_dir(&schematic)?
         .ok_or_else(|| anyhow::anyhow!("No layout path defined in {}", file_name))?;
-
     let kicad_files = utils::require_kicad_files(&layout_dir)?;
     let layout_path = kicad_files.kicad_pcb();
     if !layout_path.exists() {
@@ -55,9 +65,110 @@ pub fn execute(args: OpenArgs) -> Result<()> {
         );
     }
 
-    open_pcb_file(&layout_path)?;
+    open_pcb_file(&layout_path)
+}
 
-    Ok(())
+pub(crate) fn is_dfm_report_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(DFM_REPORT_SUFFIX))
+}
+
+pub(crate) fn open_dfm_report(path: &Path) -> Result<()> {
+    let bridge = DfmBridge::new(path)?;
+    let url = bridge.url();
+    let result = (|| {
+        open::that(&url).context("failed to launch the default browser")?;
+        bridge.serve(DFM_BRIDGE_TIMEOUT)
+    })();
+    result.with_context(|| {
+        format!(
+            "Open {DFM_VIEWER_URL} and select {} manually",
+            path.display()
+        )
+    })
+}
+
+struct DfmBridge {
+    server: Server,
+    root: String,
+    page: Vec<u8>,
+}
+
+impl DfmBridge {
+    fn new(path: &Path) -> Result<Self> {
+        let metadata = fs::metadata(path)
+            .with_context(|| format!("failed to inspect DFM report {}", path.display()))?;
+        ensure!(
+            metadata.is_file(),
+            "DFM report is not a regular file: {}",
+            path.display()
+        );
+        ensure!(
+            metadata.len() <= MAX_DFM_REPORT_BYTES,
+            "DFM report exceeds the 16 MiB automatic-open limit: {}",
+            path.display()
+        );
+        let report = fs::read(path)
+            .with_context(|| format!("failed to read DFM report {}", path.display()))?;
+        let filename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .with_context(|| format!("DFM report filename is not UTF-8: {}", path.display()))?;
+        let compressed =
+            zstd::encode_all(report.as_slice(), 19).context("failed to compress the DFM report")?;
+        let viewer_url = format!(
+            "{DFM_VIEWER_URL}#dfm=v1.{}&name={}",
+            URL_SAFE_NO_PAD.encode(compressed),
+            URL_SAFE_NO_PAD.encode(filename.as_bytes())
+        );
+        ensure!(
+            viewer_url.len() <= MAX_DFM_URL_BYTES,
+            "compressed DFM report exceeds the {} KiB automatic-open limit",
+            MAX_DFM_URL_BYTES / 1024
+        );
+        let server = Server::http("127.0.0.1:0")
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+            .context("failed to start the local DFM report bridge")?;
+
+        Ok(Self {
+            server,
+            root: format!("/{}", Uuid::new_v4().simple()),
+            page: format!(
+                r#"<!doctype html><meta charset=utf-8><script>location.replace("{viewer_url}")</script>"#
+            )
+            .into_bytes(),
+        })
+    }
+
+    fn url(&self) -> String {
+        let address = self
+            .server
+            .server_addr()
+            .to_ip()
+            .expect("DFM bridge uses an IP listener");
+        format!("http://{address}{}", self.root)
+    }
+
+    fn serve(self, timeout: Duration) -> Result<()> {
+        let request = self
+            .server
+            .recv_timeout(timeout)?
+            .context("DFM report handoff timed out")?;
+        ensure!(
+            request.method() == &Method::Get && request.url() == self.root,
+            "unexpected request to the local DFM report bridge"
+        );
+        request.respond(
+            Response::from_data(self.page)
+                .with_header(
+                    Header::from_bytes("Content-Type", "text/html; charset=utf-8").unwrap(),
+                )
+                .with_header(Header::from_bytes("Cache-Control", "no-store").unwrap())
+                .with_header(Header::from_bytes("Referrer-Policy", "no-referrer").unwrap()),
+        )?;
+        Ok(())
+    }
 }
 
 fn open_pcb_file(path: &Path) -> Result<()> {
@@ -68,4 +179,34 @@ fn open_pcb_file(path: &Path) -> Result<()> {
         )
     })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_encodes_the_exact_report_and_filename() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("board ü.dfm.json");
+        let expected = b"{\"verdict\":\"fail\"}\n\0exact";
+        fs::write(&path, expected).unwrap();
+        let bridge = DfmBridge::new(&path).unwrap();
+        let page = std::str::from_utf8(&bridge.page).unwrap();
+        let fragment = page
+            .strip_prefix(
+                r#"<!doctype html><meta charset=utf-8><script>location.replace("https://dfm.diode.computer/#dfm=v1."#,
+            )
+            .unwrap()
+            .strip_suffix(r#"")</script>"#)
+            .unwrap();
+        let (report, filename) = fragment.split_once("&name=").unwrap();
+
+        let report = URL_SAFE_NO_PAD.decode(report).unwrap();
+        assert_eq!(zstd::decode_all(report.as_slice()).unwrap(), expected);
+        assert_eq!(
+            URL_SAFE_NO_PAD.decode(filename).unwrap(),
+            "board ü.dfm.json".as_bytes()
+        );
+    }
 }


### PR DESCRIPTION
Open generated or existing DFM JSON reports in `dfm.diode.computer` without a backend upload for [ENG-1330](https://linear.app/diodeinc/issue/ENG-1330/teach-pcb-open-to-send-dfmjson-reports-to-dfmdiodecomputer). Add `pcb dfm --open` and `.dfm.json` support in `pcb open`, using a one-shot local page to pass the compressed report through a same-tab URL fragment while preserving the DFM exit status.