### PR TITLE
Simplify bundled DFM PDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Default DFM to `standard` and consolidate the bundled JLCPCB PDK.
+
 ## [0.4.48] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ pcb new board <NAME> <REPO_URL>              # Create a board repository
 pcb build [PATHS...]                         # Build and validate designs
 pcb sync                                     # Reconcile imports and dependency manifests
 pcb layout <FILE>                            # Generate layout files
-pcb dfm <FILE> --pdk standard                # Check a .zen board for manufacturability
+pcb dfm <FILE>                               # Check a .zen board for manufacturability
 pcb import <KICAD_SCH|KICAD_PRO> <OUTPUT_DIR> # Import a KiCad schematic or project
 ```
 

--- a/crates/pcb-ipc-wasm/scripts/smoke.mjs
+++ b/crates/pcb-ipc-wasm/scripts/smoke.mjs
@@ -38,7 +38,7 @@ if (!isMainThread) {
     const builtins = builtinPdks();
     assert.equal(builtins[0].name, 'standard');
     assert.ok(builtins[0].source.includes('[pdk]'));
-    assert.equal(builtins.find(pdk => pdk.name === 'jlcpcb').profile, 'one-ounce-standard-color');
+    assert.equal(builtins.find(pdk => pdk.name === 'jlcpcb-1oz').profile, 'one-ounce');
     assert.equal(builtins.find(pdk => pdk.name === 'ipc').profile, '2b');
     const bom = JSON.parse(text(document.export({ format: 'bom' })[0]));
     assert.equal(bom[0].designator, 'J1');

--- a/crates/pcb-ipc2581-tools/README.md
+++ b/crates/pcb-ipc2581-tools/README.md
@@ -49,24 +49,27 @@ by the retained geometry.
 ## DFM process design kits
 
 `dfm check` accepts a built-in process design kit name or a strict, versioned
-TOML file. Built-ins include `standard`, executable JLCPCB 1 oz profiles, and
-the nine IPC Class/Producibility profile identities:
+TOML file. Built-ins include `standard`, `jlcpcb-1oz` (`jlc`), and the nine IPC
+Class/Producibility profile identities:
 
 ```bash
 pcb ipc dfm check fabrication-panel.xml \
-  --pdk standard \
   --output dfm-report.json
 ```
 
+The PDK defaults to `standard`. Pass `--pdk` with a built-in name or a path to
+select another process definition.
+
 `standard` currently supports 2 through 10 copper layers.
-`jlcpcb` selects the standard-color 1 oz rigid FR-4 profile;
-`jlcpcb-1oz-black-white` selects its larger mask-web requirement. The
-`ipc` alias selects the opinionated Class 2 / Producibility Level B default.
-It and the explicit `ipc-1a` through `ipc-3c` profiles run Diode's opinionated
-partial baseline for plated-hole aspect ratio and via, PTH, and NPTH
-hole-to-copper clearance. Diode selected these values with IPC design topics as
-context; they are not licensed IPC numeric matrices, do not prove full IPC
-compliance, and do not imply IPC certification.
+`jlcpcb-1oz` checks JLCPCB's rigid FR-4 service with 1 oz outer copper; `jlc`
+is an alias for the same PDK. It uses the conservative 0.13 mm soldermask-web
+limit published for black and white mask across every color. The `ipc` alias
+selects the opinionated Class 2 / Producibility Level B default. It and the
+explicit `ipc-1a` through `ipc-3c` profiles run Diode's opinionated partial
+baseline for plated-hole aspect ratio and via, PTH, and NPTH hole-to-copper
+clearance. Diode selected these values with IPC design topics as context; they
+are not licensed IPC numeric matrices, do not prove full IPC compliance, and
+do not imply IPC certification.
 
 Pass a path such as `--pdk ./fab-process.toml` to use a custom PDK. Exact
 built-in names take precedence, so prefix a same-named file with `./`.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -322,9 +322,9 @@ silently.
 ## CLI
 
 ```bash
-pcb ipc dfm check board.xml --pdk standard -o board.dfm.json
-pcb dfm board.zen --pdk standard -o board.dfm.json
-pcb dfm board.zen --pdk standard --open
+pcb ipc dfm check board.xml -o board.dfm.json
+pcb dfm board.zen -o board.dfm.json
+pcb dfm board.zen --open
 pcb open board.dfm.json
 ```
 
@@ -332,21 +332,21 @@ pcb open board.dfm.json
 temporary IPC-2581 and checking the canonical board. Use `pcb ipc dfm check`
 to inspect existing manufacturing files without changing their source layout.
 
-`--pdk` accepts an exact built-in name or a TOML path. `standard`, `jlcpcb`,
-`jlcpcb-1oz-standard-color`, `jlcpcb-1oz-black-white`, and `ipc-1a` through
-`ipc-3c` are bundled. `jlcpcb` selects the standard-color profile; `ipc`
-selects the opinionated Class 2 / Producibility Level B default. Use
-`./standard` to select a same-named file. Both sources use the same parser and
-checks. `--layout-target` accepts
+`--pdk` defaults to `standard` and accepts an exact built-in name or a TOML
+path. `standard`, `jlcpcb-1oz` (`jlc`), and `ipc-1a` through `ipc-3c` are
+bundled. `ipc` selects the opinionated Class 2 / Producibility Level B default.
+Use `./standard` to select a same-named file. Both sources use the same parser
+and checks. `--layout-target` accepts
 `board` or `board-array` and defaults to `board-array`. Add
 `--waivers waivers.toml` to apply a [waiver file](#waivers).
 
-The JLCPCB profiles execute the public rigid FR-4 capability table for 2-32
-copper layers and 1 oz outer copper. They deliberately omit the one-layer
-NPTH-only service, 2 oz rules, local 3 mil BGA exceptions, and panel spacing,
-which depends on the chosen routing, mouse-bite, or V-cut process. The
-standard-color profile uses the published 0.10 mm mask web; the black/white
-profile uses 0.13 mm.
+The `jlcpcb-1oz` PDK, also available as `jlc`, executes the public rigid FR-4
+capability table for 2-32 copper layers and 1 oz outer copper. It deliberately
+omits the one-layer NPTH-only service, 2 oz rules, local 3 mil BGA exceptions,
+and panel spacing, which depends on the chosen routing, mouse-bite, or V-cut
+process. JLCPCB publishes a 0.10 mm soldermask web for standard colors and 0.13
+mm for black or white; this combined PDK conservatively uses 0.13 mm for every
+color.
 
 The nine `ipc-1a` through `ipc-3c` built-ins preserve performance Classes 1-3
 crossed with Producibility Levels A-C, but they are executable **partial Diode

--- a/crates/pcb-ipc2581-tools/pdks/jlcpcb.toml
+++ b/crates/pcb-ipc2581-tools/pdks/jlcpcb.toml
@@ -1,10 +1,10 @@
 schema_version = 2
-default_profile = "one-ounce-standard-color"
+default_profile = "one-ounce"
 
 [pdk]
 id = "jlcpcb-rigid-fr4"
 name = "JLCPCB rigid FR-4"
-revision = "capabilities-2026-09-01"
+revision = "conservative-2026-09-03"
 manufacturer = "JLCPCB"
 process = "Rigid FR-4, 1 oz outer copper"
 
@@ -12,40 +12,22 @@ process = "Rigid FR-4, 1 oz outer copper"
 title = "JLCPCB PCB Capabilities"
 url = "https://jlcpcb.com/capabilities/pcb-capabilities"
 accessed = "2026-09-01"
-note = "Public capability table. Rules use standard service values and exclude special local BGA exceptions."
+note = "Public capability table. Rules use standard service values, apply the largest published color-specific soldermask web, and exclude special local BGA exceptions."
 
-[profiles.one-ounce-standard-color]
-name = "1 oz, green/red/yellow/blue/purple soldermask"
-description = "Standard rigid FR-4 service. Green is assumed when the design does not state a mask color."
+[profiles.one-ounce]
+name = "1 oz rigid FR-4"
+description = "Standard rigid FR-4 service using the conservative 0.13 mm soldermask-web requirement for every mask color."
 technologies = ["rigid"]
-coverage = ["2-32 copper layers", "1 oz outer copper", "standard-color LPI soldermask"]
+coverage = ["2-32 copper layers", "1 oz outer copper", "all soldermask colors at 0.13 mm minimum web"]
 source = "jlc-capabilities"
 
-[profiles.one-ounce-standard-color.defaults]
+[profiles.one-ounce.defaults]
 material = "FR-4"
 board_thickness = "1.6 mm"
 outer_copper_weight = "1 oz"
 inner_copper_weight = "0.5 oz"
-soldermask_color = "green"
 
-[profiles.one-ounce-standard-color.support]
-copper_layers = { minimum = 2, maximum = 32 }
-
-[profiles.one-ounce-black-white]
-name = "1 oz, black/white soldermask"
-description = "Standard rigid FR-4 service with the larger published mask-web requirement for black or white mask. Black is assumed when color is absent."
-technologies = ["rigid"]
-coverage = ["2-32 copper layers", "1 oz outer copper", "black or white LPI soldermask"]
-source = "jlc-capabilities"
-
-[profiles.one-ounce-black-white.defaults]
-material = "FR-4"
-board_thickness = "1.6 mm"
-outer_copper_weight = "1 oz"
-inner_copper_weight = "0.5 oz"
-soldermask_color = "black"
-
-[profiles.one-ounce-black-white.support]
+[profiles.one-ounce.support]
 copper_layers = { minimum = 2, maximum = 32 }
 
 [[rules.drilling.hole_diameter]]
@@ -159,13 +141,6 @@ limit = { minimum = "0.40 mm" }
 source = "jlc-capabilities"
 
 [[rules.soldermask.web]]
-id = "jlc.soldermask.minimum_web.standard_color"
-profiles = ["one-ounce-standard-color"]
-limit = { minimum = "0.10 mm" }
-source = "jlc-capabilities"
-
-[[rules.soldermask.web]]
-id = "jlc.soldermask.minimum_web.black_white"
-profiles = ["one-ounce-black-white"]
+id = "jlc.soldermask.minimum_web"
 limit = { minimum = "0.13 mm" }
 source = "jlc-capabilities"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -679,20 +679,15 @@ limit = { minimum = "300 mil" }
 
         let jlc = builtin_pdks()
             .iter()
-            .find(|pdk| pdk.name == "jlcpcb-1oz-black-white")
+            .find(|pdk| pdk.name == "jlcpcb-1oz")
             .unwrap();
         let parsed = pdk::Pdk::parse(jlc.source).unwrap();
         let rules = rules::lower(&parsed, Some(jlc.profile)).unwrap();
         let mask = rules
             .iter()
-            .find(|rule| rule.id == "jlc.soldermask.minimum_web.black_white")
+            .find(|rule| rule.id == "jlc.soldermask.minimum_web")
             .unwrap();
         assert_eq!(mask.limit.length().millimeters(), 0.13);
-        assert!(
-            rules
-                .iter()
-                .all(|rule| rule.id != "jlc.soldermask.minimum_web.standard_color")
-        );
         let two_layer = rules
             .iter()
             .find(|rule| rule.id == "jlc.copper.minimum_feature_width.2-layer")

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/builtin_pdks.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/builtin_pdks.rs
@@ -22,13 +22,8 @@ macro_rules! builtin {
 
 pub(super) const BUILTIN_PDKS: &[BuiltinPdk] = &[
     builtin!("standard", "standard", STANDARD),
-    builtin!("jlcpcb", "one-ounce-standard-color", JLCPCB),
-    builtin!(
-        "jlcpcb-1oz-standard-color",
-        "one-ounce-standard-color",
-        JLCPCB
-    ),
-    builtin!("jlcpcb-1oz-black-white", "one-ounce-black-white", JLCPCB),
+    builtin!("jlcpcb-1oz", "one-ounce", JLCPCB),
+    builtin!("jlc", "one-ounce", JLCPCB),
     builtin!("ipc", "2b", IPC),
     builtin!("ipc-1a", "1a", IPC),
     builtin!("ipc-1b", "1b", IPC),
@@ -52,7 +47,8 @@ mod tests {
     #[test]
     fn names_are_exact_references() {
         assert!(find("standard").is_some());
-        assert!(find("jlcpcb").is_some());
+        assert!(find("jlcpcb-1oz").is_some());
+        assert!(find("jlc").is_some());
         assert_eq!(find("ipc").unwrap().profile, "2b");
         assert!(find("ipc-3c").is_some());
         assert!(find("./standard").is_none());

--- a/crates/pcbc/src/dfm.rs
+++ b/crates/pcbc/src/dfm.rs
@@ -13,8 +13,8 @@ pub struct DfmArgs {
     #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
     pub file: PathBuf,
 
-    /// Built-in PDK name or fabrication PDK TOML path (standard, JLCPCB, or IPC profile)
-    #[arg(long)]
+    /// Built-in PDK name or fabrication PDK TOML path
+    #[arg(long, default_value = "standard")]
     pub pdk: PathBuf,
 
     /// Output self-contained JSON report path. Omit to write to stdout.

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -213,8 +213,8 @@ enum DfmCommands {
         /// IPC-2581 XML file to check
         #[arg(value_hint = clap::ValueHint::FilePath)]
         file: PathBuf,
-        /// Built-in PDK name or fabrication PDK TOML path (standard, JLCPCB, or IPC profile)
-        #[arg(long)]
+        /// Built-in PDK name or fabrication PDK TOML path
+        #[arg(long, default_value = "standard")]
         pdk: PathBuf,
         /// Waiver file of accepted finding ids (TOML)
         #[arg(long, value_hint = clap::ValueHint::FilePath)]

--- a/crates/pcbc/tests/dfm.rs
+++ b/crates/pcbc/tests/dfm.rs
@@ -43,7 +43,7 @@ fn dfm_resolves_zen_exports_temporary_ipc_and_checks_standard_pdk() {
         .write("eda/BMI270.kicad_mod", FOOTPRINT)
         .write("eda/BMI270.kicad_sym", SYMBOL);
 
-    let output = run_pcbc(&mut sandbox, ["dfm", "MyBoard.zen", "--pdk", "standard"]);
+    let output = run_pcbc(&mut sandbox, ["dfm", "MyBoard.zen"]);
     let mut report: Value =
         serde_json::from_slice(&output.stdout).expect("stdout should contain only the DFM report");
 
@@ -70,14 +70,7 @@ fn dfm_resolves_zen_exports_temporary_ipc_and_checks_standard_pdk() {
 
     let file_output = run_pcbc(
         &mut sandbox,
-        [
-            "dfm",
-            "MyBoard.zen",
-            "--pdk",
-            "standard",
-            "--output",
-            "report.dfm.json",
-        ],
+        ["dfm", "MyBoard.zen", "--output", "report.dfm.json"],
     );
     assert!(file_output.stdout.is_empty());
     assert_eq!(file_output.status.code(), output.status.code());


### PR DESCRIPTION
Default pcb dfm and pcb ipc dfm check to the bundled standard PDK. Replace the color-specific JLCPCB variants with one conservative jlcpcb-1oz PDK and the jlc alias.